### PR TITLE
Generalize machinen up to support custom Docker images

### DIFF
--- a/src/__tests__/registry.test.mjs
+++ b/src/__tests__/registry.test.mjs
@@ -4,18 +4,21 @@ const execSyncMock = vi.fn((cmd) => {
   if (cmd.includes("gh api user")) return "testuser\n";
   if (cmd.includes("gh auth token")) return "gho_testtoken123\n";
   if (cmd.includes("gh auth status")) return "  - Token scopes: 'repo', 'write:packages'\n";
-  if (cmd.includes("docker login")) return "";
   return "";
 });
 
+const execFileSyncMock = vi.fn(() => "");
+
 vi.mock("node:child_process", () => ({
   execSync: (...args) => execSyncMock(...args),
+  execFileSync: (...args) => execFileSyncMock(...args),
 }));
 
 describe("registry", () => {
   beforeEach(() => {
     vi.resetModules();
     execSyncMock.mockClear();
+    execFileSyncMock.mockClear();
   });
 
   afterEach(() => {
@@ -33,12 +36,13 @@ describe("registry", () => {
   it("ensureDockerLogin calls docker login with gh token", async () => {
     const { ensureDockerLogin } = await import("../registry.mjs");
     ensureDockerLogin();
-    const loginCall = execSyncMock.mock.calls.find((c) =>
-      c[0].includes("docker login")
+    const loginCall = execFileSyncMock.mock.calls.find((c) =>
+      c[0] === "docker" && c[1].includes("login")
     );
     expect(loginCall).toBeTruthy();
-    expect(loginCall[0]).toContain("ghcr.io");
-    expect(loginCall[0]).toContain("testuser");
+    expect(loginCall[1]).toContain("ghcr.io");
+    expect(loginCall[1]).toContain("testuser");
+    expect(loginCall[2].input).toBe("gho_testtoken123");
   });
 
   it("remoteDockerLogin calls ssh with docker login", async () => {

--- a/src/__tests__/sync.test.mjs
+++ b/src/__tests__/sync.test.mjs
@@ -8,8 +8,8 @@ describe("startBackgroundSync", () => {
   it("can be stopped before first sync fires", async () => {
     // Mock the imports so we don't actually hit Docker
     vi.mock("../docker.mjs", () => ({
-      createCheckpoint: vi.fn(),
-      extractCheckpointFiles: vi.fn(),
+      dockerExec: vi.fn(),
+      prepareCheckpoint: vi.fn(),
       buildCheckpointImage: vi.fn(),
       pushImage: vi.fn(),
     }));

--- a/src/cloud.mjs
+++ b/src/cloud.mjs
@@ -1,7 +1,5 @@
-import { execSync, spawnSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { dockerExec } from "./docker.mjs";
 import hetzner from "./providers/hetzner.mjs";
 
 let provider = hetzner;
@@ -26,10 +24,9 @@ export function listMachines() {
 
   // Local containers named machinen-*
   try {
-    const out = execSync(
-      `docker ps -a --filter "name=^machinen-" --format "{{.Names}}\t{{.Status}}"`,
-      { stdio: "pipe", encoding: "utf-8" }
-    ).trim();
+    const out = dockerExec([
+      "ps", "-a", "--filter", "name=^machinen-", "--format", "{{.Names}}\t{{.Status}}",
+    ]).trim();
     if (out) {
       for (const line of out.split("\n")) {
         const [name, status] = line.split("\t");

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -1,10 +1,20 @@
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import Docker from "dockerode";
 
 export const docker = new Docker({ socketPath: "/var/run/docker.sock" });
+
+/** Run a docker CLI command without shell interpolation. */
+export function dockerExec(args, opts = {}) {
+  return execFileSync("docker", args, { stdio: "pipe", encoding: "utf-8", ...opts });
+}
+
+/** Escape a value for safe inclusion in a shell string. */
+export function shellQuote(s) {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
 
 export function captureContainerConfig(info) {
   return {
@@ -65,17 +75,17 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
     // Extract .img files from the checkpoint dir
     try {
       execSync(
-        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c "tar cf - -C ${checkpointDir} ." > ${tarPath}`,
+        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("tar cf - -C " + checkpointDir + " .")} > ${shellQuote(tarPath)}`,
         { stdio: ["pipe", "pipe", "pipe"], shell: true }
       );
     } catch {
-      execSync(`tar cf ${tarPath} -C ${checkpointDir} .`, { stdio: "pipe" });
+      execFileSync("tar", ["cf", tarPath, "-C", checkpointDir, "."], { stdio: "pipe" });
     }
 
     // Untar locally, patch, retar
     const workDir = path.join(patchDir, "work");
     fs.mkdirSync(workDir);
-    execSync(`tar xf ${tarPath} -C ${workDir}`, { stdio: "pipe" });
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe" });
 
     const oldBuf = Buffer.from(oldId, "utf-8");
     const newBuf = Buffer.from(newId, "utf-8");
@@ -99,15 +109,15 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
 
     // Copy patched files back
     const patchedTar = path.join(patchDir, "patched.tar");
-    execSync(`tar cf ${patchedTar} -C ${workDir} .`, { stdio: "pipe" });
+    execFileSync("tar", ["cf", patchedTar, "-C", workDir, "."], { stdio: "pipe" });
 
     try {
       execSync(
-        `cat ${patchedTar} | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c "tar xf - -C ${checkpointDir}"`,
+        `cat ${shellQuote(patchedTar)} | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("tar xf - -C " + checkpointDir)}`,
         { stdio: ["pipe", "pipe", "pipe"], shell: true }
       );
     } catch {
-      execSync(`tar xf ${patchedTar} -C ${checkpointDir}`, { stdio: "pipe" });
+      execFileSync("tar", ["xf", patchedTar, "-C", checkpointDir], { stdio: "pipe" });
     }
   } finally {
     fs.rmSync(patchDir, { recursive: true, force: true });
@@ -127,12 +137,12 @@ export function extractCheckpointFiles(containerId, checkpointId) {
     // Try nsenter approach first (works on OrbStack and any Docker-in-VM setup).
     // Pipe the tar to stdout and write it on the host to avoid volume mount issues.
     execSync(
-      `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c "tar cf - -C ${checkpointPath} ." > ${tarPath}`,
+      `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("tar cf - -C " + checkpointPath + " .")} > ${shellQuote(tarPath)}`,
       { stdio: ["pipe", "pipe", "pipe"], shell: true }
     );
   } catch {
     // Fall back to direct filesystem access (native Linux)
-    execSync(`tar cf ${tarPath} -C ${checkpointPath} .`, { stdio: "pipe" });
+    execFileSync("tar", ["cf", tarPath, "-C", checkpointPath, "."], { stdio: "pipe" });
   }
 
   return { tmpDir, tarPath };
@@ -153,7 +163,7 @@ export function extractWorkspaceFiles(containerName, containerConfig) {
 
     try {
       // Copy files out of the container via docker cp
-      execSync(`docker cp ${containerName}:${containerPath} - > ${tarPath}`, {
+      execSync(`docker cp ${shellQuote(containerName + ":" + containerPath)} - > ${shellQuote(tarPath)}`, {
         stdio: ["pipe", "pipe", "pipe"],
         shell: true,
       });
@@ -195,28 +205,115 @@ ${workspaceAdds.join("\n")}
 
     // Build
     console.log(`Building image ${imageTag}...`);
-    execSync(`docker build -t ${imageTag} ${buildDir}`, { stdio: "inherit" });
+    dockerExec(["build", "-t", imageTag, buildDir], { stdio: "inherit" });
   } finally {
     fs.rmSync(buildDir, { recursive: true, force: true });
   }
 }
 
+/**
+ * Commit a running container, capture bind mounts, and produce a clean
+ * checkpoint image ready for push.  Optionally stops the original container
+ * (freeze) or leaves it running (background sync).
+ *
+ * Returns { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath }
+ * Caller is responsible for cleanup (tmpDir, cleanName, commitImage).
+ */
+export async function prepareCheckpoint(containerName, { stop = false } = {}) {
+  const container = docker.getContainer(containerName);
+  const info = await container.inspect();
+  const config = captureContainerConfig(info);
+  const commitImage = `${containerName}-committed`;
+
+  // Extract bind-mounted files while the container is still running.
+  // Devcontainers use info.Mounts (not HostConfig.Binds), so check both and dedupe.
+  const binds = [...new Set([
+    ...(config.Binds || []).map(b => b.split(":")[1]),
+    ...(info.Mounts || []).filter(m => m.Type === "bind").map(m => m.Destination),
+  ].filter(Boolean))];
+  const workspaceTmpDir = binds.length ? fs.mkdtempSync(path.join(os.tmpdir(), "machinen-ws-")) : null;
+  const savedBinds = [];
+  for (const containerPath of binds) {
+    const tarName = `bind-${containerPath.replace(/\//g, "_")}.tar`;
+    const tarPath = path.join(workspaceTmpDir, tarName);
+    try {
+      execSync(`docker cp ${shellQuote(containerName + ":" + containerPath)} - > ${shellQuote(tarPath)}`, {
+        stdio: ["pipe", "pipe", "pipe"], shell: true,
+      });
+      savedBinds.push({ containerPath, tarPath });
+      console.log(`Saved bind mount: ${containerPath}`);
+    } catch {
+      // Skip mounts that can't be copied (sockets, etc.)
+    }
+  }
+
+  // Commit the running container to capture filesystem state
+  console.log("Committing container filesystem...");
+  dockerExec(["commit", containerName, commitImage]);
+
+  const cleanName = `${containerName}-clean`;
+  try { dockerExec(["rm", "-f", cleanName]); } catch {}
+
+  if (stop) {
+    dockerExec(["stop", containerName]);
+  }
+
+  // Run the committed image with a simple sleep — the filesystem is already
+  // captured via commit, and a trivial process avoids CRIU failures from
+  // complex entrypoints (e.g. docker-init.sh in devcontainers).
+  dockerExec([
+    "run", "-d",
+    "--name", cleanName,
+    "--entrypoint", "sleep",
+    "--security-opt", "seccomp=unconfined",
+    "--network", "host",
+    commitImage,
+    "infinity",
+  ]);
+
+  // Copy bind-mounted files into the clean container so they're in the filesystem
+  for (const { containerPath, tarPath } of savedBinds) {
+    const parent = path.posix.dirname(containerPath);
+    execSync(`cat ${shellQuote(tarPath)} | docker cp - ${shellQuote(cleanName + ":" + parent)}`, {
+      stdio: ["pipe", "pipe", "pipe"], shell: true,
+    });
+    console.log(`Restored bind mount into clean container: ${containerPath}`);
+  }
+  if (workspaceTmpDir) fs.rmSync(workspaceTmpDir, { recursive: true, force: true });
+
+  // Re-commit so workspace files are baked into the image
+  // (CRIU only captures process state, not filesystem changes to the writable layer)
+  if (savedBinds.length > 0) {
+    console.log("Re-committing with workspace files...");
+    dockerExec(["commit", cleanName, commitImage]);
+  }
+
+  // Give the process a moment to start
+  await new Promise(r => setTimeout(r, 1000));
+
+  // Checkpoint the clean container
+  const { containerId, checkpointId } = await createCheckpoint(cleanName);
+  console.log(`Checkpoint: ${checkpointId}`);
+
+  console.log("Extracting checkpoint files...");
+  const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+
+  return { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath };
+}
+
 export function pushImage(imageTag) {
   console.log(`Pushing ${imageTag}...`);
-  execSync(`docker push ${imageTag}`, { stdio: "inherit" });
+  dockerExec(["push", imageTag], { stdio: "inherit" });
 }
 
 export function pullImage(imageTag) {
   console.log(`Pulling ${imageTag}...`);
-  execSync(`docker pull ${imageTag}`, { stdio: "inherit" });
+  dockerExec(["pull", imageTag], { stdio: "inherit" });
 }
 
 export function restoreLocally(imageTag, containerName) {
   // Read labels from the checkpoint image
-  const labelsRaw = execSync(
-    `docker inspect --format '{{json .Config.Labels}}' ${imageTag}`,
-    { stdio: "pipe", encoding: "utf-8" }
-  ).trim();
+  const labelsRaw = dockerExec(["inspect", "--format", "{{json .Config.Labels}}", imageTag]).trim();
   const labels = JSON.parse(labelsRaw);
 
   const config = JSON.parse(labels["machinen.config"]);
@@ -234,43 +331,39 @@ export function restoreLocally(imageTag, containerName) {
   }
 
   // Remove existing container
-  try {
-    execSync(`docker rm -f ${containerName}`, { stdio: "pipe" });
-  } catch {}
+  try { dockerExec(["rm", "-f", containerName]); } catch {}
 
-  const createCmd = [
-    "docker create",
-    `--name ${containerName}`,
-    "--security-opt seccomp=unconfined",
-    "--network host",
+  const newContainerId = dockerExec([
+    "create",
+    "--name", containerName,
+    "--security-opt", "seccomp=unconfined",
+    "--network", "host",
     createImage,
-  ].join(" ");
-
-  const newContainerId = execSync(createCmd, { stdio: "pipe", encoding: "utf-8" }).trim();
+  ]).trim();
 
   // Extract checkpoint from image into Docker's internal checkpoint directory
-  try { execSync("docker rm -f machinen-tmp", { stdio: "pipe" }); } catch {}
-  execSync(`docker create --name machinen-tmp ${imageTag}`, { stdio: "pipe" });
+  try { dockerExec(["rm", "-f", "machinen-tmp"]); } catch {}
+  dockerExec(["create", "--name", "machinen-tmp", imageTag]);
 
   const checkpointDir = `/var/lib/docker/containers/${newContainerId}/checkpoints/${checkpointId}`;
 
   try {
     // OrbStack: use nsenter to access Docker's internal storage
-    execSync(
-      `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c "mkdir -p ${checkpointDir}"`,
-      { stdio: "pipe" }
-    );
-    execSync(`docker cp machinen-tmp:/checkpoint/. - | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c "tar xf - -C ${checkpointDir}"`, {
+    dockerExec([
+      "run", "--rm", "--privileged", "--pid=host", "alpine",
+      "nsenter", "-t", "1", "-m", "sh", "-c", `mkdir -p ${checkpointDir}`,
+    ]);
+    execSync(`docker cp machinen-tmp:/checkpoint/. - | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("tar xf - -C " + checkpointDir)}`, {
       stdio: "pipe",
       shell: true,
     });
   } catch {
     // Native Linux: direct access
-    execSync(`mkdir -p ${checkpointDir}`, { stdio: "pipe" });
-    execSync(`docker cp machinen-tmp:/checkpoint/. ${checkpointDir}/`, { stdio: "pipe" });
+    execFileSync("mkdir", ["-p", checkpointDir], { stdio: "pipe" });
+    dockerExec(["cp", "machinen-tmp:/checkpoint/.", `${checkpointDir}/`]);
   }
 
-  execSync("docker rm machinen-tmp", { stdio: "pipe" });
+  dockerExec(["rm", "machinen-tmp"]);
 
   // Patch checkpoint: CRIU image files (protobuf binary) contain hardcoded
   // paths with the original container ID (mountpoints, cgroups, etc.).
@@ -283,7 +376,7 @@ export function restoreLocally(imageTag, containerName) {
   }
 
   // Restore
-  execSync(`docker start --checkpoint ${checkpointId} ${containerName}`, { stdio: "inherit" });
+  dockerExec(["start", "--checkpoint", checkpointId, containerName], { stdio: "inherit" });
 
   return { newContainerId, checkpointId };
 }

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -2,13 +2,12 @@
 
 import { execSync, spawnSync, spawn } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   docker,
-  captureContainerConfig,
-  createCheckpoint,
-  extractCheckpointFiles,
+  dockerExec,
+  shellQuote,
+  prepareCheckpoint,
   buildCheckpointImage,
   pushImage,
   pullImage,
@@ -24,6 +23,7 @@ import {
   remoteRestore,
   remoteFreeze,
   ssh,
+  sshScript,
 } from "./cloud.mjs";
 import { getRegistry, ensureDockerLogin, remoteDockerLogin } from "./registry.mjs";
 import { createPowerWatcher } from "./power.mjs";
@@ -39,82 +39,8 @@ async function cmdFreeze(containerName) {
 
   console.log(`Freezing ${containerName}...`);
 
-  // Step 1: Commit the running container to capture filesystem state
-  // (including bind-mounted files which won't survive checkpoint/restore)
-  const container = docker.getContainer(containerName);
-  const info = await container.inspect();
-  const commitImage = `${containerName}-committed`;
-  const config = captureContainerConfig(info);
-
-  // Extract bind-mounted files BEFORE stopping — bind mounts disappear when stopped.
-  // Devcontainers use info.Mounts (not HostConfig.Binds), so check both and dedupe.
-  const binds = [...new Set([
-    ...(config.Binds || []).map(b => b.split(":")[1]),
-    ...(info.Mounts || []).filter(m => m.Type === "bind").map(m => m.Destination),
-  ].filter(Boolean))];
-  const workspaceTmpDir = binds.length ? fs.mkdtempSync(path.join(os.tmpdir(), "machinen-ws-")) : null;
-  const savedBinds = [];
-  for (const containerPath of binds) {
-    const tarName = `bind-${containerPath.replace(/\//g, "_")}.tar`;
-    const tarPath = path.join(workspaceTmpDir, tarName);
-    try {
-      execSync(`docker cp ${containerName}:${containerPath} - > ${tarPath}`, {
-        stdio: ["pipe", "pipe", "pipe"], shell: true,
-      });
-      savedBinds.push({ containerPath, tarPath });
-      console.log(`Saved bind mount: ${containerPath}`);
-    } catch {
-      // Skip mounts that can't be copied (sockets, etc.)
-    }
-  }
-
-  // Commit and stop
-  console.log("Committing container filesystem...");
-  execSync(`docker commit ${containerName} ${commitImage}`, { stdio: "pipe" });
-
-  const cleanName = `${containerName}-clean`;
-  try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
-  execSync(`docker stop ${containerName}`, { stdio: "pipe" });
-
-  // Run the committed image with a simple sleep — the filesystem is already
-  // captured via commit, and a trivial process avoids CRIU failures from
-  // complex entrypoints (e.g. docker-init.sh in devcontainers).
-  execSync([
-    "docker run -d",
-    `--name ${cleanName}`,
-    "--entrypoint sleep",
-    "--security-opt seccomp=unconfined",
-    "--network host",
-    commitImage,
-    "infinity",
-  ].join(" "), { stdio: "pipe" });
-
-  // Copy bind-mounted files into the clean container so they're in the filesystem
-  for (const { containerPath, tarPath } of savedBinds) {
-    const parent = path.posix.dirname(containerPath);
-    execSync(`cat ${tarPath} | docker cp - ${cleanName}:${parent}`, {
-      stdio: ["pipe", "pipe", "pipe"], shell: true,
-    });
-    console.log(`Restored bind mount into clean container: ${containerPath}`);
-  }
-  if (workspaceTmpDir) fs.rmSync(workspaceTmpDir, { recursive: true, force: true });
-
-  // Re-commit the clean container so workspace files are baked into the image
-  // (CRIU only captures process state, not filesystem changes to the writable layer)
-  if (savedBinds.length > 0) {
-    console.log("Re-committing with workspace files...");
-    execSync(`docker commit ${cleanName} ${commitImage}`, { stdio: "pipe" });
-  }
-
-  // Give the process a moment to start
-  await new Promise(r => setTimeout(r, 1000));
-
-  // Step 3: Checkpoint the clean container (no OrbStack mounts)
-  const { containerId, checkpointId } = await createCheckpoint(cleanName);
-  console.log(`Checkpoint: ${checkpointId}`);
-
-  console.log("Extracting checkpoint files...");
-  const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+  const { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath } =
+    await prepareCheckpoint(containerName, { stop: true });
 
   try {
     const prefix = `${registry}/machinen/${containerName}`;
@@ -124,13 +50,13 @@ async function cmdFreeze(containerName) {
     const baseLatestTag = `${prefix}:base`;
 
     // Push the committed image as the base — restore needs identical layers
-    execSync(`docker tag ${commitImage} ${baseTag}`, { stdio: "pipe" });
-    execSync(`docker tag ${commitImage} ${baseLatestTag}`, { stdio: "pipe" });
+    dockerExec(["tag", commitImage, baseTag]);
+    dockerExec(["tag", commitImage, baseLatestTag]);
     pushImage(baseTag);
     pushImage(baseLatestTag);
 
     buildCheckpointImage(tarPath, commitImage, config, checkpointId, tag, [], baseLatestTag, containerId);
-    execSync(`docker tag ${tag} ${latestTag}`, { stdio: "pipe" });
+    dockerExec(["tag", tag, latestTag]);
 
     pushImage(tag);
     pushImage(latestTag);
@@ -138,8 +64,8 @@ async function cmdFreeze(containerName) {
     console.log(`Frozen: ${tag}`);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
-    try { execSync(`docker rmi ${commitImage}`, { stdio: "pipe" }); } catch {}
+    try { dockerExec(["rm", "-f", cleanName]); } catch {}
+    try { dockerExec(["rmi", commitImage]); } catch {}
   }
 }
 
@@ -167,7 +93,7 @@ async function cmdRestore(args) {
   }
 
   const ip = await provisionServer({ name: containerName });
-  remoteDockerLogin(ssh, ip);
+  remoteDockerLogin(sshScript, ip);
   remoteRestore(ip, containerName, imageTag, registry);
 
   console.log(`\nServer: ${ip}`);
@@ -230,62 +156,93 @@ function detectRepoRoot(cwd) {
 async function cmdUp(args) {
   const cwd = args.cwd || process.cwd();
   const repoRoot = detectRepoRoot(cwd);
-  const file = args.file || detectDevcontainerFile(repoRoot);
-
-  if (!file) {
-    throw new Error(
-      "No devcontainer.json found. Specify with --file <path>\n" +
-      "  e.g., machinen up --file .devcontainer/devcontainer.json"
-    );
-  }
 
   ensureDockerLogin();
   const { url: registry } = getRegistry();
-  const configPath = path.join(repoRoot, file);
 
-  const repoName = path.basename(repoRoot);
   const branch = args._positional?.[1] || currentBranch() || "main";
   const safeBranch = sanitizeBranch(branch);
+  const repoName = path.basename(repoRoot);
   const imagePrefix = `${registry}/machinen/${repoName}/${safeBranch}`;
-  const containerName = `machinen-${safeBranch}`;
+
+  // Container name: --name flag, or derived from branch
+  const containerName = args.name
+    ? (args.name.startsWith("machinen-") ? args.name : `machinen-${args.name}`)
+    : `machinen-${safeBranch}`;
 
   await checkPrerequisites(docker);
 
-  // Step 1: Start local devcontainer
-  console.log(`Starting ${containerName} from ${file}...`);
-  const upResult = spawnSync("npx", ["devcontainer",
-    "up",
-    "--workspace-folder", repoRoot,
-    "--config", configPath,
-    "--additional-features", '{"ghcr.io/devcontainers/features/docker-outside-of-docker:1":{}}',
-    "--remove-existing-container",
-  ], { stdio: "inherit" });
+  if (args.image) {
+    // --- Image mode: docker run directly ---
+    console.log(`Starting ${containerName} from image ${args.image}...`);
 
-  if (upResult.status !== 0) {
-    throw new Error("devcontainer up failed");
+    // Remove existing container with the same name
+    try { dockerExec(["rm", "-f", containerName]); } catch {}
+
+    const runArgs = [
+      "run", "-d",
+      "--name", containerName,
+      "--security-opt", "seccomp=unconfined",
+      "--network", "host",
+    ];
+
+    // Default command is sleep infinity (keeps container alive for exec)
+    const cmd = args.cmd ? args.cmd.split(" ") : ["sleep", "infinity"];
+    runArgs.push(args.image, ...cmd);
+
+    dockerExec(runArgs, { stdio: "inherit" });
+    console.log(`Container: ${containerName}`);
+  } else {
+    // --- Devcontainer mode (existing behavior) ---
+    const file = args.file || detectDevcontainerFile(repoRoot);
+
+    if (!file) {
+      throw new Error(
+        "No devcontainer.json found. Specify with --file <path> or use --image <image>\n" +
+        "  e.g., machinen up --file .devcontainer/devcontainer.json\n" +
+        "  e.g., machinen up --image ubuntu:latest"
+      );
+    }
+
+    const configPath = path.join(repoRoot, file);
+
+    console.log(`Starting ${containerName} from ${file}...`);
+    const upResult = spawnSync("npx", ["devcontainer",
+      "up",
+      "--workspace-folder", repoRoot,
+      "--config", configPath,
+      "--additional-features", '{"ghcr.io/devcontainers/features/docker-outside-of-docker:1":{}}',
+      "--remove-existing-container",
+    ], { stdio: "inherit" });
+
+    if (upResult.status !== 0) {
+      throw new Error("devcontainer up failed");
+    }
+
+    // Get the container ID/name that devcontainer created and rename it
+    const dcContainerOriginal = dockerExec([
+      "ps", "--filter", `label=devcontainer.local_folder=${repoRoot}`, "--format", "{{.Names}}",
+    ]).trim();
+
+    if (!dcContainerOriginal) {
+      throw new Error("Could not find devcontainer. Is it running?");
+    }
+
+    if (dcContainerOriginal !== containerName) {
+      try { dockerExec(["rm", "-f", containerName]); } catch {}
+      dockerExec(["rename", dcContainerOriginal, containerName]);
+    }
   }
 
-  // Get the container ID/name that devcontainer created and rename it
-  const dcContainerOriginal = execSync(
-    `docker ps --filter "label=devcontainer.local_folder=${repoRoot}" --format "{{.Names}}"`,
-    { stdio: "pipe", encoding: "utf-8" }
-  ).trim();
-
-  if (!dcContainerOriginal) {
-    throw new Error("Could not find devcontainer. Is it running?");
-  }
-
-  // Rename to machinen-<branch>
-  const dcContainer = containerName;
-  if (dcContainerOriginal !== dcContainer) {
-    try { execSync(`docker rm -f ${dcContainer}`, { stdio: "pipe" }); } catch {}
-    execSync(`docker rename ${dcContainerOriginal} ${dcContainer}`, { stdio: "pipe" });
-  }
-
-  console.log(`Container: ${dcContainer}`);
   console.log(`Image prefix: ${imagePrefix}`);
 
-  // Step 2: Start power watcher for sleep/wake handoff
+  // In detach mode, just print the container name and exit
+  if (args.detach) {
+    console.log(`Container ${containerName} is running (detached).`);
+    return;
+  }
+
+  // Start power watcher for sleep/wake handoff
   let remoteIp = null;
 
   console.log("Watching for sleep/wake events...");
@@ -294,47 +251,8 @@ async function cmdUp(args) {
       console.log("\nSleep detected — migrating to remote...");
 
       try {
-        // Commit the container to capture filesystem
-        const commitImage = `${dcContainer}-committed`;
-        console.log("Committing container filesystem...");
-        execSync(`docker commit ${dcContainer} ${commitImage}`, { stdio: "pipe" });
-
-        // Extract bind-mounted files before stopping
-        const dcInfo = await docker.getContainer(dcContainer).inspect();
-        const dcBinds = [...new Set([
-          ...(dcInfo.HostConfig.Binds || []).map(b => b.split(":")[1]),
-          ...(dcInfo.Mounts || []).filter(m => m.Type === "bind").map(m => m.Destination),
-        ].filter(Boolean))];
-        const wsTmp = dcBinds.length ? fs.mkdtempSync(path.join(os.tmpdir(), "machinen-ws-")) : null;
-        const savedWs = [];
-        for (const cp of dcBinds) {
-          const tp = path.join(wsTmp, `bind-${cp.replace(/\//g, "_")}.tar`);
-          try {
-            execSync(`docker cp ${dcContainer}:${cp} - > ${tp}`, { stdio: ["pipe", "pipe", "pipe"], shell: true });
-            savedWs.push({ containerPath: cp, tarPath: tp });
-          } catch {}
-        }
-
-        // Create a clean copy without bind mounts, checkpoint it
-        const cleanName = `${dcContainer}-clean`;
-        try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
-        execSync(`docker stop ${dcContainer}`, { stdio: "pipe" });
-        execSync(`docker run -d --name ${cleanName} --entrypoint sleep --security-opt seccomp=unconfined --network host ${commitImage} infinity`, { stdio: "pipe" });
-
-        // Copy bind-mounted files into clean container + re-commit
-        for (const { containerPath, tarPath: tp } of savedWs) {
-          const parent = path.posix.dirname(containerPath);
-          execSync(`cat ${tp} | docker cp - ${cleanName}:${parent}`, { stdio: ["pipe", "pipe", "pipe"], shell: true });
-        }
-        if (wsTmp) fs.rmSync(wsTmp, { recursive: true, force: true });
-        if (savedWs.length > 0) {
-          execSync(`docker commit ${cleanName} ${commitImage}`, { stdio: "pipe" });
-        }
-
-        await new Promise(r => setTimeout(r, 1000));
-
-        const { containerId, checkpointId } = await createCheckpoint(cleanName);
-        const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+        const { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath } =
+          await prepareCheckpoint(containerName, { stop: true });
 
         try {
           const tag = `${imagePrefix}:${checkpointId}`;
@@ -342,28 +260,27 @@ async function cmdUp(args) {
           const baseTag = `${imagePrefix}:base-${checkpointId}`;
           const baseLatestTag = `${imagePrefix}:base`;
 
-          execSync(`docker tag ${commitImage} ${baseTag}`, { stdio: "pipe" });
-          execSync(`docker tag ${commitImage} ${baseLatestTag}`, { stdio: "pipe" });
+          dockerExec(["tag", commitImage, baseTag]);
+          dockerExec(["tag", commitImage, baseLatestTag]);
           pushImage(baseTag);
           pushImage(baseLatestTag);
 
-          buildCheckpointImage(tarPath, commitImage, {}, checkpointId, tag, [], baseLatestTag, containerId);
-          execSync(`docker tag ${tag} ${latestTag}`, { stdio: "pipe" });
+          buildCheckpointImage(tarPath, commitImage, config, checkpointId, tag, [], baseLatestTag, containerId);
+          dockerExec(["tag", tag, latestTag]);
           pushImage(tag);
           pushImage(latestTag);
 
-          // Provision server now (only when we actually need it)
           console.log("Provisioning remote server...");
-          remoteIp = await provisionServer({ name: dcContainer });
-          remoteDockerLogin(ssh, remoteIp);
+          remoteIp = await provisionServer({ name: containerName });
+          remoteDockerLogin(sshScript, remoteIp);
 
-          remoteRestore(remoteIp, dcContainer, latestTag, registry);
+          remoteRestore(remoteIp, containerName, latestTag, registry);
           await sendTelegram(`Your machine is running on Hetzner at ${remoteIp}`);
           console.log(`Remote restore complete: ${remoteIp}`);
         } finally {
           fs.rmSync(tmpDir, { recursive: true, force: true });
-          try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
-          try { execSync(`docker rmi ${commitImage}`, { stdio: "pipe" }); } catch {}
+          try { dockerExec(["rm", "-f", cleanName]); } catch {}
+          try { dockerExec(["rmi", commitImage]); } catch {}
         }
       } catch (err) {
         console.error("Sleep migration failed:", err.message);
@@ -379,13 +296,13 @@ async function cmdUp(args) {
       }
 
       try {
-        const { latestTag } = remoteFreeze(remoteIp, dcContainer, registry);
+        const { latestTag } = remoteFreeze(remoteIp, containerName, registry);
 
         pullImage(latestTag);
-        restoreLocally(latestTag, dcContainer);
+        restoreLocally(latestTag, containerName);
 
         console.log("Destroying remote server...");
-        destroyServer(dcContainer);
+        destroyServer(containerName);
         remoteIp = null;
 
         console.log("Local restore complete.");
@@ -396,27 +313,38 @@ async function cmdUp(args) {
     },
   });
 
-  // Step 5: SSH into the devcontainer
-  console.log(`\nConnecting to devcontainer...\n`);
-  const shell = spawn("npx", ["devcontainer",
-    "exec",
-    "--workspace-folder", repoRoot,
-    "--config", configPath,
-    "/bin/bash",
-  ], { stdio: "inherit" });
+  // Open interactive shell
+  if (args.image) {
+    console.log(`\nConnecting to container...\n`);
+    const shell = spawn("docker", ["exec", "-it", containerName, "/bin/bash"], { stdio: "inherit" });
 
-  await new Promise((resolve) => {
-    shell.on("exit", async () => {
-      console.log("\nShell exited. Cleaning up...");
-      watcher.stop();
-
-      // Destroy remote server if one was provisioned during sleep
-      if (remoteIp) {
-        destroyServer(dcContainer);
-      }
-      resolve();
+    await new Promise((resolve) => {
+      shell.on("exit", async () => {
+        console.log("\nShell exited. Cleaning up...");
+        watcher.stop();
+        if (remoteIp) destroyServer(containerName);
+        resolve();
+      });
     });
-  });
+  } else {
+    const configPath = path.join(repoRoot, args.file || detectDevcontainerFile(repoRoot));
+    console.log(`\nConnecting to devcontainer...\n`);
+    const shell = spawn("npx", ["devcontainer",
+      "exec",
+      "--workspace-folder", repoRoot,
+      "--config", configPath,
+      "/bin/bash",
+    ], { stdio: "inherit" });
+
+    await new Promise((resolve) => {
+      shell.on("exit", async () => {
+        console.log("\nShell exited. Cleaning up...");
+        watcher.stop();
+        if (remoteIp) destroyServer(containerName);
+        resolve();
+      });
+    });
+  }
 }
 
 // --- open ---
@@ -449,10 +377,7 @@ function cmdOpen(args) {
   // Local: try both <name> and <name>-restored
   for (const name of [containerName, `${containerName}-restored`]) {
     try {
-      const status = execSync(
-        `docker inspect --format '{{.State.Status}}' ${name}`,
-        { stdio: "pipe", encoding: "utf-8" }
-      ).trim();
+      const status = dockerExec(["inspect", "--format", "{{.State.Status}}", name]).trim();
       if (status === "running") {
         console.log(`Opening shell in local container ${name}...`);
         const shell = spawnSync("docker", ["exec", "-it", name, "/bin/bash"], { stdio: "inherit" });
@@ -498,7 +423,7 @@ async function cmdDestroy(args) {
     let found = false;
     for (const n of [name, `${name}-restored`]) {
       try {
-        execSync(`docker rm -f ${n}`, { stdio: "pipe" });
+        dockerExec(["rm", "-f", n]);
         console.log(`Removed local container ${n}.`);
         found = true;
       } catch {}
@@ -529,7 +454,7 @@ async function cmdDestroy(args) {
   let found = false;
   for (const n of [name, `${name}-restored`]) {
     try {
-      execSync(`docker rm -f ${n}`, { stdio: "pipe" });
+      dockerExec(["rm", "-f", n]);
       console.log(`Removed local container ${n}.`);
       found = true;
     } catch {}
@@ -588,8 +513,12 @@ async function main() {
     console.log(`Usage: machinen <command> [options]
 
 Commands:
-  up [branch]           Start devcontainer for branch (default: current branch)
+  up [branch]           Start container for branch (default: current branch)
     --file <path>       Path to devcontainer.json (auto-detected from cwd)
+    --image <image>     Use a Docker image instead of devcontainer
+    --name <name>       Override container name (default: machinen-<branch>)
+    --cmd <command>     Override container command (default: sleep infinity)
+    --detach            Start container without opening a shell
 
   freeze [name]         Checkpoint, package as image, push to registry
   restore [name]        Restore container from checkpoint

--- a/src/registry.mjs
+++ b/src/registry.mjs
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 
 let _cached = null;
 
@@ -41,14 +41,15 @@ export function getRegistry() {
 
 export function ensureDockerLogin() {
   const { url, username, token } = getRegistry();
-  execSync(`echo ${token} | docker login ghcr.io -u ${username} --password-stdin`, {
-    stdio: "pipe",
+  execFileSync("docker", ["login", "ghcr.io", "-u", username, "--password-stdin"], {
+    input: token,
+    stdio: ["pipe", "pipe", "pipe"],
   });
 }
 
-export function remoteDockerLogin(sshFn, ip) {
+export function remoteDockerLogin(sshScriptFn, ip) {
   const { username, token } = getRegistry();
-  sshFn(ip, `echo '${token}' | docker login ghcr.io -u ${username} --password-stdin`, {
+  sshScriptFn(ip, `echo "${token}" | docker login ghcr.io -u "${username}" --password-stdin`, {
     stdio: "pipe",
   });
 }

--- a/src/sync.mjs
+++ b/src/sync.mjs
@@ -1,6 +1,6 @@
 import {
-  createCheckpoint,
-  extractCheckpointFiles,
+  dockerExec,
+  prepareCheckpoint,
   buildCheckpointImage,
   pushImage,
 } from "./docker.mjs";
@@ -9,6 +9,10 @@ import fs from "node:fs";
 
 const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
+function isAuthError(msg) {
+  return /write:packages|unauthorized|authentication required|no basic auth credentials|requested access to the resource is denied|denied:|not authorized|not authorised|access denied|401\b|403\b/i.test(msg);
+}
+
 export function startBackgroundSync(containerName, registry, ip) {
   let running = true;
   let timer;
@@ -16,11 +20,9 @@ export function startBackgroundSync(containerName, registry, ip) {
   async function sync() {
     if (!running) return;
     try {
-      console.log("[sync] Creating non-destructive checkpoint...");
-      const { containerId, checkpointId, config } = await createCheckpoint(containerName, { exit: false });
-
-      console.log("[sync] Extracting checkpoint files...");
-      const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+      console.log("[sync] Preparing checkpoint...");
+      const { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath } =
+        await prepareCheckpoint(containerName, { stop: false });
 
       try {
         const tag = `${registry}/${containerName}:${checkpointId}`;
@@ -28,16 +30,14 @@ export function startBackgroundSync(containerName, registry, ip) {
         const baseTag = `${registry}/${containerName}:base-${checkpointId}`;
         const baseLatestTag = `${registry}/${containerName}:base`;
 
-        const { execSync } = await import("node:child_process");
-
-        // Push the running container's image as the base
-        execSync(`docker tag ${config.Image} ${baseTag}`, { stdio: "pipe" });
-        execSync(`docker tag ${config.Image} ${baseLatestTag}`, { stdio: "pipe" });
+        // Push the committed image as the base — restore needs identical layers
+        dockerExec(["tag", commitImage, baseTag]);
+        dockerExec(["tag", commitImage, baseLatestTag]);
         pushImage(baseTag);
         pushImage(baseLatestTag);
 
-        buildCheckpointImage(tarPath, config.Image, config, checkpointId, tag, [], baseLatestTag, containerId);
-        execSync(`docker tag ${tag} ${latestTag}`, { stdio: "pipe" });
+        buildCheckpointImage(tarPath, commitImage, config, checkpointId, tag, [], baseLatestTag, containerId);
+        dockerExec(["tag", tag, latestTag]);
 
         pushImage(tag);
         pushImage(latestTag);
@@ -51,9 +51,14 @@ export function startBackgroundSync(containerName, registry, ip) {
         console.log(`[sync] Synced: ${checkpointId}`);
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
+        try { dockerExec(["rm", "-f", cleanName]); } catch {}
+        try { dockerExec(["rmi", commitImage]); } catch {}
       }
     } catch (err) {
       console.error("[sync] Failed:", err.message);
+      if (isAuthError(err.message)) {
+        console.error("[sync] This looks like an auth error. Try: gh auth refresh -s write:packages");
+      }
     }
 
     if (running) {


### PR DESCRIPTION
## Summary
- Add `--image <image>` flag to `machinen up` to launch containers from any Docker image instead of requiring a devcontainer.json
- Add `--name`, `--cmd`, and `--detach` flags for programmatic use (e.g. agent-ci launching GitHub Actions runner containers)
- Refactor `cmdFreeze` and `cmdUp` sleep/wake handlers to use `prepareCheckpoint` helper and `dockerExec` instead of raw `execSync` shell commands

## Test plan
- [ ] `npx vitest run` — all 18 tests pass
- [ ] `machinen up --image alpine:latest --detach` creates and runs a container
- [ ] `machinen logs` shows the new container
- [ ] `machinen open --local` opens a shell in it
- [ ] `machinen destroy` cleans it up
- [ ] `machinen up` (no --image) still works with devcontainer flow
