### PR TITLE
fix: restore original process tree on checkpoint/restore

### DIFF
--- a/src/__tests__/e2e-local.mjs
+++ b/src/__tests__/e2e-local.mjs
@@ -5,9 +5,9 @@
  *
  * Verifies the full checkpoint/restore cycle:
  *   1. Create a container with known file and in-memory state
- *   2. Commit → clean copy → checkpoint → build image → push to local registry
+ *   2. Commit → checkpoint original → build image → push to local registry
  *   3. Pull from registry → restore locally
- *   4. Assert: container running, files intact, process resumed, memory preserved
+ *   4. Assert: container running, files intact, original process alive and incrementing
  *
  * Requires: Docker with experimental mode, CRIU, local registry on :5000
  */
@@ -21,6 +21,7 @@ import {
   captureContainerConfig,
   createCheckpoint,
   extractCheckpointFiles,
+  stripBindMountEntries,
   buildCheckpointImage,
   pushImage,
   pullImage,
@@ -143,29 +144,37 @@ async function main() {
       } catch {}
     }
 
-    // Create clean copy (no bind mounts)
-    rmContainer(CLEAN);
-    exec(`docker stop ${CONTAINER}`);
-    execFileSync("docker", [
-      "run", "-d", "--name", CLEAN, "--entrypoint", "sleep",
-      "--security-opt", "seccomp=unconfined", "--network", "host",
-      COMMITTED, "infinity",
-    ], { stdio: "pipe" });
-
-    // Copy bind-mounted files into clean container
-    for (const { containerPath, tarPath } of savedBinds) {
-      const parent = path.posix.dirname(containerPath);
-      exec(`cat ${tarPath} | docker cp - ${CLEAN}:${parent}`);
+    // Bake bind-mounted files into the committed image using a temp container
+    if (savedBinds.length > 0) {
+      rmContainer(CLEAN);
+      execFileSync("docker", [
+        "run", "-d", "--name", CLEAN, "--entrypoint", "sleep",
+        COMMITTED, "infinity",
+      ], { stdio: "pipe" });
+      for (const { containerPath, tarPath } of savedBinds) {
+        const parent = path.posix.dirname(containerPath);
+        exec(`cat ${tarPath} | docker cp - ${CLEAN}:${parent}`);
+      }
+      exec(`docker commit ${CLEAN} ${COMMITTED}`);
+      rmContainer(CLEAN);
     }
     fs.rmSync(wsTmpDir, { recursive: true, force: true });
 
-    await new Promise(r => setTimeout(r, 2000));
-
-    // Checkpoint
-    const { containerId, checkpointId } = await createCheckpoint(CLEAN);
+    // Checkpoint the original container directly to preserve process tree
+    const { containerId, checkpointId } = await createCheckpoint(CONTAINER, { exit: true });
     console.log(`   checkpoint: ${checkpointId}`);
 
     const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+
+    // Strip bind-mount entries from checkpoint (contents are in the committed image)
+    if (binds.length > 0) {
+      const patchDir = path.join(tmpDir, "patch");
+      fs.mkdirSync(patchDir);
+      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe" });
+      stripBindMountEntries(patchDir, binds);
+      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe" });
+      fs.rmSync(patchDir, { recursive: true, force: true });
+    }
 
     try {
       const prefix = `${REGISTRY}/machinen/${CONTAINER}`;
@@ -222,22 +231,30 @@ async function main() {
       assert(postHello === "hello from machinen", `hello lost: ${postHello}`);
       console.log("   [pass] /tmp/hello.txt preserved");
 
-      // state.txt should have counter:secret format (written by the original process,
-      // preserved in the committed filesystem)
-      const postState = dockerExec(RESTORED, "cat /tmp/state.txt");
-      const [counterStr, secret] = postState.split(":");
-      const postCounter = parseInt(counterStr, 10);
+      // The original shell loop should still be running and incrementing the counter.
+      // Read counter twice with a gap to prove the process is alive and ticking.
+      const postState1 = dockerExec(RESTORED, "cat /tmp/state.txt");
+      const [counterStr1, secret1] = postState1.split(":");
+      const postCounter1 = parseInt(counterStr1, 10);
 
-      assert(secret === "machinen-e2e-42", `in-memory SECRET lost after restore: ${secret}`);
-      console.log("   [pass] state.txt SECRET preserved");
+      assert(secret1 === "machinen-e2e-42", `in-memory SECRET lost after restore: ${secret1}`);
+      console.log("   [pass] in-memory SECRET preserved across checkpoint/restore");
 
-      assert(postCounter >= preCounter, `counter regressed (pre=${preCounter} post=${postCounter})`);
-      console.log(`   [pass] counter preserved: ${postCounter} (filesystem state restored)`);
+      assert(postCounter1 >= preCounter, `counter regressed (pre=${preCounter} post=${postCounter1})`);
+      console.log(`   [pass] counter preserved: ${postCounter1} (was ${preCounter} before freeze)`);
 
-      // Process is running (sleep infinity from the clean container)
+      // Wait and read again — counter must still be incrementing
+      await new Promise(r => setTimeout(r, 2000));
+      const postState2 = dockerExec(RESTORED, "cat /tmp/state.txt");
+      const postCounter2 = parseInt(postState2.split(":")[0], 10);
+
+      assert(postCounter2 > postCounter1, `counter not incrementing after restore (read1=${postCounter1} read2=${postCounter2}) — original process is not running`);
+      console.log(`   [pass] counter still incrementing: ${postCounter1} → ${postCounter2} (process survived restore)`);
+
+      // The original shell process should be running, not "sleep infinity"
       const ps = dockerExec(RESTORED, "ps aux");
-      assert(ps.includes("sleep"), `sleep process not found in:\n${ps}`);
-      console.log("   [pass] process tree restored");
+      assert(!ps.includes("sleep infinity"), `"sleep infinity" found — original process was replaced:\n${ps}`);
+      console.log("   [pass] original process tree restored (no sleep substitution)");
 
       // Bind-mounted workspace files (may not work in Docker-outside-of-Docker)
       try {

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -124,6 +124,53 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
   }
 }
 
+/**
+ * Strip mount entries from CRIU mountpoints image files that reference
+ * the given container paths.  Bind mounts captured during checkpoint
+ * can't be restored (the host paths don't exist); the file contents are
+ * already baked into the committed image layer, so we just drop them.
+ *
+ * Uses the same CRIU image format as patch-checkpoint.mjs:
+ *   8-byte header + repeated (4-byte LE size + protobuf payload).
+ */
+export function stripBindMountEntries(dir, bindPaths) {
+  if (!bindPaths || bindPaths.length === 0) return;
+
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.startsWith("mountpoints-") || !file.endsWith(".img")) continue;
+
+    const filePath = path.join(dir, file);
+    const data = fs.readFileSync(filePath);
+    if (data.length < 8) continue;
+
+    const header = data.subarray(0, 8);
+    let offset = 8;
+    const entries = [];
+    while (offset + 4 <= data.length) {
+      const size = data.readUInt32LE(offset);
+      if (size === 0 || offset + 4 + size > data.length) break;
+      entries.push(data.subarray(offset, offset + 4 + size));
+      offset += 4 + size;
+    }
+
+    let removedCount = 0;
+    const kept = [];
+    for (const entry of entries) {
+      const payload = entry.subarray(4).toString("latin1");
+      if (bindPaths.some(p => payload.includes(p))) {
+        removedCount++;
+      } else {
+        kept.push(entry);
+      }
+    }
+
+    if (removedCount > 0) {
+      fs.writeFileSync(filePath, Buffer.concat([header, ...kept]));
+      console.log(`  stripped ${removedCount} bind mount entries from ${file}`);
+    }
+  }
+}
+
 export function extractCheckpointFiles(containerId, checkpointId) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "machinen-"));
   const tarPath = path.join(tmpDir, "checkpoint.tar");
@@ -184,12 +231,13 @@ ${workspaceAdds.join("\n")}
 }
 
 /**
- * Commit a running container, capture bind mounts, and produce a clean
- * checkpoint image ready for push.  Optionally stops the original container
- * (freeze) or leaves it running (background sync).
+ * Commit a running container's filesystem, bake bind mounts into the image,
+ * and checkpoint the original container to preserve its process tree.
+ * Optionally stops the container after checkpoint (freeze) or leaves it
+ * running (background sync).
  *
  * Returns { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath }
- * Caller is responsible for cleanup (tmpDir, cleanName, commitImage).
+ * Caller is responsible for cleanup (tmpDir, commitImage).
  */
 export async function prepareCheckpoint(containerName, { stop = false } = {}) {
   const container = docker.getContainer(containerName);
@@ -223,52 +271,51 @@ export async function prepareCheckpoint(containerName, { stop = false } = {}) {
   console.log("Committing container filesystem...");
   dockerExec(["commit", containerName, commitImage]);
 
+  // Bake bind-mounted files into the committed image so they survive restore.
+  // Use a temporary container for this — it is NOT checkpointed.
   const cleanName = `${containerName}-clean`;
-  try { dockerExec(["rm", "-f", cleanName]); } catch {}
-
-  if (stop) {
-    dockerExec(["stop", containerName]);
-  }
-
-  // Run the committed image with a simple sleep — the filesystem is already
-  // captured via commit, and a trivial process avoids CRIU failures from
-  // complex entrypoints (e.g. docker-init.sh in devcontainers).
-  dockerExec([
-    "run", "-d",
-    "--name", cleanName,
-    "--entrypoint", "sleep",
-    "--security-opt", "seccomp=unconfined",
-    "--network", "host",
-    commitImage,
-    "infinity",
-  ]);
-
-  // Copy bind-mounted files into the clean container so they're in the filesystem
-  for (const { containerPath, tarPath } of savedBinds) {
-    const parent = path.posix.dirname(containerPath);
-    execSync(`cat ${shellQuote(tarPath)} | docker cp - ${shellQuote(cleanName + ":" + parent)}`, {
-      stdio: ["pipe", "pipe", "pipe"], shell: true,
-    });
-    console.log(`Restored bind mount into clean container: ${containerPath}`);
+  if (savedBinds.length > 0) {
+    try { dockerExec(["rm", "-f", cleanName]); } catch {}
+    dockerExec([
+      "run", "-d",
+      "--name", cleanName,
+      "--entrypoint", "sleep",
+      commitImage,
+      "infinity",
+    ]);
+    for (const { containerPath, tarPath } of savedBinds) {
+      const parent = path.posix.dirname(containerPath);
+      execSync(`cat ${shellQuote(tarPath)} | docker cp - ${shellQuote(cleanName + ":" + parent)}`, {
+        stdio: ["pipe", "pipe", "pipe"], shell: true,
+      });
+      console.log(`Restored bind mount into image: ${containerPath}`);
+    }
+    console.log("Re-committing with workspace files...");
+    dockerExec(["commit", cleanName, commitImage]);
+    dockerExec(["rm", "-f", cleanName]);
   }
   if (workspaceTmpDir) fs.rmSync(workspaceTmpDir, { recursive: true, force: true });
 
-  // Re-commit so workspace files are baked into the image
-  // (CRIU only captures process state, not filesystem changes to the writable layer)
-  if (savedBinds.length > 0) {
-    console.log("Re-committing with workspace files...");
-    dockerExec(["commit", cleanName, commitImage]);
-  }
-
-  // Give the process a moment to start
-  await new Promise(r => setTimeout(r, 1000));
-
-  // Checkpoint the clean container
-  const { containerId, checkpointId } = await createCheckpoint(cleanName);
+  // Checkpoint the original container directly to preserve the real process tree.
+  // exit=true stops the container after checkpoint (freeze); exit=false keeps it
+  // running (background sync).
+  const { containerId, checkpointId } = await createCheckpoint(containerName, { exit: stop });
   console.log(`Checkpoint: ${checkpointId}`);
 
   console.log("Extracting checkpoint files...");
   const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+
+  // Strip bind-mount entries from CRIU checkpoint — the file contents are
+  // already baked into the committed image, and the host paths won't exist
+  // on restore.
+  if (binds.length > 0) {
+    const workDir = path.join(tmpDir, "patch");
+    fs.mkdirSync(workDir);
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe" });
+    stripBindMountEntries(workDir, binds);
+    execFileSync("tar", ["cf", tarPath, "-C", workDir, "."], { stdio: "pipe" });
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
 
   return { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath };
 }

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -11,6 +11,7 @@ import {
   captureContainerConfig,
   createCheckpoint,
   extractCheckpointFiles,
+  stripBindMountEntries,
   prepareCheckpoint,
   buildCheckpointImage,
   pushImage,
@@ -635,39 +636,43 @@ Environment:
     // Commit the running container to capture writable-layer filesystem state
     execSync(`docker commit ${containerName} ${commitImage}`, { stdio: "pipe" });
 
-    // Create a clean container from the committed image with a trivial process
+    // Bake bind-mounted files into the committed image using a temp container
     const cleanName = `${containerName}-sync-clean`;
-    try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
-    execSync([
-      "docker run -d",
-      `--name ${cleanName}`,
-      "--entrypoint sleep",
-      "--security-opt seccomp=unconfined",
-      "--network host",
-      commitImage,
-      "infinity",
-    ].join(" "), { stdio: "pipe" });
-
-    // Restore bind-mounted files into the clean container
-    for (const { containerPath, tarPath: bindTarPath } of savedBinds) {
-      const parent = path.posix.dirname(containerPath);
-      execSync(`cat ${bindTarPath} | docker cp - ${cleanName}:${parent}`, {
-        stdio: ["pipe", "pipe", "pipe"], shell: true,
-      });
+    if (savedBinds.length > 0) {
+      try { execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" }); } catch {}
+      execSync([
+        "docker run -d",
+        `--name ${cleanName}`,
+        "--entrypoint sleep",
+        commitImage,
+        "infinity",
+      ].join(" "), { stdio: "pipe" });
+      for (const { containerPath, tarPath: bindTarPath } of savedBinds) {
+        const parent = path.posix.dirname(containerPath);
+        execSync(`cat ${bindTarPath} | docker cp - ${cleanName}:${parent}`, {
+          stdio: ["pipe", "pipe", "pipe"], shell: true,
+        });
+      }
+      execSync(`docker commit ${cleanName} ${commitImage}`, { stdio: "pipe" });
+      execSync(`docker rm -f ${cleanName}`, { stdio: "pipe" });
     }
     if (workspaceTmpDir) fs.rmSync(workspaceTmpDir, { recursive: true, force: true });
 
-    // Re-commit so workspace files are baked into the image
-    if (savedBinds.length > 0) {
-      execSync(`docker commit ${cleanName} ${commitImage}`, { stdio: "pipe" });
+    // Checkpoint the original container directly to preserve the real process tree.
+    // exit=false keeps the container running for continued use.
+    const { containerId, checkpointId } = await createCheckpoint(containerName, { exit: false });
+    const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+
+    // Strip bind-mount entries from checkpoint (contents are in the committed image)
+    if (binds.length > 0) {
+      const patchDir = path.join(tmpDir, "patch");
+      fs.mkdirSync(patchDir);
+      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe" });
+      stripBindMountEntries(patchDir, binds);
+      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe" });
+      fs.rmSync(patchDir, { recursive: true, force: true });
     }
 
-    // Give the process a moment to start
-    await new Promise(r => setTimeout(r, 1000));
-
-    // Checkpoint the clean container (not the original, which keeps running)
-    const { containerId, checkpointId } = await createCheckpoint(cleanName);
-    const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
     try {
       const prefix = `${registry}/machinen/${containerName}`;
       const tag = `${prefix}:${checkpointId}`;


### PR DESCRIPTION
## Summary

- Checkpoint the original container directly instead of creating a clean copy with `sleep infinity`, so CRIU captures the real process tree
- Add `stripBindMountEntries()` to remove bind-mount entries from CRIU checkpoint files (the file contents are already baked into the committed image layer)
- Update `cmdSync` inline checkpoint flow to match the new approach

## Test plan

- [x] Unit tests pass (`npx vitest run`)
- [x] E2E test passes — verifies counter keeps incrementing after restore and no `sleep infinity` in process list

Closes #13
