### PR TITLE
fix: restore CRIU checkpoint on OrbStack (macOS)

### DIFF
--- a/src/__tests__/e2e-local.mjs
+++ b/src/__tests__/e2e-local.mjs
@@ -56,7 +56,7 @@ function assert(ok, msg) {
   if (!ok) throw new Error(`ASSERTION FAILED: ${msg}`);
 }
 
-function cleanup(workspaceDir, extraDir) {
+function cleanup(dirs = []) {
   for (const c of [CONTAINER, RESTORED, CLEAN, COMMITTED, "machinen-tmp"]) {
     rmContainer(c);
   }
@@ -64,11 +64,8 @@ function cleanup(workspaceDir, extraDir) {
   for (const pattern of [`${REGISTRY}/*`, `${COMMITTED}`]) {
     try { exec(`docker images --format '{{.Repository}}:{{.Tag}}' ${pattern} | xargs -r docker rmi -f`); } catch {}
   }
-  if (workspaceDir) {
-    try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch {}
-  }
-  if (extraDir) {
-    try { fs.rmSync(extraDir, { recursive: true, force: true }); } catch {}
+  for (const d of dirs) {
+    if (d) try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
   }
 }
 
@@ -219,12 +216,12 @@ async function main() {
 
     // Strip bind-mount entries from checkpoint (contents are in the committed image)
     if (binds.length > 0) {
-      const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
+      const env = { ...process.env, COPYFILE_DISABLE: "1" };
       const patchDir = path.join(tmpDir, "patch");
       fs.mkdirSync(patchDir);
-      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe", env: tarEnv });
+      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe", env });
       stripBindMountEntries(patchDir, binds);
-      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe", env: tarEnv });
+      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe", env });
       fs.rmSync(patchDir, { recursive: true, force: true });
     }
 
@@ -343,7 +340,7 @@ async function main() {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   } finally {
-    cleanup(workspaceDir, extraDir);
+    cleanup([workspaceDir, extraDir]);
   }
 }
 

--- a/src/__tests__/e2e-local.mjs
+++ b/src/__tests__/e2e-local.mjs
@@ -9,6 +9,10 @@
  *   3. Pull from registry → restore locally
  *   4. Assert: container running, files intact, original process alive and incrementing
  *
+ * The test container is designed to exercise the same patterns as a real
+ * devcontainer: multiple bind mounts, a background daemon with a Unix socket
+ * (mimicking docker-outside-of-docker's socat), and /var/run symlink paths.
+ *
  * Requires: Docker with experimental mode, CRIU, local registry on :5000
  */
 
@@ -52,7 +56,7 @@ function assert(ok, msg) {
   if (!ok) throw new Error(`ASSERTION FAILED: ${msg}`);
 }
 
-function cleanup(workspaceDir) {
+function cleanup(workspaceDir, extraDir) {
   for (const c of [CONTAINER, RESTORED, CLEAN, COMMITTED, "machinen-tmp"]) {
     rmContainer(c);
   }
@@ -63,19 +67,23 @@ function cleanup(workspaceDir) {
   if (workspaceDir) {
     try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch {}
   }
+  if (extraDir) {
+    try { fs.rmSync(extraDir, { recursive: true, force: true }); } catch {}
+  }
 }
 
 // --- main ---
 
 async function main() {
   let workspaceDir;
+  let extraDir;
   cleanup();
 
   try {
-    // ── 1. Create container with known state + bind mount ──────────────
+    // ── 1. Create container with known state + bind mounts ────────────
     console.log("1. Creating test container with state...");
 
-    // Create a workspace dir to bind-mount. Use cwd (the repo checkout) since
+    // Create a workspace dir to bind-mount.  Use cwd (the repo checkout) since
     // it's host-mapped in both agent-ci and native Docker environments.
     // (os.tmpdir() is inside the runner container and invisible to Docker.)
     workspaceDir = path.join(process.cwd(), ".e2e-workspace");
@@ -83,10 +91,38 @@ async function main() {
     fs.writeFileSync(path.join(workspaceDir, "README.md"), "# E2E Test Workspace\n");
     fs.writeFileSync(path.join(workspaceDir, "data.json"), '{"test": true}\n');
 
-    // The entrypoint: write files, then loop incrementing a counter.
+    // Second bind mount through /var/run to exercise symlink normalisation.
+    // On Debian/Ubuntu containers /var/run → /run, so Docker reports the
+    // mount destination as /var/run/... while CRIU records /run/...
+    extraDir = path.join(process.cwd(), ".e2e-extra");
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(path.join(extraDir, "extra.txt"), "extra-data\n");
+
+    // The entrypoint:
+    //   1. Create a Unix socket with socat (mimics docker-outside-of-docker)
+    //   2. Write files + keep a file descriptor open to the bind mount
+    //   3. Loop incrementing a counter
+    //
     // After CRIU restore the shell process resumes mid-loop with $COUNTER
-    // and $SECRET still in memory.
+    // and $SECRET still in memory, the socat daemon is alive, and the open
+    // FD to the bind mount is preserved.
     const script = [
+      // Try to install socat for the socket test.  If unavailable (no network
+      // in agent-ci), skip — the test adapts below.
+      'apk add --no-cache socat >/dev/null 2>&1 && HAS_SOCAT=1 || HAS_SOCAT=0',
+
+      // Background daemon listening on a Unix socket — mirrors the socat
+      // process from the docker-outside-of-docker devcontainer feature.
+      // The socket file will be captured by `docker commit`, creating the
+      // stale-socket scenario that broke restore (issue #16).
+      'if [ "$HAS_SOCAT" = "1" ]; then socat UNIX-LISTEN:/var/run/test.sock,fork,reuseaddr SYSTEM:"echo pong" & fi',
+
+      // Keep a file descriptor open to the bind mount.  This exercises CRIU's
+      // ability to restore FDs that reference stripped mount entries — the
+      // scenario that caused the "No mapping for <mnt_id>" error.
+      'exec 3>/workspace/lockfile',
+      'echo "locked" >&3',
+
       'SECRET="machinen-e2e-42"',
       'echo "$SECRET" > /tmp/secret.txt',
       'echo "hello from machinen" > /tmp/hello.txt',
@@ -100,11 +136,24 @@ async function main() {
       "--security-opt", "seccomp=unconfined",
       "--network", "host",
       "-v", `${workspaceDir}:/workspace`,
+      "-v", `${extraDir}:/var/run/e2e-extra`,
       "alpine", "sh", "-c", script,
     ], { stdio: "pipe" });
 
-    // Let the counter tick a few times
-    await new Promise(r => setTimeout(r, 3000));
+    // Let the counter tick and socat start
+    await new Promise(r => setTimeout(r, 5000));
+
+    // Check if socat is available
+    let hasSocat = false;
+    try {
+      const socatCheck = dockerExec(CONTAINER, "sh -c 'echo ping | socat - UNIX-CONNECT:/var/run/test.sock'");
+      hasSocat = socatCheck === "pong";
+    } catch {}
+    if (hasSocat) {
+      console.log("   socat daemon running on /var/run/test.sock");
+    } else {
+      console.log("   socat not available — socket tests will be skipped");
+    }
 
     // Snapshot pre-checkpoint state
     const preSecret = dockerExec(CONTAINER, "cat /tmp/secret.txt");
@@ -121,7 +170,8 @@ async function main() {
     // ── 2. Freeze (commit → clean → checkpoint → image → push) ──────
     console.log("2. Freezing...");
 
-    // Commit filesystem
+    // Commit filesystem (captures socat socket file in overlay — the stale
+    // socket that must be whiteout'd before CRIU can re-bind it).
     exec(`docker commit ${CONTAINER} ${COMMITTED}`);
 
     const container = docker.getContainer(CONTAINER);
@@ -133,6 +183,7 @@ async function main() {
       ...(config.Binds || []).map(b => b.split(":")[1]),
       ...(info.Mounts || []).filter(m => m.Type === "bind").map(m => m.Destination),
     ].filter(Boolean))];
+    console.log(`   bind paths to strip: ${binds.join(", ")}`);
     const wsTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "machinen-e2e-ws-save-"));
     const savedBinds = [];
     for (const cp of binds) {
@@ -168,11 +219,12 @@ async function main() {
 
     // Strip bind-mount entries from checkpoint (contents are in the committed image)
     if (binds.length > 0) {
+      const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
       const patchDir = path.join(tmpDir, "patch");
       fs.mkdirSync(patchDir);
-      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe" });
+      execFileSync("tar", ["xf", tarPath, "-C", patchDir], { stdio: "pipe", env: tarEnv });
       stripBindMountEntries(patchDir, binds);
-      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe" });
+      execFileSync("tar", ["cf", tarPath, "-C", patchDir, "."], { stdio: "pipe", env: tarEnv });
       fs.rmSync(patchDir, { recursive: true, force: true });
     }
 
@@ -256,6 +308,14 @@ async function main() {
       assert(!ps.includes("sleep infinity"), `"sleep infinity" found — original process was replaced:\n${ps}`);
       console.log("   [pass] original process tree restored (no sleep substitution)");
 
+      // socat daemon should be alive (its socket was re-bound by CRIU)
+      if (hasSocat) {
+        assert(ps.includes("socat"), `socat daemon not found after restore:\n${ps}`);
+        console.log("   [pass] socat daemon survived restore");
+      } else {
+        console.log("   [skip] socat daemon test skipped (socat not installed)");
+      }
+
       // Bind-mounted workspace files (may not work in Docker-outside-of-Docker)
       try {
         const readme = dockerExec(RESTORED, "cat /workspace/README.md");
@@ -269,12 +329,21 @@ async function main() {
         console.log("   [skip] bind mount test skipped (Docker-outside-of-Docker environment)");
       }
 
+      // /var/run bind mount (tests symlink normalisation: /var/run → /run)
+      try {
+        const extra = dockerExec(RESTORED, "cat /var/run/e2e-extra/extra.txt");
+        assert(extra === "extra-data", `extra bind data lost: ${extra}`);
+        console.log("   [pass] /var/run/e2e-extra preserved (symlink path bind mount)");
+      } catch {
+        console.log("   [skip] /var/run bind mount test skipped");
+      }
+
       console.log("\nAll e2e checks passed.");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   } finally {
-    cleanup(workspaceDir);
+    cleanup(workspaceDir, extraDir);
   }
 }
 

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -67,7 +67,12 @@ export async function createCheckpoint(containerName, { exit = true } = {}) {
  * Binary-safe replace of oldId → newId in all .img files under checkpointDir.
  * Copies files out of the Docker VM, patches with Buffer, copies back.
  */
-function patchCheckpointIds(checkpointDir, oldId, newId) {
+/**
+ * Patch a checkpoint directory: replace container IDs and optionally strip
+ * leftover bind mount entries.  Both operations happen in a single pass to
+ * avoid extra tar round-trips through the Docker VM.
+ */
+function patchCheckpoint(checkpointDir, oldId, newId, bindPathsToStrip = []) {
   const patchDir = fs.mkdtempSync(path.join(os.tmpdir(), "machinen-patch-"));
   const tarPath = path.join(patchDir, "checkpoint-patch.tar");
 
@@ -83,10 +88,14 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
     }
 
     // Untar locally, patch, retar
+    // COPYFILE_DISABLE=1 prevents macOS tar from creating ._* AppleDouble
+    // resource fork files that would corrupt the CRIU checkpoint directory.
+    const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
     const workDir = path.join(patchDir, "work");
     fs.mkdirSync(workDir);
-    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe" });
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: tarEnv });
 
+    // 1. Replace container IDs in all .img files (binary-safe)
     const oldBuf = Buffer.from(oldId, "utf-8");
     const newBuf = Buffer.from(newId, "utf-8");
 
@@ -107,9 +116,14 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
       }
     }
 
+    // 2. Strip leftover bind mount entries from mountpoints
+    if (bindPathsToStrip.length > 0) {
+      stripBindMountEntries(workDir, bindPathsToStrip);
+    }
+
     // Copy patched files back
     const patchedTar = path.join(patchDir, "patched.tar");
-    execFileSync("tar", ["cf", patchedTar, "-C", workDir, "."], { stdio: "pipe" });
+    execFileSync("tar", ["cf", patchedTar, "-C", workDir, "."], { stdio: "pipe", env: tarEnv });
 
     try {
       execSync(
@@ -133,8 +147,25 @@ function patchCheckpointIds(checkpointDir, oldId, newId) {
  * Uses the same CRIU image format as patch-checkpoint.mjs:
  *   8-byte header + repeated (4-byte LE size + protobuf payload).
  */
+/**
+ * Expand bind paths to include common symlink variants.
+ * CRIU resolves symlinks (e.g. /var/run → /run) before recording mount paths,
+ * but Docker may report the unresolved path.  Generate both forms so we match
+ * regardless of which one appears in the checkpoint.
+ */
+function expandBindPaths(bindPaths) {
+  const expanded = new Set(bindPaths);
+  for (const p of bindPaths) {
+    if (p.startsWith("/var/run/")) expanded.add("/run/" + p.slice("/var/run/".length));
+    else if (p.startsWith("/run/")) expanded.add("/var/run/" + p.slice("/run/".length));
+  }
+  return [...expanded];
+}
+
 export function stripBindMountEntries(dir, bindPaths) {
   if (!bindPaths || bindPaths.length === 0) return;
+
+  const paths = expandBindPaths(bindPaths);
 
   for (const file of fs.readdirSync(dir)) {
     if (!file.startsWith("mountpoints-") || !file.endsWith(".img")) continue;
@@ -157,7 +188,7 @@ export function stripBindMountEntries(dir, bindPaths) {
     const kept = [];
     for (const entry of entries) {
       const payload = entry.subarray(4).toString("latin1");
-      if (bindPaths.some(p => payload.includes(p))) {
+      if (paths.some(p => payload.includes(p))) {
         removedCount++;
       } else {
         kept.push(entry);
@@ -189,7 +220,7 @@ export function extractCheckpointFiles(containerId, checkpointId) {
     );
   } catch {
     // Fall back to direct filesystem access (native Linux)
-    execFileSync("tar", ["cf", tarPath, "-C", checkpointPath, "."], { stdio: "pipe" });
+    execFileSync("tar", ["cf", tarPath, "-C", checkpointPath, "."], { stdio: "pipe", env: { ...process.env, COPYFILE_DISABLE: "1" } });
   }
 
   return { tmpDir, tarPath };
@@ -309,11 +340,12 @@ export async function prepareCheckpoint(containerName, { stop = false } = {}) {
   // already baked into the committed image, and the host paths won't exist
   // on restore.
   if (binds.length > 0) {
+    const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
     const workDir = path.join(tmpDir, "patch");
     fs.mkdirSync(workDir);
-    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe" });
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: tarEnv });
     stripBindMountEntries(workDir, binds);
-    execFileSync("tar", ["cf", tarPath, "-C", workDir, "."], { stdio: "pipe" });
+    execFileSync("tar", ["cf", tarPath, "-C", workDir, "."], { stdio: "pipe", env: tarEnv });
     fs.rmSync(workDir, { recursive: true, force: true });
   }
 
@@ -384,18 +416,146 @@ export function restoreLocally(imageTag, containerName) {
 
   dockerExec(["rm", "machinen-tmp"]);
 
-  // Patch checkpoint: CRIU image files (protobuf binary) contain hardcoded
-  // paths with the original container ID (mountpoints, cgroups, etc.).
-  // Replace with the new container ID so CRIU can find them.
-  // Must be binary-safe (sed mangles protobuf data), so we use Node.js
-  // Buffer.replace on the host side.
-  if (oldContainerId && oldContainerId !== newContainerId) {
-    console.log("Patching checkpoint container ID references...");
-    patchCheckpointIds(checkpointDir, oldContainerId, newContainerId);
+  // Remove macOS AppleDouble resource fork files (._*) that may have been
+  // introduced by tar on macOS.  CRIU doesn't expect them and fails to restore.
+  try {
+    execSync(
+      `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("find " + checkpointDir + " -name '._*' -delete")}`,
+      { stdio: "pipe", shell: true }
+    );
+  } catch {
+    // Native Linux or no ._* files — ignore
   }
 
-  // Restore
-  dockerExec(["start", "--checkpoint", checkpointId, containerName], { stdio: "inherit" });
+  // Patch checkpoint: replace hardcoded container IDs and strip any leftover
+  // bind mount entries.  The restore container has no bind mounts, so any
+  // bind mount still in the checkpoint would cause CRIU to fail with
+  // "No mapping for <mnt_id> mountpoint".
+  //
+  // Bind paths come from the original container's config.  They may have been
+  // stripped during freeze, but we re-strip here as a safety net (path
+  // normalization fixes, older checkpoints, etc.).
+  const origBinds = [...new Set([
+    ...(config.Binds || []).map(b => b.split(":")[1]),
+  ].filter(Boolean))];
+
+  // Also read bind mounts from devcontainer metadata if present
+  const dcMeta = labels["devcontainer.metadata"];
+  if (dcMeta) {
+    try {
+      for (const entry of JSON.parse(dcMeta)) {
+        for (const m of entry.mounts || []) {
+          if (m.type === "bind" && m.target) origBinds.push(m.target);
+          // String-format mounts: "source=...,target=...,type=bind"
+          if (typeof m === "string" && m.includes("type=bind")) {
+            const match = m.match(/target=([^,]+)/);
+            if (match) origBinds.push(match[1]);
+          }
+        }
+      }
+    } catch {}
+  }
+
+  const needsPatch = oldContainerId && oldContainerId !== newContainerId;
+  if (needsPatch || origBinds.length > 0) {
+    console.log("Patching checkpoint...");
+    patchCheckpoint(
+      checkpointDir,
+      oldContainerId || "",
+      newContainerId,
+      origBinds,
+    );
+  }
+
+  // Remove stale socket files from the container's overlay.  The committed
+  // image may contain socket files (e.g. /run/docker.sock from socat) that
+  // CRIU needs to re-bind during restore.  If the file already exists CRIU
+  // fails with "Address already in use".
+  //
+  // Since the socket may live in a lower (read-only) layer, we create an
+  // overlayfs whiteout (char device 0:0) in the upper layer to hide it.
+  const upperDir = JSON.parse(
+    dockerExec(["inspect", "--format", "{{json .GraphDriver.Data.UpperDir}}", containerName])
+  );
+  if (upperDir) {
+    // Stale socket paths that need to be hidden for CRIU to bind them.
+    const socketPaths = ["/run/docker.sock"];
+    try {
+      execSync(
+        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote(
+          socketPaths.map(sp =>
+            `mkdir -p ${upperDir}$(dirname ${sp}) && rm -f ${upperDir}${sp} && mknod ${upperDir}${sp} c 0 0`
+          ).join(" && ")
+        )}`,
+        { stdio: "pipe", shell: true }
+      );
+    } catch {
+      // Native Linux: direct access
+      for (const sp of socketPaths) {
+        try {
+          const dir = path.dirname(upperDir + sp);
+          execFileSync("mkdir", ["-p", dir], { stdio: "pipe" });
+          try { fs.unlinkSync(upperDir + sp); } catch {}
+          execFileSync("mknod", [upperDir + sp, "c", "0", "0"], { stdio: "pipe" });
+        } catch {}
+      }
+    }
+  }
+
+  // Restore — always capture CRIU diagnostics to a log file
+  const diagDir = path.join(os.homedir(), ".machinen", "logs");
+  fs.mkdirSync(diagDir, { recursive: true });
+  const diagFile = path.join(diagDir, `restore-${Date.now()}.log`);
+
+  function collectDiagnostics() {
+    const lines = [`restore timestamp: ${new Date().toISOString()}`];
+    lines.push(`checkpoint: ${checkpointId}`);
+    lines.push(`container: ${containerName} (${newContainerId})`);
+    lines.push(`old container: ${oldContainerId || "n/a"}`);
+    lines.push("");
+
+    // List checkpoint files
+    try {
+      const ls = execSync(
+        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("ls -la " + checkpointDir + "/")}`,
+        { stdio: "pipe", encoding: "utf-8", shell: true }
+      );
+      lines.push("checkpoint files:", ls);
+    } catch {
+      try {
+        lines.push("checkpoint files:", execFileSync("ls", ["-la", checkpointDir + "/"], { stdio: "pipe", encoding: "utf-8" }));
+      } catch (e) { lines.push(`checkpoint files: error: ${e.message}`); }
+    }
+
+    // CRIU restore log (written by CRIU on failure, sometimes on success)
+    try {
+      const log = execSync(
+        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("cat " + checkpointDir + "/restore.log 2>/dev/null || echo '(no restore.log)'")}`,
+        { stdio: "pipe", encoding: "utf-8", shell: true }
+      );
+      lines.push("CRIU restore.log:", log);
+    } catch {
+      try {
+        const log = fs.readFileSync(path.join(checkpointDir, "restore.log"), "utf-8");
+        lines.push("CRIU restore.log:", log);
+      } catch { lines.push("CRIU restore.log: not found"); }
+    }
+
+    return lines.join("\n");
+  }
+
+  try {
+    dockerExec(["start", "--checkpoint", checkpointId, containerName], { stdio: "inherit" });
+    const diag = collectDiagnostics();
+    fs.writeFileSync(diagFile, diag);
+    console.log(`Diagnostics saved to ${diagFile}`);
+  } catch (err) {
+    const diag = collectDiagnostics();
+    fs.writeFileSync(diagFile, diag + `\n\nERROR: ${err.message}\n`);
+    console.error(`\nCRIU restore failed. Diagnostics saved to ${diagFile}`);
+    console.error(diag);
+    throw err;
+  }
 
   return { newContainerId, checkpointId };
 }

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -6,6 +6,18 @@ import Docker from "dockerode";
 
 export const docker = new Docker({ socketPath: "/var/run/docker.sock" });
 
+/** Env for tar that suppresses macOS AppleDouble resource fork files (._*). */
+const TAR_ENV = { ...process.env, COPYFILE_DISABLE: "1" };
+
+/** Run a command inside the Docker VM via nsenter (OrbStack / Docker Desktop). */
+function nsenterExec(cmd, opts = {}) {
+  return dockerExec(
+    ["run", "--rm", "--privileged", "--pid=host", "alpine",
+     "nsenter", "-t", "1", "-m", "sh", "-c", cmd],
+    opts,
+  );
+}
+
 /** Run a docker CLI command without shell interpolation. */
 export function dockerExec(args, opts = {}) {
   return execFileSync("docker", args, { stdio: "pipe", encoding: "utf-8", ...opts });
@@ -64,10 +76,6 @@ export async function createCheckpoint(containerName, { exit = true } = {}) {
 }
 
 /**
- * Binary-safe replace of oldId → newId in all .img files under checkpointDir.
- * Copies files out of the Docker VM, patches with Buffer, copies back.
- */
-/**
  * Patch a checkpoint directory: replace container IDs and optionally strip
  * leftover bind mount entries.  Both operations happen in a single pass to
  * avoid extra tar round-trips through the Docker VM.
@@ -87,13 +95,9 @@ function patchCheckpoint(checkpointDir, oldId, newId, bindPathsToStrip = []) {
       execFileSync("tar", ["cf", tarPath, "-C", checkpointDir, "."], { stdio: "pipe" });
     }
 
-    // Untar locally, patch, retar
-    // COPYFILE_DISABLE=1 prevents macOS tar from creating ._* AppleDouble
-    // resource fork files that would corrupt the CRIU checkpoint directory.
-    const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
     const workDir = path.join(patchDir, "work");
     fs.mkdirSync(workDir);
-    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: tarEnv });
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: TAR_ENV });
 
     // 1. Replace container IDs in all .img files (binary-safe)
     const oldBuf = Buffer.from(oldId, "utf-8");
@@ -123,7 +127,7 @@ function patchCheckpoint(checkpointDir, oldId, newId, bindPathsToStrip = []) {
 
     // Copy patched files back
     const patchedTar = path.join(patchDir, "patched.tar");
-    execFileSync("tar", ["cf", patchedTar, "-C", workDir, "."], { stdio: "pipe", env: tarEnv });
+    execFileSync("tar", ["cf", patchedTar, "-C", workDir, "."], { stdio: "pipe", env: TAR_ENV });
 
     try {
       execSync(
@@ -138,15 +142,6 @@ function patchCheckpoint(checkpointDir, oldId, newId, bindPathsToStrip = []) {
   }
 }
 
-/**
- * Strip mount entries from CRIU mountpoints image files that reference
- * the given container paths.  Bind mounts captured during checkpoint
- * can't be restored (the host paths don't exist); the file contents are
- * already baked into the committed image layer, so we just drop them.
- *
- * Uses the same CRIU image format as patch-checkpoint.mjs:
- *   8-byte header + repeated (4-byte LE size + protobuf payload).
- */
 /**
  * Expand bind paths to include common symlink variants.
  * CRIU resolves symlinks (e.g. /var/run → /run) before recording mount paths,
@@ -220,7 +215,7 @@ export function extractCheckpointFiles(containerId, checkpointId) {
     );
   } catch {
     // Fall back to direct filesystem access (native Linux)
-    execFileSync("tar", ["cf", tarPath, "-C", checkpointPath, "."], { stdio: "pipe", env: { ...process.env, COPYFILE_DISABLE: "1" } });
+    execFileSync("tar", ["cf", tarPath, "-C", checkpointPath, "."], { stdio: "pipe", env: TAR_ENV });
   }
 
   return { tmpDir, tarPath };
@@ -340,12 +335,11 @@ export async function prepareCheckpoint(containerName, { stop = false } = {}) {
   // already baked into the committed image, and the host paths won't exist
   // on restore.
   if (binds.length > 0) {
-    const tarEnv = { ...process.env, COPYFILE_DISABLE: "1" };
     const workDir = path.join(tmpDir, "patch");
     fs.mkdirSync(workDir);
-    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: tarEnv });
+    execFileSync("tar", ["xf", tarPath, "-C", workDir], { stdio: "pipe", env: TAR_ENV });
     stripBindMountEntries(workDir, binds);
-    execFileSync("tar", ["cf", tarPath, "-C", workDir, "."], { stdio: "pipe", env: tarEnv });
+    execFileSync("tar", ["cf", tarPath, "-C", workDir, "."], { stdio: "pipe", env: TAR_ENV });
     fs.rmSync(workDir, { recursive: true, force: true });
   }
 
@@ -399,12 +393,10 @@ export function restoreLocally(imageTag, containerName) {
   const checkpointDir = `/var/lib/docker/containers/${newContainerId}/checkpoints/${checkpointId}`;
 
   try {
-    // OrbStack: use nsenter to access Docker's internal storage
-    dockerExec([
-      "run", "--rm", "--privileged", "--pid=host", "alpine",
-      "nsenter", "-t", "1", "-m", "sh", "-c", `mkdir -p ${checkpointDir}`,
-    ]);
-    execSync(`docker cp machinen-tmp:/checkpoint/. - | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("tar xf - -C " + checkpointDir)}`, {
+    // OrbStack: use nsenter to access Docker's internal storage.
+    // Batch mkdir + tar extract + AppleDouble cleanup into one piped nsenter.
+    nsenterExec(`mkdir -p ${checkpointDir}`);
+    execSync(`docker cp machinen-tmp:/checkpoint/. - | docker run --rm -i --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote(`tar xf - -C ${checkpointDir} && find ${checkpointDir} -name '._*' -delete`)}`, {
       stdio: "pipe",
       shell: true,
     });
@@ -415,17 +407,6 @@ export function restoreLocally(imageTag, containerName) {
   }
 
   dockerExec(["rm", "machinen-tmp"]);
-
-  // Remove macOS AppleDouble resource fork files (._*) that may have been
-  // introduced by tar on macOS.  CRIU doesn't expect them and fails to restore.
-  try {
-    execSync(
-      `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("find " + checkpointDir + " -name '._*' -delete")}`,
-      { stdio: "pipe", shell: true }
-    );
-  } catch {
-    // Native Linux or no ._* files — ignore
-  }
 
   // Patch checkpoint: replace hardcoded container IDs and strip any leftover
   // bind mount entries.  The restore container has no bind mounts, so any
@@ -444,12 +425,15 @@ export function restoreLocally(imageTag, containerName) {
   if (dcMeta) {
     try {
       for (const entry of JSON.parse(dcMeta)) {
-        for (const m of entry.mounts || []) {
-          if (m.type === "bind" && m.target) origBinds.push(m.target);
-          // String-format mounts: "source=...,target=...,type=bind"
-          if (typeof m === "string" && m.includes("type=bind")) {
-            const match = m.match(/target=([^,]+)/);
-            if (match) origBinds.push(match[1]);
+        if (!Array.isArray(entry.mounts)) continue;
+        for (const m of entry.mounts) {
+          if (typeof m === "string") {
+            if (m.includes("type=bind")) {
+              const match = m.match(/target=([^,]+)/);
+              if (match) origBinds.push(match[1]);
+            }
+          } else if (m.type === "bind" && m.target) {
+            origBinds.push(m.target);
           }
         }
       }
@@ -480,15 +464,11 @@ export function restoreLocally(imageTag, containerName) {
   if (upperDir) {
     // Stale socket paths that need to be hidden for CRIU to bind them.
     const socketPaths = ["/run/docker.sock"];
+    const whiteoutCmds = socketPaths.map(sp =>
+      `mkdir -p ${upperDir}$(dirname ${sp}) && rm -f ${upperDir}${sp} && mknod ${upperDir}${sp} c 0 0`
+    ).join(" && ");
     try {
-      execSync(
-        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote(
-          socketPaths.map(sp =>
-            `mkdir -p ${upperDir}$(dirname ${sp}) && rm -f ${upperDir}${sp} && mknod ${upperDir}${sp} c 0 0`
-          ).join(" && ")
-        )}`,
-        { stdio: "pipe", shell: true }
-      );
+      nsenterExec(whiteoutCmds);
     } catch {
       // Native Linux: direct access
       for (const sp of socketPaths) {
@@ -508,37 +488,28 @@ export function restoreLocally(imageTag, containerName) {
   const diagFile = path.join(diagDir, `restore-${Date.now()}.log`);
 
   function collectDiagnostics() {
-    const lines = [`restore timestamp: ${new Date().toISOString()}`];
-    lines.push(`checkpoint: ${checkpointId}`);
-    lines.push(`container: ${containerName} (${newContainerId})`);
-    lines.push(`old container: ${oldContainerId || "n/a"}`);
-    lines.push("");
+    const lines = [
+      `restore timestamp: ${new Date().toISOString()}`,
+      `checkpoint: ${checkpointId}`,
+      `container: ${containerName} (${newContainerId})`,
+      `old container: ${oldContainerId || "n/a"}`,
+      "",
+    ];
 
-    // List checkpoint files
+    // Batch file listing + restore log into a single nsenter call
     try {
-      const ls = execSync(
-        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("ls -la " + checkpointDir + "/")}`,
-        { stdio: "pipe", encoding: "utf-8", shell: true }
+      const out = nsenterExec(
+        `ls -la ${checkpointDir}/ 2>&1; echo '---CRIU_LOG---'; cat ${checkpointDir}/restore.log 2>/dev/null || echo '(no restore.log)'`,
+        { encoding: "utf-8" },
       );
-      lines.push("checkpoint files:", ls);
+      const [fileList, criuLog] = out.split("---CRIU_LOG---");
+      lines.push("checkpoint files:", fileList.trim(), "", "CRIU restore.log:", criuLog.trim());
     } catch {
       try {
         lines.push("checkpoint files:", execFileSync("ls", ["-la", checkpointDir + "/"], { stdio: "pipe", encoding: "utf-8" }));
-      } catch (e) { lines.push(`checkpoint files: error: ${e.message}`); }
-    }
-
-    // CRIU restore log (written by CRIU on failure, sometimes on success)
-    try {
-      const log = execSync(
-        `docker run --rm --privileged --pid=host alpine nsenter -t 1 -m sh -c ${shellQuote("cat " + checkpointDir + "/restore.log 2>/dev/null || echo '(no restore.log)'")}`,
-        { stdio: "pipe", encoding: "utf-8", shell: true }
-      );
-      lines.push("CRIU restore.log:", log);
-    } catch {
-      try {
         const log = fs.readFileSync(path.join(checkpointDir, "restore.log"), "utf-8");
         lines.push("CRIU restore.log:", log);
-      } catch { lines.push("CRIU restore.log: not found"); }
+      } catch (e) { lines.push(`diagnostics error: ${e.message}`); }
     }
 
     return lines.join("\n");


### PR DESCRIPTION
## Summary

- Fix three layered issues preventing `restore --local` on OrbStack after PR #15:
  1. **macOS `._*` AppleDouble files** polluting CRIU checkpoint directories — set `COPYFILE_DISABLE=1` on all tar ops
  2. **`/var/run` ↔ `/run` symlink mismatch** causing bind mount entries to not be stripped — added `expandBindPaths()` + restore-time stripping from devcontainer metadata
  3. **Stale `/run/docker.sock` in committed image** blocking CRIU `bind()` — create overlayfs whiteout before restore
- Add restore diagnostics saved to `~/.machinen/logs/`
- Improve e2e test to exercise all three scenarios: `/var/run` bind mounts, open FDs to bind mounts, socat socket daemon

## Test plan

- [x] `npx vitest run` — 6 files, 22 passed
- [x] `npx agent-ci run --workflow .github/workflows/e2e.yml -q` — passed
- [x] `pnpm dev restore --local` — container restored with full process tree
