### PR TITLE
fix: restore container with correct user (remoteUser)

### DIFF
--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -33,6 +33,7 @@ export function captureContainerConfig(info) {
     Image: info.Config.Image,
     Cmd: info.Config.Cmd,
     Env: info.Config.Env,
+    User: info.Config.User,
     WorkingDir: info.Config.WorkingDir,
     ExposedPorts: info.Config.ExposedPorts,
     SecurityOpt: info.HostConfig.SecurityOpt,
@@ -378,13 +379,29 @@ export function restoreLocally(imageTag, containerName) {
   // Remove existing container
   try { dockerExec(["rm", "-f", containerName]); } catch {}
 
-  const newContainerId = dockerExec([
+  // Parse devcontainer metadata once — used for user resolution and bind mount discovery.
+  let dcMetaEntries = [];
+  const dcMetaRaw = labels["devcontainer.metadata"];
+  if (dcMetaRaw) {
+    try { dcMetaEntries = JSON.parse(dcMetaRaw); } catch {}
+  }
+
+  // Resolve the container user.  The checkpoint image config stores the
+  // Docker-level User; devcontainer metadata may override via remoteUser.
+  let user = config.User || "";
+  for (const entry of dcMetaEntries) {
+    if (entry.remoteUser) user = entry.remoteUser;
+  }
+
+  const createArgs = [
     "create",
     "--name", containerName,
     "--security-opt", "seccomp=unconfined",
     "--network", "host",
-    createImage,
-  ]).trim();
+  ];
+  if (user) createArgs.push("--user", user);
+  createArgs.push(createImage);
+  const newContainerId = dockerExec(createArgs).trim();
 
   // Extract checkpoint from image into Docker's internal checkpoint directory
   try { dockerExec(["rm", "-f", "machinen-tmp"]); } catch {}
@@ -420,24 +437,19 @@ export function restoreLocally(imageTag, containerName) {
     ...(config.Binds || []).map(b => b.split(":")[1]),
   ].filter(Boolean))];
 
-  // Also read bind mounts from devcontainer metadata if present
-  const dcMeta = labels["devcontainer.metadata"];
-  if (dcMeta) {
-    try {
-      for (const entry of JSON.parse(dcMeta)) {
-        if (!Array.isArray(entry.mounts)) continue;
-        for (const m of entry.mounts) {
-          if (typeof m === "string") {
-            if (m.includes("type=bind")) {
-              const match = m.match(/target=([^,]+)/);
-              if (match) origBinds.push(match[1]);
-            }
-          } else if (m.type === "bind" && m.target) {
-            origBinds.push(m.target);
-          }
+  // Also read bind mounts from devcontainer metadata
+  for (const entry of dcMetaEntries) {
+    if (!Array.isArray(entry.mounts)) continue;
+    for (const m of entry.mounts) {
+      if (typeof m === "string") {
+        if (m.includes("type=bind")) {
+          const match = m.match(/target=([^,]+)/);
+          if (match) origBinds.push(match[1]);
         }
+      } else if (m.type === "bind" && m.target) {
+        origBinds.push(m.target);
       }
-    } catch {}
+    }
   }
 
   const needsPatch = oldContainerId && oldContainerId !== newContainerId;

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -418,7 +418,11 @@ function cmdOpen(args) {
       const status = dockerExec(["inspect", "--format", "{{.State.Status}}", name]).trim();
       if (status === "running") {
         console.log(`Opening shell in local container ${name}...`);
-        const shell = spawnSync("docker", ["exec", "-it", name, "/bin/bash"], { stdio: "inherit" });
+        const user = dockerExec(["inspect", "--format", "{{.Config.User}}", name]).trim();
+        const execArgs = ["exec", "-it"];
+        if (user) execArgs.push("--user", user);
+        execArgs.push(name, "/bin/bash");
+        const shell = spawnSync("docker", execArgs, { stdio: "inherit" });
         process.exit(shell.status || 0);
       }
     } catch {}


### PR DESCRIPTION
## Summary

- Restore container now runs as the devcontainer's `remoteUser` (e.g. `node`) instead of `root`
- `machinen open --local` execs into the shell with the correct user
- Add `User` to `captureContainerConfig` so it's preserved in checkpoint labels
- Parse devcontainer metadata once and reuse for both user and bind mount discovery

## Test plan

- [x] `npx vitest run` — 22 passed
- [x] `npx agent-ci run --workflow .github/workflows/e2e.yml -q` — passed
