### PR TITLE
fix: persist shell sessions across freeze/restore

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Run e2e test
         run: node src/__tests__/e2e-local.mjs
 
+      - name: Run session e2e test
+        run: node src/__tests__/e2e-session.mjs
+
       - name: Cleanup
         if: always()
         run: docker rm -f registry 2>/dev/null || true

--- a/src/__tests__/e2e-session.mjs
+++ b/src/__tests__/e2e-session.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+/**
+ * E2E test: shell sessions survive freeze/restore via socat
+ *
+ * Verifies that processes started through a socat session socket (child of
+ * PID 1) persist across a CRIU checkpoint/restore cycle.  This is the fix
+ * for issue #18: plain `docker exec` sessions are outside PID 1's tree and
+ * silently disappear on restore.
+ *
+ * The approach: PID 1 starts a socat listener on a Unix socket.  Each
+ * `machinen open` connection forks a shell that is a child of PID 1's
+ * process tree.  Background processes started in that shell survive CRIU.
+ *
+ * Requires: Docker with experimental mode, CRIU, local registry on :5000
+ */
+
+import { execSync, execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  docker,
+  captureContainerConfig,
+  createCheckpoint,
+  extractCheckpointFiles,
+  buildCheckpointImage,
+  pushImage,
+  pullImage,
+  restoreLocally,
+  hasSessionSocket,
+} from "../docker.mjs";
+
+const REGISTRY = "localhost:5000";
+const CONTAINER = "machinen-e2e-session";
+const RESTORED = `${CONTAINER}-restored`;
+const CLEAN = `${CONTAINER}-clean`;
+const COMMITTED = `${CONTAINER}-committed`;
+
+// --- helpers ---
+
+function exec(cmd) {
+  return execSync(cmd, { stdio: "pipe", encoding: "utf-8" }).trim();
+}
+
+function dockerExec(container, cmd) {
+  return exec(`docker exec ${container} ${cmd}`);
+}
+
+function rmContainer(name) {
+  try { exec(`docker rm -f ${name}`); } catch {}
+}
+
+function assert(ok, msg) {
+  if (!ok) throw new Error(`ASSERTION FAILED: ${msg}`);
+}
+
+function cleanup() {
+  for (const c of [CONTAINER, RESTORED, CLEAN, COMMITTED, "machinen-tmp"]) {
+    rmContainer(c);
+  }
+  for (const pattern of [`${REGISTRY}/*`, `${COMMITTED}`]) {
+    try { exec(`docker images --format '{{.Repository}}:{{.Tag}}' ${pattern} | xargs -r docker rmi -f`); } catch {}
+  }
+}
+
+// --- main ---
+
+async function main() {
+  cleanup();
+
+  try {
+    // ── 1. Create container with socat session socket ──────────────────
+    console.log("1. Creating container with session socket...");
+
+    // The entrypoint installs socat, starts a listener on a Unix socket
+    // (child of PID 1's sh), then execs sleep infinity.
+    // This mirrors what `machinen up --image` will do.
+    const script = 'apk add --no-cache socat >/dev/null 2>&1; socat UNIX-LISTEN:/tmp/machinen.sock,fork,reuseaddr EXEC:/bin/sh,sigint,sighup,sigquit & exec sleep infinity';
+
+    execFileSync("docker", [
+      "run", "-d",
+      "--name", CONTAINER,
+      "--security-opt", "seccomp=unconfined",
+      "--network", "host",
+      "alpine", "sh", "-c", script,
+    ], { stdio: "pipe" });
+
+    // Let socat start
+    await new Promise(r => setTimeout(r, 3000));
+
+    // Check if socat was installed successfully
+    try {
+      dockerExec(CONTAINER, "which socat");
+      console.log("   socat installed");
+    } catch {
+      console.log("   socat not installed — checking container logs:");
+      try { console.log(exec(`docker logs ${CONTAINER} 2>&1`)); } catch {}
+    }
+
+    // Verify session socket exists
+    const hasSock = hasSessionSocket(CONTAINER);
+    assert(hasSock, "session socket /tmp/machinen.sock not found");
+    console.log("   session socket active");
+
+    // ── 2. Start background processes via the session socket ───────────
+    console.log("2. Starting background processes via session socket...");
+
+    // Connect to the socat session and start a counter loop.
+    // This shell is forked by socat, making it a child of PID 1's tree.
+    dockerExec(CONTAINER, `sh -c 'printf "SECRET=session-survived\\necho \\$SECRET > /tmp/proof.txt\\nCOUNTER=0; while true; do COUNTER=\\$((COUNTER+1)); echo \\$COUNTER:\\$SECRET > /tmp/state.txt; sleep 1; done &\\n" | socat - UNIX-CONNECT:/tmp/machinen.sock'`);
+    await new Promise(r => setTimeout(r, 3000));
+
+    // Verify state was written
+    const preProof = dockerExec(CONTAINER, "cat /tmp/proof.txt");
+    assert(preProof === "session-survived", `proof file has wrong content: ${preProof}`);
+    console.log(`   proof: ${preProof}`);
+
+    const preState = dockerExec(CONTAINER, "cat /tmp/state.txt");
+    const preCounter = parseInt(preState.split(":")[0], 10);
+    const preSecret = preState.split(":")[1];
+    assert(preCounter > 0, `counter should be > 0, got ${preCounter}`);
+    assert(preSecret === "session-survived", `secret mismatch: ${preSecret}`);
+    console.log(`   counter=${preCounter}  secret=${preSecret}`);
+
+    // Verify the socat listener is in the process tree
+    const ps = dockerExec(CONTAINER, "ps aux");
+    assert(ps.includes("socat UNIX-LISTEN"), "socat listener not found in process tree");
+    console.log("   socat listener in PID 1 tree");
+
+    // ── 3. Freeze (commit → checkpoint → image → push) ────────────────
+    console.log("3. Freezing...");
+
+    exec(`docker commit ${CONTAINER} ${COMMITTED}`);
+
+    const container = docker.getContainer(CONTAINER);
+    const info = await container.inspect();
+    const config = captureContainerConfig(info);
+
+    const { containerId, checkpointId } = await createCheckpoint(CONTAINER, { exit: true });
+    console.log(`   checkpoint: ${checkpointId}`);
+
+    const { tmpDir, tarPath } = extractCheckpointFiles(containerId, checkpointId);
+
+    try {
+      const prefix = `${REGISTRY}/machinen/${CONTAINER}`;
+      const tag = `${prefix}:${checkpointId}`;
+      const latestTag = `${prefix}:latest`;
+      const baseTag = `${prefix}:base`;
+
+      exec(`docker tag ${COMMITTED} ${baseTag}`);
+      pushImage(baseTag);
+
+      buildCheckpointImage(
+        tarPath, COMMITTED, config, checkpointId, tag,
+        /* workspaceTars */ [],
+        /* baseImageTag */ baseTag,
+        /* checkpointedContainerId */ containerId,
+      );
+      exec(`docker tag ${tag} ${latestTag}`);
+      pushImage(tag);
+      pushImage(latestTag);
+
+      console.log("   frozen and pushed.");
+
+      // ── 4. Clean local state + restore ────────────────────────────────
+      console.log("4. Cleaning local state...");
+      rmContainer(CLEAN);
+      rmContainer(CONTAINER);
+      try { exec(`docker rmi ${COMMITTED}`); } catch {}
+
+      console.log("5. Restoring locally...");
+      pullImage(latestTag);
+      restoreLocally(latestTag, RESTORED);
+
+      // Let processes resume after restore
+      await new Promise(r => setTimeout(r, 3000));
+
+      // ── 5. Verify ────────────────────────────────────────────────────
+      console.log("6. Verifying...");
+
+      // Container is running
+      const status = exec(`docker inspect --format '{{.State.Status}}' ${RESTORED}`);
+      assert(status === "running", `container not running (status: ${status})`);
+      console.log("   [pass] container is running");
+
+      // Proof file survived
+      const postProof = dockerExec(RESTORED, "cat /tmp/proof.txt");
+      assert(postProof === "session-survived", `proof file lost: ${postProof}`);
+      console.log("   [pass] /tmp/proof.txt preserved");
+
+      // Counter still ticking with in-memory secret
+      const postState1 = dockerExec(RESTORED, "cat /tmp/state.txt");
+      const [counterStr1, secret1] = postState1.split(":");
+      const postCounter1 = parseInt(counterStr1, 10);
+
+      assert(secret1 === "session-survived", `in-memory SECRET lost: ${secret1}`);
+      console.log("   [pass] in-memory SECRET preserved across checkpoint/restore");
+
+      assert(postCounter1 >= preCounter, `counter regressed (pre=${preCounter} post=${postCounter1})`);
+      console.log(`   [pass] counter preserved: ${postCounter1} (was ${preCounter})`);
+
+      // Counter is still incrementing (process is alive)
+      await new Promise(r => setTimeout(r, 2000));
+      const postState2 = dockerExec(RESTORED, "cat /tmp/state.txt");
+      const postCounter2 = parseInt(postState2.split(":")[0], 10);
+
+      assert(postCounter2 > postCounter1, `counter not incrementing (${postCounter1} → ${postCounter2})`);
+      console.log(`   [pass] counter still incrementing: ${postCounter1} → ${postCounter2}`);
+
+      // Session socket survived restore — socat listener is alive
+      const postHasSock = hasSessionSocket(RESTORED);
+      assert(postHasSock, "session socket not found after restore");
+      console.log("   [pass] session socket survived restore");
+
+      // Can connect a new session after restore
+      dockerExec(RESTORED, `sh -c 'echo "echo post-restore > /tmp/post.txt" | socat - UNIX-CONNECT:/tmp/machinen.sock'`);
+      await new Promise(r => setTimeout(r, 1000));
+      const postCmd = dockerExec(RESTORED, "cat /tmp/post.txt");
+      assert(postCmd === "post-restore", `post-restore command failed: ${postCmd}`);
+      console.log("   [pass] new session connection works after restore");
+
+      // Process tree shows socat listener
+      const postPs = dockerExec(RESTORED, "ps aux");
+      assert(postPs.includes("socat UNIX-LISTEN"), "socat listener not in process tree after restore");
+      console.log("   [pass] socat listener in process tree");
+
+      console.log("\nAll session e2e checks passed.");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch(err => {
+  console.error(`\nE2E FAILED: ${err.message}`);
+  cleanup();
+  process.exit(1);
+});

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -357,6 +357,42 @@ export function pullImage(imageTag) {
   dockerExec(["pull", imageTag], { stdio: "inherit" });
 }
 
+// --- session socket helpers ---
+//
+// Uses socat to run user shells as children of PID 1 via a Unix socket.
+// tmux/screen can't be used because CRIU fails on internal PTY pairs
+// ("ctty inheritance detected").  socat with pipes (no PTY on server side)
+// works: checkpoint ✓, restore ✓, background processes survive.
+
+const SESSION_SOCK = "/tmp/machinen.sock";
+
+/** Check whether the machinen session socket exists inside the container. */
+export function hasSessionSocket(containerName) {
+  try {
+    dockerExec(["exec", containerName, "test", "-S", SESSION_SOCK]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Start a socat session listener inside the container if not already running. */
+export function ensureSessionSocket(containerName, { user } = {}) {
+  const execArgs = ["exec"];
+  if (user) execArgs.push("--user", user);
+  execArgs.push(containerName, "sh", "-c",
+    `test -S ${SESSION_SOCK} || (command -v socat >/dev/null || (apk add -q socat 2>/dev/null || apt-get -qq install -y socat 2>/dev/null); socat UNIX-LISTEN:${SESSION_SOCK},fork,reuseaddr EXEC:/bin/sh,sigint,sighup,sigquit &)`);
+  dockerExec(execArgs);
+}
+
+/** Return docker CLI args to connect to the session socket. */
+export function sessionAttachArgs(containerName, { user } = {}) {
+  const args = ["exec", "-it"];
+  if (user) args.push("--user", user);
+  args.push(containerName, "socat", "-,raw,echo=0", `UNIX-CONNECT:${SESSION_SOCK}`);
+  return args;
+}
+
 export function restoreLocally(imageTag, containerName) {
   // Read labels from the checkpoint image
   const labelsRaw = dockerExec(["inspect", "--format", "{{json .Config.Labels}}", imageTag]).trim();
@@ -475,7 +511,7 @@ export function restoreLocally(imageTag, containerName) {
   );
   if (upperDir) {
     // Stale socket paths that need to be hidden for CRIU to bind them.
-    const socketPaths = ["/run/docker.sock"];
+    const socketPaths = ["/run/docker.sock", SESSION_SOCK];
     const whiteoutCmds = socketPaths.map(sp =>
       `mkdir -p ${upperDir}$(dirname ${sp}) && rm -f ${upperDir}${sp} && mknod ${upperDir}${sp} c 0 0`
     ).join(" && ");

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -17,6 +17,9 @@ import {
   pushImage,
   pullImage,
   restoreLocally,
+  hasSessionSocket,
+  ensureSessionSocket,
+  sessionAttachArgs,
 } from "./docker.mjs";
 import { checkPrerequisites } from "./preflight.mjs";
 
@@ -227,8 +230,13 @@ async function cmdUp(args) {
       "--network", "host",
     ];
 
-    // Default command is sleep infinity (keeps container alive for exec)
-    const cmd = args.cmd ? args.cmd.split(" ") : ["sleep", "infinity"];
+    // Default command: install socat, start a session listener on a Unix socket
+    // (child of PID 1), then exec sleep infinity.  Shells connected via the socket
+    // are in PID 1's tree, so they survive CRIU freeze/restore.
+    // Custom --cmd skips session socket setup.
+    const cmd = args.cmd
+      ? args.cmd.split(" ")
+      : ["sh", "-c", "command -v socat >/dev/null || (apk add -q socat 2>/dev/null || apt-get -qq install -y socat 2>/dev/null); socat UNIX-LISTEN:/tmp/machinen.sock,fork,reuseaddr EXEC:/bin/sh,sigint,sighup,sigquit & exec sleep infinity"];
     runArgs.push(args.image, ...cmd);
 
     dockerExec(runArgs, { stdio: "inherit" });
@@ -272,6 +280,15 @@ async function cmdUp(args) {
     if (dcContainerOriginal !== containerName) {
       try { dockerExec(["rm", "-f", containerName]); } catch {}
       dockerExec(["rename", dcContainerOriginal, containerName]);
+    }
+
+    // Start a socat session listener inside the devcontainer so interactive
+    // shells survive CRIU freeze/restore (socat forks are children of PID 1).
+    const dcUser = dockerExec(["inspect", "--format", "{{.Config.User}}", containerName]).trim();
+    try {
+      ensureSessionSocket(containerName, { user: dcUser || undefined });
+    } catch (err) {
+      console.warn(`Warning: could not start session socket: ${err.message}`);
     }
   }
 
@@ -352,28 +369,14 @@ async function cmdUp(args) {
     },
   });
 
-  // Open interactive shell
-  if (args.image) {
-    console.log(`\nConnecting to container...\n`);
-    const shell = spawn("docker", ["exec", "-it", containerName, "/bin/bash"], { stdio: "inherit" });
+  // Open interactive shell — connect via session socket if available, fall back to bash
+  const shellArgs = hasSessionSocket(containerName)
+    ? sessionAttachArgs(containerName)
+    : ["exec", "-it", containerName, "/bin/bash"];
 
-    await new Promise((resolve) => {
-      shell.on("exit", async () => {
-        console.log("\nShell exited. Cleaning up...");
-        watcher.stop();
-        if (remoteIp) destroyServer(containerName);
-        resolve();
-      });
-    });
-  } else {
-    const configPath = path.join(repoRoot, args.file || detectDevcontainerFile(repoRoot));
-    console.log(`\nConnecting to devcontainer...\n`);
-    const shell = spawn("npx", ["devcontainer",
-      "exec",
-      "--workspace-folder", repoRoot,
-      "--config", configPath,
-      "/bin/bash",
-    ], { stdio: "inherit" });
+  {
+    console.log(`\nConnecting to container...\n`);
+    const shell = spawn("docker", shellArgs, { stdio: "inherit" });
 
     await new Promise((resolve) => {
       shell.on("exit", async () => {
@@ -404,9 +407,11 @@ function cmdOpen(args) {
       process.exit(1);
     }
     console.log(`Opening shell on remote server ${machine.ip}...`);
+    // Prefer session socket for persistence across freeze/restore
+    const remoteCmd = `docker exec -it ${containerName} socat -,raw,echo=0 UNIX-CONNECT:/tmp/machinen.sock 2>/dev/null || docker exec -it ${containerName} /bin/bash`;
     const shell = spawnSync(
       "ssh",
-      ["-t", ...SSH_OPTS, `root@${machine.ip}`, `docker exec -it ${containerName} /bin/bash`],
+      ["-t", ...SSH_OPTS, `root@${machine.ip}`, remoteCmd],
       { stdio: "inherit" }
     );
     process.exit(shell.status || 0);
@@ -419,9 +424,15 @@ function cmdOpen(args) {
       if (status === "running") {
         console.log(`Opening shell in local container ${name}...`);
         const user = dockerExec(["inspect", "--format", "{{.Config.User}}", name]).trim();
-        const execArgs = ["exec", "-it"];
-        if (user) execArgs.push("--user", user);
-        execArgs.push(name, "/bin/bash");
+        // Prefer session socket for persistence across freeze/restore
+        const execArgs = hasSessionSocket(name)
+          ? sessionAttachArgs(name, { user: user || undefined })
+          : (() => {
+              const a = ["exec", "-it"];
+              if (user) a.push("--user", user);
+              a.push(name, "/bin/bash");
+              return a;
+            })();
         const shell = spawnSync("docker", execArgs, { stdio: "inherit" });
         process.exit(shell.status || 0);
       }


### PR DESCRIPTION
## Summary

- Uses **socat** to run user shells as children of PID 1 via a Unix socket (`/tmp/machinen.sock`), so background processes survive CRIU checkpoint/restore
- tmux/screen were investigated but **can't work with CRIU** — they create internal PTY pairs that trigger CRIU's `ctty inheritance detected` error
- `machinen open` now connects via the socat session socket with fallback to `/bin/bash` for backward compatibility
- Added `/tmp/machinen.sock` to the stale socket whiteout list so CRIU can re-bind it after restore

## Test plan

- [x] `npx vitest run` — 22 unit tests pass
- [x] `npx agent-ci run --workflow .github/workflows/e2e.yml -q` — both e2e tests pass (existing + new session test)
- [x] New `e2e-session.mjs` verifies: socat listener starts, background counter with in-memory state survives freeze/restore, new connections work after restore

Closes #18
