### PR TITLE
fix: restore /etc/resolv.conf as root after local CRIU restore

### DIFF
--- a/src/__tests__/e2e-local.mjs
+++ b/src/__tests__/e2e-local.mjs
@@ -330,6 +330,11 @@ async function main() {
       assert(status === "running", `container not running (status: ${status})`);
       console.log("   [pass] container is running");
 
+      // /etc/resolv.conf must have a nameserver (non-root exec bug would leave it empty)
+      const resolvConf = dockerExec(RESTORED, "cat /etc/resolv.conf");
+      assert(/nameserver\s+[\d.]+/.test(resolvConf), `/etc/resolv.conf missing nameserver after restore:\n${resolvConf}`);
+      console.log("   [pass] /etc/resolv.conf has nameserver after restore");
+
       // Files preserved
       const postSecret = dockerExec(RESTORED, "cat /tmp/secret.txt");
       assert(postSecret === "machinen-e2e-42", `secret lost: ${postSecret}`);

--- a/src/docker.mjs
+++ b/src/docker.mjs
@@ -901,7 +901,7 @@ export function restoreLocally(imageTag, containerName) {
   // Restore DNS by copying the DiND container's resolv.conf into the devcontainer.
   try {
     const resolvConf = dindExec("cat /etc/resolv.conf", { encoding: "utf-8" });
-    dockerExec(["exec", containerName, "sh", "-c",
+    dockerExec(["exec", "--user", "root", containerName, "sh", "-c",
       `printf '%s' ${shellQuote(resolvConf)} > /etc/resolv.conf`]);
     console.log("Restored /etc/resolv.conf");
   } catch {

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -102,23 +102,27 @@ async function cmdRestore(args) {
   const prefix = `${registry}/machinen/${containerName}`;
   const imageTag = `${prefix}:latest`;
 
-  // Start DiND now (fast when cached) so we can check the registry before
-  // the slow CRIU preflight test.  checkPrerequisites will skip DiND startup
-  // since it finds it already running.
-  await ensureDiND();
-  const diNDHost = getDiNDHost();
-  process.env.DOCKER_HOST = diNDHost;
-  const { hostname: diNDHostname, port: diNDPort } = new URL(diNDHost);
-  reconnectDocker(diNDHostname, parseInt(diNDPort, 10));
-
-  // Pull the image now — fail immediately if it doesn't exist, before spending
-  // time on the CRIU preflight test.
-  if (args.local) {
+  // For local registries, check the image exists before the slow CRIU
+  // preflight — no DiND needed, just an HTTP call to the registry.
+  if (isLocal && args.local) {
+    ensureDockerLogin(); // starts the registry container if not already running
+    const slashIdx = imageTag.indexOf('/');
+    const host = imageTag.slice(0, slashIdx);
+    const rest = imageTag.slice(slashIdx + 1);
+    const colonIdx = rest.lastIndexOf(':');
+    const repo = colonIdx >= 0 ? rest.slice(0, colonIdx) : rest;
+    const tag = colonIdx >= 0 ? rest.slice(colonIdx + 1) : 'latest';
+    // host.docker.internal only resolves inside containers; on the Mac host
+    // the registry is reachable via localhost on the same port.
+    const localPort = host.includes(':') ? host.split(':')[1] : '80';
     try {
-      pullImage(imageTag);
+      const res = await fetch(`http://localhost:${localPort}/v2/${repo}/manifests/${tag}`, { method: 'HEAD' });
+      if (res.status === 404) {
+        console.error(imageNotFoundError(containerName, args));
+        process.exit(1);
+      }
     } catch {
-      console.error(imageNotFoundError(containerName, args));
-      process.exit(1);
+      // Registry unreachable — let checkPrerequisites and the pull surface the error.
     }
   }
 

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -83,16 +83,19 @@ async function cmdFreeze(containerName, opts = {}) {
 // --- restore ---
 
 function imageNotFoundError(containerName, args) {
-  let msg = `No frozen image found for "${containerName}" in the registry.`;
   if (!args.containerExplicit) {
     const branch = currentBranch();
-    msg += `\nContainer name was auto-detected from git branch "${branch}".`;
-    msg += `\nTo restore a specific container, pass its name explicitly:`;
-    msg += `\n  machinen restore --local machinen-main`;
-  } else {
-    msg += `\nCheck that this container has been frozen and pushed.`;
+    return [
+      `Container name was auto-detected from git branch "${branch}".`,
+      `No frozen image found for "${containerName}" in the registry.`,
+      `To restore a specific container, pass its name explicitly:`,
+      `  machinen restore --local machinen-main`,
+    ].join('\n');
   }
-  return msg;
+  return [
+    `No frozen image found for "${containerName}" in the registry.`,
+    `Check that this container has been frozen and pushed.`,
+  ].join('\n');
 }
 
 async function cmdRestore(args) {
@@ -137,6 +140,7 @@ async function cmdRestore(args) {
 
   if (args.local) {
     console.log(`Restoring ${containerName} locally from ${imageTag}...`);
+    pullImage(imageTag);
     const restoredName = `${containerName}-restored`;
     restoreLocally(imageTag, restoredName);
     console.log(`\nRestored as: ${restoredName}`);

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -82,13 +82,46 @@ async function cmdFreeze(containerName, opts = {}) {
 
 // --- restore ---
 
+function imageNotFoundError(containerName, args) {
+  let msg = `No frozen image found for "${containerName}" in the registry.`;
+  if (!args.containerExplicit) {
+    const branch = currentBranch();
+    msg += `\nContainer name was auto-detected from git branch "${branch}".`;
+    msg += `\nTo restore a specific container, pass its name explicitly:`;
+    msg += `\n  machinen restore --local machinen-main`;
+  } else {
+    msg += `\nCheck that this container has been frozen and pushed.`;
+  }
+  return msg;
+}
+
 async function cmdRestore(args) {
   const containerName = args.container;
-  await checkPrerequisites(docker, { clean: !!args.clean });
 
-  const { url: registry } = getRegistry();
+  const { url: registry, isLocal } = getRegistry();
   const prefix = `${registry}/machinen/${containerName}`;
   const imageTag = `${prefix}:latest`;
+
+  // For local registries, do a fast pre-flight check before the slow CRIU
+  // preflight so the user gets a clear error immediately.
+  if (isLocal) {
+    const [host, ...pathParts] = imageTag.split('/');
+    const repoAndTag = pathParts.join('/');
+    const colonIdx = repoAndTag.lastIndexOf(':');
+    const repo = colonIdx >= 0 ? repoAndTag.slice(0, colonIdx) : repoAndTag;
+    const tag = colonIdx >= 0 ? repoAndTag.slice(colonIdx + 1) : 'latest';
+    try {
+      const res = await fetch(`http://${host}/v2/${repo}/manifests/${tag}`, { method: 'HEAD' });
+      if (res.status === 404) {
+        console.error(imageNotFoundError(containerName, args));
+        process.exit(1);
+      }
+    } catch {
+      // Registry unreachable — let the pull fail with the natural error below.
+    }
+  }
+
+  await checkPrerequisites(docker, { clean: !!args.clean });
 
   checkSyncStatus(containerName);
 
@@ -102,16 +135,7 @@ async function cmdRestore(args) {
     try {
       pullImage(imageTag);
     } catch {
-      let msg = `\nNo frozen image found for "${containerName}" in the registry.`;
-      if (!args.containerExplicit) {
-        const branch = currentBranch();
-        msg += `\nContainer name was auto-detected from git branch "${branch}".`;
-        msg += `\nTo restore a specific container, pass its name explicitly:`;
-        msg += `\n  machinen restore --local machinen-main`;
-      } else {
-        msg += `\nCheck that this container has been frozen and pushed.`;
-      }
-      console.error(msg);
+      console.error(imageNotFoundError(containerName, args));
       process.exit(1);
     }
     const restoredName = `${containerName}-restored`;

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -102,22 +102,23 @@ async function cmdRestore(args) {
   const prefix = `${registry}/machinen/${containerName}`;
   const imageTag = `${prefix}:latest`;
 
-  // For local registries, do a fast pre-flight check before the slow CRIU
-  // preflight so the user gets a clear error immediately.
-  if (isLocal) {
-    const [host, ...pathParts] = imageTag.split('/');
-    const repoAndTag = pathParts.join('/');
-    const colonIdx = repoAndTag.lastIndexOf(':');
-    const repo = colonIdx >= 0 ? repoAndTag.slice(0, colonIdx) : repoAndTag;
-    const tag = colonIdx >= 0 ? repoAndTag.slice(colonIdx + 1) : 'latest';
+  // Start DiND now (fast when cached) so we can check the registry before
+  // the slow CRIU preflight test.  checkPrerequisites will skip DiND startup
+  // since it finds it already running.
+  await ensureDiND();
+  const diNDHost = getDiNDHost();
+  process.env.DOCKER_HOST = diNDHost;
+  const { hostname: diNDHostname, port: diNDPort } = new URL(diNDHost);
+  reconnectDocker(diNDHostname, parseInt(diNDPort, 10));
+
+  // Pull the image now — fail immediately if it doesn't exist, before spending
+  // time on the CRIU preflight test.
+  if (args.local) {
     try {
-      const res = await fetch(`http://${host}/v2/${repo}/manifests/${tag}`, { method: 'HEAD' });
-      if (res.status === 404) {
-        console.error(imageNotFoundError(containerName, args));
-        process.exit(1);
-      }
+      pullImage(imageTag);
     } catch {
-      // Registry unreachable — let the pull fail with the natural error below.
+      console.error(imageNotFoundError(containerName, args));
+      process.exit(1);
     }
   }
 
@@ -132,12 +133,6 @@ async function cmdRestore(args) {
 
   if (args.local) {
     console.log(`Restoring ${containerName} locally from ${imageTag}...`);
-    try {
-      pullImage(imageTag);
-    } catch {
-      console.error(imageNotFoundError(containerName, args));
-      process.exit(1);
-    }
     const restoredName = `${containerName}-restored`;
     restoreLocally(imageTag, restoredName);
     console.log(`\nRestored as: ${restoredName}`);

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -99,7 +99,21 @@ async function cmdRestore(args) {
 
   if (args.local) {
     console.log(`Restoring ${containerName} locally from ${imageTag}...`);
-    pullImage(imageTag);
+    try {
+      pullImage(imageTag);
+    } catch {
+      let msg = `\nNo frozen image found for "${containerName}" in the registry.`;
+      if (!args.containerExplicit) {
+        const branch = currentBranch();
+        msg += `\nContainer name was auto-detected from git branch "${branch}".`;
+        msg += `\nTo restore a specific container, pass its name explicitly:`;
+        msg += `\n  machinen restore --local machinen-main`;
+      } else {
+        msg += `\nCheck that this container has been frozen and pushed.`;
+      }
+      console.error(msg);
+      process.exit(1);
+    }
     const restoredName = `${containerName}-restored`;
     restoreLocally(imageTag, restoredName);
     console.log(`\nRestored as: ${restoredName}`);
@@ -937,6 +951,7 @@ async function main() {
   const containerOrName = args._positional[1];
 
   args.container = containerOrName || currentContainerName();
+  args.containerExplicit = !!containerOrName;
   args.name = args.name || args.container;
 
   const commands = {


### PR DESCRIPTION
## Summary

- After `machinen restore --local`, the restored container had no DNS (`ping google.com` → \"Temporary failure in name resolution\")
- Root cause: `docker exec` for the post-restore `/etc/resolv.conf` write ran as the devcontainer's `remoteUser` (e.g. `node`), which lacks write permission on the file — the error was silently swallowed
- Fix: add `--user root` to that one `docker exec` call, matching the pattern already used in `ensureTmuxSession` for `apt-get`
- Added an e2e assertion that `/etc/resolv.conf` contains a `nameserver` line after restore

## Test plan

- [x] `npx vitest run` — all 31 unit tests pass
- [x] `npx agent-ci run --workflow .github/workflows/e2e.yml --quiet` — e2e passes including new DNS assertion
