### PR TITLE
docs: add SmolVM competitive analysis tweet

### DIFF
--- a/.docs/marketing/tweets/aniketmaurya-smolvm.md
+++ b/.docs/marketing/tweets/aniketmaurya-smolvm.md
@@ -1,0 +1,45 @@
+# @aniketmaurya — SmolVM mention
+
+- **Date:** 2026-04-07
+- **URL:** https://x.com/aniketmaurya/status/2041277097247666583
+- **Context:** Reply to @appfactory
+
+> Agents usually require snapshotting, network control, give as a tool to agents, browser agent. Solving all of these with SmolVM
+
+Links to: https://github.com/CelestoAI/smolVM
+
+---
+
+## How this relates to machinen
+
+SmolVM and machinen both solve agent infrastructure problems — but from opposite ends.
+
+**SmolVM** is an agent sandbox runtime. It spins up disposable Firecracker micro-VMs so agents can run untrusted code and drive browsers in isolation. Think "give the agent a throwaway computer." It's focused on:
+- Ephemeral, short-lived VMs (sub-second boot, teardown after use)
+- Browser automation inside the sandbox
+- Agent framework integrations (OpenAI Agents, LangChain, PydanticAI)
+- Network egress controls (domain allowlists)
+- Snapshot/restore of VM state for multi-step agent workflows
+
+**Machinen** is a developer environment migration tool. It checkpoints real development containers and moves them between your laptop and the cloud — preserving full runtime state (memory, processes, tmux sessions). It's focused on:
+- Seamless local-to-cloud handoff (close lid -> cloud, open lid -> local)
+- CRIU-based checkpoint/restore of long-lived dev containers
+- Layer-based image transport (only ~300KB checkpoint delta transfers)
+- macOS sleep/wake integration
+- Git-aware multi-container support
+
+## Why we're different
+
+| | SmolVM | Machinen |
+|---|---|---|
+| **Primary user** | AI agent developers | Human developers |
+| **VM lifecycle** | Ephemeral (seconds to minutes) | Long-lived (days/weeks) |
+| **Isolation tech** | Firecracker micro-VMs | Docker + CRIU checkpoint/restore |
+| **Core problem** | "Give agents a safe sandbox" | "Keep my dev environment alive across machines" |
+| **Snapshotting purpose** | Pause/resume agent workflows | Migrate full containers between local and cloud |
+| **Network story** | Egress allowlists for safety | Container networking preserved across migration |
+| **Platform** | Linux only (Firecracker) | macOS (OrbStack/Docker) -> Linux cloud |
+
+## Why this tweet matters
+
+Aniket frames the problem space as: agents need snapshotting, network control, and tool access. SmolVM addresses this for agent-as-executor (run code, browse web). Machinen could address a different slice: agents-as-developers that need persistent, stateful dev environments that outlive a single session. The checkpoint/restore primitive is shared, but the use case is fundamentally different — throwaway sandboxes vs. durable workspaces.


### PR DESCRIPTION
## Summary
- Adds `.docs/marketing/tweets/` directory for tracking relevant social mentions
- Captures @aniketmaurya's tweet about SmolVM and includes a competitive comparison
- Documents how machinen differs from SmolVM: durable dev environment migration vs ephemeral agent sandboxes
