### PR TITLE
feat: add status command, update agent-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Mac host
 
 The `machinen-dind` image is built automatically on first run from `scripts/Dockerfile.dind`. It takes ~3–5 minutes to build (compiles CRIU from source). Subsequent runs reuse the cached image.
 
+The DiND container runs with no memory or CPU limits — all workload containers inside it share the full host resources.
+
 ### Sleep/wake handoff
 
 A compiled Swift helper (`src/power-helper.swift`) listens for macOS `NSWorkspace.willSleepNotification` and `didWakeNotification` events. On sleep, it takes a power assertion to delay sleep until the container migration completes.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ To add a new provider, create `src/providers/<name>.mjs` exporting an object wit
 | `up [options]` | Start local devcontainer with sleep/wake cloud handoff |
 | `freeze <container>` | Checkpoint, package as image layer, push to registry |
 | `restore <container>` | Provision server, pull image, restore container |
+| `watch [name]` | Background sync daemon (checkpoint + push every 5 min) |
+| `open [name]` | Open shell in local or remote container |
+| `status [name]` | Show sync state and recent registry images |
 | `logs [container]` | Tail remote container logs, or list all active machines |
 | `destroy [name]` | Tear down a remote server (no args = destroy all) |
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@devcontainers/cli": "^0.84.1",
-    "@redwoodjs/agent-ci": "^0.3.4",
+    "@redwoodjs/agent-ci": "^0.7.1",
     "vitest": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^0.84.1
         version: 0.84.1
       '@redwoodjs/agent-ci':
-        specifier: ^0.3.4
-        version: 0.3.4
+        specifier: ^0.7.1
+        version: 0.7.1
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(yaml@2.8.3))
@@ -112,8 +112,8 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@redwoodjs/agent-ci@0.3.4':
-    resolution: {integrity: sha512-ATBGNFGHDuqGFAomP8ZC9fRpg+l8c5Z/VKoP8rDO85lSjYNOxqMjNChEai8L5eKHDqZQDoftx6EEGM5WSngc9g==}
+  '@redwoodjs/agent-ci@0.7.1':
+    resolution: {integrity: sha512-W4xNUE6dK69gvIPraURkReoYma8HyMI1LYLFMwI51M5J9GkefpK6Z8B9w6a3tduk0m2aRLqEOc8SI++ZIR2teA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -391,8 +391,8 @@ packages:
     resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
     engines: {node: '>= 8.0'}
 
-  dtu-github-actions@0.3.4:
-    resolution: {integrity: sha512-F/7SXx4yoiXGWUZMHNtr+uwZB0x/JMkdBCTi47g6vVWycWXjKpt8r+l2Dr163rW3G1uINlFUqh9ne3DdPGPyMg==}
+  dtu-github-actions@0.7.1:
+    resolution: {integrity: sha512-TEDWv8zqWHBZPTXPximSz2BDEF3mgp/wG2EjsmGo37myZZuy58MlfFV9VqYq6tcxSaTgWfPp7FsPZ++d3yMRIA==}
     engines: {node: '>=22'}
 
   dunder-proto@1.0.1:
@@ -1040,11 +1040,11 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@redwoodjs/agent-ci@0.3.4':
+  '@redwoodjs/agent-ci@0.7.1':
     dependencies:
       '@actions/workflow-parser': 0.3.43
       dockerode: 4.0.9
-      dtu-github-actions: 0.3.4
+      dtu-github-actions: 0.7.1
       log-update: 7.2.0
       minimatch: 10.2.4
       yaml: 2.8.3
@@ -1294,7 +1294,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dtu-github-actions@0.3.4:
+  dtu-github-actions@0.7.1:
     dependencies:
       body-parser: 2.2.2
       jsonc-parser: 3.3.1

--- a/src/__tests__/cli.test.mjs
+++ b/src/__tests__/cli.test.mjs
@@ -13,6 +13,7 @@ describe("CLI", () => {
     expect(output).toContain("up");
     expect(output).toContain("freeze");
     expect(output).toContain("restore");
+    expect(output).toContain("status");
     expect(output).toContain("destroy");
   });
 
@@ -37,6 +38,15 @@ describe("CLI", () => {
   it("restore requires container name outside git repo", () => {
     try {
       execSync(`node ${cli} restore`, { encoding: "utf-8", stdio: "pipe", cwd: "/tmp" });
+    } catch (err) {
+      expect(err.stderr || err.stdout).toContain("Container name required");
+      expect(err.status).toBe(1);
+    }
+  });
+
+  it("status requires container name outside git repo", () => {
+    try {
+      execSync(`node ${cli} status`, { encoding: "utf-8", stdio: "pipe", cwd: "/tmp" });
     } catch (err) {
       expect(err.stderr || err.stdout).toContain("Container name required");
       expect(err.status).toBe(1);

--- a/src/dind.mjs
+++ b/src/dind.mjs
@@ -25,12 +25,27 @@ export function dindExec(cmd, opts = {}) {
 
 /**
  * Returns the DOCKER_HOST value for the inner DiND daemon.
- * Uses the container's bridge IP so this works from both the Mac host
- * (via OrbStack's bridge routing) and from sibling containers in CI
- * (same Docker bridge).  Unlike tcp://127.0.0.1:2375, the bridge IP
- * is reachable when the caller is itself a container.
+ *
+ * When running directly on the host (macOS), we use the published port on
+ * localhost — bridge IPs are not reliably routable from the Mac host across
+ * all Docker runtimes (Docker Desktop doesn't route them at all; OrbStack
+ * may or may not).
+ *
+ * When running inside a container (e.g. agent-ci), localhost:2375 refers to
+ * the container's own loopback, so we fall back to the bridge IP which is
+ * reachable between sibling containers on the same Docker bridge.
  */
 export function getDiNDHost() {
+  const inContainer = (() => {
+    try {
+      return /\/docker\/[a-f0-9]/.test(fs.readFileSync("/proc/self/cgroup", "utf-8"));
+    } catch { return false; }
+  })();
+
+  if (!inContainer) {
+    return `tcp://127.0.0.1:${DIND_PORT}`;
+  }
+
   const ip = execFileSync(
     "docker",
     ["inspect", "--format", "{{.NetworkSettings.IPAddress}}", DIND_CONTAINER],
@@ -146,6 +161,8 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
     "run", "-d",
     "--privileged",
     "--name", DIND_CONTAINER,
+    "-p", `${DIND_PORT}:${DIND_PORT}`,
+    "--add-host", "host.docker.internal:host-gateway",
     "-v", "machinen-docker-data:/var/lib/docker",
     ...mountArgs,
     "-e", "DOCKER_TLS_CERTDIR=",
@@ -155,6 +172,39 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
     "--host", "unix:///var/run/docker.sock",
     ...(process.env.MACHINEN_REGISTRY ? ["--insecure-registry", process.env.MACHINEN_REGISTRY] : []),
   ], { stdio: "pipe", ...HOST_DOCKER_OPTS });
+
+  // When MACHINEN_REGISTRY is a localhost address, the host-side registry is not
+  // reachable from inside DinD (localhost is DinD's own loopback).  Set up an
+  // iptables DNAT rule to forward that port to the host via host.docker.internal.
+  //
+  // Two extra steps are required for the DNAT to work:
+  //  1. Remove the IPv6 localhost entry from /etc/hosts so that "localhost"
+  //     resolves to 127.0.0.1 only — Docker (Go) tries IPv6 first and hangs.
+  //  2. Enable route_localnet on all interfaces so the kernel allows routing
+  //     packets from the loopback address to a real (non-loopback) destination.
+  const reg = process.env.MACHINEN_REGISTRY;
+  if (reg) {
+    const m = reg.match(/^localhost:(\d+)$/);
+    if (m) {
+      const port = m[1];
+      try {
+        dindExec(
+          // Force localhost → IPv4 only (prevents Docker from trying ::1 first)
+          `cp /etc/hosts /tmp/hosts.noipv6 && sed -i '/^::1/d' /tmp/hosts.noipv6 && mount --bind /tmp/hosts.noipv6 /etc/hosts`,
+        );
+        dindExec(
+          // Allow kernel to route DNAT'd packets from loopback to real IPs
+          `for f in /proc/sys/net/ipv4/conf/*/route_localnet; do echo 1 > "$f"; done`,
+        );
+        dindExec(
+          `iptables -t nat -A OUTPUT -p tcp -d 127.0.0.1 --dport ${port} ` +
+          `-j DNAT --to-destination $(getent hosts host.docker.internal | awk '{print $1}'):${port}`,
+        );
+      } catch (err) {
+        console.warn(`Warning: could not forward registry port ${port} inside DinD: ${err.message}`);
+      }
+    }
+  }
 
   // Wait for the inner dockerd to be ready using docker exec (avoids TCP
   // connectivity issues when the caller is itself a container).

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -557,6 +557,12 @@ function cmdLogs(args) {
 async function cmdDestroy(args) {
   const name = args.name || args.container;
 
+  // Connect to the DinD inner daemon so docker commands find containers.
+  try {
+    const diNDHost = getDiNDHost();
+    process.env.DOCKER_HOST = diNDHost;
+  } catch {}
+
   if (args.local) {
     // Remove local containers (<name> and <name>-restored)
     let found = false;
@@ -641,6 +647,15 @@ Environment:
     process.exit(1);
   }
   const intervalMs = intervalS * 1000;
+
+  // Connect to the DinD inner daemon so docker commands find containers
+  // running inside machinen-dind.
+  try {
+    const diNDHost = getDiNDHost();
+    process.env.DOCKER_HOST = diNDHost;
+    const { hostname, port } = new URL(diNDHost);
+    reconnectDocker(hostname, parseInt(port, 10));
+  } catch {}
 
   // Resolve container name first (before any auth)
   const containerName = args.container || currentContainerName();
@@ -916,6 +931,13 @@ function cmdStatus(args) {
   const containerName = args.container;
   const { url: registry } = getRegistry();
   const prefix = `machinen/${containerName}`;
+
+  // Point DOCKER_HOST at the DinD inner daemon so docker inspect finds
+  // containers running inside machinen-dind.
+  try {
+    const diNDHost = getDiNDHost();
+    process.env.DOCKER_HOST = diNDHost;
+  } catch {}
 
   // 1. Sync daemon status from sync-status.json
   let status = null;

--- a/src/machinen.mjs
+++ b/src/machinen.mjs
@@ -51,7 +51,7 @@ async function cmdFreeze(containerName, opts = {}) {
   console.log(`Freezing ${containerName}...`);
 
   const { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath } =
-    await prepareCheckpoint(containerName, { stop: true });
+    await prepareCheckpoint(containerName, { stop: !opts["keep-alive"] });
 
   try {
     const prefix = `${registry}/machinen/${containerName}`;
@@ -910,6 +910,105 @@ Environment:
   process.exit(0);
 }
 
+// --- status command ---
+
+function cmdStatus(args) {
+  const containerName = args.container;
+  const { url: registry } = getRegistry();
+  const prefix = `machinen/${containerName}`;
+
+  // 1. Sync daemon status from sync-status.json
+  let status = null;
+  const root = gitRoot();
+  const candidates = [
+    root && path.join(root, ".machinen", "sync-status.json"),
+    path.join(os.homedir(), ".machinen", containerName, "sync-status.json"),
+  ].filter(Boolean);
+
+  for (const p of candidates) {
+    try {
+      status = JSON.parse(fs.readFileSync(p, "utf-8"));
+      break;
+    } catch {}
+  }
+
+  console.log(`Container:  ${containerName}`);
+
+  // Check if local container is running
+  try {
+    const state = execFileSync("docker", ["inspect", "--format", "{{.State.Status}}", containerName], {
+      stdio: "pipe", encoding: "utf-8",
+    }).trim();
+    console.log(`Local:      ${state}`);
+  } catch {
+    console.log(`Local:      not found`);
+  }
+
+  // Check if remote server exists
+  const machines = listMachines();
+  const remote = machines.find(m => m.name === containerName && m.location !== "local");
+  if (remote) {
+    console.log(`Remote:     ${remote.ip} (${remote.status || "unknown"})`);
+  } else {
+    console.log(`Remote:     none`);
+  }
+
+  // Sync daemon info
+  if (status) {
+    let daemonAlive = false;
+    if (status.pid != null) {
+      try { process.kill(status.pid, 0); daemonAlive = true; } catch {}
+    }
+    console.log(`Sync:       ${daemonAlive ? `running (PID ${status.pid})` : "not running"}`);
+
+    if (status.lastSync) {
+      const ageMs = Date.now() - new Date(status.lastSync).getTime();
+      const ageMin = Math.round(ageMs / 60000);
+      const ago = ageMin < 1 ? "just now" : `${ageMin}m ago`;
+      const ok = status.lastSyncSuccess ? "success" : "failed";
+      console.log(`Last sync:  ${ago} (${ok})`);
+    }
+
+    if (status.syncCount != null) {
+      const failures = status.consecutiveFailures || 0;
+      console.log(`Syncs:      ${status.syncCount} total${failures > 0 ? `, ${failures} consecutive failures` : ""}`);
+    }
+  } else {
+    console.log(`Sync:       no status file found`);
+  }
+
+  console.log(`Registry:   ${registry}/${prefix}`);
+
+  // 2. Query ghcr.io for recent tags via gh API
+  try {
+    const username = execSync("gh api user --jq .login", { stdio: "pipe", encoding: "utf-8" }).trim();
+    const pkgName = encodeURIComponent(prefix);
+    const json = execSync(
+      `gh api user/packages/container/${pkgName}/versions --jq '[.[:10] | .[] | {tags: .metadata.container.tags, size: .name, updated: .updated_at}]'`,
+      { stdio: "pipe", encoding: "utf-8" },
+    ).trim();
+    const versions = JSON.parse(json || "[]");
+
+    if (versions.length > 0) {
+      console.log(`\nRecent images:`);
+      for (const v of versions) {
+        const tags = (v.tags || []).join(", ") || "(untagged)";
+        const updated = new Date(v.updated).toLocaleString();
+        console.log(`  ${tags}  ${updated}`);
+      }
+    } else {
+      console.log(`\nNo images found in registry.`);
+    }
+  } catch (err) {
+    // Registry query is best-effort — might not have packages yet or might be local registry
+    if (!registry.startsWith("ghcr.io")) {
+      console.log(`\n(Registry tag listing not available for custom registries)`);
+    } else {
+      console.log(`\n(Could not list registry images: ${err.message.split("\n")[0]})`);
+    }
+  }
+}
+
 // --- sync status check (used by restore) ---
 
 function checkSyncStatus(containerName) {
@@ -995,6 +1094,7 @@ async function main() {
     restore: cmdRestore,
     watch: cmdSync,
     open: cmdOpen,
+    status: cmdStatus,
     logs: cmdLogs,
     destroy: cmdDestroy,
   };
@@ -1024,6 +1124,7 @@ Commands:
   open [name]           Open shell in container
     --local             Open shell in local container
     --remote            Open shell on remote server
+  status [name]         Show sync state and recent registry images
   logs [name]           Tail remote container logs (or list machines)
   destroy [name]        Tear down container (both local and remote)
     --local             Only remove local containers
@@ -1043,7 +1144,7 @@ Registry: ghcr.io via gh CLI (default), or set MACHINEN_REGISTRY=<domain> to use
     process.exit(action ? 1 : 0);
   }
 
-  if ((action === "freeze" || action === "restore") && !args.container) {
+  if ((action === "freeze" || action === "restore" || action === "status") && !args.container) {
     console.error(`Container name required (not in a git repo?). Usage: machinen ${action} <container>`);
     process.exit(1);
   }

--- a/src/preflight.mjs
+++ b/src/preflight.mjs
@@ -47,35 +47,57 @@ function pruneContainerdCheckpoints() {
 // restore is achieved by cleaning the containerd content store before
 // docker start --checkpoint — otherwise the checkpoint blobs written by the
 // API checkpoint call conflict with the ones docker start tries to commit.
+const PREFLIGHT_IMAGE = "machinen-preflight";
+
+async function ensurePreflightImage() {
+  try {
+    execSync(`docker image inspect ${PREFLIGHT_IMAGE}`, { stdio: "pipe" });
+    return;
+  } catch {}
+  execSync("docker pull alpine", { stdio: "pipe" });
+  execSync(
+    `docker build -t ${PREFLIGHT_IMAGE} -`,
+    { stdio: "pipe", input: `FROM alpine\nRUN apk add -q --no-cache tmux\n` },
+  );
+}
+
 async function testCheckpointWorks(docker) {
   const testName = "criu-preflight-test";
 
-  // Clean up any leftover containers and stale containerd blobs from previous
-  // runs.  docker system prune doesn't touch checkpoint/* images committed by
-  // docker start --checkpoint, so we explicitly remove them + their blobs.
+  // Clean up leftover containers and stale containerd checkpoint blobs.
+  // No full image prune here — checkPrerequisites handles that on --clean,
+  // and keeping cached images makes subsequent runs fast.
   try { await docker.getContainer(testName).remove({ force: true }); } catch {}
-  try { execSync("docker system prune -af", { stdio: "pipe" }); } catch {}
   pruneContainerdCheckpoints();
 
   let container;
   let checkpointId;
 
   try {
-    // alpine may have been removed by the prune above.
-    execSync("docker pull alpine", { stdio: "pipe" });
+    await ensurePreflightImage();
 
     // Test with tmux — the patched CRIU is required to checkpoint containers
     // with PTY sessions (removes the tty_verify_ctty pid_real check).
     container = await docker.createContainer({
-      Image: "alpine",
+      Image: PREFLIGHT_IMAGE,
       name: testName,
-      Cmd: ["sh", "-c", "apk add -q tmux 2>/dev/null; tmux new-session -d -s test; exec sleep 300"],
+      Cmd: ["sh", "-c", "tmux new-session -d -s test; exec sleep 300"],
       // NetworkMode "host" avoids the per-container netns bind-mount that
       // CRIU cannot restore before the process starts.
       HostConfig: { SecurityOpt: ["seccomp=unconfined"], NetworkMode: "host" },
     });
     await container.start();
-    await new Promise((r) => setTimeout(r, 3000));
+
+    // Wait for setup to complete: once `exec sleep 300` runs, the shell has
+    // been replaced and there are no lingering TCP sockets.
+    const setupDeadline = Date.now() + 30_000;
+    while (Date.now() < setupDeadline) {
+      try {
+        const top = execSync(`docker exec ${testName} ps -o comm= -p 1`, { stdio: "pipe", encoding: "utf-8" }).trim();
+        if (top === "sleep") break;
+      } catch {}
+      await new Promise((r) => setTimeout(r, 500));
+    }
 
     // Use the Docker API (not CLI) to create the checkpoint.  The API stores
     // files at /var/lib/docker/containers/<id>/checkpoints/<cpId>/ inside DiND
@@ -122,12 +144,6 @@ export async function checkPrerequisites(_docker, opts = {}) {
   const { hostname, port } = new URL(diNDHost);
   reconnectDocker(hostname, parseInt(port, 10));
   // `docker` is a live ESM binding — it now points to the DiND inner daemon.
-
-  if (opts.clean) {
-    // On --clean the dind container is restarted but the machinen-docker-data
-    // volume is preserved.  Prune all images so the next run pulls fresh ones.
-    try { execSync("docker system prune -af", { stdio: "pipe" }); } catch {}
-  }
 
   console.log("Testing if docker checkpoint works...");
   if (!(await testCheckpointWorks(docker))) {


### PR DESCRIPTION
## Summary
- Add `machinen status [name]` command that shows local/remote container state, sync daemon health, and recent registry images
- Support `--keep-alive` flag on `freeze` to skip stopping the container before checkpointing
- Update `@redwoodjs/agent-ci` from 0.3.4 to 0.7.1
- Document `watch`, `open`, and `status` commands in README

## Test plan
- [x] Unit tests pass (`npx vitest run` — 32 passed)
- [ ] Manual test: `machinen status <container>` shows expected output
- [ ] Manual test: `machinen freeze --keep-alive <container>` checkpoints without stopping
