### PR TITLE
docs: add threepointone agents-beyond-bash research and tweet drafts

### DIFF
--- a/.docs/marketing/research/threepointone-agents-beyond-bash.md
+++ b/.docs/marketing/research/threepointone-agents-beyond-bash.md
@@ -1,0 +1,61 @@
+# @threepointone — Agents beyond bash, computing beyond Unix
+
+- **Date:** 2026-04-07
+- **URL:** https://x.com/threepointone/status/2041457759284072954
+- **Quoting:** https://x.com/theo/status/2041441945290162178
+- **Context:** Sunil Pai (Cloudflare) quote-tweeting Theo Browne (t3.gg)
+
+## The tweets
+
+**Theo:**
+> Agents are good at bash. Bash is not good for agents. We should cut our losses and restart now before it is too late.
+
+**Sunil:**
+> yes yes a 1000 times yes. after the, er, recent drama, I went into a rabbit hole exploring the space, and it's like my brain's been reprogrammed. lemme put it this way: there's nothing _fundamental_ about filesystems. or terminal commands. or _even your favourite programming language_. but there _is_ something fundamental about storage. or lambda calculus. the future of computing looks more like math+symbolic execution than unix+whatever's in the training set. (and it would be very bad for humanity if this wasn't true!)
+
+---
+
+## Background: the "recent drama"
+
+In March 2026, Malte Ubl (Vercel CTO) publicly called out Sunil for Cloudflare forking Vercel's [just-bash](https://github.com/vercel-labs/just-bash) — a TypeScript reimplementation of bash for agents.
+
+Malte's tweet: ["Cloudflare forked just-bash and they really, really should not have"](https://x.com/cramforce/status/2033285112478171373). His argument was open-source etiquette — Cloudflare forked without contributing upstream first. Community largely defended Sunil. [Paul Butler](https://x.com/paulgb/status/2033573814420804069): "Insane that Vercel picked one of the kindest, most well-meaning people in tech to go after." They eventually spoke on the phone and both apologized.
+
+The drama was literally about **bash for agents** — and it sent Sunil down a rabbit hole.
+
+## Theo's position
+
+Theo has been building toward this for a while. He identified what he calls "The Agentic Code Problem" — managing multiple AI agents across terminal windows, browser tabs, and IDEs is a cognitive nightmare. His answer was [T3 Code](https://github.com/pingdotgg/t3code), an open-source GUI wrapping agents like Claude Code and Codex with git worktree isolation, visual diffs, and multi-agent orchestration.
+
+His tweet distills it: agents are fluent in bash because that's in the training data, but bash is a terrible substrate for agent workflows. Rethink the interface now before the ecosystem calcifies.
+
+## Sunil's argument (the interesting part)
+
+Sunil agrees with Theo but goes much further — from a UX argument to a philosophical one about computing itself.
+
+**The accidental vs. the essential:**
+- Filesystems, terminal commands, Python/JS/Rust — these are *accidental* artifacts of computing history. Conventions, not laws.
+- Storage (the abstract concept), lambda calculus (the formal foundation of computation) — these are *essential*. Mathematical truths that exist independent of Unix.
+
+**The implication for agents:**
+Current coding agents are sophisticated bash scripters. They read files, run commands, edit text — all Unix primitives. But this is because that's what's in the training data. The future should look more like **math + symbolic execution** (formal reasoning about programs, proving properties, manipulating abstract representations) rather than **Unix + whatever's popular on GitHub**.
+
+**The humanity parenthetical:**
+"(and it would be very bad for humanity if this wasn't true!)" — if agents are permanently locked to accidental conventions from training data rather than discovering fundamental computational principles, AI would just be a parrot of human convention rather than a tool that can reason from first principles. That caps its usefulness and makes it fragile.
+
+**The subtext:**
+Sunil got publicly dragged over a bash fork and responded not with defensiveness but with "actually, bash itself is the wrong abstraction for this entire era of computing."
+
+## Related research
+
+- [The LLMbda Calculus](https://arxiv.org/abs/2602.20064) (Feb 2026) — a formal lambda calculus for AI agent conversations with information-flow control and safety proofs. Exactly the kind of foundation Sunil is gesturing at.
+- [Filesystems Are Having a Moment](https://madalitso.me/notes/why-everyone-is-talking-about-filesystems/) — the counter-argument: filesystems are the *right* primitive because they align with how both humans and models work.
+- [Why Do Agents Love Filesystems](https://prateekjoshi.substack.com/p/why-do-agents-love-filesystems) — argues the filesystem is "the most durable abstraction in computing" and agents naturally gravitate to it.
+
+## How this relates to machinen
+
+This debate maps directly onto machinen's design space. Machinen checkpoint/restores full development containers — processes, memory, filesystem state — using CRIU. It operates at the Unix level by design: containers, filesystems, process trees.
+
+Sunil's argument would say machinen is building on the *accidental* layer. But the counter is that developers live in the accidental layer right now, and machinen's value is making that layer seamlessly portable. The abstract mathematical future may be coming, but today's agents still need real bash, real filesystems, and real containers. Machinen makes those movable.
+
+If Sunil is right about the long-term direction, machinen's bet is that the transition takes long enough that containerized dev environments remain the dominant substrate for years to come.

--- a/.docs/marketing/tweets/re-threepointone-agents-beyond-bash.md
+++ b/.docs/marketing/tweets/re-threepointone-agents-beyond-bash.md
@@ -1,0 +1,67 @@
+# Reply + Retweet: @threepointone agents beyond bash
+
+- **Replying to:** https://x.com/threepointone/status/2041457759284072954
+- **Action:** Reply to Sunil, then retweet his tweet
+
+---
+
+## Context
+
+Sunil said:
+> "there's nothing _fundamental_ about filesystems. or terminal commands. or _even your favourite programming language_. but there _is_ something fundamental about storage. or lambda calculus. the future of computing looks more like math+symbolic execution than unix+whatever's in the training set"
+
+What we worked out:
+
+- Lambda calculus is the theory of computation (Church, 1936). It's real, it's fundamental. But it's equally underneath bash AND TypeScript AND every other language. So it doesn't tell you which to pick.
+- Bash and TypeScript are computationally equivalent (Church-Turing). They compute the same things.
+- The actual difference between them isn't computational power — it's **guardrails**. TypeScript's type system prevents errors at compile time. Bash lets everything through and fails at runtime.
+- The spectrum isn't "bash vs math." It's: how much does your tool prevent you from making mistakes?
+- For agents — who make mistakes constantly — more guardrails = fewer wasted loops = better results.
+- The one genuinely new capability is **formal verification** (∀ vs ∃). Proving correctness for all inputs, not just testing some. That's something bash literally cannot do no matter how you use it.
+
+Sunil's filesystems → storage distinction is solid. His lambda calculus framing is poetic but imprecise — the real gap is type systems and verification, not lambda calculus vs bash.
+
+---
+
+## The tweet
+
+> been chewing on this. i think you're pointing at something real but the framing is slightly off.
+>
+> filesystems → storage: yes, 100%. a filesystem is one implementation of a partial function from keys to values. the concept is bigger than the implementation.
+>
+> but lambda calculus vs programming languages — that one's trickier. bash IS lambda calculus. so is TypeScript. so is every language (Church-Turing). the math is already underneath all of them equally.
+>
+> the real difference isn't computational power. it's guardrails.
+>
+> bash: everything is a string, errors at runtime, hope for the best.
+> TypeScript: types catch a class of errors before you run anything.
+> AST tools: structural edits that can't produce invalid syntax.
+> formal verification: prove correctness for ALL inputs, not just test some.
+>
+> each layer up doesn't compute more — it prevents more mistakes. for agents that make mistakes constantly, that's everything.
+>
+> the gap isn't "bash vs math." it's "unguarded computation vs computation with guardrails." and the biggest guardrail we're missing is verification — ∃ (some tests passed) vs ∀ (proved correct for all inputs). that one's not incremental, it's a different universe.
+
+---
+
+## Shorter version
+
+> i think the real version of this insight is slightly different.
+>
+> lambda calculus is fundamental — but it's equally underneath bash and TypeScript and every language. Church-Turing says they all compute the same things. so "use math not bash" doesn't quite work.
+>
+> what actually differs is guardrails. bash lets every mistake through. types catch some at compile time. formal verification catches all of them.
+>
+> agents make mistakes constantly. their whole loop is try → fail → fix → retry. the more guardrails, the fewer loops. that's the real argument.
+>
+> and the big missing piece isn't lambda calculus — it's verification. testing checks SOME inputs (∃). verification proves ALL inputs (∀). we don't give agents that tool yet. we should.
+
+---
+
+## Shortest version
+
+> the filesystems → storage point is dead on. a filesystem is just one implementation of "save and retrieve."
+>
+> but i think the deeper insight isn't "use math instead of bash." it's "give agents more guardrails." bash has none. types have some. formal verification has all of them.
+>
+> the biggest missing piece for agents isn't lambda calculus — it's verification. testing checks some inputs. verification proves all of them. that's not a better tool, it's a different category of tool. and agents don't have it yet.


### PR DESCRIPTION
## Summary

- Research doc breaking down Sunil Pai's tweet about agents, bash, and mathematical foundations of computing (responding to Theo's "agents are good at bash, bash is not good for agents")
- Includes background on the Vercel/Cloudflare just-bash fork drama that prompted the tweet
- Tweet draft options for replying to Sunil, exploring the argument that the real gap isn't "bash vs lambda calculus" but guardrails and formal verification
