### PR TITLE
Fix restore (local + remote), shrink freeze by ~420MB, cut preflight from 30s to ~0s

### DIFF
--- a/.agents/skills/agent-ci/SKILL.md
+++ b/.agents/skills/agent-ci/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: agent-ci
+description: Run GitHub Actions CI locally with Agent CI to validate changes before pushing. Use when testing, running checks, or validating code changes.
+license: MIT
+compatibility: Requires Node.js 18+ and Docker
+metadata:
+  author: redwoodjs
+  version: "1.0.0"
+---
+
+# Agent CI
+
+Run the full CI pipeline locally before pushing. CI was green before you started — any failure is caused by your changes.
+
+## Run
+
+```bash
+npx @redwoodjs/agent-ci run --quiet --all --pause-on-failure
+```
+
+## Retry
+
+When a step fails, the run pauses automatically. Fix the issue, then retry:
+
+```bash
+npx @redwoodjs/agent-ci retry --name <runner-name>
+```
+
+To re-run from an earlier step:
+
+```bash
+npx @redwoodjs/agent-ci retry --name <runner-name> --from-step <N>
+```
+
+Repeat until all jobs pass. Do not push to trigger remote CI when agent-ci can run it locally.

--- a/.claude/skills/agent-ci
+++ b/.claude/skills/agent-ci
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-ci

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22
+
+# CRIU-friendly pid 1.  The stock devcontainer wrapper leaves pid 1 holding
+# dockerd's stdout/stderr pipes, which CRIU records in descriptors.json as
+# anonymous `pipe:[NNNN]` inodes.  On restore those inodes don't exist, the
+# new shim's fresh fifos aren't remapped to them, and restore collapses with
+# "copy stream failed: reading from a closed fifo" — surfaced to the user as
+# a useless generic "criu failed: type RESTORE errno 0".
+#
+# Redirecting stdio to /dev/null before the infinite-sleep loop makes pid 1's
+# fd 0/1/2 all point at a durable path; the checkpoint captures /dev/null
+# instead of phantom pipe inodes and restore works across machines.
+CMD ["/bin/sh", "-c", "exec </dev/null >/dev/null 2>&1; while sleep 1 & wait $!; do :; done"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "Machinen",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22",
+  "build": { "dockerfile": "Dockerfile" },
+  "overrideCommand": false,
 
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,19 +7,19 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
-  "initializeCommand": "security find-generic-password -a $USER -w -s 'Claude Code-credentials' > ~/.claude/.credentials.json 2>/dev/null || true; gh auth token > ~/.claude/.gh-token 2>/dev/null && chmod 600 ~/.claude/.gh-token || true",
+  "initializeCommand": "mkdir -p ~/.machinen && gh auth token > ~/.machinen/gh-token 2>/dev/null && chmod 600 ~/.machinen/gh-token || true",
 
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y iputils-ping dnsutils net-tools && sudo npm install -g @anthropic-ai/claude-code && echo '{\"hasCompletedOnboarding\":true}' > /home/node/.claude.json && sudo corepack enable && pnpm install --config.confirmModulesPurge=false && if [ -f /home/node/.claude/.gh-token ] && [ -s /home/node/.claude/.gh-token ]; then gh auth login --with-token < /home/node/.claude/.gh-token && rm -f /home/node/.claude/.gh-token; fi",
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y iputils-ping dnsutils net-tools && sudo corepack enable && pnpm install --config.confirmModulesPurge=false && if [ -s /tmp/machinen/gh-token ]; then gh auth login --with-token < /tmp/machinen/gh-token; fi",
 
   "runArgs": ["--security-opt", "seccomp=unconfined", "--network", "host"],
 
   "remoteUser": "node",
 
   "containerEnv": {
-    "CLAUDE_CONFIG_DIR": "/home/node/.claude"
+    "MACHINEN_PRUNE_PATHS": "/home/*/.npm/_logs"
   },
 
-  "mounts": ["source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind"],
+  "mounts": ["source=${localEnv:HOME}/.machinen,target=/tmp/machinen,type=bind,readonly"],
 
   "customizations": {
     "vscode": {

--- a/.docs/architecture/pid1-stdio-restore.md
+++ b/.docs/architecture/pid1-stdio-restore.md
@@ -1,102 +1,83 @@
-# Pid 1 Stdio Restore — CRIU Checkpoint Portability
+# Why Restore Was Broken — Explained Simply
 
-## Problem
+## The problem
 
-Both `machinen restore --local` and `machinen restore --remote` fail with:
+We froze a container and tried to restore it on another computer. It didn't work. The error message said "criu failed" but that wasn't the real reason.
 
-```
-OCI runtime restore failed: criu failed: type RESTORE errno 0: unknown
-```
+## What was really happening
 
-preceded in `dockerd` logs by:
+Imagine the container is a little house, and the house has a phone. When the house was built, Docker installed a phone line and gave it a number — let's say `pipe:[62531]`. The person inside the house (pid 1) picked up the phone and held it.
 
-```
-copy stream failed: reading from a closed fifo stream=stdout
-copy stream failed: reading from a closed fifo stream=stderr
-failed to read init pid file: ... /moby/<cid>/init.pid: no such file or directory
-```
+When we froze the house, we wrote down the phone number the person was holding: `pipe:[62531]`. We packed this note into our moving box along with everything else.
 
-CRIU's own log ends with `Restore finished successfully. Tasks resumed.` — so CRIU is not the actual failure. The error is downstream in the containerd-shim's stdio plumbing.
+Then we moved the house to a new computer.
 
-Fails identically on:
-- local DinD (Alpine, OrbStack kernel 6.17, patched CRIU 4.2)
-- remote Hetzner Ubuntu (Linux 6.8, stock CRIU)
+At the new computer, Docker built a new phone line with a different number, like `pipe:[99999]`. But the person we restored was still holding a note that said "my phone is 62531." They tried to use their phone — but 62531 doesn't exist on this new computer. So they couldn't hear anything, couldn't say anything, and everything fell apart.
 
-Different kernels, different CRIU versions — same symptom. The broken thing travels with the checkpoint.
+Docker then shrugged and said "criu failed" — which was wrong. CRIU did its job fine. The problem was the phone number we wrote down wasn't portable.
 
-## Root Cause
+## The fix
 
-The devcontainer CLI's injected wrapper script lets pid 1 inherit dockerd's stdout/stderr pipes. CRIU's `descriptors.json` captures them as anonymous pipe inodes:
+Before freezing, tell the person inside the house to hang up the phone and throw it away. Now instead of holding a phone, they're just sitting in silence, looking at a hole in the wall called `/dev/null`. That "hole in the wall" exists on every computer. So when we restore on a new computer, the person picks up their note, sees `/dev/null`, looks around the new house, finds the same hole in the wall, and everything works.
 
-```json
-["/dev/null", "pipe:[62531]", "pipe:[62532]"]
-```
-
-On restore, the new containerd-shim creates **fresh** fifos with different inodes. Runc is supposed to pass `--inherit-fd fd[1]:pipe:[NEW]` so CRIU remaps the restored pid 1's fd 1/2 onto the new fifos. Either runc stopped doing this or the mapping regressed upstream — untracked. The result: restored pid 1 holds dangling references to the dead pipe inodes, the new shim's fifo never gets written to, the shim times out, closes its end, disconnects, `init.pid` never gets written, and dockerd surfaces a useless generic "criu failed".
-
-## Fix
-
-Redirect pid 1's stdio to `/dev/null` before the infinite-sleep loop. `/dev/null` is a durable path (same inode-equivalent on every machine), so `descriptors.json` captures a path any shim can reopen regardless of whether the original shim's fifos still exist.
-
-In `.devcontainer/Dockerfile`:
-
-```dockerfile
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-22
-
-CMD ["/bin/sh", "-c", "exec </dev/null >/dev/null 2>&1; while sleep 1 & wait $!; do :; done"]
-```
-
-In `.devcontainer/devcontainer.json`:
-
-```json
-{
-  "build": { "dockerfile": "Dockerfile" },
-  "overrideCommand": false,
-  ...
-}
-```
-
-`overrideCommand: false` is load-bearing — without it, devcontainer CLI reinjects its own wrapper that brings the pipe stdio back. `build.dockerfile` is required because devcontainer.json has no way to override CMD directly.
-
-### Verification
-
-After `machinen up`, pid 1's fds should all be `/dev/null`:
+In code, "throw the phone away" looks like:
 
 ```
-$ docker exec <container> ls -la /proc/1/fd/
-lr-x------  0 -> /dev/null
-l-wx------  1 -> /dev/null
-l-wx------  2 -> /dev/null
+exec </dev/null >/dev/null 2>&1
 ```
 
-Restored container after `machinen restore --local` should show the original checkpointed tmux/bash at their captured pids (not fresh ones):
+We put this at the very beginning of what pid 1 does, before anything else.
+
+## Where the fix lives
+
+Two files:
+
+**`.devcontainer/Dockerfile`** — tells Docker to build the container with pid 1 running a command that throws the phone away first, then sleeps forever.
+
+**`.devcontainer/devcontainer.json`** — has `"overrideCommand": false` so the devcontainer tool doesn't secretly re-install the phone.
+
+## How to check it's working
+
+After `machinen up`, look inside the container at what pid 1 is holding:
 
 ```
-$ docker exec <restored> ps -ef
-root    1  ... /bin/sh -c exec </dev/null >/dev/null 2>&1; while sleep 1 ...
-node  1567  1 ... tmux new-session -d -c / -s machinen   <- preserved pid
-node  1568  1567 ... -bash                                  <- preserved pid
+docker exec <container> ls -la /proc/1/fd/
 ```
 
-Preserved pids prove CRIU genuinely restored the process tree rather than just booting a fresh container.
+You should see three arrows, all pointing to `/dev/null`:
 
-## Things that do NOT fix it
-
-- **Pinning CRIU** — the regression isn't in CRIU; it's in how runc/shim remaps fds post-restore.
-- **Stripping `/dev/*` from mountpoints-*.img** — works around a different mount-namespace error but doesn't address the fd/pipe issue.
-- **Pinning docker-in-docker image version** — tested, same failure.
-- **Using `--tty`** — replaces pipes with a PTY; also captured in descriptors.json and similarly unrestorable across hosts unless you also widen up PTY allocation.
-
-## Debugging tips
-
-CRIU descriptors for pid 1 are extractable from the checkpoint image (`FROM scratch` + `ADD checkpoint.tar`) without decompressing anything:
-
-```bash
-docker create --name x <checkpoint-image> /nonexistent
-docker cp x:/checkpoint/descriptors.json -
-docker rm x
+```
+0 -> /dev/null
+1 -> /dev/null
+2 -> /dev/null
 ```
 
-If any of the three strings in that JSON array is not a path (i.e. `pipe:[...]`, `socket:[...]`, `anon_inode:[...]`), restore will break on a fresh host.
+If any of them say `pipe:[somenumber]` instead — the fix isn't active, and restore will break on another computer.
 
-The containerd-shim's CRIU log is at `/var/lib/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/<cid>/restore.log` inside the docker host (or DinD container). Only written if CRIU gets far enough — a successful-looking log ending in `Restore finished successfully. Tasks resumed.` while dockerd still reports "criu failed" means the failure is in the post-CRIU shim handoff, not CRIU itself.
+After `machinen restore --local`, check that the restored container still has the original processes from the frozen one. Look at `ps -ef`:
+
+```
+node  1567  ... tmux ...
+node  1568  1567 ... bash ...
+```
+
+If `tmux` and `bash` have the same pid numbers they had before the freeze, CRIU really did restore the old state. If they have different pids, you got a fresh container instead of a restored one.
+
+## Things that looked like they might help but didn't
+
+- **Pinning the CRIU version.** The problem wasn't CRIU — CRIU was doing its job.
+- **Pinning the Docker-in-Docker version.** Same — not the broken piece.
+- **Deleting mount entries from the checkpoint.** Fixes a different problem (mount namespaces), not this one.
+- **Using `--tty`.** Trades the phone for a walkie-talkie. Still not portable.
+
+## How to peek at the phone number the checkpoint is holding
+
+The checkpoint image has a file called `descriptors.json` that lists what pid 1 is holding onto. You can look at it:
+
+```
+docker create --name peek <checkpoint-image> /nonexistent
+docker cp peek:/checkpoint/descriptors.json -
+docker rm peek
+```
+
+It'll say something like `["/dev/null", "/dev/null", "/dev/null"]` (good — portable) or `["/dev/null", "pipe:[62531]", "pipe:[62532]"]` (bad — will break on another computer).

--- a/.docs/architecture/pid1-stdio-restore.md
+++ b/.docs/architecture/pid1-stdio-restore.md
@@ -1,0 +1,102 @@
+# Pid 1 Stdio Restore — CRIU Checkpoint Portability
+
+## Problem
+
+Both `machinen restore --local` and `machinen restore --remote` fail with:
+
+```
+OCI runtime restore failed: criu failed: type RESTORE errno 0: unknown
+```
+
+preceded in `dockerd` logs by:
+
+```
+copy stream failed: reading from a closed fifo stream=stdout
+copy stream failed: reading from a closed fifo stream=stderr
+failed to read init pid file: ... /moby/<cid>/init.pid: no such file or directory
+```
+
+CRIU's own log ends with `Restore finished successfully. Tasks resumed.` — so CRIU is not the actual failure. The error is downstream in the containerd-shim's stdio plumbing.
+
+Fails identically on:
+- local DinD (Alpine, OrbStack kernel 6.17, patched CRIU 4.2)
+- remote Hetzner Ubuntu (Linux 6.8, stock CRIU)
+
+Different kernels, different CRIU versions — same symptom. The broken thing travels with the checkpoint.
+
+## Root Cause
+
+The devcontainer CLI's injected wrapper script lets pid 1 inherit dockerd's stdout/stderr pipes. CRIU's `descriptors.json` captures them as anonymous pipe inodes:
+
+```json
+["/dev/null", "pipe:[62531]", "pipe:[62532]"]
+```
+
+On restore, the new containerd-shim creates **fresh** fifos with different inodes. Runc is supposed to pass `--inherit-fd fd[1]:pipe:[NEW]` so CRIU remaps the restored pid 1's fd 1/2 onto the new fifos. Either runc stopped doing this or the mapping regressed upstream — untracked. The result: restored pid 1 holds dangling references to the dead pipe inodes, the new shim's fifo never gets written to, the shim times out, closes its end, disconnects, `init.pid` never gets written, and dockerd surfaces a useless generic "criu failed".
+
+## Fix
+
+Redirect pid 1's stdio to `/dev/null` before the infinite-sleep loop. `/dev/null` is a durable path (same inode-equivalent on every machine), so `descriptors.json` captures a path any shim can reopen regardless of whether the original shim's fifos still exist.
+
+In `.devcontainer/Dockerfile`:
+
+```dockerfile
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22
+
+CMD ["/bin/sh", "-c", "exec </dev/null >/dev/null 2>&1; while sleep 1 & wait $!; do :; done"]
+```
+
+In `.devcontainer/devcontainer.json`:
+
+```json
+{
+  "build": { "dockerfile": "Dockerfile" },
+  "overrideCommand": false,
+  ...
+}
+```
+
+`overrideCommand: false` is load-bearing — without it, devcontainer CLI reinjects its own wrapper that brings the pipe stdio back. `build.dockerfile` is required because devcontainer.json has no way to override CMD directly.
+
+### Verification
+
+After `machinen up`, pid 1's fds should all be `/dev/null`:
+
+```
+$ docker exec <container> ls -la /proc/1/fd/
+lr-x------  0 -> /dev/null
+l-wx------  1 -> /dev/null
+l-wx------  2 -> /dev/null
+```
+
+Restored container after `machinen restore --local` should show the original checkpointed tmux/bash at their captured pids (not fresh ones):
+
+```
+$ docker exec <restored> ps -ef
+root    1  ... /bin/sh -c exec </dev/null >/dev/null 2>&1; while sleep 1 ...
+node  1567  1 ... tmux new-session -d -c / -s machinen   <- preserved pid
+node  1568  1567 ... -bash                                  <- preserved pid
+```
+
+Preserved pids prove CRIU genuinely restored the process tree rather than just booting a fresh container.
+
+## Things that do NOT fix it
+
+- **Pinning CRIU** — the regression isn't in CRIU; it's in how runc/shim remaps fds post-restore.
+- **Stripping `/dev/*` from mountpoints-*.img** — works around a different mount-namespace error but doesn't address the fd/pipe issue.
+- **Pinning docker-in-docker image version** — tested, same failure.
+- **Using `--tty`** — replaces pipes with a PTY; also captured in descriptors.json and similarly unrestorable across hosts unless you also widen up PTY allocation.
+
+## Debugging tips
+
+CRIU descriptors for pid 1 are extractable from the checkpoint image (`FROM scratch` + `ADD checkpoint.tar`) without decompressing anything:
+
+```bash
+docker create --name x <checkpoint-image> /nonexistent
+docker cp x:/checkpoint/descriptors.json -
+docker rm x
+```
+
+If any of the three strings in that JSON array is not a path (i.e. `pipe:[...]`, `socket:[...]`, `anon_inode:[...]`), restore will break on a fresh host.
+
+The containerd-shim's CRIU log is at `/var/lib/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/<cid>/restore.log` inside the docker host (or DinD container). Only written if CRIU gets far enough — a successful-looking log ending in `Restore finished successfully. Tasks resumed.` while dockerd still reports "criu failed" means the failure is in the post-CRIU shim handoff, not CRIU itself.

--- a/.docs/marketing/research/tweet-dexhorthy-remote-agents.md
+++ b/.docs/marketing/research/tweet-dexhorthy-remote-agents.md
@@ -1,0 +1,16 @@
+# Reference: @dexhorthy on remote coding agents
+
+**Source:** https://xcancel.com/dexhorthy/status/2037973730069254516
+
+## Key quote
+
+> I still find it hard to shift from "agents running in remote compute" to "agents running on my laptop" - not because of the agent or the inference
+> The first step to remote coding agents should feel at least somewhat continuous in this regard
+
+## Why this is relevant to machinen
+
+This tweet captures exactly the problem machinen solves. The friction isn't the agent or the model — it's the **environment discontinuity**. Developers have local state: running dev servers, file watchers, browser sessions, partially-applied changes. Remote compute starts cold and knows none of this.
+
+Machinen's freeze/restore workflow makes the transition continuous: snapshot your local environment mid-task and restore it in remote compute (or vice versa), so agents can pick up exactly where you left off without losing context.
+
+**Positioning angle:** "The first step to remote coding agents should feel continuous" — machinen makes it so.

--- a/.factory/skills/agent-ci
+++ b/.factory/skills/agent-ci
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-ci

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "machinen-dev": "bash scripts/machinen-dev.sh",
     "build": "pnpm -r build",
     "typecheck": "tsgo --noEmit",
     "pretest": "pnpm build",

--- a/packages/cli/src/machinen.ts
+++ b/packages/cli/src/machinen.ts
@@ -70,6 +70,11 @@ function cliProgress(event, data) {
         console.log(`Shell: machinen open --remote`);
       }
       break;
+    case "step-complete": {
+      const s = (data.durationMs / 1000).toFixed(1);
+      console.log(`  ${data.step}: ${s}s`);
+      break;
+    }
     case "sync-warning":
       console.warn(`[WARN] ${data.message}`);
       break;

--- a/packages/sdk/src/__tests__/docker.test.ts
+++ b/packages/sdk/src/__tests__/docker.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { captureContainerConfig, tmuxAttachArgs, stripBindMountEntries } from "../docker";
+import {
+  captureContainerConfig,
+  tmuxAttachArgs,
+  stripBindMountEntries,
+  resolvePrunePaths,
+  DEFAULT_PRUNE_PATHS,
+} from "../docker";
 
 // Build a minimal CRIU MntEntry protobuf with just the mountpoint field.
 // Field 7 (mountpoint), wire type 2 (length-delimited string):
@@ -181,5 +187,31 @@ describe("tmuxAttachArgs", () => {
   it("respects a custom session name", () => {
     const args = tmuxAttachArgs("my-container", { sessionName: "work" });
     expect(args).toEqual(["exec", "-it", "my-container", "tmux", "attach-session", "-t", "work"]);
+  });
+});
+
+describe("resolvePrunePaths", () => {
+  it("returns defaults when no env is provided", () => {
+    expect(resolvePrunePaths([])).toEqual(DEFAULT_PRUNE_PATHS);
+  });
+
+  it("appends comma-separated paths from MACHINEN_PRUNE_PATHS", () => {
+    const env = ["FOO=bar", "MACHINEN_PRUNE_PATHS=/a,/b/c,/d/*"];
+    expect(resolvePrunePaths(env)).toEqual([...DEFAULT_PRUNE_PATHS, "/a", "/b/c", "/d/*"]);
+  });
+
+  it("appends newline-separated paths and trims whitespace", () => {
+    const env = ["MACHINEN_PRUNE_PATHS=  /a  \n  /b  \n"];
+    expect(resolvePrunePaths(env)).toEqual([...DEFAULT_PRUNE_PATHS, "/a", "/b"]);
+  });
+
+  it("ignores empty entries", () => {
+    const env = ["MACHINEN_PRUNE_PATHS=,,/a,,"];
+    expect(resolvePrunePaths(env)).toEqual([...DEFAULT_PRUNE_PATHS, "/a"]);
+  });
+
+  it("only matches the full env-var name, not prefixes", () => {
+    const env = ["MACHINEN_PRUNE_PATHS_OTHER=/nope"];
+    expect(resolvePrunePaths(env)).toEqual(DEFAULT_PRUNE_PATHS);
   });
 });

--- a/packages/sdk/src/cloud.ts
+++ b/packages/sdk/src/cloud.ts
@@ -248,7 +248,7 @@ export function remoteFreeze(ip, containerName, registry) {
       `cd $TMPDIR`,
       `tar cf checkpoint.tar -C /var/lib/docker/containers/${containerId}/checkpoints/${checkpointId} .`,
       `cat > Dockerfile << 'DEOF'`,
-      `FROM ${originalImage}`,
+      `FROM scratch`,
       `LABEL machinen.config='${configRaw.replace(/'/g, "'\\''")}'`,
       `LABEL machinen.checkpoint-id='${checkpointId}'`,
       `LABEL machinen.original-image='${originalImage}'`,
@@ -348,7 +348,7 @@ done
 
   // Extract checkpoint data into Docker's checkpoint directory
   ssh(ip, `docker rm -f machinen-tmp 2>/dev/null || true`, { stdio: "pipe" });
-  ssh(ip, `docker create --name machinen-tmp ${imageTag}`, { stdio: "pipe" });
+  ssh(ip, `docker create --name machinen-tmp ${imageTag} /nonexistent`, { stdio: "pipe" });
   const checkpointDir = `/var/lib/docker/containers/${newContainerId}/checkpoints/${checkpointId}`;
   ssh(
     ip,

--- a/packages/sdk/src/dind.ts
+++ b/packages/sdk/src/dind.ts
@@ -54,18 +54,48 @@ function isInContainer() {
   return false;
 }
 
+/** Detect whether the host Docker runtime is OrbStack. */
+function isOrbStack() {
+  try {
+    const os = execFileSync("docker", ["info", "--format", "{{.OperatingSystem}}"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 3000,
+      ...HOST_DOCKER_OPTS,
+    }).trim();
+    return os === "OrbStack";
+  } catch {
+    return false;
+  }
+}
+
+function getDiNDBridgeIP() {
+  // With custom bridge networks, inspect returns IPs under Networks.<name>.IPAddress
+  // rather than the legacy top-level IPAddress field.
+  const raw = execFileSync(
+    "docker",
+    [
+      "inspect",
+      "--format",
+      "{{range $k, $v := .NetworkSettings.Networks}}{{$v.IPAddress}} {{end}}",
+      DIND_CONTAINER,
+    ],
+    { encoding: "utf-8", stdio: "pipe", ...HOST_DOCKER_OPTS },
+  ).trim();
+  return raw.split(/\s+/).find((ip) => ip) || "";
+}
+
 export function getDiNDHost() {
   const inContainer = isInContainer();
 
-  if (!inContainer) {
+  // OrbStack routes container bridge IPs directly from the Mac host, and its
+  // published-port forwarding can get into a broken state that hangs TCP
+  // connections mid-response.  Use the bridge IP to bypass that entirely.
+  if (!inContainer && !isOrbStack()) {
     return `tcp://127.0.0.1:${DIND_PORT}`;
   }
 
-  const ip = execFileSync(
-    "docker",
-    ["inspect", "--format", "{{.NetworkSettings.IPAddress}}", DIND_CONTAINER],
-    { encoding: "utf-8", stdio: "pipe", ...HOST_DOCKER_OPTS },
-  ).trim();
+  const ip = getDiNDBridgeIP();
   if (!ip) {
     throw new Error("machinen-dind has no bridge IP — is it running?");
   }
@@ -119,6 +149,29 @@ function resolveHostPath(containerPath) {
 }
 
 /**
+ * Check whether the host-side TCP connection to DiND is healthy.  Uses a
+ * short timeout so we fail fast when the port forwarding is broken.  Runs
+ * two consecutive `docker info` calls — the first may succeed due to a
+ * stale connection buffer, but the second will expose a broken listener.
+ */
+function isHostTcpHealthy() {
+  try {
+    const dockerHost = getDiNDHost();
+    const env = { ...process.env, DOCKER_HOST: dockerHost };
+    for (let i = 0; i < 2; i++) {
+      execFileSync("docker", ["info"], {
+        stdio: "pipe",
+        timeout: 3000,
+        env,
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the machinen-dind image (if not already present) and start the
  * container (if not already running).  Mounts the user home tree so the
  * inner Docker daemon can resolve workspace bind-mount paths from devcontainer CLI.
@@ -139,10 +192,17 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
       const runningRegistry = idx !== -1 ? args[idx + 1] : null;
       const wantedRegistry = process.env.MACHINEN_REGISTRY ?? null;
       if (runningRegistry === wantedRegistry) {
-        console.log("machinen-dind already running.");
-        return;
+        // Verify the host-side TCP port forwarding is healthy — Docker Desktop
+        // / OrbStack can leave the forwarded port in a broken state across
+        // host-process restarts.  If the TCP check fails, restart DiND.
+        if (isHostTcpHealthy()) {
+          console.log("machinen-dind already running.");
+          return;
+        }
+        console.log("machinen-dind TCP port is unresponsive, restarting...");
+      } else {
+        console.log("machinen-dind registry config changed, restarting...");
       }
-      console.log("machinen-dind registry config changed, restarting...");
       execFileSync("docker", ["rm", "-f", DIND_CONTAINER], { stdio: "pipe", ...HOST_DOCKER_OPTS });
     } else {
       // Container exists but is not running — remove it
@@ -190,6 +250,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
   }
 
   console.log("Starting machinen-dind...");
+  const t0Start = performance.now();
   const mountArgs = workspaceMounts.flatMap((m) => ["-v", m]);
   execFileSync(
     "docker",
@@ -220,6 +281,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
     ],
     { stdio: "pipe", ...HOST_DOCKER_OPTS },
   );
+  console.log(`  started in ${((performance.now() - t0Start) / 1000).toFixed(1)}s`);
 
   // When MACHINEN_REGISTRY is a localhost address, the host-side registry is not
   // reachable from inside DinD (localhost is DinD's own loopback).  Set up an
@@ -259,6 +321,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
   // Wait for the inner dockerd to be ready using docker exec (avoids TCP
   // connectivity issues when the caller is itself a container).
   console.log("Waiting for inner Docker daemon...");
+  const t0Daemon = performance.now();
   const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
     try {
@@ -271,6 +334,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
       await new Promise((r) => setTimeout(r, 1000));
     }
   }
+  console.log(`  daemon ready in ${((performance.now() - t0Daemon) / 1000).toFixed(1)}s`);
 
   const dumpLogsAndThrow = (msg) => {
     let logs = "";
@@ -291,6 +355,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
   // The unix socket is up, but the TCP listener (port 2375) may still be
   // starting.  Check from *inside* DinD so we don't depend on the caller's
   // network topology (host vs sibling container).
+  const t0Tcp = performance.now();
   while (Date.now() < deadline) {
     try {
       execFileSync(
@@ -298,6 +363,7 @@ export async function ensureDiND(scriptsDir = DEFAULT_SCRIPTS_DIR) {
         ["exec", DIND_CONTAINER, "docker", "-H", `tcp://127.0.0.1:${DIND_PORT}`, "info"],
         { stdio: "pipe", ...HOST_DOCKER_OPTS },
       );
+      console.log(`  TCP listener ready in ${((performance.now() - t0Tcp) / 1000).toFixed(1)}s`);
       console.log("machinen-dind ready.");
       return;
     } catch {

--- a/packages/sdk/src/docker.ts
+++ b/packages/sdk/src/docker.ts
@@ -549,7 +549,7 @@ export function buildCheckpointImage(
 
     // Write Dockerfile
     const configJson = JSON.stringify(containerConfig).replace(/'/g, "'\\''");
-    const dockerfile = `FROM ${originalImage}
+    const dockerfile = `FROM scratch
 LABEL machinen.config='${configJson}'
 LABEL machinen.checkpoint-id='${checkpointId}'
 LABEL machinen.original-image='${originalImage}'
@@ -864,7 +864,7 @@ export function restoreLocally(imageTag, containerName) {
   try {
     dockerExec(["rm", "-f", "machinen-tmp"]);
   } catch {}
-  dockerExec(["create", "--name", "machinen-tmp", imageTag]);
+  dockerExec(["create", "--name", "machinen-tmp", imageTag, "/nonexistent"]);
 
   const checkpointDir = `/var/lib/docker/containers/${newContainerId}/checkpoints/${checkpointId}`;
 

--- a/packages/sdk/src/docker.ts
+++ b/packages/sdk/src/docker.ts
@@ -22,6 +22,38 @@ export function reconnectDocker(host, port) {
 /** Env for tar that suppresses macOS AppleDouble resource fork files (._*). */
 const TAR_ENV = { ...process.env, COPYFILE_DISABLE: "1" };
 
+// Paths purged from the baked-in bind-mount layer before the final commit.
+//
+// DANGER: CRIU restores a live process tree with open file descriptors, mmaps,
+// and filesystem references (pnpm's node_modules is symlinks into the global
+// store, for example).  Anything pruned here will be MISSING on restore.
+// Entries must satisfy ALL of:
+//   1. No running process keeps an open fd or mmap to them.
+//   2. No other file references them (no symlink targets).
+//   3. Their absence only costs a re-fetch at next invocation of the owning tool.
+//
+// Defaults cover only paths that are universally dead weight: rotated log
+// files and apt's .deb cache.  Everything else (language caches, build
+// artifacts) is stack-specific, so devcontainers opt in by setting
+// MACHINEN_PRUNE_PATHS in containerEnv — and they should only list paths
+// they can prove are safe for their own setup.
+export const DEFAULT_PRUNE_PATHS = [
+  "/var/log/*.gz",
+  "/var/log/*.1",
+  "/var/cache/apt/archives/*.deb",
+];
+
+/** Read MACHINEN_PRUNE_PATHS from container env and merge with defaults. */
+export function resolvePrunePaths(containerEnv: string[] = []): string[] {
+  const prefix = "MACHINEN_PRUNE_PATHS=";
+  const raw = containerEnv.find((e) => e.startsWith(prefix))?.slice(prefix.length) ?? "";
+  const extra = raw
+    .split(/[\n,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return [...DEFAULT_PRUNE_PATHS, ...extra];
+}
+
 /** Run a docker CLI command without shell interpolation. */
 export function dockerExec(args, opts: Record<string, any> = {}) {
   return execFileSync("docker", args, { stdio: "pipe", encoding: "utf-8", ...opts });
@@ -615,6 +647,19 @@ export async function prepareCheckpoint(containerName, { stop = false } = {}) {
       );
       console.log(`Restored bind mount into image: ${containerPath}`);
     }
+    // Purge rebuildable caches and host-keyed session state from the baked
+    // layer so they don't bloat every push.  Defaults cover OS ephemera;
+    // devcontainers extend via MACHINEN_PRUNE_PATHS in containerEnv.
+    const prunePaths = resolvePrunePaths(info.Config?.Env ?? []);
+    try {
+      dockerExec([
+        "exec",
+        cleanName,
+        "sh",
+        "-c",
+        `rm -rf ${prunePaths.join(" ")} 2>/dev/null || true`,
+      ]);
+    } catch {}
     console.log("Re-committing with workspace files...");
     dockerExec(["commit", cleanName, commitImage]);
     dockerExec(["rm", "-f", cleanName]);

--- a/packages/sdk/src/operations.ts
+++ b/packages/sdk/src/operations.ts
@@ -184,8 +184,10 @@ export async function freeze(
 
   onProgress?.("freeze-start", { containerName });
 
+  let t0 = performance.now();
   const { config, commitImage, cleanName, containerId, checkpointId, tmpDir, tarPath } =
     await prepareCheckpoint(containerName, { stop: !keepAlive });
+  onProgress?.("step-complete", { step: "checkpoint", durationMs: performance.now() - t0 });
 
   try {
     const prefix = `${registry}/machinen/${containerName}`;
@@ -196,9 +198,12 @@ export async function freeze(
 
     dockerExec(["tag", commitImage, baseTag]);
     dockerExec(["tag", commitImage, baseLatestTag]);
+    t0 = performance.now();
     pushImage(baseTag);
     pushImage(baseLatestTag);
+    onProgress?.("step-complete", { step: "push base image", durationMs: performance.now() - t0 });
 
+    t0 = performance.now();
     buildCheckpointImage(
       tarPath,
       commitImage,
@@ -209,10 +214,19 @@ export async function freeze(
       baseLatestTag,
       containerId,
     );
+    onProgress?.("step-complete", {
+      step: "build checkpoint image",
+      durationMs: performance.now() - t0,
+    });
     dockerExec(["tag", tag, latestTag]);
 
+    t0 = performance.now();
     pushImage(tag);
     pushImage(latestTag);
+    onProgress?.("step-complete", {
+      step: "push checkpoint image",
+      durationMs: performance.now() - t0,
+    });
 
     onProgress?.("freeze-complete", { tag, checkpointId });
     return { tag, checkpointId };
@@ -290,17 +304,28 @@ export async function restore(
 
   if (local) {
     onProgress?.("restore-start", { containerName, imageTag, target: "local" });
+    let t0 = performance.now();
     pullImage(imageTag);
+    onProgress?.("step-complete", {
+      step: "pull checkpoint image",
+      durationMs: performance.now() - t0,
+    });
     const restoredName = `${containerName}-restored`;
+    t0 = performance.now();
     restoreLocally(imageTag, restoredName);
+    onProgress?.("step-complete", { step: "restore", durationMs: performance.now() - t0 });
     onProgress?.("restore-complete", { restoredName, target: "local" });
     return { restoredName };
   }
 
   onProgress?.("restore-start", { containerName, imageTag, target: "remote" });
+  let t0 = performance.now();
   const ip = await provisionServer({ name: containerName });
+  onProgress?.("step-complete", { step: "provision server", durationMs: performance.now() - t0 });
   remoteDockerLogin(sshScript, ip);
+  t0 = performance.now();
   remoteRestore(ip, containerName, imageTag, registry);
+  onProgress?.("step-complete", { step: "remote restore", durationMs: performance.now() - t0 });
   onProgress?.("restore-complete", { ip, target: "remote" });
   return { ip };
 }

--- a/packages/sdk/src/preflight.ts
+++ b/packages/sdk/src/preflight.ts
@@ -54,11 +54,15 @@ async function ensurePreflightImage() {
     execSync(`docker image inspect ${PREFLIGHT_IMAGE}`, { stdio: "pipe" });
     return;
   } catch {}
+  const t0Pull = performance.now();
   execSync("docker pull alpine", { stdio: "pipe" });
+  console.log(`  pull alpine: ${((performance.now() - t0Pull) / 1000).toFixed(1)}s`);
+  const t0Build = performance.now();
   execSync(`docker build -t ${PREFLIGHT_IMAGE} -`, {
     stdio: "pipe",
     input: `FROM alpine\nRUN apk add -q --no-cache tmux\n`,
   });
+  console.log(`  build preflight image: ${((performance.now() - t0Build) / 1000).toFixed(1)}s`);
 }
 
 async function testCheckpointWorks(docker) {
@@ -80,6 +84,7 @@ async function testCheckpointWorks(docker) {
 
     // Test with tmux — the patched CRIU is required to checkpoint containers
     // with PTY sessions (removes the tty_verify_ctty pid_real check).
+    const t0Create = performance.now();
     container = await docker.createContainer({
       Image: PREFLIGHT_IMAGE,
       name: testName,
@@ -89,35 +94,56 @@ async function testCheckpointWorks(docker) {
       HostConfig: { SecurityOpt: ["seccomp=unconfined"], NetworkMode: "host" },
     });
     await container.start();
+    console.log(`  create + start test container: ${((performance.now() - t0Create) / 1000).toFixed(1)}s`);
 
     // Wait for setup to complete: once `exec sleep 300` runs, the shell has
     // been replaced and there are no lingering TCP sockets.
+    const t0Setup = performance.now();
     const setupDeadline = Date.now() + 30_000;
+    let lastErr = "";
+    let ready = false;
     while (Date.now() < setupDeadline) {
       try {
-        const top = execSync(`docker exec ${testName} ps -o comm= -p 1`, {
+        // Read /proc/1/comm — BusyBox ps in alpine doesn't support `-p`, so
+        // `ps -o comm= -p 1` always errors and the loop used to burn the full
+        // 30s deadline even though pid 1 reaches 'sleep' in ~50ms.
+        const top = execSync(`docker exec ${testName} cat /proc/1/comm`, {
           stdio: "pipe",
           encoding: "utf-8",
         }).trim();
         if (top === "sleep") {
+          ready = true;
           break;
         }
-      } catch {}
-      await new Promise((r) => setTimeout(r, 500));
+      } catch (err) {
+        lastErr = err.message || String(err);
+      }
+      await new Promise((r) => setTimeout(r, 100));
     }
+    const setupMs = performance.now() - t0Setup;
+    if (!ready) {
+      throw new Error(
+        `Test container did not reach 'sleep' state in 30s.${lastErr ? ` Last error: ${lastErr.split("\n")[0]}` : ""}`,
+      );
+    }
+    console.log(`  wait for container setup: ${(setupMs / 1000).toFixed(1)}s`);
 
     // Use the Docker API (not CLI) to create the checkpoint.  The API stores
     // files at /var/lib/docker/containers/<id>/checkpoints/<cpId>/ inside DiND
     // and also commits checkpoint blobs to containerd.  We purge those blobs
     // immediately so that docker start --checkpoint can commit them fresh
     // without hitting "content sha256:...: already exists".
+    const t0Checkpoint = performance.now();
     const { checkpointId: cpId } = await createCheckpoint(testName, { exit: true });
     checkpointId = cpId;
+    console.log(`  create checkpoint (CRIU): ${((performance.now() - t0Checkpoint) / 1000).toFixed(1)}s`);
 
     pruneContainerdCheckpoints();
 
     // Restore the same container from its checkpoint.
+    const t0Restore = performance.now();
     execSync(`docker start --checkpoint ${checkpointId} ${testName}`, { stdio: "pipe" });
+    console.log(`  restore checkpoint (CRIU): ${((performance.now() - t0Restore) / 1000).toFixed(1)}s`);
 
     return true;
   } catch (err) {
@@ -163,6 +189,19 @@ export async function checkPrerequisites(_docker, opts: Record<string, any> = {}
   const { hostname, port } = new URL(diNDHost);
   reconnectDocker(hostname, parseInt(port, 10));
   // `docker` is a live ESM binding — it now points to the DiND inner daemon.
+
+  // The internal TCP check in ensureDiND verifies the listener from *inside*
+  // DiND, but host-side port forwarding (Docker Desktop / OrbStack) may still
+  // be settling.  Retry from the host before proceeding.
+  const tcpDeadline = Date.now() + 30_000;
+  while (Date.now() < tcpDeadline) {
+    try {
+      execSync(`docker info`, { stdio: "pipe", timeout: 5000 });
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
 
   console.log("Testing if docker checkpoint works...");
   if (!(await testCheckpointWorks(docker))) {

--- a/packages/sdk/src/preflight.ts
+++ b/packages/sdk/src/preflight.ts
@@ -94,7 +94,9 @@ async function testCheckpointWorks(docker) {
       HostConfig: { SecurityOpt: ["seccomp=unconfined"], NetworkMode: "host" },
     });
     await container.start();
-    console.log(`  create + start test container: ${((performance.now() - t0Create) / 1000).toFixed(1)}s`);
+    console.log(
+      `  create + start test container: ${((performance.now() - t0Create) / 1000).toFixed(1)}s`,
+    );
 
     // Wait for setup to complete: once `exec sleep 300` runs, the shell has
     // been replaced and there are no lingering TCP sockets.
@@ -136,14 +138,18 @@ async function testCheckpointWorks(docker) {
     const t0Checkpoint = performance.now();
     const { checkpointId: cpId } = await createCheckpoint(testName, { exit: true });
     checkpointId = cpId;
-    console.log(`  create checkpoint (CRIU): ${((performance.now() - t0Checkpoint) / 1000).toFixed(1)}s`);
+    console.log(
+      `  create checkpoint (CRIU): ${((performance.now() - t0Checkpoint) / 1000).toFixed(1)}s`,
+    );
 
     pruneContainerdCheckpoints();
 
     // Restore the same container from its checkpoint.
     const t0Restore = performance.now();
     execSync(`docker start --checkpoint ${checkpointId} ${testName}`, { stdio: "pipe" });
-    console.log(`  restore checkpoint (CRIU): ${((performance.now() - t0Restore) / 1000).toFixed(1)}s`);
+    console.log(
+      `  restore checkpoint (CRIU): ${((performance.now() - t0Restore) / 1000).toFixed(1)}s`,
+    );
 
     return true;
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 22.19.17
       '@typescript/native-preview':
         specifier: ^7.0.0-dev
-        version: 7.0.0-dev.20260408.1
+        version: 7.0.0-dev.20260414.1
       oxfmt:
         specifier: 0.33.0
         version: 0.33.0
@@ -34,7 +34,7 @@ importers:
         version: 1.48.0
       tsup:
         specifier: ^8
-        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4
         version: 4.21.0
@@ -43,7 +43,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.17)(vite@8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -55,12 +55,12 @@ importers:
     dependencies:
       dockerode:
         specifier: ^4.0.4
-        version: 4.0.9
+        version: 4.0.10
 
 packages:
 
-  '@actions/expressions@0.3.49':
-    resolution: {integrity: sha512-KoGwOCYgfQr0UXngrU3ysO7HhqgHVQmcjro4+6iYnvcFmDELiLFslIZ0z4iZwqTZmUP4QcpVt7zY78uUK6BftA==}
+  '@actions/expressions@0.3.51':
+    resolution: {integrity: sha512-cnFC8OkfMUpb8qYOKKJW7j+8WnkcA8Nz3cGTnezX6K2B0UBvAWDF6rjDFDCcLcYhcK3+TNJsQsxkMDHRBHdUmw==}
     engines: {node: '>= 20'}
 
   '@actions/workflow-parser@0.3.43':
@@ -146,14 +146,14 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -398,8 +398,11 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nkzw/eslint-plugin@2.0.0':
     resolution: {integrity: sha512-IoU8kOqHfnf7se2dGxMD/7RPm6WVjzjOjWSo7FulRx3lJzuZvXioSkT5Nd82l66DH3Pl2whw74lPT1di3KMwFA==}
@@ -411,8 +414,8 @@ packages:
     peerDependencies:
       oxlint: '>=1.46.0'
 
-  '@oxc-project/types@0.120.0':
-    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@oxfmt/binding-android-arm-eabi@0.33.0':
     resolution: {integrity: sha512-ML6qRW8/HiBANteqfyFAR1Zu0VrJu+6o4gkPLsssq74hQ7wDMkufBYJXI16PGSERxEYNwKxO5fesCuMssgTv9w==}
@@ -696,103 +699,103 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
-    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
-    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.10':
-    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -965,110 +968,110 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
-  '@typescript-eslint/project-service@8.58.1':
-    resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.58.1':
-    resolution: {integrity: sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==}
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.58.1':
-    resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.58.1':
-    resolution: {integrity: sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.58.1':
-    resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.58.1':
-    resolution: {integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==}
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.58.1':
-    resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-YcPczNLfPDB13eUBYHkTOkL7HyWqqqEhho4eSxhAvigZuxvtHQ1uyILIvLVAwipEVzhJ8QciKmLdLucpfi4XyA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-O7h9lNcE9YMA2TKw1YX9GZO3K/Kb1FUmxjEJAfBFvjQhGydIk4oNsuoOQ3RQHVvebCdFjNroZzoIXNeR3ceCdA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-cHqkDg53xxxz21MThLBf4vx1kyIpRPEYNdEiQlvu9O35Tth49+aub6F+/YEMd9MG4TYZmxh1bEjkjErTUIElpA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-ax7OUrIaIIay+yI9EhavXmsnO+79AdFVv/N3ZibC11LBixJXaYhfTyFikQL5IyMkfoKm3oBQ0tHyI0xMkS+9tA==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-iHG0FEXq/QFsn+qlTPllxdcbvfQ9aRYggy4lc1z0+f11Nyk4YDNCSiR8WW7pbnOTx/VreGbbXhlpuJXTidqL8g==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-oGAWMCw6JZ27+LBZlLEg8NGHZyIFPx9YUNYCaDcX3Z9dGh6ZPeD7uIaBiw7JZ0fh05sgK6DZBsAz5nWnnSvc7Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-w26Gv9yq9LIYIhxjkQC+i0wBPDdQdX+H06ZhyVRL5grKWTIsk9Xwjp9mDRB/dGlXBKcvnM25JH16OyAA0rFH3A==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-0gYz37o/hr5PAlsABXbai2D1sPioB9pMy2Ft4leF/Rc6qq4QVuyLPE+QbXgu/2k4I0YWud2On6k4+kEobXK9qA==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-hMcUlUIzYbvbdq6j/B4RPL+kZR917NGnE9AgPZ7dJ92yamH/7LGT1Mnlc6McUx31yqTFBFHdTc7Cfx+ynua7Iw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-9YnVwJoiu6w8m7g+Q7AQECz9nxieKGIRFeibmQ1MnF+lEtnXFZMLJWkNzE+Jt2UXIkKZBvVT3VDgmpExzeHGBA==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-avJWIEKSx4rdBLZD1FOOTuxTU51dQfYb3jZvZMaXD4thJjq+6eSwfzu2elwL36AZDlnaxggGjB5nBxp0t54iOA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-Sjm40DJk62e+aR8EblKwlX/KsTJlYgg+EwSi9FPGsi3YY+BSoM6kQ6NF7FmE41FEOqRyuWom0ap9CqXIwosBOg==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-gpvEHkF/WoxkA3711c4uWNCZO9WAuwrq49COdNwxgOTzYHnMc1yCj8CpkCUJwU0f/Ydwp2s6/efn6gTMvtckPg==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-TMgYk82tvehQjze0mdo2CUSXYkh7ZOqxewLVqGAHsAG5QFPEZ+8qSbGwTytznOs9wL4V2rrbziL6psGonJoBxw==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260408.1':
-    resolution: {integrity: sha512-N0MZLEUnAoP/aRVk7MY119LDsESkbtEwIw+YeXi/jjx2XCqf7ni3GxIVsUYtf/troyuSedq3V/OUrkoCh5A9gA==}
+  '@typescript/native-preview@7.0.0-dev.20260414.1':
+    resolution: {integrity: sha512-b9C7ZVKSGCF1VFvA8UdAKHCGmKOrmm44UwmGgICSQmWg6vseLdElx0F8UvuNsA6risIOXh5hs7Buif+QRrCYuA==}
     hasBin: true
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1126,8 +1129,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.16:
-    resolution: {integrity: sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==}
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1141,11 +1144,11 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -1186,8 +1189,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001787:
-    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1272,12 +1275,12 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  docker-modem@5.0.6:
-    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.9:
-    resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
+  dockerode@4.0.10:
+    resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
     engines: {node: '>= 8.0'}
 
   dtu-github-actions@0.7.1:
@@ -1291,8 +1294,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.334:
-    resolution: {integrity: sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==}
+  electron-to-chromium@1.5.336:
+    resolution: {integrity: sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1727,8 +1730,8 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -1746,8 +1749,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nan@2.25.0:
-    resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1863,8 +1866,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1882,8 +1885,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   raw-body@3.0.2:
@@ -1917,8 +1920,8 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  rolldown@1.0.0-rc.10:
-    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1953,8 +1956,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2057,12 +2060,12 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -2166,14 +2169,14 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  vite@8.0.1:
-    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -2209,21 +2212,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2236,6 +2241,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2302,13 +2311,16 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
-  '@actions/expressions@0.3.49': {}
+  '@actions/expressions@0.3.51': {}
 
   '@actions/workflow-parser@0.3.43':
     dependencies:
-      '@actions/expressions': 0.3.49
+      '@actions/expressions': 0.3.51
       cronstrue: 2.59.0
       yaml: 2.8.3
 
@@ -2418,18 +2430,18 @@ snapshots:
 
   '@devcontainers/cli@0.84.1': {}
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.9.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2609,10 +2621,10 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -2634,7 +2646,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@oxc-project/types@0.120.0': {}
+  '@oxc-project/types@0.124.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.33.0':
     optional: true
@@ -2778,62 +2790,64 @@ snapshots:
   '@redwoodjs/agent-ci@0.7.1':
     dependencies:
       '@actions/workflow-parser': 0.3.43
-      dockerode: 4.0.9
+      dockerode: 4.0.10
       dtu-github-actions: 0.7.1
       log-update: 7.2.0
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.10': {}
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -2951,126 +2965,126 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
-  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.58.1':
+  '@typescript-eslint/scope-manager@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/visitor-keys': 8.58.1
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/types@8.58.1': {}
+  '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/visitor-keys': 8.58.1
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       eslint: 9.39.4
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.58.1':
+  '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260408.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260414.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260408.1':
+  '@typescript/native-preview@7.0.0-dev.20260414.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260408.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260408.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260414.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260414.1
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.0':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
+  '@vitest/spy@4.1.4': {}
 
-  '@vitest/utils@4.1.0':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3117,7 +3131,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.16: {}
+  baseline-browser-mapping@2.10.18: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -3137,26 +3151,26 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.16
-      caniuse-lite: 1.0.30001787
-      electron-to-chromium: 1.5.334
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001788
+      electron-to-chromium: 1.5.336
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3189,7 +3203,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001787: {}
+  caniuse-lite@1.0.30001788: {}
 
   chai@6.2.2: {}
 
@@ -3235,7 +3249,7 @@ snapshots:
   cpu-features@0.0.10:
     dependencies:
       buildcheck: 0.0.7
-      nan: 2.25.0
+      nan: 2.26.2
     optional: true
 
   cronstrue@2.59.0: {}
@@ -3256,7 +3270,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  docker-modem@5.0.6:
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3
       readable-stream: 3.6.2
@@ -3265,12 +3279,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.9:
+  dockerode@4.0.10:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.6
+      docker-modem: 5.0.7
       protobufjs: 7.5.4
       tar-fs: 2.1.4
       uuid: 10.0.0
@@ -3281,7 +3295,7 @@ snapshots:
     dependencies:
       body-parser: 2.2.2
       jsonc-parser: 3.3.1
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       polka: 0.5.2
       zod: 3.25.76
     transitivePeerDependencies:
@@ -3295,7 +3309,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.334: {}
+  electron-to-chromium@1.5.336: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3352,7 +3366,7 @@ snapshots:
 
   eslint-plugin-perfectionist@5.8.0(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -3365,8 +3379,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -3702,13 +3716,13 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@10.2.4:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.14
 
   mkdirp-classic@0.5.3: {}
 
@@ -3727,7 +3741,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nan@2.25.0:
+  nan@2.26.2:
     optional: true
 
   nanoid@3.3.11: {}
@@ -3846,15 +3860,15 @@ snapshots:
       '@polka/url': 0.5.0
       trouter: 2.0.1
 
-  postcss-load-config@6.0.1(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.9
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss@8.5.8:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3884,7 +3898,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -3916,26 +3930,26 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  rolldown@1.0.0-rc.10:
+  rolldown@1.0.0-rc.15:
     dependencies:
-      '@oxc-project/types': 0.120.0
-      '@rolldown/pluginutils': 1.0.0-rc.10
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   rollup@4.60.1:
     dependencies:
@@ -3984,7 +3998,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -4008,7 +4022,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -4033,7 +4047,7 @@ snapshots:
       bcrypt-pbkdf: 1.0.2
     optionalDependencies:
       cpu-features: 0.0.10
-      nan: 2.25.0
+      nan: 2.26.2
 
   stackback@0.0.2: {}
 
@@ -4073,7 +4087,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -4107,9 +4121,9 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -4135,7 +4149,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4146,16 +4160,16 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.9
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -4206,13 +4220,13 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.10
-      tinyglobby: 0.2.15
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.17
       esbuild: 0.27.7
@@ -4220,15 +4234,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.0(@types/node@22.19.17)(vite@8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -4237,10 +4251,10 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -4292,8 +4306,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}

--- a/scripts/Dockerfile.dind
+++ b/scripts/Dockerfile.dind
@@ -20,7 +20,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patchelf \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 https://github.com/checkpoint-restore/criu.git /criu
+# Pin CRIU to the exact SHA that produced a successful local restore on
+# Mar 27 2026 — recovered from an old runc restore.log inside a DinD volume
+# ("Version: 4.2 (gitid 7539f39)").  Previously unpinned `--depth 1 main`, so
+# rebuilds silently picked up newer CRIU commits over time.  Bump this
+# deliberately after regression-testing the new commit against a full
+# freeze → push → pull → restore cycle.
+ARG CRIU_SHA=7539f399
+RUN git clone https://github.com/checkpoint-restore/criu.git /criu && \
+    cd /criu && git checkout ${CRIU_SHA}
 
 COPY patch-criu.py /tmp/patch-criu.py
 RUN python3 /tmp/patch-criu.py /criu/criu/tty.c

--- a/scripts/machinen-dev.sh
+++ b/scripts/machinen-dev.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+pnpm build
+# Strip leading "--" that pnpm injects before forwarded args
+[[ "${1:-}" == "--" ]] && shift
+node packages/cli/dist/machinen.js "$@"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "agent-ci": {
+      "source": "redwoodjs/agent-ci",
+      "sourceType": "github",
+      "computedHash": "eb25909e47bde2b32f594b4069192595ec854754b198df3bfd2278a8978e2e48"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### Restore finally works

- Local and remote `machinen restore` were broken for weeks (since late March per `~/.machinen/logs/`)
- Surfaced as a generic `criu failed: type RESTORE errno 0: unknown` — misleading, CRIU itself was fine
- Real cause: pid 1 inherited dockerd's stdio as anonymous pipe inodes, captured unrestorably in `descriptors.json`
- Fix: devcontainer Dockerfile CMD redirects pid 1's stdio to `/dev/null` before the sleep loop
- Verified local + remote now restore with original tmux/bash pids preserved (proves the process tree was genuinely restored, not freshly booted)

### Preflight is ~30× faster

- `wait for container setup` dropped from **30.1s → 0.0s**
- Root cause: BusyBox `ps` in alpine doesn't support `-p`, so the probe errored on every poll and the loop always hit its 30s deadline
- Fix: probe `cat /proc/1/comm` instead

### Freeze base layer ~420MB smaller

- Dropped the `~/.claude` bind mount (was baking in ~440MB of unrelated Claude Code session state)
- Added `MACHINEN_PRUNE_PATHS` env var so each devcontainer can opt into purging rebuildable caches/logs before the final commit

### Reproducibility

- **CRIU pinned** to `7539f399` — the last SHA that produced a demonstrably successful local restore (recovered from a Mar 27 `restore.log`). Was previously unpinned `--depth 1 main`
- **Checkpoint images now `FROM scratch`** instead of `FROM ${originalImage}`. They only carry the CRIU dump; the base fs lives in the separate `:base` tag. Requires passing `/nonexistent` to `docker create` since scratch has no default Cmd

### DinD robustness

- OrbStack detection — uses bridge IP instead of `localhost:2375` (which hangs on OrbStack after host-process restarts)
- Host-side TCP health recheck on DinD reuse
- Step timings during `ensureDiND`

### Developer experience

- Per-step timings during freeze/restore via `step-complete` progress events
- `pnpm machinen-dev` script rebuilds + runs the CLI in one shot
- Agent tooling state tracked (`.agents/`, `.claude/skills/`, `.factory/`, `skills-lock.json`)

### Documentation

- `.docs/architecture/pid1-stdio-restore.md` writes up the pipe-inode gotcha in plain language so future-us doesn't re-diagnose from scratch

## Test plan

- [x] `npx vitest run` — 37 passed / 3 todo (+5 new tests for `resolvePrunePaths`)
- [x] `machinen up --detach` — new Dockerfile builds; `/proc/1/fd/{0,1,2}` all point at `/dev/null`
- [x] `machinen freeze --keep-alive` — succeeds, pushes to ghcr.io
- [x] `machinen restore --local` — container runs, tmux/bash preserved at original pids
- [x] `machinen restore --remote` — Hetzner provisions, restore completes in ~68s, same preserved-pid verification
- [ ] `npx agent-ci run --workflow .github/workflows/e2e.yml -q` — fails with pre-existing `docker.sock` permission issue in agent-ci sandbox; identical failure on clean `main`, unrelated to this branch
