### PR TITLE
try.sh workspace DIR — cpio a host directory into /workspace

### DIFF
--- a/packages/microvm/test-fixtures/mkinitramfs.py
+++ b/packages/microvm/test-fixtures/mkinitramfs.py
@@ -5,9 +5,20 @@ Newc cpio format, built byte-for-byte so we can include device nodes
 that macOS's native cpio tooling can't produce.
 
 Modes:
-  minimal           — tiny cpio with our hand-written /init + /dev/console.
-  --rootfs <dir>    — wrap an already-extracted Alpine-style rootfs, then
-                      overlay our /init and ensure /dev/console exists.
+  minimal                       — tiny cpio with our hand-written /init
+                                  + /dev/console.
+  --rootfs <dir>                — wrap an already-extracted Alpine-style
+                                  rootfs, then overlay our /init and
+                                  ensure /dev/console exists.
+  --workspace <dir> --out PATH  — emit a cpio containing only the files
+                                  under <dir>, rooted at /workspace. Meant
+                                  to be concatenated after the base
+                                  initramfs.cpio so the kernel's multi-cpio
+                                  unpacker drops the workspace into tmpfs
+                                  at /workspace. No trailer — the kernel
+                                  ignores everything after the trailer in
+                                  the base archive; we write one trailer
+                                  at the END of the concatenated stream.
 """
 import os, stat, struct, sys
 from pathlib import Path
@@ -72,8 +83,125 @@ def entries_from_rootfs(root: Path):
     yield newc(".", 0o40755)
     yield from walk("")
 
+DEFAULT_EXCLUDES = {
+    ".git",
+    "node_modules",
+    ".zig-cache",
+    "target",             # Rust
+    "dist",               # built artifacts
+    "build",              # CMake / autotools
+    "__pycache__",
+    ".venv", "venv",
+    ".DS_Store",
+    ".next", ".nuxt",     # framework caches
+    ".cache",
+    ".turbo",
+    ".pnpm-store",
+}
+
+
+def workspace_cpio(src: Path, mountpoint: str = "workspace", excludes=None):
+    """Yield cpio bytes for everything under `src`, rooted at `/<mountpoint>`.
+
+    This is appended to the base initramfs.cpio; the Linux kernel's
+    initramfs unpacker merges multiple concatenated cpio archives into
+    the same rootfs tmpfs. We emit NO trailer here — the caller writes
+    one trailer at the end of the whole stream.
+
+    `excludes` is a set of directory/file names to skip (matched by
+    basename at every level). Defaults to DEFAULT_EXCLUDES, which is
+    the usual "don't ship my 700 MB node_modules into a tmpfs" list.
+    """
+    ex = set(DEFAULT_EXCLUDES) if excludes is None else set(excludes)
+    yield newc(mountpoint, 0o40755)
+    root = str(src)
+
+    total_bytes = 0
+
+    def walk(rel):
+        nonlocal total_bytes
+        full = os.path.join(root, rel) if rel else root
+        try:
+            entries = sorted(os.listdir(full))
+        except (OSError, FileNotFoundError):
+            return
+        for name in entries:
+            if name in ex:
+                continue
+            child_rel = os.path.join(rel, name) if rel else name
+            child_full = os.path.join(full, name)
+            arc_name = f"{mountpoint}/{child_rel}"
+            try:
+                st = os.lstat(child_full)
+            except FileNotFoundError:
+                continue
+            m = st.st_mode
+            if stat.S_ISLNK(m):
+                target = os.readlink(child_full).encode()
+                yield newc(arc_name, 0o120000 | (m & 0o7777), data=target)
+            elif stat.S_ISDIR(m):
+                yield newc(arc_name, 0o40000 | (m & 0o7777))
+                yield from walk(child_rel)
+            elif stat.S_ISREG(m):
+                with open(child_full, "rb") as fh:
+                    data = fh.read()
+                total_bytes += len(data)
+                yield newc(arc_name, 0o100000 | (m & 0o7777), data=data)
+
+    yield from walk("")
+    # Reveal the size so the try.sh caller can sanity-check.
+    print(f"  workspace files: {total_bytes} bytes", file=sys.stderr)
+
+
 def main():
     args = sys.argv[1:]
+    # --workspace <dir> --out <path> [--exclude NAME]... [--max-mb N]
+    if args and args[0] == "--workspace":
+        src = Path(args[1]).resolve()
+        out = None
+        extra_ex = set()
+        max_mb = 500  # sensible default: initramfs lives in tmpfs
+        i = 2
+        while i < len(args):
+            if args[i] == "--out":
+                out = Path(args[i + 1]).resolve()
+                i += 2
+            elif args[i] == "--exclude":
+                extra_ex.add(args[i + 1])
+                i += 2
+            elif args[i] == "--max-mb":
+                max_mb = int(args[i + 1])
+                i += 2
+            else:
+                print(f"unknown flag: {args[i]}", file=sys.stderr)
+                sys.exit(2)
+        if out is None:
+            print("--workspace requires --out <path>", file=sys.stderr)
+            sys.exit(2)
+        if not src.is_dir():
+            print(f"--workspace: {src} is not a directory", file=sys.stderr)
+            sys.exit(2)
+        print(f"packing workspace: {src} -> {out}", file=sys.stderr)
+        excludes = DEFAULT_EXCLUDES | extra_ex
+        parts = list(workspace_cpio(src, excludes=excludes))
+        # Size cap — the workspace lands in tmpfs and 4 GB of guest
+        # RAM also has to hold the base rootfs + kernel. Fail loudly
+        # rather than OOM the guest silently.
+        total = sum(len(p) for p in parts)
+        cap = max_mb * 1024 * 1024
+        if total > cap:
+            print(
+                f"workspace is {total / 1024 / 1024:.0f} MB "
+                f"(cap {max_mb} MB). Try --exclude <dir> for each big subdir, "
+                f"or --max-mb <N> to raise the cap.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        parts.append(newc("TRAILER!!!", 0))
+        out.write_bytes(b"".join(parts))
+        print(f"wrote {out} ({out.stat().st_size} bytes)", file=sys.stderr)
+        return
+
     if args and args[0] == "--rootfs":
         root = Path(args[1]).resolve()
         print(f"packing rootfs: {root}")

--- a/packages/microvm/test-fixtures/try.sh
+++ b/packages/microvm/test-fixtures/try.sh
@@ -2,10 +2,11 @@
 # Boot the microVM in one of a handful of ready-made modes.
 #
 # Usage:
-#   ./test-fixtures/try.sh shell   # interactive bash prompt inside the guest
-#   ./test-fixtures/try.sh repl    # interactive Node.js REPL (type JS live)
-#   ./test-fixtures/try.sh criu    # CRIU freeze/restore demo (counter 5 → 9)
-#   ./test-fixtures/try.sh vsock   # virtio-vsock echo server + host round-trip
+#   ./test-fixtures/try.sh shell            # interactive bash prompt inside the guest
+#   ./test-fixtures/try.sh repl             # interactive Node.js REPL (type JS live)
+#   ./test-fixtures/try.sh criu             # CRIU freeze/restore demo
+#   ./test-fixtures/try.sh vsock            # virtio-vsock echo server + host round-trip
+#   ./test-fixtures/try.sh workspace DIR    # shell with DIR mounted at /workspace
 #   ./test-fixtures/try.sh --help
 #
 # What this actually does:
@@ -28,9 +29,26 @@ case "$MODE" in
         awk '/^$/{exit} NR>1{sub(/^# ?/, ""); print}' "$0"
         exit 0
         ;;
-    repl|criu|criu\ demo|criu-demo|shell|sh|bash|vsock) ;;
-    *) die "unknown mode: $MODE (try: repl | criu | shell | vsock)" ;;
+    repl|criu|criu\ demo|criu-demo|shell|sh|bash|vsock|workspace) ;;
+    *) die "unknown mode: $MODE (try: repl | criu | shell | vsock | workspace)" ;;
 esac
+
+# `workspace <DIR> [--exclude NAME ...]` — shell boot with the host DIR
+# cpio'd onto /workspace. Remaining args after DIR pass through as
+# additional excludes (default excludes already cover node_modules,
+# .git, etc).
+WORKSPACE_DIR=""
+WORKSPACE_EXTRA=()
+if [[ "$MODE" == "workspace" ]]; then
+    WORKSPACE_DIR=${2:-}
+    [[ -n "$WORKSPACE_DIR" ]] || die "workspace: need a directory. usage: try.sh workspace <DIR> [--exclude NAME]..."
+    WORKSPACE_DIR=$(cd "$WORKSPACE_DIR" && pwd)
+    [[ -d "$WORKSPACE_DIR" ]] || die "workspace: $WORKSPACE_DIR is not a directory"
+    shift 2 || true
+    WORKSPACE_EXTRA=("$@")
+    # Reuse the shell mode's demo.sh + raw-mode handling.
+    MODE=shell
+fi
 
 # Resolve the microvm package root.
 HERE=$(cd "$(dirname "$0")/.." && pwd)
@@ -190,8 +208,13 @@ echo "  netup                         # bring eth0 up with static IP + DNS"
 echo "  http https://example.com      # tiny Python HTTP client (curl isn't here)"
 echo "  claude --version              # (CC is already installed)"
 echo "  ls /dev/vda                   # virtio-blk disk (if test-fixtures/disk.img exists)"
+if [ -d /workspace ]; then
+    echo "  cd /workspace                 # your host dir, cpio'd in on boot"
+fi
 echo "  exit or Ctrl-D                # quit (kernel will panic — expected)"
 echo ""
+# Drop into /workspace when it was cpio'd in (try.sh workspace mode).
+[ -d /workspace ] && cd /workspace
 exec /bin/bash --login
 SH
         ;;
@@ -202,6 +225,24 @@ chmod +x "$ROOTFS/demo.sh"
 # --- repack + build ------------------------------------------------
 echo "==> repacking initramfs"
 python3 "$FIXTURES/mkinitramfs.py" --rootfs "$ROOTFS" | tail -1
+
+# If the user asked for `workspace <DIR>`, append a second cpio slice
+# with the host directory rooted at /workspace. The Linux kernel's
+# initramfs unpacker merges concatenated cpio archives in order.
+if [[ -n "$WORKSPACE_DIR" ]]; then
+    WS_CPIO=$FIXTURES/workspace.cpio
+    echo "==> packing workspace: $WORKSPACE_DIR -> /workspace"
+    # Forward any extra args from try.sh (--exclude NAME, --max-mb N).
+    # Bash: the idiom below expands to nothing (not an empty string)
+    # when the array is empty under `set -u`.
+    if [[ ${#WORKSPACE_EXTRA[@]} -gt 0 ]]; then
+        python3 "$FIXTURES/mkinitramfs.py" --workspace "$WORKSPACE_DIR" --out "$WS_CPIO" "${WORKSPACE_EXTRA[@]}"
+    else
+        python3 "$FIXTURES/mkinitramfs.py" --workspace "$WORKSPACE_DIR" --out "$WS_CPIO"
+    fi
+    cat "$WS_CPIO" >> "$FIXTURES/initramfs.cpio"
+    rm -f "$WS_CPIO"
+fi
 
 echo "==> building VMM test binary"
 zig build test >/dev/null 2>&1 || true   # boot test is skip-by-default; that's fine


### PR DESCRIPTION
## Summary

Fastest path to "try Claude Code on my actual code, right now."

`./packages/microvm/test-fixtures/try.sh workspace ~/path/to/code` → boot the existing shell mode with the host directory packed into a cpio slice rooted at `/workspace`. Guest auto-cd's on shell entry.

Discussed in-thread; this is option #2 from the workspace-story choices. Option #3 (bidirectional vsock file-transfer agent — push/pull artifacts without a reboot) is tracked in #57.

## Why cpio-concat and not `mkfs.ext4` + loopback

- `mkfs.ext4` isn't on macOS by default (`brew install e2fsprogs` required); cpio is Python-native.
- No mount/umount dance on the host.
- Linux kernel natively supports concatenated cpio archives as initramfs — the second slice drops straight into tmpfs.

**Tradeoff**: changes don't persist back to the host on shutdown. Fine for "let CC rewrite these files and tell me what it changed" loops where you git-commit inside the guest. For live bidirectional sync, see #57 + a future virtiofs issue.

## What's in

- **`mkinitramfs.py --workspace DIR --out PATH`** — emits a standalone cpio slice rooted at `/workspace`, meant to be appended after the base `initramfs.cpio`.
  - Default excludes: `.git`, `node_modules`, `.zig-cache`, `target`, `dist`, `build`, `__pycache__`, `.venv`/`venv`, `.DS_Store`, `.next`/`.nuxt`, `.cache`, `.turbo`, `.pnpm-store`.
  - `--exclude NAME` (repeatable) adds more.
  - `--max-mb N` cap (default 500 MB); exits 3 with actionable advice if the cpio would exceed.
- **`try.sh workspace DIR [--exclude NAME]...`** — reuses shell mode's demo.sh + raw TTY + netup/http helpers, appends the workspace cpio before the VMM starts. Guest's demo.sh auto-cd's into `/workspace` when it's present.

## Test plan

- [x] End-to-end: `try.sh workspace ~/some/code` → shell drops into `microvm:/workspace#`, files present.
- [x] Size cap trips cleanly: pointing at a 1.1 GB dir → exit code 3 with actionable message.
- [x] Default excludes keep things sane (node_modules etc. don't balloon the image).
- [x] Net smoke: 8/8 still green.
- [x] agent-ci: green in 58 s.
- [ ] GH Actions CI (pending billing).

## Example

```
$ ./packages/microvm/test-fixtures/try.sh workspace ~/gh/foo/bar
==> repacking initramfs
==> packing workspace: /Users/peterp/gh/foo/bar -> /workspace
  workspace files: 2.1 MB
==> booting; wait ~10s for the 'microvm:/#' prompt

microvm:/workspace# ls
LICENSE  README.md  src/  ...
microvm:/workspace# netup
network up: eth0=10.0.2.15, ...
microvm:/workspace# claude -p "what's in this repo?"
# ... CC takes over
```

Follow-up: #57 (vsock push/pull for artifacts out + live updates without reboot).
