### PR TITLE
boot_kvm.zig — Linux backend boot path (#50/#45)

### DIFF
--- a/.docs/learnings/microvm/kvm-backend.md
+++ b/.docs/learnings/microvm/kvm-backend.md
@@ -80,17 +80,43 @@ Equivalent to what `hvf.test.hv_vm_create and destroy` +
 `hvf.test.map a page, run hvc #0, observe exception exit` gave us
 on macOS.
 
-## What this commit doesn't do
+## `boot_kvm.zig` (now present)
 
-- **Boot Linux under KVM.** The boot path needs vgic_v3 setup,
-  MMIO routing to virtio + PL011 stubs, interrupt injection for
-  the arm timer + UART. That's `boot_kvm.zig` and it's substantial.
-- **CI exercising KVM.** GitHub ubuntu-latest is x86_64. To run
-  the arm64 guest under KVM we need an arm64 Linux runner (Oracle
-  Ampere free tier, Graviton, or a self-hosted runner on an M-series
-  Mac running Asahi or a nested arm64 Linux). Scaffold shows zig
-  compiles + unit tests pass on Linux already — that's the short-term
-  CI win.
+Parallel of `boot.zig` on the Linux side. Same kernel, same DTS,
+same rootfs, same boot protocol. Differences are all local to this
+file:
+
+- Memory via `KVM_SET_USER_MEMORY_REGION` instead of `hv_vm_map`.
+- In-kernel vgic-v3 via `KVM_CREATE_DEVICE` + `KVM_DEV_ARM_VGIC_GRP_ADDR`
+  for distributor (0x0800_0000) + redistributor (0x1000_0000),
+  `KVM_DEV_ARM_VGIC_CTRL_INIT` after vCPUs exist.
+- PSCI in-kernel: `KVM_ARM_VCPU_PSCI_0_2` feature bit on
+  `KVM_ARM_VCPU_INIT`. HVC #0 calls from the guest are served by
+  the kernel; we only see `KVM_EXIT_SYSTEM_EVENT` on shutdown/reset.
+- Arm virtual timer is built into KVM — no host-side plumbing.
+- PL011 via `pl011.zig` (shared with HVF), driven by
+  `KVM_EXIT_MMIO` events. `writeMmioReadData` on the Vcpu pokes
+  the read-back value into `kvm_run.mmio.data[...]` before the
+  next `KVM_RUN`.
+- Virtio not wired yet — currently reads return 0. Enough to watch
+  the kernel boot through console; devices follow.
+
+## What this still doesn't do
+
+- **Exercise the KVM path at runtime.** Our CI + the local Proxmox
+  are both x86_64; KVM on x86 can't host an arm64 guest (different
+  ISA). The test skips gracefully on non-arm64 hosts. Actually
+  running the boot needs an arm64 Linux host — Oracle Ampere free
+  tier, AWS Graviton, Hetzner arm64, or Asahi Linux on an M-series
+  Mac are the cheapest/most-accessible paths. Once one of those is
+  available: `MACHINEN_BOOT_TEST=1 zig build test` exercises the
+  boot end-to-end.
+- **Virtio (net/blk/vsock) under KVM.** The device models are
+  already pure-Zig and platform-agnostic; wiring them up behind
+  `KVM_EXIT_MMIO` is mechanical. Skipped in the scaffold to keep
+  the first boot commit focused.
+- **Multi-vCPU.** Just 1 vCPU today. KVM requires creating all
+  vCPUs before `GIC.finalize()`; easy extension later.
 
 ## Why compile-time \_IOC over hand-hex constants
 

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -1,0 +1,354 @@
+//! Boot an arm64 Linux kernel under KVM (Linux host).
+//!
+//! Shape mirrors boot.zig (HVF path) so the two backends pass the
+//! same kernel + dtb + initramfs through the same boot protocol.
+//! Differences, all local to this file:
+//!
+//!   * Memory: KVM_SET_USER_MEMORY_REGION instead of hv_vm_map.
+//!   * vGIC: an in-kernel vgic-v3 via KVM_CREATE_DEVICE. KVM handles
+//!     all GIC MMIO + redistributor state itself; we only need to
+//!     place the distributor + redistributor windows and call
+//!     KVM_IRQ_LINE when we want to raise an SPI.
+//!   * PSCI: enabled via VCPU_INIT feature bit (KVM_ARM_VCPU_PSCI_0_2)
+//!     so the kernel's HVC #0 calls get handled in-kernel. The guest
+//!     exits with KVM_EXIT_SYSTEM_EVENT on SYSTEM_OFF / RESET.
+//!   * Timer: the arm virtual timer is built into KVM's arm64 vcpu
+//!     model; no host-side plumbing.
+//!   * PL011: same byte-for-byte model as HVF (shared via pl011.zig),
+//!     driven by KVM_EXIT_MMIO events.
+//!   * Virtio: not wired yet. Reads/writes to virtio-mmio windows
+//!     currently return 0 / are ignored. That's enough to watch the
+//!     kernel boot through its console; devices follow.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.os.tag != .linux) {
+        @compileError("boot_kvm.zig only builds on Linux (uses /dev/kvm)");
+    }
+}
+
+const kvm = @import("kvm.zig");
+const pl011_mod = @import("pl011.zig");
+
+pub const Error = error{
+    FixtureMissing,
+    KernelTooLarge,
+    DtbTooLarge,
+    GuestCrashed,
+    RanTooLong,
+} || kvm.KvmError;
+
+pub const Config = struct {
+    kernel_path: []const u8,
+    dtb_path: []const u8,
+    initrd_path: ?[]const u8 = null,
+    ram_base: u64 = 0x4000_0000,
+    ram_size: usize = 4 * 1024 * 1024 * 1024,
+    dtb_offset: u64 = 0x0300_0000,
+    initrd_offset: u64 = 0x0400_0000,
+    capture_bytes: usize = 262144,
+    max_exits: usize = 5_000_000,
+    // GIC v3 placement. Matches our virt.dts: distributor at
+    // 0x08000000 (64 KiB window) and redistributor starting at
+    // 0x10000000 (128 KiB × nr_vcpus — just one for us).
+    gic_dist_addr: u64 = 0x0800_0000,
+    gic_redist_addr: u64 = 0x1000_0000,
+};
+
+pub const Result = struct {
+    serial: []u8,
+    saw_psci_shutdown: bool,
+    exits: usize,
+};
+
+pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
+    // --- load fixture files --------------------------------------
+    const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
+        if (err == error.FileNotFound) return error.FixtureMissing;
+        return err;
+    };
+    defer gpa.free(kernel);
+
+    const dtb = readAll(gpa, cfg.dtb_path) catch |err| {
+        if (err == error.FileNotFound) return error.FixtureMissing;
+        return err;
+    };
+    defer gpa.free(dtb);
+
+    const img = try KernelImage.parse(kernel);
+    if (img.text_offset + kernel.len > cfg.ram_size) return error.KernelTooLarge;
+    if (cfg.dtb_offset + dtb.len > cfg.ram_size) return error.DtbTooLarge;
+
+    // --- allocate + map guest RAM --------------------------------
+    const ram_ptr = std.posix.mmap(
+        null,
+        cfg.ram_size,
+        .{ .READ = true, .WRITE = true },
+        .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
+        -1,
+        0,
+    ) catch return error.KvmSetMemoryFailed;
+    defer std.posix.munmap(ram_ptr);
+    const ram: []u8 = ram_ptr;
+
+    @memcpy(ram[img.text_offset..][0..kernel.len], kernel);
+    @memcpy(ram[cfg.dtb_offset..][0..dtb.len], dtb);
+
+    if (cfg.initrd_path) |initrd_path| {
+        const initrd = readAll(gpa, initrd_path) catch |err| {
+            if (err == error.OpenFailed) return error.FixtureMissing;
+            return err;
+        };
+        defer gpa.free(initrd);
+        if (cfg.initrd_offset + initrd.len > cfg.ram_size) return error.DtbTooLarge;
+        @memcpy(ram[cfg.initrd_offset..][0..initrd.len], initrd);
+    }
+
+    // --- KVM bring-up --------------------------------------------
+    var k = try kvm.Kvm.open_();
+    defer k.close_();
+
+    var vm = try k.createVm();
+    defer vm.destroy();
+
+    try vm.mapMemory(0, cfg.ram_base, ram);
+
+    // vGIC BEFORE vCPU creation (KVM requires it).
+    var gic = try vm.createGicV3(cfg.gic_dist_addr, cfg.gic_redist_addr);
+    defer gic.destroy();
+
+    var vcpu = try vm.createVcpu(0);
+    defer vcpu.destroy();
+
+    // PSCI_0_2 lets KVM handle HVC-based shutdown / cpu-on / etc.
+    // inside the kernel — the guest calls `SYSTEM_OFF` and KVM
+    // reports it to us as KVM_EXIT_SYSTEM_EVENT instead of raw HVC.
+    var init = try vm.preferredTarget();
+    init.features[0] |= (@as(u32, 1) << @as(u5, @intCast(kvm.KVM_ARM_VCPU_PSCI_0_2)));
+    try vcpu.init(init);
+
+    // vGIC finalize happens AFTER vcpus exist.
+    try gic.finalize();
+
+    // arm64 boot protocol: X0 = dtb phys addr, PC = kernel entry.
+    const dtb_phys = cfg.ram_base + cfg.dtb_offset;
+    try vcpu.setReg(kvm.REG_X0, dtb_phys);
+    try vcpu.setReg(kvm.REG_X1, 0);
+    try vcpu.setReg(kvm.REG_X2, 0);
+    try vcpu.setReg(kvm.REG_X3, 0);
+    try vcpu.setReg(kvm.REG_PC, cfg.ram_base + img.text_offset);
+
+    // --- run loop -------------------------------------------------
+    var uart = pl011_mod.Pl011.init;
+    defer uart.deinit(gpa);
+
+    // PL011 SPI per DTS (interrupts = <0 1 4>). GIC SPI N maps to
+    // KVM irq number 32 + N. For our PL011 that's 33.
+    const pl011_irq: u32 = 32 + 1;
+
+    var exits: usize = 0;
+    var saw_off = false;
+
+    while (exits < cfg.max_exits) : (exits += 1) {
+        const reason = try vcpu.run();
+        switch (reason) {
+            .mmio => {
+                const ev = vcpu.mmioExit();
+                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq);
+            },
+            .system_event => {
+                const ev = vcpu.systemEventExit();
+                const typ: kvm.SystemEventType = @enumFromInt(ev.type);
+                if (typ == .shutdown or typ == .reset) {
+                    saw_off = true;
+                    break;
+                }
+            },
+            .intr, .debug => {
+                // Signal interruption (SIGALRM etc.) or debug exit —
+                // just re-enter.
+            },
+            else => {
+                // Everything else is a guest-state problem. Bail.
+                std.debug.print("kvm: unhandled exit reason {d}\n", .{@intFromEnum(reason)});
+                return error.GuestCrashed;
+            },
+        }
+        if (uart.captured.items.len >= cfg.capture_bytes) break;
+    }
+
+    if (exits >= cfg.max_exits) return error.RanTooLong;
+
+    const serial = try gpa.dupe(u8, uart.captured.items);
+    return .{ .serial = serial, .saw_psci_shutdown = saw_off, .exits = exits };
+}
+
+fn handleMmio(
+    gpa: std.mem.Allocator,
+    vm: *kvm.Vm,
+    vcpu: *kvm.Vcpu,
+    uart: *pl011_mod.Pl011,
+    ev: kvm.MmioExit,
+    pl011_irq: u32,
+) !void {
+    if (uart.handles(ev.phys_addr)) {
+        if (ev.is_write != 0) {
+            var val: u64 = 0;
+            const n = @min(@as(usize, ev.len), 8);
+            for (0..n) |i| {
+                val |= @as(u64, ev.data[i]) << @as(u6, @intCast(i * 8));
+            }
+            try uart.write(gpa, ev.phys_addr, val);
+            // Echo console bytes to host stderr.
+            if ((ev.phys_addr - uart.base) == 0 and ev.len > 0) {
+                const byte: [1]u8 = .{ev.data[0]};
+                _ = hostWrite(2, &byte, 1);
+            }
+        } else {
+            const val = uart.read(ev.phys_addr);
+            vcpu.writeMmioReadData(val, ev.len);
+        }
+        vm.setIrq(pl011_irq, if (uart.irqAsserted()) 1 else 0) catch {};
+        return;
+    }
+    // Other MMIO (virtio-mmio windows, etc.) — for reads, hand back
+    // zeros (the writeMmioReadData default on untouched kvm_run bytes
+    // is already zero, but be explicit so a future non-zero lingerer
+    // doesn't bite).
+    if (ev.is_write == 0) vcpu.writeMmioReadData(0, ev.len);
+}
+
+fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+    var path_buf: [4096]u8 = undefined;
+    if (path.len >= path_buf.len) return error.NameTooLong;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const path_z: [*:0]const u8 = @ptrCast(&path_buf);
+
+    const fd = hostOpen(path_z, 0, 0);
+    if (fd < 0) return error.OpenFailed;
+    defer _ = hostClose(fd);
+
+    const size_i = hostLseek(fd, 0, 2);
+    if (size_i < 0) return error.SeekFailed;
+    _ = hostLseek(fd, 0, 0);
+    const size: usize = @intCast(size_i);
+
+    const buf = try gpa.alloc(u8, size);
+    errdefer gpa.free(buf);
+    var total: usize = 0;
+    while (total < size) {
+        const n = hostRead(fd, buf[total..].ptr, size - total);
+        if (n <= 0) return error.ShortRead;
+        total += @intCast(n);
+    }
+    return buf;
+}
+
+extern "c" fn open(path: [*:0]const u8, flags: c_int, ...) c_int;
+extern "c" fn close(fd: c_int) c_int;
+extern "c" fn read(fd: c_int, buf: [*]u8, count: usize) isize;
+extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
+extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
+extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
+extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+// Rename'd because `read`/`write` collide with std method names in
+// some generic contexts; kept the extern shims unchanged.
+fn hostOpen(path: [*:0]const u8, flags: c_int, mode: c_int) c_int {
+    return open(path, flags, mode);
+}
+fn hostClose(fd: c_int) c_int {
+    return close(fd);
+}
+fn hostRead(fd: c_int, buf: [*]u8, count: usize) isize {
+    return read(fd, buf, count);
+}
+fn hostWrite(fd: c_int, buf: [*]const u8, count: usize) isize {
+    return write(fd, buf, count);
+}
+fn hostLseek(fd: c_int, offset: i64, whence: c_int) i64 {
+    return lseek(fd, offset, whence);
+}
+
+// arm64 Linux kernel Image header — same parser as hvf.zig has;
+// duplicated because that module is macOS-only. Tiny enough that
+// sharing via a third module wasn't worth the indirection yet.
+pub const KernelImage = struct {
+    text_offset: u64,
+    image_size: u64,
+    bytes: []const u8,
+
+    pub const magic: u32 = 0x644D5241; // "ARM\x64"
+    pub const Error = error{ TooSmall, BadMagic };
+
+    pub fn parse(bytes: []const u8) KernelImage.Error!KernelImage {
+        if (bytes.len < 64) return error.TooSmall;
+        const got_magic = std.mem.readInt(u32, bytes[0x38..0x3C], .little);
+        if (got_magic != magic) return error.BadMagic;
+        return .{
+            .text_offset = std.mem.readInt(u64, bytes[0x08..0x10], .little),
+            .image_size = std.mem.readInt(u64, bytes[0x10..0x18], .little),
+            .bytes = bytes,
+        };
+    }
+};
+
+// =============================================================
+// Test — gated on MACHINEN_BOOT_TEST like the HVF twin. Needs
+// /dev/kvm readable + the fixtures present. Skips gracefully.
+// =============================================================
+
+const F_OK: c_int = 0;
+const kernel_fixture = "test-fixtures/Image";
+const dtb_fixture = "test-fixtures/virt.dtb";
+const initrd_fixture = "test-fixtures/initramfs.cpio";
+
+fn fixturesPresent() bool {
+    inline for (.{ kernel_fixture, dtb_fixture, initrd_fixture }) |p| {
+        var buf: [4096]u8 = undefined;
+        if (p.len >= buf.len) return false;
+        @memcpy(buf[0..p.len], p);
+        buf[p.len] = 0;
+        const path_z: [*:0]const u8 = @ptrCast(&buf);
+        if (access(path_z, F_OK) != 0) return false;
+    }
+    return true;
+}
+
+test "KVM: boot a real arm64 Linux kernel" {
+    if (builtin.cpu.arch != .aarch64) {
+        // KVM on x86_64 can't host an arm64 guest.
+        std.debug.print("skip: KVM boot requires an arm64 Linux host\n", .{});
+        return;
+    }
+    if (getenv("MACHINEN_BOOT_TEST") == null) {
+        std.debug.print("skip: set MACHINEN_BOOT_TEST=1 to enable\n", .{});
+        return;
+    }
+    if (access("/dev/kvm\x00", F_OK) != 0) {
+        std.debug.print("skip: /dev/kvm not readable\n", .{});
+        return;
+    }
+    if (!fixturesPresent()) {
+        std.debug.print(
+            "skip: missing {s} or {s} (see test-fixtures/README.md)\n",
+            .{ kernel_fixture, dtb_fixture },
+        );
+        return;
+    }
+
+    const gpa = std.testing.allocator;
+    const result = boot(gpa, .{
+        .kernel_path = kernel_fixture,
+        .dtb_path = dtb_fixture,
+        .initrd_path = initrd_fixture,
+    }) catch |err| {
+        std.debug.print("kvm boot returned {s}\n", .{@errorName(err)});
+        return err;
+    };
+    defer gpa.free(result.serial);
+    try std.testing.expect(result.serial.len > 0);
+}

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -4,12 +4,19 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const pl011_mod = @import("pl011.zig");
 
 comptime {
     if (builtin.os.tag != .macos) {
         @compileError("hvf.zig only builds on macOS");
     }
 }
+
+// Re-export the pure-Zig PL011 model so existing hvf.Pl011 /
+// hvf.PthreadMutex callers stay green. The code lives in pl011.zig
+// so boot_kvm.zig (Linux) can reuse it.
+pub const Pl011 = pl011_mod.Pl011;
+pub const PthreadMutex = pl011_mod.PthreadMutex;
 
 // Cherry-pick headers — the umbrella Hypervisor.h pulls in
 // hv_vcpu_config.h, which has a `uint64_t values[_Nonnull 8]`
@@ -453,144 +460,6 @@ pub const Psci = struct {
             => f,
             _ => null,
         };
-    }
-};
-
-// =============================================================
-// Minimal PL011 UART
-// =============================================================
-
-/// A plain pthread mutex, usable as an inline field. Zig 0.16 moved
-/// `std.Thread.Mutex` under `std.Io` (it now requires an Io context),
-/// so we bind pthread directly rather than take on that dependency just
-/// for a lock. The macOS layout is `long __sig; char __opaque[56]` and
-/// `__sig = 0x32AAABA7` is the "default-initialized" marker — matches
-/// what `PTHREAD_MUTEX_INITIALIZER` expands to.
-pub const PthreadMutex = extern struct {
-    sig: c_long = 0x32AAABA7,
-    opaque_bytes: [56]u8 = @splat(0),
-
-    extern "c" fn pthread_mutex_lock(m: *PthreadMutex) c_int;
-    extern "c" fn pthread_mutex_unlock(m: *PthreadMutex) c_int;
-
-    pub fn lock(self: *PthreadMutex) void {
-        _ = pthread_mutex_lock(self);
-    }
-    pub fn unlock(self: *PthreadMutex) void {
-        _ = pthread_mutex_unlock(self);
-    }
-};
-
-/// Bare-bones PL011 UART (the serial port on the ARM virt machine).
-///   - DR (offset 0x000): byte writes append to `captured`; reads pop
-///     from `rx_buf` (the bytes we received from host stdin).
-///   - FR (offset 0x018): bit 4 (RXFE) = 1 when rx_buf is empty, 0 otherwise.
-///     Other bits keep their "TX empty, not busy" state.
-///   - IMSC/RIS/MIS/ICR (0x038–0x044): real PL011 interrupt regs so
-///     the Linux driver's ISR can mask/unmask and clear interrupts.
-///   - PrimeCell IDs (0xFE0–0xFFC): the AMBA bus probes these before
-///     binding the PL011 driver; without them the driver never attaches.
-pub const Pl011 = struct {
-    base: u64,
-    size: u64 = 0x1000,
-    captured: std.ArrayList(u8),
-    rx_buf: std.ArrayList(u8),
-    // Interrupt mask/status. The kernel's PL011 IRQ handler reads MIS
-    // (masked = RIS & IMSC) and clears matching bits via ICR.
-    imsc: u32 = 0,
-    ris: u32 = 0,
-    // Guards all mutable state above. The run loop accesses the UART
-    // from the main (vCPU) thread; a stdin-reader thread appends to
-    // rx_buf when the user types. Without a lock these two races.
-    // pthread_mutex_t on macOS is a 64-byte opaque struct; we store it
-    // inline so Pl011 remains a value type.
-    mutex: PthreadMutex = .{},
-
-    // Bit 4 of RIS/MIS/ICR is RX interrupt.
-    const RX_INT: u32 = 1 << 4;
-
-    pub const init: Pl011 = .{
-        .base = 0x0900_0000,
-        .captured = .empty,
-        .rx_buf = .empty,
-    };
-
-    pub fn withBase(base: u64) Pl011 {
-        return .{ .base = base, .captured = .empty, .rx_buf = .empty };
-    }
-
-    pub fn deinit(self: *Pl011, gpa: std.mem.Allocator) void {
-        self.captured.deinit(gpa);
-        self.rx_buf.deinit(gpa);
-    }
-
-    pub fn handles(self: *const Pl011, addr: u64) bool {
-        return addr >= self.base and addr < self.base + self.size;
-    }
-
-    /// IRQ line should be asserted iff there's any masked interrupt pending.
-    /// Call with the mutex held.
-    pub fn irqAsserted(self: *Pl011) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        return (self.ris & self.imsc) != 0;
-    }
-
-    pub fn pushRx(self: *Pl011, gpa: std.mem.Allocator, bytes: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        try self.rx_buf.appendSlice(gpa, bytes);
-        if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
-    }
-
-    pub fn write(self: *Pl011, gpa: std.mem.Allocator, addr: u64, value: u64) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const offset = addr - self.base;
-        switch (offset) {
-            0x000 => try self.captured.append(gpa, @truncate(value)),
-            0x038 => self.imsc = @truncate(value),
-            0x044 => {
-                self.ris &= ~@as(u32, @truncate(value));
-                if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
-            },
-            else => {},
-        }
-    }
-
-    pub fn read(self: *Pl011, addr: u64) u64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const offset = addr - self.base;
-        switch (offset) {
-            0x000 => { // DR — pop a byte from rx_buf
-                if (self.rx_buf.items.len == 0) return 0;
-                const b = self.rx_buf.items[0];
-                std.mem.copyForwards(u8, self.rx_buf.items[0 .. self.rx_buf.items.len - 1], self.rx_buf.items[1..]);
-                self.rx_buf.items.len -= 1;
-                if (self.rx_buf.items.len == 0) self.ris &= ~RX_INT;
-                return b;
-            },
-            0x018 => {
-                const rxfe: u64 = if (self.rx_buf.items.len == 0) (1 << 4) else 0;
-                return 0x80 | rxfe;
-            },
-            0x038 => return self.imsc, // IMSC
-            0x03C => return self.ris, // RIS
-            0x040 => return self.ris & self.imsc, // MIS
-            // ARM PrimeCell peripheral ID registers — without these the
-            // AMBA bus can't identify the device and the kernel's PL011
-            // driver never binds. Values are the standard for a real PL011.
-            0xFE0 => return 0x11, // PeriphID0: part[7:0]
-            0xFE4 => return 0x10, // PeriphID1: designer[3:0] | part[11:8]
-            0xFE8 => return 0x14, // PeriphID2: revision | designer[7:4]
-            0xFEC => return 0x00, // PeriphID3: configuration
-            0xFF0 => return 0x0D, // PCellID0
-            0xFF4 => return 0xF0, // PCellID1
-            0xFF8 => return 0x05, // PCellID2
-            0xFFC => return 0xB1, // PCellID3
-            else => return 0,
-        }
     }
 };
 

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -77,6 +77,14 @@ pub const KVM_SET_REGS = iow(KVMIO, 0x82, @sizeOf(X86Regs));
 pub const KVM_GET_SREGS = ior(KVMIO, 0x83, @sizeOf(X86Sregs));
 pub const KVM_SET_SREGS = iow(KVMIO, 0x84, @sizeOf(X86Sregs));
 
+// VM-scoped device creation (for vgic-v3, vsock, etc.) + per-device
+// attributes. `KVM_CREATE_DEVICE` returns a fd for the device; attr
+// ioctls happen on that fd.
+pub const KVM_CREATE_DEVICE = iowr(KVMIO, 0xE0, @sizeOf(CreateDevice));
+pub const KVM_SET_DEVICE_ATTR = iow(KVMIO, 0xE1, @sizeOf(DeviceAttr));
+pub const KVM_GET_DEVICE_ATTR = iow(KVMIO, 0xE2, @sizeOf(DeviceAttr));
+pub const KVM_HAS_DEVICE_ATTR = iow(KVMIO, 0xE3, @sizeOf(DeviceAttr));
+
 // ---------------------------------------------------------------
 // Flat structs — all have a KVM-stable layout across arm64/x86_64
 // but we only build on arm64 for our guest.
@@ -109,6 +117,40 @@ pub const Irqchip = extern struct {
     pad: u32,
     chip: [512]u8, // union of chip-specific state; opaque to us
 };
+
+// ---------------------------------------------------------------
+// KVM device ioctls (vgic-v3, etc.). `CreateDevice.type` + `flags`
+// select the device. For vgic-v3: type = KVM_DEV_TYPE_ARM_VGIC_V3
+// (7), flags = 0. After create, `fd` is populated.
+
+pub const CreateDevice = extern struct {
+    type: u32,
+    fd: u32, // out
+    flags: u32,
+};
+
+pub const DeviceAttr = extern struct {
+    flags: u32,
+    group: u32,
+    attr: u64,
+    addr: u64, // userspace pointer to the attribute's value
+};
+
+pub const KVM_DEV_TYPE_ARM_VGIC_V3: u32 = 7;
+
+// vgic-v3 attribute groups.
+pub const KVM_DEV_ARM_VGIC_GRP_ADDR: u32 = 0;
+pub const KVM_DEV_ARM_VGIC_GRP_CTRL: u32 = 4;
+
+// vgic-v3 address-type attrs inside GRP_ADDR.
+pub const KVM_VGIC_V3_ADDR_TYPE_DIST: u64 = 2;
+pub const KVM_VGIC_V3_ADDR_TYPE_REDIST: u64 = 3;
+
+// "init the device" attribute inside GRP_CTRL.
+pub const KVM_DEV_ARM_VGIC_CTRL_INIT: u64 = 0;
+
+// arm64 VCPU_INIT feature bits.
+pub const KVM_ARM_VCPU_PSCI_0_2: u32 = 2;
 
 // ---------------------------------------------------------------
 // x86_64 register banks. arm64 boots don't touch these; they live
@@ -381,6 +423,61 @@ pub const Vm = struct {
         }
     }
 
+    /// Create an in-kernel vgic-v3 and place its distributor +
+    /// redistributor MMIO windows at the given guest-physical
+    /// addresses. Call BEFORE `createVcpu` — KVM requires it.
+    /// Returns a Gic with the device fd owned; destroy() closes it.
+    pub fn createGicV3(
+        self: *Vm,
+        dist_addr: u64,
+        redist_addr: u64,
+    ) !Gic {
+        var args = CreateDevice{
+            .type = KVM_DEV_TYPE_ARM_VGIC_V3,
+            .fd = 0,
+            .flags = 0,
+        };
+        if (ioctl(self.fd, KVM_CREATE_DEVICE, &args) != 0) {
+            return error.KvmCreateIrqchipFailed;
+        }
+        const gic_fd: c_int = @intCast(args.fd);
+        errdefer _ = close(gic_fd);
+
+        var dist = dist_addr;
+        var dist_attr = DeviceAttr{
+            .flags = 0,
+            .group = KVM_DEV_ARM_VGIC_GRP_ADDR,
+            .attr = KVM_VGIC_V3_ADDR_TYPE_DIST,
+            .addr = @intFromPtr(&dist),
+        };
+        if (ioctl(gic_fd, KVM_SET_DEVICE_ATTR, &dist_attr) != 0) {
+            return error.KvmCreateIrqchipFailed;
+        }
+
+        var redist = redist_addr;
+        var redist_attr = DeviceAttr{
+            .flags = 0,
+            .group = KVM_DEV_ARM_VGIC_GRP_ADDR,
+            .attr = KVM_VGIC_V3_ADDR_TYPE_REDIST,
+            .addr = @intFromPtr(&redist),
+        };
+        if (ioctl(gic_fd, KVM_SET_DEVICE_ATTR, &redist_attr) != 0) {
+            return error.KvmCreateIrqchipFailed;
+        }
+
+        return .{ .fd = gic_fd, .vm_fd = self.fd };
+    }
+
+    /// Raise or lower an interrupt line. `irq` uses KVM's encoding:
+    /// bits 27:24 = type (0 = SPI), bits 23:16 = vcpu_id, bits 15:0 =
+    /// irq_number. For arm64 SPIs, irq_number = GIC SPI base (32) +
+    /// device-specific offset; our DTS maps PL011 to 33, virtio-net
+    /// to 48, etc.
+    pub fn setIrq(self: *Vm, irq: u32, level: u32) !void {
+        var lvl = IrqLevel{ .irq = irq, .level = level };
+        if (ioctl(self.fd, KVM_IRQ_LINE, &lvl) != 0) return error.KvmIrqLineFailed;
+    }
+
     pub fn createVcpu(self: *Vm, id: u32) !Vcpu {
         const fd = ioctl(self.fd, KVM_CREATE_VCPU, @as(c_ulong, id));
         if (fd < 0) return error.KvmCreateVcpuFailed;
@@ -398,6 +495,30 @@ pub const Vm = struct {
             return error.KvmPreferredTargetFailed;
         }
         return out;
+    }
+};
+
+/// In-kernel vgic-v3 handle. Addresses are set in createGicV3; the
+/// device is only "ready" after all vCPUs are up AND `finalize()`
+/// runs KVM_DEV_ARM_VGIC_CTRL_INIT.
+pub const Gic = struct {
+    fd: c_int,
+    vm_fd: c_int,
+
+    pub fn destroy(self: *Gic) void {
+        _ = close(self.fd);
+    }
+
+    pub fn finalize(self: *Gic) !void {
+        var attr = DeviceAttr{
+            .flags = 0,
+            .group = KVM_DEV_ARM_VGIC_GRP_CTRL,
+            .attr = KVM_DEV_ARM_VGIC_CTRL_INIT,
+            .addr = 0,
+        };
+        if (ioctl(self.fd, KVM_SET_DEVICE_ATTR, &attr) != 0) {
+            return error.KvmCreateIrqchipFailed;
+        }
     }
 };
 
@@ -457,6 +578,26 @@ pub const Vcpu = struct {
         var out: MmioExit = undefined;
         @memcpy(std.mem.asBytes(&out), base[0x90..][0..@sizeOf(MmioExit)]);
         return out;
+    }
+
+    /// Read the SYSTEM_EVENT exit payload. Used for PSCI SHUTDOWN /
+    /// RESET. Same struct union as MMIO; offset 0x90 inside kvm_run.
+    pub fn systemEventExit(self: *Vcpu) SystemEventExit {
+        const base: [*]u8 = @ptrCast(self.run_page);
+        var out: SystemEventExit = undefined;
+        @memcpy(std.mem.asBytes(&out), base[0x90..][0..@sizeOf(SystemEventExit)]);
+        return out;
+    }
+
+    /// When handling an MMIO READ exit, the guest expects us to
+    /// fill `kvm_run.mmio.data[0..len]` with the register contents
+    /// before the next `KVM_RUN`. This writes up to 8 bytes at the
+    /// in-struct data offset (0x90 + 8 = 0x98 on arm64 kvm_run).
+    pub fn writeMmioReadData(self: *Vcpu, value: u64, len: u32) void {
+        const base: [*]u8 = @ptrCast(self.run_page);
+        const slot: []u8 = base[0x98 .. 0x98 + 8];
+        std.mem.writeInt(u64, slot[0..8], value, .little);
+        _ = len;
     }
 
     // x86-specific register access. arm64 uses setReg/getReg above.

--- a/packages/microvm/src/pl011.zig
+++ b/packages/microvm/src/pl011.zig
@@ -1,0 +1,148 @@
+//! Bare-bones PL011 UART (the serial port on the ARM virt machine).
+//!
+//! Hypervisor-independent — HVF and KVM both route MMIO for this
+//! device back into here. See hvf.zig / boot_kvm.zig for wiring.
+//!
+//!   - DR (offset 0x000): byte writes append to `captured`; reads pop
+//!     from `rx_buf` (the bytes we received from host stdin).
+//!   - FR (offset 0x018): bit 4 (RXFE) = 1 when rx_buf is empty, 0 otherwise.
+//!     Other bits keep their "TX empty, not busy" state.
+//!   - IMSC/RIS/MIS/ICR (0x038–0x044): real PL011 interrupt regs so
+//!     the Linux driver's ISR can mask/unmask and clear interrupts.
+//!   - PrimeCell IDs (0xFE0–0xFFC): the AMBA bus probes these before
+//!     binding the PL011 driver; without them the driver never attaches.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Platform-sized pthread mutex. Zig 0.16 moved `std.Thread.Mutex`
+/// under `std.Io` (it now requires an Io context), so we bind
+/// pthread directly rather than take on that dependency just for
+/// a lock. macOS layout: 64 bytes with a `sig` magic. Linux glibc
+/// layout: 40 bytes, all-zeros == `PTHREAD_MUTEX_INITIALIZER`.
+pub const PthreadMutex = extern struct {
+    pub const macos_pad: usize = 56;
+    pub const linux_pad: usize = 40;
+
+    // One union-like blob sized for the bigger platform; we just
+    // zero-init the whole thing and let pthread handle it. macOS
+    // has a sentinel magic it requires, which we write into the
+    // first 8 bytes.
+    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macosInit() else @splat(0),
+
+    fn macosInit() [64]u8 {
+        var out: [64]u8 = @splat(0);
+        // sig = 0x32AAABA7 (PTHREAD_MUTEX_INITIALIZER's magic).
+        const sig: u64 = 0x32AAABA7;
+        std.mem.writeInt(u64, out[0..8], sig, .little);
+        return out;
+    }
+
+    extern "c" fn pthread_mutex_lock(m: *PthreadMutex) c_int;
+    extern "c" fn pthread_mutex_unlock(m: *PthreadMutex) c_int;
+
+    pub fn lock(self: *PthreadMutex) void {
+        _ = pthread_mutex_lock(self);
+    }
+    pub fn unlock(self: *PthreadMutex) void {
+        _ = pthread_mutex_unlock(self);
+    }
+};
+
+pub const Pl011 = struct {
+    base: u64,
+    size: u64 = 0x1000,
+    captured: std.ArrayList(u8),
+    rx_buf: std.ArrayList(u8),
+    // Interrupt mask/status. The kernel's PL011 IRQ handler reads MIS
+    // (masked = RIS & IMSC) and clears matching bits via ICR.
+    imsc: u32 = 0,
+    ris: u32 = 0,
+    mutex: PthreadMutex = .{},
+
+    // Bit 4 of RIS/MIS/ICR is RX interrupt.
+    pub const RX_INT: u32 = 1 << 4;
+
+    pub const init: Pl011 = .{
+        .base = 0x0900_0000,
+        .captured = .empty,
+        .rx_buf = .empty,
+    };
+
+    pub fn withBase(base: u64) Pl011 {
+        return .{ .base = base, .captured = .empty, .rx_buf = .empty };
+    }
+
+    pub fn deinit(self: *Pl011, gpa: std.mem.Allocator) void {
+        self.captured.deinit(gpa);
+        self.rx_buf.deinit(gpa);
+    }
+
+    pub fn handles(self: *const Pl011, addr: u64) bool {
+        return addr >= self.base and addr < self.base + self.size;
+    }
+
+    /// IRQ line should be asserted iff there's any masked interrupt pending.
+    pub fn irqAsserted(self: *Pl011) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return (self.ris & self.imsc) != 0;
+    }
+
+    pub fn pushRx(self: *Pl011, gpa: std.mem.Allocator, bytes: []const u8) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        try self.rx_buf.appendSlice(gpa, bytes);
+        if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
+    }
+
+    pub fn write(self: *Pl011, gpa: std.mem.Allocator, addr: u64, value: u64) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const offset = addr - self.base;
+        switch (offset) {
+            0x000 => try self.captured.append(gpa, @truncate(value)),
+            0x038 => self.imsc = @truncate(value),
+            0x044 => {
+                self.ris &= ~@as(u32, @truncate(value));
+                if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
+            },
+            else => {},
+        }
+    }
+
+    pub fn read(self: *Pl011, addr: u64) u64 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const offset = addr - self.base;
+        switch (offset) {
+            0x000 => {
+                if (self.rx_buf.items.len == 0) return 0;
+                const b = self.rx_buf.items[0];
+                std.mem.copyForwards(u8, self.rx_buf.items[0 .. self.rx_buf.items.len - 1], self.rx_buf.items[1..]);
+                self.rx_buf.items.len -= 1;
+                if (self.rx_buf.items.len == 0) self.ris &= ~RX_INT;
+                return b;
+            },
+            0x018 => {
+                const rxfe: u64 = if (self.rx_buf.items.len == 0) (1 << 4) else 0;
+                return 0x80 | rxfe;
+            },
+            0x038 => return self.imsc,
+            0x03C => return self.ris,
+            0x040 => return self.ris & self.imsc,
+            // ARM PrimeCell peripheral ID registers — without these the
+            // AMBA bus can't identify the device and the kernel's PL011
+            // driver never binds. Values are the standard for a real PL011.
+            0xFE0 => return 0x11,
+            0xFE4 => return 0x10,
+            0xFE8 => return 0x14,
+            0xFEC => return 0x00,
+            0xFF0 => return 0x0D,
+            0xFF4 => return 0xF0,
+            0xFF8 => return 0x05,
+            0xFFC => return 0xB1,
+            else => return 0,
+        }
+    }
+};

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -16,9 +16,11 @@ pub const hvf = if (builtin.os.tag == .macos) @import("hvf.zig") else struct {};
 pub const boot = if (builtin.os.tag == .macos) @import("boot.zig") else struct {};
 pub const slirp = if (builtin.os.tag == .macos) @import("slirp.zig") else struct {};
 pub const kvm = if (builtin.os.tag == .linux) @import("kvm.zig") else struct {};
+pub const boot_kvm = if (builtin.os.tag == .linux) @import("boot_kvm.zig") else struct {};
 pub const virtio = @import("virtio.zig"); // pure Zig, builds everywhere
 pub const blk = @import("blk.zig"); // pure Zig virtio-blk backend
 pub const vsock = @import("vsock.zig"); // pure Zig virtio-vsock bridge
+pub const pl011 = @import("pl011.zig"); // pure Zig PL011 UART (shared HVF/KVM)
 
 pub const Backend = enum { hvf, kvm, none };
 
@@ -77,7 +79,9 @@ test {
     }
     if (builtin.os.tag == .linux) {
         _ = @import("kvm.zig");
+        _ = @import("boot_kvm.zig");
     }
     _ = @import("virtio.zig");
     _ = @import("vsock.zig");
+    _ = @import("pl011.zig");
 }


### PR DESCRIPTION
## Summary

Completes the Linux-side plumbing for the KVM backend. PR #55 shipped the lifecycle scaffold + proof-of-life; this commit adds the GIC + IRQ + exit-decode surface plus the actual `boot_kvm.zig` boot path.

## What's in

- **`pl011.zig` (new)** — pure-Zig PL011 UART model, extracted out of `hvf.zig` so both backends share it. Includes a platform-sized `PthreadMutex`. `hvf.zig` re-exports to keep existing callers green.
- **`kvm.zig` additions**:
  - `KVM_CREATE_DEVICE` / `{GET,SET,HAS}_DEVICE_ATTR` ioctls + structs for in-kernel vgic-v3.
  - `Vm.createGicV3(dist_addr, redist_addr)` → `Gic` handle.
  - `Gic.finalize()` — runs `KVM_DEV_ARM_VGIC_CTRL_INIT` once all vCPUs exist.
  - `Vm.setIrq(irq, level)` — `KVM_IRQ_LINE` helper.
  - `KVM_ARM_VCPU_PSCI_0_2` feature bit + `SystemEventType` enum.
  - `Vcpu.systemEventExit()` / `Vcpu.writeMmioReadData(value, len)`.
- **`boot_kvm.zig` (new)** — parallel of `boot.zig`. Loads kernel + dtb + optional initramfs into mmap'd guest RAM, vgic-v3 at the same addresses the DTS advertises, vCPU with PSCI_0_2, runs. Loop handles `KVM_EXIT_MMIO` (routed to PL011; virtio windows return 0 for now) + `KVM_EXIT_SYSTEM_EVENT` (PSCI shutdown).

## Verified

- **macOS (HVF)**: 43/43 unit tests pass. `pl011.zig` extraction doesn't regress any HVF paths.
- **Linux x86_64 (Proxmox)**: 35/35 unit tests pass. boot_kvm test skips on non-arm64, correctly.
- **Linux arm64 (Hetzner cax11, ubuntu-24.04)**: **35/35 unit tests pass**, including all 7 kvm.* tests (ioctl numbers, struct sizes, arm64 reg encoding, arch-agnostic smoke, x86_64 proof-of-life skip, arm64 proof-of-life skip). Pure-Zig layout + ioctl math is correct on real arm64.
- **agent-ci**: green in 53 s.

## What wasn't verifiable

Hetzner's arm shared instances (`cax*`) are themselves KVM guests on a shared host. Their kernel boot reports `kvm [1]: HYP mode not available` — nested virtualization on arm64 isn't exposed. Our VMM needs bare-metal `/dev/kvm` to boot a Linux guest, so the actual boot-Linux exercise has to wait for one of:

- Oracle Ampere free tier (bare-metal Ampere, 4 vCPU + 24 GB RAM)
- AWS `c6g.metal` (~€0.10/hr)
- Asahi Linux on an M-series Mac (native arm64)
- Raspberry Pi 5 or similar arm64 bare-metal

Everything short of that runtime step is locked down here: code compiles on both archs, ioctl layouts verified, unit tests green on real arm64 hardware.

## What this doesn't do

- **Boot Linux on real arm64 KVM.** Code is wired end-to-end; needs a bare-metal arm64 Linux host. Next-session work.
- **Virtio under KVM.** Device models (virtio.zig, blk.zig, vsock.zig) are platform-agnostic; wiring them behind `KVM_EXIT_MMIO` is a mechanical follow-up.
- **Multi-vCPU.** 1 vCPU today.

## Test plan

- [x] `zig build test` green on macOS — 43/43
- [x] `zig build test` green on Linux x86_64 — 35/35
- [x] `zig build test` green on **Linux arm64 (real hardware)** — 35/35
- [x] agent-ci green
- [ ] Boot Linux under KVM on a bare-metal arm64 host
