### PR TITLE
KVM backend: fix wrong mmio offsets, unhang the boot test

### DIFF
--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -179,7 +179,13 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         if (uart.captured.items.len >= cfg.capture_bytes) break;
     }
 
-    if (exits >= cfg.max_exits) return error.RanTooLong;
+    if (exits >= cfg.max_exits) {
+        std.debug.print(
+            "kvm boot: RanTooLong after {d} exits. Captured serial ({d} bytes):\n{s}\n",
+            .{ exits, uart.captured.items.len, uart.captured.items },
+        );
+        return error.RanTooLong;
+    }
 
     const serial = try gpa.dupe(u8, uart.captured.items);
     return .{ .serial = serial, .saw_psci_shutdown = saw_off, .exits = exits };
@@ -345,10 +351,18 @@ test "KVM: boot a real arm64 Linux kernel" {
         .kernel_path = kernel_fixture,
         .dtb_path = dtb_fixture,
         .initrd_path = initrd_fixture,
+        // The fixture init drops into an interactive shell that waits
+        // on stdin (which we don't feed), so KVM_RUN will block forever
+        // once it's idle. Break as soon as we've seen enough serial to
+        // prove the kernel banner printed; the sanity check below
+        // verifies it's actually a Linux banner.
+        .capture_bytes = 512,
     }) catch |err| {
         std.debug.print("kvm boot returned {s}\n", .{@errorName(err)});
         return err;
     };
     defer gpa.free(result.serial);
     try std.testing.expect(result.serial.len > 0);
+    // Sanity: the Linux banner should land within the first few KB.
+    try std.testing.expect(std.mem.indexOf(u8, result.serial, "Linux") != null);
 }

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -571,31 +571,32 @@ pub const Vcpu = struct {
     }
 
     /// Read the MMIO exit payload. Call only when run() returned
-    /// .mmio. The payload lives at offset 0x90 on arm64 kvm_run (a
-    /// kernel-ABI offset stable since kernel v3.x).
+    /// .mmio. The union starts at offset 0x20 inside kvm_run (right
+    /// after `apic_base` at 0x18), on builds without the S390
+    /// extension — which matches x86_64 and arm64.
     pub fn mmioExit(self: *Vcpu) MmioExit {
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: MmioExit = undefined;
-        @memcpy(std.mem.asBytes(&out), base[0x90..][0..@sizeOf(MmioExit)]);
+        @memcpy(std.mem.asBytes(&out), base[0x20..][0..@sizeOf(MmioExit)]);
         return out;
     }
 
     /// Read the SYSTEM_EVENT exit payload. Used for PSCI SHUTDOWN /
-    /// RESET. Same struct union as MMIO; offset 0x90 inside kvm_run.
+    /// RESET. Same struct union as MMIO; offset 0x20 inside kvm_run.
     pub fn systemEventExit(self: *Vcpu) SystemEventExit {
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: SystemEventExit = undefined;
-        @memcpy(std.mem.asBytes(&out), base[0x90..][0..@sizeOf(SystemEventExit)]);
+        @memcpy(std.mem.asBytes(&out), base[0x20..][0..@sizeOf(SystemEventExit)]);
         return out;
     }
 
     /// When handling an MMIO READ exit, the guest expects us to
     /// fill `kvm_run.mmio.data[0..len]` with the register contents
-    /// before the next `KVM_RUN`. This writes up to 8 bytes at the
-    /// in-struct data offset (0x90 + 8 = 0x98 on arm64 kvm_run).
+    /// before the next `KVM_RUN`. `mmio.data` lives at 0x20 + 8 =
+    /// 0x28 in the kvm_run page.
     pub fn writeMmioReadData(self: *Vcpu, value: u64, len: u32) void {
         const base: [*]u8 = @ptrCast(self.run_page);
-        const slot: []u8 = base[0x98 .. 0x98 + 8];
+        const slot: []u8 = base[0x28 .. 0x28 + 8];
         std.mem.writeInt(u64, slot[0..8], value, .little);
         _ = len;
     }
@@ -775,11 +776,16 @@ test "KVM proof-of-life: create VM, create vCPU, map + run one instr" {
     defer _ = munmap(page_ptr.?, page_size);
     const page: [*]u8 = @ptrCast(page_ptr.?);
 
-    // ARM64 `wfi` = 0xD503207F (little-endian: 0x7F 0x20 0x03 0xD5).
-    page[0] = 0x7F;
-    page[1] = 0x20;
-    page[2] = 0x03;
-    page[3] = 0xD5;
+    // ARM64 `LDR W0, [X0]` = 0xB9400000 (little-endian: 00 00 40 B9).
+    // With X0 preloaded to an unmapped guest-physical address, the
+    // load faults and KVM bounces back to userspace with KVM_EXIT_MMIO.
+    // This is the most portable "did a guest instruction run and did
+    // KVM return cleanly" check — WFI and HVC both have kernel paths
+    // that can swallow the exit.
+    page[0] = 0x00;
+    page[1] = 0x00;
+    page[2] = 0x40;
+    page[3] = 0xB9;
 
     const guest_phys: u64 = 0x4000_0000;
     try vm.mapMemory(0, guest_phys, page[0..page_size]);
@@ -791,10 +797,10 @@ test "KVM proof-of-life: create VM, create vCPU, map + run one instr" {
 
     try vcpu.init(target);
     try vcpu.setReg(REG_PC, guest_phys);
+    // Unmapped address — the load will fault and exit with MMIO.
+    try vcpu.setReg(REG_X0, 0xA000_0000);
 
     const reason = try vcpu.run();
-    // The guest went to sleep on WFI — KVM reports that as an
-    // internal exit (WFI without an interrupt pending parks the
-    // vCPU). Any clean exit is fine for "the plumbing works."
     std.debug.print("kvm proof-of-life: exit reason = {d}\n", .{@intFromEnum(reason)});
+    try std.testing.expectEqual(ExitReason.mmio, reason);
 }


### PR DESCRIPTION
## Summary

Three fixes found while bringing the KVM backend up on a real arm64 Linux host (NVIDIA GB10 Grace Blackwell).

- **Wrong `kvm_run` offsets.** Our `mmioExit` / `systemEventExit` / `writeMmioReadData` read from `0x90` / `0x98`. The actual layout on Linux has `mmio.phys_addr` at `0x20` and `mmio.data` at `0x28`. Never caught before because no prior test actually exercised MMIO parsing with `/dev/kvm` access.
- **Proof-of-life test used `wfi`.** Parks the vCPU on some kernels and blocks `KVM_RUN` forever. Swapped for a load from an unmapped guest address — always comes back as `KVM_EXIT_MMIO`.
- **Boot test `capture_bytes` was too large.** Kernel prints ~1.4 KB and idles at a bash prompt; the loop re-entered `KVM_RUN` and hung. Dropped to 512 and added a `"Linux"` substring assertion.

## Test plan

- [x] macOS: `zig build test` — 44/44 passing
- [x] arm64 Linux (GB10): `zig build test` — 35/35 passing including the MMIO proof-of-life
- [x] arm64 Linux: `MACHINEN_BOOT_TEST=1` — boots Debian 6.1 under the Zig VMM end-to-end
- [x] arm64 Linux: CRIU hot-move demo (node counter dumped + restored, counter resumes past the dump point)
