### PR TITLE
cross-host CRIU demo: freeze on macOS, restore on Linux

### DIFF
--- a/packages/microvm/test-fixtures/handoff-dump.sh
+++ b/packages/microvm/test-fixtures/handoff-dump.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Dumps a Node counter with CRIU, writes the dump as a cpio stream to
+# /dev/vda (no filesystem — the host just reads it back with `cpio -id`).
+# Pairs with handoff-restore.sh which runs on the other host.
+PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PATH
+
+say() { printf '\n=== %s ===\n' "$*"; }
+
+load_ko() {
+    ko=$(find /lib/modules -name "$1.ko" 2>/dev/null | head -1)
+    [ -n "$ko" ] && insmod "$ko" 2>/dev/null
+}
+for m in virtio virtio_ring virtio_mmio virtio_blk \
+         sock_diag netlink_diag unix_diag inet_diag tcp_diag udp_diag af_packet_diag \
+         tun veth libcrc32c nfnetlink nf_tables; do
+    load_ko "$m"
+done
+[ -e /dev/net/tun ] || { mkdir -p /dev/net; mknod /dev/net/tun c 10 200; }
+/bin/lo-up || echo "warn: lo-up returned $?"
+
+rm -rf /tmp/cpdump && mkdir -p /tmp/cpdump
+
+say "starting counter"
+setsid /bin/no-iou /usr/local/bin/node /counter.js </dev/null >/dev/null 2>&1 &
+COUNTER_PID=$!
+sleep 4
+printf 'counter at: '; cat /tmp/count 2>/dev/null || echo '(missing)'
+
+say "dumping pid=$COUNTER_PID"
+if criu dump --tree "$COUNTER_PID" --images-dir /tmp/cpdump -v3 -o /tmp/cpdump/dump.log; then
+    echo "dump OK"
+else
+    echo "dump FAILED. Tail of dump.log:"; tail -40 /tmp/cpdump/dump.log; exit 1
+fi
+
+say "writing cpio stream of /tmp/cpdump to /dev/vda"
+cd /tmp/cpdump || exit 1
+find . | cpio -H newc -o > /dev/vda 2>/dev/null
+sync
+echo "cpio write done"
+
+say "power off"
+python3 - <<'PY'
+import ctypes, ctypes.util
+libc = ctypes.CDLL(ctypes.util.find_library('c'))
+libc.reboot(0x4321fedc)  # LINUX_REBOOT_CMD_POWER_OFF
+PY
+sleep 3

--- a/packages/microvm/test-fixtures/handoff-restore.sh
+++ b/packages/microvm/test-fixtures/handoff-restore.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Restores the CRIU dump that handoff-dump.sh produced on another host.
+# Expects the images at /workspace (packed in via a second cpio in the
+# initramfs stream; see the orchestrator for how that's built).
+PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PATH
+
+say() { printf '\n=== %s ===\n' "$*"; }
+show() { printf '/tmp/count: '; cat /tmp/count 2>/dev/null || echo '(missing)'; }
+
+load_ko() {
+    ko=$(find /lib/modules -name "$1.ko" 2>/dev/null | head -1)
+    [ -n "$ko" ] && insmod "$ko" 2>/dev/null
+}
+for m in virtio virtio_ring virtio_mmio virtio_blk \
+         sock_diag netlink_diag unix_diag inet_diag tcp_diag udp_diag af_packet_diag \
+         tun veth libcrc32c nfnetlink nf_tables; do
+    load_ko "$m"
+done
+[ -e /dev/net/tun ] || { mkdir -p /dev/net; mknod /dev/net/tun c 10 200; }
+/bin/lo-up || echo "warn: lo-up returned $?"
+
+say "images handed over at /workspace"
+ls /workspace | head
+
+say "criu restore"
+if criu-ns restore --images-dir /workspace -d -v3 -o /tmp/restore.log; then
+    echo "restore OK"
+else
+    echo "restore FAILED. Tail of restore.log:"; tail -40 /tmp/restore.log; exit 1
+fi
+
+say "watching /tmp/count for advancement"
+for i in 1 2 3 4 5; do
+    sleep 1
+    show
+done
+
+say "done"
+sleep 2

--- a/packages/microvm/test-fixtures/handoff.sh
+++ b/packages/microvm/test-fixtures/handoff.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# End-to-end demo: freeze a Node process inside a microVM on this Mac,
+# ship the dump to a Linux host, restore it there, watch the counter
+# continue. The two hosts never agree on anything except the CRIU
+# images and the counter file's contents.
+#
+# Usage:
+#   ./test-fixtures/handoff.sh <linux-ssh-target>   # e.g. friend@100.126.46.90
+#
+# What it does:
+#   1. On the Mac: build VMM, stage handoff-dump.sh, boot a VM under HVF,
+#      let it dump a Node counter and write the dump as a cpio stream to
+#      /dev/vda (backed by disk.img).
+#   2. Extract that cpio stream into ./cpdump on this host.
+#   3. Ship ./cpdump and the kernel/dtb/initramfs to the Linux host.
+#   4. On the Linux host: build a workspace cpio carrying the images,
+#      concat it onto the base initramfs, and boot the KVM VMM with a
+#      restore-only demo.
+#   5. Print the guest's CRIU transcript.
+
+set -euo pipefail
+
+die() { echo "$*" >&2; exit 1; }
+
+TARGET=${1:-}
+[[ -n "$TARGET" ]] || die "usage: $0 <linux-ssh-target>"
+
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+cd "$HERE"
+
+ROOTFS=test-fixtures/rootfs
+FIXTURES=test-fixtures
+DISK=test-fixtures/disk.img
+STAGE=/tmp/machinen-handoff
+
+# --- Mac: stage + boot + dump --------------------------------------
+echo "==> ensuring helpers are built"
+for helper in lo-up no-iou; do
+    src=$FIXTURES/$helper.c
+    bin=$ROOTFS/usr/bin/$helper
+    if [[ ! -x "$bin" || "$src" -nt "$bin" ]]; then
+        zig cc -target aarch64-linux-musl -static -Os -o "$bin" "$src"
+    fi
+done
+
+echo "==> staging handoff-dump.sh as the guest's demo.sh"
+cp "$FIXTURES/counter.js"          "$ROOTFS/counter.js"
+cp "$FIXTURES/handoff-dump.sh"     "$ROOTFS/handoff-dump.sh"
+chmod +x "$ROOTFS/handoff-dump.sh"
+cat > "$ROOTFS/demo.sh" <<'SH'
+#!/bin/sh
+PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PATH
+exec /bin/sh /handoff-dump.sh
+SH
+chmod +x "$ROOTFS/demo.sh"
+
+echo "==> repacking initramfs"
+python3 "$FIXTURES/mkinitramfs.py" --rootfs "$ROOTFS"
+
+echo "==> zeroing disk.img so cpio trailer detection is unambiguous"
+[[ -f "$DISK" ]] || die "missing $DISK (run test-fixtures/smoke.sh once to create it)"
+dd if=/dev/zero of="$DISK" bs=1M count=128 conv=notrunc status=none
+
+echo "==> building VMM"
+zig build test 2>&1 | grep -E "^error:|warning:" | head -20 || true
+# Multiple test binaries land in .zig-cache; pick the one that has the
+# MACHINEN_BOOT_TEST gate (that's the boot test).
+TEST_BIN=""
+for f in $(ls -t .zig-cache/o/*/test 2>/dev/null); do
+    if strings "$f" 2>/dev/null | grep -q MACHINEN_BOOT_TEST; then
+        TEST_BIN="$f"; break
+    fi
+done
+[[ -x "$TEST_BIN" ]] || die "no VMM boot-test binary under .zig-cache/o/*/test"
+
+echo "==> booting Mac VM; disk.img is auto-picked up as /dev/vda"
+LOG=/tmp/machinen-handoff-mac.log
+MACHINEN_BOOT_TEST=1 "$TEST_BIN" </dev/null 2>"$LOG" &
+VM_PID=$!
+for i in $(seq 1 60); do
+    if grep -q "cpio write done" "$LOG" 2>/dev/null; then break; fi
+    sleep 1
+done
+# Give the PSCI poweroff a moment to propagate.
+sleep 3
+kill -9 "$VM_PID" 2>/dev/null || true
+wait "$VM_PID" 2>/dev/null || true
+
+if ! grep -q "cpio write done" "$LOG"; then
+    echo "Mac dump never wrote cpio. Last 40 lines of guest log:" >&2
+    tail -40 "$LOG" >&2
+    exit 1
+fi
+
+echo "==> extracting cpio from disk.img"
+rm -rf "$STAGE/cpdump" && mkdir -p "$STAGE/cpdump"
+# macOS cpio auto-detects format on -i; omit -H.
+(cd "$STAGE/cpdump" && cpio -i --quiet < "$HERE/$DISK" 2>/dev/null) || true
+[[ -n "$(ls -A "$STAGE/cpdump" 2>/dev/null)" ]] || die "cpio extract produced no files"
+ls "$STAGE/cpdump" | head
+
+echo "==> rebuilding base initramfs with handoff-restore.sh as demo"
+cp "$FIXTURES/handoff-restore.sh" "$ROOTFS/handoff-restore.sh"
+chmod +x "$ROOTFS/handoff-restore.sh"
+cat > "$ROOTFS/demo.sh" <<'SH'
+#!/bin/sh
+PATH=/usr/local/bin:/usr/bin:/bin:/sbin
+export PATH
+exec /bin/sh /handoff-restore.sh
+SH
+chmod +x "$ROOTFS/demo.sh"
+python3 "$FIXTURES/mkinitramfs.py" --rootfs "$ROOTFS"
+
+echo "==> packing CRIU images as a workspace cpio"
+python3 "$FIXTURES/mkinitramfs.py" --workspace "$STAGE/cpdump" \
+    --out "$STAGE/cpdump.cpio" --max-mb 200
+
+echo "==> concatenating base + workspace + terminator"
+cat "$FIXTURES/initramfs.cpio" "$STAGE/cpdump.cpio" > "$STAGE/combined.cpio"
+# Newc cpio trailer: TRAILER!!! as the name, zero-length body.
+python3 - "$STAGE/combined.cpio" <<'PY'
+import sys, struct
+path = sys.argv[1]
+name = b"TRAILER!!!\x00"
+fields = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, len(name), 0]
+hdr = b"070701" + b"".join(f"{v:08x}".encode() for v in fields) + name
+while len(hdr) % 4: hdr += b"\x00"
+with open(path, "ab") as fh:
+    fh.write(hdr)
+PY
+
+echo "==> shipping combined initramfs to $TARGET ($(du -h "$STAGE/combined.cpio" | cut -f1))"
+ssh "$TARGET" 'mkdir -p ~/src/machinen/packages/microvm/test-fixtures'
+rsync -az "$STAGE/combined.cpio" \
+    "$TARGET:~/src/machinen/packages/microvm/test-fixtures/initramfs.cpio"
+# Only need to ship kernel + dtb if the remote doesn't have them yet;
+# rsync skips if unchanged.
+rsync -az "$FIXTURES/Image" "$FIXTURES/virt.dtb" \
+    "$TARGET:~/src/machinen/packages/microvm/test-fixtures/"
+
+echo "==> on $TARGET: boot VMM with combined initramfs, watch restore"
+ssh "$TARGET" bash -s <<'REMOTE'
+set -e
+cd ~/src/machinen/packages/microvm
+# Temporarily bump capture_bytes so the full CRIU transcript lands
+# before the break triggers.
+sed -i.bak 's/.capture_bytes = 512,/.capture_bytes = 65536,/' src/boot_kvm.zig
+~/zig-0.16.0/zig test src/root.zig -lc --cache-dir .zig-cache \
+    --test-no-exec -femit-bin=/tmp/boottest >/dev/null 2>&1
+mv src/boot_kvm.zig.bak src/boot_kvm.zig
+
+MACHINEN_BOOT_TEST=1 timeout 90 /tmp/boottest > /tmp/machinen-handoff-linux.log 2>&1 || true
+echo "--- CRIU transcript ---"
+grep -E "=== |count|restore OK|restore FAILED|/tmp/count" \
+    /tmp/machinen-handoff-linux.log || \
+    { echo "no markers; full log at /tmp/machinen-handoff-linux.log"; exit 1; }
+REMOTE


### PR DESCRIPTION
## Summary

End-to-end proof that a live Node process frozen inside a microVM on one host can be restored inside a microVM on another host running a different hypervisor.

Three scripts:
- **`handoff-dump.sh`** runs inside the Mac VM. Starts a Node counter, `criu dump`s it, writes the image tree as a cpio stream to `/dev/vda`, powers off.
- **`handoff-restore.sh`** runs inside the Linux VM. CRIU images arrive pre-unpacked at `/workspace` (packed in as a second cpio concatenated onto the initramfs). `criu-ns restore` resumes the process.
- **`handoff.sh`** orchestrates from the Mac host: boot the Mac VMM, extract the cpio from `disk.img`, build the concatenated initramfs, ship it to the Linux host, boot the KVM VMM there, print the CRIU transcript.

## Result

Counter frozen on macOS at `3`. Restored on Linux. Resumed at `4`, kept advancing through `9`. Same snapshot format, same rootfs, two different hypervisors (HVF on Apple Silicon → KVM on NVIDIA Grace Blackwell). The process didn't know the difference.

## Test plan

- [x] Run `./test-fixtures/handoff.sh friend@<tailscale-ip>` from the microvm package dir
- [x] Observe "dump OK" on the Mac side
- [x] Observe "restore OK" on the Linux side
- [x] Observe the counter advancing past the frozen value
