### PR TITLE
fix(release): pin zig 0.16 + install libslirp on darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,13 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.16.0
+      - name: Install libslirp
+        # zig build links `-lslirp` for the user-mode network backend.
+        # macos-14 runners don't ship it; install via Homebrew.
+        run: brew install libslirp
       - name: Build VMM (darwin-arm64, native)
         # macos-14 is arm64 — native build picks up the Hypervisor
         # framework from the system SDK. Passing -Dtarget=aarch64-macos
@@ -49,9 +53,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.16.0
       - name: Build VMM (linux-arm64, native)
         working-directory: packages/microvm
         run: zig build -Doptimize=ReleaseSafe
@@ -70,9 +74,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.16.0
       - name: Install dtc
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends device-tree-compiler
       - name: Build base assets


### PR DESCRIPTION
## Problem

The release workflow failed on the first post-merge run: https://github.com/redwoodjs/machinen/actions/runs/24718764162

Two separate issues in `.github/workflows/release.yml`:

1. **Zig version mismatch.** `tests.yml` was migrated to `mlugg/setup-zig@v2` with Zig 0.16.0, but `release.yml` still used `goto-bus-stop/setup-zig@v2` with 0.14.0. `packages/microvm/src/main.zig` uses `std.process.Init`, a 0.16 API, so all three zig jobs (darwin-arm64 VMM, linux-arm64 VMM, base-assets) failed with:

   ```
   src/main.zig:4:30: error: root source file struct 'process' has no member named 'Init'
   ```

2. **Missing libslirp on macos-14.** The darwin VMM links `-lslirp` for the user-mode network backend. `macos-14` runners don't ship it, so the build errored out searching `/opt/homebrew/lib/libslirp.*`.

## Solution

- Align all three jobs with `tests.yml`: `mlugg/setup-zig@v2` + `version: 0.16.0`.
- Add a `brew install libslirp` step to the darwin VMM job, matching how local darwin dev boxes provide the library (the same dep that `packages/vmm-arm64-darwin/postinstall.mjs` probes for on the end-user side).

Once this lands on `main`, the release workflow will re-run and the "Version Packages" PR can be opened (no changesets are queued yet, so this run won't publish — it just needs to be green before we write the first changeset).

## Test plan

- [ ] CI runs and all three zig jobs are green
- [ ] `build-vmm-darwin-arm64` produces a signed binary
- [ ] `build-base-assets` uploads `release-assets/` artifact
- [ ] `release` job reaches `changesets/action` (expected: no-op, no publish, since no changesets pending)
