### PR TITLE
Wire main.zig to the real boot path — machinen run now boots an interactive Debian shell (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ One system dep is not yet statically linked:
 ## Boot a microVM
 
 ```bash
-machinen install                  # pre-fetch kernel + rootfs for the current release
 machinen run ./path/to/bundle     # spawn a microVM from a bundle directory
+```
+
+On first run, the kernel + rootfs for the current release are fetched into
+`~/.machinen/` automatically. To pre-fetch them ahead of time (CI cache warming,
+airgapped prep):
+
+```bash
+machinen install                  # optional: pre-fetch base assets
+machinen install --version <tag>  # pin to a specific release tag
 ```
 
 A bundle is a directory containing `rootfs/` (overlay on top of the base Debian

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format:check": "oxfmt --check",
     "changeset": "changeset",
     "version": "changeset version && oxfmt",
-    "release": "pnpm -F @machinen/runtime -F @machinen/cli build && changeset publish"
+    "release": "pnpm -F @machinen/runtime -F @machinen/cli build && changeset publish",
+    "machinen-dev": "bash scripts/machinen-dev.sh"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -227,8 +227,36 @@ async function cmdRun(args: string[]): Promise<number> {
   vm.stderr.pipe(process.stderr);
   process.stdin.pipe(vm.stdin);
 
-  const { code } = await vm.wait();
-  return code ?? 0;
+  // Propagate SIGINT/SIGTERM to the VMM child. A terminal Ctrl-C
+  // already signals the whole process group (both us and the VMM), so
+  // this mostly matters when only the CLI is signalled — e.g. a
+  // supervisor sending SIGTERM to node, or `kill -INT <cli-pid>` from
+  // another shell. Without this, the VMM survives as an orphan.
+  let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
+  const onSigint = () => {
+    forwardedSignal = "SIGINT";
+    void vm.kill();
+  };
+  const onSigterm = () => {
+    forwardedSignal = "SIGTERM";
+    void vm.kill();
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+
+  try {
+    const { code } = await vm.wait();
+    if (forwardedSignal === "SIGINT") {
+      return 130;
+    }
+    if (forwardedSignal === "SIGTERM") {
+      return 143;
+    }
+    return code ?? 0;
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
 }
 
 async function cmdInstall(args: string[]): Promise<number> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -212,6 +212,9 @@ async function cmdRun(args: string[]): Promise<number> {
       kernel: kernelPath,
       dtb: dtbPath,
       baseRootfs: baseRootfsPath,
+      // Interactive CLI: the session lives as long as the guest does.
+      // Don't impose the default 60s cap.
+      timeoutMs: null,
     });
   } catch (err) {
     if (err instanceof SpawnError) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -193,9 +193,16 @@ async function cmdRun(args: string[]): Promise<number> {
     await ensureBaseAssets(RELEASE_TAG);
   }
 
+  // Resolve the kernel + DTB. MACHINEN_ASSETS_DIR uses the unrenamed
+  // build-base-assets.sh output names; the cache renames on download
+  // (see `ensureBaseAssets`'s `assets` array).
+  const baseDir = assetsOverride ? resolve(assetsOverride) : baseDirFor(RELEASE_TAG);
+  const kernelPath = join(baseDir, assetsOverride ? "Image-arm64" : "Image");
+  const dtbPath = join(baseDir, assetsOverride ? "virt-arm64.dtb" : "virt.dtb");
+
   let vm;
   try {
-    vm = await spawn({ bundle });
+    vm = await spawn({ bundle, kernel: kernelPath, dtb: dtbPath });
   } catch (err) {
     if (err instanceof SpawnError) {
       die(err.message);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -193,16 +193,26 @@ async function cmdRun(args: string[]): Promise<number> {
     await ensureBaseAssets(RELEASE_TAG);
   }
 
-  // Resolve the kernel + DTB. MACHINEN_ASSETS_DIR uses the unrenamed
-  // build-base-assets.sh output names; the cache renames on download
-  // (see `ensureBaseAssets`'s `assets` array).
+  // Resolve the kernel, DTB, and base rootfs tarball.
+  // MACHINEN_ASSETS_DIR uses the unrenamed build-base-assets.sh output
+  // names; the cache renames on download (see `ensureBaseAssets`'s
+  // `assets` array).
   const baseDir = assetsOverride ? resolve(assetsOverride) : baseDirFor(RELEASE_TAG);
   const kernelPath = join(baseDir, assetsOverride ? "Image-arm64" : "Image");
   const dtbPath = join(baseDir, assetsOverride ? "virt-arm64.dtb" : "virt.dtb");
+  const baseRootfsPath = join(
+    baseDir,
+    assetsOverride ? "rootfs-debian-arm64.tar.gz" : "rootfs.tar.gz",
+  );
 
   let vm;
   try {
-    vm = await spawn({ bundle, kernel: kernelPath, dtb: dtbPath });
+    vm = await spawn({
+      bundle,
+      kernel: kernelPath,
+      dtb: dtbPath,
+      baseRootfs: baseRootfsPath,
+    });
   } catch (err) {
     if (err instanceof SpawnError) {
       die(err.message);

--- a/packages/microvm/docs/architecture.md
+++ b/packages/microvm/docs/architecture.md
@@ -41,7 +41,7 @@ them. Each host OS has its own:
   idea, different OS — KVM is Linux's built-in hypervisor interface.
 
 `src/root.zig` picks between them at compile-time via
-`detectBackend()`. `src/boot.zig` / `src/boot_kvm.zig` are the
+`detectBackend()`. `src/boot_hvf.zig` / `src/boot_kvm.zig` are the
 per-backend kernel loaders — the register ABI at the kernel jump is
 the same, but how you set those registers differs per API.
 
@@ -147,7 +147,7 @@ HOST                                       GUEST
 The code is the source of truth. Starting points:
 
 - `../src/root.zig` — backend selection, module map
-- `../src/boot.zig` / `../src/boot_kvm.zig` — kernel + DTB load, vCPU setup
+- `../src/boot_hvf.zig` / `../src/boot_kvm.zig` — kernel + DTB load, vCPU setup
 - `../src/hvf.zig` / `../src/kvm.zig` — the two hypervisor backends
 - `../src/pl011.zig`, `../src/virtio.zig`, `../src/blk.zig`,
   `../src/vsock.zig`, `../src/slirp.zig` — device models

--- a/packages/microvm/src/boot.zig
+++ b/packages/microvm/src/boot.zig
@@ -487,7 +487,12 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     }
     defer {
         slirp_stop.store(true, .release);
-        if (slirp_thread) |t| t.detach();
+        // Join (not detach): the sibling `defer` that destroys the
+        // slirp instance runs right after this one, and the pump
+        // thread calls slirp_pollfds_poll(self.handle, …) every ~10ms.
+        // Detach leaves the thread racing against destroy() and
+        // segfaulting on a freed handle.
+        if (slirp_thread) |t| t.join();
     }
 
     // Stdin-reader thread: blocks on read(0) and, when bytes arrive,

--- a/packages/microvm/src/boot.zig
+++ b/packages/microvm/src/boot.zig
@@ -61,8 +61,15 @@ pub const Config = struct {
     // `linux,initrd-start` property in the DTB's /chosen node.
     initrd_offset: u64 = 0x0400_0000, // 64 MB into RAM
     // How many bytes to capture from serial before we declare the
-    // boot "far enough along to stop."
+    // boot "far enough along to stop." Ignored when `unbounded_serial`
+    // is true.
     capture_bytes: usize = 262144,
+    // When false (default), the vCPU loop breaks once `captured` grows
+    // past `capture_bytes` — a safety valve for tests that just want to
+    // prove the kernel booted. When true, the loop only ends on PSCI
+    // SYSTEM_OFF, an unhandled exception, or `max_exits`. Production
+    // boots (main.zig) want this on; test fixtures want it off.
+    unbounded_serial: bool = false,
     // Stop the loop after this many data-abort/HVC exits no matter what.
     max_exits: usize = 5_000_000,
 };
@@ -666,9 +673,11 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
             },
         }
 
-        // Stop condition: we've seen enough serial output to be
-        // confident the kernel booted far enough to prove our point.
-        if (uart.captured.items.len >= cfg.capture_bytes) break;
+        // Test-mode stop condition: we've seen enough serial output to
+        // be confident the kernel booted far enough to prove our point.
+        // Production boots set `unbounded_serial` so the loop ends only
+        // on PSCI SYSTEM_OFF (or max_exits).
+        if (!cfg.unbounded_serial and uart.captured.items.len >= cfg.capture_bytes) break;
     }
 
     if (exits >= cfg.max_exits) return error.RanTooLong;

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -18,7 +18,7 @@ const builtin = @import("builtin");
 
 comptime {
     if (builtin.os.tag != .macos) {
-        @compileError("boot.zig only builds on macOS (uses HVF)");
+        @compileError("boot_hvf.zig only builds on macOS (uses HVF)");
     }
 }
 

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -1,6 +1,6 @@
 //! Boot an arm64 Linux kernel under KVM (Linux host).
 //!
-//! Shape mirrors boot.zig (HVF path) so the two backends pass the
+//! Shape mirrors boot_hvf.zig (HVF path) so the two backends pass the
 //! same kernel + dtb + initramfs through the same boot protocol.
 //! Differences, all local to this file:
 //!
@@ -49,7 +49,7 @@ pub const Config = struct {
     dtb_offset: u64 = 0x0300_0000,
     initrd_offset: u64 = 0x0400_0000,
     capture_bytes: usize = 262144,
-    // Mirrors boot.zig's flag. When false (default), the loop exits
+    // Mirrors boot_hvf.zig's flag. When false (default), the loop exits
     // after `capture_bytes` bytes of serial — a test-oriented safety
     // valve. When true, the loop runs until PSCI SYSTEM_OFF or
     // `max_exits`. main.zig sets this for production boots.

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -49,6 +49,11 @@ pub const Config = struct {
     dtb_offset: u64 = 0x0300_0000,
     initrd_offset: u64 = 0x0400_0000,
     capture_bytes: usize = 262144,
+    // Mirrors boot.zig's flag. When false (default), the loop exits
+    // after `capture_bytes` bytes of serial — a test-oriented safety
+    // valve. When true, the loop runs until PSCI SYSTEM_OFF or
+    // `max_exits`. main.zig sets this for production boots.
+    unbounded_serial: bool = false,
     max_exits: usize = 5_000_000,
     // GIC v3 placement. Matches our virt.dts: distributor at
     // 0x08000000 (64 KiB window) and redistributor starting at
@@ -176,7 +181,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                 return error.GuestCrashed;
             },
         }
-        if (uart.captured.items.len >= cfg.capture_bytes) break;
+        if (!cfg.unbounded_serial and uart.captured.items.len >= cfg.capture_bytes) break;
     }
 
     if (exits >= cfg.max_exits) {

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -6,7 +6,7 @@
 //! decode. GIC wiring (distributor + redistributor for in-kernel
 //! vgic_v3) is stubbed here — a real boot path will flesh that out.
 //!
-//! Layered so boot.zig (on Linux) can call into a kvm.Vm/kvm.Vcpu
+//! Layered so boot_kvm.zig can call into a kvm.Vm/kvm.Vcpu
 //! pair that has the same shape as hvf.Vm/hvf.Vcpu. Not yet wired
 //! into a Linux boot path; this commit is the ioctl scaffold.
 
@@ -359,8 +359,8 @@ pub const KvmError = error{
 };
 
 // ---------------------------------------------------------------
-// Thin wrappers. The Vm/Vcpu types mirror hvf.zig naming so boot.zig
-// can eventually dispatch at comptime without special-casing.
+// Thin wrappers. The Vm/Vcpu types mirror hvf.zig naming so the
+// boot_{hvf,kvm}.zig pair can stay structurally symmetric.
 
 /// Top-level handle. Owns /dev/kvm and the VM fd.
 pub const Kvm = struct {

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -29,11 +29,11 @@ pub fn main(init: std.process.Init) !void {
     const initrd_path = envRequired("MACHINEN_INITRD");
 
     // Guest console is live-echoed to stderr from inside the boot loop
-    // (boot.zig's PL011 DR-write handler). The result.serial buffer is
+    // (boot_hvf.zig's PL011 DR-write handler). The result.serial buffer is
     // the same bytes, captured for tests — don't re-emit here.
     if (builtin.os.tag == .macos) {
         const disk_path = envOptional("MACHINEN_DISK");
-        const result = try microvm.boot.boot(gpa, .{
+        const result = try microvm.boot_hvf.boot(gpa, .{
             .kernel_path = kernel_path,
             .dtb_path = dtb_path,
             .initrd_path = initrd_path,

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -38,6 +38,7 @@ pub fn main(init: std.process.Init) !void {
             .dtb_path = dtb_path,
             .initrd_path = initrd_path,
             .disk_path = disk_path,
+            .unbounded_serial = true,
         });
         gpa.free(result.serial);
         std.process.exit(if (result.saw_psci_shutdown) 0 else 1);
@@ -48,6 +49,7 @@ pub fn main(init: std.process.Init) !void {
             .kernel_path = kernel_path,
             .dtb_path = dtb_path,
             .initrd_path = initrd_path,
+            .unbounded_serial = true,
         });
         gpa.free(result.serial);
         std.process.exit(if (result.saw_psci_shutdown) 0 else 1);

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -1,14 +1,80 @@
+// machinen-microvm entrypoint. Reads the asset paths the runtime hands
+// down in env vars, dispatches on the host's available backend, and
+// invokes the real boot path. The VMM is a dumb engine here: no cache
+// discovery, no tag awareness — that's the CLI's job.
+//
+// Invoked by @machinen/runtime's spawn(). Direct invocation requires
+// setting the MACHINEN_* env vars by hand; the usage error below points
+// at `machinen run`.
+
 const std = @import("std");
+const builtin = @import("builtin");
 const microvm = @import("microvm");
+
+comptime {
+    if (builtin.os.tag != .macos and builtin.os.tag != .linux) {
+        @compileError("machinen-microvm only supports macOS (HVF) and arm64 Linux (KVM)");
+    }
+}
+
+extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 pub fn main(init: std.process.Init) !void {
     _ = init;
-    std.debug.print("machinen-microvm: scaffold\n", .{});
-    std.debug.print("target: arm64 HVF + x86_64/arm64 KVM Linux-guest VMM\n", .{});
-    std.debug.print("next: hv_vm_create — boot a Debian kernel (see redwoodjs/machinen#42)\n", .{});
 
-    const backend = microvm.detectBackend();
-    std.debug.print("detected backend: {s}\n", .{@tagName(backend)});
+    const gpa = std.heap.page_allocator;
+
+    const kernel_path = envRequired("MACHINEN_KERNEL");
+    const dtb_path = envRequired("MACHINEN_DTB");
+    const initrd_path = envRequired("MACHINEN_INITRD");
+
+    // Guest console is live-echoed to stderr from inside the boot loop
+    // (boot.zig's PL011 DR-write handler). The result.serial buffer is
+    // the same bytes, captured for tests — don't re-emit here.
+    if (builtin.os.tag == .macos) {
+        const disk_path = envOptional("MACHINEN_DISK");
+        const result = try microvm.boot.boot(gpa, .{
+            .kernel_path = kernel_path,
+            .dtb_path = dtb_path,
+            .initrd_path = initrd_path,
+            .disk_path = disk_path,
+        });
+        gpa.free(result.serial);
+        std.process.exit(if (result.saw_psci_shutdown) 0 else 1);
+    } else {
+        // KVM's Config doesn't carry disk_path yet — follow-up to #68.
+        // The boot-to-shell goal doesn't need virtio-blk.
+        const result = try microvm.boot_kvm.boot(gpa, .{
+            .kernel_path = kernel_path,
+            .dtb_path = dtb_path,
+            .initrd_path = initrd_path,
+        });
+        gpa.free(result.serial);
+        std.process.exit(if (result.saw_psci_shutdown) 0 else 1);
+    }
+}
+
+fn envRequired(comptime name: [:0]const u8) []const u8 {
+    const raw = getenv(name.ptr) orelse dieUsage(name);
+    const s = std.mem.span(raw);
+    if (s.len == 0) dieUsage(name);
+    return s;
+}
+
+fn envOptional(comptime name: [:0]const u8) ?[]const u8 {
+    const raw = getenv(name.ptr) orelse return null;
+    const s = std.mem.span(raw);
+    return if (s.len == 0) null else s;
+}
+
+fn dieUsage(missing: []const u8) noreturn {
+    std.debug.print(
+        "machinen-microvm: {s} is unset.\n" ++
+            "  This binary is invoked by @machinen/runtime, not directly.\n" ++
+            "  Use `machinen run <bundle>` instead.\n",
+        .{missing},
+    );
+    std.process.exit(2);
 }
 
 test "backend detection is non-null" {

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -13,7 +13,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 pub const hvf = if (builtin.os.tag == .macos) @import("hvf.zig") else struct {};
-pub const boot = if (builtin.os.tag == .macos) @import("boot.zig") else struct {};
+pub const boot_hvf = if (builtin.os.tag == .macos) @import("boot_hvf.zig") else struct {};
 pub const slirp = if (builtin.os.tag == .macos) @import("slirp.zig") else struct {};
 pub const kvm = if (builtin.os.tag == .linux) @import("kvm.zig") else struct {};
 pub const boot_kvm = if (builtin.os.tag == .linux) @import("boot_kvm.zig") else struct {};
@@ -75,7 +75,7 @@ test "backendAvailable is a bool that corresponds to the OS" {
 test {
     if (builtin.os.tag == .macos) {
         _ = @import("hvf.zig");
-        _ = @import("boot.zig");
+        _ = @import("boot_hvf.zig");
     }
     if (builtin.os.tag == .linux) {
         _ = @import("kvm.zig");

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -636,7 +636,7 @@ pub const Connection = struct {
 pub const BridgeConfig = struct {
     guest_cid: u64 = default_guest_cid,
     ports: []const PortMap,
-    /// Set by boot.zig to hvf.Gic.setSpi(irq, true). Called after we
+    /// Set by boot_hvf.zig to hvf.Gic.setSpi(irq, true). Called after we
     /// inject an RX packet so the guest sees the virtio interrupt.
     raise_irq: ?*const fn (ctx: ?*anyopaque) void = null,
     raise_irq_ctx: ?*anyopaque = null,

--- a/packages/microvm/test-fixtures/mkinitramfs.py
+++ b/packages/microvm/test-fixtures/mkinitramfs.py
@@ -20,7 +20,7 @@ Modes:
                                   the base archive; we write one trailer
                                   at the END of the concatenated stream.
 """
-import fnmatch, os, stat, struct, sys
+import fnmatch, os, shutil, stat, struct, subprocess, sys, tempfile
 from pathlib import Path
 
 HERE = Path(__file__).parent
@@ -270,6 +270,22 @@ def main():
         excludes = load_excludes(Path(args[i + 1]).resolve())
         del args[i:i + 2]
 
+    # Optional base rootfs tarball. When combined with --bundle, extract
+    # the tarball into a temp dir, overlay the bundle's rootfs/ on top,
+    # and pack the merged tree. Matches the overlay model in
+    # .docs/learnings/microvm/rootfs-contract.md — bundles ship diffs,
+    # not standalone rootfses.
+    base_tarball = None
+    if "--base" in args:
+        i = args.index("--base")
+        base_tarball = Path(args[i + 1]).resolve()
+        del args[i:i + 2]
+        if not base_tarball.is_file():
+            print(f"--base: {base_tarball} is not a regular file", file=sys.stderr)
+            sys.exit(2)
+
+    merge_tmp = None
+
     if args and args[0] == "--bundle":
         # Bundle layout: <dir>/rootfs + <dir>/machinen-config.json.
         bundle = Path(args[1]).resolve()
@@ -281,8 +297,29 @@ def main():
         if not cfg_path.is_file():
             print(f"--bundle: missing {cfg_path}", file=sys.stderr)
             sys.exit(2)
+
+        if base_tarball is not None:
+            merge_tmp = Path(tempfile.mkdtemp(prefix="machinen-mkinitramfs-"))
+            print(f"extracting base: {base_tarball} -> {merge_tmp}")
+            subprocess.run(
+                ["tar", "-xzf", str(base_tarball), "-C", str(merge_tmp)],
+                check=True,
+            )
+            print(f"overlaying bundle/rootfs: {rootfs_dir} -> {merge_tmp}")
+            shutil.copytree(
+                rootfs_dir, merge_tmp,
+                dirs_exist_ok=True, symlinks=True,
+            )
+            pack_src = merge_tmp
+        else:
+            pack_src = rootfs_dir
+
         print(f"packing bundle: {bundle}")
-        parts = list(entries_from_rootfs(rootfs_dir, excludes=excludes))
+        try:
+            parts = list(entries_from_rootfs(pack_src, excludes=excludes))
+        finally:
+            if merge_tmp is not None:
+                shutil.rmtree(merge_tmp, ignore_errors=True)
         config_bytes = cfg_path.read_bytes()
     elif args and args[0] == "--rootfs":
         root = Path(args[1]).resolve()

--- a/packages/microvm/test-fixtures/smoke.sh
+++ b/packages/microvm/test-fixtures/smoke.sh
@@ -254,7 +254,7 @@ smoke_spawn() {
     local disk=$FIXTURES/disk.img
     # Drop Claude Code, npm, yarn, udev, most kernel driver modules —
     # none are touched by spawn-warmup.sh / spawn-restore.sh. Combined
-    # with the DTB initrd-end patch in src/boot.zig (kernel scans the
+    # with the DTB initrd-end patch in src/boot_hvf.zig (kernel scans the
     # initrd window for concatenated archives at ~1 GB/s wall-clock),
     # this drives `spawn → restore OK` under a second. See #50.
     local slim="--exclude-from $FIXTURES/spawn-minimal.excludes"

--- a/packages/runtime/src/__tests__/spawn.test.ts
+++ b/packages/runtime/src/__tests__/spawn.test.ts
@@ -149,6 +149,62 @@ describe("disk option", () => {
   });
 });
 
+describe("kernel option", () => {
+  it("throws SpawnError when the kernel path does not exist", async () => {
+    await expect(spawn({ binary: "/bin/sh", kernel: "/nope/missing-kernel" })).rejects.toThrow(
+      /kernel not found/,
+    );
+  });
+
+  it("passes the resolved kernel path as MACHINEN_KERNEL to the child", async () => {
+    const kernel = `/tmp/machinen-runtime-kernel-${process.pid}`;
+    writeFileSync(kernel, "");
+    try {
+      const vm = await spawn({
+        binary: "/bin/sh",
+        args: ["-c", "printf 'KERNEL=%s\\n' \"$MACHINEN_KERNEL\""],
+        kernel,
+        timeoutMs: 2_000,
+      });
+      await vm.wait();
+      const out = await vm.output();
+      expect(out.trim()).toBe(`KERNEL=${kernel}`);
+    } finally {
+      try {
+        unlinkSync(kernel);
+      } catch {}
+    }
+  });
+});
+
+describe("dtb option", () => {
+  it("throws SpawnError when the dtb path does not exist", async () => {
+    await expect(spawn({ binary: "/bin/sh", dtb: "/nope/missing-dtb" })).rejects.toThrow(
+      /dtb not found/,
+    );
+  });
+
+  it("passes the resolved dtb path as MACHINEN_DTB to the child", async () => {
+    const dtb = `/tmp/machinen-runtime-dtb-${process.pid}`;
+    writeFileSync(dtb, "");
+    try {
+      const vm = await spawn({
+        binary: "/bin/sh",
+        args: ["-c", "printf 'DTB=%s\\n' \"$MACHINEN_DTB\""],
+        dtb,
+        timeoutMs: 2_000,
+      });
+      await vm.wait();
+      const out = await vm.output();
+      expect(out.trim()).toBe(`DTB=${dtb}`);
+    } finally {
+      try {
+        unlinkSync(dtb);
+      } catch {}
+    }
+  });
+});
+
 describe("measureFirstByte", () => {
   it("returns the wall-clock time before the child produces stderr", async () => {
     // /bin/sh writes the `1` to stderr immediately.

--- a/packages/runtime/src/__tests__/spawn.test.ts
+++ b/packages/runtime/src/__tests__/spawn.test.ts
@@ -251,6 +251,19 @@ describe("bundle option", () => {
     }
   });
 
+  it("throws SpawnError when baseRootfs is set but the tarball is missing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-test-bundle-"));
+    try {
+      mkdirSync(join(dir, "rootfs"));
+      writeFileSync(join(dir, "machinen-config.json"), "{}");
+      await expect(
+        spawn({ binary: "/bin/sh", bundle: dir, baseRootfs: "/nope/missing-tarball.tgz" }),
+      ).rejects.toThrow(/base rootfs tarball not found/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("boots a bundle and the guest runs the cmd from machinen-config.json", async () => {
     const binary = findBootTestBinary();
     if (!binary || !fixturesPresent()) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -110,6 +110,10 @@ export interface SpawnOptions {
    * shortcut. See #47 (virtio-blk) and #50 (snapshot-from-disk).
    */
   disk?: string;
+  /** Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`. */
+  kernel?: string;
+  /** Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`. */
+  dtb?: string;
   /**
    * Path to a bundle directory: `<bundle>/rootfs/` + `<bundle>/machinen-config.json`.
    * When set, the runtime packs the bundle into a cpio initramfs and
@@ -161,6 +165,20 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
       throw new SpawnError(`disk image not found: ${abs}`);
     }
     env.MACHINEN_DISK = abs;
+  }
+  if (opts.kernel) {
+    const abs = resolve(opts.cwd ?? process.cwd(), opts.kernel);
+    if (!existsSync(abs)) {
+      throw new SpawnError(`kernel not found: ${abs}`);
+    }
+    env.MACHINEN_KERNEL = abs;
+  }
+  if (opts.dtb) {
+    const abs = resolve(opts.cwd ?? process.cwd(), opts.dtb);
+    if (!existsSync(abs)) {
+      throw new SpawnError(`dtb not found: ${abs}`);
+    }
+    env.MACHINEN_DTB = abs;
   }
 
   let bundleTempDir: string | undefined;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -122,6 +122,14 @@ export interface SpawnOptions {
    */
   bundle?: string;
   /**
+   * Optional path to the base rootfs tarball (e.g. the one shipped in
+   * GitHub Releases as `rootfs-debian-arm64.tar.gz`). When provided with
+   * `bundle`, the runtime extracts the tarball and overlays
+   * `<bundle>/rootfs/` on top before packing the cpio. When omitted,
+   * `<bundle>/rootfs/` is treated as a standalone rootfs.
+   */
+  baseRootfs?: string;
+  /**
    * Override the mkinitramfs.py helper used to pack bundles. Defaults
    * to the script in this monorepo's `packages/microvm/test-fixtures/`.
    * Callers outside the monorepo (rare today) must supply it.
@@ -278,7 +286,18 @@ function packBundle(opts: SpawnOptions): { tempDir: string; cpioPath: string } {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
   const cpioPath = join(tempDir, "initramfs.cpio");
 
-  const res = spawnSync("python3", [mk, "--bundle", bundleDir, "--out", cpioPath], {
+  const mkArgs = ["--bundle", bundleDir, "--out", cpioPath];
+  if (opts.baseRootfs) {
+    const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.baseRootfs);
+    if (!existsSync(baseAbs)) {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {}
+      throw new SpawnError(`base rootfs tarball not found: ${baseAbs}`);
+    }
+    mkArgs.unshift("--base", baseAbs);
+  }
+  const res = spawnSync("python3", [mk, ...mkArgs], {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (res.status !== 0) {

--- a/scripts/machinen-dev.sh
+++ b/scripts/machinen-dev.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Build everything from source and boot a microVM into an interactive /bin/sh.
+# No caching — every step runs on every invocation, so this is a reliable
+# "it works end-to-end" check. For the fast dev loop, invoke the underlying
+# CLI directly against an already-built tree.
+#
+# Usage:
+#   pnpm machinen-dev
+# or:
+#   bash scripts/machinen-dev.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+step() { printf '\n==> %s\n' "$*" >&2; }
+
+step "building @machinen/runtime + @machinen/cli"
+pnpm -F @machinen/runtime -F @machinen/cli build
+
+step "building Zig VMM (ReleaseSafe) + codesigning with HVF entitlement"
+(
+  cd packages/microvm
+  zig build -Doptimize=ReleaseSafe
+  codesign -s - --force --entitlements entitlements.plist zig-out/bin/microvm
+)
+mkdir -p packages/vmm-arm64-darwin/bin
+cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-darwin/bin/microvm
+
+step "building base assets (kernel + dtb + rootfs tarball)"
+./scripts/build-base-assets.sh
+
+BUNDLE=/tmp/machinen-dev-bundle
+step "creating bundle at $BUNDLE"
+rm -rf "$BUNDLE"
+mkdir -p "$BUNDLE/rootfs"
+cat > "$BUNDLE/machinen-config.json" <<'JSON'
+{
+  "cmd": ["/bin/sh"],
+  "env": {
+    "PATH": "/usr/local/bin:/usr/bin:/bin:/sbin",
+    "HOME": "/root",
+    "TERM": "xterm-256color"
+  }
+}
+JSON
+
+step "booting — Ctrl-D (in shell) to exit cleanly, Ctrl-C to kill from host"
+exec env MACHINEN_ASSETS_DIR="$ROOT/release-assets" \
+  node "$ROOT/packages/cli/dist/cli.js" run "$BUNDLE"


### PR DESCRIPTION
## Summary

Closes #68 M1–M6. `machinen run <bundle>` now boots a real arm64 Debian microVM end-to-end on darwin:

```
$ machinen run ./my-bundle
[    0.000000] Booting Linux on physical CPU 0x0000000000 …
=== machinen /init: reading /machinen-config.json ===
# ls /
bin  boot  dev  etc  home  init  lib  machinen-config.json  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
# exit
```

Before this PR, `main.zig` was a 17-line scaffold that printed a banner; the real boot code lived in `boot.zig` but was only reachable via a gated test. Now `main.zig` reads asset paths from env, `spawn()` / `cmdRun` plumb kernel + DTB + base-rootfs tarball through to it, and a minimal bundle (empty `rootfs/` + `machinen-config.json`) boots cleanly.

## Milestones shipped (see #68 for the full plan)

- **M1** — `main.zig` reads `MACHINEN_{KERNEL,DTB,INITRD,DISK}`, dispatches on backend, calls `boot()`. Also fixes a latent slirp pump-thread race exposed by reaching the clean exit path.
- **M2** — `SpawnOptions.{kernel,dtb}` forwarded as env; `cmdRun` passes them.
- **M3** — `mkinitramfs.py --base <tarball>` composes base Debian rootfs + bundle overlay; `SpawnOptions.baseRootfs` + `cmdRun` wire it up. Minimal bundles with an empty `rootfs/` now boot.
- **M4** — `boot.zig` / `boot_kvm.zig` grew `unbounded_serial: bool`; production boots run until PSCI SYSTEM_OFF instead of being killed at 256KB of serial. Tests keep their default-false cap.
- **M5** — CLI `timeoutMs: null` so interactive sessions aren't killed at 60s. HVF stdin thread was already wired in `boot()`; M4 + the timeout fix are the last pieces.
- **M6** — CLI SIGINT/SIGTERM listeners call `vm.kill()` and exit with 130/143. Previously, signalling only the CLI (supervisors, `kill -INT <cli-pid>`) left the VMM running as an orphan.

Each milestone was committed separately with a manual-test record in the message; you can review them one at a time.

## Deferred to follow-ups

- **M7 — KVM parity.** `boot_kvm.zig` needs the same stdin-thread + `unbounded_serial` wiring as HVF, plus optional `disk_path`. Mechanical change, but we can't verify without an arm64 Linux host — agent-ci runs Linux x86_64, not arm64. Filing as its own issue.
- **Clean guest-side PSCI_OFF from host Ctrl-C.** Needs `hv_vcpus_exit` on HVF (break the vCPU loop from another thread) and signal-driven `KVM_RUN` break on Linux. The plan flagged this as follow-up; M6 covers the host-side teardown without it.
- **Pre-tty-setup stdin bytes.** Piping stdin immediately at boot loses bytes during the kernel's tty init (`tcsetattr(TCSAFLUSH)` discards the pre-buffered line). Doesn't affect real interactive use — users type well after boot — but worth noting.

## Test plan

- [x] Unit tests: `npx vitest run` → 31 / 31 passed (was 26 — four new kernel/dtb tests plus one `baseRootfs` existence-check test)
- [x] Local CI: `npx agent-ci run --all -q -p` → 1 / 1 passed
- [x] Manual M1: `MACHINEN_KERNEL=… MACHINEN_DTB=… MACHINEN_INITRD=… ./microvm` → Debian 6.1 kernel log + shell cmd output + clean exit 0.
- [x] Manual M2: `MACHINEN_ASSETS_DIR=./release-assets machinen run <pre-merged-bundle>` — same, via CLI path.
- [x] Manual M3: bundle with empty `rootfs/` + `machinen-config.json` + one overlay file. Boots, cmd runs, overlay file contents visible.
- [x] Manual M4: 30,000-line workload (~350KB of serial) runs to completion, PSCI-offs, exit 0. (Before: killed mid-stream at 256KB.)
- [x] Manual M5: `cmd=["/bin/sh"]` + delayed stdin (`ls /`, `exit`). Full shell prompt, listing, exit, clean VMM shutdown.
- [x] Manual M6: SIGINT-only-to-CLI → 38ms, exit 130, VMM dies. SIGTERM-only-to-CLI → 40ms, exit 143, VMM dies. No orphans.
