### PR TITLE
Shrink base rootfs from 74MB to 38MB

### DIFF
--- a/packages/microvm/test-fixtures/init.zig
+++ b/packages/microvm/test-fixtures/init.zig
@@ -42,6 +42,9 @@ extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
 extern "c" fn fork() c_int;
 extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
 extern "c" fn _exit(status: c_int) noreturn;
+extern "c" fn clock_settime(clk_id: c_int, tp: *const timespec) c_int;
+
+const CLOCK_REALTIME: c_int = 0;
 
 const timespec = extern struct { tv_sec: i64, tv_nsec: i64 };
 
@@ -80,6 +83,26 @@ fn mountIgnore(src: [*:0]const u8, dst: [*:0]const u8, fstype: [*:0]const u8) vo
 
 fn mkdirIgnore(path: [*:0]const u8) void {
     _ = mkdir(path, 0o755);
+}
+
+// Set the realtime clock from /etc/machinen-boot-epoch. mkinitramfs.py
+// bakes the host's wall-clock epoch into the cpio at pack time; without
+// this the guest boots at 1970 and TLS / apt date checks fail.
+fn setBootClock() void {
+    const fd = open("/etc/machinen-boot-epoch", O_RDONLY);
+    if (fd < 0) return;
+    defer _ = close(fd);
+    var buf: [32]u8 = undefined;
+    const n = read(fd, &buf, buf.len);
+    if (n <= 0) return;
+    var sec: i64 = 0;
+    for (buf[0..@intCast(n)]) |b| {
+        if (b < '0' or b > '9') break;
+        sec = sec * 10 + @as(i64, b - '0');
+    }
+    if (sec <= 0) return;
+    const ts: timespec = .{ .tv_sec = sec, .tv_nsec = 0 };
+    _ = clock_settime(CLOCK_REALTIME, &ts);
 }
 
 // Bring up the user-mode network by fork+execing /sbin/machinen-netup
@@ -234,6 +257,7 @@ pub fn main() noreturn {
 
     writeStr(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
 
+    setBootClock();
     bringUpNetwork();
 
     // Page allocator works on musl via mmap.

--- a/packages/microvm/test-fixtures/init.zig
+++ b/packages/microvm/test-fixtures/init.zig
@@ -39,6 +39,9 @@ extern "c" fn mount(
 ) c_int;
 extern "c" fn nanosleep(req: *const timespec, rem: ?*timespec) c_int;
 extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
+extern "c" fn fork() c_int;
+extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
+extern "c" fn _exit(status: c_int) noreturn;
 
 const timespec = extern struct { tv_sec: i64, tv_nsec: i64 };
 
@@ -77,6 +80,28 @@ fn mountIgnore(src: [*:0]const u8, dst: [*:0]const u8, fstype: [*:0]const u8) vo
 
 fn mkdirIgnore(path: [*:0]const u8) void {
     _ = mkdir(path, 0o755);
+}
+
+// Bring up the user-mode network by fork+execing /sbin/machinen-netup
+// (a static helper shipped in the base rootfs). Best-effort: if the
+// helper is missing or fails, log and continue — the user cmd still
+// runs, just without networking.
+fn bringUpNetwork() void {
+    const pid = fork();
+    if (pid < 0) {
+        logLine("init: fork failed — skipping network bring-up");
+        return;
+    }
+    if (pid == 0) {
+        const path: [*:0]const u8 = "/sbin/machinen-netup";
+        const argv = [_:null]?[*:0]const u8{path};
+        const envp = [_:null]?[*:0]const u8{};
+        _ = execve(path, &argv, &envp);
+        _exit(127);
+    }
+    var status: c_int = 0;
+    _ = waitpid(pid, &status, 0);
+    if (status != 0) logLine("init: machinen-netup exited non-zero — network may not be up");
 }
 
 fn waitForConsole() c_int {
@@ -208,6 +233,8 @@ pub fn main() noreturn {
     }
 
     writeStr(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
+
+    bringUpNetwork();
 
     // Page allocator works on musl via mmap.
     var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/packages/microvm/test-fixtures/machinen-netup.c
+++ b/packages/microvm/test-fixtures/machinen-netup.c
@@ -1,0 +1,72 @@
+// Bring up lo + eth0, assign 10.0.2.15/24 to eth0, install a default
+// route via 10.0.2.2. Matches SLIRP's defaults (see
+// packages/microvm/src/slirp.zig — guest net 10.0.2.0/24, gw 10.0.2.2,
+// DNS 10.0.2.3). Static musl binary invoked once by /init before it
+// execve's the user cmd, so every machinen microVM boots with working
+// network with no bundle-level boilerplate.
+//
+// We skip DHCP (no client in the minbase rootfs) and use the same
+// address libslirp's DHCP server would have handed out.
+//
+// Build: zig cc -target aarch64-linux-musl -static -Os -o machinen-netup machinen-netup.c
+#include <stdio.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <net/route.h>
+#include <unistd.h>
+
+static int if_up(int s, const char *name) {
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+    if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) return -1;
+    ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+    if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) return -1;
+    return 0;
+}
+
+static int if_addr(int s, const char *name, const char *ip, const char *mask) {
+    struct ifreq ifr;
+    struct sockaddr_in *sin = (struct sockaddr_in *)&ifr.ifr_addr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+    sin->sin_family = AF_INET;
+
+    if (inet_pton(AF_INET, ip, &sin->sin_addr) != 1) return -1;
+    if (ioctl(s, SIOCSIFADDR, &ifr) < 0) return -1;
+
+    if (inet_pton(AF_INET, mask, &sin->sin_addr) != 1) return -1;
+    if (ioctl(s, SIOCSIFNETMASK, &ifr) < 0) return -1;
+    return 0;
+}
+
+static int gw_set(int s, const char *gw) {
+    struct rtentry rt;
+    memset(&rt, 0, sizeof(rt));
+    struct sockaddr_in *dst = (struct sockaddr_in *)&rt.rt_dst;
+    struct sockaddr_in *g   = (struct sockaddr_in *)&rt.rt_gateway;
+    struct sockaddr_in *msk = (struct sockaddr_in *)&rt.rt_genmask;
+    dst->sin_family = AF_INET;
+    msk->sin_family = AF_INET;
+    g->sin_family   = AF_INET;
+    if (inet_pton(AF_INET, gw, &g->sin_addr) != 1) return -1;
+    rt.rt_flags = RTF_UP | RTF_GATEWAY;
+    if (ioctl(s, SIOCADDRT, &rt) < 0) return -1;
+    return 0;
+}
+
+int main(void) {
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s < 0) { perror("socket"); return 1; }
+    if (if_up(s, "lo") < 0) perror("lo up");                  // non-fatal
+    if (if_up(s, "eth0") < 0) { perror("eth0 up"); return 2; }
+    if (if_addr(s, "eth0", "10.0.2.15", "255.255.255.0") < 0) {
+        perror("eth0 addr"); return 3;
+    }
+    if (gw_set(s, "10.0.2.2") < 0) { perror("gw set"); return 4; }
+    close(s);
+    return 0;
+}

--- a/packages/microvm/test-fixtures/machinen-netup.c
+++ b/packages/microvm/test-fixtures/machinen-netup.c
@@ -10,10 +10,13 @@
 //
 // Build: zig cc -target aarch64-linux-musl -static -Os -o machinen-netup machinen-netup.c
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #include <net/if.h>
 #include <net/route.h>
 #include <unistd.h>
@@ -58,7 +61,45 @@ static int gw_set(int s, const char *gw) {
     return 0;
 }
 
+// The Debian cloud-arm64 kernel ships virtio_mmio (the bus transport
+// that drives the virtio_mmio@... DTB entries) and virtio_net (the
+// net-device driver) as separate modules on orthogonal axes.
+// virtio_net depends on virtio + virtio_ring but NOT on virtio_mmio,
+// so we have to modprobe both: virtio_mmio to bind the DTB entries,
+// virtio_net to claim the resulting virtio devices.
+static int modprobe_virtio_net(void) {
+    pid_t pid = fork();
+    if (pid < 0) return -1;
+    if (pid == 0) {
+        execl("/sbin/modprobe", "modprobe", "-a", "virtio_mmio", "virtio_net", (char *)NULL);
+        _exit(127);
+    }
+    int st = 0;
+    if (waitpid(pid, &st, 0) < 0) return -1;
+    return (WIFEXITED(st) && WEXITSTATUS(st) == 0) ? 0 : -1;
+}
+
+// Poll /sys/class/net/eth0 for up to ~1s — virtio probe is async
+// after modprobe returns.
+static int wait_for_eth0(void) {
+    struct stat st;
+    for (int i = 0; i < 20; i++) {
+        if (stat("/sys/class/net/eth0", &st) == 0) return 0;
+        usleep(50 * 1000);
+    }
+    return -1;
+}
+
 int main(void) {
+    if (modprobe_virtio_net() < 0) {
+        fprintf(stderr, "machinen-netup: modprobe virtio_net failed\n");
+        return 5;
+    }
+    if (wait_for_eth0() < 0) {
+        fprintf(stderr, "machinen-netup: eth0 did not appear\n");
+        return 6;
+    }
+
     int s = socket(AF_INET, SOCK_DGRAM, 0);
     if (s < 0) { perror("socket"); return 1; }
     if (if_up(s, "lo") < 0) perror("lo up");                  // non-fatal

--- a/packages/microvm/test-fixtures/mkinitramfs.py
+++ b/packages/microvm/test-fixtures/mkinitramfs.py
@@ -20,7 +20,7 @@ Modes:
                                   the base archive; we write one trailer
                                   at the END of the concatenated stream.
 """
-import fnmatch, os, shutil, stat, struct, subprocess, sys, tempfile
+import fnmatch, os, shutil, stat, struct, subprocess, sys, tempfile, time
 from pathlib import Path
 
 HERE = Path(__file__).parent
@@ -285,8 +285,10 @@ def main():
             sys.exit(2)
 
     merge_tmp = None
+    bundle_mode = False
 
     if args and args[0] == "--bundle":
+        bundle_mode = True
         # Bundle layout: <dir>/rootfs + <dir>/machinen-config.json.
         bundle = Path(args[1]).resolve()
         rootfs_dir = bundle / "rootfs"
@@ -333,14 +335,32 @@ def main():
             newc("dev", 0o40755),
             newc("init", 0o100755, data=init_bytes),
         ]
-    # Always ensure /init is our compiled one and /dev/console exists.
-    if INIT.exists():
+    # Legacy --rootfs callers (try.sh, smoke.sh, handoff.sh) pass a
+    # rootfs tree that doesn't carry its own /init, so we slap our
+    # pre-compiled test-fixtures/init on top. --bundle mode gets /init
+    # from the base rootfs tarball (built by build-base-assets.sh) and
+    # overriding it here would shadow build-time updates — don't.
+    if not bundle_mode and INIT.exists():
         init_bytes = INIT.read_bytes()
         parts.append(newc("init", 0o100755, data=init_bytes))
     if config_bytes is not None:
         parts.append(newc("machinen-config.json", 0o100644, data=config_bytes))
+    # Bake the host's current epoch so /init can set the guest clock.
+    # Without this the guest boots at 1970-01-01 and TLS + apt Release
+    # date validation break.
+    parts.append(newc("etc", 0o40755))
+    parts.append(newc(
+        "etc/machinen-boot-epoch",
+        0o100644,
+        data=str(int(time.time())).encode(),
+    ))
     parts.append(newc("dev", 0o40755))
     parts.append(newc("dev/console", 0o20600, rmajor=5, rminor=1))
+    # Force /tmp to the canonical sticky-world-writable (1777). The base
+    # tarball ships /tmp that way but macOS tar strips the sticky bit
+    # when extracting as non-root, so apt (which drops privs to _apt for
+    # downloads) fails with "Couldn't create temporary file".
+    parts.append(newc("tmp", 0o41777))
     # Trailer.
     parts.append(newc("TRAILER!!!", 0))
 

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -134,8 +134,31 @@ mmdebstrap \
   --setup-hook=/tmp/setup-hook.sh \
   bookworm /work/rootfs
 
-# Depmod so modprobe can resolve dependencies without a live uname.
+# linux-image-cloud-arm64 ships every driver the Debian cloud kernel
+# knows about (~28MB of .ko). We only ever modprobe a handful at boot
+# (see packages/microvm/test-fixtures/machinen-netup.c), so prune
+# the rest. Saves roughly 25MB on the rootfs tarball.
 KVER=$(ls /work/rootfs/lib/modules | head -1)
+KMODS=/work/rootfs/lib/modules/$KVER/kernel
+STAGE=$(mktemp -d)
+for f in \
+  drivers/virtio/virtio.ko \
+  drivers/virtio/virtio_ring.ko \
+  drivers/virtio/virtio_mmio.ko \
+  drivers/net/virtio_net.ko \
+  drivers/net/net_failover.ko \
+  net/core/failover.ko
+do
+  [ -f "$KMODS/$f" ] || { echo "missing module: $f" >&2; exit 1; }
+  mkdir -p "$STAGE/$(dirname "$f")"
+  mv "$KMODS/$f" "$STAGE/$f"
+done
+rm -rf "$KMODS"
+mkdir -p "$KMODS"
+cp -a "$STAGE/." "$KMODS/"
+rm -rf "$STAGE"
+
+# Depmod so modprobe can resolve dependencies without a live uname.
 chroot /work/rootfs depmod -a "$KVER"
 
 # Belt-and-braces cleanup for things path-exclude doesn't cover.

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -10,6 +10,7 @@
 #   packages/microvm/test-fixtures/virt.dts
 #   packages/microvm/test-fixtures/init.zig
 #   packages/microvm/test-fixtures/exec-agent.zig
+#   packages/microvm/test-fixtures/machinen-netup.c
 #
 # Requirements:
 #   - docker (with arm64 emulation; GH runners have this by default via
@@ -48,10 +49,11 @@ echo "==> Compiling virt.dts -> virt-arm64.dtb"
 dtc -I dts -O dtb "${FIXTURES}/virt.dts" -o "${OUT}/virt-arm64.dtb"
 
 # ------------------------------------------------------------
-# 3. Guest binaries: /init + /exec-agent, statically linked musl
+# 3. Guest binaries: /init + /exec-agent + /sbin/machinen-netup
+#    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent) for aarch64-linux-musl"
+echo "==> Building guest binaries (init, exec-agent, machinen-netup) for aarch64-linux-musl"
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STAGE"' EXIT
 
@@ -63,6 +65,12 @@ for name in init exec-agent; do
     -femit-bin="${STAGE}/${name}"
   rm -f "${STAGE}/${name}.o"
 done
+
+zig cc "${FIXTURES}/machinen-netup.c" \
+  -target aarch64-linux-musl \
+  -static \
+  -Os \
+  -o "${STAGE}/machinen-netup"
 
 # ------------------------------------------------------------
 # 4. Rootfs — mmdebstrap minbase + aggressive strip + guest binaries
@@ -129,8 +137,25 @@ rm -rf \
 find /work/rootfs/usr/share/locale -mindepth 1 -maxdepth 1 \
   ! -name "en*" -exec rm -rf {} + 2>/dev/null || true
 
+# Strip /dev/* device nodes. Two reasons:
+#   1) devtmpfs at boot populates /dev with real nodes anyway.
+#   2) Character-device entries in a tar archive can't be extracted as
+#      a non-root user (e.g. during `mkinitramfs` on darwin) — mknod
+#      requires CAP_MKNOD.
+# Keep /dev itself as an empty directory so the kernel has somewhere
+# to mount devtmpfs.
+rm -rf /work/rootfs/dev
+mkdir -m 0755 /work/rootfs/dev
+
+# DNS resolver. SLIRP (see packages/microvm/src/slirp.zig) exposes a
+# virtual nameserver at 10.0.2.3. Without a resolv.conf, glibc falls
+# back to 127.0.0.1 which has nothing listening — `apt-get update`
+# and any other hostname lookup will fail.
+echo "nameserver 10.0.2.3" > /work/rootfs/etc/resolv.conf
+
 install -m 0755 /stage/init       /work/rootfs/init
 install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
+install -m 0755 -D /stage/machinen-netup /work/rootfs/sbin/machinen-netup
 
 # Deterministic tar + gzip written as a single file to the bind mount.
 tar --sort=name --owner=0 --group=0 --numeric-owner \

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -3,7 +3,7 @@
 #
 #   Image-arm64                    ← Debian cloud arm64 kernel
 #   virt-arm64.dtb                 ← compiled device tree
-#   rootfs-debian-arm64.tar.gz     ← node:lts-slim + /init + /exec-agent
+#   rootfs-debian-arm64.tar.gz     ← debian minbase + /init + /exec-agent
 #   *.sha256                       ← integrity sidecars
 #
 # Inputs (relative to repo root):
@@ -65,33 +65,79 @@ for name in init exec-agent; do
 done
 
 # ------------------------------------------------------------
-# 4. Rootfs tarball — node:lts-slim arm64 + injected guest binaries
+# 4. Rootfs — mmdebstrap minbase + aggressive strip + guest binaries
 # ------------------------------------------------------------
+#
+# Single docker run: build inside the container's own filesystem and
+# only write the final tarball to the bind-mounted /out. Reason:
+# Docker Desktop on darwin uses virtio-fs for bind mounts, and dpkg
+# install touches symlinks (e.g. /usr/share/man/man7/pam.7.gz) that
+# trigger I/O errors through virtio-fs under qemu emulation. Building
+# on the container's overlay2 sidesteps that entirely.
+#
+# --privileged: mmdebstrap needs CAP_SYS_ADMIN for `unshare --mount`.
+# gpg + debian-archive-keyring: required to verify the Release signature.
+# --setup-hook: pre-seeds dpkg path-excludes BEFORE essential package
+#   install, so man/doc/info are never unpacked to begin with.
 
-echo "==> Exporting node:lts-slim arm64 rootfs + injecting guest binaries"
-CID=$(docker create --platform linux/arm64 node:lts-slim sleep 0)
-trap 'docker rm -f "$CID" >/dev/null 2>&1 || true; rm -rf "$STAGE"' EXIT
+echo "==> Building minimal Debian arm64 rootfs via mmdebstrap"
 
-ROOTFS_STAGE="${STAGE}/rootfs"
-mkdir -p "$ROOTFS_STAGE"
-docker export "$CID" | tar -x -C "$ROOTFS_STAGE"
-
-install -m 0755 "${STAGE}/init" "${ROOTFS_STAGE}/init"
-install -m 0755 "${STAGE}/exec-agent" "${ROOTFS_STAGE}/exec-agent"
-
-# Deterministic tar + gzip. We run this inside a container so the flags
-# (`--sort`, `--mtime`, `--owner`, `--group`, `--numeric-owner`) behave
-# consistently on Linux runners + darwin dev boxes; BSD tar on macOS
-# doesn't support these options.
-docker run --rm \
-  -v "$ROOTFS_STAGE":/rootfs:ro \
+docker run --rm -i --privileged --platform linux/arm64 \
+  -v "${STAGE}":/stage:ro \
   -v "$OUT":/out \
-  debian:bookworm-slim bash -c '
-    tar --sort=name --owner=0 --group=0 --numeric-owner \
-      --mtime="2020-01-01 00:00Z" \
-      -C /rootfs -cf - . |
-    gzip -n > /out/rootfs-debian-arm64.tar.gz
-  '
+  debian:bookworm-slim bash -s <<'CONTAINER_SCRIPT'
+set -euo pipefail
+
+apt-get update -qq > /dev/null
+apt-get install -y --no-install-recommends \
+  mmdebstrap gpg debian-archive-keyring > /dev/null
+
+mkdir -p /work
+
+cat > /tmp/setup-hook.sh <<'HOOK'
+#!/bin/sh
+set -e
+mkdir -p "$1/etc/dpkg/dpkg.cfg.d" "$1/etc/apt/apt.conf.d"
+cat > "$1/etc/dpkg/dpkg.cfg.d/99-machinen" <<EOF
+path-exclude /usr/share/doc/*
+path-exclude /usr/share/man/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en*
+EOF
+cat > "$1/etc/apt/apt.conf.d/99-machinen" <<EOF
+APT::Install-Recommends "false";
+APT::Install-Suggests  "false";
+EOF
+HOOK
+chmod +x /tmp/setup-hook.sh
+
+mmdebstrap \
+  --variant=minbase \
+  --architectures=arm64 \
+  --setup-hook=/tmp/setup-hook.sh \
+  bookworm /work/rootfs
+
+# Belt-and-braces cleanup for things path-exclude doesn't cover.
+rm -rf \
+  /work/rootfs/usr/share/man \
+  /work/rootfs/usr/share/doc \
+  /work/rootfs/usr/share/info \
+  /work/rootfs/var/cache/apt/archives/*.deb \
+  /work/rootfs/var/lib/apt/lists/* \
+  /work/rootfs/var/log/*
+find /work/rootfs/usr/share/locale -mindepth 1 -maxdepth 1 \
+  ! -name "en*" -exec rm -rf {} + 2>/dev/null || true
+
+install -m 0755 /stage/init       /work/rootfs/init
+install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
+
+# Deterministic tar + gzip written as a single file to the bind mount.
+tar --sort=name --owner=0 --group=0 --numeric-owner \
+  --mtime="2020-01-01 00:00Z" \
+  -C /work/rootfs -cf - . |
+gzip -n > /out/rootfs-debian-arm64.tar.gz
+CONTAINER_SCRIPT
 
 # ------------------------------------------------------------
 # 5. Sha256 sidecars

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -120,20 +120,37 @@ EOF
 HOOK
 chmod +x /tmp/setup-hook.sh
 
+# linux-image-cloud-arm64 + kmod: the Debian cloud kernel we ship
+# (scripts/build-base-assets.sh section 1) carries virtio_mmio /
+# virtio_net as modules, not built-in. Without /lib/modules inside
+# the guest and modprobe to load them, the kernel sees virtio-mmio
+# devices in the DTB but has no driver to bind to them — no eth0,
+# no networking. Install the matching kernel package and kmod;
+# /init will `modprobe virtio_net` via /sbin/machinen-netup at boot.
 mmdebstrap \
   --variant=minbase \
   --architectures=arm64 \
+  --include=linux-image-cloud-arm64,kmod \
   --setup-hook=/tmp/setup-hook.sh \
   bookworm /work/rootfs
 
+# Depmod so modprobe can resolve dependencies without a live uname.
+KVER=$(ls /work/rootfs/lib/modules | head -1)
+chroot /work/rootfs depmod -a "$KVER"
+
 # Belt-and-braces cleanup for things path-exclude doesn't cover.
+# Also drop the second copy of the kernel image and initrd hooks we
+# don't use (we boot Image-arm64 from release-assets, not from
+# inside the guest's /boot).
 rm -rf \
   /work/rootfs/usr/share/man \
   /work/rootfs/usr/share/doc \
   /work/rootfs/usr/share/info \
   /work/rootfs/var/cache/apt/archives/*.deb \
   /work/rootfs/var/lib/apt/lists/* \
-  /work/rootfs/var/log/*
+  /work/rootfs/var/log/* \
+  /work/rootfs/boot/* \
+  /work/rootfs/etc/kernel
 find /work/rootfs/usr/share/locale -mindepth 1 -maxdepth 1 \
   ! -name "en*" -exec rm -rf {} + 2>/dev/null || true
 


### PR DESCRIPTION
## Problem

Every microVM starts from a base filesystem image. Until this change, that base was built by exporting Docker's `node:lts-slim` container — 74MB on the wire that shipped Node.js and a pile of other tooling to every guest, whether the workload needed it or not. The project direction is the opposite: the base should carry the minimum needed to boot and install more software, and any runtime (Node, Python, etc.) is the user's choice.

Swapping to a truly minimal Debian base turned out to be one easy change followed by a long tail of smaller problems that together made `apt-get update` fail inside a freshly booted VM.

## Solution

Four commits, each fixing a different layer of the stack.

### 1. Rebuild the base with `mmdebstrap --variant=minbase`

Replace the `node:lts-slim` export with `mmdebstrap` — a Debian tool that produces minimal Debian installations. Ship just `apt`, `dpkg`, and the essential packages they need. Before any package unpacks, install a `dpkg` config that tells it to skip man pages, docs, info files, and non-English locales, so those never land on disk in the first place. After install, remove `apt`'s download cache, package lists, and log files. Do all of this on the build container's own disk and only copy the finished tarball out — this avoids a `virtio-fs` input/output error on macOS Docker Desktop that trips on certain symlinks during package install.

### 2. Make `/init` bring up networking automatically

The old `try.sh` demo had a `netup` bash function the user ran by hand. Move that into `/init` so every microVM boots with working network. A new tiny static helper (`/sbin/machinen-netup`, from `packages/microvm/test-fixtures/machinen-netup.c`) runs the ioctls that bring `lo` and `eth0` up, assign `10.0.2.15/24` (matching SLIRP's defaults), and install a default route via `10.0.2.2`. Bake `nameserver 10.0.2.3` into `/etc/resolv.conf` at build time so the guest knows where to send DNS queries.

### 3. Ship the kernel modules networking needs

The Debian cloud kernel we use carries `virtio_mmio` (the bus driver that binds the `virtio_mmio@...` device-tree entries) and `virtio_net` (the NIC driver) as separate loadable modules, not built into the kernel. Without them loaded, the kernel sees three virtio slots in the device tree and has no driver to bind to them — `/sys/class/net` never gains `eth0`.

Install `linux-image-cloud-arm64` + `kmod` during the rootfs build, run `depmod`, and have `machinen-netup` call `modprobe -a virtio_mmio virtio_net` before the ioctls. `virtio_net`'s module dependencies don't pull in `virtio_mmio` — they live on orthogonal axes (device kind vs bus transport), so both have to be loaded explicitly.

### 4. Fix the four remaining papercuts that still broke `apt-get update`

With networking up, `apt-get update` still failed four different ways. All four are fixed in one commit:

1. The pack script `mkinitramfs.py` was unconditionally slapping a stale pre-built `/init` binary on top of whatever the base rootfs shipped, so recent `/init` changes (like the network bring-up) never actually ran at boot. Keep the override for legacy callers that pass a bare rootfs, but skip it in bundle mode where the base already has `/init`.
2. `/init` wasn't setting the clock, so the guest booted at 1970-01-01 and `apt`'s date validation rejected every repository as "not valid yet (invalid for another 20000+ days)". The pack script now bakes the host's current epoch into `/etc/machinen-boot-epoch`, and `/init` reads it and calls `clock_settime` before networking comes up.
3. macOS's `tar` drops the sticky bit from directories when extracting as non-root, so `/tmp` inside the VM became mode `755` instead of `1777`. `apt` drops privileges to the `_apt` user for downloads and failed with "couldn't create temporary file". The pack script now emits an explicit `/tmp` entry with mode `1777` at the end of the cpio so the guest always sees it correctly.
4. `linux-image-cloud-arm64` ships roughly 28MB of kernel modules — every driver the Debian cloud kernel knows about. At boot we only ever load six of them. Prune the rest after install and re-run `depmod` so `modprobe` still resolves the ones we keep.

## Result

Rootfs tarball size across the change:

| Step | Size |
|-----|-----|
| `node:lts-slim` (starting point) | 74MB |
| minbase alone | 38MB |
| minbase + full kernel module tree | 66MB |
| minbase + pruned kernel modules (final) | **47MB** |

Inside a fresh microVM: clock matches the host, `eth0` comes up with the right IP and default route, DNS resolves through SLIRP, `apt-get update` fetches 15.5MB of package lists, `apt install -y iputils-ping` completes, and `ping 1.1.1.1` gets replies with ~50ms round-trip time.

## Test plan

- [x] `pnpm machinen-dev` drops into a shell with working network
- [x] `apt-get update && apt install -y iputils-ping` succeeds in that shell
- [x] `ping 1.1.1.1` returns replies
- [x] `date` shows the current host time (not 1970)
- [x] `ls -ld /tmp` shows `drwxrwxrwt`
