### PR TITLE
ci(release): bump darwin-arm64 runner to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ jobs:
   # ------------------------------------------------------------
 
   build-vmm-darwin-arm64:
-    runs-on: macos-14
+    # macos-15: boot_hvf.zig uses the GICv3 API (hv_gic_*) Apple added in
+    # macOS 15 / Xcode 16 SDK. macos-14's SDK doesn't export those symbols
+    # and the link fails.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
@@ -29,10 +32,10 @@ jobs:
           version: 0.16.0
       - name: Install libslirp
         # zig build links `-lslirp` for the user-mode network backend.
-        # macos-14 runners don't ship it; install via Homebrew.
+        # GitHub runners don't ship it; install via Homebrew.
         run: brew install libslirp
       - name: Build VMM (darwin-arm64, native)
-        # macos-14 is arm64 — native build picks up the Hypervisor
+        # macos-15 is arm64 — native build picks up the Hypervisor
         # framework from the system SDK. Passing -Dtarget=aarch64-macos
         # would make Zig treat this as a cross-compile and fail to
         # locate the framework.


### PR DESCRIPTION
## Summary
- Release workflow has been failing on main since #71 — `build-vmm-darwin-arm64` can't link 16 `hv_gic_*` symbols.
- Those symbols are Apple's GICv3 API in Hypervisor.framework, added in macOS 15 / Xcode 16 SDK. The runner was `macos-14` (14.8.5), whose SDK doesn't export them.
- Why it flipped at #71: the references lived in `hvf.zig` / `boot_hvf.zig` since #52, but nothing called `boot_hvf.boot` — main.zig was a scaffold. Zig dead-stripped the whole HVF boot path. #71 ("wire main.zig to the real boot path") made those references live, and the missing symbols started failing the link. Tests stayed green because they don't ReleaseSafe-build the darwin binary.

## Test plan
- [ ] Release workflow passes on this branch (the darwin-arm64 job is the one that was failing — other jobs were already green).
