### PR TITLE
docs: reframe README around transporting live processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import { spawn, snapshot, restore } from "@machinen/runtime";
 const vm = await spawn({ bundle: "./examples/node-counter" });
 // ... let it run, serve traffic, accumulate state ...
 
-const artifact = await snapshot(vm);      // Buffer or writable stream
+const artifact = await snapshot(vm); // Buffer or writable stream
 await fs.writeFile("counter.tar", artifact);
 
 // elsewhere:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # machinen
 
-Native arm64 microVM runtime for AI agents. Spawn a Linux VM from a bundle
-directory in under a second, drive it from Node, throw it away when you're done.
+Transport a running Linux process between machines. Freeze it on your laptop,
+thaw it on a server, resume it next week — heap, sockets, and open files
+intact.
+
+A native arm64 microVM runtime under the hood. Node.js is the first-class
+target; Python, bash, and anything else that boots in a Linux VM works too.
 
 ## Install
 
@@ -19,6 +23,24 @@ One system dep is not yet statically linked:
 - Debian/Ubuntu: `apt install libslirp0`
 - Fedora/RHEL: `dnf install libslirp`
 - Alpine: `apk add libslirp`
+
+## Transport a Node.js process
+
+```bash
+# host A
+machinen run ./examples/node-counter &   # HTTP server on :3000, counts requests
+curl localhost:3000/hit                   # { count: 1 }
+curl localhost:3000/hit                   # { count: 2 }
+
+machinen freeze <id> > counter.tar        # snapshot + rootfs delta
+
+# copy counter.tar to host B, then:
+machinen thaw counter.tar
+curl localhost:3000/hit                   # { count: 3 }  ← same process
+```
+
+Same arch only (arm64 ↔ arm64). The VM's memory, file descriptors, and
+timers come back exactly as they were.
 
 ## Boot a microVM
 
@@ -43,13 +65,17 @@ for the contract.
 ## Drive it from Node
 
 ```ts
-import { spawn } from "@machinen/runtime";
+import { spawn, freeze, thaw } from "@machinen/runtime";
 
 // binary auto-resolves via @machinen/vmm-<arch>-<os> installed alongside.
-const vm = await spawn({ bundle: "./path/to/bundle" });
-vm.stdout.pipe(process.stdout);
-vm.stdin.write("echo hello from inside\n");
-await vm.wait();
+const vm = await spawn({ bundle: "./examples/node-counter" });
+// ... let it run, serve traffic, accumulate state ...
+
+const artifact = await freeze(vm);        // Buffer or writable stream
+await fs.writeFile("counter.tar", artifact);
+
+// elsewhere:
+const restored = await thaw("counter.tar");
 ```
 
 See [`packages/runtime/README.md`](packages/runtime/README.md) for the full surface.

--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ for the contract.
 ## Drive it from Node
 
 ```ts
-import { spawn, freeze, thaw } from "@machinen/runtime";
+import { spawn, snapshot, restore } from "@machinen/runtime";
 
 // binary auto-resolves via @machinen/vmm-<arch>-<os> installed alongside.
 const vm = await spawn({ bundle: "./examples/node-counter" });
 // ... let it run, serve traffic, accumulate state ...
 
-const artifact = await freeze(vm);        // Buffer or writable stream
+const artifact = await snapshot(vm);      // Buffer or writable stream
 await fs.writeFile("counter.tar", artifact);
 
 // elsewhere:
-const restored = await thaw("counter.tar");
+const restored = await restore("counter.tar");
 ```
 
 See [`packages/runtime/README.md`](packages/runtime/README.md) for the full surface.


### PR DESCRIPTION
## Problem

The README sold machinen as "a microVM runtime for AI agents." That framing was too narrow on one axis and too vague on the other. It told the reader who the tool was for, but not what it actually did better than any alternative. When two people encountered the project cold (see issue #41), neither clicked with the pitch — they latched onto different things because the headline did not say what the product is.

The direction has also shifted. The project is microVM-only now, and the capability that makes it different is concrete: freeze a running Linux process on one machine, move the snapshot to another machine, and thaw it there with its memory, open files, and network sockets intact.

## Solution

Rewrite the top of the README around that concrete capability.

1. Replace the "microVM runtime for AI agents" headline with a plain description of what the product does: transport a running Linux process between machines.
2. Add a "Transport a Node.js process" section with a worked example — a small HTTP server that keeps counting across the move.
3. Update the TypeScript example to show the library's `snapshot` and `restore` functions. The naming split is intentional: the command-line tool uses `freeze` and `thaw` because those names sell the story, while the library uses `snapshot` and `restore` because those names are accurate.
4. Remove the "for AI agents" line. Who the tool is for can be decided later. Right now the story is what it does.

This pull request is documentation only. The `freeze` and `thaw` commands shown in the new section are not implemented yet; they are the next deliverables on issue #41.

## Test plan

- [ ] Read the new README front-to-back. The opening sentence should make sense without any prior context.
