### PR TITLE
rootfs: base gains CRIU capability (#77 step 1)

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -127,6 +127,40 @@ fn bringUpNetwork() void {
     if (status != 0) logLine("init: machinen-netup exited non-zero — network may not be up");
 }
 
+// Load kernel modules that every machinen workload assumes are usable:
+//   virtio_blk — /dev/vda, for snapshot disks + persistent workspaces
+//   vsock stack — AF_VSOCK sockets; the exec-agent + file/secrets/winsize
+//                 agents all bind here. modprobe resolves the transport
+//                 dep chain (pulls in the _common module).
+//
+// All are in the base rootfs (whitelisted in scripts/build-base-assets.sh).
+// Best-effort: if a module is missing or fails to insert, log and move
+// on — the user cmd may still work depending on what it needs.
+// machinen-netup handles virtio_mmio + virtio_net separately so this
+// function stays focused on the non-network plumbing.
+fn loadPlumbingModules() void {
+    const mods = [_][*:0]const u8{
+        "virtio_blk",
+        "vmw_vsock_virtio_transport",
+    };
+    for (mods) |mod| {
+        const pid = fork();
+        if (pid < 0) continue;
+        if (pid == 0) {
+            const argv = [_:null]?[*:0]const u8{
+                "modprobe",
+                "-q",
+                mod,
+            };
+            const envp = [_:null]?[*:0]const u8{};
+            _ = execve("/sbin/modprobe", &argv, &envp);
+            _exit(127);
+        }
+        var status: c_int = 0;
+        _ = waitpid(pid, &status, 0);
+    }
+}
+
 fn waitForConsole() c_int {
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
@@ -258,6 +292,7 @@ pub fn main() noreturn {
     writeStr(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
 
     setBootClock();
+    loadPlumbingModules();
     bringUpNetwork();
 
     // Page allocator works on musl via mmap.

--- a/packages/microvm/assets/lo-up.zig
+++ b/packages/microvm/assets/lo-up.zig
@@ -1,0 +1,67 @@
+//! Brings up the loopback interface.
+//!
+//! CRIU's kerndat_tcp_repair probe creates a TCP socket and calls
+//! connect(), which fails with ENETUNREACH when `lo` is still DOWN —
+//! and CRIU treats that as a fatal init error. Any snapshot/restore
+//! flow needs loopback up first; this is the minimum ioctl that
+//! accomplishes it, without dragging iproute2 into the base rootfs.
+//!
+//! Build (from packages/microvm):
+//!   zig build-exe assets/lo-up.zig \
+//!     -target aarch64-linux-musl -static -O ReleaseSmall \
+//!     -lc -femit-bin=<out>/machinen-lo-up
+
+const std = @import("std");
+
+const AF_INET: c_int = 2;
+const SOCK_DGRAM: c_int = 2;
+const IFNAMSIZ: usize = 16;
+const SIOCGIFFLAGS: c_ulong = 0x8913;
+const SIOCSIFFLAGS: c_ulong = 0x8914;
+const IFF_UP: c_short = 0x1;
+const IFF_RUNNING: c_short = 0x40;
+
+const ifmap = extern struct {
+    mem_start: c_ulong,
+    mem_end: c_ulong,
+    base_addr: c_ushort,
+    irq: u8,
+    dma: u8,
+    port: u8,
+};
+
+const ifreq = extern struct {
+    ifr_name: [IFNAMSIZ]u8,
+    ifru: extern union {
+        flags: c_short,
+        ivalue: c_int,
+        mtu: c_int,
+        map: ifmap,
+        slave: [IFNAMSIZ]u8,
+        newname: [IFNAMSIZ]u8,
+        data: ?*anyopaque,
+        // pad to the largest union member on any reasonable libc; we
+        // only touch flags, but the kernel copies the full struct.
+        _pad: [24]u8,
+    },
+};
+
+extern "c" fn socket(domain: c_int, socktype: c_int, protocol: c_int) c_int;
+extern "c" fn ioctl(fd: c_int, request: c_ulong, ...) c_int;
+extern "c" fn close(fd: c_int) c_int;
+
+pub fn main() u8 {
+    const fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) return 1;
+    defer _ = close(fd);
+
+    var req: ifreq = std.mem.zeroes(ifreq);
+    req.ifr_name[0] = 'l';
+    req.ifr_name[1] = 'o';
+    req.ifr_name[2] = 0;
+
+    if (ioctl(fd, SIOCGIFFLAGS, &req) < 0) return 2;
+    req.ifru.flags |= IFF_UP | IFF_RUNNING;
+    if (ioctl(fd, SIOCSIFFLAGS, &req) < 0) return 3;
+    return 0;
+}

--- a/packages/microvm/assets/no-iou.zig
+++ b/packages/microvm/assets/no-iou.zig
@@ -1,0 +1,118 @@
+//! Runs a child with io_uring_setup / _enter / _register blocked via seccomp.
+//!
+//! CRIU can't dump a process that holds an io_uring fd. Node.js's libuv
+//! opens rings unconditionally on newer kernels even when UV_USE_IO_URING=0
+//! (the env var is a no-op in some builds), so we seccomp-block the syscalls
+//! and let libuv fall back to epoll silently. To CRIU the process then looks
+//! like any other epoll-based one.
+//!
+//! Usage: machinen-no-iou CMD [ARGS...]
+//!
+//! Build (from packages/microvm):
+//!   zig build-exe assets/no-iou.zig \
+//!     -target aarch64-linux-musl -static -O ReleaseSmall \
+//!     -lc -femit-bin=<out>/machinen-no-iou
+
+// Syscall numbers — same on all architectures for io_uring since it's
+// in the generic syscall table.
+const NR_io_uring_setup: u32 = 425;
+const NR_io_uring_enter: u32 = 426;
+const NR_io_uring_register: u32 = 427;
+
+const PR_SET_NO_NEW_PRIVS: c_int = 38;
+const PR_SET_SECCOMP: c_int = 22;
+const SECCOMP_MODE_FILTER: c_ulong = 2;
+
+// BPF instruction classes and fields — stable ABI from <linux/bpf_common.h>
+// and <linux/filter.h>.
+const BPF_LD: u16 = 0x00;
+const BPF_JMP: u16 = 0x05;
+const BPF_RET: u16 = 0x06;
+const BPF_W: u16 = 0x00;
+const BPF_ABS: u16 = 0x20;
+const BPF_JEQ: u16 = 0x10;
+const BPF_K: u16 = 0x00;
+
+const ENOSYS: u32 = 38;
+const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+const SECCOMP_RET_DATA: u32 = 0x0000_ffff;
+
+const sock_filter = extern struct {
+    code: u16,
+    jt: u8,
+    jf: u8,
+    k: u32,
+};
+
+const sock_fprog = extern struct {
+    len: c_ushort,
+    filter: [*]sock_filter,
+};
+
+// Offset of `nr` in `struct seccomp_data`. First field, so 0.
+const SECCOMP_DATA_NR_OFFSET: u32 = 0;
+
+const std = @import("std");
+
+extern "c" fn prctl(option: c_int, arg2: c_ulong, arg3: c_ulong, arg4: c_ulong, arg5: c_ulong) c_int;
+extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+extern "c" fn perror(s: [*:0]const u8) void;
+extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
+
+fn writeStr(fd: c_int, s: []const u8) void {
+    _ = write(fd, s.ptr, s.len);
+}
+
+pub fn main(init: std.process.Init.Minimal) u8 {
+    // On linux-with-libc, args.vector is `[]const [*:0]const u8` — pointers
+    // into the stack-allocated argv the kernel handed us. Stable for process
+    // lifetime, which is all execvp needs.
+    const argv = init.args.vector;
+    if (argv.len < 2) {
+        writeStr(2, "usage: machinen-no-iou CMD [ARGS...]\n");
+        return 2;
+    }
+
+    var filter = [_]sock_filter{
+        // Load seccomp_data.nr into accumulator.
+        .{ .code = BPF_LD | BPF_W | BPF_ABS, .jt = 0, .jf = 0, .k = SECCOMP_DATA_NR_OFFSET },
+        // If nr == io_uring_setup, jump 3 ahead (to ENOSYS return).
+        .{ .code = BPF_JMP | BPF_JEQ | BPF_K, .jt = 3, .jf = 0, .k = NR_io_uring_setup },
+        // If nr == io_uring_enter, jump 2 ahead.
+        .{ .code = BPF_JMP | BPF_JEQ | BPF_K, .jt = 2, .jf = 0, .k = NR_io_uring_enter },
+        // If nr == io_uring_register, jump 1 ahead.
+        .{ .code = BPF_JMP | BPF_JEQ | BPF_K, .jt = 1, .jf = 0, .k = NR_io_uring_register },
+        // Fallthrough: allow.
+        .{ .code = BPF_RET | BPF_K, .jt = 0, .jf = 0, .k = SECCOMP_RET_ALLOW },
+        // Matched io_uring_*: return ENOSYS so libuv sees "not supported"
+        // and falls back cleanly instead of seeing the syscall killed.
+        .{ .code = BPF_RET | BPF_K, .jt = 0, .jf = 0, .k = SECCOMP_RET_ERRNO | (ENOSYS & SECCOMP_RET_DATA) },
+    };
+
+    const prog = sock_fprog{ .len = filter.len, .filter = &filter };
+
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0) {
+        perror("PR_SET_NO_NEW_PRIVS");
+        return 3;
+    }
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, @intFromPtr(&prog), 0, 0) < 0) {
+        perror("PR_SET_SECCOMP");
+        return 4;
+    }
+
+    // Build a sentinel-terminated argv for execvp. std.process's slice isn't
+    // null-terminated, but the raw memory it points at IS (the C ABI
+    // guarantees argv[argc] == NULL), so a small stack array is enough.
+    var child_argv: [256]?[*:0]const u8 = undefined;
+    if (argv.len > child_argv.len) {
+        writeStr(2, "machinen-no-iou: argv too long\n");
+        return 6;
+    }
+    for (argv[1..], 0..) |a, i| child_argv[i] = a;
+    child_argv[argv.len - 1] = null;
+
+    _ = execvp(argv[1], @ptrCast(&child_argv));
+    perror("execvp");
+    return 5;
+}

--- a/packages/microvm/assets/poweroff.zig
+++ b/packages/microvm/assets/poweroff.zig
@@ -1,0 +1,37 @@
+//! Triggers PSCI SYSTEM_OFF so the VMM exits cleanly.
+//!
+//! The only way a userspace process on arm64 can ask the kernel to
+//! call PSCI SYSTEM_OFF is `reboot(LINUX_REBOOT_CMD_POWER_OFF)`.
+//! Letting /init exit panics the kernel (which fires PSCI SYSTEM_RESET
+//! on arm64 virt — the VMM restarts the guest instead of exiting).
+//! sysvinit-utils' `poweroff` would do this but pulls in ~500 KB of
+//! binaries we otherwise don't use. This is ~15 lines of Zig instead.
+//!
+//! Build (from packages/microvm):
+//!   zig build-exe assets/poweroff.zig \
+//!     -target aarch64-linux-musl -static -O ReleaseSmall \
+//!     -lc -femit-bin=<out>/machinen-poweroff
+
+// Magic numbers from <linux/reboot.h>. Stable ABI since forever.
+const LINUX_REBOOT_MAGIC1: c_int = @bitCast(@as(u32, 0xfee1dead));
+const LINUX_REBOOT_MAGIC2: c_int = 672274793;
+const LINUX_REBOOT_CMD_POWER_OFF: c_int = @bitCast(@as(u32, 0x4321fedc));
+
+extern "c" fn reboot(cmd: c_int) c_int;
+extern "c" fn sync() void;
+
+pub fn main() u8 {
+    // Flush any in-flight disk writes before pulling the plug. Matters
+    // for the CRIU images on /dev/vda — the restore boot needs them
+    // fully on-disk.
+    sync();
+
+    // glibc's reboot(3) wrapper uses only the cmd; musl forwards it to
+    // SYS_reboot(MAGIC1, MAGIC2, cmd, NULL). Either way we pass the
+    // POWER_OFF command and the kernel handles the magic check.
+    _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);
+
+    // Shouldn't return on success. If it does, the kernel refused;
+    // loop so /init doesn't exit and panic the machine.
+    while (true) {}
+}

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -172,6 +172,14 @@ mmdebstrap \
 #   dump; cheap to bake in:
 #     libcrc32c, nfnetlink, nf_tables
 #
+#   AF_VSOCK — the build()/spawn() install-hook flow drives the guest
+#   via a vsock exec-agent. CONFIG_VSOCKETS=m in the Debian cloud
+#   kernel, so we have to ship the module set; /init modprobes them
+#   at boot so userspace can `socket(AF_VSOCK, SOCK_STREAM, 0)`.
+#   vsock_diag is for CRIU walking vsock connections at dump time:
+#     vsock, vmw_vsock_virtio_transport,
+#     vmw_vsock_virtio_transport_common, vsock_diag
+#
 # Resolve each module by filename (find) rather than hard-coded path,
 # so the whitelist is robust to Debian kernel-package layout changes.
 KVER=$(ls /work/rootfs/lib/modules | head -1)
@@ -181,7 +189,8 @@ for m in \
   virtio virtio_ring virtio_mmio virtio_net net_failover failover \
   virtio_blk \
   netlink_diag unix_diag inet_diag tcp_diag udp_diag af_packet_diag \
-  libcrc32c nfnetlink nf_tables
+  libcrc32c nfnetlink nf_tables \
+  vsock vmw_vsock_virtio_transport vmw_vsock_virtio_transport_common vsock_diag
 do
   src=$(find "$KMODS" -type f -name "$m.ko" | head -1)
   [ -n "$src" ] || { echo "missing module: $m.ko" >&2; exit 1; }

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -11,6 +11,9 @@
 #   packages/microvm/assets/init.zig
 #   packages/microvm/assets/exec-agent.zig
 #   packages/microvm/assets/machinen-netup.c
+#   packages/microvm/assets/lo-up.zig         ← CRIU plumbing (loopback ioctl)
+#   packages/microvm/assets/no-iou.zig        ← CRIU plumbing (block io_uring)
+#   packages/microvm/assets/poweroff.zig      ← clean shutdown → PSCI SYSTEM_OFF
 #
 # Requirements:
 #   - docker (with arm64 emulation; GH runners have this by default via
@@ -53,11 +56,15 @@ dtc -I dts -O dtb "${ASSETS}/virt.dts" -o "${OUT}/virt-arm64.dtb"
 #    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent, machinen-netup) for aarch64-linux-musl"
+echo "==> Building guest binaries (init, exec-agent, CRIU helpers, poweroff) for aarch64-linux-musl"
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STAGE"' EXIT
 
-for name in init exec-agent; do
+# init + exec-agent land at /init and /exec-agent (machinen-owned root
+# entrypoints). lo-up, no-iou, poweroff are machinen-namespaced helpers
+# needed by any CRIU-based snapshot flow; they go under /sbin with the
+# machinen- prefix alongside machinen-netup.
+for name in init exec-agent lo-up no-iou poweroff; do
   zig build-exe "${ASSETS}/${name}.zig" \
     -target aarch64-linux-musl \
     -O ReleaseSmall \
@@ -127,31 +134,60 @@ chmod +x /tmp/setup-hook.sh
 # devices in the DTB but has no driver to bind to them — no eth0,
 # no networking. Install the matching kernel package and kmod;
 # /init will `modprobe virtio_net` via /sbin/machinen-netup at boot.
+#
+# criu: required by any snapshot flow (`build()` dumps at freeze
+# time, `spawn({ snapshot })` restores at boot time). Pulls ~5MB of
+# libs (libnl, libprotobuf-c, libnftables). The criu-ns shell helper
+# that solves PID collisions across boots ships in the same package.
+# APT::Install-Recommends "false" is already set by the setup hook,
+# so criu's optional python3 suggestion is skipped.
 mmdebstrap \
   --variant=minbase \
   --architectures=arm64 \
-  --include=linux-image-cloud-arm64,kmod \
+  --include=linux-image-cloud-arm64,kmod,criu \
   --setup-hook=/tmp/setup-hook.sh \
   bookworm /work/rootfs
 
 # linux-image-cloud-arm64 ships every driver the Debian cloud kernel
-# knows about (~28MB of .ko). We only ever modprobe a handful at boot
-# (see packages/microvm/assets/machinen-netup.c), so prune
-# the rest. Saves roughly 25MB on the rootfs tarball.
+# knows about (~28MB of .ko). Keep only the modules the base flow
+# actually loads:
+#
+#   Networking at boot (see machinen-netup.c):
+#     virtio, virtio_ring, virtio_mmio, virtio_net, net_failover, failover
+#
+#   Block device for snapshot images + persistent workspaces:
+#     virtio_blk
+#
+#   Socket state diag — CRIU walks these to dump/restore sockets.
+#   Missing any of them makes `criu dump` fail with obscure kerndat
+#   errors on a process that touches sockets (i.e. most of them).
+#   sock_diag itself is built into the Debian cloud kernel
+#   (CONFIG_SOCK_DIAG=y), so only the per-family backends need to
+#   be kept as modules:
+#     netlink_diag, unix_diag, inet_diag, tcp_diag, udp_diag,
+#     af_packet_diag
+#
+#   Netfilter + crc32c — defensively kept for processes that hold
+#   any iptables/nftables state. CRIU loads these lazily during
+#   dump; cheap to bake in:
+#     libcrc32c, nfnetlink, nf_tables
+#
+# Resolve each module by filename (find) rather than hard-coded path,
+# so the whitelist is robust to Debian kernel-package layout changes.
 KVER=$(ls /work/rootfs/lib/modules | head -1)
 KMODS=/work/rootfs/lib/modules/$KVER/kernel
 STAGE=$(mktemp -d)
-for f in \
-  drivers/virtio/virtio.ko \
-  drivers/virtio/virtio_ring.ko \
-  drivers/virtio/virtio_mmio.ko \
-  drivers/net/virtio_net.ko \
-  drivers/net/net_failover.ko \
-  net/core/failover.ko
+for m in \
+  virtio virtio_ring virtio_mmio virtio_net net_failover failover \
+  virtio_blk \
+  netlink_diag unix_diag inet_diag tcp_diag udp_diag af_packet_diag \
+  libcrc32c nfnetlink nf_tables
 do
-  [ -f "$KMODS/$f" ] || { echo "missing module: $f" >&2; exit 1; }
-  mkdir -p "$STAGE/$(dirname "$f")"
-  mv "$KMODS/$f" "$STAGE/$f"
+  src=$(find "$KMODS" -type f -name "$m.ko" | head -1)
+  [ -n "$src" ] || { echo "missing module: $m.ko" >&2; exit 1; }
+  rel=${src#$KMODS/}
+  mkdir -p "$STAGE/$(dirname "$rel")"
+  mv "$src" "$STAGE/$rel"
 done
 rm -rf "$KMODS"
 mkdir -p "$KMODS"
@@ -165,10 +201,21 @@ chroot /work/rootfs depmod -a "$KVER"
 # Also drop the second copy of the kernel image and initrd hooks we
 # don't use (we boot Image-arm64 from release-assets, not from
 # inside the guest's /boot).
+#
+# Python: criu Depends on python3-protobuf for the `crit` image-debug
+# tool. crit is the only python caller; we don't run it. Deleting the
+# interpreter + stdlib after install (rather than path-excluding during
+# install, which breaks python's own postinst) saves ~30 MB extracted
+# / ~10 MB gz. dpkg's database still lists the packages as installed
+# (`dpkg -l` shows ii) — only the on-disk files are gone.
 rm -rf \
   /work/rootfs/usr/share/man \
   /work/rootfs/usr/share/doc \
   /work/rootfs/usr/share/info \
+  /work/rootfs/usr/bin/python3 /work/rootfs/usr/bin/python3.* \
+  /work/rootfs/usr/lib/python3 \
+  /work/rootfs/usr/lib/python3.* \
+  /work/rootfs/usr/share/python3 \
   /work/rootfs/var/cache/apt/archives/*.deb \
   /work/rootfs/var/lib/apt/lists/* \
   /work/rootfs/var/log/* \
@@ -195,7 +242,10 @@ echo "nameserver 10.0.2.3" > /work/rootfs/etc/resolv.conf
 
 install -m 0755 /stage/init       /work/rootfs/init
 install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
-install -m 0755 -D /stage/machinen-netup /work/rootfs/sbin/machinen-netup
+install -m 0755 -D /stage/machinen-netup    /work/rootfs/sbin/machinen-netup
+install -m 0755 -D /stage/lo-up             /work/rootfs/sbin/machinen-lo-up
+install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou
+install -m 0755 -D /stage/poweroff          /work/rootfs/sbin/machinen-poweroff
 
 # Deterministic tar + gzip written as a single file to the bind mount.
 tar --sort=name --owner=0 --group=0 --numeric-owner \

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -244,5 +244,54 @@ else
   fail "T3 expected $T3_BUNDLE_MARKER (not $T3_MOUNT_MARKER) in guest output"
 fi
 
+# ----------------------------------------------------------------
+# Phase-1 base-rootfs contract tests — verify #77 step 1 plumbing.
+# Each asserts one thing scripts/build-base-assets.sh claims to ship.
+# ----------------------------------------------------------------
+
+# ---- P1: criu binary present and usable ----
+# Absolute path — the CLI wraps non-absolute cmds in `/usr/bin/env`,
+# which does its own PATH search that doesn't know about /sbin by
+# default. Using /usr/sbin/criu directly bypasses that and tests
+# exactly what phase 1 shipped.
+echo "P1: machinen run -- /usr/sbin/criu --version"
+P1_LOG="$FIXTURE/p1.log"
+run_timeout 60 node "$CLI" run -- /usr/sbin/criu --version >"$P1_LOG" 2>&1 || true
+if grep -q "^Version:" "$P1_LOG"; then
+  pass "criu runs inside the base rootfs"
+else
+  tail -50 "$P1_LOG" >&2
+  fail "P1 — criu --version did not print a Version: line"
+fi
+
+# ---- P2: virtio_blk + vmw_vsock_virtio_transport modprobed at boot ----
+# /init's loadPlumbingModules() runs before exec'ing the user cmd, so
+# /proc/modules should list both. Reading /proc directly avoids
+# depending on lsmod's PATH location.
+echo "P2: machinen run -- cat /proc/modules (virtio_blk + vmw_vsock_virtio_transport)"
+P2_LOG="$FIXTURE/p2.log"
+run_timeout 60 node "$CLI" run -- /bin/cat /proc/modules >"$P2_LOG" 2>&1 || true
+if grep -qE "^virtio_blk " "$P2_LOG" && grep -qE "^vmw_vsock_virtio_transport " "$P2_LOG"; then
+  pass "init loaded virtio_blk + vmw_vsock_virtio_transport"
+else
+  tail -50 "$P2_LOG" >&2
+  fail "P2 — expected virtio_blk and vmw_vsock_virtio_transport in /proc/modules"
+fi
+
+# ---- P3: machinen-poweroff triggers PSCI SYSTEM_OFF, VMM exits cleanly ----
+# The normal exit path (init exits → kernel panic → panic reboot) can
+# look the same to an outside observer. We specifically want to prove
+# the /sbin/machinen-poweroff helper works: the kernel prints
+# "reboot: Power down" only on a real POWER_OFF syscall.
+echo "P3: machinen run -- /sbin/machinen-poweroff"
+P3_LOG="$FIXTURE/p3.log"
+run_timeout 60 node "$CLI" run -- /sbin/machinen-poweroff >"$P3_LOG" 2>&1 || true
+if grep -q "reboot: Power down" "$P3_LOG"; then
+  pass "machinen-poweroff invoked reboot(POWER_OFF)"
+else
+  tail -50 "$P3_LOG" >&2
+  fail "P3 — kernel never reported 'reboot: Power down'"
+fi
+
 echo
 echo "all smoke tests passed"


### PR DESCRIPTION
## Problem

#77 asks for `@machinen/runtime` to expose `build({ install })`, which boots the base rootfs, runs a user-supplied install hook via vsock, then freezes with CRIU and writes a snapshot. The first thing that surface needs is a *CRIU-capable* base to boot — and the current minbase (#72, #73) didn't have one.

Missing pieces, audited against the `smoke_spawn` warmup/restore flow and the vsock agents:

- `criu` + `criu-ns`
- `virtio_blk.ko` (pruned in c7e19d5) — no disk → nowhere to put the CRIU image set
- Six `*_diag` kernel modules CRIU walks to dump socket state; `vsock_diag` for vsock-holding processes
- `vsock` + `vmw_vsock_virtio_transport{,_common}` — the agents all bind AF_VSOCK; `CONFIG_VSOCKETS=m` so these have to ship as modules *and* be modprobed at boot
- `/bin/lo-up`, `/bin/no-iou` — built only as test-fixture C helpers in `smoke_criu`, never shipped
- A clean-shutdown path — `spawn-warmup.sh` used `python3 -c '...libc.reboot(POWER_OFF)'`, and python left with #73

Asking every user to write `apt-get install -y criu` in their `build.ts` is boilerplate for machinen's own snapshot primitive. This is base plumbing, same category as `/init` and the vsock agents.

## Solution

1. **`criu` + `criu-ns`** via `mmdebstrap --include=...,criu` (~5 MB of libs: libprotobuf-c, libnftables, libnl). Python is deleted post-install because criu hard-depends on `python3-protobuf` for the `crit` image-debug tool we never call.
2. **Kernel-module whitelist widens from 6 → 20.** `virtio_blk` + 6 per-family socket-diag modules + `libcrc32c`/`nfnetlink`/`nf_tables` (defensive) + the 4 vsock modules. `sock_diag` itself is `CONFIG_SOCK_DIAG=y` in the Debian cloud kernel. Prune logic refactored to resolve modules by filename (`find`) rather than hard-coded paths.
3. **Three new Zig static binaries** in `packages/microvm/assets/`, matching `init.zig` / `exec-agent.zig`, installed under `/sbin`:

   | Binary | Purpose |
   |---|---|
   | `machinen-lo-up` | `SIOCSIFFLAGS IFF_UP` on `lo`. CRIU's `kerndat_tcp_repair` probe calls `connect()` and fails with `ENETUNREACH` if loopback is down. |
   | `machinen-no-iou` | seccomp-BPF blocking `io_uring_setup/enter/register`, then `execvp` the child. libuv opens rings even with `UV_USE_IO_URING=0`; CRIU can't checkpoint them. |
   | `machinen-poweroff` | `reboot(LINUX_REBOOT_CMD_POWER_OFF)`. Only way userspace triggers PSCI `SYSTEM_OFF` so the VMM exits cleanly (letting init exit fires `SYSTEM_RESET` and the guest just restarts). Replaces the `python3 -c` hack. |

4. **`/init` modprobes `virtio_blk` + `vmw_vsock_virtio_transport` at boot**, before execing the user cmd. Without this the modules are present in the rootfs but unbound, and the agents can't `socket(AF_VSOCK, ...)`.

5. **Three new assertions in `scripts/smoke-tests.sh`** (`pnpm smoke-tests`). Previous claim of "green under vitest + agent-ci" was operationally meaningless — neither check boots the rootfs we ship. These do:

   - `P1: machinen run -- /usr/sbin/criu --version` → prints `Version: …` (criu binary + libs present).
   - `P2: machinen run -- cat /proc/modules` → lists `virtio_blk` and `vmw_vsock_virtio_transport` (/init's modprobe chain works).
   - `P3: machinen run -- /sbin/machinen-poweroff` → kernel prints `reboot: Power down` (the Zig helper genuinely triggers PSCI SYSTEM_OFF, vs a panic-reboot that would look the same from outside).

Verified failure mode: removing any module from the staged rootfs makes P1 or P2 fail instead of passing.

Size: `rootfs-debian-arm64.tar.gz` 47 MB → 52 MB.

## Scope

- **In:** `scripts/build-base-assets.sh`, three Zig sources under `packages/microvm/assets/`, `init.zig` modprobe, smoke-test additions.
- **Out:** the TS `build({ install })` surface. Lives on `pp-implement-77-build-ts-surface`, next PR.

## Test plan

- [x] `bash scripts/build-base-assets.sh` produces a 52 MB tarball with `/usr/sbin/criu`, `/usr/sbin/machinen-{lo-up,no-iou,poweroff,netup}`, 20 whitelisted `.ko` modules, no `/usr/bin/python3*`.
- [x] `pnpm smoke-tests` — all 10 tests pass (V1-V4 validation, T1-T3 CLI, P1-P3 phase-1).
- [x] `npx vitest run` — 39/39.
- [x] `npx agent-ci run --all -q -p` — 1/1.
