### PR TITLE
runtime: build({ install }) TS surface for filesystem snapshots

### DIFF
--- a/packages/runtime/src/__tests__/build.test.ts
+++ b/packages/runtime/src/__tests__/build.test.ts
@@ -1,10 +1,12 @@
 // build() round-trip.
 //
 // Unit:        validates input handling without booting a VMM.
-// Integration: boots the base rootfs, runs `apt-get install tree` via the
-//              install hook, freezes, then spawns from the produced
-//              snapshot and asserts `tree --version` runs. Skips when
-//              the HVF test binary or base rootfs tarball aren't staged.
+// Integration: boots the base rootfs, writes a marker file via the install
+//              hook, freezes, then spawns from the produced snapshot and
+//              asserts the marker's content + mode survive. Skips when the
+//              HVF test binary or base rootfs tarball aren't staged. Stays
+//              off the apt/network path — libslirp stability under sustained
+//              transfer is a separate concern (#82).
 
 import { execSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
@@ -59,93 +61,92 @@ describe("build", () => {
     ).rejects.toBeInstanceOf(BuildError);
   });
 
-  it("produces a snapshot tarball that spawn() can consume", async () => {
-    const prereqs = integrationPrereqs();
-    if (!prereqs) {
-      console.warn(
-        "skip build integration: run `bash scripts/build-base-assets.sh` and `zig build test` first",
-      );
-      return;
-    }
-
-    const workDir = mkdtempSync(join(tmpdir(), "machinen-build-test-"));
-    const out = join(workDir, "warm.tar.gz");
-
-    try {
-      const result = await build({
-        binary: prereqs.binary,
-        cwd: microvmRoot,
-        env: { MACHINEN_BOOT_TEST: "1", MACHINEN_DEBUG: "1" },
-        base: prereqs.base,
-        install: async (vm) => {
-          // A single apt-get install is the smallest honest proof that
-          // the install hook and round-trip work — the package is
-          // present post-build iff our repackDiskTarToGz captured state
-          // correctly. `apt-get update` is retried because libslirp's
-          // user-mode network stack is flaky under sustained transfer
-          // and occasionally drops hash-index downloads; unrelated to
-          // what we're testing here.
-          let lastErr: unknown;
-          for (let attempt = 1; attempt <= 3; attempt++) {
-            try {
-              await vm.exec("apt-get update");
-              lastErr = undefined;
-              break;
-            } catch (err) {
-              lastErr = err;
-            }
-          }
-          if (lastErr) throw lastErr;
-          await vm.exec("apt-get install -y --no-install-recommends tree");
-        },
-        out,
-        // Leave some slack for apt over slirp DNS.
-        timeoutMs: 5 * 60 * 1000,
-      });
-
-      expect(existsSync(result.snapshotPath)).toBe(true);
-      expect(result.sizeBytes).toBeGreaterThan(30 * 1024 * 1024);
-
-      // Round-trip: boot from the produced snapshot, assert tree runs.
-      const bundleDir = mkdtempSync(join(tmpdir(), "machinen-build-spawn-"));
-      const udsPath = join(workDir, "exec.sock");
-      try {
-        execSync(`mkdir -p ${join(bundleDir, "rootfs")}`);
-        execSync(
-          `printf '%s' '${JSON.stringify({
-            cmd: ["/exec-agent"],
-            env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
-          })}' > ${join(bundleDir, "machinen-config.json")}`,
+  it(
+    "produces a snapshot tarball that spawn() can consume",
+    async () => {
+      const prereqs = integrationPrereqs();
+      if (!prereqs) {
+        console.warn(
+          "skip build integration: run `bash scripts/build-base-assets.sh` and `zig build test` first",
         );
+        return;
+      }
 
-        const vm = await spawn({
+      const workDir = mkdtempSync(join(tmpdir(), "machinen-build-test-"));
+      const out = join(workDir, "warm.tar.gz");
+
+      try {
+        // The install hook writes a file with a recognizable payload and
+        // a non-default mode. The round-trip below asserts both survive:
+        // content proves repackDiskTarToGz captured the write; mode proves
+        // tar `--numeric-owner` / perms were preserved. No network — the
+        // apt path depends on libslirp under sustained load, which is
+        // tracked separately (#82) and is not what this test validates.
+        const result = await build({
           binary: prereqs.binary,
           cwd: microvmRoot,
-          env: {
-            MACHINEN_BOOT_TEST: "1",
-            MACHINEN_VSOCK: `in:1978:${udsPath}`,
+          env: { MACHINEN_BOOT_TEST: "1", MACHINEN_DEBUG: "1" },
+          base: prereqs.base,
+          install: async (vm) => {
+            await vm.exec(
+              "mkdir -p /warm && printf machinen-build-ok > /warm/marker && chmod 0640 /warm/marker",
+            );
           },
-          baseRootfs: result.snapshotPath,
-          bundle: bundleDir,
-          timeoutMs: null,
+          out,
+          timeoutMs: 3 * 60 * 1000,
         });
+
+        expect(existsSync(result.snapshotPath)).toBe(true);
+        // Sanity: the snapshot is the base rootfs plus our marker; it
+        // should be within spitting distance of the base tarball size.
+        expect(result.sizeBytes).toBeGreaterThan(30 * 1024 * 1024);
+
+        // Round-trip: boot from the produced snapshot and read the marker.
+        const bundleDir = mkdtempSync(join(tmpdir(), "machinen-build-spawn-"));
+        const udsPath = join(workDir, "exec.sock");
         try {
-          const res = await VsockExec.run(udsPath, "tree --version", {
-            connectTimeoutMs: 60_000,
+          execSync(`mkdir -p ${join(bundleDir, "rootfs")}`);
+          execSync(
+            `printf '%s' '${JSON.stringify({
+              cmd: ["/exec-agent"],
+              env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+            })}' > ${join(bundleDir, "machinen-config.json")}`,
+          );
+
+          const vm = await spawn({
+            binary: prereqs.binary,
+            cwd: microvmRoot,
+            env: {
+              MACHINEN_BOOT_TEST: "1",
+              MACHINEN_VSOCK: `in:1978:${udsPath}`,
+            },
+            baseRootfs: result.snapshotPath,
+            bundle: bundleDir,
+            timeoutMs: null,
           });
-          expect(res.exitCode).toBe(0);
-          expect(res.stdout).toMatch(/tree/i);
+          try {
+            const content = await VsockExec.run(udsPath, "cat /warm/marker", {
+              connectTimeoutMs: 60_000,
+            });
+            expect(content.exitCode).toBe(0);
+            expect(content.stdout).toBe("machinen-build-ok");
+
+            const mode = await VsockExec.run(udsPath, "stat -c %a /warm/marker");
+            expect(mode.exitCode).toBe(0);
+            expect(mode.stdout.trim()).toBe("640");
+          } finally {
+            await vm.kill();
+          }
         } finally {
-          await vm.kill();
+          rmSync(bundleDir, { recursive: true, force: true });
+          try {
+            rmSync(udsPath);
+          } catch {}
         }
       } finally {
-        rmSync(bundleDir, { recursive: true, force: true });
-        try {
-          rmSync(udsPath);
-        } catch {}
+        rmSync(workDir, { recursive: true, force: true });
       }
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
-  }, 10 * 60 * 1000);
+    },
+    5 * 60 * 1000,
+  );
 });

--- a/packages/runtime/src/__tests__/build.test.ts
+++ b/packages/runtime/src/__tests__/build.test.ts
@@ -1,0 +1,151 @@
+// build() round-trip.
+//
+// Unit:        validates input handling without booting a VMM.
+// Integration: boots the base rootfs, runs `apt-get install tree` via the
+//              install hook, freezes, then spawns from the produced
+//              snapshot and asserts `tree --version` runs. Skips when
+//              the HVF test binary or base rootfs tarball aren't staged.
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { build, BuildError, VsockExec, spawn } from "../index.ts";
+
+const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
+const releaseAssets = resolve(microvmRoot, "../../release-assets");
+
+function findBootTestBinary(): string | undefined {
+  const cacheDir = resolve(microvmRoot, ".zig-cache/o");
+  if (!existsSync(cacheDir)) {
+    return undefined;
+  }
+  const candidates = readdirSync(cacheDir)
+    .map((name) => resolve(cacheDir, name, "test"))
+    .filter((p) => existsSync(p))
+    .map((p) => ({ p, mtime: statSync(p).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  for (const { p } of candidates) {
+    try {
+      const haystack = execSync(`strings ${p}`, { encoding: "utf8" });
+      if (haystack.includes("MACHINEN_BOOT_TEST")) {
+        return p;
+      }
+    } catch {}
+  }
+  return undefined;
+}
+
+function integrationPrereqs(): { binary: string; base: string } | undefined {
+  const binary = findBootTestBinary();
+  const base = resolve(releaseAssets, "rootfs-debian-arm64.tar.gz");
+  const kernel = resolve(microvmRoot, "test-fixtures/Image");
+  const dtb = resolve(microvmRoot, "test-fixtures/virt.dtb");
+  if (!binary || !existsSync(base) || !existsSync(kernel) || !existsSync(dtb)) {
+    return undefined;
+  }
+  return { binary, base };
+}
+
+describe("build", () => {
+  it("rejects a missing base rootfs path", async () => {
+    await expect(
+      build({
+        base: "/nonexistent/rootfs.tar.gz",
+        install: async () => {},
+        out: join(tmpdir(), "ignored.tar.gz"),
+      }),
+    ).rejects.toBeInstanceOf(BuildError);
+  });
+
+  it("produces a snapshot tarball that spawn() can consume", async () => {
+    const prereqs = integrationPrereqs();
+    if (!prereqs) {
+      console.warn(
+        "skip build integration: run `bash scripts/build-base-assets.sh` and `zig build test` first",
+      );
+      return;
+    }
+
+    const workDir = mkdtempSync(join(tmpdir(), "machinen-build-test-"));
+    const out = join(workDir, "warm.tar.gz");
+
+    try {
+      const result = await build({
+        binary: prereqs.binary,
+        cwd: microvmRoot,
+        env: { MACHINEN_BOOT_TEST: "1", MACHINEN_DEBUG: "1" },
+        base: prereqs.base,
+        install: async (vm) => {
+          // A single apt-get install is the smallest honest proof that
+          // the install hook and round-trip work — the package is
+          // present post-build iff our repackDiskTarToGz captured state
+          // correctly. `apt-get update` is retried because libslirp's
+          // user-mode network stack is flaky under sustained transfer
+          // and occasionally drops hash-index downloads; unrelated to
+          // what we're testing here.
+          let lastErr: unknown;
+          for (let attempt = 1; attempt <= 3; attempt++) {
+            try {
+              await vm.exec("apt-get update");
+              lastErr = undefined;
+              break;
+            } catch (err) {
+              lastErr = err;
+            }
+          }
+          if (lastErr) throw lastErr;
+          await vm.exec("apt-get install -y --no-install-recommends tree");
+        },
+        out,
+        // Leave some slack for apt over slirp DNS.
+        timeoutMs: 5 * 60 * 1000,
+      });
+
+      expect(existsSync(result.snapshotPath)).toBe(true);
+      expect(result.sizeBytes).toBeGreaterThan(30 * 1024 * 1024);
+
+      // Round-trip: boot from the produced snapshot, assert tree runs.
+      const bundleDir = mkdtempSync(join(tmpdir(), "machinen-build-spawn-"));
+      const udsPath = join(workDir, "exec.sock");
+      try {
+        execSync(`mkdir -p ${join(bundleDir, "rootfs")}`);
+        execSync(
+          `printf '%s' '${JSON.stringify({
+            cmd: ["/exec-agent"],
+            env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+          })}' > ${join(bundleDir, "machinen-config.json")}`,
+        );
+
+        const vm = await spawn({
+          binary: prereqs.binary,
+          cwd: microvmRoot,
+          env: {
+            MACHINEN_BOOT_TEST: "1",
+            MACHINEN_VSOCK: `in:1978:${udsPath}`,
+          },
+          baseRootfs: result.snapshotPath,
+          bundle: bundleDir,
+          timeoutMs: null,
+        });
+        try {
+          const res = await VsockExec.run(udsPath, "tree --version", {
+            connectTimeoutMs: 60_000,
+          });
+          expect(res.exitCode).toBe(0);
+          expect(res.stdout).toMatch(/tree/i);
+        } finally {
+          await vm.kill();
+        }
+      } finally {
+        rmSync(bundleDir, { recursive: true, force: true });
+        try {
+          rmSync(udsPath);
+        } catch {}
+      }
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }, 10 * 60 * 1000);
+});

--- a/packages/runtime/src/__tests__/build.test.ts
+++ b/packages/runtime/src/__tests__/build.test.ts
@@ -9,11 +9,11 @@
 //              transfer is a separate concern (#82).
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
-import { build, BuildError, VsockExec, spawn } from "../index.ts";
+import { afterEach, describe, expect, it } from "vitest";
+import { build, BuildError, resolveBaseRootfs, VsockExec, spawn } from "../index.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
 const releaseAssets = resolve(microvmRoot, "../../release-assets");
@@ -59,6 +59,54 @@ describe("build", () => {
         out: join(tmpdir(), "ignored.tar.gz"),
       }),
     ).rejects.toBeInstanceOf(BuildError);
+  });
+
+  describe("resolveBaseRootfs", () => {
+    const originalAssetsDir = process.env.MACHINEN_ASSETS_DIR;
+    afterEach(() => {
+      if (originalAssetsDir === undefined) {
+        delete process.env.MACHINEN_ASSETS_DIR;
+      } else {
+        process.env.MACHINEN_ASSETS_DIR = originalAssetsDir;
+      }
+    });
+
+    it("honors an explicit path", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-base-explicit-"));
+      const p = join(dir, "explicit.tar.gz");
+      try {
+        writeFileSync(p, "");
+        expect(resolveBaseRootfs(p)).toBe(p);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("throws if the explicit path is missing", () => {
+      expect(() => resolveBaseRootfs("/nope/does/not/exist.tar.gz")).toThrow(BuildError);
+    });
+
+    it("falls back to MACHINEN_ASSETS_DIR when base is omitted", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-base-envdir-"));
+      const p = join(dir, "rootfs-debian-arm64.tar.gz");
+      try {
+        writeFileSync(p, "");
+        process.env.MACHINEN_ASSETS_DIR = dir;
+        expect(resolveBaseRootfs()).toBe(p);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("throws if MACHINEN_ASSETS_DIR is set but missing the tarball", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-base-envdir-empty-"));
+      try {
+        process.env.MACHINEN_ASSETS_DIR = dir;
+        expect(() => resolveBaseRootfs()).toThrow(BuildError);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   it(

--- a/packages/runtime/src/build.ts
+++ b/packages/runtime/src/build.ts
@@ -1,0 +1,347 @@
+// build() — boot the base rootfs, run a user install hook via vsock,
+// freeze the resulting filesystem state to a new rootfs tarball.
+//
+// The first cut (v1) produces a *filesystem* snapshot only: a tarball
+// that layers on top of the base rootfs. It is designed to be consumed
+// via `spawn({ baseRootfs: <build-output> })`, which overlays it onto
+// the base at pack-time the same way a bundle rootfs does. No CRIU
+// process freeze in this cut — sub-second spawn is explicitly a
+// #77 non-goal. The next cut adds CRIU dump on top of this flow.
+//
+// Minimum correct round-trip:
+//
+//   const snap = await build({
+//     base: "./rootfs-debian-arm64.tar.gz",
+//     install: async vm => {
+//       await vm.exec("apt-get update");
+//       await vm.exec("apt-get install -y --no-install-recommends tree");
+//     },
+//     out: "./warm.tar.gz",
+//   });
+//
+//   const vm = await spawn({
+//     baseRootfs: snap.snapshotPath,
+//     bundle: "./my-app-bundle",
+//   });
+
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { VsockExec, type VsockExecResult } from "./exec.ts";
+import { spawn, SpawnError } from "./index.ts";
+
+export class BuildError extends Error {}
+
+/**
+ * The object passed to the user's `install` hook. For now, the only
+ * method is `exec()`; later iterations will add `writeFile()`,
+ * `readFile()`, etc. built on the existing `VsockFiles` agent.
+ */
+export interface BuildHandle {
+  /**
+   * Run a shell command inside the guest. Throws BuildError on non-zero
+   * exit (callers who want to inspect failures should use `execRaw`).
+   *
+   * The command is passed verbatim to `sh -c` inside the guest, so
+   * shell syntax (pipes, redirection, env) works.
+   */
+  exec(cmd: string): Promise<VsockExecResult>;
+
+  /** Like exec(), but does not throw on non-zero exit. */
+  execRaw(cmd: string): Promise<VsockExecResult>;
+}
+
+export interface BuildOptions {
+  /**
+   * Path to the base rootfs tarball to start from. Typically the
+   * `rootfs-debian-arm64.tar.gz` produced by
+   * `scripts/build-base-assets.sh` or shipped in a machinen release.
+   */
+  base: string;
+
+  /**
+   * User-supplied provisioning steps. Runs inside the guest via vsock.
+   */
+  install: (vm: BuildHandle) => Promise<void>;
+
+  /**
+   * Output path for the resulting rootfs tarball. Will be overwritten.
+   * Consumed via `spawn({ baseRootfs: out })`.
+   */
+  out: string;
+
+  /**
+   * Optional VMM binary path. Same lookup rules as `spawn()` — if
+   * omitted, resolves `@machinen/vmm-<arch>-<os>`.
+   */
+  binary?: string;
+
+  /** Working directory. Defaults to process.cwd(). */
+  cwd?: string;
+
+  /**
+   * Size of the scratch disk used to ferry the tarball from guest to
+   * host. Must be larger than the expected post-install rootfs size.
+   * Default: 1 GiB (sparse, so it doesn't actually take that space).
+   */
+  scratchDiskSizeBytes?: number;
+
+  /**
+   * Wall-clock ceiling for the whole build. If the install hook plus
+   * the final archive + shutdown doesn't finish in this window, we
+   * SIGKILL the VMM and fail. Default: 10 minutes.
+   */
+  timeoutMs?: number;
+
+  /**
+   * Extra env passed to the VMM. Useful for dev overrides like
+   * `MACHINEN_BOOT_TEST`, `MACHINEN_KERNEL`, `MACHINEN_DTB`.
+   */
+  env?: Record<string, string>;
+
+  /** Path to the guest kernel. Same semantics as `spawn({ kernel })`. */
+  kernel?: string;
+
+  /** Path to the guest DTB. Same semantics as `spawn({ dtb })`. */
+  dtb?: string;
+}
+
+export interface BuildResult {
+  /** Absolute path to the output tarball. */
+  snapshotPath: string;
+
+  /** Size of the output tarball in bytes. */
+  sizeBytes: number;
+
+  /** Wall-clock time from build() entry to return. */
+  elapsedMs: number;
+}
+
+/**
+ * The guest-side command we run after `install` completes to capture
+ * the rootfs state onto the scratch disk. Excludes volatile + special
+ * filesystems; everything else goes into the tar stream we then write
+ * raw to `/dev/vda`. At pack-time there is no filesystem on the disk,
+ * so we're appending tar directly to the block device. The host reads
+ * it back the same way (the trailing two zero blocks mark the end).
+ */
+const TAR_TO_DISK_CMD = [
+  "tar",
+  "-C /",
+  "--exclude=./proc",
+  "--exclude=./sys",
+  "--exclude=./dev",
+  "--exclude=./tmp",
+  "--exclude=./run",
+  "--exclude=./mnt",
+  "--exclude=./machinen-config.json",
+  "--exclude=./etc/machinen-boot-epoch",
+  "--sort=name",
+  "--numeric-owner",
+  "--owner=0",
+  "--group=0",
+  "-cf /dev/vda",
+  ".",
+].join(" ");
+
+export async function build(opts: BuildOptions): Promise<BuildResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const baseAbs = resolve(cwd, opts.base);
+  if (!existsSync(baseAbs)) {
+    throw new BuildError(`base rootfs tarball not found: ${baseAbs}`);
+  }
+  const outAbs = resolve(cwd, opts.out);
+
+  const t0 = Date.now();
+  const workDir = mkdtempSync(join(tmpdir(), "machinen-build-"));
+  const bundleDir = join(workDir, "bundle");
+  const rootfsDir = join(bundleDir, "rootfs");
+  const diskPath = join(workDir, "scratch.img");
+  const udsPath = join(workDir, "exec.sock");
+
+  try {
+    // Minimal bundle: just a machinen-config.json pointing at the
+    // exec-agent. rootfs/ stays empty — the base rootfs is merged in
+    // by packBundle via `baseRootfs`.
+    mkdirSync(rootfsDir, { recursive: true });
+    writeFileSync(
+      join(bundleDir, "machinen-config.json"),
+      JSON.stringify({
+        cmd: ["/exec-agent"],
+        env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+      }),
+    );
+
+    // Allocate the scratch disk sparsely.
+    allocateSparseFile(diskPath, opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024);
+
+    // Spawn the VMM. MACHINEN_VSOCK=in:1978:<uds> bridges the guest's
+    // vsock listener at port 1978 to a host UDS we can connect to.
+    const vm = await spawn({
+      binary: opts.binary,
+      cwd: opts.cwd,
+      env: {
+        ...opts.env,
+        MACHINEN_VSOCK: `in:1978:${udsPath}`,
+      },
+      kernel: opts.kernel,
+      dtb: opts.dtb,
+      baseRootfs: baseAbs,
+      bundle: bundleDir,
+      disk: diskPath,
+      // We drive the guest to exit via /sbin/machinen-poweroff at the
+      // end; wait() has its own ceiling below.
+      timeoutMs: null,
+    });
+
+    const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
+    const killTimer = setTimeout(() => void vm.kill(), deadlineMs);
+    killTimer.unref();
+
+    // Buffer stderr so a timed-out VsockExec can surface the VMM's
+    // actual complaint instead of a bare ENOENT on the UDS. Keep up to
+    // 128 KB so we catch kernel boot output + vsock bridge messages,
+    // not just the zig unit-test tail.
+    const tailBuf: Buffer[] = [];
+    let tailBytes = 0;
+    const TAIL_MAX = 128 * 1024;
+    vm.stderr.on("data", (chunk: Buffer) => {
+      tailBuf.push(chunk);
+      tailBytes += chunk.length;
+      while (tailBytes > TAIL_MAX && tailBuf.length > 1) {
+        tailBytes -= tailBuf[0]!.length;
+        tailBuf.shift();
+      }
+      if (process.env.MACHINEN_BUILD_DEBUG) {
+        process.stderr.write(chunk);
+      }
+    });
+    const stderrTail = () => Buffer.concat(tailBuf).slice(-TAIL_MAX).toString("utf8");
+
+    try {
+      // Hand control to the install hook.
+      const handle: BuildHandle = {
+        exec: async (cmd: string) => {
+          const res = await VsockExec.run(udsPath, cmd);
+          if (res.exitCode !== 0) {
+            throw new BuildError(
+              `exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
+            );
+          }
+          return res;
+        },
+        execRaw: (cmd: string) => VsockExec.run(udsPath, cmd),
+      };
+      try {
+        await opts.install(handle);
+      } catch (err) {
+        const tail = stderrTail();
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new BuildError(`install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`);
+      }
+
+      // Post-install: archive / to /dev/vda, then tell the guest to
+      // power off cleanly (PSCI SYSTEM_OFF via /sbin/machinen-poweroff).
+      // A failed tar here means our scratch disk was too small; surface
+      // that specifically.
+      const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
+        execTimeoutMs: deadlineMs,
+      });
+      if (tar.exitCode !== 0) {
+        throw new BuildError(
+          `tar / to /dev/vda failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
+            `Bump scratchDiskSizeBytes. stderr:\n${tar.stderr}`,
+        );
+      }
+
+      // Poweroff. /sbin/machinen-poweroff syncs, calls reboot(POWER_OFF),
+      // and the VMM exits on PSCI SYSTEM_OFF. The connection can fail in
+      // several equivalent ways (ECONNRESET mid-transaction, "agent
+      // closed before X frame", or a fast-retry hitting ECONNREFUSED
+      // after the VMM has already exited) — all are fine; vm.wait()
+      // below is the real success signal. Short connect timeout so
+      // we don't burn 30s retrying a bridge that's already gone.
+      await VsockExec.run(udsPath, "/sbin/machinen-poweroff", {
+        connectTimeoutMs: 2_000,
+      }).catch(() => {});
+
+      await vm.wait();
+    } finally {
+      clearTimeout(killTimer);
+      if (vm.pid > 0) {
+        await vm.kill().catch(() => {});
+      }
+    }
+
+    // Scratch disk now holds a raw tar stream (padded with zeros up to
+    // the scratch size). Repack it as a gzipped tarball at `out`, which
+    // trims trailing zeros and normalizes compression.
+    repackDiskTarToGz(diskPath, outAbs);
+
+    const sizeBytes = statSync(outAbs).size;
+    return {
+      snapshotPath: outAbs,
+      sizeBytes,
+      elapsedMs: Date.now() - t0,
+    };
+  } finally {
+    try {
+      rmSync(workDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+function allocateSparseFile(path: string, sizeBytes: number): void {
+  const fd = openSync(path, "w");
+  try {
+    const buf = Buffer.alloc(1);
+    writeSync(fd, buf, 0, 1, sizeBytes - 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Read the raw tar stream the guest wrote to the scratch disk and
+ * re-emit it as a deterministic gzipped tarball. Extract+re-tar rather
+ * than pipe tar through gzip directly: tar -x reliably stops at the
+ * two-zero-block trailer on a block device / padded file, and a second
+ * tar -c gives us the same deterministic options as the base rootfs.
+ */
+function repackDiskTarToGz(diskPath: string, outAbs: string): void {
+  const extractDir = mkdtempSync(join(tmpdir(), "machinen-build-extract-"));
+  try {
+    execFileSync("tar", ["-xf", diskPath, "-C", extractDir]);
+    execFileSync(
+      "tar",
+      [
+        "--sort=name",
+        "--numeric-owner",
+        "--owner=0",
+        "--group=0",
+        "--mtime=2020-01-01 00:00Z",
+        "-czf",
+        outAbs,
+        "-C",
+        extractDir,
+        ".",
+      ],
+      { stdio: ["ignore", "ignore", "inherit"] },
+    );
+  } finally {
+    try {
+      rmSync(extractDir, { recursive: true, force: true });
+    } catch {}
+  }
+}

--- a/packages/runtime/src/build.ts
+++ b/packages/runtime/src/build.ts
@@ -31,12 +31,13 @@ import {
   mkdirSync,
   mkdtempSync,
   openSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { VsockExec, type VsockExecResult } from "./exec.ts";
 import { spawn } from "./index.ts";
@@ -67,8 +68,12 @@ export interface BuildOptions {
    * Path to the base rootfs tarball to start from. Typically the
    * `rootfs-debian-arm64.tar.gz` produced by
    * `scripts/build-base-assets.sh` or shipped in a machinen release.
+   *
+   * Optional — when omitted, `build()` resolves it via `resolveBaseRootfs()`
+   * (MACHINEN_ASSETS_DIR env override, falling back to the `@machinen/cli`
+   * cache at `~/.machinen/@machinen/runtime@<version>/bases/debian-arm64/`).
    */
-  base: string;
+  base?: string;
 
   /**
    * User-supplied provisioning steps. Runs inside the guest via vsock.
@@ -155,12 +160,73 @@ const TAR_TO_DISK_CMD = [
   ".",
 ].join(" ");
 
+/**
+ * Resolve the path to the base rootfs tarball, in the same order
+ * `build()` itself does:
+ *
+ *   1. `explicit` — the caller-supplied path (resolved against `cwd`).
+ *   2. `MACHINEN_ASSETS_DIR` env var — points at a directory laid out like
+ *      `scripts/build-base-assets.sh`'s output (contains
+ *      `rootfs-debian-arm64.tar.gz`). Same convention `@machinen/cli`
+ *      honors for local/dev builds.
+ *   3. `@machinen/cli`'s on-disk cache at
+ *      `~/.machinen/@machinen/runtime@<version>/bases/debian-arm64/rootfs.tar.gz`.
+ *      Populated by running `machinen` once against the installed runtime.
+ *
+ * Throws `BuildError` with guidance if none of those turn up a file.
+ * Exported so callers can pre-check or build their own tooling on it.
+ */
+export function resolveBaseRootfs(explicit?: string, cwd: string = process.cwd()): string {
+  if (explicit) {
+    const abs = resolve(cwd, explicit);
+    if (!existsSync(abs)) {
+      throw new BuildError(`base rootfs tarball not found: ${abs}`);
+    }
+    return abs;
+  }
+
+  const assetsDir = process.env.MACHINEN_ASSETS_DIR;
+  if (assetsDir) {
+    const p = resolve(assetsDir, "rootfs-debian-arm64.tar.gz");
+    if (!existsSync(p)) {
+      throw new BuildError(
+        `MACHINEN_ASSETS_DIR=${assetsDir} does not contain rootfs-debian-arm64.tar.gz`,
+      );
+    }
+    return p;
+  }
+
+  const cached = cliCachedRootfsPath();
+  if (existsSync(cached)) {
+    return cached;
+  }
+
+  throw new BuildError(
+    `base rootfs not found. Either:\n` +
+      `  - pass \`base\` explicitly, or\n` +
+      `  - set MACHINEN_ASSETS_DIR to a directory containing rootfs-debian-arm64.tar.gz, or\n` +
+      `  - install @machinen/cli and run it once to populate ${cached}`,
+  );
+}
+
+function cliCachedRootfsPath(): string {
+  // Mirrors `@machinen/cli`'s `baseDirFor(RELEASE_TAG)` where
+  // RELEASE_TAG = `@machinen/runtime@${VERSION}`.
+  const pkgPath = resolve(import.meta.dirname, "..", "package.json");
+  const version = (JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string }).version;
+  return join(
+    homedir(),
+    ".machinen",
+    `@machinen/runtime@${version}`,
+    "bases",
+    "debian-arm64",
+    "rootfs.tar.gz",
+  );
+}
+
 export async function build(opts: BuildOptions): Promise<BuildResult> {
   const cwd = opts.cwd ?? process.cwd();
-  const baseAbs = resolve(cwd, opts.base);
-  if (!existsSync(baseAbs)) {
-    throw new BuildError(`base rootfs tarball not found: ${baseAbs}`);
-  }
+  const baseAbs = resolveBaseRootfs(opts.base, cwd);
   const outAbs = resolve(cwd, opts.out);
 
   const t0 = Date.now();

--- a/packages/runtime/src/build.ts
+++ b/packages/runtime/src/build.ts
@@ -39,7 +39,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { VsockExec, type VsockExecResult } from "./exec.ts";
-import { spawn, SpawnError } from "./index.ts";
+import { spawn } from "./index.ts";
 
 export class BuildError extends Error {}
 
@@ -230,10 +230,13 @@ export async function build(opts: BuildOptions): Promise<BuildResult> {
     const stderrTail = () => Buffer.concat(tailBuf).slice(-TAIL_MAX).toString("utf8");
 
     try {
-      // Hand control to the install hook.
+      // Hand control to the install hook. Per-command exec timeout
+      // inherits the outer build deadline — any single command that
+      // runs that long has already blown the budget; VsockExec's own
+      // 5-min default would otherwise trip first on slow libslirp.
       const handle: BuildHandle = {
         exec: async (cmd: string) => {
-          const res = await VsockExec.run(udsPath, cmd);
+          const res = await VsockExec.run(udsPath, cmd, { execTimeoutMs: deadlineMs });
           if (res.exitCode !== 0) {
             throw new BuildError(
               `exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
@@ -241,14 +244,16 @@ export async function build(opts: BuildOptions): Promise<BuildResult> {
           }
           return res;
         },
-        execRaw: (cmd: string) => VsockExec.run(udsPath, cmd),
+        execRaw: (cmd: string) => VsockExec.run(udsPath, cmd, { execTimeoutMs: deadlineMs }),
       };
       try {
         await opts.install(handle);
       } catch (err) {
         const tail = stderrTail();
         const msg = err instanceof Error ? err.message : String(err);
-        throw new BuildError(`install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`);
+        throw new BuildError(
+          `install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`,
+        );
       }
 
       // Post-install: archive / to /dev/vda, then tell the guest to
@@ -314,31 +319,26 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
 
 /**
  * Read the raw tar stream the guest wrote to the scratch disk and
- * re-emit it as a deterministic gzipped tarball. Extract+re-tar rather
- * than pipe tar through gzip directly: tar -x reliably stops at the
- * two-zero-block trailer on a block device / padded file, and a second
- * tar -c gives us the same deterministic options as the base rootfs.
+ * re-emit it as a gzipped tarball. Extract+re-tar rather than pipe tar
+ * through gzip directly: `tar -x` reliably stops at the two-zero-block
+ * trailer on a padded block device, so we don't have to size-trim the
+ * scratch file ourselves.
+ *
+ * The guest's tar already normalized ordering + ownership via GNU flags
+ * (`--sort=name --numeric-owner --owner=0 --group=0`), so the extracted
+ * tree is already deterministic. The host re-tar only needs to gzip;
+ * using only the flags both GNU tar (Linux/CI) and bsdtar (macOS) accept
+ * keeps the build path cross-platform. Byte-for-byte reproducibility
+ * across hosts is a nice-to-have we can layer on later if it ever
+ * matters (swap in a Node-side tar writer).
  */
 function repackDiskTarToGz(diskPath: string, outAbs: string): void {
   const extractDir = mkdtempSync(join(tmpdir(), "machinen-build-extract-"));
   try {
     execFileSync("tar", ["-xf", diskPath, "-C", extractDir]);
-    execFileSync(
-      "tar",
-      [
-        "--sort=name",
-        "--numeric-owner",
-        "--owner=0",
-        "--group=0",
-        "--mtime=2020-01-01 00:00Z",
-        "-czf",
-        outAbs,
-        "-C",
-        extractDir,
-        ".",
-      ],
-      { stdio: ["ignore", "ignore", "inherit"] },
-    );
+    execFileSync("tar", ["-czf", outAbs, "-C", extractDir, "."], {
+      stdio: ["ignore", "ignore", "inherit"],
+    });
   } finally {
     try {
       rmSync(extractDir, { recursive: true, force: true });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,6 +10,8 @@ export { VsockFiles } from "./files.ts";
 export type { VsockFilesOptions } from "./files.ts";
 export { VsockExec } from "./exec.ts";
 export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
+export { build, BuildError } from "./build.ts";
+export type { BuildHandle, BuildOptions, BuildResult } from "./build.ts";
 export {
   packBundle as mkinitramfsBundle,
   packRootfs as mkinitramfsRootfs,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,7 +10,7 @@ export { VsockFiles } from "./files.ts";
 export type { VsockFilesOptions } from "./files.ts";
 export { VsockExec } from "./exec.ts";
 export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
-export { build, BuildError } from "./build.ts";
+export { build, BuildError, resolveBaseRootfs } from "./build.ts";
 export type { BuildHandle, BuildOptions, BuildResult } from "./build.ts";
 export {
   packBundle as mkinitramfsBundle,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -237,6 +237,11 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
     stderr: child.stderr,
 
     async wait() {
+      // If the child already exited before we got here, `once("exit")`
+      // never fires — the event has already been emitted. Check first.
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return { code: child.exitCode, signal: child.signalCode };
+      }
       const settled = once(child, "exit") as Promise<[number | null, NodeJS.Signals | null]>;
       const race =
         timeoutMs === null
@@ -259,6 +264,11 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
         return;
       }
       child.kill("SIGKILL");
+      // Same race: the child may finish dying between the guard above
+      // and the listener below. Re-check before waiting.
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
       await once(child, "exit");
     },
 


### PR DESCRIPTION
## Summary

Closes #81. Ships `@machinen/runtime.build({ base, install, out })` — boot the base rootfs, run a user-supplied install hook inside the guest via the vsock exec-agent, capture the resulting rootfs state as a gzipped tarball, and write it to a configurable path. Output is consumed via `spawn({ baseRootfs: out })`; no new spawn option needed.

```ts
await build({
  base: "./rootfs-debian-arm64.tar.gz",
  install: async vm => {
    await vm.exec("mkdir -p /warm && echo hello > /warm/marker");
  },
  out: "./warm.tar.gz",
});

const vm = await spawn({ baseRootfs: "./warm.tar.gz", bundle });
```

Filesystem snapshot only — CRIU process freeze is explicitly deferred (see #50).

## What's in the commits

**`2fe295e`** — The surface itself. `build(opts)` + `BuildHandle` + `BuildResult` types. Synthesizes a minimal bundle whose cmd is `/exec-agent`, attaches a 1 GiB sparse scratch disk as `/dev/vda`, drives the install hook over vsock, tars the resulting rootfs onto the disk, runs `/sbin/machinen-poweroff`. Host-side repacks the tar stream into a gzipped tarball at `out`.

**`5b3921a`** — Three fixes found while proving it end-to-end:

1. `vm.wait()` / `vm.kill()` exit-race. `once(child, "exit")` doesn't fire if the event has already been emitted, so a fast-exiting VMM (install + tar + poweroff in <1 s) hung forever instead of returning. Guard with `child.exitCode` / `child.signalCode` first.
2. Host-side repack used GNU-only tar flags that bsdtar on macOS rejects. Stripped to cross-platform flags — the guest's tar already normalized ordering + ownership inside the archive.
3. `BuildHandle.exec` now passes `execTimeoutMs: deadlineMs` so per-command timeouts inherit the outer build budget instead of VsockExec's 5-min default.

## Non-goals

Per #81: no CRIU process freeze, no sub-second spawn, no libslirp performance work.

## Test plan

- [x] `npx vitest run` — 41/41 green (2/2 in build.test.ts).
- [x] `npx agent-ci run --all -q -p` — 1/1 green, 1m 50s.
- [x] Integration test exercises the full round-trip: boot base, run install hook (writes marker file + non-default mode), freeze, spawn from produced snapshot, assert content + mode survive.
- [x] `pnpm run format:check` + `pnpm run lint` — clean.

The integration test stays off apt/network — libslirp's `sbcopy` abort under sustained TCP (reported on #82) would trip it otherwise, and that's not what #81 ships.

## Related

- Closes #81.
- Follow-up #83 — stream logs from `build()` install hook.
- Commented on #82 with the libslirp `sbcopy` abort signature.
