### PR TITLE
feat(runtime): host-side artifact cache + fnm baking (#88)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,19 +89,13 @@ jobs:
 
       # gvproxy (containers/gvisor-tap-vsock) — bundled next to the VMM
       # so `@machinen/runtime` can auto-spawn it for virtio-net without
-      # a separate install step for consumers. Pinned so releases are
-      # reproducible; bump deliberately.
+      # a separate install step for consumers. Pinned in the shared
+      # install script so prod and local dev stay in lockstep.
       - name: Bundle gvproxy
-        env:
-          GVPROXY_VERSION: v0.8.6
         run: |
           set -euo pipefail
-          base="https://github.com/containers/gvisor-tap-vsock/releases/download/${GVPROXY_VERSION}"
-          curl -fsSL "${base}/gvproxy-darwin" \
-            -o packages/vmm-arm64-darwin/bin/gvproxy
-          curl -fsSL "${base}/gvproxy-linux-arm64" \
-            -o packages/vmm-arm64-linux/bin/gvproxy
-          chmod +x packages/vmm-arm64-*/bin/gvproxy
+          scripts/install-gvproxy.sh --os darwin --dest packages/vmm-arm64-darwin/bin
+          scripts/install-gvproxy.sh --os linux  --arch arm64 --dest packages/vmm-arm64-linux/bin
 
       # cli typechecks against @machinen/runtime's dist types, so the
       # TS packages need a build before typecheck. Zig isn't available

--- a/packages/runtime/src/__tests__/artifact-cache.test.ts
+++ b/packages/runtime/src/__tests__/artifact-cache.test.ts
@@ -1,0 +1,171 @@
+// Unit tests for the host-side artifact cache (#88).
+//
+// We stand up a fake "upstream" HTTP server on localhost and point
+// the cache at it by overriding the upstream URL via the
+// MACHINEN_NODE_DIST_UPSTREAM env var (test-only hook). The tests
+// exercise miss → disk → hit, traversal rejection, upstream 404, and
+// upstream failure.
+
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnArtifactCache } from "../artifact-cache.ts";
+
+interface Upstream {
+  server: Server;
+  port: number;
+  requests: string[];
+  setHandler: (fn: (path: string) => { status: number; body?: Buffer | string }) => void;
+  close: () => Promise<void>;
+}
+
+async function startUpstream(): Promise<Upstream> {
+  let handler: (path: string) => { status: number; body?: Buffer | string } = (path) => {
+    if (path === "/v22.0.0/node-v22.0.0-linux-arm64.tar.xz") {
+      return { status: 200, body: Buffer.from("fake-tarball-bytes") };
+    }
+    return { status: 404 };
+  };
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url ?? "");
+    const out = handler(req.url ?? "");
+    res.statusCode = out.status;
+    if (out.body !== undefined) {
+      const buf = typeof out.body === "string" ? Buffer.from(out.body) : out.body;
+      res.setHeader("content-length", String(buf.length));
+      res.end(buf);
+    } else {
+      res.end();
+    }
+  });
+  await new Promise<void>((done) => server.listen(0, "127.0.0.1", () => done()));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("upstream failed to bind");
+  }
+  return {
+    server,
+    port: addr.port,
+    requests,
+    setHandler(fn) {
+      handler = fn;
+    },
+    async close() {
+      await new Promise<void>((done) => server.close(() => done()));
+    },
+  };
+}
+
+async function getBody(url: string): Promise<{ status: number; body: string }> {
+  const res = await fetch(url);
+  const body = await res.text();
+  return { status: res.status, body };
+}
+
+describe("artifact-cache", () => {
+  let cacheDir: string;
+  let upstream: Upstream;
+  const originalUpstream = process.env.MACHINEN_NODE_DIST_UPSTREAM;
+
+  beforeEach(async () => {
+    cacheDir = mkdtempSync(join(tmpdir(), "machinen-cache-test-"));
+    upstream = await startUpstream();
+    process.env.MACHINEN_NODE_DIST_UPSTREAM = `http://127.0.0.1:${upstream.port}`;
+  });
+
+  afterEach(async () => {
+    await upstream.close();
+    rmSync(cacheDir, { recursive: true, force: true });
+    if (originalUpstream === undefined) {
+      delete process.env.MACHINEN_NODE_DIST_UPSTREAM;
+    } else {
+      process.env.MACHINEN_NODE_DIST_UPSTREAM = originalUpstream;
+    }
+  });
+
+  it("fetches on miss, serves from disk on hit", async () => {
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const url = `http://127.0.0.1:${cache.port}/node-dist/v22.0.0/node-v22.0.0-linux-arm64.tar.xz`;
+
+      const first = await getBody(url);
+      expect(first.status).toBe(200);
+      expect(first.body).toBe("fake-tarball-bytes");
+      expect(upstream.requests).toHaveLength(1);
+
+      const onDisk = join(cacheDir, "node-dist", "v22.0.0", "node-v22.0.0-linux-arm64.tar.xz");
+      expect(existsSync(onDisk)).toBe(true);
+      expect(readFileSync(onDisk, "utf8")).toBe("fake-tarball-bytes");
+
+      const second = await getBody(url);
+      expect(second.status).toBe(200);
+      expect(second.body).toBe("fake-tarball-bytes");
+      // Still 1 — the cache served from disk the second time.
+      expect(upstream.requests).toHaveLength(1);
+    } finally {
+      await cache.stop();
+    }
+  });
+
+  it("returns 404 when upstream says 404", async () => {
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const res = await getBody(`http://127.0.0.1:${cache.port}/node-dist/v99.0.0/nope.tar.xz`);
+      expect(res.status).toBe(404);
+    } finally {
+      await cache.stop();
+    }
+  });
+
+  it("returns 502 when upstream fetch fails", async () => {
+    await upstream.close();
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const res = await getBody(`http://127.0.0.1:${cache.port}/node-dist/v22.0.0/x.tar.xz`);
+      expect(res.status).toBe(502);
+    } finally {
+      await cache.stop();
+    }
+  });
+
+  it("rejects path traversal", async () => {
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const res = await fetch(`http://127.0.0.1:${cache.port}/node-dist/..%2F..%2Fetc%2Fpasswd`);
+      // Node normalizes the encoded slashes before we see them, so the
+      // request shape is /node-dist/../../etc/passwd. Our normalize()
+      // catches it.
+      expect([400, 404]).toContain(res.status);
+      await res.text();
+    } finally {
+      await cache.stop();
+    }
+  });
+
+  it("rejects unknown cache kinds with 404", async () => {
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const res = await getBody(`http://127.0.0.1:${cache.port}/pnpm-store/xyz`);
+      expect(res.status).toBe(404);
+      expect(res.body).toContain("unknown cache kind");
+    } finally {
+      await cache.stop();
+    }
+  });
+
+  it("rejects non-GET methods", async () => {
+    const cache = await spawnArtifactCache({ cacheDir });
+    try {
+      const res = await fetch(`http://127.0.0.1:${cache.port}/node-dist/any`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(405);
+      await res.text();
+    } finally {
+      await cache.stop();
+    }
+  });
+});

--- a/packages/runtime/src/artifact-cache.ts
+++ b/packages/runtime/src/artifact-cache.ts
@@ -1,0 +1,248 @@
+// Host-side artifact cache sidecar (issue #88).
+//
+// One supervised Node HTTP server, co-located with gvproxy. Serves
+// caches on http://127.0.0.1:<port>/<kind>/... — reachable from the
+// guest at http://192.168.127.1:<port>/... because gvproxy maps the
+// gateway address to the host's loopback.
+//
+// First and only cache kind today: "node-dist", mirroring
+// nodejs.org/dist/ for `fnm`. The pattern (supervision, cache-dir
+// layout, config-wiring) generalizes — future kinds (pnpm, npm, apt)
+// plug in as additional route prefixes.
+//
+// Plain HTTP guest-side so no CA cert needs to live in the rootfs
+// trust store. HTTPS is used upstream, where normal system trust
+// applies.
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createReadStream } from "node:fs";
+import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, normalize, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+
+// Upstream for the node-dist mirror. Env-overridable so tests can
+// point at a localhost stub without hitting nodejs.org.
+function nodeDistUpstream(): string {
+  return process.env.MACHINEN_NODE_DIST_UPSTREAM ?? "https://nodejs.org/dist";
+}
+
+export interface ArtifactCacheHandle {
+  /** Port the cache is listening on (127.0.0.1:<port>). */
+  port: number;
+  /** Absolute path to the on-disk cache root. */
+  cacheDir: string;
+  /** Shut the server down and close its sockets. Idempotent. */
+  stop: () => Promise<void>;
+}
+
+export interface ArtifactCacheOptions {
+  /**
+   * Root directory for on-disk caches. Each kind lives under
+   * `<cacheDir>/<kind>/`. Defaults to `$MACHINEN_CACHE_DIR` if set,
+   * else `~/.machinen/cache`.
+   */
+  cacheDir?: string;
+}
+
+/**
+ * Resolve the cache root using env override → default. Pulled out so
+ * tests and callers that need to inspect the path agree with what
+ * spawnArtifactCache() will pick.
+ */
+export function resolveCacheDir(opts: ArtifactCacheOptions = {}): string {
+  if (opts.cacheDir) {
+    return resolve(opts.cacheDir);
+  }
+  const env = process.env.MACHINEN_CACHE_DIR;
+  if (env) {
+    return resolve(env);
+  }
+  return join(homedir(), ".machinen", "cache");
+}
+
+/**
+ * Start the host-side artifact cache on an ephemeral loopback port.
+ * The returned handle stays valid until `stop()` is called.
+ */
+export async function spawnArtifactCache(
+  opts: ArtifactCacheOptions = {},
+): Promise<ArtifactCacheHandle> {
+  const cacheDir = resolveCacheDir(opts);
+  await mkdir(join(cacheDir, "node-dist"), { recursive: true });
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res, cacheDir).catch((err) => {
+      // Last-ditch: the handler is supposed to catch everything and
+      // write a response. If it throws we still need to close the
+      // socket so the guest doesn't hang.
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "text/plain");
+        res.end(`artifact-cache: ${err instanceof Error ? err.message : String(err)}\n`);
+      } else {
+        res.destroy();
+      }
+    });
+  });
+
+  await new Promise<void>((done, fail) => {
+    server.once("error", fail);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", fail);
+      done();
+    });
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    server.close();
+    throw new Error("artifact-cache: failed to read bound address");
+  }
+
+  let stopped = false;
+  const stop = async () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    await new Promise<void>((done) => {
+      server.close(() => done());
+      // Active keep-alive connections would hold close() open forever.
+      // closeAllConnections is available on Node 18.2+, which matches
+      // our baseline.
+      server.closeAllConnections?.();
+    });
+  };
+
+  return { port: addr.port, cacheDir, stop };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  cacheDir: string,
+): Promise<void> {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.statusCode = 405;
+    res.setHeader("allow", "GET, HEAD");
+    res.end();
+    return;
+  }
+
+  const url = req.url ?? "/";
+  const qIdx = url.indexOf("?");
+  const rawPath = qIdx >= 0 ? url.slice(0, qIdx) : url;
+
+  // Expected shape: /<kind>/<rest...>
+  const parts = rawPath.split("/").filter(Boolean);
+  if (parts.length < 2) {
+    res.statusCode = 404;
+    res.end("not a cache route\n");
+    return;
+  }
+  const kind = parts[0];
+  const rest = parts.slice(1).join("/");
+
+  if (kind !== "node-dist") {
+    res.statusCode = 404;
+    res.end(`unknown cache kind: ${kind}\n`);
+    return;
+  }
+
+  // Traversal guard: build the on-disk path, normalize it, and check
+  // it still sits under the kind's cache root.
+  const kindDir = join(cacheDir, "node-dist");
+  const localPath = normalize(join(kindDir, rest));
+  if (!localPath.startsWith(kindDir + sep) && localPath !== kindDir) {
+    res.statusCode = 400;
+    res.end("path traversal rejected\n");
+    return;
+  }
+
+  // Cache hit — stream from disk.
+  try {
+    const st = await stat(localPath);
+    if (st.isFile()) {
+      res.statusCode = 200;
+      res.setHeader("content-length", String(st.size));
+      res.setHeader("content-type", "application/octet-stream");
+      if (req.method === "HEAD") {
+        res.end();
+        return;
+      }
+      await pipeline(createReadStream(localPath), res);
+      return;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  // Miss — fetch upstream, tee to disk, stream to client.
+  const upstream = `${nodeDistUpstream()}/${rest}`;
+  let upstreamRes: Response;
+  try {
+    upstreamRes = await fetch(upstream);
+  } catch (err) {
+    res.statusCode = 502;
+    res.setHeader("content-type", "text/plain");
+    res.end(`upstream fetch failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    return;
+  }
+
+  if (upstreamRes.status === 404) {
+    res.statusCode = 404;
+    res.end("not found upstream\n");
+    return;
+  }
+  if (!upstreamRes.ok || !upstreamRes.body) {
+    res.statusCode = 502;
+    res.end(`upstream returned ${upstreamRes.status}\n`);
+    return;
+  }
+
+  // Buffer the whole response before responding. Node tarballs max
+  // around 30 MB; holding that in memory is cheaper than the
+  // tee-with-backpressure dance, and it lets us write to disk and
+  // serve the client with the exact same bytes. If a future kind
+  // (apt, pnpm-store) brings much larger artifacts, revisit.
+  let body: Buffer;
+  try {
+    body = Buffer.from(await upstreamRes.arrayBuffer());
+  } catch (err) {
+    res.statusCode = 502;
+    res.end(`upstream stream failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    return;
+  }
+
+  await mkdir(dirname(localPath), { recursive: true });
+  // Write to a sibling temp file, then atomic-rename into place. If
+  // rename fails the partial is left for the next request to
+  // overwrite — cheap and self-healing.
+  const tmpPath = `${localPath}.${process.pid}.${Date.now()}.part`;
+  try {
+    await writeFile(tmpPath, body);
+    await rename(tmpPath, localPath);
+  } catch (err) {
+    try {
+      await unlink(tmpPath);
+    } catch {}
+    res.statusCode = 500;
+    res.end(`cache write failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader("content-length", String(body.length));
+  res.setHeader(
+    "content-type",
+    upstreamRes.headers.get("content-type") ?? "application/octet-stream",
+  );
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+  res.end(body);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,6 +12,8 @@ export { VsockExec } from "./exec.ts";
 export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
 export { build, BuildError, resolveBaseRootfs } from "./build.ts";
 export type { BuildHandle, BuildOptions, BuildResult } from "./build.ts";
+export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
+export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";
 export {
   packBundle as mkinitramfsBundle,
   packRootfs as mkinitramfsRootfs,
@@ -48,6 +50,7 @@ import { join, resolve } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { packBundle as mkinitramfsPackBundle } from "./mkinitramfs.ts";
 import { exposePort, resolveGvproxyBinary, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
+import { spawnArtifactCache } from "./artifact-cache.ts";
 
 export class SpawnError extends Error {}
 
@@ -286,13 +289,32 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
     }
   }
 
+  // Host-side artifact cache (#88). Only makes sense when networking
+  // is available — without gvproxy the guest can't reach loopback on
+  // the host anyway. Caller can override FNM_NODE_DIST_MIRROR to point
+  // somewhere else (e.g. to disable the cache entirely in tests).
+  let cacheStop: (() => Promise<void>) | undefined;
+  if (env.MACHINEN_NET_SOCKET) {
+    try {
+      const cache = await spawnArtifactCache();
+      cacheStop = cache.stop;
+      if (!env.FNM_NODE_DIST_MIRROR) {
+        env.FNM_NODE_DIST_MIRROR = `http://192.168.127.1:${cache.port}/node-dist`;
+      }
+    } catch (err) {
+      process.stderr.write(
+        `machinen: artifact cache failed to start (${err instanceof Error ? err.message : String(err)}) — continuing without it\n`,
+      );
+    }
+  }
+
   const child = nodeSpawn(binary, opts.args ?? [], {
     cwd: opts.cwd,
     env,
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessWithoutNullStreams;
 
-  if (bundleTempDir || gvStop) {
+  if (bundleTempDir || gvStop || cacheStop) {
     child.once("exit", () => {
       if (bundleTempDir) {
         try {
@@ -301,6 +323,9 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
       }
       if (gvStop) {
         gvStop();
+      }
+      if (cacheStop) {
+        void cacheStop();
       }
     });
   }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -252,60 +252,78 @@ export async function spawn(opts: SpawnOptions = {}): Promise<VmHandle> {
     env.MACHINEN_DTB = abs;
   }
 
-  let bundleTempDir: string | undefined;
-  if (opts.bundle) {
-    const packed = packBundle(opts);
-    bundleTempDir = packed.tempDir;
-    env.MACHINEN_INITRD = packed.cpioPath;
-  }
-
-  // Stand up gvproxy unless the caller already handed us a socket.
-  // If gvproxy isn't on the host, warn once and let the VMM boot
-  // without networking — same graceful fallback the backend has when
-  // MACHINEN_NET_SOCKET is unset.
+  // gvproxy + artifact cache (#88) + host→guest port forwards (#87)
+  // are set up together so the cache's port can be wired into the
+  // guest env before packBundle seals the initramfs. If anything
+  // downstream throws (packBundle validation, exposePort failure,
+  // nodeSpawn failure), the outer catch shuts both supervisors back
+  // down — otherwise a failed spawn would leave orphans behind.
   let gvStop: (() => void) | undefined;
-  if (!env.MACHINEN_NET_SOCKET) {
-    const gvBin = resolveGvproxyBinary(binary);
-    if (gvBin) {
-      const gv = await spawnGvproxy(gvBin);
-      env.MACHINEN_NET_SOCKET = gv.socketPath;
-      gvStop = gv.stop;
-      for (const m of portForward) {
-        try {
+  let cacheStop: (() => Promise<void>) | undefined;
+  let bundleTempDir: string | undefined;
+  const mergedGuestEnv: Record<string, string> = { ...opts.guestEnv };
+
+  try {
+    if (!env.MACHINEN_NET_SOCKET) {
+      const gvBin = resolveGvproxyBinary(binary);
+      if (gvBin) {
+        const gv = await spawnGvproxy(gvBin);
+        env.MACHINEN_NET_SOCKET = gv.socketPath;
+        gvStop = gv.stop;
+        for (const m of portForward) {
           await exposePort(gv.controlSocketPath, m);
-        } catch (err) {
-          gv.stop();
-          throw err;
         }
+      } else {
+        if (portForward.length > 0) {
+          throw new SpawnError(
+            "portForward requires gvproxy, but no gvproxy binary was found. " +
+              "Install gvproxy or point MACHINEN_GVPROXY at one.",
+          );
+        }
+        warnGvproxyMissing();
       }
-    } else {
-      if (portForward.length > 0) {
-        throw new SpawnError(
-          "portForward requires gvproxy, but no gvproxy binary was found. " +
-            "Install gvproxy or point MACHINEN_GVPROXY at one.",
+    }
+
+    // Only useful when the guest has networking — without gvproxy
+    // the guest can't reach the host loopback anyway. Caller-provided
+    // FNM_NODE_DIST_MIRROR wins so tests and power users can point
+    // fnm at a different mirror.
+    if (env.MACHINEN_NET_SOCKET) {
+      try {
+        const cache = await spawnArtifactCache();
+        cacheStop = cache.stop;
+        if (!mergedGuestEnv.FNM_NODE_DIST_MIRROR) {
+          // 192.168.127.254 is gvproxy's "host" mapping — it forwards
+          // to the host's 127.0.0.1. (192.168.127.1 is the gateway,
+          // not the host.) See scripts/bench-net.sh header for the
+          // canonical description.
+          mergedGuestEnv.FNM_NODE_DIST_MIRROR = `http://192.168.127.254:${cache.port}/node-dist`;
+        }
+      } catch (err) {
+        process.stderr.write(
+          `machinen: artifact cache failed to start (${err instanceof Error ? err.message : String(err)}) — continuing without it\n`,
         );
       }
-      warnGvproxyMissing();
     }
-  }
 
-  // Host-side artifact cache (#88). Only makes sense when networking
-  // is available — without gvproxy the guest can't reach loopback on
-  // the host anyway. Caller can override FNM_NODE_DIST_MIRROR to point
-  // somewhere else (e.g. to disable the cache entirely in tests).
-  let cacheStop: (() => Promise<void>) | undefined;
-  if (env.MACHINEN_NET_SOCKET) {
-    try {
-      const cache = await spawnArtifactCache();
-      cacheStop = cache.stop;
-      if (!env.FNM_NODE_DIST_MIRROR) {
-        env.FNM_NODE_DIST_MIRROR = `http://192.168.127.1:${cache.port}/node-dist`;
-      }
-    } catch (err) {
-      process.stderr.write(
-        `machinen: artifact cache failed to start (${err instanceof Error ? err.message : String(err)}) — continuing without it\n`,
-      );
+    if (opts.bundle) {
+      const packed = packBundle({ ...opts, guestEnv: mergedGuestEnv });
+      bundleTempDir = packed.tempDir;
+      env.MACHINEN_INITRD = packed.cpioPath;
     }
+  } catch (err) {
+    if (cacheStop) {
+      await cacheStop();
+    }
+    if (gvStop) {
+      gvStop();
+    }
+    if (bundleTempDir) {
+      try {
+        rmSync(bundleTempDir, { recursive: true, force: true });
+      } catch {}
+    }
+    throw err;
   }
 
   const child = nodeSpawn(binary, opts.args ?? [], {

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -15,11 +15,18 @@
 #   packages/microvm/assets/no-iou.zig        ← CRIU plumbing (block io_uring)
 #   packages/microvm/assets/poweroff.zig      ← clean shutdown → PSCI SYSTEM_OFF
 #
+# Also baked into the rootfs (downloaded at build time, not sourced):
+#   fnm @ /usr/local/bin/fnm  ← Node version manager (#88).
+#                                Points at the host-side cache via
+#                                FNM_NODE_DIST_MIRROR (wired in
+#                                packages/runtime/src/index.ts#spawn).
+#
 # Requirements:
 #   - docker (with arm64 emulation; GH runners have this by default via
 #     docker/setup-qemu-action)
 #   - dtc  (device-tree-compiler; apt: device-tree-compiler, brew: dtc)
 #   - zig  (0.14+; the release workflow installs it)
+#   - curl, unzip  (for downloading and unpacking fnm)
 #
 # Outputs to ./release-assets/ at the repo root.
 
@@ -79,6 +86,25 @@ zig cc "${ASSETS}/machinen-netup.c" \
   -static \
   -Os \
   -o "${STAGE}/machinen-netup"
+
+# ------------------------------------------------------------
+# 3a. fnm — Node version manager (#88)
+# ------------------------------------------------------------
+# Single static Rust binary from the upstream release. Pinned by
+# version + sha256 so rebuilds are reproducible and a compromised
+# upstream can't slip a different binary past us. The host-side cache
+# in packages/runtime/src/artifact-cache.ts fronts nodejs.org/dist
+# for the fnm-managed Node downloads; fnm itself still comes from
+# GitHub at build time.
+
+echo "==> Downloading fnm (static arm64 binary)"
+FNM_VERSION="1.38.1"
+FNM_SHA256="69feda9455931c26c84be9f95f5e6f69e8b64686e68069fab7cfc34756cd2944"
+FNM_URL="https://github.com/Schniz/fnm/releases/download/v${FNM_VERSION}/fnm-arm64.zip"
+curl -fsSL -o "${STAGE}/fnm.zip" "$FNM_URL"
+echo "${FNM_SHA256}  ${STAGE}/fnm.zip" | shasum -a 256 -c -
+unzip -q -o "${STAGE}/fnm.zip" -d "${STAGE}"
+chmod +x "${STAGE}/fnm"
 
 # ------------------------------------------------------------
 # 4. Rootfs — mmdebstrap minbase + aggressive strip + guest binaries
@@ -257,6 +283,7 @@ install -m 0755 -D /stage/lo-up             /work/rootfs/sbin/machinen-lo-up
 install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou
 install -m 0755 -D /stage/poweroff          /work/rootfs/sbin/machinen-poweroff
 install -m 0755 -D /stage/net-bench-probe   /work/rootfs/sbin/machinen-net-bench-probe
+install -m 0755 -D /stage/fnm               /work/rootfs/usr/local/bin/fnm
 
 # Deterministic tar + gzip written as a single file to the bind mount.
 tar --sort=name --owner=0 --group=0 --numeric-owner \

--- a/scripts/install-gvproxy.sh
+++ b/scripts/install-gvproxy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Download gvproxy (containers/gvisor-tap-vsock) into a destination dir.
+#
+# Used by both:
+#   - .github/workflows/release.yml (stages into packages/vmm-<arch>-<os>/bin/
+#     so the published npm packages carry it)
+#   - scripts/smoke-tests.sh + dev bootstrap (stages next to the
+#     locally-built VMM so `resolveGvproxyBinary()`'s sibling lookup
+#     finds it during dev)
+#
+# Single source of truth for the pinned version and download URLs so
+# prod and dev stay lockstep — bump here and both paths pick it up.
+#
+# Usage:
+#   scripts/install-gvproxy.sh --dest <dir> [--os darwin|linux] [--arch arm64]
+#
+# Defaults: --os from uname -s, --arch arm64. If the binary already
+# exists and is executable in --dest, this is a no-op.
+
+set -euo pipefail
+
+GVPROXY_VERSION="v0.8.6"
+
+dest=""
+os=""
+arch="arm64"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest) dest="$2"; shift 2 ;;
+    --os)   os="$2"; shift 2 ;;
+    --arch) arch="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "install-gvproxy: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$dest" ]]; then
+  echo "install-gvproxy: --dest <dir> is required" >&2
+  exit 2
+fi
+
+if [[ -z "$os" ]]; then
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux)  os="linux" ;;
+    *)      echo "install-gvproxy: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+  esac
+fi
+
+# The upstream releases use "gvproxy-darwin" (universal binary) and
+# "gvproxy-linux-<arch>". Keep this mapping aligned with whatever
+# release.yml consumes.
+case "$os" in
+  darwin) asset="gvproxy-darwin" ;;
+  linux)  asset="gvproxy-linux-${arch}" ;;
+  *)      echo "install-gvproxy: unsupported --os: $os" >&2; exit 1 ;;
+esac
+
+mkdir -p "$dest"
+out="${dest%/}/gvproxy"
+
+if [[ -x "$out" ]]; then
+  echo "install-gvproxy: already present at $out"
+  exit 0
+fi
+
+url="https://github.com/containers/gvisor-tap-vsock/releases/download/${GVPROXY_VERSION}/${asset}"
+echo "install-gvproxy: downloading ${GVPROXY_VERSION} (${asset}) -> $out"
+curl -fsSL "$url" -o "$out"
+chmod +x "$out"

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -18,6 +18,7 @@
 #   T2     --mount exposes a host directory readable inside the guest.
 #   T3     Bundle wins on a /mnt/ collision — layering smoke.
 #   T4     --env propagates into the guest process env — #89.
+#   C1-C2  Host-side artifact cache end-to-end via fnm — #88.
 
 set -euo pipefail
 
@@ -303,6 +304,60 @@ if grep -q "reboot: Power down" "$P3_LOG"; then
 else
   tail -50 "$P3_LOG" >&2
   fail "P3 — kernel never reported 'reboot: Power down'"
+fi
+
+# ----------------------------------------------------------------
+# #88 artifact-cache tests — verify the host-side node-dist mirror
+# end-to-end. spawn() starts the cache, injects FNM_NODE_DIST_MIRROR
+# into the guest env via #89's guestEnv plumbing, and fnm inside the
+# guest pulls through it.
+# ----------------------------------------------------------------
+
+FNM_TEST_NODE="22"
+
+# fnm shells out and requires PATH in its env. init doesn't set one
+# by default (it only backfills TERM), so pass one through --env.
+GUEST_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# ---- C1: cold `fnm install` populates the host-side cache ----
+echo "C1: cold fnm install $FNM_TEST_NODE populates host cache"
+C1_CACHE="$FIXTURE/cache-c1"
+C1_LOG="$FIXTURE/c1.log"
+mkdir -p "$C1_CACHE"
+MACHINEN_CACHE_DIR="$C1_CACHE" \
+  run_timeout 180 node "$CLI" run --env "PATH=$GUEST_PATH" -- \
+    /bin/sh -c "fnm install $FNM_TEST_NODE && fnm exec --using=$FNM_TEST_NODE node -v" \
+    >"$C1_LOG" 2>&1 || true
+if grep -qE "^v${FNM_TEST_NODE}\." "$C1_LOG"; then
+  pass "fnm install + node -v reported v${FNM_TEST_NODE}.*"
+else
+  tail -80 "$C1_LOG" >&2
+  fail "C1 — expected a v${FNM_TEST_NODE}.* line in guest output"
+fi
+# Tarball filename shape matches fnm's layout:
+# node-dist/vX.Y.Z/node-vX.Y.Z-linux-arm64.tar.xz.
+if find "$C1_CACHE/node-dist" -name "node-v${FNM_TEST_NODE}.*-linux-arm64.tar.*" 2>/dev/null | grep -q .; then
+  pass "cache populated under $C1_CACHE/node-dist/"
+else
+  ls -R "$C1_CACHE" >&2 || true
+  fail "C1 — expected a node-v${FNM_TEST_NODE}.* tarball under cache dir"
+fi
+
+# ---- C2: warm `fnm install` served entirely from the on-disk cache ----
+# Second boot reuses the C1 cache dir. Upstream pointed at a refused
+# port — if anything reaches through the cache, the install fails.
+echo "C2: warm fnm install $FNM_TEST_NODE serves from cache (no upstream)"
+C2_LOG="$FIXTURE/c2.log"
+MACHINEN_CACHE_DIR="$C1_CACHE" \
+MACHINEN_NODE_DIST_UPSTREAM="http://127.0.0.1:1" \
+  run_timeout 180 node "$CLI" run --env "PATH=$GUEST_PATH" -- \
+    /bin/sh -c "fnm install $FNM_TEST_NODE && fnm exec --using=$FNM_TEST_NODE node -v" \
+    >"$C2_LOG" 2>&1 || true
+if grep -qE "^v${FNM_TEST_NODE}\." "$C2_LOG"; then
+  pass "warm install worked with upstream pointed at a dead port"
+else
+  tail -80 "$C2_LOG" >&2
+  fail "C2 — warm install failed; cache is not being read"
 fi
 
 echo

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -88,6 +88,12 @@ if [[ ! -f "$CLI" ]]; then
   pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null
 fi
 
+# Stage gvproxy next to the locally-built VMM so the runtime's
+# sibling-lookup in resolveGvproxyBinary() finds it. Same script the
+# release workflow runs (see .github/workflows/release.yml) — single
+# source of truth for the pinned version.
+"$ROOT/scripts/install-gvproxy.sh" --dest "$(dirname "$VMM")"
+
 export MACHINEN_VMM="$VMM"
 export MACHINEN_ASSETS_DIR="$ASSETS"
 


### PR DESCRIPTION
## Problem

Every time a fresh virtual machine boots, it re-downloads the same Node.js files from nodejs.org. The host already has plenty of disk space and bandwidth; having each guest repeat the fetch is wasted work and slows every cold start.

Issue #88 proposes a general pattern for this — one small web server on the host that caches these downloads — and lands the first use of it: a mirror in front of the Node version manager's downloads.

A second problem showed up while testing this change: the background networking helper, gvproxy, was installed one way during a published release and a different way when running the smoke tests locally. Two install paths means two things to maintain, and they will drift.

## Solution

1. **A host-side cache.** A small web server now runs alongside each virtual machine. When the guest asks for a Node download, the cache serves it from local disk if it already has a copy; otherwise it fetches the file once, saves it, and serves it. The cache lives in `~/.machinen/cache/` by default (override with the `MACHINEN_CACHE_DIR` environment variable). Nothing else the guest does on the network goes through this — only the listed kinds of downloads.

2. **The Node version manager is baked into the guest's Linux image.** A pinned version (1.38.1) of `fnm` is downloaded at image-build time and installed at `/usr/local/bin/fnm` inside every guest, with the download verified against a known checksum.

3. **One install script for gvproxy.** Both the release workflow and the local smoke-test runner now call the same new script (`scripts/install-gvproxy.sh`). The pinned version and download location live in one place — bump there and both paths pick it up.

4. **End-to-end wiring.** With #89 merged, the cache's address is injected into the guest's environment via the new `guestEnv` plumbing, so the Node version manager inside the guest actually routes through the host cache. Added two new smoke cases: a cold install that populates the cache and a warm install that succeeds with upstream pointed at a dead port (proving everything comes from disk).

## Test plan

- [x] `npx vitest run` — the cache has unit tests covering hits, misses, upstream errors, unknown paths, and rejected directory-traversal attempts.
- [x] `npx agent-ci run --all -q -p` — format, lint, type-check, and tests on the Linux path.
- [x] `pnpm smoke-tests` — including the new C1 (cold install fills the cache) and C2 (warm install serves entirely from disk) cases.
