### PR TITLE
runtime,cli: propagate host-side env into the guest (#89)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { ParseRunArgsError, parseRunArgs } from "../parse-run-args.ts";
+
+describe("parseRunArgs --env", () => {
+  it("collects repeated --env flags into guestEnv", () => {
+    const parsed = parseRunArgs(["--env", "FOO=bar", "--env", "BAZ=qux", "--", "/bin/echo"]);
+    expect(parsed.guestEnv).toEqual({ FOO: "bar", BAZ: "qux" });
+    expect(parsed.double_dash_args).toEqual(["/bin/echo"]);
+  });
+
+  it("supports --env=KEY=VALUE form", () => {
+    const parsed = parseRunArgs(["--env=FOO=bar", "--", "/bin/true"]);
+    expect(parsed.guestEnv).toEqual({ FOO: "bar" });
+  });
+
+  it("accepts values that contain '=' characters", () => {
+    const parsed = parseRunArgs([
+      "--env",
+      "FNM_NODE_DIST_MIRROR=http://192.168.127.1:9000/node-dist?x=1",
+      "--",
+      "/bin/true",
+    ]);
+    expect(parsed.guestEnv).toEqual({
+      FNM_NODE_DIST_MIRROR: "http://192.168.127.1:9000/node-dist?x=1",
+    });
+  });
+
+  it("allows empty string values", () => {
+    const parsed = parseRunArgs(["--env", "FOO=", "--", "/bin/true"]);
+    expect(parsed.guestEnv).toEqual({ FOO: "" });
+  });
+
+  it("lets a later --env override an earlier one", () => {
+    const parsed = parseRunArgs(["--env", "FOO=first", "--env", "FOO=second", "--", "/bin/true"]);
+    expect(parsed.guestEnv).toEqual({ FOO: "second" });
+  });
+
+  it("returns undefined guestEnv when no --env is given", () => {
+    const parsed = parseRunArgs(["./my-bundle"]);
+    expect(parsed.guestEnv).toBeUndefined();
+    expect(parsed.positional).toEqual(["./my-bundle"]);
+  });
+
+  it("rejects --env without a '=' separator", () => {
+    expect(() => parseRunArgs(["--env", "FOO", "--", "/bin/true"])).toThrow(ParseRunArgsError);
+  });
+
+  it("rejects --env with an empty key", () => {
+    expect(() => parseRunArgs(["--env", "=bar", "--", "/bin/true"])).toThrow(ParseRunArgsError);
+  });
+
+  it("rejects a bare --env with no following argument", () => {
+    expect(() => parseRunArgs(["--env"])).toThrow(/--env requires/);
+  });
+
+  it("coexists with --mount", () => {
+    const parsed = parseRunArgs([
+      "--mount",
+      "/tmp/app:/mnt/app",
+      "--env",
+      "NODE_ENV=production",
+      "--",
+      "node",
+      "/mnt/app/index.js",
+    ]);
+    expect(parsed.mount).toEqual({ host: "/tmp/app", guest: "/mnt/app" });
+    expect(parsed.guestEnv).toEqual({ NODE_ENV: "production" });
+    expect(parsed.double_dash_args).toEqual(["node", "/mnt/app/index.js"]);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,12 +5,11 @@
 // v0 surface:
 //   machinen run <bundle-dir>
 //   machinen run <bundle-dir> --mount <host-dir>:<guest-path>
-//   machinen run [--mount <host-dir>:<guest-path>] -- <cmd>...
+//   machinen run [--mount <host-dir>:<guest-path>] [--env KEY=VALUE]... -- <cmd>...
 //   machinen install [--version <tag>]
 //   machinen --version | -h | --help
 //
 // Deferred (needs runtime API changes):
-//   machinen run --env FOO=bar ...
 //   machinen run --base alpine
 
 import { createHash } from "node:crypto";
@@ -34,6 +33,7 @@ import { pipeline } from "node:stream/promises";
 import { spawn, SpawnError } from "@machinen/runtime";
 
 import pkg from "../package.json" with { type: "json" };
+import { parseRunArgs, ParseRunArgsError } from "./parse-run-args.ts";
 
 const VERSION = pkg.version;
 const RELEASE_TAG = `@machinen/runtime@${VERSION}`;
@@ -163,10 +163,22 @@ function sha256OfFile(path: string): string {
 // ------------------------------------------------------------
 
 async function cmdRun(args: string[]): Promise<number> {
-  const { positional, double_dash_args, mount } = parseRunArgs(args);
+  let parsed;
+  try {
+    parsed = parseRunArgs(args);
+  } catch (err) {
+    if (err instanceof ParseRunArgsError) {
+      die(err.message);
+    }
+    throw err;
+  }
+  const { positional, double_dash_args, mount, guestEnv } = parsed;
 
   if (positional.length > 1) {
-    die("usage: machinen run [<bundle-dir>] [--mount <host-dir>:<guest-path>] [-- <cmd>...]");
+    die(
+      "usage: machinen run [<bundle-dir>] [--mount <host-dir>:<guest-path>] " +
+        "[--env KEY=VALUE]... [-- <cmd>...]",
+    );
   }
 
   let bundle: string;
@@ -251,6 +263,7 @@ async function cmdRun(args: string[]): Promise<number> {
       dtb: dtbPath,
       baseRootfs: baseRootfsPath,
       mount,
+      guestEnv,
       // Interactive CLI: the session lives as long as the guest does.
       // Don't impose the default 60s cap.
       timeoutMs: null,
@@ -314,48 +327,6 @@ async function cmdInstall(args: string[]): Promise<number> {
 // Arg helpers
 // ------------------------------------------------------------
 
-interface ParsedRunArgs {
-  positional: string[];
-  double_dash_args: string[];
-  mount?: { host: string; guest: string };
-}
-
-function parseRunArgs(argv: string[]): ParsedRunArgs {
-  const idx = argv.indexOf("--");
-  const pre = idx === -1 ? argv : argv.slice(0, idx);
-  const double_dash_args = idx === -1 ? [] : argv.slice(idx + 1);
-
-  const positional: string[] = [];
-  let mount: { host: string; guest: string } | undefined;
-  for (let i = 0; i < pre.length; i++) {
-    const a = pre[i]!;
-    let spec: string | undefined;
-    if (a === "--mount") {
-      spec = pre[i + 1];
-      if (spec === undefined) {
-        die("--mount requires a <host-dir>:<guest-path> value");
-      }
-      i++;
-    } else if (a.startsWith("--mount=")) {
-      spec = a.slice("--mount=".length);
-    } else if (a.startsWith("-")) {
-      die(`unknown flag: ${a}`);
-    } else {
-      positional.push(a);
-      continue;
-    }
-    if (mount) {
-      die("--mount may be given at most once per invocation");
-    }
-    const colon = spec!.indexOf(":");
-    if (colon <= 0 || colon === spec!.length - 1) {
-      die(`--mount: expected <host-dir>:<guest-path>, got '${spec}'`);
-    }
-    mount = { host: spec!.slice(0, colon), guest: spec!.slice(colon + 1) };
-  }
-  return { positional, double_dash_args, mount };
-}
-
 function argValue(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
   if (i === -1) {
@@ -384,6 +355,10 @@ function printHelp(): void {
       `                                           exits; the host directory on disk is\n` +
       `                                           never modified. Bundle files win on\n` +
       `                                           path collisions.\n` +
+      `    --env KEY=VALUE                        Set an env var inside the guest (for\n` +
+      `                                           the process run by the bundle's cmd).\n` +
+      `                                           Repeatable. Bundle's on-disk env wins\n` +
+      `                                           on key collision.\n` +
       `  machinen install                         Pre-fetch the current-tag base assets\n` +
       `    --version <tag>                        Pin to a specific release tag\n` +
       `  machinen --version | -h                  Print version / help\n` +
@@ -392,6 +367,7 @@ function printHelp(): void {
       `  machinen run ./my-bundle\n` +
       `  machinen run --mount ./my-app:/mnt/app -- node /mnt/app/index.js\n` +
       `  machinen run ./my-bundle --mount ./data:/mnt/data\n` +
+      `  machinen run --env NODE_ENV=production -- node -e 'console.log(process.env.NODE_ENV)'\n` +
       `\n` +
       `Environment:\n` +
       `  MACHINEN_VMM                             Override the VMM binary path (dev)\n` +

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -1,0 +1,73 @@
+// Pure arg parser for `machinen run`. Split out from cli.ts so tests
+// can import it without pulling @machinen/runtime (which resolves to
+// dist/ and is unbuilt in the monorepo dev loop).
+
+export interface ParsedRunArgs {
+  positional: string[];
+  double_dash_args: string[];
+  mount?: { host: string; guest: string };
+  guestEnv?: Record<string, string>;
+}
+
+export class ParseRunArgsError extends Error {}
+
+export function parseRunArgs(argv: string[]): ParsedRunArgs {
+  const idx = argv.indexOf("--");
+  const pre = idx === -1 ? argv : argv.slice(0, idx);
+  const double_dash_args = idx === -1 ? [] : argv.slice(idx + 1);
+
+  const positional: string[] = [];
+  let mount: { host: string; guest: string } | undefined;
+  const guestEnv: Record<string, string> = {};
+  for (let i = 0; i < pre.length; i++) {
+    const a = pre[i]!;
+    if (a === "--mount" || a.startsWith("--mount=")) {
+      let spec: string | undefined;
+      if (a === "--mount") {
+        spec = pre[i + 1];
+        if (spec === undefined) {
+          throw new ParseRunArgsError("--mount requires a <host-dir>:<guest-path> value");
+        }
+        i++;
+      } else {
+        spec = a.slice("--mount=".length);
+      }
+      if (mount) {
+        throw new ParseRunArgsError("--mount may be given at most once per invocation");
+      }
+      const colon = spec!.indexOf(":");
+      if (colon <= 0 || colon === spec!.length - 1) {
+        throw new ParseRunArgsError(`--mount: expected <host-dir>:<guest-path>, got '${spec}'`);
+      }
+      mount = { host: spec!.slice(0, colon), guest: spec!.slice(colon + 1) };
+    } else if (a === "--env" || a.startsWith("--env=")) {
+      let spec: string | undefined;
+      if (a === "--env") {
+        spec = pre[i + 1];
+        if (spec === undefined) {
+          throw new ParseRunArgsError("--env requires a KEY=VALUE value");
+        }
+        i++;
+      } else {
+        spec = a.slice("--env=".length);
+      }
+      const eq = spec!.indexOf("=");
+      if (eq <= 0) {
+        throw new ParseRunArgsError(`--env: expected KEY=VALUE, got '${spec}'`);
+      }
+      const key = spec!.slice(0, eq);
+      const value = spec!.slice(eq + 1);
+      guestEnv[key] = value;
+    } else if (a.startsWith("-")) {
+      throw new ParseRunArgsError(`unknown flag: ${a}`);
+    } else {
+      positional.push(a);
+    }
+  }
+  return {
+    positional,
+    double_dash_args,
+    mount,
+    guestEnv: Object.keys(guestEnv).length > 0 ? guestEnv : undefined,
+  };
+}

--- a/packages/runtime/src/__tests__/mkinitramfs.test.ts
+++ b/packages/runtime/src/__tests__/mkinitramfs.test.ts
@@ -9,7 +9,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { packBundle } from "../mkinitramfs.ts";
+import { packBundle, patchConfigEnv } from "../mkinitramfs.ts";
 
 // Minimal parser for the newc cpio format produced by mkinitramfs.ts.
 // Returns a name → {data, mode} map for all non-TRAILER entries.
@@ -46,6 +46,33 @@ function listCpioEntries(cpioPath: string): Map<string, { data: Buffer; mode: nu
   }
   return out;
 }
+
+describe("patchConfigEnv", () => {
+  it("returns the original buffer untouched when guestEnv is absent", () => {
+    const input = Buffer.from(JSON.stringify({ cmd: ["/bin/true"] }), "utf8");
+    expect(patchConfigEnv(input, undefined)).toBe(input);
+    expect(patchConfigEnv(input, {})).toBe(input);
+  });
+
+  it("adds env field to configs that don't have one", () => {
+    const input = Buffer.from(JSON.stringify({ cmd: ["/bin/true"] }), "utf8");
+    const out = patchConfigEnv(input, { FOO: "bar" });
+    expect(JSON.parse(out.toString("utf8"))).toEqual({
+      cmd: ["/bin/true"],
+      env: { FOO: "bar" },
+    });
+  });
+
+  it("lets the on-disk env win on key collision", () => {
+    const input = Buffer.from(
+      JSON.stringify({ cmd: ["/bin/true"], env: { FOO: "bundle" } }),
+      "utf8",
+    );
+    const out = patchConfigEnv(input, { FOO: "runtime", BAR: "runtime" });
+    const parsed = JSON.parse(out.toString("utf8"));
+    expect(parsed.env).toEqual({ FOO: "bundle", BAR: "runtime" });
+  });
+});
 
 describe("packBundle mount", () => {
   let tmp: string;
@@ -105,6 +132,57 @@ describe("packBundle mount", () => {
 
     const entries = listCpioEntries(out);
     expect(entries.get("mnt/app/x.txt")?.data.toString("utf8")).toBe("bundle");
+  });
+
+  it("merges guestEnv into the packed machinen-config.json", () => {
+    const bundle = makeEmptyBundle();
+    const out = join(tmp, "out.cpio");
+    packBundle({
+      bundle,
+      out,
+      guestEnv: { FNM_NODE_DIST_MIRROR: "http://192.168.127.1:9000/node-dist" },
+    });
+
+    const entries = listCpioEntries(out);
+    const cfg = entries.get("machinen-config.json");
+    expect(cfg).toBeDefined();
+    const parsed = JSON.parse(cfg!.data.toString("utf8"));
+    expect(parsed.env).toEqual({
+      FNM_NODE_DIST_MIRROR: "http://192.168.127.1:9000/node-dist",
+    });
+    expect(parsed.cmd).toEqual(["/bin/true"]);
+  });
+
+  it("lets the bundle's on-disk env win over guestEnv on key collision", () => {
+    const bundleDir = join(tmp, "bundle");
+    mkdirSync(join(bundleDir, "rootfs"), { recursive: true });
+    writeFileSync(
+      join(bundleDir, "machinen-config.json"),
+      JSON.stringify({ cmd: ["/bin/true"], env: { FOO: "from-bundle" } }),
+    );
+
+    const out = join(tmp, "out.cpio");
+    packBundle({
+      bundle: bundleDir,
+      out,
+      guestEnv: { FOO: "from-runtime", BAR: "from-runtime" },
+    });
+
+    const entries = listCpioEntries(out);
+    const parsed = JSON.parse(entries.get("machinen-config.json")!.data.toString("utf8"));
+    expect(parsed.env).toEqual({ FOO: "from-bundle", BAR: "from-runtime" });
+  });
+
+  it("leaves bundle config untouched when guestEnv is absent", () => {
+    const bundle = makeEmptyBundle();
+    const out = join(tmp, "out.cpio");
+    packBundle({ bundle, out });
+
+    const entries = listCpioEntries(out);
+    const parsed = JSON.parse(entries.get("machinen-config.json")!.data.toString("utf8"));
+    // No env field should have been added.
+    expect(parsed.env).toBeUndefined();
+    expect(parsed.cmd).toEqual(["/bin/true"]);
   });
 
   it("leaves non-colliding mount paths alone when the bundle overlays a sibling", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -145,6 +145,14 @@ export interface SpawnOptions {
    * #64. Live-share follow-up: #78.
    */
   mount?: { host: string; guest: string };
+  /**
+   * Env vars to expose to the guest workload (i.e. to the process
+   * `cmd` execs inside the VM). Merged into the `env` field of the
+   * packed `/machinen-config.json`; the bundle's on-disk env wins on
+   * key collision. Distinct from `env`, which only affects the host-
+   * side VMM process. See #89.
+   */
+  guestEnv?: Record<string, string>;
 }
 
 export interface VmHandle {
@@ -351,7 +359,13 @@ function packBundle(opts: SpawnOptions): { tempDir: string; cpioPath: string } {
   }
 
   try {
-    mkinitramfsPackBundle({ bundle: bundleDir, out: cpioPath, base: baseAbs, mount });
+    mkinitramfsPackBundle({
+      bundle: bundleDir,
+      out: cpioPath,
+      base: baseAbs,
+      mount,
+      guestEnv: opts.guestEnv,
+    });
   } catch (err) {
     cleanup();
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -324,6 +324,13 @@ export interface PackBundleOptions {
    * and is a directory, and that guest lives under `/mnt/`. See #64.
    */
   mount?: { host: string; guest: string };
+  /**
+   * Extra env vars to merge into the bundle's machinen-config.json `env`
+   * field before packing. The bundle's on-disk env wins on key collision
+   * (same precedence as the mount overlay — bundle always gets the last
+   * word). See #89.
+   */
+  guestEnv?: Record<string, string>;
   /** fnmatch patterns matched against each rootfs-relative path. */
   excludes?: string[];
   /** Optional path to the compiled /init. Default: ../microvm/test-fixtures/init relative to this file. */
@@ -375,7 +382,7 @@ export function packBundle(opts: PackBundleOptions): void {
     }
     appendFinalEntries(parts, {
       initPath: opts.initPath ?? defaultInitPath(),
-      config: readFileSync(cfgPath),
+      config: patchConfigEnv(readFileSync(cfgPath), opts.guestEnv),
       injectInit: false,
     });
     writeFileSync(opts.out, Buffer.concat(parts));
@@ -384,6 +391,28 @@ export function packBundle(opts: PackBundleOptions): void {
       rmSync(mergeTmp, { recursive: true, force: true });
     }
   }
+}
+
+/**
+ * Merge runtime-injected env into the bundle's machinen-config.json
+ * `env` object. Bundle keys win on collision: the on-disk config is the
+ * source of truth, and runtime injection fills in anything it hasn't
+ * already declared. Bundles without an `env` field get one created.
+ *
+ * Returns the original buffer unchanged when there's nothing to inject,
+ * so unrelated callers don't pay a parse/stringify round-trip.
+ */
+export function patchConfigEnv(config: Buffer, guestEnv?: Record<string, string>): Buffer {
+  if (!guestEnv || Object.keys(guestEnv).length === 0) {
+    return config;
+  }
+  const parsed = JSON.parse(config.toString("utf8")) as {
+    env?: Record<string, string>;
+    [k: string]: unknown;
+  };
+  const existing = parsed.env ?? {};
+  parsed.env = { ...guestEnv, ...existing };
+  return Buffer.from(JSON.stringify(parsed), "utf8");
 }
 
 /**

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -17,6 +17,7 @@
 #   T1     Base-only spawn — `echo hello-world` reaches the host console.
 #   T2     --mount exposes a host directory readable inside the guest.
 #   T3     Bundle wins on a /mnt/ collision — layering smoke.
+#   T4     --env propagates into the guest process env — #89.
 
 set -euo pipefail
 
@@ -232,6 +233,21 @@ if grep -q "$T3_BUNDLE_MARKER" "$T3_LOG" && ! grep -q "$T3_MOUNT_MARKER" "$T3_LO
 else
   tail -50 "$T3_LOG" >&2
   fail "T3 expected $T3_BUNDLE_MARKER (not $T3_MOUNT_MARKER) in guest output"
+fi
+
+# ---- T4: --env propagates into the guest process env (#89) ----
+echo "T4: machinen run --env FOO=bar -- sh -c 'echo FOO=\$FOO'"
+T4_MARKER="env-marker-$$"
+T4_LOG="$FIXTURE/t4.log"
+run_timeout 60 node "$CLI" run \
+  --env "FOO=$T4_MARKER" \
+  -- /bin/sh -c 'echo FOO=$FOO' \
+  >"$T4_LOG" 2>&1 || true
+if grep -q "FOO=$T4_MARKER" "$T4_LOG"; then
+  pass "--env value visible inside the guest"
+else
+  tail -50 "$T4_LOG" >&2
+  fail "T4 marker (FOO=$T4_MARKER) not found in guest output"
 fi
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
## Problem

`spawn()`'s `env` only reaches the VMM process on the host — not the guest workload. The guest's init reads its env from `/machinen-config.json`, and nothing was populating that field from the runtime side. The CLI already flagged this: `machinen run --env FOO=bar` was listed as *"Deferred (needs runtime API changes)"*.

Closes #89.

## Solution

- `SpawnOptions.guestEnv?: Record<string, string>` — merged into the packed `machinen-config.json` `env` field during bundle assembly.
- Bundle's on-disk env wins on key collision (same precedence as the `--mount` overlay from #64 — bundle always gets the last word).
- `machinen run --env KEY=VALUE` (repeatable, `--env=KEY=VAL` form also accepted) threads through to `guestEnv`.
- `parseRunArgs` split into its own module so the CLI tests don't pull `@machinen/runtime` through its unbuilt-in-dev-loop `exports.default`.
- Unit tests: `patchConfigEnv` round-trip, `packBundle` merge/collision/passthrough, CLI flag parsing.
- `smoke-tests.sh` T4 exercises the CLI end-to-end (`machinen run --env FOO=... -- sh -c 'echo FOO=\$FOO'`). Matches #89's "Done when" wording.

Unblocks #88 (host-side artifact cache) — `FNM_NODE_DIST_MIRROR` can now be wired through `guestEnv` and actually reach fnm inside the guest.

## Test plan

- [x] `npx vitest run` — 61 tests, green.
- [x] `npx agent-ci run --all -q -p` — green.
- [ ] `pnpm smoke-tests` on a dev box to exercise T4 end-to-end (requires HVF/KVM + release-assets; local-only per the script's header).
