### PR TITLE
feat(runtime,cli): DEBUG=machinen:* internal debug logging (#101)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,11 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@machinen/runtime": "workspace:*"
+    "@machinen/runtime": "workspace:*",
+    "debug": "^4.4.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/node": "^22",
     "tsup": "^8.3.5"
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,9 +30,12 @@ import { dirname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 
 import { attach, boot, BootError, list } from "@machinen/runtime";
+import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
 import { parseRunArgs, ParseRunArgsError } from "./parse-run-args.ts";
+
+const debug = debugLib("machinen:cli");
 
 const VERSION = pkg.version;
 const RELEASE_TAG = `@machinen/runtime@${VERSION}`;
@@ -210,6 +213,15 @@ async function cmdBoot(args: string[]): Promise<number> {
     assetsOverride ? "rootfs-debian-arm64.tar.gz" : "rootfs.tar.gz",
   );
   const imagePath = imageOverride ? resolve(imageOverride) : defaultImagePath;
+  debug(
+    "boot baseDir=%s kernel=%s dtb=%s image=%s snapshot=%s name=%s",
+    baseDir,
+    kernelPath,
+    dtbPath,
+    imagePath,
+    snapshot ?? "<none>",
+    name ?? "<unset>",
+  );
 
   // Wrap the user cmd in /usr/bin/env so bare names like `node` or
   // `bash` are PATH-resolved. The guest init uses execve(), which
@@ -570,6 +582,7 @@ function printHelp(): void {
 
 async function main(): Promise<number> {
   const [sub, ...rest] = process.argv.slice(2);
+  debug("dispatch sub=%s argc=%d", sub ?? "<empty>", rest.length);
 
   if (!sub || sub === "-h" || sub === "--help") {
     printHelp();

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -121,6 +121,32 @@ Thin clients for the vsock services the guest `/init` + `exec-agent` expose:
 `Sandboxes` and `Supervisor` let a single host process manage multiple VMs with
 per-sandbox stdio routing. See `src/multiplex.ts` for the surface.
 
+## Debugging
+
+Set `DEBUG=machinen:*` to stream internal diagnostics to stderr. Uses the
+[`debug`](https://github.com/debug-js/debug) package, so it's zero-overhead
+when unset and supports the usual comma-separated namespace patterns.
+
+| Namespace              | Covers                                                          |
+| ---------------------- | --------------------------------------------------------------- |
+| `machinen:boot`        | `boot()` lifecycle — VMM spawn, vsock bridge, registry          |
+| `machinen:provision`   | `provision()` steps — install hook, tar-to-disk, repack         |
+| `machinen:exec`        | vsock exec — connect retries, frames, exit codes                |
+| `machinen:snapshot`    | CRIU dump trigger, wait, console-log inspection                 |
+| `machinen:attach`      | attach lookup, VM resolution                                    |
+| `machinen:registry`    | `~/.machinen/vms/` reads, writes, stale-entry pruning           |
+| `machinen:gvproxy`     | sidecar spawn, port-forward setup                               |
+| `machinen:cache`       | artifact-cache hits, misses, upstream fetches                   |
+| `machinen:mkinitramfs` | rootfs/bundle pack steps                                        |
+| `machinen:cli`         | `@machinen/cli` argv parsing and command dispatch               |
+| `machinen:vmm`         | tee VMM stderr to host stderr (replaces `MACHINEN_BUILD_DEBUG`) |
+
+```sh
+DEBUG=machinen:* machinen boot ./rootfs.tar.gz -- /bin/sh
+DEBUG=machinen:exec,machinen:registry node script.js
+DEBUG=machinen:cache* pnpm smoke-tests
+```
+
 ## License
 
 [FSL-1.1-MIT](../../LICENSE) — converts to MIT two years after each release.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -26,9 +26,11 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
+    "debug": "^4.4.1",
     "node-pty": "^1.0.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/node": "^22",
     "tsup": "^8.3.5"
   },

--- a/packages/runtime/src/artifact-cache.ts
+++ b/packages/runtime/src/artifact-cache.ts
@@ -20,6 +20,9 @@ import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, normalize, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:cache");
 
 // Upstream for the node-dist mirror. Env-overridable so tests can
 // point at a localhost stub without hitting nodejs.org.
@@ -99,6 +102,7 @@ export async function spawnArtifactCache(
     server.close();
     throw new Error("artifact-cache: failed to read bound address");
   }
+  debug("listening port=%d cacheDir=%s", addr.port, cacheDir);
 
   let stopped = false;
   const stop = async () => {
@@ -164,6 +168,7 @@ async function handleRequest(
   try {
     const st = await stat(localPath);
     if (st.isFile()) {
+      debug("hit %s %s sizeBytes=%d", req.method, rest, st.size);
       res.statusCode = 200;
       res.setHeader("content-length", String(st.size));
       res.setHeader("content-type", "application/octet-stream");
@@ -182,10 +187,17 @@ async function handleRequest(
 
   // Miss — fetch upstream, tee to disk, stream to client.
   const upstream = `${nodeDistUpstream()}/${rest}`;
+  debug("miss %s upstream=%s", rest, upstream);
+  const fetchT0 = Date.now();
   let upstreamRes: Response;
   try {
     upstreamRes = await fetch(upstream);
   } catch (err) {
+    debug(
+      "upstream fetch failed %s err=%s",
+      upstream,
+      err instanceof Error ? err.message : String(err),
+    );
     res.statusCode = 502;
     res.setHeader("content-type", "text/plain");
     res.end(`upstream fetch failed: ${err instanceof Error ? err.message : String(err)}\n`);
@@ -234,6 +246,7 @@ async function handleRequest(
     return;
   }
 
+  debug("populated %s sizeBytes=%d fetchMs=%d", rest, body.length, Date.now() - fetchT0);
   res.statusCode = 200;
   res.setHeader("content-length", String(body.length));
   res.setHeader(

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -19,6 +19,9 @@
 //   // res.exitCode, res.stdout, res.stderr
 
 import { connect as netConnect, type Socket } from "node:net";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:exec");
 
 export interface VsockExecOptions {
   /** How long to keep retrying the UDS connect. Default 30s. */
@@ -63,26 +66,47 @@ export const VsockExec = {
     const connectTimeout = opts.connectTimeoutMs ?? 30_000;
     const retryMs = opts.retryMs ?? 250;
     const deadline = Date.now() + connectTimeout;
+    debug("run uds=%s cmd=%j connectTimeoutMs=%d", udsPath, cmd, connectTimeout);
+    const t0 = Date.now();
     let lastErr: Error | null = null;
+    let attempt = 0;
     while (Date.now() < deadline) {
+      attempt++;
       const socket = await connectWithRetry(udsPath, {
         ...opts,
         connectTimeoutMs: Math.max(0, deadline - Date.now()),
       });
       try {
-        return await runOnSocket(socket, cmd, opts);
+        const res = await runOnSocket(socket, cmd, opts);
+        debug(
+          "run done attempt=%d exit=%d stdout=%dB stderr=%dB elapsed=%dms",
+          attempt,
+          res.exitCode,
+          res.stdout.length,
+          res.stderr.length,
+          Date.now() - t0,
+        );
+        return res;
       } catch (err) {
         lastErr = err as Error;
         // EPIPE on write / unexpected close-before-X — the agent
         // probably wasn't listening yet. Retry the whole command.
         if (!isTransientAgentError(lastErr)) {
+          debug("run failed (non-transient) attempt=%d err=%s", attempt, lastErr.message);
           throw lastErr;
         }
+        debug(
+          "run transient err attempt=%d code=%s msg=%s — retrying",
+          attempt,
+          (lastErr as Error & { code?: string }).code,
+          lastErr.message,
+        );
       } finally {
         await endSocket(socket);
       }
       await new Promise((r) => setTimeout(r, retryMs));
     }
+    debug("run gave up after %dms attempts=%d", connectTimeout, attempt);
     throw new Error(
       `VsockExec.run: agent did not respond within ${connectTimeout}ms: ${lastErr?.message ?? "no error"}`,
     );
@@ -210,19 +234,33 @@ async function runOnSocket(
 }
 
 async function connectWithRetry(udsPath: string, opts: VsockExecOptions): Promise<Socket> {
-  const deadline = Date.now() + (opts.connectTimeoutMs ?? 30_000);
+  const totalMs = opts.connectTimeoutMs ?? 30_000;
+  const deadline = Date.now() + totalMs;
   const retryMs = opts.retryMs ?? 250;
   let lastErr: Error | null = null;
+  let attempt = 0;
   while (Date.now() < deadline) {
+    attempt++;
     try {
-      return await connectOnce(udsPath);
+      const s = await connectOnce(udsPath);
+      if (attempt > 1) {
+        debug("connect ok after attempt=%d", attempt);
+      }
+      return s;
     } catch (err) {
       lastErr = err as Error;
       await new Promise((r) => setTimeout(r, retryMs));
     }
   }
+  debug(
+    "connect gave up uds=%s after %dms attempts=%d lastErr=%s",
+    udsPath,
+    totalMs,
+    attempt,
+    lastErr?.message,
+  );
   throw new Error(
-    `VsockExec: could not reach ${udsPath} within ${opts.connectTimeoutMs ?? 30_000}ms: ${lastErr?.message ?? "no error"}`,
+    `VsockExec: could not reach ${udsPath} within ${totalMs}ms: ${lastErr?.message ?? "no error"}`,
   );
 }
 

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -20,6 +20,9 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { delimiter as pathSep, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:gvproxy");
 
 let warnedMissing = false;
 
@@ -31,6 +34,7 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
   const envOverride = process.env.MACHINEN_GVPROXY;
   if (envOverride) {
     if (existsSync(envOverride)) {
+      debug("resolved via MACHINEN_GVPROXY=%s", envOverride);
       return envOverride;
     }
     // Explicit override that points at nothing is a user mistake —
@@ -40,6 +44,7 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
 
   const sibling = join(dirname(vmmBinary), "gvproxy");
   if (existsSync(sibling)) {
+    debug("resolved via VMM sibling=%s", sibling);
     return sibling;
   }
 
@@ -50,9 +55,11 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
     }
     const candidate = join(dir, "gvproxy");
     if (existsSync(candidate)) {
+      debug("resolved via PATH=%s", candidate);
       return candidate;
     }
   }
+  debug("not found (env, sibling, PATH all missed)");
   return null;
 }
 
@@ -90,6 +97,7 @@ export async function spawnGvproxy(
   // the VMM dials for frames; `-listen` is gvproxy's HTTP control API,
   // used by `exposePort()` to install host->guest port forwards. Both
   // unix:// URLs, both auto-created by gvproxy. No vsock listener.
+  const spawnT0 = Date.now();
   const child = nodeSpawn(
     binary,
     ["-listen-qemu", `unix://${socketPath}`, "-listen", `unix://${controlSocketPath}`],
@@ -97,6 +105,7 @@ export async function spawnGvproxy(
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+  debug("spawned pid=%d qemu=%s ctrl=%s", child.pid ?? -1, socketPath, controlSocketPath);
 
   let stopped = false;
   const stop = () => {
@@ -105,6 +114,7 @@ export async function spawnGvproxy(
     }
     stopped = true;
     if (child.exitCode === null && child.signalCode === null) {
+      debug("stop() killing pid=%d", child.pid ?? -1);
       child.kill("SIGTERM");
     }
     try {
@@ -144,9 +154,11 @@ export async function spawnGvproxy(
   try {
     await Promise.race([socketReady, earlyExit]);
   } catch (err) {
+    debug("startup failed err=%s", err instanceof Error ? err.message : String(err));
     stop();
     throw err;
   }
+  debug("ready elapsed=%dms", Date.now() - spawnT0);
 
   return { socketPath, controlSocketPath, child, stop };
 }
@@ -180,6 +192,7 @@ export async function exposePort(
     local: `${hostAddr}:${opts.hostPort}`,
     remote: `${guestAddr}:${opts.guestPort}`,
   });
+  debug("expose %s:%d -> %s:%d", hostAddr, opts.hostPort, guestAddr, opts.guestPort);
 
   await new Promise<void>((done, fail) => {
     const req = httpRequest(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -64,11 +64,17 @@ import { createRequire } from "node:module";
 import { arch as osArch, platform as osPlatform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Readable, Writable } from "node:stream";
+import debugLib from "debug";
 import { packBundle as mkinitramfsPackBundle } from "./mkinitramfs.ts";
 import { exposePort, resolveGvproxyBinary, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
 import { findEntry, isAlive, newVmId, removeEntry, writeEntry } from "./registry.ts";
+
+const debug = debugLib("machinen:boot");
+const debugAttach = debugLib("machinen:attach");
+const debugSnapshot = debugLib("machinen:snapshot");
+const vmmDebug = debugLib("machinen:vmm");
 
 export class BootError extends Error {}
 
@@ -271,6 +277,16 @@ export interface SnapshotResult {
 }
 
 export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
+  const bootT0 = Date.now();
+  debug(
+    "boot entry image=%s cmd=%j name=%s portForward=%d hasSnapshot=%s mount=%s",
+    opts.image ?? "<none>",
+    opts.cmd ?? null,
+    opts.name ?? "<unset>",
+    (opts.portForward ?? []).length,
+    Boolean(opts.snapshot),
+    opts.mount ? `${opts.mount.host}->${opts.mount.guest}` : "<none>",
+  );
   // Validate portForward up front — before resolving the binary or
   // touching the filesystem — so caller-input errors surface with a
   // clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
@@ -351,10 +367,16 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   let vsockTempDir: string | undefined;
   if (env.MACHINEN_VSOCK) {
     vsockUdsPath = parseVsockUdsPath(env.MACHINEN_VSOCK);
+    debug(
+      "vsock spec from caller env: %s (uds=%s)",
+      env.MACHINEN_VSOCK,
+      vsockUdsPath ?? "<unparsed>",
+    );
   } else {
     vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
     vsockUdsPath = join(vsockTempDir, "exec.sock");
     env.MACHINEN_VSOCK = `in:1978:${vsockUdsPath}`;
+    debug("vsock auto uds=%s", vsockUdsPath);
   }
 
   // gvproxy + artifact cache (#88) + host→guest port forwards (#87)
@@ -372,6 +394,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     if (!env.MACHINEN_NET_SOCKET) {
       const gvBin = resolveGvproxyBinary(binary);
       if (gvBin) {
+        debug("starting gvproxy bin=%s", gvBin);
         const gv = await spawnGvproxy(gvBin);
         env.MACHINEN_NET_SOCKET = gv.socketPath;
         gvStop = gv.stop;
@@ -385,8 +408,11 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
               "Install gvproxy or point MACHINEN_GVPROXY at one.",
           );
         }
+        debug("gvproxy not found — booting without networking");
         warnGvproxyMissing();
       }
+    } else {
+      debug("MACHINEN_NET_SOCKET already set — skipping gvproxy spawn");
     }
 
     // Only useful when the guest has networking — without gvproxy
@@ -412,9 +438,11 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     }
 
     if (opts.image || opts.cmd) {
+      const packT0 = Date.now();
       const packed = synthesizeAndPackBundle(opts, mergedGuestEnv);
       bundleTempDir = packed.tempDir;
       env.MACHINEN_INITRD = packed.cpioPath;
+      debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, Date.now() - packT0);
     }
   } catch (err) {
     if (cacheStop) {
@@ -441,6 +469,12 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     env,
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessWithoutNullStreams;
+  debug(
+    "VMM spawned pid=%d binary=%s elapsedSinceEntry=%dms",
+    child.pid ?? -1,
+    binary,
+    Date.now() - bootT0,
+  );
 
   // #98: register the running VM so another process can attach. The
   // entry is keyed by an auto-generated id; optional name lets
@@ -460,13 +494,25 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         startedAt: Date.now(),
       });
       registered = true;
-    } catch {
+      debug("registered id=%s name=%s pid=%d", id, vmName ?? "<unset>", childPid);
+    } catch (err) {
       // Registry write is best-effort; attach won't find this VM but
       // local boot-and-use still works fine.
+      debug(
+        "registry write failed (best-effort) err=%s",
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 
-  child.once("exit", () => {
+  child.once("exit", (code, signal) => {
+    debug(
+      "VMM exit pid=%d code=%s signal=%s lifetimeMs=%d",
+      childPid,
+      code,
+      signal,
+      Date.now() - bootT0,
+    );
     if (bundleTempDir) {
       try {
         rmSync(bundleTempDir, { recursive: true, force: true });
@@ -498,6 +544,15 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // to fill a pipe buffer if nothing's draining it).
   const outputCollector = collect(child.stdout);
   const errorCollector = collect(child.stderr);
+
+  // DEBUG=machinen:vmm tees the VMM's stderr (kernel + early-userspace
+  // console) to the host stderr in real time. Replaces the legacy
+  // MACHINEN_BUILD_DEBUG flag.
+  if (vmmDebug.enabled) {
+    child.stderr.on("data", (chunk: Buffer) => {
+      process.stderr.write(chunk);
+    });
+  }
 
   const handle: VmHandle = {
     id,
@@ -596,6 +651,13 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       const dumpCmd = snapshotOpts?.dumpCmd ?? "/sbin/machinen-dump";
       const deadlineMs = snapshotOpts?.timeoutMs ?? 90_000;
       const t0 = Date.now();
+      debugSnapshot(
+        "snapshot start id=%s out=%s dumpCmd=%s timeoutMs=%d",
+        id,
+        outPath,
+        dumpCmd,
+        deadlineMs,
+      );
 
       // Trigger the in-guest dump. The vsock connection typically closes
       // mid-transaction as the guest powers off — all such close modes
@@ -611,8 +673,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       }
       const elapsedMs = Date.now() - t0;
       const consoleLog = await this.errorOutput();
+      debugSnapshot("guest exited elapsed=%dms consoleBytes=%d", elapsedMs, consoleLog.length);
 
       if (!consoleLog.includes("dump OK")) {
+        debugSnapshot("dump OK not found in console — failing");
         throw new BootError(
           `vm.snapshot: guest did not report "dump OK" — check console log:\n${consoleLog.slice(-2000)}`,
         );
@@ -620,8 +684,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 
       const outAbs = resolve(outPath);
       if (outAbs !== diskAbs) {
+        debugSnapshot("copy disk %s -> %s", diskAbs, outAbs);
         copyFileSync(diskAbs, outAbs);
       }
+      debugSnapshot("snapshot done out=%s", outAbs);
       return { snapshotPath: outAbs, elapsedMs, consoleLog };
     },
   };
@@ -660,11 +726,20 @@ export interface AttachOptions {
  * `wait()` polls the pid rather than listening for `exit`.
  */
 export async function attach(opts: AttachOptions): Promise<VmHandle> {
+  debugAttach("attach lookup id=%s name=%s", opts.id ?? "<unset>", opts.name ?? "<unset>");
   const entry = findEntry(opts);
   if (!entry) {
     const q = opts.id ? `id ${opts.id}` : `name ${opts.name}`;
+    debugAttach("attach miss for %s", q);
     throw new BootError(`attach: no running VM found for ${q}`);
   }
+  debugAttach(
+    "attach hit id=%s name=%s pid=%d sock=%s",
+    entry.id,
+    entry.name ?? "<unset>",
+    entry.pid,
+    entry.socketPath,
+  );
   const { PassThrough } = await import("node:stream");
   const stdin = new PassThrough();
   const stdout = new PassThrough();

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -36,6 +36,9 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:mkinitramfs");
 
 /**
  * Default excludes applied to --workspace packs. Skip the usual dev
@@ -338,6 +341,7 @@ export interface PackBundleOptions {
 }
 
 export function packBundle(opts: PackBundleOptions): void {
+  const t0 = Date.now();
   const rootfsDir = join(opts.bundle, "rootfs");
   const cfgPath = join(opts.bundle, "machinen-config.json");
   if (!statSync(rootfsDir).isDirectory()) {
@@ -348,17 +352,27 @@ export function packBundle(opts: PackBundleOptions): void {
   }
 
   const needsMerge = Boolean(opts.base) || Boolean(opts.mount);
+  debug(
+    "packBundle bundle=%s out=%s base=%s mount=%s needsMerge=%s",
+    opts.bundle,
+    opts.out,
+    opts.base ?? "<none>",
+    opts.mount ? `${opts.mount.host}->${opts.mount.guest}` : "<none>",
+    needsMerge,
+  );
 
   let packSrc = rootfsDir;
   let mergeTmp: string | undefined;
   if (needsMerge) {
     mergeTmp = mkdtempSync(join(tmpdir(), "machinen-mkinitramfs-"));
     if (opts.base) {
+      const extractT0 = Date.now();
       const res = spawnSync("tar", ["-xzf", opts.base, "-C", mergeTmp]);
       if (res.status !== 0) {
         rmSync(mergeTmp, { recursive: true, force: true });
         throw new Error(`tar -xzf ${opts.base} failed: ${res.stderr?.toString() ?? ""}`);
       }
+      debug("base extracted elapsed=%dms", Date.now() - extractT0);
     }
     if (opts.mount) {
       overlayMount(mergeTmp, opts.mount.host, opts.mount.guest);
@@ -386,6 +400,12 @@ export function packBundle(opts: PackBundleOptions): void {
       injectInit: false,
     });
     writeFileSync(opts.out, Buffer.concat(parts));
+    debug(
+      "packBundle done files=%d bytes=%d elapsed=%dms",
+      counts.files,
+      counts.bytes,
+      Date.now() - t0,
+    );
   } finally {
     if (mergeTmp) {
       rmSync(mergeTmp, { recursive: true, force: true });

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -35,8 +35,12 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import debugLib from "debug";
 import { VsockExec } from "./exec.ts";
 import { boot, type VmHandle } from "./index.ts";
+
+const debug = debugLib("machinen:provision");
+const vmmDebug = debugLib("machinen:vmm");
 
 export class ProvisionError extends Error {}
 
@@ -226,12 +230,15 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
   const workDir = mkdtempSync(join(tmpdir(), "machinen-provision-"));
   const diskPath = join(workDir, "scratch.img");
   const udsPath = join(workDir, "exec.sock");
+  debug("provision start base=%s out=%s workDir=%s", baseAbs, outAbs, workDir);
 
   try {
     // Allocate the scratch disk sparsely. The guest tars its filesystem
     // into this block device; the host then repacks the raw tar stream
     // into the output tarball.
-    allocateSparseFile(diskPath, opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024);
+    const scratchBytes = opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024;
+    allocateSparseFile(diskPath, scratchBytes);
+    debug("scratch disk allocated path=%s sizeBytes=%d", diskPath, scratchBytes);
 
     // Boot the VMM with the base rootfs as the image and the exec-agent
     // as the cmd. We set MACHINEN_VSOCK explicitly via `vmmEnv` so the
@@ -273,7 +280,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
         tailBytes -= tailBuf[0]!.length;
         tailBuf.shift();
       }
-      if (process.env.MACHINEN_BUILD_DEBUG) {
+      if (vmmDebug.enabled) {
         process.stderr.write(chunk);
       }
     });
@@ -283,23 +290,30 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // Hand control to the install hook. The spawned VM already has
       // exec()/execRaw() hooked up to the vsock UDS we set via env, so
       // the hook uses the same VmHandle shape as any other caller.
+      const installT0 = Date.now();
+      debug("install hook entry");
       try {
         await opts.install(vm);
       } catch (err) {
         const tail = stderrTail();
         const msg = err instanceof Error ? err.message : String(err);
+        debug("install hook failed err=%s tailBytes=%d", msg, tail.length);
         throw new ProvisionError(
           `install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`,
         );
       }
+      debug("install hook done elapsed=%dms", Date.now() - installT0);
 
       // Post-install: archive / to /dev/vda, then tell the guest to
       // power off cleanly (PSCI SYSTEM_OFF via /sbin/machinen-poweroff).
       // A failed tar here means our scratch disk was too small; surface
       // that specifically.
+      debug("tar / -> /dev/vda starting");
+      const tarT0 = Date.now();
       const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
         execTimeoutMs: deadlineMs,
       });
+      debug("tar / -> /dev/vda done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
       if (tar.exitCode !== 0) {
         throw new ProvisionError(
           `tar / to /dev/vda failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
@@ -314,11 +328,13 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // after the VMM has already exited) — all are fine; vm.wait()
       // below is the real success signal. Short connect timeout so
       // we don't burn 30s retrying a bridge that's already gone.
+      debug("requesting guest poweroff");
       await VsockExec.run(udsPath, "/sbin/machinen-poweroff", {
         connectTimeoutMs: 2_000,
       }).catch(() => {});
 
       await vm.wait();
+      debug("guest exited");
     } finally {
       clearTimeout(killTimer);
       if (vm.pid > 0) {
@@ -329,9 +345,13 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     // Scratch disk now holds a raw tar stream (padded with zeros up to
     // the scratch size). Repack it as a gzipped tarball at `out`, which
     // trims trailing zeros and normalizes compression.
+    debug("repack disk tar -> %s starting", outAbs);
+    const repackT0 = Date.now();
     repackDiskTarToGz(diskPath, outAbs, { cmd: opts.cmd, env: opts.env });
+    debug("repack done elapsed=%dms", Date.now() - repackT0);
 
     const sizeBytes = statSync(outAbs).size;
+    debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, Date.now() - t0);
     return {
       imagePath: outAbs,
       sizeBytes,

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -17,6 +17,9 @@ import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:registry");
 
 export interface RegistryEntry {
   /** Auto-generated short id. Unique per VM. */
@@ -54,10 +57,18 @@ export function writeEntry(entry: RegistryEntry): void {
   const dir = join(root, entry.id);
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "meta.json"), JSON.stringify(entry));
+  debug(
+    "write id=%s name=%s pid=%d sock=%s",
+    entry.id,
+    entry.name ?? "<unset>",
+    entry.pid,
+    entry.socketPath,
+  );
 }
 
 /** Remove a registry entry. No-op if it's already gone. */
 export function removeEntry(id: string): void {
+  debug("remove id=%s", id);
   try {
     rmSync(join(registryRoot(), id), { recursive: true, force: true });
   } catch {}
@@ -102,19 +113,23 @@ export function list(): RegistryEntry[] {
     return [];
   }
   const out: RegistryEntry[] = [];
+  let pruned = 0;
   for (const id of readdirSync(root)) {
     const entry = readEntry(id);
     if (!entry) {
       // Malformed or missing meta.json — clean it up.
       removeEntry(id);
+      pruned++;
       continue;
     }
     if (!isAlive(entry.pid)) {
       removeEntry(entry.id);
+      pruned++;
       continue;
     }
     out.push(entry);
   }
+  debug("list root=%s alive=%d pruned=%d", root, out.length, pruned);
   return out;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,13 @@ importers:
       '@machinen/runtime':
         specifier: workspace:*
         version: link:../runtime
+      debug:
+        specifier: ^4.4.1
+        version: 4.4.3
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.13
       '@types/node':
         specifier: ^22
         version: 22.19.17
@@ -69,10 +75,16 @@ importers:
 
   packages/runtime:
     dependencies:
+      debug:
+        specifier: ^4.4.1
+        version: 4.4.3
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.13
       '@types/node':
         specifier: ^22
         version: 22.19.17
@@ -1059,6 +1071,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1067,6 +1082,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -3427,11 +3445,17 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 


### PR DESCRIPTION
## Problem

Machinen had no systematic debug-logging surface. Diagnosing a misbehaving boot/provision/exec required either flipping `MACHINEN_BUILD_DEBUG` (one bit, only during `provision()`), inspecting `vm.errorOutput()` after the fact, or sprinkling `console.log`. Closes #101.

## Solution

Adopt the `debug` package convention. Each subsystem gets one namespace; zero overhead when `DEBUG` is unset.

| Namespace | Covers |
| --- | --- |
| `machinen:boot` | `boot()` lifecycle |
| `machinen:provision` | `provision()` steps |
| `machinen:exec` | vsock exec frames + retries |
| `machinen:snapshot` | CRIU dump, console-log inspection |
| `machinen:attach` | attach lookup |
| `machinen:registry` | `~/.machinen/vms/` I/O |
| `machinen:gvproxy` | sidecar spawn, port forwards |
| `machinen:cache` | artifact-cache hits, misses, fetches |
| `machinen:mkinitramfs` | bundle pack steps |
| `machinen:cli` | argv dispatch + boot path |
| `machinen:vmm` | VMM stderr passthrough |

`DEBUG=machinen:vmm` replaces `MACHINEN_BUILD_DEBUG` and now also covers `boot()` (not just `provision()`).

## Test plan

- [x] `npx vitest run` (105 passed)
- [x] `npx agent-ci run --all -q -p` (all green)
- [x] Default behavior unchanged with `DEBUG` unset
