### PR TITLE
feat(runtime,cli): unified error model (#102)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,6 @@
+import { ParseError } from "@machinen/runtime";
 import { describe, expect, it } from "vitest";
-import { ParseRunArgsError, parseRunArgs } from "../parse-run-args.ts";
+import { parseRunArgs } from "../parse-run-args.ts";
 
 describe("parseRunArgs --env", () => {
   it("collects repeated --env flags into env", () => {
@@ -42,11 +43,11 @@ describe("parseRunArgs --env", () => {
   });
 
   it("rejects --env without a '=' separator", () => {
-    expect(() => parseRunArgs(["--env", "FOO", "--", "/bin/true"])).toThrow(ParseRunArgsError);
+    expect(() => parseRunArgs(["--env", "FOO", "--", "/bin/true"])).toThrow(ParseError);
   });
 
   it("rejects --env with an empty key", () => {
-    expect(() => parseRunArgs(["--env", "=bar", "--", "/bin/true"])).toThrow(ParseRunArgsError);
+    expect(() => parseRunArgs(["--env", "=bar", "--", "/bin/true"])).toThrow(ParseError);
   });
 
   it("rejects a bare --env with no following argument", () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,10 +29,10 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 
-import { attach, boot, BootError, list } from "@machinen/runtime";
+import { attach, boot, formatMachinenError, isMachinenError, list } from "@machinen/runtime";
 
 import pkg from "../package.json" with { type: "json" };
-import { parseRunArgs, ParseRunArgsError } from "./parse-run-args.ts";
+import { parseRunArgs } from "./parse-run-args.ts";
 
 const VERSION = pkg.version;
 const RELEASE_TAG = `@machinen/runtime@${VERSION}`;
@@ -166,10 +166,7 @@ async function cmdBoot(args: string[]): Promise<number> {
   try {
     parsed = parseRunArgs(args);
   } catch (err) {
-    if (err instanceof ParseRunArgsError) {
-      die(err.message);
-    }
-    throw err;
+    handleError(err);
   }
   const { positional, double_dash_args, mount, env, portForward, snapshot, name } = parsed;
 
@@ -236,10 +233,7 @@ async function cmdBoot(args: string[]): Promise<number> {
       timeoutMs: null,
     });
   } catch (err) {
-    if (err instanceof BootError) {
-      die(err.message);
-    }
-    throw err;
+    handleError(err);
   }
 
   vm.stdout.pipe(process.stdout);
@@ -348,12 +342,7 @@ async function cmdExec(args: string[]): Promise<number> {
     die("usage: machinen exec <name-or-id> -- <cmd>");
   }
   const target = pre[0]!;
-  const vm = await attach(lookupQuery(target)).catch((err) => {
-    if (err instanceof BootError) {
-      die(err.message);
-    }
-    throw err;
-  });
+  const vm = await attach(lookupQuery(target)).catch(handleError);
   try {
     // Shell out via `sh -c` on the guest so caller can pass piped
     // commands naturally. Users who want raw exec of a single binary
@@ -373,21 +362,13 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     die("usage: machinen snapshot <name-or-id> <out-path>");
   }
   const [target, outPath] = args;
-  const vm = await attach(lookupQuery(target!)).catch((err) => {
-    if (err instanceof BootError) {
-      die(err.message);
-    }
-    throw err;
-  });
+  const vm = await attach(lookupQuery(target!)).catch(handleError);
   try {
     const res = await vm.snapshot(outPath!);
     process.stdout.write(`snapshot: ${res.snapshotPath} (${res.elapsedMs}ms)\n`);
     return 0;
   } catch (err) {
-    if (err instanceof BootError) {
-      die(err.message);
-    }
-    throw err;
+    handleError(err);
   } finally {
     await vm.detach();
   }
@@ -398,12 +379,7 @@ async function cmdAttach(args: string[]): Promise<number> {
     die("usage: machinen attach <name-or-id>");
   }
   const target = args[0]!;
-  const vm = await attach(lookupQuery(target)).catch((err) => {
-    if (err instanceof BootError) {
-      die(err.message);
-    }
-    throw err;
-  });
+  const vm = await attach(lookupQuery(target)).catch(handleError);
   process.stderr.write(`attached to ${vm.name ?? vm.id} (pid ${vm.pid})\n`);
   process.stderr.write(`type commands; Ctrl-D to detach.\n`);
   try {
@@ -521,6 +497,19 @@ function die(msg: string): never {
   process.exit(1);
 }
 
+/**
+ * Unified error handler. MachinenError gets a formatted `(CODE): message`
+ * + cause chain and an exit(1). Anything else re-throws so Node prints
+ * the full stack — those are genuine surprises we want to see.
+ */
+function handleError(err: unknown): never {
+  if (isMachinenError(err)) {
+    process.stderr.write(`machinen: ${formatMachinenError(err)}\n`);
+    process.exit(1);
+  }
+  throw err;
+}
+
 function printHelp(): void {
   process.stdout.write(
     `machinen ${VERSION}\n` +
@@ -605,6 +594,10 @@ async function main(): Promise<number> {
 main().then(
   (code) => process.exit(code),
   (err) => {
+    if (isMachinenError(err)) {
+      process.stderr.write(`machinen: ${formatMachinenError(err)}\n`);
+      process.exit(1);
+    }
     process.stderr.write(
       `machinen: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
     );

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -2,6 +2,8 @@
 // can import it without pulling @machinen/runtime (which resolves to
 // dist/ and is unbuilt in the monorepo dev loop).
 
+import { ParseError } from "@machinen/runtime";
+
 export interface ParsedRunArgs {
   positional: string[];
   double_dash_args: string[];
@@ -13,8 +15,6 @@ export interface ParsedRunArgs {
   /** Optional VM name registered for `attach` (`--name <name>`). */
   name?: string;
 }
-
-export class ParseRunArgsError extends Error {}
 
 export function parseRunArgs(argv: string[]): ParsedRunArgs {
   const idx = argv.indexOf("--");
@@ -35,18 +35,27 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       if (a === "--mount") {
         spec = pre[i + 1];
         if (spec === undefined) {
-          throw new ParseRunArgsError("--mount requires a <host-dir>:<guest-path> value");
+          throw new ParseError(
+            "PARSE_FLAG_MISSING_VALUE",
+            "--mount requires a <host-dir>:<guest-path> value",
+          );
         }
         i++;
       } else {
         spec = a.slice("--mount=".length);
       }
       if (mount) {
-        throw new ParseRunArgsError("--mount may be given at most once per invocation");
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--mount may be given at most once per invocation",
+        );
       }
       const colon = spec!.indexOf(":");
       if (colon <= 0 || colon === spec!.length - 1) {
-        throw new ParseRunArgsError(`--mount: expected <host-dir>:<guest-path>, got '${spec}'`);
+        throw new ParseError(
+          "PARSE_FLAG_MALFORMED",
+          `--mount: expected <host-dir>:<guest-path>, got '${spec}'`,
+        );
       }
       mount = { host: spec!.slice(0, colon), guest: spec!.slice(colon + 1) };
     } else if (a === "--env" || a.startsWith("--env=")) {
@@ -54,7 +63,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       if (a === "--env") {
         spec = pre[i + 1];
         if (spec === undefined) {
-          throw new ParseRunArgsError("--env requires a KEY=VALUE value");
+          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--env requires a KEY=VALUE value");
         }
         i++;
       } else {
@@ -62,7 +71,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       }
       const eq = spec!.indexOf("=");
       if (eq <= 0) {
-        throw new ParseRunArgsError(`--env: expected KEY=VALUE, got '${spec}'`);
+        throw new ParseError("PARSE_FLAG_MALFORMED", `--env: expected KEY=VALUE, got '${spec}'`);
       }
       const key = spec!.slice(0, eq);
       const value = spec!.slice(eq + 1);
@@ -77,7 +86,10 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       if (a === "-p" || a === "--publish") {
         spec = pre[i + 1];
         if (spec === undefined) {
-          throw new ParseRunArgsError(`${a} requires a <hostPort>:<guestPort> value`);
+          throw new ParseError(
+            "PARSE_FLAG_MISSING_VALUE",
+            `${a} requires a <hostPort>:<guestPort> value`,
+          );
         }
         i++;
       } else if (a.startsWith("-p=")) {
@@ -87,12 +99,15 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       }
       const colon = spec!.indexOf(":");
       if (colon <= 0 || colon === spec!.length - 1) {
-        throw new ParseRunArgsError(`-p: expected <hostPort>:<guestPort>, got '${spec}'`);
+        throw new ParseError(
+          "PARSE_FLAG_MALFORMED",
+          `-p: expected <hostPort>:<guestPort>, got '${spec}'`,
+        );
       }
       const hostPort = parsePort(spec!.slice(0, colon), "hostPort");
       const guestPort = parsePort(spec!.slice(colon + 1), "guestPort");
       if (seenHostPorts.has(hostPort)) {
-        throw new ParseRunArgsError(`-p: duplicate hostPort ${hostPort}`);
+        throw new ParseError("PARSE_FLAG_DUPLICATE", `-p: duplicate hostPort ${hostPort}`);
       }
       seenHostPorts.add(hostPort);
       portForward.push({ hostPort, guestPort });
@@ -101,14 +116,17 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       if (a === "--snapshot") {
         spec = pre[i + 1];
         if (spec === undefined) {
-          throw new ParseRunArgsError("--snapshot requires a path value");
+          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--snapshot requires a path value");
         }
         i++;
       } else {
         spec = a.slice("--snapshot=".length);
       }
       if (snapshot) {
-        throw new ParseRunArgsError("--snapshot may be given at most once per invocation");
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--snapshot may be given at most once per invocation",
+        );
       }
       snapshot = spec;
     } else if (a === "--name" || a.startsWith("--name=")) {
@@ -116,18 +134,21 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       if (a === "--name") {
         spec = pre[i + 1];
         if (spec === undefined) {
-          throw new ParseRunArgsError("--name requires a value");
+          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
         }
         i++;
       } else {
         spec = a.slice("--name=".length);
       }
       if (name) {
-        throw new ParseRunArgsError("--name may be given at most once per invocation");
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--name may be given at most once per invocation",
+        );
       }
       name = spec;
     } else if (a.startsWith("-")) {
-      throw new ParseRunArgsError(`unknown flag: ${a}`);
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
     } else {
       positional.push(a);
     }
@@ -145,11 +166,11 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
 
 function parsePort(raw: string, label: string): number {
   if (!/^[0-9]+$/.test(raw)) {
-    throw new ParseRunArgsError(`-p: ${label} must be numeric (got '${raw}')`);
+    throw new ParseError("PARSE_PORT_INVALID", `-p: ${label} must be numeric (got '${raw}')`);
   }
   const n = Number(raw);
   if (n < 1 || n > 65535) {
-    throw new ParseRunArgsError(`-p: ${label} must be in 1..65535 (got ${n})`);
+    throw new ParseError("PARSE_PORT_INVALID", `-p: ${label} must be in 1..65535 (got ${n})`);
   }
   return n;
 }

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -20,7 +20,7 @@ import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { BootError, measureFirstByte, boot } from "../index.ts";
+import { BootError, ExecError, measureFirstByte, boot } from "../index.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
 
@@ -526,7 +526,7 @@ describe("vm.exec", () => {
     }
   });
 
-  it("exec() throws BootError on non-zero exit and surfaces stderr", async () => {
+  it("exec() throws ExecError on non-zero exit and surfaces stderr", async () => {
     const udsPath = join(tmpdir(), `machinen-vm-exec-${process.pid}-2.sock`);
     try {
       unlinkSync(udsPath);
@@ -543,7 +543,7 @@ describe("vm.exec", () => {
         timeoutMs: 5_000,
       });
       try {
-        await expect(vm.exec("doesnt-matter")).rejects.toThrow(BootError);
+        await expect(vm.exec("doesnt-matter")).rejects.toThrow(ExecError);
         await expect(vm.exec("doesnt-matter")).rejects.toThrow(/code 7.*boom happened/s);
       } finally {
         await vm.kill();

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { BootError, attach, boot, list, type RegistryEntry } from "../index.ts";
+import { RegistryError, attach, boot, list, type RegistryEntry } from "../index.ts";
 import {
   findEntry,
   isAlive,
@@ -190,9 +190,9 @@ describe("boot + attach end-to-end", () => {
     }
   });
 
-  it("attach() throws BootError when no VM matches", async () => {
-    await expect(attach({ name: "nothing-here" })).rejects.toThrow(BootError);
-    await expect(attach({ id: "deadbeef" })).rejects.toThrow(BootError);
+  it("attach() throws RegistryError when no VM matches", async () => {
+    await expect(attach({ name: "nothing-here" })).rejects.toThrow(RegistryError);
+    await expect(attach({ id: "deadbeef" })).rejects.toThrow(RegistryError);
   });
 
   it("vm.kill() removes the registry entry via child exit", async () => {

--- a/packages/runtime/src/artifact-cache.ts
+++ b/packages/runtime/src/artifact-cache.ts
@@ -20,6 +20,7 @@ import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, normalize, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
+import { CacheError } from "./errors.ts";
 
 // Upstream for the node-dist mirror. Env-overridable so tests can
 // point at a localhost stub without hitting nodejs.org.
@@ -97,7 +98,7 @@ export async function spawnArtifactCache(
   const addr = server.address();
   if (!addr || typeof addr === "string") {
     server.close();
-    throw new Error("artifact-cache: failed to read bound address");
+    throw new CacheError("CACHE_BIND_FAILED", "artifact-cache: failed to read bound address");
   }
 
   let stopped = false;

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -1,0 +1,166 @@
+// Unified error model for @machinen/runtime (#102).
+//
+// One base class (`MachinenError`) carrying a flat `code` string, a
+// `retryable` hint, and a `cause` chain. Thin category subclasses
+// (`BootError`, `ProvisionError`, `ExecError`, `RegistryError`,
+// `CacheError`, `GvproxyError`, `MkinitramfsError`, `ParseError`) are
+// purely for `instanceof` filtering — all semantics live on the code.
+//
+// Usage:
+//
+//   throw new BootError("BOOT_VMM_MISSING", `VMM binary not found at ${bin}`);
+//   throw new ExecError("EXEC_AGENT_TIMEOUT", "agent timed out", {
+//     retryable: true,
+//     cause: err,
+//   });
+//
+//   if (isMachinenError(err, "BOOT_VMM_MISSING")) { ... }     // narrow by code
+//   if (isMachinenError(err) && err.retryable)   { ... }      // generic filter
+//
+// TypeScript has no `throws` clause; we rely on the code being a const
+// enum (typos don't compile) and JSDoc `@throws` for documentation.
+
+export const ErrorCode = {
+  // boot — VM lifecycle, binary lookup, config validation
+  BOOT_VMM_MISSING: "BOOT_VMM_MISSING",
+  BOOT_VMM_PACKAGE_BROKEN: "BOOT_VMM_PACKAGE_BROKEN",
+  BOOT_IMAGE_NOT_FOUND: "BOOT_IMAGE_NOT_FOUND",
+  BOOT_SNAPSHOT_NOT_FOUND: "BOOT_SNAPSHOT_NOT_FOUND",
+  BOOT_KERNEL_NOT_FOUND: "BOOT_KERNEL_NOT_FOUND",
+  BOOT_DTB_NOT_FOUND: "BOOT_DTB_NOT_FOUND",
+  BOOT_CMD_WITHOUT_IMAGE: "BOOT_CMD_WITHOUT_IMAGE",
+  BOOT_CMD_MISSING: "BOOT_CMD_MISSING",
+  BOOT_MOUNT_INVALID: "BOOT_MOUNT_INVALID",
+  BOOT_MOUNT_HOST_NOT_FOUND: "BOOT_MOUNT_HOST_NOT_FOUND",
+  BOOT_PORT_FORWARD_INVALID: "BOOT_PORT_FORWARD_INVALID",
+  BOOT_PORT_FORWARD_CONFLICT: "BOOT_PORT_FORWARD_CONFLICT",
+  BOOT_PORT_FORWARD_NO_GVPROXY: "BOOT_PORT_FORWARD_NO_GVPROXY",
+  BOOT_PACK_FAILED: "BOOT_PACK_FAILED",
+  BOOT_TIMEOUT: "BOOT_TIMEOUT",
+
+  // exec — vsock command execution
+  EXEC_VSOCK_UNAVAILABLE: "EXEC_VSOCK_UNAVAILABLE",
+  EXEC_AGENT_UNAVAILABLE: "EXEC_AGENT_UNAVAILABLE",
+  EXEC_AGENT_TIMEOUT: "EXEC_AGENT_TIMEOUT",
+  EXEC_CMD_INVALID: "EXEC_CMD_INVALID",
+  EXEC_NONZERO_EXIT: "EXEC_NONZERO_EXIT",
+  EXEC_PROTOCOL: "EXEC_PROTOCOL",
+
+  // snapshot — CRIU-based VM snapshotting
+  SNAPSHOT_NO_DISK: "SNAPSHOT_NO_DISK",
+  SNAPSHOT_DUMP_FAILED: "SNAPSHOT_DUMP_FAILED",
+  SNAPSHOT_UNSUPPORTED_ON_ATTACH: "SNAPSHOT_UNSUPPORTED_ON_ATTACH",
+
+  // provision — image builder
+  PROVISION_BASE_NOT_FOUND: "PROVISION_BASE_NOT_FOUND",
+  PROVISION_ASSETS_DIR_INVALID: "PROVISION_ASSETS_DIR_INVALID",
+  PROVISION_INSTALL_HOOK_FAILED: "PROVISION_INSTALL_HOOK_FAILED",
+  PROVISION_DISK_TOO_SMALL: "PROVISION_DISK_TOO_SMALL",
+
+  // registry / attach
+  REGISTRY_VM_NOT_FOUND: "REGISTRY_VM_NOT_FOUND",
+
+  // files — vsock push/pull
+  FILES_HOST_DIR_NOT_FOUND: "FILES_HOST_DIR_NOT_FOUND",
+  FILES_AGENT_UNAVAILABLE: "FILES_AGENT_UNAVAILABLE",
+
+  // secrets — vsock KEY=VALUE injection
+  SECRETS_VALUE_INVALID: "SECRETS_VALUE_INVALID",
+  SECRETS_AGENT_UNAVAILABLE: "SECRETS_AGENT_UNAVAILABLE",
+
+  // winsize — vsock resize forwarder
+  WINSIZE_AGENT_UNAVAILABLE: "WINSIZE_AGENT_UNAVAILABLE",
+
+  // multiplex — sandbox registry
+  SANDBOX_ID_DUPLICATE: "SANDBOX_ID_DUPLICATE",
+  SANDBOX_ID_UNKNOWN: "SANDBOX_ID_UNKNOWN",
+
+  // cache — host-side artifact mirror
+  CACHE_BIND_FAILED: "CACHE_BIND_FAILED",
+
+  // gvproxy — user-mode network bridge
+  GVPROXY_NOT_FOUND: "GVPROXY_NOT_FOUND",
+  GVPROXY_EXPOSE_FAILED: "GVPROXY_EXPOSE_FAILED",
+
+  // mkinitramfs — initramfs packer
+  MKINITRAMFS_BUNDLE_INVALID: "MKINITRAMFS_BUNDLE_INVALID",
+  MKINITRAMFS_WORKSPACE_INVALID: "MKINITRAMFS_WORKSPACE_INVALID",
+  MKINITRAMFS_WORKSPACE_TOO_LARGE: "MKINITRAMFS_WORKSPACE_TOO_LARGE",
+  MKINITRAMFS_BASE_EXTRACT_FAILED: "MKINITRAMFS_BASE_EXTRACT_FAILED",
+
+  // parse — CLI arg parser
+  PARSE_FLAG_UNKNOWN: "PARSE_FLAG_UNKNOWN",
+  PARSE_FLAG_MISSING_VALUE: "PARSE_FLAG_MISSING_VALUE",
+  PARSE_FLAG_DUPLICATE: "PARSE_FLAG_DUPLICATE",
+  PARSE_FLAG_MALFORMED: "PARSE_FLAG_MALFORMED",
+  PARSE_PORT_INVALID: "PARSE_PORT_INVALID",
+} as const;
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export interface MachinenErrorOptions {
+  /**
+   * True if retrying the same call could plausibly succeed (transient
+   * network blip, upstream fetch, vsock agent not listening yet). False
+   * for misconfiguration (missing binary, bad mount path, invalid
+   * port).
+   */
+  retryable?: boolean;
+  /** Underlying error preserved via the standard `Error.cause` chain. */
+  cause?: unknown;
+}
+
+/**
+ * Base class for every error raised by @machinen/runtime and
+ * @machinen/cli. Carries a flat `code`, a `retryable` hint, and the
+ * underlying cause via the standard `Error.cause` mechanism.
+ */
+export class MachinenError extends Error {
+  readonly code: ErrorCode;
+  readonly retryable: boolean;
+
+  constructor(code: ErrorCode, message: string, opts: MachinenErrorOptions = {}) {
+    super(message, { cause: opts.cause });
+    this.code = code;
+    this.retryable = opts.retryable ?? false;
+    this.name = new.target.name;
+  }
+}
+
+// Category subclasses. Purely for `instanceof` filtering — no behavior.
+export class BootError extends MachinenError {}
+export class ExecError extends MachinenError {}
+export class SnapshotError extends MachinenError {}
+export class ProvisionError extends MachinenError {}
+export class RegistryError extends MachinenError {}
+export class FilesError extends MachinenError {}
+export class SecretsError extends MachinenError {}
+export class WinsizeError extends MachinenError {}
+export class SandboxError extends MachinenError {}
+export class CacheError extends MachinenError {}
+export class GvproxyError extends MachinenError {}
+export class MkinitramfsError extends MachinenError {}
+export class ParseError extends MachinenError {}
+
+/**
+ * Narrowing type guard. Pass a specific `code` to check both identity
+ * and discriminant in one call.
+ */
+export function isMachinenError(err: unknown, code?: ErrorCode): err is MachinenError {
+  return err instanceof MachinenError && (code === undefined || err.code === code);
+}
+
+/**
+ * Format a MachinenError for CLI stderr. Shows the code inline and walks
+ * the `cause` chain. Used by the CLI's unified `handleError`; exported so
+ * library callers can adopt the same format if they want to.
+ */
+export function formatMachinenError(err: MachinenError): string {
+  const lines: string[] = [`(${err.code}): ${err.message}`];
+  let cur: unknown = err.cause;
+  while (cur !== undefined && cur !== null) {
+    const msg = cur instanceof Error ? cur.message : String(cur);
+    lines.push(`  caused by: ${msg}`);
+    cur = cur instanceof Error ? (cur as Error & { cause?: unknown }).cause : undefined;
+  }
+  return lines.join("\n");
+}

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -19,6 +19,7 @@
 //   // res.exitCode, res.stdout, res.stderr
 
 import { connect as netConnect, type Socket } from "node:net";
+import { ExecError } from "./errors.ts";
 
 export interface VsockExecOptions {
   /** How long to keep retrying the UDS connect. Default 30s. */
@@ -56,9 +57,13 @@ export const VsockExec = {
    * when the bridge tries to forward them. We retry on those resets
    * until the agent is actually listening.
    */
+  /**
+   * @throws {ExecError} EXEC_CMD_INVALID | EXEC_AGENT_UNAVAILABLE (retryable) |
+   *   EXEC_AGENT_TIMEOUT (retryable) | EXEC_PROTOCOL
+   */
   async run(udsPath: string, cmd: string, opts: VsockExecOptions = {}): Promise<VsockExecResult> {
     if (/\r|\n/.test(cmd)) {
-      throw new Error("VsockExec.run: cmd must not contain newlines");
+      throw new ExecError("EXEC_CMD_INVALID", "VsockExec.run: cmd must not contain newlines");
     }
     const connectTimeout = opts.connectTimeoutMs ?? 30_000;
     const retryMs = opts.retryMs ?? 250;
@@ -83,8 +88,10 @@ export const VsockExec = {
       }
       await new Promise((r) => setTimeout(r, retryMs));
     }
-    throw new Error(
+    throw new ExecError(
+      "EXEC_AGENT_UNAVAILABLE",
       `VsockExec.run: agent did not respond within ${connectTimeout}ms: ${lastErr?.message ?? "no error"}`,
+      { retryable: true, cause: lastErr ?? undefined },
     );
   },
 } as const;
@@ -119,7 +126,11 @@ async function runOnSocket(
 
     const deadline = opts.execTimeoutMs ?? 5 * 60 * 1000;
     const timer = setTimeout(() => {
-      fail(new Error(`VsockExec.run: timed out after ${deadline}ms`));
+      fail(
+        new ExecError("EXEC_AGENT_TIMEOUT", `VsockExec.run: timed out after ${deadline}ms`, {
+          retryable: true,
+        }),
+      );
       socket.destroy();
     }, deadline);
     timer.unref();
@@ -127,7 +138,13 @@ async function runOnSocket(
     const finish = () => {
       clearTimeout(timer);
       if (exitCode === null) {
-        fail(new Error("VsockExec.run: agent closed connection before X frame"));
+        fail(
+          new ExecError(
+            "EXEC_AGENT_UNAVAILABLE",
+            "VsockExec.run: agent closed connection before X frame",
+            { retryable: true },
+          ),
+        );
       } else {
         done({
           exitCode,
@@ -175,13 +192,17 @@ async function runOnSocket(
         }
         if (tag !== "O" && tag !== "E") {
           // Unknown frame tag — treat as protocol error and end.
-          fail(new Error(`VsockExec: unknown frame tag ${JSON.stringify(tag)}`));
+          fail(
+            new ExecError("EXEC_PROTOCOL", `VsockExec: unknown frame tag ${JSON.stringify(tag)}`),
+          );
           socket.destroy();
           return;
         }
         const n = Number.parseInt(nStr ?? "", 10);
         if (!Number.isFinite(n) || n < 0) {
-          fail(new Error(`VsockExec: bad frame length ${JSON.stringify(nStr)}`));
+          fail(
+            new ExecError("EXEC_PROTOCOL", `VsockExec: bad frame length ${JSON.stringify(nStr)}`),
+          );
           socket.destroy();
           return;
         }
@@ -221,8 +242,10 @@ async function connectWithRetry(udsPath: string, opts: VsockExecOptions): Promis
       await new Promise((r) => setTimeout(r, retryMs));
     }
   }
-  throw new Error(
+  throw new ExecError(
+    "EXEC_AGENT_UNAVAILABLE",
     `VsockExec: could not reach ${udsPath} within ${opts.connectTimeoutMs ?? 30_000}ms: ${lastErr?.message ?? "no error"}`,
+    { retryable: true, cause: lastErr ?? undefined },
   );
 }
 

--- a/packages/runtime/src/files.ts
+++ b/packages/runtime/src/files.ts
@@ -21,6 +21,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { connect as netConnect, type Socket } from "node:net";
 import { PassThrough } from "node:stream";
+import { FilesError } from "./errors.ts";
 
 export interface VsockFilesOptions {
   /** How long to retry the UDS connect. Default 5s. */
@@ -43,7 +44,7 @@ export const VsockFiles = {
     opts: VsockFilesOptions = {},
   ): Promise<void> {
     if (!existsSync(hostDir)) {
-      throw new Error(`push: host dir does not exist: ${hostDir}`);
+      throw new FilesError("FILES_HOST_DIR_NOT_FOUND", `push: host dir does not exist: ${hostDir}`);
     }
     const sock = await connectWithRetry(udsPath, opts);
     try {
@@ -132,7 +133,11 @@ async function connectWithRetry(udsPath: string, opts: VsockFilesOptions): Promi
       await new Promise((r) => setTimeout(r, retryMs));
     }
   }
-  throw new Error(`VsockFiles: could not connect to ${udsPath}: ${last?.message ?? "no error"}`);
+  throw new FilesError(
+    "FILES_AGENT_UNAVAILABLE",
+    `VsockFiles: could not connect to ${udsPath}: ${last?.message ?? "no error"}`,
+    { retryable: true, cause: last ?? undefined },
+  );
 }
 
 function connectOnce(udsPath: string): Promise<Socket> {

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { delimiter as pathSep, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { GvproxyError } from "./errors.ts";
 
 let warnedMissing = false;
 
@@ -35,7 +36,10 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
     }
     // Explicit override that points at nothing is a user mistake —
     // surface it rather than silently falling through.
-    throw new Error(`MACHINEN_GVPROXY=${envOverride} is set but that file does not exist.`);
+    throw new GvproxyError(
+      "GVPROXY_NOT_FOUND",
+      `MACHINEN_GVPROXY=${envOverride} is set but that file does not exist.`,
+    );
   }
 
   const sibling = join(dirname(vmmBinary), "gvproxy");
@@ -136,7 +140,8 @@ export async function spawnGvproxy(
       }
       await new Promise((r) => setTimeout(r, 25));
     }
-    throw new Error(
+    throw new GvproxyError(
+      "GVPROXY_NOT_FOUND",
       `gvproxy did not create ${socketPath} within ${timeoutMs}ms. ` + `Binary: ${binary}`,
     );
   })();
@@ -203,7 +208,8 @@ export async function exposePort(
           }
           const text = Buffer.concat(chunks).toString("utf8").trim();
           fail(
-            new Error(
+            new GvproxyError(
+              "GVPROXY_EXPOSE_FAILED",
               `gvproxy expose failed (${status}) for ${hostAddr}:${opts.hostPort} -> ${guestAddr}:${opts.guestPort}: ${text || "<empty body>"}`,
             ),
           );

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,7 +10,7 @@ export { VsockFiles } from "./files.ts";
 export type { VsockFilesOptions } from "./files.ts";
 export { VsockExec } from "./exec.ts";
 export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
-export { provision, ProvisionError, resolveBaseRootfs } from "./provision.ts";
+export { provision, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
 export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";
@@ -23,6 +23,26 @@ export {
   packMinimal as mkinitramfsMinimal,
   cli as mkinitramfsCli,
 } from "./mkinitramfs.ts";
+export {
+  MachinenError,
+  BootError,
+  ExecError,
+  SnapshotError,
+  ProvisionError,
+  RegistryError,
+  FilesError,
+  SecretsError,
+  WinsizeError,
+  SandboxError,
+  CacheError,
+  GvproxyError,
+  MkinitramfsError,
+  ParseError,
+  ErrorCode,
+  isMachinenError,
+  formatMachinenError,
+} from "./errors.ts";
+export type { MachinenErrorOptions } from "./errors.ts";
 
 // @machinen/runtime — TypeScript surface for booting microVMs.
 //
@@ -67,10 +87,9 @@ import type { Readable, Writable } from "node:stream";
 import { packBundle as mkinitramfsPackBundle } from "./mkinitramfs.ts";
 import { exposePort, resolveGvproxyBinary, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
+import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
 import { findEntry, isAlive, newVmId, removeEntry, writeEntry } from "./registry.ts";
-
-export class BootError extends Error {}
 
 const require_ = createRequire(import.meta.url);
 
@@ -80,13 +99,18 @@ const require_ = createRequire(import.meta.url);
  *   2. `require.resolve("@machinen/vmm-<arch>-<os>")` → `binary` export
  *
  * Callers can pass an explicit `binary` to `boot()` to bypass this.
+ *
+ * @throws {BootError} BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN
  */
 export function resolveVmmBinary(): string {
   const envOverride = process.env.MACHINEN_VMM;
   if (envOverride) {
     const abs = resolve(envOverride);
     if (!existsSync(abs)) {
-      throw new BootError(`MACHINEN_VMM is set to ${envOverride}, but that file does not exist.`);
+      throw new BootError(
+        "BOOT_VMM_MISSING",
+        `MACHINEN_VMM is set to ${envOverride}, but that file does not exist.`,
+      );
     }
     return abs;
   }
@@ -96,19 +120,22 @@ export function resolveVmmBinary(): string {
   try {
     const mod = require_(pkgName) as { binary: string };
     if (!mod.binary || !existsSync(mod.binary)) {
-      throw new BootError(`${pkgName} is installed but its binary is missing at ${mod.binary}.`);
+      throw new BootError(
+        "BOOT_VMM_PACKAGE_BROKEN",
+        `${pkgName} is installed but its binary is missing at ${mod.binary}.`,
+      );
     }
     return mod.binary;
   } catch (err) {
     if (err instanceof BootError) {
       throw err;
     }
-    const msg = err instanceof Error ? err.message : String(err);
     throw new BootError(
+      "BOOT_VMM_MISSING",
       `No VMM binary found for ${key}.\n` +
         `  Expected package: ${pkgName}\n` +
-        `  Install: npm i ${pkgName}   (or npm i -g @machinen/cli)\n` +
-        `  Error: ${msg}`,
+        `  Install: npm i ${pkgName}   (or npm i -g @machinen/cli)`,
+      { cause: err },
     );
   }
 }
@@ -270,6 +297,17 @@ export interface SnapshotResult {
   consoleLog: string;
 }
 
+/**
+ * Boot a microVM and return a handle to interact with it.
+ *
+ * @throws {BootError} BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
+ *   BOOT_IMAGE_NOT_FOUND | BOOT_SNAPSHOT_NOT_FOUND |
+ *   BOOT_KERNEL_NOT_FOUND | BOOT_DTB_NOT_FOUND |
+ *   BOOT_CMD_WITHOUT_IMAGE | BOOT_CMD_MISSING |
+ *   BOOT_MOUNT_INVALID | BOOT_MOUNT_HOST_NOT_FOUND |
+ *   BOOT_PORT_FORWARD_INVALID | BOOT_PORT_FORWARD_CONFLICT |
+ *   BOOT_PORT_FORWARD_NO_GVPROXY | BOOT_PACK_FAILED
+ */
 export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // Validate portForward up front — before resolving the binary or
   // touching the filesystem — so caller-input errors surface with a
@@ -281,6 +319,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET;
     if (preSetNetSock) {
       throw new BootError(
+        "BOOT_PORT_FORWARD_INVALID",
         "portForward requires the runtime to own gvproxy, but MACHINEN_NET_SOCKET " +
           "is already set. Either drop the env var or install the forwards yourself " +
           "against your gvproxy's control API.",
@@ -293,11 +332,17 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         ["guestPort", m.guestPort],
       ] as const) {
         if (!Number.isInteger(port) || port < 1 || port > 65535) {
-          throw new BootError(`portForward: ${label} must be an integer in 1..65535 (got ${port})`);
+          throw new BootError(
+            "BOOT_PORT_FORWARD_INVALID",
+            `portForward: ${label} must be an integer in 1..65535 (got ${port})`,
+          );
         }
       }
       if (seen.has(m.hostPort)) {
-        throw new BootError(`portForward: duplicate hostPort ${m.hostPort}`);
+        throw new BootError(
+          "BOOT_PORT_FORWARD_CONFLICT",
+          `portForward: duplicate hostPort ${m.hostPort}`,
+        );
       }
       seen.add(m.hostPort);
     }
@@ -306,7 +351,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   const binaryInput = opts.binary ?? resolveVmmBinary();
   const binary = resolve(opts.cwd ?? process.cwd(), binaryInput);
   if (!existsSync(binary)) {
-    throw new BootError(`VMM binary not found at ${binary}`);
+    throw new BootError("BOOT_VMM_MISSING", `VMM binary not found at ${binary}`);
   }
 
   // `cmd` requires an image to run against. `image` alone is allowed
@@ -314,7 +359,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // `provision({ cmd })`); if it doesn't and the user didn't pass
   // one, `synthesizeAndPackBundle` errors with a clear message.
   if (opts.cmd && !opts.image) {
-    throw new BootError("boot: `image` is required when `cmd` is set.");
+    throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
   }
 
   const env: Record<string, string> = {
@@ -325,21 +370,21 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   if (opts.snapshot) {
     diskAbs = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
     if (!existsSync(diskAbs)) {
-      throw new BootError(`snapshot image not found: ${diskAbs}`);
+      throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${diskAbs}`);
     }
     env.MACHINEN_DISK = diskAbs;
   }
   if (opts.kernel) {
     const abs = resolve(opts.cwd ?? process.cwd(), opts.kernel);
     if (!existsSync(abs)) {
-      throw new BootError(`kernel not found: ${abs}`);
+      throw new BootError("BOOT_KERNEL_NOT_FOUND", `kernel not found: ${abs}`);
     }
     env.MACHINEN_KERNEL = abs;
   }
   if (opts.dtb) {
     const abs = resolve(opts.cwd ?? process.cwd(), opts.dtb);
     if (!existsSync(abs)) {
-      throw new BootError(`dtb not found: ${abs}`);
+      throw new BootError("BOOT_DTB_NOT_FOUND", `dtb not found: ${abs}`);
     }
     env.MACHINEN_DTB = abs;
   }
@@ -381,6 +426,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       } else {
         if (portForward.length > 0) {
           throw new BootError(
+            "BOOT_PORT_FORWARD_NO_GVPROXY",
             "portForward requires gvproxy, but no gvproxy binary was found. " +
               "Install gvproxy or point MACHINEN_GVPROXY at one.",
           );
@@ -521,7 +567,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
               settled,
               new Promise<never>((_, reject) => {
                 setTimeout(
-                  () => reject(new BootError(`VMM did not exit within ${timeoutMs}ms`)),
+                  () =>
+                    reject(new BootError("BOOT_TIMEOUT", `VMM did not exit within ${timeoutMs}ms`)),
                   timeoutMs,
                 ).unref();
               }),
@@ -560,14 +607,16 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 
     async exec(cmd, execOpts) {
       if (!vsockUdsPath) {
-        throw new BootError(
+        throw new ExecError(
+          "EXEC_VSOCK_UNAVAILABLE",
           "vm.exec: no vsock UDS available — MACHINEN_VSOCK was set to an " +
             "unrecognized spec. Expected `in:<port>:<uds-path>`.",
         );
       }
       const res = await VsockExec.run(vsockUdsPath, cmd, execOpts);
       if (res.exitCode !== 0) {
-        throw new BootError(
+        throw new ExecError(
+          "EXEC_NONZERO_EXIT",
           `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
         );
       }
@@ -577,7 +626,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     execRaw(cmd, execOpts) {
       if (!vsockUdsPath) {
         return Promise.reject(
-          new BootError(
+          new ExecError(
+            "EXEC_VSOCK_UNAVAILABLE",
             "vm.execRaw: no vsock UDS available — MACHINEN_VSOCK was set to " +
               "an unrecognized spec. Expected `in:<port>:<uds-path>`.",
           ),
@@ -588,7 +638,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 
     async snapshot(outPath, snapshotOpts) {
       if (!diskAbs) {
-        throw new BootError(
+        throw new SnapshotError(
+          "SNAPSHOT_NO_DISK",
           "vm.snapshot: no disk was attached at boot. Pass `snapshot: '<path>'` to " +
             "boot() so CRIU has a target to write to.",
         );
@@ -613,7 +664,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       const consoleLog = await this.errorOutput();
 
       if (!consoleLog.includes("dump OK")) {
-        throw new BootError(
+        throw new SnapshotError(
+          "SNAPSHOT_DUMP_FAILED",
           `vm.snapshot: guest did not report "dump OK" — check console log:\n${consoleLog.slice(-2000)}`,
         );
       }
@@ -658,12 +710,14 @@ export interface AttachOptions {
  * `stderr` are empty `PassThrough`s) — those belong to the original
  * booter. `output()`/`errorOutput()` resolve with the empty string.
  * `wait()` polls the pid rather than listening for `exit`.
+ *
+ * @throws {RegistryError} REGISTRY_VM_NOT_FOUND
  */
 export async function attach(opts: AttachOptions): Promise<VmHandle> {
   const entry = findEntry(opts);
   if (!entry) {
     const q = opts.id ? `id ${opts.id}` : `name ${opts.name}`;
-    throw new BootError(`attach: no running VM found for ${q}`);
+    throw new RegistryError("REGISTRY_VM_NOT_FOUND", `attach: no running VM found for ${q}`);
   }
   const { PassThrough } = await import("node:stream");
   const stdin = new PassThrough();
@@ -724,7 +778,8 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
     async exec(cmd, execOpts) {
       const res = await VsockExec.run(entry.socketPath, cmd, execOpts);
       if (res.exitCode !== 0) {
-        throw new BootError(
+        throw new ExecError(
+          "EXEC_NONZERO_EXIT",
           `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
         );
       }
@@ -740,7 +795,8 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
       // with. Triggering a CRIU dump still works; the output is written
       // to /dev/vda inside the guest, but we have no way to copy it
       // from here. Snapshot-from-attach is deferred to a follow-up.
-      throw new BootError(
+      throw new SnapshotError(
+        "SNAPSHOT_UNSUPPORTED_ON_ATTACH",
         "vm.snapshot() is not supported on attached handles yet — snapshot " +
           "from the process that called boot(). Output path was: " +
           String(outPath) +
@@ -797,7 +853,7 @@ function synthesizeAndPackBundle(
     baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
     if (!existsSync(baseAbs)) {
       cleanup();
-      throw new BootError(`image tarball not found: ${baseAbs}`);
+      throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
     }
     imageConfig = readImageConfig(baseAbs);
   }
@@ -808,6 +864,7 @@ function synthesizeAndPackBundle(
   if (!effectiveCmd) {
     cleanup();
     throw new BootError(
+      "BOOT_CMD_MISSING",
       "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
         "image via `provision({ cmd })`.",
     );
@@ -836,11 +893,17 @@ function synthesizeAndPackBundle(
     const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
     if (!existsSync(hostAbs)) {
       cleanup();
-      throw new BootError(`mount host path not found: ${opts.mount.host}`);
+      throw new BootError(
+        "BOOT_MOUNT_HOST_NOT_FOUND",
+        `mount host path not found: ${opts.mount.host}`,
+      );
     }
     if (!statSync(hostAbs).isDirectory()) {
       cleanup();
-      throw new BootError(`mount host path must be a directory (got a file): ${opts.mount.host}`);
+      throw new BootError(
+        "BOOT_MOUNT_INVALID",
+        `mount host path must be a directory (got a file): ${opts.mount.host}`,
+      );
     }
     mount = { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
   }
@@ -856,7 +919,7 @@ function synthesizeAndPackBundle(
   } catch (err) {
     cleanup();
     const msg = err instanceof Error ? err.message : String(err);
-    throw new BootError(`mkinitramfs pack failed: ${msg}`);
+    throw new BootError("BOOT_PACK_FAILED", `mkinitramfs pack failed: ${msg}`, { cause: err });
   }
   return { tempDir, cpioPath };
 }
@@ -871,11 +934,12 @@ function normalizeMountGuest(guest: string): string {
 
 function validateMountGuest(guest: string): void {
   if (!guest || !guest.startsWith("/")) {
-    throw new BootError(`mount guest path must be absolute: ${guest}`);
+    throw new BootError("BOOT_MOUNT_INVALID", `mount guest path must be absolute: ${guest}`);
   }
   const trimmed = normalizeMountGuest(guest);
   if (!trimmed.startsWith(MOUNT_ROOT) || trimmed === MOUNT_ROOT.replace(/\/$/, "")) {
     throw new BootError(
+      "BOOT_MOUNT_INVALID",
       `mount guest path must live under ${MOUNT_ROOT} (got ${guest}) — ` +
         `pick a sub-path like ${MOUNT_ROOT}app`,
     );

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -36,6 +36,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { MkinitramfsError } from "./errors.ts";
 
 /**
  * Default excludes applied to --workspace packs. Skip the usual dev
@@ -341,10 +342,10 @@ export function packBundle(opts: PackBundleOptions): void {
   const rootfsDir = join(opts.bundle, "rootfs");
   const cfgPath = join(opts.bundle, "machinen-config.json");
   if (!statSync(rootfsDir).isDirectory()) {
-    throw new Error(`--bundle: missing ${rootfsDir}`);
+    throw new MkinitramfsError("MKINITRAMFS_BUNDLE_INVALID", `--bundle: missing ${rootfsDir}`);
   }
   if (!statSync(cfgPath).isFile()) {
-    throw new Error(`--bundle: missing ${cfgPath}`);
+    throw new MkinitramfsError("MKINITRAMFS_BUNDLE_INVALID", `--bundle: missing ${cfgPath}`);
   }
 
   const needsMerge = Boolean(opts.base) || Boolean(opts.mount);
@@ -357,7 +358,10 @@ export function packBundle(opts: PackBundleOptions): void {
       const res = spawnSync("tar", ["-xzf", opts.base, "-C", mergeTmp]);
       if (res.status !== 0) {
         rmSync(mergeTmp, { recursive: true, force: true });
-        throw new Error(`tar -xzf ${opts.base} failed: ${res.stderr?.toString() ?? ""}`);
+        throw new MkinitramfsError(
+          "MKINITRAMFS_BASE_EXTRACT_FAILED",
+          `tar -xzf ${opts.base} failed: ${res.stderr?.toString() ?? ""}`,
+        );
       }
     }
     if (opts.mount) {
@@ -491,7 +495,10 @@ export function packWorkspace(opts: PackWorkspaceOptions): void {
   const maxMb = opts.maxMb ?? 500;
 
   if (!statSync(opts.workspace).isDirectory()) {
-    throw new Error(`--workspace: ${opts.workspace} is not a directory`);
+    throw new MkinitramfsError(
+      "MKINITRAMFS_WORKSPACE_INVALID",
+      `--workspace: ${opts.workspace} is not a directory`,
+    );
   }
 
   const counts: WalkCounts = { files: 0, bytes: 0 };
@@ -501,7 +508,8 @@ export function packWorkspace(opts: PackWorkspaceOptions): void {
   }
   const total = parts.reduce((n, b) => n + b.length, 0);
   if (total > maxMb * 1024 * 1024) {
-    throw new Error(
+    throw new MkinitramfsError(
+      "MKINITRAMFS_WORKSPACE_TOO_LARGE",
       `workspace is ${(total / 1024 / 1024).toFixed(0)} MB (cap ${maxMb} MB). ` +
         `Try --exclude <dir> for each big subdir, or --max-mb <N> to raise the cap.`,
     );

--- a/packages/runtime/src/multiplex.ts
+++ b/packages/runtime/src/multiplex.ts
@@ -17,6 +17,7 @@
 // obvious next step; this is the pipe-based M1.
 
 import type { Writable } from "node:stream";
+import { SandboxError } from "./errors.ts";
 import type { VmHandle } from "./index.ts";
 
 export interface SandboxEntry {
@@ -53,7 +54,7 @@ export class Sandboxes {
 
   add(id: string, vm: VmHandle): void {
     if (this.items.has(id)) {
-      throw new Error(`sandbox id already registered: ${id}`);
+      throw new SandboxError("SANDBOX_ID_DUPLICATE", `sandbox id already registered: ${id}`);
     }
     const entry: SandboxEntry = {
       id,
@@ -233,7 +234,7 @@ export class Supervisor {
     this.detach();
     const entry = this.sandboxes.get(id);
     if (!entry) {
-      throw new Error(`unknown sandboxes id: ${id}`);
+      throw new SandboxError("SANDBOX_ID_UNKNOWN", `unknown sandboxes id: ${id}`);
     }
     this.attachedId = id;
     // Replay scrollback so the user sees recent output.

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -35,10 +35,9 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import { boot, type VmHandle } from "./index.ts";
-
-export class ProvisionError extends Error {}
 
 export interface ProvisionOptions {
   /**
@@ -168,12 +167,14 @@ const TAR_TO_DISK_CMD = [
  *
  * Throws `ProvisionError` with guidance if none of those turn up a file.
  * Exported so callers can pre-check or build their own tooling on it.
+ *
+ * @throws {ProvisionError} PROVISION_BASE_NOT_FOUND | PROVISION_ASSETS_DIR_INVALID
  */
 export function resolveBaseRootfs(explicit?: string, cwd: string = process.cwd()): string {
   if (explicit) {
     const abs = resolve(cwd, explicit);
     if (!existsSync(abs)) {
-      throw new ProvisionError(`base rootfs tarball not found: ${abs}`);
+      throw new ProvisionError("PROVISION_BASE_NOT_FOUND", `base rootfs tarball not found: ${abs}`);
     }
     return abs;
   }
@@ -183,6 +184,7 @@ export function resolveBaseRootfs(explicit?: string, cwd: string = process.cwd()
     const p = resolve(assetsDir, "rootfs-debian-arm64.tar.gz");
     if (!existsSync(p)) {
       throw new ProvisionError(
+        "PROVISION_ASSETS_DIR_INVALID",
         `MACHINEN_ASSETS_DIR=${assetsDir} does not contain rootfs-debian-arm64.tar.gz`,
       );
     }
@@ -195,6 +197,7 @@ export function resolveBaseRootfs(explicit?: string, cwd: string = process.cwd()
   }
 
   throw new ProvisionError(
+    "PROVISION_BASE_NOT_FOUND",
     `base rootfs not found. Either:\n` +
       `  - pass \`base\` explicitly, or\n` +
       `  - set MACHINEN_ASSETS_DIR to a directory containing rootfs-debian-arm64.tar.gz, or\n` +
@@ -217,6 +220,15 @@ function cliCachedRootfsPath(): string {
   );
 }
 
+/**
+ * Boot the base rootfs, run the user install hook, and freeze the
+ * resulting filesystem state to a new tarball at `opts.out`.
+ *
+ * @throws {ProvisionError} PROVISION_BASE_NOT_FOUND |
+ *   PROVISION_ASSETS_DIR_INVALID | PROVISION_INSTALL_HOOK_FAILED |
+ *   PROVISION_DISK_TOO_SMALL
+ * @throws {BootError} see `boot()` — propagated from the inner boot
+ */
 export async function provision(opts: ProvisionOptions): Promise<ProvisionResult> {
   const cwd = opts.cwd ?? process.cwd();
   const baseAbs = resolveBaseRootfs(opts.base, cwd);
@@ -289,7 +301,9 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
         const tail = stderrTail();
         const msg = err instanceof Error ? err.message : String(err);
         throw new ProvisionError(
+          "PROVISION_INSTALL_HOOK_FAILED",
           `install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`,
+          { cause: err },
         );
       }
 
@@ -302,6 +316,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       });
       if (tar.exitCode !== 0) {
         throw new ProvisionError(
+          "PROVISION_DISK_TOO_SMALL",
           `tar / to /dev/vda failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
             `Bump scratchDiskSizeBytes. stderr:\n${tar.stderr}`,
         );

--- a/packages/runtime/src/secrets.ts
+++ b/packages/runtime/src/secrets.ts
@@ -21,6 +21,7 @@
 //   });
 
 import { connect as netConnect, type Socket } from "node:net";
+import { SecretsError } from "./errors.ts";
 
 export interface VsockSecretsOptions {
   /** How long to keep retrying the UDS connect. Default 10s. */
@@ -45,7 +46,10 @@ export const VsockSecrets = {
   ): Promise<void> {
     for (const [k, v] of Object.entries(secrets)) {
       if (/[\r\n]/.test(v)) {
-        throw new Error(`secret ${k} contains a newline — reject at the host`);
+        throw new SecretsError(
+          "SECRETS_VALUE_INVALID",
+          `secret ${k} contains a newline — reject at the host`,
+        );
       }
     }
     const socket = await connectWithRetry(udsPath, opts);
@@ -71,8 +75,10 @@ async function connectWithRetry(udsPath: string, opts: VsockSecretsOptions): Pro
       await new Promise((r) => setTimeout(r, retryMs));
     }
   }
-  throw new Error(
+  throw new SecretsError(
+    "SECRETS_AGENT_UNAVAILABLE",
     `VsockSecrets.send(${udsPath}) gave up after ${opts.timeoutMs ?? 10_000}ms: ${lastErr?.message ?? "no error"}`,
+    { retryable: true, cause: lastErr ?? undefined },
   );
 }
 

--- a/packages/runtime/src/winsize.ts
+++ b/packages/runtime/src/winsize.ts
@@ -25,6 +25,7 @@
 //   ws.send(process.stdout.columns ?? 80, process.stdout.rows ?? 24);
 
 import { connect as netConnect, type Socket } from "node:net";
+import { WinsizeError } from "./errors.ts";
 
 export interface VsockWinsizeOptions {
   /** How long to keep retrying the UDS connect. Default 10s. */
@@ -70,8 +71,10 @@ export class VsockWinsize {
         await new Promise((r) => setTimeout(r, retryMs));
       }
     }
-    throw new Error(
+    throw new WinsizeError(
+      "WINSIZE_AGENT_UNAVAILABLE",
       `VsockWinsize.connect(${udsPath}) gave up after ${opts.timeoutMs ?? 10_000}ms: ${lastErr?.message ?? "no error"}`,
+      { retryable: true, cause: lastErr ?? undefined },
     );
   }
 


### PR DESCRIPTION
## Problem

Error handling in machinen was inconsistent and hard to program against: three empty error classes (`BootError`, `ProvisionError`, `ParseRunArgsError`) with no fields, ~40 plain `throw new Error(...)` sites in the runtime, no cause chaining, no retry hint, and a CLI that caught errors unevenly. Callers couldn't distinguish "VMM binary not found" from "mount path invalid" from "vsock agent timed out" without string-matching the message.

## Solution

One base class, coded, with cause chaining and a retry hint.

- `packages/runtime/src/errors.ts` — `MachinenError` with a flat `ErrorCode` string enum, `retryable` flag, and `cause` via the standard `Error.cause` mechanism. Thin category subclasses (`BootError`, `ExecError`, `SnapshotError`, `ProvisionError`, `RegistryError`, `FilesError`, `SecretsError`, `WinsizeError`, `SandboxError`, `CacheError`, `GvproxyError`, `MkinitramfsError`, `ParseError`) exist purely for `instanceof` filtering.
- Every throw in `packages/runtime/src/` and `packages/cli/src/` now carries a code. Transient failures (vsock agent not listening yet, host-side connect retries, exec timeouts) are flagged `retryable: true`; misconfiguration is not.
- `isMachinenError(err, code?)` narrows; `formatMachinenError(err)` renders the code + message + cause chain.
- `@throws` JSDoc on public runtime entry points (`boot`, `attach`, `resolveVmmBinary`, `provision`, `resolveBaseRootfs`, `VsockExec.run`) lists the codes each can raise. No compile-time enforcement — the codes themselves are typed.
- CLI routes all command-level errors through a single `handleError(err)` helper. Output format:
  ```
  machinen: (BOOT_VMM_MISSING): VMM binary not found at /path/to/vmm
    caused by: ENOENT: no such file or directory, stat '/path/to/vmm'
  ```
  Non-MachinenError still prints the full stack — those are genuine surprises.
- Tests updated where subclass identity changed: `attach()` now throws `RegistryError`, `vm.exec()` non-zero exits throw `ExecError`.

Breaking change on `.name` / subclass identity, but machinen is pre-1.0 so we take the churn once. No back-compat shims.

Follow-up tracked in #105: render the `@throws` JSDoc into a published API reference.

## Test plan

- [x] `npx vitest run` — 105 passed
- [x] `npx @redwoodjs/agent-ci run --quiet --all --pause-on-failure` — green
