### PR TITLE
feat(runtime,cli): streaming logs on every API + gvproxy auto-install

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -359,9 +359,10 @@ async function cmdExec(args: string[]): Promise<number> {
     // commands naturally. Users who want raw exec of a single binary
     // can quote it like `machinen exec foo -- /bin/ls`.
     const joined = cmdArgs.join(" ");
-    const res = await vm.execRaw(joined);
-    process.stdout.write(res.stdout);
-    process.stderr.write(res.stderr);
+    const res = await vm.execRaw(joined, {
+      onStdout: (chunk) => process.stdout.write(chunk),
+      onStderr: (chunk) => process.stderr.write(chunk),
+    });
     return res.exitCode;
   } finally {
     await vm.detach();
@@ -413,9 +414,10 @@ async function cmdAttach(args: string[]): Promise<number> {
       if (line.length === 0) {
         continue;
       }
-      const res = await vm.execRaw(line);
-      process.stdout.write(res.stdout);
-      process.stderr.write(res.stderr);
+      await vm.execRaw(line, {
+        onStdout: (chunk) => process.stdout.write(chunk),
+        onStderr: (chunk) => process.stderr.write(chunk),
+      });
     }
     return 0;
   } finally {

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -57,10 +57,42 @@ Key options (all optional):
 | `binary`      | VMM binary path — auto-resolved if omitted                      |
 | `vmmEnv`      | Env for the VMM process itself (host side, rarely needed)       |
 | `timeoutMs`   | `wait()` deadline (default 60s, `null` to wait forever)         |
+| `onLog`       | Stream every byte of guest output (console + every exec)        |
 
 Images produced by `provision({ cmd, env })` carry a baked-in default cmd (and
 env) in `/machinen-config.json`, so callers can `boot({ image })` with no
 further args. User-supplied `cmd`/`env` on `boot()` override the image defaults.
+
+### Streaming logs
+
+Every long-running API — `boot`, `provision`, `vm.snapshot`, `attach` —
+accepts an `onLog` callback that fires for every byte of guest output as
+it arrives. Each event is tagged so callers can tell kernel console
+bytes from exec bytes:
+
+```ts
+import { provision, type LogEvent } from "@machinen/runtime";
+
+await provision({
+  base: "./rootfs-debian-arm64.tar.gz",
+  install: async (vm) => {
+    await vm.exec("apt-get update");
+    await vm.exec("apt-get install -y tree");
+  },
+  out: "./warm.tar.gz",
+  onLog: (evt: LogEvent) => {
+    // evt.source: "guest-console" | "exec-stdout" | "exec-stderr"
+    // evt.cmd:    the command string, when source is exec-*
+    // evt.chunk:  raw bytes as they arrive
+    process.stderr.write(evt.chunk);
+  },
+});
+```
+
+For a single exec with narrower output-only tees, `vm.exec` / `vm.execRaw`
+still take `{ onStdout, onStderr }`. Both layers coexist: `onLog` on
+`boot()` fires for every exec made through the handle; per-call
+`onStdout` / `onStderr` fires on top when set.
 
 ### Binary resolution
 
@@ -86,6 +118,22 @@ The VM exits as part of the snapshot. Restore for a sub-second cold start with
 `boot({ snapshot: snap.snapshotPath })`. Requires `snapshot` at boot (CRIU's
 target) and a guest-side dump helper at `/sbin/machinen-dump` (override via
 `opts.dumpCmd`).
+
+### Networking (gvproxy)
+
+`boot()` starts [gvproxy](https://github.com/containers/gvisor-tap-vsock) to
+provide the guest with outbound networking. It's resolved in this order:
+
+1. `$MACHINEN_GVPROXY` override.
+2. Sibling of the VMM binary — our `@machinen/vmm-*` npm packages bundle it.
+3. `~/.machinen/gvproxy/<version>/gvproxy` — auto-installed on first use.
+4. `gvproxy` on `$PATH`.
+
+If none of the above hit, `boot()` fetches the pinned release from
+`containers/gvisor-tap-vsock` into the cache dir. You'll see a single stderr
+line (`machinen: installing gvproxy v0.8.6 …`) the first time; subsequent
+boots are silent. If the fetch fails (offline), networking stays disabled
+and `boot()` continues.
 
 ### Host-side artifact cache
 

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -1,0 +1,76 @@
+// Streaming log smoke test — #83.
+//
+// Exercises the framing path in VsockExec.run with a local UDS that
+// acts like the guest exec-agent: send an early chunk, pause, then send
+// a late chunk and an exit frame. Asserts the `onStdout` callback fires
+// *before* the whole command returns — i.e. output streams instead of
+// being collected and delivered at the end.
+//
+// No VMM involved. This is the primitive that every onLog path in the
+// runtime is built on, so a fast local check here catches regressions
+// without paying the cost of a full boot.
+
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VsockExec } from "../exec.ts";
+
+describe("VsockExec streaming", () => {
+  let workDir: string;
+  let server: Server | undefined;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "machinen-streaming-"));
+  });
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((done) => server!.close(() => done()));
+      server = undefined;
+    }
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("delivers onStdout chunks as they arrive, not only after exit", async () => {
+    const udsPath = join(workDir, "exec.sock");
+    const gapMs = 150;
+    let earlyWrittenAt = 0;
+    let lateWrittenAt = 0;
+    server = createServer((sock: Socket) => {
+      sock.once("data", () => {
+        // Agent-shape framing: O <len>\n<payload>
+        const early = "early\n";
+        sock.write(`O ${early.length}\n${early}`);
+        earlyWrittenAt = Date.now();
+        setTimeout(() => {
+          const late = "late\n";
+          sock.write(`O ${late.length}\n${late}`);
+          lateWrittenAt = Date.now();
+          sock.write("X 0\n");
+          sock.end();
+        }, gapMs);
+      });
+    });
+    await new Promise<void>((done) => server!.listen(udsPath, () => done()));
+
+    const chunks: { t: number; data: string }[] = [];
+    const res = await VsockExec.run(udsPath, "pretend-cmd", {
+      onStdout: (c) => chunks.push({ t: Date.now(), data: c.toString("utf8") }),
+    });
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe("early\nlate\n");
+
+    // Two streamed chunks, not one merged one.
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]!.data).toBe("early\n");
+    expect(chunks[1]!.data).toBe("late\n");
+
+    // The first chunk must arrive well before the second is written —
+    // that's the streaming guarantee. Use a generous margin to stay
+    // robust on a loaded CI box; the real gap is `gapMs`.
+    expect(chunks[0]!.t).toBeLessThan(lateWrittenAt - gapMs / 2);
+    expect(chunks[0]!.t).toBeGreaterThanOrEqual(earlyWrittenAt);
+  });
+});

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -10,18 +10,42 @@
 //   1. $MACHINEN_GVPROXY — explicit override, for dev and CI.
 //   2. Sibling of the VMM binary (our vmm-<arch>-<os> packages bundle
 //      gvproxy alongside the `microvm` binary).
-//   3. `gvproxy` on PATH — for users who already have it installed
+//   3. `~/.machinen/gvproxy/<version>/gvproxy` — auto-install cache
+//      populated by `ensureGvproxy()` (see below).
+//   4. `gvproxy` on PATH — for users who already have it installed
 //      (Podman, manual download, etc.).
-//   4. `null` — no gvproxy found. The VMM falls back to "no network"
-//      and the rest of the process runs fine.
+//   5. `null` — no gvproxy found. Callers that only need resolution
+//      can stop here; callers that can install it on demand go through
+//      `ensureGvproxy()`.
 
 import { type ChildProcess, spawn as nodeSpawn } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
+import { createServer, type AddressInfo } from "node:net";
+import { arch as osArch, homedir, platform as osPlatform, tmpdir } from "node:os";
 import { delimiter as pathSep, dirname, join } from "node:path";
-import { tmpdir } from "node:os";
+
+/**
+ * Pinned gvproxy version — matches `scripts/install-gvproxy.sh`. Bump
+ * in lockstep with that script so the release path (bundled in
+ * `@machinen/vmm-*`) and the dev auto-install path stay aligned.
+ */
+export const GVPROXY_VERSION = "v0.8.6";
 
 let warnedMissing = false;
+let installInFlight: Promise<string | null> | null = null;
 
 /**
  * Find the gvproxy binary using the documented lookup order. Returns
@@ -30,6 +54,12 @@ let warnedMissing = false;
 export function resolveGvproxyBinary(vmmBinary: string): string | null {
   const envOverride = process.env.MACHINEN_GVPROXY;
   if (envOverride) {
+    // Sentinel values — opt out of gvproxy entirely without fabricating
+    // a fake path. Used by the test harness so stub-binary boots don't
+    // pay the auto-install cost.
+    if (isGvproxyDisabledSentinel(envOverride)) {
+      return null;
+    }
     if (existsSync(envOverride)) {
       return envOverride;
     }
@@ -43,6 +73,11 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
     return sibling;
   }
 
+  const cached = gvproxyCachePath();
+  if (existsSync(cached)) {
+    return cached;
+  }
+
   const pathDirs = (process.env.PATH ?? "").split(pathSep);
   for (const dir of pathDirs) {
     if (!dir) {
@@ -54,6 +89,249 @@ export function resolveGvproxyBinary(vmmBinary: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Path on disk where `ensureGvproxy()` caches auto-installed binaries.
+ * Versioned so a pinned-version bump re-downloads instead of silently
+ * reusing a stale binary.
+ */
+export function gvproxyCachePath(): string {
+  return join(homedir(), ".machinen", "gvproxy", GVPROXY_VERSION, "gvproxy");
+}
+
+/**
+ * Resolve gvproxy, and if nothing's available, auto-download it into
+ * `~/.machinen/gvproxy/<version>/gvproxy` and return that path. First
+ * run on a given host emits a visible "installing" line on stderr; the
+ * second run is silent (sees the cached file via `resolveGvproxyBinary`).
+ *
+ * Returns `null` only when every lookup fails *and* the download also
+ * fails (typically offline) — callers should then fall back to
+ * `warnGvproxyMissing()` and continue without networking.
+ *
+ * Concurrent callers within the same process share a single install
+ * promise so we don't race on the same temp file.
+ */
+export async function ensureGvproxy(vmmBinary: string): Promise<string | null> {
+  // Respect the same disable-sentinel the sync resolver honors —
+  // otherwise a "disabled" env would still trigger a download attempt.
+  const envOverride = process.env.MACHINEN_GVPROXY;
+  if (envOverride && isGvproxyDisabledSentinel(envOverride)) {
+    return null;
+  }
+  const found = resolveGvproxyBinary(vmmBinary);
+  if (found) {
+    return found;
+  }
+  if (!installInFlight) {
+    installInFlight = downloadGvproxy().catch((err) => {
+      process.stderr.write(
+        `machinen: auto-install of gvproxy failed (${err instanceof Error ? err.message : String(err)})\n` +
+          `  Networking stays disabled for this boot. Manual install: \n` +
+          `  bash scripts/install-gvproxy.sh --dest ${dirname(gvproxyCachePath())}\n`,
+      );
+      return null;
+    });
+  }
+  return installInFlight;
+}
+
+async function downloadGvproxy(): Promise<string> {
+  const outPath = gvproxyCachePath();
+  const outDir = dirname(outPath);
+  mkdirSync(outDir, { recursive: true });
+
+  // Cross-process serialization. Multiple vitest workers (and real
+  // callers that boot VMs concurrently) all hit this path on a fresh
+  // host — without a lock, two processes racing on the same output
+  // file produce `ETXTBSY` when one tries to exec while the other
+  // still has a write fd open. The lock funnels writes through a
+  // single process; the others wait for the cache file to appear.
+  const lockPath = `${outPath}.lock`;
+  let lockFd: number | null = null;
+  try {
+    lockFd = openSync(lockPath, "wx");
+  } catch {
+    // Someone else holds the lock. If they've already landed the
+    // binary, pick it up; otherwise wait for them to finish.
+    if (existsSync(outPath)) {
+      return outPath;
+    }
+    return waitForCachedGvproxy(outPath, lockPath);
+  }
+
+  try {
+    // Re-check after claiming the lock: a racer may have finished
+    // between our resolve attempt and the lock acquisition.
+    if (existsSync(outPath)) {
+      return outPath;
+    }
+
+    const assetName = gvproxyAssetName();
+    const url = `https://github.com/containers/gvisor-tap-vsock/releases/download/${GVPROXY_VERSION}/${assetName}`;
+
+    // Visible: one line before the fetch, one after. Same cadence the
+    // base-asset auto-fetch uses in `@machinen/cli`.
+    process.stderr.write(
+      `machinen: installing gvproxy ${GVPROXY_VERSION} (${assetName}) → ${outPath}\n`,
+    );
+
+    const tmp = `${outPath}.partial.${process.pid}`;
+    const res = await fetch(url, { redirect: "follow" });
+    if (!res.ok) {
+      throw new Error(`fetch ${url} failed: ${res.status} ${res.statusText}`);
+    }
+    const body = Buffer.from(await res.arrayBuffer());
+    // writeFile + explicit fsync + close before rename: createWriteStream
+    // doesn't guarantee the kernel has dropped the write fd by the time
+    // the returned promise resolves, and a still-open write fd is what
+    // triggers `ETXTBSY` when another process exec()s the renamed file.
+    await writeFile(tmp, body);
+    const tmpFd = openSync(tmp, "r+");
+    try {
+      fsyncSync(tmpFd);
+    } finally {
+      closeSync(tmpFd);
+    }
+    chmodSync(tmp, 0o755);
+    renameSync(tmp, outPath);
+
+    process.stderr.write(`machinen: gvproxy installed at ${outPath}\n`);
+    return outPath;
+  } finally {
+    if (lockFd !== null) {
+      try {
+        closeSync(lockFd);
+      } catch {}
+    }
+    try {
+      unlinkSync(lockPath);
+    } catch {}
+  }
+}
+
+/**
+ * Poll until another process finishes downloading gvproxy. Bounded so
+ * a stuck peer doesn't wedge the caller forever.
+ */
+async function waitForCachedGvproxy(
+  outPath: string,
+  lockPath: string,
+  timeoutMs = 60_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(outPath)) {
+      return outPath;
+    }
+    if (!existsSync(lockPath)) {
+      // Lock cleared but binary still missing — the owner failed.
+      // Retry from scratch so we don't spin on stale state.
+      return downloadGvproxy();
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(
+    `timed out waiting ${timeoutMs}ms for another process to finish downloading gvproxy to ${outPath}`,
+  );
+}
+
+/**
+ * Spawn a process with retry on `ETXTBSY`. Linux fires that errno when
+ * a freshly-written binary is exec'd while any peer still holds an
+ * open write fd — typical for multi-worker test runs where the
+ * auto-installer just landed the binary. Retries briefly until the fd
+ * drains. Handles both the sync-throw and the async-`error`-event
+ * shapes Node's `spawn()` uses on different platforms.
+ */
+async function spawnWithEtxtbsyRetry(
+  binary: string,
+  args: string[],
+  attempts = 20,
+): Promise<ChildProcess> {
+  let lastErr: unknown = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const child = nodeSpawn(binary, args, { stdio: ["ignore", "pipe", "pipe"] });
+      const earlyErr = await new Promise<Error | null>((resolve) => {
+        const onError = (err: Error) => {
+          child.removeListener("spawn", onSpawn);
+          resolve(err);
+        };
+        const onSpawn = () => {
+          child.removeListener("error", onError);
+          resolve(null);
+        };
+        child.once("error", onError);
+        child.once("spawn", onSpawn);
+      });
+      if (!earlyErr) {
+        return child;
+      }
+      lastErr = earlyErr;
+      if ((earlyErr as NodeJS.ErrnoException).code !== "ETXTBSY") {
+        throw earlyErr;
+      }
+    } catch (err) {
+      lastErr = err;
+      if ((err as NodeJS.ErrnoException).code !== "ETXTBSY") {
+        throw err;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error(`spawn ${binary}: ETXTBSY after ${attempts} retries`);
+}
+
+/**
+ * Bind to 127.0.0.1:0 to let the OS pick a free TCP port, close the
+ * probe socket, return the number. Good enough for gvproxy's
+ * `-ssh-port` where the tiny close-to-bind race is ~never observed.
+ */
+async function pickEphemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen({ port: 0, host: "127.0.0.1" }, () => {
+      const addr = srv.address() as AddressInfo;
+      srv.close(() => resolve(addr.port));
+    });
+  });
+}
+
+/**
+ * Recognize the caller opt-out tokens for `MACHINEN_GVPROXY`. Set to
+ * one of these when a process (typically a test) doesn't want the
+ * runtime to download, discover, or spawn gvproxy at all — `boot()`
+ * will fall through the warn-and-continue path.
+ */
+function isGvproxyDisabledSentinel(value: string): boolean {
+  const v = value.toLowerCase().trim();
+  return v === "disabled" || v === "off" || v === "false" || v === "0" || v === "none";
+}
+
+/**
+ * Pick the upstream release asset for this host. Mirrors the mapping
+ * in `scripts/install-gvproxy.sh` so the release path (bundled in
+ * `@machinen/vmm-*` via CI) and the dev auto-install path stay lockstep.
+ */
+function gvproxyAssetName(): string {
+  const platform = osPlatform();
+  if (platform === "darwin") {
+    return "gvproxy-darwin";
+  }
+  if (platform === "linux") {
+    const arch = osArch();
+    // gvproxy's release assets name x86_64 as `amd64`; aarch64 stays
+    // `arm64`. Node reports `x64` and `arm64`.
+    const gvArch = arch === "x64" ? "amd64" : arch;
+    return `gvproxy-linux-${gvArch}`;
+  }
+  throw new Error(`gvproxy: no prebuilt release asset for platform ${platform}`);
 }
 
 export interface GvproxyHandle {
@@ -90,13 +368,29 @@ export async function spawnGvproxy(
   // the VMM dials for frames; `-listen` is gvproxy's HTTP control API,
   // used by `exposePort()` to install host->guest port forwards. Both
   // unix:// URLs, both auto-created by gvproxy. No vsock listener.
-  const child = nodeSpawn(
-    binary,
-    ["-listen-qemu", `unix://${socketPath}`, "-listen", `unix://${controlSocketPath}`],
-    {
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
+  //
+  // `-ssh-port` defaults to 2222, which collides the moment a second
+  // gvproxy spawns on the host (multi-VM, parallel tests). None of our
+  // flows use gvproxy's built-in SSH forwarder, so we pick an
+  // ephemeral port per spawn — the OS hands us a free one, we close
+  // the probe socket, gvproxy binds immediately after. A race window
+  // of ~0 in practice; a retry could gild it further if we ever see
+  // it bite.
+  const sshPort = await pickEphemeralPort();
+  const args = [
+    "-listen-qemu",
+    `unix://${socketPath}`,
+    "-listen",
+    `unix://${controlSocketPath}`,
+    "-ssh-port",
+    String(sshPort),
+  ];
+  // Small retry loop around exec() for `ETXTBSY`. On Linux this fires
+  // briefly after a freshly-written binary gets exec'd while a peer
+  // still has a write fd open — rare with the lock + fsync in
+  // `downloadGvproxy`, but belt-and-suspenders for multi-process
+  // test runners.
+  const child = await spawnWithEtxtbsyRetry(binary, args);
 
   let stopped = false;
   const stop = () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,6 +10,7 @@ export { VsockFiles } from "./files.ts";
 export type { VsockFilesOptions } from "./files.ts";
 export { VsockExec } from "./exec.ts";
 export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
+export type { LogEvent, OnLog } from "./log.ts";
 export { provision, ProvisionError, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
@@ -65,9 +66,10 @@ import { arch as osArch, platform as osPlatform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { packBundle as mkinitramfsPackBundle } from "./mkinitramfs.ts";
-import { exposePort, resolveGvproxyBinary, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
+import { ensureGvproxy, exposePort, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
+import type { OnLog } from "./log.ts";
 import { findEntry, isAlive, newVmId, removeEntry, writeEntry } from "./registry.ts";
 
 export class BootError extends Error {}
@@ -183,6 +185,14 @@ export interface BootOptions {
    * name is just for discovery.
    */
   name?: string;
+  /**
+   * Streaming log callback — fires for every byte of guest output:
+   * kernel console (VMM stderr) and every exec invocation made through
+   * the returned handle. See `LogEvent.source` to tell them apart. See
+   * #83. For per-call output-only tees on a single exec, use
+   * `vm.exec({ onStdout, onStderr })` instead.
+   */
+  onLog?: OnLog;
 }
 
 export interface VmHandle {
@@ -259,6 +269,12 @@ export interface SnapshotOptions {
    * in this window we SIGKILL it and fail. Default 90s.
    */
   timeoutMs?: number;
+  /**
+   * Streaming log callback — fires for every byte the dump emits
+   * (guest console + the dump exec). See #83. When both the snapshot
+   * call and `boot({ onLog })` have a callback set, both fire.
+   */
+  onLog?: OnLog;
 }
 
 export interface SnapshotResult {
@@ -370,7 +386,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 
   try {
     if (!env.MACHINEN_NET_SOCKET) {
-      const gvBin = resolveGvproxyBinary(binary);
+      // Auto-install gvproxy on first use if not already resolvable —
+      // visible stderr line; cached under ~/.machinen so subsequent
+      // boots are silent. See #83 follow-up.
+      const gvBin = await ensureGvproxy(binary);
       if (gvBin) {
         const gv = await spawnGvproxy(gvBin);
         env.MACHINEN_NET_SOCKET = gv.socketPath;
@@ -498,6 +517,12 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // to fill a pipe buffer if nothing's draining it).
   const outputCollector = collect(child.stdout);
   const errorCollector = collect(child.stderr);
+  const onLog = opts.onLog;
+  if (onLog) {
+    child.stderr.on("data", (chunk: Buffer) => {
+      onLog({ source: "guest-console", chunk });
+    });
+  }
 
   const handle: VmHandle = {
     id,
@@ -565,7 +590,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
             "unrecognized spec. Expected `in:<port>:<uds-path>`.",
         );
       }
-      const res = await VsockExec.run(vsockUdsPath, cmd, execOpts);
+      const res = await VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
       if (res.exitCode !== 0) {
         throw new BootError(
           `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
@@ -583,7 +608,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
           ),
         );
       }
-      return VsockExec.run(vsockUdsPath, cmd, execOpts);
+      return VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
     },
 
     async snapshot(outPath, snapshotOpts) {
@@ -596,11 +621,29 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       const dumpCmd = snapshotOpts?.dumpCmd ?? "/sbin/machinen-dump";
       const deadlineMs = snapshotOpts?.timeoutMs ?? 90_000;
       const t0 = Date.now();
+      const snapshotOnLog = snapshotOpts?.onLog;
+
+      // If the caller asked for streaming, tee the VMM's stderr into it
+      // too — otherwise they'd only see the dump exec, not the kernel /
+      // CRIU console output that explains a dump-gone-wrong.
+      if (snapshotOnLog) {
+        child.stderr.on("data", (chunk: Buffer) => {
+          snapshotOnLog({ source: "guest-console", chunk });
+        });
+      }
 
       // Trigger the in-guest dump. The vsock connection typically closes
       // mid-transaction as the guest powers off — all such close modes
       // are fine; `wait()` below is the real success signal.
-      await this.execRaw(dumpCmd, { connectTimeoutMs: 2_000 }).catch(() => {});
+      await this.execRaw(dumpCmd, {
+        connectTimeoutMs: 2_000,
+        onStdout: snapshotOnLog
+          ? (chunk) => snapshotOnLog({ source: "exec-stdout", cmd: dumpCmd, chunk })
+          : undefined,
+        onStderr: snapshotOnLog
+          ? (chunk) => snapshotOnLog({ source: "exec-stderr", cmd: dumpCmd, chunk })
+          : undefined,
+      }).catch(() => {});
 
       const killTimer = setTimeout(() => void this.kill(), deadlineMs);
       killTimer.unref();
@@ -646,6 +689,13 @@ export interface AttachOptions {
   id?: string;
   /** Look up a VM by the name passed to `boot({ name })`. */
   name?: string;
+  /**
+   * Streaming log callback — fires for every byte of output from execs
+   * made through the returned handle. See #83. Guest kernel console is
+   * not available on attach handles (it belongs to the process that
+   * called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
+   */
+  onLog?: OnLog;
 }
 
 /**
@@ -722,7 +772,7 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
     },
 
     async exec(cmd, execOpts) {
-      const res = await VsockExec.run(entry.socketPath, cmd, execOpts);
+      const res = await VsockExec.run(entry.socketPath, cmd, teeOnLog(cmd, execOpts, opts.onLog));
       if (res.exitCode !== 0) {
         throw new BootError(
           `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
@@ -732,7 +782,7 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
     },
 
     execRaw(cmd, execOpts) {
-      return VsockExec.run(entry.socketPath, cmd, execOpts);
+      return VsockExec.run(entry.socketPath, cmd, teeOnLog(cmd, execOpts, opts.onLog));
     },
 
     async snapshot(outPath, snapshotOpts) {
@@ -880,6 +930,34 @@ function validateMountGuest(guest: string): void {
         `pick a sub-path like ${MOUNT_ROOT}app`,
     );
   }
+}
+
+/**
+ * Layer an `onLog` over per-call `onStdout` / `onStderr`: the caller's
+ * narrow callbacks still fire if they set them, and the handle-level
+ * `onLog` receives a tagged event for every chunk. See #83.
+ */
+function teeOnLog(
+  cmd: string,
+  execOpts: VsockExecOptions | undefined,
+  onLog: OnLog | undefined,
+): VsockExecOptions | undefined {
+  if (!onLog) {
+    return execOpts;
+  }
+  const userOnStdout = execOpts?.onStdout;
+  const userOnStderr = execOpts?.onStderr;
+  return {
+    ...execOpts,
+    onStdout(chunk) {
+      onLog({ source: "exec-stdout", cmd, chunk });
+      userOnStdout?.(chunk);
+    },
+    onStderr(chunk) {
+      onLog({ source: "exec-stderr", cmd, chunk });
+      userOnStderr?.(chunk);
+    },
+  };
 }
 
 function collect(stream: Readable): Promise<string> {

--- a/packages/runtime/src/log.ts
+++ b/packages/runtime/src/log.ts
@@ -1,0 +1,28 @@
+// Shared streaming-log surface — see #83.
+//
+// APIs that run work (boot, provision, vm.snapshot, attach) take an
+// `onLog` callback. It fires for every byte of output the guest emits,
+// tagged by source so a caller can tell kernel-console bytes from exec
+// bytes without having to stitch callbacks onto every vm.exec().
+//
+// vm.exec / vm.execRaw keep their narrower {onStdout, onStderr} option
+// — one command, two pipes is a cleaner shape there. Callers wiring an
+// onLog at boot-level get exec output too: the handle tees each exec
+// into the onLog under the `exec-stdout` / `exec-stderr` sources with
+// the command string set on `cmd`.
+
+export interface LogEvent {
+  /**
+   * Where the chunk came from:
+   *   - `guest-console` — kernel / PL011 console bytes (VMM stderr)
+   *   - `exec-stdout`   — stdout of an exec invocation
+   *   - `exec-stderr`   — stderr of an exec invocation
+   */
+  source: "guest-console" | "exec-stdout" | "exec-stderr";
+  /** Command string; set when `source` is `exec-stdout` or `exec-stderr`. */
+  cmd?: string;
+  /** Raw bytes as they arrive — not line-split, not decoded. */
+  chunk: Buffer;
+}
+
+export type OnLog = (evt: LogEvent) => void;

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -37,6 +37,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { VsockExec } from "./exec.ts";
 import { boot, type VmHandle } from "./index.ts";
+import type { OnLog } from "./log.ts";
 
 export class ProvisionError extends Error {}
 
@@ -113,6 +114,14 @@ export interface ProvisionOptions {
 
   /** Path to the guest DTB. Same semantics as `boot({ dtb })`. */
   dtb?: string;
+
+  /**
+   * Streaming log callback — fires for every byte of guest output
+   * during the build: guest kernel console, every `vm.exec()` call
+   * the install hook makes, and the internal tar / poweroff execs.
+   * See `LogEvent.source` to tell them apart. See #83.
+   */
+  onLog?: OnLog;
 }
 
 export interface ProvisionResult {
@@ -253,6 +262,9 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // We drive the guest to exit via /sbin/machinen-poweroff at the
       // end; wait() has its own ceiling below.
       timeoutMs: null,
+      // Forward guest console + install-hook exec output to the caller.
+      // Internal tar / poweroff execs are forwarded explicitly below.
+      onLog: opts.onLog,
     });
 
     const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
@@ -299,6 +311,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // that specifically.
       const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
         execTimeoutMs: deadlineMs,
+        ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
       });
       if (tar.exitCode !== 0) {
         throw new ProvisionError(
@@ -316,6 +329,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // we don't burn 30s retrying a bridge that's already gone.
       await VsockExec.run(udsPath, "/sbin/machinen-poweroff", {
         connectTimeoutMs: 2_000,
+        ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
       }).catch(() => {});
 
       await vm.wait();
@@ -342,6 +356,25 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       rmSync(workDir, { recursive: true, force: true });
     } catch {}
   }
+}
+
+/**
+ * Bridge a raw `VsockExec.run` call into the provision-level `onLog`.
+ * The bare VsockExec calls inside provision (tar, poweroff) don't go
+ * through the VmHandle, so they miss the handle-level tee; this applies
+ * the same `exec-stdout` / `exec-stderr` tagging shape by hand.
+ */
+function tapExecForLog(
+  cmd: string,
+  onLog: OnLog | undefined,
+): { onStdout?: (chunk: Buffer) => void; onStderr?: (chunk: Buffer) => void } {
+  if (!onLog) {
+    return {};
+  }
+  return {
+    onStdout: (chunk) => onLog({ source: "exec-stdout", cmd, chunk }),
+    onStderr: (chunk) => onLog({ source: "exec-stderr", cmd, chunk }),
+  };
 }
 
 function allocateSparseFile(path: string, sizeBytes: number): void {

--- a/scripts/stream-demo.ts
+++ b/scripts/stream-demo.ts
@@ -54,7 +54,9 @@ const dtb = resolve(assetsDir, "virt-arm64.dtb");
 const microvmRoot = resolve(import.meta.dirname, "..", "packages", "microvm");
 const fixturesDir = join(microvmRoot, "test-fixtures");
 function stageFixture(src: string, dest: string) {
-  if (existsSync(dest)) return;
+  if (existsSync(dest)) {
+    return;
+  }
   mkdirSync(dirname(dest), { recursive: true });
   symlinkSync(src, dest);
 }
@@ -88,7 +90,9 @@ function printer(api: string) {
     let pending = (buffers.get(key) ?? "") + evt.chunk.toString("utf8");
     for (;;) {
       const nl = pending.indexOf("\n");
-      if (nl === -1) break;
+      if (nl === -1) {
+        break;
+      }
       process.stdout.write(`${prefix} ${pending.slice(0, nl)}\n`);
       pending = pending.slice(nl + 1);
     }

--- a/scripts/stream-demo.ts
+++ b/scripts/stream-demo.ts
@@ -1,0 +1,167 @@
+// Demo: wire `onLog` into every runtime API and print each LogEvent.
+//
+// Run:
+//   MACHINEN_ASSETS_DIR=./release-assets \
+//   MACHINEN_VMM=$(find packages/microvm/.zig-cache/o -name test -type f \
+//                    -exec bash -c 'strings "$1" | grep -q MACHINEN_BOOT_TEST && echo "$1"' _ {} \; | head -1) \
+//   npx tsx scripts/stream-demo.ts
+//
+// Needs:
+//   - A built VMM binary (packages/microvm: `zig build test`)
+//   - Base assets (release-assets/{Image-arm64,virt-arm64.dtb,rootfs-debian-arm64.tar.gz})
+//     produced by scripts/build-base-assets.sh.
+//
+// Prints every LogEvent as `[api][source cmd?] <bytes>` so the streaming
+// behavior is visible per-API: provision, boot, exec, snapshot, attach.
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  symlinkSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  attach,
+  boot,
+  provision,
+  type LogEvent,
+  type VmHandle,
+} from "../packages/runtime/src/index.ts";
+
+const assetsDir = process.env.MACHINEN_ASSETS_DIR;
+if (!assetsDir) {
+  process.stderr.write("error: set MACHINEN_ASSETS_DIR to a dir with rootfs/Image/dtb\n");
+  process.exit(1);
+}
+
+const kernel = resolve(assetsDir, "Image-arm64");
+const dtb = resolve(assetsDir, "virt-arm64.dtb");
+
+// The VMM test binary hardcodes kernel_path = "test-fixtures/Image",
+// dtb_path = "test-fixtures/virt.dtb", initrd_fixture = "test-fixtures/
+// initramfs.cpio" relative to its cwd (see boot_hvf.zig). Without those
+// files present the boot test silently skips and the VMM exits,
+// starving every vsock call of an agent. Stage them as symlinks to
+// whatever release-assets has; the runtime still passes its own
+// kernel/dtb/initrd via env at boot time, so what's in test-fixtures/
+// only needs to satisfy the existence check.
+const microvmRoot = resolve(import.meta.dirname, "..", "packages", "microvm");
+const fixturesDir = join(microvmRoot, "test-fixtures");
+function stageFixture(src: string, dest: string) {
+  if (existsSync(dest)) return;
+  mkdirSync(dirname(dest), { recursive: true });
+  symlinkSync(src, dest);
+}
+stageFixture(kernel, join(fixturesDir, "Image"));
+stageFixture(dtb, join(fixturesDir, "virt.dtb"));
+// initramfs.cpio just needs to exist for fixturesPresent(). The runtime
+// overrides it via MACHINEN_INITRD per boot. An empty file works.
+const dummyInitrd = join(fixturesDir, "initramfs.cpio");
+if (!existsSync(dummyInitrd)) {
+  mkdirSync(fixturesDir, { recursive: true });
+  closeSync(openSync(dummyInitrd, "w"));
+}
+
+const workDir = mkdtempSync(join(tmpdir(), "machinen-stream-demo-"));
+const warmImage = join(workDir, "warm.tar.gz");
+const scratchSnap = join(workDir, "scratch.img");
+const savedSnap = join(workDir, "saved.snap");
+
+/**
+ * Build a printer that buffers bytes per-source-key and flushes one
+ * prefixed line per newline. The PL011 emits single-byte frames
+ * (`p`, `r`, `i`, `n`…) so prefixing each chunk literally is noisy;
+ * buffering makes the same stream readable without losing the
+ * source/command tags.
+ */
+function printer(api: string) {
+  const buffers = new Map<string, string>();
+  return (evt: LogEvent) => {
+    const prefix = evt.cmd ? `[${api}][${evt.source} ${evt.cmd}]` : `[${api}][${evt.source}]`;
+    const key = `${evt.source}|${evt.cmd ?? ""}`;
+    let pending = (buffers.get(key) ?? "") + evt.chunk.toString("utf8");
+    for (;;) {
+      const nl = pending.indexOf("\n");
+      if (nl === -1) break;
+      process.stdout.write(`${prefix} ${pending.slice(0, nl)}\n`);
+      pending = pending.slice(nl + 1);
+    }
+    buffers.set(key, pending);
+  };
+}
+
+// The Zig test binary gates actual boot behavior on MACHINEN_BOOT_TEST.
+// Without it, the binary runs its own trivial self-test ("1/1 main.test…
+// OK") and exits without ever booting a guest, so vsock exec times out.
+// The integration tests (packages/runtime/src/__tests__/*.test.ts) set
+// the same flag; mirror it here.
+const sharedVmmEnv = { MACHINEN_BOOT_TEST: "1" };
+
+try {
+  process.stdout.write("\n=== provision ===\n");
+  await provision({
+    cwd: microvmRoot,
+    kernel,
+    dtb,
+    vmmEnv: sharedVmmEnv,
+    install: async (vm: VmHandle) => {
+      await vm.exec("echo 'install-hook: hello' && uname -m");
+    },
+    cmd: ["/exec-agent"],
+    env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+    out: warmImage,
+    onLog: printer("provision"),
+  });
+
+  // `snapshot: <path>` on boot() is "attach this file as /dev/vda".
+  // vm.snapshot() later writes a CRIU dump into that disk, then copies
+  // it to the caller's outPath. Allocate a 1 GiB sparse scratch so the
+  // disk exists before boot() validates it.
+  const fd = openSync(scratchSnap, "w");
+  writeSync(fd, Buffer.alloc(1), 0, 1, 1024 * 1024 * 1024 - 1);
+  closeSync(fd);
+
+  process.stdout.write("\n=== boot + exec (streaming long-ish output) ===\n");
+  const vm = await boot({
+    cwd: microvmRoot,
+    image: warmImage,
+    kernel,
+    dtb,
+    vmmEnv: sharedVmmEnv,
+    name: "stream-demo",
+    snapshot: scratchSnap,
+    timeoutMs: null,
+    onLog: printer("boot"),
+  });
+
+  try {
+    // The payload proves streaming: "early" arrives, then a 2s gap,
+    // then "late" — watch the timestamps of the boot[exec-stdout]
+    // lines below.
+    await vm.exec("echo early; sleep 2; echo late");
+
+    process.stdout.write("\n=== attach (from another 'process') ===\n");
+    const alt = await attach({ name: "stream-demo", onLog: printer("attach") });
+    await alt.execRaw("echo from-attached");
+    await alt.detach();
+
+    process.stdout.write("\n=== snapshot ===\n");
+    await vm.snapshot(savedSnap, { onLog: printer("snapshot") }).catch((err: unknown) => {
+      // The base rootfs may not ship /sbin/machinen-dump; surface the
+      // failure but don't abort the demo.
+      process.stderr.write(
+        `snapshot skipped: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}\n`,
+      );
+    });
+  } finally {
+    await vm.kill();
+  }
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["packages/*/src/__tests__/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,9 @@
+// Disable gvproxy auto-install/spawn for the whole test suite.
+//
+// Most tests boot stub binaries (`/bin/cat`, `/usr/bin/true`, fixture
+// VMMs) and don't need a real user-mode network stack. Auto-spawning
+// gvproxy — and more importantly auto-downloading it on a fresh host —
+// costs seconds of test wall-clock and is just noise. Any test that
+// actually wants gvproxy can `delete process.env.MACHINEN_GVPROXY` at
+// the top of its case.
+process.env.MACHINEN_GVPROXY = "disabled";


### PR DESCRIPTION
Closes #83.

## Summary

- `onLog` callback on `boot`, `provision`, `vm.snapshot`, `attach` — fires for every byte of guest output as it arrives (kernel console + every exec invocation), each event tagged with `source: "guest-console" | "exec-stdout" | "exec-stderr"` and `cmd` for exec-*. Callers no longer need to stitch per-call callbacks onto every `vm.exec`.
- `vm.exec` / `vm.execRaw` keep their narrower `{ onStdout, onStderr }` option; the two layers compose — a handle-level `onLog` receives exec output too.
- `machinen exec` and `machinen attach` stream to the terminal instead of buffering until the command returns.
- Auto-install gvproxy on first boot into `~/.machinen/gvproxy/<version>/`, with a single visible stderr line while downloading. Cross-process lock + fsync + atomic rename so concurrent callers (vitest workers, multi-VM boots) don't race into `ETXTBSY`. Random `-ssh-port` per spawn so multiple gvproxy instances don't collide on `127.0.0.1:2222`.

## Shape

```ts
type LogEvent = {
  source: "guest-console" | "exec-stdout" | "exec-stderr";
  cmd?: string;
  chunk: Buffer;
};

await provision({
  base: "./rootfs.tar.gz",
  install: async (vm) => { await vm.exec("apt-get install tree"); },
  out: "./warm.tar.gz",
  onLog: (evt) => process.stderr.write(evt.chunk),
});
```

## Demo

`scripts/stream-demo.ts` exercises all four APIs with `onLog` hooked up and prints one prefixed line per log event. A run on a local dev box produces output like:

```
=== boot + exec (streaming long-ish output) ===
[boot][guest-console] exec-agent: listening on vsock port 1978
[boot][exec-stdout echo early; sleep 2; echo late] early
[boot][exec-stdout echo early; sleep 2; echo late] late       ← arrives 2s after the first line

=== attach (from another 'process') ===
[attach][exec-stdout echo from-attached] from-attached

=== snapshot ===
[boot][exec-stderr /sbin/machinen-dump] sh: 1: /sbin/machinen-dump: not found
[snapshot][exec-stderr /sbin/machinen-dump] sh: 1: /sbin/machinen-dump: not found
```

The `early` and `late` lines arriving 2s apart in wall-clock are the streaming proof called out in the issue's "Done when" criterion.

## Test plan

- [x] `streaming.test.ts` — stub UDS framing test asserts `onStdout` fires twice with the gap between chunks preserved.
- [x] `npx vitest run` — 106 tests pass.
- [x] `npx agent-ci run --all -q -p` — green.
- [ ] Reviewer spot-check: does `onLog` on `boot()` surface exec output from every `vm.exec` call made through the handle?
