### PR TITLE
feat(microvm,runtime): boot from virtio-blk root (#114)

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -25,6 +25,9 @@ extern "c" fn close(fd: c_int) c_int;
 extern "c" fn dup2(oldfd: c_int, newfd: c_int) c_int;
 extern "c" fn mkdir(path: [*:0]const u8, mode: c_uint) c_int;
 extern "c" fn chdir(path: [*:0]const u8) c_int;
+extern "c" fn chroot(path: [*:0]const u8) c_int;
+extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
+extern "c" fn umount2(target: [*:0]const u8, flags: c_int) c_int;
 extern "c" fn execve(
     path: [*:0]const u8,
     argv: [*:null]const ?[*:0]const u8,
@@ -53,8 +56,22 @@ const O_RDONLY: c_int = 0;
 const O_RDWR: c_int = 2;
 const SEEK_END: c_int = 2;
 const SEEK_SET: c_int = 0;
+const F_OK: c_int = 0;
+const MS_MOVE: c_ulong = 8192;
+const MNT_DETACH: c_int = 2;
 
 const CONFIG_PATH = "/machinen-config.json";
+
+// Where the rootdisk gets mounted before the chroot. Anything not
+// already in use under / works; we pick a name unlikely to collide with
+// a user-visible directory inside the rootfs.
+const ROOTDISK_DEV = "/dev/vda";
+const NEWROOT = "/newroot";
+// Marker file we expect to find inside the rootfs to know "yes, this
+// is a machinen rootfs and we should pivot into it." machinen-supervisor
+// is shipped by every machinen base rootfs (scripts/build-base-assets.sh)
+// so its presence is a reliable signal. See #114.
+const ROOTFS_MARKER = "/newroot/sbin/machinen-supervisor";
 
 fn writeStr(fd: c_int, s: []const u8) void {
     _ = write(fd, s.ptr, s.len);
@@ -420,6 +437,106 @@ fn nowMs() i64 {
     return ts.tv_sec * 1000 + @divTrunc(ts.tv_nsec, 1_000_000);
 }
 
+// Try to mount /dev/vda as ext4 and chroot into it. Returns true if the
+// pivot happened (the caller's view of `/` has changed), false if we
+// fell through to the legacy initramfs-as-rootfs path.
+//
+// Detection is conservative: we mount, then check for /sbin/machinen-
+// supervisor inside the candidate root. If the marker is missing we
+// unmount and fall through. That way a CRIU scratch disk attached as
+// /dev/vda (legacy behavior) doesn't accidentally become the rootfs.
+//
+// Pre-conditions:
+//   * loadPlumbingModules() has already run (virtio_blk loaded so /dev/vda
+//     can appear).
+//   * /machinen-config.json exists in the cpio rootfs at /.
+//   * /etc/machinen-boot-epoch may exist in the cpio rootfs at /.
+//
+// On success the function copies the per-boot ephemera that lived in
+// the cpio (machinen-config.json, machinen-boot-epoch) into the
+// freshly-mounted rootfs, moves /proc, /sys, /dev across, then calls
+// chroot(NEWROOT) + chdir("/"). Subsequent code runs against the
+// on-disk rootfs.
+fn tryRootDiskPivot() bool {
+    // Wait briefly for the device node — modprobe of virtio_blk runs
+    // asynchronously so /dev/vda may not be there immediately.
+    if (!waitForPath(ROOTDISK_DEV, 2_000)) return false;
+
+    mkdirIgnore(NEWROOT);
+    if (mount(ROOTDISK_DEV, NEWROOT, "ext4", 0, null) != 0) {
+        // /dev/vda isn't ext4 — assume legacy CRIU scratch mode.
+        return false;
+    }
+    if (access(ROOTFS_MARKER, F_OK) != 0) {
+        // Mounted, but no machinen rootfs inside — assume CRIU scratch.
+        _ = umount2(NEWROOT, MNT_DETACH);
+        return false;
+    }
+
+    // Hand off /proc, /sys, /dev to the new root via MS_MOVE so the
+    // already-mounted filesystems stay live across the chroot. mkdir
+    // first in case the on-disk rootfs is too lean to ship them.
+    mkdirIgnore("/newroot/proc");
+    mkdirIgnore("/newroot/sys");
+    mkdirIgnore("/newroot/dev");
+    _ = mount("/proc", "/newroot/proc", "", MS_MOVE, null);
+    _ = mount("/sys", "/newroot/sys", "", MS_MOVE, null);
+    _ = mount("/dev", "/newroot/dev", "", MS_MOVE, null);
+
+    // Carry the per-boot ephemera the cpio packed at root level. The
+    // on-disk rootfs is shared across boots and intentionally doesn't
+    // bake these in.
+    copyFileBest("/machinen-config.json", "/newroot/machinen-config.json");
+    copyFileBest("/etc/machinen-boot-epoch", "/newroot/etc/machinen-boot-epoch");
+
+    if (chroot(NEWROOT) != 0) {
+        // chroot can't really fail at PID 1 with valid args, but if it
+        // does we'd be in a half-broken state. Best-effort fall-through.
+        return false;
+    }
+    if (chdir("/") != 0) {
+        // Same: shouldn't happen post-chroot.
+    }
+    writeStr(1, "init: pivoted into /dev/vda rootfs\n");
+    return true;
+}
+
+/// Wait up to `timeout_ms` for `path` to exist. Used to bridge the gap
+/// between modprobe and devtmpfs creating the matching device node.
+fn waitForPath(path: [*:0]const u8, timeout_ms: i64) bool {
+    const deadline_ms = nowMs() + timeout_ms;
+    while (nowMs() < deadline_ms) {
+        if (access(path, F_OK) == 0) return true;
+        sleepMs(25);
+    }
+    return false;
+}
+
+/// Best-effort `cp src dst`. Used to bring the per-boot config + epoch
+/// files across the pivot. Failures are silent — the boot continues
+/// without them and the caller deals with the consequences.
+fn copyFileBest(src: [*:0]const u8, dst: [*:0]const u8) void {
+    const in_fd = open(src, O_RDONLY);
+    if (in_fd < 0) return;
+    defer _ = close(in_fd);
+    // O_WRONLY | O_CREAT | O_TRUNC = 1 | 64 | 512 on Linux/musl.
+    const out_fd = open(dst, 0o1 | 0o100 | 0o1000, @as(c_uint, 0o644));
+    if (out_fd < 0) return;
+    defer _ = close(out_fd);
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = read(in_fd, &buf, buf.len);
+        if (n <= 0) return;
+        var off: usize = 0;
+        const total: usize = @intCast(n);
+        while (off < total) {
+            const w = write(out_fd, buf[off..].ptr, total - off);
+            if (w <= 0) return;
+            off += @intCast(w);
+        }
+    }
+}
+
 pub fn main() noreturn {
     // Basic FS mounts. Ignore failures — the kernel might have mounted
     // some already, or we might be in a stripped rootfs.
@@ -439,8 +556,20 @@ pub fn main() noreturn {
 
     writeStr(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
 
-    setBootClock();
+    // virtio_blk has to load before we can probe /dev/vda for a
+    // rootdisk. The legacy path (no rootdisk) doesn't care about ordering
+    // — virtio_blk just shows up by the time provision()'s tar-to-disk
+    // runs. The pivot path needs it loaded right now.
     loadPlumbingModules();
+
+    // #114: try the virtio-blk-root pivot before doing any other setup.
+    // If /dev/vda has a machinen rootfs (ext4 + marker), we mount it +
+    // chroot into it; subsequent setup runs against the on-disk rootfs
+    // rather than the cpio-extracted tmpfs. Falls through silently to
+    // the legacy path if /dev/vda isn't a rootdisk.
+    _ = tryRootDiskPivot();
+
+    setBootClock();
     bringUpNetwork();
 
     // Page allocator works on musl via mmap.

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -41,6 +41,7 @@ extern "c" fn mount(
     data: ?*const anyopaque,
 ) c_int;
 extern "c" fn nanosleep(req: *const timespec, rem: ?*timespec) c_int;
+extern "c" fn sched_yield() c_int;
 extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
 extern "c" fn fork() c_int;
 extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
@@ -146,7 +147,10 @@ fn bringUpNetwork() void {
 }
 
 // Load kernel modules that every machinen workload assumes are usable:
-//   virtio_blk — /dev/vda, for snapshot disks + persistent workspaces
+//   virtio_mmio — the bus that publishes DTS virtio_mmio@... slots into
+//                 the virtio framework. Required for virtio_blk (and
+//                 virtio_net later) to find any devices to bind.
+//   virtio_blk  — /dev/vda, for snapshot disks + persistent workspaces.
 //   vsock stack — AF_VSOCK sockets; the exec-agent + file/secrets/winsize
 //                 agents all bind here. modprobe resolves the transport
 //                 dep chain (pulls in the _common module).
@@ -154,10 +158,11 @@ fn bringUpNetwork() void {
 // All are in the base rootfs (whitelisted in scripts/build-base-assets.sh).
 // Best-effort: if a module is missing or fails to insert, log and move
 // on — the user cmd may still work depending on what it needs.
-// machinen-netup handles virtio_mmio + virtio_net separately so this
-// function stays focused on the non-network plumbing.
+// virtio_net loads separately under /sbin/machinen-netup once we know
+// we want a network up.
 fn loadPlumbingModules() void {
     const mods = [_][*:0]const u8{
+        "virtio_mmio",
         "virtio_blk",
         "vmw_vsock_virtio_transport",
     };
@@ -458,17 +463,37 @@ fn nowMs() i64 {
 // chroot(NEWROOT) + chdir("/"). Subsequent code runs against the
 // on-disk rootfs.
 fn tryRootDiskPivot() bool {
-    // Wait briefly for the device node — modprobe of virtio_blk runs
-    // asynchronously so /dev/vda may not be there immediately.
-    if (!waitForPath(ROOTDISK_DEV, 2_000)) return false;
+    // Wait for the device node. virtio_mmio + virtio_blk are loaded by
+    // loadPlumbingModules() right above; the kernel finishes binding
+    // /dev/vda within a few tens of ms. We cap the wait at 2s in case
+    // modprobe failed silently. sched_yield rather than nanosleep
+    // because with a single guest vCPU, nanosleep parks the whole
+    // guest and the kernel's deferred-probe workqueue can't progress.
+    {
+        const deadline_ms = nowMs() + 2_000;
+        var found = false;
+        while (nowMs() < deadline_ms) {
+            if (access(ROOTDISK_DEV, F_OK) == 0) {
+                found = true;
+                break;
+            }
+            _ = sched_yield();
+        }
+        if (!found) {
+            logLine("init: rootdisk skip: /dev/vda did not appear");
+            return false;
+        }
+    }
 
     mkdirIgnore(NEWROOT);
     if (mount(ROOTDISK_DEV, NEWROOT, "ext4", 0, null) != 0) {
         // /dev/vda isn't ext4 — assume legacy CRIU scratch mode.
+        logLine("init: rootdisk skip: mount /dev/vda failed");
         return false;
     }
     if (access(ROOTFS_MARKER, F_OK) != 0) {
         // Mounted, but no machinen rootfs inside — assume CRIU scratch.
+        logLine("init: rootdisk skip: marker /sbin/machinen-supervisor missing");
         _ = umount2(NEWROOT, MNT_DETACH);
         return false;
     }

--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
-# /sbin/machinen-dump — dumps the user workload with CRIU onto /dev/vda
-# and triggers a clean poweroff.
+# /sbin/machinen-dump — dumps the user workload with CRIU onto the
+# scratch disk and triggers a clean poweroff.
 #
 # Runs inside the guest, invoked by `vm.snapshot()` via vsock exec.
-# The host-side `vm.snapshot()` then copies /dev/vda's backing file
-# to the caller's outPath and returns.
+# The host-side `vm.snapshot()` then copies the scratch disk's backing
+# file to the caller's outPath and returns.
 #
-# Layout on /dev/vda after a successful dump:
+# Scratch disk lives at /dev/vdb when the VM was booted with virtio-blk
+# root (/dev/vda is the rootfs in that case — see #114). On legacy
+# initramfs-as-rootfs boots there's only one virtio-blk device and it
+# lands at /dev/vda, so we fall back to that. The first existing path
+# wins.
+#
+# Layout on the scratch disk after a successful dump:
 #   /img/core-*.img           ← CRIU images
 #   /img/dump.log             ← CRIU verbose log (useful on failure)
 #
@@ -22,6 +28,14 @@ set -eu
 # PATH regardless of what /init's envp carried.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
+
+# Pick the scratch disk: /dev/vdb when virtio-blk-root booted (rootfs
+# took /dev/vda); else /dev/vda for the legacy single-disk layout.
+if [ -b /dev/vdb ]; then
+    SCRATCH=/dev/vdb
+else
+    SCRATCH=/dev/vda
+fi
 
 # /init writes the workload's PID after fork. Fall back to PID 2 if
 # the file is missing — that's what's produced by the supervisor
@@ -51,15 +65,16 @@ echo "machinen-dump: preparing (pid=$DUMP_PID)"
     exit 1
 }
 
-# Format /dev/vda ext4 on first use. Subsequent snapshots just remount.
+# Format the scratch disk ext4 on first use. Subsequent snapshots just
+# remount.
 # -F: force (existing data is a scratch allocation; we're overwriting).
 # -q: quiet; noisy output confuses the host-side log tee.
-if ! blkid /dev/vda 2>/dev/null | grep -q ext4; then
-    echo "machinen-dump: formatting /dev/vda as ext4"
-    mkfs.ext4 -F -q /dev/vda
+if ! blkid "$SCRATCH" 2>/dev/null | grep -q ext4; then
+    echo "machinen-dump: formatting $SCRATCH as ext4"
+    mkfs.ext4 -F -q "$SCRATCH"
 fi
 mkdir -p /mnt/snap
-mount /dev/vda /mnt/snap
+mount "$SCRATCH" /mnt/snap
 
 # Clear previous images so a rerun doesn't mix core-*.img files across
 # generations. The CRIU restore side globs core-*.img for PID discovery,

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -28,13 +28,21 @@ export PATH
 /exec-agent </dev/null >/dev/null 2>&1 &
 AGENT_PID=$!
 
-# Mount the CRIU image store.
+# Mount the CRIU image store. Pick /dev/vdb when virtio-blk-root booted
+# (rootfs took /dev/vda); else /dev/vda for the legacy single-disk
+# layout. See #114.
+if [ -b /dev/vdb ]; then
+    SCRATCH=/dev/vdb
+else
+    SCRATCH=/dev/vda
+fi
+
 mkdir -p /mnt/snap
-if ! blkid /dev/vda 2>/dev/null | grep -q ext4; then
-    echo "machinen-restore: /dev/vda is not ext4 — aborting" >&2
+if ! blkid "$SCRATCH" 2>/dev/null | grep -q ext4; then
+    echo "machinen-restore: $SCRATCH is not ext4 — aborting" >&2
     exit 1
 fi
-mount /dev/vda /mnt/snap
+mount "$SCRATCH" /mnt/snap
 if [ ! -d /mnt/snap/img ] || [ -z "$(ls -A /mnt/snap/img 2>/dev/null)" ]; then
     echo "machinen-restore: no images at /mnt/snap/img — aborting" >&2
     exit 1

--- a/packages/microvm/assets/virt.dts
+++ b/packages/microvm/assets/virt.dts
@@ -5,13 +5,18 @@
 // What stays in is what the guest kernel + our VMM actually touch:
 //   * the GIC v3 (interrupt controller — required)
 //   * PL011 UART at 0x9000000 (console)
-//   * three virtio-mmio slots (net / blk / vsock at 0x0a000000+i*0x200)
+//   * four virtio-mmio slots (net / blk / vsock / blk2 at 0x0a000000+i*0x200)
 //   * CPU, timer, psci, apb-pclk
+//
+// Slot 1 (blk) and slot 3 (blk2) carry the two virtio-blk devices:
+// rootdisk on slot 1 (becomes /dev/vda) and scratch on slot 3
+// (/dev/vdb when both are present). The runtime feeds them via
+// MACHINEN_ROOTDISK and MACHINEN_DISK respectively. See #114.
 //
 // Nodes we *used* to carry via the QEMU virt reference DTS and have
 // now dropped for sub-second-spawn work (#50): `pcie`, `pl031` rtc,
 // `pmu`, `flash`, `fw-cfg`, `platform-bus`, `gpio-keys`/`pl061`, the
-// GIC ITS, and 29 unused virtio_mmio slots. Each of these made the
+// GIC ITS, and 28 unused virtio_mmio slots. Each of these made the
 // kernel spend time probing things we never use.
 
 / {
@@ -54,6 +59,13 @@
 		dma-coherent;
 		interrupts = <0x00 0x12 0x01>;
 		reg = <0x00 0xa000400 0x00 0x200>;
+		compatible = "virtio,mmio";
+	};
+
+	virtio_mmio@a000600 {
+		dma-coherent;
+		interrupts = <0x00 0x13 0x01>;
+		reg = <0x00 0xa000600 0x00 0x200>;
 		compatible = "virtio,mmio";
 	};
 

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -30,13 +30,22 @@ const vsock_mod = @import("vsock.zig");
 
 // Guest-physical bases. Each virtio-MMIO device lives in a 0x200
 // window. The DTS has 32 slots at 0x0A000000 + i*0x200; we wire up
-// the first three.
+// the first four.
+//
+// Slot 0 = net, slot 1 = blk (rootdisk), slot 2 = vsock,
+// slot 3 = blk2 (scratch / CRIU disk). When both blk slots are
+// populated the kernel sees them in DTB order, so slot 1 = /dev/vda
+// (rootfs) and slot 3 = /dev/vdb (scratch). When only one is
+// populated, Linux still names the lone device /dev/vda regardless
+// of its slot. See #114.
 const virtio_net_base: u64 = 0x0A00_0000;
 const virtio_net_size: u64 = 0x200;
 const virtio_blk_base: u64 = 0x0A00_0200;
 const virtio_blk_size: u64 = 0x200;
 const virtio_vsock_base: u64 = 0x0A00_0400;
 const virtio_vsock_size: u64 = 0x200;
+const virtio_blk2_base: u64 = 0x0A00_0600;
+const virtio_blk2_size: u64 = 0x200;
 
 pub const Error = error{
     FixtureMissing,
@@ -50,8 +59,15 @@ pub const Config = struct {
     kernel_path: []const u8,
     dtb_path: []const u8,
     initrd_path: ?[]const u8 = null,
-    /// Optional path to a host file that becomes `/dev/vda` inside
-    /// the guest. `null` disables the virtio-blk device entirely.
+    /// Optional path to a host file backing the rootdisk. When set,
+    /// it lands on slot 1 (DTS `virtio_mmio@a000200`) and the kernel
+    /// sees it as `/dev/vda`. The runtime mounts it as the rootfs and
+    /// switch_roots into it (see init.zig + #114).
+    rootdisk_path: ?[]const u8 = null,
+    /// Optional path to a host file backing the scratch disk. With
+    /// rootdisk_path set, this lands on slot 3 and the kernel names
+    /// it `/dev/vdb`. With no rootdisk it lands on slot 1 and the
+    /// kernel names it `/dev/vda` (legacy, pre-#114 layout).
     disk_path: ?[]const u8 = null,
     ram_base: u64 = 0x4000_0000,
     ram_size: usize = 4 * 1024 * 1024 * 1024, // 4 GB — room for Debian+Node+CRIU+Claude Code in the initramfs tmpfs
@@ -337,13 +353,23 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .tx_ctx = @ptrCast(&tx_stats),
     };
 
-    // virtio-blk (#47). If the caller gave us a host file path,
-    // open it read-write and expose it as `/dev/vda`. If the file is
-    // missing, just skip — the rest of the VMM still runs.
+    // virtio-blk (#47, #114). Two slots:
+    //   slot 1 (virtio_blk_base)  — rootdisk preferred; falls back to
+    //                                disk_path so legacy boots (single
+    //                                /dev/vda for snapshot) keep working.
+    //   slot 3 (virtio_blk2_base) — scratch when rootdisk is also
+    //                                present; otherwise empty.
+    //
+    // Linux probes virtio-mmio buses in DTB order, so slot 1 always
+    // becomes /dev/vda and slot 3 becomes /dev/vdb when both are
+    // populated. With only one, the lone device is /dev/vda.
+    const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
+    const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
+
     var blk_backend_opt: ?blk_mod.Backend = null;
     defer if (blk_backend_opt) |*b| b.deinit();
     var blkdev_opt: ?virtio.Device = null;
-    if (cfg.disk_path) |path| {
+    if (slot1_path) |path| {
         if (blk_mod.openFile(path)) |backend| {
             blk_backend_opt = backend;
             blkdev_opt = virtio.Device{
@@ -358,10 +384,33 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                 .request_ctx = @ptrCast(&blk_backend_opt.?),
             };
         } else |err| {
-            std.debug.print("virtio-blk disabled: {s} ({s})\n", .{ @errorName(err), path });
+            std.debug.print("virtio-blk slot 1 disabled: {s} ({s})\n", .{ @errorName(err), path });
         }
     }
     const blkdev_ptr: ?*virtio.Device = if (blkdev_opt) |_| &blkdev_opt.? else null;
+
+    var blk2_backend_opt: ?blk_mod.Backend = null;
+    defer if (blk2_backend_opt) |*b| b.deinit();
+    var blk2dev_opt: ?virtio.Device = null;
+    if (slot3_path) |path| {
+        if (blk_mod.openFile(path)) |backend| {
+            blk2_backend_opt = backend;
+            blk2dev_opt = virtio.Device{
+                .base = virtio_blk2_base,
+                .size = virtio_blk2_size,
+                .id = .block,
+                .features = (1 << 32),
+                .config = std.mem.asBytes(&blk2_backend_opt.?.config),
+                .ram = ram,
+                .ram_base = cfg.ram_base,
+                .request_handler = &blk_mod.Backend.handleRequest,
+                .request_ctx = @ptrCast(&blk2_backend_opt.?),
+            };
+        } else |err| {
+            std.debug.print("virtio-blk slot 3 disabled: {s} ({s})\n", .{ @errorName(err), path });
+        }
+    }
+    const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
 
     // virtio-vsock (#44). Off by default; set MACHINEN_VSOCK to enable.
     // Syntax (comma-separated):
@@ -436,11 +485,15 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // The absolute GIC id is `spi.base + <n>`.
     const spi = try hvf.Gic.spiRange();
     const pl011_irq: u32 = spi.base + 1;
-    // DTS interrupts = <0 16 1> and <0 17 1> for the first two
-    // virtio-mmio slots. spi.base + 16 is net, + 17 is blk.
+    // DTS interrupts = <0 N 1> for each virtio-mmio slot. Slots:
+    //   slot 0 → SPI #16 (net)
+    //   slot 1 → SPI #17 (blk / rootdisk)
+    //   slot 2 → SPI #18 (vsock)
+    //   slot 3 → SPI #19 (blk2 / scratch)
     const virtio_irq: u32 = spi.base + 16;
     const virtio_blk_irq: u32 = spi.base + 17;
     const virtio_vsock_irq: u32 = spi.base + 18;
+    const virtio_blk2_irq: u32 = spi.base + 19;
 
     // Feed the virtio IRQ id into the network bridge, and arm the
     // RX callback so the net backend can raise the SPI after each
@@ -617,6 +670,16 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                         try vcpu.setReg(reg, d.read(info.ipa));
                     }
                     hvf.Gic.setSpi(virtio_blk_irq, d.interrupt_status != 0) catch {};
+                } else if (blk2dev_ptr != null and blk2dev_ptr.?.handles(info.ipa)) {
+                    const d = blk2dev_ptr.?;
+                    if (info.is_write) {
+                        const value = try info.readSource(vcpu);
+                        d.write(info.ipa, value);
+                    } else if (info.srt != 31) {
+                        const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
+                        try vcpu.setReg(reg, d.read(info.ipa));
+                    }
+                    hvf.Gic.setSpi(virtio_blk2_irq, d.interrupt_status != 0) catch {};
                 } else if (vsock_dev_ptr != null and vsock_dev_ptr.?.handles(info.ipa)) {
                     const d = vsock_dev_ptr.?;
                     if (info.is_write) {
@@ -902,10 +965,22 @@ test "boot a real arm64 Linux kernel" {
         }
         break :blk initrd_fixture;
     };
+    // The test fixture supports either layout: legacy single-disk
+    // (MACHINEN_DISK only) or virtio-blk root (MACHINEN_ROOTDISK +
+    // optional MACHINEN_DISK). #114.
+    const rootdisk_env = getenv("MACHINEN_ROOTDISK");
+    const rootdisk_path: ?[]const u8 = blk: {
+        if (rootdisk_env) |p| {
+            const s = std.mem.span(p);
+            if (s.len > 0) break :blk s;
+        }
+        break :blk null;
+    };
     const result = boot(gpa, .{
         .kernel_path = kernel_fixture,
         .dtb_path = dtb_fixture,
         .initrd_path = initrd_path,
+        .rootdisk_path = rootdisk_path,
         .disk_path = disk_path,
     }) catch |err| {
         std.debug.print("boot returned {s}\n", .{@errorName(err)});

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -33,10 +33,12 @@ pub fn main(init: std.process.Init) !void {
     // the same bytes, captured for tests — don't re-emit here.
     if (builtin.os.tag == .macos) {
         const disk_path = envOptional("MACHINEN_DISK");
+        const rootdisk_path = envOptional("MACHINEN_ROOTDISK");
         const result = try microvm.boot_hvf.boot(gpa, .{
             .kernel_path = kernel_path,
             .dtb_path = dtb_path,
             .initrd_path = initrd_path,
+            .rootdisk_path = rootdisk_path,
             .disk_path = disk_path,
             .unbounded_serial = true,
         });

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -1,0 +1,141 @@
+// Tests for ensureRootfsImage — the tar→ext4-img materializer that
+// backs `boot({ rootDisk: true })` (#114).
+//
+// These tests don't actually materialize ext4 images (that requires
+// e2fsprogs on PATH and is verified in the smoke harness). They cover
+// the host-side logic the runtime owns: input validation, the
+// missing-tool error path, and that an explicit `rootDisk: '<path>'`
+// surfaces through to MACHINEN_ROOTDISK in the spawned VMM's env.
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { boot, BootError, ensureRootfsImage, ProvisionError } from "../index.ts";
+
+describe("ensureRootfsImage", () => {
+  it("throws PROVISION_BASE_NOT_FOUND when the tarball is missing", () => {
+    expect(() => ensureRootfsImage("/nope/missing.tar.gz")).toThrow(ProvisionError);
+  });
+
+  it("throws with an install hint when no e2fsprogs binary is on PATH", () => {
+    // We can't reliably make the binary absent on every CI runner, so
+    // instead we drive the function with an empty PATH override. The
+    // `which` lookup walks through `/usr/bin/env which`, which itself
+    // resolves at the shell level — pointing PATH at an empty dir
+    // suffices to make every name unfindable.
+    const tarPath = `/tmp/machinen-rootfs-img-test-${process.pid}.tar.gz`;
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-cache-"));
+    writeFileSync(tarPath, "");
+    const emptyDir = mkdtempSync(join(tmpdir(), "machinen-empty-path-"));
+    const savedPath = process.env.PATH;
+    process.env.PATH = emptyDir;
+    try {
+      // The empty PATH won't find `tar` either, so the implementation
+      // throws either at the missing-tool check or at the tar-extract
+      // step. Both surface as ProvisionError. We just want to know
+      // it doesn't silently succeed.
+      expect(() => ensureRootfsImage(tarPath, { cacheDir })).toThrow(ProvisionError);
+    } finally {
+      if (savedPath !== undefined) {
+        process.env.PATH = savedPath;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(cacheDir, { recursive: true, force: true });
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("returns the cached path when the tarball's sha256 already has an .img", () => {
+    // Build a real (tiny) tarball so sha256ing has something to chew
+    // on, then plant a pre-existing cache file at the matching name.
+    // The function should hit the cache and short-circuit before
+    // reaching the (potentially-missing) mke2fs path.
+    const tarPath = `/tmp/machinen-rootfs-img-cache-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-cache-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-cache-img-"));
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      // Compute sha256 of the tarball matching the implementation.
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const expected = join(cacheDir, `${sha}.img`);
+      writeFileSync(expected, "fake image bytes");
+      const result = ensureRootfsImage(tarPath, { cacheDir });
+      expect(result).toBe(expected);
+      // Cache file untouched.
+      expect(existsSync(expected)).toBe(true);
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+});
+
+describe("boot({ rootDisk })", () => {
+  it("rejects rootDisk: true without an image to materialize from", async () => {
+    await expect(boot({ binary: "/bin/sh", rootDisk: true })).rejects.toThrow(BootError);
+  });
+
+  it("throws when rootDisk path does not exist", async () => {
+    await expect(boot({ binary: "/bin/sh", rootDisk: "/nope/missing-rootfs.img" })).rejects.toThrow(
+      /rootDisk image not found/,
+    );
+  });
+
+  it("passes the resolved rootDisk path as MACHINEN_ROOTDISK to the child", async () => {
+    // Round-trip: spawn /bin/sh with args that print MACHINEN_ROOTDISK,
+    // pass an existing file as `rootDisk`. Doesn't boot a real VMM.
+    const rd = `/tmp/machinen-runtime-rootdisk-${process.pid}`;
+    writeFileSync(rd, "");
+    try {
+      const vm = await boot({
+        binary: "/bin/sh",
+        args: ["-c", "printf 'ROOTDISK=%s\\n' \"$MACHINEN_ROOTDISK\""],
+        rootDisk: rd,
+        timeoutMs: 2_000,
+      });
+      await vm.wait();
+      const out = await vm.output();
+      expect(out.trim()).toBe(`ROOTDISK=${rd}`);
+    } finally {
+      try {
+        unlinkSync(rd);
+      } catch {}
+    }
+  });
+
+  it("forwards MACHINEN_ROOTDISK alongside MACHINEN_DISK when both are set", async () => {
+    const rd = `/tmp/machinen-runtime-rootdisk2-${process.pid}`;
+    const snap = `/tmp/machinen-runtime-snap2-${process.pid}`;
+    writeFileSync(rd, "");
+    writeFileSync(snap, "");
+    try {
+      const vm = await boot({
+        binary: "/bin/sh",
+        args: ["-c", 'printf \'ROOTDISK=%s DISK=%s\\n\' "$MACHINEN_ROOTDISK" "$MACHINEN_DISK"'],
+        rootDisk: rd,
+        snapshot: snap,
+        timeoutMs: 2_000,
+      });
+      await vm.wait();
+      const out = await vm.output();
+      expect(out.trim()).toBe(`ROOTDISK=${rd} DISK=${snap}`);
+    } finally {
+      try {
+        unlinkSync(rd);
+      } catch {}
+      try {
+        unlinkSync(snap);
+      } catch {}
+    }
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -13,6 +13,8 @@ export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
 export type { LogEvent, OnLog } from "./log.ts";
 export { provision, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
+export { ensureRootfsImage, rootfsImgCacheDir } from "./rootfs-img.ts";
+export type { EnsureRootfsImageOptions } from "./rootfs-img.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
 export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";
 export { list, registryRoot } from "./registry.ts";
@@ -99,6 +101,7 @@ import { defaultFuseAgentPath, packBundle as mkinitramfsPackBundle } from "./mki
 import { ensureGvproxy, exposePort, spawnGvproxy, warnGvproxyMissing } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
+import { ensureRootfsImage } from "./rootfs-img.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
 import { serveLiveMount } from "./mount-server.ts";
 import type { OnLog } from "./log.ts";
@@ -179,11 +182,32 @@ export interface BootOptions {
    */
   env?: Record<string, string>;
   /**
-   * Attach this host file as `/dev/vda` inside the guest. Typically a
+   * Attach this host file as the scratch virtio-blk device — `/dev/vdb`
+   * inside the guest when `rootDisk` is also set, or `/dev/vda` when
+   * only this disk is attached (legacy / pre-#114 layout). Typically a
    * CRIU snapshot image produced by `vm.snapshot()`, for a sub-second
    * restore on boot. See #47 (virtio-blk) and #50.
    */
   snapshot?: string;
+  /**
+   * Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
+   * instead of inflating the whole rootfs into a RAM-backed tmpfs via
+   * the initramfs. See #114.
+   *
+   *   - `true` — materialize an ext4 image from `image` (cached under
+   *              `~/.cache/machinen/rootfs/<sha256>.img`) and attach
+   *              it as the rootdisk. The guest's `/init` mounts +
+   *              chroots into it before running the user cmd.
+   *   - `string` — path to a pre-built ext4 `.img` file to attach
+   *                directly. Skips the cache.
+   *   - `false` / unset — legacy initramfs-as-rootfs path. The cpio
+   *                        in `image` becomes the live rootfs in tmpfs.
+   *
+   * Materialization requires `mke2fs` (or `mkfs.ext4`) on PATH. On
+   * macOS run `brew install e2fsprogs`; on Linux it ships in the
+   * `e2fsprogs` package.
+   */
+  rootDisk?: boolean | string;
   /**
    * Optional name to register this VM under (`attach({ name })`
    * lookup key). Path-shaped strings ("worker/9012") are allowed.
@@ -473,6 +497,34 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${diskAbs}`);
     }
     env.MACHINEN_DISK = diskAbs;
+  }
+
+  // #114: optional rootdisk. When set, the guest mounts /dev/vda as
+  // ext4 and chroots into it. The cpio initramfs becomes a tiny
+  // bootloader rather than the entire rootfs, sidestepping the "RAM
+  // scales 8× with rootfs" failure mode of initramfs-as-rootfs.
+  let rootDiskAbs: string | undefined;
+  if (opts.rootDisk) {
+    if (typeof opts.rootDisk === "string") {
+      rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
+      if (!existsSync(rootDiskAbs)) {
+        throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
+      }
+    } else {
+      // rootDisk: true — materialize from `image` if present.
+      if (!opts.image) {
+        throw new BootError(
+          "BOOT_CMD_WITHOUT_IMAGE",
+          "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
+        );
+      }
+      const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
+      if (!existsSync(baseAbs)) {
+        throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
+      }
+      rootDiskAbs = ensureRootfsImage(baseAbs);
+    }
+    env.MACHINEN_ROOTDISK = rootDiskAbs;
   }
   if (opts.kernel) {
     const abs = resolve(opts.cwd ?? process.cwd(), opts.kernel);

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -1,0 +1,241 @@
+// Materialize a `.tar.gz` rootfs into an ext4 `.img` and cache the
+// result, keyed by sha256 of the tarball.
+//
+// Architectural shape (#114):
+//   * Wire format / `provision()` output stays `.tar.gz` — compressible,
+//     deterministic, easy to ship.
+//   * Runtime materializes a per-tarball `.img` on first boot and
+//     re-uses it on subsequent boots. The kernel pages the rootfs in
+//     on demand from the disk instead of inflating the whole tree into
+//     a RAM-backed tmpfs.
+//
+// Cache layout:
+//   ~/.cache/machinen/rootfs/<sha256>.img         ← cached image
+//   ~/.cache/machinen/rootfs/<sha256>.staging/    ← in-progress (atomic
+//                                                  rename on success)
+//
+// Materialization is synchronous and uses the host's `mke2fs -d`
+// (e2fsprogs) to write an ext4 image directly from a staging directory
+// — no privileged loop mount required. On hosts that don't ship the
+// tool the function throws with a clear install hint; the runtime
+// falls back to the legacy initramfs-as-rootfs path in that case.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import debugLib from "debug";
+import { ProvisionError } from "./errors.ts";
+
+const debug = debugLib("machinen:rootfs-img");
+
+/** Default cache root: `~/.cache/machinen/rootfs`. */
+export function rootfsImgCacheDir(): string {
+  return join(homedir(), ".cache", "machinen", "rootfs");
+}
+
+export interface EnsureRootfsImageOptions {
+  /**
+   * Override the cache directory. Default: `~/.cache/machinen/rootfs`.
+   * Useful for tests.
+   */
+  cacheDir?: string;
+  /**
+   * Force re-materialization even if a cached image is already present.
+   * Mostly for debugging the materializer.
+   */
+  force?: boolean;
+  /**
+   * Slack multiplier above the unpacked tarball size when sizing the
+   * ext4 filesystem. Default: 1.4 (40% slack for ext4 metadata + room
+   * for guest writes). Bump if the workload writes a lot post-boot.
+   */
+  sizeMultiplier?: number;
+  /**
+   * Minimum image size in bytes. The materializer enforces at least
+   * this for very small rootfs (where the multiplier alone would leave
+   * insufficient ext4 metadata room). Default: 256 MiB.
+   */
+  minSizeBytes?: number;
+}
+
+/**
+ * Resolve `tarPath` to a cached ext4 `.img`, materializing it on first
+ * call. Returns the absolute path to the cached image.
+ *
+ * Cache key: sha256 of the tarball. Same tarball → same image, even
+ * across runs and processes. Concurrent callers do not race because
+ * we materialize into a uniquely-named staging directory and atomically
+ * rename into place — at worst two callers do redundant work; the
+ * loser of the rename race re-checks and uses the winner's image.
+ *
+ * @throws {ProvisionError} ROOTFS_IMG_TOOL_MISSING |
+ *   ROOTFS_IMG_MATERIALIZE_FAILED | ROOTFS_IMG_TARBALL_NOT_FOUND
+ */
+export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOptions = {}): string {
+  const tarAbs = resolve(tarPath);
+  if (!existsSync(tarAbs)) {
+    throw new ProvisionError(
+      "PROVISION_BASE_NOT_FOUND",
+      `ensureRootfsImage: tarball not found at ${tarAbs}`,
+    );
+  }
+  const cacheDir = opts.cacheDir ?? rootfsImgCacheDir();
+  mkdirSync(cacheDir, { recursive: true });
+
+  const sha = sha256OfFile(tarAbs);
+  const imgPath = join(cacheDir, `${sha}.img`);
+  if (!opts.force && existsSync(imgPath)) {
+    debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
+    return imgPath;
+  }
+
+  // mke2fs -d takes a staging directory and writes an ext4 image. Try
+  // a few names because Linux distros and macOS-via-brew disagree on
+  // which binary ships.
+  const mke2fs = whichFirst(["mke2fs", "mkfs.ext4"]);
+  if (!mke2fs) {
+    throw new ProvisionError(
+      "PROVISION_INSTALL_HOOK_FAILED",
+      "ensureRootfsImage: no e2fsprogs binary on PATH (looked for mke2fs / " +
+        "mkfs.ext4). Install it:\n" +
+        "  • macOS:  brew install e2fsprogs\n" +
+        "  • Linux:  apt-get install -y e2fsprogs (or your distro's package)\n" +
+        "  • or skip virtio-blk root and let boot() use the legacy " +
+        "initramfs-as-rootfs path.",
+    );
+  }
+
+  const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-staging-`));
+  const stagingTree = join(stagingDir, "tree");
+  const stagingImg = join(stagingDir, "rootfs.img");
+  mkdirSync(stagingTree, { recursive: true });
+  try {
+    debug("materialize sha=%s tar=%s", sha.slice(0, 12), tarAbs);
+
+    // 1. Extract the tarball into the staging directory. tar handles
+    //    both gzip and plain.
+    const extract = spawnSync("tar", ["-xf", tarAbs, "-C", stagingTree], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (extract.status !== 0) {
+      throw new ProvisionError(
+        "PROVISION_INSTALL_HOOK_FAILED",
+        `ensureRootfsImage: tar -xf failed (code ${extract.status}): ${extract.stderr?.toString() ?? ""}`,
+      );
+    }
+
+    // 2. Size the image: unpacked tree + slack, with a floor.
+    const treeBytes = duBytes(stagingTree);
+    const multiplier = opts.sizeMultiplier ?? 1.4;
+    const minBytes = opts.minSizeBytes ?? 256 * 1024 * 1024;
+    const sizeBytes = Math.max(minBytes, Math.ceil(treeBytes * multiplier));
+    debug("size tree=%d size=%d multiplier=%s", treeBytes, sizeBytes, multiplier);
+    allocateSparseFile(stagingImg, sizeBytes);
+
+    // 3. mke2fs -d <tree> -t ext4 -F <img> <size-in-blocks>. The 4-KiB
+    //    block size matches the kernel's default page size on arm64
+    //    so reads are page-cache-aligned.
+    const blocks = Math.floor(sizeBytes / 4096);
+    const mk = spawnSync(
+      mke2fs,
+      ["-d", stagingTree, "-t", "ext4", "-F", "-q", "-b", "4096", stagingImg, String(blocks)],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    if (mk.status !== 0) {
+      throw new ProvisionError(
+        "PROVISION_INSTALL_HOOK_FAILED",
+        `ensureRootfsImage: ${mke2fs} failed (code ${mk.status}): ${mk.stderr?.toString() ?? ""}`,
+      );
+    }
+
+    // 4. Atomic rename into the cache. Concurrent materializers can
+    //    race here; the second `rename` clobbers the first, but both
+    //    files have identical content (same sha), so it doesn't
+    //    matter who wins.
+    renameSync(stagingImg, imgPath);
+    debug("materialize done sha=%s img=%s sizeBytes=%d", sha.slice(0, 12), imgPath, sizeBytes);
+    return imgPath;
+  } finally {
+    try {
+      rmSync(stagingDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+function sha256OfFile(path: string): string {
+  // Streaming hash — these tarballs are big (hundreds of MB) and we
+  // call this on every boot in the cache-hit path.
+  const h = createHash("sha256");
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(64 * 1024);
+    while (true) {
+      const nread = readSync(fd, buf, 0, buf.length, null);
+      if (nread <= 0) {
+        break;
+      }
+      h.update(buf.subarray(0, nread));
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return h.digest("hex");
+}
+
+function whichFirst(names: string[]): string | undefined {
+  for (const name of names) {
+    try {
+      const out = execFileSync("/usr/bin/env", ["which", name], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (out) {
+        return out;
+      }
+    } catch {
+      // not on PATH — try the next.
+    }
+  }
+  return undefined;
+}
+
+function duBytes(path: string): number {
+  // `du -sk` returns size-on-disk in 1-KiB blocks. Faster than walking
+  // ourselves and works on both GNU and BSD du.
+  try {
+    const out = execFileSync("du", ["-sk", path], { encoding: "utf8" }).trim();
+    const kib = parseInt(out.split(/\s+/, 1)[0]!, 10);
+    if (Number.isFinite(kib) && kib > 0) {
+      return kib * 1024;
+    }
+  } catch {}
+  // Fallback: stat the directory itself (won't be accurate for trees).
+  return statSync(path).size || 0;
+}
+
+function allocateSparseFile(path: string, sizeBytes: number): void {
+  const fd = openSync(path, "w");
+  try {
+    const buf = Buffer.alloc(1);
+    writeSync(fd, buf, 0, 1, sizeBytes - 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// Visible to tests that want to assert without invoking the real
+// materializer.
+export const _internal = { sha256OfFile, whichFirst };


### PR DESCRIPTION
## Problem

Closes #114.

Today the runtime packs the entire rootfs into the **initramfs** — a cpio archive embedded in the kernel boot data — and the kernel decompresses it into a `tmpfs` mounted at `/`. That tmpfs is the live filesystem for the rest of the VM's life.

This breaks the moment the rootfs grows. With a real workload (Debian + Node + pnpm + a coding agent + 256 npm dependencies) the rootfs is ~1.5 GB unpacked. The kernel needs roughly 2× the rootfs size during boot (the compressed cpio plus the freshly unpacked tmpfs, both alive at the same time), so a 1.5 GB rootfs hits a 4 GB RAM ceiling and the boot fails with `Initramfs unpacking failed: write error`.

The current workaround is a host-side environment variable that bumps the guest's RAM ceiling to compensate, but the formula scales the wrong axis: every byte added to the rootfs costs ~8 bytes of guest RAM, forever.

## Solution

Add an opt-in path that mounts the rootfs from a virtio block device (a real disk) instead of a tmpfs in RAM. The kernel pages the rootfs in on demand instead of inflating the whole thing up front.

This pull request lays the foundation for that path. It does not yet flip the default — the existing initramfs-as-rootfs flow stays the default and is unchanged. Callers opt in via `boot({ rootDisk })`.

1. **Two virtio block slots in the VMM.** The device tree gets a fourth virtio slot, and the macOS hypervisor backend (HVF) wires up two block devices instead of one. With a rootdisk attached the layout is `/dev/vda` = rootfs, `/dev/vdb` = scratch. Without one, the single attached disk lands at `/dev/vda` exactly as before.

2. **Guest `/init` can pivot into the rootdisk.** When `/dev/vda` mounts as ext4 and contains the marker file `/sbin/machinen-supervisor`, the init binary moves the kernel filesystems across, copies the per-boot config files into the new root, and `chroot`s into it before continuing. If `/dev/vda` is missing or doesn't look like a machinen rootfs, init falls through to the existing tmpfs path.

3. **A host-side tarball-to-image helper.** `ensureRootfsImage(tarPath)` builds an ext4 image from a tarball using `mke2fs -d` (no privileged loop mount required) and caches it under `~/.cache/machinen/rootfs/<sha256>.img`. Same tarball, same image, even across processes. The function throws a clear install-hint error when no `mke2fs` binary is on `PATH`.

4. **`boot({ rootDisk })` in the runtime.** Pass `true` to materialize from the existing `image:` tarball, or pass a path to use a pre-built `.img` directly. The runtime forwards the resolved path as `MACHINEN_ROOTDISK` to the VMM. Existing snapshot semantics are unchanged.

5. **CRIU dump / restore scripts learn to find the scratch disk.** They prefer `/dev/vdb` when it exists (the new layout) and fall back to `/dev/vda` (the legacy layout).

### Smoke discoveries (folded into a follow-up commit on this branch)

End-to-end testing on darwin-arm64 surfaced two issues that the unit tests didn't catch. Both are now fixed in `3af0b57`:

- **`virtio_mmio` wasn't loaded before the pivot attempt.** `virtio_blk` alone isn't enough — the bus driver that publishes DTS slots into the virtio framework is also a module on the Debian cloud kernel. Without it loaded, no `/dev/vda` ever appears. Added `virtio_mmio` to the modprobe list in `/init`.
- **`nanosleep` parks the whole guest under HVF.** With a single guest vCPU, sleeping the only userspace task halts the vCPU, and the kernel's deferred-probe workqueue can't make progress. The `/dev/vda` bind kept landing exactly when the wait loop expired (5 s, 10 s — measured both). Swapped the polling loop from `nanosleep` to `sched_yield` so the vCPU stays active; `/dev/vda` now appears in tens of milliseconds.

## Cleanup after merge

This pull request stops short of a few follow-ups so it can land safely:

- The cpio still contains the full base rootfs, so the kernel still pays the unpack cost at boot. Shrinking the cpio to a tiny bootstrap (just `/init`, the per-boot config, and the kernel modules needed to mount `/dev/vda`) requires either a kernel rebuild that makes `virtio_blk` built-in, or shipping `insmod` plus the relevant `.ko` files in the cpio. Both are outside this scope.
- Auto-materialization on plain `boot({ image: '*.tar.gz' })` (without an explicit `rootDisk: true`) is not enabled. Today the user opts in. Flipping the default belongs in the same change that shrinks the cpio.
- The rootdisk is mounted read-write, so guest writes persist across boots from the same `.img`. To match the current "ephemeral" semantics, a follow-up should either copy the cached image per boot (cheap on APFS / btrfs via reflink) or layer a tmpfs over the read-only base via overlayfs.

## Test plan

- [x] `npx vitest run` passes (222 tests, including 7 new ones for `rootDisk` and `ensureRootfsImage`).
- [x] `zig build test` in `packages/microvm` passes.
- [x] `pnpm typecheck` passes.
- [x] `pnpm format:check` passes.
- [x] `pnpm lint` is at the existing baseline (15 errors, 1 warning — all preexisting on `main`, none introduced).
- [x] Smoke test on a real arm64 macOS host: built `release-assets/{Image-arm64,virt-arm64.dtb,rootfs-debian-arm64.tar.gz}` and a codesigned VMM, materialized the rootdisk image (~3.6s, 56 MB tarball → 307 MiB ext4), booted twice:
  - `rootDisk: true` → `init: pivoted into /dev/vda rootfs`, `/proc/mounts` shows `/dev/vda / ext4 rw,relatime`, `BOOT_OK` reached.
  - `rootDisk` unset → `init: rootdisk skip: /dev/vda did not appear`, root stays as the legacy tmpfs (`rootfs / rootfs rw`), `BOOT_OK` reached.
