### PR TITLE
feat(runtime): default boot() to virtio-blk root, opt-out via rootDisk: false

### DIFF
--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -244,6 +244,12 @@ describe("image + cmd", () => {
         binary: "/bin/sh",
         args: ["-c", "true"],
         image: imgPath,
+        // Skip the rootDisk materialize step: this test exercises the
+        // baked-config code path with /bin/sh as a stand-in VMM, so
+        // hashing + mkfs the placeholder tarball would fail (no
+        // e2fsprogs on the test runner) without exercising anything
+        // we actually care about here.
+        rootDisk: false,
         timeoutMs: 3_000,
       });
       await vm.wait();

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -113,6 +113,51 @@ describe("boot({ rootDisk })", () => {
     }
   });
 
+  it("defaults to materializing the image when rootDisk is omitted", async () => {
+    // No explicit rootDisk + an image present → the runtime should
+    // try to materialize. We don't have mke2fs guaranteed on the
+    // runner, so we point image at a missing path and assert we
+    // hit the materialize path (which surfaces the "tarball not
+    // found" error before any e2fsprogs lookup).
+    const missing = `/tmp/machinen-rootdisk-default-missing-${process.pid}.tar.gz`;
+    await expect(
+      boot({
+        binary: "/bin/sh",
+        image: missing,
+        cmd: ["/bin/true"],
+        timeoutMs: 2_000,
+      }),
+    ).rejects.toThrow(/image tarball not found/);
+  });
+
+  it("opts back to the legacy initramfs path on rootDisk: false", async () => {
+    // Same shape as the test above, but with rootDisk: false the
+    // runtime should never call ensureRootfsImage. Confirms the
+    // escape hatch still routes around materialization.
+    const tarPath = `/tmp/machinen-rootdisk-optout-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootdisk-optout-"));
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      const vm = await boot({
+        binary: "/bin/sh",
+        args: ["-c", "printf 'ROOTDISK=%s\\n' \"${MACHINEN_ROOTDISK:-unset}\""],
+        image: tarPath,
+        cmd: ["/bin/true"],
+        rootDisk: false,
+        timeoutMs: 2_000,
+      });
+      await vm.wait();
+      const out = await vm.output();
+      expect(out.trim()).toBe("ROOTDISK=unset");
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("forwards MACHINEN_ROOTDISK alongside MACHINEN_DISK when both are set", async () => {
     const rd = `/tmp/machinen-runtime-rootdisk2-${process.pid}`;
     const snap = `/tmp/machinen-runtime-snap2-${process.pid}`;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -194,18 +194,21 @@ export interface BootOptions {
    * instead of inflating the whole rootfs into a RAM-backed tmpfs via
    * the initramfs. See #114.
    *
-   *   - `true` — materialize an ext4 image from `image` (cached under
-   *              `~/.cache/machinen/rootfs/<sha256>.img`) and attach
-   *              it as the rootdisk. The guest's `/init` mounts +
-   *              chroots into it before running the user cmd.
-   *   - `string` — path to a pre-built ext4 `.img` file to attach
-   *                directly. Skips the cache.
-   *   - `false` / unset — legacy initramfs-as-rootfs path. The cpio
-   *                        in `image` becomes the live rootfs in tmpfs.
+   * Default: `true` whenever `image` is set. The runtime materializes
+   * an ext4 image from `image` (cached at
+   * `~/.cache/machinen/rootfs/<sha256>.img`) and attaches it as the
+   * rootdisk; the guest's `/init` mounts + chroots into it before
+   * running the user cmd. Materialization needs `mke2fs` (or
+   * `mkfs.ext4`) on PATH — `brew install e2fsprogs` on macOS, the
+   * `e2fsprogs` package on Linux.
    *
-   * Materialization requires `mke2fs` (or `mkfs.ext4`) on PATH. On
-   * macOS run `brew install e2fsprogs`; on Linux it ships in the
-   * `e2fsprogs` package.
+   *   - `string` — path to a pre-built ext4 `.img` file to attach
+   *                directly. Skips the materialize step + cache.
+   *   - `false`  — opt out: keep the cpio-as-rootfs path. The whole
+   *                rootfs lands in a tmpfs at boot (RAM scales ~8×
+   *                with rootfs size). Mostly an escape hatch for
+   *                tooling that doesn't need disk-backed semantics
+   *                (e.g. `provision()` itself).
    */
   rootDisk?: boolean | string;
   /**
@@ -499,32 +502,20 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     env.MACHINEN_DISK = diskAbs;
   }
 
-  // #114: optional rootdisk. When set, the guest mounts /dev/vda as
-  // ext4 and chroots into it. The cpio initramfs becomes a tiny
-  // bootloader rather than the entire rootfs, sidestepping the "RAM
-  // scales 8× with rootfs" failure mode of initramfs-as-rootfs.
-  let rootDiskAbs: string | undefined;
-  if (opts.rootDisk) {
-    if (typeof opts.rootDisk === "string") {
-      rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
-      if (!existsSync(rootDiskAbs)) {
-        throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
-      }
-    } else {
-      // rootDisk: true — materialize from `image` if present.
-      if (!opts.image) {
-        throw new BootError(
-          "BOOT_CMD_WITHOUT_IMAGE",
-          "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
-        );
-      }
-      const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
-      if (!existsSync(baseAbs)) {
-        throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
-      }
-      rootDiskAbs = ensureRootfsImage(baseAbs);
-    }
-    env.MACHINEN_ROOTDISK = rootDiskAbs;
+  // #114: rootdisk-by-default. Boot mounts the rootfs from a
+  // virtio-blk device (/dev/vda) instead of inflating the whole tree
+  // into a RAM-backed tmpfs at boot. The user passes `rootDisk: false`
+  // to opt back into the legacy cpio-as-rootfs path (mostly used by
+  // `provision()` itself, which writes its scratch tar to /dev/vda).
+  // Resolution + materialization happens later, alongside packBundle,
+  // so per-arg validation (mount paths, liveMount, baked-cmd) fires
+  // before we spend time hashing the tarball.
+  const wantsRootDisk = opts.rootDisk !== false && (opts.rootDisk !== undefined || !!opts.image);
+  if (wantsRootDisk && typeof opts.rootDisk !== "string" && !opts.image) {
+    throw new BootError(
+      "BOOT_CMD_WITHOUT_IMAGE",
+      "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
+    );
   }
   if (opts.kernel) {
     const abs = resolve(opts.cwd ?? process.cwd(), opts.kernel);
@@ -659,6 +650,23 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       bundleTempDir = packed.tempDir;
       env.MACHINEN_INITRD = packed.cpioPath;
       debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, Date.now() - packT0);
+    }
+
+    // #114: rootDisk materialization. After all input validation has
+    // passed (so a bad mount path or missing image fails before we
+    // hash a multi-GB tarball). On a cache hit this is a few ms.
+    if (wantsRootDisk) {
+      let rootDiskAbs: string;
+      if (typeof opts.rootDisk === "string") {
+        rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
+        if (!existsSync(rootDiskAbs)) {
+          throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
+        }
+      } else {
+        const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
+        rootDiskAbs = ensureRootfsImage(baseAbs);
+      }
+      env.MACHINEN_ROOTDISK = rootDiskAbs;
     }
   } catch (err) {
     for (const stop of liveMountStops) {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -278,6 +278,12 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       cmd: ["/exec-agent"],
       env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
       snapshot: diskPath,
+      // Opt out of the disk-backed boot path: the post-install
+      // `tar / -cf /dev/vda` below writes the captured rootfs onto
+      // the snapshot disk (which is /dev/vda when no rootdisk is
+      // attached). Promoting provision() to virtio-blk root would
+      // need a /dev/vdb-aware tar dump and is tracked separately.
+      rootDisk: false,
       // We drive the guest to exit via /sbin/machinen-poweroff at the
       // end; wait() has its own ceiling below.
       timeoutMs: null,


### PR DESCRIPTION
## Problem

#118 added `boot({ rootDisk: true })` as an opt-in path that mounts the rootfs from a virtio block device instead of a RAM-backed tmpfs. Without the opt-in, a 1.5 GB rootfs still hits the 4 GB guest RAM ceiling at boot.

We don't have external users yet, so the right move is to flip the default now and force the new path through real use, rather than carry both indefinitely.

## Solution

Flip the default. `boot({ image })` with no explicit `rootDisk` field now uses the disk-backed path:

1. **Default → disk-backed.** `boot({ image })` materializes an ext4 image from the tarball (cached at `~/.cache/machinen/rootfs/<sha>.img`) and attaches it as `/dev/vda`. Guest `/init` chroots into it before running the user cmd.
2. **`rootDisk: '<path>'`** still accepts a pre-built `.img` directly, skipping the materializer.
3. **`rootDisk: false`** is the new opt-out for the legacy initramfs-as-rootfs path. `provision()` uses this so its post-install `tar / -cf /dev/vda` keeps writing to the snapshot disk; the rest of the codebase is on the new default.

## Related change (already applied)

- Materialization moved to after `packBundle` inside `boot()`'s try block. Per-arg validation (mount path, liveMount path, baked cmd) now fires before we spend time hashing a multi-GB tarball.

## Test plan

- [x] `npx vitest run` passes — 224 tests (up from 222: 2 new ones for the default-on behavior and the `rootDisk: false` opt-out).
- [x] `pnpm typecheck` clean.
- [x] `pnpm format:check` clean.
- [x] `pnpm lint` at the existing baseline (15 errors, 1 warning — preexisting on `main`).
- [x] Smoke on darwin-arm64 against a freshly built kernel + rootfs:
  - `boot({ image })` → `init: pivoted into /dev/vda rootfs`, root mount is `/dev/vda` ext4, `BOOT_OK` reached.
  - `boot({ image, rootDisk: false })` → `init: rootdisk skip`, root stays as the legacy `rootfs` tmpfs, `BOOT_OK` reached.

Ref #114, follows up #118, closes #122 (on-by-default half).
