### PR TITLE
fix(microvm): carry /mnt across rootdisk pivot in /init (#125)

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -48,10 +48,28 @@ extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
 extern "c" fn _exit(status: c_int) noreturn;
 extern "c" fn clock_settime(clk_id: c_int, tp: *const timespec) c_int;
 extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
+extern "c" fn opendir(path: [*:0]const u8) ?*anyopaque;
+extern "c" fn closedir(dirp: *anyopaque) c_int;
+extern "c" fn readdir(dirp: *anyopaque) ?*Dirent;
+extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsize: usize) isize;
+extern "c" fn symlink(target: [*:0]const u8, linkpath: [*:0]const u8) c_int;
 
 const CLOCK_REALTIME: c_int = 0;
 
 const timespec = extern struct { tv_sec: i64, tv_nsec: i64 };
+
+// musl dirent layout. d_type + d_name are the only fields we touch.
+const Dirent = extern struct {
+    d_ino: u64,
+    d_off: i64,
+    d_reclen: u16,
+    d_type: u8,
+    d_name: [256]u8,
+};
+
+const DT_DIR: u8 = 4;
+const DT_REG: u8 = 8;
+const DT_LNK: u8 = 10;
 
 const O_RDONLY: c_int = 0;
 const O_RDWR: c_int = 2;
@@ -514,6 +532,13 @@ fn tryRootDiskPivot() bool {
     copyFileBest("/machinen-config.json", "/newroot/machinen-config.json");
     copyFileBest("/etc/machinen-boot-epoch", "/newroot/etc/machinen-boot-epoch");
 
+    // #125: carry the user's `mount: { host, guest }` payload across
+    // the pivot. mkinitramfs.ts overlays it under /mnt/<guest>/ in
+    // the cpio; without this copy it would be stranded on the
+    // discarded initramfs tmpfs after the chroot below. No-op when
+    // the user didn't pass a mount.
+    copyTreeBest("/mnt", "/newroot/mnt");
+
     if (chroot(NEWROOT) != 0) {
         // chroot can't really fail at PID 1 with valid args, but if it
         // does we'd be in a half-broken state. Best-effort fall-through.
@@ -558,6 +583,56 @@ fn copyFileBest(src: [*:0]const u8, dst: [*:0]const u8) void {
             const w = write(out_fd, buf[off..].ptr, total - off);
             if (w <= 0) return;
             off += @intCast(w);
+        }
+    }
+}
+
+// Best-effort recursive `cp -a` of the `src` directory into `dst`.
+// Used to bring the `mount: { host, guest }` payload (overlaid into
+// the initramfs at /mnt/<guest>/ by mkinitramfs.ts) across the
+// rootdisk pivot — the chroot to /newroot would otherwise strand it
+// on the discarded initramfs tmpfs. See #125.
+//
+// Failures are silent on a per-entry basis: a missing source dir, a
+// symlink whose target overruns PATH_MAX, or a single-file copy
+// failure does not abort the walk. The caller takes the resulting
+// "best-effort partial" mount as-is, mirroring copyFileBest's policy
+// for the per-boot ephemera the pivot also carries across.
+fn copyTreeBest(src: [*:0]const u8, dst: [*:0]const u8) void {
+    if (access(src, F_OK) != 0) return;
+    mkdirIgnore(dst);
+    const dir = opendir(src) orelse return;
+    defer _ = closedir(dir);
+
+    const src_str = std.mem.span(src);
+    const dst_str = std.mem.span(dst);
+
+    while (readdir(dir)) |ent| {
+        const name_ptr: [*:0]const u8 = @ptrCast(&ent.d_name);
+        const name = std.mem.span(name_ptr);
+        if (name.len == 0) continue;
+        if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) continue;
+
+        // PATH_MAX on Linux is 4096; cap each path here regardless of
+        // the initial src/dst length. bufPrintZ failure means the
+        // path overruns, which we silently skip.
+        var src_buf: [4096]u8 = undefined;
+        var dst_buf: [4096]u8 = undefined;
+        const src_path = std.fmt.bufPrintZ(&src_buf, "{s}/{s}", .{ src_str, name }) catch continue;
+        const dst_path = std.fmt.bufPrintZ(&dst_buf, "{s}/{s}", .{ dst_str, name }) catch continue;
+
+        switch (ent.d_type) {
+            DT_DIR => copyTreeBest(src_path.ptr, dst_path.ptr),
+            DT_REG => copyFileBest(src_path.ptr, dst_path.ptr),
+            DT_LNK => {
+                var tgt_buf: [4096]u8 = undefined;
+                const n = readlink(src_path.ptr, &tgt_buf, tgt_buf.len - 1);
+                if (n <= 0) continue;
+                tgt_buf[@intCast(n)] = 0;
+                const tgt_ptr: [*:0]const u8 = @ptrCast(&tgt_buf[0]);
+                _ = symlink(tgt_ptr, dst_path.ptr);
+            },
+            else => {},
         }
     }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -228,6 +228,14 @@ export interface BootOptions {
    * A single host directory copied into the guest at boot. The guest
    * path must live under `/mnt/`. Copy-once semantics: guest writes are
    * discarded when the VM exits. See #64, #78.
+   *
+   * The payload rides through the initramfs cpio (overlaid under
+   * `/mnt/<guest>/` at pack time) and is then carried across the
+   * rootdisk pivot by `/init` into the on-disk rootfs. With
+   * `rootDisk: true` (the default) the mount briefly counts against
+   * the initramfs RAM ceiling at unpack — the same ceiling #114 was
+   * designed to relieve for the rootfs proper. For very large mounts
+   * prefer `liveMount` (FUSE pass-through, no copy). See #125.
    */
   mount?: { host: string; guest: string };
   /**


### PR DESCRIPTION
## Problem

Since #114 / #123 made virtio-blk root the default, `boot({ mount: { host, guest } })` silently has no effect. The mount payload is overlaid into the initramfs cpio at `/mnt/<guest>/`, but `/init` mounts `/dev/vda` and `chroot`s into it — leaving the cpio's `/mnt` stranded on the discarded initramfs tmpfs.

## Solution

In `tryRootDiskPivot`, between the `MS_MOVE` block and the `chroot`, recursively copy `/mnt` from the initramfs root into `/newroot/mnt`. Mirrors the existing `copyFileBest` pattern that already carries `machinen-config.json` and `machinen-boot-epoch` across.

- New `copyTreeBest(src, dst)` helper — best-effort `cp -a` over libc `opendir` / `readdir` / `readlink` / `symlink`, silent per-entry failure (same policy as `copyFileBest`).
- One call site in `tryRootDiskPivot`. No-op when the user didn't pass a mount.
- `BootOptions.mount` JSDoc updated to mention the rootDisk interaction and the brief initramfs RAM cost (which #114 was specifically designed to avoid for the rootfs proper; for very large mounts users should prefer `liveMount`).

Closes #125.

## Test plan

- [x] `pnpm test` — 224/224 passed (existing `mkinitramfs.test.ts` "packBundle mount" suite still covers the cpio-overlay side).
- [x] `pnpm run format:check`, `pnpm run lint`, `pnpm typecheck` all pass locally.
- [x] Rebuilt `test-fixtures/init`; verified `/newroot/mnt` is in the binary.
- [x] Manual smoke: boot with `rootDisk: true` + `mount: { host, guest: "/mnt/workspace" }` and confirm `ls /mnt/workspace` inside the guest shows the host's files.

> Note: `npx @redwoodjs/agent-ci run --quiet --all --pause-on-failure` is blocked locally on `Cannot find module '/home/runner/_work/machinen/machinen/node_modules/oxfmt/bin/oxfmt'` — the runner's `node_modules/oxfmt/bin/oxfmt` is missing while local `pnpm run format:check` passes. This branch only changes `init.zig` and `index.ts` (no package.json / lockfile changes), so it looks like an oxfmt hydration glitch in the runner's pnpm install rather than something in this diff.
