### PR TITLE
fix(runtime): probe Homebrew keg-only e2fsprogs prefix on macOS

### DIFF
--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { boot, BootError, ensureRootfsImage, ProvisionError } from "../index.ts";
+import { _internal } from "../rootfs-img.ts";
 
 describe("ensureRootfsImage", () => {
   it("throws PROVISION_BASE_NOT_FOUND when the tarball is missing", () => {
@@ -48,6 +49,31 @@ describe("ensureRootfsImage", () => {
       rmSync(emptyDir, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("findKegOnlyE2fs returns the absolute path when the binary lives in a keg-only prefix", () => {
+    // Simulates Homebrew's keg-only e2fsprogs install on macOS (#124),
+    // where `mke2fs` is on disk but not on PATH. The function should
+    // probe the supplied dirs and return the first match.
+    const dir = mkdtempSync(join(tmpdir(), "machinen-kegonly-"));
+    const fake = join(dir, "mke2fs");
+    writeFileSync(fake, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    try {
+      const found = _internal.findKegOnlyE2fs(["mke2fs", "mkfs.ext4"], [dir]);
+      expect(found).toBe(fake);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("findKegOnlyE2fs returns undefined when no candidate exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-kegonly-empty-"));
+    try {
+      const found = _internal.findKegOnlyE2fs(["mke2fs", "mkfs.ext4"], [dir]);
+      expect(found).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   it("returns the cached path when the tarball's sha256 already has an .img", () => {
     // Build a real (tiny) tarball so sha256ing has something to chew

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -104,14 +104,20 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
 
   // mke2fs -d takes a staging directory and writes an ext4 image. Try
   // a few names because Linux distros and macOS-via-brew disagree on
-  // which binary ships.
-  const mke2fs = whichFirst(["mke2fs", "mkfs.ext4"]);
+  // which binary ships. On macOS Homebrew installs e2fsprogs keg-only
+  // (its mkfs.ext4 / mke2fs would shadow the BSD newfs_* family), so
+  // fall back to the well-known brew prefix when PATH lookup fails.
+  const names = ["mke2fs", "mkfs.ext4"];
+  const mke2fs = whichFirst(names) ?? findKegOnlyE2fs(names);
   if (!mke2fs) {
     throw new ProvisionError(
       "PROVISION_INSTALL_HOOK_FAILED",
-      "ensureRootfsImage: no e2fsprogs binary on PATH (looked for mke2fs / " +
-        "mkfs.ext4). Install it:\n" +
+      "ensureRootfsImage: no e2fsprogs binary found (looked for mke2fs / " +
+        "mkfs.ext4 on PATH and in Homebrew's keg-only prefix). Install it:\n" +
         "  • macOS:  brew install e2fsprogs\n" +
+        "            (e2fsprogs is keg-only on Homebrew; machinen also " +
+        "probes /opt/homebrew/opt/e2fsprogs/sbin and " +
+        "/usr/local/opt/e2fsprogs/sbin automatically)\n" +
         "  • Linux:  apt-get install -y e2fsprogs (or your distro's package)\n" +
         "  • or skip virtio-blk root and let boot() use the legacy " +
         "initramfs-as-rootfs path.",
@@ -212,6 +218,30 @@ function whichFirst(names: string[]): string | undefined {
   return undefined;
 }
 
+// Homebrew installs e2fsprogs keg-only because mkfs.ext4 / mke2fs would
+// shadow the BSD newfs_* family. The binaries land here instead of on
+// PATH, so users who run the recommended `brew install` see "not found"
+// errors anyway. Probe these prefixes directly so the install Just Works.
+const KEG_ONLY_E2FS_DIRS = [
+  "/opt/homebrew/opt/e2fsprogs/sbin", // Apple Silicon
+  "/usr/local/opt/e2fsprogs/sbin", // Intel
+];
+
+function findKegOnlyE2fs(
+  names: string[],
+  dirs: readonly string[] = KEG_ONLY_E2FS_DIRS,
+): string | undefined {
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
 function duBytes(path: string): number {
   // `du -sk` returns size-on-disk in 1-KiB blocks. Faster than walking
   // ourselves and works on both GNU and BSD du.
@@ -238,4 +268,4 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
 
 // Visible to tests that want to assert without invoking the real
 // materializer.
-export const _internal = { sha256OfFile, whichFirst };
+export const _internal = { sha256OfFile, whichFirst, findKegOnlyE2fs };


### PR DESCRIPTION
## Problem

On a fresh macOS machine, the very first `boot()` call fails with a "no e2fsprogs binary on PATH" error and tells the user to run `brew install e2fsprogs`. The user runs it, and the next `boot()` fails with the same error. Confusing, and easy to spend twenty minutes on.

The catch: Homebrew installs e2fsprogs as "keg-only," meaning it deliberately skips creating the usual shortcut into `/opt/homebrew/bin/`. It does this because the tool's commands (`mke2fs`, `mkfs.ext4`) would clash with macOS's own filesystem tools. The binaries do exist after the install — they just live at `/opt/homebrew/opt/e2fsprogs/sbin/` (Apple Silicon) or `/usr/local/opt/e2fsprogs/sbin/` (Intel), where the shell can't find them by name.

Reported and reproduced in #124.

## Solution

1. After looking for `mke2fs` / `mkfs.ext4` the normal way and coming up empty, also check the two well-known Homebrew install paths directly. If the binary is there, use it. The user's `brew install` now Just Works on the next boot.
2. Reword the install hint shown when even those paths come up empty, so it explicitly mentions the keg-only quirk and tells the reader where the runtime already looked. Anyone who somehow lands on a non-standard install will know what to try next.

## Test plan

- [x] New unit tests cover the helper finding the binary in a keg-only path and returning nothing when it isn't there.
- [x] Full unit suite runs (one unrelated test file fails on a clean checkout too — it's a pre-existing build-order issue, not caused by this change).
- [x] Local CI workflows pass (`agent-ci run --all`).
