### PR TITLE
fix(runtime): fsck cached rootfs .img on reuse (#134)

### DIFF
--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -8,11 +8,21 @@
 // surfaces through to MACHINEN_ROOTDISK in the spawned VMM's env.
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+  closeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { boot, BootError, ensureRootfsImage, ProvisionError } from "../index.ts";
+import { _internal } from "../rootfs-img.ts";
 
 describe("ensureRootfsImage", () => {
   it("throws PROVISION_BASE_NOT_FOUND when the tarball is missing", () => {
@@ -48,6 +58,58 @@ describe("ensureRootfsImage", () => {
       rmSync(emptyDir, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("looksLikeExt4 rejects files without the superblock magic", () => {
+    // The cache-trust escape hatch: anything that doesn't sniff as ext4
+    // is handed back as-is (test stubs, pre-baked non-ext4 images, etc.).
+    const stub = `/tmp/machinen-rootfs-img-magic-${process.pid}`;
+    writeFileSync(stub, "not an ext4 image, just bytes");
+    try {
+      expect(_internal.looksLikeExt4(stub)).toBe(false);
+    } finally {
+      try {
+        unlinkSync(stub);
+      } catch {}
+    }
+  });
+
+  it("looksLikeExt4 detects the 0xEF53 superblock magic at offset 1080", () => {
+    // Plant the two magic bytes at the right offset (inside what would
+    // be the ext4 superblock); everything else can be zeros. We don't
+    // need a complete superblock — only the sniff has to succeed.
+    const stub = `/tmp/machinen-rootfs-img-magic-yes-${process.pid}`;
+    const fd = openSync(stub, "w");
+    try {
+      const zeroPad = Buffer.alloc(1080);
+      writeSync(fd, zeroPad, 0, zeroPad.length, 0);
+      const magic = Buffer.from([0x53, 0xef]); // little-endian 0xEF53
+      writeSync(fd, magic, 0, magic.length, 1080);
+    } finally {
+      closeSync(fd);
+    }
+    try {
+      expect(_internal.looksLikeExt4(stub)).toBe(true);
+    } finally {
+      try {
+        unlinkSync(stub);
+      } catch {}
+    }
+  });
+
+  it("cachedImageIsUsable trusts non-ext4 cache hits without invoking e2fsck", () => {
+    // A planted cache file with stub bytes should be returned as-is —
+    // matches the existing "returns the cached path" test below, just
+    // exercises the helper directly so the contract is pinned down.
+    const stub = `/tmp/machinen-rootfs-img-trust-${process.pid}`;
+    writeFileSync(stub, "fake image bytes");
+    try {
+      expect(_internal.cachedImageIsUsable(stub)).toBe(true);
+    } finally {
+      try {
+        unlinkSync(stub);
+      } catch {}
+    }
+  });
 
   it("returns the cached path when the tarball's sha256 already has an .img", () => {
     // Build a real (tiny) tarball so sha256ing has something to chew

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -19,6 +19,17 @@
 // — no privileged loop mount required. On hosts that don't ship the
 // tool the function throws with a clear install hint; the runtime
 // falls back to the legacy initramfs-as-rootfs path in that case.
+//
+// Cache-hit safety (#134): the cached `.img` is the same file the
+// guest writes to via virtio-blk. If the previous VMM died mid-write
+// (kill -9, host crash, panic), the ext4 journal is left half-applied
+// and the next mount fails with "JBD2: Invalid checksum recovering
+// data block … / EXT4-fs (vda): error loading journal". Without
+// intervention every future boot of the same image hits the same
+// broken file. Before returning a cache-hit path we run `e2fsck -fy`
+// so any unreplayable journal / orphaned-inode state gets fixed (or,
+// if it can't be fixed, the file is wiped and rematerialized from
+// the tarball).
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -32,6 +43,7 @@ import {
   renameSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -99,7 +111,15 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   const imgPath = join(cacheDir, `${sha}.img`);
   if (!opts.force && existsSync(imgPath)) {
     debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
-    return imgPath;
+    if (cachedImageIsUsable(imgPath)) {
+      return imgPath;
+    }
+    // Unrecoverable. Wipe and fall through to materialize a fresh image
+    // from the tarball — same path a force=true caller would take.
+    debug("cache hit unusable, wiping img=%s", imgPath);
+    try {
+      unlinkSync(imgPath);
+    } catch {}
   }
 
   // mke2fs -d takes a staging directory and writes an ext4 image. Try
@@ -175,6 +195,78 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   }
 }
 
+// Decide whether a cache-hit `.img` is safe to hand back to virtio-blk.
+//
+// `e2fsck -fy <img>` does the heavy lifting: replays the journal, fixes
+// orphaned inodes / cross-linked blocks, and exits 0 (clean) or 1/2
+// (errors corrected, no manual intervention required) when the image
+// is recoverable. Any other exit code (4 = uncorrected errors,
+// 8 = operational error, …) means the image is unusable; the caller
+// wipes it and rematerializes from the tarball.
+//
+// Pre-flights:
+//   * Skip when the file doesn't carry the ext4 superblock magic.
+//     Lets test fixtures plant arbitrary bytes at the cache path
+//     without tripping fsck, and matches the legacy behavior of
+//     trusting whatever's in the cache for non-ext4 layouts.
+//   * Skip when no `e2fsck` is on PATH. Cache hits historically didn't
+//     require e2fsprogs (you could pre-bake a `.img` and drop it in);
+//     we don't want to regress that. Hosts that DO ship e2fsprogs get
+//     the corruption recovery for free.
+function cachedImageIsUsable(imgPath: string): boolean {
+  if (!looksLikeExt4(imgPath)) {
+    return true;
+  }
+  const e2fsck = whichFirst(["e2fsck"]);
+  if (!e2fsck) {
+    debug("no e2fsck on PATH; trusting cached img=%s", imgPath);
+    return true;
+  }
+  // -f forces a full check even when the superblock is marked clean
+  // (a half-applied journal is invisible to the cleanliness flag).
+  // -y answers yes to every prompt so the call is non-interactive.
+  const r = spawnSync(e2fsck, ["-fy", imgPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  // Exit codes per e2fsck(8): 0 = no errors, 1 = errors corrected,
+  // 2 = errors corrected (reboot suggested — host kernel doesn't care).
+  // Anything else = unusable.
+  if (r.status === 0 || r.status === 1 || r.status === 2) {
+    return true;
+  }
+  debug(
+    "e2fsck rejected img=%s status=%s stderr=%s",
+    imgPath,
+    r.status,
+    r.stderr?.toString().slice(0, 200) ?? "",
+  );
+  return false;
+}
+
+// Sniff the ext4 superblock magic at offset 1080 (1024-byte superblock
+// offset + 0x38 byte offset of `s_magic` inside it). Cheap to do and
+// avoids a fork+exec for files that obviously aren't ext4.
+function looksLikeExt4(path: string): boolean {
+  let fd = -1;
+  try {
+    fd = openSync(path, "r");
+    const buf = Buffer.alloc(2);
+    const nread = readSync(fd, buf, 0, 2, 1080);
+    if (nread !== 2) {
+      return false;
+    }
+    return buf.readUInt16LE(0) === 0xef53;
+  } catch {
+    return false;
+  } finally {
+    if (fd >= 0) {
+      try {
+        closeSync(fd);
+      } catch {}
+    }
+  }
+}
+
 function sha256OfFile(path: string): string {
   // Streaming hash — these tarballs are big (hundreds of MB) and we
   // call this on every boot in the cache-hit path.
@@ -238,4 +330,4 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
 
 // Visible to tests that want to assert without invoking the real
 // materializer.
-export const _internal = { sha256OfFile, whichFirst };
+export const _internal = { sha256OfFile, whichFirst, cachedImageIsUsable, looksLikeExt4 };


### PR DESCRIPTION
## Summary

- Closes #134 (option A — the safety net).
- On cache hit, `ensureRootfsImage()` now sniffs the ext4 superblock magic at offset 1080. If present, it runs `e2fsck -fy <img>`. Exit codes 0/1/2 → reuse. Anything else → wipe and rematerialize from the tarball.
- Hosts without `e2fsck` on PATH keep today's behavior (trust the cache). Pre-baked non-ext4 images that don't carry the magic byte are also left untouched.
- Architectural fix (B — CoW per boot via `clonefile()`/reflink) is left for a follow-up. Landing (A) first means corruption stops being sticky regardless of when (B) merges.

## Why this matters

Today, after a `kill -9` of the VMM mid-write, the cached `<sha>.img` is left with a half-applied journal. Every subsequent `boot()` of the same image hits the same broken file → `JBD2: Invalid checksum recovering data block …` → mount fails → fall-through to the tiny initramfs without `/sbin/machinen-supervisor` → `ENOENT` on `execve`. From the user's perspective: "my VM crashed, now I can't boot a new one."

## Test plan

- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 17 suites / 239 tests pass (236 prior + 3 new for `looksLikeExt4` / `cachedImageIsUsable`).
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass.
- [ ] Reviewer: simulate corruption by `kill -9`'ing a running VMM mid-write; next `boot()` should succeed without manually wiping `~/.cache/machinen/rootfs/`.
