### PR TITLE
fix(microvm): refresh test-fixtures /init + drop built-in modules (#129)

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -212,13 +212,19 @@ fn bringUpNetwork() void {
 // Load every kernel module the boot path needs by finit_module(2)'ing
 // the .ko files staged at /modules/*.ko in the cpio. Order matters:
 // virtio + virtio_ring expose the symbols virtio_mmio binds against,
-// jbd2 + mbcache are deps of ext4, failover is a dep of net_failover,
-// and the vsock transports layer on the vsock core.
+// failover is a dep of net_failover, and the vsock transports layer
+// on the vsock core.
 //
 // The list is duplicated against scripts/build-base-assets.sh; if you
 // add or remove a .ko there you have to update it here too. We chose
 // a fixed list rather than walking /modules/ alphabetically because
 // load order is load-bearing and `ls`-order isn't load-order.
+//
+// ext4 / mbcache / jbd2 used to be in this list; they are CONFIG_*=y
+// in the Debian cloud arm64 kernel (built-in, not modules), so the
+// .ko files don't exist in modules-arm64.tar.gz. loadModule is a
+// silent no-op when the .ko is missing, but listing them anyway is
+// noise — the rootdisk pivot's ext4 mount works regardless. See #129.
 //
 // Per-module failure is logged and skipped — a missing virtio_net hurts
 // networking but not the rootdisk pivot, and we'd rather boot degraded
@@ -230,9 +236,6 @@ fn loadPlumbingModules() void {
         "virtio_ring",
         "virtio_mmio",
         "virtio_blk",
-        "mbcache",
-        "jbd2",
-        "ext4",
         "failover",
         "net_failover",
         "virtio_net",

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -92,6 +92,17 @@ zig cc "${ASSETS}/machinen-netup.c" \
   -Os \
   -o "${STAGE}/machinen-netup"
 
+# Refresh the in-tree /init that mkinitramfs.packTinyBundle() reads via
+# defaultInitPath() (packages/runtime/src/mkinitramfs.ts). Without this,
+# every user-facing boot() ships the binary that was checked in last,
+# regardless of how often you rerun this script — release-assets gets
+# the new /init, the tiny initramfs path keeps using the stale one,
+# and rootDisk: true boots silently regress. See issue #129.
+TEST_FIXTURES="${ROOT}/packages/microvm/test-fixtures"
+mkdir -p "${TEST_FIXTURES}"
+install -m 0755 "${STAGE}/init"        "${TEST_FIXTURES}/init"
+install -m 0755 "${STAGE}/exec-agent"  "${TEST_FIXTURES}/exec-agent"
+
 # ------------------------------------------------------------
 # 3a. fnm — Node version manager (#88)
 # ------------------------------------------------------------
@@ -262,7 +273,6 @@ for m in \
   netlink_diag unix_diag inet_diag tcp_diag udp_diag af_packet_diag \
   libcrc32c nfnetlink nf_tables \
   vsock vmw_vsock_virtio_transport vmw_vsock_virtio_transport_common vsock_diag \
-  ext4 mbcache jbd2 \
   fuse
 do
   src=$(find "$KMODS" -type f -name "$m.ko" | head -1)


### PR DESCRIPTION
## Summary

Closes #129 — `rootDisk: true` boots silently dying between `=== reading config ===` and `execve failed` on macOS HVF.

Two pieces, together:

1. **Refresh `packages/microvm/test-fixtures/{init,exec-agent}` from `scripts/build-base-assets.sh`.** `mkinitramfs.packTinyBundle()` reads `/init` from this fixture path via `defaultInitPath()`. Without the install step at the end of the build, every user-facing `boot()` shipped the binary that was checked in last — so changes to `init.zig` only landed in `release-assets` and never in the tiny-cpio path. That's the actual root cause: edits to `/init` looked applied (the file changed, the bytes were on disk in `release-assets`) but the boot path kept using a stale binary.
2. **Drop `ext4`, `mbcache`, `jbd2` from the modules list** in both the build script's `for m in …` loop and `init.zig`'s `loadPlumbingModules`. They're `CONFIG_*=y` in the Debian cloud arm64 kernel — built-in, not modules — so the `.ko` files don't exist in `modules-arm64.tar.gz`, and the build script's `[ -n "$src" ] || exit 1` guard was failing the build on every fresh clone. Built-in `ext4` still mounts `/dev/vda` identically; nothing about the rootdisk pivot relies on the `.ko` path.

## Why this matters

Before this PR, `bash scripts/build-base-assets.sh` failed on every fresh clone (missing `ext4.ko`), and even when the user worked around that by hand, every change they made to `init.zig` silently no-op'd on the `rootDisk: true` path because the tiny-cpio path kept using a stale binary checked into `test-fixtures/`. So #129's user-visible symptom ("silent writes between two known-working log lines") was downstream of "the `/init` running in the VM is not the `/init` you just edited."

The Zig 0.16 inline-asm clobber syntax that #129's repro recipe also calls out has already been fixed in #135 (#136), so this PR doesn't need to touch that.

## Test plan

- [x] `zig build-exe init.zig` for `aarch64-linux-musl` (clean, ~127 KB ELF).
- [x] `bash -n scripts/build-base-assets.sh` (syntax OK).
- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 17 suites / 239 tests pass.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass.
- [ ] Reviewer: full-cycle build, then `MACHINEN_ASSETS_DIR=$PWD/release-assets node packages/cli/dist/cli.js boot -- /bin/sh -c 'echo BOOT-OK; exit 0'` should print `BOOT-OK` and exit cleanly on macOS HVF (the original repro from the issue).
