### PR TITLE
fix(cli,microvm): clarify attach semantics + fix bash -i under supervisor (#132)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -486,7 +486,12 @@ async function cmdAttach(args: string[]): Promise<number> {
   const target = parseTargetFlags(args, "attach");
   const vm = await attach(target).catch(handleError);
   process.stderr.write(`attached to ${vm.name ?? `pid ${vm.pid}`}\n`);
-  process.stderr.write(`type commands; Ctrl-D to detach.\n`);
+  process.stderr.write(
+    `each line is a fresh one-shot exec — cd / env vars / history do NOT persist.\n` +
+      `for a real interactive shell open another terminal and run:\n` +
+      `  machinen exec ${vm.name ? `--name ${vm.name}` : `--pid ${vm.pid}`} -- bash -i\n` +
+      `Ctrl-D to detach.\n`,
+  );
   try {
     const { createInterface } = await import("node:readline");
     const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
@@ -701,9 +706,17 @@ function printHelp(): void {
       `  Targeting a running VM:\n` +
       `    --name <name>     |  --pid <pid>             pick exactly one\n` +
       `\n` +
-      `  machinen exec     <target-flag> -- <cmd>       Run a command in a running VM\n` +
+      `  machinen exec     <target-flag> -- <cmd>       Run a command in a running VM.\n` +
+      `                                                 For a real interactive shell from a\n` +
+      `                                                 second terminal, use:\n` +
+      `                                                   machinen exec <target-flag> -- bash -i\n` +
       `  machinen snapshot <target-flag> --out-dir <d>  CRIU-snapshot a running VM into <d>\n` +
-      `  machinen attach   <target-flag>                Line-based shell against a running VM\n` +
+      `  machinen attach   <target-flag>                Per-line REPL: each line you type is\n` +
+      `                                                 a fresh one-shot \`exec\`, not a\n` +
+      `                                                 persistent shell — \`cd\`, env vars,\n` +
+      `                                                 and shell history do NOT carry over\n` +
+      `                                                 between lines. For an actual shell\n` +
+      `                                                 use \`machinen exec ... -- bash -i\`.\n` +
       `\n` +
       `  machinen install                               Pre-fetch the current-tag base assets\n` +
       `    --version <tag>                              Pin to a specific release tag\n` +
@@ -713,7 +726,10 @@ function printHelp(): void {
       `Examples:\n` +
       `  machinen boot --name worker -- node server.js\n` +
       `  machinen ls\n` +
-      `  machinen exec --name worker -- ps aux\n` +
+      `  machinen exec --name worker -- ps aux                # one-off command\n` +
+      `  machinen exec --name worker -- bash -i               # open a new terminal\n` +
+      `                                                       # (independent of the boot\n` +
+      `                                                       # console; bash holds state)\n` +
       `  machinen snapshot --name worker --out-dir ./warm\n` +
       `  machinen restore ./warm\n` +
       `\n` +

--- a/packages/microvm/assets/machinen-supervisor.sh
+++ b/packages/microvm/assets/machinen-supervisor.sh
@@ -34,32 +34,55 @@ set -u
 /exec-agent </dev/null >/dev/null 2>&1 &
 AGENT_PID=$!
 
-# `--session` runs the workload under setsid so CRIU can dump it.
-# Without its own session, the workload inherits the supervisor's,
-# and `criu dump --shell-job` fails with "A session leader of N(N)
-# is outside of its pid namespace" because the session leader
-# (supervisor) lives outside the dump tree. The runtime passes
-# --session when opts.snapshot is set (the VM is going to be
-# dumped); interactive boots skip it so Ctrl-C / job-control still
-# work against the console.
-USE_SETSID=0
+mkdir -p /run 2>/dev/null || true
+
+# `--session` is the legacy "run under setsid" toggle from when CRIU
+# dumps required it but interactive boots didn't. Both modes now go
+# through the same `setsid -c -w` path below — see the rationale block —
+# so the flag is just consumed and discarded for back-compat.
 if [ "${1:-}" = "--session" ]; then
-    USE_SETSID=1
     shift
 fi
 
-if [ "$USE_SETSID" = "1" ]; then
-    /usr/bin/setsid "$@" &
-else
-    "$@" &
-fi
+# Run the workload under `setsid -c -w` with stdio bound to /dev/console:
+#
+#   - `setsid` puts the workload in a brand-new session as leader.
+#     Required for CRIU `--shell-job` to dump cleanly: without it the
+#     session leader (supervisor) lives outside the dump tree and
+#     CRIU bails with "A session leader of N(N) is outside of its
+#     pid namespace".
+#   - `-c` (TIOCSCTTY) claims /dev/console as the new session's
+#     controlling terminal. Without this, backgrounding with `&` puts
+#     the workload in a process group that isn't the foreground of
+#     /dev/console — `/bin/sh -i` reads return EIO (orphaned pgrp),
+#     it prints the prompt once and exits, the supervisor's `wait`
+#     returns, and machinen-poweroff fires before the user types
+#     anything.
+#   - `-w` makes setsid(1) `wait` for the workload after the fork
+#     it has to perform when invoked from a process-group leader (we
+#     are one, courtesy of `&`). Without `-w`, the parent setsid
+#     forks, exits immediately, and `wait "$!"` returns before the
+#     workload starts — orphaning it under PID 1 and dropping the
+#     trap target.
+#   - Explicit </dev/console redirect ensures fd 0 is a tty when
+#     setsid runs (`-c` reads ctty from stdin).
+#
+# The inner `sh -c` writes /run/machinen-workload.pid using its own
+# $$ — which, because it then `exec`s the workload, IS the workload's
+# PID. Doing it here (rather than from the supervisor with $!) is
+# essential: $! points at the parent setsid, which has already exited.
+# That PID is what machinen-dump feeds to `criu dump --tree`, so
+# getting it wrong dumps a dead PID and CRIU bails with exit 32.
+/usr/bin/setsid -c -w sh -c \
+    'printf "%s" "$$" > /run/machinen-workload.pid; exec "$@"' \
+    inner "$@" </dev/console >/dev/console 2>/dev/console &
 PID=$!
-mkdir -p /run 2>/dev/null || true
-printf '%s' "$PID" > /run/machinen-workload.pid 2>/dev/null || true
 
 # Propagate SIGTERM / SIGINT to the workload so host-side vm.kill()
-# and Ctrl-C from the console signal the right process.
-trap 'kill -TERM "$PID" 2>/dev/null; wait "$PID"' TERM INT
+# and Ctrl-C from the console signal the right process. Read the pid
+# from the file rather than $! because $! is the setsid wrapper, not
+# the workload (see comment above).
+trap 'kill -TERM "$(cat /run/machinen-workload.pid 2>/dev/null)" 2>/dev/null; wait "$PID"' TERM INT
 
 wait "$PID"
 


### PR DESCRIPTION
## Summary

Tackles the user-visible part of #132 without doing the rename — that stays open as a follow-up.

1. **CLI help text + attach greeting** now spell out that `machinen attach` is a per-line REPL: each line is a fresh one-shot exec, `cd`/env vars/history do NOT carry over. Both surfaces point at `machinen exec <target> -- bash -i` for an actual interactive shell.

2. **machinen-supervisor.sh** now runs the workload under `setsid -c -w sh -c '... exec "\$@"'` with stdio bound to `/dev/console`. This is what unblocks `bash -i` (and any `-i` shell) as a workload:
   - `-c` (TIOCSCTTY) makes the new session claim `/dev/console` as its controlling terminal. Without it, `&` puts the workload in an orphaned process group on `/dev/console` → `read()` returns EIO → `bash -i` exits immediately → supervisor's `wait` returns → `machinen-poweroff` fires before the user types anything.
   - `-w` makes `setsid(1)` `wait` for the workload after the fork it has to perform when invoked from a process-group leader. Without `-w`, setsid forks + exits before the workload starts, racing the trap.
   - Inner `sh -c` writes `/run/machinen-workload.pid` using its own `$$` — which, post-`exec`, IS the workload's PID. The supervisor's `$!` points at the (already-exited) setsid wrapper, so feeding that to `criu dump --tree` would dump a dead PID and bail with exit 32.
   - Legacy `--session` flag is consumed and discarded for back-compat; both modes go through the same path now.

## What's NOT in this PR

The bigger architectural move from #132 — renaming `attach` → `repl` and making `attach` actually attach (long-running PTY shell) — is left for follow-up. That's the right shape but deserves its own design pass and a CHANGELOG entry. This PR is the band-aid that makes today's `attach` honest and unblocks the recommended workaround (`machinen exec ... -- bash -i`).

## Test plan

- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 17 suites / 239 tests pass.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass.
- [x] `sh -n machinen-supervisor.sh` — syntax OK.
- [ ] Reviewer: `machinen exec --name <vm> -- bash -i` (or boot with `-- bash -i` directly) should drop you at a prompt that doesn't immediately exit; CRIU snapshot of a running VM should still succeed (the `--shell-job` invariant is preserved by the new setsid path).
