### PR TITLE
fix(microvm): remove 5M-exit cap on production boots

### DIFF
--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -31,6 +31,12 @@ pub fn main(init: std.process.Init) !void {
     // Guest console is live-echoed to stderr from inside the boot loop
     // (boot_hvf.zig's PL011 DR-write handler). The result.serial buffer is
     // the same bytes, captured for tests — don't re-emit here.
+    // Production boots end on PSCI SYSTEM_OFF or a fatal exception, not
+    // on a vCPU-exit counter. The 5_000_000 default in boot_{hvf,kvm}.zig
+    // is a test-fixture safety valve — easy to hit during a long-running
+    // interactive shell or a busy server, where it surfaces as a
+    // mysterious `error.RanTooLong` and the VM dies mid-session. Lift
+    // the cap here.
     if (builtin.os.tag == .macos) {
         const disk_path = envOptional("MACHINEN_DISK");
         const rootdisk_path = envOptional("MACHINEN_ROOTDISK");
@@ -41,6 +47,7 @@ pub fn main(init: std.process.Init) !void {
             .rootdisk_path = rootdisk_path,
             .disk_path = disk_path,
             .unbounded_serial = true,
+            .max_exits = std.math.maxInt(usize),
         });
         gpa.free(result.serial);
         std.process.exit(if (result.saw_psci_shutdown) 0 else 1);
@@ -52,6 +59,7 @@ pub fn main(init: std.process.Init) !void {
             .dtb_path = dtb_path,
             .initrd_path = initrd_path,
             .unbounded_serial = true,
+            .max_exits = std.math.maxInt(usize),
         });
         gpa.free(result.serial);
         std.process.exit(if (result.saw_psci_shutdown) 0 else 1);


### PR DESCRIPTION
## Summary

`boot_{hvf,kvm}.zig` default `max_exits` to `5_000_000` — a vCPU-exit counter that's a useful safety valve for test fixtures (the boot loop can't run forever in unit tests) but a footgun for production. Long-running interactive shells, busy servers, and any workload that traps frequently can hit it. When they do, the boot loop returns `error.RanTooLong` and the VM dies mid-session with no prior warning to the host.

This PR lifts the cap on both production paths by passing `.max_exits = std.math.maxInt(usize)` at the call site in `main.zig`. Production boots now end on **PSCI SYSTEM_OFF** or a **fatal exception**, full stop. Test fixtures keep the existing 5M default.

## Why now

Surfaced during dogfooding: a `bash -i` workload accumulates vCPU exits at a rate that hits 5M faster than you'd think (every page fault, every device-MMIO touch counts). The symptom was a session that "just died" after some random duration. Easy fix; it just never made it into a commit.

## Test plan

- [x] `zig build` — clean.
- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 17 suites / 239 tests pass.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass.
- [ ] Reviewer: a long-running interactive shell (`machinen boot -- bash -i` and leave it idle for a while) should no longer die with `error.RanTooLong`.
