### PR TITLE
feat(microvm,runtime,cli): PTY-over-vsock for interactive sessions (#133)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -428,12 +428,26 @@ function formatUptime(ms: number): string {
 }
 
 async function cmdExec(args: string[]): Promise<number> {
-  const dashIdx = args.indexOf("--");
-  if (dashIdx === -1 || dashIdx === args.length - 1) {
-    die("usage: machinen exec ( --name <name> | --pid <pid> ) -- <cmd>");
+  // Pull --tty out before the `--` boundary so it isn't passed to the
+  // workload. Auto-enable when stdin is a TTY and no --tty was passed
+  // explicitly is *not* what we want — `machinen exec --name foo --
+  // ps aux` from a terminal should still be one-shot pipes, otherwise
+  // every output gets line-discipline-translated. Caller opts in.
+  let usePty = false;
+  const filtered: string[] = [];
+  for (const a of args) {
+    if (a === "--tty" || a === "--pty") {
+      usePty = true;
+    } else {
+      filtered.push(a);
+    }
   }
-  const pre = args.slice(0, dashIdx);
-  const cmdArgs = args.slice(dashIdx + 1);
+  const dashIdx = filtered.indexOf("--");
+  if (dashIdx === -1 || dashIdx === filtered.length - 1) {
+    die("usage: machinen exec ( --name <name> | --pid <pid> ) [--tty] -- <cmd>");
+  }
+  const pre = filtered.slice(0, dashIdx);
+  const cmdArgs = filtered.slice(dashIdx + 1);
   const target = parseTargetFlags(pre, "exec");
   const vm = await attach(target).catch(handleError);
   try {
@@ -441,6 +455,9 @@ async function cmdExec(args: string[]): Promise<number> {
     // commands naturally. Users who want raw exec of a single binary
     // can quote it like `machinen exec --name foo -- /bin/ls`.
     const joined = cmdArgs.join(" ");
+    if (usePty) {
+      return await runPtyExec(vm, joined);
+    }
     const res = await vm.execRaw(joined, {
       onStdout: (chunk) => process.stdout.write(chunk),
       onStderr: (chunk) => process.stderr.write(chunk),
@@ -448,6 +465,59 @@ async function cmdExec(args: string[]): Promise<number> {
     return res.exitCode;
   } finally {
     await vm.detach();
+  }
+}
+
+async function runPtyExec(
+  vm: {
+    execPty: (
+      cmd: string,
+      opts: import("@machinen/runtime").VsockExecPtyOptions,
+    ) => import("@machinen/runtime").VsockExecPtyHandle;
+  },
+  cmd: string,
+): Promise<number> {
+  // PTY mode (#133): bidirectional bytes between this terminal and a
+  // guest pseudoterminal. Flip stdin to raw so Ctrl-C, arrows, and
+  // function keys reach the guest as untranslated bytes; restore on
+  // every exit path so the user's shell isn't left in raw mode.
+  if (!process.stdin.isTTY) {
+    die("machinen exec --tty: stdin is not a TTY; pass via terminal or drop --tty");
+  }
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+  const initialCols = stdout.columns ?? 80;
+  const initialRows = stdout.rows ?? 24;
+
+  const wasRaw = stdin.isRaw === true;
+  stdin.setRawMode(true);
+  stdin.resume();
+
+  const handle = vm.execPty(cmd, {
+    cols: initialCols,
+    rows: initialRows,
+    stdin,
+    stdout,
+  });
+
+  const onResize = () => {
+    handle.resize(stdout.columns ?? initialCols, stdout.rows ?? initialRows);
+  };
+  stdout.on("resize", onResize);
+
+  try {
+    const { exitCode } = await handle.result;
+    return exitCode;
+  } finally {
+    stdout.removeListener("resize", onResize);
+    if (!wasRaw) {
+      try {
+        stdin.setRawMode(false);
+      } catch {
+        // Already restored or stream destroyed; ignore.
+      }
+    }
+    // Don't .pause() — the parent process will exit shortly.
   }
 }
 
@@ -488,8 +558,8 @@ async function cmdAttach(args: string[]): Promise<number> {
   process.stderr.write(`attached to ${vm.name ?? `pid ${vm.pid}`}\n`);
   process.stderr.write(
     `each line is a fresh one-shot exec — cd / env vars / history do NOT persist.\n` +
-      `for a real interactive shell open another terminal and run:\n` +
-      `  machinen exec ${vm.name ? `--name ${vm.name}` : `--pid ${vm.pid}`} -- bash -i\n` +
+      `for a real interactive shell with job control + TUI support, open another terminal:\n` +
+      `  machinen exec ${vm.name ? `--name ${vm.name}` : `--pid ${vm.pid}`} --tty -- bash -i\n` +
       `Ctrl-D to detach.\n`,
   );
   try {
@@ -706,10 +776,15 @@ function printHelp(): void {
       `  Targeting a running VM:\n` +
       `    --name <name>     |  --pid <pid>             pick exactly one\n` +
       `\n` +
-      `  machinen exec     <target-flag> -- <cmd>       Run a command in a running VM.\n` +
-      `                                                 For a real interactive shell from a\n` +
-      `                                                 second terminal, use:\n` +
-      `                                                   machinen exec <target-flag> -- bash -i\n` +
+      `  machinen exec     <target-flag> [--tty] -- <cmd>\n` +
+      `                                                 Run a command in a running VM. Pass\n` +
+      `                                                 --tty for a real PTY session — needed\n` +
+      `                                                 for an interactive shell, vim, htop,\n` +
+      `                                                 or anything that wants job control.\n` +
+      `                                                 Without --tty stdio is line-buffered\n` +
+      `                                                 pipes (good for one-shot commands).\n` +
+      `                                                 Example:\n` +
+      `                                                   machinen exec <target-flag> --tty -- bash -i\n` +
       `  machinen snapshot <target-flag> --out-dir <d>  CRIU-snapshot a running VM into <d>\n` +
       `  machinen attach   <target-flag>                Per-line REPL: each line you type is\n` +
       `                                                 a fresh one-shot \`exec\`, not a\n` +
@@ -727,9 +802,8 @@ function printHelp(): void {
       `  machinen boot --name worker -- node server.js\n` +
       `  machinen ls\n` +
       `  machinen exec --name worker -- ps aux                # one-off command\n` +
-      `  machinen exec --name worker -- bash -i               # open a new terminal\n` +
-      `                                                       # (independent of the boot\n` +
-      `                                                       # console; bash holds state)\n` +
+      `  machinen exec --name worker --tty -- bash -i         # interactive shell w/ job control\n` +
+      `  machinen exec --name worker --tty -- vim /etc/passwd # full-screen TUI in a PTY\n` +
       `  machinen snapshot --name worker --out-dir ./warm\n` +
       `  machinen restore ./warm\n` +
       `\n` +

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -50,6 +50,35 @@ extern "c" fn _exit(status: c_int) noreturn;
 extern "c" fn waitpid(pid: pid_t, status: ?*c_int, options: c_int) pid_t;
 extern "c" fn shutdown(fd: c_int, how: c_int) c_int;
 extern "c" fn signal(signum: c_int, handler: usize) usize;
+// PTY plumbing for the PTY opcode (#133).
+//   forkpty(3) — musl ships it in the main libc (no -lutil needed).
+//     Allocates a /dev/ptmx + /dev/pts/N pair, forks, dups the slave
+//     onto the child's stdio, sets it as the child's controlling tty,
+//     and returns the master fd to the parent. Saves us the
+//     posix_openpt/grantpt/unlockpt/ptsname/setsid/TIOCSCTTY dance.
+//   ioctl(2) — used here only for TIOCSWINSZ on resize. Variadic in C
+//     but every call site below passes exactly one trailing arg, so a
+//     fixed three-arg signature is fine for Zig's purposes.
+//   poll(2) — multiplex master fd ↔ vsock client_fd in the parent.
+const winsize = extern struct {
+    ws_row: u16,
+    ws_col: u16,
+    ws_xpixel: u16,
+    ws_ypixel: u16,
+};
+extern "c" fn forkpty(
+    amaster: *c_int,
+    name: ?[*]u8,
+    termp: ?*const anyopaque,
+    winp: ?*const winsize,
+) pid_t;
+extern "c" fn ioctl(fd: c_int, req: c_ulong, arg: *const anyopaque) c_int;
+const pollfd = extern struct {
+    fd: c_int,
+    events: i16,
+    revents: i16,
+};
+extern "c" fn poll(fds: [*]pollfd, nfds: c_uint, timeout: c_int) c_int;
 
 const AF_VSOCK: c_int = 40;
 const SOCK_STREAM: c_int = 1;
@@ -57,6 +86,13 @@ const SHUT_WR: c_int = 1;
 const SIGPIPE: c_int = 13;
 const SIG_IGN: usize = 1;
 const O_CLOEXEC: c_int = 0o02000000;
+// arm64 Linux constants. TIOCSWINSZ is the same on every Linux arch
+// (asm-generic/ioctls.h: 0x5414); poll event bits are too.
+const TIOCSWINSZ: c_ulong = 0x5414;
+const POLLIN: i16 = 0x0001;
+const POLLERR: i16 = 0x0008;
+const POLLHUP: i16 = 0x0010;
+const POLLNVAL: i16 = 0x0020;
 
 // Linux's VSOCK sockaddr layout (linux/vm_sockets.h):
 //   sa_family (u16) + reserved1 (u16) + port (u32) + cid (u32) + zero[4]
@@ -147,6 +183,11 @@ fn readExact(fd: c_int, out: []u8) bool {
 // belong in the file/mount paths.
 const MAX_EXEC2_CMD: usize = 1 * 1024 * 1024;
 
+// Cap on a single PTY `I <n>\n` input frame. Real keystroke bursts are
+// well under 1 KiB; this is a defensive ceiling so a malicious / buggy
+// client can't make us alloc unbounded.
+const MAX_PTY_INPUT: usize = 64 * 1024;
+
 fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void {
     // Make a NUL-terminated copy for the shell.
     const cmd_z = try alloc.dupeZ(u8, cmd);
@@ -196,6 +237,141 @@ fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void
     _ = shutdown(client_fd, SHUT_WR);
 }
 
+// PTY mode (#133). The host opens a session with the workload through
+// a pseudoterminal pair: workload's stdio is the slave, agent owns the
+// master. Bytes flow both ways via I/O frames; window-size updates
+// arrive as R frames. Ctrl-C / Ctrl-Z / EOF go through the PTY line
+// discipline naturally — the kernel translates them to signals on the
+// foreground process group and we don't need a separate signal channel
+// for the MVP.
+//
+// Closing the master fd at the end sends SIGHUP to the workload's
+// session leader, so the child terminates cleanly even when the host
+// disconnects mid-session.
+fn runPtyCommand(
+    client_fd: c_int,
+    cmd: []const u8,
+    cols: u16,
+    rows: u16,
+    alloc: std.mem.Allocator,
+) !void {
+    const cmd_z = try alloc.dupeZ(u8, cmd);
+    defer alloc.free(cmd_z);
+
+    const ws = winsize{
+        .ws_row = rows,
+        .ws_col = cols,
+        .ws_xpixel = 0,
+        .ws_ypixel = 0,
+    };
+
+    var master_fd: c_int = -1;
+    const pid = forkpty(&master_fd, null, null, &ws);
+    if (pid < 0) return error.ForkPtyFailed;
+    if (pid == 0) {
+        // Child: forkpty has already wired the slave onto fd 0/1/2 and
+        // promoted us to session leader with the slave as ctty. Just
+        // exec — no signals to clear, no fds to close.
+        const argv = &[_:null]?[*:0]const u8{ "sh", "-c", cmd_z.ptr, null };
+        const envp = &[_:null]?[*:0]const u8{
+            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            // Default to a sane TERM so curses-based TUIs work
+            // out of the box. The host can override via env in cmd
+            // (e.g. `TERM=xterm-kitty bash -i`) if it knows better.
+            "TERM=xterm-256color",
+            null,
+        };
+        _ = execve("/bin/sh", argv, envp);
+        _exit(127);
+    }
+
+    // Parent. Multiplex master_fd ↔ client_fd via poll. The client
+    // direction reads frames synchronously after poll signals POLLIN —
+    // a partial header would block the master pump until the rest of
+    // the header arrives, which in practice never happens because the
+    // host writes whole frames in one syscall and TCP-over-vsock
+    // doesn't fragment them. If that assumption ever breaks we'd need
+    // a buffered non-blocking parser; for now keep it simple.
+    var fds = [_]pollfd{
+        .{ .fd = master_fd, .events = POLLIN, .revents = 0 },
+        .{ .fd = client_fd, .events = POLLIN, .revents = 0 },
+    };
+    var saw_master_eof = false;
+    pump: while (!saw_master_eof) {
+        fds[0].revents = 0;
+        fds[1].revents = 0;
+        const n = poll(&fds, 2, -1);
+        if (n < 0) {
+            // EINTR is the expected interruption (SIGCHLD, etc.). Loop.
+            continue;
+        }
+
+        if ((fds[0].revents & POLLIN) != 0) {
+            var out_buf: [CHUNK]u8 = undefined;
+            const r = read(master_fd, &out_buf, out_buf.len);
+            if (r > 0) {
+                if (!sendFrame(client_fd, 'O', out_buf[0..@intCast(r)])) break :pump;
+            } else {
+                // EOF on master = the slave was fully closed by the
+                // child (and any descendants that inherited it).
+                // Workload has exited or is about to.
+                saw_master_eof = true;
+            }
+        }
+        if ((fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+            saw_master_eof = true;
+        }
+
+        if ((fds[1].revents & POLLIN) != 0) {
+            var header: [256]u8 = undefined;
+            const hlen = readLine(client_fd, &header) orelse break :pump;
+            const line = header[0..hlen];
+            if (line.len >= 2 and std.mem.startsWith(u8, line, "I ")) {
+                const ilen = std.fmt.parseInt(usize, line[2..], 10) catch break :pump;
+                if (ilen > MAX_PTY_INPUT) {
+                    logErr("exec-agent: PTY I frame too large");
+                    break :pump;
+                }
+                if (ilen > 0) {
+                    var ibuf: [MAX_PTY_INPUT]u8 = undefined;
+                    if (!readExact(client_fd, ibuf[0..ilen])) break :pump;
+                    if (!writeAll(master_fd, ibuf[0..ilen])) break :pump;
+                }
+            } else if (line.len >= 2 and std.mem.startsWith(u8, line, "R ")) {
+                var it = std.mem.tokenizeScalar(u8, line[2..], ' ');
+                const c_str = it.next() orelse break :pump;
+                const r_str = it.next() orelse break :pump;
+                const new_cols = std.fmt.parseInt(u16, c_str, 10) catch continue :pump;
+                const new_rows = std.fmt.parseInt(u16, r_str, 10) catch continue :pump;
+                const new_ws = winsize{
+                    .ws_row = new_rows,
+                    .ws_col = new_cols,
+                    .ws_xpixel = 0,
+                    .ws_ypixel = 0,
+                };
+                _ = ioctl(master_fd, TIOCSWINSZ, &new_ws);
+            } else {
+                // Unknown frame on a PTY connection — bail rather than
+                // get out of sync.
+                logErr("exec-agent: PTY unknown frame");
+                break :pump;
+            }
+        }
+        if ((fds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+            // Host disconnected. Closing master_fd below sends SIGHUP
+            // to the workload's session, so the child exits cleanly.
+            break :pump;
+        }
+    }
+
+    _ = close(master_fd);
+    const code = waitExitStatus(pid);
+    var tail_buf: [32]u8 = undefined;
+    const tail = std.fmt.bufPrint(&tail_buf, "X {d}\n", .{code}) catch "X 1\n";
+    _ = writeAll(client_fd, tail);
+    _ = shutdown(client_fd, SHUT_WR);
+}
+
 fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
     defer _ = close(client_fd);
     var line_buf: [4096]u8 = undefined;
@@ -204,6 +380,57 @@ fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
         return;
     };
     const line = line_buf[0..len];
+
+    // PTY <cols> <rows> <cmd-bytes>\n<cmd-bytes> — interactive
+    // session with a pseudoterminal pair. Length-prefixed cmd like
+    // EXEC2 so binary content (escape sequences in TUI scripts) and
+    // newlines pass through unchanged. See #133.
+    if (std.mem.startsWith(u8, line, "PTY ")) {
+        var it = std.mem.tokenizeScalar(u8, line[4..], ' ');
+        const cols_str = it.next() orelse {
+            logErr("exec-agent: PTY missing cols");
+            return;
+        };
+        const rows_str = it.next() orelse {
+            logErr("exec-agent: PTY missing rows");
+            return;
+        };
+        const len_str = it.next() orelse {
+            logErr("exec-agent: PTY missing cmd-bytes");
+            return;
+        };
+        const cols = std.fmt.parseInt(u16, cols_str, 10) catch {
+            logErr("exec-agent: PTY bad cols");
+            return;
+        };
+        const rows = std.fmt.parseInt(u16, rows_str, 10) catch {
+            logErr("exec-agent: PTY bad rows");
+            return;
+        };
+        const cmd_len = std.fmt.parseInt(usize, len_str, 10) catch {
+            logErr("exec-agent: PTY bad length");
+            return;
+        };
+        if (cmd_len > MAX_EXEC2_CMD) {
+            logErr("exec-agent: PTY cmd too large");
+            return;
+        }
+        const cmd_buf = alloc.alloc(u8, cmd_len) catch {
+            logErr("exec-agent: PTY alloc failed");
+            return;
+        };
+        defer alloc.free(cmd_buf);
+        if (cmd_len > 0 and !readExact(client_fd, cmd_buf)) {
+            logErr("exec-agent: PTY short read");
+            return;
+        }
+        runPtyCommand(client_fd, cmd_buf, cols, rows, alloc) catch |err| {
+            var msg_buf: [128]u8 = undefined;
+            const msg = std.fmt.bufPrint(&msg_buf, "exec-agent: pty error: {s}", .{@errorName(err)}) catch "exec-agent: pty error";
+            logErr(msg);
+        };
+        return;
+    }
 
     // EXEC2 <bytes>\n<cmd-bytes> — length-prefixed, supports newlines (#112).
     if (std.mem.startsWith(u8, line, "EXEC2 ")) {

--- a/packages/runtime/src/__tests__/exec-pty.test.ts
+++ b/packages/runtime/src/__tests__/exec-pty.test.ts
@@ -1,0 +1,229 @@
+// PTY-over-vsock wire protocol — #133.
+//
+// Pairs with assets/exec-agent.zig. These tests exercise the host
+// side without a real VM by standing up a local UDS server that
+// records the bytes the host sent and replays canned O/X frames so
+// we can assert the round-trip framing.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VsockExec } from "../exec.ts";
+
+function startCapturingAgent(
+  socketPath: string,
+  replay: (sock: Socket) => void,
+): {
+  server: Server;
+  received: Buffer[];
+  stop: () => Promise<void>;
+} {
+  const received: Buffer[] = [];
+  const server = createServer((sock: Socket) => {
+    sock.on("data", (chunk: Buffer) => {
+      received.push(Buffer.from(chunk));
+    });
+    replay(sock);
+  });
+  server.listen(socketPath);
+  return {
+    server,
+    received,
+    stop: () =>
+      new Promise<void>((done) => {
+        server.close(() => done());
+      }),
+  };
+}
+
+function collectBytes(buffers: Buffer[]): Buffer {
+  return Buffer.concat(buffers);
+}
+
+class CapturingWritable extends Writable {
+  chunks: Buffer[] = [];
+  _write(chunk: Buffer, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+    this.chunks.push(Buffer.from(chunk));
+    cb();
+  }
+  bytes(): Buffer {
+    return Buffer.concat(this.chunks);
+  }
+}
+
+describe("VsockExec.startPty wire protocol", () => {
+  let tmpDir: string;
+  let socketPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "machinen-exec-pty-"));
+    socketPath = join(tmpDir, "agent.sock");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("sends a PTY header with cols, rows, and length-prefixed cmd", async () => {
+    // Agent: just send X 0 + close so the host resolves quickly. We
+    // care about what the host wrote on the wire, not the response.
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      // Tiny delay so the host has a chance to write the header
+      // before we close from under it.
+      setTimeout(() => {
+        sock.write("X 0\n");
+        sock.end();
+      }, 10);
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "bash -i", {
+        cols: 132,
+        rows: 50,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+      });
+      const res = await handle.result;
+      expect(res.exitCode).toBe(0);
+      const sent = collectBytes(agent.received).toString("utf8");
+      expect(sent.startsWith("PTY 132 50 7\n")).toBe(true);
+      expect(sent.slice("PTY 132 50 7\n".length, "PTY 132 50 7\n".length + 7)).toBe("bash -i");
+    } finally {
+      await agent.stop();
+    }
+  });
+
+  it("forwards stdin chunks as I <n>\\n<bytes> frames", async () => {
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      // Wait for input, then exit.
+      let inputSeen = false;
+      sock.on("data", (data: Buffer) => {
+        // After header + cmd + at least one I frame, exit. The
+        // capturing handler on the test side already saved the bytes.
+        const s = data.toString("utf8");
+        if (s.includes("I ")) {
+          inputSeen = true;
+        }
+        if (inputSeen) {
+          sock.write("X 0\n");
+          sock.end();
+        }
+      });
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "echo hi", {
+        cols: 80,
+        rows: 24,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+      });
+      // Push a keystroke after a short delay so the connection has
+      // settled and stdin's listener is hooked.
+      setTimeout(() => stdin.write("hello\n"), 30);
+      const res = await handle.result;
+      expect(res.exitCode).toBe(0);
+      const sent = collectBytes(agent.received).toString("utf8");
+      // Header + cmd + then `I 6\n` + `hello\n`. Order matters; just
+      // assert the I frame arrived with the right length.
+      expect(sent).toContain("I 6\n");
+      expect(sent.includes("hello\n")).toBe(true);
+    } finally {
+      await agent.stop();
+    }
+  });
+
+  it("emits R <cols> <rows>\\n on resize()", async () => {
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      setTimeout(() => {
+        sock.write("X 0\n");
+        sock.end();
+      }, 50);
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "true", {
+        cols: 80,
+        rows: 24,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+      });
+      // Give the connect a moment, then resize twice.
+      await new Promise((r) => setTimeout(r, 20));
+      handle.resize(120, 40);
+      handle.resize(200, 60);
+      const res = await handle.result;
+      expect(res.exitCode).toBe(0);
+      const sent = collectBytes(agent.received).toString("utf8");
+      expect(sent).toContain("R 120 40\n");
+      expect(sent).toContain("R 200 60\n");
+    } finally {
+      await agent.stop();
+    }
+  });
+
+  it("parses O frames into stdout and resolves on X", async () => {
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      // Send two O frames split across two writes to exercise the
+      // partial-frame path, then X 42.
+      setTimeout(() => {
+        sock.write("O 5\nhello");
+        setTimeout(() => {
+          sock.write("O 6\n world");
+          setTimeout(() => {
+            sock.write("X 42\n");
+            sock.end();
+          }, 10);
+        }, 10);
+      }, 10);
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "x", {
+        cols: 80,
+        rows: 24,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+      });
+      const res = await handle.result;
+      expect(res.exitCode).toBe(42);
+      expect(stdout.bytes().toString("utf8")).toBe("hello world");
+    } finally {
+      await agent.stop();
+    }
+  });
+
+  it("rejects with EXEC_PROTOCOL on unknown frame tag", async () => {
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      setTimeout(() => {
+        sock.write("Z 999\n");
+        sock.end();
+      }, 10);
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "x", {
+        cols: 80,
+        rows: 24,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+      });
+      await expect(handle.result).rejects.toThrow(/unknown PTY frame tag/);
+    } finally {
+      await agent.stop();
+    }
+  });
+});

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -29,6 +29,7 @@
 //   // res.exitCode, res.stdout, res.stderr
 
 import { connect as netConnect, type Socket } from "node:net";
+import type { Readable, Writable } from "node:stream";
 import debugLib from "debug";
 import { ExecError } from "./errors.ts";
 
@@ -125,7 +126,63 @@ export const VsockExec = {
       { retryable: true, cause: lastErr ?? undefined },
     );
   },
+
+  /**
+   * PTY-mode session against the exec-agent (#133). Bytes flow
+   * bidirectionally between `opts.stdin` (host keystrokes) and
+   * `opts.stdout` (workload's pty output); the returned handle's
+   * `.resize(cols, rows)` propagates window-size changes to the
+   * guest's `ioctl(TIOCSWINSZ)`, and `.cancel()` disconnects (the
+   * agent then closes its master fd, which sends SIGHUP to the
+   * workload's session and reaps the child).
+   *
+   * Resolves with `{ exitCode }` once the workload exits and the
+   * agent emits the X frame. The stdin listener attaches eagerly —
+   * the caller is responsible for putting the host terminal in raw
+   * mode beforehand (so Ctrl-C, arrows, etc. reach the guest as
+   * untranslated bytes) and restoring it after `result` settles.
+   *
+   * Connect retries are intentionally absent here: PTY sessions are
+   * always against an already-running VM whose agent is up. If the
+   * UDS isn't reachable on the first try, that's a real error worth
+   * surfacing — not a transient bring-up race like the `run()` path.
+   */
+  startPty(udsPath: string, cmd: string, opts: VsockExecPtyOptions): VsockExecPtyHandle {
+    return startPtyImpl(udsPath, cmd, opts);
+  },
 } as const;
+
+export interface VsockExecPtyOptions {
+  /** Initial window size; the guest passes this to forkpty()'s winp. */
+  cols: number;
+  rows: number;
+  /**
+   * Host-side input source. Each `data` chunk is forwarded as an
+   * `I <n>\n<bytes>` frame. Caller wires `process.stdin` (in raw
+   * mode) here for an interactive shell.
+   */
+  stdin: Readable;
+  /**
+   * Host-side sink for PTY master output (`O <n>\n<bytes>` frames).
+   * Caller wires `process.stdout`.
+   */
+  stdout: Writable;
+  /** Connect timeout (ms). Default 5000 — agent should already be up. */
+  connectTimeoutMs?: number;
+}
+
+export interface VsockExecPtyResult {
+  exitCode: number;
+}
+
+export interface VsockExecPtyHandle {
+  /** Resolves with the workload's exit code once X arrives. */
+  readonly result: Promise<VsockExecPtyResult>;
+  /** Send a TIOCSWINSZ update. Hook from host's SIGWINCH. */
+  resize(cols: number, rows: number): void;
+  /** Disconnect; agent will SIGHUP the workload. */
+  cancel(): void;
+}
 
 function isTransientAgentError(err: Error): boolean {
   // Node tags socket errors with `code`; cast narrowly.
@@ -327,5 +384,182 @@ function endSocket(s: Socket): Promise<void> {
     }
     s.once("close", () => done());
     s.end();
+  });
+}
+
+// Wire `cols`/`rows` + the existing `cmd` into the PTY opcode header,
+// then plug bidirectional pumps onto an already-connected socket. Why
+// a separate helper: keeps `startPty` readable — the public method is
+// "build a handle, kick off connect+pumps, return"; the actual frame
+// machinery lives here.
+function startPtyImpl(udsPath: string, cmd: string, opts: VsockExecPtyOptions): VsockExecPtyHandle {
+  let socket: Socket | null = null;
+  let exitCode: number | null = null;
+  let settled = false;
+  let resolveResult: (r: VsockExecPtyResult) => void;
+  let rejectResult: (e: Error) => void;
+  const result = new Promise<VsockExecPtyResult>((res, rej) => {
+    resolveResult = res;
+    rejectResult = rej;
+  });
+
+  // O-frame parser state: we may receive partial frames across
+  // socket data events. `awaitingBytes` > 0 means we're inside an
+  // O payload; otherwise we're scanning for the next header line.
+  let parseBuf: Buffer = Buffer.alloc(0);
+  let awaitingBytes = 0;
+
+  const reject = (err: Error) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    rejectResult(err);
+    if (socket && !socket.destroyed) {
+      socket.destroy();
+    }
+  };
+
+  const resolve = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    if (exitCode === null) {
+      rejectResult(
+        new ExecError("EXEC_AGENT_UNAVAILABLE", "VsockExec.startPty: agent closed before X frame", {
+          retryable: false,
+        }),
+      );
+      return;
+    }
+    resolveResult({ exitCode });
+  };
+
+  const onSocketData = (data: Buffer) => {
+    parseBuf = parseBuf.length === 0 ? data : Buffer.concat([parseBuf, data]);
+    while (true) {
+      if (awaitingBytes > 0) {
+        if (parseBuf.length === 0) {
+          return;
+        }
+        const take = Math.min(awaitingBytes, parseBuf.length);
+        const chunk = parseBuf.subarray(0, take);
+        parseBuf = parseBuf.subarray(take);
+        awaitingBytes -= take;
+        opts.stdout.write(chunk);
+        continue;
+      }
+      const nl = parseBuf.indexOf(0x0a);
+      if (nl === -1) {
+        return;
+      }
+      const line = parseBuf.subarray(0, nl).toString("ascii");
+      parseBuf = parseBuf.subarray(nl + 1);
+      const [tag, nStr] = line.split(" ");
+      if (tag === "X") {
+        exitCode = Number.parseInt(nStr ?? "0", 10);
+        // Agent will close right after; wait for `close` event so we
+        // don't race the rest of the buffered O bytes.
+        return;
+      }
+      if (tag !== "O") {
+        reject(new ExecError("EXEC_PROTOCOL", `VsockExec.startPty: unknown PTY frame tag ${tag}`));
+        return;
+      }
+      const n = Number.parseInt(nStr ?? "", 10);
+      if (!Number.isFinite(n) || n < 0) {
+        reject(
+          new ExecError(
+            "EXEC_PROTOCOL",
+            `VsockExec.startPty: bad O frame length ${JSON.stringify(nStr)}`,
+          ),
+        );
+        return;
+      }
+      awaitingBytes = n;
+    }
+  };
+
+  const onStdinData = (chunk: Buffer | string) => {
+    if (!socket || socket.destroyed) {
+      return;
+    }
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    if (buf.length === 0) {
+      return;
+    }
+    // I <n>\n<bytes>. Two writes are fine — TCP-over-vsock will pass
+    // the bytes through in order, and the guest's readLine + readExact
+    // pair handles the split correctly.
+    socket.write(`I ${buf.length}\n`);
+    socket.write(buf);
+  };
+
+  // Kick off the connect + setup. We don't retry: the caller is
+  // attaching to an already-running VM whose agent is up. A first-try
+  // failure is real.
+  void (async () => {
+    try {
+      const connectTimeoutMs = opts.connectTimeoutMs ?? 5_000;
+      socket = await connectOnceWithTimeout(udsPath, connectTimeoutMs);
+      const cmdBuf = Buffer.from(cmd, "utf8");
+      socket.write(`PTY ${opts.cols} ${opts.rows} ${cmdBuf.length}\n`);
+      if (cmdBuf.length > 0) {
+        socket.write(cmdBuf);
+      }
+      socket.on("data", onSocketData);
+      socket.on("error", (err) => reject(err));
+      socket.on("close", () => {
+        opts.stdin.removeListener("data", onStdinData);
+        resolve();
+      });
+      opts.stdin.on("data", onStdinData);
+      debug("startPty connected uds=%s cols=%d rows=%d", udsPath, opts.cols, opts.rows);
+    } catch (err) {
+      reject(err as Error);
+    }
+  })();
+
+  return {
+    result,
+    resize(cols, rows) {
+      if (!socket || socket.destroyed) {
+        return;
+      }
+      socket.write(`R ${cols} ${rows}\n`);
+    },
+    cancel() {
+      if (socket && !socket.destroyed) {
+        socket.destroy();
+      }
+    },
+  };
+}
+
+// One-shot connect with an explicit timeout. Distinct from
+// `connectWithRetry` because PTY sessions don't want the bring-up
+// retry loop — see startPty's comment.
+function connectOnceWithTimeout(udsPath: string, timeoutMs: number): Promise<Socket> {
+  return new Promise((done, fail) => {
+    const s = netConnect(udsPath);
+    const timer = setTimeout(() => {
+      s.destroy();
+      fail(
+        new ExecError(
+          "EXEC_AGENT_UNAVAILABLE",
+          `VsockExec.startPty: connect to ${udsPath} timed out after ${timeoutMs}ms`,
+          { retryable: false },
+        ),
+      );
+    }, timeoutMs);
+    s.once("error", (e) => {
+      clearTimeout(timer);
+      fail(e);
+    });
+    s.once("connect", () => {
+      clearTimeout(timer);
+      done(s);
+    });
   });
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,7 +9,13 @@ export type { VsockSecretsOptions } from "./secrets.ts";
 export { VsockFiles } from "./files.ts";
 export type { VsockFilesOptions } from "./files.ts";
 export { VsockExec } from "./exec.ts";
-export type { VsockExecOptions, VsockExecResult } from "./exec.ts";
+export type {
+  VsockExecOptions,
+  VsockExecPtyHandle,
+  VsockExecPtyOptions,
+  VsockExecPtyResult,
+  VsockExecResult,
+} from "./exec.ts";
 export type { LogEvent, OnLog } from "./log.ts";
 export { provision, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
@@ -108,7 +114,13 @@ import { ensureGvproxy, exposePort, spawnGvproxy, warnGvproxyMissing } from "./g
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
 import { ensureRootfsImage } from "./rootfs-img.ts";
-import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
+import {
+  VsockExec,
+  type VsockExecOptions,
+  type VsockExecPtyHandle,
+  type VsockExecPtyOptions,
+  type VsockExecResult,
+} from "./exec.ts";
 import { serveLiveMount } from "./mount-server.ts";
 import type { OnLog } from "./log.ts";
 import { claimName, findEntry, isAlive, removeEntry, writeEntry } from "./registry.ts";
@@ -350,6 +362,19 @@ export interface VmHandle {
 
   /** Like `exec()` but returns non-zero exit codes instead of throwing. */
   execRaw(cmd: string, opts?: VsockExecOptions): Promise<VsockExecResult>;
+
+  /**
+   * Run a shell command inside a pseudoterminal. Bidirectional bytes
+   * flow between `opts.stdin` and `opts.stdout`; the returned handle's
+   * `.resize(cols, rows)` propagates window-size changes (hook your
+   * host's SIGWINCH).
+   *
+   * Caller is responsible for putting the host terminal in raw mode
+   * before calling and restoring it after `.result` settles — without
+   * raw mode, Ctrl-C / arrow keys / etc. won't reach the guest as
+   * untranslated bytes. See #133.
+   */
+  execPty(cmd: string, opts: VsockExecPtyOptions): VsockExecPtyHandle;
 
   /**
    * Write `contents` to `guestPath` inside the VM. Convenience over
@@ -945,6 +970,24 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       return VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
     },
 
+    execPty(cmd, ptyOpts) {
+      if (!vsockUdsPath) {
+        // Synchronous-handle API can't reject like execRaw — surface
+        // a handle whose `result` is already a rejected promise.
+        const err = new ExecError(
+          "EXEC_VSOCK_UNAVAILABLE",
+          "vm.execPty: no vsock UDS available — MACHINEN_VSOCK was set to " +
+            "an unrecognized spec. Expected `in:<port>:<uds-path>`.",
+        );
+        return {
+          result: Promise.reject(err),
+          resize: () => {},
+          cancel: () => {},
+        };
+      }
+      return VsockExec.startPty(vsockUdsPath, cmd, ptyOpts);
+    },
+
     async writeFile(guestPath, contents, writeOpts) {
       await this.exec(buildWriteFileCmd(guestPath, contents, writeOpts));
     },
@@ -1118,6 +1161,10 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
 
     execRaw(cmd, execOpts) {
       return VsockExec.run(entry.socketPath, cmd, teeOnLog(cmd, execOpts, opts.onLog));
+    },
+
+    execPty(cmd, ptyOpts) {
+      return VsockExec.startPty(entry.socketPath, cmd, ptyOpts);
     },
 
     async writeFile(guestPath, contents, writeOpts) {


### PR DESCRIPTION
## Summary

Closes #133. Adds a PTY-mode path to the exec-agent so `machinen exec --tty -- bash -i` opens a **real** pseudoterminal session: no more `cannot set terminal process group` warnings, job control works, full-screen TUIs (`vim`, `htop`, `less`) render correctly, and host-terminal resizes propagate to the guest.

## Wire protocol (vsock port 1978, new opcode)

Setup:
```
PTY <cols> <rows> <cmd-bytes>\n<cmd>
```

Bidirectional after setup:
```
host -> guest: I <n>\n<bytes>     stdin keystrokes
               R <cols> <rows>\n  TIOCSWINSZ resize
guest -> host: O <n>\n<bytes>     pty master output
               X <code>\n         workload exited; close
```

Length-prefixed cmd matches EXEC2 (#112) so binary content + newlines pass through unchanged. Ctrl-C / Ctrl-Z / EOF go through the PTY line discipline naturally — the kernel translates them to signals on the foreground process group; no separate signal channel needed for the MVP.

## Guest (assets/exec-agent.zig)

`forkpty(3)` — musl ships it in libc, no `-lutil`. The child execs `sh -c <cmd>` with the slave PTY already wired onto fd 0/1/2 and the slave already promoted to controlling terminal. Parent runs a `poll(2)` loop multiplexing the master fd against the vsock client fd. Closing `master_fd` on session end SIGHUPs the workload's session, so the child terminates cleanly even when the host disconnects mid-session.

## Host (runtime/src/exec.ts)

`VsockExec.startPty` returns a sync handle:
```ts
{ result: Promise<{ exitCode }>, resize(cols, rows), cancel() }
```
`result` settles when the X frame arrives. `resize()` emits an R frame (hook from `process.stdout.on("resize")` for SIGWINCH-equivalent updates). Connect retries are intentionally absent — PTY sessions go against an already-running VM whose agent is already up; a first-try failure is real, not a bring-up race like `VsockExec.run`.

`vm.execPty(cmd, opts)` on the runtime VM object is the public surface; it forwards to `VsockExec.startPty` with the right UDS for boot- vs attach-handles.

## CLI

`machinen exec --tty -- <cmd>` (alias `--pty`). Flips `process.stdin` to raw mode for the duration of the session, hooks `process.stdout.on("resize")` for SIGWINCH, restores state on every exit path. Help text + the `attach` greeting both now point users at `--tty` for interactive shells / TUIs.

## Tests

5 new tests in `packages/runtime/src/__tests__/exec-pty.test.ts` standing up a local UDS server that captures bytes the host writes and replays canned O/X frames. Covers header framing, I-frame encoding, R-frame encoding, partial O-frame parsing across socket events, and the unknown-tag protocol error. No real VM needed.

## Out of scope (future work)

Signal forwarding beyond PTY ldisc, scrollback / session reattach, auto-detect from `process.stdin.isTTY` without an explicit `--tty`. #133's acceptance criteria are met without these.

## Test plan

- [x] `zig build-exe exec-agent.zig` for `aarch64-linux-musl` — clean (~221 KB ELF).
- [x] `pnpm -r build` — clean (TypeScript dts emit succeeded).
- [x] `npx vitest run` — 18 suites / 244 tests pass (incl. 5 new PTY tests).
- [x] `pnpm format:check` + `pnpm lint` — clean.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass in 1m 4s.
- [ ] Reviewer manual: build base assets + boot a VM, then in another terminal `machinen exec --name <vm> --tty -- bash -i` should give a real prompt with no warnings; `vim /etc/passwd` should render; resize the terminal and `tput cols` inside should reflect the new width.
