### PR TITLE
fix(microvm): mount devpts on /dev/pts in /init for PTY support

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -725,6 +725,15 @@ pub fn main() noreturn {
     mountIgnore("devtmpfs", "/dev", "devtmpfs");
     mountIgnore("proc", "/proc", "proc");
     mountIgnore("sysfs", "/sys", "sysfs");
+    // /dev/pts is the slave-side namespace for pseudoterminals.
+    // Without it, anything that allocates a PTY pair via /dev/ptmx
+    // (e.g. forkpty(3) in the exec-agent's PTY path — #133, or
+    // `script` / `screen` / `tmux` invoked by the user) fails to
+    // open the slave node, because the slave name /dev/pts/<n> only
+    // resolves once devpts is mounted there. /dev/ptmx itself is
+    // already in /dev (devtmpfs creates it).
+    mkdirIgnore("/dev/pts");
+    mountIgnore("devpts", "/dev/pts", "devpts");
 
     // Wire up the serial console.
     const console = waitForConsole();


### PR DESCRIPTION
## Summary

Follow-up to #143. Without devpts mounted at `/dev/pts`, anything that allocates a pseudoterminal pair via `/dev/ptmx` — #143's exec-agent PTY path (`forkpty`) and any user-invoked `script` / `screen` / `tmux` — fails to open the slave node. The slave name `/dev/pts/<n>` only resolves once devpts is mounted there; `/dev/ptmx` itself is already in `/dev` (devtmpfs creates it). Lift the mount into `/init`'s standard mount sequence so users don't have to do it by hand on every boot.

## How this surfaced

End-to-end smoke of #143:

```bash
machinen boot --name pty-test -- /bin/sh -c 'sleep 600' &
machinen exec --name pty-test --tty -- bash -i
```

Pre-fix:

```
machinen: (EXEC_AGENT_UNAVAILABLE): VsockExec.startPty: agent closed before X frame
```

The exec-agent's stdout/stderr go to `/dev/null` per the supervisor, so `forkpty` failing inside the guest is invisible from the host log; `agent closed before X frame` was the only signal.

After manually doing `mount -t devpts devpts /dev/pts` from a regular `machinen exec`, the same command opens a clean PTY session:

```
$ machinen exec --name pty-test --tty -- 'tty; tput cols; echo OK'
/dev/pts/0
80
OK
```

…and `bash -i` now runs without any of the warnings #133 was meant to eliminate (no `cannot set terminal process group`, no `no job control in this shell`, persistent shell state across prompts, `$COLUMNS` populated from `TIOCGWINSZ`).

This patch lifts that mount up into `/init` so it happens automatically.

## Test plan

- [x] `zig build-exe init.zig` for `aarch64-linux-musl` — clean.
- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 18 suites / 244 tests pass.
- [x] `npx agent-ci run --all -q -p` (backgrounded + Monitor'd) — 2/2 workflows pass in 1m 7s.
- [x] Manual end-to-end on macOS HVF: rebuild base assets, wipe `~/.cache/machinen/rootfs/*.img`, boot a fresh VM, then `machinen exec --tty -- 'tty; tput cols; tput lines; echo SMOKE-OK'` returns `/dev/pts/0` + `80` + `24` + `SMOKE-OK` with no manual mount needed. `bash -i` is clean — no warnings, prompts update, `$COLUMNS` set.
