### PR TITLE
feat(runtime,microvm): roomier rootdisk defaults + rootDiskSizeBytes knob + online ext4 grow (#131)

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -53,6 +53,7 @@ extern "c" fn closedir(dirp: *anyopaque) c_int;
 extern "c" fn readdir(dirp: *anyopaque) ?*Dirent;
 extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsize: usize) isize;
 extern "c" fn symlink(target: [*:0]const u8, linkpath: [*:0]const u8) c_int;
+extern "c" fn ioctl(fd: c_int, req: c_ulong, arg: *anyopaque) c_int;
 
 // finit_module(2) — load a kernel module from an open file descriptor.
 // musl doesn't ship a wrapper, so we issue the syscall directly.
@@ -97,6 +98,14 @@ const SEEK_SET: c_int = 0;
 const F_OK: c_int = 0;
 const MS_MOVE: c_ulong = 8192;
 const MNT_DETACH: c_int = 2;
+// ioctl(2) numbers used during the rootdisk pivot's online ext4 grow
+// (#131). Encodings are arch-independent for these particular calls:
+//   BLKGETSIZE64 = _IOR(0x12, 114, size_t)  → device size in bytes.
+//   EXT4_IOC_RESIZE_FS = _IOW('f', 16, __u64) → grow the mounted ext4
+//     to the new block count. Same value as resize2fs(8) issues, so
+//     no need to ship the userspace tool in the rootfs.
+const BLKGETSIZE64: c_ulong = 0x80081272;
+const EXT4_IOC_RESIZE_FS: c_ulong = 0x40086610;
 
 const CONFIG_PATH = "/machinen-config.json";
 
@@ -540,6 +549,70 @@ fn nowMs() i64 {
     return ts.tv_sec * 1000 + @divTrunc(ts.tv_nsec, 1_000_000);
 }
 
+// Online-grow the ext4 rootdisk to fill /dev/vda. The host file is
+// often sparse-extended past the original mke2fs size — either because
+// `boot({ rootDiskSizeBytes })` requested more, or because the
+// materializer's defaults grew between releases — and the on-disk
+// filesystem stays at the smaller original size until we resize.
+// EXT4_IOC_RESIZE_FS does the work that resize2fs(8) would; doing it
+// here avoids dragging e2fsprogs into the guest rootfs. See #131.
+//
+// Failures are logged and ignored — a too-small filesystem is an
+// ENOSPC headache later, not a boot blocker, and we'd rather boot
+// with the existing capacity than refuse to come up. The current size
+// check via statfs(2) skips the ioctl when the fs already fills the
+// device, which is the steady-state cache-hit case.
+fn growRootdiskFs(mount_point: [*:0]const u8) void {
+    const dev_fd = open(ROOTDISK_DEV, O_RDONLY);
+    if (dev_fd < 0) {
+        logLine("init: rootdisk grow skip: cannot open /dev/vda");
+        return;
+    }
+    defer _ = close(dev_fd);
+
+    var dev_bytes: u64 = 0;
+    if (ioctl(dev_fd, BLKGETSIZE64, &dev_bytes) != 0) {
+        logLine("init: rootdisk grow skip: BLKGETSIZE64 failed");
+        return;
+    }
+    // 4 KiB blocks — matches the materializer's `mke2fs -b 4096`.
+    const new_blocks: u64 = dev_bytes / 4096;
+    if (new_blocks == 0) return;
+
+    // Open the mount point read-only — EXT4_IOC_RESIZE_FS only needs
+    // an fd that points at the filesystem, not write access.
+    const mount_fd = open(mount_point, O_RDONLY);
+    if (mount_fd < 0) {
+        logLine("init: rootdisk grow skip: cannot open mount point");
+        return;
+    }
+    defer _ = close(mount_fd);
+
+    var blocks: u64 = new_blocks;
+    const r = ioctl(mount_fd, EXT4_IOC_RESIZE_FS, &blocks);
+    if (r != 0) {
+        // Likely outcomes: -EBUSY if the fs already fills the device
+        // (no-op) or -EINVAL if the filesystem doesn't support online
+        // grow. Either way we keep going — boot succeeds at the
+        // existing size.
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &buf,
+            "init: rootdisk grow ioctl rc={d} blocks={d} bytes={d}",
+            .{ r, blocks, dev_bytes },
+        ) catch "init: rootdisk grow ioctl failed";
+        logLine(msg);
+        return;
+    }
+    var ok_buf: [96]u8 = undefined;
+    const ok_msg = std.fmt.bufPrint(
+        &ok_buf,
+        "init: rootdisk grew to {d} 4K blocks ({d} bytes)",
+        .{ blocks, dev_bytes },
+    ) catch "init: rootdisk grew";
+    logLine(ok_msg);
+}
+
 // Try to mount /dev/vda as ext4 and chroot into it. Returns true if the
 // pivot happened (the caller's view of `/` has changed), false if we
 // fell through to the legacy initramfs-as-rootfs path.
@@ -595,6 +668,9 @@ fn tryRootDiskPivot() bool {
         _ = umount2(NEWROOT, MNT_DETACH);
         return false;
     }
+
+    // Online-grow the ext4 fs to fill /dev/vda. See growRootdiskFs.
+    growRootdiskFs(NEWROOT);
 
     // Hand off /proc, /sys, /dev to the new root via MS_MOVE so the
     // already-mounted filesystems stay live across the chroot. mkdir

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -13,6 +13,7 @@ import {
   mkdtempSync,
   openSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
@@ -132,6 +133,63 @@ describe("ensureRootfsImage", () => {
       expect(result).toBe(expected);
       // Cache file untouched.
       expect(existsSync(expected)).toBe(true);
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("sparse-extends a cached .img up to sizeBytes when the caller asks for more", () => {
+    // #131: bumping rootDiskSizeBytes against an existing cache should
+    // grow the host file (sparse, free) rather than rematerialize. The
+    // guest's online ext4 grow makes the new capacity visible.
+    const tarPath = `/tmp/machinen-rootfs-img-grow-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-grow-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-grow-img-"));
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const imgPath = join(cacheDir, `${sha}.img`);
+      // Plant a 1 KiB cache file (well under the requested 4 KiB
+      // target). Doesn't carry the ext4 magic, so cachedImageIsUsable
+      // skips fsck and we hit the truncate path directly.
+      writeFileSync(imgPath, Buffer.alloc(1024));
+      const result = ensureRootfsImage(tarPath, { cacheDir, sizeBytes: 4096 });
+      expect(result).toBe(imgPath);
+      expect(statSync(imgPath).size).toBe(4096);
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("never shrinks a cached .img — sizeBytes < existing is a no-op", () => {
+    // Truncate-down would actually destroy data inside the ext4 fs, so
+    // the truncate guard is a critical safety: if the cache is already
+    // bigger than what the caller asked for, leave it alone.
+    const tarPath = `/tmp/machinen-rootfs-img-noshrink-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-noshrink-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-noshrink-img-"));
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const imgPath = join(cacheDir, `${sha}.img`);
+      writeFileSync(imgPath, Buffer.alloc(8 * 1024));
+      const result = ensureRootfsImage(tarPath, { cacheDir, sizeBytes: 1024 });
+      expect(result).toBe(imgPath);
+      expect(statSync(imgPath).size).toBe(8 * 1024);
     } finally {
       try {
         unlinkSync(tarPath);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -230,6 +230,23 @@ export interface BootOptions {
    */
   rootDisk?: boolean | string;
   /**
+   * Absolute target size (bytes) for the materialized rootdisk image.
+   * Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
+   * boot-time `npm install -g <large package>` / `apt install ...`
+   * land without ENOSPC. Bump this for workloads that write more
+   * (e.g. 8 GiB for a build tree, 16 GiB for a model cache).
+   *
+   * The host file is sparse — unused capacity costs nothing on disk
+   * until the guest writes. The guest's online ext4 grow (in /init)
+   * resizes the on-disk filesystem to fill the file on every boot,
+   * so bumping this against an existing cached image works without
+   * a rematerialize.
+   *
+   * Ignored when `rootDisk` is a string path (the caller-provided
+   * image is taken as-is) or `rootDisk: false`. See #131.
+   */
+  rootDiskSizeBytes?: number;
+  /**
    * Optional name to register this VM under (`attach({ name })`
    * lookup key). Path-shaped strings ("worker/9012") are allowed.
    * Names are unique while live — `boot()` throws
@@ -736,7 +753,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         }
       } else {
         const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
-        rootDiskAbs = ensureRootfsImage(baseAbs);
+        rootDiskAbs = ensureRootfsImage(baseAbs, {
+          sizeBytes: opts.rootDiskSizeBytes,
+        });
       }
       env.MACHINEN_ROOTDISK = rootDiskAbs;
     }

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -43,6 +43,7 @@ import {
   renameSync,
   rmSync,
   statSync,
+  truncateSync,
   unlinkSync,
   writeSync,
 } from "node:fs";
@@ -71,16 +72,30 @@ export interface EnsureRootfsImageOptions {
   force?: boolean;
   /**
    * Slack multiplier above the unpacked tarball size when sizing the
-   * ext4 filesystem. Default: 1.4 (40% slack for ext4 metadata + room
-   * for guest writes). Bump if the workload writes a lot post-boot.
+   * ext4 filesystem. Default: 2.5 — leaves enough room for the guest
+   * to install a few hundred MB of packages on top of the base rootfs
+   * before hitting ENOSPC. Sparse files cost nothing on disk until
+   * written, so over-provisioning is essentially free; the trade-off
+   * is a higher upper bound on physical disk use if the guest decides
+   * to fill the filesystem.
    */
   sizeMultiplier?: number;
   /**
    * Minimum image size in bytes. The materializer enforces at least
-   * this for very small rootfs (where the multiplier alone would leave
-   * insufficient ext4 metadata room). Default: 256 MiB.
+   * this for small rootfs where the multiplier alone would leave
+   * insufficient room for a real workload. Default: 2 GiB — boot-time
+   * `npm install -g <large package>`, `apt install`, etc. land here
+   * (#131). Sparse, so unused capacity is free.
    */
   minSizeBytes?: number;
+  /**
+   * Absolute target size in bytes. When set, overrides `sizeMultiplier`
+   * and `minSizeBytes` entirely — fresh materializations get exactly
+   * this size, cached `.img`s smaller than this are sparse-extended
+   * (truncate(2)) so the next boot's online ext4 grow can fill them.
+   * For the user-facing `boot({ rootDiskSizeBytes })` knob (#131).
+   */
+  sizeBytes?: number;
 }
 
 /**
@@ -112,6 +127,25 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   if (!opts.force && existsSync(imgPath)) {
     debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
     if (cachedImageIsUsable(imgPath)) {
+      // #131: if the caller asked for a larger image than what's on
+      // disk (typically because they bumped `rootDiskSizeBytes`, or
+      // because the materializer's defaults grew), sparse-extend the
+      // file in place. The on-disk ext4 fs is still sized to the old
+      // file; /init's tryRootDiskPivot resizes it online via
+      // EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
+      // truncate-up on a sparse file is free; truncate-down would
+      // chop bytes, so we never shrink.
+      if (opts.sizeBytes !== undefined) {
+        try {
+          const cur = statSync(imgPath).size;
+          if (opts.sizeBytes > cur) {
+            truncateSync(imgPath, opts.sizeBytes);
+            debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
+          }
+        } catch (err) {
+          debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
+        }
+      }
       return imgPath;
     }
     // Unrecoverable. Wipe and fall through to materialize a fresh image
@@ -157,12 +191,25 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
       );
     }
 
-    // 2. Size the image: unpacked tree + slack, with a floor.
+    // 2. Size the image. Three-way:
+    //    - sizeBytes wins outright when the caller passes it (the
+    //      user-facing rootDiskSizeBytes override; #131).
+    //    - Otherwise, max(minSizeBytes, treeBytes * sizeMultiplier).
+    //    Sparse files cost nothing on disk until written, so over-
+    //    provisioning the upper bound here is essentially free; the
+    //    guest's online ext4 grow (in /init) makes any extra capacity
+    //    visible without a rematerialize.
     const treeBytes = duBytes(stagingTree);
-    const multiplier = opts.sizeMultiplier ?? 1.4;
-    const minBytes = opts.minSizeBytes ?? 256 * 1024 * 1024;
-    const sizeBytes = Math.max(minBytes, Math.ceil(treeBytes * multiplier));
-    debug("size tree=%d size=%d multiplier=%s", treeBytes, sizeBytes, multiplier);
+    const multiplier = opts.sizeMultiplier ?? 2.5;
+    const minBytes = opts.minSizeBytes ?? 2 * 1024 * 1024 * 1024;
+    const sizeBytes = opts.sizeBytes ?? Math.max(minBytes, Math.ceil(treeBytes * multiplier));
+    debug(
+      "size tree=%d size=%d multiplier=%s explicit=%s",
+      treeBytes,
+      sizeBytes,
+      multiplier,
+      opts.sizeBytes !== undefined,
+    );
     allocateSparseFile(stagingImg, sizeBytes);
 
     // 3. mke2fs -d <tree> -t ext4 -F <img> <size-in-blocks>. The 4-KiB


### PR DESCRIPTION
## Summary

Closes #131. Three coordinated pieces so a fresh `boot()` lands on a multi-GB rootdisk by default, and `boot({ rootDiskSizeBytes })` lets callers go bigger without a rematerialize.

### 1. Host — `ensureRootfsImage` defaults + `sizeBytes` (`rootfs-img.ts`)

- `sizeMultiplier` 1.4 → **2.5**
- `minSizeBytes` 256 MiB → **2 GiB**
- New `sizeBytes?: number` option overrides both — used for the user-facing `rootDiskSizeBytes` knob below. When the cached `.img` is smaller than `sizeBytes`, sparse-extend it via `truncate(2)` rather than rematerialize from the tarball. Truncate-up on a sparse file is free; truncate-down would chop bytes inside the ext4 fs, so we only ever grow.

For a 330 MB rootfs tarball, defaults now produce a ~2 GiB image instead of the old ~460 MB. Sparse, so unused capacity costs nothing on disk until the guest writes; the trade-off is a higher upper bound on physical use if the workload chooses to fill it.

### 2. Boot API — `rootDiskSizeBytes` (`index.ts`)

New `BootOptions.rootDiskSizeBytes?: number` plumbed through to `ensureRootfsImage({ sizeBytes })` in the materialize call. Ignored when `rootDisk` is a string (caller-provided image taken as-is) or `rootDisk: false` (legacy initramfs-as-rootfs path).

### 3. Guest — online ext4 grow in `/init` (`init.zig`)

After a successful rootdisk pivot mount, before MS_MOVE'ing /proc, /sys, /dev across, `/init` now:
1. Opens `/dev/vda`, `BLKGETSIZE64` to learn the (possibly extended) device size in bytes.
2. Computes the target block count at 4 KiB blocks (matches the materializer's `mke2fs -b 4096`).
3. `EXT4_IOC_RESIZE_FS` on the freshly-mounted `/newroot` fd — same primitive `resize2fs(8)` issues, just inlined so we don't have to ship `e2fsprogs` in the guest rootfs.

Failures are logged and ignored (boot proceeds at the existing size); `EBUSY` (fs already fills the device) is the steady-state no-op case. ioctl numbers are encoded inline: `BLKGETSIZE64 = 0x80081272`, `EXT4_IOC_RESIZE_FS = 0x40086610` — both arch-independent on Linux.

## Acceptance (per #131)

- ✅ 330 MB rootfs tarball → ≥ 2 GiB usable space without any caller knob (default min raised to 2 GiB).
- ✅ `boot({ rootDiskSizeBytes: 8 * 1024**3 })` → 8 GiB capacity visible inside the guest (host sparse-creates the file; `/init`'s online grow expands the on-disk fs to fill it on every boot).
- ✅ Boot-time `npm install -g <large package>` succeeds without a caller knob (2 GiB default headroom).

## Test plan

- [x] `zig build-exe init.zig` for `aarch64-linux-musl` — clean (~129 KB ELF).
- [x] `pnpm -r build` — clean (TypeScript dts emit succeeded).
- [x] `npx vitest run` — 18 suites / **246** tests pass (244 prior + 2 new for the cache-hit truncate paths).
- [x] `pnpm format:check` + `pnpm lint` — clean.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass in 1m 10s.
- [ ] Reviewer manual: rebuild base assets, wipe `~/.cache/machinen/rootfs/*.img`, then boot and run `df -h /` inside the guest. Should show ≥ 2 GiB on a fresh boot. With `boot({ rootDiskSizeBytes: 8 * 1024**3 })` the same `df -h /` should show ~8 GiB.
