### PR TITLE
fix(microvm): mount tmpfs on /run in /init

### DIFF
--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -810,6 +810,18 @@ pub fn main() noreturn {
     // already in /dev (devtmpfs creates it).
     mkdirIgnore("/dev/pts");
     mountIgnore("devpts", "/dev/pts", "devpts");
+    // Fresh tmpfs on /run, matching the systemd / Debian default.
+    // Many maintainer scripts assume /run is a writable tmpfs:
+    // adduser/addgroup take a flock on /run/adduser, apt parks lock
+    // files in /run/lock, openssh-server's postinst expects /run/sshd,
+    // cron / dbus / etc. drop pid files there. Without this mount the
+    // user's rootfs tarball's /run is exposed as-is — any quirk in its
+    // permissions, ownership, or contents (a leftover lock from a
+    // previous provision, an unexpected symlink, root-not-owning the
+    // dir) breaks postinst flows mid-install. tmpfs gives every boot
+    // a clean, root-owned, writable /run regardless of what's on disk.
+    mkdirIgnore("/run");
+    mountIgnore("tmpfs", "/run", "tmpfs");
 
     // Wire up the serial console.
     const console = waitForConsole();


### PR DESCRIPTION
## Summary

Many Debian maintainer scripts assume `/run` is a fresh, root-owned tmpfs:

- `adduser` / `addgroup` take a flock on `/run/adduser`
- `apt` parks lock files in `/run/lock`
- `openssh-server` postinst expects `/run/sshd`
- `cron`, `dbus`, etc. drop pid files there

Without this mount, `/init` exposes the rootfs tarball's `/run` as-is — any quirk in its permissions, ownership, or contents (a leftover lock from a previous provision, an unexpected symlink, root-not-owning the directory) breaks postinst flows mid-install.

## Surfaced from

A downstream `provision()` run hit:

```
addgroup: could not open lock file /run/adduser!
dpkg: error processing package openssh-client (--configure):
 installed openssh-client package post-installation script subprocess returned error exit status 1
```

…with the rootfs's pre-existing `/run` owned by `uid:gid 501:dialout` — `mmdebstrap` runs as the host user and leaks that ownership into the tarball; inside the guest, the same uid/gid no longer corresponds to the same user but the perms still don't match what postinst scripts expect.

With `tmpfs` on `/run`, every boot starts with a clean, writable, root-owned `/run` — same as every modern Linux distro under systemd.

## Test plan

- [x] `zig build-exe init.zig` for `aarch64-linux-musl` — clean.
- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 18 suites / 246 tests pass.
- [x] `pnpm format:check` + `pnpm lint` — clean.
- [x] `npx agent-ci run --all -q -p` — 2/2 workflows pass in 1m 12s.
- [ ] Reviewer manual: rerun the failing downstream `provision()` (apt-get install of openssh-client + adduser-using packages); the addgroup/lock-file error should not recur.
