### PR TITLE
fix(runtime): inject fresh /init in packBundle so provision-cached rootfs picks up upstream init.zig changes

### DIFF
--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -416,7 +416,17 @@ export function packBundle(opts: PackBundleOptions): void {
       initPath: opts.initPath ?? defaultInitPath(),
       config: patchConfigEnv(readFileSync(cfgPath), opts.env),
       fuseAgentPath: opts.fuseAgentPath,
-      injectInit: false,
+      // Always inject the fresh /init AFTER walking the rootfs.
+      // `provision()` flows feed the previous run's frozen rootfs back
+      // in as `base`, and that capture has /init at root. The walked
+      // copy is whatever was captured the last time provision ran;
+      // injecting machinen's current /init here means the cpio carries
+      // duplicate /init entries with the latest one last — Linux's
+      // initramfs unpacker resolves duplicates by overwriting earlier
+      // entries with later ones, so the fresh /init wins. Without
+      // this, fixes that land in init.zig (e.g. the /run tmpfs mount
+      // from #146) silently regress on every provision-cached image.
+      injectInit: true,
     });
     writeFileSync(opts.out, Buffer.concat(parts));
     debug(


### PR DESCRIPTION
## Summary

`provision()` flows feed the previous run's frozen rootfs back in as `base` when re-provisioning. The frozen capture has `/init` at root (machinen's `/init` was unpacked from the cpio onto the previous boot's tmpfs root and got picked up by the rootfs walk on freeze). When the runtime's `packBundle` then walks that base tarball, the captured `/init` lands in the cpio at `/init` — and because `appendFinalEntries` was called with `injectInit: false`, **machinen's current `/init` was never written**, leaving the user running a stale binary on every re-provision.

## How this surfaced

A downstream `provision()` kept hitting `addgroup: could not open lock file /run/adduser!` even after #146 landed the `/run` tmpfs mount in `init.zig`. The new mount call WAS in the source, but the running `/init` was the pre-#146 binary captured in the user's `app.tar.gz`. Confirmed by extracting `/init` from the user's tarball: 127 992 bytes (older), vs. machinen's current 129 360-byte build.

## Fix

Flip `injectInit` to `true` in `packBundle`. `appendFinalEntries` runs after the rootfs walk, so the cpio carries **duplicate** `/init` entries with the latest one last. Linux's initramfs unpacker resolves duplicates by overwriting earlier entries with later ones (see `init/initramfs.c: init_eat_existing` in the kernel) — so the fresh `/init` wins. Same dedup trick the kernel docs use for layered initramfs sources.

## Test plan

- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 18 suites / 246 tests pass.
- [x] `pnpm format:check` + `pnpm lint` — clean.
- [x] `npx agent-ci run --all -q -p` — 2/2 in 1m 6s.
- [x] **End-to-end** against the original failing downstream `provision()`: the `addgroup` / `/run/adduser` error is gone. apt install completes through `openssh-client`'s postinst. (Provision now hits a different `$HOME not set` issue from `git config`; that's a separate bug — follow-up PR.)
