### PR TITLE
fix(microvm,runtime): set HOME=/root in exec-agent + inject fresh agent in packBundle

### DIFF
--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -209,7 +209,18 @@ fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void
         _ = close(err_pipe[0]);
         _ = close(err_pipe[1]);
         const argv = &[_:null]?[*:0]const u8{ "sh", "-c", cmd_z.ptr, null };
-        const envp = &[_:null]?[*:0]const u8{ "PATH=/usr/local/bin:/usr/bin:/bin:/sbin", null };
+        // HOME is the second-most-likely-to-bite missing env after
+        // PATH: git refuses without it ("fatal: $HOME not set"),
+        // ssh-keygen / npm / many install hooks read it, and shells
+        // expand `~` against it. Default to /root since the agent
+        // runs as PID 1's child and there's no real login session
+        // here. Callers who want a different home can override via
+        // the cmd itself (`HOME=/foo bash -c ...`).
+        const envp = &[_:null]?[*:0]const u8{
+            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            "HOME=/root",
+            null,
+        };
         _ = execve("/bin/sh", argv, envp);
         _exit(127);
     }
@@ -275,6 +286,9 @@ fn runPtyCommand(
         const argv = &[_:null]?[*:0]const u8{ "sh", "-c", cmd_z.ptr, null };
         const envp = &[_:null]?[*:0]const u8{
             "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            // See the matching comment in runCommand — same rationale
+            // for HOME (git/npm/ssh-keygen/shells need it).
+            "HOME=/root",
             // Default to a sane TERM so curses-based TUIs work
             // out of the box. The host can override via env in cmd
             // (e.g. `TERM=xterm-kitty bash -i`) if it knows better.

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -353,6 +353,12 @@ export interface PackBundleOptions {
    * initramfs so /init can fork it per live-share mount. See #78.
    */
   fuseAgentPath?: string;
+  /**
+   * Optional path to the compiled /exec-agent. Default: same dir as
+   * /init under packages/microvm/test-fixtures/. Used to override the
+   * stale /exec-agent that may live in a re-provisioned base tarball.
+   */
+  execAgentPath?: string;
 }
 
 export function packBundle(opts: PackBundleOptions): void {
@@ -427,6 +433,13 @@ export function packBundle(opts: PackBundleOptions): void {
       // this, fixes that land in init.zig (e.g. the /run tmpfs mount
       // from #146) silently regress on every provision-cached image.
       injectInit: true,
+      // Same dedup trick for /exec-agent: the user's frozen rootfs
+      // captures whatever /exec-agent was running at provision time,
+      // and that gets re-walked back into the cpio on the next round.
+      // Inject the fresh one so changes to exec-agent.zig (env
+      // defaults like HOME=/root, new opcodes) actually reach the
+      // running binary.
+      execAgentPath: opts.execAgentPath ?? defaultExecAgentPath(),
     });
     writeFileSync(opts.out, Buffer.concat(parts));
     debug(
@@ -751,6 +764,15 @@ interface FinalOptions {
   injectInit: boolean;
   /** Optional path to fuse-agent; staged at /fuse-agent when provided. */
   fuseAgentPath?: string;
+  /**
+   * Optional path to /exec-agent. When set, the binary is appended to
+   * the cpio after the rootfs walk so that any stale /exec-agent
+   * captured in the base tarball gets overwritten by Linux's
+   * initramfs unpacker (last entry wins). Same trick as `injectInit`.
+   * Used by the provision flow where the base is the previous run's
+   * frozen rootfs.
+   */
+  execAgentPath?: string;
 }
 
 function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
@@ -760,6 +782,18 @@ function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
       parts.push(newc("init", 0o100755, { data: initBytes }));
     } catch {
       // init is optional — matches the Python code's `if INIT.exists():` guard.
+    }
+  }
+  if (opts.execAgentPath) {
+    try {
+      const bytes = readFileSync(opts.execAgentPath);
+      parts.push(newc("exec-agent", 0o100755, { data: bytes }));
+    } catch {
+      // Optional — if the build hasn't produced one yet (fresh
+      // checkout, first run before build-base-assets.sh), boots that
+      // didn't need exec-agent (no vm.exec, no provision) keep
+      // working. The provision flow itself depends on it and will
+      // fail downstream with a clearer error if it's truly absent.
     }
   }
   if (opts.fuseAgentPath) {
@@ -812,6 +846,17 @@ function defaultInitPath(): string {
 export function defaultFuseAgentPath(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return join(here, "..", "..", "microvm", "test-fixtures", "fuse-agent");
+}
+
+/**
+ * Default path to the compiled /exec-agent binary. Sibling of the
+ * default /init. Used by the provision flow's cpio injection to
+ * override whatever stale /exec-agent the user's base tarball may
+ * have captured from a previous run.
+ */
+export function defaultExecAgentPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "..", "microvm", "test-fixtures", "exec-agent");
 }
 
 // --- CLI entrypoint -----------------------------------------------


### PR DESCRIPTION
## Summary

Two coordinated changes that unblock provision-time install hooks running under the exec-agent.

### `exec-agent.zig`: bake `HOME=/root` into the child envp

`git` refuses without `HOME` (`fatal: $HOME not set`); `ssh-keygen`, `npm`, many install hooks read it; shells expand `~` against it. The agent ran the workload with `envp = ["PATH=…"]` only, so any caller's `vm.exec("git config …")` blew up downstream. Default to `/root` because the agent runs as PID 1's child and there's no real login session — callers who want a different home can override inside the cmd (`HOME=/foo bash -c …`). Same change applied to both `runCommand` (EXEC/EXEC2) and `runPtyCommand` (PTY) paths.

### `mkinitramfs.ts`: also inject fresh `/exec-agent` in `packBundle`

#147 fixed the same staleness issue for `/init`: `provision()`'s incremental flow feeds the previous frozen rootfs back in as `base`, and the captured `/exec-agent` gets re-walked into every new cpio. So the HOME-aware exec-agent landed today would never reach the running guest until the cache was wiped by hand.

Adds a sibling `defaultExecAgentPath()` (mirrors `defaultInitPath`) and a new `execAgentPath` option threaded through `packBundle` → `appendFinalEntries`. Same Linux-initramfs last-entry-wins dedup trick: cpio carries duplicate `/exec-agent` entries, fresh one appended last, kernel's `init/initramfs.c` overwrites earlier with later, fresh wins.

## End-to-end verification

The downstream `provision()` that's been failing all afternoon (`addgroup: could not open lock file /run/adduser!` → `fatal: $HOME not set` after #146 / #147) now runs to completion:

```
apt install (incl. openssh-client postinst)   ✓
fnm install Node v22.22.2                     ✓
npm install (257 packages)                    ✓
clean PSCI poweroff                           ✓
total: 144.2s
```

## Test plan

- [x] `zig build-exe exec-agent.zig` for `aarch64-linux-musl` — clean.
- [x] `pnpm -r build` — clean.
- [x] `npx vitest run` — 18 suites / 246 tests pass.
- [x] `pnpm format:check` + `pnpm lint` — clean.
- [x] `npx agent-ci run --all -q -p` — 2/2 in 1m 10s.
- [x] **End-to-end:** the original failing downstream `provision()` runs all the way to `Built ./app.tar.gz` (144.2s).
