### PR TITLE
fix(microvm,runtime): unhang --mount-live by shipping fuse-agent + flipping vsock direction (#113)

### DIFF
--- a/.docs/marketing/research/jer-pocketos-railway-cursor-incident.md
+++ b/.docs/marketing/research/jer-pocketos-railway-cursor-incident.md
@@ -1,0 +1,47 @@
+# JER / PocketOS — Cursor + Railway production-data deletion (Apr 25, 2026)
+
+- **Source:** https://x.com/lifeof_jer (post got 1.4M views)
+- **Summary:** Cursor agent (Claude Opus 4.6) "fixed" a credential mismatch in
+  staging by reaching for an unrelated Railway CLI token it found on disk and
+  calling `volumeDelete` on production. Volume + in-volume backups gone in 9s.
+  Last off-volume backup was 3 months old.
+
+## The hooks worth amplifying (not JER's post itself)
+
+- **Simon Willison:** "every agent framework should come with best-in-class
+  sandboxing out of the box. Currently, setting up a sandbox is mostly left
+  as an exercise for the user, and doing that well is really difficult."
+  → Direct articulation of machinen's value prop from a credible voice.
+- **Dylan Mikus:** "the tooling for running agents should do a better job
+  isolating itself — ie run it in a sandbox with just the git repo."
+- **Jake Cooper (Railway CEO):** "There's a massive opportunity for
+  'vibecode safely in prod at scale.' 1B+ developers who look like JER...
+  the burden of making bulletproof tooling goes up."
+
+These three are the conversation to ride. JER's own post is an active
+incident — don't dunk, don't pile on.
+
+## Lessons we think are actually right
+
+1. **Don't run agents anywhere they can reach prod credentials.** Knowing
+   which creds are reachable from the agent's process is on you.
+2. **Keep tested, independently-hosted backups.** (Not a machinen story —
+   see below.)
+
+## Where machinen fits
+
+- **Lesson 1: yes, directly.** A microVM is a hard boundary. An agent
+  running inside `machinen boot` can't `grep` the host's `~/.config` for a
+  Railway token it was never given. This is the Simon-Willison-shaped
+  opportunity.
+- **Lesson 2: no, don't stretch.** Backups are an architecture problem
+  (off-host, different blast radius, restore-tested). machinen is a
+  process/VM transport tool. The closest honest claim is "snapshots are
+  naturally off-box artifacts" — but that's about workload portability,
+  not Postgres backups. Don't lead with it.
+
+## Tone
+
+Boring-but-correct. "Here's what sandboxed agent execution looks like in
+~30 lines" beats "told you so." The audience is toolmakers in Jake's
+replies, not JER's mentions.

--- a/packages/microvm/assets/fuse-agent.zig
+++ b/packages/microvm/assets/fuse-agent.zig
@@ -21,6 +21,14 @@
 //!
 //!   fuse-agent <vsock-port> <mount-path>
 //!
+//! The agent dials cid=2 (host) at the given port; the host-side VMM
+//! routes that REQUEST to the configured UDS where the mount-server is
+//! listening (MACHINEN_VSOCK="out:<port>:<uds>"). Listening on the
+//! guest side would also work, but only if some host-side actor dialed
+//! the VMM's UDS to trigger the bridge — and the mount-server is itself
+//! a UDS server, so there's no such actor. Guest-initiates is the path
+//! that closes the loop without a third process in the middle.
+//!
 //! The mount-path is created if missing. Mount flags are kept tight:
 //! MS_NOSUID | MS_NODEV, plus `default_permissions` so the guest
 //! kernel does its own permission check on the attrs we hand back.
@@ -42,9 +50,7 @@ extern "c" fn close(fd: c_int) c_int;
 extern "c" fn read(fd: c_int, buf: [*]u8, count: usize) isize;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
 extern "c" fn socket(domain: c_int, sock_type: c_int, protocol: c_int) c_int;
-extern "c" fn bind(fd: c_int, addr: *const anyopaque, addrlen: c_uint) c_int;
-extern "c" fn listen(fd: c_int, backlog: c_int) c_int;
-extern "c" fn accept(fd: c_int, addr: ?*anyopaque, addrlen: ?*c_uint) c_int;
+extern "c" fn connect(fd: c_int, addr: *const anyopaque, addrlen: c_uint) c_int;
 extern "c" fn mount(
     src: [*:0]const u8,
     dst: [*:0]const u8,
@@ -67,7 +73,9 @@ const MS_NODEV: c_ulong = 4;
 const MNT_DETACH: c_int = 2;
 const SIGPIPE: c_int = 13;
 const SIG_IGN: usize = 1;
-const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
+// host_cid=2 is the well-known CID for "this hypervisor" in AF_VSOCK,
+// matching the host_cid constant in packages/microvm/src/vsock.zig.
+const VMADDR_CID_HOST: u32 = 2;
 
 // /proc/sys/fs/fuse/conn/*/max_read — kernel's read buffer. 128KiB is
 // the common ceiling matching max_write negotiated in FUSE_INIT.
@@ -267,14 +275,17 @@ pub fn main(init: std.process.Init.Minimal) !void {
     var log_buf: [256]u8 = undefined;
     const log_msg = std.fmt.bufPrint(
         &log_buf,
-        "fuse-agent: mounted {s} (dev_fd={d}); listening on vsock port {d}",
+        "fuse-agent: mounted {s} (dev_fd={d}); dialing host on vsock port {d}",
         .{ mount_path, dev_fd, port },
-    ) catch "fuse-agent: mounted; listening";
+    ) catch "fuse-agent: mounted; dialing";
     logLine(log_msg);
 
-    // Listen on vsock.
-    const srv_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
-    if (srv_fd < 0) {
+    // Dial the host. The VMM's vsock bridge sees the REQUEST for
+    // (cid=2, port) and connects the configured UDS where the
+    // mount-server is listening; a successful return here means the
+    // bridge is fully wired and we can start forwarding bytes.
+    const sock_fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (sock_fd < 0) {
         _ = umount2(target_z.ptr, MNT_DETACH);
         logLine("fuse-agent: vsock socket() failed");
         return error.VsockSocketFailed;
@@ -283,30 +294,16 @@ pub fn main(init: std.process.Init.Minimal) !void {
         .svm_family = @intCast(AF_VSOCK),
         .svm_reserved1 = 0,
         .svm_port = port,
-        .svm_cid = VMADDR_CID_ANY,
+        .svm_cid = VMADDR_CID_HOST,
         .svm_zero = .{ 0, 0, 0, 0 },
     };
-    if (bind(srv_fd, @ptrCast(&addr), @sizeOf(SockaddrVm)) < 0) {
+    if (connect(sock_fd, @ptrCast(&addr), @sizeOf(SockaddrVm)) < 0) {
+        _ = close(sock_fd);
         _ = umount2(target_z.ptr, MNT_DETACH);
-        logLine("fuse-agent: vsock bind() failed");
-        return error.VsockBindFailed;
+        logLine("fuse-agent: vsock connect() to host failed");
+        return error.VsockConnectFailed;
     }
-    if (listen(srv_fd, 1) < 0) {
-        _ = umount2(target_z.ptr, MNT_DETACH);
-        logLine("fuse-agent: vsock listen() failed");
-        return error.VsockListenFailed;
-    }
-
-    // One mount per agent, one connection per mount. The host server
-    // is also single-connection.
-    const sock_fd = accept(srv_fd, null, null);
-    if (sock_fd < 0) {
-        _ = umount2(target_z.ptr, MNT_DETACH);
-        logLine("fuse-agent: vsock accept() failed");
-        return error.VsockAcceptFailed;
-    }
-    _ = close(srv_fd);
-    logLine("fuse-agent: host connected; forwarding");
+    logLine("fuse-agent: connected to host; forwarding");
 
     var pipe = Pipe{ .dev_fd = dev_fd, .sock_fd = sock_fd };
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -650,7 +650,12 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     }
     liveMountsResolved = resolveLiveMounts(opts.liveMounts!, opts.cwd, vsockTempDir);
     for (const lm of liveMountsResolved) {
-      env.MACHINEN_VSOCK = `${env.MACHINEN_VSOCK},in:${lm.port}:${lm.udsPath}`;
+      // `out:` — the guest fuse-agent connects to (cid=2, port=lm.port);
+      // when the VMM sees the REQUEST it dials the host's UDS where
+      // serveLiveMount is listening. Using `in:` here would have the
+      // VMM also listen on the UDS (clobbering serveLiveMount), and
+      // since fuse-agent doesn't initiate, nothing would ever bridge.
+      env.MACHINEN_VSOCK = `${env.MACHINEN_VSOCK},out:${lm.port}:${lm.udsPath}`;
     }
   }
 

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -75,16 +75,18 @@ dtc -I dts -O dtb "${ASSETS}/virt.dts" -o "${OUT}/virt-arm64.dtb"
 #    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent, CRIU helpers, poweroff, net-bench-probe) for aarch64-linux-musl"
+echo "==> Building guest binaries (init, exec-agent, fuse-agent, CRIU helpers, poweroff, net-bench-probe) for aarch64-linux-musl"
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STAGE"' EXIT
 
-# init + exec-agent land at /init and /exec-agent (machinen-owned root
-# entrypoints). lo-up, no-iou, poweroff are machinen-namespaced helpers
-# needed by any CRIU-based snapshot flow; they go under /sbin with the
-# machinen- prefix alongside machinen-netup. net-bench-probe is the
-# #82 gvproxy throughput/latency probe used by the smoke harness.
-for name in init exec-agent lo-up no-iou poweroff net-bench-probe; do
+# init + exec-agent + fuse-agent land at /init, /exec-agent, /fuse-agent
+# (machinen-owned root entrypoints). lo-up, no-iou, poweroff are
+# machinen-namespaced helpers needed by any CRIU-based snapshot flow;
+# they go under /sbin with the machinen- prefix alongside machinen-netup.
+# net-bench-probe is the #82 gvproxy throughput/latency probe used by
+# the smoke harness. fuse-agent is the guest byte-pump for #78
+# `--mount-live`; /init forks it per liveMount entry.
+for name in init exec-agent fuse-agent lo-up no-iou poweroff net-bench-probe; do
   zig build-exe "${ASSETS}/${name}.zig" \
     -target aarch64-linux-musl \
     -O ReleaseSmall \
@@ -109,6 +111,7 @@ TEST_FIXTURES="${ROOT}/packages/microvm/test-fixtures"
 mkdir -p "${TEST_FIXTURES}"
 install -m 0755 "${STAGE}/init"        "${TEST_FIXTURES}/init"
 install -m 0755 "${STAGE}/exec-agent"  "${TEST_FIXTURES}/exec-agent"
+install -m 0755 "${STAGE}/fuse-agent"  "${TEST_FIXTURES}/fuse-agent"
 
 # ------------------------------------------------------------
 # 3a. fnm — Node version manager (#88)
@@ -351,6 +354,7 @@ echo "nameserver 192.168.127.1" > /work/rootfs/etc/resolv.conf
 
 install -m 0755 /stage/init       /work/rootfs/init
 install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
+install -m 0755 /stage/fuse-agent /work/rootfs/fuse-agent
 install -m 0755 -D /stage/machinen-netup    /work/rootfs/sbin/machinen-netup
 install -m 0755 -D /stage/lo-up             /work/rootfs/sbin/machinen-lo-up
 install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou


### PR DESCRIPTION
## Summary

Closes #113. `--mount-live` (#78) was non-functional on a stock build for two independent reasons.

**Bug 1 — `/fuse-agent` was never built into the rootfs.** `build-base-assets.sh` skipped it, so `/init` execed a missing binary and the live mount never appeared in `/proc/self/mounts`. Fix: add `fuse-agent` to the zig build loop, stage it into `packages/microvm/test-fixtures/` (where `defaultFuseAgentPath()` picks it up for the cpio injection), and install it at `/fuse-agent` inside the rootfs tarball so it survives the rootdisk pivot.

**Bug 2 — the vsock direction was inverted.** `mount-server.ts` listens on a UDS and `fuse-agent` was also `listen()+accept()`-ing on its vsock port — both ends passive. `MACHINEN_VSOCK="in:..."` told the VMM to listen on the same UDS too, clobbering `mount-server`. First `stat`/`readdir` on the mount sent FUSE_INIT to `/dev/fuse`; nothing ever read it, so userspace dropped into uninterruptible sleep. Fix: flip to `out:` (VMM dials the host UDS when the guest sends REQUEST), and switch `fuse-agent` from listen+accept to `connect(cid=2, port)` so the guest initiates and `mount-server`'s accept fires.

## Test plan

- [x] `npx vitest run` — 246 passed
- [x] `npx agent-ci run --all -q -p` — 2 passed
- [ ] Repro from #113 (boot with `liveMounts: [{ host, guest }]`, `ls /mnt/share` from inside the guest) returns directory contents instead of hanging in D-state
