### PR TITLE
feat(runtime,cli): --mount-live :rw write-through (#151)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -71,14 +71,14 @@ describe("parseRunArgs --env", () => {
 });
 
 describe("parseRunArgs --mount-live", () => {
-  it("captures a single --mount-live", () => {
+  it("captures a single --mount-live (defaults to ro)", () => {
     const parsed = parseRunArgs(["--mount-live", "./src:/mnt/src", "--", "/bin/true"]);
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
   });
 
   it("accepts the =form", () => {
     const parsed = parseRunArgs(["--mount-live=./src:/mnt/src"]);
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
   });
 
   it("is repeatable and preserves order", () => {
@@ -90,16 +90,16 @@ describe("parseRunArgs --mount-live", () => {
       "./c:/mnt/c",
     ]);
     expect(parsed.liveMounts).toEqual([
-      { host: "./a", guest: "/mnt/a" },
-      { host: "./b", guest: "/mnt/b" },
-      { host: "./c", guest: "/mnt/c" },
+      { host: "./a", guest: "/mnt/a", mode: "ro" },
+      { host: "./b", guest: "/mnt/b", mode: "ro" },
+      { host: "./c", guest: "/mnt/c", mode: "ro" },
     ]);
   });
 
   it("coexists with --mount (copy-once stays separate)", () => {
     const parsed = parseRunArgs(["--mount", "./cfg:/mnt/cfg", "--mount-live", "./src:/mnt/src"]);
     expect(parsed.mount).toEqual({ host: "./cfg", guest: "/mnt/cfg" });
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
   });
 
   it("returns undefined liveMounts when the flag is absent", () => {
@@ -109,7 +109,7 @@ describe("parseRunArgs --mount-live", () => {
 
   it("rejects a malformed spec (missing colon)", () => {
     expect(() => parseRunArgs(["--mount-live", "./src"])).toThrow(
-      /expected <host-dir>:<guest-path>/,
+      /expected <host-dir>:<guest-path>\[:<mode>\]/,
     );
   });
 
@@ -117,9 +117,25 @@ describe("parseRunArgs --mount-live", () => {
     expect(() => parseRunArgs(["--mount-live"])).toThrow(/--mount-live requires/);
   });
 
-  it("rejects a spec with a trailing :rw (reserved for write-through)", () => {
-    expect(() => parseRunArgs(["--mount-live", "./src:/mnt/src:rw"])).toThrow(
-      /expected <host-dir>:<guest-path>/,
+  it("accepts an explicit :ro suffix", () => {
+    const parsed = parseRunArgs(["--mount-live", "./src:/mnt/src:ro"]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
+  });
+
+  it("accepts a :rw suffix for write-through", () => {
+    const parsed = parseRunArgs(["--mount-live", "./src:/mnt/src:rw"]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "rw" }]);
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(() => parseRunArgs(["--mount-live", "./src:/mnt/src:xx"])).toThrow(
+      /mode must be 'ro' or 'rw'/,
+    );
+  });
+
+  it("rejects a spec with too many colons", () => {
+    expect(() => parseRunArgs(["--mount-live", "./src:/mnt/src:rw:extra"])).toThrow(
+      /expected <host-dir>:<guest-path>\[:<mode>\]/,
     );
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -760,9 +760,11 @@ function printHelp(): void {
       `                                                 disk for a future vm.snapshot().\n` +
       `    --mount <host-dir>:<guest-path>              Expose one host dir inside the guest\n` +
       `                                                 (path under /mnt/; copy-once).\n` +
-      `    --mount-live <host-dir>:<guest-path>         Live-share a host dir over FUSE.\n` +
+      `    --mount-live <host-dir>:<guest-path>[:<mode>]\n` +
+      `                                                 Live-share a host dir over FUSE.\n` +
       `                                                 Guest reads stream in on demand; no\n` +
-      `                                                 copy at boot. Read-only for now.\n` +
+      `                                                 copy at boot. mode is 'ro' (default)\n` +
+      `                                                 or 'rw' for write-through.\n` +
       `    --env KEY=VALUE                              Set an env var inside the guest.\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -9,11 +9,12 @@ export interface ParsedRunArgs {
   double_dash_args: string[];
   mount?: { host: string; guest: string };
   /**
-   * Live-share FUSE mounts (`--mount-live <host>:<guest>`). Each
-   * entry stays connected to the host filesystem for the VM's life;
-   * guest reads stream in on demand. Read-only in this build. See #78.
+   * Live-share FUSE mounts (`--mount-live <host>:<guest>[:<mode>]`).
+   * Each entry stays connected to the host filesystem for the VM's
+   * life; guest reads stream in on demand. `mode` is `ro` (default) or
+   * `rw` for write-through. See #78, #151.
    */
-  liveMounts?: Array<{ host: string; guest: string }>;
+  liveMounts?: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
   env?: Record<string, string>;
   portForward?: Array<{ hostPort: number; guestPort: number }>;
   /** Snapshot image to restore from (`--snapshot <path>`). */
@@ -29,7 +30,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
 
   const positional: string[] = [];
   let mount: { host: string; guest: string } | undefined;
-  const liveMounts: Array<{ host: string; guest: string }> = [];
+  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
   const env: Record<string, string> = {};
   const portForward: Array<{ hostPort: number; guestPort: number }> = [];
   const seenHostPorts = new Set<number>();
@@ -79,18 +80,28 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       } else {
         spec = a.slice("--mount-live=".length);
       }
-      // Intentionally strict for v0: plain `<host>:<guest>`, no `:rw`
-      // suffix yet. Refusing any extra `:` now avoids callers baking
-      // `:rw` into scripts before write-through actually works and
-      // keeps the future upgrade additive.
-      const colon = spec!.indexOf(":");
-      if (colon <= 0 || colon === spec!.length - 1 || spec!.indexOf(":", colon + 1) !== -1) {
+      // Format: `<host>:<guest>[:<mode>]`. Mode defaults to `ro`;
+      // explicit `:rw` enables write-through (#151). A guest path
+      // containing a colon is rejected — same trade-off as `--mount`.
+      const parts = spec!.split(":");
+      if (parts.length < 2 || parts.length > 3 || !parts[0] || !parts[1]) {
         throw new ParseError(
           "PARSE_FLAG_MALFORMED",
-          `--mount-live: expected <host-dir>:<guest-path>, got '${spec}'`,
+          `--mount-live: expected <host-dir>:<guest-path>[:<mode>], got '${spec}'`,
         );
       }
-      liveMounts.push({ host: spec!.slice(0, colon), guest: spec!.slice(colon + 1) });
+      const modeRaw = parts[2];
+      if (modeRaw !== undefined && modeRaw !== "ro" && modeRaw !== "rw") {
+        throw new ParseError(
+          "PARSE_FLAG_MALFORMED",
+          `--mount-live: mode must be 'ro' or 'rw', got '${modeRaw}'`,
+        );
+      }
+      liveMounts.push({
+        host: parts[0]!,
+        guest: parts[1]!,
+        mode: (modeRaw as "ro" | "rw" | undefined) ?? "ro",
+      });
     } else if (a === "--env" || a.startsWith("--env=")) {
       let spec: string | undefined;
       if (a === "--env") {

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -9,7 +9,16 @@
 // exercises the actual mount → read path.
 
 import { connect as netConnect } from "node:net";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -377,8 +386,8 @@ describe("live mount server — symlink semantics", () => {
   });
 });
 
-describe("live mount server — unknown ops reply ENOSYS", () => {
-  it("WRITE (not supported in RO v0) → ENOSYS", async () => {
+describe("live mount server — :ro mounts reject mutations", () => {
+  it("WRITE returns EROFS in :ro mode", async () => {
     await withConnection(async (conn) => {
       await doInit(conn);
       const reply = await conn.request(FUSE_OP.WRITE, {
@@ -386,7 +395,244 @@ describe("live mount server — unknown ops reply ENOSYS", () => {
         nodeid: 1n,
         payload: new Uint8Array(40),
       });
-      expect(reply.header.error).toBe(-38); // -ENOSYS
+      expect(reply.header.error).toBe(-30); // -EROFS
+    });
+  });
+
+  it("CREATE returns EROFS in :ro mode", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const payload = new Uint8Array(16 + "new.txt\0".length);
+      const dv = new DataView(payload.buffer);
+      dv.setUint32(0, 0o100, true); // O_CREAT
+      dv.setUint32(4, 0o644, true); // mode
+      payload.set(new TextEncoder().encode("new.txt\0"), 16);
+      const reply = await conn.request(FUSE_OP.CREATE, {
+        unique: 2n,
+        nodeid: 1n,
+        payload,
+      });
+      expect(reply.header.error).toBe(-30); // -EROFS
+    });
+  });
+
+  it("UNLINK returns EROFS in :ro mode", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.UNLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      expect(reply.header.error).toBe(-30);
+    });
+  });
+});
+
+// ---------------- :rw write-through ----------------
+
+describe("live mount server — :rw write-through", () => {
+  let rwScratch: string;
+  let rwRoot: string;
+  let rwUds: string;
+  let rwHandle: LiveMountServerHandle | undefined;
+
+  beforeEach(async () => {
+    rwScratch = mkdtempSync(join(tmpdir(), "machinen-mount-server-rw-"));
+    rwRoot = join(rwScratch, "root");
+    mkdirSync(rwRoot);
+    writeFileSync(join(rwRoot, "existing.txt"), "old\n");
+    mkdirSync(join(rwRoot, "dir"));
+    writeFileSync(join(rwRoot, "dir/file.txt"), "x");
+    rwUds = join(rwScratch, "fuse.sock");
+    rwHandle = await serveLiveMount(rwUds, { rootAbs: rwRoot, mode: "rw" });
+  });
+
+  afterEach(async () => {
+    await rwHandle?.stop();
+    rwHandle = undefined;
+    rmSync(rwScratch, { recursive: true, force: true });
+  });
+
+  async function rwConn(fn: (c: TestConnection) => Promise<void>): Promise<void> {
+    await withConnectionTo(rwUds, fn);
+  }
+
+  it("CREATE makes a new file and writes land on the host", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      // CREATE "new.txt" under root
+      const create = await conn.request(FUSE_OP.CREATE, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buildCreateInWithName({ flags: 0o102, mode: 0o644, name: "new.txt" }),
+      });
+      expect(create.header.error).toBe(0);
+      // payload = entry_out (128) + open_out (16) = 144
+      expect(create.payload.length).toBe(144);
+      const fh = new DataView(
+        create.payload.buffer,
+        create.payload.byteOffset + 128,
+        16,
+      ).getBigUint64(0, true);
+      const inode = bigintFromEntry(create.payload);
+
+      // WRITE bytes
+      const data = new TextEncoder().encode("hello write\n");
+      const writeBody = buildWriteInWithData({ fh, offset: 0n, data });
+      const w = await conn.request(FUSE_OP.WRITE, {
+        unique: 3n,
+        nodeid: inode,
+        payload: writeBody,
+      });
+      expect(w.header.error).toBe(0);
+      // fuse_write_out: u32 size, u32 padding
+      expect(new DataView(w.payload.buffer, w.payload.byteOffset, 8).getUint32(0, true)).toBe(
+        data.length,
+      );
+
+      const rel = await conn.request(FUSE_OP.RELEASE, {
+        unique: 4n,
+        nodeid: inode,
+        payload: buildReleaseIn({ fh }),
+      });
+      expect(rel.header.error).toBe(0);
+
+      // The host file should exist with the bytes we wrote.
+      const onDisk = readFileSync(join(rwRoot, "new.txt"), "utf8");
+      expect(onDisk).toBe("hello write\n");
+    });
+  });
+
+  it("UNLINK removes a file from the host", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.UNLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("existing.txt"),
+      });
+      expect(reply.header.error).toBe(0);
+      expect(existsSync(join(rwRoot, "existing.txt"))).toBe(false);
+    });
+  });
+
+  it("MKDIR + RMDIR round-trips on the host", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      // fuse_mkdir_in: u32 mode, u32 umask, then NUL-terminated name
+      const name = "new-dir";
+      const buf = new Uint8Array(8 + name.length + 1);
+      const dv = new DataView(buf.buffer);
+      dv.setUint32(0, 0o755, true);
+      dv.setUint32(4, 0, true);
+      buf.set(new TextEncoder().encode(name), 8);
+      const mk = await conn.request(FUSE_OP.MKDIR, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buf,
+      });
+      expect(mk.header.error).toBe(0);
+      expect(statSync(join(rwRoot, name)).isDirectory()).toBe(true);
+
+      const rm = await conn.request(FUSE_OP.RMDIR, {
+        unique: 3n,
+        nodeid: 1n,
+        payload: nameBuf(name),
+      });
+      expect(rm.header.error).toBe(0);
+      expect(existsSync(join(rwRoot, name))).toBe(false);
+    });
+  });
+
+  it("RENAME moves a file under the host", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      // fuse_rename_in: u64 newdir, then "old\0new\0"
+      const buf = new Uint8Array(8 + "existing.txt\0renamed.txt\0".length);
+      const dv = new DataView(buf.buffer);
+      dv.setBigUint64(0, 1n, true); // newdir = root
+      buf.set(new TextEncoder().encode("existing.txt\0renamed.txt\0"), 8);
+      const reply = await conn.request(FUSE_OP.RENAME, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buf,
+      });
+      expect(reply.header.error).toBe(0);
+      expect(existsSync(join(rwRoot, "existing.txt"))).toBe(false);
+      expect(readFileSync(join(rwRoot, "renamed.txt"), "utf8")).toBe("old\n");
+    });
+  });
+
+  it("SETATTR with FATTR_SIZE truncates the file", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("existing.txt"),
+      });
+      const ino = bigintFromEntry(lookup.payload);
+      // fuse_setattr_in: 88 bytes. We set FATTR_SIZE (1<<3) and size=0.
+      const buf = new Uint8Array(88);
+      const dv = new DataView(buf.buffer);
+      dv.setUint32(0, 1 << 3, true); // valid = FATTR_SIZE
+      dv.setBigUint64(16, 0n, true); // size = 0
+      const reply = await conn.request(FUSE_OP.SETATTR, {
+        unique: 3n,
+        nodeid: ino,
+        payload: buf,
+      });
+      expect(reply.header.error).toBe(0);
+      expect(readFileSync(join(rwRoot, "existing.txt"), "utf8")).toBe("");
+    });
+  });
+
+  it("CREATE refuses a malformed name (slash in basename → EINVAL)", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.CREATE, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buildCreateInWithName({
+          flags: 0o102,
+          mode: 0o644,
+          name: "../escape.txt",
+        }),
+      });
+      expect(reply.header.error).toBe(-22); // -EINVAL
+    });
+  });
+
+  it("CREATE through a symlink that escapes the root → ENOENT", async () => {
+    // Plant a symlink inside the mount that points to a directory
+    // outside it, then try to CREATE a file under that link's inode.
+    // The resolver realpath's the parent through the symlink, sees
+    // the result is outside `rwRoot`, and throws MountError →
+    // ENOENT on the wire. The host's outside dir must stay untouched.
+    const outside = join(rwScratch, "outside");
+    mkdirSync(outside);
+    symlinkSync(outside, join(rwRoot, "escape-link"));
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("escape-link"),
+      });
+      expect(lookup.header.error).toBe(0);
+      const linkIno = bigintFromEntry(lookup.payload);
+      const create = await conn.request(FUSE_OP.CREATE, {
+        unique: 3n,
+        nodeid: linkIno,
+        payload: buildCreateInWithName({
+          flags: 0o102,
+          mode: 0o644,
+          name: "planted.txt",
+        }),
+      });
+      expect(create.header.error).toBe(-2); // -ENOENT
+      expect(existsSync(join(outside, "planted.txt"))).toBe(false);
     });
   });
 });
@@ -405,8 +651,15 @@ interface TestConnection {
 }
 
 async function withConnection(fn: (c: TestConnection) => Promise<void>): Promise<void> {
+  return withConnectionTo(udsPath, fn);
+}
+
+async function withConnectionTo(
+  path: string,
+  fn: (c: TestConnection) => Promise<void>,
+): Promise<void> {
   const sock = await new Promise<Awaited<ReturnType<typeof netConnect>>>((done, fail) => {
-    const s = netConnect(udsPath);
+    const s = netConnect(path);
     s.once("error", fail);
     s.once("connect", () => {
       s.off("error", fail);
@@ -501,6 +754,27 @@ function buildReleaseIn(opts: { fh: bigint }): Uint8Array {
   const buf = new Uint8Array(24);
   const dv = new DataView(buf.buffer);
   dv.setBigUint64(0, opts.fh, true);
+  return buf;
+}
+
+function buildCreateInWithName(opts: { flags: number; mode: number; name: string }): Uint8Array {
+  const nameBytes = new TextEncoder().encode(opts.name);
+  const buf = new Uint8Array(16 + nameBytes.length + 1);
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(0, opts.flags, true);
+  dv.setUint32(4, opts.mode, true);
+  // umask + open_flags = 0
+  buf.set(nameBytes, 16);
+  return buf;
+}
+
+function buildWriteInWithData(opts: { fh: bigint; offset: bigint; data: Uint8Array }): Uint8Array {
+  const buf = new Uint8Array(40 + opts.data.length);
+  const dv = new DataView(buf.buffer);
+  dv.setBigUint64(0, opts.fh, true);
+  dv.setBigUint64(8, opts.offset, true);
+  dv.setUint32(16, opts.data.length, true);
+  buf.set(opts.data, 40);
   return buf;
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -277,8 +277,9 @@ export interface BootOptions {
    * Host directories exposed to the guest as live-share FUSE mounts
    * (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
    * connected to the host: the guest reads on demand via a vsock FUSE
-   * relay, and nothing is copied at boot. Read-only in this build;
-   * `:rw` write-through is a follow-up.
+   * relay, and nothing is copied at boot. `mode` defaults to `"ro"`;
+   * `"rw"` enables write-through so guest writes land on the host
+   * (#151).
    *
    * Each guest path must live under `/mnt/` (same rule as `mount`).
    * Repeatable; each entry gets its own vsock port.
@@ -289,7 +290,7 @@ export interface BootOptions {
    * no such runtime channel and is strictly safer — prefer it for
    * inputs you don't need write-through on.
    */
-  liveMounts?: Array<{ host: string; guest: string }>;
+  liveMounts?: Array<{ host: string; guest: string; mode?: "ro" | "rw" }>;
   /**
    * Host -> guest TCP port forwards installed via gvproxy's control
    * API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -727,7 +728,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     // past /dev/fuse mount; if we started them after the VMM, the
     // agent would spin in connect-retry for as long as we took.
     for (const lm of liveMountsResolved) {
-      const handle = await serveLiveMount(lm.udsPath, { rootAbs: lm.host });
+      const handle = await serveLiveMount(lm.udsPath, {
+        rootAbs: lm.host,
+        mode: lm.mode,
+      });
       liveMountStops.push(handle.stop);
     }
 
@@ -1262,6 +1266,7 @@ interface ResolvedLiveMount {
   guest: string;
   port: number;
   udsPath: string;
+  mode: "ro" | "rw";
 }
 
 /** Base vsock port for live mounts. Chosen below the exec/file/
@@ -1269,7 +1274,7 @@ interface ResolvedLiveMount {
 const LIVE_MOUNT_PORT_BASE = 1970;
 
 function resolveLiveMounts(
-  mounts: Array<{ host: string; guest: string }>,
+  mounts: Array<{ host: string; guest: string; mode?: "ro" | "rw" }>,
   cwd: string | undefined,
   udsDir: string,
 ): ResolvedLiveMount[] {
@@ -1293,6 +1298,7 @@ function resolveLiveMounts(
       guest: normalizeMountGuest(m.guest),
       port: LIVE_MOUNT_PORT_BASE + i,
       udsPath: join(udsDir, `live-mount-${i}.sock`),
+      mode: m.mode ?? "ro",
     };
   });
 }

--- a/packages/runtime/src/mount-fuse-protocol.ts
+++ b/packages/runtime/src/mount-fuse-protocol.ts
@@ -37,12 +37,18 @@ export const FUSE_OP = {
   LOOKUP: 1,
   FORGET: 2,
   GETATTR: 3,
+  SETATTR: 4,
   READLINK: 5,
+  MKDIR: 9,
+  UNLINK: 10,
+  RMDIR: 11,
+  RENAME: 12,
   OPEN: 14,
   READ: 15,
   WRITE: 16,
   STATFS: 17,
   RELEASE: 18,
+  FSYNC: 20,
   FLUSH: 25,
   INIT: 26,
   OPENDIR: 27,
@@ -54,6 +60,24 @@ export const FUSE_OP = {
   DESTROY: 38,
   BATCH_FORGET: 42,
   READDIRPLUS: 44,
+} as const;
+
+/**
+ * `fuse_setattr_in.valid` flags (uapi/linux/fuse.h FATTR_*).
+ * Tells the server which fields of the struct are meaningful.
+ */
+export const FATTR = {
+  MODE: 1 << 0,
+  UID: 1 << 1,
+  GID: 1 << 2,
+  SIZE: 1 << 3,
+  ATIME: 1 << 4,
+  MTIME: 1 << 5,
+  FH: 1 << 6,
+  ATIME_NOW: 1 << 7,
+  MTIME_NOW: 1 << 8,
+  LOCKOWNER: 1 << 9,
+  CTIME: 1 << 10,
 } as const;
 
 export type FuseOp = (typeof FUSE_OP)[keyof typeof FUSE_OP];
@@ -509,6 +533,161 @@ export const DT = {
   LNK: 10,
   SOCK: 12,
 } as const;
+
+// --- fuse_write_in / fuse_write_out -------------------------------------
+
+/**
+ * fuse_write_in is 40 bytes on protocol >=7.9 (which we require for
+ * INIT). Older kernels send a 24-byte prefix; we don't support those.
+ */
+export const FUSE_WRITE_IN_SIZE = 40;
+
+export interface FuseWriteIn {
+  fh: bigint;
+  offset: bigint;
+  size: number;
+  write_flags: number;
+  lock_owner: bigint;
+  flags: number;
+}
+
+export function readWriteIn(buf: Uint8Array, off = 0): FuseWriteIn {
+  const dv = viewOf(buf, off, FUSE_WRITE_IN_SIZE);
+  return {
+    fh: dv.getBigUint64(0, true),
+    offset: dv.getBigUint64(8, true),
+    size: dv.getUint32(16, true),
+    write_flags: dv.getUint32(20, true),
+    lock_owner: dv.getBigUint64(24, true),
+    flags: dv.getUint32(32, true),
+    // padding at 36
+  };
+}
+
+export interface FuseWriteOut {
+  size: number;
+}
+
+export function buildWriteOut(o: FuseWriteOut): Uint8Array {
+  const buf = new Uint8Array(8);
+  const dv = viewOf(buf, 0, 8);
+  dv.setUint32(0, o.size, true);
+  // padding at 4
+  return buf;
+}
+
+// --- fuse_create_in (CREATE = open + create in one round-trip) ----------
+
+/**
+ * fuse_create_in is 16 bytes on protocol >=7.12 (mode + flags + umask
+ * + open_flags). Followed by NUL-terminated name. We negotiate 7.31,
+ * so the wider layout is always present.
+ */
+export const FUSE_CREATE_IN_SIZE = 16;
+
+export interface FuseCreateIn {
+  flags: number;
+  mode: number;
+  umask: number;
+  open_flags: number;
+}
+
+export function readCreateIn(buf: Uint8Array, off = 0): FuseCreateIn {
+  const dv = viewOf(buf, off, FUSE_CREATE_IN_SIZE);
+  return {
+    flags: dv.getUint32(0, true),
+    mode: dv.getUint32(4, true),
+    umask: dv.getUint32(8, true),
+    open_flags: dv.getUint32(12, true),
+  };
+}
+
+/**
+ * CREATE response is fuse_entry_out (128) immediately followed by
+ * fuse_open_out (16) — the kernel reads both back-to-back.
+ */
+export function buildCreateOut(entry: FuseEntryOut, open: FuseOpenOut): Uint8Array {
+  const entryBuf = buildEntryOut(entry);
+  const openBuf = buildOpenOut(open);
+  const out = new Uint8Array(entryBuf.length + openBuf.length);
+  out.set(entryBuf, 0);
+  out.set(openBuf, entryBuf.length);
+  return out;
+}
+
+// --- fuse_setattr_in -----------------------------------------------------
+
+export const FUSE_SETATTR_IN_SIZE = 88;
+
+export interface FuseSetattrIn {
+  valid: number;
+  fh: bigint;
+  size: bigint;
+  lock_owner: bigint;
+  atime: bigint;
+  mtime: bigint;
+  ctime: bigint;
+  atimensec: number;
+  mtimensec: number;
+  ctimensec: number;
+  mode: number;
+  uid: number;
+  gid: number;
+}
+
+export function readSetattrIn(buf: Uint8Array, off = 0): FuseSetattrIn {
+  const dv = viewOf(buf, off, FUSE_SETATTR_IN_SIZE);
+  return {
+    valid: dv.getUint32(0, true),
+    // padding at 4
+    fh: dv.getBigUint64(8, true),
+    size: dv.getBigUint64(16, true),
+    lock_owner: dv.getBigUint64(24, true),
+    atime: dv.getBigUint64(32, true),
+    mtime: dv.getBigUint64(40, true),
+    ctime: dv.getBigUint64(48, true),
+    atimensec: dv.getUint32(56, true),
+    mtimensec: dv.getUint32(60, true),
+    ctimensec: dv.getUint32(64, true),
+    mode: dv.getUint32(68, true),
+    // unused4 at 72
+    uid: dv.getUint32(76, true),
+    gid: dv.getUint32(80, true),
+    // unused5 at 84
+  };
+}
+
+// --- fuse_mkdir_in ------------------------------------------------------
+
+export const FUSE_MKDIR_IN_SIZE = 8;
+
+export interface FuseMkdirIn {
+  mode: number;
+  umask: number;
+}
+
+export function readMkdirIn(buf: Uint8Array, off = 0): FuseMkdirIn {
+  const dv = viewOf(buf, off, FUSE_MKDIR_IN_SIZE);
+  return {
+    mode: dv.getUint32(0, true),
+    umask: dv.getUint32(4, true),
+  };
+}
+
+// --- fuse_rename_in -----------------------------------------------------
+
+export const FUSE_RENAME_IN_SIZE = 8;
+
+export interface FuseRenameIn {
+  newdir: bigint;
+}
+
+export function readRenameIn(buf: Uint8Array, off = 0): FuseRenameIn {
+  const dv = viewOf(buf, off, FUSE_RENAME_IN_SIZE);
+  return {
+    newdir: dv.getBigUint64(0, true),
+  };
+}
 
 // --- helpers -------------------------------------------------------------
 

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -1,4 +1,4 @@
-// Live-share mount server for `--mount-live` (#78).
+// Live-share mount server for `--mount-live` (#78, #151).
 //
 // One instance per mount. Binds a Unix socket that the VMM's vsock
 // bridge muxes to a fixed guest port (see MACHINEN_VSOCK spec). The
@@ -7,18 +7,31 @@
 // the other end of that pipe: it parses each FUSE kernel message,
 // dispatches to a handler, and writes the FUSE response back.
 //
-// Read-only v0. Every mutating op replies with ENOSYS; that's enough
-// for the default `--mount-live` user contract (guest can read the
-// host directory, writes stay in a scratch layer managed by the
-// kernel on top of our read-only mount). `:rw` lands in a follow-up.
+// Mode is per-mount: `ro` (default) accepts only read-side ops and
+// rejects mutations with EROFS; `rw` enables write-through so guest
+// writes land on the host directory.
 //
 // Path containment routes through `resolveUnderRoot` — the load-
 // bearing piece that keeps a crafted guest path from escaping the
 // mount root. See mount-resolver.ts.
 
 import { createServer, type Server, type Socket } from "node:net";
-import { open as fsOpen, lstat, readdir, realpath, statfs } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  open as fsOpen,
+  lstat,
+  readdir,
+  realpath,
+  rename,
+  rmdir,
+  statfs,
+  truncate,
+  unlink,
+  utimes,
+} from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import type { Stats } from "node:fs";
 import { join } from "node:path";
 import debug from "debug";
@@ -26,13 +39,16 @@ import { MountError, isMachinenError } from "./errors.ts";
 import { resolveUnderRoot } from "./mount-resolver.ts";
 import {
   DT,
+  FATTR,
   FUSE_CAP,
   FUSE_IN_HEADER_SIZE,
   FUSE_KERNEL_MINOR_VERSION,
   FUSE_KERNEL_VERSION,
   FUSE_OP,
+  FUSE_WRITE_IN_SIZE,
   type FuseInHeader,
   buildAttrOut,
+  buildCreateOut,
   buildDirent,
   buildEntryOut,
   buildErrorResponse,
@@ -40,14 +56,20 @@ import {
   buildKstatfs,
   buildOpenOut,
   buildResponse,
+  buildWriteOut,
   payloadOf,
   readBatchForgetIn,
+  readCreateIn,
   readForgetIn,
   readInHeader,
   readInitIn,
+  readMkdirIn,
   readOpenIn,
   readReadIn,
   readReleaseIn,
+  readRenameIn,
+  readSetattrIn,
+  readWriteIn,
 } from "./mount-fuse-protocol.ts";
 
 const log = debug("machinen:mount-server");
@@ -87,6 +109,12 @@ type OpenEntry = { kind: "file"; fh: FileHandle } | { kind: "dir"; entries: Uint
 export interface LiveMountServerOptions {
   /** Absolute host path that bounds every op. */
   rootAbs: string;
+  /**
+   * `"ro"` (default) rejects mutating ops with EROFS. `"rw"` enables
+   * write-through: WRITE/CREATE/MKDIR/RMDIR/UNLINK/RENAME/SETATTR/FSYNC
+   * land on the host filesystem, all gated through `resolveUnderRoot`.
+   */
+  mode?: "ro" | "rw";
 }
 
 export interface LiveMountServerHandle {
@@ -104,7 +132,7 @@ export async function serveLiveMount(
   udsPath: string,
   opts: LiveMountServerOptions,
 ): Promise<LiveMountServerHandle> {
-  const state = createState(opts.rootAbs);
+  const state = createState(opts.rootAbs, opts.mode ?? "ro");
   const server = createServer((sock) => void handleConnection(sock, state));
   await new Promise<void>((done, fail) => {
     server.once("error", fail);
@@ -113,7 +141,7 @@ export async function serveLiveMount(
       done();
     });
   });
-  log("listening udsPath=%s rootAbs=%s", udsPath, opts.rootAbs);
+  log("listening udsPath=%s rootAbs=%s mode=%s", udsPath, opts.rootAbs, state.mode);
   return {
     stop: () => shutdown(server, state),
   };
@@ -121,6 +149,7 @@ export async function serveLiveMount(
 
 interface ServerState {
   rootAbs: string;
+  mode: "ro" | "rw";
   inodes: Map<bigint, InodeEntry>;
   nextInode: bigint;
   handles: Map<bigint, OpenEntry>;
@@ -128,12 +157,13 @@ interface ServerState {
   socket: Socket | null;
 }
 
-function createState(rootAbs: string): ServerState {
+function createState(rootAbs: string, mode: "ro" | "rw"): ServerState {
   const inodes = new Map<bigint, InodeEntry>();
   // Root is pinned. nlookup=Infinity sentinel means "never evict".
   inodes.set(1n, { relPath: "", nlookup: Number.POSITIVE_INFINITY });
   return {
     rootAbs,
+    mode,
     inodes,
     nextInode: 2n,
     handles: new Map(),
@@ -242,12 +272,26 @@ async function handle(
       return await onLookup(hdr, msg, state);
     case FUSE_OP.GETATTR:
       return await onGetattr(hdr, state);
+    case FUSE_OP.SETATTR:
+      return await onSetattr(hdr, msg, state);
     case FUSE_OP.STATFS:
       return await onStatfs(hdr, state);
     case FUSE_OP.OPEN:
       return await onOpen(hdr, msg, state);
     case FUSE_OP.READ:
       return await onRead(hdr, msg, state);
+    case FUSE_OP.WRITE:
+      return await onWrite(hdr, msg, state);
+    case FUSE_OP.CREATE:
+      return await onCreate(hdr, msg, state);
+    case FUSE_OP.MKDIR:
+      return await onMkdir(hdr, msg, state);
+    case FUSE_OP.RMDIR:
+      return await onRmdir(hdr, msg, state);
+    case FUSE_OP.UNLINK:
+      return await onUnlink(hdr, msg, state);
+    case FUSE_OP.RENAME:
+      return await onRename(hdr, msg, state);
     case FUSE_OP.RELEASE:
       return await onRelease(hdr, msg, state);
     case FUSE_OP.OPENDIR:
@@ -256,6 +300,8 @@ async function handle(
       return await onReaddir(hdr, msg, state);
     case FUSE_OP.RELEASEDIR:
       return onReleasedir(hdr, msg, state);
+    case FUSE_OP.FSYNC:
+      return await onFsync(hdr, msg, state);
     case FUSE_OP.FLUSH:
     case FUSE_OP.ACCESS:
       // Userspace ok-to-ignore ops: reply success with no payload.
@@ -395,16 +441,15 @@ async function onStatfs(hdr: FuseInHeader, state: ServerState): Promise<Uint8Arr
 
 async function onOpen(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): Promise<Uint8Array> {
   const req = readOpenIn(payloadOf(msg));
-  // RO v0: reject anything that isn't pure-read.
   const accessMode = req.flags & 0o3; // O_RDONLY=0, O_WRONLY=1, O_RDWR=2
-  if (accessMode !== 0) {
+  if (accessMode !== 0 && state.mode === "ro") {
     return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
   }
   const entry = requireInode(state, hdr.nodeid);
   // OPEN always targets a real regular file (LOOKUP returned S_IFREG),
   // so following any residual intermediate symlinks is fine.
   const abs = await absPathForTraversal(state, entry);
-  const fh = await fsOpen(abs, "r");
+  const fh = await fsOpen(abs, linuxOpenFlagsToNode(req.flags));
   const id = state.nextHandle++;
   state.handles.set(id, { kind: "file", fh });
   return buildResponse(hdr.unique, buildOpenOut({ fh: id, open_flags: 0 }));
@@ -496,6 +541,272 @@ async function onReaddir(
 function onReleasedir(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): Uint8Array {
   const { fh } = readReleaseIn(payloadOf(msg));
   state.handles.delete(fh);
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+// --- write-through handlers (only reachable in :rw mode) ----------------
+
+async function onWrite(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readWriteIn(body);
+  const data = body.subarray(FUSE_WRITE_IN_SIZE, FUSE_WRITE_IN_SIZE + req.size);
+  const handle = state.handles.get(req.fh);
+  if (!handle || handle.kind !== "file") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EBADF);
+  }
+  const buf = Buffer.from(data.buffer, data.byteOffset, data.length);
+  const { bytesWritten } = await handle.fh.write(buf, 0, data.length, Number(req.offset));
+  return buildResponse(hdr.unique, buildWriteOut({ size: bytesWritten }));
+}
+
+async function onCreate(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readCreateIn(body);
+  const name = decodeName(body.subarray(16));
+  validateName(name);
+  const parent = requireInode(state, hdr.nodeid);
+  const parentAbs = await absPathForTraversal(state, parent);
+  const childAbs = join(parentAbs, name);
+  const childRel = joinRel(parent.relPath, name);
+  // Honour the kernel's flags + the request's mode verbatim. The
+  // kernel has already applied the guest's umask before sending us
+  // CREATE (we don't advertise FUSE_DONT_MASK).
+  const nodeFlags = linuxOpenFlagsToNode(req.flags) | fsConstants.O_CREAT;
+  const fh = await fsOpen(childAbs, nodeFlags, req.mode);
+  const st = await fh.stat();
+  const ino = bindInode(state, childRel);
+  const id = state.nextHandle++;
+  state.handles.set(id, { kind: "file", fh });
+  return buildResponse(
+    hdr.unique,
+    buildCreateOut(
+      {
+        nodeid: ino,
+        generation: 0n,
+        entry_valid: 1n,
+        attr_valid: 1n,
+        entry_valid_nsec: 0,
+        attr_valid_nsec: 0,
+        attr: statToAttr(st, ino),
+      },
+      { fh: id, open_flags: 0 },
+    ),
+  );
+}
+
+async function onMkdir(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readMkdirIn(body);
+  const name = decodeName(body.subarray(8));
+  validateName(name);
+  const parent = requireInode(state, hdr.nodeid);
+  const parentAbs = await absPathForTraversal(state, parent);
+  const childAbs = join(parentAbs, name);
+  const childRel = joinRel(parent.relPath, name);
+  // mode includes type bits in CREATE/MKNOD; for MKDIR the kernel
+  // already strips them. Mask to perm bits to be defensive.
+  await mkdir(childAbs, { mode: req.mode & 0o7777 });
+  const st = await lstat(childAbs);
+  const ino = bindInode(state, childRel);
+  return buildResponse(
+    hdr.unique,
+    buildEntryOut({
+      nodeid: ino,
+      generation: 0n,
+      entry_valid: 1n,
+      attr_valid: 1n,
+      entry_valid_nsec: 0,
+      attr_valid_nsec: 0,
+      attr: statToAttr(st, ino),
+    }),
+  );
+}
+
+async function onRmdir(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const name = decodeName(payloadOf(msg));
+  validateName(name);
+  const parent = requireInode(state, hdr.nodeid);
+  const parentAbs = await absPathForTraversal(state, parent);
+  await rmdir(join(parentAbs, name));
+  forgetByRelPath(state, joinRel(parent.relPath, name));
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+async function onUnlink(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const name = decodeName(payloadOf(msg));
+  validateName(name);
+  const parent = requireInode(state, hdr.nodeid);
+  const parentAbs = await absPathForTraversal(state, parent);
+  await unlink(join(parentAbs, name));
+  forgetByRelPath(state, joinRel(parent.relPath, name));
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+async function onRename(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readRenameIn(body);
+  // Two NUL-terminated names back-to-back after the struct.
+  const after = body.subarray(8);
+  const firstNul = after.indexOf(0);
+  if (firstNul < 0) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const oldName = decodeName(after.subarray(0, firstNul));
+  const newName = decodeName(after.subarray(firstNul + 1));
+  validateName(oldName);
+  validateName(newName);
+  const oldParent = requireInode(state, hdr.nodeid);
+  const newParent = requireInode(state, req.newdir);
+  // Resolve both parent dirs through the containment gate. The
+  // basename joins are then on canonical paths, so a symlink in either
+  // basename can't redirect outside root (the resolver realpath'd the
+  // parent, and join doesn't follow links).
+  const oldParentAbs = await absPathForTraversal(state, oldParent);
+  const newParentAbs = await absPathForTraversal(state, newParent);
+  await rename(join(oldParentAbs, oldName), join(newParentAbs, newName));
+  forgetByRelPath(state, joinRel(oldParent.relPath, oldName));
+  // The new name might shadow an existing inode entry; drop it so the
+  // next LOOKUP rebinds.
+  forgetByRelPath(state, joinRel(newParent.relPath, newName));
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+async function onSetattr(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  const req = readSetattrIn(payloadOf(msg));
+  // Pure attr-fetch SETATTR (valid==0) is meaningless; treat as a
+  // no-op GETATTR-style reply. Otherwise mutating, so RO mounts
+  // refuse.
+  const isMutating =
+    (req.valid &
+      (FATTR.MODE |
+        FATTR.SIZE |
+        FATTR.ATIME |
+        FATTR.MTIME |
+        FATTR.CTIME |
+        FATTR.ATIME_NOW |
+        FATTR.MTIME_NOW |
+        FATTR.UID |
+        FATTR.GID)) !==
+    0;
+  if (isMutating && state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const entry = requireInode(state, hdr.nodeid);
+  const abs = await absPathForTraversal(state, entry);
+  if (req.valid & FATTR.SIZE) {
+    if (req.valid & FATTR.FH) {
+      const handle = state.handles.get(req.fh);
+      if (!handle || handle.kind !== "file") {
+        return buildErrorResponse(hdr.unique, -ERRNO.EBADF);
+      }
+      await handle.fh.truncate(Number(req.size));
+    } else {
+      await truncate(abs, Number(req.size));
+    }
+  }
+  if (req.valid & FATTR.MODE) {
+    await chmod(abs, req.mode & 0o7777);
+  }
+  if (req.valid & (FATTR.ATIME | FATTR.MTIME | FATTR.ATIME_NOW | FATTR.MTIME_NOW)) {
+    // utimes wants seconds-since-epoch as numbers. Use current values
+    // for any axis the kernel didn't ask us to change, plus _NOW
+    // overrides.
+    const st = await lstat(abs);
+    const now = Date.now() / 1000;
+    const a =
+      req.valid & FATTR.ATIME_NOW
+        ? now
+        : req.valid & FATTR.ATIME
+          ? Number(req.atime) + req.atimensec / 1e9
+          : st.atimeMs / 1000;
+    const m =
+      req.valid & FATTR.MTIME_NOW
+        ? now
+        : req.valid & FATTR.MTIME
+          ? Number(req.mtime) + req.mtimensec / 1e9
+          : st.mtimeMs / 1000;
+    await utimes(abs, a, m);
+  }
+  // FATTR.UID / FATTR.GID: ignored. The host process is unprivileged
+  // in the typical case; chown would EPERM. The guest sees its own
+  // (uid=0) view via INIT and we don't pretend to enforce it.
+  const st = await lstat(abs);
+  return buildResponse(
+    hdr.unique,
+    buildAttrOut({
+      attr_valid: 1n,
+      attr_valid_nsec: 0,
+      attr: statToAttr(st, hdr.nodeid),
+    }),
+  );
+}
+
+async function onFsync(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  // fuse_fsync_in: { fh: u64, fsync_flags: u32, padding: u32 }
+  const body = payloadOf(msg);
+  if (body.length < 8) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const dv = new DataView(body.buffer, body.byteOffset, body.length);
+  const fh = dv.getBigUint64(0, true);
+  const handle = state.handles.get(fh);
+  if (!handle || handle.kind !== "file") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EBADF);
+  }
+  // `:ro` mounts have no dirty data — sync is still legal (it's a
+  // read-side guarantee), so honour without a mode check. fsync is a
+  // no-op on a clean fd.
+  await handle.fh.sync();
   return buildErrorResponse(hdr.unique, 0);
 }
 
@@ -600,6 +911,57 @@ function decrefInode(state: ServerState, ino: bigint, n: number): void {
   if (e.nlookup <= 0) {
     state.inodes.delete(ino);
   }
+}
+
+/**
+ * Drop any inode entry pointing at `relPath`. Called after RMDIR /
+ * UNLINK / RENAME so a subsequent LOOKUP at the same path mints a
+ * fresh inode rather than reusing one whose underlying file is gone.
+ * The kernel still holds nlookup refs to the old inode and will
+ * FORGET it later — that's fine, decrefInode tolerates a missing
+ * entry.
+ */
+function forgetByRelPath(state: ServerState, relPath: string): void {
+  for (const [ino, e] of state.inodes) {
+    if (e.relPath === relPath) {
+      state.inodes.delete(ino);
+      return;
+    }
+  }
+}
+
+/**
+ * Translate Linux fcntl open flags (as the guest kernel sends them)
+ * into Node's portable `fs.constants` flags. The numeric values
+ * differ between Linux and macOS, so we can't pass the wire flags
+ * straight to `fs.open` on a macOS host.
+ *
+ * O_CREAT is intentionally not honoured here — plain OPEN never
+ * creates; CREATE is a separate FUSE op. Same for O_EXCL.
+ */
+function linuxOpenFlagsToNode(flags: number): number {
+  // Linux fcntl values, stable on x86_64 / arm64. RDONLY=0 is the
+  // default branch.
+  const LINUX_O_WRONLY = 1;
+  const LINUX_O_RDWR = 2;
+  const LINUX_O_TRUNC = 0o1000;
+  const LINUX_O_APPEND = 0o2000;
+  const accessMode = flags & 0o3;
+  let out: number;
+  if (accessMode === LINUX_O_WRONLY) {
+    out = fsConstants.O_WRONLY;
+  } else if (accessMode === LINUX_O_RDWR) {
+    out = fsConstants.O_RDWR;
+  } else {
+    out = fsConstants.O_RDONLY;
+  }
+  if (flags & LINUX_O_TRUNC) {
+    out |= fsConstants.O_TRUNC;
+  }
+  if (flags & LINUX_O_APPEND) {
+    out |= fsConstants.O_APPEND;
+  }
+  return out;
 }
 
 function statToAttr(st: Stats, ino: bigint) {

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -14,9 +14,12 @@
 # Tests:
 #   V1-V4  Validation paths (no boot): host-missing, host-is-a-file,
 #          guest-outside-/mnt/, second --mount.
+#   V5-V8  --mount-live validation, including :ro / :rw modes — #78, #151.
 #   T1     Base-only boot — `echo hello-world` reaches the host console.
 #   T2     --mount exposes a host directory readable inside the guest.
+#   T3     --mount-live :ro streams a host file in lazily — #78.
 #   T4     --env propagates into the guest process env — #89.
+#   T5     --mount-live :rw guest writes land on the host — #151.
 #   C1-C2  Host-side artifact cache end-to-end via fnm — #88.
 #   P1-P3  Base-rootfs contract (criu, virtio modules, poweroff) — #77.
 #   N1-N5  New #93 CLI surface: ls, exec, attach-unknown, completion,
@@ -224,9 +227,9 @@ expect_cli_error \
   boot --mount-live "$EMPTY_DIR:/etc/passwd" -- true
 
 expect_cli_error \
-  "V8: --mount-live rejects the :rw suffix (reserved for write-through)" \
-  "expected <host-dir>:<guest-path>" \
-  boot --mount-live "$EMPTY_DIR:/mnt/x:rw" -- true
+  "V8: --mount-live rejects an unknown mode" \
+  "mode must be 'ro' or 'rw'" \
+  boot --mount-live "$EMPTY_DIR:/mnt/x:xx" -- true
 
 # ----------------------------------------------------------------
 # Boot tests — need HVF/KVM. Slow.
@@ -299,6 +302,33 @@ else
   else
     tail -80 "$T3_LOG" >&2
     fail "T3 marker ($T3_MARKER) not found — live mount didn't stream through"
+  fi
+fi
+
+# ---- T5: --mount-live :rw writes from inside the guest land on the host (#151) ----
+#
+# Boots with `--mount-live <dir>:/mnt/live:rw`, has the guest echo a
+# marker into a file under that mount, then asserts the file appears
+# on the host filesystem with the right contents AFTER the VM exits.
+# Same fuse.ko gate as T3.
+echo "T5: machinen boot --mount-live :rw — guest write reaches the host"
+if ! tar -tzf "$ASSETS/rootfs.tar.gz" 2>/dev/null | grep -q 'fuse\.ko'; then
+  echo "  skip: fuse.ko not in release-assets/rootfs.tar.gz — rebuild base assets"
+else
+  T5_MARKER="livemount-rw-marker-$$"
+  T5_SRC="$FIXTURE/live-rw"
+  T5_LOG="$FIXTURE/t5.log"
+  mkdir -p "$T5_SRC"
+  run_timeout 60 node "$CLI" boot \
+    --mount-live "$T5_SRC:/mnt/live:rw" \
+    -- /bin/sh -c "echo $T5_MARKER >/mnt/live/from-guest.txt && sync" \
+    >"$T5_LOG" 2>&1 || true
+  if [[ -f "$T5_SRC/from-guest.txt" ]] && grep -q "$T5_MARKER" "$T5_SRC/from-guest.txt"; then
+    pass "guest write through :rw live-mount visible on the host"
+  else
+    tail -80 "$T5_LOG" >&2
+    echo "  host file: $(ls -la "$T5_SRC" 2>&1)" >&2
+    fail "T5 marker ($T5_MARKER) not found in $T5_SRC/from-guest.txt"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- `--mount-live <host>:<guest>[:<mode>]` now accepts an optional `:ro` (default) or `:rw` suffix.
- `:rw` enables write-through on the host FUSE server: WRITE, CREATE, MKDIR, RMDIR, UNLINK, RENAME, SETATTR, and FSYNC land on the real host directory.
- All write paths route through the existing `resolveUnderRoot` containment gate, so symlink escapes return `ENOENT` and never reveal "elsewhere on the host". `:ro` mounts continue to refuse mutations (now with `EROFS` in place of `ENOSYS`).

Closes #151.

### Open questions resolved
- **Snapshot/restore**: kept the existing refusal while a live mount is active (vsock channel doesn't survive CRIU).
- **Symlink CREATE**: `SYMLINK` opcode left as `ENOSYS` — out of scope for this PR.
- **Durability**: `FSYNC` honoured via `fh.sync()`; `FLUSH` stays a no-op.
- **uid/gid mapping**: unchanged — host process uid owns new files. Documented as a known footgun.
- **CREATE mode**: honoured verbatim. The kernel has already applied the guest's umask before sending us CREATE (we don't advertise `FUSE_DONT_MASK`).

## Test plan
- [x] `npx vitest run packages/cli/src/__tests__/cli.test.ts` (36 tests; new cases for `:ro`, `:rw`, unknown mode, too-many-colons)
- [x] `npx vitest run packages/runtime/src/__tests__/mount-server.test.ts` (25 tests; `:rw` round-trips for CREATE+WRITE, UNLINK, MKDIR/RMDIR, RENAME, SETATTR truncate, plus a symlink-escape-write test that verifies the outside dir stays untouched)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- [x] `npx vitest run` — 259 passed; the 2 failures (`exec.test.ts`, `provision.test.ts`) are pre-existing on `main` (missing `modules-arm64.tar.gz` in dev env)
- [x] `npx agent-ci run --all -q -p` — 3 pre-existing infra failures (linux-arm64 `pty.node` prebuild, `release.yml` `/stage/init`, darwin vmm build), none touching mount-live code
