### PR TITLE
fix(microvm): unhang FUSE byte-pump + inject /fuse-agent across pivot (#113)

### DIFF
--- a/packages/microvm/assets/fuse-agent.zig
+++ b/packages/microvm/assets/fuse-agent.zig
@@ -77,9 +77,13 @@ const SIG_IGN: usize = 1;
 // matching the host_cid constant in packages/microvm/src/vsock.zig.
 const VMADDR_CID_HOST: u32 = 2;
 
-// /proc/sys/fs/fuse/conn/*/max_read — kernel's read buffer. 128KiB is
-// the common ceiling matching max_write negotiated in FUSE_INIT.
-const BUF_SIZE: usize = 128 * 1024;
+// Read buffer for /dev/fuse. The kernel rejects reads with `nbytes`
+// less than the largest queued request. With max_write=128KiB and
+// max_pages=32 we need room for a max-sized FUSE_WRITE: 40-byte
+// fuse_in_header + 64-byte fuse_write_in + 128KiB body + slack.
+// Linux's libfuse uses pagesize + max_write as its sizing rule;
+// matching that gives one full page of header headroom.
+const BUF_SIZE: usize = 128 * 1024 + 4096;
 // Upper bound for a single FUSE response body the host might send.
 // The kernel's max reply is max_write + headers; 256KiB is generous.
 const INBOUND_CAP: usize = 256 * 1024;
@@ -140,9 +144,16 @@ const Pipe = struct {
 /// host's readFrames() to reassemble framing from the 4-byte length
 /// prefix.
 fn devToSockThread(pipe: *Pipe) void {
-    var buf: [BUF_SIZE]u8 = undefined;
+    // Heap-allocated. BUF_SIZE (132 KiB) is larger than the default
+    // thread stack musl gives a std.Thread.spawn worker on aarch64
+    // (~80 KiB), so a stack-local would scribble past the guard page.
+    const buf = std.heap.c_allocator.alloc(u8, BUF_SIZE) catch {
+        logLine("fuse-agent: dev->sock buf alloc failed");
+        return;
+    };
+    defer std.heap.c_allocator.free(buf);
     while (true) {
-        const n = read(pipe.dev_fd, &buf, buf.len);
+        const n = read(pipe.dev_fd, buf.ptr, buf.len);
         if (n <= 0) {
             logErr("fuse-agent: /dev/fuse read ended", n);
             return;

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -688,6 +688,15 @@ fn tryRootDiskPivot() bool {
     copyFileBest("/machinen-config.json", "/newroot/machinen-config.json");
     copyFileBest("/etc/machinen-boot-epoch", "/newroot/etc/machinen-boot-epoch");
 
+    // #113: carry /fuse-agent from the cpio across the pivot so the
+    // freshest binary always wins, mirroring the /init injection
+    // pattern (#147). Cached rootdisks materialized from older
+    // rootfs tarballs may carry a stale /fuse-agent (or none at all);
+    // packBundle drops the current one at /fuse-agent in the cpio
+    // and we overwrite the disk version here. No-op when liveMounts
+    // wasn't requested (cpio /fuse-agent absent).
+    copyExecBest("/fuse-agent", "/newroot/fuse-agent");
+
     // #125: carry the user's `mount: { host, guest }` payload across
     // the pivot. mkinitramfs.ts overlays it under /mnt/<guest>/ in
     // the cpio; without this copy it would be stranded on the
@@ -722,11 +731,23 @@ fn waitForPath(path: [*:0]const u8, timeout_ms: i64) bool {
 /// files across the pivot. Failures are silent — the boot continues
 /// without them and the caller deals with the consequences.
 fn copyFileBest(src: [*:0]const u8, dst: [*:0]const u8) void {
+    copyFileWithMode(src, dst, 0o644);
+}
+
+/// Same as copyFileBest but creates the destination with mode 0755.
+/// Used for /fuse-agent — without the executable bit, /init's
+/// fork+exec of /fuse-agent fails with EACCES on first boot against a
+/// rootfs that doesn't already carry the binary.
+fn copyExecBest(src: [*:0]const u8, dst: [*:0]const u8) void {
+    copyFileWithMode(src, dst, 0o755);
+}
+
+fn copyFileWithMode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) void {
     const in_fd = open(src, O_RDONLY);
     if (in_fd < 0) return;
     defer _ = close(in_fd);
     // O_WRONLY | O_CREAT | O_TRUNC = 1 | 64 | 512 on Linux/musl.
-    const out_fd = open(dst, 0o1 | 0o100 | 0o1000, @as(c_uint, 0o644));
+    const out_fd = open(dst, 0o1 | 0o100 | 0o1000, mode);
     if (out_fd < 0) return;
     defer _ = close(out_fd);
     var buf: [8192]u8 = undefined;


### PR DESCRIPTION
## Summary
- Cherry-picks `f5c1f3b` from `pp-fix-113-mount-live-hang`. PR #149 closed #113 with the vsock-direction flip + fuse-agent shipping, but the follow-on commit on the same branch never got its own PR. Without it, `--mount-live` boots into a working FUSE INIT/GETATTR exchange and then the guest's read on `/dev/fuse` returns EINVAL, hanging the mount on the very first `ls`.
- Two bugs in one commit:
  1. fuse-agent's dev→sock buffer was exactly `max_write` (128 KiB). The kernel rejects FUSE reads where `nbytes < max_write + page` (libfuse's sizing rule). Bumped to 132 KiB and moved off-stack (musl's default thread stack on aarch64 is ~80 KiB).
  2. Cached rootdisks materialized from older rootfs tarballs don't carry `/fuse-agent`. Mirrored the `/init` injection from #147: `/init` copies the cpio's `/fuse-agent` across the rootdisk pivot so a stale rootdisk doesn't EACCES on fork+exec.

Together this is what unblocks `:ro` reads and (via the just-merged #151) `:rw` write-through end-to-end.

## Test plan
- [x] Verified locally on a cherry-pick: `machinen boot --mount-live <dir>:/mnt/live:rw -- sh -c 'echo marker >/mnt/live/from-guest.txt'` lands `marker` on the host. Without this fix, the guest hangs after FUSE GETATTR.
- [x] T3 (`:ro` smoke) and T5 (`:rw` smoke, added in #152) now reach the user cmd instead of the "live mount never appeared" timeout.
