### PR TITLE
feat(runtime,cli): default --mount-live to :rw (#156)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -71,14 +71,14 @@ describe("parseRunArgs --env", () => {
 });
 
 describe("parseRunArgs --mount-live", () => {
-  it("captures a single --mount-live (defaults to ro)", () => {
+  it("captures a single --mount-live (defaults to rw)", () => {
     const parsed = parseRunArgs(["--mount-live", "./src:/mnt/src", "--", "/bin/true"]);
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "rw" }]);
   });
 
   it("accepts the =form", () => {
     const parsed = parseRunArgs(["--mount-live=./src:/mnt/src"]);
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "rw" }]);
   });
 
   it("is repeatable and preserves order", () => {
@@ -90,16 +90,16 @@ describe("parseRunArgs --mount-live", () => {
       "./c:/mnt/c",
     ]);
     expect(parsed.liveMounts).toEqual([
-      { host: "./a", guest: "/mnt/a", mode: "ro" },
-      { host: "./b", guest: "/mnt/b", mode: "ro" },
-      { host: "./c", guest: "/mnt/c", mode: "ro" },
+      { host: "./a", guest: "/mnt/a", mode: "rw" },
+      { host: "./b", guest: "/mnt/b", mode: "rw" },
+      { host: "./c", guest: "/mnt/c", mode: "rw" },
     ]);
   });
 
   it("coexists with --mount (copy-once stays separate)", () => {
     const parsed = parseRunArgs(["--mount", "./cfg:/mnt/cfg", "--mount-live", "./src:/mnt/src"]);
     expect(parsed.mount).toEqual({ host: "./cfg", guest: "/mnt/cfg" });
-    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "ro" }]);
+    expect(parsed.liveMounts).toEqual([{ host: "./src", guest: "/mnt/src", mode: "rw" }]);
   });
 
   it("returns undefined liveMounts when the flag is absent", () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -763,8 +763,8 @@ function printHelp(): void {
       `    --mount-live <host-dir>:<guest-path>[:<mode>]\n` +
       `                                                 Live-share a host dir over FUSE.\n` +
       `                                                 Guest reads stream in on demand; no\n` +
-      `                                                 copy at boot. mode is 'ro' (default)\n` +
-      `                                                 or 'rw' for write-through.\n` +
+      `                                                 copy at boot. mode is 'rw' (default,\n` +
+      `                                                 write-through) or 'ro' (read-only).\n` +
       `    --env KEY=VALUE                              Set an env var inside the guest.\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -11,8 +11,8 @@ export interface ParsedRunArgs {
   /**
    * Live-share FUSE mounts (`--mount-live <host>:<guest>[:<mode>]`).
    * Each entry stays connected to the host filesystem for the VM's
-   * life; guest reads stream in on demand. `mode` is `ro` (default) or
-   * `rw` for write-through. See #78, #151.
+   * life; guest reads stream in on demand. `mode` is `rw` (default,
+   * write-through) or `ro` for read-only. See #78, #151.
    */
   liveMounts?: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
   env?: Record<string, string>;
@@ -80,8 +80,8 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       } else {
         spec = a.slice("--mount-live=".length);
       }
-      // Format: `<host>:<guest>[:<mode>]`. Mode defaults to `ro`;
-      // explicit `:rw` enables write-through (#151). A guest path
+      // Format: `<host>:<guest>[:<mode>]`. Mode defaults to `rw`
+      // (write-through, #151); pass `:ro` for read-only. A guest path
       // containing a colon is rejected — same trade-off as `--mount`.
       const parts = spec!.split(":");
       if (parts.length < 2 || parts.length > 3 || !parts[0] || !parts[1]) {
@@ -100,7 +100,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       liveMounts.push({
         host: parts[0]!,
         guest: parts[1]!,
-        mode: (modeRaw as "ro" | "rw" | undefined) ?? "ro",
+        mode: (modeRaw as "ro" | "rw" | undefined) ?? "rw",
       });
     } else if (a === "--env" || a.startsWith("--env=")) {
       let spec: string | undefined;

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -60,7 +60,10 @@ beforeEach(async () => {
   symlinkSync("sub", join(root, "link-inside"));
   symlinkSync(join(scratch, "outside"), join(root, "link-outside"));
   udsPath = join(scratch, "fuse.sock");
-  handle = await serveLiveMount(udsPath, { rootAbs: root });
+  // Default fixture is :ro — most tests in this file probe read paths
+  // or assert EROFS on mutations. The :rw write-through block below
+  // builds its own server.
+  handle = await serveLiveMount(udsPath, { rootAbs: root, mode: "ro" });
 });
 
 afterEach(async () => {
@@ -426,6 +429,34 @@ describe("live mount server — :ro mounts reject mutations", () => {
       });
       expect(reply.header.error).toBe(-30);
     });
+  });
+});
+
+// ---------------- default mode is :rw ----------------
+
+describe("live mount server — bare options default to :rw (#156)", () => {
+  it("a server with no mode flag accepts WRITE without EROFS", async () => {
+    const localScratch = mkdtempSync(join(tmpdir(), "machinen-mount-server-default-"));
+    const localRoot = join(localScratch, "root");
+    mkdirSync(localRoot);
+    const localUds = join(localScratch, "fuse.sock");
+    // No `mode` — assert the default is rw, not ro.
+    const localHandle = await serveLiveMount(localUds, { rootAbs: localRoot });
+    try {
+      await withConnectionTo(localUds, async (conn) => {
+        await doInit(conn);
+        const reply = await conn.request(FUSE_OP.WRITE, {
+          unique: 2n,
+          nodeid: 1n,
+          payload: new Uint8Array(40),
+        });
+        // RW with no FH yields EBADF, not EROFS — that's the ro→rw signal.
+        expect(reply.header.error).toBe(-9); // -EBADF
+      });
+    } finally {
+      await localHandle.stop();
+      rmSync(localScratch, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -277,9 +277,9 @@ export interface BootOptions {
    * Host directories exposed to the guest as live-share FUSE mounts
    * (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
    * connected to the host: the guest reads on demand via a vsock FUSE
-   * relay, and nothing is copied at boot. `mode` defaults to `"ro"`;
-   * `"rw"` enables write-through so guest writes land on the host
-   * (#151).
+   * relay, and nothing is copied at boot. `mode` defaults to `"rw"` —
+   * guest writes land on the host (#151, #156). Set `"ro"` for a
+   * one-way share (host caches, untrusted guests).
    *
    * Each guest path must live under `/mnt/` (same rule as `mount`).
    * Repeatable; each entry gets its own vsock port.
@@ -1298,7 +1298,7 @@ function resolveLiveMounts(
       guest: normalizeMountGuest(m.guest),
       port: LIVE_MOUNT_PORT_BASE + i,
       udsPath: join(udsDir, `live-mount-${i}.sock`),
-      mode: m.mode ?? "ro",
+      mode: m.mode ?? "rw",
     };
   });
 }

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -110,9 +110,9 @@ export interface LiveMountServerOptions {
   /** Absolute host path that bounds every op. */
   rootAbs: string;
   /**
-   * `"ro"` (default) rejects mutating ops with EROFS. `"rw"` enables
-   * write-through: WRITE/CREATE/MKDIR/RMDIR/UNLINK/RENAME/SETATTR/FSYNC
-   * land on the host filesystem, all gated through `resolveUnderRoot`.
+   * `"rw"` (default) enables write-through: WRITE/CREATE/MKDIR/RMDIR/
+   * UNLINK/RENAME/SETATTR/FSYNC land on the host filesystem, all gated
+   * through `resolveUnderRoot`. `"ro"` rejects mutating ops with EROFS.
    */
   mode?: "ro" | "rw";
 }
@@ -132,7 +132,7 @@ export async function serveLiveMount(
   udsPath: string,
   opts: LiveMountServerOptions,
 ): Promise<LiveMountServerHandle> {
-  const state = createState(opts.rootAbs, opts.mode ?? "ro");
+  const state = createState(opts.rootAbs, opts.mode ?? "rw");
   const server = createServer((sock) => void handleConnection(sock, state));
   await new Promise<void>((done, fail) => {
     server.once("error", fail);

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -19,7 +19,7 @@
 #   T2     --mount exposes a host directory readable inside the guest.
 #   T3     --mount-live :ro streams a host file in lazily — #78.
 #   T4     --env propagates into the guest process env — #89.
-#   T5     --mount-live :rw guest writes land on the host — #151.
+#   T5     --mount-live (default :rw) guest writes land on the host — #151, #156.
 #   C1-C2  Host-side artifact cache end-to-end via fnm — #88.
 #   P1-P3  Base-rootfs contract (criu, virtio modules, poweroff) — #77.
 #   N1-N5  New #93 CLI surface: ls, exec, attach-unknown, completion,
@@ -276,9 +276,9 @@ fi
 # Skips if the current base kernel doesn't carry fuse.ko yet. That
 # whitelist change is in scripts/build-base-assets.sh on this branch
 # but the cached release-assets/ rootfs tarball may predate it.
-echo "T3: machinen boot --mount-live ./fixture:/mnt/live -- cat /mnt/live/hello.txt"
-if ! tar -tzf "$ASSETS/rootfs.tar.gz" 2>/dev/null | grep -q 'fuse\.ko'; then
-  echo "  skip: fuse.ko not in release-assets/rootfs.tar.gz — rebuild base assets"
+echo "T3: machinen boot --mount-live ./fixture:/mnt/live:ro -- cat /mnt/live/hello.txt"
+if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse\.ko'; then
+  echo "  skip: fuse.ko not in $ROOTFS_TAR — rebuild base assets"
 else
   T3_MARKER="livemount-marker-$$"
   T3_SRC="$FIXTURE/live-src"
@@ -292,8 +292,10 @@ else
     echo "$T3_MARKER" >"$T3_SRC/hello.txt"
   ) &
   SEEDER=$!
+  # Explicit `:ro` since the default is `:rw` (#156); this test
+  # intentionally exercises the read-only path.
   run_timeout 60 node "$CLI" boot \
-    --mount-live "$T3_SRC:/mnt/live" \
+    --mount-live "$T3_SRC:/mnt/live:ro" \
     -- /bin/sh -c 'sleep 4 && cat /mnt/live/hello.txt' \
     >"$T3_LOG" 2>&1 || true
   wait "$SEEDER" 2>/dev/null || true
@@ -307,24 +309,24 @@ fi
 
 # ---- T5: --mount-live :rw writes from inside the guest land on the host (#151) ----
 #
-# Boots with `--mount-live <dir>:/mnt/live:rw`, has the guest echo a
-# marker into a file under that mount, then asserts the file appears
-# on the host filesystem with the right contents AFTER the VM exits.
-# Same fuse.ko gate as T3.
-echo "T5: machinen boot --mount-live :rw — guest write reaches the host"
-if ! tar -tzf "$ASSETS/rootfs.tar.gz" 2>/dev/null | grep -q 'fuse\.ko'; then
-  echo "  skip: fuse.ko not in release-assets/rootfs.tar.gz — rebuild base assets"
+# Boots with `--mount-live <dir>:/mnt/live` (default :rw post-#156),
+# has the guest echo a marker into a file under that mount, then
+# asserts the file appears on the host filesystem with the right
+# contents AFTER the VM exits. Same fuse.ko gate as T3.
+echo "T5: machinen boot --mount-live (default :rw) — guest write reaches the host"
+if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse\.ko'; then
+  echo "  skip: fuse.ko not in $ROOTFS_TAR — rebuild base assets"
 else
   T5_MARKER="livemount-rw-marker-$$"
   T5_SRC="$FIXTURE/live-rw"
   T5_LOG="$FIXTURE/t5.log"
   mkdir -p "$T5_SRC"
   run_timeout 60 node "$CLI" boot \
-    --mount-live "$T5_SRC:/mnt/live:rw" \
+    --mount-live "$T5_SRC:/mnt/live" \
     -- /bin/sh -c "echo $T5_MARKER >/mnt/live/from-guest.txt && sync" \
     >"$T5_LOG" 2>&1 || true
   if [[ -f "$T5_SRC/from-guest.txt" ]] && grep -q "$T5_MARKER" "$T5_SRC/from-guest.txt"; then
-    pass "guest write through :rw live-mount visible on the host"
+    pass "guest write through default-rw live-mount visible on the host"
   else
     tail -80 "$T5_LOG" >&2
     echo "  host file: $(ls -la "$T5_SRC" 2>&1)" >&2


### PR DESCRIPTION
## Summary
- Flips the default `--mount-live` mode from `:ro` to `:rw` in both `BootOptions.liveMounts[].mode` and the CLI parser. `:ro` becomes an explicit opt-out.
- The defensive `:ro` default made sense while write-through wasn't implemented. Now that host-side write handlers ship (#151), the surprising default was the read-only one.
- Smoke T3 (the read-only test) gains an explicit `:ro` suffix. T5 drops `:rw` to exercise the new default.
- Drive-by: fixes a path bug in T3/T5's fuse.ko skip-gate (`\$ASSETS/rootfs.tar.gz` → `\$ROOTFS_TAR`) — the gate was always skipping silently.

Closes #156.

## Test plan
- [x] `npx vitest run` — 26/26 mount-server tests pass; 36/36 cli tests pass.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- [x] New mount-server test: bare `serveLiveMount({ rootAbs })` with no `mode` accepts WRITE (returns EBADF for missing fh, not EROFS).
- [x] CLI tests: `parseRunArgs(["--mount-live", "./src:/mnt/src"])` now yields `{ mode: "rw" }`. Explicit `:ro` and `:rw` unchanged.
