### PR TITLE
feat: self-hosted provision.ts/vm.ts for in-VM machinen dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,15 @@
     "release": "pnpm -F @machinen/runtime -F @machinen/cli build && changeset publish",
     "docs": "typedoc",
     "dev": "bash scripts/dev.sh",
+    "provision": "tsx provision.ts",
+    "vm": "tsx vm.ts",
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
     "bench-net": "bash scripts/bench-net.sh"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
+    "@machinen/runtime": "workspace:*",
     "@nkzw/oxlint-config": "1.0.1",
     "@redwoodjs/agent-ci": "^0.12.4",
     "@types/node": "^22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.31.0(@types/node@22.19.17)
+      '@machinen/runtime':
+        specifier: workspace:*
+        version: link:packages/runtime
       '@nkzw/oxlint-config':
         specifier: 1.0.1
         version: 1.0.1(eslint@9.39.4)(oxlint@1.48.0)(typescript@5.9.3)

--- a/provision.ts
+++ b/provision.ts
@@ -1,0 +1,204 @@
+// Build a "ready-to-work" rootfs by running an install hook inside a
+// base rootfs, then freezing the result to a tarball.
+//
+//   pnpm provision           # incremental — runs only what changed
+//   pnpm provision --force   # ignore the stamp, full rebuild
+//
+// See packages/runtime docs and the comments in vm.ts for the runtime
+// model (initramfs-as-rootfs, copy-once vs. live mounts, etc.).
+
+import { provision } from "@machinen/runtime";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Homebrew's e2fsprogs is keg-only — see vm.ts for rationale.
+const BREW_E2FS = "/opt/homebrew/opt/e2fsprogs/sbin";
+if (existsSync(BREW_E2FS) && !(process.env.PATH ?? "").includes(BREW_E2FS)) {
+  process.env.PATH = `${BREW_E2FS}:${process.env.PATH ?? ""}`;
+}
+
+const require = createRequire(import.meta.url);
+const runtimeEntry = require.resolve("@machinen/runtime");
+const ASSETS =
+  process.env.MACHINEN_ASSETS_DIR ??
+  resolve(dirname(runtimeEntry), "..", "..", "..", "release-assets");
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// Build artifacts live in ~/.cache so they don't get dragged into the
+// guest's view of the workspace via the live mount in vm.ts.
+const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(HERE));
+mkdirSync(CACHE_DIR, { recursive: true });
+const OUT = join(CACHE_DIR, "app.tar.gz");
+const STAMP = `${OUT}.stamp`;
+const FORCE = process.argv.includes("--force");
+
+// pnpm version is pinned by the host repo's `packageManager` field —
+// match it inside the guest so installs use the same resolver.
+const PKG = JSON.parse(readFileSync(join(HERE, "package.json"), "utf8")) as {
+  packageManager?: string;
+};
+const PNPM_VERSION = (() => {
+  const pm = PKG.packageManager ?? "";
+  const m = /^pnpm@([\d.]+)/.exec(pm);
+  if (!m) {
+    throw new Error(`provision: cannot parse packageManager from package.json: ${pm}`);
+  }
+  return m[1];
+})();
+
+const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
+  // Remount tmpfs root at size=100% so pnpm/apt installs don't hit ENOSPC.
+  await vm.exec("mount -o remount,size=100% /");
+
+  // gvproxy DNS jitter under apt's parallel fan-out — same hardening as
+  // the reference setup.
+  const aptResilience = [
+    'Acquire::Retries "5";',
+    'Acquire::Queue-Mode "access";',
+    'Acquire::http::Pipeline-Depth "0";',
+    'Acquire::http::Timeout "60";',
+    'Acquire::https::Timeout "60";',
+  ].join("\n");
+  const aptResilienceB64 = Buffer.from(aptResilience).toString("base64");
+  await vm.exec(
+    `echo ${aptResilienceB64} | base64 -d > /etc/apt/apt.conf.d/99-machinen-resilience`,
+  );
+
+  // System packages.
+  //   ripgrep, fd-find        — fast code search.
+  //   jq                       — JSON munging.
+  //   less, vim-tiny           — usable interactive shell.
+  //   openssh-client, gh       — git/ssh + GitHub CLI.
+  // fd-find is shipped as `/usr/bin/fdfind`; symlink to the upstream name.
+  await vm.exec(
+    "apt-get update -qq && " +
+      "apt-get install -y --no-install-recommends " +
+      "bash git build-essential ca-certificates curl " +
+      "ripgrep fd-find jq less vim-tiny openssh-client gh && " +
+      "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
+  );
+
+  // Pre-bake git identity so commits inside the guest don't prompt.
+  await vm.exec(
+    "git config --global user.email 'peter.pistorius@gmail.com' && " +
+      "git config --global user.name 'Peter Pistorius' && " +
+      "git config --global init.defaultBranch main",
+  );
+
+  // Node + pnpm + claude code via fnm. Idempotent: re-running a fnm/npm
+  // install of an already-installed version is sub-second.
+  await vm.exec(
+    "export FNM_DIR=/root/.local/share/fnm && " +
+      "fnm install 22 && " +
+      "fnm default 22 && " +
+      "NODE_BIN=$(fnm exec --using=22 -- sh -c 'dirname $(which node)') && " +
+      "ln -sf $NODE_BIN/node /usr/local/bin/node && " +
+      "ln -sf $NODE_BIN/npm  /usr/local/bin/npm  && " +
+      "ln -sf $NODE_BIN/npx  /usr/local/bin/npx  && " +
+      `fnm exec --using=22 npm install -g pnpm@${PNPM_VERSION} @anthropic-ai/claude-code && ` +
+      "ln -sf $NODE_BIN/pnpm   /usr/local/bin/pnpm && " +
+      "ln -sf $NODE_BIN/claude /usr/local/bin/claude",
+  );
+
+  // Claude Code on Linux falls back to ~/.claude/.credentials.json when
+  // no keychain is present. The actual token is injected per-boot from
+  // the host's Keychain (see vm.ts) — we only stage the directory and
+  // a tiny boot-time helper that materializes the file from $CLAUDE_CREDENTIALS.
+  //
+  // The helper is sourced from /etc/profile.d/, so it runs whenever bash
+  // starts as a login shell (which is how vm.ts spawns it).
+  const claudeBootstrap = [
+    "#!/bin/sh",
+    "# Materialize ~/.claude/.credentials.json from the boot env, once.",
+    'if [ -n "${CLAUDE_CREDENTIALS:-}" ]; then',
+    '  mkdir -p "$HOME/.claude"',
+    '  printf "%s" "$CLAUDE_CREDENTIALS" > "$HOME/.claude/.credentials.json"',
+    '  chmod 600 "$HOME/.claude/.credentials.json"',
+    "  unset CLAUDE_CREDENTIALS",
+    "fi",
+    "",
+  ].join("\n");
+  const claudeBootstrapB64 = Buffer.from(claudeBootstrap).toString("base64");
+  await vm.exec(
+    `echo ${claudeBootstrapB64} | base64 -d > /etc/profile.d/00-claude-credentials.sh && ` +
+      "chmod 0755 /etc/profile.d/00-claude-credentials.sh",
+  );
+
+  // Sanity check.
+  await vm.exec(
+    "node --version && pnpm --version && claude --version && bash --version | head -1 && git --version && gh --version | head -1",
+  );
+};
+
+// --- stamp check ---------------------------------------------------------
+
+const sourceHash = createHash("sha256")
+  .update(readFileSync(fileURLToPath(import.meta.url)))
+  .digest("hex");
+
+if (!FORCE && existsSync(OUT) && existsSync(STAMP)) {
+  const prior = readFileSync(STAMP, "utf8").trim();
+  if (prior === sourceHash) {
+    console.log(`provision: ${OUT} is up to date (stamp matches) — skipping.`);
+    console.log("           pass --force to rebuild.");
+    process.exit(0);
+  }
+}
+
+// --- incremental base ----------------------------------------------------
+
+const base = !FORCE && existsSync(OUT) ? OUT : join(ASSETS, "rootfs-debian-arm64.tar.gz");
+console.log(`provision: base=${base === OUT ? "./app.tar.gz (incremental)" : base}`);
+
+// RAM auto-size from gzipped rootfs — see vm.ts for the formula's derivation.
+function ramForImage(path: string): number {
+  const compressed = statSync(path).size;
+  const GIB = 1024 * 1024 * 1024;
+  const raw = Math.max(4 * GIB, compressed * 16 + 2 * GIB);
+  const align = 256 * 1024 * 1024;
+  return Math.ceil(raw / align) * align;
+}
+console.log(
+  `provision: ram=${(ramForImage(base) / 1024 ** 3).toFixed(1)} GiB ` +
+    `(base=${(statSync(base).size / 1024 ** 2).toFixed(0)} MB)`,
+);
+
+// --- run -----------------------------------------------------------------
+
+const result = await provision({
+  base,
+  kernel: join(ASSETS, "Image-arm64"),
+  dtb: join(ASSETS, "virt-arm64.dtb"),
+  out: OUT,
+
+  // 1 GiB scratch is too small once node_modules + global npm pkgs land.
+  scratchDiskSizeBytes: 8 * 1024 * 1024 * 1024,
+
+  vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(base)) },
+
+  cmd: ["/usr/bin/env", "/bin/bash", "-i"],
+  env: {
+    PATH: "/root/.local/share/fnm:/usr/local/bin:/usr/bin:/bin:/sbin",
+    HOME: "/root",
+    TERM: "xterm-256color",
+    PS1: "(machinen) # ",
+  },
+
+  onLog: (evt) => {
+    if (evt.source === "exec-stdout" || evt.source === "guest-console") {
+      process.stdout.write(evt.chunk);
+    } else if (evt.source === "exec-stderr") {
+      process.stderr.write(evt.chunk);
+    }
+  },
+
+  timeoutMs: 30 * 60_000,
+  install: installSteps,
+});
+
+writeFileSync(STAMP, sourceHash);
+console.log(`\nBuilt ${result.imagePath} (${(result.elapsedMs / 1000).toFixed(1)}s)`);

--- a/vm.ts
+++ b/vm.ts
@@ -1,0 +1,161 @@
+// Boot a machinen microVM from the provisioned ./app.tar.gz with the
+// current git worktree live-mounted at /mnt/workspace.
+//
+//   pnpm provision   # one-time, builds ./app.tar.gz
+//   pnpm vm          # boots from app.tar.gz
+//
+// Hard requirement: vm.ts only runs from a linked git worktree (the kind
+// `wt-pick` creates). Running it from the main checkout aborts — that's
+// the convention to keep the main tree clean and per-issue work isolated.
+
+import { boot } from "@machinen/runtime";
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// e2fsprogs is keg-only on Homebrew (its `mkfs.ext4`/`mke2fs` would
+// collide with macOS's `newfs_*` family) — its binaries live under
+// /opt/homebrew/opt/e2fsprogs/sbin/. Harmless on Linux / when absent.
+const BREW_E2FS = "/opt/homebrew/opt/e2fsprogs/sbin";
+if (existsSync(BREW_E2FS) && !(process.env.PATH ?? "").includes(BREW_E2FS)) {
+  process.env.PATH = `${BREW_E2FS}:${process.env.PATH ?? ""}`;
+}
+
+const require = createRequire(import.meta.url);
+const runtimeEntry = require.resolve("@machinen/runtime");
+const ASSETS =
+  process.env.MACHINEN_ASSETS_DIR ??
+  resolve(dirname(runtimeEntry), "..", "..", "..", "release-assets");
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// --- worktree guard ------------------------------------------------------
+//
+// `git rev-parse --git-dir` returns `.git` (or absolute `<repo>/.git`) in
+// the main checkout, but `<repo>/.git/worktrees/<name>` inside a linked
+// worktree. `--git-common-dir` always points at the main `.git`. When the
+// two differ we're in a linked worktree.
+function ensureWorktree(): void {
+  const run = (args: string[]): string =>
+    execFileSync("git", args, {
+      cwd: HERE,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+
+  let gitDir: string;
+  let commonDir: string;
+  try {
+    gitDir = run(["rev-parse", "--absolute-git-dir"]);
+    commonDir = run(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
+    console.error(`vm.ts: not a git repo at ${HERE} (${msg})`);
+    process.exit(1);
+  }
+  if (gitDir === commonDir) {
+    console.error(
+      `vm.ts: refusing to boot from the main checkout (${HERE}).\n` +
+        "       vm.ts only runs from a linked worktree. Use `wt-pick` to\n" +
+        "       create or switch to a per-issue worktree, then re-run pnpm vm.",
+    );
+    process.exit(1);
+  }
+}
+ensureWorktree();
+
+// Build artifacts live OUTSIDE the project dir so they're not visible
+// inside the guest via the live mount of HERE → /mnt/workspace.
+const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(HERE));
+await mkdir(CACHE_DIR, { recursive: true });
+const IMAGE = join(CACHE_DIR, "app.tar.gz");
+
+if (!existsSync(IMAGE)) {
+  console.error(`vm.ts: ${IMAGE} not found — run \`pnpm provision\` first.`);
+  process.exit(1);
+}
+
+// RAM scales with gzipped rootfs size — see provision.ts for the formula.
+function ramForImage(path: string): number {
+  const compressed = statSync(path).size;
+  const GIB = 1024 * 1024 * 1024;
+  const raw = Math.max(4 * GIB, compressed * 16 + 2 * GIB);
+  const align = 256 * 1024 * 1024;
+  return Math.ceil(raw / align) * align;
+}
+process.stderr.write(
+  `[machinen] ram=${(ramForImage(IMAGE) / 1024 ** 3).toFixed(1)} GiB ` +
+    `(image=${(statSync(IMAGE).size / 1024 ** 2).toFixed(0)} MB)\n`,
+);
+
+// --- secrets from host ---------------------------------------------------
+//
+// All secrets are pulled per-boot from the host (gh / Keychain) and
+// injected into the guest as env vars. Nothing is baked into app.tar.gz.
+function readHostCmd(label: string, file: string, args: string[]): string {
+  try {
+    return execFileSync(file, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
+    console.error(`vm.ts: failed to read ${label}: ${msg}`);
+    console.error(`            (cmd: ${file} ${args.join(" ")})`);
+    process.exit(1);
+  }
+}
+
+const ghToken = readHostCmd("GH_TOKEN", "gh", ["auth", "token"]);
+
+// Claude Code stores its OAuth blob in the macOS Keychain under
+// "Claude Code-credentials". -w prints just the password (the JSON blob).
+// On the guest, /etc/profile.d/00-claude-credentials.sh (staged at
+// provision time) writes it to ~/.claude/.credentials.json on first
+// shell start, then unsets the env var.
+const claudeCreds = readHostCmd("Claude Code credentials", "security", [
+  "find-generic-password",
+  "-s",
+  "Claude Code-credentials",
+  "-w",
+]);
+
+const secretEnv: Record<string, string> = {
+  GH_TOKEN: ghToken,
+  GITHUB_TOKEN: ghToken,
+  CLAUDE_CREDENTIALS: claudeCreds,
+};
+
+const vm = await boot({
+  kernel: join(ASSETS, "Image-arm64"),
+  dtb: join(ASSETS, "virt-arm64.dtb"),
+  image: IMAGE,
+  // Live-share mount: host edits land in the guest's view immediately.
+  liveMounts: [{ host: HERE, guest: "/mnt/workspace", mode: "rw" }],
+  env: secretEnv,
+  vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)) },
+  // Interactive — don't apply the default 60s ceiling.
+  timeoutMs: null,
+});
+
+const stdin = process.stdin as NodeJS.ReadStream & {
+  setRawMode?: (m: boolean) => void;
+};
+const isTty = stdin.isTTY === true && typeof stdin.setRawMode === "function";
+if (isTty) {
+  stdin.setRawMode!(true);
+}
+
+vm.stdout.pipe(process.stdout);
+vm.stderr.pipe(process.stderr);
+process.stdin.pipe(vm.stdin);
+
+const { code } = await vm.wait();
+if (isTty) {
+  stdin.setRawMode!(false);
+}
+process.exit(code ?? 0);


### PR DESCRIPTION
## Summary
- Add `provision.ts` (build a Node 22 + pnpm + Claude Code rootfs from `release-assets/rootfs-debian-arm64.tar.gz`, cached in `~/.cache/machinen/<dir>/app.tar.gz` with stamp-based incremental rebuilds) and `vm.ts` (boot it with the current dir live-mounted rw at `/mnt/workspace`).
- `vm.ts` enforces a worktree guard: it compares `git rev-parse --absolute-git-dir` against `--git-common-dir` and aborts on the main checkout. Use `wt-pick` to land in a per-issue worktree first.
- Inject host secrets per-boot: `GH_TOKEN`/`GITHUB_TOKEN` from `gh auth token`, plus the Claude Code OAuth blob from the macOS Keychain (`Claude Code-credentials`). A `/etc/profile.d` hook materializes `~/.claude/.credentials.json` (chmod 600) on first login and unsets the env var. No secrets are baked into the rootfs.
- Adds `provision` / `vm` scripts to `package.json` and a `@machinen/runtime: workspace:*` devDep so the root typechecks.

## Test plan
- [ ] `pnpm provision` from a linked worktree builds `~/.cache/machinen/<dir>/app.tar.gz`.
- [ ] `pnpm vm` from the main checkout aborts with the wt-pick guidance.
- [ ] `pnpm vm` from a worktree boots, mounts the worktree at `/mnt/workspace`, and `claude --version` / `gh auth status` work without prompting.
- [ ] Re-running `pnpm provision` with no source changes is a no-op (stamp matches).

Note: agent-ci's `pnpm test` fails on a pre-existing `node-pty` `linux-arm64` prebuild issue — confirmed identical failure on clean `main`. Local `vitest run` passes.
