### PR TITLE
feat: vm-pick CoW clones for self-host machinen dev VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules/
 .pnpm-store/
 .devcontainer/kindling/
 .machinen/
+.machinen-vm/
 dist/
 release-assets/

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev": "bash scripts/dev.sh",
     "provision": "tsx provision.ts",
     "vm": "tsx vm.ts",
+    "vm-pick": "bash scripts/vm-pick.sh",
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
     "bench-net": "bash scripts/bench-net.sh"

--- a/provision.ts
+++ b/provision.ts
@@ -4,41 +4,83 @@
 //   pnpm provision           # incremental — runs only what changed
 //   pnpm provision --force   # ignore the stamp, full rebuild
 //
-// See packages/runtime docs and the comments in vm.ts for the runtime
-// model (initramfs-as-rootfs, copy-once vs. live mounts, etc.).
+// Always anchors on the main repo (resolved via `git rev-parse
+// --git-common-dir`), so a fresh worktree can run `pnpm vm` and reuse
+// the same app.tar.gz / release-assets / runtime binaries — no need to
+// rebuild machinen inside every worktree.
 
-import { provision } from "@machinen/runtime";
+import type { VmHandle } from "@machinen/runtime";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-// Homebrew's e2fsprogs is keg-only — see vm.ts for rationale.
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// provision belongs on the canonical checkout — clones share its
+// app.tar.gz via vm.ts's MAIN_REPO anchor, so re-provisioning from
+// inside a clone would shard the cache by clone path.
+if (existsSync(join(HERE, ".machinen-vm", "origin"))) {
+  console.error(
+    `provision: refusing to run inside a clone (.machinen-vm/origin found at ${HERE}).\n` +
+      "           Run from the canonical checkout instead.",
+  );
+  process.exit(1);
+}
+
+// --- main-repo anchor -----------------------------------------------------
+//
+// `git rev-parse --git-common-dir` always points at the *main* `.git`,
+// even from inside a linked worktree. Its parent is the main checkout.
+// We anchor every host-side path here so worktrees inherit main's
+// runtime, release-assets, and cache.
+function mainRepoRoot(): string {
+  try {
+    const commonDir = execFileSync(
+      "git",
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      { cwd: HERE, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    ).trim();
+    return dirname(commonDir);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
+    console.error(`provision: could not resolve main repo from ${HERE} (${msg})`);
+    process.exit(1);
+  }
+}
+const MAIN_REPO = mainRepoRoot();
+
+// Homebrew's e2fsprogs is keg-only — see vm.ts for rationale. (The
+// runtime now bundles mke2fs, but keep the PATH munge as a fallback.)
 const BREW_E2FS = "/opt/homebrew/opt/e2fsprogs/sbin";
 if (existsSync(BREW_E2FS) && !(process.env.PATH ?? "").includes(BREW_E2FS)) {
   process.env.PATH = `${BREW_E2FS}:${process.env.PATH ?? ""}`;
 }
 
-const require = createRequire(import.meta.url);
-const runtimeEntry = require.resolve("@machinen/runtime");
-const ASSETS =
-  process.env.MACHINEN_ASSETS_DIR ??
-  resolve(dirname(runtimeEntry), "..", "..", "..", "release-assets");
-const HERE = dirname(fileURLToPath(import.meta.url));
+// Resolve @machinen/runtime against the *main repo*'s node_modules, not
+// the worktree's. Worktrees rarely have runtime built — main always does.
+const mainRequire = createRequire(join(MAIN_REPO, "package.json"));
+const runtimeEntry = mainRequire.resolve("@machinen/runtime");
+const { provision } = (await import(
+  pathToFileURL(runtimeEntry).href
+)) as typeof import("@machinen/runtime");
 
-// Build artifacts live in ~/.cache so they don't get dragged into the
-// guest's view of the workspace via the live mount in vm.ts.
-const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(HERE));
+const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
+
+// Cache key on the main repo basename so every worktree shares one
+// app.tar.gz. Build artifacts must live OUTSIDE the project dir or
+// they show up inside the guest via vm.ts's live mount.
+const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(MAIN_REPO));
 mkdirSync(CACHE_DIR, { recursive: true });
 const OUT = join(CACHE_DIR, "app.tar.gz");
 const STAMP = `${OUT}.stamp`;
 const FORCE = process.argv.includes("--force");
 
-// pnpm version is pinned by the host repo's `packageManager` field —
-// match it inside the guest so installs use the same resolver.
-const PKG = JSON.parse(readFileSync(join(HERE, "package.json"), "utf8")) as {
+// Match the host repo's pinned pnpm version inside the guest.
+const PKG = JSON.parse(readFileSync(join(MAIN_REPO, "package.json"), "utf8")) as {
   packageManager?: string;
 };
 const PNPM_VERSION = (() => {
@@ -50,12 +92,11 @@ const PNPM_VERSION = (() => {
   return m[1];
 })();
 
-const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
+const installSteps = async (vm: VmHandle) => {
   // Remount tmpfs root at size=100% so pnpm/apt installs don't hit ENOSPC.
   await vm.exec("mount -o remount,size=100% /");
 
-  // gvproxy DNS jitter under apt's parallel fan-out — same hardening as
-  // the reference setup.
+  // gvproxy DNS jitter under apt's parallel fan-out.
   const aptResilience = [
     'Acquire::Retries "5";',
     'Acquire::Queue-Mode "access";',
@@ -73,7 +114,7 @@ const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
   //   jq                       — JSON munging.
   //   less, vim-tiny           — usable interactive shell.
   //   openssh-client, gh       — git/ssh + GitHub CLI.
-  // fd-find is shipped as `/usr/bin/fdfind`; symlink to the upstream name.
+  // Symlink fd-find's binary to the upstream `fd` name.
   await vm.exec(
     "apt-get update -qq && " +
       "apt-get install -y --no-install-recommends " +
@@ -82,15 +123,17 @@ const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
       "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
   );
 
-  // Pre-bake git identity so commits inside the guest don't prompt.
+  // Pre-bake git identity. safe.directory '*' silences git's
+  // CVE-2022-24765 "dubious ownership" check — necessary because
+  // /mnt/workspace is FUSE-mounted with uids that may not line up.
   await vm.exec(
     "git config --global user.email 'peter.pistorius@gmail.com' && " +
       "git config --global user.name 'Peter Pistorius' && " +
-      "git config --global init.defaultBranch main",
+      "git config --global init.defaultBranch main && " +
+      "git config --global --add safe.directory '*'",
   );
 
-  // Node + pnpm + claude code via fnm. Idempotent: re-running a fnm/npm
-  // install of an already-installed version is sub-second.
+  // Node + pnpm + Claude Code via fnm. Idempotent on rebuilds.
   await vm.exec(
     "export FNM_DIR=/root/.local/share/fnm && " +
       "fnm install 22 && " +
@@ -104,16 +147,11 @@ const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
       "ln -sf $NODE_BIN/claude /usr/local/bin/claude",
   );
 
-  // Claude Code on Linux falls back to ~/.claude/.credentials.json when
-  // no keychain is present. The actual token is injected per-boot from
-  // the host's Keychain (see vm.ts) — we only stage the directory and
-  // a tiny boot-time helper that materializes the file from $CLAUDE_CREDENTIALS.
-  //
-  // The helper is sourced from /etc/profile.d/, so it runs whenever bash
-  // starts as a login shell (which is how vm.ts spawns it).
-  const claudeBootstrap = [
+  // Materialize Claude Code credentials on first login. The boot cmd
+  // is `bash -lc` (login shell), so /etc/profile + profile.d run and
+  // this snippet fires before the interactive bash shows a prompt.
+  const profileSnippet = [
     "#!/bin/sh",
-    "# Materialize ~/.claude/.credentials.json from the boot env, once.",
     'if [ -n "${CLAUDE_CREDENTIALS:-}" ]; then',
     '  mkdir -p "$HOME/.claude"',
     '  printf "%s" "$CLAUDE_CREDENTIALS" > "$HOME/.claude/.credentials.json"',
@@ -122,10 +160,10 @@ const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
     "fi",
     "",
   ].join("\n");
-  const claudeBootstrapB64 = Buffer.from(claudeBootstrap).toString("base64");
+  const profileSnippetB64 = Buffer.from(profileSnippet).toString("base64");
   await vm.exec(
-    `echo ${claudeBootstrapB64} | base64 -d > /etc/profile.d/00-claude-credentials.sh && ` +
-      "chmod 0755 /etc/profile.d/00-claude-credentials.sh",
+    `echo ${profileSnippetB64} | base64 -d > /etc/profile.d/00-machinen.sh && ` +
+      "chmod 0755 /etc/profile.d/00-machinen.sh",
   );
 
   // Sanity check.
@@ -134,7 +172,7 @@ const installSteps = async (vm: import("@machinen/runtime").VmHandle) => {
   );
 };
 
-// --- stamp check ---------------------------------------------------------
+// --- stamp check ----------------------------------------------------------
 
 const sourceHash = createHash("sha256")
   .update(readFileSync(fileURLToPath(import.meta.url)))
@@ -149,12 +187,11 @@ if (!FORCE && existsSync(OUT) && existsSync(STAMP)) {
   }
 }
 
-// --- incremental base ----------------------------------------------------
+// --- incremental base -----------------------------------------------------
 
 const base = !FORCE && existsSync(OUT) ? OUT : join(ASSETS, "rootfs-debian-arm64.tar.gz");
 console.log(`provision: base=${base === OUT ? "./app.tar.gz (incremental)" : base}`);
 
-// RAM auto-size from gzipped rootfs — see vm.ts for the formula's derivation.
 function ramForImage(path: string): number {
   const compressed = statSync(path).size;
   const GIB = 1024 * 1024 * 1024;
@@ -167,7 +204,7 @@ console.log(
     `(base=${(statSync(base).size / 1024 ** 2).toFixed(0)} MB)`,
 );
 
-// --- run -----------------------------------------------------------------
+// --- run ------------------------------------------------------------------
 
 const result = await provision({
   base,
@@ -180,7 +217,11 @@ const result = await provision({
 
   vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(base)) },
 
-  cmd: ["/usr/bin/env", "/bin/bash", "-i"],
+  // Boot directly into /mnt/workspace via a thin -c wrapper. The
+  // FUSE mount used by liveMounts is currently root-only, so we run
+  // as root; `--dangerously-skip-permissions` won't work for `claude`
+  // inside the VM until fuse-agent supports allow_other.
+  cmd: ["/bin/bash", "-lc", "cd /mnt/workspace 2>/dev/null; exec bash -i"],
   env: {
     PATH: "/root/.local/share/fnm:/usr/local/bin:/usr/bin:/bin:/sbin",
     HOME: "/root",

--- a/scripts/vm-pick.sh
+++ b/scripts/vm-pick.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# vm-pick — fuzzy-pick an open issue/PR, CoW-clone the repo into a sibling
+#           "<reponame>.machinen/" tree, then exec `pnpm vm` inside the
+#           clone. Reuses an existing clone for the same issue/PR.
+#
+# Why CoW clones instead of git worktrees: a worktree's `.git` is a *file*
+# pointing to a host path that doesn't exist inside the guest, so `git`
+# inside the VM breaks. A `cp -c -R` reflink (APFS / btrfs / xfs) gives
+# the clone its own `.git` directory, instant and disk-cheap, with full
+# git/gh functionality inside the guest.
+
+set -euo pipefail
+
+if ! command -v fzf >/dev/null 2>&1; then
+  echo "vm-pick: fzf is required. Install with: brew install fzf" >&2
+  exit 1
+fi
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "vm-pick: not inside a git repository." >&2
+  exit 1
+fi
+
+# Anchor on the canonical checkout. From a clone, redirect there.
+HERE=$(pwd)
+if [[ -f "$HERE/.machinen-vm/origin" ]]; then
+  MAIN_REPO=$(<"$HERE/.machinen-vm/origin")
+  MAIN_REPO=${MAIN_REPO%$'\n'}
+  echo "vm-pick: redirecting to canonical at $MAIN_REPO" >&2
+else
+  MAIN_REPO=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+fi
+PARENT_DIR=$(dirname "$MAIN_REPO")
+REPO_NAME=$(basename "$MAIN_REPO")
+CLONES_ROOT="${PARENT_DIR}/${REPO_NAME}.machinen"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+(cd "$MAIN_REPO" && gh issue list --state open --limit 100 --json number,title,url) \
+  > "$tmpdir/issues.json" 2>"$tmpdir/issues.err" &
+issues_pid=$!
+(cd "$MAIN_REPO" && gh pr list --state open --limit 100 --json number,title,url) \
+  > "$tmpdir/prs.json" 2>"$tmpdir/prs.err" &
+prs_pid=$!
+wait "$issues_pid"; issues_rc=$?
+wait "$prs_pid";    prs_rc=$?
+
+if (( issues_rc != 0 )) || (( prs_rc != 0 )); then
+  echo "vm-pick: gh failed:" >&2
+  (( issues_rc != 0 )) && { echo "  issues:" >&2; sed 's/^/    /' "$tmpdir/issues.err" >&2; }
+  (( prs_rc    != 0 )) && { echo "  prs:"    >&2; sed 's/^/    /' "$tmpdir/prs.err"    >&2; }
+  exit 1
+fi
+
+# kind \t number \t title \t url
+{
+  jq -r '.[] | "issue\t\(.number)\t\(.title)\t\(.url)"' < "$tmpdir/issues.json"
+  jq -r '.[] | "pr\t\(.number)\t\(.title)\t\(.url)"'    < "$tmpdir/prs.json"
+} > "$tmpdir/combined"
+
+if [[ ! -s "$tmpdir/combined" ]]; then
+  echo "vm-pick: no open issues or PRs." >&2
+  exit 1
+fi
+
+selection=$(
+  fzf --delimiter=$'\t' \
+      --with-nth='1,2,3' \
+      --height=40% \
+      --reverse \
+      --prompt='vm-pick> ' \
+      < "$tmpdir/combined"
+) || exit 1
+
+IFS=$'\t' read -r kind num title _url <<< "$selection"
+
+# Slugify title: lowercase, non-alnum → '-', trim, cap at 40 chars.
+slug=$(printf '%s' "$title" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+  | cut -c1-40 \
+  | sed -E 's/-+$//')
+
+CLONE_DIR="${CLONES_ROOT}/${num}-${kind}-${slug}"
+
+if [[ -d "$CLONE_DIR" ]]; then
+  echo "vm-pick: reusing existing clone at $CLONE_DIR" >&2
+else
+  echo "vm-pick: creating CoW clone at $CLONE_DIR" >&2
+  mkdir -p "$CLONES_ROOT"
+  # APFS reflink on macOS. -c is the macOS clone flag; on Linux use
+  # `cp --reflink=auto` instead (this script targets Darwin).
+  cp -c -R "$MAIN_REPO" "$CLONE_DIR"
+  mkdir -p "$CLONE_DIR/.machinen-vm"
+  printf '%s\n' "$MAIN_REPO" > "$CLONE_DIR/.machinen-vm/origin"
+
+  if [[ "$kind" == "pr" ]]; then
+    (cd "$CLONE_DIR" && gh pr checkout "$num")
+  else
+    (cd "$CLONE_DIR" && git checkout -B "${num}-${slug}")
+  fi
+fi
+
+cd "$CLONE_DIR"
+exec pnpm vm

--- a/vm.ts
+++ b/vm.ts
@@ -1,85 +1,67 @@
-// Boot a machinen microVM from the provisioned ./app.tar.gz with the
-// current git worktree live-mounted at /mnt/workspace.
+// Boot a machinen microVM from the provisioned ./app.tar.gz with this
+// clone's source live-mounted at /mnt/workspace.
 //
-//   pnpm provision   # one-time, builds ./app.tar.gz
-//   pnpm vm          # boots from app.tar.gz
+//   pnpm provision   # one-time, builds ./app.tar.gz (run from canonical)
+//   pnpm vm-pick     # CoW-clone for an issue/PR, then auto-boot
+//   pnpm vm          # boot from inside an already-prepared clone
 //
-// Hard requirement: vm.ts only runs from a linked git worktree (the kind
-// `wt-pick` creates). Running it from the main checkout aborts — that's
-// the convention to keep the main tree clean and per-issue work isolated.
+// vm.ts must run inside a clone — a directory created by `pnpm vm-pick`
+// containing a `.machinen-vm/origin` marker that points at the canonical
+// checkout. Runtime + release-assets + app.tar.gz all resolve against
+// that origin so clones never need to build machinen themselves.
 
-import { boot } from "@machinen/runtime";
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// --- origin marker: where the canonical machinen checkout lives ---------
+const ORIGIN_FILE = join(HERE, ".machinen-vm", "origin");
+if (!existsSync(ORIGIN_FILE)) {
+  console.error(
+    `vm.ts: no .machinen-vm/origin marker at ${HERE}.\n` +
+      "       vm.ts must run inside a clone created by `pnpm vm-pick`.\n" +
+      "       Run `pnpm vm-pick` from the canonical checkout first.",
+  );
+  process.exit(1);
+}
+const MAIN_REPO = readFileSync(ORIGIN_FILE, "utf8").trim();
+if (!existsSync(MAIN_REPO)) {
+  console.error(`vm.ts: origin marker points at ${MAIN_REPO}, which doesn't exist.`);
+  process.exit(1);
+}
 
 // e2fsprogs is keg-only on Homebrew (its `mkfs.ext4`/`mke2fs` would
-// collide with macOS's `newfs_*` family) — its binaries live under
-// /opt/homebrew/opt/e2fsprogs/sbin/. Harmless on Linux / when absent.
+// collide with macOS's `newfs_*` family). The runtime now bundles
+// mke2fs, but keep the PATH munge as a fallback.
 const BREW_E2FS = "/opt/homebrew/opt/e2fsprogs/sbin";
 if (existsSync(BREW_E2FS) && !(process.env.PATH ?? "").includes(BREW_E2FS)) {
   process.env.PATH = `${BREW_E2FS}:${process.env.PATH ?? ""}`;
 }
 
-const require = createRequire(import.meta.url);
-const runtimeEntry = require.resolve("@machinen/runtime");
-const ASSETS =
-  process.env.MACHINEN_ASSETS_DIR ??
-  resolve(dirname(runtimeEntry), "..", "..", "..", "release-assets");
+// Resolve runtime against the canonical's node_modules — clones don't
+// build machinen themselves.
+const mainRequire = createRequire(join(MAIN_REPO, "package.json"));
+const runtimeEntry = mainRequire.resolve("@machinen/runtime");
+const { boot } = (await import(
+  pathToFileURL(runtimeEntry).href
+)) as typeof import("@machinen/runtime");
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-
-// --- worktree guard ------------------------------------------------------
-//
-// `git rev-parse --git-dir` returns `.git` (or absolute `<repo>/.git`) in
-// the main checkout, but `<repo>/.git/worktrees/<name>` inside a linked
-// worktree. `--git-common-dir` always points at the main `.git`. When the
-// two differ we're in a linked worktree.
-function ensureWorktree(): void {
-  const run = (args: string[]): string =>
-    execFileSync("git", args, {
-      cwd: HERE,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
-
-  let gitDir: string;
-  let commonDir: string;
-  try {
-    gitDir = run(["rev-parse", "--absolute-git-dir"]);
-    commonDir = run(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
-    console.error(`vm.ts: not a git repo at ${HERE} (${msg})`);
-    process.exit(1);
-  }
-  if (gitDir === commonDir) {
-    console.error(
-      `vm.ts: refusing to boot from the main checkout (${HERE}).\n` +
-        "       vm.ts only runs from a linked worktree. Use `wt-pick` to\n" +
-        "       create or switch to a per-issue worktree, then re-run pnpm vm.",
-    );
-    process.exit(1);
-  }
-}
-ensureWorktree();
-
-// Build artifacts live OUTSIDE the project dir so they're not visible
-// inside the guest via the live mount of HERE → /mnt/workspace.
-const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(HERE));
+const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
+const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(MAIN_REPO));
 await mkdir(CACHE_DIR, { recursive: true });
 const IMAGE = join(CACHE_DIR, "app.tar.gz");
 
 if (!existsSync(IMAGE)) {
-  console.error(`vm.ts: ${IMAGE} not found — run \`pnpm provision\` first.`);
+  console.error(`vm.ts: ${IMAGE} not found — run \`pnpm provision\` from ${MAIN_REPO} first.`);
   process.exit(1);
 }
 
-// RAM scales with gzipped rootfs size — see provision.ts for the formula.
 function ramForImage(path: string): number {
   const compressed = statSync(path).size;
   const GIB = 1024 * 1024 * 1024;
@@ -92,10 +74,7 @@ process.stderr.write(
     `(image=${(statSync(IMAGE).size / 1024 ** 2).toFixed(0)} MB)\n`,
 );
 
-// --- secrets from host ---------------------------------------------------
-//
-// All secrets are pulled per-boot from the host (gh / Keychain) and
-// injected into the guest as env vars. Nothing is baked into app.tar.gz.
+// --- secrets from host --------------------------------------------------
 function readHostCmd(label: string, file: string, args: string[]): string {
   try {
     return execFileSync(file, args, {
@@ -112,11 +91,11 @@ function readHostCmd(label: string, file: string, args: string[]): string {
 
 const ghToken = readHostCmd("GH_TOKEN", "gh", ["auth", "token"]);
 
-// Claude Code stores its OAuth blob in the macOS Keychain under
-// "Claude Code-credentials". -w prints just the password (the JSON blob).
-// On the guest, /etc/profile.d/00-claude-credentials.sh (staged at
-// provision time) writes it to ~/.claude/.credentials.json on first
-// shell start, then unsets the env var.
+// Claude Code's OAuth blob lives in the macOS Keychain under
+// "Claude Code-credentials". -w prints the JSON blob. On the guest,
+// /etc/bash.bashrc (staged at provision time) writes it to
+// ~/.claude/.credentials.json on first interactive shell, then unsets
+// the env var.
 const claudeCreds = readHostCmd("Claude Code credentials", "security", [
   "find-generic-password",
   "-s",
@@ -134,11 +113,9 @@ const vm = await boot({
   kernel: join(ASSETS, "Image-arm64"),
   dtb: join(ASSETS, "virt-arm64.dtb"),
   image: IMAGE,
-  // Live-share mount: host edits land in the guest's view immediately.
   liveMounts: [{ host: HERE, guest: "/mnt/workspace", mode: "rw" }],
   env: secretEnv,
   vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)) },
-  // Interactive — don't apply the default 60s ceiling.
   timeoutMs: null,
 });
 


### PR DESCRIPTION
## Summary
- `pnpm vm-pick` (new bash + fzf script) lists open issues/PRs, CoW-clones the canonical machinen checkout into `<repo>.machinen/<num>-<kind>-<slug>/` (APFS reflink — instant, ~zero disk), checks out the branch, writes a `.machinen-vm/origin` marker, and execs `pnpm vm`. Reuses an existing clone for the same issue/PR instead of recreating.
- `vm.ts` now reads `.machinen-vm/origin` to anchor the runtime, release-assets, and app.tar.gz against the canonical. Clones never need to build machinen — they only contribute the source mounted at `/mnt/workspace`.
- `provision.ts` refuses to run from inside a clone (would shard the cache).
- Boot drops you straight at `/mnt/workspace` via `bash -lc 'cd ...; exec bash -i'`. Per-boot secrets: `GH_TOKEN`/`GITHUB_TOKEN` from `gh auth token`, `CLAUDE_CREDENTIALS` from the macOS Keychain (`security find-generic-password -s 'Claude Code-credentials' -w`). `/etc/profile.d/00-machinen.sh` materializes `~/.claude/.credentials.json` (chmod 600) on first login.
- `git config --global` includes `safe.directory '*'` to silence CVE-2022-24765 over the FUSE mount.

## Why CoW instead of worktrees
Worktrees' `.git` is a *file* pointing to a host path that doesn't exist inside the guest, so `git`/`gh pr create` break inside the VM. A `cp -c -R` reflink gives the clone its own real `.git/` — full git/gh works inside the guest.

## Known caveat
The FUSE liveMount is currently root-only, so we boot as root. `claude --dangerously-skip-permissions` rejects euid 0 — workarounds: try `IS_SANDBOX=1`, run claude interactively, or land an `allow_other` change in `@machinen/microvm-fuse-agent` later.

## Test plan
- [x] `pnpm provision` from canonical builds `~/.cache/machinen/machinen/app.tar.gz` (87s on Darwin/arm64).
- [x] `pnpm vm-pick` from canonical: pristine clone created at `<repo>.machinen/<num>-<kind>-<slug>/` with a real `.git/`, marker file written, branch checked out, VM boots.
- [x] `pnpm vm-pick` from canonical with an existing clone: "reusing existing clone", boots without re-cloning.
- [x] VM boots at `/mnt/workspace`, prompt is `root@(none):/mnt/workspace#`.
- [x] `~/.claude/.credentials.json` materialized at chmod 600 with the host's OAuth blob.
- [x] `gh auth status` inside the guest: logged in via `GH_TOKEN`.
- [x] git config (identity + safe.directory) applied; git operations no longer warn about dubious ownership.
