### PR TITLE
fix(runtime): fuse-agent symlink/link/readlink for pnpm install on /mnt/workspace

### DIFF
--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -11,9 +11,11 @@
 import { connect as netConnect } from "node:net";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -364,6 +366,26 @@ describe("live mount server — symlink semantics", () => {
     });
   });
 
+  it("READLINK returns the raw target bytes (no NUL terminator)", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("link-inside"),
+      });
+      const linkIno = bigintFromEntry(lookup.payload);
+      const reply = await conn.request(FUSE_OP.READLINK, {
+        unique: 3n,
+        nodeid: linkIno,
+        payload: new Uint8Array(0),
+      });
+      expect(reply.header.error).toBe(0);
+      // fixture symlink target is "sub" — bytes only, no trailing NUL
+      expect(new TextDecoder().decode(reply.payload)).toBe("sub");
+    });
+  });
+
   it("rejects LOOKUP with `..` as name (EINVAL)", async () => {
     await withConnection(async (conn) => {
       await doInit(conn);
@@ -426,6 +448,35 @@ describe("live mount server — :ro mounts reject mutations", () => {
         unique: 2n,
         nodeid: 1n,
         payload: nameBuf("hello.txt"),
+      });
+      expect(reply.header.error).toBe(-30);
+    });
+  });
+
+  it("SYMLINK returns EROFS in :ro mode", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.SYMLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: twoNulStrings("new-link", "target"),
+      });
+      expect(reply.header.error).toBe(-30);
+    });
+  });
+
+  it("LINK returns EROFS in :ro mode", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      // body: u64 oldnodeid + name\0
+      const buf = new Uint8Array(8 + "lnk\0".length);
+      const dv = new DataView(buf.buffer);
+      dv.setBigUint64(0, 1n, true); // oldnodeid (ignored on EROFS)
+      buf.set(new TextEncoder().encode("lnk\0"), 8);
+      const reply = await conn.request(FUSE_OP.LINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buf,
       });
       expect(reply.header.error).toBe(-30);
     });
@@ -619,6 +670,102 @@ describe("live mount server — :rw write-through", () => {
     });
   });
 
+  it("SYMLINK creates a symlink with the exact target bytes (#163)", async () => {
+    // pnpm install builds node_modules/.pnpm out of relative symlinks
+    // like "../../ms@2.1.3/node_modules/ms". Critical: target is
+    // stored verbatim, not realpath'd through the host fs.
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const target = "../../ms@2.1.3/node_modules/ms";
+      const reply = await conn.request(FUSE_OP.SYMLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: twoNulStrings("ms", target),
+      });
+      expect(reply.header.error).toBe(0);
+      const attr = readAttr(reply.payload, 40);
+      expect(attr.mode & 0o170000).toBe(0o120000); // S_IFLNK
+      const onDisk = join(rwRoot, "ms");
+      expect(lstatSync(onDisk).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(onDisk)).toBe(target);
+    });
+  });
+
+  it("SYMLINK then READLINK round-trips the target (#163)", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const target = "./dir/file.txt";
+      const sym = await conn.request(FUSE_OP.SYMLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: twoNulStrings("link", target),
+      });
+      expect(sym.header.error).toBe(0);
+      const linkIno = bigintFromEntry(sym.payload);
+      const reply = await conn.request(FUSE_OP.READLINK, {
+        unique: 3n,
+        nodeid: linkIno,
+        payload: new Uint8Array(0),
+      });
+      expect(reply.header.error).toBe(0);
+      expect(new TextDecoder().decode(reply.payload)).toBe(target);
+    });
+  });
+
+  it("SYMLINK rejects an empty target with EINVAL", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.SYMLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: twoNulStrings("bad", ""),
+      });
+      expect(reply.header.error).toBe(-22); // -EINVAL
+    });
+  });
+
+  it("SYMLINK refuses a name with `..` (EINVAL)", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.SYMLINK, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: twoNulStrings("..", "target"),
+      });
+      expect(reply.header.error).toBe(-22);
+    });
+  });
+
+  it("LINK creates a hard link to an existing file (#163)", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      // First LOOKUP existing.txt to get its inode.
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("existing.txt"),
+      });
+      const oldIno = bigintFromEntry(lookup.payload);
+      // body: u64 oldnodeid + "hardlink\0"
+      const name = "hardlink";
+      const body = new Uint8Array(8 + name.length + 1);
+      const dv = new DataView(body.buffer);
+      dv.setBigUint64(0, oldIno, true);
+      body.set(new TextEncoder().encode(name), 8);
+      const reply = await conn.request(FUSE_OP.LINK, {
+        unique: 3n,
+        nodeid: 1n,
+        payload: body,
+      });
+      expect(reply.header.error).toBe(0);
+      const attr = readAttr(reply.payload, 40);
+      expect(attr.mode & 0o170000).toBe(0o100000); // S_IFREG
+      // Same content, same inode on host.
+      expect(readFileSync(join(rwRoot, name), "utf8")).toBe("old\n");
+      expect(statSync(join(rwRoot, name)).ino).toBe(statSync(join(rwRoot, "existing.txt")).ino);
+    });
+  });
+
   it("CREATE refuses a malformed name (slash in basename → EINVAL)", async () => {
     await rwConn(async (conn) => {
       await doInit(conn);
@@ -807,6 +954,16 @@ function buildWriteInWithData(opts: { fh: bigint; offset: bigint; data: Uint8Arr
   dv.setUint32(16, opts.data.length, true);
   buf.set(opts.data, 40);
   return buf;
+}
+
+function twoNulStrings(a: string, b: string): Uint8Array {
+  const aBytes = new TextEncoder().encode(a);
+  const bBytes = new TextEncoder().encode(b);
+  const out = new Uint8Array(aBytes.length + 1 + bBytes.length + 1);
+  out.set(aBytes, 0);
+  out.set(bBytes, aBytes.length + 1);
+  // trailing NULs already zero
+  return out;
 }
 
 function nameBuf(name: string): Uint8Array {

--- a/packages/runtime/src/mount-fuse-protocol.ts
+++ b/packages/runtime/src/mount-fuse-protocol.ts
@@ -39,10 +39,12 @@ export const FUSE_OP = {
   GETATTR: 3,
   SETATTR: 4,
   READLINK: 5,
+  SYMLINK: 6,
   MKDIR: 9,
   UNLINK: 10,
   RMDIR: 11,
   RENAME: 12,
+  LINK: 13,
   OPEN: 14,
   READ: 15,
   WRITE: 16,
@@ -671,6 +673,25 @@ export function readMkdirIn(buf: Uint8Array, off = 0): FuseMkdirIn {
   return {
     mode: dv.getUint32(0, true),
     umask: dv.getUint32(4, true),
+  };
+}
+
+// --- fuse_link_in -------------------------------------------------------
+
+/**
+ * fuse_link_in: u64 oldnodeid. The new name follows as a NUL-
+ * terminated string after the struct.
+ */
+export const FUSE_LINK_IN_SIZE = 8;
+
+export interface FuseLinkIn {
+  oldnodeid: bigint;
+}
+
+export function readLinkIn(buf: Uint8Array, off = 0): FuseLinkIn {
+  const dv = viewOf(buf, off, FUSE_LINK_IN_SIZE);
+  return {
+    oldnodeid: dv.getBigUint64(0, true),
   };
 }
 

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -18,14 +18,17 @@
 import { createServer, type Server, type Socket } from "node:net";
 import {
   chmod,
+  link,
   mkdir,
   open as fsOpen,
   lstat,
   readdir,
+  readlink,
   realpath,
   rename,
   rmdir,
   statfs,
+  symlink,
   truncate,
   unlink,
   utimes,
@@ -63,6 +66,7 @@ import {
   readForgetIn,
   readInHeader,
   readInitIn,
+  readLinkIn,
   readMkdirIn,
   readOpenIn,
   readReadIn,
@@ -272,6 +276,12 @@ async function handle(
       return await onLookup(hdr, msg, state);
     case FUSE_OP.GETATTR:
       return await onGetattr(hdr, state);
+    case FUSE_OP.READLINK:
+      return await onReadlink(hdr, state);
+    case FUSE_OP.SYMLINK:
+      return await onSymlink(hdr, msg, state);
+    case FUSE_OP.LINK:
+      return await onLink(hdr, msg, state);
     case FUSE_OP.SETATTR:
       return await onSetattr(hdr, msg, state);
     case FUSE_OP.STATFS:
@@ -401,6 +411,19 @@ async function onGetattr(hdr: FuseInHeader, state: ServerState): Promise<Uint8Ar
       attr: statToAttr(st, hdr.nodeid),
     }),
   );
+}
+
+async function onReadlink(hdr: FuseInHeader, state: ServerState): Promise<Uint8Array> {
+  const entry = requireInode(state, hdr.nodeid);
+  // Don't follow the final component — the inode IS the symlink. We
+  // still gate the parent through the resolver so a symlink basename
+  // pointing outside root is opaque to the guest (the kernel will
+  // re-LOOKUP each component of the target through us, and the
+  // resolver catches escapes there).
+  const abs = await absPathForLstat(state, entry);
+  const target = await readlink(abs);
+  // FUSE READLINK reply is the raw target bytes — no NUL terminator.
+  return buildResponse(hdr.unique, new TextEncoder().encode(target));
 }
 
 async function onStatfs(hdr: FuseInHeader, state: ServerState): Promise<Uint8Array> {
@@ -605,6 +628,88 @@ async function onCreate(
       },
       { fh: id, open_flags: 0 },
     ),
+  );
+}
+
+async function onSymlink(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  // Wire format: two NUL-terminated strings, name then target. No
+  // fixed-size struct prefix.
+  const body = payloadOf(msg);
+  const firstNul = body.indexOf(0);
+  if (firstNul < 0) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const name = decodeName(body.subarray(0, firstNul));
+  validateName(name);
+  // Target is a raw byte string stored verbatim on the host. It can
+  // be relative ("../foo") or absolute, can contain "..", can point
+  // outside the mount root — that's POSIX-compliant. The guest can't
+  // *traverse* through an out-of-root target because every subsequent
+  // LOOKUP through it gets gated by the resolver.
+  const targetEnd = body.indexOf(0, firstNul + 1);
+  const target = decodeName(body.subarray(firstNul + 1, targetEnd < 0 ? body.length : targetEnd));
+  if (target === "" || target.includes("\0")) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const parent = requireInode(state, hdr.nodeid);
+  const parentAbs = await absPathForTraversal(state, parent);
+  const childAbs = join(parentAbs, name);
+  const childRel = joinRel(parent.relPath, name);
+  await symlink(target, childAbs);
+  const st = await lstat(childAbs);
+  const ino = bindInode(state, childRel);
+  return buildResponse(
+    hdr.unique,
+    buildEntryOut({
+      nodeid: ino,
+      generation: 0n,
+      entry_valid: 1n,
+      attr_valid: 1n,
+      entry_valid_nsec: 0,
+      attr_valid_nsec: 0,
+      attr: statToAttr(st, ino),
+    }),
+  );
+}
+
+async function onLink(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readLinkIn(body);
+  const name = decodeName(body.subarray(8));
+  validateName(name);
+  const oldEntry = requireInode(state, req.oldnodeid);
+  const parent = requireInode(state, hdr.nodeid);
+  // For the source, use lstat-style resolution: link() should target
+  // the inode itself, not what a final-component symlink points at.
+  // (POSIX link(2) does not follow a trailing symlink.)
+  const oldAbs = await absPathForLstat(state, oldEntry);
+  const parentAbs = await absPathForTraversal(state, parent);
+  const childAbs = join(parentAbs, name);
+  const childRel = joinRel(parent.relPath, name);
+  await link(oldAbs, childAbs);
+  const st = await lstat(childAbs);
+  const ino = bindInode(state, childRel);
+  return buildResponse(
+    hdr.unique,
+    buildEntryOut({
+      nodeid: ino,
+      generation: 0n,
+      entry_valid: 1n,
+      attr_valid: 1n,
+      entry_valid_nsec: 0,
+      attr_valid_nsec: 0,
+      attr: statToAttr(st, ino),
+    }),
   );
 }
 


### PR DESCRIPTION
## Problem

Closes #163.

`pnpm install` inside a machinen dev VM against the live-mounted workspace aborts on the very first symlink:

```
ERR_PNPM_ENOSYS  ENOSYS: function not implemented,
  symlink '../../ms@2.1.3/node_modules/ms'
       -> '/mnt/workspace/.../node_modules/.pnpm/debug@4.4.3/node_modules/ms'
```

pnpm's default isolated layout is built entirely on symlinks; the FUSE server didn't implement `symlink`, `link`, or `readlink` (the last fell through to `ENOSYS`).

## Solution

Three new ops in `mount-server.ts`, all thin host-fs passthroughs:

- **READLINK** — `lstat`-style path resolution (don't follow the final component) + `readlink(2)`. Reply is the raw target bytes (no NUL terminator) per FUSE ABI.
- **SYMLINK** — parses the unusual `name\0target\0` wire format (no fixed struct prefix), validates the name like other mutations, stores the target **verbatim** so pnpm's relative `../../foo` shape lands on disk byte-for-byte. Returns `EROFS` on `:ro` mounts.
- **LINK** — `fuse_link_in` (8-byte u64 oldnodeid) + name. Resolves the source with `lstat` semantics so a trailing symlink stays a symlink (POSIX `link(2)` doesn't follow). Returns `EROFS` on `:ro` mounts.

Path containment is unchanged: parents go through `resolveUnderRoot`, basenames are joined raw. A symlink target pointing outside the mount is allowed (it's just bytes on disk) — the kernel will re-LOOKUP each component on traversal, and the resolver catches the escape there.

The guest byte-pump is op-agnostic — no Zig changes.

## Test plan

- [x] 7 new unit tests in `mount-server.test.ts` (drive the real server through a UDS, send actual FUSE wire bytes):
  - READLINK on a fixture symlink returns the target with no NUL
  - SYMLINK in :rw stores `../../ms@2.1.3/node_modules/ms` byte-for-byte on disk
  - SYMLINK→READLINK round-trip
  - SYMLINK rejects empty target / `..` name with EINVAL
  - LINK creates a hard link (same host inode)
  - SYMLINK and LINK both EROFS in :ro
- [x] `npx vitest run` for `mount-server.test.ts` + `mount-fuse-protocol.test.ts`: 84/84 passing
- [x] **End-to-end repro inside a real dev VM**: a fresh `pnpm install` against `/mnt/workspace` now completes (`Done in 1.1s … PNPM_EXIT=0`), `node_modules/.pnpm/debug@4.4.3/node_modules/ms` is the expected relative symlink, and `require("debug")` resolves. The same symlinks are visible and resolvable from the host.

## Performance caveat

This issue was scoped to **correctness**. Every `node_modules` symlink hop now costs a FUSE round-trip; the warm-cache mount on top of `node_modules` is a separate follow-up.
