### PR TITLE
test(runtime): wedge-bounded FUSE op coverage (#165 layer 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,20 @@ If either fails, fix the issue and re-run. Do not tell the user work is done unt
 - Node.js ESM + TypeScript. Use `import`, not `require`.
 - Package manager is pnpm (pinned via `packageManager` in package.json).
 - The user authenticates via OAuth (`gh auth login`), never API keys.
+
+## FUSE ops (mount-server)
+
+When you wire up a new FUSE opcode in `packages/runtime/src/mount-server.ts`,
+add its tests in the same change to `mount-server.test.ts`:
+
+1. **Happy path** — the op succeeds and the host fs reflects the change.
+2. **Error path** — the op returns the right errno (`ENOENT`, `EEXIST`,
+   `EBADF`, etc.) for the expected failure modes.
+3. **`:ro` gate** — if the op is mutating, assert it returns `EROFS` on a
+   read-only mount and never touches the host fs.
+4. **Wedge guard** — wrap the call in `raceWithDeadline()` so a hang
+   becomes a fast test failure instead of a stuck CI run.
+
+If you remove an op from the dispatch (intentionally going back to
+`ENOSYS`), move it into the `UNIMPLEMENTED_OPS` table at the top of the
+test file so its `ENOSYS`-within-deadline assertion stays in CI.

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -411,6 +411,168 @@ describe("live mount server — symlink semantics", () => {
   });
 });
 
+// ---------------- unimplemented-op coverage (#165) ----------------
+
+// Opcode -> minimal payload that the dispatcher will see. We never reach
+// the per-op decoder for these ops (the dispatch switch's default case
+// fires first), so payload size only has to clear the FUSE framing min.
+// Numbers are from Linux v6.1 uapi/linux/fuse.h. If any of these gets
+// implemented later, move it out of this list and add a happy-path test
+// in the same change (per AGENTS.md).
+const UNIMPLEMENTED_OPS = [
+  { name: "MKNOD", op: 8 },
+  { name: "SETXATTR", op: 21 },
+  { name: "GETXATTR", op: 22 },
+  { name: "LISTXATTR", op: 23 },
+  { name: "REMOVEXATTR", op: 24 },
+  { name: "FSYNCDIR", op: 30 },
+  { name: "GETLK", op: 31 },
+  { name: "SETLK", op: 32 },
+  { name: "SETLKW", op: 33 },
+  { name: "FALLOCATE", op: 43 },
+  { name: "READDIRPLUS", op: 44 },
+  { name: "RENAME2", op: 45 },
+  { name: "LSEEK", op: 46 },
+  { name: "COPY_FILE_RANGE", op: 47 },
+] as const;
+
+// Tight enough to flag a wedge but loose enough not to flake on a busy
+// CI runner. The dispatcher hits the default case synchronously, so the
+// real bound is socket round-trip, which is sub-millisecond locally.
+const OP_REPLY_DEADLINE_MS = 250;
+
+describe("live mount server — unimplemented ops reply ENOSYS without wedging (#165)", () => {
+  // The wedge class we're catching: a request that the dispatcher
+  // accepts but never replies to. The mount-server today routes every
+  // non-listed opcode through the default case, which builds a
+  // synchronous error response — but if anyone wires up an op without
+  // a reply path (or accidentally awaits a never-resolving promise),
+  // the kernel hangs the syscall forever. A bounded race turns that
+  // hang into a loud test failure.
+  it.each(UNIMPLEMENTED_OPS)("$name (op=$op) returns -ENOSYS within deadline", async ({ op }) => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await raceWithDeadline(
+        conn.request(op, {
+          unique: 100n + BigInt(op),
+          nodeid: 1n,
+          // Most missing ops have non-zero-size structs in the wire
+          // protocol, but the dispatcher never decodes them. 16 bytes
+          // is wide enough that even an op with a u64 fh + u64 something
+          // wouldn't underflow the framing checks.
+          payload: new Uint8Array(16),
+        }),
+        `op=${op}`,
+      );
+      expect(reply.header.error).toBe(-38); // -ENOSYS
+      expect(reply.payload.length).toBe(0);
+    });
+  });
+});
+
+describe("live mount server — defined-op coverage (#165)", () => {
+  it("STATFS returns a kstatfs payload", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.STATFS, { unique: 2n, nodeid: 1n, payload: new Uint8Array(0) }),
+        "STATFS",
+      );
+      expect(reply.header.error).toBe(0);
+      // fuse_kstatfs is 80 bytes
+      expect(reply.payload.length).toBe(80);
+    });
+  });
+
+  it("FLUSH replies success (no-op) within deadline", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await raceWithDeadline(
+        // fuse_flush_in is { fh, unused, padding, lock_owner } = 24 bytes,
+        // but the dispatcher sends FLUSH straight to the success branch
+        // without decoding, so any payload is fine.
+        conn.request(FUSE_OP.FLUSH, { unique: 2n, nodeid: 1n, payload: new Uint8Array(24) }),
+        "FLUSH",
+      );
+      expect(reply.header.error).toBe(0);
+    });
+  });
+
+  it("ACCESS replies success (no-op) within deadline", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.ACCESS, { unique: 2n, nodeid: 1n, payload: new Uint8Array(8) }),
+        "ACCESS",
+      );
+      expect(reply.header.error).toBe(0);
+    });
+  });
+
+  it("DESTROY replies success (no-op) within deadline", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.DESTROY, { unique: 2n, nodeid: 0n, payload: new Uint8Array(0) }),
+        "DESTROY",
+      );
+      expect(reply.header.error).toBe(0);
+    });
+  });
+
+  it("LOOKUP with empty name → EINVAL", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf(""),
+      });
+      expect(reply.header.error).toBe(-22); // -EINVAL
+    });
+  });
+
+  it("GETATTR on a stale (never-allocated) inode → ESTALE", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const reply = await conn.request(FUSE_OP.GETATTR, {
+        unique: 2n,
+        nodeid: 9_999_999n, // never minted
+        payload: new Uint8Array(16),
+      });
+      expect(reply.header.error).toBe(-116); // -ESTALE
+    });
+  });
+
+  it("INTERRUPT yields no reply at all (silent op)", async () => {
+    // FUSE_INTERRUPT MUST never be answered — the kernel uses it as a
+    // unidirectional signal. If we reply, the kernel mismatches `unique`
+    // on the next op. Assert by waiting a bounded window and seeing
+    // *nothing* arrive on the socket.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const interruptUnique = 99n;
+      let gotReply = false;
+      const inflight = conn
+        .request(0x24 /* FUSE_INTERRUPT = 36 */, {
+          unique: interruptUnique,
+          nodeid: 0n,
+          payload: new Uint8Array(8),
+        })
+        .then(() => {
+          gotReply = true;
+        });
+      // Race against a short window. If the reply landed (gotReply
+      // flipped), the test fails. If the deadline wins, INTERRUPT was
+      // correctly silent.
+      await new Promise((done) => setTimeout(done, 75));
+      expect(gotReply).toBe(false);
+      // Don't await `inflight` — it would never resolve, by design.
+      void inflight;
+    });
+  });
+});
+
 describe("live mount server — :ro mounts reject mutations", () => {
   it("WRITE returns EROFS in :ro mode", async () => {
     await withConnection(async (conn) => {
@@ -766,6 +928,25 @@ describe("live mount server — :rw write-through", () => {
     });
   });
 
+  it("RENAME with no NUL between old and new names → EINVAL (#165)", async () => {
+    await rwConn(async (conn) => {
+      await doInit(conn);
+      // u64 newdir + bytes WITHOUT a NUL terminator anywhere — the
+      // server scans for the first NUL and rejects when it can't find
+      // one. Catches malformed-frame handling on a write-side op.
+      const buf = new Uint8Array(8 + 4);
+      const dv = new DataView(buf.buffer);
+      dv.setBigUint64(0, 1n, true);
+      buf.set(new TextEncoder().encode("AAAA"), 8);
+      const reply = await conn.request(FUSE_OP.RENAME, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: buf,
+      });
+      expect(reply.header.error).toBe(-22); // -EINVAL
+    });
+  });
+
   it("CREATE refuses a malformed name (slash in basename → EINVAL)", async () => {
     await rwConn(async (conn) => {
       await doInit(conn);
@@ -954,6 +1135,26 @@ function buildWriteInWithData(opts: { fh: bigint; offset: bigint; data: Uint8Arr
   dv.setUint32(16, opts.data.length, true);
   buf.set(opts.data, 40);
   return buf;
+}
+
+/**
+ * Race a request reply against a hard deadline. Catches the wedge
+ * class — an op the server accepts but never replies to — by turning
+ * an indefinite hang into a fast, specific test failure. See #165.
+ */
+async function raceWithDeadline<T>(p: Promise<T>, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, fail) => {
+    timer = setTimeout(
+      () => fail(new Error(`${label} did not reply within ${OP_REPLY_DEADLINE_MS}ms`)),
+      OP_REPLY_DEADLINE_MS,
+    );
+  });
+  try {
+    return await Promise.race([p, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function twoNulStrings(a: string, b: string): Uint8Array {

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -1153,7 +1153,9 @@ async function raceWithDeadline<T>(p: Promise<T>, label: string): Promise<T> {
   try {
     return await Promise.race([p, deadline]);
   } finally {
-    if (timer) clearTimeout(timer);
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Closes #165 layer 1 (issue body decomposes into three layers — see "Out of scope" below for the rest).

We discover missing or wedging FUSE ops reactively, in the middle of dev work — `pnpm install` first crashed on `symlink` (#163), then a related run *hung 60+ s* on writes to a tmp dir with no further progress and no error. The wedge class is the dangerous one: an op the dispatcher accepts but never replies to, so the guest kernel hangs the syscall forever.

## Solution

A `raceWithDeadline()` helper that bounds every test request at 250 ms. Reuses `Promise.race` so a hang surfaces as a fast, specific test failure instead of a stuck CI run.

Three test families wired through it:

- **`ENOSYS`-within-deadline for every unimplemented op** in the audit table (MKNOD, all xattr ops, all lock ops, FSYNCDIR, FALLOCATE, READDIRPLUS, RENAME2, LSEEK, COPY_FILE_RANGE) — 14 cases via `it.each`. If anyone wires up an op without a reply path, this catches it on the next test run.
- **Happy-path** for previously-uncovered defined ops: STATFS, FLUSH, ACCESS, DESTROY.
- **Error-path**: LOOKUP empty name → `EINVAL`, GETATTR on a never-minted inode → `ESTALE`, RENAME with no NUL → `EINVAL`, INTERRUPT correctly silent (the test asserts the kernel does *not* receive a reply, by waiting a window and checking).

`AGENTS.md` gains a "FUSE ops" section codifying the contract: a new opcode lands with happy/error/EROFS/wedge tests in the same change, and removing an op from the dispatch moves it into the `UNIMPLEMENTED_OPS` table so its `ENOSYS` assertion stays in CI.

## Test plan

- [x] `npx vitest run packages/runtime/src/__tests__/mount-server.test.ts` — 56/56 (was 34/34, +22).
- [x] Sanity-checked `raceWithDeadline()` against a `new Promise(() => {})` — rejects with the expected timeout error.
- [x] `oxfmt --check` clean.

## Out of scope (follow-up PRs)

- **Layer 2** — workload integration suite (pnpm install both linkers, git clone+checkout, tar -xf, sqlite WAL, find at scale) running against a booted VM with `:rw` mount. Needs new CI plumbing.
- **Layer 3** — `pjdfstest` baked into the rootfs with a checked-in baseline pass count, ratcheted upward over time.
