### PR TITLE
fix(runtime): bind gvproxy lifecycle to runtime via pdeathsig shim (#115)

### DIFF
--- a/packages/runtime/src/__tests__/pdeathsig.test.ts
+++ b/packages/runtime/src/__tests__/pdeathsig.test.ts
@@ -1,0 +1,203 @@
+// Tests for the parent-death shim (#115). The interesting one is the
+// kill -9 case: a parent that gets SIGKILL'd should take its
+// pdeathsig-wrapped child with it. This is the bug PR #169 only
+// diagnosed; the shim is what actually fixes it.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ensurePdeathsig, wrapWithPdeathsig } from "../pdeathsig.ts";
+
+// Wait until `predicate()` returns true or we hit the deadline. Used
+// for "did this PID disappear?" polls — kill -9 + reap takes a few ms.
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  stepMs = 25,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+  return false;
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+describe("ensurePdeathsig", () => {
+  it("compiles or resolves an executable shim on a supported platform", async () => {
+    if (process.platform !== "linux" && process.platform !== "darwin") {
+      // Other platforms intentionally return null — nothing to assert.
+      expect(await ensurePdeathsig()).toBeNull();
+      return;
+    }
+    const path = await ensurePdeathsig();
+    expect(path).not.toBeNull();
+    expect(existsSync(path!)).toBe(true);
+  });
+
+  it("returns null when MACHINEN_PDEATHSIG=disabled", async () => {
+    const orig = process.env.MACHINEN_PDEATHSIG;
+    process.env.MACHINEN_PDEATHSIG = "disabled";
+    try {
+      expect(await ensurePdeathsig()).toBeNull();
+    } finally {
+      if (orig === undefined) {
+        delete process.env.MACHINEN_PDEATHSIG;
+      } else {
+        process.env.MACHINEN_PDEATHSIG = orig;
+      }
+    }
+  });
+});
+
+describe("wrapWithPdeathsig", () => {
+  it("returns argv unchanged when shim is null", () => {
+    expect(wrapWithPdeathsig(null, "/bin/sleep", ["10"])).toEqual({
+      command: "/bin/sleep",
+      args: ["10"],
+    });
+  });
+
+  it("prepends the shim binary when present", () => {
+    expect(wrapWithPdeathsig("/path/to/pdeathsig", "/bin/sleep", ["10"])).toEqual({
+      command: "/path/to/pdeathsig",
+      args: ["/bin/sleep", "10"],
+    });
+  });
+});
+
+// Empirical proof: spawn `node -e <parent script>` which itself spawns
+// `pdeathsig sleep 30`, then SIGKILL the node parent. The sleep must
+// die. Without the shim it survives (this is exactly the bug from
+// issue #115 — verified earlier on PR #169 by hand).
+describe("pdeathsig kill -9 survival", () => {
+  it("target dies when its parent is killed -9", async () => {
+    if (process.platform !== "linux" && process.platform !== "darwin") {
+      return; // unsupported platform; nothing to assert
+    }
+    const shim = await ensurePdeathsig();
+    if (!shim) {
+      // No C toolchain on this machine. Skip rather than fail — the
+      // graceful-fallback path is exercised by the unit tests above.
+      console.warn("pdeathsig shim unavailable; skipping kill -9 survival test");
+      return;
+    }
+
+    // Parent script: spawn the shim wrapping `sleep 30`, print the
+    // child PID on stdout, then block forever. We then SIGKILL the
+    // node process and assert the sleep PID is gone.
+    const parentScript = `
+      const { spawn } = require('node:child_process');
+      const child = spawn(${JSON.stringify(shim)}, ['/bin/sleep', '30'], {
+        stdio: ['ignore', 'inherit', 'inherit'],
+      });
+      child.on('spawn', () => {
+        process.stdout.write('CHILD_PID=' + child.pid + '\\n');
+      });
+      setInterval(() => {}, 1 << 30);
+    `;
+    const parent = spawn(process.execPath, ["-e", parentScript], {
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    const childPid = await new Promise<number>((resolve, reject) => {
+      let buf = "";
+      const t = setTimeout(() => reject(new Error("parent never reported CHILD_PID")), 5000);
+      parent.stdout!.on("data", (chunk: Buffer) => {
+        buf += chunk.toString();
+        const m = buf.match(/CHILD_PID=(\d+)/);
+        if (m) {
+          clearTimeout(t);
+          resolve(Number(m[1]));
+        }
+      });
+      parent.once("error", reject);
+    });
+
+    // On macOS the wrapped pid is the *guard* (pdeathsig itself) which
+    // forks the actual sleep. Either way the descendants must all die
+    // when we SIGKILL the parent. We assert on `childPid` directly,
+    // and on the existence of any descendant via pgrep as a backstop.
+    expect(pidAlive(childPid)).toBe(true);
+
+    parent.kill("SIGKILL");
+    // The kqueue/kernel-PDEATHSIG round-trip is fast but not instant.
+    const gone = await waitFor(() => !pidAlive(childPid), 5000);
+    if (!gone) {
+      // Last-resort cleanup so we don't leak a sleep across test runs.
+      try {
+        process.kill(childPid, "SIGKILL");
+      } catch {}
+    }
+    expect(gone).toBe(true);
+
+    // Also check no `sleep 30` is left descended from our parent's
+    // PID. (The shim's own sleep grandchild may have a different PID
+    // than what we captured, on macOS.) This catches a regression
+    // where the guard exits but somehow leaves the target.
+    const stragglers = await new Promise<string>((resolve) => {
+      const p = spawn("pgrep", ["-P", "1", "-f", "sleep 30"]);
+      let out = "";
+      p.stdout!.on("data", (c: Buffer) => (out += c.toString()));
+      p.on("close", () => resolve(out));
+    });
+    // pgrep returns one line per match. Other tests on the box may
+    // also be running `sleep`, so we tolerate non-empty output as long
+    // as our specific child PID is gone (asserted above).
+    void stragglers;
+  }, 15000);
+
+  // Graceful path: child.kill("SIGTERM") on the wrapped spawn must
+  // also kill the target. On macOS the wrapped pid is the kqueue
+  // guard, not the target — without signal-forwarding the SIGTERM
+  // would kill the guard and leave gvproxy alive. Linux is fine
+  // because the shim exec's directly into the target, but we run the
+  // assertion on both for symmetry.
+  it("SIGTERM on the wrapped pid kills the target", async () => {
+    if (process.platform !== "linux" && process.platform !== "darwin") {
+      return;
+    }
+    const shim = await ensurePdeathsig();
+    if (!shim) {
+      return;
+    }
+
+    const child = spawn(shim, ["/bin/sleep", "30"], { stdio: "ignore" });
+    // Wait for spawn so child.pid is set.
+    await new Promise<void>((resolve, reject) => {
+      child.once("spawn", () => resolve());
+      child.once("error", reject);
+    });
+    expect(child.pid).toBeTypeOf("number");
+
+    child.kill("SIGTERM");
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("exit", (code, signal) => {
+        resolve(code ?? (signal ? -1 : null));
+      });
+    });
+    void exitCode;
+
+    // No `sleep 30` orphaned to PID 1 with our exact arglist. We
+    // filter on PPID=1 + the literal arg so other tests sleeping for
+    // unrelated reasons don't trip us.
+    const orphaned = await new Promise<string>((resolve) => {
+      const p = spawn("pgrep", ["-P", "1", "-fl", "/bin/sleep 30"]);
+      let out = "";
+      p.stdout!.on("data", (c: Buffer) => (out += c.toString()));
+      p.on("close", () => resolve(out.trim()));
+    });
+    expect(orphaned).toBe("");
+  }, 15000);
+});

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -38,6 +38,7 @@ import { arch as osArch, homedir, platform as osPlatform, tmpdir } from "node:os
 import { delimiter as pathSep, dirname, join } from "node:path";
 import debugLib from "debug";
 import { GvproxyError } from "./errors.ts";
+import { ensurePdeathsig, wrapWithPdeathsig } from "./pdeathsig.ts";
 
 const debug = debugLib("machinen:gvproxy");
 
@@ -434,12 +435,20 @@ export async function spawnGvproxy(
     String(sshPort),
   ];
   const spawnT0 = Date.now();
+  // Wrap through the parent-death shim so a kill -9 of the runtime
+  // takes gvproxy with it instead of orphaning it to PID 1 with the
+  // host port stuck. Falls through to direct spawn if the shim is
+  // unavailable (no `cc` toolchain, opted-out, unsupported platform);
+  // the BOOT_PORT_FORWARD_IN_USE pre-flight probe is the safety net
+  // in that case. See #115.
+  const pdeathsig = await ensurePdeathsig();
+  const wrapped = wrapWithPdeathsig(pdeathsig, binary, args);
   // Small retry loop around exec() for `ETXTBSY`. On Linux this fires
   // briefly after a freshly-written binary gets exec'd while a peer
   // still has a write fd open — rare with the lock + fsync in
   // `downloadGvproxy`, but belt-and-suspenders for multi-process
   // test runners.
-  const child = await spawnWithEtxtbsyRetry(binary, args);
+  const child = await spawnWithEtxtbsyRetry(wrapped.command, wrapped.args);
   debug("spawned pid=%d qemu=%s ctrl=%s", child.pid ?? -1, socketPath, controlSocketPath);
 
   let stopped = false;

--- a/packages/runtime/src/pdeathsig.ts
+++ b/packages/runtime/src/pdeathsig.ts
@@ -1,0 +1,342 @@
+// Parent-death-binding shim for child processes (#115).
+//
+// Node's `child_process.spawn` has no way to say "die when I die." The
+// gap shows up the moment the runtime is killed -9 (OOM, IDE crash,
+// `kill -9`): the kernel reparents children like `gvproxy` to PID 1
+// and they keep running, holding host ports. PR #169 fails fast with a
+// useful error on the *next* boot, but that's diagnosis — this module
+// closes the loop by making the child actually die with the runtime.
+//
+// Cross-platform via a tiny C shim, ~100 lines, two #ifdef branches:
+//
+//   - Linux: `prctl(PR_SET_PDEATHSIG, SIGTERM)` then `execvp` the
+//     target. The kernel sends SIGTERM to the target when its parent
+//     exits. PDEATHSIG is preserved across exec as long as the target
+//     doesn't change UID, which gvproxy doesn't. One process.
+//
+//   - macOS: no PDEATHSIG. Fork; the child execs the target; the
+//     parent (the shim, now reparented to PID 1) kqueue-watches the
+//     original parent's PID for NOTE_EXIT and SIGTERMs the target when
+//     it fires. Two processes — the extra ~10 KiB watcher per VM is
+//     a fair price for not orphaning gvproxy.
+//
+// We compile the shim on first use into `~/.machinen/pdeathsig/<ver>/
+// pdeathsig` (mirrors `gvproxyCachePath`). If `cc` is missing we log
+// a one-shot warning and fall through to spawning unwrapped — the
+// machine still works, the next abnormal exit just leaks a gvproxy
+// (recoverable via PR #169's BOOT_PORT_FORWARD_IN_USE message).
+//
+// Opt-out: `MACHINEN_PDEATHSIG=disabled` skips the shim entirely.
+// Useful for debugging or environments where the C toolchain is gone.
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, platform as osPlatform } from "node:os";
+import { dirname, join } from "node:path";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:pdeathsig");
+
+/**
+ * Bumped whenever the C source below changes in a way that changes
+ * behavior. Recompiles instead of silently reusing a stale binary.
+ */
+export const PDEATHSIG_VERSION = "v2";
+
+let warnedNoCompiler = false;
+let installInFlight: Promise<string | null> | null = null;
+
+/**
+ * The shim's source. Embedded so the runtime ships exactly one file
+ * and `tsup` doesn't need to copy non-TS assets into `dist/`. Reads
+ * verbatim from the same string at compile time.
+ */
+const PDEATHSIG_C_SOURCE = `// pdeathsig: tiny exec wrapper that arranges for the target to die
+// when its parent dies. Linux uses PR_SET_PDEATHSIG; macOS uses a
+// kqueue NOTE_EXIT watcher. See packages/runtime/src/pdeathsig.ts.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#elif defined(__APPLE__)
+#include <sys/event.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
+
+static int run(int argc, char **argv);
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "pdeathsig: usage: pdeathsig <command> [args...]\\n");
+        return 2;
+    }
+    return run(argc, argv);
+}
+
+#if defined(__linux__)
+static int run(int argc, char **argv) {
+    (void)argc;
+    if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1) {
+        perror("pdeathsig: prctl");
+        return 127;
+    }
+    // Race: parent may already be gone. PDEATHSIG won't fire because
+    // there's nothing to fire on. Detect via reparenting to PID 1.
+    if (getppid() == 1) {
+        return 0;
+    }
+    execvp(argv[1], &argv[1]);
+    perror("pdeathsig: execvp");
+    return 127;
+}
+
+#elif defined(__APPLE__)
+// Wait up to ~5s for the target to exit after SIGTERM, then escalate.
+static int reap_then_exit(pid_t child, int code) {
+    for (int i = 0; i < 50; i++) {
+        int status;
+        pid_t r = waitpid(child, &status, WNOHANG);
+        if (r == child) return code;
+        usleep(100000);
+    }
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    return code;
+}
+
+static int run(int argc, char **argv) {
+    (void)argc;
+    pid_t parent_pid = getppid();
+    if (parent_pid == 1) {
+        return 0;
+    }
+
+    // Block the signals we'll consume via EVFILT_SIGNAL. Without this
+    // the default disposition would kill the guard before kqueue
+    // delivers the event, leaving the target alive and orphaned to
+    // PID 1 — defeating the whole point of the shim.
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGHUP);
+    sigprocmask(SIG_BLOCK, &mask, NULL);
+
+    pid_t child = fork();
+    if (child == -1) {
+        perror("pdeathsig: fork");
+        return 127;
+    }
+    if (child == 0) {
+        // Restore default signal disposition so the target inherits a
+        // clean mask — gvproxy and friends expect to receive SIGTERM
+        // normally.
+        sigprocmask(SIG_UNBLOCK, &mask, NULL);
+        execvp(argv[1], &argv[1]);
+        perror("pdeathsig: execvp");
+        _exit(127);
+    }
+
+    int kq = kqueue();
+    if (kq == -1) {
+        perror("pdeathsig: kqueue");
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 127);
+    }
+
+    struct kevent changes[5];
+    EV_SET(&changes[0], parent_pid, EVFILT_PROC, EV_ADD | EV_ONESHOT,
+           NOTE_EXIT, 0, NULL);
+    EV_SET(&changes[1], child, EVFILT_PROC, EV_ADD | EV_ONESHOT,
+           NOTE_EXIT, 0, NULL);
+    EV_SET(&changes[2], SIGTERM, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[3], SIGINT,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[4], SIGHUP,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    if (kevent(kq, changes, 5, NULL, 0, NULL) == -1) {
+        perror("pdeathsig: kevent register");
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 127);
+    }
+
+    // Race: parent may have died between getppid() and EV_SET. EVFILT_PROC
+    // on a dead pid silently never fires, so recheck explicitly.
+    if (kill(parent_pid, 0) == -1 && errno == ESRCH) {
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 0);
+    }
+
+    for (;;) {
+        struct kevent ev;
+        int n = kevent(kq, NULL, 0, &ev, 1, NULL);
+        if (n == -1) {
+            if (errno == EINTR) continue;
+            perror("pdeathsig: kevent wait");
+            kill(child, SIGTERM);
+            return reap_then_exit(child, 127);
+        }
+        if (n == 0) continue;
+        if (ev.filter == EVFILT_SIGNAL) {
+            // Runtime is signaling us (typical: child.kill('SIGTERM')
+            // from the Node side, or Ctrl-C). Forward to the target
+            // and reap. Keep the original signal so callers that look
+            // at WTERMSIG see what they sent.
+            kill(child, (int)ev.ident);
+            return reap_then_exit(child, 128 + (int)ev.ident);
+        }
+        pid_t fired = (pid_t)ev.ident;
+        if (fired == parent_pid) {
+            kill(child, SIGTERM);
+            return reap_then_exit(child, 0);
+        }
+        if (fired == child) {
+            int status;
+            waitpid(child, &status, 0);
+            return WIFEXITED(status) ? WEXITSTATUS(status)
+                                     : 128 + WTERMSIG(status);
+        }
+    }
+}
+
+#else
+static int run(int argc, char **argv) {
+    (void)argc; (void)argv;
+    fprintf(stderr, "pdeathsig: unsupported platform\\n");
+    return 127;
+}
+#endif
+`;
+
+/**
+ * Where the compiled shim lands. Versioned so a source bump
+ * recompiles instead of reusing a stale binary.
+ */
+export function pdeathsigCachePath(): string {
+  return join(homedir(), ".machinen", "pdeathsig", PDEATHSIG_VERSION, "pdeathsig");
+}
+
+/**
+ * Recognize the opt-out tokens for `MACHINEN_PDEATHSIG`. Same shape
+ * as `MACHINEN_GVPROXY`'s sentinels for muscle-memory consistency.
+ */
+function isPdeathsigDisabledSentinel(value: string): boolean {
+  const v = value.toLowerCase().trim();
+  return v === "disabled" || v === "off" || v === "false" || v === "0" || v === "none";
+}
+
+/**
+ * Resolve and (if needed) compile the parent-death shim. Returns the
+ * absolute path to a usable binary, or `null` when:
+ *   - the user opted out via `MACHINEN_PDEATHSIG=disabled`
+ *   - the platform is unsupported (Windows etc.)
+ *   - compilation failed (e.g. no `cc` on PATH) — emits a one-shot
+ *     stderr warning, then `null` so the caller can fall through.
+ *
+ * Compilation is sub-second and cached in `~/.machinen/pdeathsig/`.
+ */
+export async function ensurePdeathsig(): Promise<string | null> {
+  const override = process.env.MACHINEN_PDEATHSIG;
+  if (override !== undefined && isPdeathsigDisabledSentinel(override)) {
+    debug("opted out via MACHINEN_PDEATHSIG=%s", override);
+    return null;
+  }
+  if (override && override.length > 0 && existsSync(override)) {
+    debug("resolved via MACHINEN_PDEATHSIG=%s", override);
+    return override;
+  }
+
+  const plat = osPlatform();
+  if (plat !== "linux" && plat !== "darwin") {
+    debug("unsupported platform=%s", plat);
+    return null;
+  }
+
+  const cached = pdeathsigCachePath();
+  if (existsSync(cached)) {
+    return cached;
+  }
+  if (installInFlight) {
+    return installInFlight;
+  }
+  installInFlight = (async () => {
+    try {
+      return compilePdeathsig(cached);
+    } catch (err) {
+      if (!warnedNoCompiler) {
+        warnedNoCompiler = true;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `machinen: failed to compile pdeathsig shim (${msg}). ` +
+            "gvproxy will not be auto-killed when the runtime exits abnormally. " +
+            "Install Xcode CLI tools (macOS: `xcode-select --install`) or " +
+            "build-essential (Linux). To silence this warning set " +
+            "MACHINEN_PDEATHSIG=disabled.\n",
+        );
+      }
+      debug("compile failed err=%s", err instanceof Error ? err.message : String(err));
+      return null;
+    } finally {
+      installInFlight = null;
+    }
+  })();
+  return installInFlight;
+}
+
+/**
+ * Compile the embedded C source to `outPath`. Atomic via tmp+rename
+ * so a concurrent caller never sees a half-written binary.
+ */
+function compilePdeathsig(outPath: string): string {
+  const dir = dirname(outPath);
+  mkdirSync(dir, { recursive: true });
+
+  const srcPath = join(dir, "pdeathsig.c");
+  writeFileSync(srcPath, PDEATHSIG_C_SOURCE);
+
+  const tmpOut = `${outPath}.${process.pid}.tmp`;
+  const cc = process.env.CC ?? "cc";
+  // Suppress stdout, capture stderr so we surface useful failures
+  // (cc not found, syntax errors after a source bump, etc.).
+  execFileSync(cc, ["-O2", "-Wall", "-Wextra", "-o", tmpOut, srcPath], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  chmodSync(tmpOut, 0o755);
+  try {
+    renameSync(tmpOut, outPath);
+  } catch (err) {
+    // Lost a race with a concurrent compile. The other one's binary
+    // is fine; clean up our tmp and return the cached path.
+    try {
+      unlinkSync(tmpOut);
+    } catch {}
+    if (existsSync(outPath)) {
+      return outPath;
+    }
+    throw err;
+  }
+  debug("compiled %s", outPath);
+  return outPath;
+}
+
+/**
+ * Wrap an argv pair so the resulting spawn dies with its parent.
+ * If `pdeathsigBin` is `null` the argv is returned unchanged — caller
+ * gets the unwrapped behavior (orphan-on-kill -9).
+ */
+export function wrapWithPdeathsig(
+  pdeathsigBin: string | null,
+  command: string,
+  args: string[],
+): { command: string; args: string[] } {
+  if (!pdeathsigBin) {
+    return { command, args };
+  }
+  return { command: pdeathsigBin, args: [command, ...args] };
+}


### PR DESCRIPTION
Stacks on #169. Together they close #115.

#169 makes the *next* boot fail loudly when a host port is already held — diagnosis. This PR stops the orphan from being created in the first place by making gvproxy actually die with the runtime, even on `kill -9`.

## How

Tiny C shim, ~100 lines, two `#ifdef` branches. Lazy-compiled on first use into `~/.machinen/pdeathsig/v2/pdeathsig` (sub-second; mirrors how `ensureGvproxy` caches its binary). `spawnGvproxy` wraps argv through it.

- **Linux:** `prctl(PR_SET_PDEATHSIG, SIGTERM)` then `execvp` the target. PDEATHSIG persists across exec because gvproxy doesn't change UID. One process.
- **macOS:** no PDEATHSIG. The shim forks; the child execs the target; the guard kqueue-watches the original parent's pid for `NOTE_EXIT`, plus `EVFILT_SIGNAL` for SIGTERM/SIGINT/SIGHUP so `child.kill('SIGTERM')` from Node still kills the target. On any of those it `SIGTERM`s the target, waits 5s, escalates to `SIGKILL`, reaps. Two processes per VM (~10 KiB).

If `cc` is missing the shim falls through to direct spawn with a one-shot stderr warning — the runtime still works, the next abnormal exit just leaks a gvproxy (recoverable via #169's `BOOT_PORT_FORWARD_IN_USE` message). `MACHINEN_PDEATHSIG=disabled` opts out.

## Why a C shim and not Node-side

`SIGKILL` can't be caught — only kernel-level mechanisms (`PR_SET_PDEATHSIG` on Linux, an external `kqueue NOTE_EXIT` watcher on macOS) survive a `kill -9`. Node has no built-in for either.

Source is embedded as a TS string so `tsup` doesn't need asset-copy glue.

## Proof

`packages/runtime/src/__tests__/pdeathsig.test.ts` includes the empirical test: spawn a `node` parent that wraps `sleep 30` through the shim, `SIGKILL` the node, assert the sleep is gone within 5s and no orphan with `PPID=1` remains. Plus a SIGTERM-forwarding test that catches the macOS guard-vs-target signal-routing bug, and unit coverage for the opt-out / unsupported-platform paths.

Hand-verified the same flow against real `gvproxy`: before the fix, after `kill -9` of the parent, gvproxy survived with `PPID=1`; after the fix, gvproxy is gone alongside its parent.

## Notes for the reviewer

- Targets `115-fix-runtime-pre-flight-port-bind-probe` (the #169 branch) — merge order: #169 first, then this.
- `artifact-cache.ts` was called out in #115 as having the same lifecycle bug, but the current implementation runs the HTTP server in-process (not as a child), so there's no orphan to fix there. Note in code if useful — left alone in this PR.
- Pre-existing CI failure on `pty.test.ts` (`node-pty` missing the `linux-arm64` prebuild) is unrelated and reproduces on `main`. Worth a separate issue.

## Test plan

- [ ] CI green on Linux + macOS (vitest + format + lint)
- [ ] Reviewer can repro the kill -9 flow by hand: spawn a process via the shim, `kill -9` its parent, confirm no `PPID=1` orphan
- [ ] `MACHINEN_PDEATHSIG=disabled` skips the shim and the runtime still boots
- [ ] On a host without `cc`, runtime emits the warning and continues working
