### PR TITLE
test(runtime): pjdfstest layer 3 + fuse-workloads CI workflow (#165)

### DIFF
--- a/.github/workflows/fuse-workloads.yml
+++ b/.github/workflows/fuse-workloads.yml
@@ -1,0 +1,98 @@
+name: FUSE workload tests
+
+# Real-VM workload integration tests for /mnt/workspace (#165 layer 2 + 3).
+#
+# Runs the workload subset of vitest against a fully booted microVM:
+#   - Builds the linux-arm64 VMM (zig).
+#   - Pulls / builds the cached base assets (kernel + dtb + rootfs).
+#   - Runs `pnpm provision-test-vm` to bake test-vm.tar.gz with the
+#     extra tools (git, rsync, sqlite3, pjdfstest).
+#   - Runs the workload-only vitest filter, which boots a real VM per
+#     test case and asserts behaviour against the live FUSE mount.
+#
+# Kept off the default `Tests` workflow because it (a) needs an arm64
+# runner — KVM only works for the matching arch and our VMM is only
+# wired up for arm64 today — and (b) takes minutes, not seconds.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/runtime/**"
+      - "packages/microvm/**"
+      - "scripts/build-base-assets.sh"
+      - "scripts/provision-test-vm.ts"
+      - "provision.ts"
+      - ".github/workflows/fuse-workloads.yml"
+      - ".github/workflows/_build-base-assets.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/runtime/**"
+      - "packages/microvm/**"
+      - "scripts/build-base-assets.sh"
+      - "scripts/provision-test-vm.ts"
+      - "provision.ts"
+      - ".github/workflows/fuse-workloads.yml"
+      - ".github/workflows/_build-base-assets.yml"
+
+jobs:
+  base-assets:
+    uses: ./.github/workflows/_build-base-assets.yml
+
+  workloads:
+    needs: [base-assets]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # The runtime spawns the VMM as a child process. On linux-arm64
+      # KVM is the hypervisor — the runner image exposes /dev/kvm to
+      # rootless processes via a udev rule, but we still need group
+      # membership; the GitHub-hosted arm64 runner already grants this
+      # to the workflow user.
+      - name: Confirm KVM is available
+        run: test -c /dev/kvm
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Build linux-arm64 VMM
+        working-directory: packages/microvm
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Stage VMM for the runtime to find
+        run: |
+          mkdir -p packages/vmm-arm64-linux/bin
+          cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-linux/bin/microvm
+          cp packages/microvm/zig-out/bin/gvproxy packages/vmm-arm64-linux/bin/gvproxy
+
+      - run: pnpm install --frozen-lockfile
+
+      # Build runtime + cli so the workload tests import the compiled
+      # dist (vitest uses the source via tsx, but boot() flows through
+      # @machinen/runtime's package entrypoint which the test imports
+      # by relative path — rebuild keeps types in sync regardless).
+      - run: pnpm -F @machinen/runtime -F @machinen/cli build
+
+      - name: Materialize cached base assets
+        uses: actions/download-artifact@v4
+        with:
+          name: base-assets
+          path: release-assets/
+
+      - name: Provision the test VM image
+        run: pnpm provision-test-vm
+
+      # Filter to workloads — the rest of vitest already runs in the
+      # plain Tests workflow.
+      - name: Run workload tests
+        run: pnpm exec vitest run packages/runtime/src/__tests__/mount-server-workloads.test.ts

--- a/packages/runtime/src/__tests__/mount-server-workloads.test.ts
+++ b/packages/runtime/src/__tests__/mount-server-workloads.test.ts
@@ -78,8 +78,15 @@ interface WorkloadResult {
  * no shell-after-workload fallback. Stdout/stderr are buffered into
  * strings, fine for the verifier `echo` lines we use; for big payloads
  * write to a file in the workspace and read it host-side instead.
+ *
+ * `timeoutMs` overrides the per-VM timeout (the pjdfstest workload
+ * runs ~8500 cases through FUSE and needs minutes, not the default 2).
  */
-async function runWorkload(scratch: string, script: string): Promise<WorkloadResult> {
+async function runWorkload(
+  scratch: string,
+  script: string,
+  timeoutMs: number = VM_BOOT_TIMEOUT_MS,
+): Promise<WorkloadResult> {
   const ramBytes = (() => {
     const size = statSync(TEST_VM_TAR).size;
     const GIB = 1024 ** 3;
@@ -103,7 +110,7 @@ async function runWorkload(scratch: string, script: string): Promise<WorkloadRes
       cmd: ["/bin/bash", "-lc", script],
       liveMounts: [{ host: scratch, guest: "/mnt/workspace", mode: "rw" }],
       vmmEnv: { MACHINEN_RAM_BYTES: String(ramBytes) },
-      timeoutMs: VM_BOOT_TIMEOUT_MS,
+      timeoutMs,
     });
 
     let stdout = "";
@@ -140,6 +147,54 @@ function reportFailure(label: string, result: WorkloadResult): never {
       `--- stdout (last 4KB) ---\n${result.stdout.slice(-4096)}\n` +
       `--- stderr (last 4KB) ---\n${result.stderr.slice(-4096)}`,
   );
+}
+
+interface PjdfstestSummary {
+  /** Total tests run (Files=…). */
+  files: number;
+  /** Total individual assertions (Tests=…). */
+  tests: number;
+  /** Number of asserting passes. */
+  passes: number;
+  /** Number of asserting failures. Always tests - passes for our parser. */
+  failures: number;
+}
+
+/**
+ * Parse the trailing summary that `prove` prints after a run. Two
+ * lines we depend on (in order):
+ *
+ *   Files=NN, Tests=MMMM, …
+ *   Result: PASS|FAIL
+ *
+ * When tests fail, `prove` also prints a per-file "Failed: M/M" line
+ * we can sum to derive `passes`. If failures are zero the summary
+ * line gives us everything directly.
+ *
+ * Returns null if neither anchor line is found — the caller treats
+ * that as a setup bug (suite didn't run) rather than a test failure.
+ */
+function parsePjdfstestSummary(text: string): PjdfstestSummary | null {
+  // "Files=37, Tests=8519,  173 wallclock secs (...)"
+  const fileMatch = text.match(/Files=(\d+),\s*Tests=(\d+)/);
+  if (!fileMatch) {
+    return null;
+  }
+  const files = Number(fileMatch[1]);
+  const tests = Number(fileMatch[2]);
+
+  // Sum any per-file "Failed: K/N" — this also catches the
+  // "Failed Tests" block prove emits before the summary line.
+  let failures = 0;
+  for (const m of text.matchAll(/Failed:\s+(\d+)\/\d+/g)) {
+    failures += Number(m[1]);
+  }
+  // Belt-and-suspenders: prove's "Result: FAIL" with no per-file
+  // breakdown still implies at least one failure.
+  if (failures === 0 && /Result:\s+FAIL/.test(text)) {
+    failures = 1;
+  }
+  return { files, tests, passes: tests - failures, failures };
 }
 
 // ----------------------------------------------------------------------
@@ -424,6 +479,97 @@ describe.runIf(assetsPresent())("FUSE live-mount workloads (#165)", () => {
       }
     },
     TEST_TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------
+  // pjdfstest (#165 layer 3) — POSIX filesystem conformance suite.
+  // ~8500 test cases covering chmod/chown/link/mkdir/mkfifo/open/
+  // rename/rmdir/symlink/truncate/unlink. Built into /opt/pjdfstest in
+  // the test image (see scripts/provision-test-vm.ts).
+  //
+  // We don't pass everything on day one — the baseline is recorded in
+  // pjdfstest-baseline.json and the test ratchets it. A drop in passes
+  // fails CI; a rise prints a hint to bump the baseline.
+  // -------------------------------------------------------------------
+
+  it(
+    "pjdfstest baseline holds (no regressions in POSIX conformance)",
+    async () => {
+      const { scratch, cleanup } = makeScratch();
+      try {
+        const result = await runWorkload(
+          scratch,
+          [
+            "set +e", // prove returns non-zero on any test failure; we capture it
+            "cd /mnt/workspace",
+            // Run the suite verbosely so the prove summary line lands
+            // in stdout for the host parser. --norc skips the per-user
+            // .proverc, --timer is harmless and useful for debug.
+            "prove -r --norc --timer /opt/pjdfstest/tests",
+            // Sentinel echo so the parser can find the trailing
+            // summary unambiguously even if prove's own output is
+            // interleaved with kernel logs.
+            'echo "PJDFSTEST_DONE"',
+          ].join("\n"),
+          // 8 minutes inside the VM. The outer it() timeout is 10
+          // minutes, leaving 2 min of margin for shutdown + parsing.
+          8 * 60_000,
+        );
+
+        const summary = parsePjdfstestSummary(result.stdout + "\n" + result.stderr);
+        if (!summary) {
+          throw new Error(
+            "pjdfstest workload: couldn't parse prove summary.\n" +
+              `--- stdout (last 4KB) ---\n${result.stdout.slice(-4096)}\n` +
+              `--- stderr (last 4KB) ---\n${result.stderr.slice(-4096)}`,
+          );
+        }
+
+        const baselinePath = join(import.meta.dirname, "pjdfstest-baseline.json");
+        if (!existsSync(baselinePath)) {
+          // First run: record current totals as the floor and fail
+          // loudly so a maintainer reviews the numbers before they
+          // become "the" baseline.
+          writeFileSync(baselinePath, `${JSON.stringify(summary, null, 2)}\n`);
+          throw new Error(
+            `pjdfstest baseline written to ${baselinePath} ` +
+              `(${JSON.stringify(summary)}). Review and commit, then re-run.`,
+          );
+        }
+
+        const baseline = JSON.parse(readFileSync(baselinePath, "utf8")) as typeof summary;
+
+        // Total-tests floor: pjdfstest occasionally adds upstream
+        // cases. A 5% drop means the suite was truncated (e.g. half
+        // the perl scripts didn't run) — that's a setup bug, not a
+        // conformance regression.
+        if (summary.tests < Math.floor(baseline.tests * 0.95)) {
+          throw new Error(
+            `pjdfstest: total tests dropped from ${baseline.tests} to ${summary.tests} — ` +
+              "is the suite truncated?",
+          );
+        }
+        if (summary.passes < baseline.passes) {
+          throw new Error(
+            `pjdfstest: passing tests regressed from ${baseline.passes} to ${summary.passes}. ` +
+              "If this is intentional, update pjdfstest-baseline.json.",
+          );
+        }
+        if (summary.passes > baseline.passes) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[pjdfstest] passes improved from ${baseline.passes} to ${summary.passes}. ` +
+              "Bump pjdfstest-baseline.json to lock in.",
+          );
+        }
+      } finally {
+        cleanup();
+      }
+    },
+    // pjdfstest is the slow workload — ~8500 cases through FUSE take
+    // a couple of minutes. 10 min ceiling so a wedge surfaces as a
+    // bounded failure rather than a hung CI job.
+    10 * 60_000,
   );
 
   // -------------------------------------------------------------------

--- a/packages/runtime/src/__tests__/pjdfstest-baseline.json
+++ b/packages/runtime/src/__tests__/pjdfstest-baseline.json
@@ -1,0 +1,6 @@
+{
+  "files": 237,
+  "tests": 8789,
+  "passes": 8788,
+  "failures": 1
+}

--- a/scripts/provision-test-vm.ts
+++ b/scripts/provision-test-vm.ts
@@ -49,19 +49,49 @@ const { provision } = (await import(
   resolve(MAIN_REPO, "node_modules/@machinen/runtime/dist/index.js")
 )) as typeof import("@machinen/runtime");
 
-// Minimal install: only the tools the workload tests need. The base
-// rootfs from scripts/build-base-assets.sh is bare Debian — even git
-// isn't in it. tar lives in coreutils; everything else gets added here.
+// Tools the workload tests need. The base rootfs from
+// scripts/build-base-assets.sh is bare Debian — even git isn't in it.
+// Layer 3 (pjdfstest) needs a C toolchain + autoconf to build from
+// source inside the VM, plus perl + Test::Harness to drive the suite.
 const installSteps = async (vm: VmHandle): Promise<void> => {
   await vm.exec(
     "apt-get update -qq && " +
-      "apt-get install -y --no-install-recommends git rsync sqlite3 && " +
+      "apt-get install -y --no-install-recommends " +
+      // ca-certificates: minbase rootfs doesn't ship them, so the
+      // git-clone step below fails TLS verification without this.
+      "ca-certificates " +
+      // workload basics
+      "git rsync sqlite3 " +
+      // pjdfstest build deps + runner. autoconf/automake/libtool drive
+      // its autogen.sh; libacl1-dev exposes the ACL syscalls a few
+      // tests touch (others probe and skip cleanly when ACLs aren't
+      // backed by the fs). prove ships in perl.
+      "build-essential autoconf automake libtool libacl1-dev perl && " +
       "apt-get clean && rm -rf /var/lib/apt/lists/*",
   );
   // file:// clones from the live FUSE mount fall foul of CVE-2022-24765
   // "dubious ownership" warnings — the FUSE uid won't match the guest's
   // uid. safe.directory '*' opts out, same as the dev provision.
   await vm.exec("git config --global --add safe.directory '*'");
+
+  // Build pjdfstest from source. Autotools build — autoreconf
+  // generates ./configure, which writes a Makefile that compiles the
+  // single C helper used by every test. The perl/prove scripts live
+  // in tests/ and are invoked at workload time, not here. Pin via
+  // the SHA recorded in /opt/pjdfstest/COMMIT so a baseline drift
+  // can be diagnosed; pinning to a fixed commit upstream is fine to
+  // do later if drift becomes a real problem.
+  await vm.exec(
+    "git clone --quiet --depth 1 https://github.com/pjd/pjdfstest /opt/pjdfstest && " +
+      "cd /opt/pjdfstest && " +
+      "git rev-parse HEAD > COMMIT && " +
+      "autoreconf -ifs >/dev/null && " +
+      "./configure --quiet >/dev/null && " +
+      "make pjdfstest >/dev/null && " +
+      // Drop the .git dir to keep the resulting image small — we
+      // recorded the SHA in COMMIT for traceability.
+      "rm -rf /opt/pjdfstest/.git",
+  );
 };
 
 // Stamp = hash of this file's contents. Any edit (new package, version


### PR DESCRIPTION
## Problem

Closes #165 layers 3 (pjdfstest) and the CI plumbing follow-up. Stacks on **#168** — base it onto that PR's branch, not main.

## Solution

### Layer 3 — `pjdfstest` baseline ratchet

`pjdfstest` is the de-facto POSIX filesystem conformance suite (~8500 cases across `chmod`, `chown`, `link`, `mkdir`, `mkfifo`, `open`, `rename`, `rmdir`, `symlink`, `truncate`, `unlink`).

- `scripts/provision-test-vm.ts` installs the build chain (`build-essential autoconf automake libtool libacl1-dev perl ca-certificates`), clones `pjdfstest` shallow at HEAD, and builds it via `autoreconf + configure + make pjdfstest`. The source SHA is recorded at `/opt/pjdfstest/COMMIT` for traceability.
- New workload runs `prove -r /opt/pjdfstest/tests` against `/mnt/workspace` and parses the prove summary (`Files=…, Tests=…`) to extract pass/fail counts.
- `packages/runtime/src/__tests__/pjdfstest-baseline.json` checked in with the floor. **Initial baseline: 8788/8789 passing through FUSE — one conformance failure**, which is excellent for a custom FUSE implementation.
- The test ratchets: a drop in passes fails, a rise prints a hint to bump the baseline. A 5%+ drop in *total* tests fails too, so a half-run suite is caught.

### CI plumbing — `.github/workflows/fuse-workloads.yml`

- Triggers on PRs touching `packages/runtime/**`, `packages/microvm/**`, `provision.ts`, `scripts/{build-base-assets,provision-test-vm}.ts`, and the workflow file itself.
- Reuses the existing `_build-base-assets.yml` to get kernel + dtb + rootfs.
- Runs on `ubuntu-24.04-arm` (KVM is per-arch, our VMM is arm64-only).
- Builds the linux-arm64 VMM with zig, stages it under `packages/vmm-arm64-linux/bin/` where `resolveVmmBinary()` looks.
- Runs `pnpm provision-test-vm` to bake `test-vm.tar.gz`.
- Filters vitest to just the workload file — the rest already runs in the default `Tests` workflow, no point duplicating.
- Kept off the default `Tests` workflow because boot + workload runs take minutes vs the unit suite's seconds.

### Misc

`runWorkload()` gains a per-call `timeoutMs` override — `pjdfstest`'s 8500 cases through FUSE take ~3 min, not the default 2.

## Test plan

- [x] `pnpm provision-test-vm --force` — builds 158 MB `test-vm.tar.gz` (was 66 MB before, +92 MB for gcc + pjdfstest source).
- [x] `npx vitest run mount-server-workloads.test.ts` — 7/7 passing in ~165 s (pjdfstest is the long pole at ~150 s).
- [x] Re-run after baseline written — passes deterministically.
- [x] `oxlint` and `oxfmt --check` clean.

## Stacking note

Branched off `test/fuse-workload-integration-165` (PR #168). Merge #168 first, then this PR rebases onto main automatically.
