### PR TITLE
fix(runtime): move provision() to virtio-blk root so the rootfs stops fitting in RAM

### DIFF
--- a/.github/workflows/_build-vmm-darwin-arm64.yml
+++ b/.github/workflows/_build-vmm-darwin-arm64.yml
@@ -4,7 +4,7 @@ name: Build VMM darwin-arm64 (reusable)
 # codesigns the darwin-arm64 VMM binary so it can use HVF at runtime.
 #
 # Uploads a single artifact named `vmm-arm64-darwin` containing the
-# codesigned `microvm` binary.
+# codesigned `machinen-vm` binary.
 #
 # Cached on packages/microvm/{src,assets}/** + build.zig + entitlements
 # so re-runs on unchanged inputs skip the ~3-minute zig build.
@@ -25,7 +25,7 @@ jobs:
         id: cache
         uses: actions/cache@v4
         with:
-          path: packages/microvm/zig-out/bin/microvm
+          path: packages/microvm/zig-out/bin/machinen-vm
           key: vmm-darwin-arm64-${{ hashFiles('packages/microvm/src/**', 'packages/microvm/assets/**/*.zig', 'packages/microvm/build.zig', 'packages/microvm/build.zig.zon', 'packages/microvm/entitlements.plist') }}
 
       - name: Setup Zig
@@ -51,11 +51,11 @@ jobs:
         run: |
           codesign -s - --force \
             --entitlements entitlements.plist \
-            zig-out/bin/microvm
+            zig-out/bin/machinen-vm
 
       - uses: actions/upload-artifact@v4
         with:
           name: vmm-arm64-darwin
-          path: packages/microvm/zig-out/bin/microvm
+          path: packages/microvm/zig-out/bin/machinen-vm
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/fuse-workloads.yml
+++ b/.github/workflows/fuse-workloads.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Stage VMM for the runtime to find
         run: |
           mkdir -p packages/vmm-arm64-linux/bin
-          cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-linux/bin/microvm
+          cp packages/microvm/zig-out/bin/machinen-vm packages/vmm-arm64-linux/bin/machinen-vm
           cp packages/microvm/zig-out/bin/gvproxy packages/vmm-arm64-linux/bin/gvproxy
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: vmm-arm64-linux
-          path: packages/microvm/zig-out/bin/microvm
+          path: packages/microvm/zig-out/bin/machinen-vm
           if-no-files-found: error
 
   # ------------------------------------------------------------
@@ -85,7 +85,7 @@ jobs:
         with:
           name: vmm-arm64-linux
           path: packages/vmm-arm64-linux/bin/
-      - run: chmod +x packages/vmm-arm64-*/bin/microvm
+      - run: chmod +x packages/vmm-arm64-*/bin/machinen-vm
 
       # gvproxy (containers/gvisor-tap-vsock) — bundled next to the VMM
       # so `@machinen/runtime` can auto-spawn it for virtio-net without

--- a/packages/microvm/build.zig
+++ b/packages/microvm/build.zig
@@ -68,7 +68,7 @@ pub fn build(b: *std.Build) void {
     // If neither case applies to you, feel free to delete the declaration you
     // don't need and to put everything under a single module.
     const exe = b.addExecutable(.{
-        .name = "microvm",
+        .name = "machinen-vm",
         .root_module = b.createModule(.{
             // b.createModule defines a new module just like b.addModule but,
             // unlike b.addModule, it does not expose the module to consumers of

--- a/packages/runtime/src/__tests__/exec.test.ts
+++ b/packages/runtime/src/__tests__/exec.test.ts
@@ -53,7 +53,8 @@ describe("VsockExec", () => {
       return;
     }
     const debianTar = resolve(microvmRoot, "../../release-assets/rootfs-debian-arm64.tar.gz");
-    if (!existsSync(debianTar)) {
+    const modulesTar = resolve(microvmRoot, "../../release-assets/modules-arm64.tar.gz");
+    if (!existsSync(debianTar) || !existsSync(modulesTar)) {
       return;
     }
     const udsPath = join(tmpdir(), `machinen-exec-${process.pid}.sock`);
@@ -70,6 +71,10 @@ describe("VsockExec", () => {
         vmmEnv: {
           MACHINEN_BOOT_TEST: "1",
           MACHINEN_VSOCK: `in:1978:${udsPath}`,
+          // Test-fixture binary loads test-fixtures/Image directly, so
+          // the runtime never sees a MACHINEN_KERNEL it can probe for
+          // modules. Hand it the path explicitly.
+          MACHINEN_MODULES: modulesTar,
         },
         image: debianTar,
         cmd: ["/exec-agent"],

--- a/packages/runtime/src/__tests__/port-forward.test.ts
+++ b/packages/runtime/src/__tests__/port-forward.test.ts
@@ -170,7 +170,6 @@ async function holdEphemeralPort(): Promise<{ port: number; stop: () => Promise<
     stop: () =>
       new Promise<void>((done) => {
         srv.close(() => done());
-        srv.closeAllConnections?.();
       }),
   };
 }

--- a/packages/runtime/src/__tests__/provision.test.ts
+++ b/packages/runtime/src/__tests__/provision.test.ts
@@ -39,15 +39,22 @@ function findBootTestBinary(): string | undefined {
   return undefined;
 }
 
-function integrationPrereqs(): { binary: string; base: string } | undefined {
+function integrationPrereqs(): { binary: string; base: string; modules: string } | undefined {
   const binary = findBootTestBinary();
   const base = resolve(releaseAssets, "rootfs-debian-arm64.tar.gz");
+  const modules = resolve(releaseAssets, "modules-arm64.tar.gz");
   const kernel = resolve(microvmRoot, "test-fixtures/Image");
   const dtb = resolve(microvmRoot, "test-fixtures/virt.dtb");
-  if (!binary || !existsSync(base) || !existsSync(kernel) || !existsSync(dtb)) {
+  if (
+    !binary ||
+    !existsSync(base) ||
+    !existsSync(modules) ||
+    !existsSync(kernel) ||
+    !existsSync(dtb)
+  ) {
     return undefined;
   }
-  return { binary, base };
+  return { binary, base, modules };
 }
 
 describe("provision", () => {
@@ -132,7 +139,14 @@ describe("provision", () => {
         const result = await provision({
           binary: prereqs.binary,
           cwd: microvmRoot,
-          vmmEnv: { MACHINEN_BOOT_TEST: "1", MACHINEN_DEBUG: "1" },
+          vmmEnv: {
+            MACHINEN_BOOT_TEST: "1",
+            MACHINEN_DEBUG: "1",
+            // Test-fixture binary uses test-fixtures/Image directly, so
+            // the runtime can't probe for modules next to MACHINEN_KERNEL
+            // (it never sets one). Hand it the path explicitly.
+            MACHINEN_MODULES: prereqs.modules,
+          },
           base: prereqs.base,
           install: async (vm) => {
             await vm.exec(
@@ -152,7 +166,10 @@ describe("provision", () => {
         const vm = await boot({
           binary: prereqs.binary,
           cwd: microvmRoot,
-          vmmEnv: { MACHINEN_BOOT_TEST: "1" },
+          vmmEnv: {
+            MACHINEN_BOOT_TEST: "1",
+            MACHINEN_MODULES: prereqs.modules,
+          },
           image: result.imagePath,
           cmd: ["/exec-agent"],
           env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -618,8 +618,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // #114: rootdisk-by-default. Boot mounts the rootfs from a
   // virtio-blk device (/dev/vda) instead of inflating the whole tree
   // into a RAM-backed tmpfs at boot. The user passes `rootDisk: false`
-  // to opt back into the legacy cpio-as-rootfs path (mostly used by
-  // `provision()` itself, which writes its scratch tar to /dev/vda).
+  // to opt back into the legacy cpio-as-rootfs path (rare — mostly for
+  // tests that need to assert the initramfs path explicitly).
   // Resolution + materialization happens later, alongside packBundle,
   // so per-arg validation (mount paths, liveMount, baked-cmd) fires
   // before we spend time hashing the tarball.
@@ -1497,10 +1497,9 @@ function synthesizeAndPackBundle(
         fuseAgentPath: liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
       });
     } else {
-      // Legacy fat cpio: provision()'s `tar / -cf /dev/vda` and any
-      // explicit `rootDisk: false` opt-out. Drags the entire base
-      // tarball into RAM, by design — those callers need a Debian
-      // userland in the cpio.
+      // Legacy fat cpio: explicit `rootDisk: false` opt-out. Drags the
+      // entire base tarball into RAM, by design — callers that need a
+      // Debian userland in the cpio (no virtio-blk root) land here.
       mkinitramfsPackBundle({
         bundle: synthBundleDir,
         out: cpioPath,

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -24,6 +24,8 @@
 import { execFileSync } from "node:child_process";
 import {
   closeSync,
+  constants as fsConstants,
+  copyFileSync,
   existsSync,
   mkdtempSync,
   openSync,
@@ -40,6 +42,7 @@ import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import { boot, type VmHandle } from "./index.ts";
 import type { OnLog } from "./log.ts";
+import { ensureRootfsImage } from "./rootfs-img.ts";
 
 const debug = debugLib("machinen:provision");
 const vmmDebug = debugLib("machinen:vmm");
@@ -141,10 +144,12 @@ export interface ProvisionResult {
 /**
  * The guest-side command we run after `install` completes to capture
  * the rootfs state onto the scratch disk. Excludes volatile + special
- * filesystems; everything else goes into the tar stream we then write
- * raw to `/dev/vda`. At pack-time there is no filesystem on the disk,
- * so we're appending tar directly to the block device. The host reads
- * it back the same way (the trailing two zero blocks mark the end).
+ * filesystems; everything else goes into the tar stream we write raw
+ * to `/dev/vdb`. The scratch disk is the second virtio-blk slot (vda
+ * holds the live ext4 rootfs the guest is running from); at pack-time
+ * vdb has no filesystem so we append tar directly to the block device.
+ * The host reads it back the same way (the trailing two zero blocks
+ * mark the end).
  */
 const TAR_TO_DISK_CMD = [
   "tar",
@@ -154,14 +159,13 @@ const TAR_TO_DISK_CMD = [
   "--exclude=./dev",
   "--exclude=./tmp",
   "--exclude=./run",
-  "--exclude=./mnt",
   "--exclude=./machinen-config.json",
   "--exclude=./etc/machinen-boot-epoch",
   "--sort=name",
   "--numeric-owner",
   "--owner=0",
   "--group=0",
-  "-cf /dev/vda",
+  "-cf /dev/vdb",
   ".",
 ].join(" ");
 
@@ -250,6 +254,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
   const t0 = Date.now();
   const workDir = mkdtempSync(join(tmpdir(), "machinen-provision-"));
   const diskPath = join(workDir, "scratch.img");
+  const rootDiskPath = join(workDir, "rootfs.img");
   const udsPath = join(workDir, "exec.sock");
   debug("provision start base=%s out=%s workDir=%s", baseAbs, outAbs, workDir);
 
@@ -261,10 +266,22 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     allocateSparseFile(diskPath, scratchBytes);
     debug("scratch disk allocated path=%s sizeBytes=%d", diskPath, scratchBytes);
 
-    // Boot the VMM with the base rootfs as the image and the exec-agent
-    // as the cmd. We set MACHINEN_VSOCK explicitly via `vmmEnv` so the
-    // UDS path lives under workDir (predictable cleanup) rather than
-    // boot()'s auto-allocated tmp dir.
+    // Materialize the base tarball into an ext4 image and COW-clone it
+    // into the workDir. The install hook mutates this throwaway copy, so
+    // the persistent ~/.cache/machinen/rootfs/<sha>.img cache stays
+    // pristine for normal `boot({ image })` callers that share the same
+    // base. COPYFILE_FICLONE → APFS clonefile / Linux FICLONE on
+    // reflink-capable fs (free); falls back to a regular copy elsewhere
+    // (one-time cost, sparse).
+    const cachedImg = ensureRootfsImage(baseAbs);
+    copyFileSync(cachedImg, rootDiskPath, fsConstants.COPYFILE_FICLONE);
+    debug("rootdisk cloned src=%s dst=%s", cachedImg, rootDiskPath);
+
+    // Boot the VMM with the base rootfs on /dev/vda (mounted ext4) and
+    // the exec-agent as the cmd. The scratch disk lands on /dev/vdb,
+    // ready for the post-install tar dump. We set MACHINEN_VSOCK
+    // explicitly via `vmmEnv` so the UDS path lives under workDir
+    // (predictable cleanup) rather than boot()'s auto-allocated tmp dir.
     const vm = await boot({
       binary: opts.binary,
       cwd: opts.cwd,
@@ -278,12 +295,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       cmd: ["/exec-agent"],
       env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
       snapshot: diskPath,
-      // Opt out of the disk-backed boot path: the post-install
-      // `tar / -cf /dev/vda` below writes the captured rootfs onto
-      // the snapshot disk (which is /dev/vda when no rootdisk is
-      // attached). Promoting provision() to virtio-blk root would
-      // need a /dev/vdb-aware tar dump and is tracked separately.
-      rootDisk: false,
+      rootDisk: rootDiskPath,
       // We drive the guest to exit via /sbin/machinen-poweroff at the
       // end; wait() has its own ceiling below.
       timeoutMs: null,
@@ -336,21 +348,21 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       }
       debug("install hook done elapsed=%dms", Date.now() - installT0);
 
-      // Post-install: archive / to /dev/vda, then tell the guest to
-      // power off cleanly (PSCI SYSTEM_OFF via /sbin/machinen-poweroff).
-      // A failed tar here means our scratch disk was too small; surface
-      // that specifically.
-      debug("tar / -> /dev/vda starting");
+      // Post-install: archive / to /dev/vdb (the scratch disk), then
+      // tell the guest to power off cleanly (PSCI SYSTEM_OFF via
+      // /sbin/machinen-poweroff). A failed tar here means our scratch
+      // disk was too small; surface that specifically.
+      debug("tar / -> /dev/vdb starting");
       const tarT0 = Date.now();
       const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
         execTimeoutMs: deadlineMs,
         ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
       });
-      debug("tar / -> /dev/vda done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
+      debug("tar / -> /dev/vdb done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
       if (tar.exitCode !== 0) {
         throw new ProvisionError(
           "PROVISION_DISK_TOO_SMALL",
-          `tar / to /dev/vda failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
+          `tar / to /dev/vdb failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
             `Bump scratchDiskSizeBytes. stderr:\n${tar.stderr}`,
         );
       }

--- a/packages/vmm-arm64-darwin/.gitignore
+++ b/packages/vmm-arm64-darwin/.gitignore
@@ -1,1 +1,1 @@
-bin/microvm
+bin/machinen-vm

--- a/packages/vmm-arm64-darwin/index.mjs
+++ b/packages/vmm-arm64-darwin/index.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 
 const binDir = join(dirname(fileURLToPath(import.meta.url)), "bin");
 
-export const binary = join(binDir, "microvm");
+export const binary = join(binDir, "machinen-vm");
 // gvproxy (containers/gvisor-tap-vsock) — optional sibling binary the
 // runtime auto-spawns for virtio-net. Present when CI stages it during
 // publish; absent in the repo so `git status` stays clean.

--- a/packages/vmm-arm64-linux/.gitignore
+++ b/packages/vmm-arm64-linux/.gitignore
@@ -1,1 +1,1 @@
-bin/microvm
+bin/machinen-vm

--- a/packages/vmm-arm64-linux/index.mjs
+++ b/packages/vmm-arm64-linux/index.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 
 const binDir = join(dirname(fileURLToPath(import.meta.url)), "bin");
 
-export const binary = join(binDir, "microvm");
+export const binary = join(binDir, "machinen-vm");
 // gvproxy (containers/gvisor-tap-vsock) — optional sibling binary the
 // runtime auto-spawns for virtio-net. Present when CI stages it during
 // publish; absent in the repo so `git status` stays clean.

--- a/provision.ts
+++ b/provision.ts
@@ -12,7 +12,7 @@
 import type { VmHandle } from "@machinen/runtime";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -204,18 +204,6 @@ if (!FORCE && existsSync(OUT) && existsSync(STAMP)) {
 const base = !FORCE && existsSync(OUT) ? OUT : join(ASSETS, "rootfs-debian-arm64.tar.gz");
 console.log(`provision: base=${base === OUT ? "./app.tar.gz (incremental)" : base}`);
 
-function ramForImage(path: string): number {
-  const compressed = statSync(path).size;
-  const GIB = 1024 * 1024 * 1024;
-  const raw = Math.max(4 * GIB, compressed * 16 + 2 * GIB);
-  const align = 256 * 1024 * 1024;
-  return Math.ceil(raw / align) * align;
-}
-console.log(
-  `provision: ram=${(ramForImage(base) / 1024 ** 3).toFixed(1)} GiB ` +
-    `(base=${(statSync(base).size / 1024 ** 2).toFixed(0)} MB)`,
-);
-
 // --- run ------------------------------------------------------------------
 
 const result = await provision({
@@ -226,8 +214,6 @@ const result = await provision({
 
   // 1 GiB scratch is too small once node_modules + global npm pkgs land.
   scratchDiskSizeBytes: 8 * 1024 * 1024 * 1024,
-
-  vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(base)) },
 
   // Boot directly into /mnt/workspace via a thin -c wrapper. The
   // FUSE mount used by liveMounts is currently root-only, so we run

--- a/scripts/machinen-dev.sh
+++ b/scripts/machinen-dev.sh
@@ -23,10 +23,10 @@ step "building Zig VMM (ReleaseSafe) + codesigning with HVF entitlement"
 (
   cd packages/microvm
   zig build -Doptimize=ReleaseSafe
-  codesign -s - --force --entitlements entitlements.plist zig-out/bin/microvm
+  codesign -s - --force --entitlements entitlements.plist zig-out/bin/machinen-vm
 )
 mkdir -p packages/vmm-arm64-darwin/bin
-cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-darwin/bin/microvm
+cp packages/microvm/zig-out/bin/machinen-vm packages/vmm-arm64-darwin/bin/machinen-vm
 
 step "building base assets (kernel + dtb + rootfs tarball)"
 ./scripts/build-base-assets.sh


### PR DESCRIPTION
## Summary

- `provision()` was on the legacy initramfs-as-rootfs path, so the entire userland had to fit in RAM at boot. Each incremental run used the prior output as its base, and the kernel briefly holds both the initrd cpio and the unpacking tmpfs in physical RAM (peak ~2× the rootfs). Past 4 GB the unpack failed with `Initramfs unpacking failed: write error` and init couldn't exec `/bin/bash`. The host-side `MACHINEN_RAM_BYTES` knob was a no-op — the VMM never read it.
- Switched `provision()` to the disk-backed boot path: materialize the base into an ext4 image via `ensureRootfsImage()`, COW-clone (`COPYFILE_FICLONE`) into the per-run workDir so the install hook mutates a throwaway copy, and dump the captured rootfs to `/dev/vdb` (the second virtio-blk slot) instead of `/dev/vda`. Rootfs no longer has to fit in RAM, the persistent `~/.cache/machinen/rootfs/<sha>.img` cache stays pristine, and the dead `MACHINEN_RAM_BYTES` plumbing is gone on both sides.
- Tests: `provision.test.ts` + `exec.test.ts` now pass `MACHINEN_MODULES` explicitly. The test-fixture binary uses its own kernel and never sets `MACHINEN_KERNEL`, so the runtime's modules-tarball resolver has nothing to anchor on otherwise.

## Test plan

- [x] `npx vitest run` — 310 passed, including the provision integration round-trip (boots a real VM, runs install hook, captures, re-boots, asserts marker file).
- [x] `npx agent-ci run --workflow .github/workflows/tests.yml -q -p` — only failure is `pty.test.ts × 3` with `Cannot find module './prebuilds/linux-arm64//pty.node'`. Verified pre-existing on `main` via `git stash`; it's a `node-pty@1.1.0` prebuild gap on linux-arm64, unrelated to this change.
- [ ] Reviewer: re-run `pnpm provision --force` on a fresh `~/.cache/machinen` and confirm subsequent incremental runs no longer balloon past the 4 GB ceiling.
