### PR TITLE
fix(provision): bootstrap /tmp + /var/tmp before apt drops privs

### DIFF
--- a/provision.ts
+++ b/provision.ts
@@ -93,8 +93,14 @@ const PNPM_VERSION = (() => {
 })();
 
 const installSteps = async (vm: VmHandle) => {
-  // Remount tmpfs root at size=100% so pnpm/apt installs don't hit ENOSPC.
-  await vm.exec("mount -o remount,size=100% /");
+  // /tmp + /var/tmp need to exist with sticky-1777 before anything that
+  // drops privs (apt → _apt). Two reasons they may be off:
+  //   • Fresh base — mke2fs -d on macOS as a non-root user captures
+  //     uid 501 and silently drops sticky bits, so /tmp lands at 0755.
+  //   • Incremental base — the prior provision's tar excludes ./tmp,
+  //     so the directory is missing entirely on this boot.
+  // mkdir -p + chmod handles both shapes.
+  await vm.exec("mkdir -p /tmp /var/tmp && chmod 1777 /tmp /var/tmp");
 
   // gvproxy DNS jitter under apt's parallel fan-out.
   const aptResilience = [


### PR DESCRIPTION
## Summary

- Follow-up to #175. After moving `provision()` to the disk-backed boot path, the install hook's first step (`mount -o remount,size=100% /`) became nonsensical — `/` is now ext4, not tmpfs, so the kernel printed `ext4: Unknown parameter 'size'` and the step failed.
- Past that, `apt-get update` failed with `Couldn't create temporary file /tmp/apt.conf.*` because `/tmp` was either at mode `0755` (`mke2fs -d` on macOS-as-non-root captures the host uid and silently drops sticky bits) or absent entirely (incremental rebuilds tar a base whose `./tmp` was explicitly excluded).
- Replace the dead remount with an idempotent `mkdir -p /tmp /var/tmp && chmod 1777 /tmp /var/tmp` so apt's `_apt` user can write to `/tmp` regardless of which shape the base came in. The deeper "all-files-owned-by-uid-501" issue from `mke2fs -d`-on-macOS is left for a follow-up in `rootfs-img.ts`.

## Test plan

- [x] Fresh provision from `rootfs-debian-arm64.tar.gz` — 83s, 500 MB output, all sanity checks pass (node, pnpm, claude, bash, git, gh).
- [x] Incremental rebuild from prior `app.tar.gz` — 49s, output stable, no kernel `Initramfs unpacking failed: write error`.
- [x] Second incremental rebuild — 57s, no growth or regression.
