### PR TITLE
feat(runtime): VsockExec.execTimeoutMs accepts null for "no timeout"

### DIFF
--- a/packages/runtime/src/__tests__/exec-timeout.test.ts
+++ b/packages/runtime/src/__tests__/exec-timeout.test.ts
@@ -1,0 +1,128 @@
+// VsockExec.run wall-clock timeout — #158.
+//
+// `execTimeoutMs` defaults to 5 minutes; passing `null` or `Infinity`
+// disables it so long-running siblings (dev servers, watchers) can
+// outlive the default ceiling. These tests stand up a local UDS that
+// holds the connection open without ever sending an X frame so we can
+// observe whether the host's deadline fires.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VsockExec } from "../exec.ts";
+
+function startStallingAgent(socketPath: string): {
+  server: Server;
+  sockets: Socket[];
+  stop: () => Promise<void>;
+} {
+  const sockets: Socket[] = [];
+  const server = createServer((sock: Socket) => {
+    sockets.push(sock);
+    // Drain the EXEC header so the host's write doesn't backpressure,
+    // but never reply with O/E/X — we want the host's wall-clock timer
+    // to be the only thing that can settle the call.
+    sock.on("data", () => {});
+    sock.on("error", () => {});
+  });
+  server.listen(socketPath);
+  return {
+    server,
+    sockets,
+    stop: () =>
+      new Promise<void>((done) => {
+        for (const s of sockets) {
+          if (!s.destroyed) {
+            s.destroy();
+          }
+        }
+        server.close(() => done());
+      }),
+  };
+}
+
+describe("VsockExec.run execTimeoutMs", () => {
+  let workDir: string;
+  let agent: ReturnType<typeof startStallingAgent> | undefined;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "machinen-exec-timeout-"));
+  });
+  afterEach(async () => {
+    if (agent) {
+      await agent.stop();
+      agent = undefined;
+    }
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("rejects with EXEC_AGENT_TIMEOUT when the wall-clock deadline elapses", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startStallingAgent(uds);
+    await expect(VsockExec.run(uds, "sleep forever", { execTimeoutMs: 50 })).rejects.toMatchObject({
+      code: "EXEC_AGENT_TIMEOUT",
+    });
+  });
+
+  it("error message hints at { execTimeoutMs: null } as the escape hatch", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startStallingAgent(uds);
+    await expect(VsockExec.run(uds, "sleep forever", { execTimeoutMs: 30 })).rejects.toThrow(
+      /execTimeoutMs: null/,
+    );
+  });
+
+  it("does not fire the timer when execTimeoutMs is null (long-running sibling)", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startStallingAgent(uds);
+    let settled = false;
+    // Short connectTimeoutMs so the post-stop retry loop in
+    // VsockExec.run gives up fast and the test can finish.
+    const p = VsockExec.run(uds, "tail -F /var/log/foo", {
+      execTimeoutMs: null,
+      connectTimeoutMs: 1_000,
+    }).then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    // Wait long enough that, were the wall-clock timer firing on a
+    // short fallback, it would have already rejected. 250ms is plenty
+    // — we only need to prove the timer didn't fire.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(settled).toBe(false);
+    // Tear down the fake agent so the call eventually resolves with
+    // EXEC_AGENT_UNAVAILABLE (close-before-X). That's fine — we only
+    // care that it didn't reject *via the wall-clock timer* earlier.
+    await agent.stop();
+    agent = undefined;
+    await p;
+  });
+
+  it("does not fire the timer when execTimeoutMs is Infinity", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startStallingAgent(uds);
+    let settled = false;
+    const p = VsockExec.run(uds, "watch", {
+      execTimeoutMs: Infinity,
+      connectTimeoutMs: 1_000,
+    }).then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await new Promise((r) => setTimeout(r, 250));
+    expect(settled).toBe(false);
+    await agent.stop();
+    agent = undefined;
+    await p;
+  });
+});

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -40,8 +40,13 @@ export interface VsockExecOptions {
   connectTimeoutMs?: number;
   /** Poll interval in ms while retrying. Default 250. */
   retryMs?: number;
-  /** Cap total time spent on this command. Default 5 minutes. */
-  execTimeoutMs?: number;
+  /**
+   * Wall-clock ceiling for the spawned command. Default 5 minutes.
+   * Pass `null` (or `Infinity`) to disable — appropriate for
+   * long-running siblings (dev servers, file watchers, log tailers)
+   * that should live for the VM's lifetime. Mirrors `boot({ timeoutMs: null })`.
+   */
+  execTimeoutMs?: number | null;
   /** Called with each stdout chunk as it arrives (pass-through tee). */
   onStdout?: (chunk: Buffer) => void;
   /** Called with each stderr chunk as it arrives (pass-through tee). */
@@ -221,19 +226,35 @@ async function runOnSocket(
     let awaitingBytes = 0;
     let payloadTag: "O" | "E" | null = null;
 
-    const deadline = opts.execTimeoutMs ?? 5 * 60 * 1000;
-    const timer = setTimeout(() => {
-      fail(
-        new ExecError("EXEC_AGENT_TIMEOUT", `VsockExec.run: timed out after ${deadline}ms`, {
-          retryable: true,
-        }),
-      );
-      socket.destroy();
-    }, deadline);
-    timer.unref();
+    // `null` (or `Infinity`) disables the wall-clock ceiling — the
+    // command lives until it exits on its own or the VM goes away. The
+    // default 5-min cap is intentional for one-shot install/build steps
+    // where exceeding it means something's wedged; long-running
+    // siblings (dev servers, watchers) should opt out explicitly.
+    const deadlineOpt = opts.execTimeoutMs;
+    const deadline =
+      deadlineOpt === null || deadlineOpt === Infinity ? null : (deadlineOpt ?? 5 * 60 * 1000);
+    const timer =
+      deadline === null
+        ? null
+        : setTimeout(() => {
+            fail(
+              new ExecError(
+                "EXEC_AGENT_TIMEOUT",
+                `VsockExec.run: timed out after ${deadline}ms (default). ` +
+                  `Long-running siblings (dev servers, watchers) should pass ` +
+                  `{ execTimeoutMs: null } to disable this ceiling.`,
+                { retryable: true },
+              ),
+            );
+            socket.destroy();
+          }, deadline);
+    timer?.unref();
 
     const finish = () => {
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       if (exitCode === null) {
         fail(
           new ExecError(
@@ -318,7 +339,9 @@ async function runOnSocket(
       }
     });
     socket.on("error", (err) => {
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       fail(err);
     });
     socket.on("close", () => {


### PR DESCRIPTION
## Problem

`vm.execRaw(cmd)` looks like `child_process.exec(cmd)` — but it has a hidden 5-minute timer. After 5 minutes, your command is killed. That's fine for one-shot installs ("if it took 5 min, it's wedged"), but it's a footgun for the natural pattern of starting a dev server alongside an interactive shell: the server silently dies, the bash session is still alive, and the user has no idea what happened. The error message (`EXEC_AGENT_TIMEOUT`) reads like "the agent went away" rather than "your child outlived a default."

## Solution

Let the caller say "no timeout" out loud. `execTimeoutMs: null` (or `Infinity`) disables the ceiling — same shape as `boot({ timeoutMs: null })`, which already does this for the VMM-process timeout. Default of 5 minutes stays for callers who don't opt out. When the timer does fire, the new error message tells the reader exactly how to disable it.

```ts
// before — silently killed at 5 min
void vm.execRaw("pnpm serve", { onStdout: log });

// after — runs for the VM's lifetime
void vm.execRaw("pnpm serve", { execTimeoutMs: null, onStdout: log });
```

## Summary

- Widen `VsockExecOptions.execTimeoutMs` to `number | null`. `null` or `Infinity` disables the wall-clock ceiling.
- Default 5-minute behavior is unchanged for callers who don't opt out.
- The `EXEC_AGENT_TIMEOUT` message now hints at `{ execTimeoutMs: null }` as the escape hatch.

Closes #158.

## Test plan

- [x] New `exec-timeout.test.ts` covers the default-path timeout (still fires), the new error message, and that the timer does not fire under `null` or `Infinity`. All 4 new tests pass alongside the existing 17 exec-related tests.
- [x] `npx tsc -p packages/runtime --noEmit` — clean.
- [x] `npx oxlint` on changed files — clean.
- [ ] `npx agent-ci run --all -q -p` — could not run locally (sandbox lacks Docker socket); CI to verify.
