### PR TITLE
fix(runtime): bound supervisor console buffers (Phase 1 of #150)

### DIFF
--- a/packages/runtime/src/__tests__/console-tail.test.ts
+++ b/packages/runtime/src/__tests__/console-tail.test.ts
@@ -1,0 +1,79 @@
+// Ring-buffer behavior of the supervisor's stdout/stderr collector
+// (issue #150). The collector retains only the most recent
+// CONSOLE_TAIL_BYTES of a stream, so a multi-hour VM doesn't drag the
+// JS supervisor's heap toward 4 GB.
+//
+// No VMM involved — drives a PassThrough end-to-end so the test stays
+// fast and exercises the eviction logic directly.
+
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { _internal } from "../index.ts";
+
+const { collect, CONSOLE_TAIL_BYTES } = _internal;
+
+describe("collect() ring buffer", () => {
+  it("returns the full stream when total bytes are under the cap", async () => {
+    const stream = new PassThrough();
+    const promise = collect(stream);
+    stream.write("hello ");
+    stream.write("world");
+    stream.end();
+    expect(await promise).toBe("hello world");
+  });
+
+  it("retains only the tail when total bytes exceed the cap", async () => {
+    const stream = new PassThrough();
+    const cap = 16;
+    const promise = collect(stream, cap);
+    // Each chunk is 8 bytes. After all writes, 32 bytes were sent;
+    // only the last `cap` bytes should survive.
+    stream.write("AAAAAAAA");
+    stream.write("BBBBBBBB");
+    stream.write("CCCCCCCC");
+    stream.write("DDDDDDDD");
+    stream.end();
+    const result = await promise;
+    expect(result.length).toBeLessThanOrEqual(cap);
+    expect(result).toBe("CCCCCCCCDDDDDDDD");
+  });
+
+  it("bounds memory across many small chunks (steady-state)", async () => {
+    const stream = new PassThrough();
+    const cap = 1024;
+    const promise = collect(stream, cap);
+    // 10 KiB total in 10-byte chunks — simulates a long-running VM
+    // dribbling console lines for hours.
+    for (let i = 0; i < 1024; i++) {
+      stream.write("xxxxxxxxxx");
+    }
+    stream.end();
+    const result = await promise;
+    // The retained tail must not exceed the cap by more than one
+    // chunk-sized overhang (the head we couldn't safely drop).
+    expect(result.length).toBeLessThanOrEqual(cap + 10);
+    expect(result.length).toBeGreaterThanOrEqual(cap);
+  });
+
+  it("tail-slices a single oversized chunk on finish", async () => {
+    const stream = new PassThrough();
+    const cap = 8;
+    const promise = collect(stream, cap);
+    stream.write("0123456789ABCDEF"); // 16 bytes in one chunk
+    stream.end();
+    const result = await promise;
+    expect(result).toBe("89ABCDEF");
+  });
+
+  it("default cap is exposed as CONSOLE_TAIL_BYTES = 1 MiB", () => {
+    expect(CONSOLE_TAIL_BYTES).toBe(1_048_576);
+  });
+
+  it("rejects on stream error", async () => {
+    const stream = new PassThrough();
+    const promise = collect(stream);
+    const err = new Error("boom");
+    stream.destroy(err);
+    await expect(promise).rejects.toBe(err);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -367,7 +367,12 @@ export interface VmHandle {
    */
   detach(): Promise<void>;
 
-  /** Buffer stdout until the process exits; return it as a UTF-8 string. */
+  /**
+   * Buffer stdout until the process exits; return it as a UTF-8 string.
+   * Capped at ~1 MiB tail — long-running VMs keep only the most recent
+   * bytes (issue #150). Sufficient for kernel boot console + test
+   * assertions; not a full transcript.
+   */
   output(): Promise<string>;
 
   /** Same as `output()` but for stderr (where guest console lands). */
@@ -916,6 +921,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // importantly, the child backpressures if no one is reading (the
   // PL011 echo path writes a lot of bytes during kernel boot, enough
   // to fill a pipe buffer if nothing's draining it).
+  //
+  // `collect()` ring-buffers to `CONSOLE_TAIL_BYTES` so a multi-hour
+  // VM doesn't drag the supervisor toward OOM (issue #150).
   const outputCollector = collect(child.stdout);
   const errorCollector = collect(child.stderr);
   const onLog = opts.onLog;
@@ -1611,15 +1619,51 @@ function teeOnLog(
   };
 }
 
-function collect(stream: Readable): Promise<string> {
+/**
+ * Cap on bytes retained per stream by `collect()`. Each VM session keeps
+ * the *last* this-many bytes of stdout/stderr; older bytes are dropped.
+ * The kernel boot console fits well under this, snapshot debugging only
+ * uses the last ~2 KB, and a multi-hour idle VM no longer accumulates
+ * gigabytes of console chatter in the supervisor's heap (issue #150).
+ */
+const CONSOLE_TAIL_BYTES = 1_048_576;
+
+function collect(stream: Readable, capBytes: number = CONSOLE_TAIL_BYTES): Promise<string> {
   return new Promise((done, fail) => {
     const chunks: Buffer[] = [];
-    stream.on("data", (c: Buffer) => chunks.push(c));
-    stream.on("end", () => done(Buffer.concat(chunks).toString("utf8")));
-    stream.on("close", () => done(Buffer.concat(chunks).toString("utf8")));
+    let totalBytes = 0;
+    stream.on("data", (c: Buffer) => {
+      chunks.push(c);
+      totalBytes += c.length;
+      // Drop whole chunks from the head while doing so leaves at least
+      // `capBytes` retained. This keeps the ring within [cap, cap +
+      // size-of-head-chunk] in steady state, which for line-buffered
+      // VMM stderr is comfortably bounded.
+      while (chunks.length > 1 && totalBytes - chunks[0].length >= capBytes) {
+        totalBytes -= chunks.shift()!.length;
+      }
+    });
+    const finish = () => {
+      let merged = Buffer.concat(chunks);
+      // If a single oversized chunk pushed us above cap (or we ended
+      // up holding more than cap because no head was safe to drop),
+      // tail-slice on the way out so the resolved string honors the cap.
+      if (merged.length > capBytes) {
+        merged = merged.subarray(merged.length - capBytes);
+      }
+      done(merged.toString("utf8"));
+    };
+    stream.on("end", finish);
+    stream.on("close", finish);
     stream.on("error", fail);
   });
 }
+
+// Visible to tests that exercise the ring-buffer logic without booting a VM.
+export const _internal = {
+  collect,
+  CONSOLE_TAIL_BYTES,
+};
 
 // =============================================================
 // Snapshots — #50 M2


### PR DESCRIPTION
## Problem

After several hours running a single VM, the JS supervisor process backing it OOM'd at ~4 GB old-space and took the VM down with it (#150). The VMM itself is a Zig binary that has no business needing a Node parent at all, but today it's parented to the JS supervisor for the entire session — so any leak in that supervisor is fatal to the VM.

The audit pinned the dominant leak to `collect()` in `packages/runtime/src/index.ts`: it pushed every stdout/stderr chunk from the VMM child into an unbounded `Buffer[]` for the VM's entire lifetime. The kernel + early-userspace console (PL011 echo path) plus anything written to vmm stderr over hours accumulated in the supervisor's heap until V8 gave up.

Other surfaces were audited and ruled out as the dominant leak:
- `exec.ts` per-exec buffers are function-local; GC'd on Promise settlement.
- `mount-server.ts` inode/handle Maps are guest-FORGET/RELEASE driven (only leak under a misbehaving guest, separate bug class).
- `artifact-cache.ts` request handler is stateless.
- snapshot's `teeGuestConsole` listener at `index.ts:1081` only attaches during snapshot; the VMM exits as part of snapshot, so the listener dies with the stream.

## Solution

Convert `collect()` into a ring buffer capped at 1 MiB per stream (`CONSOLE_TAIL_BYTES`). Drop whole head chunks while doing so leaves at least the cap retained; tail-slice on finish for the rare oversized-single-chunk case. Document the new tail-only contract on `VmHandle.output()`.

The cap is safe for all in-tree consumers: snapshot error paths use `.slice(-2000)` already, tests assert on short kernel-boot substrings, and nothing depends on the full multi-hour transcript. A long-running idle VM now sees steady-state memory instead of unbounded growth.

This is **Phase 1** of #150 — the highest-leverage, smallest-change fix the issue itself recommends starting with. Phase 2 (detached-boot mode so the Zig VMM survives the JS parent) and Phase 3 (extracting the artifact cache + live-mount FUSE servers out of the JS process) are deferred to follow-up PRs.

## Summary

- `collect()` in `packages/runtime/src/index.ts` retained every stdout/stderr chunk from the VMM child for the VM's entire lifetime — multi-hour sessions accumulated GiBs of console output in the JS supervisor's heap until Node OOM'd at ~4 GB and killed the VM with it.
- Replace with a ring buffer capped at 1 MiB per stream; drop whole head chunks while doing so leaves at least the cap retained; tail-slice on finish for the rare oversized-single-chunk case.
- Document the tail-only contract on `VmHandle.output()`; export a small `_internal` for unit tests (matching the precedent in `rootfs-img.ts:435`).
- Add `console-tail.test.ts` covering under-cap, over-cap, steady-state, oversized-chunk, default constant, and error paths — runs in 7 ms with no VMM.

## Test plan

- [x] `npx vitest run packages/runtime/src/__tests__/console-tail.test.ts` — 6/6 pass.
- [x] Full `npx vitest run` — 304 pass; 5 unrelated failures are environmental (sandbox can't exec the macOS-arm64 VMM, no `pgrep`, no disk space) and don't touch the changed code.
- [ ] Multi-hour soak (idle VM + periodic exec) keeps RSS bounded — recommended before merging; can't be run in CI.
