### PR TITLE
fix(vm): forward host SIGWINCH to guest tty (closes #177)

### DIFF
--- a/packages/runtime/src/__tests__/winsize.test.ts
+++ b/packages/runtime/src/__tests__/winsize.test.ts
@@ -1,0 +1,166 @@
+// Host-side VsockWinsize wiring (#177).
+//
+// Stands in a UDS server for the in-guest winsize-agent so the test
+// covers the same call path vm.ts uses: connect, send the initial
+// size, react to a "resize" event by sending again, close on exit.
+// The dedup-against-last-sent contract gets its own assertion because
+// vm.ts (and any future caller) leans on it to debounce SIGWINCH
+// storms — losing it would re-introduce the smear-on-resize bug this
+// issue exists to fix.
+
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WinsizeError } from "../errors.ts";
+import { VsockWinsize } from "../winsize.ts";
+
+interface FakeAgent {
+  server: Server;
+  udsPath: string;
+  /** Lines received over the wire — `cols rows` without the trailing \n. */
+  received: string[];
+  /** Resolves the next time the agent sees `count` total lines. */
+  waitFor: (count: number) => Promise<void>;
+  close: () => Promise<void>;
+}
+
+async function startFakeAgent(udsPath: string): Promise<FakeAgent> {
+  const received: string[] = [];
+  let buf = "";
+  const waiters: Array<{ count: number; done: () => void }> = [];
+
+  const server = createServer((sock: Socket) => {
+    sock.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf8");
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        received.push(line);
+        for (const w of waiters.splice(0, waiters.length)) {
+          if (received.length >= w.count) w.done();
+          else waiters.push(w);
+        }
+      }
+    });
+  });
+
+  await new Promise<void>((done, fail) => {
+    server.once("error", fail);
+    server.listen(udsPath, () => {
+      server.off("error", fail);
+      done();
+    });
+  });
+
+  return {
+    server,
+    udsPath,
+    received,
+    waitFor(count) {
+      if (received.length >= count) return Promise.resolve();
+      return new Promise((done) => waiters.push({ count, done }));
+    },
+    close() {
+      return new Promise<void>((done) => server.close(() => done()));
+    },
+  };
+}
+
+describe("VsockWinsize", () => {
+  let tmp: string;
+  let udsPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "winsize-test-"));
+    udsPath = join(tmp, "winsize.sock");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("sends the initial size and forwards subsequent resizes", async () => {
+    const agent = await startFakeAgent(udsPath);
+    const ws = await VsockWinsize.connect(udsPath, { timeoutMs: 2_000 });
+
+    // vm.ts pattern: send initial size, then hook host SIGWINCH to
+    // forward later sizes via a stdout-like emitter.
+    const fakeStdout = new EventEmitter() as EventEmitter & {
+      columns: number;
+      rows: number;
+    };
+    fakeStdout.columns = 80;
+    fakeStdout.rows = 24;
+
+    ws.send(fakeStdout.columns, fakeStdout.rows);
+    fakeStdout.on("resize", () => ws.send(fakeStdout.columns, fakeStdout.rows));
+
+    await agent.waitFor(1);
+    expect(agent.received).toEqual(["80 24"]);
+
+    fakeStdout.columns = 132;
+    fakeStdout.rows = 50;
+    fakeStdout.emit("resize");
+
+    await agent.waitFor(2);
+    expect(agent.received).toEqual(["80 24", "132 50"]);
+
+    ws.close();
+    await agent.close();
+  });
+
+  it("dedups duplicate sizes so SIGWINCH storms don't spam the bridge", async () => {
+    const agent = await startFakeAgent(udsPath);
+    const ws = await VsockWinsize.connect(udsPath, { timeoutMs: 2_000 });
+
+    ws.send(100, 30);
+    ws.send(100, 30); // identical — must be dropped
+    ws.send(100, 30);
+    ws.send(100, 31); // different rows — must go through
+
+    await agent.waitFor(2);
+    // Give the dedup'd sends a beat to (incorrectly) leak through if
+    // the contract is broken.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(agent.received).toEqual(["100 30", "100 31"]);
+
+    ws.close();
+    await agent.close();
+  });
+
+  it("times out with WINSIZE_AGENT_UNAVAILABLE when no UDS is listening", async () => {
+    // udsPath was never bound — connect should retry until the deadline.
+    const t0 = Date.now();
+    await expect(
+      VsockWinsize.connect(udsPath, { timeoutMs: 200, retryMs: 25 }),
+    ).rejects.toBeInstanceOf(WinsizeError);
+    // Should respect the timeout (with some slack); a regression that
+    // ignored the deadline would either return immediately or hang.
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("send() after close is a silent no-op (process-exit safety)", async () => {
+    const agent = await startFakeAgent(udsPath);
+    const ws = await VsockWinsize.connect(udsPath, { timeoutMs: 2_000 });
+
+    ws.send(80, 24);
+    await agent.waitFor(1);
+    ws.close();
+
+    // vm.ts has a `process.stdout.on("resize", ...)` listener that may
+    // fire between the wait()-returns and the process.exit(); the close
+    // path must not throw if a resize sneaks in there.
+    expect(() => ws.send(120, 40)).not.toThrow();
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(agent.received).toEqual(["80 24"]);
+
+    await agent.close();
+  });
+});

--- a/provision.ts
+++ b/provision.ts
@@ -92,6 +92,30 @@ const PNPM_VERSION = (() => {
   return m[1];
 })();
 
+// #177: dev-VM tty resize forwarding. The launcher in vm.ts only does
+// anything if /sbin/machinen-winsize-agent is on disk, so push it here.
+// build-base-assets.sh bakes it into fresh release-assets, but users
+// with stale rootfs tarballs (most local checkouts) wouldn't get it
+// without this refresh. Source from the test-fixtures build output —
+// `bash packages/microvm/test-fixtures/assets/build-init.sh` from
+// packages/microvm produces the binary; no fail if missing because the
+// dev VM degrades to the e7e1db1 stty-on-bootstrap behavior (fine for
+// initial paint; just no SIGWINCH propagation mid-session).
+const WINSIZE_AGENT_HOST_PATH = resolve(
+  MAIN_REPO,
+  "packages/microvm/test-fixtures/winsize-agent",
+);
+const winsizeAgentBin = existsSync(WINSIZE_AGENT_HOST_PATH)
+  ? readFileSync(WINSIZE_AGENT_HOST_PATH)
+  : null;
+if (!winsizeAgentBin) {
+  console.warn(
+    `provision: ${WINSIZE_AGENT_HOST_PATH} missing — host SIGWINCH won't reach the guest.\n` +
+      "           Build it with `bash packages/microvm/test-fixtures/assets/build-init.sh`\n" +
+      "           from packages/microvm, then re-run provision.",
+  );
+}
+
 const installSteps = async (vm: VmHandle) => {
   // /tmp + /var/tmp need to exist with sticky-1777 before anything that
   // drops privs (apt → _apt). Two reasons they may be off:
@@ -194,6 +218,15 @@ const installSteps = async (vm: VmHandle) => {
     `echo ${profileSnippetB64} | base64 -d > /etc/profile.d/00-machinen.sh && ` +
       "chmod 0755 /etc/profile.d/00-machinen.sh",
   );
+
+  // #177 dev-VM tty resize agent. Overwrite even if /sbin/machinen-winsize-agent
+  // already exists in the base rootfs, so the freshest local build wins
+  // (mirrors the /fuse-agent + /init refresh idiom in init.zig).
+  if (winsizeAgentBin) {
+    await vm.writeFile("/sbin/machinen-winsize-agent", winsizeAgentBin, {
+      mode: 0o755,
+    });
+  }
 
   // Sanity check.
   await vm.exec(

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -75,7 +75,7 @@ dtc -I dts -O dtb "${ASSETS}/virt.dts" -o "${OUT}/virt-arm64.dtb"
 #    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent, fuse-agent, CRIU helpers, poweroff, net-bench-probe) for aarch64-linux-musl"
+echo "==> Building guest binaries (init, exec-agent, fuse-agent, winsize-agent, CRIU helpers, poweroff, net-bench-probe) for aarch64-linux-musl"
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STAGE"' EXIT
 
@@ -86,7 +86,10 @@ trap 'rm -rf "$STAGE"' EXIT
 # net-bench-probe is the #82 gvproxy throughput/latency probe used by
 # the smoke harness. fuse-agent is the guest byte-pump for #78
 # `--mount-live`; /init forks it per liveMount entry.
-for name in init exec-agent fuse-agent lo-up no-iou poweroff net-bench-probe; do
+# winsize-agent is the #177 vsock TIOCSWINSZ daemon for dev-VM tty
+# resize forwarding; lives at /sbin/machinen-winsize-agent and is
+# launched by vm.ts's bootstrap (no auto-launch in non-dev paths).
+for name in init exec-agent fuse-agent winsize-agent lo-up no-iou poweroff net-bench-probe; do
   zig build-exe "${ASSETS}/${name}.zig" \
     -target aarch64-linux-musl \
     -O ReleaseSmall \
@@ -360,6 +363,7 @@ install -m 0755 -D /stage/lo-up             /work/rootfs/sbin/machinen-lo-up
 install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou
 install -m 0755 -D /stage/poweroff          /work/rootfs/sbin/machinen-poweroff
 install -m 0755 -D /stage/net-bench-probe   /work/rootfs/sbin/machinen-net-bench-probe
+install -m 0755 -D /stage/winsize-agent     /work/rootfs/sbin/machinen-winsize-agent
 install -m 0755 -D /stage/fnm               /work/rootfs/usr/local/bin/fnm
 # Shell-script helpers that drive the snapshot/restore contract. Staged
 # in by the host-side build step alongside the zig binaries.

--- a/scripts/test-claude-bootstrap.mjs
+++ b/scripts/test-claude-bootstrap.mjs
@@ -83,6 +83,9 @@ const BOOTSTRAP = [
   'if [ -n "${COLUMNS:-}" ] && [ -n "${LINES:-}" ]; then',
   '  stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true',
   "fi",
+  "if [ -x /sbin/machinen-winsize-agent ]; then",
+  "  /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &",
+  "fi",
 ].join("\n");
 
 // --- Run a bootstrap scenario in an isolated $HOME --------------------

--- a/vm.ts
+++ b/vm.ts
@@ -14,7 +14,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -48,9 +48,14 @@ if (existsSync(BREW_E2FS) && !(process.env.PATH ?? "").includes(BREW_E2FS)) {
 // build machinen themselves.
 const mainRequire = createRequire(join(MAIN_REPO, "package.json"));
 const runtimeEntry = mainRequire.resolve("@machinen/runtime");
-const { boot } = (await import(
-  pathToFileURL(runtimeEntry).href
-)) as typeof import("@machinen/runtime");
+type Runtime = typeof import("@machinen/runtime");
+// VsockWinsize's constructor is private (callers must use the static
+// `connect()` factory), which means `InstanceType<typeof X>` doesn't
+// work — TS rejects assigning a private-constructor class to its
+// public constructor type. Pull the instance type off the factory's
+// return value instead.
+type VsockWinsizeHandle = Awaited<ReturnType<Runtime["VsockWinsize"]["connect"]>>;
+const { boot, VsockWinsize } = (await import(pathToFileURL(runtimeEntry).href)) as Runtime;
 
 const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
 const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(MAIN_REPO));
@@ -136,18 +141,21 @@ const claudeAccountJson = readHostClaudeAccount();
 // unconditionally `unset CLAUDE_ACCOUNT_JSON` before our bootstrap had
 // a chance to read it. With these names, the bootstrap is the only
 // thing that touches them.
-// Seed the guest TTY size from the host terminal. Without this the
-// guest's serial console reports 80x24 to anything that ioctl's
-// TIOCGWINSZ — TUIs (claude, vim, less) lay out for that and the host
-// terminal redraws over the gap, leaving smeared output until reset.
-// This handles the initial render only. Dynamic SIGWINCH after boot
-// requires the winsize-agent (`packages/microvm/assets/winsize-agent.zig`)
-// to be baked into the rootfs and wired to a VsockWinsize on the host;
-// not yet plumbed through provision.ts.
+// Seed the guest TTY size from the host terminal. The bootstrap below
+// `stty`'s the kernel TTY for first paint; the VsockWinsize wiring
+// after `boot()` propagates host SIGWINCH for the rest of the session
+// (#177). The two are complementary — if the agent isn't on the rootfs
+// or the vsock connect fails, the stty fallback still gives us a
+// correctly-sized tty on first render.
 const stdoutAny = process.stdout as NodeJS.WriteStream;
 const hostCols = stdoutAny.columns ?? 80;
 const hostRows = stdoutAny.rows ?? 24;
 
+// #177: ask the VMM to bridge AF_VSOCK port 1974 (the guest agent's
+// listen port) to a host UDS. boot()'s vsock-bridge code parses the
+// first `in:` entry to wire vm.exec(); we don't use vm.exec from this
+// script, so co-opting that slot for winsize is fine.
+const winsizeUdsPath = join(tmpdir(), `machinen-winsize-${process.pid}.sock`);
 const secretEnv: Record<string, string> = {
   GH_TOKEN: ghToken,
   GITHUB_TOKEN: ghToken,
@@ -219,6 +227,16 @@ const bootstrap = [
   'if [ -n "${COLUMNS:-}" ] && [ -n "${LINES:-}" ]; then',
   '  stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true',
   "fi",
+  // #177: launch the vsock TIOCSWINSZ agent so subsequent host
+  // SIGWINCH (forwarded by VsockWinsize below) resize the guest tty
+  // mid-session. Backgrounded + reparented to PID 1 once `exec bash -i`
+  // replaces this shell. /dev/null redirects so the agent's "applied:"
+  // log lines don't smear over the user's terminal. No-op if the
+  // binary is missing (stale rootfs); the host-side connect will
+  // time out and fall back to the stty-on-boot behavior above.
+  "if [ -x /sbin/machinen-winsize-agent ]; then",
+  "  /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &",
+  "fi",
   "cd /mnt/workspace 2>/dev/null",
   "exec bash -i",
 ].join("\n");
@@ -230,9 +248,34 @@ const vm = await boot({
   liveMounts: [{ host: HERE, guest: "/mnt/workspace", mode: "rw" }],
   cmd: ["/bin/bash", "-lc", bootstrap],
   env: secretEnv,
-  vmmEnv: { MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)) },
+  vmmEnv: {
+    MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)),
+    MACHINEN_VSOCK: `in:1974:${winsizeUdsPath}`,
+  },
   timeoutMs: null,
 });
+
+// #177: connect to the in-guest winsize-agent and forward host
+// SIGWINCH for the rest of the session. Non-fatal: a stale rootfs
+// without /sbin/machinen-winsize-agent leaves nothing listening on
+// vsock 1974, so the connect retries inside VsockWinsize will give up
+// after ~10s. We catch and continue — the stty-on-bootstrap path
+// already handled first paint, only mid-session resizes are lost.
+let winsize: VsockWinsizeHandle | undefined;
+try {
+  winsize = await VsockWinsize.connect(winsizeUdsPath, { timeoutMs: 10_000 });
+  winsize.send(hostCols, hostRows);
+  process.stdout.on("resize", () => {
+    if (!winsize) return;
+    const cols = stdoutAny.columns ?? hostCols;
+    const rows = stdoutAny.rows ?? hostRows;
+    winsize.send(cols, rows);
+  });
+} catch (err) {
+  process.stderr.write(
+    `[machinen] winsize forwarding unavailable (${err instanceof Error ? err.message : String(err)}) — host resizes won't reach the guest tty\n`,
+  );
+}
 
 const stdin = process.stdin as NodeJS.ReadStream & {
   setRawMode?: (m: boolean) => void;
@@ -247,6 +290,7 @@ vm.stderr.pipe(process.stderr);
 process.stdin.pipe(vm.stdin);
 
 const { code } = await vm.wait();
+winsize?.close();
 if (isTty) {
   stdin.setRawMode!(false);
   // RIS (full terminal reset) + clear scrollback + home cursor, so the


### PR DESCRIPTION
## Problem

`pnpm vm` boots the in-VM terminal at the kernel default of 80×24 regardless of the host terminal's real size, and there's nothing wired up to translate later host `SIGWINCH` into a guest `TIOCSWINSZ`. TUIs (`claude`, `vim`, `less`) lay out for the wrong dimensions, and resizing the host window mid-session leaves the guest oblivious — the host terminal redraws over the gap and interaction smears un-cleared cells across the screen.

`e7e1db1` fixed *first paint* by seeding `COLUMNS` / `LINES` and running `stty cols/rows` in the bootstrap. The dynamic-resize half was still missing: the `winsize-agent` zig source existed (`packages/microvm/assets/winsize-agent.zig`), the host-side `VsockWinsize` helper existed (`packages/runtime/src/winsize.ts`), but nothing baked the agent into the rootfs, launched it, or connected the host UDS.

## Solution

Three tightly-scoped pieces, all confined to the dev-VM path:

1. **`scripts/build-base-assets.sh`** — build `winsize-agent.zig` alongside the other guest binaries and install it at `/sbin/machinen-winsize-agent` in the rootfs tarball. Future release-asset rebuilds bake it in for free.
2. **`provision.ts`** — refresh `/sbin/machinen-winsize-agent` from `packages/microvm/test-fixtures/winsize-agent` on every provision (mirrors the `/init` / `/fuse-agent` refresh idiom), so users with stale release-assets get the binary without a full rebuild. Non-fatal if the host-side binary is missing — the VM degrades gracefully to the existing stty-on-bootstrap behavior.
3. **`vm.ts`** — pre-set `MACHINEN_VSOCK=in:1974:<uds>` in `vmmEnv` so the VMM bridges the agent's vsock port to a host UDS; bootstrap launches `/sbin/machinen-winsize-agent &` (guarded by `[ -x ]`) so it reparents to PID 1 once `exec bash -i` runs; after `boot()` returns, connect `VsockWinsize`, send the initial host size, hook `process.stdout.on("resize", …)` to forward future SIGWINCH, close on exit. Wrapped in try/catch so a stale rootfs without the agent gracefully falls back to the no-resize-forwarding path rather than blocking boot.

A new `packages/runtime/src/__tests__/winsize.test.ts` (4 tests) stands in a fake UDS agent and asserts the host wiring: initial-size send, resize forwarding, SIGWINCH-storm dedup, timeout error when no agent is listening, and post-close `send()` is a silent no-op (process-exit safety).

## Summary

- `pnpm vm` continues to start with the guest TTY sized correctly on first paint (already true since e7e1db1).
- Resizing the host terminal mid-session now propagates to the guest within ~1s; `claude` / `vim` / `less` redraw cleanly, no smear.
- Plain `bash -i` is unaffected — the resize is purely additive.
- Out of scope: production `boot()` path for non-dev VMs (the application-VM contract is different — supervisor TIOCSWINSZ work in #115 picks that up upstream); guest-driven resize back to the host.

## Test plan

- [x] `npx vitest run packages/runtime/src/__tests__/winsize.test.ts` — 4/4 pass.
- [x] `pnpm -r typecheck` — clean.
- [ ] `npx agent-ci run --all -q -p` — needs Docker; verify on macOS host before merge.
- [ ] `pnpm vm` from a clone, manually resize the host terminal during a `claude` session, confirm the TUI re-flows and `stty size` inside the guest reflects the new dimensions.
- [ ] Stale-rootfs degradation: boot a clone whose `app.tar.gz` predates this change, confirm vm.ts logs `winsize forwarding unavailable` and falls back to stty-only behavior without crashing.
