### PR TITLE
fix(runtime): rebuild rootdisk cache after kill mid-write (#170)

### DIFF
--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -22,7 +22,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { boot, BootError, ensureRootfsImage, ProvisionError } from "../index.ts";
+import {
+  boot,
+  BootError,
+  ensureRootfsImage,
+  markRootfsImageClean,
+  ProvisionError,
+} from "../index.ts";
 import { _internal } from "../rootfs-img.ts";
 
 describe("ensureRootfsImage", () => {
@@ -169,10 +175,17 @@ describe("ensureRootfsImage", () => {
         .split(/\s+/, 1)[0]!;
       const expected = join(cacheDir, `${sha}.img`);
       writeFileSync(expected, "fake image bytes");
+      // #170: planted .img also needs the clean-shutdown marker;
+      // without it the cache hit path would treat the image as
+      // poisoned and rematerialize.
+      writeFileSync(_internal.okMarkerPath(expected), "");
       const result = ensureRootfsImage(tarPath, { cacheDir });
       expect(result).toBe(expected);
       // Cache file untouched.
       expect(existsSync(expected)).toBe(true);
+      // The marker is consumed atomically on hand-off so a kill
+      // between here and the next clean exit leaves it dirty.
+      expect(existsSync(_internal.okMarkerPath(expected))).toBe(false);
     } finally {
       try {
         unlinkSync(tarPath);
@@ -200,6 +213,7 @@ describe("ensureRootfsImage", () => {
       // target). Doesn't carry the ext4 magic, so cachedImageIsUsable
       // skips fsck and we hit the truncate path directly.
       writeFileSync(imgPath, Buffer.alloc(1024));
+      writeFileSync(_internal.okMarkerPath(imgPath), "");
       const result = ensureRootfsImage(tarPath, { cacheDir, sizeBytes: 4096 });
       expect(result).toBe(imgPath);
       expect(statSync(imgPath).size).toBe(4096);
@@ -211,6 +225,73 @@ describe("ensureRootfsImage", () => {
       rmSync(cacheDir, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("wipes a cached .img with no clean-shutdown marker (#170)", () => {
+    // Simulates a previous boot that was killed mid-write: the .img
+    // is on disk but the .ok marker was never re-created. The next
+    // call must NOT trust the planted bytes — it should wipe and
+    // try to rematerialize from the tarball.
+    const tarPath = `/tmp/machinen-rootfs-img-poisoned-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-poisoned-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-poisoned-img-"));
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const imgPath = join(cacheDir, `${sha}.img`);
+      // Plant a stub `.img` with no `.ok` next to it — the dirty
+      // state a kill mid-boot leaves behind.
+      const planted = Buffer.from("poisoned bytes that look nothing like ext4");
+      writeFileSync(imgPath, planted);
+      // No e2fsprogs guaranteed on the runner — if rematerialization
+      // can't run the function throws ProvisionError. Either outcome
+      // proves the planted bytes were rejected.
+      let rematerialized = false;
+      try {
+        ensureRootfsImage(tarPath, { cacheDir });
+        rematerialized = true;
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProvisionError);
+      }
+      if (rematerialized) {
+        // If we got back an image, it must NOT be the planted bytes.
+        const after = statSync(imgPath).size;
+        expect(after).not.toBe(planted.length);
+      } else {
+        // Materialize failed — the planted file should still have
+        // been wiped on entry.
+        expect(existsSync(imgPath)).toBe(false);
+      }
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("markRootfsImageClean writes the .ok marker only when the image exists", () => {
+    // The runtime calls this on a clean VMM exit so the next boot
+    // can reuse the cached file. No-op when the image is missing —
+    // marking a non-existent file would cause `ensureRootfsImage`
+    // to trust a phantom cache hit.
+    const dir = mkdtempSync(join(tmpdir(), "machinen-rootfs-mark-clean-"));
+    try {
+      const missing = join(dir, "missing.img");
+      markRootfsImageClean(missing);
+      expect(existsSync(_internal.okMarkerPath(missing))).toBe(false);
+
+      const present = join(dir, "present.img");
+      writeFileSync(present, "fake image bytes");
+      markRootfsImageClean(present);
+      expect(existsSync(_internal.okMarkerPath(present))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   it("never shrinks a cached .img — sizeBytes < existing is a no-op", () => {
     // Truncate-down would actually destroy data inside the ext4 fs, so
@@ -227,6 +308,7 @@ describe("ensureRootfsImage", () => {
         .split(/\s+/, 1)[0]!;
       const imgPath = join(cacheDir, `${sha}.img`);
       writeFileSync(imgPath, Buffer.alloc(8 * 1024));
+      writeFileSync(_internal.okMarkerPath(imgPath), "");
       const result = ensureRootfsImage(tarPath, { cacheDir, sizeBytes: 1024 });
       expect(result).toBe(imgPath);
       expect(statSync(imgPath).size).toBe(8 * 1024);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,7 +19,7 @@ export type {
 export type { LogEvent, OnLog } from "./log.ts";
 export { provision, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
-export { ensureRootfsImage, rootfsImgCacheDir } from "./rootfs-img.ts";
+export { ensureRootfsImage, markRootfsImageClean, rootfsImgCacheDir } from "./rootfs-img.ts";
 export type { EnsureRootfsImageOptions } from "./rootfs-img.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
 export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";
@@ -119,7 +119,7 @@ import {
 } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
-import { ensureRootfsImage } from "./rootfs-img.ts";
+import { ensureRootfsImage, markRootfsImageClean } from "./rootfs-img.ts";
 import {
   VsockExec,
   type VsockExecOptions,
@@ -607,6 +607,11 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     ...opts.vmmEnv,
   };
   let diskAbs: string | undefined;
+  // #170: tracks the cached `<sha>.img` we materialized for this boot
+  // so the exit handler can mark it clean on a signal-free child exit.
+  // Stays undefined for a caller-supplied `rootDisk: '<path>'` (we
+  // don't manage that file's lifecycle) or `rootDisk: false`.
+  let cacheManagedRootDisk: string | undefined;
   if (opts.snapshot) {
     diskAbs = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
     if (!existsSync(diskAbs)) {
@@ -791,6 +796,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         rootDiskAbs = ensureRootfsImage(baseAbs, {
           sizeBytes: opts.rootDiskSizeBytes,
         });
+        // The cache owns this image — mark it clean again on a
+        // signal-free child exit so the next boot can reuse it.
+        cacheManagedRootDisk = rootDiskAbs;
       }
       env.MACHINEN_ROOTDISK = rootDiskAbs;
     }
@@ -884,6 +892,17 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       signal,
       Date.now() - bootT0,
     );
+    // #170: a signal-free exit means the kernel had time to flush
+    // and dismount the ext4 fs cleanly, so the cached image is safe
+    // to reuse. A signal exit (SIGKILL from vm.kill(), SIGTERM from a
+    // ctrl-C'd test runner) leaves the marker absent — next boot
+    // wipes and rebuilds. A non-zero exit code is fine: the guest's
+    // command failed, but the kernel still shut down normally.
+    if (cacheManagedRootDisk && signal === null) {
+      try {
+        markRootfsImageClean(cacheManagedRootDisk);
+      } catch {}
+    }
     if (bundleTempDir) {
       try {
         rmSync(bundleTempDir, { recursive: true, force: true });

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -42,7 +42,7 @@ import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import { boot, type VmHandle } from "./index.ts";
 import type { OnLog } from "./log.ts";
-import { ensureRootfsImage } from "./rootfs-img.ts";
+import { ensureRootfsImage, markRootfsImageClean } from "./rootfs-img.ts";
 
 const debug = debugLib("machinen:provision");
 const vmmDebug = debugLib("machinen:vmm");
@@ -276,6 +276,13 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     const cachedImg = ensureRootfsImage(baseAbs);
     copyFileSync(cachedImg, rootDiskPath, fsConstants.COPYFILE_FICLONE);
     debug("rootdisk cloned src=%s dst=%s", cachedImg, rootDiskPath);
+    // The cached `<sha>.img` was only READ here — the FICLONE / copy
+    // landed in workDir, and the upcoming boot() targets that copy via
+    // `rootDisk: rootDiskPath`. Restore the clean-shutdown marker the
+    // cache entry semantics expect (#170): without this the next
+    // provision() with the same base would see a missing `.ok` and
+    // wastefully rematerialize a known-good image.
+    markRootfsImageClean(cachedImg);
 
     // Boot the VMM with the base rootfs on /dev/vda (mounted ext4) and
     // the exec-agent as the cmd. The scratch disk lands on /dev/vdb,

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -30,12 +30,25 @@
 // so any unreplayable journal / orphaned-inode state gets fixed (or,
 // if it can't be fixed, the file is wiped and rematerialized from
 // the tarball).
+//
+// Clean-shutdown sentinel (#170): e2fsck handles the journal but
+// not torn data-block writes. A test killed mid-`apt`/`pnpm` can
+// leave bytes inside the ext4 fs that fsck declares clean yet the
+// kernel later faults on with `EXT4-fs error … checksumming
+// directory block` at runtime. We pair the cache file with a
+// sibling marker `<sha>.img.ok` whose presence means "the previous
+// owner exited cleanly." On entry the marker is atomically removed
+// before the path is handed to the VMM; on a clean child exit the
+// runtime calls `markRootfsImageClean()` to recreate it. A cache
+// hit with no marker is treated as poisoned — wiped and
+// rematerialized from the tarball.
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
+  fsyncSync,
   mkdirSync,
   mkdtempSync,
   openSync,
@@ -58,6 +71,51 @@ const debug = debugLib("machinen:rootfs-img");
 /** Default cache root: `~/.cache/machinen/rootfs`. */
 export function rootfsImgCacheDir(): string {
   return join(homedir(), ".cache", "machinen", "rootfs");
+}
+
+function okMarkerPath(imgPath: string): string {
+  return `${imgPath}.ok`;
+}
+
+/**
+ * Mark a cached rootfs image as "cleanly released" by writing the
+ * sentinel that `ensureRootfsImage()` looks for on the next boot.
+ * Called by the runtime after a VMM child exits without a signal —
+ * an exit-code-only termination means the kernel had time to flush
+ * and dismount the ext4 fs, so reusing the file is safe.
+ *
+ * No-op if the image doesn't exist (e.g. the runtime never
+ * materialized one). Failures are swallowed: a missing marker just
+ * means the next boot rebuilds from the tarball, which is wasteful
+ * but never wrong.
+ */
+export function markRootfsImageClean(imgPath: string): void {
+  if (!existsSync(imgPath)) {
+    return;
+  }
+  const okPath = okMarkerPath(imgPath);
+  // tmp + fsync + atomic rename so the marker is durable. If the
+  // host crashes between rename and the next reboot, we still see
+  // a complete `.ok` file rather than a half-written one.
+  const tmp = `${okPath}.tmp.${process.pid}`;
+  let fd = -1;
+  try {
+    fd = openSync(tmp, "w");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = -1;
+    renameSync(tmp, okPath);
+  } catch (err) {
+    debug("markRootfsImageClean failed img=%s err=%s", imgPath, (err as Error).message);
+    if (fd >= 0) {
+      try {
+        closeSync(fd);
+      } catch {}
+    }
+    try {
+      unlinkSync(tmp);
+    } catch {}
+  }
 }
 
 export interface EnsureRootfsImageOptions {
@@ -109,6 +167,15 @@ export interface EnsureRootfsImageOptions {
  * rename into place — at worst two callers do redundant work; the
  * loser of the rename race re-checks and uses the winner's image.
  *
+ * Lifecycle (#170): the returned path is handed back in the "in-use"
+ * state (no `.ok` marker on disk). The caller is expected to invoke
+ * `markRootfsImageClean(path)` once they're done — `boot()` does this
+ * from its child-exit handler when the VMM exits without a signal,
+ * `provision()` does it after cloning the image read-only. If the
+ * marker is never recreated (caller crashed mid-write or simply
+ * forgot), the next `ensureRootfsImage()` for the same tarball
+ * treats the image as poisoned and rebuilds it.
+ *
  * @throws {ProvisionError} ROOTFS_IMG_TOOL_MISSING |
  *   ROOTFS_IMG_MATERIALIZE_FAILED | ROOTFS_IMG_TARBALL_NOT_FOUND
  */
@@ -125,36 +192,54 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
 
   const sha = sha256OfFile(tarAbs);
   const imgPath = join(cacheDir, `${sha}.img`);
+  const okPath = okMarkerPath(imgPath);
   if (!opts.force && existsSync(imgPath)) {
     debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
-    if (cachedImageIsUsable(imgPath)) {
-      // #131: if the caller asked for a larger image than what's on
-      // disk (typically because they bumped `rootDiskSizeBytes`, or
-      // because the materializer's defaults grew), sparse-extend the
-      // file in place. The on-disk ext4 fs is still sized to the old
-      // file; /init's tryRootDiskPivot resizes it online via
-      // EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
-      // truncate-up on a sparse file is free; truncate-down would
-      // chop bytes, so we never shrink.
-      if (opts.sizeBytes !== undefined) {
-        try {
-          const cur = statSync(imgPath).size;
-          if (opts.sizeBytes > cur) {
-            truncateSync(imgPath, opts.sizeBytes);
-            debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
+    // #170: require the clean-shutdown marker. Missing means the
+    // previous VMM was killed mid-write — fsck won't catch torn data
+    // blocks, so treat the image as poisoned and rebuild from the
+    // tarball.
+    if (!existsSync(okPath)) {
+      debug("cache hit but no clean marker, wiping img=%s", imgPath);
+      try {
+        unlinkSync(imgPath);
+      } catch {}
+    } else {
+      // Atomically clear the marker BEFORE handing the path off, so
+      // a kill between here and `markRootfsImageClean()` leaves the
+      // image flagged dirty for the next boot.
+      try {
+        unlinkSync(okPath);
+      } catch {}
+      if (cachedImageIsUsable(imgPath)) {
+        // #131: if the caller asked for a larger image than what's on
+        // disk (typically because they bumped `rootDiskSizeBytes`, or
+        // because the materializer's defaults grew), sparse-extend the
+        // file in place. The on-disk ext4 fs is still sized to the old
+        // file; /init's tryRootDiskPivot resizes it online via
+        // EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
+        // truncate-up on a sparse file is free; truncate-down would
+        // chop bytes, so we never shrink.
+        if (opts.sizeBytes !== undefined) {
+          try {
+            const cur = statSync(imgPath).size;
+            if (opts.sizeBytes > cur) {
+              truncateSync(imgPath, opts.sizeBytes);
+              debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
+            }
+          } catch (err) {
+            debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
           }
-        } catch (err) {
-          debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
         }
+        return imgPath;
       }
-      return imgPath;
+      // Unrecoverable. Wipe and fall through to materialize a fresh image
+      // from the tarball — same path a force=true caller would take.
+      debug("cache hit unusable, wiping img=%s", imgPath);
+      try {
+        unlinkSync(imgPath);
+      } catch {}
     }
-    // Unrecoverable. Wipe and fall through to materialize a fresh image
-    // from the tarball — same path a force=true caller would take.
-    debug("cache hit unusable, wiping img=%s", imgPath);
-    try {
-      unlinkSync(imgPath);
-    } catch {}
   }
 
   // Resolve mke2fs in three steps:
@@ -439,4 +524,5 @@ export const _internal = {
   looksLikeExt4,
   findKegOnlyE2fs,
   findBundledMke2fs,
+  okMarkerPath,
 };


### PR DESCRIPTION
## Problem

When you cache a rootdisk image and the VMM gets killed mid-write (ctrl-C, vitest timeout, OOM), the file on disk is left in a half-written state. `e2fsck` on the next boot fixes the journal but can't see torn data blocks, so the next boot reuses the broken image and the kernel later screams `EXT4-fs error … checksumming directory block` at runtime — cosmetic `apt` warnings on the lucky path, an 88-second `pnpm install` wedge on the unlucky one.

## Solution

Drop a `<sha>.img.ok` flag next to each cached image that only exists when the last user shut down cleanly. Before handing the image to a VMM, the flag is removed; once the VMM exits without a signal, `markRootfsImageClean()` puts it back. A cache hit with no flag means "the previous run was killed" — the image is wiped and rebuilt from the tarball.

## Summary

- Closes #170.
- New `markRootfsImageClean()` writes the marker via tmp + fsync + atomic rename.
- `boot()` calls it from the VMM child's `exit` handler only when `signal === null`. A SIGKILL/SIGTERM exit (ctrl-C'd test, `vm.kill()`) leaves the marker absent and forces a rebuild on the next boot.
- `provision()` calls it after its read-only FICLONE copy so back-to-back runs don't waste time rebuilding a known-good image.

## Tradeoffs / scope

This is option (2) from the issue (sentinel file). Option (1)'s bonus — preventing concurrent vitest workers from corrupting the same cached image — needs a different shape (per-boot copy-on-write or VMM-lifetime lock + API redesign) and is left for a follow-up.

## Test plan

- [x] `npx vitest run packages/runtime/src/__tests__/rootfs-img.test.ts` — 19/19 pass (added 2 new tests: cache-hit-without-marker wipes the planted bytes; `markRootfsImageClean` is a no-op when the image is missing).
- [x] Full `npx vitest run` — 300 passed (was 298 on `main`), same 5 environment-bound failures as `main` (Hypervisor.framework only on darwin, missing `pgrep`, `/tmp` ENOSPC for the 2 GB sparse copy in `provision.test.ts`).
- [ ] `npx agent-ci run --all -q -p` — couldn't run locally (sandbox has no Docker socket). Relying on CI here.
- [ ] Manual verification of the original repro: boot a VM with `image: <tar>`, kill mid-boot, re-run — the next boot should rebuild from the tarball instead of reusing the corrupt image.
