### PR TITLE
feat(runtime): surface provision progress during host-side repack

### DIFF
--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -380,6 +380,10 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
         ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
       }).catch(() => {});
 
+      // Surface progress without requiring DEBUG. The kernel's last
+      // visible line is `reboot: Power down`, after which there's a
+      // 30–90 s gap of silent host-side CPU. See #162.
+      console.error("provision: waiting for guest exit…");
       await vm.wait();
       debug("guest exited");
     } finally {
@@ -462,6 +466,9 @@ function repackDiskTarToGz(
 ): void {
   const extractDir = mkdtempSync(join(tmpdir(), "machinen-provision-extract-"));
   try {
+    // Visible progress so the silent multi-GB tar pass doesn't look
+    // like a hang. See #162.
+    console.error("provision: packaging rootfs…");
     execFileSync("tar", ["-xf", diskPath, "-C", extractDir]);
     // Bake the image's default cmd/env into /machinen-config.json so
     // `boot({ image })` can run without every caller re-passing the


### PR DESCRIPTION
## Summary
- Print `provision: waiting for guest exit…` after the poweroff request, before `vm.wait()`.
- Print `provision: packaging rootfs…` at the top of `repackDiskTarToGz`, before the host-side `tar -xf` / `tar -czf`.

After the kernel's `reboot: Power down`, `provision()` does 30–90 s of silent host-side work — easy to mistake for a hang. These two `console.error` lines surface progress without requiring `DEBUG=machinen:provision`.

Closes #162

## Test plan
- [ ] `pnpm provision --force` from a clean cache — confirm the two new lines appear during the gap between `reboot: Power down` and `Built …/app.tar.gz`.
- [ ] `npx vitest run` passes locally.
- [ ] `npx agent-ci run --all -q -p` passes locally.
