### PR TITLE
fix(runtime): unblock vm.writeFile of multi-hundred-KB payloads

### DIFF
--- a/packages/runtime/src/__tests__/exec-multiline.test.ts
+++ b/packages/runtime/src/__tests__/exec-multiline.test.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { VsockExec } from "../exec.ts";
-import { buildWriteFileCmd } from "../index.ts";
+import { buildWriteFileCmd, buildWriteFileCmds } from "../index.ts";
 
 interface FakeRequest {
   /** Raw bytes the host sent before the agent wrote its `X 0` reply. */
@@ -154,6 +154,21 @@ describe("VsockExec multi-line wire format", () => {
     expect(res.exitCode).toBe(0);
     expect(agent.requests[0]!.header.startsWith("EXEC2 ")).toBe(true);
   });
+
+  // The agent's `readLine` uses a 4096-byte buffer; a newline-free cmd
+  // bigger than that overflows it and the agent logs "bad header" then
+  // closes. vm.writeFile() of a multi-hundred-KB binary tripped this.
+  // The host must promote to EXEC2 on size, not just on newlines.
+  it("switches to EXEC2 for large newline-free cmds (4096-byte agent buffer)", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startFakeAgent(uds);
+    const cmd = `echo ${"a".repeat(8000)}`;
+    const res = await VsockExec.run(uds, cmd);
+    expect(res.exitCode).toBe(0);
+    const req = agent.requests[0]!;
+    expect(req.header).toBe(`EXEC2 ${Buffer.byteLength(cmd, "utf8")}`);
+    expect(req.body.toString("utf8")).toBe(cmd);
+  });
 });
 
 describe("buildWriteFileCmd", () => {
@@ -204,5 +219,86 @@ describe("buildWriteFileCmd", () => {
     expect(() => buildWriteFileCmd("/x", "y", { mode: -1 })).toThrow(RangeError);
     expect(() => buildWriteFileCmd("/x", "y", { mode: 0o10000 })).toThrow(RangeError);
     expect(() => buildWriteFileCmd("/x", "y", { mode: 1.5 })).toThrow(RangeError);
+  });
+});
+
+describe("buildWriteFileCmds (chunking)", () => {
+  it("returns a single cmd for small payloads (matches buildWriteFileCmd)", () => {
+    const cmds = buildWriteFileCmds("/etc/foo.conf", "hello\n", { mode: 0o644 });
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toBe(buildWriteFileCmd("/etc/foo.conf", "hello\n", { mode: 0o644 }));
+  });
+
+  // Linux's MAX_ARG_STRLEN caps a single argv element at 128 KB; the
+  // exec-agent runs cmds via `sh -c <cmd>`, so a 200 KB binary's base64
+  // pipeline (~270 KB) blows past it and execve fails with E2BIG → 127.
+  // Chunking writes the base64 in append-batches and decodes once.
+  it("splits large payloads into setup + N append + finalize cmds, each < 128 KB", () => {
+    const big = Buffer.alloc(200 * 1024, 0x5a);
+    const cmds = buildWriteFileCmds("/sbin/winsize", big, { mode: 0o755 });
+    expect(cmds.length).toBeGreaterThanOrEqual(3);
+    for (const c of cmds) {
+      expect(Buffer.byteLength(c, "utf8")).toBeLessThan(128 * 1024);
+    }
+    expect(cmds[0]).toContain("mkdir -p");
+    const stageMatch = /(\/tmp\/\.machinen-wf\.[a-f0-9]+)/.exec(cmds[0]!);
+    expect(stageMatch).not.toBeNull();
+    const stage = stageMatch![1]!;
+    expect(cmds[0]).toContain(`: > ${stage}`);
+    const stageRe = new RegExp(`^printf %s '[A-Za-z0-9+/=]+' >> ${stage.replace(/\./g, "\\.")}$`);
+    for (const c of cmds.slice(1, -1)) {
+      expect(c).toMatch(stageRe);
+    }
+    const final = cmds[cmds.length - 1]!;
+    expect(final).toContain(`base64 -d < ${stage} > '/sbin/winsize'`);
+    expect(final).toContain(`rm -f ${stage}`);
+    expect(final).toContain("chmod 755 '/sbin/winsize'");
+  });
+
+  // The earlier $$ scheme broke here: each cmd ran in its own `sh -c`,
+  // so $$ expanded to a different PID per invocation and the chunks
+  // scattered across files. The host must bake a fixed suffix in.
+  it("uses a single host-generated staging path across every cmd", () => {
+    const big = Buffer.alloc(200 * 1024, 0x42);
+    const cmds = buildWriteFileCmds("/sbin/x", big);
+    const stages = cmds.map((c) => /(\/tmp\/\.machinen-wf\.[a-f0-9]+)/.exec(c)?.[1]);
+    for (const s of stages) {
+      expect(s).toBeDefined();
+    }
+    expect(new Set(stages).size).toBe(1);
+    for (const c of cmds) {
+      expect(c).not.toContain("$$");
+    }
+  });
+
+  it("reconstructs the original bytes when the chunked cmds are replayed", () => {
+    // Simulate the guest: run the cmds against a shell-like reducer.
+    const big = Buffer.from(
+      Array.from({ length: 150 * 1024 }, (_, i) => (i * 7 + 11) & 0xff),
+    );
+    const cmds = buildWriteFileCmds("/tmp/out", big);
+    let staged = "";
+    for (const c of cmds) {
+      // Pull the base64 chunk out of `printf %s '<b64>' >> /tmp/...`.
+      const m = /^printf %s '([A-Za-z0-9+/=]+)' >> /.exec(c);
+      if (m) {
+        staged += m[1]!;
+      }
+    }
+    expect(Buffer.from(staged, "base64").equals(big)).toBe(true);
+  });
+
+  it("uses >> (append) in the finalize step when opts.append is set", () => {
+    const big = Buffer.alloc(100 * 1024);
+    const cmds = buildWriteFileCmds("/var/log/x", big, { append: true });
+    const final = cmds[cmds.length - 1]!;
+    expect(final).toContain(">> '/var/log/x'");
+    expect(final).not.toMatch(/[^>]> '\/var\/log\/x'/);
+  });
+
+  it("validates mode up front before staging anything", () => {
+    const big = Buffer.alloc(100 * 1024);
+    expect(() => buildWriteFileCmds("/x", big, { mode: -1 })).toThrow(RangeError);
+    expect(() => buildWriteFileCmds("/x", big, { mode: 0o10000 })).toThrow(RangeError);
   });
 });

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -198,6 +198,13 @@ function isTransientAgentError(err: Error): boolean {
   return /agent closed connection before X frame/.test(err.message);
 }
 
+// EXEC's guest-side `readLine` uses a 4096-byte buffer (see
+// packages/microvm/assets/exec-agent.zig). Anything approaching that
+// length must take the EXEC2 path or the agent will overflow and
+// log "bad header". 3500 leaves comfortable slack for the `EXEC `
+// prefix, the trailing `\n`, and minor encoding overhead.
+const EXEC_LEGACY_MAX_BYTES = 3500;
+
 async function runOnSocket(
   socket: Socket,
   cmd: string,
@@ -205,8 +212,10 @@ async function runOnSocket(
 ): Promise<VsockExecResult> {
   // Newline-free cmds use the legacy `EXEC <cmd>\n` opcode so older
   // agents (rootfs images that pre-date #112) still work. Anything with
-  // an embedded newline goes through the length-prefixed EXEC2 frame.
-  if (/\r|\n/.test(cmd)) {
+  // an embedded newline — or anything that wouldn't fit in the agent's
+  // line buffer — goes through the length-prefixed EXEC2 frame.
+  const cmdBytes = Buffer.byteLength(cmd, "utf8");
+  if (/\r|\n/.test(cmd) || cmdBytes > EXEC_LEGACY_MAX_BYTES) {
     const buf = Buffer.from(cmd, "utf8");
     socket.write(`EXEC2 ${buf.length}\n`);
     socket.write(buf);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -88,6 +88,7 @@ import {
   execFileSync,
   spawn as nodeSpawn,
 } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import {
   copyFileSync,
@@ -1077,7 +1078,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     },
 
     async writeFile(guestPath, contents, writeOpts) {
-      await this.exec(buildWriteFileCmd(guestPath, contents, writeOpts));
+      for (const cmd of buildWriteFileCmds(guestPath, contents, writeOpts)) {
+        await this.exec(cmd);
+      }
     },
 
     async snapshot(snapshotOpts) {
@@ -1256,7 +1259,9 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
     },
 
     async writeFile(guestPath, contents, writeOpts) {
-      await this.exec(buildWriteFileCmd(guestPath, contents, writeOpts));
+      for (const cmd of buildWriteFileCmds(guestPath, contents, writeOpts)) {
+        await this.exec(cmd);
+      }
     },
 
     async snapshot(snapshotOpts) {
@@ -1591,6 +1596,10 @@ function shellQuote(s: string): string {
  * Encoding: contents go over the wire as base64 inside an `echo … |
  * base64 -d` pipe, so any byte sequence (binary, newlines, quotes) is
  * safe. `mkdir -p` runs first when `recursive` (the default).
+ *
+ * Returns a single cmd string. For payloads that would exceed Linux's
+ * `MAX_ARG_STRLEN` (128 KB per argv element) once shell-wrapped, use
+ * `buildWriteFileCmds` instead — `vm.writeFile()` does.
  */
 export function buildWriteFileCmd(
   guestPath: string,
@@ -1615,6 +1624,64 @@ export function buildWriteFileCmd(
     parts.push(`chmod ${opts.mode.toString(8).padStart(3, "0")} ${path}`);
   }
   return parts.join(" && ");
+}
+
+// Linux's `MAX_ARG_STRLEN` caps a single argv element at 32 pages
+// (128 KB on 4 KB-page arches). The exec-agent runs cmds via
+// `execve("/bin/sh", {"sh","-c",cmd,null}, ...)`, so the whole shell
+// pipeline is one argv element. Going over -> execve returns E2BIG ->
+// the agent's child falls through to `_exit(127)` and `vm.exec`
+// surfaces it as "vm.exec failed (code 127)". 64 KB per chunk leaves
+// generous headroom for the surrounding `printf %s '...' >> /tmp/X`
+// wrapper while still letting a typical small payload finish in one cmd.
+const WRITE_FILE_B64_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Plan the cmd sequence `vm.writeFile()` issues for `contents`.
+ * Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
+ * single cmd identical to `buildWriteFileCmd`'s output. Larger payloads
+ * stage the base64 to /tmp in append-chunks and then decode once at the
+ * end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
+ */
+export function buildWriteFileCmds(
+  guestPath: string,
+  contents: Buffer | string,
+  opts: WriteFileOptions = {},
+): string[] {
+  const buf = typeof contents === "string" ? Buffer.from(contents, "utf8") : contents;
+  const b64 = buf.toString("base64");
+  if (b64.length <= WRITE_FILE_B64_CHUNK_BYTES) {
+    return [buildWriteFileCmd(guestPath, contents, opts)];
+  }
+  if (opts.mode !== undefined) {
+    if (!Number.isInteger(opts.mode) || opts.mode < 0 || opts.mode > 0o7777) {
+      throw new RangeError(`writeFile: mode out of range (got ${opts.mode})`);
+    }
+  }
+  const path = shellQuote(guestPath);
+  const redir = opts.append ? ">>" : ">";
+  // Each cmd in the sequence runs in its own `sh -c`, so `$$` would
+  // expand to a different PID per invocation and the chunks would
+  // scatter across files. Bake a host-generated suffix into every cmd
+  // so they all hit the same staging file.
+  const stage = `/tmp/.machinen-wf.${randomBytes(8).toString("hex")}`;
+  const cmds: string[] = [];
+  const setupParts: string[] = [];
+  if (opts.recursive ?? true) {
+    setupParts.push(`mkdir -p -- "$(dirname -- ${path})"`);
+  }
+  setupParts.push(`: > ${stage}`);
+  cmds.push(setupParts.join(" && "));
+  for (let i = 0; i < b64.length; i += WRITE_FILE_B64_CHUNK_BYTES) {
+    const chunk = b64.slice(i, i + WRITE_FILE_B64_CHUNK_BYTES);
+    cmds.push(`printf %s ${shellQuote(chunk)} >> ${stage}`);
+  }
+  const finalParts: string[] = [`base64 -d < ${stage} ${redir} ${path}`, `rm -f ${stage}`];
+  if (opts.mode !== undefined) {
+    finalParts.push(`chmod ${opts.mode.toString(8).padStart(3, "0")} ${path}`);
+  }
+  cmds.push(finalParts.join(" && "));
+  return cmds;
 }
 
 /**


### PR DESCRIPTION
## Summary

`pnpm provision --force` aborted on `vm.writeFile("/sbin/machinen-winsize-agent", winsizeAgentBin, ...)` (a 200 KB binary). Two distinct host-side bugs along the same code path:

**1. EXEC line buffer overflow → `exec-agent: bad header` retry loop.**
The agent's `readLine` (`packages/microvm/assets/exec-agent.zig:391`) uses a fixed **4096-byte** buffer. The host only switched to the length-prefixed `EXEC2` opcode when the cmd contained a newline, so a single-line ~270 KB base64 pipeline overflowed the buffer, the agent closed the socket, and `VsockExec.run` retried until the 30 s `connectTimeoutMs` ceiling tripped with `EXEC_AGENT_UNAVAILABLE`.

Fix: `runOnSocket` now also promotes to `EXEC2` when the cmd byte length exceeds `EXEC_LEGACY_MAX_BYTES = 3500` (slack under 4 KB for the `EXEC ` prefix and trailing `\n`).

**2. `MAX_ARG_STRLEN` truncation → `vm.exec failed (code 127)`.**
With the wire framing fixed, the cmd reaches the guest, but the agent runs it via `execve("/bin/sh", {"sh","-c",cmd,null}, ...)`. Linux caps a single argv element at `MAX_ARG_STRLEN` (32 pages = 128 KB on 4 KB-page arches). 270 KB → `E2BIG` → the agent's child falls through to `_exit(127)`.

Fix: new `buildWriteFileCmds` returns a sequence of cmds for large payloads — a setup cmd (`mkdir -p` + `: > /tmp/.machinen-wf.$$`), N `printf %s '<chunk>' >> /tmp/...` appends (64 KB base64 per chunk), and a finalize cmd (`base64 -d < ... > path && rm && chmod`). `vm.writeFile()` iterates them via `vm.exec`. Small payloads still collapse to a single cmd identical to `buildWriteFileCmd`'s today, so back-compat is preserved.

Host-side change only — no rootfs/agent rebuild required.

## Test plan
- [x] `npx vitest run` — 335/335 (5 new chunking tests in `exec-multiline.test.ts`).
- [x] `npx oxlint` clean on changed files.
- [ ] `pnpm provision --force` completes through the 200 KB winsize-agent writeFile and onward to `provision: waiting for guest exit…` / `Built …app.tar.gz`.
