### PR TITLE
fix(runtime): clone cached rootdisk per-boot so guest writes don't persist (#121)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@changesets/cli": "^2.30.0",
     "@machinen/runtime": "workspace:*",
     "@nkzw/oxlint-config": "1.0.1",
-    "@redwoodjs/agent-ci": "^0.12.4",
+    "@redwoodjs/agent-ci": "^0.13.0",
     "@types/node": "^22",
     "@typescript/native-preview": "^7.0.0-dev",
     "fallow": "^2.44.2",

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -9,15 +9,17 @@
 
 import { execSync } from "node:child_process";
 import {
+  closeSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   openSync,
+  readFileSync,
   rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
-  closeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -527,4 +529,157 @@ describe("boot({ rootDisk })", () => {
       rmSync(modStage, { recursive: true, force: true });
     }
   });
+});
+
+// #121: per-boot reflink copy of the cached rootfs image.
+//
+// `boot({ rootDisk: true })` mounts the image read-write on virtio-blk,
+// so handing the cached `<sha>.img` directly to the VMM would let one
+// boot's writes persist into the next boot from the same tarball.
+// The runtime now COPYFILE_FICLONEs the cache template to a per-boot
+// path, hands that copy to the VMM, and unlinks it on exit.
+//
+// These tests run `binary: "/bin/sh"` against a planted cache template
+// inside a private $HOME so they exercise the host-side wiring without
+// needing e2fsprogs or a real VMM.
+describe("boot({ rootDisk }) per-boot copy (#121)", () => {
+  // Plant a cache template under a temp $HOME and return the bits each
+  // test needs to drive boot() and assert against the copy.
+  function buildHarness(label: string) {
+    const homeDir = mkdtempSync(join(tmpdir(), `machinen-home-${label}-`));
+    const cacheDir = join(homeDir, ".cache", "machinen", "rootfs");
+    mkdirSync(cacheDir, { recursive: true });
+
+    // Unique tarball content per harness so the sha256-keyed cache
+    // entry never collides between concurrent vitest workers.
+    const tarPath = join(homeDir, `${label}.tar.gz`);
+    const stageDir = mkdtempSync(join(tmpdir(), `machinen-stage-${label}-`));
+    writeFileSync(join(stageDir, "stub"), `stub-${label}-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${stageDir} .`);
+
+    const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+      .trim()
+      .split(/\s+/, 1)[0]!;
+    const cachedImg = join(cacheDir, `${sha}.img`);
+    // Plant non-ext4 bytes so cachedImageIsUsable's e2fsck sniff is
+    // skipped and we reach the COPYFILE_FICLONE path directly.
+    writeFileSync(cachedImg, "TEMPLATE_CONTENT");
+    writeFileSync(`${cachedImg}.ok`, "");
+
+    // packTinyBundle requires a modules tarball; an empty gzipped tar
+    // is enough to satisfy it for an env-passthrough boot.
+    const modsTar = join(homeDir, `mods-${label}.tar.gz`);
+    const modsStage = mkdtempSync(join(tmpdir(), `machinen-mods-${label}-`));
+    execSync(`tar -czf ${modsTar} -C ${modsStage} .`);
+
+    return {
+      homeDir,
+      tarPath,
+      cachedImg,
+      modsTar,
+      cleanup() {
+        rmSync(homeDir, { recursive: true, force: true });
+        rmSync(stageDir, { recursive: true, force: true });
+        rmSync(modsStage, { recursive: true, force: true });
+      },
+    };
+  }
+
+  function withHome<T>(homeDir: string, fn: () => Promise<T>): Promise<T> {
+    const saved = process.env.HOME;
+    process.env.HOME = homeDir;
+    return fn().finally(() => {
+      if (saved === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = saved;
+      }
+    });
+  }
+
+  it("clones the cached image to a per-boot path and removes it on exit", async () => {
+    const h = buildHarness(`clone-${process.pid}`);
+    try {
+      await withHome(h.homeDir, async () => {
+        const vm = await boot({
+          binary: "/bin/sh",
+          args: ["-c", 'printf "ROOTDISK=%s\\n" "$MACHINEN_ROOTDISK"'],
+          image: h.tarPath,
+          cmd: ["/bin/true"],
+          vmmEnv: { MACHINEN_MODULES: h.modsTar },
+          timeoutMs: 5_000,
+        });
+        await vm.wait();
+        const out = (await vm.output()).trim();
+        const m = /^ROOTDISK=(.+)$/m.exec(out);
+        expect(m, `no ROOTDISK line in output: ${out}`).not.toBeNull();
+        const perBoot = m![1]!;
+        // Per-boot path is a distinct file from the cached template.
+        expect(perBoot).not.toBe(h.cachedImg);
+        // Exit handler unlinks the per-boot file before vm.wait() resolves.
+        expect(existsSync(perBoot)).toBe(false);
+        // Cached template survives the boot.
+        expect(existsSync(h.cachedImg)).toBe(true);
+        expect(readFileSync(h.cachedImg, "utf8")).toBe("TEMPLATE_CONTENT");
+      });
+    } finally {
+      h.cleanup();
+    }
+  }, 20_000);
+
+  it("guest writes to the per-boot copy do not leak into the cached template", async () => {
+    const h = buildHarness(`leak-${process.pid}`);
+    try {
+      await withHome(h.homeDir, async () => {
+        const vm = await boot({
+          binary: "/bin/sh",
+          args: ["-c", 'printf "GUEST_WROTE_HERE" > "$MACHINEN_ROOTDISK"'],
+          image: h.tarPath,
+          cmd: ["/bin/true"],
+          vmmEnv: { MACHINEN_MODULES: h.modsTar },
+          timeoutMs: 5_000,
+        });
+        await vm.wait();
+        // The mock "guest" overwrote MACHINEN_ROOTDISK; the cached
+        // template at <sha>.img must be unchanged. This is the core
+        // contract per-boot copies restore.
+        expect(readFileSync(h.cachedImg, "utf8")).toBe("TEMPLATE_CONTENT");
+      });
+    } finally {
+      h.cleanup();
+    }
+  }, 20_000);
+
+  it("back-to-back boots from the same tarball get distinct per-boot copies", async () => {
+    const h = buildHarness(`distinct-${process.pid}`);
+    try {
+      await withHome(h.homeDir, async () => {
+        const launch = async () => {
+          const vm = await boot({
+            binary: "/bin/sh",
+            args: ["-c", 'printf "ROOTDISK=%s\\n" "$MACHINEN_ROOTDISK"'],
+            image: h.tarPath,
+            cmd: ["/bin/true"],
+            vmmEnv: { MACHINEN_MODULES: h.modsTar },
+            timeoutMs: 5_000,
+          });
+          await vm.wait();
+          const out = (await vm.output()).trim();
+          return /^ROOTDISK=(.+)$/m.exec(out)![1]!;
+        };
+        // Sequential rather than parallel — the cache marker
+        // (#170) is single-consumer, so two simultaneous boots
+        // would race on it. The per-boot path is what we're
+        // asserting on; two back-to-back boots each get their
+        // own copy in tmpdir.
+        const p1 = await launch();
+        const p2 = await launch();
+        expect(p1).not.toBe(p2);
+        expect(existsSync(p1)).toBe(false);
+        expect(existsSync(p2)).toBe(false);
+      });
+    } finally {
+      h.cleanup();
+    }
+  }, 30_000);
 });

--- a/packages/runtime/src/__tests__/winsize.test.ts
+++ b/packages/runtime/src/__tests__/winsize.test.ts
@@ -41,8 +41,11 @@ async function startFakeAgent(udsPath: string): Promise<FakeAgent> {
         buf = buf.slice(nl + 1);
         received.push(line);
         for (const w of waiters.splice(0, waiters.length)) {
-          if (received.length >= w.count) w.done();
-          else waiters.push(w);
+          if (received.length >= w.count) {
+            w.done();
+          } else {
+            waiters.push(w);
+          }
         }
       }
     });
@@ -61,7 +64,9 @@ async function startFakeAgent(udsPath: string): Promise<FakeAgent> {
     udsPath,
     received,
     waitFor(count) {
-      if (received.length >= count) return Promise.resolve();
+      if (received.length >= count) {
+        return Promise.resolve();
+      }
       return new Promise((done) => waiters.push({ count, done }));
     },
     close() {

--- a/packages/runtime/src/mount-fuse-protocol.ts
+++ b/packages/runtime/src/mount-fuse-protocol.ts
@@ -82,8 +82,6 @@ export const FATTR = {
   CTIME: 1 << 10,
 } as const;
 
-type FuseOp = (typeof FUSE_OP)[keyof typeof FUSE_OP];
-
 /**
  * FUSE_INIT capability flags (fuse_init_in.flags / fuse_init_out.flags).
  * We only honor flags we actively support — everything else we mask
@@ -319,7 +317,6 @@ export function buildKstatfs(s: FuseKstatfs): Uint8Array {
 
 // --- fuse_init_in / fuse_init_out ----------------------------------------
 
-const FUSE_INIT_IN_MIN_SIZE = 8; // pre-7.23 kernels send only major/minor
 export const FUSE_INIT_OUT_SIZE = 64;
 
 interface FuseInitIn {

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -25,6 +25,7 @@ import {
 import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import {
+  constants as fsConstants,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -33,6 +34,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
@@ -394,11 +396,12 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     ...opts.vmmEnv,
   };
   let diskAbs: string | undefined;
-  // #170: tracks the cached `<sha>.img` we materialized for this boot
-  // so the exit handler can mark it clean on a signal-free child exit.
-  // Stays undefined for a caller-supplied `rootDisk: '<path>'` (we
-  // don't manage that file's lifecycle) or `rootDisk: false`.
-  let cacheManagedRootDisk: string | undefined;
+  // #121: per-boot reflink clone of the cached `<sha>.img`. Tracking
+  // it lets the exit handler delete the copy so guest writes don't
+  // leak into the next boot from the same tarball. Stays undefined
+  // for a caller-supplied `rootDisk: '<path>'` (we don't manage that
+  // file's lifecycle) or `rootDisk: false`.
+  let perBootRootDisk: string | undefined;
   if (opts.snapshot) {
     diskAbs = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
     if (!existsSync(diskAbs)) {
@@ -579,13 +582,30 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
           throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
         }
       } else {
+        // #121: hand the VMM a per-boot reflink clone of the cached
+        // template, never the template itself. virtio-blk mounts the
+        // image read-write, so without the clone every boot from the
+        // same tarball would inherit the previous boot's writes
+        // (apt installs leaking, /var/log poisoning, two concurrent
+        // boots stomping each other's filesystem). COPYFILE_FICLONE →
+        // APFS clonefile / Linux FICLONE on reflink-capable fs (free,
+        // shared blocks until the guest writes); falls back to a
+        // regular copy elsewhere (one-time cost, sparse).
         const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
-        rootDiskAbs = ensureRootfsImage(baseAbs, {
+        const cachedImg = ensureRootfsImage(baseAbs, {
           sizeBytes: opts.rootDiskSizeBytes,
         });
-        // The cache owns this image — mark it clean again on a
-        // signal-free child exit so the next boot can reuse it.
-        cacheManagedRootDisk = rootDiskAbs;
+        const perBoot = join(
+          tmpdir(),
+          `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+        );
+        copyFileSync(cachedImg, perBoot, fsConstants.COPYFILE_FICLONE);
+        // The cache file was only READ here — restore the
+        // clean-shutdown marker so the next boot finds a usable
+        // template instead of wiping and rematerializing (#170).
+        markRootfsImageClean(cachedImg);
+        perBootRootDisk = perBoot;
+        rootDiskAbs = perBoot;
       }
       env.MACHINEN_ROOTDISK = rootDiskAbs;
     }
@@ -607,6 +627,11 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     if (vsockTempDir) {
       try {
         rmSync(vsockTempDir, { recursive: true, force: true });
+      } catch {}
+    }
+    if (perBootRootDisk) {
+      try {
+        unlinkSync(perBootRootDisk);
       } catch {}
     }
     throw err;
@@ -679,15 +704,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       signal,
       Date.now() - bootT0,
     );
-    // #170: a signal-free exit means the kernel had time to flush
-    // and dismount the ext4 fs cleanly, so the cached image is safe
-    // to reuse. A signal exit (SIGKILL from vm.kill(), SIGTERM from a
-    // ctrl-C'd test runner) leaves the marker absent — next boot
-    // wipes and rebuilds. A non-zero exit code is fine: the guest's
-    // command failed, but the kernel still shut down normally.
-    if (cacheManagedRootDisk && signal === null) {
+    // #121: drop the per-boot reflink copy so guest writes don't
+    // persist across boots. Runs unconditionally (clean exit, signal
+    // exit, kernel panic) — the cached `<sha>.img` template was
+    // marked clean inline at copy time, so nothing here depends on
+    // the exit being graceful.
+    if (perBootRootDisk) {
       try {
-        markRootfsImageClean(cacheManagedRootDisk);
+        unlinkSync(perBootRootDisk);
       } catch {}
     }
     if (bundleTempDir) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(eslint@9.39.4)(oxlint@1.48.0)(typescript@5.9.3)
       '@redwoodjs/agent-ci':
-        specifier: ^0.12.4
-        version: 0.12.4
+        specifier: ^0.13.0
+        version: 0.13.0
       '@types/node':
         specifier: ^22
         version: 22.19.17
@@ -884,8 +884,8 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@redwoodjs/agent-ci@0.12.4':
-    resolution: {integrity: sha512-D9dXyMxOTh/SgLZzA5w6iaSLUHz9x30eORaqnTyQTmTTYw2IcqcCgENreP3/so5PvK/p/y5UJT2EeLZjt7VFgA==}
+  '@redwoodjs/agent-ci@0.13.0':
+    resolution: {integrity: sha512-3yN+c/DhgBRwPwwuNmP/1+1SYaBC0wXO25QdjNeUK3ehmZRMviiewPRyhTqbyS275fCmYME+Ehlst5S7gB6HXg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -1529,8 +1529,8 @@ packages:
     resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
     engines: {node: '>= 8.0'}
 
-  dtu-github-actions@0.12.4:
-    resolution: {integrity: sha512-+pAQVOP+DjvN4FCjhtBR3ogfQEV82TRde+7TVPsE5K/DlMXTbx2Jry2+oYvJ8Arv92eVqbNdCID0Aob72uWRWg==}
+  dtu-github-actions@0.13.0:
+    resolution: {integrity: sha512-JkuGc8xJ4eI2RObQRyMt+ZsqF5HwRJCqAW8ISSHKV4rLcRaryyQtfYrLRFo8iZGiJtZoiFlF/k5Q7/yEMuxIig==}
     engines: {node: '>=22'}
 
   dunder-proto@1.0.1:
@@ -3508,11 +3508,11 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@redwoodjs/agent-ci@0.12.4':
+  '@redwoodjs/agent-ci@0.13.0':
     dependencies:
       '@actions/workflow-parser': 0.3.43
       dockerode: 4.0.10
-      dtu-github-actions: 0.12.4
+      dtu-github-actions: 0.13.0
       log-update: 7.2.0
       minimatch: 10.2.5
       yaml: 2.8.3
@@ -4057,7 +4057,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dtu-github-actions@0.12.4:
+  dtu-github-actions@0.13.0:
     dependencies:
       body-parser: 2.2.2
       jsonc-parser: 3.3.1

--- a/vm.ts
+++ b/vm.ts
@@ -290,7 +290,9 @@ try {
   winsize = await VsockWinsize.connect(winsizeUdsPath, { timeoutMs: 10_000 });
   winsize.send(hostCols, hostRows);
   process.stdout.on("resize", () => {
-    if (!winsize) return;
+    if (!winsize) {
+      return;
+    }
     const cols = stdoutAny.columns ?? hostCols;
     const rows = stdoutAny.rows ?? hostRows;
     winsize.send(cols, rows);


### PR DESCRIPTION
## Problem

After #114, `boot({ rootDisk: true })` mounts the cached `~/.cache/machinen/rootfs/<sha>.img` read-write and hands that same file to the VMM on every boot from the same tarball. The cached image is shared, so anything the guest writes survives shutdown:

- `apt-get install` inside one boot leaks into the next.
- A guest that fills `/var/log` poisons every later boot until the cache is cleared.
- Two concurrent boots from the same tarball corrupt each other's filesystem.

This breaks the contract the legacy initramfs-as-rootfs path provided — every boot used to start from a pristine rootfs and writes vanished on shutdown.

## Solution

Clone the cached template into a per-boot file before handing it to the VMM, then unlink the copy on exit.

```
~/.cache/machinen/rootfs/<sha>.img            ← read-only template
/tmp/machinen-rootdisk-<pid>-<rand>.img        ← per-boot copy, RW
```

`copyFileSync(..., COPYFILE_FICLONE)` reflinks on APFS / btrfs / xfs (essentially free, shared blocks until the guest writes) and falls back to a regular copy elsewhere. Caller-supplied `rootDisk: '<path>'` keeps its original semantics — we don't manage that file's lifecycle.

The clean-shutdown marker (#170) is now restored inline at copy time rather than on a clean child exit, since the cache file is only ever read.

## Summary

- `packages/runtime/src/vm.ts`: COPYFILE_FICLONE the cached image to a per-boot path; track + unlink on exit and on the boot-failure cleanup path.
- `packages/runtime/src/__tests__/rootfs-img.test.ts`: three new tests pinning down the contract — per-boot path is distinct from the cache, guest writes don't leak into the template, back-to-back boots get distinct copies, all per-boot files are removed after `vm.wait()`.
- `chore: clear pre-existing oxlint --deny-warnings violations` — six pre-existing lint failures (curly + unused-vars) were blocking `pnpm run lint` on `main`; fixed in a separate commit so they're easy to lift out if preferred.
- `chore: bump @redwoodjs/agent-ci to ^0.13.0` — latest version pnpm's default `minimumReleaseAge` lets us pull (0.14.0 / 0.15.0 are too fresh).

## Test plan

- [x] `npx vitest run` — 349 passed, 7 skipped, including 3 new tests for #121.
- [x] `pnpm run lint`, `pnpm run format:check`, `pnpm typecheck` — all green.
- [ ] `npx agent-ci run --all -q -p` — `fuse-workloads.yml > base-assets/build` fails locally with `install: cannot stat '/stage/init'`. Reproduced on unmodified `main`, so it's an environment-specific pre-existing failure, not from this PR.

Closes #121.
