### PR TITLE
feat(vm-pick): run guest as non-root dev user (uid 501)

### DIFF
--- a/provision.ts
+++ b/provision.ts
@@ -150,14 +150,15 @@ const installSteps = async (vm: VmHandle) => {
       "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
   );
 
-  // Pre-bake git identity. safe.directory '*' silences git's
+  // Pre-bake git identity in /etc/gitconfig (--system) so both root
+  // and the dev user inherit it. safe.directory '*' silences git's
   // CVE-2022-24765 "dubious ownership" check — necessary because
   // /mnt/workspace is FUSE-mounted with uids that may not line up.
   await vm.exec(
-    "git config --global user.email 'peter.pistorius@gmail.com' && " +
-      "git config --global user.name 'Peter Pistorius' && " +
-      "git config --global init.defaultBranch main && " +
-      "git config --global --add safe.directory '*'",
+    "git config --system user.email 'peter.pistorius@gmail.com' && " +
+      "git config --system user.name 'Peter Pistorius' && " +
+      "git config --system init.defaultBranch main && " +
+      "git config --system --add safe.directory '*'",
   );
 
   // Node + pnpm + Claude Code via fnm. Idempotent on rebuilds.
@@ -225,9 +226,19 @@ const installSteps = async (vm: VmHandle) => {
     });
   }
 
-  // Sanity check.
+  // Non-root dev user. uid 501 matches the typical macOS host uid so
+  // files on the live FUSE mount line up. #161 added `allow_other` to
+  // the FUSE mount so dev can traverse it; this user is what vm.ts
+  // drops into so `claude --dangerously-skip-permissions` (which
+  // refuses euid 0) works inside the guest. Idempotent on rebuilds.
+  await vm.exec("id dev >/dev/null 2>&1 || useradd -m -u 501 -s /bin/bash dev");
+
+  // Sanity check — covers both root and dev (verifies the dev user
+  // inherits node/pnpm/claude via /usr/local/bin and gets git config
+  // via /etc/gitconfig).
   await vm.exec(
-    "node --version && pnpm --version && claude --version && bash --version | head -1 && git --version && gh --version | head -1",
+    "node --version && pnpm --version && claude --version && bash --version | head -1 && git --version && gh --version | head -1 && " +
+      "runuser -l dev -c 'node --version && pnpm --version && claude --version && git config --get user.email'",
   );
 };
 
@@ -262,10 +273,10 @@ const result = await provision({
   // 1 GiB scratch is too small once node_modules + global npm pkgs land.
   scratchDiskSizeBytes: 8 * 1024 * 1024 * 1024,
 
-  // Boot directly into /mnt/workspace via a thin -c wrapper. We run
-  // as root for now; switching to a non-root dev user (uid 501 to
-  // match the host) is unblocked since #161 added `allow_other` to
-  // the FUSE mount, but is left as a follow-up.
+  // Keep-alive shell for the install-phase boot. Runs as root because
+  // installSteps issue commands via vsock-exec (which always lands as
+  // root) and the cmd here is just init's foreground placeholder until
+  // provision powers off the VM. vm.ts drops to the dev user.
   cmd: ["/bin/bash", "-lc", "cd /mnt/workspace 2>/dev/null; exec bash -i"],
   env: {
     PATH: "/root/.local/share/fnm:/usr/local/bin:/usr/bin:/bin:/sbin",

--- a/scripts/test-claude-bootstrap.mjs
+++ b/scripts/test-claude-bootstrap.mjs
@@ -43,9 +43,10 @@ function readHostSlice() {
   return JSON.stringify(slice);
 }
 
-// --- Mirror vm.ts's bootstrap (minus `exec bash -i`) ------------------
-// Keep this byte-for-byte in sync with the bootstrap in vm.ts. The only
-// change is dropping the final `exec bash -i` so the test process exits.
+// --- Mirror vm.ts's STAGE_BOOTSTRAP -----------------------------------
+// Keep this byte-for-byte in sync with STAGE_BOOTSTRAP in vm.ts. The
+// dev-side bits (stty, winsize agent, cd, exec) and the runuser handoff
+// run after a uid switch and aren't exercised here.
 const BOOTSTRAP = [
   'mkdir -p "$HOME/.claude"',
   'if [ -n "${MACHINEN_CLAUDE_CREDENTIALS:-}" ]; then',
@@ -79,12 +80,6 @@ const BOOTSTRAP = [
   "EOF",
   'if ! grep -q ".bashrc.machinen" "$HOME/.bashrc" 2>/dev/null; then',
   '  printf "\\n[ -f \\"\\$HOME/.bashrc.machinen\\" ] && . \\"\\$HOME/.bashrc.machinen\\"\\n" >> "$HOME/.bashrc"',
-  "fi",
-  'if [ -n "${COLUMNS:-}" ] && [ -n "${LINES:-}" ]; then',
-  '  stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true',
-  "fi",
-  "if [ -x /sbin/machinen-winsize-agent ]; then",
-  "  /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &",
   "fi",
 ].join("\n");
 

--- a/vm.ts
+++ b/vm.ts
@@ -290,7 +290,7 @@ const bootstrap = [
   // the uid switch (without -m it would reset HOME/USER/etc.).
   // PATH includes /usr/local/bin where node/pnpm/claude live as symlinks.
   "exec env -i " +
-    'HOME=/home/dev USER=dev LOGNAME=dev SHELL=/bin/bash ' +
+    "HOME=/home/dev USER=dev LOGNAME=dev SHELL=/bin/bash " +
     'TERM="${TERM:-xterm-256color}" ' +
     'COLUMNS="${COLUMNS:-80}" LINES="${LINES:-24}" ' +
     'GH_TOKEN="${GH_TOKEN:-}" GITHUB_TOKEN="${GITHUB_TOKEN:-}" ' +

--- a/vm.ts
+++ b/vm.ts
@@ -178,6 +178,11 @@ const secretEnv: Record<string, string> = {
   MACHINEN_CLAUDE_ACCOUNT_JSON: claudeAccountJson,
   COLUMNS: String(hostCols),
   LINES: String(hostRows),
+  // The bootstrap below stages credentials into $HOME and then drops
+  // privileges to the `dev` user (uid 501, provisioned by provision.ts
+  // in install hooks). Setting HOME up front targets dev's home for the
+  // staging step, so a single chown -R hands everything off cleanly.
+  HOME: "/home/dev",
 };
 
 // Bootstrap credentials at boot time (not via /etc/profile.d) so a
@@ -185,15 +190,21 @@ const secretEnv: Record<string, string> = {
 // current when the image was last provisioned. Always overwrite — the
 // host's keychain + ~/.claude.json are the source of truth, the image
 // is not.
-// IMPORTANT: this snippet is mirrored byte-for-byte (sans the final
-// `exec bash -i`) by scripts/test-claude-bootstrap.mjs, which executes
-// it on the host against an isolated $HOME to verify behaviour without
-// a 30-second VM boot loop. Keep them in sync.
+//
+// Two-stage: STAGE_BOOTSTRAP runs as root with HOME=/home/dev (set in
+// secretEnv) and writes credentials/bashrc into the dev user's home.
+// DEV_BOOTSTRAP runs after a chown + uid switch via runuser, and
+// handles tty setup, the winsize agent, and the final exec.
+//
+// IMPORTANT: STAGE_BOOTSTRAP is mirrored byte-for-byte by
+// scripts/test-claude-bootstrap.mjs, which executes it on the host
+// against an isolated $HOME to verify behaviour without a 30-second VM
+// boot loop. Keep them in sync.
 //
 // Older images may have a missing /tmp (pre fix #176) and a missing
 // /dev/fd (no proc->fd symlinks staged), so avoid both `mktemp` and
 // bash process substitution `<(...)`. Stage everything in $HOME.
-const bootstrap = [
+const STAGE_BOOTSTRAP = [
   'mkdir -p "$HOME/.claude"',
   'if [ -n "${MACHINEN_CLAUDE_CREDENTIALS:-}" ]; then',
   '  printf "%s" "$MACHINEN_CLAUDE_CREDENTIALS" > "$HOME/.claude/.credentials.json"',
@@ -236,33 +247,55 @@ const bootstrap = [
   'if ! grep -q ".bashrc.machinen" "$HOME/.bashrc" 2>/dev/null; then',
   '  printf "\\n[ -f \\"\\$HOME/.bashrc.machinen\\" ] && . \\"\\$HOME/.bashrc.machinen\\"\\n" >> "$HOME/.bashrc"',
   "fi",
-  // Apply COLUMNS/LINES from vm.ts to the kernel TTY so TUIs see the
-  // host terminal's real dimensions on first paint. Failure (no tty,
-  // bad size) is silent — bash will fall back to its 80x24 default.
+];
+
+// Dev-side bootstrap. Runs as uid 501 (the `dev` user) after the
+// chown + runuser handoff. issueNumber-aware exec mirrors the previous
+// flow: when vm-pick stamped an issue ref, exec straight into claude
+// so it owns the host TTY (functions don't survive exec, so inline the
+// IS_SANDBOX/--dangerously-skip-permissions pair). Otherwise drop into
+// an interactive bash, which sources ~/.bashrc.machinen for the
+// `claude` wrapper.
+const DEV_BOOTSTRAP = [
+  // Apply COLUMNS/LINES to the kernel TTY for first-paint sizing (#177's
+  // VsockWinsize handles mid-session resizes). Silent on failure.
   'if [ -n "${COLUMNS:-}" ] && [ -n "${LINES:-}" ]; then',
   '  stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true',
   "fi",
-  // #177: launch the vsock TIOCSWINSZ agent so subsequent host
-  // SIGWINCH (forwarded by VsockWinsize below) resize the guest tty
-  // mid-session. Backgrounded + reparented to PID 1 once `exec bash -i`
-  // replaces this shell. /dev/null redirects so the agent's "applied:"
-  // log lines don't smear over the user's terminal. No-op if the
-  // binary is missing (stale rootfs); the host-side connect will
-  // time out and fall back to the stty-on-boot behavior above.
+  // #177 vsock TIOCSWINSZ agent. Reparented to PID 1 once exec replaces
+  // this shell. Vsock has no privileged-port concept so dev can bind 1974.
   "if [ -x /sbin/machinen-winsize-agent ]; then",
   "  /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &",
   "fi",
   "cd /mnt/workspace 2>/dev/null",
-  // When vm-pick stamped an issue ref, hand the host TTY directly to
-  // claude — exec replaces the bootstrap shell so claude is the
-  // foreground process the user is interacting with, not a child of
-  // bash. The IS_SANDBOX/--dangerously-skip-permissions pair mirrors
-  // the bashrc.machinen `claude` function (functions don't survive
-  // exec, so inline them). When claude exits, the bootstrap ends and
-  // the VM powers off.
   issueNumber
     ? `exec env IS_SANDBOX=1 claude --dangerously-skip-permissions "work on #${issueNumber}"`
     : "exec bash -i",
+].join("\n");
+const DEV_BOOTSTRAP_B64 = Buffer.from(DEV_BOOTSTRAP).toString("base64");
+
+const bootstrap = [
+  ...STAGE_BOOTSTRAP,
+  // Hand the staged files off to dev. Cheap because /home/dev is
+  // small (creds + bashrc files only).
+  'chown -R dev:dev "$HOME"',
+  // Stage the dev-side bootstrap as a script. Base64 sidesteps the
+  // quoting headache of nesting a multi-line shell snippet inside the
+  // outer runuser invocation.
+  `echo ${DEV_BOOTSTRAP_B64} | base64 -d > /tmp/machinen-dev-bootstrap.sh`,
+  "chmod 755 /tmp/machinen-dev-bootstrap.sh",
+  // Drop privs to dev with a controlled env. `env -i` clears the
+  // inherited env (including MACHINEN_* leftovers) and we forward only
+  // what dev needs. `runuser -m` preserves the env we just built across
+  // the uid switch (without -m it would reset HOME/USER/etc.).
+  // PATH includes /usr/local/bin where node/pnpm/claude live as symlinks.
+  "exec env -i " +
+    'HOME=/home/dev USER=dev LOGNAME=dev SHELL=/bin/bash ' +
+    'TERM="${TERM:-xterm-256color}" ' +
+    'COLUMNS="${COLUMNS:-80}" LINES="${LINES:-24}" ' +
+    'GH_TOKEN="${GH_TOKEN:-}" GITHUB_TOKEN="${GITHUB_TOKEN:-}" ' +
+    "PATH=/usr/local/bin:/usr/bin:/bin:/sbin " +
+    "runuser -m -u dev -- bash /tmp/machinen-dev-bootstrap.sh",
 ].join("\n");
 
 const vm = await boot({


### PR DESCRIPTION
## Problem

`claude --dangerously-skip-permissions` refuses to run as euid 0, so the
microVM-based vm-pick flow couldn't actually launch claude after #161
landed. The guest was still booting straight into a root shell, while
the FUSE mount was already prepared (via `allow_other`, #186) for a
uid-501 client.

## Solution

Provision a `dev` user at uid 501 (matches the typical macOS host uid so
files on the live FUSE mount line up) and drop privileges to it before
`exec`-ing claude or the interactive shell.

- **provision.ts**: `useradd -u 501 dev` (idempotent on rebuild). git
  config moves from `--global` (root's home) to `--system` (`/etc/gitconfig`)
  so dev inherits it. The sanity check now runs `runuser -l dev -c '...'`
  to prove dev can resolve `node`/`pnpm`/`claude` via `/usr/local/bin`
  symlinks and picks up the system git config.
- **vm.ts**: split the boot-time bootstrap into two stages.
  `STAGE_BOOTSTRAP` runs as root with `HOME=/home/dev` and writes creds +
  `~/.bashrc.machinen` into the dev user's home. After a single
  `chown -R dev:dev "$HOME"`, `DEV_BOOTSTRAP` (base64'd to sidestep
  nested-quoting hell) runs under `runuser -m -u dev` with a scrubbed env
  (`env -i` + allowlist) and owns the host TTY for stty/winsize-agent/exec.
- **scripts/test-claude-bootstrap.mjs**: mirrors STAGE_BOOTSTRAP only.
  The dev-side bits (stty, winsize agent, runuser handoff) run
  post-uid-switch and aren't exercised on the host.

## Summary

- Guest now boots as uid 501 with a clean env; root only runs the
  install-phase bootstrap and the credential staging.
- `claude --dangerously-skip-permissions` works inside the VM.
- Live FUSE mount uids line up between host and guest.
- vsock 1974 has no privileged-port concept, so the winsize agent
  binds fine as dev.

## Test plan

- [x] `npx vitest run` — 350 passed
- [x] `node scripts/test-claude-bootstrap.mjs` — 8/8 scenarios PASS
- [x] `npx agent-ci run --all -q -p` — `tests.yml` and
      `fuse-workloads.yml > base-assets/build` pass; the two
      remaining failures (`docs.yml` API.md drift,
      `fuse-workloads.yml > workloads` "Confirm KVM is available")
      are pre-existing on the clean tree
- [ ] Real boot via `pnpm vm-pick <issue>`: verify `whoami → dev`,
      `id -u → 501`, `gh auth status` passes, `cd /mnt/workspace`
      works, winsize agent starts as dev and host SIGWINCH still
      resizes, `claude --dangerously-skip-permissions` runs

Closes #161.
