### PR TITLE
fix(runtime): wrap VMM spawn with pdeathsig (#200)

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2983,7 +2983,7 @@ ms epoch when `vm.snapshot()` returned.
 
 ### BootOptions
 
-Defined in: [vm.ts:127](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L127)
+Defined in: [vm.ts:128](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L128)
 
 #### Properties
 
@@ -2991,7 +2991,7 @@ Defined in: [vm.ts:127](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L134)
+Defined in: [vm.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L135)
 
 Path to a rootfs tarball to boot from (e.g. the output of
 `provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
@@ -3002,7 +3002,7 @@ boots and snapshot-only restores both skip initramfs packing).
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:140](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L140)
+Defined in: [vm.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L141)
 
 Command to run inside the guest. Packed into the synthesized
 `/machinen-config.json`. Paired with `image` — both required, or
@@ -3012,7 +3012,7 @@ neither.
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:146](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L146)
+Defined in: [vm.ts:147](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L147)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3022,7 +3022,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:158](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L158)
+Defined in: [vm.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L159)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3038,7 +3038,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **snapshot?**: `string`
 
-Defined in: [vm.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L166)
+Defined in: [vm.ts:167](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L167)
 
 Attach this host file as the scratch virtio-blk device — `/dev/vdb`
 inside the guest when `rootDisk` is also set, or `/dev/vda` when
@@ -3050,7 +3050,7 @@ restore on boot. See #47 (virtio-blk) and #50.
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:188](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L188)
+Defined in: [vm.ts:189](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L189)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3076,7 +3076,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L205)
+Defined in: [vm.ts:206](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L206)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3097,7 +3097,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:212](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L212)
+Defined in: [vm.ts:213](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L213)
 
 Optional name to register this VM under (`attach({ name })`
 lookup key). Path-shaped strings ("worker/9012") are allowed.
@@ -3108,7 +3108,7 @@ Names are unique while live — `boot()` throws
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:218](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L218)
+Defined in: [vm.ts:219](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L219)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3118,7 +3118,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:232](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L232)
+Defined in: [vm.ts:233](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L233)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3144,7 +3144,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:250](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L250)
+Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3178,7 +3178,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:256](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L256)
+Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3200,7 +3200,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:264](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L264)
+Defined in: [vm.ts:265](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L265)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3209,7 +3209,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:266](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L266)
+Defined in: [vm.ts:267](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L267)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3217,7 +3217,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:268](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L268)
+Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
 
 Extra argv for the VMM.
 
@@ -3225,7 +3225,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:270](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L270)
+Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3233,7 +3233,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:272](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L272)
+Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3241,7 +3241,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:277](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L277)
+Defined in: [vm.ts:278](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L278)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3250,7 +3250,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:282](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L282)
+Defined in: [vm.ts:283](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L283)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3259,7 +3259,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:290](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L290)
+Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3271,7 +3271,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:940](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L940)
+Defined in: [vm.ts:949](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L949)
 
 #### Properties
 
@@ -3279,7 +3279,7 @@ Defined in: [vm.ts:940](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:946](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L946)
+Defined in: [vm.ts:955](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L955)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3289,7 +3289,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:948](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L948)
+Defined in: [vm.ts:957](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L957)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3297,7 +3297,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:955](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L955)
+Defined in: [vm.ts:964](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L964)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3308,7 +3308,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:1766](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1766)
+Defined in: [vm.ts:1775](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1775)
 
 #### Extends
 
@@ -3320,7 +3320,7 @@ Defined in: [vm.ts:1766](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:146](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L146)
+Defined in: [vm.ts:147](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L147)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3334,7 +3334,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:158](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L158)
+Defined in: [vm.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L159)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3354,7 +3354,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:188](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L188)
+Defined in: [vm.ts:189](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L189)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3384,7 +3384,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L205)
+Defined in: [vm.ts:206](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L206)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3409,7 +3409,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:218](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L218)
+Defined in: [vm.ts:219](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L219)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3423,7 +3423,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:232](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L232)
+Defined in: [vm.ts:233](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L233)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3453,7 +3453,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:250](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L250)
+Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3491,7 +3491,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:256](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L256)
+Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3517,7 +3517,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:264](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L264)
+Defined in: [vm.ts:265](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L265)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3530,7 +3530,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:266](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L266)
+Defined in: [vm.ts:267](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L267)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3542,7 +3542,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:268](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L268)
+Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
 
 Extra argv for the VMM.
 
@@ -3554,7 +3554,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:270](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L270)
+Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3566,7 +3566,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:272](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L272)
+Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3578,7 +3578,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:277](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L277)
+Defined in: [vm.ts:278](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L278)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3591,7 +3591,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:282](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L282)
+Defined in: [vm.ts:283](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L283)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3604,7 +3604,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:290](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L290)
+Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3620,7 +3620,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:1771](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1771)
+Defined in: [vm.ts:1780](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1780)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3629,7 +3629,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:1779](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1779)
+Defined in: [vm.ts:1788](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1788)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3641,7 +3641,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1785](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1785)
+Defined in: [vm.ts:1794](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1794)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4127,7 +4127,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1576](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1576)
+Defined in: [vm.ts:1585](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1585)
 
 #### Type Declaration
 
@@ -4598,7 +4598,7 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveVmmBinary**(): `string`
 
-Defined in: [vm.ts:89](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L89)
+Defined in: [vm.ts:90](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L90)
 
 Locate the VMM binary using the same lookup order as `@machinen/cli`:
   1. `MACHINEN_VMM` env var (dev-mode override)
@@ -4620,7 +4620,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN
 
 > **boot**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
+Defined in: [vm.ts:306](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L306)
 
 Boot a microVM and return a handle to interact with it.
 
@@ -4651,7 +4651,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:971](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L971)
+Defined in: [vm.ts:980](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L980)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4683,7 +4683,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1424](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1424)
+Defined in: [vm.ts:1433](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1433)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4722,7 +4722,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1466](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1466)
+Defined in: [vm.ts:1475](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1475)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4754,7 +4754,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1804](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1804)
+Defined in: [vm.ts:1813](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1813)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -4789,7 +4789,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:1851](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1851)
+Defined in: [vm.ts:1860](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1860)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -6,7 +6,7 @@
 // expression. Skipped (not failed) if the prerequisites aren't there:
 // Image/virt.dtb/initramfs fixtures, or the HVF-entitled test binary.
 
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { BootError, ExecError, buildMachinenConfig, measureFirstByte, boot } from "../index.ts";
+import { ensurePdeathsig } from "../pdeathsig.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
 
@@ -61,6 +62,86 @@ describe("boot", () => {
   it("throws BootError when the binary path does not exist", async () => {
     await expect(boot({ binary: "/nope/does/not/exist" })).rejects.toThrow(BootError);
   });
+
+  // #200: the VMM was spawned without parent-death wiring, so a
+  // SIGKILL of the runtime process orphaned `machinen-vm` to PID 1
+  // with the rootdisk fd and ~1.7 GiB RSS still held. Wrap the spawn
+  // through the same shim `spawnGvproxy` uses; assert end-to-end that
+  // the VMM dies with its parent.
+  it("VMM dies with the parent process (#200)", async () => {
+    if (process.platform !== "linux" && process.platform !== "darwin") {
+      return; // shim is no-op on other platforms
+    }
+    const shim = await ensurePdeathsig();
+    if (!shim) {
+      // No C toolchain — graceful-fallback path is still safe (issue #200
+      // notes the unwrapped behavior is the previous status quo). Nothing
+      // for this test to assert.
+      console.warn("pdeathsig shim unavailable; skipping VMM orphan test");
+      return;
+    }
+
+    const fixture = resolve(import.meta.dirname, "fixtures/boot-and-hold.ts");
+    // `node --import tsx` keeps everything in a single node process —
+    // important here, because we need the SIGKILL'd process to be the
+    // VMM's direct parent. (The `tsx` CLI binary spawns its target as
+    // a child, which would put another layer between us and the VMM.)
+    const parent = spawn(process.execPath, ["--import", "tsx", fixture], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const pidLine = await new Promise<number>((res, rej) => {
+      let buf = "";
+      const t = setTimeout(() => rej(new Error("never received VMM_PID")), 30_000);
+      parent.stdout!.on("data", (c: Buffer) => {
+        buf += c.toString();
+        const m = buf.match(/VMM_PID=(\d+)/);
+        if (m) {
+          clearTimeout(t);
+          res(Number(m[1]));
+        }
+      });
+      parent.once("error", rej);
+      parent.once("exit", (code, signal) => {
+        if (!buf.match(/VMM_PID=(\d+)/)) {
+          clearTimeout(t);
+          rej(new Error(`fixture exited before reporting VMM_PID (code=${code} sig=${signal})`));
+        }
+      });
+    });
+
+    const pidAlive = (pid: number): boolean => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err) {
+        return (err as NodeJS.ErrnoException).code !== "ESRCH";
+      }
+    };
+    expect(pidAlive(pidLine)).toBe(true);
+
+    // SIGKILL the parent. With the shim in place, `pidLine` (the VMM
+    // wrapper on darwin, the VMM directly on linux) must die within a
+    // few hundred ms.
+    parent.kill("SIGKILL");
+
+    const deadline = Date.now() + 5_000;
+    let gone = false;
+    while (Date.now() < deadline) {
+      if (!pidAlive(pidLine)) {
+        gone = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    if (!gone) {
+      // Last-resort cleanup so we don't leak a sleep(1) across runs.
+      try {
+        process.kill(pidLine, "SIGKILL");
+      } catch {}
+    }
+    expect(gone).toBe(true);
+  }, 60_000);
 
   it("rejects wait() when the VMM exceeds its timeout", async () => {
     // Use a binary that just sleeps (the macOS `yes` command never

--- a/packages/runtime/src/__tests__/fixtures/boot-and-hold.ts
+++ b/packages/runtime/src/__tests__/fixtures/boot-and-hold.ts
@@ -1,0 +1,17 @@
+// Test harness for #200's parent-death assertion.
+//
+// Boots a long-running stand-in for the VMM (`/usr/bin/yes`) via
+// `boot()`, prints `VMM_PID=<pid>` to stdout, and blocks forever.
+// The parent test SIGKILLs this process and asserts the VMM PID is
+// gone within a deadline — proving the spawn was wrapped through
+// the parent-death shim.
+
+import { boot } from "../../index.ts";
+
+// `/bin/sleep` doesn't write to stdout, so it won't exit via SIGPIPE
+// when the parent's stdio pipes close. That makes it a faithful
+// stand-in for the real VMM (which the orphan repro in #200 left
+// running for 39 minutes after the parent died).
+const vm = await boot({ binary: "/bin/sleep", args: ["99999"], timeoutMs: null });
+process.stdout.write(`VMM_PID=${vm.pid}\n`);
+setInterval(() => {}, 1 << 30);

--- a/packages/runtime/src/pdeathsig.ts
+++ b/packages/runtime/src/pdeathsig.ts
@@ -44,7 +44,13 @@ const debug = debugLib("machinen:pdeathsig");
 const PDEATHSIG_VERSION = "v2";
 
 let warnedNoCompiler = false;
-let installInFlight: Promise<string | null> | null = null;
+// Keyed by the resolved cache path. Two reasons it has to be a map and
+// not a single global: tests rebind `process.env.HOME` per-case (so the
+// cache path differs across calls in the same process), and the
+// runtime now calls `ensurePdeathsig()` in two spots per `boot()`
+// (gvproxy + the VMM, #200) — caching by path keeps the dedup correct
+// without leaking a stale promise from one HOME into the next call.
+const installInFlight = new Map<string, Promise<string | null>>();
 
 /**
  * The shim's source. Embedded so the runtime ships exactly one file
@@ -262,10 +268,11 @@ export async function ensurePdeathsig(): Promise<string | null> {
   if (existsSync(cached)) {
     return cached;
   }
-  if (installInFlight) {
-    return installInFlight;
+  const existing = installInFlight.get(cached);
+  if (existing) {
+    return existing;
   }
-  installInFlight = (async () => {
+  const promise = (async () => {
     try {
       return compilePdeathsig(cached);
     } catch (err) {
@@ -282,11 +289,15 @@ export async function ensurePdeathsig(): Promise<string | null> {
       }
       debug("compile failed err=%s", err instanceof Error ? err.message : String(err));
       return null;
-    } finally {
-      installInFlight = null;
     }
   })();
-  return installInFlight;
+  installInFlight.set(cached, promise);
+  void promise.finally(() => {
+    if (installInFlight.get(cached) === promise) {
+      installInFlight.delete(cached);
+    }
+  });
+  return promise;
 }
 
 /**

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -57,6 +57,7 @@ import {
 } from "./gvproxy.ts";
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
+import { ensurePdeathsig, wrapWithPdeathsig } from "./pdeathsig.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "./rootfs-img.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
 import { serveLiveMount } from "./mount-server.ts";
@@ -637,15 +638,23 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     throw err;
   }
 
-  const child = nodeSpawn(binary, opts.args ?? [], {
+  // Wrap through the parent-death shim so the VMM dies with the
+  // runtime instead of orphaning to PID 1 holding the rootdisk fd and
+  // ~1.7 GiB RSS (#200). Mirrors `spawnGvproxy`. Falls through to a
+  // direct spawn if the shim is unavailable (no `cc`, opted-out,
+  // unsupported platform).
+  const vmmPdeathsig = await ensurePdeathsig();
+  const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, binary, opts.args ?? []);
+  const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
     cwd: opts.cwd,
     env,
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessWithoutNullStreams;
   debug(
-    "VMM spawned pid=%d binary=%s elapsedSinceEntry=%dms",
+    "VMM spawned pid=%d binary=%s wrapped=%s elapsedSinceEntry=%dms",
     child.pid ?? -1,
     binary,
+    vmmPdeathsig ? "yes" : "no",
     Date.now() - bootT0,
   );
 


### PR DESCRIPTION
## Summary

- Wrap the VMM spawn in `vm.ts` with the existing `pdeathsig` shim so a SIGKILL of the runtime takes `machinen-vm` with it instead of orphaning it to PID 1 holding the rootdisk fd, vsock UDSes, and ~1.7 GiB RSS.
- Fix a latent bug in `ensurePdeathsig` where `installInFlight` was a single global, causing a stale promise from one HOME to be returned for calls resolving against a different HOME — now keyed by the resolved cache path.
- Add an integration test that spawns a child process which boots a long-running stand-in VMM, SIGKILLs the child, and asserts the VMM pid is gone within 5s.

## Problem

When the runtime process that called `boot()` is killed (`SIGKILL`, OOM, IDE crash), `machinen-vm` reparents to PID 1 and survives — holding the rootdisk fd, vsock UDSes, and ~1.7 GiB RSS until manually killed.

`gvproxy` already gets wrapped with the parent-death shim (`gvproxy.ts:510`), but the VMM spawn at `vm.ts:640` was missed.

Closes #200.

## Solution

Wrap the VMM spawn with `wrapWithPdeathsig` the same way `spawnGvproxy` does — `ensurePdeathsig()` resolves (and on first use compiles) the shim, `wrapWithPdeathsig` prepends it to the argv. Falls through to direct spawn if the shim is unavailable (no `cc`, opted out via `MACHINEN_PDEATHSIG=disabled`, unsupported platform), preserving prior behavior.

Also fixes the `installInFlight` bug: the `finally { installInFlight = null }` reset was overwritten by the outer assignment, so once a compile resolved the global continued to point at that promise. Latent because the only caller — `spawnGvproxy` — runs once per `boot()` and `homedir()` doesn't change in production. The new VMM call site plus tests that rebind `process.env.HOME` per case (`rootfs-img.test.ts`) made it visible.
