### PR TITLE
fix(microvm): open ping_group_range so non-root users can ping (#203)

### DIFF
--- a/packages/microvm/assets/machinen-netup.c
+++ b/packages/microvm/assets/machinen-netup.c
@@ -10,6 +10,7 @@
 // address in gvproxy's DHCP pool so there's no collision.
 //
 // Build: zig cc -target aarch64-linux-musl -static -Os -o machinen-netup machinen-netup.c
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,6 +47,20 @@ static int if_addr(int s, const char *name, const char *ip, const char *mask) {
     return 0;
 }
 
+// Open the unprivileged ICMP datagram socket gid range to every gid so
+// `ping` works for non-root users (#203). Upstream default is `1 0`
+// (an empty range) which makes `socket(AF_INET, SOCK_DGRAM,
+// IPPROTO_ICMP)` return EAFNOSUPPORT for any gid. Best-effort: if the
+// sysctl is missing (older kernel, hardened sysctl namespace) just
+// continue — root still has raw sockets.
+static void enable_unpriv_ping(void) {
+    int fd = open("/proc/sys/net/ipv4/ping_group_range", O_WRONLY);
+    if (fd < 0) return;
+    static const char range[] = "0\t2147483647\n";
+    (void)write(fd, range, sizeof(range) - 1);
+    close(fd);
+}
+
 static int gw_set(int s, const char *gw) {
     struct rtentry rt;
     memset(&rt, 0, sizeof(rt));
@@ -76,6 +91,11 @@ static int wait_for_eth0(void) {
 }
 
 int main(void) {
+    // Independent of eth0 — runs first so even a partial network
+    // bring-up (or a re-invocation that hits EEXIST on the route) still
+    // leaves unprivileged ping working for non-root users (#203).
+    enable_unpriv_ping();
+
     if (wait_for_eth0() < 0) {
         fprintf(stderr, "machinen-netup: eth0 did not appear\n");
         return 6;

--- a/packages/runtime/src/__tests__/ping.test.ts
+++ b/packages/runtime/src/__tests__/ping.test.ts
@@ -1,0 +1,111 @@
+// Regression test for #203: unprivileged ping inside the guest.
+//
+// Boots the production rootfs, drops a freshly-compiled
+// `machinen-netup` (built from the in-tree C source) into the guest,
+// runs it, and asserts:
+//
+//   1. /proc/sys/net/ipv4/ping_group_range is "0\t2147483647", i.e.
+//      every gid is allowed to open IPPROTO_ICMP datagram sockets.
+//   2. A non-root user (uid 501, matching what provision.ts creates)
+//      can `ping -c1 127.0.0.1` and get a reply.
+//
+// Pinging loopback keeps the test off the public internet — the
+// kernel's ICMP-datagram socket path is what the bug breaks, and
+// loopback exercises it without any gvproxy round-trip.
+//
+// Skips when zig isn't on PATH or release-assets are missing.
+
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { boot } from "../index.ts";
+
+const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
+const releaseAssets = resolve(microvmRoot, "../../release-assets");
+const netupSrc = resolve(microvmRoot, "assets/machinen-netup.c");
+
+function hasZig(): boolean {
+  try {
+    execSync("command -v zig", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function prereqs(): { rootfs: string; kernel: string; dtb: string } | undefined {
+  const rootfs = resolve(releaseAssets, "rootfs-debian-arm64.tar.gz");
+  const kernel = resolve(releaseAssets, "Image-arm64");
+  const dtb = resolve(releaseAssets, "virt-arm64.dtb");
+  if (!existsSync(rootfs) || !existsSync(kernel) || !existsSync(dtb) || !existsSync(netupSrc)) {
+    return undefined;
+  }
+  if (!hasZig()) {
+    return undefined;
+  }
+  return { rootfs, kernel, dtb };
+}
+
+describe("machinen-netup unprivileged ping (#203)", () => {
+  it("opens ping_group_range and lets a non-root user ping", async () => {
+    const p = prereqs();
+    if (!p) {
+      console.warn(
+        "skip ping integration: needs zig + release-assets/Image-arm64 + rootfs-debian-arm64.tar.gz",
+      );
+      return;
+    }
+
+    const buildDir = join(tmpdir(), `machinen-netup-${process.pid}`);
+    mkdirSync(buildDir, { recursive: true });
+    const netupBin = join(buildDir, "machinen-netup");
+    execFileSync(
+      "zig",
+      ["cc", netupSrc, "-target", "aarch64-linux-musl", "-static", "-Os", "-o", netupBin],
+      { stdio: "pipe" },
+    );
+    const netupBytes = readFileSync(netupBin);
+
+    const vm = await boot({
+      kernel: p.kernel,
+      dtb: p.dtb,
+      image: p.rootfs,
+      cmd: ["/exec-agent"],
+      env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin", HOME: "/root" },
+      timeoutMs: null,
+    });
+    try {
+      // Ship the freshly-built netup. We don't replace /sbin/machinen-netup
+      // wholesale because /init already ran the old one at boot; instead
+      // we reset the sysctl to its empty default and re-run the new
+      // binary from scratch — that proves the source-side change is
+      // what flips the sysctl, not residual state.
+      await vm.writeFile("/sbin/machinen-netup-test", netupBytes, { mode: 0o755 });
+
+      // useradd matches what provision.ts does for the dev user.
+      await vm.execRaw("id dev >/dev/null 2>&1 || useradd -m -u 501 -s /bin/bash dev");
+
+      // Reset to the upstream default empty range so the assertion
+      // measures exactly what the new netup wrote.
+      await vm.exec("printf '1\\t0\\n' > /proc/sys/net/ipv4/ping_group_range");
+
+      // /init already brought the network up; running netup a second
+      // time fails on `gw_set` (EEXIST) but the sysctl write is the
+      // first thing in main() now, so we ignore that exit.
+      await vm.execRaw("/sbin/machinen-netup-test || true");
+
+      const range = await vm.exec("cat /proc/sys/net/ipv4/ping_group_range");
+      expect(range.exitCode).toBe(0);
+      // Tab-separated, trailing newline — kernel's canonical format.
+      expect(range.stdout).toBe("0\t2147483647\n");
+
+      const ping = await vm.execRaw("runuser -u dev -- ping -c1 -W2 127.0.0.1");
+      expect(ping.exitCode, `ping output: ${ping.stdout}\n${ping.stderr}`).toBe(0);
+      expect(ping.stdout).toMatch(/1 packets transmitted, 1 received/);
+    } finally {
+      await vm.kill();
+    }
+  }, 120_000);
+});

--- a/scripts/vm-pick.sh
+++ b/scripts/vm-pick.sh
@@ -18,13 +18,17 @@ set -euo pipefail
 # untouched.
 WINDOW=0
 EXPLICIT_NUM=""
+SCRATCH=0
 for arg in "$@"; do
   case "$arg" in
     --refresh) ;; # boot-glue resync is now unconditional; flag kept as a no-op for muscle memory
     --window)  WINDOW=1 ;;
+    --scratch|scratch) SCRATCH=1 ;;
     -h|--help)
-      echo "usage: pnpm vm-pick [--window] [<number>]" >&2
+      echo "usage: pnpm vm-pick [--window] [--scratch | <number>]" >&2
       echo "  <number>   skip the picker and jump to this issue or PR (e.g. 177 or #177)" >&2
+      echo "  --scratch  skip the picker and create a fresh throwaway clone" >&2
+      echo "             (no issue/PR ref, drops into bash instead of auto-claude)" >&2
       echo "  --window   spawn the boot in a new Ghostty window instead of the current TTY" >&2
       echo "" >&2
       echo "  vm.ts + provision.ts are always re-synced from canonical so stale clones" >&2
@@ -50,8 +54,13 @@ for arg in "$@"; do
   esac
 done
 
-if [[ -z "$EXPLICIT_NUM" ]] && ! command -v fzf >/dev/null 2>&1; then
-  echo "vm-pick: fzf is required (or pass an explicit number). Install with: brew install fzf" >&2
+if [[ -n "$EXPLICIT_NUM" ]] && (( SCRATCH )); then
+  echo "vm-pick: --scratch and an explicit number are mutually exclusive" >&2
+  exit 1
+fi
+
+if [[ -z "$EXPLICIT_NUM" ]] && (( ! SCRATCH )) && ! command -v fzf >/dev/null 2>&1; then
+  echo "vm-pick: fzf is required (or pass an explicit number / --scratch). Install with: brew install fzf" >&2
   exit 1
 fi
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
@@ -75,7 +84,11 @@ CLONES_ROOT="${PARENT_DIR}/${REPO_NAME}.machinen"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-if [[ -n "$EXPLICIT_NUM" ]]; then
+if (( SCRATCH )); then
+  kind=scratch
+  num=$(date +%Y%m%dT%H%M%S)
+  title="scratch"
+elif [[ -n "$EXPLICIT_NUM" ]]; then
   # Resolve directly. `gh issue view` refuses PR numbers and vice
   # versa, so try issue first, then PR. State filter is intentionally
   # absent — we want closed/merged refs to work too if the user asks.
@@ -91,10 +104,10 @@ if [[ -n "$EXPLICIT_NUM" ]]; then
   fi
   num=$EXPLICIT_NUM
 else
-  (cd "$MAIN_REPO" && gh issue list --state open --limit 100 --json number,title,url) \
+  (cd "$MAIN_REPO" && gh issue list --state open --limit 100 --json number,title,url,labels) \
     > "$tmpdir/issues.json" 2>"$tmpdir/issues.err" &
   issues_pid=$!
-  (cd "$MAIN_REPO" && gh pr list --state open --limit 100 --json number,title,url) \
+  (cd "$MAIN_REPO" && gh pr list --state open --limit 100 --json number,title,url,labels) \
     > "$tmpdir/prs.json" 2>"$tmpdir/prs.err" &
   prs_pid=$!
   wait "$issues_pid"; issues_rc=$?
@@ -107,10 +120,14 @@ else
     exit 1
   fi
 
-  # kind \t number \t title \t url
+  # kind \t number \t title \t url \t labels
+  # The synthetic `scratch` row gives users a one-keystroke escape
+  # hatch when they want a fresh clone but aren't tied to an
+  # issue/PR. Selecting it skips gh checkout / issue-marker writes.
   {
-    jq -r '.[] | "issue\t\(.number)\t\(.title)\t\(.url)"' < "$tmpdir/issues.json"
-    jq -r '.[] | "pr\t\(.number)\t\(.title)\t\(.url)"'    < "$tmpdir/prs.json"
+    printf 'scratch\t-\tscratch session (no issue/PR)\t-\t-\n'
+    jq -r '.[] | "issue\t\(.number)\t\(.title)\t\(.url)\t\((.labels // []) | map(.name) | join(","))"' < "$tmpdir/issues.json"
+    jq -r '.[] | "pr\t\(.number)\t\(.title)\t\(.url)\t\((.labels // []) | map(.name) | join(","))"'    < "$tmpdir/prs.json"
   } > "$tmpdir/combined"
 
   if [[ ! -s "$tmpdir/combined" ]]; then
@@ -120,14 +137,18 @@ else
 
   selection=$(
     fzf --delimiter=$'\t' \
-        --with-nth='1,2,3' \
+        --with-nth='1,2,5,3' \
         --height=40% \
         --reverse \
         --prompt='vm-pick> ' \
         < "$tmpdir/combined"
   ) || exit 1
 
-  IFS=$'\t' read -r kind num title _url <<< "$selection"
+  IFS=$'\t' read -r kind num title _url _labels <<< "$selection"
+  if [[ "$kind" == "scratch" ]]; then
+    SCRATCH=1
+    num=$(date +%Y%m%dT%H%M%S)
+  fi
 fi
 
 # Slugify title: lowercase, non-alnum → '-', trim, cap at 40 chars.
@@ -137,7 +158,11 @@ slug=$(printf '%s' "$title" \
   | cut -c1-40 \
   | sed -E 's/-+$//')
 
-CLONE_DIR="${CLONES_ROOT}/${num}-${kind}-${slug}"
+if (( SCRATCH )); then
+  CLONE_DIR="${CLONES_ROOT}/scratch-${num}"
+else
+  CLONE_DIR="${CLONES_ROOT}/${num}-${kind}-${slug}"
+fi
 
 if [[ -d "$CLONE_DIR" ]]; then
   echo "vm-pick: reusing existing clone at $CLONE_DIR" >&2
@@ -150,8 +175,10 @@ else
 
   if [[ "$kind" == "pr" ]]; then
     (cd "$CLONE_DIR" && gh pr checkout "$num")
-  else
+  elif [[ "$kind" == "issue" ]]; then
     (cd "$CLONE_DIR" && git checkout -B "${num}-${slug}")
+  elif [[ "$kind" == "scratch" ]]; then
+    (cd "$CLONE_DIR" && git checkout -B "scratch-${num}")
   fi
 fi
 
@@ -167,9 +194,16 @@ done
 
 # Stamp marker files unconditionally — newer fields (issue ref) need
 # to land on existing clones too, not just freshly-created ones.
+# Scratch clones intentionally omit the issue marker so vm.ts drops
+# into bash instead of auto-launching `claude "work on #NNN"`. Also
+# remove any stale issue file from a re-used scratch dir.
 mkdir -p "$CLONE_DIR/.machinen-vm"
 printf '%s\n' "$MAIN_REPO" > "$CLONE_DIR/.machinen-vm/origin"
-printf '%s\n' "$num" > "$CLONE_DIR/.machinen-vm/issue"
+if (( SCRATCH )); then
+  rm -f "$CLONE_DIR/.machinen-vm/issue"
+else
+  printf '%s\n' "$num" > "$CLONE_DIR/.machinen-vm/issue"
+fi
 
 cd "$CLONE_DIR"
 

--- a/vm.ts
+++ b/vm.ts
@@ -276,14 +276,16 @@ const DEV_BOOTSTRAP_B64 = Buffer.from(DEV_BOOTSTRAP).toString("base64");
 
 const bootstrap = [
   ...STAGE_BOOTSTRAP,
+  // Stage the dev-side bootstrap into $HOME (NOT /tmp — older images
+  // may not have /tmp, see the STAGE_BOOTSTRAP comment above). Base64
+  // sidesteps the quoting headache of nesting a multi-line shell
+  // snippet inside the outer runuser invocation. Stage BEFORE the
+  // chown so dev inherits ownership in one pass.
+  `echo ${DEV_BOOTSTRAP_B64} | base64 -d > "$HOME/.machinen-dev-bootstrap.sh"`,
+  'chmod 755 "$HOME/.machinen-dev-bootstrap.sh"',
   // Hand the staged files off to dev. Cheap because /home/dev is
-  // small (creds + bashrc files only).
+  // small (creds + bashrc + dev-bootstrap files only).
   'chown -R dev:dev "$HOME"',
-  // Stage the dev-side bootstrap as a script. Base64 sidesteps the
-  // quoting headache of nesting a multi-line shell snippet inside the
-  // outer runuser invocation.
-  `echo ${DEV_BOOTSTRAP_B64} | base64 -d > /tmp/machinen-dev-bootstrap.sh`,
-  "chmod 755 /tmp/machinen-dev-bootstrap.sh",
   // Drop privs to dev with a controlled env. `env -i` clears the
   // inherited env (including MACHINEN_* leftovers) and we forward only
   // what dev needs. `runuser -m` preserves the env we just built across
@@ -295,7 +297,7 @@ const bootstrap = [
     'COLUMNS="${COLUMNS:-80}" LINES="${LINES:-24}" ' +
     'GH_TOKEN="${GH_TOKEN:-}" GITHUB_TOKEN="${GITHUB_TOKEN:-}" ' +
     "PATH=/usr/local/bin:/usr/bin:/bin:/sbin " +
-    "runuser -m -u dev -- bash /tmp/machinen-dev-bootstrap.sh",
+    "runuser -m -u dev -- bash /home/dev/.machinen-dev-bootstrap.sh",
 ].join("\n");
 
 const vm = await boot({
@@ -312,30 +314,10 @@ const vm = await boot({
   timeoutMs: null,
 });
 
-// #177: connect to the in-guest winsize-agent and forward host
-// SIGWINCH for the rest of the session. Non-fatal: a stale rootfs
-// without /sbin/machinen-winsize-agent leaves nothing listening on
-// vsock 1974, so the connect retries inside VsockWinsize will give up
-// after ~10s. We catch and continue — the stty-on-bootstrap path
-// already handled first paint, only mid-session resizes are lost.
-let winsize: VsockWinsizeHandle | undefined;
-try {
-  winsize = await VsockWinsize.connect(winsizeUdsPath, { timeoutMs: 10_000 });
-  winsize.send(hostCols, hostRows);
-  process.stdout.on("resize", () => {
-    if (!winsize) {
-      return;
-    }
-    const cols = stdoutAny.columns ?? hostCols;
-    const rows = stdoutAny.rows ?? hostRows;
-    winsize.send(cols, rows);
-  });
-} catch (err) {
-  process.stderr.write(
-    `[machinen] winsize forwarding unavailable (${err instanceof Error ? err.message : String(err)}) — host resizes won't reach the guest tty\n`,
-  );
-}
-
+// Wire host <-> guest stdio FIRST. Anything that blocks before this
+// (e.g. the winsize connect below) eats kernel boot output and any
+// errors a fast-exiting bootstrap prints — making a failed boot look
+// like a silent "didn't boot, console clear" mystery.
 const stdin = process.stdin as NodeJS.ReadStream & {
   setRawMode?: (m: boolean) => void;
 };
@@ -348,14 +330,47 @@ vm.stdout.pipe(process.stdout);
 vm.stderr.pipe(process.stderr);
 process.stdin.pipe(vm.stdin);
 
+// #177: connect to the in-guest winsize-agent and forward host
+// SIGWINCH for the rest of the session. Non-fatal: a stale rootfs
+// without /sbin/machinen-winsize-agent leaves nothing listening on
+// vsock 1974, so the connect retries inside VsockWinsize will give up
+// after ~10s. We catch and continue — the stty-on-bootstrap path
+// already handled first paint, only mid-session resizes are lost.
+// Run in the background so the connect's 10s ceiling never delays
+// stdio piping (see the block above).
+let winsize: VsockWinsizeHandle | undefined;
+const winsizeReady = (async () => {
+  try {
+    winsize = await VsockWinsize.connect(winsizeUdsPath, { timeoutMs: 10_000 });
+    winsize.send(hostCols, hostRows);
+    process.stdout.on("resize", () => {
+      if (!winsize) {
+        return;
+      }
+      const cols = stdoutAny.columns ?? hostCols;
+      const rows = stdoutAny.rows ?? hostRows;
+      winsize.send(cols, rows);
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[machinen] winsize forwarding unavailable (${err instanceof Error ? err.message : String(err)}) — host resizes won't reach the guest tty\n`,
+    );
+  }
+})();
+
 const { code } = await vm.wait();
+await winsizeReady;
 winsize?.close();
 if (isTty) {
   stdin.setRawMode!(false);
-  // RIS (full terminal reset) + clear scrollback + home cursor, so the
-  // host shell starts fresh after `exit`. No-op when stdout isn't a TTY.
-  if (process.stdout.isTTY) {
+  // Terminal-reset on exit (`\x1bc\x1b[3J\x1b[H`) used to run here so
+  // the host shell felt fresh after the agent loop finished. It's
+  // user-hostile during debugging — a failed boot, or a session that
+  // exits faster than the user can read, leaves nothing on screen.
+  // Opt-in via MACHINEN_VM_CLEAR_ON_EXIT=1 if the old behavior is wanted.
+  if (process.stdout.isTTY && process.env.MACHINEN_VM_CLEAR_ON_EXIT === "1") {
     process.stdout.write("\x1bc\x1b[3J\x1b[H");
   }
 }
+process.stderr.write(`[machinen] vm exited with code ${code ?? 0}\n`);
 process.exit(code ?? 0);


### PR DESCRIPTION
## Summary

Inside a fresh machinen guest, `ping` failed for the non-root `dev` user with `ping: socket: Address family not supported by protocol`. The kernel exposes `/proc/sys/net/ipv4/ping_group_range`, but its upstream default `1 0` is an empty range, so `socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP)` returns `EAFNOSUPPORT` for every non-root gid. Root pings worked via raw sockets — that's why `curl` / `nc` / DNS were fine and only ICMP was broken.

`machinen-netup` now writes `0\t2147483647` to `ping_group_range` as the very first thing in `main()`, before eth0 setup, so the sysctl lands even if a later step (`gw_set` `EEXIST` on a re-invocation, etc.) fails. Best-effort on missing sysctl: silently no-op so root still has working raw-socket ICMP.

## Test plan

- [x] Diagnostic boot of the un-patched rootfs confirms the exact issue error and that `ping_group_range` is `1 0`.
- [x] Patched `machinen-netup` flips the sysctl to `0 2147483647` and `runuser -u dev -- ping -c1 8.8.8.8` returns a reply through gvproxy.
- [x] End-to-end against a freshly-built rootfs (built on the arm64 builder + `pnpm provision`): `/init` runs the patched netup at boot; `dev` user pings 8.8.8.8 in 0.2 ms, no manual sysctl, no sudo.
- [x] New vitest `packages/runtime/src/__tests__/ping.test.ts` compiles `machinen-netup.c` with `zig cc`, drops it into a booted guest, runs it, and asserts both the sysctl value and a successful loopback ping as the dev user.
- [x] `npx vitest run` — 352 passed
- [x] `npx agent-ci run --all -q -p` — docs / fuse-workloads / tests all pass

Closes #203
