### PR TITLE
fix: make snapshot/restore round-trip work end-to-end

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,7 +23,6 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
-  statSync,
   symlinkSync,
   unlinkSync,
 } from "node:fs";
@@ -163,7 +162,7 @@ function ghAuthToken(): string {
     const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
     die(
       `failed to read gh auth token (${msg}).\n` +
-        "  Install GitHub CLI and run \`gh auth login\` so the runtime can fetch\n" +
+        "  Install GitHub CLI and run `gh auth login` so the runtime can fetch\n" +
         `  release assets from the private repo ${REPO}.`,
     );
   }
@@ -209,11 +208,7 @@ async function downloadWithChecksum(
   process.stderr.write(`  fetch ${asset}\n`);
   await downloadAssetById(asset, tmp, index, token);
 
-  const sha = (
-    await fetchAssetText(`${asset}.sha256`, index, token)
-  )
-    .trim()
-    .split(/\s+/)[0];
+  const sha = (await fetchAssetText(`${asset}.sha256`, index, token)).trim().split(/\s+/)[0];
   const got = sha256OfFile(tmp);
   if (sha && got !== sha) {
     unlinkSync(tmp);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,10 +14,12 @@
 //   machinen completion <bash|zsh|fish>
 //   machinen --version | -h | --help
 
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   createWriteStream,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   renameSync,
@@ -45,7 +47,13 @@ import { parseRunArgs } from "./parse-run-args.ts";
 const debug = debugLib("machinen:cli");
 
 const VERSION = pkg.version;
-const RELEASE_TAG = `@machinen/runtime@${VERSION}`;
+// Slash-free tag shape — GitHub's release web UI and the
+// `releases/download/<tag>/<asset>` URL pattern both fall over when the
+// tag itself contains a `/` (the router can't tell where the tag ends
+// and the asset path begins). The previous `@machinen/runtime@0.0.0`
+// tag created releases that the API could see but no public URL could
+// fetch from. Keep the shape `runtime-v<semver>`.
+const RELEASE_TAG = `runtime-v${VERSION}`;
 const REPO = "redwoodjs/machinen";
 const CACHE_ROOT = join(homedir(), ".machinen");
 
@@ -101,13 +109,21 @@ async function ensureBaseAssets(tag: string): Promise<string> {
 
   mkdirSync(base, { recursive: true });
 
+  // The repo is private, so the public `releases/download/<tag>/<asset>`
+  // path 404s for unauthenticated callers. Look up asset IDs once via
+  // the API (with the host's `gh auth token`) and stream each one
+  // through `releases/assets/<id>` with `Accept: application/octet-stream`,
+  // which is the same path `gh release download` uses internally.
+  const token = ghAuthToken();
+  const assetIndex = await fetchReleaseAssets(tag, token);
+
   const assets = [
     { name: "Image-arm64", dest: kernel },
     { name: "virt-arm64.dtb", dest: dtb },
     { name: "rootfs-debian-arm64.tar.gz", dest: tarball },
   ];
 
-  await Promise.all(assets.map((a) => downloadWithChecksum(tag, a.name, a.dest)));
+  await Promise.all(assets.map((a) => downloadWithChecksum(a.name, a.dest, assetIndex, token)));
 
   const current = join(CACHE_ROOT, "current");
   try {
@@ -121,21 +137,83 @@ async function ensureBaseAssets(tag: string): Promise<string> {
 }
 
 function isSymlink(p: string): boolean {
+  // lstatSync (NOT statSync) so we still detect a dangling symlink whose
+  // target was removed — `existsSync` and `statSync` both follow the
+  // link and return false in that case, leaving stale `current`
+  // symlinks in place and breaking the unlink+symlinkSync replace below.
   try {
-    return statSync(p).isSymbolicLink();
+    return lstatSync(p).isSymbolicLink();
   } catch {
     return false;
   }
 }
 
-async function downloadWithChecksum(tag: string, asset: string, dest: string): Promise<void> {
-  const base = `https://github.com/${REPO}/releases/download/${encodeURIComponent(tag)}`;
+function ghAuthToken(): string {
+  // `gh auth token` is the user-facing way to get the OAuth token —
+  // matches the project's stance of "user authenticates via gh, never
+  // raw API keys" (see CLAUDE.md). Errors loud if gh isn't installed
+  // or the user hasn't logged in: re-running with a hint is much
+  // friendlier than a downstream 401 on the API call.
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message.split("\n")[0] : String(err);
+    die(
+      `failed to read gh auth token (${msg}).\n` +
+        "  Install GitHub CLI and run \`gh auth login\` so the runtime can fetch\n" +
+        `  release assets from the private repo ${REPO}.`,
+    );
+  }
+}
+
+interface ReleaseAssetIndex {
+  byName: Map<string, number>;
+}
+
+async function fetchReleaseAssets(tag: string, token: string): Promise<ReleaseAssetIndex> {
+  const url = `https://api.github.com/repos/${REPO}/releases/tags/${encodeURIComponent(tag)}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    die(
+      `lookup release ${tag} failed: ${res.status} ${res.statusText}\n` +
+        `  url: ${url}\n` +
+        "  check that `gh auth token` returns a token with repo-read scope, and that the\n" +
+        `  release tag exists in ${REPO}.`,
+    );
+  }
+  const body = (await res.json()) as { assets?: Array<{ id: number; name: string }> };
+  const byName = new Map<string, number>();
+  for (const a of body.assets ?? []) {
+    byName.set(a.name, a.id);
+  }
+  return { byName };
+}
+
+async function downloadWithChecksum(
+  asset: string,
+  dest: string,
+  index: ReleaseAssetIndex,
+  token: string,
+): Promise<void> {
   const tmp = `${dest}.partial`;
 
   process.stderr.write(`  fetch ${asset}\n`);
-  await downloadTo(`${base}/${asset}`, tmp);
+  await downloadAssetById(asset, tmp, index, token);
 
-  const sha = (await fetchText(`${base}/${asset}.sha256`)).trim().split(/\s+/)[0];
+  const sha = (
+    await fetchAssetText(`${asset}.sha256`, index, token)
+  )
+    .trim()
+    .split(/\s+/)[0];
   const got = sha256OfFile(tmp);
   if (sha && got !== sha) {
     unlinkSync(tmp);
@@ -144,19 +222,52 @@ async function downloadWithChecksum(tag: string, asset: string, dest: string): P
   renameSync(tmp, dest);
 }
 
-async function downloadTo(url: string, dest: string): Promise<void> {
+async function downloadAssetById(
+  name: string,
+  dest: string,
+  index: ReleaseAssetIndex,
+  token: string,
+): Promise<void> {
+  const id = index.byName.get(name);
+  if (id === undefined) {
+    die(`asset not found in release: ${name}`);
+  }
   mkdirSync(dirname(dest), { recursive: true });
-  const res = await fetch(url, { redirect: "follow" });
+  const url = `https://api.github.com/repos/${REPO}/releases/assets/${id}`;
+  const res = await fetch(url, {
+    redirect: "follow",
+    headers: {
+      Accept: "application/octet-stream",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
   if (!res.ok || !res.body) {
-    die(`fetch ${url} failed: ${res.status} ${res.statusText}`);
+    die(`fetch asset ${name} failed: ${res.status} ${res.statusText}`);
   }
   await pipeline(res.body as unknown as NodeJS.ReadableStream, createWriteStream(dest));
 }
 
-async function fetchText(url: string): Promise<string> {
-  const res = await fetch(url, { redirect: "follow" });
+async function fetchAssetText(
+  name: string,
+  index: ReleaseAssetIndex,
+  token: string,
+): Promise<string> {
+  const id = index.byName.get(name);
+  if (id === undefined) {
+    die(`asset not found in release: ${name}`);
+  }
+  const url = `https://api.github.com/repos/${REPO}/releases/assets/${id}`;
+  const res = await fetch(url, {
+    redirect: "follow",
+    headers: {
+      Accept: "application/octet-stream",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
   if (!res.ok) {
-    die(`fetch ${url} failed: ${res.status} ${res.statusText}`);
+    die(`fetch asset ${name} failed: ${res.status} ${res.statusText}`);
   }
   return res.text();
 }
@@ -557,7 +668,12 @@ async function cmdSnapshot(args: string[]): Promise<number> {
   const target = parseTargetFlags(rest, "snapshot");
   const vm = await attach(target).catch(handleError);
   try {
-    const res = await vm.snapshot({ outDir: resolve(outDir) });
+    const res = await vm.snapshot({
+      outDir: resolve(outDir),
+      onLog: (evt) => {
+        process.stderr.write(evt.chunk);
+      },
+    });
     process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
     return 0;
   } catch (err) {

--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -65,6 +65,14 @@ echo "machinen-dump: preparing (pid=$DUMP_PID)"
     exit 1
 }
 
+# CRIU's kerndat_has_move_mount_set_group probe creates a throwaway dir
+# under /tmp (`/tmp/.criu.move_mount_set_group.XXXXXX`); a rootfs with
+# no /tmp (older app.tar.gz layers, minimal images) makes it fail with
+# ENOENT and aborts the dump before it touches the workload. The base
+# rootfs ships /tmp, but be defensive in case a layered image stripped it.
+mkdir -p /tmp
+chmod 1777 /tmp 2>/dev/null || true
+
 # Format the scratch disk ext4 on first use. Subsequent snapshots just
 # remount.
 # -F: force (existing data is a scratch allocation; we're overwriting).

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -21,6 +21,15 @@ export PATH
 # (TCP kerndat, IPv6 probes, etc.).
 /sbin/machinen-lo-up || echo "machinen-restore: lo-up failed" >&2
 
+# /tmp must exist for CRIU's kerndat probes (kerndat_has_move_mount_set_group
+# mkdirs `/tmp/.criu.move_mount_set_group.XXXXXX`). The base rootfs ships
+# /tmp 1777, but be defensive in case a layered image (app.tar.gz) stripped
+# it — without /tmp here, criu restore fails kerndat init, exits 1, and
+# /init dying with that exit code panics the kernel ("Attempted to kill
+# init!"), which is a much more confusing failure than a clean error.
+mkdir -p /tmp
+chmod 1777 /tmp 2>/dev/null || true
+
 # Spawn a fresh exec-agent so vm.exec / vm.snapshot work on the
 # restored VM. The original dump tree did NOT include exec-agent —
 # that was a sibling under the supervisor, not a descendant of the

--- a/packages/microvm/assets/machinen-supervisor.sh
+++ b/packages/microvm/assets/machinen-supervisor.sh
@@ -34,7 +34,32 @@ set -u
 /exec-agent </dev/null >/dev/null 2>&1 &
 AGENT_PID=$!
 
+# Spawn winsize-agent (vsock 1974, see #177) as a SIBLING of the
+# workload — never as a descendant. CRIU 3.17 has no AF_VSOCK dump
+# support; any vsock fd inside the workload tree breaks `criu dump`
+# with "BUG! Unknown socket collected (family 40)". Putting the agent
+# here, alongside exec-agent, keeps it outside `criu dump --tree
+# <workload-pid>` so snapshot just works on VMs that asked the runtime
+# to bridge in:1974. Optional — older rootfs builds (or callers that
+# didn't include the agent) just skip this. Same /dev/null teardown
+# pattern as exec-agent so workload stdout stays clean.
+WINSIZE_PID=""
+if [ -x /sbin/machinen-winsize-agent ]; then
+    /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &
+    WINSIZE_PID=$!
+fi
+
 mkdir -p /run 2>/dev/null || true
+# /tmp is required by CRIU's kerndat probes (mkdir under /tmp on every
+# `criu dump` AND `criu restore`), and by lots of other software that
+# expects a sticky-writable scratch dir. The base rootfs ships it 1777,
+# but layered images (app.tar.gz produced by provision.ts intentionally
+# excludes ./tmp) drop it on the floor — without this `machinen
+# snapshot` and any restore both fail kerndat init. Universal fix: make
+# the supervisor responsible for the directory's existence so any
+# rootfs the runtime boots gets a usable /tmp before the workload runs.
+mkdir -p /tmp /var/tmp 2>/dev/null || true
+chmod 1777 /tmp /var/tmp 2>/dev/null || true
 
 # `--session` is the legacy "run under setsid" toggle from when CRIU
 # dumps required it but interactive boots didn't. Both modes now go
@@ -86,7 +111,11 @@ trap 'kill -TERM "$(cat /run/machinen-workload.pid 2>/dev/null)" 2>/dev/null; wa
 
 wait "$PID"
 
-# Workload exited — stop the agent and power off cleanly.
+# Workload exited — stop the agents and power off cleanly.
 kill -TERM "$AGENT_PID" 2>/dev/null || true
 wait "$AGENT_PID" 2>/dev/null || true
+if [ -n "$WINSIZE_PID" ]; then
+    kill -TERM "$WINSIZE_PID" 2>/dev/null || true
+    wait "$WINSIZE_PID" 2>/dev/null || true
+fi
 exec /sbin/machinen-poweroff

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2983,7 +2983,7 @@ ms epoch when `vm.snapshot()` returned.
 
 ### BootOptions
 
-Defined in: [vm.ts:128](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L128)
+Defined in: [vm.ts:151](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L151)
 
 #### Properties
 
@@ -2991,7 +2991,7 @@ Defined in: [vm.ts:128](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L135)
+Defined in: [vm.ts:158](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L158)
 
 Path to a rootfs tarball to boot from (e.g. the output of
 `provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
@@ -3002,7 +3002,7 @@ boots and snapshot-only restores both skip initramfs packing).
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L141)
+Defined in: [vm.ts:164](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L164)
 
 Command to run inside the guest. Packed into the synthesized
 `/machinen-config.json`. Paired with `image` — both required, or
@@ -3012,7 +3012,7 @@ neither.
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:147](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L147)
+Defined in: [vm.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L170)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3022,7 +3022,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L159)
+Defined in: [vm.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L182)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3036,21 +3036,34 @@ image-baked `cwd` is overridden by this field when both are set.
 
 ##### snapshot?
 
-> `optional` **snapshot?**: `string`
+> `optional` **snapshot?**: `string` \| `false`
 
-Defined in: [vm.ts:167](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L167)
+Defined in: [vm.ts:203](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L203)
 
-Attach this host file as the scratch virtio-blk device — `/dev/vdb`
-inside the guest when `rootDisk` is also set, or `/dev/vda` when
-only this disk is attached (legacy / pre-#114 layout). Typically a
-CRIU snapshot image produced by `vm.snapshot()`, for a sub-second
-restore on boot. See #47 (virtio-blk) and #50.
+Attach a scratch virtio-blk device (`/dev/vdb`, or `/dev/vda` on
+pre-#114 layouts) so this VM can be CRIU-snapshotted later via
+`vm.snapshot()`. Three forms:
+
+  - `undefined` (default) — the runtime auto-allocates a per-boot
+    ~8 GiB sparse scratch in `tmpdir()` and unlinks it on VM exit.
+    Disk usage stays at zero until the guest writes; the upside is
+    every booted VM is snapshotable without re-booting. See #50.
+
+  - `'<path>'` — caller-managed file. Used as-is (must exist).
+    Required when restoring: pass the snapshot bundle's disk image
+    produced by a prior `vm.snapshot()`. The runtime synthesizes
+    `cmd: ['/sbin/machinen-restore']` if no other cmd is given.
+
+  - `false` — opt out entirely. No `/dev/vdb` attached. Use when
+    you don't need snapshot capability and want to skip the
+    (sparse, but still nonzero) inode allocation — typical for
+    fast-cycling test boots.
 
 ##### rootDisk?
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:189](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L189)
+Defined in: [vm.ts:225](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L225)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3076,7 +3089,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:206](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L206)
+Defined in: [vm.ts:242](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L242)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3097,7 +3110,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:213](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L213)
+Defined in: [vm.ts:249](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L249)
 
 Optional name to register this VM under (`attach({ name })`
 lookup key). Path-shaped strings ("worker/9012") are allowed.
@@ -3108,7 +3121,7 @@ Names are unique while live — `boot()` throws
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:219](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L219)
+Defined in: [vm.ts:255](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L255)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3118,7 +3131,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:233](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L233)
+Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3144,7 +3157,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
+Defined in: [vm.ts:287](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L287)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3178,7 +3191,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
+Defined in: [vm.ts:293](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L293)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3200,7 +3213,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:265](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L265)
+Defined in: [vm.ts:301](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L301)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3209,7 +3222,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:267](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L267)
+Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3217,7 +3230,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Extra argv for the VMM.
 
@@ -3225,7 +3238,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3233,7 +3246,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3241,7 +3254,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:278](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L278)
+Defined in: [vm.ts:314](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L314)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3250,7 +3263,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:283](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L283)
+Defined in: [vm.ts:319](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L319)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3259,7 +3272,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
+Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3271,7 +3284,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:949](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L949)
+Defined in: [vm.ts:1032](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1032)
 
 #### Properties
 
@@ -3279,7 +3292,7 @@ Defined in: [vm.ts:949](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:955](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L955)
+Defined in: [vm.ts:1038](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1038)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3289,7 +3302,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:957](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L957)
+Defined in: [vm.ts:1040](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1040)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3297,7 +3310,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:964](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L964)
+Defined in: [vm.ts:1047](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1047)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3308,7 +3321,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:1775](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1775)
+Defined in: [vm.ts:1967](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1967)
 
 #### Extends
 
@@ -3320,7 +3333,7 @@ Defined in: [vm.ts:1775](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:147](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L147)
+Defined in: [vm.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L170)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3334,7 +3347,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L159)
+Defined in: [vm.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L182)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3354,7 +3367,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:189](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L189)
+Defined in: [vm.ts:225](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L225)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3384,7 +3397,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:206](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L206)
+Defined in: [vm.ts:242](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L242)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3409,7 +3422,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:219](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L219)
+Defined in: [vm.ts:255](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L255)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3423,7 +3436,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:233](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L233)
+Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3453,7 +3466,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
+Defined in: [vm.ts:287](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L287)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3491,7 +3504,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
+Defined in: [vm.ts:293](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L293)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3517,7 +3530,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:265](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L265)
+Defined in: [vm.ts:301](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L301)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3530,7 +3543,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:267](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L267)
+Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3542,7 +3555,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Extra argv for the VMM.
 
@@ -3554,7 +3567,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3566,7 +3579,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3578,7 +3591,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:278](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L278)
+Defined in: [vm.ts:314](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L314)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3591,7 +3604,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:283](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L283)
+Defined in: [vm.ts:319](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L319)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3604,7 +3617,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
+Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3620,7 +3633,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:1780](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1780)
+Defined in: [vm.ts:1972](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1972)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3629,7 +3642,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:1788](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1788)
+Defined in: [vm.ts:1980](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1980)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3641,7 +3654,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1794](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1794)
+Defined in: [vm.ts:1986](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1986)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4127,7 +4140,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1585](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1585)
+Defined in: [vm.ts:1671](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1671)
 
 #### Type Declaration
 
@@ -4425,7 +4438,7 @@ PROVISION_BASE_NOT_FOUND | PROVISION_ASSETS_DIR_INVALID
 
 > **provision**(`opts`): `Promise`\<[`ProvisionResult`](#provisionresult)\>
 
-Defined in: [provision.ts:250](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L250)
+Defined in: [provision.ts:252](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L252)
 
 Boot the base rootfs, run the user install hook, and freeze the
 resulting filesystem state to a new tarball at `opts.out`.
@@ -4598,7 +4611,7 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveVmmBinary**(): `string`
 
-Defined in: [vm.ts:90](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L90)
+Defined in: [vm.ts:113](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L113)
 
 Locate the VMM binary using the same lookup order as `@machinen/cli`:
   1. `MACHINEN_VMM` env var (dev-mode override)
@@ -4620,7 +4633,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN
 
 > **boot**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:306](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L306)
+Defined in: [vm.ts:342](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L342)
 
 Boot a microVM and return a handle to interact with it.
 
@@ -4651,7 +4664,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:980](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L980)
+Defined in: [vm.ts:1063](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1063)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4683,7 +4696,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1433](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1433)
+Defined in: [vm.ts:1519](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1519)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4722,7 +4735,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1475](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1475)
+Defined in: [vm.ts:1561](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1561)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4754,7 +4767,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1813](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1813)
+Defined in: [vm.ts:2005](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2005)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -4789,7 +4802,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:1860](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1860)
+Defined in: [vm.ts:2052](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2052)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -225,13 +225,15 @@ export function resolveBaseRootfs(explicit?: string, cwd: string = process.cwd()
 
 function cliCachedRootfsPath(): string {
   // Mirrors `@machinen/cli`'s `baseDirFor(RELEASE_TAG)` where
-  // RELEASE_TAG = `@machinen/runtime@${VERSION}`.
+  // RELEASE_TAG = `runtime-v${VERSION}` (slash-free so the GitHub
+  // release URL pattern works — see the comment on RELEASE_TAG in
+  // packages/cli/src/cli.ts).
   const pkgPath = resolve(import.meta.dirname, "..", "package.json");
   const version = (JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string }).version;
   return join(
     homedir(),
     ".machinen",
-    `@machinen/runtime@${version}`,
+    `runtime-v${version}`,
     "bases",
     "debian-arm64",
     "rootfs.tar.gz",

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -29,11 +29,13 @@ import {
   constants as fsConstants,
   copyFileSync,
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   openSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -1009,15 +1011,22 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 }
 
 /**
- * Parse the UDS path out of a `MACHINEN_VSOCK` spec. Format is
- * `<direction>:<port>:<uds-path>` — we return the path portion so
- * `vm.exec()` knows where to dial. Returns undefined on unrecognized
- * shapes (caller-provided bespoke formats) so the handle can throw a
- * clear error if `.exec()` ends up called on it.
+ * Parse the UDS path out of a `MACHINEN_VSOCK` spec. The spec may be a
+ * single `<direction>:<port>:<uds-path>` entry or a comma-joined list
+ * of them (`in:1978:/a,in:1974:/b,out:1970:/c`). For attach/exec we want
+ * the FIRST `in:` entry's path — that's the exec-agent UDS the runtime
+ * just allocated (or, when the caller set MACHINEN_VSOCK explicitly,
+ * the entry they put first). Returns undefined on unrecognized shapes
+ * so the handle can throw a clear error if `.exec()` ends up called on it.
  */
 function parseVsockUdsPath(spec: string): string | undefined {
-  const match = spec.match(/^[^:]+:\d+:(.+)$/);
-  return match ? match[1] : undefined;
+  for (const entry of spec.split(",")) {
+    const match = entry.match(/^[^:]+:\d+:(.+)$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
 }
 
 export interface AttachOptions {
@@ -1758,6 +1767,35 @@ async function performSnapshot(
   // cases where /usr/bin/true (or any no-op binary) exits cleanly
   // before the dump has any effect.
   const preMtime = statSync(ctx.diskPath).mtimeMs;
+  // Hardlink the live scratch disk into the bundle BEFORE the dump
+  // dispatches. boot()'s VMM-exit handler unlinks `perBootSnapDisk`
+  // synchronously (see `child.once("exit", ...)`), and when the
+  // snapshot is driven from a different process (e.g. `machinen
+  // snapshot --name X` against a backgrounded `machinen boot`), that
+  // unlink races our `copyFileSync(diskPath, ...)` after `wait()`
+  // returns — and wins, because the boot-process handler is sync-on-exit
+  // while we're poll-based. The hardlink shares the inode so guest
+  // writes still land on the same data, but our second name keeps it
+  // alive even after the boot process drops its name. We rename the
+  // staging name to disk.img on success; on failure we unlink it.
+  // Falls back to copyFileSync at the bottom of the function if we
+  // can't link (cross-fs EXDEV — rare, since tmpdir and snapDir are
+  // usually the same fs).
+  const stagingPath = join(snapDir, "disk.img.staging");
+  let stagedViaLink = false;
+  try {
+    if (existsSync(stagingPath)) {
+      unlinkSync(stagingPath);
+    }
+    linkSync(ctx.diskPath, stagingPath);
+    stagedViaLink = true;
+    debugSnapshot("staged scratch via hardlink %s -> %s", ctx.diskPath, stagingPath);
+  } catch (err) {
+    debugSnapshot(
+      "hardlink staging skipped (%s) — falling back to post-exit copy",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
   debugSnapshot(
     "snapshot start pid=%d snapDir=%s dumpCmd=%s timeoutMs=%d diskPath=%s preMtime=%d",
     ctx.pid,
@@ -1775,13 +1813,31 @@ async function performSnapshot(
   }
 
   // Kick off the in-guest dump. The vsock connection typically closes
-  // mid-transaction as the guest powers off — `.catch(() => {})` swallows
-  // that expected tear-down; the real success signal is the VMM exit
-  // below. If the dump script fails outright before the guest powers
-  // off, the kill-timer below catches the hang.
-  void ctx
+  // mid-transaction as the guest powers off (CRIU kills the dumped tree,
+  // the supervisor poweroffs, the agent dies with it) — that path
+  // surfaces here as either a clean exit or an EXEC_AGENT_UNAVAILABLE
+  // rejection. We capture both so that on SNAPSHOT_TIMEOUT we can tell
+  // the caller whether the dump even reached the guest.
+  type DumpOutcome = { kind: "exited"; exitCode: number } | { kind: "rejected"; error: unknown };
+  let dumpOutcome: DumpOutcome | undefined;
+  const dumpDispatch = ctx
     .execRaw(dumpCmd, {
-      connectTimeoutMs: 2_000,
+      // Default exec connect is 30s. The dump runs against an
+      // already-attached, healthy VM, so we don't need that much, but
+      // 2s was tight enough to reject under load and then get silently
+      // swallowed — leaving the host to wait the full deadline for an
+      // exit that was never going to come. Bound by the snapshot
+      // deadline so a small `timeoutMs` (e.g. unit tests pointing
+      // `/usr/bin/true` at this) doesn't stall on connect retries
+      // longer than the caller is willing to wait for the whole op.
+      connectTimeoutMs: Math.min(deadlineMs, 10_000),
+      // Bound the per-call exec timeout by the snapshot deadline. Without
+      // this, a kill-timer-induced VMM SIGKILL doesn't always close the
+      // host-side vsock socket cleanly; the exec pump then sits waiting
+      // for EOF until VsockExec.run's own 5-min default fires, which
+      // means `await dumpDispatch` below blocks for up to 300s after the
+      // snapshot has already declared SNAPSHOT_TIMEOUT.
+      execTimeoutMs: deadlineMs,
       onStdout: onLog
         ? (chunk) => onLog({ source: "exec-stdout", cmd: dumpCmd, chunk })
         : undefined,
@@ -1789,7 +1845,19 @@ async function performSnapshot(
         ? (chunk) => onLog({ source: "exec-stderr", cmd: dumpCmd, chunk })
         : undefined,
     })
-    .catch(() => {});
+    .then(
+      (res) => {
+        dumpOutcome = { kind: "exited", exitCode: res.exitCode };
+        debugSnapshot("dump exec returned exitCode=%d", res.exitCode);
+      },
+      (err) => {
+        dumpOutcome = { kind: "rejected", error: err };
+        debugSnapshot(
+          "dump exec dispatch rejected: %s",
+          err instanceof Error ? err.message : String(err),
+        );
+      },
+    );
 
   let timedOut = false;
   const killTimer = setTimeout(() => {
@@ -1802,19 +1870,33 @@ async function performSnapshot(
   } finally {
     clearTimeout(killTimer);
   }
+  // The dispatch promise may still be racing the VMM exit; wait it out
+  // so the timeout/dump-failed errors below can include its outcome.
+  // `.then(_, _)` converts the rejection into a resolution, so this
+  // never throws.
+  await dumpDispatch;
   const elapsedMs = Date.now() - t0;
   const consoleLog = await ctx.errorOutput();
   debugSnapshot(
-    "guest exited elapsed=%dms consoleBytes=%d timedOut=%s",
+    "guest exited elapsed=%dms consoleBytes=%d timedOut=%s dumpOutcome=%j",
     elapsedMs,
     consoleLog.length,
     timedOut,
+    dumpOutcome,
   );
 
+  const dumpHint = formatDumpOutcomeHint(dumpOutcome);
+
   if (timedOut) {
+    if (stagedViaLink) {
+      try {
+        unlinkSync(stagingPath);
+      } catch {}
+    }
     throw new SnapshotError(
       "SNAPSHOT_TIMEOUT",
       `vm.snapshot: guest did not shut down within ${deadlineMs}ms — dump likely failed.` +
+        dumpHint +
         (consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : ""),
     );
   }
@@ -1823,19 +1905,35 @@ async function performSnapshot(
   // actually ran. `/usr/bin/true` boots, exits immediately, and the
   // VMM comes down cleanly without ever touching the disk — we don't
   // want that to pass as success. mtime delta catches it.
-  const postMtime = statSync(ctx.diskPath).mtimeMs;
+  // Post-mtime check — read via the staging hardlink when we have one
+  // (it shares the inode with `ctx.diskPath`, so the mtime is identical
+  // and survives the boot-process unlink). Falls back to the live path
+  // when staging wasn't possible.
+  const mtimeProbePath = stagedViaLink ? stagingPath : ctx.diskPath;
+  const postMtime = statSync(mtimeProbePath).mtimeMs;
   if (postMtime === preMtime) {
+    if (stagedViaLink) {
+      try {
+        unlinkSync(stagingPath);
+      } catch {}
+    }
     throw new SnapshotError(
       "SNAPSHOT_DUMP_FAILED",
       "vm.snapshot: guest exited without writing to the disk — the dump script " +
         "never ran (is /sbin/machinen-dump present in the rootfs?)." +
+        dumpHint +
         (consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : ""),
     );
   }
 
   const diskOut = join(snapDir, "disk.img");
-  debugSnapshot("copy disk %s -> %s", ctx.diskPath, diskOut);
-  copyFileSync(ctx.diskPath, diskOut);
+  if (stagedViaLink) {
+    debugSnapshot("promote staging %s -> %s", stagingPath, diskOut);
+    renameSync(stagingPath, diskOut);
+  } else {
+    debugSnapshot("copy disk %s -> %s", ctx.diskPath, diskOut);
+    copyFileSync(ctx.diskPath, diskOut);
+  }
 
   // Drop the bundle metadata next to the image so `restore({ snapDir })`
   // can recover the source name without poking at the disk.
@@ -1847,6 +1945,23 @@ async function performSnapshot(
 
   debugSnapshot("snapshot done snapDir=%s postMtime=%d", snapDir, postMtime);
   return { snapDir, diskPath: diskOut, elapsedMs, consoleLog };
+}
+
+function formatDumpOutcomeHint(
+  outcome: { kind: "exited"; exitCode: number } | { kind: "rejected"; error: unknown } | undefined,
+): string {
+  if (!outcome) {
+    return "";
+  }
+  if (outcome.kind === "rejected") {
+    const err = outcome.error;
+    const msg = err instanceof Error ? err.message : String(err);
+    return `\nDump exec dispatch failed: ${msg}`;
+  }
+  if (outcome.exitCode !== 0) {
+    return `\nDump exec exited ${outcome.exitCode} (workload kept running).`;
+  }
+  return "";
 }
 
 export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" | "cmd" | "name"> {

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -314,6 +314,17 @@ mkdir -m 0755 /work/rootfs/dev
 # `apt-get update` and any other hostname lookup will fail.
 echo "nameserver 192.168.127.1" > /work/rootfs/etc/resolv.conf
 
+# /tmp — mmdebstrap minbase doesn't always include this directory in the
+# extracted rootfs (depends on which essential packages happen to ship
+# /tmp ownership, and our path-excludes can shave it). Without a 1777
+# /tmp the guest is missing a place anyone-can-write things, and CRIU's
+# kerndat probes (run on every `criu dump` AND `criu restore` from
+# kerndat_has_move_mount_set_group on) try to mkdir
+# `/tmp/.criu.move_mount_set_group.XXXXXX` and bail with ENOENT,
+# breaking both snapshot and restore. Create it explicitly with the
+# usual sticky-write-everyone mode so any caller can rely on it.
+install -m 1777 -d /work/rootfs/tmp
+
 install -m 0755 /stage/init       /work/rootfs/init
 install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
 install -m 0755 /stage/fuse-agent /work/rootfs/fuse-agent

--- a/scripts/build-kernel-arm64.sh
+++ b/scripts/build-kernel-arm64.sh
@@ -73,7 +73,29 @@ make ARCH=arm64 defconfig >/dev/null
 # host over vsock; without VSOCKETS + virtio transport, vm.exec breaks.
 #
 # Netfilter — defensively kept for processes that hold iptables/nftables
-# state at dump time. Cheap to bake in.
+# state at dump time. NF_TABLES + NETFILTER_NETLINK alone is not enough:
+# CRIU's kerndat probes (run on every `criu dump`, not gated by flags)
+# create an `inet`-AF nftables table and a concat-typed set to verify
+# the kernel can support its restore plan. Without NF_TABLES_INET those
+# probes return EOPNOTSUPP and dump bails before doing anything. NFT_CT
+# covers connection-tracking expressions; NF_CONNTRACK is the underlying
+# subsystem any restore that touches conntrack needs. The set types
+# themselves (hash / rbtree / pipapo) are no longer separate Kconfig
+# options in 6.x — NF_TABLES_CORE selects them in.
+#
+# VETH — CRIU's kerndat also creates a throwaway veth pair via netlink to
+# verify RTM_NEWLINK. Without the veth driver this returns EOPNOTSUPP (-95)
+# and the dump fails the same way. Independent of whether the workload
+# uses veth — it's a probe.
+#
+# USERFAULTFD — CRIU's lazy-pages probe needs userfaultfd(2). Dump runs
+# without it (just emits a warning), but restore can hang attempting to
+# install pages via uffd. Built in.
+#
+# IPV6 — defconfig leaves this =m. CRIU restore walks IPv6 socket diag
+# during the network-restore phase even when the workload only used
+# IPv4, and a missing module here can hang the restore loop. Force =y
+# to match the rest of the boot-path drivers.
 #
 # FUSE — guest side of `--mount-live` (#78). Builtin so liveMounts work
 # without /init having to finit_module fuse first.
@@ -93,7 +115,11 @@ make ARCH=arm64 defconfig >/dev/null
   --enable INET_DIAG --enable NETLINK_DIAG --enable UNIX_DIAG \
   --enable INET_TCP_DIAG --enable INET_UDP_DIAG \
   --enable PACKET_DIAG --enable VSOCKETS_DIAG \
-  --enable NF_TABLES --enable NETFILTER_NETLINK \
+  --enable NF_TABLES --enable NF_TABLES_INET --enable NETFILTER_NETLINK \
+  --enable NF_CONNTRACK --enable NFT_CT \
+  --enable VETH \
+  --enable USERFAULTFD \
+  --enable IPV6 \
   --enable LIBCRC32C \
   --enable FUSE_FS \
   --enable IKCONFIG --enable IKCONFIG_PROC \
@@ -111,6 +137,12 @@ required=(
   NET_FAILOVER FAILOVER
   EXT4_FS
   VSOCKETS VIRTIO_VSOCKETS
+  VETH
+  NF_TABLES NF_TABLES_INET NETFILTER_NETLINK
+  NFT_CT
+  NF_CONNTRACK
+  USERFAULTFD
+  IPV6
 )
 for c in "${required[@]}"; do
   if ! grep -q "^CONFIG_${c}=y" .config; then

--- a/vm.ts
+++ b/vm.ts
@@ -258,7 +258,7 @@ const STAGE_BOOTSTRAP = [
   "claude() {",
   '  IS_SANDBOX=1 command claude --dangerously-skip-permissions "$@"',
   "}",
-  "if [ -d /mnt/workspace ] && [ \"$PWD\" = \"$HOME\" ]; then",
+  'if [ -d /mnt/workspace ] && [ "$PWD" = "$HOME" ]; then',
   "  cd /mnt/workspace",
   "fi",
   "EOF",

--- a/vm.ts
+++ b/vm.ts
@@ -166,10 +166,15 @@ const stdoutAny = process.stdout as NodeJS.WriteStream;
 const hostCols = stdoutAny.columns ?? 80;
 const hostRows = stdoutAny.rows ?? 24;
 
-// #177: ask the VMM to bridge AF_VSOCK port 1974 (the guest agent's
-// listen port) to a host UDS. boot()'s vsock-bridge code parses the
-// first `in:` entry to wire vm.exec(); we don't use vm.exec from this
-// script, so co-opting that slot for winsize is fine.
+// #177: ask the VMM to bridge AF_VSOCK port 1974 (winsize agent) to a
+// host UDS. We ALSO wire up port 1978 (exec-agent) so `machinen exec
+// --pid <X>` and `machinen snapshot --pid <X>` work against this VM —
+// the runtime's registry stores the FIRST entry's UDS as the socket
+// path attach handles use, so put exec first and winsize second.
+// Without this the registered socketPath was the winsize UDS, which
+// doesn't speak the exec protocol, and any exec/snapshot stalled until
+// timeout with zero output.
+const execUdsPath = join(tmpdir(), `machinen-exec-${process.pid}.sock`);
 const winsizeUdsPath = join(tmpdir(), `machinen-winsize-${process.pid}.sock`);
 const secretEnv: Record<string, string> = {
   GH_TOKEN: ghToken,
@@ -239,10 +244,23 @@ const STAGE_BOOTSTRAP = [
   // function in ~/.bashrc.machinen, sourced once from ~/.bashrc. The
   // function uses `command claude` to bypass recursion. Re-written
   // each boot so changes here propagate without manual cleanup.
+  // ~/.bashrc.machinen: claude wrapper + auto-cd into /mnt/workspace.
+  // The auto-cd lives in bashrc rather than the dev bootstrap so the
+  // EXEC'd workload's CWD stays at /home/dev (always exists in the
+  // rootfs). Snapshotting a workload whose CWD points at the live FUSE
+  // bind mount /mnt/workspace makes restore fail with "Can't open cwd"
+  // because that path doesn't exist on the restored VM (no live mount
+  // is re-attached on restore). Keeping the workload's CWD at /home/dev
+  // and pushing the convenience cd into interactive shells means
+  // snapshot/restore round-trips cleanly while the user still lands in
+  // the workspace dir on every new shell.
   'cat > "$HOME/.bashrc.machinen" <<\\EOF',
   "claude() {",
   '  IS_SANDBOX=1 command claude --dangerously-skip-permissions "$@"',
   "}",
+  "if [ -d /mnt/workspace ] && [ \"$PWD\" = \"$HOME\" ]; then",
+  "  cd /mnt/workspace",
+  "fi",
   "EOF",
   'if ! grep -q ".bashrc.machinen" "$HOME/.bashrc" 2>/dev/null; then',
   '  printf "\\n[ -f \\"\\$HOME/.bashrc.machinen\\" ] && . \\"\\$HOME/.bashrc.machinen\\"\\n" >> "$HOME/.bashrc"',
@@ -262,14 +280,18 @@ const DEV_BOOTSTRAP = [
   'if [ -n "${COLUMNS:-}" ] && [ -n "${LINES:-}" ]; then',
   '  stty cols "$COLUMNS" rows "$LINES" 2>/dev/null || true',
   "fi",
-  // #177 vsock TIOCSWINSZ agent. Reparented to PID 1 once exec replaces
-  // this shell. Vsock has no privileged-port concept so dev can bind 1974.
-  "if [ -x /sbin/machinen-winsize-agent ]; then",
-  "  /sbin/machinen-winsize-agent </dev/null >/dev/null 2>&1 &",
-  "fi",
-  "cd /mnt/workspace 2>/dev/null",
+  // #177 vsock TIOCSWINSZ agent is now spawned by /sbin/machinen-supervisor
+  // as a SIBLING of the workload (alongside /exec-agent), so its
+  // AF_VSOCK fd never appears inside the dumpable workload tree.
+  // Putting the spawn here used to make the agent a workload descendant,
+  // which broke `criu dump` ("BUG! Unknown socket collected (family 40)")
+  // and made `machinen snapshot --pid X` fail on every vm-pick'd VM.
+  // CWD stays at /home/dev (set by env above) so snapshot/restore can
+  // re-open it on the restored VM. ~/.bashrc.machinen handles the
+  // convenience cd into /mnt/workspace for interactive shells — see the
+  // STAGE_BOOTSTRAP block where that bashrc snippet is staged.
   issueNumber
-    ? `exec env IS_SANDBOX=1 claude --dangerously-skip-permissions "work on #${issueNumber}"`
+    ? `cd /mnt/workspace 2>/dev/null; exec env IS_SANDBOX=1 claude --dangerously-skip-permissions "work on #${issueNumber}"`
     : "exec bash -i",
 ].join("\n");
 const DEV_BOOTSTRAP_B64 = Buffer.from(DEV_BOOTSTRAP).toString("base64");
@@ -309,7 +331,7 @@ const vm = await boot({
   env: secretEnv,
   vmmEnv: {
     MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)),
-    MACHINEN_VSOCK: `in:1974:${winsizeUdsPath}`,
+    MACHINEN_VSOCK: `in:1978:${execUdsPath},in:1974:${winsizeUdsPath}`,
   },
   timeoutMs: null,
 });


### PR DESCRIPTION
## Problem

Taking a snapshot of a running virtual machine and restoring it from that snapshot did not work. Every attempt looked the same: the snapshot command sat silently for 90 seconds and then errored out with no useful information. Even if you got past that, the restored virtual machine would crash immediately with a kernel panic. Anyone trying to use the feature had no way to tell what was going wrong, because the command-line tool printed nothing at all while it waited.

Underneath the silent failure were several separate problems that each had to be fixed:

- The kernel we ship inside our virtual machines was missing settings that the snapshot tool checks for at the start of every run. Without them the tool gave up before it ever touched the user's workload.
- The base filesystem we ship was missing a `/tmp` directory. The snapshot tool needs `/tmp` to write throwaway files during its setup checks.
- The developer virtual machine workflow (`pnpm vm-pick`) started a small helper process as a child of the user's workload. The snapshot tool refuses to capture that helper because it uses a kind of socket the tool does not understand, which broke every snapshot of a developer virtual machine.
- The developer virtual machine wired up only one of the two communication channels with the host, so commands like `machinen exec --pid X` and `machinen snapshot --pid X` hung silently — they were trying to talk to the wrong agent inside the guest.
- The user's interactive shell started in a directory that only exists while the virtual machine is running (a live folder shared from the host). When restoring, that directory was gone and the restore aborted.

On top of all that, the command-line tool made debugging harder than it needed to be. It threw away the underlying error from the in-guest snapshot helper, and it had no way to download our pre-built kernel and filesystem from the private GitHub repository where they live.

## Solution

After this change, you can run `pnpm machinen install`, `pnpm vm-pick --scratch`, `pnpm machinen snapshot --pid <id> --out-dir t1`, and `pnpm machinen restore t1 --name r` on a fresh checkout with nothing but a logged-in `gh` command, and it works end-to-end.

The changes group into five areas:

1. **Kernel and base filesystem.** Turn on the kernel settings the snapshot tool checks for, and ship a `/tmp` directory in the base filesystem. Both are pinned in the build scripts so a future change cannot silently take them away.
2. **Guest helper scripts.** The supervisor that runs as process 1 inside every virtual machine now creates `/tmp` itself if it is missing, and it now starts the window-size helper as a sibling of the user's workload instead of a child. That keeps the helper outside the set of processes the snapshot tool tries to capture.
3. **Snapshot mechanics in the runtime.** When the in-guest snapshot helper fails, the runtime now captures and reports the reason instead of letting the user stare at a 90-second silence. The snapshot file is hardlinked into the destination directory before the dump starts, which prevents a race between the dump finishing and the original boot process cleaning up. The wait on the in-guest helper is bounded by the snapshot's own deadline, so the worst case stays at 90 seconds instead of slipping out to 5 minutes.
4. **Command-line tool.** The snapshot command now streams the live output from inside the virtual machine to your terminal, so you can see what is happening. The first-run setup that downloads the kernel and filesystem from GitHub now uses your local `gh` login (via `gh auth token`) and the GitHub API, so it works against private repositories too. The release tag was renamed to a form GitHub's URL routing can handle.
5. **Developer virtual machine glue (`vm.ts`).** Wire up both host-to-guest communication channels, so attaching to a developer virtual machine works. The user's shell now starts in their home directory and only changes into `/mnt/workspace` from inside `~/.bashrc.machinen`, so a snapshot does not capture a directory that will not exist on restore.
