### PR TITLE
fix(microvm): pre-flight reject raw IP sockets before CRIU dump

### DIFF
--- a/packages/microvm/assets/machinen-dump-preflight.sh
+++ b/packages/microvm/assets/machinen-dump-preflight.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# /sbin/machinen-dump-preflight — pre-flight checks run by
+# /sbin/machinen-dump before it hands off to `criu dump`. Lives in its
+# own file so the logic can be unit-tested against a synthetic /proc
+# tree without booting a VM (see dump-preflight.test.ts).
+#
+# Sourceable + executable:
+#   - sourced from machinen-dump.sh (defines the function, no side
+#     effects from the body),
+#   - or invoked directly: `machinen-dump-preflight <root-pid>` runs
+#     the function and exits with its status — that's the path the
+#     unit test exercises.
+#
+# Both paths read /proc by default. Tests override via $PROC.
+
+# Refuse to dump trees that hold raw IP sockets. CRIU has no encoder
+# for SOCK_RAW of any IPPROTO_* (sk-inet.c rejects with "Unsupported
+# proto N for socket M" deep in the dumper, which is unactionable
+# without reading the source). Catch them up front and emit a
+# pid+fd+ipproto line so the user can find and close the offending fd.
+#
+# Unprivileged ping sockets (SOCK_DGRAM / IPPROTO_ICMP) live in
+# /proc/net/icmp{,6} and are explicitly NOT scanned — CRIU 3.17+
+# supports those, and machinen-netup widens net.ipv4.ping_group_range
+# at boot so iputils-ping uses that path by default (#203).
+scan_raw_inet_sockets() {
+    root=$1
+    proc=${PROC:-/proc}
+
+    # BFS the descendant tree using /proc/<pid>/task/<pid>/children —
+    # the kernel's authoritative list of immediate children, so we
+    # don't have to scan all of /proc and parse PPIDs out of stat.
+    pids="$root"
+    frontier="$root"
+    while [ -n "$frontier" ]; do
+        next=""
+        for p in $frontier; do
+            if [ -r "$proc/$p/task/$p/children" ]; then
+                kids=$(cat "$proc/$p/task/$p/children" 2>/dev/null) || kids=""
+                for k in $kids; do
+                    pids="$pids $k"
+                    next="$next $k"
+                done
+            fi
+        done
+        frontier=$next
+    done
+
+    bad=""
+    for pid in $pids; do
+        [ -d "$proc/$pid/fd" ] || continue
+        # Per-pid net view in case anything in the tree unshare'd a
+        # network namespace; raw sockets there wouldn't appear in the
+        # init netns's /proc/net/raw.
+        map=""
+        for f in "$proc/$pid/net/raw" "$proc/$pid/net/raw6"; do
+            [ -r "$f" ] || continue
+            entries=$(awk 'NR>1 { split($2,a,":"); printf "%s %s\n", $10, a[2] }' "$f")
+            [ -n "$entries" ] && map="$map
+$entries"
+        done
+        [ -z "$map" ] && continue
+
+        for fd in "$proc/$pid"/fd/*; do
+            [ -L "$fd" ] || continue
+            tgt=$(readlink "$fd" 2>/dev/null) || continue
+            case "$tgt" in
+                "socket:["*"]")
+                    inode=${tgt#socket:\[}
+                    inode=${inode%\]}
+                    hex=$(printf '%s\n' "$map" | awk -v i="$inode" '$1==i {print $2; exit}')
+                    if [ -n "$hex" ]; then
+                        proto=$(printf '%d' "0x$hex" 2>/dev/null) || proto="0x$hex"
+                        bad="$bad
+  pid=$pid fd=${fd##*/} ipproto=$proto"
+                    fi
+                    ;;
+            esac
+        done
+    done
+
+    if [ -n "$bad" ]; then
+        cat >&2 <<EOF
+machinen-dump: workload holds raw IP socket(s) — CRIU has no encoder
+  for SOCK_RAW and the dump would fail with "Unsupported proto N":$bad
+machinen-dump: close the offending fd(s) before snapshot. The
+  unprivileged ping path (SOCK_DGRAM / IPPROTO_ICMP) IS supported —
+  use it instead of SOCK_RAW where possible.
+EOF
+        return 1
+    fi
+    return 0
+}
+
+# When invoked directly (not sourced), run the scan against $1. dash
+# doesn't expose `BASH_SOURCE`, so we use the convention of comparing
+# $0's basename — when sourced, $0 is whatever sourced us.
+case "${0##*/}" in
+    machinen-dump-preflight|machinen-dump-preflight.sh)
+        if [ "$#" -ne 1 ]; then
+            echo "usage: machinen-dump-preflight <root-pid>" >&2
+            exit 2
+        fi
+        scan_raw_inet_sockets "$1"
+        exit $?
+        ;;
+esac

--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -57,6 +57,14 @@ esac
 
 echo "machinen-dump: preparing (pid=$DUMP_PID)"
 
+# Pre-flight: refuse to dump trees that hold raw IP sockets, etc.
+# Logic lives in machinen-dump-preflight.sh so it can be unit-tested
+# against a synthetic /proc tree without booting a VM.
+. /sbin/machinen-dump-preflight
+if ! scan_raw_inet_sockets "$DUMP_PID"; then
+    exit 1
+fi
+
 # CRIU's kerndat_tcp_repair probe fails with ENETUNREACH if `lo` is
 # still DOWN. /init doesn't bring it up; we do it here so snapshot is
 # self-contained.

--- a/packages/runtime/src/__tests__/dump-preflight.test.ts
+++ b/packages/runtime/src/__tests__/dump-preflight.test.ts
@@ -1,0 +1,220 @@
+// Unit test for /sbin/machinen-dump-preflight — the in-guest scan that
+// runs before `criu dump` and refuses trees holding raw IP sockets
+// (CRIU has no encoder for SOCK_RAW of any IPPROTO_*, so dumping such
+// a tree fails deep in sk-inet.c with "Unsupported proto N for socket
+// M"). Exercises the script directly under dash against a synthetic
+// /proc tree built in a tmpdir; no VM boot needed.
+//
+// Skips when /bin/dash isn't present (we ship the helper as a POSIX
+// /bin/sh script and want test parity with the in-guest interpreter).
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const preflight = resolve(
+  import.meta.dirname,
+  "../../../microvm/assets/machinen-dump-preflight.sh",
+);
+
+function hasDash(): boolean {
+  try {
+    execFileSync("/bin/dash", ["-c", "true"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Build a synthetic /proc with the given pid layout. Returns the path
+// to use as $PROC. The caller is responsible for rmSync-ing the
+// returned tmpdir's root.
+type FakePid = {
+  pid: number;
+  children?: number[];
+  // fds: numeric fd → readlink target (e.g. "socket:[5648]" or
+  // "/dev/null"). Anything not starting with "socket:" is wired up as
+  // a symlink to /dev/null so [ -L ] passes.
+  fds?: Record<number, string>;
+  // Lines to drop into /proc/<pid>/net/raw (excluding the header,
+  // which we synthesize). Each line is the raw kernel format, only
+  // the local_address ($2) and inode ($10) fields actually matter.
+  rawLines?: string[];
+  raw6Lines?: string[];
+};
+
+function buildProc(root: string, pids: FakePid[]): string {
+  const procRoot = join(root, "proc");
+  mkdirSync(procRoot, { recursive: true });
+  for (const p of pids) {
+    const base = join(procRoot, String(p.pid));
+    mkdirSync(join(base, "task", String(p.pid)), { recursive: true });
+    mkdirSync(join(base, "fd"), { recursive: true });
+    mkdirSync(join(base, "net"), { recursive: true });
+
+    writeFileSync(
+      join(base, "task", String(p.pid), "children"),
+      (p.children ?? []).map(String).join(" ") + (p.children?.length ? "\n" : ""),
+    );
+
+    for (const [fd, target] of Object.entries(p.fds ?? {})) {
+      // For "socket:[N]" targets we still need readlink to return the
+      // string. Linux exposes these via symlinks whose link-target IS
+      // the literal "socket:[N]" — readlink reports it verbatim. Plain
+      // POSIX symlinks behave the same: the link target is whatever
+      // string we pass. So we can just symlink to the literal value.
+      symlinkSync(target, join(base, "fd", fd));
+    }
+
+    const rawHeader =
+      "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops\n";
+    writeFileSync(
+      join(base, "net", "raw"),
+      rawHeader + (p.rawLines ?? []).join("\n") + (p.rawLines?.length ? "\n" : ""),
+    );
+    writeFileSync(
+      join(base, "net", "raw6"),
+      rawHeader + (p.raw6Lines ?? []).join("\n") + (p.raw6Lines?.length ? "\n" : ""),
+    );
+  }
+  return procRoot;
+}
+
+// Build a /proc/net/raw line for an inode + IPPROTO. The kernel format
+// stuffs the protocol into the "remote port" half of $2 (local_address),
+// uppercase hex, two digits.
+function rawLine(inode: number, ipproto: number): string {
+  const hex = ipproto.toString(16).toUpperCase().padStart(4, "0");
+  return `   0: 00000000:${hex} 00000000:0000 07 00000000:00000000 00:00000000 00000000     0        0  ${inode} 2 ffffffff 0`;
+}
+
+function runPreflight(procRoot: string, rootPid: number) {
+  return spawnSync("/bin/dash", [preflight, String(rootPid)], {
+    encoding: "utf8",
+    env: { ...process.env, PROC: procRoot },
+  });
+}
+
+describe("machinen-dump-preflight", () => {
+  if (!hasDash()) {
+    it.skip("requires /bin/dash", () => {});
+    return;
+  }
+
+  it("passes when no descendant holds a raw IP socket", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-clean-"));
+    try {
+      const procRoot = buildProc(root, [
+        { pid: 100, children: [200] },
+        // pid 200 holds a regular fd to /dev/null — readlink target
+        // doesn't start with "socket:[", so the scanner ignores it.
+        { pid: 200, fds: { 3: "/dev/null" } },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status, `stdout=${r.stdout}\nstderr=${r.stderr}`).toBe(0);
+      expect(r.stderr).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a raw-ICMP socket on a descendant pid with pid+fd+ipproto", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-raw-icmp-"));
+    try {
+      const procRoot = buildProc(root, [
+        { pid: 100, children: [200] },
+        {
+          pid: 200,
+          fds: { 5: "socket:[5648]" },
+          rawLines: [rawLine(5648, 1)], // IPPROTO_ICMP
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/raw IP socket/);
+      expect(r.stderr).toMatch(/pid=200 fd=5 ipproto=1/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags raw sockets of other IPPROTO_* values too (e.g. IPPROTO_TCP=6)", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-raw-tcp-"));
+    try {
+      const procRoot = buildProc(root, [
+        {
+          pid: 100,
+          fds: { 7: "socket:[12345]" },
+          rawLines: [rawLine(12345, 6)],
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/pid=100 fd=7 ipproto=6/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores socket fds whose inode is not in /proc/net/raw{,6}", () => {
+    // Specifically: a SOCK_DGRAM/IPPROTO_ICMP "ping" socket lives in
+    // /proc/net/icmp, NOT /proc/net/raw — CRIU 3.17+ supports it, so
+    // the scan must NOT flag it.
+    const root = mkdtempSync(join(tmpdir(), "preflight-ping-ok-"));
+    try {
+      const procRoot = buildProc(root, [
+        {
+          pid: 100,
+          fds: { 9: "socket:[7777]" },
+          // /proc/net/raw is empty — the inode 7777 is not a raw socket.
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status, `stderr=${r.stderr}`).toBe(0);
+      expect(r.stderr).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("walks deep descendant trees, not just direct children", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-deep-"));
+    try {
+      const procRoot = buildProc(root, [
+        { pid: 100, children: [200] },
+        { pid: 200, children: [300] },
+        {
+          pid: 300,
+          fds: { 4: "socket:[42]" },
+          rawLines: [rawLine(42, 1)],
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/pid=300 fd=4 ipproto=1/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles raw6 (IPv6 raw sockets)", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-raw6-"));
+    try {
+      const procRoot = buildProc(root, [
+        {
+          pid: 100,
+          fds: { 6: "socket:[314]" },
+          // ICMPv6 = 58 (0x3A); use the IPv6 file.
+          raw6Lines: [rawLine(314, 58)],
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/pid=100 fd=6 ipproto=58/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -190,10 +190,12 @@ chmod +x "${STAGE}/fnm"
 # Stage the shell-script helpers that implement the snapshot contract
 # (supervisor, dump, restore). They end up under /sbin/machinen-* inside
 # the guest — see the `install -m 0755` block further down.
-cp "${ASSETS}/machinen-supervisor.sh" "${STAGE}/machinen-supervisor.sh"
-cp "${ASSETS}/machinen-dump.sh"       "${STAGE}/machinen-dump.sh"
-cp "${ASSETS}/machinen-restore.sh"    "${STAGE}/machinen-restore.sh"
-chmod +x "${STAGE}/machinen-supervisor.sh" "${STAGE}/machinen-dump.sh" "${STAGE}/machinen-restore.sh"
+cp "${ASSETS}/machinen-supervisor.sh"      "${STAGE}/machinen-supervisor.sh"
+cp "${ASSETS}/machinen-dump.sh"            "${STAGE}/machinen-dump.sh"
+cp "${ASSETS}/machinen-dump-preflight.sh"  "${STAGE}/machinen-dump-preflight.sh"
+cp "${ASSETS}/machinen-restore.sh"         "${STAGE}/machinen-restore.sh"
+chmod +x "${STAGE}/machinen-supervisor.sh" "${STAGE}/machinen-dump.sh" \
+         "${STAGE}/machinen-dump-preflight.sh" "${STAGE}/machinen-restore.sh"
 
 # ------------------------------------------------------------
 # 4. Rootfs — mmdebstrap minbase + aggressive strip + guest binaries
@@ -337,9 +339,10 @@ install -m 0755 -D /stage/winsize-agent     /work/rootfs/sbin/machinen-winsize-a
 install -m 0755 -D /stage/fnm               /work/rootfs/usr/local/bin/fnm
 # Shell-script helpers that drive the snapshot/restore contract. Staged
 # in by the host-side build step alongside the zig binaries.
-install -m 0755 -D /stage/machinen-supervisor.sh /work/rootfs/sbin/machinen-supervisor
-install -m 0755 -D /stage/machinen-dump.sh       /work/rootfs/sbin/machinen-dump
-install -m 0755 -D /stage/machinen-restore.sh    /work/rootfs/sbin/machinen-restore
+install -m 0755 -D /stage/machinen-supervisor.sh     /work/rootfs/sbin/machinen-supervisor
+install -m 0755 -D /stage/machinen-dump.sh           /work/rootfs/sbin/machinen-dump
+install -m 0755 -D /stage/machinen-dump-preflight.sh /work/rootfs/sbin/machinen-dump-preflight
+install -m 0755 -D /stage/machinen-restore.sh        /work/rootfs/sbin/machinen-restore
 
 # Deterministic tar + gzip written as a single file to the bind mount.
 tar --sort=name --owner=0 --group=0 --numeric-owner \


### PR DESCRIPTION
## Problem

CRIU's `sk-inet.c` has no encoder for `SOCK_RAW` of any `IPPROTO_*`. When a workload in the dumped tree holds a raw IP socket (e.g. root-running `ping` that bypasses the `ping_group_range` path, `traceroute -I`, `mtr`, `hping3`), the dump fails deep inside CRIU with `Unsupported proto N for socket M` — a message that's unactionable without reading the CRIU source, and that surfaces to the caller as a generic `SNAPSHOT_TIMEOUT` with the cryptic line buried in the console tail.

`SOCK_DGRAM`/`IPPROTO_ICMP` "ping" sockets are NOT this problem — those live in `/proc/net/icmp{,6}`, are supported by CRIU 3.17+, and `machinen-netup` already widens `ping_group_range` at boot (#203) so iputils-ping uses that supported path by default. The failure is specifically the raw variant.

## Solution

New `/sbin/machinen-dump-preflight` runs before `criu dump`. It walks the descendant tree of the workload pid, intersects every socket fd against `/proc/<pid>/net/raw{,6}`, and on a match aborts with a clear `pid=N fd=M ipproto=K` line plus a one-sentence remediation hint. `/proc/net/icmp{,6}` is explicitly not scanned, so legitimate ping sockets pass through.

The helper lives in its own sourceable + executable shell file with a `$PROC` env-var override, so the scan logic can be exercised against synthetic `/proc` trees without booting a VM. `machinen-dump.sh` sources it and calls `scan_raw_inet_sockets "$DUMP_PID"`.

A pre-flight failure leaves the workload alive (no criu invocation), so the supervisor's `wait` keeps blocking and the host's existing kill-timer fires — caller sees the established `SNAPSHOT_TIMEOUT` / `SNAPSHOT_DUMP_FAILED` path with the new friendly stderr line in the console tail. No host-side TS changes needed.

## Summary

- New `packages/microvm/assets/machinen-dump-preflight.sh` — sourceable + executable, reads `${PROC:-/proc}` so it's testable without a VM.
- `packages/microvm/assets/machinen-dump.sh` — sources the helper and calls it before `criu dump`.
- `scripts/build-base-assets.sh` — stages and installs the new helper at `/sbin/machinen-dump-preflight`.
- Note: rootfs needs a rebuild via `scripts/build-base-assets.sh` for the in-guest path to pick up the new helper.
