### PR TITLE
fix: CRIU pre-flight catches ping sockets, plus smoke + boot-test fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,11 @@ Before completing any work, you MUST run and pass:
 
 1. Unit tests: `npx vitest run`
 2. Workflows: `npx agent-ci run --all -q -p`
+3. Smoke tests: `pnpm smoke-tests` — end-to-end VM boot/exec/snapshot
+   coverage the unit suite can't reach. Treat as a peer of 1 and 2;
+   don't report work done while it's red.
 
-If either fails, fix the issue and re-run. Do not tell the user work is done until both pass.
+If any of the three fails, fix the issue and re-run.
 
 ## CI
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -698,10 +698,14 @@ async function cmdAttach(args: string[]): Promise<number> {
     }
   }
   const target = parseTargetFlags(filtered, "attach");
+  // Resolve the target before the TTY check: a typo in --name should
+  // surface "no running VM found", not the TTY error. The TTY error
+  // is only useful once we know the VM exists.
+  const vm = await attach(target).catch(handleError);
   if (!process.stdin.isTTY) {
+    await vm.detach();
     die("machinen attach: stdin is not a TTY (pipe scripts via `machinen repl` instead)");
   }
-  const vm = await attach(target).catch(handleError);
   process.stderr.write(`attached to ${vm.name ?? `pid ${vm.pid}`} — exit the shell to detach.\n`);
   try {
     return await runPtyExec(vm, shell);

--- a/packages/microvm/assets/machinen-dump-preflight.sh
+++ b/packages/microvm/assets/machinen-dump-preflight.sh
@@ -13,16 +13,24 @@
 #
 # Both paths read /proc by default. Tests override via $PROC.
 
-# Refuse to dump trees that hold raw IP sockets. CRIU has no encoder
-# for SOCK_RAW of any IPPROTO_* (sk-inet.c rejects with "Unsupported
-# proto N for socket M" deep in the dumper, which is unactionable
-# without reading the source). Catch them up front and emit a
-# pid+fd+ipproto line so the user can find and close the offending fd.
+# Refuse to dump trees that hold ICMP sockets — both SOCK_RAW (any
+# IPPROTO_*) and SOCK_DGRAM (the "unprivileged ping" path,
+# IPPROTO_ICMP{,V6}). CRIU 3.17.1 (Debian 12's package) rejects both
+# in `can_dump_ipproto` (criu/sk-inet.c:128) with "Unsupported proto N
+# for socket M": SOCK_RAW with non-{IP,TCP,UDP,UDPLITE} fails the
+# proto switch, and SOCK_DGRAM IPPROTO_ICMP fails for the same reason
+# because IPPROTO_ICMP isn't in 3.17.1's allowed set. Upstream master
+# added IPPROTO_ICMP/ICMPV6 to the switch, but the Debian build we
+# ship doesn't have that yet, so we have to be conservative.
 #
-# Unprivileged ping sockets (SOCK_DGRAM / IPPROTO_ICMP) live in
-# /proc/net/icmp{,6} and are explicitly NOT scanned — CRIU 3.17+
-# supports those, and machinen-netup widens net.ipv4.ping_group_range
-# at boot so iputils-ping uses that path by default (#203).
+# `machinen-netup` widens net.ipv4.ping_group_range at boot so
+# iputils-ping uses SOCK_DGRAM IPPROTO_ICMP by default (#203). That
+# means a workload that ran `ping` and held the socket open is the
+# common trigger for the failure mode this guard catches.
+#
+# Catch the offenders up front and emit a pid+fd+ipproto line so the
+# user can find and close the fd. Both SOCK_RAW and SOCK_DGRAM ICMP
+# variants surface here.
 scan_raw_inet_sockets() {
     root=$1
     proc=${PROC:-/proc}
@@ -52,6 +60,15 @@ scan_raw_inet_sockets() {
         # Per-pid net view in case anything in the tree unshare'd a
         # network namespace; raw sockets there wouldn't appear in the
         # init netns's /proc/net/raw.
+        #
+        # /proc/net/{raw,raw6}  → SOCK_RAW; col 2's right half is the
+        #                          IPPROTO_*. CRIU rejects all of these.
+        # /proc/net/{icmp,icmp6} → SOCK_DGRAM IPPROTO_ICMP{,V6}
+        #                          ("unprivileged ping"); CRIU 3.17.1
+        #                          rejects these too. col 2's right
+        #                          half is the source port (not proto)
+        #                          for icmp{,6}, so we hardcode the
+        #                          proto in the map.
         map=""
         for f in "$proc/$pid/net/raw" "$proc/$pid/net/raw6"; do
             [ -r "$f" ] || continue
@@ -59,6 +76,18 @@ scan_raw_inet_sockets() {
             [ -n "$entries" ] && map="$map
 $entries"
         done
+        # icmp = 1 (0x01), icmp6 = 58 (0x3A). Hex to match the raw-side
+        # encoding so the consumer below can treat both maps uniformly.
+        if [ -r "$proc/$pid/net/icmp" ]; then
+            entries=$(awk 'NR>1 { printf "%s 0001\n", $10 }' "$proc/$pid/net/icmp")
+            [ -n "$entries" ] && map="$map
+$entries"
+        fi
+        if [ -r "$proc/$pid/net/icmp6" ]; then
+            entries=$(awk 'NR>1 { printf "%s 003A\n", $10 }' "$proc/$pid/net/icmp6")
+            [ -n "$entries" ] && map="$map
+$entries"
+        fi
         [ -z "$map" ] && continue
 
         for fd in "$proc/$pid"/fd/*; do
@@ -81,11 +110,12 @@ $entries"
 
     if [ -n "$bad" ]; then
         cat >&2 <<EOF
-machinen-dump: workload holds raw IP socket(s) — CRIU has no encoder
-  for SOCK_RAW and the dump would fail with "Unsupported proto N":$bad
-machinen-dump: close the offending fd(s) before snapshot. The
-  unprivileged ping path (SOCK_DGRAM / IPPROTO_ICMP) IS supported —
-  use it instead of SOCK_RAW where possible.
+machinen-dump: workload holds ICMP/raw IP socket(s) — CRIU 3.17.1
+  rejects these in can_dump_ipproto (sk-inet.c:128) and the dump
+  would fail with "Unsupported proto N":$bad
+machinen-dump: close the offending fd(s) before snapshot. iputils-ping
+  uses SOCK_DGRAM/IPPROTO_ICMP via ping_group_range (#203); a recent
+  \`ping\` whose socket is still open is the common trigger.
 EOF
         return 1
     fi

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3284,7 +3284,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:1050](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1050)
+Defined in: [vm.ts:1079](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1079)
 
 #### Properties
 
@@ -3292,7 +3292,7 @@ Defined in: [vm.ts:1050](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1056](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1056)
+Defined in: [vm.ts:1085](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1085)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3302,7 +3302,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1058](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1058)
+Defined in: [vm.ts:1087](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1087)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3310,7 +3310,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1065](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1065)
+Defined in: [vm.ts:1094](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1094)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3321,7 +3321,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:1985](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1985)
+Defined in: [vm.ts:2014](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2014)
 
 #### Extends
 
@@ -3633,7 +3633,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:1990](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1990)
+Defined in: [vm.ts:2019](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2019)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3642,7 +3642,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:1998](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1998)
+Defined in: [vm.ts:2027](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2027)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3654,7 +3654,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2004](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2004)
+Defined in: [vm.ts:2033](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2033)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4140,7 +4140,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1689](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1689)
+Defined in: [vm.ts:1718](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1718)
 
 #### Type Declaration
 
@@ -4664,7 +4664,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1081](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1081)
+Defined in: [vm.ts:1110](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1110)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4696,7 +4696,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1537](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1537)
+Defined in: [vm.ts:1566](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1566)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4735,7 +4735,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1579](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1579)
+Defined in: [vm.ts:1608](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1608)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4767,7 +4767,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2023](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2023)
+Defined in: [vm.ts:2052](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2052)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -4802,7 +4802,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2070](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2070)
+Defined in: [vm.ts:2099](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2099)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/dump-preflight.test.ts
+++ b/packages/runtime/src/__tests__/dump-preflight.test.ts
@@ -180,7 +180,7 @@ describe("machinen-dump-preflight", () => {
     }
   });
 
-  it("flags SOCK_DGRAM/IPPROTO_ICMP \"ping\" sockets (CRIU 3.17.1 rejects them)", () => {
+  it('flags SOCK_DGRAM/IPPROTO_ICMP "ping" sockets (CRIU 3.17.1 rejects them)', () => {
     // CRIU 3.17.1's can_dump_ipproto (criu/sk-inet.c:128) only allows
     // non-SOCK_RAW sockets with proto ∈ {IP, TCP, UDP, UDPLITE}, so a
     // SOCK_DGRAM/IPPROTO_ICMP socket — what iputils-ping uses by

--- a/packages/runtime/src/__tests__/dump-preflight.test.ts
+++ b/packages/runtime/src/__tests__/dump-preflight.test.ts
@@ -43,6 +43,12 @@ type FakePid = {
   // the local_address ($2) and inode ($10) fields actually matter.
   rawLines?: string[];
   raw6Lines?: string[];
+  // /proc/<pid>/net/icmp{,6} entries — SOCK_DGRAM IPPROTO_ICMP{,V6}
+  // ("unprivileged ping" sockets). Same kernel layout as raw, but
+  // col 2's right half is the source port instead of the proto, so
+  // only $10 (inode) is consulted by the scanner.
+  icmpLines?: string[];
+  icmp6Lines?: string[];
 };
 
 function buildProc(root: string, pids: FakePid[]): string {
@@ -78,6 +84,14 @@ function buildProc(root: string, pids: FakePid[]): string {
       join(base, "net", "raw6"),
       rawHeader + (p.raw6Lines ?? []).join("\n") + (p.raw6Lines?.length ? "\n" : ""),
     );
+    writeFileSync(
+      join(base, "net", "icmp"),
+      rawHeader + (p.icmpLines ?? []).join("\n") + (p.icmpLines?.length ? "\n" : ""),
+    );
+    writeFileSync(
+      join(base, "net", "icmp6"),
+      rawHeader + (p.icmp6Lines ?? []).join("\n") + (p.icmp6Lines?.length ? "\n" : ""),
+    );
   }
   return procRoot;
 }
@@ -88,6 +102,14 @@ function buildProc(root: string, pids: FakePid[]): string {
 function rawLine(inode: number, ipproto: number): string {
   const hex = ipproto.toString(16).toUpperCase().padStart(4, "0");
   return `   0: 00000000:${hex} 00000000:0000 07 00000000:00000000 00:00000000 00000000     0        0  ${inode} 2 ffffffff 0`;
+}
+
+// Build a /proc/net/icmp{,6} line for an inode. The right half of $2
+// is the source port for these (not the protocol); the scanner ignores
+// it and hardcodes the proto based on which file the entry came from.
+function icmpLine(inode: number, srcPort: number = 0): string {
+  const portHex = srcPort.toString(16).toUpperCase().padStart(4, "0");
+  return `   0: 00000000:${portHex} 00000000:0000 07 00000000:00000000 00:00000000 00000000     0        0  ${inode} 2 ffffffff 0`;
 }
 
 function runPreflight(procRoot: string, rootPid: number) {
@@ -158,17 +180,56 @@ describe("machinen-dump-preflight", () => {
     }
   });
 
-  it("ignores socket fds whose inode is not in /proc/net/raw{,6}", () => {
-    // Specifically: a SOCK_DGRAM/IPPROTO_ICMP "ping" socket lives in
-    // /proc/net/icmp, NOT /proc/net/raw — CRIU 3.17+ supports it, so
-    // the scan must NOT flag it.
-    const root = mkdtempSync(join(tmpdir(), "preflight-ping-ok-"));
+  it("flags SOCK_DGRAM/IPPROTO_ICMP \"ping\" sockets (CRIU 3.17.1 rejects them)", () => {
+    // CRIU 3.17.1's can_dump_ipproto (criu/sk-inet.c:128) only allows
+    // non-SOCK_RAW sockets with proto ∈ {IP, TCP, UDP, UDPLITE}, so a
+    // SOCK_DGRAM/IPPROTO_ICMP socket — what iputils-ping uses by
+    // default once machinen-netup widens ping_group_range (#203) —
+    // makes the dump fail. The scanner reports it as ipproto=1.
+    const root = mkdtempSync(join(tmpdir(), "preflight-ping-icmp-"));
     try {
       const procRoot = buildProc(root, [
         {
           pid: 100,
           fds: { 9: "socket:[7777]" },
-          // /proc/net/raw is empty — the inode 7777 is not a raw socket.
+          icmpLines: [icmpLine(7777)],
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/pid=100 fd=9 ipproto=1/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags SOCK_DGRAM/IPPROTO_ICMPV6 ping sockets via /proc/net/icmp6", () => {
+    const root = mkdtempSync(join(tmpdir(), "preflight-ping-icmp6-"));
+    try {
+      const procRoot = buildProc(root, [
+        {
+          pid: 100,
+          fds: { 8: "socket:[8888]" },
+          icmp6Lines: [icmpLine(8888)],
+        },
+      ]);
+      const r = runPreflight(procRoot, 100);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/pid=100 fd=8 ipproto=58/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores socket fds whose inode is in none of raw/raw6/icmp/icmp6", () => {
+    // E.g. a TCP socket — listed in /proc/net/tcp, which the scanner
+    // doesn't read (CRIU handles TCP fine). Must pass through.
+    const root = mkdtempSync(join(tmpdir(), "preflight-tcp-ok-"));
+    try {
+      const procRoot = buildProc(root, [
+        {
+          pid: 100,
+          fds: { 9: "socket:[7777]" },
         },
       ]);
       const r = runPreflight(procRoot, 100);

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -460,22 +460,32 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     if (!existsSync(bundleDisk)) {
       throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${bundleDisk}`);
     }
-    // Reflink-clone the bundle disk into a per-boot path so the
-    // restored VM can be snapshotted again (#207). machinen-dump
-    // mkfs's the scratch disk on every dump; without the clone, the
-    // second snapshot would corrupt the parent bundle on the host fs.
-    // Same pattern as #121 for the rootdisk: COPYFILE_FICLONE → cheap
-    // shared blocks until guest writes, falls back to a full copy on
-    // non-reflink filesystems.
-    const perBoot = join(
-      tmpdir(),
-      `machinen-snap-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-    );
-    copyFileSync(bundleDisk, perBoot, fsConstants.COPYFILE_FICLONE);
-    diskAbs = perBoot;
-    perBootSnapDisk = perBoot;
-    env.MACHINEN_DISK = perBoot;
-    debug("snap-restore reflink-clone src=%s dst=%s", bundleDisk, perBoot);
+    // An explicit `cmd` means the caller is running their own workload
+    // (e.g. provision()'s tar-to-/dev/vdb dump), not restoring a CRIU
+    // bundle — so attach the disk in place. The reflink-clone below is
+    // only needed for the restore path, where machinen-dump.sh later
+    // mkfs's the scratch disk and would otherwise corrupt the source
+    // bundle on the host fs (#207).
+    if (opts.cmd) {
+      diskAbs = bundleDisk;
+      env.MACHINEN_DISK = bundleDisk;
+      debug("snap-restore in-place (explicit cmd) path=%s", bundleDisk);
+    } else {
+      // Reflink-clone the bundle disk into a per-boot path so the
+      // restored VM can be snapshotted again (#207). Same pattern as
+      // #121 for the rootdisk: COPYFILE_FICLONE → cheap shared blocks
+      // until guest writes, falls back to a full copy on non-reflink
+      // filesystems.
+      const perBoot = join(
+        tmpdir(),
+        `machinen-snap-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+      );
+      copyFileSync(bundleDisk, perBoot, fsConstants.COPYFILE_FICLONE);
+      diskAbs = perBoot;
+      perBootSnapDisk = perBoot;
+      env.MACHINEN_DISK = perBoot;
+      debug("snap-restore reflink-clone src=%s dst=%s", bundleDisk, perBoot);
+    }
   } else if (opts.image) {
     // Auto-allocate only when the caller is booting a real image-backed
     // guest. VMM-only smoke boots (no image — e.g. MACHINEN_BOOT_TEST=1)
@@ -904,13 +914,32 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       if (child.exitCode !== null || child.signalCode !== null) {
         return;
       }
-      child.kill("SIGKILL");
-      // Same race: the child may finish dying between the guard above
-      // and the listener below. Re-check before waiting.
+      // Send SIGTERM, not SIGKILL: on darwin the spawn target is the
+      // pdeathsig shim, which can't catch SIGKILL — that orphans its
+      // inner VMM (#200), keeping the stderr pipe open so any caller
+      // awaiting `errorOutput()` (collected via stream "close") never
+      // wakes up. The shim does catch SIGTERM and forwards it to the
+      // VMM, which exits cleanly. Linux has the same shape via
+      // PR_SET_PDEATHSIG, so the same path applies.
+      child.kill("SIGTERM");
       if (child.exitCode !== null || child.signalCode !== null) {
         return;
       }
-      await once(child, "exit");
+      // Escalate to SIGKILL if the shim+inner don't exit within 2s —
+      // covers a wedged inner that ignores SIGTERM. SIGKILL'ing the
+      // shim still orphans the inner, but at that point the inner is
+      // already unresponsive and we've done what we can from here.
+      const escalate = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {}
+      }, 2_000);
+      escalate.unref();
+      try {
+        await once(child, "exit");
+      } finally {
+        clearTimeout(escalate);
+      }
     },
 
     output: () => outputCollector,

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -8,7 +8,7 @@
 # This script is self-sufficient: it builds anything it needs that
 # isn't already built, then runs the tests.
 #   - @machinen/runtime + @machinen/cli  (fast)
-#   - packages/microvm/zig-out/bin/microvm  (~30s on first run)
+#   - packages/microvm/zig-out/bin/machinen-vm  (~30s on first run)
 #   - release-assets/ (Image, dtb, rootfs tarball)  (~5 min, needs Docker)
 #
 # Tests:
@@ -29,7 +29,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 CLI="$ROOT/packages/cli/dist/cli.js"
-VMM="$ROOT/packages/microvm/zig-out/bin/microvm"
+VMM="$ROOT/packages/microvm/zig-out/bin/machinen-vm"
 ASSETS="$ROOT/release-assets"
 OS=$(uname -s)
 
@@ -542,7 +542,7 @@ fi
 echo "P2: machinen boot -- /sys/class/block/vda + AF_VSOCK in /proc/net/protocols"
 P2_LOG="$FIXTURE/p2.log"
 run_timeout 60 node "$CLI" boot -- /bin/sh -c \
-  'ls /sys/class/block/vda 2>/dev/null && grep -E "^AF_VSOCK " /proc/net/protocols' \
+  'ls -d /sys/class/block/vda 2>/dev/null && grep -E "^AF_VSOCK " /proc/net/protocols' \
   >"$P2_LOG" 2>&1 || true
 if grep -q "/sys/class/block/vda" "$P2_LOG" && grep -qE "^AF_VSOCK " "$P2_LOG"; then
   pass "kernel has virtio_blk + vsock built in (/dev/vda + AF_VSOCK live)"


### PR DESCRIPTION
## Problem

`vm.snapshot()` was failing deep inside CRIU 3.17.1's `can_dump_ipproto` ("Unsupported proto 1 for socket M") whenever the workload held an unprivileged ping socket — even though the dump pre-flight had OK'd the dump. The pre-flight comment claimed CRIU 3.17+ supports `SOCK_DGRAM IPPROTO_ICMP` and explicitly skipped `/proc/<pid>/net/icmp{,6}`, but that's wrong: 3.17.1's non-`SOCK_RAW` proto switch only accepts `{IP, TCP, UDP, UDPLITE}`. `IPPROTO_ICMP/ICMPV6` were added on master but aren't in the build we ship. `machinen-netup` widens `net.ipv4.ping_group_range` (#203) so `iputils-ping` uses `SOCK_DGRAM/IPPROTO_ICMP` by default, which makes "ran ping, held the socket open" the common trigger.

Several adjacent bugs surfaced while wiring this up and running the smoke / boot suites against it:

- `vm.kill()` sent `SIGKILL` to the spawn target, which on darwin is the pdeathsig shim. The shim can't catch `SIGKILL` (it's untrappable), so its inner VMM child got orphaned and kept stderr open — `errorOutput()` callers hung forever, timing out the `boots the VMM and the kernel reaches userspace` integration test at 30 s.
- PR #208's unconditional reflink-clone of `snapshot: <string>` broke `provision()`: the guest wrote its rootfs tar to a per-boot clone, the host extracted from the (still-empty) original, and `app.tar.gz` came out 606 bytes — kernel-panicking subsequent vm-pick boots with `init: execve failed errno=2 path=/sbin/machinen-supervisor`.
- `machinen attach --name <typo>` from a non-TTY context errored with "stdin is not a TTY" instead of the relevant "no running VM found" — the TTY check ran before name resolution.
- `scripts/smoke-tests.sh` aborted at codesign because the Zig binary was renamed `microvm` → `machinen-vm` without updating the script. P2 used `ls /sys/class/block/vda` (lists directory contents) instead of `ls -d` (prints the path), so the grep for `/sys/class/block/vda` never matched even on a healthy boot.
- All of the drift above shipped to `main` green because the smoke suite wasn't part of the required-tests gate in `AGENTS.md`.

## Solution

- **Pre-flight**: also scan `/proc/<pid>/net/icmp{,6}` and reject entries there. The `/proc` layout for those files puts the source port in the column the raw-side scan reads as proto, so hardcode `ipproto` 1/58 for the two icmp files. Update tests: flip the ping-passes case to ping-flagged, add an `ICMPv6` case, keep a TCP-passes negative test.
- **`vm.kill()`**: send `SIGTERM` (the shim's `kqueue` catches it and forwards to the inner child cleanly; Linux has the same shape via `PR_SET_PDEATHSIG`). Escalate to `SIGKILL` after a 2 s grace for wedged inners.
- **`snapshot:` in-place when `cmd` is provided**: an explicit `cmd` means the caller is running their own workload (e.g. `provision()`'s tar-to-`/dev/vdb` dump), not restoring a CRIU bundle, so attach the disk in place. The reflink-clone is still applied for the restore-bundle path (no `cmd` → synthesized `/sbin/machinen-restore`), where `machinen-dump.sh` would otherwise mkfs over the source bundle.
- **CLI `attach`**: resolve the target before the TTY check, so unknown-name yields the useful error first.
- **Smoke-tests**: VMM binary path (`microvm` → `machinen-vm`); P2 `ls` → `ls -d`.
- **`AGENTS.md`**: add `pnpm smoke-tests` as a third required test step alongside vitest and agent-ci, so this kind of drift gets caught in pre-merge instead of by the next person reaching for snapshot.

## Summary

- `packages/microvm/assets/machinen-dump-preflight.sh` — extend scan to `/proc/<pid>/net/icmp{,6}`; correct the misleading 3.17 comment.
- `packages/runtime/src/__tests__/dump-preflight.test.ts` — flip ping-passes → ping-flagged, add ICMPv6 case, retain TCP-passes negative test.
- `packages/runtime/src/vm.ts` — `vm.kill()` SIGTERM-then-escalate; `snapshot:` in-place when `cmd` is provided.
- `packages/cli/src/cli.ts` — `attach` resolves target before TTY check.
- `scripts/smoke-tests.sh` — binary path + P2 `ls -d`.
- `AGENTS.md` — `pnpm smoke-tests` is now a required test step.
- `packages/runtime/API.md` — typedoc regen (vm.ts grew, link line numbers drifted).
