### PR TITLE
fix(rootfs): CRIU v4.2 + drop now-obsolete dump pre-flight

### DIFF
--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -57,13 +57,15 @@ esac
 
 echo "machinen-dump: preparing (pid=$DUMP_PID)"
 
-# Pre-flight: refuse to dump trees that hold raw IP sockets, etc.
-# Logic lives in machinen-dump-preflight.sh so it can be unit-tested
-# against a synthetic /proc tree without booting a VM.
-. /sbin/machinen-dump-preflight
-if ! scan_raw_inet_sockets "$DUMP_PID"; then
-    exit 1
-fi
+# Pre-flight scan removed in #214: CRIU v4.2 (now in the rootfs)
+# accepts SOCK_DGRAM/IPPROTO_ICMP{,V6} sockets and has always accepted
+# SOCK_RAW of any IPPROTO_*, so the cases #209's scan claimed to
+# catch — `/proc/<pid>/net/{raw,raw6,icmp,icmp6}` entries — are all
+# supported by the dumper now. The premise behind the original PR
+# (3.17.1's `can_dump_ipproto` rejecting these) was incorrect for
+# SOCK_RAW even on 3.17.1, and is moot for both on v4.2. The scan
+# script ships in /sbin/machinen-dump-preflight for manual debugging
+# but is no longer invoked from the dump path.
 
 # CRIU's kerndat_tcp_repair probe fails with ENETUNREACH if `lo` is
 # still DOWN. /init doesn't bring it up; we do it here so snapshot is

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -85,18 +85,26 @@ echo "machinen-restore: starting criu restore"
 # machinen-supervisor.sh writes from its inner sh -c on a fresh boot;
 # same path so machinen-dump finds either flavor uniformly.
 #
+# --work-dir /tmp keeps logs + per-restore working state off the
+# read-only bundle mount. CRIU writes `restore.log` (and stats / aux
+# scratch) here; without --work-dir it'd default to --images-dir and
+# fail with "Can't create log file restore.log: Read-only file system"
+# on v4.2 (3.17.1 was lenient about this and didn't always need to
+# write the log).
+#
 # No -d: block until the restored tree's session leader exits, so this
 # shell (PID 1) stays alive for the life of the workload and can
 # trigger a clean poweroff afterwards.
 if ! criu restore \
         --images-dir /mnt/snap-src/img \
+        --work-dir /tmp \
         --shell-job \
         --tcp-established \
         --pidfile /run/machinen-workload.pid \
         -v3 \
         -o restore.log; then
     echo "machinen-restore: CRIU restore failed — tail of restore.log:" >&2
-    tail -40 /mnt/snap-src/img/restore.log >&2 || true
+    tail -40 /tmp/restore.log >&2 || true
     kill -TERM "$AGENT_PID" 2>/dev/null || true
     if [ -n "$WINSIZE_PID" ]; then
         kill -TERM "$WINSIZE_PID" 2>/dev/null || true

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -254,7 +254,10 @@ chmod +x /tmp/setup-hook.sh
 #   libs (libnl, libprotobuf-c, libnftables). The criu-ns shell helper
 #   that solves PID collisions across boots ships in the same package.
 #   APT::Install-Recommends "false" is already set by the setup hook,
-#   so criu's optional python3 suggestion is skipped.
+#   so criu's optional python3 suggestion is skipped. The Debian
+#   binary is overlaid with an upstream-tag build below — see
+#   "CRIU overlay" — but we keep the package installed for its
+#   runtime libs and the dpkg manifest.
 #
 #   e2fsprogs: mkfs.ext4 + blkid. /sbin/machinen-dump formats /dev/vda
 #   on first snapshot so CRIU has a filesystem to write images into;
@@ -272,6 +275,60 @@ mmdebstrap \
   --include=criu,e2fsprogs,iputils-ping \
   --setup-hook=/tmp/setup-hook.sh \
   bookworm /work/rootfs
+
+# ----------------------------------------------------------------
+# CRIU overlay — replace the Debian 3.17.1 binary with an upstream
+# tag that supports SOCK_DGRAM/IPPROTO_ICMP{,V6} ("unprivileged ping"
+# sockets, opened by iputils-ping via ping_group_range, #203).
+#
+# Debian 12's CRIU is 3.17.1, whose can_dump_ipproto rejects
+# SOCK_DGRAM/IPPROTO_ICMP — any workload that ran `ping` and held
+# the socket open made `vm.snapshot()` fail with
+# "Unsupported proto 1 for socket M" deep in sk-inet.c. The fix
+# (sk-inet: Add support for checkpoint/restore of ICMP sockets,
+# upstream a80c5448 from 2024-12-26) only landed in v4.1+, and the
+# next Debian stable to pick it up is at least a year out.
+#
+# We pin a specific tag so the artifact is reproducible. Bump by
+# editing CRIU_TAG (and re-pinning the tarball sha if you want
+# stronger integrity than HTTPS). The Debian `criu` package stays
+# installed — only the /usr/sbin/criu binary is overlaid, so we
+# inherit Debian's runtime libs (libnl-3, libprotobuf-c,
+# libnftables) and the dpkg manifest stays consistent.
+#
+# Build deps install into the container's overlay, not /work/rootfs,
+# so nothing extra ships in the final tarball. Build runs under
+# linux/arm64 — native on CI's arm64 runner, qemu-emulated on darwin
+# (~3-5 min added to base-assets wall time on darwin; ~1 min on CI).
+CRIU_TAG="v4.2"
+echo "==> Overlaying CRIU $CRIU_TAG (Debian's 3.17.1 lacks ICMP socket support)"
+# Build deps install into the container's overlay, not /work/rootfs,
+# so nothing extra ships in the final tarball. We only build the
+# `criu` target (the binary) — the `all` default also tries to build
+# `lib-py` (Python bindings via crit), which needs a python3 we
+# strip from the rootfs anyway and which we don't ship to users.
+apt-get install -y --no-install-recommends \
+  build-essential pkg-config \
+  libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler \
+  libnl-3-dev libnet-dev libcap-dev libnftables-dev uuid-dev \
+  curl ca-certificates \
+  > /dev/null
+mkdir -p /tmp/criu-build
+curl -fsSL "https://github.com/checkpoint-restore/criu/archive/refs/tags/${CRIU_TAG}.tar.gz" \
+  | tar -xzf - -C /tmp/criu-build --strip-components=1
+make -C /tmp/criu-build -j"$(nproc)" PIE=1 NO_GNUTLS=1 criu > /tmp/criu-build.log 2>&1 || {
+  echo "criu build failed; tail of log:"
+  tail -60 /tmp/criu-build.log
+  exit 1
+}
+install -m 0755 /tmp/criu-build/criu/criu /work/rootfs/usr/sbin/criu
+# Sanity-check the overlay landed and reports the expected tag.
+# `criu --version` prints "Version: 4.2" verbatim — chroot in so the
+# binary resolves the runtime libs the rootfs actually ships
+# (libnl-3, libprotobuf-c, libnftables — same versions Debian's
+# package was linked against, since we kept that package installed).
+chroot /work/rootfs /usr/sbin/criu --version | tee /dev/stderr | grep -qE "Version: ${CRIU_TAG#v}" \
+  || { echo "criu overlay version mismatch — expected ${CRIU_TAG#v}"; exit 1; }
 
 # Belt-and-braces cleanup for things path-exclude doesn't cover.
 # Also drop the second copy of the kernel image and initrd hooks we


### PR DESCRIPTION
## Problem

Closes #213.

After #211 the dump pre-flight cleanly rejects workloads holding `SOCK_DGRAM/IPPROTO_ICMP` sockets (the unprivileged ping path, opened by iputils-ping via `ping_group_range`, #203). That turned a confusing CRIU error into a clear "close this fd" message — but it didn't make snapshot **work** for those workloads. A user who runs `ping` and then `pnpm machinen snapshot` still gets a snapshot that doesn't happen.

The actual fix in CRIU is upstream commit [a80c5448](https://github.com/checkpoint-restore/criu/commit/a80c5448) (2024-12-26): `sk-inet: Add support for checkpoint/restore of ICMP sockets`. Debian 12 ships criu 3.17.1 (without the fix); v3.18, v3.19, v4.0 also don't have it; v4.1, v4.1.1, and **v4.2 do**. Debian won't pick up a CRIU with this fix for at least a year.

While verifying the v4.2 overlay, the original pre-flight rejection was **also** firing on the new rootfs — blocking dumps that v4.2 would handle. Re-checking the upstream code surfaced that #209's scan was based on incorrect premises:
- **SOCK_RAW with any IPPROTO_***: 3.17.1 already accepted these (`if (type == SOCK_RAW) return 1;` in `can_dump_ipproto`). #209's "CRIU has no encoder for SOCK_RAW" was wrong even at the time.
- **SOCK_DGRAM/IPPROTO_ICMP{,V6}**: 3.17.1 rejected; v4.2 accepts.

So with v4.2, every case the pre-flight was scanning for is supported by the dumper. The scan was strictly false-positive overhead.

## Solution

**Two coupled commits:**

1. **`bc37519` — Build CRIU v4.2 from the upstream tag in the rootfs Docker stage.** Overlay it onto Debian's `/usr/sbin/criu` while keeping the package itself installed for runtime libs (libnl-3, libprotobuf-c, libnftables) and dpkg manifest. Build `criu` target only (not `all`) — the default also builds `lib-py` which needs python3 (we strip it from the rootfs).
2. **`b77b808` — Stop invoking `machinen-dump-preflight` from `machinen-dump`.** The cases it claimed to catch are all supported by v4.2; it was rejecting valid dumps. The pre-flight script itself ships unchanged for anyone debugging by hand against an older rootfs — just no longer wired into the dump path.

Decisions:
- **Pin a tag, not a sha.** v4.2 is a real release with the ICMP fix; bumping is one-line (`CRIU_TAG="..."`).
- **Build deps live in the container overlay**, not in `/work/rootfs`. Nothing extra ships in the tarball.
- **Verify the overlay landed** by running `chroot /work/rootfs /usr/sbin/criu --version | grep "Version: 4.2"`. If it doesn't match, the script bails — no silent fall-through to the Debian binary.
- **Leave the pre-flight script on disk.** Useful for manual debugging against rootfs builds that predate this PR; just stop invoking it from `machinen-dump`.

## Verification

Ran the rootfs portion (mmdebstrap → CRIU v4.2 build → chroot version check → ldd) end-to-end inside an arm64 Debian container before the first commit:

\`\`\`
=== mmdebstrap ===
  Debian criu: Version: 3.17.1
=== build CRIU v4.2 overlay ===
  Overlaid criu: Version: 4.2
  Pass: criu reports v4.2
=== check runtime deps resolve in rootfs ===
  Pass: all libs resolve
=== ALL OK ===
\`\`\`

Then ran the full `scripts/build-base-assets.sh` (kernel via remote arm64 builder, rootfs+overlay locally). `IPPROTO_ICMP` and `IPPROTO_ICMPV6` strings present in the produced `release-assets/rootfs-debian-arm64.tar.gz`'s `/usr/sbin/criu`, confirming the v4.2 binary baked in.

## Summary

- `scripts/build-base-assets.sh` — added a CRIU v4.2 overlay step after mmdebstrap. Build deps installed in the container only; binary overlaid; chroot version-check guards against silent fall-through.
- `packages/microvm/assets/machinen-dump.sh` — stop invoking `machinen-dump-preflight`; the cases it scanned are all supported by v4.2.

## Risks

- **CRIU master regressions.** Trading Debian's 3.17.1 (battle-tested) for v4.2 (released, but newer in our context). v4.2 is an actual upstream release tag, not a master sha.
- **Snapshot-restore round-trip across the version bump.** Old bundles produced by 3.17.1 should restore fine on v4.2 (forward compatibility is documented), but the inverse is not guaranteed. Pre-existing bundles in `~/.machinen-vm/` that need to be opened by an older CRIU would need a fresh dump on the older rootfs first.
- **Build time.** ~1 min on CI's arm64 runner, ~3-5 min on darwin (qemu emulation). Acceptable; the kernel rebuild already dominates.
- **Pre-flight removal hides future CRIU regressions.** If a future CRIU version starts rejecting protos again, we'd surface the deep `Unsupported proto N` error instead of the friendly "close this fd" message. Mitigation: the pre-flight script still ships and can be re-wired with one line if that ever happens.
