### PR TITLE
test: stop silent skips when microVM fixtures are missing or stale

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,10 @@ jobs:
 
       - run: pnpm typecheck
 
+      # Hosted runners don't have the microVM fixtures (Image, virt.dtb,
+      # built boot-test binary). #212 made missing fixtures a hard
+      # failure for local dev; opt CI out so the integration cases skip
+      # cleanly the way they always have.
       - run: pnpm test
+        env:
+          MACHINEN_REQUIRE_FIXTURES: "0"

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -49,13 +49,43 @@ function findBootTestBinary(): string | undefined {
   return undefined;
 }
 
-function fixturesPresent(): boolean {
-  for (const f of ["Image", "virt.dtb", "initramfs.cpio"]) {
+const FIXTURE_FILES = ["Image", "virt.dtb", "initramfs.cpio"];
+
+// #212: replace silent `return` skips on missing fixtures with a loud
+// failure so a stale or absent kernel can't masquerade as a passing
+// run. Set MACHINEN_REQUIRE_FIXTURES=0 to keep the legacy skip on
+// hosts that can't build the microVM artifacts (CI smoke runners,
+// docs-only contributors).
+function requireFixturesOrSkip(extraPaths: string[] = []): {
+  skip: boolean;
+  binary: string;
+} {
+  const binary = findBootTestBinary();
+  const missing: string[] = [];
+  if (!binary) {
+    missing.push("microvm/.zig-cache boot-test binary");
+  }
+  for (const f of FIXTURE_FILES) {
     if (!existsSync(resolve(microvmRoot, "test-fixtures", f))) {
-      return false;
+      missing.push(`test-fixtures/${f}`);
     }
   }
-  return true;
+  for (const p of extraPaths) {
+    if (!existsSync(p)) {
+      missing.push(p);
+    }
+  }
+  if (missing.length === 0) {
+    return { skip: false, binary: binary! };
+  }
+  if (process.env.MACHINEN_REQUIRE_FIXTURES === "0") {
+    return { skip: true, binary: "" };
+  }
+  throw new Error(
+    `test requires microVM fixtures (missing: ${missing.join(", ")}); ` +
+      `run scripts/build-base-assets.sh + pnpm provision ` +
+      `(or set MACHINEN_REQUIRE_FIXTURES=0 to opt out)`,
+  );
 }
 
 describe("boot", () => {
@@ -156,9 +186,8 @@ describe("boot", () => {
   });
 
   it("boots the VMM and the kernel reaches userspace", async () => {
-    const binary = findBootTestBinary();
-    if (!binary || !fixturesPresent()) {
-      // Fixtures missing — skip. Run ./scripts/build-base-assets.sh to produce them.
+    const { skip, binary } = requireFixturesOrSkip();
+    if (skip) {
       return;
     }
 
@@ -384,14 +413,9 @@ describe("image + cmd", () => {
   });
 
   it("boots an image + cmd and the guest runs the cmd", async () => {
-    const binary = findBootTestBinary();
-    if (!binary || !fixturesPresent()) {
-      // VMM fixtures missing — skip.
-      return;
-    }
     const debianRootfs = resolve(microvmRoot, "test-fixtures/rootfs-debian-arm64.tar.gz");
-    if (!existsSync(debianRootfs)) {
-      // Debian rootfs tarball not produced in this checkout — skip.
+    const { skip, binary } = requireFixturesOrSkip([debianRootfs]);
+    if (skip) {
       return;
     }
 

--- a/packages/runtime/src/__tests__/exec.test.ts
+++ b/packages/runtime/src/__tests__/exec.test.ts
@@ -37,23 +37,49 @@ function findBootTestBinary(): string | undefined {
   return undefined;
 }
 
-function fixturesPresent(): boolean {
-  for (const f of ["Image", "virt.dtb"]) {
+const FIXTURE_FILES = ["Image", "virt.dtb"];
+
+// #212: replace silent skip on missing fixtures with a loud throw so a
+// stale or absent kernel cannot masquerade as a passing run. Set
+// MACHINEN_REQUIRE_FIXTURES=0 to keep the legacy skip on hosts that
+// can't build the microVM artifacts.
+function requireFixturesOrSkip(extraPaths: string[] = []): {
+  skip: boolean;
+  binary: string;
+} {
+  const binary = findBootTestBinary();
+  const missing: string[] = [];
+  if (!binary) {
+    missing.push("microvm/.zig-cache boot-test binary");
+  }
+  for (const f of FIXTURE_FILES) {
     if (!existsSync(resolve(microvmRoot, "test-fixtures", f))) {
-      return false;
+      missing.push(`test-fixtures/${f}`);
     }
   }
-  return true;
+  for (const p of extraPaths) {
+    if (!existsSync(p)) {
+      missing.push(p);
+    }
+  }
+  if (missing.length === 0) {
+    return { skip: false, binary: binary! };
+  }
+  if (process.env.MACHINEN_REQUIRE_FIXTURES === "0") {
+    return { skip: true, binary: "" };
+  }
+  throw new Error(
+    `test requires microVM fixtures (missing: ${missing.join(", ")}); ` +
+      `run scripts/build-base-assets.sh + pnpm provision ` +
+      `(or set MACHINEN_REQUIRE_FIXTURES=0 to opt out)`,
+  );
 }
 
 describe("VsockExec", () => {
   it("runs commands inside a booted bundle and returns exit codes", async () => {
-    const binary = findBootTestBinary();
-    if (!binary || !fixturesPresent()) {
-      return;
-    }
     const debianTar = resolve(microvmRoot, "../../release-assets/rootfs-debian-arm64.tar.gz");
-    if (!existsSync(debianTar)) {
+    const { skip, binary } = requireFixturesOrSkip([debianTar]);
+    if (skip) {
       return;
     }
     const udsPath = join(tmpdir(), `machinen-exec-${process.pid}.sock`);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,3 +7,39 @@
 // actually wants gvproxy can `delete process.env.MACHINEN_GVPROXY` at
 // the top of its case.
 process.env.MACHINEN_GVPROXY = "disabled";
+
+// Auto-refresh stale microVM test fixtures from release-assets/.
+//
+// The kernel + DTB in packages/microvm/test-fixtures/ are copies of the
+// canonical artifacts the build script writes to release-assets/. There
+// is no automatic resync after `pnpm provision`, so a developer who
+// rebuilds release-assets but forgets to copy ends up running boot
+// tests against a kernel that is days (or weeks) older than the rootfs
+// userspace it has to drive. In #211 that drift kernel-panicked the
+// integration tests on every run, and the failures were misread as
+// pre-existing flakes. See issue #212.
+import { copyFileSync, existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = import.meta.dirname;
+const fixturesDir = resolve(repoRoot, "packages/microvm/test-fixtures");
+const releaseDir = resolve(repoRoot, "release-assets");
+
+for (const [src, dst] of [
+  ["Image-arm64", "Image"],
+  ["virt-arm64.dtb", "virt.dtb"],
+] as const) {
+  const srcPath = resolve(releaseDir, src);
+  const dstPath = resolve(fixturesDir, dst);
+  if (!existsSync(srcPath)) {
+    continue; // no canonical copy on this checkout — nothing to sync from
+  }
+  const srcMtime = statSync(srcPath).mtimeMs;
+  const dstMtime = existsSync(dstPath) ? statSync(dstPath).mtimeMs : 0;
+  if (srcMtime > dstMtime) {
+    copyFileSync(srcPath, dstPath);
+    console.error(
+      `[vitest.setup] test-fixtures/${dst} was stale, refreshed from release-assets/${src}`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #212.

## Problem

`packages/runtime/src/__tests__/boot.test.ts` and `exec.test.ts` early-return when `test-fixtures/{Image,virt.dtb}` or the boot-test binary are absent. Two failure modes that were silent:

- **Missing fixtures pass.** A fresh checkout that never produced fixtures runs the integration tests as no-ops and reports green.
- **Stale fixtures pass.** During #211 the kernel at `test-fixtures/Image` was 12 days older than `release-assets/Image-arm64`. The exec/provision tests kernel-panicked every run; the failures were dismissed as "pre-existing flakes" because nothing said "your fixture is stale."

`scripts/build-base-assets.sh` writes the canonical kernel + DTB to `release-assets/`; a separate copy gets staged into `test-fixtures/` (manual step in `try.sh`). Nothing enforces those stay in sync.

## Solution

Two layered fixes:

1. **`vitest.setup.ts` auto-syncs.** Compare `test-fixtures/{Image,virt.dtb}` mtimes against `release-assets/{Image-arm64,virt-arm64.dtb}`. If release-assets is newer, copy and print one stderr line per file (`[vitest.setup] test-fixtures/Image was stale, refreshed from release-assets/Image-arm64`).

2. **Loud failure on missing fixtures.** Replace the silent `return` with a `requireFixturesOrSkip()` helper in `boot.test.ts` and `exec.test.ts` that throws

   > test requires microVM fixtures (missing: ...); run scripts/build-base-assets.sh + pnpm provision (or set MACHINEN_REQUIRE_FIXTURES=0 to opt out)

   Gated behind `process.env.MACHINEN_REQUIRE_FIXTURES !== '0'`. Default = required.

3. **CI keeps skipping.** `.github/workflows/tests.yml` exports `MACHINEN_REQUIRE_FIXTURES=0` for the `pnpm test` step — hosted runners have no fixtures by design, so the env-var opt-out preserves the existing CI behaviour. agent-ci confirmed this is needed (the no-env run failed exactly the way the issue predicted).

## Test plan

- [x] `npx vitest run` — 361 passed, 7 skipped, 0 failed
- [x] `npx agent-ci run --all -q -p` — 4/4 workflows passed
- [x] `pnpm smoke-tests` — all smoke tests passed
- [x] Verified auto-sync: backdate `test-fixtures/Image` and run vitest; the stderr line fires and the file gets refreshed.
- [x] Verified loud failure: with no fixtures + default env, `boot.test.ts` and `exec.test.ts` throw the clear missing-fixtures error.
- [x] Verified opt-out: `MACHINEN_REQUIRE_FIXTURES=0` reverts to silent skip (the path agent-ci's tests.yml runner takes).
