### PR TITLE
fix(microvm): isolate chained-restore PIDs in a fresh sub-namespace

### DIFF
--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -24,10 +24,21 @@
 set -eu
 
 # Debian's dash defaults PATH to /usr/bin:/bin when unset — criu,
-# blkid, and mkfs.ext4 all live under /usr/sbin, so export a broad
-# PATH regardless of what /init's envp carried.
+# blkid, mkfs.ext4, and nsenter all live under /usr/sbin or /usr/bin,
+# so export a broad PATH regardless of what /init's envp carried.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
+
+# Recursive-self-exec marker: when we re-enter via `nsenter` for the
+# chained-restore case (#215), the second pass skips the discovery
+# logic and trusts the in-NS pid passed on the command line.
+IN_SUB_NS=0
+case "${1:-}" in
+    --in-sub-ns)
+        IN_SUB_NS=1
+        shift
+        ;;
+esac
 
 # Pick the scratch disk: /dev/vdb when virtio-blk-root booted (rootfs
 # took /dev/vda); else /dev/vda for the legacy single-disk layout.
@@ -37,39 +48,125 @@ else
     SCRATCH=/dev/vda
 fi
 
-# /init writes the workload's PID after fork. Fall back to PID 2 if
-# the file is missing — that's what's produced by the supervisor
-# spawning the workload as its first background job.
-PIDFILE=/run/machinen-workload.pid
-if [ -f "$PIDFILE" ]; then
-    DUMP_PID=$(cat "$PIDFILE")
+if [ "$IN_SUB_NS" -eq 1 ]; then
+    # Inside the sub-PID-NS now. The first arg is the in-NS pid that
+    # criu restore wrote via --pidfile.
+    DUMP_PID="${1:-}"
+    SUB_NS_HOST_PID=""
 else
-    echo "machinen-dump: $PIDFILE missing; falling back to PID 2" >&2
-    DUMP_PID=2
+    # /init writes the workload's PID after fork. Fall back to PID 2 if
+    # the file is missing — that's what's produced by the supervisor
+    # spawning the workload as its first background job.
+    PIDFILE=/run/machinen-workload.pid
+    if [ -f "$PIDFILE" ]; then
+        DUMP_PID=$(cat "$PIDFILE")
+    else
+        echo "machinen-dump: $PIDFILE missing; falling back to PID 2" >&2
+        DUMP_PID=2
+    fi
+
+    # /sbin/machinen-restore writes the host PID of the criu restorer
+    # when the restored workload was placed in a sub-PID-namespace
+    # (#215). Presence of this file means we're in the chained-restore
+    # case: we need to re-enter the sub-NS via nsenter, because criu
+    # walks /proc and /proc reflects the parent NS out here.
+    SUB_NS_HOST_PID_FILE=/run/machinen-workload-host.pid
+    SUB_NS_HOST_PID=""
+    if [ -s "$SUB_NS_HOST_PID_FILE" ]; then
+        candidate=$(cat "$SUB_NS_HOST_PID_FILE")
+        case "$candidate" in
+            ''|*[!0-9]*)
+                echo "machinen-dump: invalid pid in $SUB_NS_HOST_PID_FILE: $candidate" >&2
+                exit 1
+                ;;
+            *)
+                if [ -d "/proc/$candidate" ]; then
+                    SUB_NS_HOST_PID="$candidate"
+                else
+                    echo "machinen-dump: criu host PID $candidate is gone — sub-NS died" >&2
+                    exit 1
+                fi
+                ;;
+        esac
+    fi
 fi
 
 case "$DUMP_PID" in
     ''|*[!0-9]*)
-        echo "machinen-dump: invalid pid in $PIDFILE: $DUMP_PID" >&2
+        echo "machinen-dump: invalid dump pid: $DUMP_PID" >&2
         exit 1
         ;;
 esac
 
-echo "machinen-dump: preparing (pid=$DUMP_PID)"
+echo "machinen-dump: preparing (pid=$DUMP_PID, sub_ns=${SUB_NS_HOST_PID:-none}, in_sub_ns=$IN_SUB_NS)"
 
-# Pre-flight scan removed in #214: CRIU v4.2 (now in the rootfs)
-# accepts SOCK_DGRAM/IPPROTO_ICMP{,V6} sockets and has always accepted
-# SOCK_RAW of any IPPROTO_*, so the cases #209's scan claimed to
-# catch — `/proc/<pid>/net/{raw,raw6,icmp,icmp6}` entries — are all
-# supported by the dumper now. The premise behind the original PR
-# (3.17.1's `can_dump_ipproto` rejecting these) was incorrect for
-# SOCK_RAW even on 3.17.1, and is moot for both on v4.2. The scan
-# script ships in /sbin/machinen-dump-preflight for manual debugging
-# but is no longer invoked from the dump path.
+if [ "$IN_SUB_NS" -eq 0 ] && [ -n "$SUB_NS_HOST_PID" ]; then
+    # Drop the parent's read-only bundle mount before we hand off to
+    # the sub-NS — mkfs (re-)formats the device from inside, and we
+    # don't want the parent to keep an open ref. The sub-NS has its
+    # own copy of /mnt/snap-src (cloned at unshare time); the
+    # re-entered half umounts that one.
+    if mountpoint -q /mnt/snap-src 2>/dev/null; then
+        umount /mnt/snap-src 2>/dev/null || umount -l /mnt/snap-src
+    fi
+
+    # Re-enter the sub-PID + sub-mount NS by re-exec'ing ourselves.
+    # nsenter forks a child into the target NS; the child's exit
+    # status comes back as nsenter's exit. We don't `exec` here
+    # because the sub-NS dies as soon as criu kills the dumped tree
+    # (criu_restore is PID 1 of the NS and exits the moment its
+    # workload is gone) — and the kernel SIGKILLs everything
+    # remaining in that NS, including our re-exec'd self mid-cleanup.
+    # We need the parent to survive the nsenter exit to flush the
+    # block device and verify the dump landed on disk.
+    #
+    # /usr/sbin/machinen-dump (not /sbin/...) — the sub-NS's mount
+    # namespace was cloned by `unshare --mount-proc`, but Debian's
+    # /sbin → /usr/sbin merge is a top-level symlink and CRIU may
+    # have pivoted into a private root that doesn't see it. Going
+    # through the canonical path skips the dependency.
+    # `--root` switches the process's fs root to the target's root
+    # before exec. Without it, our process keeps its parent-NS chroot
+    # view and path lookup into the new mount NS misses everything
+    # (every "/usr/sbin/foo" comes back ENOENT) — the rootfs IS
+    # there, just not at the path our chroot points to. `--wd /` is
+    # belt-and-braces in case the parent's cwd doesn't exist in the
+    # target NS.
+    set +e
+    nsenter --target "$SUB_NS_HOST_PID" --pid --mount --root --wd=/ -- \
+        /usr/sbin/machinen-dump --in-sub-ns "$DUMP_PID"
+    nsenter_rc=$?
+    set -e
+
+    # Flush the block device — sync covers all pages regardless of
+    # which mount namespace dirtied them.
+    sync
+
+    # Verify the dump landed on disk: mount the scratch in our parent
+    # NS (it was unmounted when the sub-NS died) and look for CRIU
+    # core images. nsenter_rc is unreliable here — exit 137 (SIGKILL)
+    # is normal when the sub-NS dies on us, but exit 0 also happens
+    # if our re-exec'd self finishes cleanup before the SIGKILL lands.
+    mkdir -p /mnt/snap
+    if ! mount "$SCRATCH" /mnt/snap 2>/dev/null; then
+        echo "machinen-dump: chained dump — couldn't mount $SCRATCH to verify (nsenter rc=$nsenter_rc)" >&2
+        exit 1
+    fi
+    if ! ls /mnt/snap/img/core-*.img >/dev/null 2>&1; then
+        echo "machinen-dump: chained CRIU dump failed (nsenter rc=$nsenter_rc) — tail of dump.log:" >&2
+        tail -40 /mnt/snap/img/dump.log 2>/dev/null >&2 || echo "(no dump.log)" >&2
+        exit 1
+    fi
+    sync
+    umount /mnt/snap
+    sync
+    exit 0
+fi
 
 # CRIU's kerndat_tcp_repair probe fails with ENETUNREACH if `lo` is
 # still DOWN. /init doesn't bring it up; we do it here so snapshot is
-# self-contained.
+# self-contained. (lo-up is idempotent and the network NS is shared
+# with the parent, so this is a no-op when we're inside the sub-NS.)
 /sbin/machinen-lo-up || {
     echo "machinen-dump: lo-up failed" >&2
     exit 1
@@ -83,20 +180,13 @@ echo "machinen-dump: preparing (pid=$DUMP_PID)"
 mkdir -p /tmp
 chmod 1777 /tmp 2>/dev/null || true
 
-# Drop any lingering restore-side mount of the same disk (#207).
+# Drop the read-only bundle mount in our current NS.
 # /sbin/machinen-restore mounts the bundle's images at /mnt/snap-src
 # (read-only) and doesn't unmount when restore returns. The parent
 # bundle's images aren't needed for the running workload; clear the
 # mount so the kernel will let us re-mount $SCRATCH at /mnt/snap
-# (the kernel rejects mounting the same block device at a second
-# point with the original "already mounted" error otherwise).
+# (mkfs.ext4 -F refuses if the device is mounted anywhere visible).
 if mountpoint -q /mnt/snap-src 2>/dev/null; then
-    # `umount -l` (lazy) as a fallback: criu may still hold an fd into
-    # the restored images while it's parenting the workload. Lazy
-    # detach removes the mount from the namespace immediately and
-    # defers actual freeing until the last reference closes — which
-    # is enough for the kernel to let us mount the same device
-    # elsewhere.
     umount /mnt/snap-src 2>/dev/null || umount -l /mnt/snap-src
 fi
 
@@ -148,4 +238,11 @@ sync
 # Racing two poweroffs from different processes works but makes for
 # confusing logs; leaving it to the supervisor keeps the shutdown path
 # single-sourced.
+#
+# In the chained-restore case (--in-sub-ns), the same chain works: criu
+# dump kills the dumped tree → criu_restore's wait returns → criu_restore
+# exits → /sbin/machinen-restore unblocks → /sbin/machinen-poweroff.
+# Our process here may be SIGKILLed by the kernel's pid_ns destruction
+# before this exit fires (we're a process inside the dying sub-NS), but
+# the data has already been flushed to the block device above.
 exit 0

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -11,8 +11,8 @@
 set -eu
 
 # Debian's dash defaults PATH to /usr/bin:/bin when unset, which
-# leaves criu (in /usr/sbin) unreachable. Export a broad PATH
-# regardless of what /init's envp carried.
+# leaves criu (in /usr/sbin) and unshare/nsenter unreachable. Export
+# a broad PATH regardless of what /init's envp carried.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
 
@@ -70,20 +70,32 @@ if [ ! -d /mnt/snap-src/img ] || [ -z "$(ls -A /mnt/snap-src/img 2>/dev/null)" ]
     exit 1
 fi
 
-echo "machinen-restore: starting criu restore"
-# No `unshare --pid` (#207): the original layout put criu in a fresh
-# PID namespace so dumped PIDs couldn't collide with anything in the
-# restore container, but that left the restored workload one namespace
-# below where /sbin/machinen-dump runs — making it impossible to dump
-# again. We're PID 1 with only exec-agent / winsize-agent (low PIDs)
-# alongside us, dumped workload PIDs are typically much higher, so
-# collisions are rare in practice. If they happen, criu surfaces a
-# clear error instead of corrupting state.
+echo "machinen-restore: starting criu restore in a fresh PID namespace"
+# Run criu inside `unshare --pid --fork --mount-proc` so the restored
+# workload's PIDs land in a fresh namespace (#215). Without this, the
+# dumped tree's PIDs (e.g. 60, 73, 77 — captured wherever the source
+# VM's PID counter happened to sit) collide with PIDs already
+# allocated to /exec-agent, machinen-winsize-agent, and the
+# mount/blkid/grep/mkdir helpers above, and `criu` aborts with
+# `clone3(set_tid=N): EEXIST`. Burning PIDs in the parent NS is
+# unreliable because the dumped range is open-ended (longer chains
+# amplify it); a fresh sub-NS guarantees the dumped PIDs are free.
 #
-# --pidfile writes the restored task's host PID to a file we can hand
-# to a future `criu dump --tree <pid>`. Counterpart of what
-# machinen-supervisor.sh writes from its inner sh -c on a fresh boot;
-# same path so machinen-dump finds either flavor uniformly.
+# --pid: new PID namespace.
+# --fork: required because unshare(CLONE_NEWPID) only takes effect for
+#   the calling process's children; --fork makes unshare actually do
+#   that fork before exec'ing criu, so criu becomes PID 1 of the new NS.
+# --mount-proc: clones the mount namespace and remounts /proc to
+#   reflect the new PID NS. Without this, criu would read the parent's
+#   /proc and see PIDs that don't match its own NS.
+#
+# We background the unshare so we can record the criu host PID before
+# `wait`-ing — `/sbin/machinen-dump` needs it to nsenter the sub-NS
+# on a chained snapshot.
+#
+# --pidfile writes the restored task's pid (in the new NS) — useful for
+# `criu dump --tree <pid>` after we nsenter into the sub-NS. The
+# corresponding host PID is captured below.
 #
 # --work-dir /tmp keeps logs + per-restore working state off the
 # read-only bundle mount. CRIU writes `restore.log` (and stats / aux
@@ -91,19 +103,51 @@ echo "machinen-restore: starting criu restore"
 # fail with "Can't create log file restore.log: Read-only file system"
 # on v4.2 (3.17.1 was lenient about this and didn't always need to
 # write the log).
-#
-# No -d: block until the restored tree's session leader exits, so this
-# shell (PID 1) stays alive for the life of the workload and can
-# trigger a clean poweroff afterwards.
-if ! criu restore \
-        --images-dir /mnt/snap-src/img \
-        --work-dir /tmp \
-        --shell-job \
-        --tcp-established \
-        --pidfile /run/machinen-workload.pid \
-        -v3 \
-        -o restore.log; then
-    echo "machinen-restore: CRIU restore failed — tail of restore.log:" >&2
+unshare --pid --fork --mount-proc -- \
+        criu restore \
+            --images-dir /mnt/snap-src/img \
+            --work-dir /tmp \
+            --shell-job \
+            --tcp-established \
+            --pidfile /run/machinen-workload.pid \
+            -v3 \
+            -o restore.log &
+UNSHARE_PID=$!
+
+# Discover the criu host PID (the sole child of the unshare process).
+# /proc/<pid>/task/<pid>/children is space-separated; in our case
+# there's exactly one entry — the forked child that exec'd criu.
+# Loop briefly because unshare's fork happens after we capture $!.
+CRIU_HOST_PID=""
+i=0
+while [ $i -lt 50 ]; do
+    if [ -r "/proc/$UNSHARE_PID/task/$UNSHARE_PID/children" ]; then
+        first=$(cut -d' ' -f1 < "/proc/$UNSHARE_PID/task/$UNSHARE_PID/children" 2>/dev/null || true)
+        case "$first" in
+            ''|*[!0-9]*) ;;
+            *) CRIU_HOST_PID="$first"; break ;;
+        esac
+    fi
+    sleep 0.1
+    i=$((i + 1))
+done
+
+# Persist the criu host PID for /sbin/machinen-dump. Empty means a
+# chained snapshot will refuse to dump and the user gets a clear
+# error rather than CRIU walking the wrong tree.
+if [ -n "$CRIU_HOST_PID" ]; then
+    printf '%s' "$CRIU_HOST_PID" > /run/machinen-workload-host.pid
+else
+    echo "machinen-restore: warning — could not discover criu host PID" >&2
+fi
+
+# Wait for criu to finish (it blocks until the restored tree exits,
+# courtesy of no -d). Using `|| RC=$?` keeps `set -e` from yanking us
+# before we can drain logs and signal the agents.
+RC=0
+wait "$UNSHARE_PID" || RC=$?
+if [ "$RC" -ne 0 ]; then
+    echo "machinen-restore: CRIU restore failed (rc=$RC) — tail of restore.log:" >&2
     tail -40 /tmp/restore.log >&2 || true
     kill -TERM "$AGENT_PID" 2>/dev/null || true
     if [ -n "$WINSIZE_PID" ]; then

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3321,7 +3321,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2014](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2014)
+Defined in: [vm.ts:2016](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2016)
 
 #### Extends
 
@@ -3633,7 +3633,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2019](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2019)
+Defined in: [vm.ts:2021](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2021)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3642,7 +3642,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2027](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2027)
+Defined in: [vm.ts:2029](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2029)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3654,7 +3654,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2033](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2033)
+Defined in: [vm.ts:2035](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2035)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4140,7 +4140,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1718](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1718)
+Defined in: [vm.ts:1720](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1720)
 
 #### Type Declaration
 
@@ -4696,7 +4696,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1566](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1566)
+Defined in: [vm.ts:1568](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1568)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4735,7 +4735,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1608](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1608)
+Defined in: [vm.ts:1610](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1610)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4767,7 +4767,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2052](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2052)
+Defined in: [vm.ts:2054](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2054)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -4802,7 +4802,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2099](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2099)
+Defined in: [vm.ts:2101](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2101)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/snapshot-latency.test.ts
+++ b/packages/runtime/src/__tests__/snapshot-latency.test.ts
@@ -85,7 +85,7 @@ describe("latency", () => {
     console.log(
       JSON.stringify({
         spawnToRestoreOkMs: restoreOkMs,
-        note: "cold VMM boot + kernel + criu-ns restore to 'restore OK'",
+        note: "cold VMM boot + kernel + criu restore (in fresh PID NS) to 'restore OK'",
       }),
     );
   }, 60_000);

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -1379,8 +1379,10 @@ function synthesizeAndPackBundle(
   // cmd resolution:
   //   - Snapshot-only restore (`boot({ snapshot })` with no cmd):
   //     synthesize `["/sbin/machinen-restore"]`. The helper mounts
-  //     /dev/vda, spawns a fresh exec-agent, and runs `criu-ns
-  //     restore` against the baked images.
+  //     /dev/vda, spawns a fresh exec-agent, and runs `criu restore`
+  //     inside `unshare --pid --fork --mount-proc` so the dumped
+  //     workload's PIDs don't collide with the restore-side helpers
+  //     on chained restores (#215).
   //   - Normal boot: user's cmd wins; fall back to image's baked
   //     default. Then wrap in /sbin/machinen-supervisor so the
   //     workload runs as a CRIU-dumpable child of /init and the

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -59,7 +59,11 @@ OUT="${ROOT}/release-assets"
 ROOTFS_IMG_CACHE="${HOME}/.cache/machinen/rootfs"
 
 mkdir -p "$OUT"
-rm -f "$OUT"/*
+# Preserve any pre-staged kernel/dtb (darwin dev workflow); wipe
+# everything else so a stale rootfs.tar.gz can't get picked up.
+find "$OUT" -mindepth 1 -maxdepth 1 \
+  ! -name 'Image-arm64' ! -name 'virt-arm64.dtb' ! -name '*.sha256' \
+  -exec rm -f {} +
 rm -rf "${ROOTFS_IMG_CACHE:?}"/*.img "${ROOTFS_IMG_CACHE:?}"/*-staging-* 2>/dev/null || true
 
 # ------------------------------------------------------------
@@ -75,6 +79,9 @@ rm -rf "${ROOTFS_IMG_CACHE:?}"/*.img "${ROOTFS_IMG_CACHE:?}"/*-staging-* 2>/dev/
 # to ssh into a native arm64 box). qemu-emulated kernel builds work
 # but take hours, so we hard-fail rather than silently sandbag.
 
+if [ -f "$OUT/Image-arm64" ]; then
+  echo "==> Reusing existing kernel: $OUT/Image-arm64 ($(stat -f %z "$OUT/Image-arm64" 2>/dev/null || stat -c %s "$OUT/Image-arm64") bytes)"
+else
 echo "==> Building custom arm64 kernel with virtio_* + ext4 + vsock + fuse =y"
 
 if [ -n "${MACHINEN_REMOTE_BUILDER:-}" ]; then
@@ -105,13 +112,18 @@ else
   echo "  delegate the build, or run this script on ubuntu-24.04-arm." >&2
   exit 1
 fi
+fi  # close the "Reuse existing kernel" guard
 
 # ------------------------------------------------------------
 # 2. Device tree blob
 # ------------------------------------------------------------
 
-echo "==> Compiling virt.dts -> virt-arm64.dtb"
-dtc -I dts -O dtb "${ASSETS}/virt.dts" -o "${OUT}/virt-arm64.dtb"
+if [ -f "$OUT/virt-arm64.dtb" ]; then
+  echo "==> Reusing existing dtb: $OUT/virt-arm64.dtb"
+else
+  echo "==> Compiling virt.dts -> virt-arm64.dtb"
+  dtc -I dts -O dtb "${ASSETS}/virt.dts" -o "${OUT}/virt-arm64.dtb"
+fi
 
 # ------------------------------------------------------------
 # 3. Guest binaries: /init + /exec-agent + /sbin/machinen-netup
@@ -251,20 +263,26 @@ chmod +x /tmp/setup-hook.sh
 #
 #   criu: required by any snapshot flow (`build()` dumps at freeze
 #   time, `spawn({ snapshot })` restores at boot time). Pulls ~5MB of
-#   libs (libnl, libprotobuf-c, libnftables). The criu-ns shell helper
-#   that solves PID collisions across boots ships in the same package.
-#   APT::Install-Recommends "false" is already set by the setup hook,
-#   so criu's optional python3 suggestion is skipped. The Debian
-#   binary is overlaid with an upstream-tag build below — see
-#   "CRIU overlay" — but we keep the package installed for its
-#   runtime libs and the dpkg manifest.
+#   libs (libnl, libprotobuf-c, libnftables).  The PID-namespace
+#   isolation that solves cross-restore collisions (#215) is wrapped
+#   in /sbin/machinen-restore with util-linux's `unshare`, not the
+#   upstream criu-ns Python helper — Python is stripped from the
+#   rootfs to save ~30 MB.  APT::Install-Recommends "false" is set
+#   by the setup hook so criu's optional python3 suggestion is
+#   skipped.  The Debian binary is overlaid with an upstream-tag
+#   build below — see "CRIU overlay" — but we keep the package
+#   installed for its runtime libs and the dpkg manifest.
 #
 #   e2fsprogs: mkfs.ext4 + blkid. /sbin/machinen-dump formats /dev/vda
 #   on first snapshot so CRIU has a filesystem to write images into;
 #   /sbin/machinen-restore uses blkid to verify before mounting.
 #
-#   mount: util-linux's `mount` / `umount` are Essential on Debian,
-#   so they ride in with minbase — no extra --include line needed.
+#   mount + unshare + nsenter: util-linux's `mount`/`umount` are
+#   Essential on Debian, so they ride in with minbase — no extra
+#   --include line needed. `unshare` (used by /sbin/machinen-restore
+#   to put criu in a fresh PID NS, #215) and `nsenter` (used by
+#   /sbin/machinen-dump to dump across the sub-NS boundary) are
+#   shipped in the same util-linux package.
 #
 #   iputils-ping: baked in so users can sanity-check connectivity
 #   without an `apt install`. Over gvproxy ICMP works via unprivileged

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -107,17 +107,20 @@ echo "smoke: VMM=$MACHINEN_VMM"
 echo "smoke: ASSETS=$MACHINEN_ASSETS_DIR"
 echo
 
-# Capability probe: N-series (vsock exec) and P/C-series (criu, vsock
-# modules, fnm) need a #77+ rootfs. Peek inside the tarball for marker
-# files; skip dependent sections with a warning if we're running
-# against a stale (pre-#77) rootfs. Rebuild with
-# ./scripts/build-base-assets.sh to pick them up.
+# Capability probe: N-series (vsock exec) and P/C-series (criu, fnm)
+# need a #77+ rootfs. Peek inside the tarball for marker files; skip
+# dependent sections with a warning if we're running against a stale
+# (pre-#77) rootfs. Rebuild with ./scripts/build-base-assets.sh to
+# pick them up.
 ROOTFS_TAR="$ASSETS/rootfs-debian-arm64.tar.gz"
 ROOTFS_SUPPORTS_VSOCK_EXEC=1
 ROOTFS_SUPPORTS_CRIU=1
 ROOTFS_SUPPORTS_SNAPSHOT_HELPERS=1
-if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "vmw_vsock_virtio_transport"; then
-  echo "smoke: WARN rootfs lacks vsock modules — N-series (vm.exec) will be skipped"
+# vsock support moved from /lib/modules into the kernel image (#119),
+# so the modern marker is /exec-agent in the rootfs (#93's vsock-using
+# helper) rather than the old `vmw_vsock_virtio_transport.ko` path.
+if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "^./exec-agent$"; then
+  echo "smoke: WARN rootfs lacks /exec-agent — N-series (vm.exec) will be skipped"
   ROOTFS_SUPPORTS_VSOCK_EXEC=0
 fi
 if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "usr/sbin/criu"; then
@@ -737,31 +740,62 @@ else
 fi  # S1 rootfs-capability gate
 
 # ----------------------------------------------------------------
-# S2: chained snapshot — snapshot a restored VM (#207).
-#   1. boot fresh, snapshot → bundle A
+# S2: chained snapshot — snapshot a restored VM (#207, #215).
+#   1. boot a high-PID bash workload, snapshot → bundle A
 #   2. restore bundle A
-#   3. snapshot the restored VM → bundle B
-#   4. restore bundle B and exec on it to prove it's alive
-# Verifies the reflink-clone (so bundle A survives step 3) and
-# /run/machinen-workload.pid (written by criu --pidfile on restore so
-# step 3 can find the workload).
+#   3. snapshot the restored VM → bundle B  (2nd-generation chain)
+#   4. restore bundle B
+#   5. snapshot the chain-restored VM → bundle C  (3rd-gen chain — #215)
+#   6. restore bundle C and exec on it to prove it's alive
+# Verifies:
+#   - reflink-clone (bundle A survives step 3) — #207
+#   - /run/machinen-workload.pid (written by criu --pidfile on restore so
+#     step 3 can find the workload) — #207
+#   - PID-namespace isolation in machinen-restore.sh (#215). The bash
+#     workload below runs 200 short-lived subshells before the long
+#     sleep loop so the dumped tree's PIDs are well above what the
+#     restore-side helpers (exec-agent, mount, blkid, mkdir, the sub-NS
+#     criu daemon) want to allocate. Without #215's `unshare --pid`
+#     the chained restore (step 4) fails with `clone3(set_tid=N): EEXIST`
+#     and the kernel panics ("init exited 1").
 # ----------------------------------------------------------------
 if [[ "$ROOTFS_SUPPORTS_VSOCK_EXEC" -eq 0 || "$ROOTFS_SUPPORTS_CRIU" -eq 0 || "$ROOTFS_SUPPORTS_SNAPSHOT_HELPERS" -eq 0 ]]; then
   echo "S2: skipped (rootfs lacks vsock/criu/snapshot helpers)"
 else
-  echo "S2: chained snapshot (snapshot a restored VM)"
+  echo "S2: chained snapshot (snapshot a restored VM, 3 generations, high PIDs)"
   S2_NAME="chained-smoke-$$"
   S2_BG_LOG="$FIXTURE/s2-bg.log"
   S2_SNAP_A="$FIXTURE/s2-snap-a"
   S2_SNAP_B="$FIXTURE/s2-snap-b"
+  S2_SNAP_C="$FIXTURE/s2-snap-c"
   S2_SCRATCH="$FIXTURE/s2-scratch.img"
   S2_RESTORE_A_LOG="$FIXTURE/s2-restore-a.log"
   S2_RESTORE_B_LOG="$FIXTURE/s2-restore-b.log"
+  S2_RESTORE_C_LOG="$FIXTURE/s2-restore-c.log"
 
   truncate -s 256M "$S2_SCRATCH"
 
+  # Spawn 30 long-running sleep children so the dumped tree spans a
+  # range of PIDs (workload + 30 sleeps as direct children). This
+  # reproduces the #215 collision: on chained restore CRIU has to
+  # set_tid each PID in turn, and its own internal forks between
+  # set_tid calls land on the same range — last_pid advances past
+  # the next set_tid target and clone3() returns EEXIST. Without
+  # `unshare --pid` in /sbin/machinen-restore the chain falls over
+  # at gen-2 or gen-3 with "Can't fork for N: File exists" and
+  # /init dies, panicking the kernel ("Attempted to kill init!").
+  # /bin/bash isn't in the base rootfs (Debian minbase ships
+  # /bin/dash + /bin/sh) so we use sh; the dumped tree shape is
+  # what matters, not the shell choice.
   S2_PID=$(boot_bg "$S2_NAME" "$S2_BG_LOG" --snapshot "$S2_SCRATCH" -- \
-    /bin/sh -c "while :; do sleep 1; done")
+    /bin/sh -c '
+      i=0
+      while [ "$i" -lt 30 ]; do
+        sleep 100000 &
+        i=$((i + 1))
+      done
+      wait
+    ')
   cleanup_s2() {
     kill -TERM "$S2_PID" 2>/dev/null || true
     wait "$S2_PID" 2>/dev/null || true
@@ -867,14 +901,67 @@ else
   S2_RESTORE_B_EXEC_LOG="$FIXTURE/s2-restore-b-exec.log"
   if cli exec --name "$S2_RESTORED_B" -- uname -m >"$S2_RESTORE_B_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S2_RESTORE_B_EXEC_LOG"; then
-    pass "exec-agent responds on the chain-restored VM"
+    pass "exec-agent responds on the chain-restored VM (gen 2)"
   else
     cat "$S2_RESTORE_B_EXEC_LOG" >&2
     tail -60 "$S2_RESTORE_B_LOG" >&2
     fail "S2 — exec against chain-restored VM failed"
   fi
 
-  cleanup_s2_restore_b
+  # 3rd-generation chain (#215): snapshot the chain-restored VM, then
+  # restore that and exec. This is the case the issue calls out as
+  # recursive-safe — the dumped tree's PIDs accumulate as the chain
+  # deepens, so a depth-3 restore is the canary for whether
+  # /sbin/machinen-dump can dump across a sub-NS boundary.
+  S2_DUMP_C_LOG="$FIXTURE/s2-dump-c.log"
+  if ! cli snapshot --name "$S2_RESTORED_B" --out-dir "$S2_SNAP_C" 2>"$S2_DUMP_C_LOG"; then
+    tail -80 "$S2_RESTORE_B_LOG" >&2
+    cat "$S2_DUMP_C_LOG" >&2
+    fail "S2 — gen-3 'machinen snapshot' (restored-B → C) failed"
+  fi
+  wait "$S2_RESTORE_B_PID" 2>/dev/null || true
+  pass "gen-3 chained snapshot → bundle C"
+
+  if [[ ! -s "$S2_SNAP_C/disk.img" ]]; then
+    fail "S2 — gen-3 snapshot bundle C has empty disk.img"
+  fi
+
+  node "$CLI" restore "$S2_SNAP_C" >"$S2_RESTORE_C_LOG" 2>&1 &
+  S2_RESTORE_C_PID=$!
+  cleanup_s2_restore_c() {
+    kill -TERM "$S2_RESTORE_C_PID" 2>/dev/null || true
+    wait "$S2_RESTORE_C_PID" 2>/dev/null || true
+  }
+  trap 'cleanup_s2; cleanup_s2_restore_c; rm -rf "$FIXTURE"' EXIT
+
+  S2_RESTORED_C=""
+  deadline=$((SECONDS + 45))
+  while (( SECONDS < deadline )); do
+    cand=$(cli ls 2>/dev/null | awk -v src="$S2_RESTORED_B/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+    if [[ -n "$cand" ]]; then
+      S2_RESTORED_C=$cand
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$S2_RESTORED_C" ]]; then
+    tail -80 "$S2_RESTORE_C_LOG" >&2
+    cli ls >&2 || true
+    fail "S2 — gen-3 restored-from-C VM never registered"
+  fi
+  pass "restored bundle C as '$S2_RESTORED_C'"
+
+  S2_RESTORE_C_EXEC_LOG="$FIXTURE/s2-restore-c-exec.log"
+  if cli exec --name "$S2_RESTORED_C" -- uname -m >"$S2_RESTORE_C_EXEC_LOG" 2>&1 \
+     && grep -qE "aarch64|arm64" "$S2_RESTORE_C_EXEC_LOG"; then
+    pass "exec-agent responds on the gen-3 chain-restored VM"
+  else
+    cat "$S2_RESTORE_C_EXEC_LOG" >&2
+    tail -60 "$S2_RESTORE_C_LOG" >&2
+    fail "S2 — exec against gen-3 chain-restored VM failed"
+  fi
+
+  cleanup_s2_restore_c
   trap 'rm -rf "$FIXTURE"' EXIT
 fi  # S2 rootfs-capability gate
 


### PR DESCRIPTION
## Summary
- Wrap `criu restore` in `unshare --pid --fork --mount-proc` so the dumped tree's PIDs land in a fresh namespace and can't collide with restore-side helpers (#215). Capture the criu host PID for the dump path.
- Make `/sbin/machinen-dump` re-enter the sub-NS via `nsenter --pid --mount --root --wd=/` and re-exec itself with `--in-sub-ns <pid>` when the workload lives in a sub-PID-NS. `--root` is required because criu's mount NS has a pivoted root the parent NS can't path-resolve into.
- Smoke S2 now snapshots a 30-child sleep tree (high PIDs) through three generations of chain so the collision is reproduced in CI, not just on real workloads.
- Drop the stale `vmw_vsock_virtio_transport.ko` smoke-test gate (vsock has been built into the kernel since #119) and add a darwin-friendly "reuse pre-staged kernel/dtb" path to `build-base-assets.sh`.

Closes #215

## Test plan
- [x] \`npx vitest run\` — 24 passed, 1 skipped, 361/368 tests
- [x] \`npx agent-ci run --all -q -p\` — ✓ 4 workflows passed
- [x] \`pnpm smoke-tests\` — S2 passes through gen-1 (snapshot → A), gen-2 (chained → B), and gen-3 (chained → C); `exec` succeeds on the gen-3 chain-restored VM
- [ ] CI green on push
