### PR TITLE
feat: vm.fork() — snapshot-and-restore without killing the source (#216)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       # don't need the C++ toolchain or Zig that node-pty/microvm want.
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - run: pnpm run docs
+      - run: pnpm run build:docs
 
       # Fail if the committed API.md drifts from the regenerated one —
       # this is the canary for @throws (and other JSDoc) going stale.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "pnpm -F @machinen/runtime -F @machinen/cli build && changeset publish",
     "premachinen": "pnpm -F @machinen/runtime -F @machinen/cli build",
     "machinen": "MACHINEN_ASSETS_DIR=${MACHINEN_ASSETS_DIR:-$PWD/release-assets} node packages/cli/dist/cli.js",
-    "docs": "typedoc",
+    "build:docs": "typedoc",
     "dev": "bash scripts/dev.sh",
     "provision": "node provision.ts",
     "provision-test-vm": "node scripts/provision-test-vm.ts",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,12 +21,13 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   renameSync,
   symlinkSync,
   unlinkSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 
@@ -673,8 +674,10 @@ async function runPtyExec(
 }
 
 async function cmdSnapshot(args: string[]): Promise<number> {
-  // Pull --out-dir out of the arg list, then parse the target flags.
+  // Pull --out-dir / --keep-alive out of the arg list, then parse the
+  // target flags.
   let outDir: string | undefined;
+  let keepAlive = false;
   const rest: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
@@ -683,23 +686,113 @@ async function cmdSnapshot(args: string[]): Promise<number> {
       if (!outDir) {
         die("--out-dir requires a directory path");
       }
+    } else if (a === "--keep-alive") {
+      // Source survives the dump (CRIU --leave-running). Default
+      // closes inherited TCP sockets — two live copies sharing the
+      // same connection state can't both talk to the peer cleanly.
+      keepAlive = true;
     } else {
       rest.push(a);
     }
   }
   if (!outDir) {
-    die("usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir>");
+    die(
+      "usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive]",
+    );
   }
   const target = parseTargetFlags(rest, "snapshot");
   const vm = await attach(target).catch(handleError);
   try {
     const res = await vm.snapshot({
       outDir: resolve(outDir),
+      leaveRunning: keepAlive,
+      tcpClose: keepAlive,
       onLog: (evt) => {
         process.stderr.write(evt.chunk);
       },
     });
     process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
+    return 0;
+  } catch (err) {
+    handleError(err);
+  } finally {
+    await vm.detach();
+  }
+}
+
+async function cmdFork(args: string[]): Promise<number> {
+  // `machinen fork ( --name <src> | --pid <pid> ) [--new-name <dst>]
+  //                [--out-dir <dir>] [--tcp-keep]`.
+  //
+  // Snapshots the source live (--leave-running), restores into a
+  // sibling, and prints the new VM's identity. Source keeps running.
+  let newName: string | undefined;
+  let outDir: string | undefined;
+  let tcpKeep = false;
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--new-name" || a.startsWith("--new-name=")) {
+      newName = a === "--new-name" ? args[++i] : a.slice("--new-name=".length);
+      if (!newName) {
+        die("--new-name requires a value");
+      }
+    } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
+      outDir = a === "--out-dir" ? args[++i] : a.slice("--out-dir=".length);
+      if (!outDir) {
+        die("--out-dir requires a directory path");
+      }
+    } else if (a === "--tcp-keep") {
+      tcpKeep = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  const target = parseTargetFlags(rest, "fork");
+
+  // The fork is a fresh restore boot, so it needs the same base
+  // assets `cmdRestore` resolves (kernel + dtb + rootfs in the
+  // initramfs for /sbin/machinen-restore + criu).
+  const assetsOverride = process.env.MACHINEN_ASSETS_DIR;
+  if (assetsOverride) {
+    validateAssetsDir(assetsOverride);
+  } else if (!baseAssetsComplete(RELEASE_TAG)) {
+    process.stderr.write(`machinen: fetching base assets for ${RELEASE_TAG} (first run)\n`);
+    await ensureBaseAssets(RELEASE_TAG);
+  }
+  const baseDir = assetsOverride ? resolve(assetsOverride) : baseDirFor(RELEASE_TAG);
+  const kernelPath = join(baseDir, assetsOverride ? "Image-arm64" : "Image");
+  const dtbPath = join(baseDir, assetsOverride ? "virt-arm64.dtb" : "virt.dtb");
+  const imagePath = join(baseDir, assetsOverride ? "rootfs-debian-arm64.tar.gz" : "rootfs.tar.gz");
+
+  // The runtime's ephemeral-bundle cleanup hangs off `fork.wait()`,
+  // which the CLI can't await — `cmdFork` returns as soon as the
+  // fork is registered. So the CLI always materializes an explicit
+  // outDir (caller-supplied or a temp dir we print) and skips the
+  // runtime's ephemeral mode. When --out-dir was omitted the user
+  // is responsible for `rm -rf`-ing the printed path.
+  const resolvedOutDir = outDir ? resolve(outDir) : mkdtempSync(join(tmpdir(), "machinen-fork-"));
+  const vm = await attach(target).catch(handleError);
+  try {
+    const fork = await vm.fork({
+      name: newName,
+      outDir: resolvedOutDir,
+      image: imagePath,
+      kernel: kernelPath,
+      dtb: dtbPath,
+      tcpKeep,
+      onLog: (evt) => {
+        process.stderr.write(evt.chunk);
+      },
+    });
+    process.stdout.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
+    if (!outDir) {
+      process.stderr.write(`bundle: ${resolvedOutDir} (rm -rf when the fork exits)\n`);
+    }
+    // Detach the fork handle — the new VM keeps running, owned by its
+    // own VMM process. Same shape as `cmdSnapshot`: we did the work,
+    // hand it off, return.
+    await fork.detach();
     return 0;
   } catch (err) {
     handleError(err);
@@ -841,7 +934,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install ls ps exec snapshot attach repl completion --version --help -h -v"
+  local cmds="boot restore install ls ps exec snapshot fork attach repl completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -861,7 +954,7 @@ _machinen_completion() {
       ;;
   esac
   case "\${words[1]}" in
-    exec|snapshot|attach|repl)
+    exec|snapshot|fork|attach|repl)
       COMPREPLY=( $(compgen -W "--name --pid" -- "\${cur}") )
       return
       ;;
@@ -874,7 +967,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install ls ps exec snapshot attach repl completion)
+  cmds=(boot restore install ls ps exec snapshot fork attach repl completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -894,7 +987,7 @@ _machinen() {
       ;;
   esac
   case "\${words[2]}" in
-    exec|snapshot|attach|repl)
+    exec|snapshot|fork|attach|repl)
       _describe 'flag' '(--name --pid)'
       return
       ;;
@@ -905,9 +998,9 @@ compdef _machinen machinen
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install ls ps exec snapshot attach repl completion
+set -l cmds boot restore install ls ps exec snapshot fork attach repl completion
 complete -c machinen -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
-for sub in exec snapshot attach repl
+for sub in exec snapshot fork attach repl
   complete -c machinen -f -n "__fish_seen_subcommand_from $sub" -l name \\
     -a '(machinen ls 2>/dev/null | awk \\'NR>1 && $2!="-"{print $2}\\')'
   complete -c machinen -f -n "__fish_seen_subcommand_from $sub" -l pid \\
@@ -986,7 +1079,18 @@ function printHelp(): void {
       `                                                 pipes (good for one-shot commands).\n` +
       `                                                 Example:\n` +
       `                                                   machinen exec <target-flag> --tty -- bash -i\n` +
-      `  machinen snapshot <target-flag> --out-dir <d>  CRIU-snapshot a running VM into <d>\n` +
+      `  machinen snapshot <target-flag> --out-dir <d> [--keep-alive]\n` +
+      `                                                 CRIU-snapshot a running VM into <d>.\n` +
+      `                                                 Default: source VM exits as part of the\n` +
+      `                                                 dump. --keep-alive leaves it running\n` +
+      `                                                 (and closes inherited TCP sockets to\n` +
+      `                                                 avoid two live copies racing on shared\n` +
+      `                                                 connection state).\n` +
+      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep]\n` +
+      `                                                 Snapshot the source live (it keeps\n` +
+      `                                                 running) and restore into a sibling VM.\n` +
+      `                                                 Without --out-dir, the bundle is\n` +
+      `                                                 ephemeral and removed when the fork exits.\n` +
       `  machinen attach   <target-flag> [--shell <c>]  Drop into an interactive PTY shell\n` +
       `                                                 in the running VM (default \`bash -i\`).\n` +
       `                                                 \`cd\`, env vars, history, job control\n` +
@@ -1055,6 +1159,8 @@ async function main(): Promise<number> {
       return cmdExec(rest);
     case "snapshot":
       return cmdSnapshot(rest);
+    case "fork":
+      return cmdFork(rest);
     case "attach":
       return cmdAttach(rest);
     case "repl":

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -696,9 +696,7 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     }
   }
   if (!outDir) {
-    die(
-      "usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive]",
-    );
+    die("usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive]");
   }
   const target = parseTargetFlags(rest, "snapshot");
   const vm = await attach(target).catch(handleError);

--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
 # /sbin/machinen-dump — dumps the user workload with CRIU onto the
-# scratch disk and triggers a clean poweroff.
+# scratch disk and triggers a clean poweroff (or, with
+# MACHINEN_DUMP_LEAVE_RUNNING=1, leaves the workload running so the
+# host can fork it — see #216).
 #
 # Runs inside the guest, invoked by `vm.snapshot()` via vsock exec.
 # The host-side `vm.snapshot()` then copies the scratch disk's backing
 # file to the caller's outPath and returns.
+#
+# Env knobs:
+#   MACHINEN_DUMP_LEAVE_RUNNING=1   pass --leave-running to criu dump.
+#                                    The workload survives the dump and
+#                                    the supervisor's wait does NOT
+#                                    return — the host signals success
+#                                    by this script's exit, not by VMM
+#                                    poweroff. Used by `vm.fork()`.
+#   MACHINEN_DUMP_TCP_CLOSE=1        omit --tcp-established. Default
+#                                    (no env / unset) keeps it. The
+#                                    fork path sets this so the cloned
+#                                    VM doesn't share live TCP state
+#                                    with the parent.
 #
 # Scratch disk lives at /dev/vdb when the VM was booted with virtio-blk
 # root (/dev/vda is the rootfs in that case — see #114). On legacy
@@ -39,6 +54,18 @@ case "${1:-}" in
         shift
         ;;
 esac
+
+# Read fork-mode knobs (#216). nsenter passes env through to the
+# re-exec'd self in the sub-NS, so reading them here covers both the
+# direct dump and the chained dump path.
+LEAVE_RUNNING=0
+if [ "${MACHINEN_DUMP_LEAVE_RUNNING:-0}" = "1" ]; then
+    LEAVE_RUNNING=1
+fi
+TCP_CLOSE=0
+if [ "${MACHINEN_DUMP_TCP_CLOSE:-0}" = "1" ]; then
+    TCP_CLOSE=1
+fi
 
 # Pick the scratch disk: /dev/vdb when virtio-blk-root booted (rootfs
 # took /dev/vda); else /dev/vda for the legacy single-disk layout.
@@ -208,18 +235,29 @@ mount "$SCRATCH" /mnt/snap
 rm -rf /mnt/snap/img
 mkdir -p /mnt/snap/img
 
-echo "machinen-dump: dumping tree rooted at pid=$DUMP_PID"
+echo "machinen-dump: dumping tree rooted at pid=$DUMP_PID (leave_running=$LEAVE_RUNNING tcp_close=$TCP_CLOSE)"
 # --tree recurses automatically.
 # --shell-job lets CRIU dump processes whose session leader is /init.
-# --tcp-established keeps TCP sockets (gvproxy-backed connections etc.)
+# --tcp-established keeps TCP sockets (gvproxy-backed connections etc.).
+#   Omitted when MACHINEN_DUMP_TCP_CLOSE=1 — fork (#216) sets that so
+#   the new VM doesn't share live TCP sockets with the source. CRIU
+#   restores those sockets in CLOSED state on the new side, which the
+#   workload sees as ECONNRESET on first I/O — the right semantic for
+#   "this is a copy, not a continuation."
+# --leave-running: CRIU normally SIGKILLs the dumped tree on success.
+#   Fork (#216) wants the source VM to keep going; this flag suppresses
+#   the kill so the supervisor's `wait` stays blocked and the workload
+#   resumes execution from the dump point with no observable hiccup.
 # -v3 + log file: if dump fails, tail /mnt/snap/img/dump.log on stderr.
-if ! criu dump \
-        --tree "$DUMP_PID" \
-        --images-dir /mnt/snap/img \
-        --shell-job \
-        --tcp-established \
-        -v3 \
-        -o dump.log; then
+DUMP_ARGS="--tree $DUMP_PID --images-dir /mnt/snap/img --shell-job -v3 -o dump.log"
+if [ "$TCP_CLOSE" -eq 0 ]; then
+    DUMP_ARGS="$DUMP_ARGS --tcp-established"
+fi
+if [ "$LEAVE_RUNNING" -eq 1 ]; then
+    DUMP_ARGS="$DUMP_ARGS --leave-running"
+fi
+# shellcheck disable=SC2086 # word splitting on DUMP_ARGS is intentional
+if ! criu dump $DUMP_ARGS; then
     echo "machinen-dump: CRIU dump failed — tail of dump.log:" >&2
     tail -40 /mnt/snap/img/dump.log >&2 || true
     # Leave the mount + images in place for post-mortem. The host's
@@ -245,4 +283,10 @@ sync
 # Our process here may be SIGKILLed by the kernel's pid_ns destruction
 # before this exit fires (we're a process inside the dying sub-NS), but
 # the data has already been flushed to the block device above.
+#
+# Leave-running mode (#216): CRIU did NOT kill the workload, so the
+# supervisor's wait stays blocked and the VM keeps running. The host
+# uses our exit code (delivered over vsock by the exec-agent) as the
+# success signal instead of the VMM exit. There's nothing further to
+# do here; just exit 0.
 exit 0

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2796,7 +2796,7 @@ EXEC_VSOCK_UNAVAILABLE | EXEC_NONZERO_EXIT |
 
 > **snapshot**(`opts`): `Promise`\<[`SnapshotResult`](#snapshotresult)\>
 
-Defined in: [vm-handle.ts:129](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L129)
+Defined in: [vm-handle.ts:131](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L131)
 
 Freeze this VM with CRIU and write a snapshot bundle into
 `opts.outDir`. The bundle is a directory containing:
@@ -2821,8 +2821,10 @@ plus an mtime bump on the disk file — timer expiration throws
 Supported on both boot-owned and attach handles — attach uses
 the `diskPath` stored in the VM registry entry at boot time.
 
-The VM exits as part of the dump. To continue using the VM
-afterwards, restore from the produced snapshot bundle.
+By default the VM exits as part of the dump (CRIU kills the
+dumped tree on success). Pass `opts.leaveRunning: true` to keep
+the source VM alive — the workload resumes from the dump point
+and the bundle can be restored into a sibling VM (`vm.fork()`).
 
 ###### Parameters
 
@@ -2834,11 +2836,47 @@ afterwards, restore from the produced snapshot bundle.
 
 `Promise`\<[`SnapshotResult`](#snapshotresult)\>
 
+##### fork()
+
+> **fork**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
+
+Defined in: [vm-handle.ts:154](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L154)
+
+Snapshot this VM without killing it and immediately restore the
+bundle into a new sibling VM. Both source and fork keep running,
+independently addressable. See #216.
+
+Wraps `vm.snapshot({ leaveRunning: true })` + `restore()` with
+the safety defaults a fork wants:
+  - `tcpKeep: false` (default) → the fork sees ECONNRESET on
+    inherited TCP sockets, source keeps them. Set `tcpKeep: true`
+    if you want both copies to share state (rarely correct).
+  - `portForward: []` (default) → host ports are NOT inherited
+    (they're global; source + fork would race). Pass new
+    forwards explicitly.
+
+Returns a handle to the forked VM. The source VM is unaffected
+apart from being briefly frozen during `criu dump`.
+
+Bundle lifecycle: when `opts.outDir` is set, the bundle is kept
+and you can re-restore from it. When omitted, the bundle is
+written to a temp dir and removed when the fork exits.
+
+###### Parameters
+
+###### opts?
+
+[`ForkOptions`](#forkoptions)
+
+###### Returns
+
+`Promise`\<[`VmHandle`](#vmhandle)\>
+
 ***
 
 ### WriteFileOptions
 
-Defined in: [vm-handle.ts:132](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L132)
+Defined in: [vm-handle.ts:157](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L157)
 
 #### Properties
 
@@ -2846,7 +2884,7 @@ Defined in: [vm-handle.ts:132](https://github.com/redwoodjs/machinen/blob/main/p
 
 > `optional` **mode?**: `number`
 
-Defined in: [vm-handle.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L134)
+Defined in: [vm-handle.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L159)
 
 Octal mode for the destination file (e.g. `0o755`). Default: leave as-is.
 
@@ -2854,7 +2892,7 @@ Octal mode for the destination file (e.g. `0o755`). Default: leave as-is.
 
 > `optional` **recursive?**: `boolean`
 
-Defined in: [vm-handle.ts:136](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L136)
+Defined in: [vm-handle.ts:161](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L161)
 
 `mkdir -p` the parent directory before writing. Default: true.
 
@@ -2862,7 +2900,7 @@ Defined in: [vm-handle.ts:136](https://github.com/redwoodjs/machinen/blob/main/p
 
 > `optional` **append?**: `boolean`
 
-Defined in: [vm-handle.ts:138](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L138)
+Defined in: [vm-handle.ts:163](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L163)
 
 Append to the file instead of overwriting. Default: false.
 
@@ -2870,7 +2908,7 @@ Append to the file instead of overwriting. Default: false.
 
 ### SnapshotOptions
 
-Defined in: [vm-handle.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L141)
+Defined in: [vm-handle.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L166)
 
 #### Properties
 
@@ -2878,7 +2916,7 @@ Defined in: [vm-handle.ts:141](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **outDir**: `string`
 
-Defined in: [vm-handle.ts:147](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L147)
+Defined in: [vm-handle.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L172)
 
 Directory the snapshot bundle is written to. Created if missing
 and required to be empty (or absent) so a previous snapshot
@@ -2888,7 +2926,7 @@ can't be silently overwritten.
 
 > `optional` **dumpCmd?**: `string`
 
-Defined in: [vm-handle.ts:152](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L152)
+Defined in: [vm-handle.ts:177](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L177)
 
 Command to run in the guest to trigger the CRIU dump. Defaults to
 `/sbin/machinen-dump`.
@@ -2897,7 +2935,7 @@ Command to run in the guest to trigger the CRIU dump. Defaults to
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm-handle.ts:157](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L157)
+Defined in: [vm-handle.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L182)
 
 Wall-clock ceiling for the dump + shutdown. If the VMM hasn't exited
 in this window we SIGKILL it and fail. Default 90s.
@@ -2906,17 +2944,44 @@ in this window we SIGKILL it and fail. Default 90s.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm-handle.ts:163](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L163)
+Defined in: [vm-handle.ts:188](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L188)
 
 Streaming log callback — fires for every byte the dump emits
 (guest console + the dump exec). See #83. When both the snapshot
 call and `boot({ onLog })` have a callback set, both fire.
 
+##### leaveRunning?
+
+> `optional` **leaveRunning?**: `boolean`
+
+Defined in: [vm-handle.ts:197](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L197)
+
+Pass `--leave-running` to `criu dump` so the source workload
+survives the snapshot. The VMM stays up after the dump; success
+is signalled by the dump exec returning 0 instead of by VMM exit.
+Used by `vm.fork()` (#216).
+
+Default: false (current destructive snapshot behavior).
+
+##### tcpClose?
+
+> `optional` **tcpClose?**: `boolean`
+
+Defined in: [vm-handle.ts:207](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L207)
+
+Omit `--tcp-established` from `criu dump`. Restored sockets come
+back in CLOSED state — the workload sees ECONNRESET on first
+I/O, which is the right semantic when the dump is the source for
+a fork (otherwise both copies would race on the same connection
+state). See #216.
+
+Default: false (preserve TCP — current snapshot/restore behavior).
+
 ***
 
 ### SnapshotResult
 
-Defined in: [vm-handle.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L166)
+Defined in: [vm-handle.ts:210](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L210)
 
 #### Properties
 
@@ -2924,7 +2989,7 @@ Defined in: [vm-handle.ts:166](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **snapDir**: `string`
 
-Defined in: [vm-handle.ts:168](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L168)
+Defined in: [vm-handle.ts:212](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L212)
 
 Absolute path to the snapshot bundle directory.
 
@@ -2932,7 +2997,7 @@ Absolute path to the snapshot bundle directory.
 
 > **diskPath**: `string`
 
-Defined in: [vm-handle.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L170)
+Defined in: [vm-handle.ts:214](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L214)
 
 Absolute path to the disk image inside the bundle.
 
@@ -2940,7 +3005,7 @@ Absolute path to the disk image inside the bundle.
 
 > **elapsedMs**: `number`
 
-Defined in: [vm-handle.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L172)
+Defined in: [vm-handle.ts:216](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L216)
 
 Time from `snapshot()` entry to VMM exit, in milliseconds.
 
@@ -2948,7 +3013,7 @@ Time from `snapshot()` entry to VMM exit, in milliseconds.
 
 > **consoleLog**: `string`
 
-Defined in: [vm-handle.ts:174](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L174)
+Defined in: [vm-handle.ts:218](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L218)
 
 Guest console output captured during the dump.
 
@@ -2956,7 +3021,7 @@ Guest console output captured during the dump.
 
 ### SnapshotMeta
 
-Defined in: [vm-handle.ts:181](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L181)
+Defined in: [vm-handle.ts:225](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L225)
 
 On-disk shape of the bundle's `meta.json`. Read by `restore()`
 to reconstruct the source VM's name when registering the fork.
@@ -2967,7 +3032,7 @@ to reconstruct the source VM's name when registering the fork.
 
 > `optional` **sourceName?**: `string`
 
-Defined in: [vm-handle.ts:183](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L183)
+Defined in: [vm-handle.ts:227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L227)
 
 Name passed to `boot({ name })` when the source VM was started.
 
@@ -2975,15 +3040,120 @@ Name passed to `boot({ name })` when the source VM was started.
 
 > **snappedAt**: `number`
 
-Defined in: [vm-handle.ts:185](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L185)
+Defined in: [vm-handle.ts:229](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L229)
 
 ms epoch when `vm.snapshot()` returned.
 
 ***
 
+### ForkOptions
+
+Defined in: [vm-handle.ts:232](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L232)
+
+#### Properties
+
+##### name?
+
+> `optional` **name?**: `string`
+
+Defined in: [vm-handle.ts:237](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L237)
+
+Name for the forked VM. When omitted, the existing restore()
+auto-naming kicks in: `<sourceName>/<fork.pid>`.
+
+##### outDir?
+
+> `optional` **outDir?**: `string`
+
+Defined in: [vm-handle.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L244)
+
+If set, the snapshot bundle is written here and kept after the
+fork exits — re-restore from this path to spawn another sibling.
+If omitted, the bundle is written to a temp dir and removed
+when the fork's VMM exits.
+
+##### image?
+
+> `optional` **image?**: `string`
+
+Defined in: [vm-handle.ts:249](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L249)
+
+Override the rootfs image used for the fork's restore boot.
+Same semantics as `restore({ image })`.
+
+##### kernel?
+
+> `optional` **kernel?**: `string`
+
+Defined in: [vm-handle.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L251)
+
+Kernel path for the fork's boot. Same semantics as `boot({ kernel })`.
+
+##### dtb?
+
+> `optional` **dtb?**: `string`
+
+Defined in: [vm-handle.ts:253](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L253)
+
+DTB path for the fork's boot. Same semantics as `boot({ dtb })`.
+
+##### timeoutMs?
+
+> `optional` **timeoutMs?**: `number`
+
+Defined in: [vm-handle.ts:259](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L259)
+
+Wall-clock ceiling for the dump half. Default 90s (matches
+`vm.snapshot({ timeoutMs })`). Restore boot has its own
+implicit deadlines via `boot()`.
+
+##### onLog?
+
+> `optional` **onLog?**: [`OnLog`](#onlog)
+
+Defined in: [vm-handle.ts:264](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L264)
+
+Streaming log callback for the snapshot half. Same shape as
+`vm.snapshot({ onLog })`.
+
+##### tcpKeep?
+
+> `optional` **tcpKeep?**: `boolean`
+
+Defined in: [vm-handle.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L271)
+
+Default false: omit `--tcp-established` from the dump so the
+fork sees ECONNRESET on sockets the source had open. Set true
+to clone live TCP state into the fork (both VMs then race on
+the same connection — only correct in narrow scenarios).
+
+##### portForward?
+
+> `optional` **portForward?**: `object`[]
+
+Defined in: [vm-handle.ts:277](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L277)
+
+Host→guest port forwards for the fork. NOT inherited from the
+source — host ports are global and source + fork would race on
+the same bind. Pass explicitly when the fork needs forwards.
+
+###### hostPort
+
+> **hostPort**: `number`
+
+###### guestPort
+
+> **guestPort**: `number`
+
+###### hostAddr?
+
+> `optional` **hostAddr?**: `string`
+
+***
+
 ### BootOptions
 
-Defined in: [vm.ts:151](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L151)
+Defined in: [vm.ts:153](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L153)
 
 #### Properties
 
@@ -2991,7 +3161,7 @@ Defined in: [vm.ts:151](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:158](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L158)
+Defined in: [vm.ts:160](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L160)
 
 Path to a rootfs tarball to boot from (e.g. the output of
 `provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
@@ -3002,7 +3172,7 @@ boots and snapshot-only restores both skip initramfs packing).
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:164](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L164)
+Defined in: [vm.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L166)
 
 Command to run inside the guest. Packed into the synthesized
 `/machinen-config.json`. Paired with `image` — both required, or
@@ -3012,7 +3182,7 @@ neither.
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L170)
+Defined in: [vm.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L172)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3022,7 +3192,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L182)
+Defined in: [vm.ts:184](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L184)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3038,7 +3208,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **snapshot?**: `string` \| `false`
 
-Defined in: [vm.ts:203](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L203)
+Defined in: [vm.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L205)
 
 Attach a scratch virtio-blk device (`/dev/vdb`, or `/dev/vda` on
 pre-#114 layouts) so this VM can be CRIU-snapshotted later via
@@ -3063,7 +3233,7 @@ pre-#114 layouts) so this VM can be CRIU-snapshotted later via
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:225](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L225)
+Defined in: [vm.ts:227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L227)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3089,7 +3259,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:242](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L242)
+Defined in: [vm.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L244)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3110,7 +3280,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:249](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L249)
+Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
 
 Optional name to register this VM under (`attach({ name })`
 lookup key). Path-shaped strings ("worker/9012") are allowed.
@@ -3121,7 +3291,7 @@ Names are unique while live — `boot()` throws
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:255](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L255)
+Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3131,7 +3301,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
+Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3157,7 +3327,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:287](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L287)
+Defined in: [vm.ts:289](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L289)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3191,7 +3361,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:293](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L293)
+Defined in: [vm.ts:295](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L295)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3213,7 +3383,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:301](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L301)
+Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3222,7 +3392,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3230,7 +3400,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Extra argv for the VMM.
 
@@ -3238,7 +3408,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3246,15 +3416,30 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
+Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
+
+##### pdeathsig?
+
+> `optional` **pdeathsig?**: `boolean`
+
+Defined in: [vm.ts:322](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L322)
+
+Wrap the VMM through the parent-death shim so it dies with this
+runtime process. Default true — the right answer for the common
+"boot, do work, exit" CLI flow.
+
+Set to false when the VMM is supposed to outlive the spawning
+process. `vm.fork()` (#216) sets this so the forked sibling
+survives `cli fork` returning. Without it, the kqueue-watching
+shim catches the CLI exit and SIGTERMs the fork mid-startup.
 
 ##### timeoutMs?
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:314](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L314)
+Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3263,7 +3448,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:319](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L319)
+Defined in: [vm.ts:332](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L332)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3272,7 +3457,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
+Defined in: [vm.ts:340](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L340)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3284,7 +3469,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:1079](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1079)
+Defined in: [vm.ts:1124](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1124)
 
 #### Properties
 
@@ -3292,7 +3477,7 @@ Defined in: [vm.ts:1079](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1085](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1085)
+Defined in: [vm.ts:1130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1130)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3302,7 +3487,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1087](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1087)
+Defined in: [vm.ts:1132](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1132)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3310,7 +3495,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1094](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1094)
+Defined in: [vm.ts:1139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1139)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3321,7 +3506,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2016](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2016)
+Defined in: [vm.ts:2161](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2161)
 
 #### Extends
 
@@ -3333,7 +3518,7 @@ Defined in: [vm.ts:2016](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L170)
+Defined in: [vm.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L172)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3347,7 +3532,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L182)
+Defined in: [vm.ts:184](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L184)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3367,7 +3552,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:225](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L225)
+Defined in: [vm.ts:227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L227)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3397,7 +3582,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:242](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L242)
+Defined in: [vm.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L244)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3422,7 +3607,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:255](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L255)
+Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3436,7 +3621,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:269](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L269)
+Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3466,7 +3651,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:287](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L287)
+Defined in: [vm.ts:289](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L289)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3504,7 +3689,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:293](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L293)
+Defined in: [vm.ts:295](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L295)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3524,13 +3709,13 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`portForward`](#portforward)
+[`BootOptions`](#bootoptions).[`portForward`](#portforward-1)
 
 ##### binary?
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:301](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L301)
+Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3543,7 +3728,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3555,7 +3740,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Extra argv for the VMM.
 
@@ -3567,44 +3752,63 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`kernel`](#kernel-1)
+[`BootOptions`](#bootoptions).[`kernel`](#kernel-2)
 
 ##### dtb?
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
+Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`dtb`](#dtb-1)
+[`BootOptions`](#bootoptions).[`dtb`](#dtb-2)
+
+##### pdeathsig?
+
+> `optional` **pdeathsig?**: `boolean`
+
+Defined in: [vm.ts:322](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L322)
+
+Wrap the VMM through the parent-death shim so it dies with this
+runtime process. Default true — the right answer for the common
+"boot, do work, exit" CLI flow.
+
+Set to false when the VMM is supposed to outlive the spawning
+process. `vm.fork()` (#216) sets this so the forked sibling
+survives `cli fork` returning. Without it, the kqueue-watching
+shim catches the CLI exit and SIGTERMs the fork mid-startup.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`pdeathsig`](#pdeathsig)
 
 ##### timeoutMs?
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:314](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L314)
+Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`timeoutMs`](#timeoutms-4)
+[`BootOptions`](#bootoptions).[`timeoutMs`](#timeoutms-5)
 
 ##### vmmEnv?
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:319](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L319)
+Defined in: [vm.ts:332](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L332)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3617,7 +3821,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
+Defined in: [vm.ts:340](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L340)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3627,13 +3831,13 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`onLog`](#onlog-3)
+[`BootOptions`](#bootoptions).[`onLog`](#onlog-4)
 
 ##### snapDir
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2021](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2021)
+Defined in: [vm.ts:2166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2166)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3642,7 +3846,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2029](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2029)
+Defined in: [vm.ts:2174](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2174)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3654,7 +3858,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2035](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2035)
+Defined in: [vm.ts:2180](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2180)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4140,7 +4344,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1720](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1720)
+Defined in: [vm.ts:1787](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1787)
 
 #### Type Declaration
 
@@ -4611,7 +4815,7 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveVmmBinary**(): `string`
 
-Defined in: [vm.ts:113](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L113)
+Defined in: [vm.ts:115](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L115)
 
 Locate the VMM binary using the same lookup order as `@machinen/cli`:
   1. `MACHINEN_VMM` env var (dev-mode override)
@@ -4633,7 +4837,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN
 
 > **boot**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:342](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L342)
+Defined in: [vm.ts:355](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L355)
 
 Boot a microVM and return a handle to interact with it.
 
@@ -4664,7 +4868,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1110](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1110)
+Defined in: [vm.ts:1155](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1155)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4696,7 +4900,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1568](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1568)
+Defined in: [vm.ts:1635](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1635)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4735,7 +4939,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1610](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1610)
+Defined in: [vm.ts:1677](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1677)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4767,7 +4971,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2054](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2054)
+Defined in: [vm.ts:2199](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2199)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -4802,7 +5006,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2101](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2101)
+Defined in: [vm.ts:2353](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2353)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -771,6 +771,48 @@ describe("vm.snapshot", () => {
     }
   });
 
+  it("vm.fork throws SNAPSHOT_NO_DISK when source booted with snapshot:false", async () => {
+    // The source can't be CRIU-dumped without a /dev/vda scratch — so
+    // fork (which always snapshots) refuses up front. Same shape as
+    // vm.snapshot's own NO_DISK guard, just under a different name.
+    const vm = await boot({ binary: "/usr/bin/yes", snapshot: false, timeoutMs: 5_000 });
+    try {
+      await expect(vm.fork()).rejects.toThrow(/has no scratch disk/);
+    } finally {
+      await vm.kill();
+    }
+  });
+
+  it("vm.fork throws SNAPSHOT_LIVE_MOUNT_ACTIVE when source has a live mount", async () => {
+    // Same constraint as vm.snapshot — vsock FUSE channels don't
+    // survive CRIU, so neither dump-then-restore nor fork can compose
+    // with --mount-live.
+    const snap = `/tmp/machinen-fork-livemount-${process.pid}.img`;
+    writeFileSync(snap, Buffer.alloc(1024));
+    const liveDir = `/tmp/machinen-fork-livemount-${process.pid}`;
+    mkdirSync(liveDir, { recursive: true });
+    try {
+      const vm = await boot({
+        binary: "/usr/bin/yes",
+        snapshot: snap,
+        liveMounts: [{ host: liveDir, guest: "/mnt/src" }],
+        timeoutMs: 5_000,
+      });
+      try {
+        await expect(vm.fork()).rejects.toThrow(/cannot fork .* --mount-live active/);
+      } finally {
+        await vm.kill();
+      }
+    } finally {
+      try {
+        rmSync(liveDir, { recursive: true, force: true });
+      } catch {}
+      try {
+        unlinkSync(snap);
+      } catch {}
+    }
+  });
+
   it("throws when the guest exits without writing to the disk", async () => {
     // /usr/bin/true exits immediately, so the VMM comes down cleanly
     // before the in-guest dump script has any chance to run. The mtime

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -69,6 +69,7 @@ export {
 } from "./errors.ts";
 export type { MachinenErrorOptions } from "./errors.ts";
 export type {
+  ForkOptions,
   SnapshotMeta,
   SnapshotOptions,
   SnapshotResult,

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -239,7 +239,21 @@ function walkPins(dir: string, onFile: (path: string) => void): void {
  */
 export function claimName(name: string, pid: number): boolean {
   const pin = pinPath(name);
-  mkdirSync(dirname(pin), { recursive: true });
+  // Path-shaped names like `<src>/<pid>` (chained restore — #208) need
+  // their parent dir to exist. mkdir is idempotent for directories;
+  // it throws EEXIST when a regular file blocks the parent path —
+  // typical when the source VM is alive and pinned at `<src>` (the
+  // fork case, #216). Treat that as "name unavailable" so callers
+  // can fall back to a non-nested name rather than crash.
+  try {
+    mkdirSync(dirname(pin), { recursive: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      debug("claimName name=%s parent path is a live pin — refusing", name);
+      return false;
+    }
+    throw err;
+  }
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       writeFileSync(pin, String(pid), { flag: "wx" });

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -123,10 +123,35 @@ export interface VmHandle {
    * Supported on both boot-owned and attach handles — attach uses
    * the `diskPath` stored in the VM registry entry at boot time.
    *
-   * The VM exits as part of the dump. To continue using the VM
-   * afterwards, restore from the produced snapshot bundle.
+   * By default the VM exits as part of the dump (CRIU kills the
+   * dumped tree on success). Pass `opts.leaveRunning: true` to keep
+   * the source VM alive — the workload resumes from the dump point
+   * and the bundle can be restored into a sibling VM (`vm.fork()`).
    */
   snapshot(opts: SnapshotOptions): Promise<SnapshotResult>;
+
+  /**
+   * Snapshot this VM without killing it and immediately restore the
+   * bundle into a new sibling VM. Both source and fork keep running,
+   * independently addressable. See #216.
+   *
+   * Wraps `vm.snapshot({ leaveRunning: true })` + `restore()` with
+   * the safety defaults a fork wants:
+   *   - `tcpKeep: false` (default) → the fork sees ECONNRESET on
+   *     inherited TCP sockets, source keeps them. Set `tcpKeep: true`
+   *     if you want both copies to share state (rarely correct).
+   *   - `portForward: []` (default) → host ports are NOT inherited
+   *     (they're global; source + fork would race). Pass new
+   *     forwards explicitly.
+   *
+   * Returns a handle to the forked VM. The source VM is unaffected
+   * apart from being briefly frozen during `criu dump`.
+   *
+   * Bundle lifecycle: when `opts.outDir` is set, the bundle is kept
+   * and you can re-restore from it. When omitted, the bundle is
+   * written to a temp dir and removed when the fork exits.
+   */
+  fork(opts?: ForkOptions): Promise<VmHandle>;
 }
 
 export interface WriteFileOptions {
@@ -161,6 +186,25 @@ export interface SnapshotOptions {
    * call and `boot({ onLog })` have a callback set, both fire.
    */
   onLog?: OnLog;
+  /**
+   * Pass `--leave-running` to `criu dump` so the source workload
+   * survives the snapshot. The VMM stays up after the dump; success
+   * is signalled by the dump exec returning 0 instead of by VMM exit.
+   * Used by `vm.fork()` (#216).
+   *
+   * Default: false (current destructive snapshot behavior).
+   */
+  leaveRunning?: boolean;
+  /**
+   * Omit `--tcp-established` from `criu dump`. Restored sockets come
+   * back in CLOSED state — the workload sees ECONNRESET on first
+   * I/O, which is the right semantic when the dump is the source for
+   * a fork (otherwise both copies would race on the same connection
+   * state). See #216.
+   *
+   * Default: false (preserve TCP — current snapshot/restore behavior).
+   */
+  tcpClose?: boolean;
 }
 
 export interface SnapshotResult {
@@ -183,4 +227,52 @@ export interface SnapshotMeta {
   sourceName?: string;
   /** ms epoch when `vm.snapshot()` returned. */
   snappedAt: number;
+}
+
+export interface ForkOptions {
+  /**
+   * Name for the forked VM. When omitted, the existing restore()
+   * auto-naming kicks in: `<sourceName>/<fork.pid>`.
+   */
+  name?: string;
+  /**
+   * If set, the snapshot bundle is written here and kept after the
+   * fork exits — re-restore from this path to spawn another sibling.
+   * If omitted, the bundle is written to a temp dir and removed
+   * when the fork's VMM exits.
+   */
+  outDir?: string;
+  /**
+   * Override the rootfs image used for the fork's restore boot.
+   * Same semantics as `restore({ image })`.
+   */
+  image?: string;
+  /** Kernel path for the fork's boot. Same semantics as `boot({ kernel })`. */
+  kernel?: string;
+  /** DTB path for the fork's boot. Same semantics as `boot({ dtb })`. */
+  dtb?: string;
+  /**
+   * Wall-clock ceiling for the dump half. Default 90s (matches
+   * `vm.snapshot({ timeoutMs })`). Restore boot has its own
+   * implicit deadlines via `boot()`.
+   */
+  timeoutMs?: number;
+  /**
+   * Streaming log callback for the snapshot half. Same shape as
+   * `vm.snapshot({ onLog })`.
+   */
+  onLog?: OnLog;
+  /**
+   * Default false: omit `--tcp-established` from the dump so the
+   * fork sees ECONNRESET on sockets the source had open. Set true
+   * to clone live TCP state into the fork (both VMs then race on
+   * the same connection — only correct in narrow scenarios).
+   */
+  tcpKeep?: boolean;
+  /**
+   * Host→guest port forwards for the fork. NOT inherited from the
+   * source — host ports are global and source + fork would race on
+   * the same bind. Pass explicitly when the fork needs forwards.
+   */
+  portForward?: Array<{ hostPort: number; guestPort: number; hostAddr?: string }>;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -69,6 +69,7 @@ import { serveLiveMount } from "./mount-server.ts";
 import type { OnLog } from "./log.ts";
 import { claimName, findEntry, isAlive, removeEntry, writeEntry } from "./registry.ts";
 import type {
+  ForkOptions,
   SnapshotMeta,
   SnapshotOptions,
   SnapshotResult,
@@ -79,6 +80,7 @@ import type {
 const debug = debugLib("machinen:boot");
 const debugAttach = debugLib("machinen:attach");
 const debugSnapshot = debugLib("machinen:snapshot");
+const debugFork = debugLib("machinen:fork");
 const vmmDebug = debugLib("machinen:vmm");
 
 const require_ = createRequire(import.meta.url);
@@ -307,6 +309,17 @@ export interface BootOptions {
   kernel?: string;
   /** Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`. */
   dtb?: string;
+  /**
+   * Wrap the VMM through the parent-death shim so it dies with this
+   * runtime process. Default true — the right answer for the common
+   * "boot, do work, exit" CLI flow.
+   *
+   * Set to false when the VMM is supposed to outlive the spawning
+   * process. `vm.fork()` (#216) sets this so the forked sibling
+   * survives `cli fork` returning. Without it, the kqueue-watching
+   * shim catches the CLI exit and SIGTERMs the fork mid-startup.
+   */
+  pdeathsig?: boolean;
   /**
    * Milliseconds to wait in `wait()` before giving up and rejecting.
    * Defaults to 60s. Pass `null` to wait forever.
@@ -741,7 +754,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // ~1.7 GiB RSS (#200). Mirrors `spawnGvproxy`. Falls through to a
   // direct spawn if the shim is unavailable (no `cc`, opted-out,
   // unsupported platform).
-  const vmmPdeathsig = await ensurePdeathsig();
+  const vmmPdeathsig = opts.pdeathsig === false ? null : await ensurePdeathsig();
   const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, binary, opts.args ?? []);
   const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
     cwd: opts.cwd,
@@ -1052,6 +1065,38 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         snapshotOpts,
       );
     },
+
+    async fork(forkOpts) {
+      if (!diskAbs) {
+        throw new SnapshotError(
+          "SNAPSHOT_NO_DISK",
+          "vm.fork: source VM has no scratch disk (booted with `snapshot: false`). " +
+            "Re-boot the source without that flag so it can be snapshotted.",
+        );
+      }
+      if (liveMountsResolved.length > 0) {
+        throw new SnapshotError(
+          "SNAPSHOT_LIVE_MOUNT_ACTIVE",
+          "vm.fork: cannot fork a VM with --mount-live active (same reason " +
+            "vm.snapshot refuses — vsock FUSE channels don't survive CRIU).",
+        );
+      }
+      return performFork(
+        {
+          pid: childPid,
+          sourceName: vmName,
+          diskPath: diskAbs,
+          execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
+          wait: () => this.wait(),
+          kill: () => this.kill(),
+          teeGuestConsole: (onChunk) => {
+            child.stderr.on("data", onChunk);
+          },
+          errorOutput: () => this.errorOutput(),
+        },
+        forkOpts ?? {},
+      );
+    },
   };
 
   return handle;
@@ -1225,6 +1270,28 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
           errorOutput: async () => "",
         },
         snapshotOpts,
+      );
+    },
+
+    async fork(forkOpts) {
+      if (!entry.diskPath) {
+        throw new SnapshotError(
+          "SNAPSHOT_NO_DISK",
+          "vm.fork: source VM has no scratch disk (booted with `snapshot: false`).",
+        );
+      }
+      return performFork(
+        {
+          pid: entry.pid,
+          sourceName: entry.name,
+          diskPath: entry.diskPath,
+          execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
+          wait: () => this.wait(),
+          kill: () => this.kill(),
+          teeGuestConsole: undefined,
+          errorOutput: async () => "",
+        },
+        forkOpts ?? {},
       );
     },
   };
@@ -1781,9 +1848,22 @@ async function performSnapshot(
   ctx: SnapshotContext,
   opts: SnapshotOptions,
 ): Promise<SnapshotResult> {
-  const dumpCmd = opts.dumpCmd ?? "/sbin/machinen-dump";
+  const baseDumpCmd = opts.dumpCmd ?? "/sbin/machinen-dump";
   const deadlineMs = opts.timeoutMs ?? 90_000;
   const onLog = opts.onLog;
+  const leaveRunning = opts.leaveRunning === true;
+  const tcpClose = opts.tcpClose === true;
+  // Env-prefix the dump command so /sbin/machinen-dump picks the
+  // knobs up (#216). The exec-agent runs commands via `sh -c`, so
+  // standard shell `VAR=val cmd` syntax flows through unmodified.
+  const envPrefix: string[] = [];
+  if (leaveRunning) {
+    envPrefix.push("MACHINEN_DUMP_LEAVE_RUNNING=1");
+  }
+  if (tcpClose) {
+    envPrefix.push("MACHINEN_DUMP_TCP_CLOSE=1");
+  }
+  const dumpCmd = envPrefix.length > 0 ? `${envPrefix.join(" ")} ${baseDumpCmd}` : baseDumpCmd;
   const t0 = Date.now();
 
   // Validate / prepare the bundle directory. We refuse to overwrite
@@ -1908,29 +1988,62 @@ async function performSnapshot(
       },
     );
 
+  // Success-signal split:
+  //
+  // Default (destructive) path: CRIU kills the dumped tree → the
+  // supervisor's `wait` returns → the supervisor poweroffs → VMM
+  // exits. Wait for VMM exit; SIGKILL it if the deadline fires.
+  //
+  // Leave-running path (#216): CRIU does NOT kill the dumped tree, so
+  // the supervisor's `wait` stays blocked and the VMM never exits on
+  // its own. The dump exec returning over vsock is the success signal
+  // instead. We must NOT kill the VM on timeout — it's supposed to
+  // keep running for the caller (`vm.fork()` is the typical caller).
   let timedOut = false;
-  const killTimer = setTimeout(() => {
-    timedOut = true;
-    void ctx.kill();
-  }, deadlineMs);
-  killTimer.unref();
-  try {
-    await ctx.wait();
-  } finally {
-    clearTimeout(killTimer);
+  if (leaveRunning) {
+    // Race the dump exec against a plain timer. The exec already has
+    // its own execTimeoutMs bound to deadlineMs, so we'll get either
+    // a resolution from dumpDispatch or our own timeout fires first.
+    let timer: NodeJS.Timeout | undefined;
+    await Promise.race([
+      dumpDispatch,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, deadlineMs);
+        timer.unref();
+      }),
+    ]);
+    if (timer) {
+      clearTimeout(timer);
+    }
+    // Never kill the VM here — the source must survive the snapshot.
+  } else {
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      void ctx.kill();
+    }, deadlineMs);
+    killTimer.unref();
+    try {
+      await ctx.wait();
+    } finally {
+      clearTimeout(killTimer);
+    }
+    // The dispatch promise may still be racing the VMM exit; wait it
+    // out so the timeout/dump-failed errors below can include its
+    // outcome. `.then(_, _)` converts the rejection into a resolution,
+    // so this never throws.
+    await dumpDispatch;
   }
-  // The dispatch promise may still be racing the VMM exit; wait it out
-  // so the timeout/dump-failed errors below can include its outcome.
-  // `.then(_, _)` converts the rejection into a resolution, so this
-  // never throws.
-  await dumpDispatch;
   const elapsedMs = Date.now() - t0;
   const consoleLog = await ctx.errorOutput();
   debugSnapshot(
-    "guest exited elapsed=%dms consoleBytes=%d timedOut=%s dumpOutcome=%j",
+    "guest exited elapsed=%dms consoleBytes=%d timedOut=%s leaveRunning=%s dumpOutcome=%j",
     elapsedMs,
     consoleLog.length,
     timedOut,
+    leaveRunning,
     dumpOutcome,
   );
 
@@ -1942,12 +2055,44 @@ async function performSnapshot(
         unlinkSync(stagingPath);
       } catch {}
     }
+    const what = leaveRunning ? "dump exec did not return" : "guest did not shut down";
     throw new SnapshotError(
       "SNAPSHOT_TIMEOUT",
-      `vm.snapshot: guest did not shut down within ${deadlineMs}ms — dump likely failed.` +
+      `vm.snapshot: ${what} within ${deadlineMs}ms — dump likely failed.` +
         dumpHint +
         (consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : ""),
     );
+  }
+
+  if (leaveRunning) {
+    // In leave-running mode, the dump exec's exit code IS the success
+    // signal. A non-zero exit (or a rejected dispatch — vsock dropped
+    // mid-call) means the dump did not land cleanly; refuse to
+    // promote the staging bundle.
+    if (!dumpOutcome) {
+      if (stagedViaLink) {
+        try {
+          unlinkSync(stagingPath);
+        } catch {}
+      }
+      throw new SnapshotError(
+        "SNAPSHOT_DUMP_FAILED",
+        "vm.snapshot(leaveRunning): dump exec produced no outcome — dispatch raced the timeout.",
+      );
+    }
+    if (dumpOutcome.kind === "rejected" || dumpOutcome.exitCode !== 0) {
+      if (stagedViaLink) {
+        try {
+          unlinkSync(stagingPath);
+        } catch {}
+      }
+      throw new SnapshotError(
+        "SNAPSHOT_DUMP_FAILED",
+        `vm.snapshot(leaveRunning): dump exec failed.` +
+          dumpHint +
+          (consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : ""),
+      );
+    }
   }
 
   // The VMM exited in time, but we still need to confirm the dump
@@ -2080,18 +2225,125 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   });
 
   if (!opts.name && meta.sourceName) {
-    const autoName = `${meta.sourceName}/${vm.pid}`;
-    if (claimName(autoName, vm.pid)) {
-      // Promote the registry entry to carry the auto-name.
-      const cur = findEntry({ pid: vm.pid });
-      if (cur) {
-        writeEntry({ ...cur, name: autoName });
+    // Default auto-name nests under the source: `<src>/<pid>`.
+    // claimName refuses (returns false) when `<src>` exists as a live
+    // pin file blocking the parent dir — the fork case (#216), where
+    // the source VM is still running. In that case fall back to a
+    // flat sibling name `<src>~<pid>` so the fork still gets a
+    // meaningful auto-id in `machinen ls`.
+    const candidates = [`${meta.sourceName}/${vm.pid}`, `${meta.sourceName}~${vm.pid}`];
+    for (const candidate of candidates) {
+      if (claimName(candidate, vm.pid)) {
+        // Promote the registry entry to carry the auto-name.
+        const cur = findEntry({ pid: vm.pid });
+        if (cur) {
+          writeEntry({ ...cur, name: candidate });
+        }
+        // Mutate the handle so `vm.name` reflects the resolved name.
+        (vm as { name?: string }).name = candidate;
+        break;
       }
-      // Mutate the handle so `vm.name` reflects the resolved name.
-      (vm as { name?: string }).name = autoName;
     }
   }
   return vm;
+}
+
+// =============================================================
+// Fork — #216
+// =============================================================
+
+/**
+ * Snapshot the VM with --leave-running, immediately restore the
+ * bundle into a sibling, and (optionally) clean up the bundle when
+ * the fork exits. Shared between boot-owned and attach-owned handles.
+ *
+ * Bundle lifecycle:
+ *   - opts.outDir set:    bundle stays at that path; caller owns cleanup.
+ *   - opts.outDir absent: bundle in a temp dir, removed on fork.wait().
+ */
+async function performFork(ctx: SnapshotContext, opts: ForkOptions): Promise<VmHandle> {
+  const ephemeral = !opts.outDir;
+  const snapDir = opts.outDir
+    ? resolve(opts.outDir)
+    : mkdtempSync(join(tmpdir(), "machinen-fork-"));
+  debugFork(
+    "fork start srcPid=%d srcName=%s snapDir=%s ephemeral=%s tcpKeep=%s",
+    ctx.pid,
+    ctx.sourceName ?? "<unset>",
+    snapDir,
+    ephemeral,
+    opts.tcpKeep === true,
+  );
+
+  // Snapshot half: source survives. tcpClose flips the spec's default.
+  let snap: SnapshotResult;
+  try {
+    snap = await performSnapshot(ctx, {
+      outDir: snapDir,
+      leaveRunning: true,
+      tcpClose: opts.tcpKeep !== true,
+      timeoutMs: opts.timeoutMs,
+      onLog: opts.onLog,
+    });
+  } catch (err) {
+    // Don't leave an empty temp dir behind on snapshot failure.
+    if (ephemeral) {
+      try {
+        rmSync(snapDir, { recursive: true, force: true });
+      } catch {}
+    }
+    throw err;
+  }
+  debugFork("fork dump complete elapsedMs=%d", snap.elapsedMs);
+
+  // Restore half: a fresh sibling VM. boot() inside restore() auto-
+  // allocates its own vsock UDS and (if needed) gvproxy — vsock
+  // identity and L2 networking are isolated per-VM. portForward is
+  // intentionally NOT inherited from the source: host ports are
+  // global, so source + fork would race on the same bind.
+  let fork: VmHandle;
+  try {
+    fork = await restore({
+      snapDir,
+      name: opts.name,
+      image: opts.image,
+      kernel: opts.kernel,
+      dtb: opts.dtb,
+      portForward: opts.portForward ?? [],
+      // The fork outlives the process that spawned it (CLI returns
+      // immediately; programmatic callers detach() and move on).
+      // Skip the parent-death shim so the fork's VMM isn't SIGTERM'd
+      // when this process exits.
+      pdeathsig: false,
+    });
+  } catch (err) {
+    if (ephemeral) {
+      try {
+        rmSync(snapDir, { recursive: true, force: true });
+      } catch {}
+    }
+    throw err;
+  }
+  debugFork("fork restored pid=%d name=%s", fork.pid, fork.name ?? "<unset>");
+
+  if (ephemeral) {
+    void fork
+      .wait()
+      .catch(() => {})
+      .finally(() => {
+        try {
+          rmSync(snapDir, { recursive: true, force: true });
+          debugFork("fork ephemeral bundle cleaned up snapDir=%s", snapDir);
+        } catch (cleanupErr) {
+          debugFork(
+            "fork ephemeral cleanup failed snapDir=%s err=%s",
+            snapDir,
+            cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          );
+        }
+      });
+  }
+  return fork;
 }
 
 /**

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -965,5 +965,158 @@ else
   trap 'rm -rf "$FIXTURE"' EXIT
 fi  # S2 rootfs-capability gate
 
+# ----------------------------------------------------------------
+# S3: fork (#216) — snapshot a live VM and restore into a sibling
+# without killing the source. Then fork the fork. Verifies:
+#   1. `machinen fork` returns a new VM and the source stays alive.
+#   2. Both VMs have independent disk state — writes on the source
+#      don't appear on the fork and vice versa.
+#   3. Fork-of-fork works (chained leave-running snapshot exercises
+#      the same #215 sub-NS dump path that S2 covers for destructive
+#      snapshots).
+#   4. Each generation has independent disk state from its siblings.
+# ----------------------------------------------------------------
+if [[ "$ROOTFS_SUPPORTS_VSOCK_EXEC" -eq 0 || "$ROOTFS_SUPPORTS_CRIU" -eq 0 || "$ROOTFS_SUPPORTS_SNAPSHOT_HELPERS" -eq 0 ]]; then
+  echo "S3: skipped (rootfs lacks vsock/criu/snapshot helpers)"
+else
+  echo "S3: machinen fork (live snapshot + sibling, fork-the-fork)"
+  S3_NAME="fork-smoke-$$"
+  S3_BG_LOG="$FIXTURE/s3-bg.log"
+  S3_SCRATCH="$FIXTURE/s3-scratch.img"
+  truncate -s 256M "$S3_SCRATCH"
+
+  # Long-lived sleep workload — fork doesn't care what the workload
+  # does, only that it stays running across the dump.
+  S3_PID=$(boot_bg "$S3_NAME" "$S3_BG_LOG" --snapshot "$S3_SCRATCH" -- \
+    /bin/sh -c '
+      while :; do sleep 1000; done
+    ')
+  cleanup_s3() {
+    kill -TERM "$S3_PID" 2>/dev/null || true
+    wait "$S3_PID" 2>/dev/null || true
+  }
+  trap 'cleanup_s3; rm -rf "$FIXTURE"' EXIT
+
+  if ! wait_for_vm "$S3_NAME"; then
+    tail -80 "$S3_BG_LOG" >&2
+    fail "S3 — '$S3_NAME' never appeared in 'machinen ls'"
+  fi
+  pass "boot --name --snapshot registered '$S3_NAME'"
+
+  # Mark the source's disk before forking. The fork inherits this
+  # exact byte (it's part of the dumped state) but writes after the
+  # fork must NOT cross between source and fork.
+  # `cli exec` joins all post-`--` args with spaces and runs the result
+  # under `sh -c` in the guest. To get a real shell redirect inside the
+  # guest we have to send `>` as a literal arg (single-quoted on the
+  # host so the host bash doesn't interpret it as a redirect).
+  if ! cli exec --name "$S3_NAME" -- echo source '>' /tmp/who; then
+    tail -60 "$S3_BG_LOG" >&2
+    fail "S3 — couldn't seed /tmp/who on source"
+  fi
+
+  # Fork. Source stays alive; fork registers under '<src>/<pid>' via
+  # the standard restore() auto-naming.
+  S3_FORK_LOG="$FIXTURE/s3-fork.log"
+  S3_FORK_BUNDLE="$FIXTURE/s3-fork-bundle"
+  if ! cli fork --name "$S3_NAME" --out-dir "$S3_FORK_BUNDLE" 2>"$S3_FORK_LOG"; then
+    cat "$S3_FORK_LOG" >&2
+    tail -60 "$S3_BG_LOG" >&2
+    fail "S3 — 'machinen fork' failed"
+  fi
+  S3_FORK_NAME=""
+  deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    # Fork's auto-name is `<src>~<pid>` when source is alive (#216),
+    # falling back from the chained-restore convention `<src>/<pid>`
+    # which collides on the live source's pin file.
+    cand=$(cli ls 2>/dev/null | awk -v src="$S3_NAME~" 'NR>1 && index($2, src)==1 {print $2; exit}')
+    if [[ -n "$cand" ]]; then
+      S3_FORK_NAME=$cand
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$S3_FORK_NAME" ]]; then
+    cat "$S3_FORK_LOG" >&2
+    cli ls >&2 || true
+    fail "S3 — fork never appeared in 'machinen ls' under '$S3_NAME/...'"
+  fi
+  pass "fork registered as '$S3_FORK_NAME'"
+
+  # Source must still be in the registry — proves --leave-running
+  # actually left it running. Without it, criu would have killed the
+  # workload, the supervisor would have powered off, and the source
+  # would be gone from `machinen ls`.
+  if ! cli ls 2>/dev/null | awk -v n="$S3_NAME" 'NR>1 && $2==n {found=1} END{exit !found}'; then
+    cli ls >&2 || true
+    fail "S3 — source VM '$S3_NAME' disappeared after fork (--leave-running broke?)"
+  fi
+  pass "source VM '$S3_NAME' survived the fork"
+
+  # Independence check: write 'fork' on the fork's disk, 'source' is
+  # already on the source. Re-read both — neither should see the
+  # other's value.
+  if ! cli exec --name "$S3_FORK_NAME" -- echo fork '>' /tmp/who; then
+    tail -60 "$S3_BG_LOG" >&2
+    fail "S3 — couldn't write /tmp/who on fork"
+  fi
+  S3_SRC_AFTER=$(cli exec --name "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FORK_AFTER=$(cli exec --name "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  if [[ "$S3_SRC_AFTER" != "source" || "$S3_FORK_AFTER" != "fork" ]]; then
+    fail "S3 — disk state crossed between source ('$S3_SRC_AFTER') and fork ('$S3_FORK_AFTER')"
+  fi
+  pass "source & fork have independent disk state"
+
+  # Fork-the-fork. The fork is itself snapshot-eligible (it boots
+  # with the standard scratch disk). Exercises the leave-running
+  # path through machinen-restore.sh's sub-NS — the same combo S2
+  # hits with destructive snapshots.
+  S3_GRAND_LOG="$FIXTURE/s3-fork-of-fork.log"
+  S3_GRAND_BUNDLE="$FIXTURE/s3-grand-bundle"
+  if ! cli fork --name "$S3_FORK_NAME" --out-dir "$S3_GRAND_BUNDLE" 2>"$S3_GRAND_LOG"; then
+    cat "$S3_GRAND_LOG" >&2
+    tail -60 "$S3_BG_LOG" >&2
+    fail "S3 — 'machinen fork' on the fork (gen-2) failed"
+  fi
+  S3_GRAND_NAME=""
+  deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    cand=$(cli ls 2>/dev/null | awk -v src="$S3_FORK_NAME~" 'NR>1 && index($2, src)==1 {print $2; exit}')
+    if [[ -n "$cand" ]]; then
+      S3_GRAND_NAME=$cand
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$S3_GRAND_NAME" ]]; then
+    cat "$S3_GRAND_LOG" >&2
+    cli ls >&2 || true
+    fail "S3 — fork-of-fork never appeared in 'machinen ls' under '$S3_FORK_NAME/...'"
+  fi
+  pass "fork-of-fork registered as '$S3_GRAND_NAME'"
+
+  # Three-way independence: write 'grand' on the grandchild, then
+  # check all three /tmp/who files are independent.
+  if ! cli exec --name "$S3_GRAND_NAME" -- echo grand '>' /tmp/who; then
+    fail "S3 — couldn't write /tmp/who on grand"
+  fi
+  S3_FINAL_SRC=$(cli exec --name "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FINAL_FORK=$(cli exec --name "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FINAL_GRAND=$(cli exec --name "$S3_GRAND_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  if [[ "$S3_FINAL_SRC" != "source" || "$S3_FINAL_FORK" != "fork" || "$S3_FINAL_GRAND" != "grand" ]]; then
+    fail "S3 — three-way independence broken: src='$S3_FINAL_SRC' fork='$S3_FINAL_FORK' grand='$S3_FINAL_GRAND'"
+  fi
+  pass "source, fork, and fork-of-fork all hold independent disk state"
+
+  # Tear down the forks (poweroff via vsock). The source goes down
+  # with cleanup_s3 below.
+  cli exec --name "$S3_GRAND_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
+  cli exec --name "$S3_FORK_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
+  rm -rf "$S3_GRAND_BUNDLE" "$S3_FORK_BUNDLE" 2>/dev/null || true
+  cleanup_s3
+  trap 'rm -rf "$FIXTURE"' EXIT
+fi  # S3 rootfs-capability gate
+
 echo
 echo "all smoke tests passed"


### PR DESCRIPTION
## Summary

Closes #216. Adds `vm.fork()` and `machinen fork` — snapshot a live VM, restore the bundle into a sibling, and leave the source running. Both VMs are independently addressable; the fork inherits the source's process tree at dump-time and diverges from there.

Three-way independence is verified end-to-end by smoke S3 (boot → fork → fork-the-fork, each with its own `/tmp/who` value).

## Key design decisions

- **`--leave-running` plumbed via env var** through `machinen-dump.sh` so the chained sub-NS dump path from #215 picks it up for free. Success signal flips from "VMM exit" to "dump exec returns 0" — the supervisor's `wait` no longer returns when the workload survives.
- **`tcpKeep: false` by default** — restored sockets come back closed (workload sees `ECONNRESET` on first I/O), avoiding both copies racing on the same TCP state. Opt-in via `--tcp-keep`.
- **Port forwards aren't inherited** — host ports are global and source/fork would race on the same bind. Pass new ones explicitly.
- **`<src>/<pid>` auto-name falls through to `<src>~<pid>`** when the source is alive (its pin file blocks the parent-dir path). `claimName` returns false on EEXIST instead of crashing; `restore()` tries the flat fallback.
- **Forked VMM skips `pdeathsig`** — a new `BootOptions.pdeathsig: false` makes the fork outlive the spawning process. Without it, the kqueue shim catches the CLI exit and SIGTERMs the fork mid-startup.
- **CLI always materializes `outDir`** (caller-supplied or `mkdtemp`) and prints the path when ephemeral. The runtime's `fork.wait()`-based ephemeral cleanup is for programmatic users; the CLI returns before it can fire.

## Test plan
- [x] `npx vitest run` — 363 passed, 2 new fork guards (`SNAPSHOT_NO_DISK`, `SNAPSHOT_LIVE_MOUNT_ACTIVE`)
- [x] `npx agent-ci run --all -q -p` — 4/4 workflows pass (~2m)
- [x] `pnpm smoke-tests` — V/T/N/P/C/S1/S2/S3 all green; S3 explicitly verifies source survival, sibling independence, and fork-the-fork against high-PID interactive workloads

## Out of scope (mentioned in #216)
- Mount-live divergence on fork (both VMs share the host path at `:rw`) — punt with a doc'd caveat.
- Pre-minted MAC for the fork — each VM has its own gvproxy on a separate UDS, so MAC duplication isn't a host conflict in the current architecture.
