### PR TITLE
feat(boot): per-phase timing + macOS reflink fast-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "repro-192": "node scripts/repro-issue-192.ts",
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
-    "bench-net": "bash scripts/bench-net.sh"
+    "bench-net": "bash scripts/bench-net.sh",
+    "bench-boot": "tsx scripts/bench-boot.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2069,7 +2069,7 @@ by default when `output` is a TTY.
 
 ### ProvisionOptions
 
-Defined in: [provision.ts:51](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L51)
+Defined in: [provision.ts:50](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L50)
 
 #### Properties
 
@@ -2077,7 +2077,7 @@ Defined in: [provision.ts:51](https://github.com/redwoodjs/machinen/blob/main/pa
 
 > `optional` **base?**: `string`
 
-Defined in: [provision.ts:61](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L61)
+Defined in: [provision.ts:60](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L60)
 
 Path to the base rootfs tarball to start from. Typically the
 `rootfs-debian-arm64.tar.gz` produced by
@@ -2091,7 +2091,7 @@ cache at `~/.machinen/@machinen/runtime@<version>/bases/debian-arm64/`).
 
 > **install**: (`vm`) => `Promise`\<`void`\>
 
-Defined in: [provision.ts:66](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L66)
+Defined in: [provision.ts:65](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L65)
 
 User-supplied provisioning steps. Runs inside the guest via vsock.
 
@@ -2109,7 +2109,7 @@ User-supplied provisioning steps. Runs inside the guest via vsock.
 
 > **out**: `string`
 
-Defined in: [provision.ts:72](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L72)
+Defined in: [provision.ts:71](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L71)
 
 Output path for the resulting rootfs tarball. Will be overwritten.
 Consumed via `boot({ image: out })`.
@@ -2118,7 +2118,7 @@ Consumed via `boot({ image: out })`.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [provision.ts:80](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L80)
+Defined in: [provision.ts:79](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L79)
 
 Default cmd baked into the image as `/machinen-config.json`.
 When the image is later booted via `boot({ image })` without a
@@ -2129,7 +2129,7 @@ user-supplied `cmd`, the guest runs this. User-supplied `cmd` on
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:87](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L87)
+Defined in: [provision.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L86)
 
 Default guest env baked into the image alongside `cmd`. Merged
 with `boot({ env })` at boot time, with the caller's `env`
@@ -2139,7 +2139,7 @@ overriding on key collision.
 
 > `optional` **binary?**: `string`
 
-Defined in: [provision.ts:93](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L93)
+Defined in: [provision.ts:92](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L92)
 
 Optional VMM binary path. Same lookup rules as `boot()` — if
 omitted, resolves `@machinen/vmm-<arch>-<os>`.
@@ -2148,7 +2148,7 @@ omitted, resolves `@machinen/vmm-<arch>-<os>`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [provision.ts:96](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L96)
+Defined in: [provision.ts:95](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L95)
 
 Working directory. Defaults to process.cwd().
 
@@ -2156,7 +2156,7 @@ Working directory. Defaults to process.cwd().
 
 > `optional` **scratchDiskSizeBytes?**: `number`
 
-Defined in: [provision.ts:103](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L103)
+Defined in: [provision.ts:102](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L102)
 
 Size of the scratch disk used to ferry the tarball from guest to
 host. Must be larger than the expected post-install rootfs size.
@@ -2166,7 +2166,7 @@ Default: 1 GiB (sparse, so it doesn't actually take that space).
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [provision.ts:110](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L110)
+Defined in: [provision.ts:109](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L109)
 
 Wall-clock ceiling for the whole build. If the install hook plus
 the final archive + shutdown doesn't finish in this window, we
@@ -2176,7 +2176,7 @@ SIGKILL the VMM and fail. Default: 10 minutes.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:117](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L117)
+Defined in: [provision.ts:116](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L116)
 
 Extra env passed to the VMM process on the host side. Useful for
 dev overrides like `MACHINEN_BOOT_TEST`. Distinct from `env`,
@@ -2186,7 +2186,7 @@ which bakes guest-workload env into the produced image.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [provision.ts:120](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L120)
+Defined in: [provision.ts:119](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L119)
 
 Path to the guest kernel. Same semantics as `boot({ kernel })`.
 
@@ -2194,7 +2194,7 @@ Path to the guest kernel. Same semantics as `boot({ kernel })`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [provision.ts:123](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L123)
+Defined in: [provision.ts:122](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L122)
 
 Path to the guest DTB. Same semantics as `boot({ dtb })`.
 
@@ -2202,7 +2202,7 @@ Path to the guest DTB. Same semantics as `boot({ dtb })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [provision.ts:131](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L131)
+Defined in: [provision.ts:130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L130)
 
 Streaming log callback — fires for every byte of guest output
 during the build: guest kernel console, every `vm.exec()` call
@@ -2213,7 +2213,7 @@ See `LogEvent.source` to tell them apart. See #83.
 
 ### ProvisionResult
 
-Defined in: [provision.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L134)
+Defined in: [provision.ts:133](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L133)
 
 #### Properties
 
@@ -2221,7 +2221,7 @@ Defined in: [provision.ts:134](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **imagePath**: `string`
 
-Defined in: [provision.ts:136](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L136)
+Defined in: [provision.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L135)
 
 Absolute path to the output tarball.
 
@@ -2229,7 +2229,7 @@ Absolute path to the output tarball.
 
 > **sizeBytes**: `number`
 
-Defined in: [provision.ts:139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L139)
+Defined in: [provision.ts:138](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L138)
 
 Size of the output tarball in bytes.
 
@@ -2237,7 +2237,7 @@ Size of the output tarball in bytes.
 
 > **elapsedMs**: `number`
 
-Defined in: [provision.ts:142](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L142)
+Defined in: [provision.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L141)
 
 Wall-clock time from build() entry to return.
 
@@ -3153,7 +3153,7 @@ the same bind. Pass explicitly when the fork needs forwards.
 
 ### BootOptions
 
-Defined in: [vm.ts:153](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L153)
+Defined in: [vm.ts:155](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L155)
 
 #### Properties
 
@@ -3161,7 +3161,7 @@ Defined in: [vm.ts:153](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:160](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L160)
+Defined in: [vm.ts:162](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L162)
 
 Path to a rootfs tarball to boot from (e.g. the output of
 `provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
@@ -3172,7 +3172,7 @@ boots and snapshot-only restores both skip initramfs packing).
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L166)
+Defined in: [vm.ts:168](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L168)
 
 Command to run inside the guest. Packed into the synthesized
 `/machinen-config.json`. Paired with `image` — both required, or
@@ -3182,7 +3182,7 @@ neither.
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L172)
+Defined in: [vm.ts:174](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L174)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3192,7 +3192,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:184](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L184)
+Defined in: [vm.ts:186](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L186)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3208,7 +3208,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **snapshot?**: `string` \| `false`
 
-Defined in: [vm.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L205)
+Defined in: [vm.ts:207](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L207)
 
 Attach a scratch virtio-blk device (`/dev/vdb`, or `/dev/vda` on
 pre-#114 layouts) so this VM can be CRIU-snapshotted later via
@@ -3233,7 +3233,7 @@ pre-#114 layouts) so this VM can be CRIU-snapshotted later via
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L227)
+Defined in: [vm.ts:229](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L229)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3259,7 +3259,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L244)
+Defined in: [vm.ts:246](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L246)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3280,7 +3280,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L251)
+Defined in: [vm.ts:253](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L253)
 
 Optional name to register this VM under (`attach({ name })`
 lookup key). Path-shaped strings ("worker/9012") are allowed.
@@ -3291,7 +3291,7 @@ Names are unique while live — `boot()` throws
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
+Defined in: [vm.ts:259](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L259)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3301,7 +3301,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
+Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3327,7 +3327,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:289](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L289)
+Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3361,7 +3361,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:295](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L295)
+Defined in: [vm.ts:297](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L297)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3383,7 +3383,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3392,7 +3392,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3400,7 +3400,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Extra argv for the VMM.
 
@@ -3408,7 +3408,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
+Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3416,7 +3416,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
+Defined in: [vm.ts:313](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L313)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3424,7 +3424,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **pdeathsig?**: `boolean`
 
-Defined in: [vm.ts:322](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L322)
+Defined in: [vm.ts:324](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L324)
 
 Wrap the VMM through the parent-death shim so it dies with this
 runtime process. Default true — the right answer for the common
@@ -3439,7 +3439,7 @@ shim catches the CLI exit and SIGTERMs the fork mid-startup.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
+Defined in: [vm.ts:329](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L329)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3448,7 +3448,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:332](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L332)
+Defined in: [vm.ts:334](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L334)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3457,7 +3457,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:340](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L340)
+Defined in: [vm.ts:342](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L342)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3469,7 +3469,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:1124](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1124)
+Defined in: [vm.ts:1186](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1186)
 
 #### Properties
 
@@ -3477,7 +3477,7 @@ Defined in: [vm.ts:1124](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1130)
+Defined in: [vm.ts:1192](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1192)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3487,7 +3487,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1132](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1132)
+Defined in: [vm.ts:1194](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1194)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3495,7 +3495,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1139)
+Defined in: [vm.ts:1201](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1201)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3506,7 +3506,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2161](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2161)
+Defined in: [vm.ts:2285](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2285)
 
 #### Extends
 
@@ -3518,7 +3518,7 @@ Defined in: [vm.ts:2161](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:172](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L172)
+Defined in: [vm.ts:174](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L174)
 
 Env vars exposed to the guest workload. Packed into the synthesized
 `/machinen-config.json`. Distinct from `vmmEnv`, which only affects
@@ -3532,7 +3532,7 @@ the host-side VMM process.
 
 > `optional` **guestCwd?**: `string`
 
-Defined in: [vm.ts:184](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L184)
+Defined in: [vm.ts:186](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L186)
 
 Working directory for the guest cmd. Lands as `cwd` in the
 synthesized `/machinen-config.json`; `/init` calls `chdir()` to
@@ -3552,7 +3552,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 > `optional` **rootDisk?**: `string` \| `boolean`
 
-Defined in: [vm.ts:227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L227)
+Defined in: [vm.ts:229](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L229)
 
 Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
 instead of inflating the whole rootfs into a RAM-backed tmpfs via
@@ -3582,7 +3582,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 > `optional` **rootDiskSizeBytes?**: `number`
 
-Defined in: [vm.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L244)
+Defined in: [vm.ts:246](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L246)
 
 Absolute target size (bytes) for the materialized rootdisk image.
 Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
@@ -3607,7 +3607,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [vm.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L257)
+Defined in: [vm.ts:259](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L259)
 
 Bookkeeping: absolute path to the snapshot bundle this VM was
 forked from. Set by `restore({ snapDir })`; visible in
@@ -3621,7 +3621,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-Defined in: [vm.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L271)
+Defined in: [vm.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L273)
 
 A single host directory copied into the guest at boot. The guest
 path must live under `/mnt/`. Copy-once semantics: guest writes are
@@ -3651,7 +3651,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 > `optional` **liveMounts?**: `object`[]
 
-Defined in: [vm.ts:289](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L289)
+Defined in: [vm.ts:291](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L291)
 
 Host directories exposed to the guest as live-share FUSE mounts
 (#78). Unlike `mount` (copy-once into the boot rootfs), these stay
@@ -3689,7 +3689,7 @@ inputs you don't need write-through on.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm.ts:295](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L295)
+Defined in: [vm.ts:297](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L297)
 
 Host -> guest TCP port forwards installed via gvproxy's control
 API. Each entry maps `hostPort` on the host (bound to `hostAddr`,
@@ -3715,7 +3715,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 > `optional` **binary?**: `string`
 
-Defined in: [vm.ts:303](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L303)
+Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
 
 Absolute or cwd-relative path to the VMM binary. Optional —
 if omitted, `boot()` resolves it via `resolveVmmBinary()`.
@@ -3728,7 +3728,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:305](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L305)
+Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
 
 Working directory for the VMM (for finding fixture files).
 
@@ -3740,7 +3740,7 @@ Working directory for the VMM (for finding fixture files).
 
 > `optional` **args?**: `string`[]
 
-Defined in: [vm.ts:307](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L307)
+Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
 
 Extra argv for the VMM.
 
@@ -3752,7 +3752,7 @@ Extra argv for the VMM.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm.ts:309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L309)
+Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
 
 Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
@@ -3764,7 +3764,7 @@ Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm.ts:311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L311)
+Defined in: [vm.ts:313](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L313)
 
 Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
@@ -3776,7 +3776,7 @@ Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
 
 > `optional` **pdeathsig?**: `boolean`
 
-Defined in: [vm.ts:322](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L322)
+Defined in: [vm.ts:324](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L324)
 
 Wrap the VMM through the parent-death shim so it dies with this
 runtime process. Default true — the right answer for the common
@@ -3795,7 +3795,7 @@ shim catches the CLI exit and SIGTERMs the fork mid-startup.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm.ts:327](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L327)
+Defined in: [vm.ts:329](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L329)
 
 Milliseconds to wait in `wait()` before giving up and rejecting.
 Defaults to 60s. Pass `null` to wait forever.
@@ -3808,7 +3808,7 @@ Defaults to 60s. Pass `null` to wait forever.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:332](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L332)
+Defined in: [vm.ts:334](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L334)
 
 Env passed to the VMM process on the host side (not exposed to the
 guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
@@ -3821,7 +3821,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:340](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L340)
+Defined in: [vm.ts:342](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L342)
 
 Streaming log callback — fires for every byte of guest output:
 kernel console (VMM stderr) and every exec invocation made through
@@ -3837,7 +3837,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2166)
+Defined in: [vm.ts:2290](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2290)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3846,7 +3846,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2174](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2174)
+Defined in: [vm.ts:2298](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2298)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3858,7 +3858,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2180](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2180)
+Defined in: [vm.ts:2304](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2304)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4344,7 +4344,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1787](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1787)
+Defined in: [vm.ts:1900](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1900)
 
 #### Type Declaration
 
@@ -4601,7 +4601,7 @@ Kept argv-compatible with the old Python script so shell fixtures
 
 > **resolveBaseRootfs**(`explicit?`, `cwd?`): `string`
 
-Defined in: [provision.ts:191](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L191)
+Defined in: [provision.ts:190](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L190)
 
 Resolve the path to the base rootfs tarball, in the same order
 `provision()` itself does:
@@ -4642,7 +4642,7 @@ PROVISION_BASE_NOT_FOUND | PROVISION_ASSETS_DIR_INVALID
 
 > **provision**(`opts`): `Promise`\<[`ProvisionResult`](#provisionresult)\>
 
-Defined in: [provision.ts:252](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L252)
+Defined in: [provision.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L251)
 
 Boot the base rootfs, run the user install hook, and freeze the
 resulting filesystem state to a new tarball at `opts.out`.
@@ -4815,7 +4815,7 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveVmmBinary**(): `string`
 
-Defined in: [vm.ts:115](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L115)
+Defined in: [vm.ts:117](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L117)
 
 Locate the VMM binary using the same lookup order as `@machinen/cli`:
   1. `MACHINEN_VMM` env var (dev-mode override)
@@ -4837,7 +4837,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN
 
 > **boot**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:355](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L355)
+Defined in: [vm.ts:357](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L357)
 
 Boot a microVM and return a handle to interact with it.
 
@@ -4868,7 +4868,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1155](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1155)
+Defined in: [vm.ts:1217](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1217)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4900,7 +4900,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1635](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1635)
+Defined in: [vm.ts:1748](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1748)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4939,7 +4939,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1677](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1677)
+Defined in: [vm.ts:1790](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1790)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4971,7 +4971,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2199](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2199)
+Defined in: [vm.ts:2323](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2323)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5006,7 +5006,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2353](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2353)
+Defined in: [vm.ts:2576](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2576)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/image-config-cache.test.ts
+++ b/packages/runtime/src/__tests__/image-config-cache.test.ts
@@ -1,0 +1,115 @@
+// #221 — image-config cache.
+//
+// `readImageConfig` decompresses a multi-GB gzip stream looking for
+// `./machinen-config.json` on every boot. Most user-built tarballs
+// don't carry the file, so on every boot we paid ~170 ms for a
+// negative result. The cache writes a tiny JSON file keyed by
+// (basename, size, mtime) and short-circuits subsequent calls.
+//
+// We assert: (1) the cache file gets written; (2) it's actually used
+// (a stale tarball whose contents change but mtime/size don't is
+// allowed to return the stale answer — that mirrors the behaviour
+// of `ensureRootfsImage`'s sha cache, which has the same fingerprint
+// trade-off); (3) modifying the tarball (mtime bump + size delta)
+// invalidates.
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readImageConfig } from "../vm.ts";
+
+const CACHE_DIR = join(homedir(), ".cache", "machinen", "image-config");
+
+function buildTarball(target: string, configBody: string | null): void {
+  const stage = `${target}.stage`;
+  mkdirSync(stage, { recursive: true });
+  if (configBody !== null) {
+    writeFileSync(join(stage, "machinen-config.json"), configBody);
+  }
+  // Pad with a small filler so different bodies produce different
+  // tarball sizes (which the cache uses as part of its key).
+  writeFileSync(join(stage, "filler.txt"), configBody ?? "no-config");
+  execFileSync("tar", ["-czf", target, "-C", stage, "."]);
+  rmSync(stage, { recursive: true, force: true });
+}
+
+function cacheEntriesFor(tarball: string): string[] {
+  if (!existsSync(CACHE_DIR)) {
+    return [];
+  }
+  const base = tarball.split("/").pop()!;
+  return readdirSync(CACHE_DIR).filter((n) => n.startsWith(base));
+}
+
+describe("readImageConfig cache (#221)", () => {
+  let workDir: string | undefined;
+
+  afterEach(() => {
+    if (workDir && existsSync(workDir)) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+    // Clear only the cache entries this test wrote — leave the rest.
+    if (workDir && existsSync(CACHE_DIR)) {
+      const base = "rootfs-test-";
+      for (const f of readdirSync(CACHE_DIR)) {
+        if (f.startsWith(base)) {
+          rmSync(join(CACHE_DIR, f), { force: true });
+        }
+      }
+    }
+    workDir = undefined;
+  });
+
+  it("returns the embedded config and caches the parsed result", () => {
+    workDir = mkdtempSync(join(tmpdir(), "image-cfg-"));
+    const tarball = join(workDir, `rootfs-test-positive-${Date.now()}.tar.gz`);
+    buildTarball(tarball, JSON.stringify({ cmd: ["/bin/echo", "hi"] }));
+
+    expect(cacheEntriesFor(tarball)).toEqual([]);
+    const first = readImageConfig(tarball);
+    expect(first).toEqual({ cmd: ["/bin/echo", "hi"] });
+    expect(cacheEntriesFor(tarball).length).toBe(1);
+
+    const second = readImageConfig(tarball);
+    expect(second).toEqual({ cmd: ["/bin/echo", "hi"] });
+  });
+
+  it("caches the negative result (no embedded config)", () => {
+    workDir = mkdtempSync(join(tmpdir(), "image-cfg-"));
+    const tarball = join(workDir, `rootfs-test-negative-${Date.now()}.tar.gz`);
+    buildTarball(tarball, null);
+
+    expect(readImageConfig(tarball)).toBeUndefined();
+    expect(cacheEntriesFor(tarball).length).toBe(1);
+    expect(readImageConfig(tarball)).toBeUndefined();
+  });
+
+  it("invalidates when the tarball mtime or size changes", () => {
+    workDir = mkdtempSync(join(tmpdir(), "image-cfg-"));
+    const tarball = join(workDir, `rootfs-test-invalidate-${Date.now()}.tar.gz`);
+    buildTarball(tarball, JSON.stringify({ cmd: ["/v1"] }));
+    expect(readImageConfig(tarball)).toEqual({ cmd: ["/v1"] });
+
+    // Rebuild with different contents → different size → different
+    // cache key. Bump mtime explicitly because some filesystems give
+    // us coarse mtime resolution and a fast rebuild could land in the
+    // same millisecond.
+    buildTarball(tarball, JSON.stringify({ cmd: ["/v2-with-much-longer-payload"] }));
+    const future = new Date(Date.now() + 5_000);
+    utimesSync(tarball, future, future);
+    expect(readImageConfig(tarball)).toEqual({ cmd: ["/v2-with-much-longer-payload"] });
+
+    // Two cache entries should now exist for the same basename.
+    expect(cacheEntriesFor(tarball).length).toBe(2);
+  });
+});

--- a/packages/runtime/src/__tests__/phase-timer.test.ts
+++ b/packages/runtime/src/__tests__/phase-timer.test.ts
@@ -1,0 +1,65 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { PhaseTimer } from "../phase-timer.ts";
+
+describe("PhaseTimer", () => {
+  it("records phases in insertion order with non-negative durations", async () => {
+    const t = new PhaseTimer();
+    t.start("a");
+    await sleep(5);
+    t.end("a");
+    t.start("b");
+    await sleep(5);
+    t.end("b");
+    const keys = [...t.phases().keys()];
+    expect(keys).toEqual(["a", "b"]);
+    for (const ms of t.phases().values()) {
+      expect(ms).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("end() without matching start() is a no-op", () => {
+    const t = new PhaseTimer();
+    expect(t.end("never-started")).toBeUndefined();
+    expect(t.phases().size).toBe(0);
+  });
+
+  it("mark() records externally-measured phases and skips undefined", () => {
+    const t = new PhaseTimer();
+    t.mark("inherited", 42);
+    t.mark("skip-me", undefined);
+    expect([...t.phases()]).toEqual([["inherited", 42]]);
+  });
+
+  it("format() emits kind, total, and phase k=v pairs in order", () => {
+    const t = new PhaseTimer();
+    t.mark("first", 10);
+    t.mark("second", 20);
+    const line = t.format("boot", 100);
+    expect(line).toBe("phases kind=boot total=100 first=10 second=20");
+  });
+
+  it("totalMs is at least the sum of measured phases", async () => {
+    const t = new PhaseTimer();
+    t.start("a");
+    await sleep(5);
+    t.end("a");
+    t.start("b");
+    await sleep(5);
+    t.end("b");
+    const sum = [...t.phases().values()].reduce((s, n) => s + n, 0);
+    expect(t.totalMs()).toBeGreaterThanOrEqual(sum);
+  });
+
+  it("flush() invokes the debug fn with the formatted line", () => {
+    const t = new PhaseTimer();
+    t.mark("only", 7);
+    let captured = "";
+    const fakeDebug = ((fmt: string, line: string) => {
+      // debug uses printf-style; we know we pass "%s" + line.
+      captured = fmt.replace("%s", line);
+    }) as unknown as Parameters<PhaseTimer["flush"]>[0];
+    t.flush(fakeDebug, "snapshot", 50);
+    expect(captured).toBe("phases kind=snapshot total=50 only=7");
+  });
+});

--- a/packages/runtime/src/__tests__/reflink.test.ts
+++ b/packages/runtime/src/__tests__/reflink.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { reflinkCopy } from "../reflink.ts";
+
+describe("reflinkCopy", () => {
+  let workDir: string | undefined;
+
+  afterEach(() => {
+    if (workDir && existsSync(workDir)) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+    workDir = undefined;
+  });
+
+  it("clones a file byte-for-byte to a fresh destination", () => {
+    workDir = mkdtempSync(join(tmpdir(), "reflink-test-"));
+    const src = join(workDir, "src.bin");
+    const dst = join(workDir, "dst.bin");
+    const payload = Buffer.alloc(64 * 1024);
+    payload.fill("A");
+    writeFileSync(src, payload);
+    reflinkCopy(src, dst);
+    expect(readFileSync(dst).equals(payload)).toBe(true);
+  });
+
+  it("the clone is independent — writes to the source don't propagate", () => {
+    workDir = mkdtempSync(join(tmpdir(), "reflink-test-"));
+    const src = join(workDir, "src.bin");
+    const dst = join(workDir, "dst.bin");
+    writeFileSync(src, Buffer.from("original"));
+    reflinkCopy(src, dst);
+    writeFileSync(src, Buffer.from("modified-after-clone"));
+    expect(readFileSync(dst).toString()).toBe("original");
+  });
+});

--- a/packages/runtime/src/phase-timer.ts
+++ b/packages/runtime/src/phase-timer.ts
@@ -1,0 +1,94 @@
+// #221 — per-phase wall-clock instrumentation for boot/restore/snapshot.
+//
+// Records (phase-name → elapsed ms) for one run, then flushes a single
+// structured line so a `DEBUG=machinen:boot` (or :restore / :snapshot)
+// log is one grep away from a diffable timeline:
+//
+//   phases kind=boot total=12345 asset-resolve=80 disk-prep=12 \
+//     net-services.gvproxy=3010 net-services.cache=42 initramfs-pack=1180 \
+//     rootdisk-materialize=15 vmm-spawn=23 first-guest-byte=420
+//
+// One line per run keeps the output regression-friendly (grep "^  machinen:boot phases "
+// across two runs and diff). Phases preserve insertion order so the line
+// reads like a timeline, not an alphabetised dump.
+//
+// Phase names use dot-separation for sub-marks
+// (`net-services.gvproxy`, `net-services.cache`, …) so a top-level
+// rollup and its components are both visible in the same line.
+
+import type debugLib from "debug";
+
+type DebugFn = ReturnType<typeof debugLib>;
+
+export class PhaseTimer {
+  private readonly t0: number;
+  private readonly starts = new Map<string, number>();
+  private readonly durations = new Map<string, number>();
+
+  constructor() {
+    this.t0 = Date.now();
+  }
+
+  /** Begin a phase. Subsequent `end(name)` records the elapsed wall-clock. */
+  start(name: string): void {
+    this.starts.set(name, Date.now());
+  }
+
+  /**
+   * End a previously-started phase. No-op if `start` wasn't called for
+   * `name` — keeps callsites that conditionally enter a phase tidy.
+   */
+  end(name: string): number | undefined {
+    const t = this.starts.get(name);
+    if (t === undefined) {
+      return undefined;
+    }
+    const elapsed = Date.now() - t;
+    this.starts.delete(name);
+    this.durations.set(name, elapsed);
+    return elapsed;
+  }
+
+  /**
+   * Record a phase whose duration was timed externally (e.g. inherited
+   * from a nested `boot()` call inside `restore()`). Skips entirely when
+   * `ms` is undefined so call-sites don't have to branch.
+   */
+  mark(name: string, ms: number | undefined): void {
+    if (ms === undefined) {
+      return;
+    }
+    this.durations.set(name, ms);
+  }
+
+  /** Wall-clock since timer construction. */
+  totalMs(): number {
+    return Date.now() - this.t0;
+  }
+
+  /** Snapshot of recorded phases (insertion-ordered). */
+  phases(): ReadonlyMap<string, number> {
+    return this.durations;
+  }
+
+  /**
+   * Format the structured one-liner. Exposed separately from `flush`
+   * so tests can assert shape without piping through `debug`.
+   */
+  format(kind: string, totalMs?: number): string {
+    const total = totalMs ?? this.totalMs();
+    const parts = [`kind=${kind}`, `total=${total}`];
+    for (const [name, ms] of this.durations) {
+      parts.push(`${name}=${ms}`);
+    }
+    return `phases ${parts.join(" ")}`;
+  }
+
+  /**
+   * Emit the one-liner via `debugFn`. `kind` distinguishes boot /
+   * restore / snapshot in the output.
+   */
+  flush(debugFn: DebugFn, kind: string, totalMs?: number): void {
+    debugFn("%s", this.format(kind, totalMs));
+  }
+}

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -24,8 +24,6 @@
 import { execFileSync } from "node:child_process";
 import {
   closeSync,
-  constants as fsConstants,
-  copyFileSync,
   existsSync,
   mkdtempSync,
   openSync,
@@ -40,6 +38,7 @@ import { join, resolve } from "node:path";
 import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
+import { reflinkCopy } from "./reflink.ts";
 import { boot } from "./vm.ts";
 import type { VmHandle } from "./vm-handle.ts";
 import type { OnLog } from "./log.ts";
@@ -273,11 +272,11 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     // into the workDir. The install hook mutates this throwaway copy, so
     // the persistent ~/.cache/machinen/rootfs/<sha>.img cache stays
     // pristine for normal `boot({ image })` callers that share the same
-    // base. COPYFILE_FICLONE → APFS clonefile / Linux FICLONE on
-    // reflink-capable fs (free); falls back to a regular copy elsewhere
+    // base. reflinkCopy → APFS clonefile / Linux FICLONE on reflink-
+    // capable fs (free); falls back to a regular copy elsewhere
     // (one-time cost, sparse).
     const cachedImg = ensureRootfsImage(baseAbs);
-    copyFileSync(cachedImg, rootDiskPath, fsConstants.COPYFILE_FICLONE);
+    reflinkCopy(cachedImg, rootDiskPath);
     debug("rootdisk cloned src=%s dst=%s", cachedImg, rootDiskPath);
     // The cached `<sha>.img` was only READ here — the FICLONE / copy
     // landed in workDir, and the upcoming boot() targets that copy via

--- a/packages/runtime/src/reflink.ts
+++ b/packages/runtime/src/reflink.ts
@@ -1,0 +1,48 @@
+// #221 follow-up — fast reflink/CoW copy.
+//
+// Why this exists: Node's `fs.copyFileSync(src, dst, COPYFILE_FICLONE)`
+// on macOS goes through the BSD `copyfile(3)` library function (with
+// CLONE flag), not the underlying `clonefile(2)` syscall. `copyfile(3)`
+// does extra ACL/metadata bookkeeping that scales with file size — for
+// a 2 GiB rootdisk image we measured ~635 ms there, vs ~20 ms for
+// `cp -c` (which calls `clonefile(2)` directly). On every warm boot
+// this was 73 % of `rootdisk-materialize`. See issue #221.
+//
+// On Linux, libuv's COPYFILE_FICLONE path uses the FICLONE ioctl
+// directly and is already fast — no need to special-case.
+//
+// Strategy:
+//   - Darwin: spawnSync `/bin/cp -c src dst`. Process spawn is ~5 ms,
+//     dwarfed by the saving. If it fails (e.g. cross-volume — clonefile
+//     is volume-local), fall back to plain copyFileSync without the
+//     reflink flag (correctness over speed for the rare cross-volume
+//     case).
+//   - Everywhere else: stay on `copyFileSync(... COPYFILE_FICLONE)`
+//     which is the right primitive on Linux/BSD.
+
+import { spawnSync } from "node:child_process";
+import { constants as fsConstants, copyFileSync } from "node:fs";
+import { platform } from "node:os";
+
+/**
+ * Reflink-clone `src` to `dst`. The destination must NOT exist (same
+ * contract as `clonefile(2)`). Falls back to a regular byte copy on
+ * filesystems that don't support reflinks.
+ */
+export function reflinkCopy(src: string, dst: string): void {
+  if (platform() === "darwin") {
+    const res = spawnSync("/bin/cp", ["-c", src, dst], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (res.status === 0) {
+      return;
+    }
+    // `cp -c` failed (cross-volume, EACCES, dst exists, etc). Fall
+    // through to a plain copy — slower but correct. We deliberately
+    // drop COPYFILE_FICLONE on the fallback because the only reason
+    // to retry is when the reflink path didn't work.
+    copyFileSync(src, dst);
+    return;
+  }
+  copyFileSync(src, dst, fsConstants.COPYFILE_FICLONE);
+}

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -42,7 +42,7 @@ import {
   writeSync,
 } from "node:fs";
 import { createRequire } from "node:module";
-import { arch as osArch, platform as osPlatform, tmpdir } from "node:os";
+import { arch as osArch, homedir, platform as osPlatform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Readable } from "node:stream";
 import debugLib from "debug";
@@ -1366,9 +1366,52 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
  * undefined when the image has no config baked in — plain rootfs
  * tarballs that pre-date this feature still boot fine.
  */
-function readImageConfig(
-  imagePath: string,
-): { cmd?: string[]; env?: Record<string, string>; cwd?: string } | undefined {
+type ImageConfig = { cmd?: string[]; env?: Record<string, string>; cwd?: string };
+
+/**
+ * Disk cache for `readImageConfig`. The base tarball is regenerated only
+ * by `scripts/build-base-assets.sh` / `provision()`, so its (size, mtime)
+ * is a reliable fingerprint between runs. Without this cache, every
+ * boot() pays ~170 ms decompressing a 2 GiB gzip stream looking for
+ * (or failing to find) `./machinen-config.json` — that single call
+ * was ~98 % of the `initramfs-pack` phase. Negative results are cached
+ * too: most user-built tarballs don't carry the file.
+ */
+function imageConfigCacheDir(): string {
+  return join(homedir(), ".cache", "machinen", "image-config");
+}
+
+function imageConfigCachePath(imagePath: string): string | undefined {
+  let st;
+  try {
+    st = statSync(imagePath);
+  } catch {
+    return undefined;
+  }
+  // basename + size + mtime is enough to distinguish typical builds;
+  // collisions are harmless because the cache file's body is the
+  // authoritative answer for the keying tarball — a stale cache means
+  // the tarball was overwritten without changing size+mtime, which
+  // would also confuse `ensureRootfsImage`'s sha-based cache the same
+  // way.
+  const base = imagePath.split("/").pop() ?? "image";
+  const key = `${base}-${st.size}-${Math.floor(st.mtimeMs)}.json`;
+  return join(imageConfigCacheDir(), key);
+}
+
+/** @internal — exported for tests; production callers should not use directly. */
+export function readImageConfig(imagePath: string): ImageConfig | undefined {
+  const cachePath = imageConfigCachePath(imagePath);
+  if (cachePath && existsSync(cachePath)) {
+    try {
+      const raw = readFileSync(cachePath, "utf8");
+      const cached = JSON.parse(raw) as { config: ImageConfig | null };
+      return cached.config ?? undefined;
+    } catch {
+      // Corrupt cache — fall through, regenerate.
+    }
+  }
+  let result: ImageConfig | undefined;
   try {
     // `-x` stream-extract, `-O` to stdout, `-z` auto-detect gzip. The
     // target path matches the layout `provision()` writes.
@@ -1376,15 +1419,23 @@ function readImageConfig(
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     });
-    if (!out.trim()) {
-      return undefined;
+    if (out.trim()) {
+      result = JSON.parse(out) as ImageConfig;
     }
-    return JSON.parse(out) as { cmd?: string[]; env?: Record<string, string>; cwd?: string };
   } catch {
     // Either the tarball lacks the file or it's not a tarball we can
     // read — boot will still try to use the rootfs as-is.
-    return undefined;
   }
+  if (cachePath) {
+    try {
+      mkdirSync(imageConfigCacheDir(), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ config: result ?? null }));
+    } catch {
+      // Best-effort cache write — a missing cache just means we redo
+      // the slow path next time.
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -26,7 +26,6 @@ import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import {
   closeSync,
-  constants as fsConstants,
   copyFileSync,
   existsSync,
   linkSync,
@@ -63,10 +62,12 @@ import {
 import { spawnArtifactCache } from "./artifact-cache.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "./errors.ts";
 import { ensurePdeathsig, wrapWithPdeathsig } from "./pdeathsig.ts";
+import { reflinkCopy } from "./reflink.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "./rootfs-img.ts";
 import { VsockExec, type VsockExecOptions, type VsockExecResult } from "./exec.ts";
 import { serveLiveMount } from "./mount-server.ts";
 import type { OnLog } from "./log.ts";
+import { PhaseTimer } from "./phase-timer.ts";
 import { claimName, findEntry, isAlive, removeEntry, writeEntry } from "./registry.ts";
 import type {
   ForkOptions,
@@ -79,6 +80,7 @@ import type {
 
 const debug = debugLib("machinen:boot");
 const debugAttach = debugLib("machinen:attach");
+const debugRestore = debugLib("machinen:restore");
 const debugSnapshot = debugLib("machinen:snapshot");
 const debugFork = debugLib("machinen:fork");
 const vmmDebug = debugLib("machinen:vmm");
@@ -354,6 +356,9 @@ export interface BootOptions {
  */
 export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   const bootT0 = Date.now();
+  // #221: per-phase wall-clock timeline emitted as one line under
+  // DEBUG=machinen:boot once the VMM produces its first console byte.
+  const phases = new PhaseTimer();
   debug(
     "boot entry image=%s cmd=%j name=%s portForward=%d hasSnapshot=%s mount=%s",
     opts.image ?? "<none>",
@@ -363,6 +368,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     Boolean(opts.snapshot),
     opts.mount ? `${opts.mount.host}->${opts.mount.guest}` : "<none>",
   );
+  phases.start("asset-resolve");
   // Validate portForward up front — before resolving the binary or
   // touching the filesystem — so caller-input errors surface with a
   // clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
@@ -440,11 +446,13 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   if (opts.cmd && !opts.image) {
     throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
   }
+  phases.end("asset-resolve");
 
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
     ...opts.vmmEnv,
   };
+  phases.start("disk-prep");
   let diskAbs: string | undefined;
   // #121: per-boot reflink clone of the cached `<sha>.img`. Tracking
   // it lets the exit handler delete the copy so guest writes don't
@@ -493,7 +501,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         tmpdir(),
         `machinen-snap-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
       );
-      copyFileSync(bundleDisk, perBoot, fsConstants.COPYFILE_FICLONE);
+      reflinkCopy(bundleDisk, perBoot);
       diskAbs = perBoot;
       perBootSnapDisk = perBoot;
       env.MACHINEN_DISK = perBoot;
@@ -516,6 +524,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     env.MACHINEN_DISK = scratchPath;
     debug("snap-scratch auto path=%s sizeBytes=%d", scratchPath, SNAP_SCRATCH_BYTES);
   }
+  phases.end("disk-prep");
 
   // #114: rootdisk-by-default. Boot mounts the rootfs from a
   // virtio-blk device (/dev/vda) instead of inflating the whole tree
@@ -612,6 +621,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   }
 
   try {
+    phases.start("net-services");
+    phases.start("net-services.gvproxy");
     if (!env.MACHINEN_NET_SOCKET) {
       // Auto-install gvproxy on first use if not already resolvable —
       // visible stderr line; cached under ~/.machinen so subsequent
@@ -639,11 +650,13 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     } else {
       debug("MACHINEN_NET_SOCKET already set — skipping gvproxy spawn");
     }
+    phases.end("net-services.gvproxy");
 
     // Only useful when the guest has networking — without gvproxy
     // the guest can't reach the host loopback anyway. Caller-provided
     // FNM_NODE_DIST_MIRROR wins so tests and power users can point
     // fnm at a different mirror.
+    phases.start("net-services.cache");
     if (env.MACHINEN_NET_SOCKET) {
       try {
         const cache = await spawnArtifactCache();
@@ -661,11 +674,13 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         );
       }
     }
+    phases.end("net-services.cache");
 
     // #78: start one live-share server per resolved mount before the
     // VMM boots. The guest fuse-agent will dial these UDSes once it's
     // past /dev/fuse mount; if we started them after the VMM, the
     // agent would spin in connect-retry for as long as we took.
+    phases.start("net-services.live-mounts");
     for (const lm of liveMountsResolved) {
       const handle = await serveLiveMount(lm.udsPath, {
         rootAbs: lm.host,
@@ -673,25 +688,29 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       });
       liveMountStops.push(handle.stop);
     }
+    phases.end("net-services.live-mounts");
+    phases.end("net-services");
 
     // Pack an initramfs whenever the guest needs userspace (image +
     // cmd + snapshot-only restore all need /init + synthesized
     // machinen-config.json). Test-mode zig boots fall through with no
     // INITRD env set — the VMM uses its own fixture initramfs.
     if (opts.image || opts.cmd || opts.snapshot) {
-      const packT0 = Date.now();
+      phases.start("initramfs-pack");
       const packed = synthesizeAndPackBundle(opts, mergedGuestEnv, liveMountsResolved, {
         useTiny: wantsRootDisk,
         env,
       });
       bundleTempDir = packed.tempDir;
       env.MACHINEN_INITRD = packed.cpioPath;
-      debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, Date.now() - packT0);
+      const packMs = phases.end("initramfs-pack");
+      debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
     }
 
     // #114: rootDisk materialization. After all input validation has
     // passed (so a bad mount path or missing image fails before we
     // hash a multi-GB tarball). On a cache hit this is a few ms.
+    phases.start("rootdisk-materialize");
     if (wantsRootDisk) {
       let rootDiskAbs: string;
       if (typeof opts.rootDisk === "string") {
@@ -717,7 +736,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
           tmpdir(),
           `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
         );
-        copyFileSync(cachedImg, perBoot, fsConstants.COPYFILE_FICLONE);
+        reflinkCopy(cachedImg, perBoot);
         // The cache file was only READ here — restore the
         // clean-shutdown marker so the next boot finds a usable
         // template instead of wiping and rematerializing (#170).
@@ -727,6 +746,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       }
       env.MACHINEN_ROOTDISK = rootDiskAbs;
     }
+    phases.end("rootdisk-materialize");
   } catch (err) {
     for (const stop of liveMountStops) {
       await stop().catch(() => {});
@@ -765,6 +785,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // ~1.7 GiB RSS (#200). Mirrors `spawnGvproxy`. Falls through to a
   // direct spawn if the shim is unavailable (no `cc`, opted-out,
   // unsupported platform).
+  phases.start("vmm-spawn");
   const vmmPdeathsig = opts.pdeathsig === false ? null : await ensurePdeathsig();
   const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, binary, opts.args ?? []);
   const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
@@ -772,6 +793,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     env,
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessWithoutNullStreams;
+  phases.end("vmm-spawn");
+  // first-guest-byte starts ticking from VMM-spawn — that's the point
+  // after which any console output is real guest progress.
+  phases.start("first-guest-byte");
   debug(
     "VMM spawned pid=%d binary=%s wrapped=%s elapsedSinceEntry=%dms",
     child.pid ?? -1,
@@ -902,6 +927,21 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       process.stderr.write(chunk);
     });
   }
+
+  // #221: stamp first-guest-byte and emit the boot timeline. Either
+  // path (first stderr byte, or VMM exit before any output) flushes
+  // exactly once — `phases.end` is a no-op the second time around.
+  let phasesFlushed = false;
+  const flushPhases = () => {
+    if (phasesFlushed) {
+      return;
+    }
+    phasesFlushed = true;
+    phases.end("first-guest-byte");
+    phases.flush(debug, "boot");
+  };
+  child.stderr.once("data", flushPhases);
+  child.once("exit", flushPhases);
 
   const handle: VmHandle = {
     pid: childPid,
@@ -1887,6 +1927,9 @@ async function performSnapshot(
   }
   const dumpCmd = envPrefix.length > 0 ? `${envPrefix.join(" ")} ${baseDumpCmd}` : baseDumpCmd;
   const t0 = Date.now();
+  // #221: per-phase timeline emitted under DEBUG=machinen:snapshot.
+  const phases = new PhaseTimer();
+  phases.start("staging");
 
   // Validate / prepare the bundle directory. We refuse to overwrite
   // an existing populated directory so a previous snapshot can't
@@ -1962,6 +2005,8 @@ async function performSnapshot(
       onLog({ source: "guest-console", chunk });
     });
   }
+  phases.end("staging");
+  phases.start("dump-exec");
 
   // Kick off the in-guest dump. The vsock connection typically closes
   // mid-transaction as the guest powers off (CRIU kills the dumped tree,
@@ -2058,6 +2103,8 @@ async function performSnapshot(
     // so this never throws.
     await dumpDispatch;
   }
+  phases.end("dump-exec");
+  phases.start("validation");
   const elapsedMs = Date.now() - t0;
   const consoleLog = await ctx.errorOutput();
   debugSnapshot(
@@ -2142,6 +2189,8 @@ async function performSnapshot(
     );
   }
 
+  phases.end("validation");
+  phases.start("finalize");
   const diskOut = join(snapDir, "disk.img");
   if (stagedViaLink) {
     debugSnapshot("promote staging %s -> %s", stagingPath, diskOut);
@@ -2158,8 +2207,10 @@ async function performSnapshot(
     snappedAt: Date.now(),
   };
   writeFileSync(join(snapDir, "meta.json"), JSON.stringify(meta));
+  phases.end("finalize");
 
   debugSnapshot("snapshot done snapDir=%s postMtime=%d", snapDir, postMtime);
+  phases.flush(debugSnapshot, "snapshot");
   return { snapDir, diskPath: diskOut, elapsedMs, consoleLog };
 }
 
@@ -2219,12 +2270,18 @@ export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" |
  *   is missing.
  */
 export async function restore(opts: RestoreOptions): Promise<VmHandle> {
+  // #221: per-phase timeline for restore. Boot's own phases get logged
+  // separately under DEBUG=machinen:boot — restore tracks the parts
+  // that are restore-specific (meta-read, the boot rollup, and the
+  // wall-clock until the restored guest is responsive over vsock).
+  const phases = new PhaseTimer();
   const snapDir = resolve(opts.snapDir);
   const diskPath = join(snapDir, "disk.img");
   const metaPath = join(snapDir, "meta.json");
   if (!existsSync(diskPath)) {
     throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${diskPath} not found`);
   }
+  phases.start("snapshot-meta-read");
   let meta: SnapshotMeta = { snappedAt: 0 };
   if (existsSync(metaPath)) {
     try {
@@ -2235,16 +2292,19 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
       // have a memorable auto-name.
     }
   }
+  phases.end("snapshot-meta-read");
 
   // boot() doesn't know the pid until after the VMM is spawned, so
   // we can't pass `<sourceName>/<pid>` up front. Boot anonymous,
   // then claim the auto-name and patch the registry entry below.
+  phases.start("boot");
   const vm = await boot({
     ...opts,
     snapshot: diskPath,
     forkedFrom: snapDir,
     name: opts.name,
   });
+  phases.end("boot");
 
   if (!opts.name && meta.sourceName) {
     // Default auto-name nests under the source: `<src>/<pid>`.
@@ -2273,7 +2333,17 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   // `hostname <label>` over vsock (fire-and-forget) so the guest's
   // kernel hostname uniquely identifies this VM, with the host VMM
   // pid as the disambiguator. See buildGuestHostname for the format.
-  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name));
+  //
+  // #221: piggy-back on the same vsock round-trip to time how long
+  // CRIU restore + supervisor takes to become responsive. Anything
+  // that lets the hostname call return is a usable proxy for "guest
+  // ready". We don't await it — boot() already happened, this just
+  // closes the timing line in the background.
+  phases.start("criu-restore-probe");
+  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).finally(() => {
+    phases.end("criu-restore-probe");
+    phases.flush(debugRestore, "restore");
+  });
   return vm;
 }
 

--- a/scripts/bench-boot.ts
+++ b/scripts/bench-boot.ts
@@ -1,0 +1,471 @@
+// #221 — Boot/restore phase-latency bench.
+//
+// Boots a microVM N times in a row, captures each run's structured
+// `phases` line (DEBUG=machinen:boot), and prints a per-phase table
+// (n / min / median / p95 / max / sum) so before/after numbers are
+// straightforward to diff.
+//
+// Two modes:
+//   --mode=boot     N cold + N warm boots (default)
+//   --mode=restore  produce one snapshot, then N restore() runs
+//
+// Cold vs warm:
+//   "Cold" wipes the rootfs-img materialization cache
+//   (`~/.cache/machinen/rootfs/<sha>.img`) before each iteration so
+//   `rootdisk-materialize` pays the full mke2fs price. "Warm" leaves
+//   it in place and the same iteration shows reflink-clone-only cost.
+//   gvproxy install / artifact-cache / initramfs-pack are NOT cleared:
+//   their per-boot cost is what we want to measure here.
+//
+// Usage:
+//   pnpm bench-boot                       # 5 cold + 5 warm boots
+//   pnpm bench-boot --n 3                 # 3 + 3
+//   pnpm bench-boot --mode=restore --n 3  # snapshot once, restore x3 (cold+warm)
+//   pnpm bench-boot --warm-only           # skip the cold pass
+//   pnpm bench-boot --cold-only           # skip the warm pass
+//
+// Exit codes: 0 success. 2 missing fixtures / args. 3 a run failed.
+//
+// Output:
+//   - Each iteration prints "[run-iN] phases ..." (the structured line).
+//   - The final summary table is plain text, easy to paste into the
+//     issue thread.
+
+// `debug` snapshots the DEBUG envvar at import time, so we set it
+// BEFORE pulling in @machinen/runtime — which eagerly creates
+// `debugLib("machinen:boot")` instances at module load. ESM hoists
+// static imports above any top-level statements, so the runtime
+// import has to be dynamic (inside main()) for our env tweak to land
+// before the namespace caches enabled-state.
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type RuntimeMod = typeof import("@machinen/runtime");
+let runtime: RuntimeMod | undefined;
+async function loadRuntime(): Promise<RuntimeMod> {
+  if (!runtime) {
+    process.env.DEBUG = (process.env.DEBUG ?? "") + ",machinen:boot,machinen:restore";
+    runtime = await import("@machinen/runtime");
+  }
+  return runtime;
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const ASSETS = join(REPO_ROOT, "release-assets");
+// Fallback to the runtime asset cache (~/.machinen/runtime-vX/bases/<base>)
+// so bench-boot works on a checkout that hasn't run scripts/build-base-assets.sh.
+const FALLBACK_BASE = join(homedir(), ".machinen", "runtime-v0.0.0", "bases", "debian-arm64");
+const KERNEL = pickFirstExisting([join(ASSETS, "Image-arm64"), join(FALLBACK_BASE, "Image")]);
+const DTB = pickFirstExisting([join(ASSETS, "virt-arm64.dtb"), join(FALLBACK_BASE, "virt.dtb")]);
+const IMAGE = pickFirstExisting([
+  join(ASSETS, "rootfs-debian-arm64.tar.gz"),
+  join(FALLBACK_BASE, "rootfs.tar.gz"),
+]);
+const ROOTFS_IMG_CACHE = join(homedir(), ".cache", "machinen", "rootfs");
+
+function pickFirstExisting(candidates: string[]): string {
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      return c;
+    }
+  }
+  return candidates[0]!;
+}
+
+type Mode = "boot" | "restore";
+
+interface Args {
+  n: number;
+  mode: Mode;
+  coldOnly: boolean;
+  warmOnly: boolean;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const out: Args = { n: 5, mode: "boot", coldOnly: false, warmOnly: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--n" || a === "-n") {
+      out.n = Number.parseInt(argv[++i] ?? "", 10);
+    } else if (a.startsWith("--n=")) {
+      out.n = Number.parseInt(a.slice(4), 10);
+    } else if (a === "--mode") {
+      out.mode = argv[++i] as Mode;
+    } else if (a.startsWith("--mode=")) {
+      out.mode = a.slice(7) as Mode;
+    } else if (a === "--cold-only") {
+      out.coldOnly = true;
+    } else if (a === "--warm-only") {
+      out.warmOnly = true;
+    } else if (a === "-h" || a === "--help") {
+      printUsageAndExit(0);
+    } else {
+      console.error(`bench-boot: unknown arg ${a}`);
+      printUsageAndExit(2);
+    }
+  }
+  if (!Number.isInteger(out.n) || out.n < 1) {
+    console.error(`bench-boot: --n must be a positive integer (got ${out.n})`);
+    process.exit(2);
+  }
+  if (out.mode !== "boot" && out.mode !== "restore") {
+    console.error(`bench-boot: --mode must be 'boot' or 'restore' (got ${out.mode})`);
+    process.exit(2);
+  }
+  if (out.coldOnly && out.warmOnly) {
+    console.error("bench-boot: --cold-only and --warm-only are mutually exclusive");
+    process.exit(2);
+  }
+  return out;
+}
+
+function printUsageAndExit(code: number): never {
+  console.log("usage: bench-boot [--n N] [--mode boot|restore] [--cold-only|--warm-only]");
+  process.exit(code);
+}
+
+function requireAssets(): void {
+  for (const p of [KERNEL, DTB, IMAGE]) {
+    if (!existsSync(p)) {
+      console.error(
+        `bench-boot: missing fixture ${p}. Run scripts/build-base-assets.sh + pnpm provision.`,
+      );
+      process.exit(2);
+    }
+  }
+}
+
+function clearRootfsImgCache(): void {
+  if (existsSync(ROOTFS_IMG_CACHE)) {
+    rmSync(ROOTFS_IMG_CACHE, { recursive: true, force: true });
+  }
+  mkdirSync(ROOTFS_IMG_CACHE, { recursive: true });
+}
+
+interface PhaseLine {
+  kind: string;
+  total: number;
+  phases: Map<string, number>;
+}
+
+/**
+ * Parse one "phases kind=X total=Y a=N b=N..." line. Returns null on
+ * shape mismatches (e.g. partial line caught mid-flush).
+ */
+function parsePhaseLine(line: string): PhaseLine | null {
+  const idx = line.indexOf("phases ");
+  if (idx < 0) {
+    return null;
+  }
+  const tail = line.slice(idx + "phases ".length).trim();
+  const tokens = tail.split(/\s+/);
+  let kind = "";
+  let total = -1;
+  const phases = new Map<string, number>();
+  for (const t of tokens) {
+    const eq = t.indexOf("=");
+    if (eq < 0) {
+      return null;
+    }
+    const k = t.slice(0, eq);
+    const v = t.slice(eq + 1);
+    if (k === "kind") {
+      kind = v;
+    } else if (k === "total") {
+      total = Number.parseInt(v, 10);
+    } else {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n)) {
+        phases.set(k, n);
+      }
+    }
+  }
+  if (!kind || total < 0) {
+    return null;
+  }
+  return { kind, total, phases };
+}
+
+/**
+ * Run one boot, wait for first console byte, kill, return the parsed
+ * phases line. Picks the line off this process's stderr by attaching
+ * a `debug` write listener — the runtime's `debug` writes go to
+ * process.stderr, so we tee into a buffer and parse from there.
+ */
+async function runOneBoot(label: string): Promise<PhaseLine> {
+  const lines: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  // Tee stderr so we capture the structured line without losing the
+  // stream. Cleared in `finally` so a thrown boot doesn't leak the hook.
+  (process.stderr as { write: typeof orig }).write = ((
+    chunk: string | Uint8Array,
+    encOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ) => {
+    const s = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    lines.push(s);
+    return orig(chunk as Buffer, encOrCb as BufferEncoding, cb);
+  }) as typeof orig;
+
+  try {
+    process.stderr.write(`[${label}] booting...\n`);
+    const { boot } = await loadRuntime();
+    const vm = await boot({
+      image: IMAGE,
+      kernel: KERNEL,
+      dtb: DTB,
+      cmd: ["/bin/true"],
+      timeoutMs: 60_000,
+    });
+    // Wait for first byte (or VMM exit) so the phases line gets
+    // flushed before we kill.
+    await Promise.race([
+      new Promise<void>((res) => {
+        vm.stderr.once("data", () => res());
+      }),
+      vm.wait().then(
+        () => undefined,
+        () => undefined,
+      ),
+    ]);
+    await vm.kill().catch(() => {});
+    await vm.wait().catch(() => undefined);
+  } finally {
+    (process.stderr as { write: typeof orig }).write = orig;
+  }
+  const captured = lines.join("");
+  for (const ln of captured.split("\n").reverse()) {
+    const parsed = parsePhaseLine(ln);
+    if (parsed && parsed.kind === "boot") {
+      return parsed;
+    }
+  }
+  throw new Error(`bench-boot: no machinen:boot phases line captured in ${label}`);
+}
+
+async function runOneRestore(snapDir: string, label: string): Promise<PhaseLine[]> {
+  const lines: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  (process.stderr as { write: typeof orig }).write = ((
+    chunk: string | Uint8Array,
+    encOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ) => {
+    const s = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    lines.push(s);
+    return orig(chunk as Buffer, encOrCb as BufferEncoding, cb);
+  }) as typeof orig;
+
+  try {
+    process.stderr.write(`[${label}] restoring...\n`);
+    const { restore } = await loadRuntime();
+    const vm = await restore({ snapDir, image: IMAGE, kernel: KERNEL, dtb: DTB });
+    await Promise.race([
+      new Promise<void>((res) => {
+        vm.stderr.once("data", () => res());
+      }),
+      vm.wait().then(
+        () => undefined,
+        () => undefined,
+      ),
+    ]);
+    // Give criu-restore-probe a chance to land its phases line — it's
+    // fired from setGuestHostname's vsock round-trip after boot returns.
+    await new Promise((res) => setTimeout(res, 250));
+    await vm.kill().catch(() => {});
+    await vm.wait().catch(() => undefined);
+  } finally {
+    (process.stderr as { write: typeof orig }).write = orig;
+  }
+  const captured = lines.join("");
+  const found: PhaseLine[] = [];
+  for (const ln of captured.split("\n")) {
+    const parsed = parsePhaseLine(ln);
+    if (parsed && (parsed.kind === "boot" || parsed.kind === "restore")) {
+      found.push(parsed);
+    }
+  }
+  return found;
+}
+
+async function takeSnapshot(): Promise<string> {
+  const snapDir = join(tmpdir(), `bench-boot-snap-${process.pid}`);
+  if (existsSync(snapDir)) {
+    rmSync(snapDir, { recursive: true, force: true });
+  }
+  process.stderr.write(`[snapshot-source] booting + dumping into ${snapDir}\n`);
+  const { boot } = await loadRuntime();
+  // Same workload shape smoke-tests.sh uses for snapshot tests — a
+  // /bin/sh busy-loop that idles forever, leaving the VM CRIU-dumpable
+  // for as long as the snapshot dispatcher needs.
+  const vm = await boot({
+    image: IMAGE,
+    kernel: KERNEL,
+    dtb: DTB,
+    cmd: ["/bin/sh", "-c", "while :; do sleep 1; done"],
+    timeoutMs: 60_000,
+  });
+  // Wait for the guest to settle (kernel + supervisor + workload exec)
+  // before dispatching the dump. If the source dies before we get there,
+  // surface the console tail so the failure is diagnosable.
+  vm.wait().then(
+    async (res) => {
+      if (res.code !== null && res.code !== 0) {
+        const tail = (await vm.errorOutput().catch(() => "")) || "<no console output>";
+        process.stderr.write(
+          `[snapshot-source] VMM exited code=${res.code} signal=${res.signal} before snapshot dispatched.\n` +
+            `Console tail (last 4 KiB):\n${tail.slice(-4096)}\n`,
+        );
+      }
+    },
+    () => {},
+  );
+  await new Promise((res) => setTimeout(res, 1500));
+  await vm.snapshot({ outDir: snapDir, timeoutMs: 60_000 });
+  return snapDir;
+}
+
+interface Stats {
+  n: number;
+  min: number;
+  med: number;
+  p95: number;
+  max: number;
+  sum: number;
+}
+
+function stats(samples: number[]): Stats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const med = sorted[Math.floor(n / 2)] ?? 0;
+  const p95 = sorted[Math.min(n - 1, Math.floor(n * 0.95))] ?? 0;
+  const sum = sorted.reduce((s, x) => s + x, 0);
+  return { n, min: sorted[0] ?? 0, med, p95, max: sorted[n - 1] ?? 0, sum };
+}
+
+function aggregate(label: string, runs: PhaseLine[]): void {
+  if (runs.length === 0) {
+    console.log(`\n=== ${label} (no runs) ===`);
+    return;
+  }
+  // Union of phase keys, in first-run order so the table reads as a timeline.
+  const keys: string[] = ["total"];
+  const seen = new Set<string>(["total"]);
+  for (const r of runs) {
+    for (const k of r.phases.keys()) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        keys.push(k);
+      }
+    }
+  }
+  console.log(`\n=== ${label} (n=${runs.length}) ===`);
+  console.log(`  ${"phase".padEnd(28)}  min   med   p95   max  (ms)`);
+  for (const k of keys) {
+    const samples: number[] = [];
+    for (const r of runs) {
+      const v = k === "total" ? r.total : r.phases.get(k);
+      if (typeof v === "number") {
+        samples.push(v);
+      }
+    }
+    if (samples.length === 0) {
+      continue;
+    }
+    const s = stats(samples);
+    console.log(
+      `  ${k.padEnd(28)}  ${String(s.min).padStart(4)}  ${String(s.med).padStart(4)}  ${String(s.p95).padStart(4)}  ${String(s.max).padStart(4)}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  requireAssets();
+
+  if (args.mode === "boot") {
+    const cold: PhaseLine[] = [];
+    const warm: PhaseLine[] = [];
+    if (!args.warmOnly) {
+      for (let i = 0; i < args.n; i++) {
+        clearRootfsImgCache();
+        cold.push(await runOneBoot(`cold-${i + 1}`));
+      }
+    }
+    if (!args.coldOnly) {
+      // Warm = cache populated. Run one priming boot first if we just
+      // wiped it (cold pass), then N measured warm runs.
+      if (!args.warmOnly) {
+        // The last cold pass already populated the cache; that's our prime.
+      } else {
+        // Prime explicitly so the first warm run isn't accidentally cold.
+        await runOneBoot("warm-prime");
+      }
+      for (let i = 0; i < args.n; i++) {
+        warm.push(await runOneBoot(`warm-${i + 1}`));
+      }
+    }
+    if (cold.length) {
+      aggregate("BOOT (cold)", cold);
+    }
+    if (warm.length) {
+      aggregate("BOOT (warm)", warm);
+    }
+    return;
+  }
+
+  // Restore mode.
+  let snapDir: string | undefined;
+  try {
+    snapDir = await takeSnapshot();
+    if (!existsSync(join(snapDir, "disk.img"))) {
+      throw new Error(`takeSnapshot did not produce ${snapDir}/disk.img`);
+    }
+    const cold: PhaseLine[] = [];
+    const warm: PhaseLine[] = [];
+    const collect = (out: PhaseLine[], lines: PhaseLine[]) => {
+      const r = lines.find((l) => l.kind === "restore");
+      if (r) {
+        out.push(r);
+      }
+    };
+    if (!args.warmOnly) {
+      for (let i = 0; i < args.n; i++) {
+        clearRootfsImgCache();
+        collect(cold, await runOneRestore(snapDir, `cold-${i + 1}`));
+      }
+    }
+    if (!args.coldOnly) {
+      if (args.warmOnly) {
+        await runOneRestore(snapDir, "warm-prime");
+      }
+      for (let i = 0; i < args.n; i++) {
+        collect(warm, await runOneRestore(snapDir, `warm-${i + 1}`));
+      }
+    }
+    if (cold.length) {
+      aggregate("RESTORE (cold)", cold);
+    }
+    if (warm.length) {
+      aggregate("RESTORE (warm)", warm);
+    }
+  } finally {
+    if (snapDir && existsSync(snapDir)) {
+      try {
+        rmSync(snapDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error("bench-boot failed:", err instanceof Error ? err.stack || err.message : err);
+    process.exit(3);
+  },
+);


### PR DESCRIPTION
Closes #221.

## Summary

- Adds `PhaseTimer` (`packages/runtime/src/phase-timer.ts`) — emits one structured line per run, e.g. `machinen:boot phases kind=boot total=106 ... initramfs-pack=1 ... rootdisk-materialize=37 ...`.
- Instruments `boot()` (asset-resolve, disk-prep, net-services.{gvproxy,cache,live-mounts}, initramfs-pack, rootdisk-materialize, vmm-spawn, first-guest-byte), `restore()` (snapshot-meta-read, boot rollup, criu-restore-probe), and `performSnapshot()` (staging, dump-exec, validation, finalize).
- `scripts/bench-boot.ts` (`pnpm bench-boot`) runs N cold + N warm boots/restores and prints a min/med/p95/max table per phase.
- **Win #1 — `reflinkCopy`**: bypasses Node's slow `fs.copyFileSync(... COPYFILE_FICLONE)` on macOS by calling `clonefile(2)` via `/bin/cp -c`. Node's API goes through BSD `copyfile(3)` which scales with file size (~635 ms vs 19 ms for a 2 GiB rootdisk). Linux stays on the fast `copyFileSync` FICLONE-ioctl path.
- **Win #2 — image-config cache**: `readImageConfig()` was shelling out to `tar -xzOf <2 GiB tarball> ./machinen-config.json` on every boot to look for an embedded cmd/env/cwd. Gzip end-to-end was 171 ms even on the negative path. Now cached at `~/.cache/machinen/image-config/<basename>-<size>-<mtime>.json` with explicit negative-result entries.

## Bench (macOS arm64, n=3, debian-arm64 base)

| | baseline | after Win #1 | after Win #2 |
|---|---:|---:|---:|
| total warm (med) | 920 ms | 259 ms | **106 ms** |
| speedup vs baseline | 1.0× | 3.6× | **8.7×** |

| phase                    | warm before | after #1 | after #2 |
|--------------------------|------------:|---------:|---------:|
| **total**                | 920         | 259      | **106**  |
| rootdisk-materialize     | 681         | **30**   | 37       |
| initramfs-pack           | 166         | 162      | **1**    |
| net-services             | 27          | 27       | 27       |
| first-guest-byte         | 44          | 39       | 39       |

Cold boot also benefits from Win #1 (2474 → 1429 ms median, –42 %); Win #2 is warm-only since the tarball read happens once-per-tarball regardless of cache state.

## Test plan

- [x] `npx vitest run` — 27 files, 374 passing; fixture-deps skipped via `MACHINEN_REQUIRE_FIXTURES=0`. New tests: `phase-timer.test.ts` (6), `reflink.test.ts` (2), `image-config-cache.test.ts` (3).
- [x] `npx agent-ci run --all -q -p` — ✓ 4/4 workflows pass (run twice, after each commit).
- [x] End-to-end `pnpm bench-boot --n 3` against cached debian-arm64 base on darwin/arm64.
- [ ] `pnpm smoke-tests` — needs `release-assets/` (Docker + ~5 min); not run on this machine.
