### PR TITLE
feat(rootfs): prebake <base>.img.gz to skip cold mke2fs (#223)

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2471,7 +2471,7 @@ ms epoch when the entry was created.
 
 ### EnsureRootfsImageOptions
 
-Defined in: [rootfs-img.ts:121](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L121)
+Defined in: [rootfs-img.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L134)
 
 #### Properties
 
@@ -2479,7 +2479,7 @@ Defined in: [rootfs-img.ts:121](https://github.com/redwoodjs/machinen/blob/main/
 
 > `optional` **cacheDir?**: `string`
 
-Defined in: [rootfs-img.ts:126](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L126)
+Defined in: [rootfs-img.ts:139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L139)
 
 Override the cache directory. Default: `~/.cache/machinen/rootfs`.
 Useful for tests.
@@ -2488,7 +2488,7 @@ Useful for tests.
 
 > `optional` **force?**: `boolean`
 
-Defined in: [rootfs-img.ts:131](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L131)
+Defined in: [rootfs-img.ts:144](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L144)
 
 Force re-materialization even if a cached image is already present.
 Mostly for debugging the materializer.
@@ -2497,7 +2497,7 @@ Mostly for debugging the materializer.
 
 > `optional` **sizeMultiplier?**: `number`
 
-Defined in: [rootfs-img.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L141)
+Defined in: [rootfs-img.ts:154](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L154)
 
 Slack multiplier above the unpacked tarball size when sizing the
 ext4 filesystem. Default: 2.5 — leaves enough room for the guest
@@ -2511,7 +2511,7 @@ to fill the filesystem.
 
 > `optional` **minSizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:149](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L149)
+Defined in: [rootfs-img.ts:162](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L162)
 
 Minimum image size in bytes. The materializer enforces at least
 this for small rootfs where the multiplier alone would leave
@@ -2523,7 +2523,7 @@ insufficient room for a real workload. Default: 2 GiB — boot-time
 
 > `optional` **sizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:157](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L157)
+Defined in: [rootfs-img.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L170)
 
 Absolute target size in bytes. When set, overrides `sizeMultiplier`
 and `minSizeBytes` entirely — fresh materializations get exactly
@@ -4726,7 +4726,7 @@ effect, so a crashed VMM doesn't leave a stuck record behind.
 
 > **rootfsImgCacheDir**(): `string`
 
-Defined in: [rootfs-img.ts:72](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L72)
+Defined in: [rootfs-img.ts:85](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L85)
 
 Default cache root: `~/.cache/machinen/rootfs`.
 
@@ -4740,7 +4740,7 @@ Default cache root: `~/.cache/machinen/rootfs`.
 
 > **markRootfsImageClean**(`imgPath`): `void`
 
-Defined in: [rootfs-img.ts:92](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L92)
+Defined in: [rootfs-img.ts:105](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L105)
 
 Mark a cached rootfs image as "cleanly released" by writing the
 sentinel that `ensureRootfsImage()` looks for on the next boot.
@@ -4769,7 +4769,7 @@ but never wrong.
 
 > **ensureRootfsImage**(`tarPath`, `opts?`): `string`
 
-Defined in: [rootfs-img.ts:183](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L183)
+Defined in: [rootfs-img.ts:196](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L196)
 
 Resolve `tarPath` to a cached ext4 `.img`, materializing it on first
 call. Returns the absolute path to the cached image.

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -386,6 +386,151 @@ describe("ensureRootfsImage", () => {
     }
   });
 
+  // #223 prebake fast path. When build-base-assets.sh ships a
+  // sibling `<basename>.img.gz` next to the tarball, ensureRootfsImage
+  // gunzips it directly into the cache and skips tar -xf + mke2fs.
+  // Tests use a synthetic "image" that's just the ext4 superblock
+  // magic stamped at offset 1080 — looksLikeExt4 sniffs that and
+  // doesn't need e2fsprogs on the runner.
+  function writeFakeExt4Image(path: string, sizeBytes = 4096): void {
+    const fd = openSync(path, "w");
+    try {
+      writeSync(fd, Buffer.alloc(sizeBytes), 0, sizeBytes, 0);
+      // Little-endian 0xEF53 at offset 1080 — the ext4 superblock magic.
+      writeSync(fd, Buffer.from([0x53, 0xef]), 0, 2, 1080);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  it("siblingPrebakePath strips .tar.gz / .tgz / .tar and appends .img.gz", () => {
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar.gz")).toBe("/r/rootfs.img.gz");
+    expect(_internal.siblingPrebakePath("/r/rootfs.tgz")).toBe("/r/rootfs.img.gz");
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar")).toBe("/r/rootfs.img.gz");
+    // Non-tarball paths return undefined — no prebake convention exists
+    // for them, so the runtime falls through to the materialize path.
+    expect(_internal.siblingPrebakePath("/r/rootfs")).toBeUndefined();
+    expect(_internal.siblingPrebakePath("/r/rootfs.zip")).toBeUndefined();
+  });
+
+  it("uses a sibling .img.gz to populate the cache and skips mke2fs", () => {
+    // Pair a tarball with a sibling prebake. Pointing MACHINEN_MKE2FS
+    // at a missing path proves the materialize branch was never
+    // reached — the override would throw ROOTFS_IMG_TOOL_MISSING the
+    // moment we tried to resolve mke2fs.
+    const tarPath = `/tmp/machinen-rootfs-prebake-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const fakeImg = join(tmpDir, "fake.img");
+    writeFakeExt4Image(fakeImg, 4096);
+    const sibling = tarPath.replace(/\.tar\.gz$/, ".img.gz");
+    execSync(`gzip -n -c ${fakeImg} > ${sibling}`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const result = ensureRootfsImage(tarPath, { cacheDir });
+      expect(result).toBe(join(cacheDir, `${sha}.img`));
+      expect(_internal.looksLikeExt4(result)).toBe(true);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(sibling);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("sibling .img.gz fast path sparse-extends to sizeBytes when larger", () => {
+    const tarPath = `/tmp/machinen-rootfs-prebake-grow-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-grow-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-grow-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-grow-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const fakeImg = join(tmpDir, "fake.img");
+    writeFakeExt4Image(fakeImg, 4096);
+    const sibling = tarPath.replace(/\.tar\.gz$/, ".img.gz");
+    execSync(`gzip -n -c ${fakeImg} > ${sibling}`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      const requested = 32 * 1024;
+      const result = ensureRootfsImage(tarPath, { cacheDir, sizeBytes: requested });
+      // The decompressed image was 4 KiB; sizeBytes asks for 32 KiB,
+      // which is sparse-extended in place before atomic-rename so the
+      // guest's online ext4 grow has the headroom #131 promises.
+      expect(statSync(result).size).toBe(requested);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(sibling);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("falls back to materialize when sibling .img.gz decompresses to non-ext4 bytes", () => {
+    // Corrupted prebake: gunzip succeeds but the bytes inside don't
+    // carry the ext4 superblock magic. The fast path must reject the
+    // decompressed file and fall through to the materialize branch.
+    // We point MACHINEN_MKE2FS at nothing so the fallback throws —
+    // the throw itself proves the prebake branch returned undefined.
+    const tarPath = `/tmp/machinen-rootfs-prebake-corrupt-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-corrupt-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-corrupt-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-corrupt-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const garbage = join(tmpDir, "garbage.bin");
+    writeFileSync(garbage, "not an ext4 image, just some bytes");
+    const sibling = tarPath.replace(/\.tar\.gz$/, ".img.gz");
+    execSync(`gzip -n -c ${garbage} > ${sibling}`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      expect(() => ensureRootfsImage(tarPath, { cacheDir })).toThrow(ProvisionError);
+      try {
+        ensureRootfsImage(tarPath, { cacheDir });
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProvisionError);
+        expect((err as ProvisionError).code).toBe("ROOTFS_IMG_TOOL_MISSING");
+      }
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(sibling);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   it("never shrinks a cached .img — sizeBytes < existing is a no-op", () => {
     // Truncate-down would actually destroy data inside the ext4 fs, so
     // the truncate guard is a critical safety: if the cache is already

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -42,6 +42,19 @@
 // runtime calls `markRootfsImageClean()` to recreate it. A cache
 // hit with no marker is treated as poisoned — wiped and
 // rematerialized from the tarball.
+//
+// Prebake fast path (#223): when the release build shipped an
+// already-materialized `<basename>.img.gz` next to the tarball
+// (build-base-assets.sh runs mke2fs once at release time), we
+// gunzip it directly into the cache instead of doing tar -xf +
+// mke2fs every cold boot. Drops cold rootdisk-materialize from
+// ~1100 ms to ~150 ms (gunzip-only). The cache key stays the
+// tarball sha so the .ok marker, sparse-extend, and per-boot
+// reflink clones (#121) all work unchanged. Falls back to the
+// materialize path when no sibling is present (provision()-built
+// tarballs, fixture builds) or when the sibling fails to
+// decompress / lacks the ext4 magic — the fallback is invisible
+// to the caller.
 
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -240,6 +253,30 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
       try {
         unlinkSync(imgPath);
       } catch {}
+    }
+  }
+
+  // #223: prebake fast path. If the release build dropped a
+  // sibling `<basename>.img.gz` next to the tarball, gunzip it
+  // straight into the cache and skip tar+mke2fs. The decompressed
+  // bytes are an ext4 image; the cache key (tarball sha) is the
+  // same one the materialize path would write to, so downstream
+  // (per-boot reflink, sparse-extend, .ok marker) is unchanged.
+  if (!opts.force) {
+    const sibling = siblingPrebakePath(tarAbs);
+    if (sibling && existsSync(sibling)) {
+      const fast = tryPrebakeFromSibling({
+        sibling,
+        cacheDir,
+        sha,
+        imgPath,
+        sizeBytes: opts.sizeBytes,
+      });
+      if (fast) {
+        return fast;
+      }
+      // Fall through to materialize on any failure — same outcome
+      // as if the sibling weren't there. Slow but always correct.
     }
   }
 
@@ -533,6 +570,86 @@ function duBytes(path: string): number {
   return statSync(path).size || 0;
 }
 
+// Resolve the prebake sibling that build-base-assets.sh produces
+// (`<basename>.img.gz`). We strip a recognized tarball suffix from
+// the input — `.tar.gz`, `.tgz`, `.tar` — and append `.img.gz`.
+// Returns undefined when the path doesn't look like a tarball at
+// all; nothing else carries a meaningful sibling pairing.
+function siblingPrebakePath(tarAbs: string): string | undefined {
+  const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(tarAbs);
+  if (!m) {
+    return undefined;
+  }
+  return `${m[1]}.img.gz`;
+}
+
+// Try to populate the cache by decompressing a prebuilt sibling
+// `.img.gz`. Returns the cache path on success, undefined on any
+// failure (gunzip error, decompressed bytes don't look like ext4).
+// The caller falls back to the slow materialize path on undefined.
+function tryPrebakeFromSibling(args: {
+  sibling: string;
+  cacheDir: string;
+  sha: string;
+  imgPath: string;
+  sizeBytes?: number;
+}): string | undefined {
+  const { sibling, cacheDir, sha, imgPath, sizeBytes } = args;
+  const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-prebake-`));
+  const stagingImg = join(stagingDir, "rootfs.img");
+  try {
+    debug("prebake try sibling=%s sha=%s", sibling, sha.slice(0, 12));
+    const dstFd = openSync(stagingImg, "w");
+    let gunzipOk = false;
+    try {
+      const r = spawnSync("gunzip", ["-c", sibling], {
+        stdio: ["ignore", dstFd, "pipe"],
+      });
+      gunzipOk = r.status === 0;
+      if (!gunzipOk) {
+        debug(
+          "prebake gunzip failed sibling=%s status=%s stderr=%s",
+          sibling,
+          r.status,
+          r.stderr?.toString().slice(0, 200) ?? "",
+        );
+      }
+    } finally {
+      closeSync(dstFd);
+    }
+    if (!gunzipOk) {
+      return undefined;
+    }
+    // Sniff ext4 magic so a corrupted / wrong-content sibling can't
+    // pollute the cache. We don't run e2fsck here — the build
+    // pipeline already produced a clean fs, and a host crash this
+    // soon after rename is rare enough that the .ok marker handles
+    // it on the next boot.
+    if (!looksLikeExt4(stagingImg)) {
+      debug("prebake sibling did not decompress to ext4 — falling back");
+      return undefined;
+    }
+    // #131: sparse-extend in place if the caller wants more headroom
+    // than the prebuilt image's native size.
+    if (sizeBytes !== undefined) {
+      const cur = statSync(stagingImg).size;
+      if (sizeBytes > cur) {
+        truncateSync(stagingImg, sizeBytes);
+      }
+    }
+    renameSync(stagingImg, imgPath);
+    debug("prebake done sha=%s img=%s", sha.slice(0, 12), imgPath);
+    return imgPath;
+  } catch (err) {
+    debug("prebake error sibling=%s err=%s", sibling, (err as Error).message);
+    return undefined;
+  } finally {
+    try {
+      rmSync(stagingDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
 function allocateSparseFile(path: string, sizeBytes: number): void {
   const fd = openSync(path, "w");
   try {
@@ -554,4 +671,5 @@ export const _rootfsImgInternal = {
   findBundledMke2fs,
   resolveMke2fsEnvOverride,
   okMarkerPath,
+  siblingPrebakePath,
 };

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -10,6 +10,11 @@
 #                                    issue #119.
 #   virt-arm64.dtb                 ← compiled device tree
 #   rootfs-debian-arm64.tar.gz     ← debian minbase + /init + /exec-agent
+#   rootfs-debian-arm64.img.gz     ← prebaked ext4 image of the same
+#                                    rootfs; lets cold boots skip
+#                                    tar -xf + mke2fs (#223). Sparse
+#                                    inside the gzip — wire size is
+#                                    close to the tarball.
 #   *.sha256                       ← integrity sidecars
 #
 # We no longer ship modules-arm64.tar.gz — the boot-path drivers are
@@ -64,7 +69,8 @@ mkdir -p "$OUT"
 find "$OUT" -mindepth 1 -maxdepth 1 \
   ! -name 'Image-arm64' ! -name 'virt-arm64.dtb' ! -name '*.sha256' \
   -exec rm -f {} +
-rm -rf "${ROOTFS_IMG_CACHE:?}"/*.img "${ROOTFS_IMG_CACHE:?}"/*-staging-* 2>/dev/null || true
+rm -rf "${ROOTFS_IMG_CACHE:?}"/*.img "${ROOTFS_IMG_CACHE:?}"/*-staging-* \
+       "${ROOTFS_IMG_CACHE:?}"/*-prebake-* 2>/dev/null || true
 
 # ------------------------------------------------------------
 # 1. Kernel — custom upstream arm64 build with built-in drivers (#119)
@@ -234,8 +240,11 @@ docker run --rm -i --privileged --platform linux/arm64 \
 set -euo pipefail
 
 apt-get update -qq > /dev/null
+# e2fsprogs is the host-side tool that builds the prebake `.img` from
+# the staged rootfs tree (#223). gzip ships with debian:bookworm-slim
+# already; listed here for clarity.
 apt-get install -y --no-install-recommends \
-  mmdebstrap gpg debian-archive-keyring > /dev/null
+  mmdebstrap gpg debian-archive-keyring e2fsprogs gzip > /dev/null
 
 mkdir -p /work
 
@@ -424,6 +433,31 @@ tar --sort=name --owner=0 --group=0 --numeric-owner \
   --mtime="2020-01-01 00:00Z" \
   -C /work/rootfs -cf - . |
 gzip -n > /out/rootfs-debian-arm64.tar.gz
+
+# ----------------------------------------------------------------
+# #223: prebake the ext4 `.img` next to the tarball so cold boots
+# can skip tar -xf + mke2fs entirely. Materializes once at release
+# time (which already takes minutes for the rest of the bake) so
+# every consumer of the published asset bundle inherits a ~1100 ms
+# cold-boot win.
+#
+# The image size mirrors ensureRootfsImage's defaults:
+#   max(2 GiB, du -sk(rootfs) * 2.5 KiB rounded up to whole bytes)
+# Sparse, so over-provisioning costs nothing on the wire (gzip
+# collapses zero-runs) and gives the guest room to apt install on
+# top of the base. `rootDiskSizeBytes` callers still sparse-extend
+# in place against the unpacked .img, same as cache-hit paths today.
+#
+# 4-KiB block size matches the kernel's arm64 page size so reads
+# are page-cache-aligned; same as the runtime materializer.
+TREE_KIB=$(du -sk /work/rootfs | awk '{print $1}')
+SIZE_BYTES=$(awk -v k="$TREE_KIB" 'BEGIN { s = int(k * 1024 * 2.5); m = 2 * 1024 * 1024 * 1024; if (s < m) s = m; print s }')
+BLOCKS=$(( SIZE_BYTES / 4096 ))
+echo "==> Prebaking rootfs ext4 image: ${SIZE_BYTES} bytes (${BLOCKS} x 4 KiB blocks)"
+truncate -s "$SIZE_BYTES" /tmp/rootfs.img
+mke2fs -d /work/rootfs -t ext4 -F -q -b 4096 /tmp/rootfs.img "$BLOCKS"
+gzip -n -c /tmp/rootfs.img > /out/rootfs-debian-arm64.img.gz
+rm -f /tmp/rootfs.img
 CONTAINER_SCRIPT
 
 # ------------------------------------------------------------
@@ -432,7 +466,7 @@ CONTAINER_SCRIPT
 
 echo "==> Writing sha256 sidecars"
 cd "$OUT"
-for f in Image-arm64 virt-arm64.dtb rootfs-debian-arm64.tar.gz; do
+for f in Image-arm64 virt-arm64.dtb rootfs-debian-arm64.tar.gz rootfs-debian-arm64.img.gz; do
   shasum -a 256 "$f" > "${f}.sha256"
 done
 


### PR DESCRIPTION
Closes #223.

## Summary

- `scripts/build-base-assets.sh` now materializes the ext4 rootdisk once at release time and ships `release-assets/rootfs-debian-arm64.img.gz` next to the tarball (with a `.sha256` sidecar for download verification).
- `ensureRootfsImage` looks for a sibling `<basename>.img.gz` and, when present, gunzips it straight into the `<sha>.img` cache. Skips `tar -xf` + `mke2fs` entirely on cold boot.
- Falls back to the existing materialize path when no sibling is present (provision()-built tarballs, fixture builds) or the decompressed bytes don't carry the ext4 superblock magic — invisible to callers.
- Cache key (tarball sha), `.ok` marker discipline (#170), per-boot reflink clones (#121), and `rootDiskSizeBytes` sparse-extend (#131) all work unchanged.

Cold `rootdisk-materialize` drops from ~1100 ms (tar + mke2fs) to ~150 ms (gunzip-only) — full bench numbers will follow once a release with the prebaked asset is cut and `pnpm bench-boot --cold-only` can run against it.

## Test plan

- [x] `npx vitest run` — 27 files, 378 passing (+4 new prebake tests in `rootfs-img.test.ts`).
- [x] `npx agent-ci run --all -q -p` — 4/4 workflows pass.
- [ ] `pnpm smoke-tests` — needs `release-assets/` (Docker + ~5 min, kernel build needs arm64 host); not run on this machine.
- [ ] Cold-boot benchmark against a release with the new prebake — pending a release tag.
