### PR TITLE
fix(fork): restore tty fg-PG so Ctrl-C kills foreground jobs in forks

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -809,6 +809,22 @@ async function cmdFork(args: string[]): Promise<number> {
     fork.stderr.pipe(process.stderr);
     const restoreStdin = rawModeStdinIfTTY();
     process.stdin.pipe(fork.stdin);
+    // The source shell printed PS1 to the source's tty before the
+    // dump, so the restored shell starts up sitting in read() without
+    // redrawing — without this nudge the user has to hit Enter
+    // themselves to see anything past `machinen-restore: starting…`.
+    // The CR makes bash treat it as an empty Enter and reprints the
+    // prompt. Wait ~1.5s before sending: at `vm.fork()`-resolve the
+    // VMM's just spawned and the kernel is still booting; bytes sent
+    // earlier get dropped before bash starts reading from the tty.
+    const promptNudge = setTimeout(() => {
+      try {
+        fork.stdin.write("\r");
+      } catch {
+        // fork already exited / pipe closed — nothing to nudge.
+      }
+    }, 1500);
+    promptNudge.unref();
 
     let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
     const onSigint = () => {

--- a/packages/microvm/assets/machinen-dump.sh
+++ b/packages/microvm/assets/machinen-dump.sh
@@ -245,7 +245,14 @@ mkdir -p /mnt/snap/img
 
 echo "machinen-dump: dumping tree rooted at pid=$DUMP_PID (leave_running=$LEAVE_RUNNING tcp_close=$TCP_CLOSE)"
 # --tree recurses automatically.
-# --shell-job lets CRIU dump processes whose session leader is /init.
+# We DO NOT pass --shell-job. The supervisor's `setsid -c` makes the
+# workload its own session leader, and that session leader IS the
+# dump tree's root — so CRIU has all the session info it needs in-
+# tree. --shell-job tells CRIU "the session leader lives outside the
+# dump and the calling process will reattach the tty for you"; that
+# mode skips restoring the tty's foreground process group, which left
+# a forked VM with `tpgid=-1` and VINTR/VSUSP signals silently going
+# nowhere (Ctrl-C/Ctrl-Z were no-ops in the restored shell).
 # --tcp-established keeps TCP sockets (gvproxy-backed connections etc.).
 #   Omitted when MACHINEN_DUMP_TCP_CLOSE=1 — fork (#216) sets that so
 #   the new VM doesn't share live TCP sockets with the source. CRIU
@@ -257,7 +264,7 @@ echo "machinen-dump: dumping tree rooted at pid=$DUMP_PID (leave_running=$LEAVE_
 #   the kill so the supervisor's `wait` stays blocked and the workload
 #   resumes execution from the dump point with no observable hiccup.
 # -v3 + log file: if dump fails, tail /mnt/snap/img/dump.log on stderr.
-DUMP_ARGS="--tree $DUMP_PID --images-dir /mnt/snap/img --shell-job -v3 -o dump.log"
+DUMP_ARGS="--tree $DUMP_PID --images-dir /mnt/snap/img -v3 -o dump.log"
 if [ "$TCP_CLOSE" -eq 0 ]; then
     DUMP_ARGS="$DUMP_ARGS --tcp-established"
 fi

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -107,7 +107,6 @@ unshare --pid --fork --mount-proc -- \
         criu restore \
             --images-dir /mnt/snap-src/img \
             --work-dir /tmp \
-            --shell-job \
             --tcp-established \
             --pidfile /run/machinen-workload.pid \
             -v3 \

--- a/packages/microvm/assets/machinen-supervisor.sh
+++ b/packages/microvm/assets/machinen-supervisor.sh
@@ -79,27 +79,31 @@ if [ "${1:-}" = "--session" ]; then
     shift
 fi
 
-# Run the workload under `setsid -c -w` with stdio bound to /dev/console:
+# Run the workload under `setsid -c -w` with stdio bound to /dev/ttyAMA0:
 #
 #   - `setsid` puts the workload in a brand-new session as leader.
-#     Required for CRIU `--shell-job` to dump cleanly: without it the
-#     session leader (supervisor) lives outside the dump tree and
-#     CRIU bails with "A session leader of N(N) is outside of its
-#     pid namespace".
-#   - `-c` (TIOCSCTTY) claims /dev/console as the new session's
+#     The session leader IS the dump tree's root, so CRIU has the
+#     full session info in-tree and we don't need --shell-job.
+#   - `-c` (TIOCSCTTY) claims the tty on fd 0 as the new session's
 #     controlling terminal. Without this, backgrounding with `&` puts
-#     the workload in a process group that isn't the foreground of
-#     /dev/console — `/bin/sh -i` reads return EIO (orphaned pgrp),
-#     it prints the prompt once and exits, the supervisor's `wait`
-#     returns, and machinen-poweroff fires before the user types
-#     anything.
+#     the workload in a process group that isn't the tty's foreground
+#     PG — `/bin/sh -i` reads return EIO (orphaned pgrp), it prints
+#     the prompt once and exits, the supervisor's `wait` returns, and
+#     machinen-poweroff fires before the user types anything.
+#   - We bind to **/dev/ttyAMA0** (the real PL011 tty), not
+#     /dev/console (the kernel's virtual console proxy). CRIU can't
+#     reliably round-trip the foreground-PG state on /dev/console:
+#     a forked VM ended up with `tpgid=-1` so VINTR/VSUSP fired in
+#     the kernel but went nowhere — Ctrl-C/Ctrl-Z became no-ops in
+#     the restored shell. /dev/ttyAMA0 is a regular tty inode that
+#     CRIU restores cleanly.
 #   - `-w` makes setsid(1) `wait` for the workload after the fork
 #     it has to perform when invoked from a process-group leader (we
 #     are one, courtesy of `&`). Without `-w`, the parent setsid
 #     forks, exits immediately, and `wait "$!"` returns before the
 #     workload starts — orphaning it under PID 1 and dropping the
 #     trap target.
-#   - Explicit </dev/console redirect ensures fd 0 is a tty when
+#   - Explicit </dev/ttyAMA0 redirect ensures fd 0 is a tty when
 #     setsid runs (`-c` reads ctty from stdin).
 #
 # The inner `sh -c` writes /run/machinen-workload.pid using its own
@@ -110,7 +114,7 @@ fi
 # getting it wrong dumps a dead PID and CRIU bails with exit 32.
 /usr/bin/setsid -c -w sh -c \
     'printf "%s" "$$" > /run/machinen-workload.pid; exec "$@"' \
-    inner "$@" </dev/console >/dev/console 2>/dev/console &
+    inner "$@" </dev/ttyAMA0 >/dev/ttyAMA0 2>/dev/ttyAMA0 &
 PID=$!
 
 # Propagate SIGTERM / SIGINT to the workload so host-side vm.kill()


### PR DESCRIPTION
## Problem

In an interactive `machinen fork`, the restored shell sat with `tpgid=-1` on its controlling tty. The kernel still ran VINTR/VSUSP translation, but with no foreground process group set, the resulting SIGINT/SIGTSTP went to nobody — Ctrl-C and Ctrl-Z were silent no-ops in the forked VM. `ping` (and any other foreground job) wouldn't die. Source VMs were unaffected because their tty fg-PG was set live by `setsid -c`; only restored shells exhibited the bug.

A second cosmetic issue: after the boot logs ended with `machinen-restore: starting criu restore in a fresh PID namespace`, the prompt didn't redraw and the user had to hit Enter to see it.

## Solution

Three coordinated changes:

1. **Drop `--shell-job` from `criu dump` and `criu restore`** (`packages/microvm/assets/machinen-dump.sh`, `packages/microvm/assets/machinen-restore.sh`). `--shell-job` tells CRIU "the session leader is outside the dump tree and the caller will reattach the tty for you," and as a side effect skips restoring the tty's foreground process group. The supervisor's `setsid -c` already makes the workload its own session leader inside the dump tree, so the flag was never the right one — removing it lets CRIU restore the fg-PG end-to-end.

2. **Bind the workload's stdio to `/dev/ttyAMA0` instead of `/dev/console`** in `machinen-supervisor.sh`. `/dev/console` is the kernel's virtual console proxy; CRIU can't reliably round-trip its fg-PG state. `/dev/ttyAMA0` is the real PL011 tty inode, which CRIU restores cleanly. Fresh boots are unaffected (both names route the same PL011 stream).

3. **Nudge the restored shell to redraw its prompt in `cmdFork`** (`packages/cli/src/cli.ts`). The source bash had already emitted PS1 to the source's tty before the dump, so the restored bash starts up sitting in `read()` and never redraws on its own. After `vm.fork()` resolves, wait ~1.5s (so the kernel has finished booting and bash is reading from the tty) and write `\r` to the fork's stdin — bash treats it as an empty Enter and reprints the prompt.

## Test plan

- [x] Unit tests (`npx vitest run`) green.
- [x] Manual repro: `machinen boot --name vm1 -- /bin/bash -i` in one terminal, `machinen fork --name vm1` in another. Inside the fork: `awk '{print "tpgid="$8}' /proc/$$/stat` now reports a non-`-1` value, and a single Ctrl-C kills `ping -c 30 127.0.0.1` cleanly.
- [ ] Smoke tests (`pnpm smoke-tests`) — needs CI run; the supervisor + dump/restore changes touch the snapshot/restore round-trip path that S1/S2/S3 cover.
