### PR TITLE
feat(microvm): wire virtio-vsock into the KVM backend

### DIFF
--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -17,8 +17,10 @@
 //!   * PL011: same byte-for-byte model as HVF (shared via pl011.zig),
 //!     driven by KVM_EXIT_MMIO events.
 //!   * Virtio-blk: slots 1 and 3 are wired the same way HVF does it
-//!     (#114). Slot 0 (net) and slot 2 (vsock) are not yet wired —
-//!     reads/writes to those windows still return 0 / are ignored.
+//!     (#114).
+//!   * Virtio-vsock: slot 2 wires up the same Bridge HVF uses (#44),
+//!     opt-in via `MACHINEN_VSOCK`. Slot 0 (net) is not yet wired —
+//!     reads/writes to that window still return 0 / are ignored.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -33,12 +35,15 @@ const kvm = @import("kvm.zig");
 const pl011_mod = @import("pl011.zig");
 const virtio = @import("virtio.zig");
 const blk_mod = @import("blk.zig");
+const vsock_mod = @import("vsock.zig");
 
 // Guest-physical bases. Same MMIO layout as HVF (see boot_hvf.zig
 // for the slot layout doc) so the shared `virt.dts` works for both
 // backends.
 const virtio_blk_base: u64 = 0x0A00_0200;
 const virtio_blk_size: u64 = 0x200;
+const virtio_vsock_base: u64 = 0x0A00_0400;
+const virtio_vsock_size: u64 = 0x200;
 const virtio_blk2_base: u64 = 0x0A00_0600;
 const virtio_blk2_size: u64 = 0x200;
 
@@ -229,6 +234,76 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     }
     const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
 
+    // virtio-vsock (#44). Off by default; the runtime sets MACHINEN_VSOCK
+    // when it wants the guest exec/fuse agents to be reachable. Same
+    // env grammar as HVF (see boot_hvf.zig for the syntax doc) — parsed
+    // ports are gpa-allocated and leak for the VMM's life.
+    const virtio_vsock_irq: u32 = 32 + 18;
+    var vsock_cid_storage: u64 = vsock_mod.default_guest_cid;
+    var vsock_ports: []vsock_mod.PortMap = &.{};
+    if (getenv("MACHINEN_VSOCK")) |raw| {
+        const s = std.mem.span(raw);
+        if (s.len > 0) {
+            vsock_ports = vsock_mod.parseEnv(gpa, s) catch |err| blk: {
+                std.debug.print("vsock: MACHINEN_VSOCK parse failed ({s}); ignoring\n", .{@errorName(err)});
+                break :blk &.{};
+            };
+        }
+    }
+    var vsock_dev_opt: ?virtio.Device = null;
+    var vsock_bridge_opt: ?*vsock_mod.Bridge = null;
+    if (vsock_ports.len > 0) {
+        vsock_dev_opt = virtio.Device{
+            .base = virtio_vsock_base,
+            .size = virtio_vsock_size,
+            .id = .vsock,
+            .features = (1 << 32), // VIRTIO_F_VERSION_1
+            .config = std.mem.asBytes(&vsock_cid_storage),
+            .ram = ram,
+            .ram_base = cfg.ram_base,
+            .request_handler = &vsock_mod.Bridge.handleTxChain,
+            .request_ctx = null,
+            // Queues 0 (RX) and 2 (event) are driver-posts-empty-buffers
+            // queues — host fills them on demand, not on every kick.
+            .skip_notify_queues = (1 << 0) | (1 << 2),
+        };
+    }
+    const vsock_dev_ptr: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
+
+    var vsock_irq_ctx = VsockIrqCtx{ .vm = &vm, .irq = virtio_vsock_irq };
+    if (vsock_dev_ptr) |d| {
+        vsock_bridge_opt = vsock_mod.Bridge.create(gpa, d, .{
+            .ports = vsock_ports,
+            .raise_irq = &onVsockIrq,
+            .raise_irq_ctx = @ptrCast(&vsock_irq_ctx),
+        }) catch |err| blk: {
+            std.debug.print("vsock: bridge create failed: {s}\n", .{@errorName(err)});
+            break :blk null;
+        };
+        if (vsock_bridge_opt) |b| {
+            d.request_ctx = @ptrCast(b);
+            b.start() catch |err| {
+                std.debug.print("vsock: bridge start failed: {s}\n", .{@errorName(err)});
+                b.destroy();
+                vsock_bridge_opt = null;
+                vsock_dev_opt = null;
+            };
+            if (vsock_bridge_opt != null) {
+                for (vsock_ports) |pm| {
+                    const tag: []const u8 = switch (pm.direction) {
+                        .inbound => "in",
+                        .outbound => "out",
+                    };
+                    std.debug.print("vsock: {s} {d} <-> {s}\n", .{ tag, pm.guest_port, pm.uds_path });
+                }
+            }
+        }
+    }
+    defer if (vsock_bridge_opt) |b| b.destroy();
+    // The vsock_dev pointer might have been cleared above on bridge
+    // start failure; re-resolve so the run loop dispatch matches.
+    const vsock_dev_ptr_run: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
+
     var exits: usize = 0;
     var saw_off = false;
 
@@ -237,7 +312,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         switch (reason) {
             .mmio => {
                 const ev = vcpu.mmioExit();
-                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq);
+                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq, vsock_dev_ptr_run, virtio_vsock_irq);
             },
             .system_event => {
                 const ev = vcpu.systemEventExit();
@@ -283,6 +358,8 @@ fn handleMmio(
     virtio_blk_irq: u32,
     blk2dev: ?*virtio.Device,
     virtio_blk2_irq: u32,
+    vsockdev: ?*virtio.Device,
+    virtio_vsock_irq: u32,
 ) !void {
     if (uart.handles(ev.phys_addr)) {
         if (ev.is_write != 0) {
@@ -322,7 +399,21 @@ fn handleMmio(
             return;
         }
     }
-    // Other MMIO (virtio-mmio net/vsock windows, etc.) — for reads, hand
+    if (vsockdev) |d| {
+        if (d.handles(ev.phys_addr)) {
+            if (ev.is_write != 0) {
+                // TX notify runs on the vCPU thread and shares the
+                // bridge's connection table with the bridge poll
+                // thread; the handler takes the mutex.
+                d.write(ev.phys_addr, mmioReadValue(ev));
+            } else {
+                vcpu.writeMmioReadData(d.read(ev.phys_addr), ev.len);
+            }
+            vm.setIrq(virtio_vsock_irq, if (d.interrupt_status != 0) 1 else 0) catch {};
+            return;
+        }
+    }
+    // Other MMIO (virtio-mmio net window, etc.) — for reads, hand
     // back zeros (the writeMmioReadData default on untouched kvm_run
     // bytes is already zero, but be explicit so a future non-zero
     // lingerer doesn't bite).
@@ -391,6 +482,20 @@ fn hostWrite(fd: c_int, buf: [*]const u8, count: usize) isize {
 }
 fn hostLseek(fd: c_int, offset: i64, whence: c_int) i64 {
     return lseek(fd, offset, whence);
+}
+
+/// Carried as the bridge's raise_irq context. The Bridge poll thread
+/// calls onVsockIrq(ctx) when it has injected RX/event traffic; we
+/// pulse the SPI line via KVM_IRQ_LINE on whichever VM the boot loop
+/// owns.
+pub const VsockIrqCtx = struct {
+    vm: *kvm.Vm,
+    irq: u32,
+};
+
+fn onVsockIrq(ctx: ?*anyopaque) void {
+    const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
+    c.vm.setIrq(c.irq, 1) catch {};
 }
 
 // arm64 Linux kernel Image header — same parser as hvf.zig has;

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -173,9 +173,12 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var uart = pl011_mod.Pl011.init;
     defer uart.deinit(gpa);
 
-    // PL011 SPI per DTS (interrupts = <0 1 4>). GIC SPI N maps to
-    // KVM irq number 32 + N. For our PL011 that's 33.
-    const pl011_irq: u32 = 32 + 1;
+    // SPI numbers per DTS, encoded for KVM_IRQ_LINE. The encoding
+    // (KVM_ARM_IRQ_TYPE_SPI in bits 27:24) is non-optional — without
+    // it, KVM treats the call as the legacy CPU-line type and the
+    // delivery silently drops, which manifests as virtio doorbells
+    // never reaching the guest after the kernel writes QueueNotify.
+    const pl011_irq: u32 = kvm.irqSpi(1);
 
     // virtio-blk (#114). Two slots, mirroring boot_hvf.zig:
     //   slot 1 → SPI #17 → /dev/vda — rootdisk preferred, else disk.
@@ -183,8 +186,8 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // Linux probes virtio-mmio buses in DTB order, so DTB slot order
     // determines /dev/vd* naming. With only one slot populated the
     // lone device is always /dev/vda regardless of which slot.
-    const virtio_blk_irq: u32 = 32 + 17;
-    const virtio_blk2_irq: u32 = 32 + 19;
+    const virtio_blk_irq: u32 = kvm.irqSpi(17);
+    const virtio_blk2_irq: u32 = kvm.irqSpi(19);
     const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
     const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
 
@@ -238,7 +241,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // when it wants the guest exec/fuse agents to be reachable. Same
     // env grammar as HVF (see boot_hvf.zig for the syntax doc) — parsed
     // ports are gpa-allocated and leak for the VMM's life.
-    const virtio_vsock_irq: u32 = 32 + 18;
+    const virtio_vsock_irq: u32 = kvm.irqSpi(18);
     var vsock_cid_storage: u64 = vsock_mod.default_guest_cid;
     var vsock_ports: []vsock_mod.PortMap = &.{};
     if (getenv("MACHINEN_VSOCK")) |raw| {

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -152,6 +152,21 @@ pub const KVM_DEV_ARM_VGIC_CTRL_INIT: u64 = 0;
 // arm64 VCPU_INIT feature bits.
 pub const KVM_ARM_VCPU_PSCI_0_2: u32 = 2;
 
+// KVM_IRQ_LINE encoding (arm64).
+pub const KVM_ARM_IRQ_TYPE_SHIFT: u5 = 24;
+pub const KVM_ARM_IRQ_TYPE_CPU: u32 = 0;
+pub const KVM_ARM_IRQ_TYPE_SPI: u32 = 1;
+pub const KVM_ARM_IRQ_TYPE_PPI: u32 = 2;
+
+/// Encode `KVM_ARM_IRQ_TYPE_SPI | (32 + spi_id)` for `Vm.setIrq`.
+/// `spi_id` is the device-tree-relative SPI number (e.g. PL011 = 1,
+/// virtio-blk slot 1 = 17). Without the type bits, KVM treats the
+/// call as a legacy CPU-line IRQ (type 0) and silently drops virtio
+/// doorbells, which manifests as guest hangs after QueueNotify.
+pub fn irqSpi(spi_id: u32) u32 {
+    return (KVM_ARM_IRQ_TYPE_SPI << KVM_ARM_IRQ_TYPE_SHIFT) | (32 + spi_id);
+}
+
 // ---------------------------------------------------------------
 // x86_64 register banks. arm64 boots don't touch these; they live
 // here so the same kvm.zig wrapper serves both arches. Layouts
@@ -468,11 +483,18 @@ pub const Vm = struct {
         return .{ .fd = gic_fd, .vm_fd = self.fd };
     }
 
-    /// Raise or lower an interrupt line. `irq` uses KVM's encoding:
-    /// bits 27:24 = type (0 = SPI), bits 23:16 = vcpu_id, bits 15:0 =
-    /// irq_number. For arm64 SPIs, irq_number = GIC SPI base (32) +
-    /// device-specific offset; our DTS maps PL011 to 33, virtio-net
-    /// to 48, etc.
+    /// Raise or lower an interrupt line. `irq` uses KVM's arm64
+    /// encoding (uapi/linux/kvm.h):
+    ///
+    ///   bits 27:24 = type (KVM_ARM_IRQ_TYPE_SPI = 1, _PPI = 2, _CPU = 0)
+    ///   bits 23:16 = vCPU index (PPI/CPU only; SPI is system-wide)
+    ///   bits 15:0  = irq_number; for SPI this is the GIC INTID
+    ///                (private-IRQs offset 32 already included; KVM
+    ///                subtracts 32 internally before talking to vgic).
+    ///
+    /// Use `irqSpi(spi_id)` to encode the type+id correctly. Without
+    /// the type bits, KVM treats the call as a CPU-line legacy IRQ
+    /// (type 0) which silently drops virtio doorbells.
     pub fn setIrq(self: *Vm, irq: u32, level: u32) !void {
         var lvl = IrqLevel{ .irq = irq, .level = level };
         if (ioctl(self.fd, KVM_IRQ_LINE, &lvl) != 0) return error.KvmIrqLineFailed;


### PR DESCRIPTION
## Problem

Companion to the virtio-blk wire-up in #225. The runtime drives the guest exec-agent and fuse-agent over vsock; under HVF that's a `Bridge` + `virtio.Device` pair on slot 2 (DTS `virtio_mmio@a000400`). The KVM backend had `vsock_mod.Bridge` already in scope but no MMIO dispatch — so on linux-arm64 hosts, `MACHINEN_VSOCK` was a silent no-op and every `pnpm provision-test-vm` / workload test would have stalled in `connect ENOENT exec.sock` once #225 let the kernel actually mount /dev/vda.

## Solution

Port the slot-2 vsock setup from `boot_hvf.zig` to `boot_kvm.zig`. The shared bits (`vsock_mod.parseEnv`, `Bridge.{create,start,destroy}`, `Bridge.handleTxChain`, `skip_notify_queues = (1<<0) | (1<<2)`) are arch-neutral — only the host-side IRQ raise and the MMIO read/write decode are per-backend.

- `getenv("MACHINEN_VSOCK")` → `vsock_mod.parseEnv` → port-map list. Same env grammar as HVF; multiple comma-separated entries supported (the runtime appends `out:` entries for live-mount FUSE bridges).
- A `virtio.Device` lands at `0x0a000400-0x0a000600` with `id = .vsock`; queues 0 (RX) and 2 (event) are `skip_notify_queues` so the bridge fills them on demand.
- Bridge's `raise_irq` hooks a small `onVsockIrq` that pulses the SPI through `vm.setIrq(spi, 1)`. Bridge poll thread → KVM_IRQ_LINE syscall, which is thread-safe (KVM serializes per-ioctl).
- The MMIO dispatch in `handleMmio` adds a `vsockdev` branch that calls `dev.read`/`dev.write` and re-syncs the SPI based on `dev.interrupt_status` after every access — same pattern as the blk dispatch in #225.
- `vsock_dev_ptr_run` re-resolves the device pointer **after** bridge-start runs, because a start-failure clears `vsock_dev_opt` and a single up-front pointer would dangle into the null variant by the time the run loop dispatches.
- Slot 0 (net) still returns zeros — out of scope for the FUSE workload tests in #197 since gvproxy isn't on the FUSE path.

## Validation

On `friend@100.126.46.90` (Ampere, Ubuntu 24.04, kernel 6.17, KVM):

- `zig build -Doptimize=ReleaseSafe` clean.
- All 35 zig tests still pass (no new tests yet — bridge + virtio.Device are exercised by the existing virtio/vsock test suites).
- With `loglevel=7` patched into the DTB bootargs, `machinen boot --image rootfs-debian-arm64.tar.gz -- echo hello-world`:
  - `virtio_blk virtio0: [vda] 4194304 512-byte logical blocks` ✓ (rootdisk wired)
  - Slot 2 doesn't trip the kernel's "Wrong magic" check (only slot 0 / net does, since net isn't wired) ✓ (vsock device space looks valid to the guest)
  - Bridge starts and prints `vsock: in 1978 <-> /tmp/.../exec.sock` ✓
  - Host-side UDS connect to the bridge succeeds ✓

What this PR does **not** yet validate end-to-end: the actual exec-agent round-trip times out at `Freeing initrd memory` — the kernel currently hangs after unpacking the initramfs but before running `/init`. This is **independent** of the vsock wiring (same hang reproduces on the blk-only branch with `quiet` removed) and likely lives in the kernel→userspace pivot or `init.zig`'s early console-wait. Tracking that separately; this PR is the second of the three blockers called out in #197.

## Test plan

- [ ] On an arm64 KVM host: `MACHINEN_VSOCK=in:1978:/tmp/exec.sock machinen boot --image …` boots and the bridge prints `vsock: in 1978 <-> /tmp/exec.sock`.
- [ ] On macOS (HVF unchanged): `pnpm smoke-tests` still green.
- [ ] CI: `Tests` and `Docs` workflows pass on the existing GitHub-hosted runners.

## Related

- #225 — virtio-blk wire-up (this PR is stacked on top).
- #197 — KVM-capable arm64 runner for the FUSE workload tests.
