### PR TITLE
fix(rootfs): force integer output from awk size calc

### DIFF
--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -451,7 +451,7 @@ gzip -n > /out/rootfs-debian-arm64.tar.gz
 # 4-KiB block size matches the kernel's arm64 page size so reads
 # are page-cache-aligned; same as the runtime materializer.
 TREE_KIB=$(du -sk /work/rootfs | awk '{print $1}')
-SIZE_BYTES=$(awk -v k="$TREE_KIB" 'BEGIN { s = int(k * 1024 * 2.5); m = 2 * 1024 * 1024 * 1024; if (s < m) s = m; print s }')
+SIZE_BYTES=$(awk -v k="$TREE_KIB" 'BEGIN { s = int(k * 1024 * 2.5); m = 2 * 1024 * 1024 * 1024; if (s < m) s = m; printf "%d\n", s }')
 BLOCKS=$(( SIZE_BYTES / 4096 ))
 echo "==> Prebaking rootfs ext4 image: ${SIZE_BYTES} bytes (${BLOCKS} x 4 KiB blocks)"
 truncate -s "$SIZE_BYTES" /tmp/rootfs.img


### PR DESCRIPTION
## Summary

`scripts/build-base-assets.sh` fails partway through the Debian rootfs build with:

```
bash: line 216: 2.14748e+09: syntax error: invalid arithmetic operator (error token is ".14748e+09")
bash: line 217: BLOCKS: unbound variable
```

awk's default `print` formats the 2 GiB minimum (`2 * 1024 * 1024 * 1024 = 2147483648`) as `2.14748e+09`, which bash's `$(( SIZE_BYTES / 4096 ))` on the next line can't parse, leaving `BLOCKS` unset and aborting the build.

Switch the awk one-liner from `print s` to `printf "%d\n", s` so the size hits bash arithmetic as a plain integer.

Regression from #223 / #224 (the `<base>.img.gz` prebake change).

## Test plan

- [ ] `MACHINEN_REMOTE_BUILDER=<arm64-host> bash scripts/build-base-assets.sh` runs to completion
- [ ] `==> Prebaking rootfs ext4 image: 2147483647 bytes (524287 x 4 KiB blocks)` line appears (or higher, when the rootfs tree is large enough to exceed the 2 GiB floor)
- [ ] `release-assets/rootfs-debian-arm64.img.gz` is produced
