### PR TITLE
fix(smoke): gate T3/T5 on fuse-agent, not fuse.ko

### DIFF
--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -276,12 +276,13 @@ fi
 # via the vsock FUSE server, NOT be baked into the boot cpio. We
 # write the marker after the VM starts to prove that.
 #
-# Skips if the current base kernel doesn't carry fuse.ko yet. That
-# whitelist change is in scripts/build-base-assets.sh on this branch
-# but the cached release-assets/ rootfs tarball may predate it.
+# Skips if the rootfs tarball doesn't ship the fuse-agent userspace
+# relay — the kernel always has FUSE built in (`=y`, see
+# build-kernel-arm64.sh), so the previous `fuse.ko` gate would skip
+# forever. Stale tarballs from before #78 won't have fuse-agent.
 echo "T3: machinen boot --mount-live ./fixture:/mnt/live:ro -- cat /mnt/live/hello.txt"
-if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse\.ko'; then
-  echo "  skip: fuse.ko not in $ROOTFS_TAR — rebuild base assets"
+if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse-agent$'; then
+  echo "  skip: fuse-agent not in $ROOTFS_TAR — rebuild base assets"
 else
   T3_MARKER="livemount-marker-$$"
   T3_SRC="$FIXTURE/live-src"
@@ -315,10 +316,10 @@ fi
 # Boots with `--mount-live <dir>:/mnt/live` (default :rw post-#156),
 # has the guest echo a marker into a file under that mount, then
 # asserts the file appears on the host filesystem with the right
-# contents AFTER the VM exits. Same fuse.ko gate as T3.
+# contents AFTER the VM exits. Same fuse-agent gate as T3.
 echo "T5: machinen boot --mount-live (default :rw) — guest write reaches the host"
-if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse\.ko'; then
-  echo "  skip: fuse.ko not in $ROOTFS_TAR — rebuild base assets"
+if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse-agent$'; then
+  echo "  skip: fuse-agent not in $ROOTFS_TAR — rebuild base assets"
 else
   T5_MARKER="livemount-rw-marker-$$"
   T5_SRC="$FIXTURE/live-rw"


### PR DESCRIPTION
## Problem

`scripts/smoke-tests.sh` gates T3 (`--mount-live :ro`) and T5 (`--mount-live :rw`) on the rootfs tarball containing `fuse.ko`:

```bash
if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse\.ko'; then
  echo "  skip: fuse.ko not in $ROOTFS_TAR — rebuild base assets"
```

But `scripts/build-kernel-arm64.sh` builds FUSE into the kernel (`CONFIG_FUSE_FS=y`):

```
# FUSE — guest side of `--mount-live` (#78). Builtin so liveMounts work
--enable FUSE_FS
```

A `=y` config produces no `.ko` file at all — modules only exist for `=m`. So the gate is permanently dead and T3/T5 always skip, regardless of how fresh the rootfs is. Even right after `pnpm provision` against a freshly-built rootfs, both tests skip.

## Solution

Gate on the artifact T3/T5 actually need: the userspace `fuse-agent` byte pump (the vsock-FUSE relay from #78), which IS in the tarball. The new precheck:

```bash
if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse-agent$'; then
  echo "  skip: fuse-agent not in $ROOTFS_TAR — rebuild base assets"
```

Stale tarballs from before #78 won't ship `fuse-agent`, so the skip path still triggers when it should.

## Test plan

- [ ] `pnpm smoke-tests` against a fresh rootfs no longer skips T3/T5; both pass
- [ ] If `fuse-agent` were stripped from the rootfs, T3/T5 would skip with the new message
