### PR TITLE
fix(microvm): atomic interrupt_status across vCPU + bridge threads

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -659,7 +659,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
                         try vcpu.setReg(reg, netdev.read(info.ipa));
                     }
-                    hvf.Gic.setSpi(virtio_irq, netdev.interrupt_status != 0) catch {};
+                    hvf.Gic.setSpi(virtio_irq, @atomicLoad(u32, &netdev.interrupt_status, .acquire) != 0) catch {};
                 } else if (blkdev_ptr != null and blkdev_ptr.?.handles(info.ipa)) {
                     const d = blkdev_ptr.?;
                     if (info.is_write) {
@@ -669,7 +669,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
                         try vcpu.setReg(reg, d.read(info.ipa));
                     }
-                    hvf.Gic.setSpi(virtio_blk_irq, d.interrupt_status != 0) catch {};
+                    hvf.Gic.setSpi(virtio_blk_irq, @atomicLoad(u32, &d.interrupt_status, .acquire) != 0) catch {};
                 } else if (blk2dev_ptr != null and blk2dev_ptr.?.handles(info.ipa)) {
                     const d = blk2dev_ptr.?;
                     if (info.is_write) {
@@ -679,7 +679,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
                         try vcpu.setReg(reg, d.read(info.ipa));
                     }
-                    hvf.Gic.setSpi(virtio_blk2_irq, d.interrupt_status != 0) catch {};
+                    hvf.Gic.setSpi(virtio_blk2_irq, @atomicLoad(u32, &d.interrupt_status, .acquire) != 0) catch {};
                 } else if (vsock_dev_ptr != null and vsock_dev_ptr.?.handles(info.ipa)) {
                     const d = vsock_dev_ptr.?;
                     if (info.is_write) {
@@ -692,7 +692,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
                         try vcpu.setReg(reg, d.read(info.ipa));
                     }
-                    hvf.Gic.setSpi(virtio_vsock_irq, d.interrupt_status != 0) catch {};
+                    hvf.Gic.setSpi(virtio_vsock_irq, @atomicLoad(u32, &d.interrupt_status, .acquire) != 0) catch {};
                 } else if (info.ipa >= 0x1000_0000 and info.ipa < 0x1200_0000) {
                     // Redistributor MMIO. Each vCPU's frame is 128 KB.
                     // For our single-vCPU setup, frame 0 = [0x10000000,

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -387,7 +387,7 @@ fn handleMmio(
             } else {
                 vcpu.writeMmioReadData(d.read(ev.phys_addr), ev.len);
             }
-            vm.setIrq(virtio_blk_irq, if (d.interrupt_status != 0) 1 else 0) catch {};
+            vm.setIrq(virtio_blk_irq, if (@atomicLoad(u32, &d.interrupt_status, .acquire) != 0) 1 else 0) catch {};
             return;
         }
     }
@@ -398,7 +398,7 @@ fn handleMmio(
             } else {
                 vcpu.writeMmioReadData(d.read(ev.phys_addr), ev.len);
             }
-            vm.setIrq(virtio_blk2_irq, if (d.interrupt_status != 0) 1 else 0) catch {};
+            vm.setIrq(virtio_blk2_irq, if (@atomicLoad(u32, &d.interrupt_status, .acquire) != 0) 1 else 0) catch {};
             return;
         }
     }
@@ -412,7 +412,7 @@ fn handleMmio(
             } else {
                 vcpu.writeMmioReadData(d.read(ev.phys_addr), ev.len);
             }
-            vm.setIrq(virtio_vsock_irq, if (d.interrupt_status != 0) 1 else 0) catch {};
+            vm.setIrq(virtio_vsock_irq, if (@atomicLoad(u32, &d.interrupt_status, .acquire) != 0) 1 else 0) catch {};
             return;
         }
     }

--- a/packages/microvm/src/virtio.zig
+++ b/packages/microvm/src/virtio.zig
@@ -185,7 +185,7 @@ pub const Device = struct {
             },
             0x034 => if (self.queue_sel < max_queues) self.queue_num_max else 0,
             0x044 => if (self.queue_sel < max_queues) self.queues[self.queue_sel].ready else 0,
-            0x060 => self.interrupt_status,
+            0x060 => @atomicLoad(u32, &self.interrupt_status, .acquire),
             0x070 => @as(u32, @bitCast(self.status)),
             0x0FC => self.config_generation,
             0x100...0x1FF => self.readConfig(@intCast(off - 0x100)),
@@ -214,7 +214,7 @@ pub const Device = struct {
                 self.queues[self.queue_sel].ready = v32;
             },
             0x050 => self.notify(v32),
-            0x064 => self.interrupt_status &= ~v32,
+            0x064 => _ = @atomicRmw(u32, &self.interrupt_status, .And, ~v32, .acq_rel),
             0x070 => self.status = @bitCast(v32),
             // 64-bit guest addresses written as low/high halves. Store
             // them so reads (if any) round-trip; actual parsing is M2.
@@ -291,7 +291,7 @@ pub const Device = struct {
                 handler(self.request_ctx, self, q_idx, head);
                 q.last_avail_idx +%= 1;
             }
-            self.interrupt_status |= IRQ_USED_BUFFER;
+            _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
             return;
         }
 
@@ -380,7 +380,7 @@ pub const Device = struct {
 
         self.pushUsed(q, head, written);
         q.last_avail_idx +%= 1;
-        self.interrupt_status |= IRQ_USED_BUFFER;
+        _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
         _ = total_len;
         return true;
     }
@@ -393,7 +393,7 @@ pub const Device = struct {
             self.pushUsed(q, head, total_len);
             q.last_avail_idx +%= 1;
         }
-        self.interrupt_status |= IRQ_USED_BUFFER;
+        _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
     }
 
     /// Walk a descriptor chain, read every byte it covers into a

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -975,7 +975,7 @@ pub const Bridge = struct {
         const written = writePacket(self.dev, Q_RX, head, hdr, body) orelse return false;
         self.dev.queuePushUsed(Q_RX, head, written);
         q.last_avail_idx +%= 1;
-        self.dev.interrupt_status |= virtio.IRQ_USED_BUFFER;
+        _ = @atomicRmw(u32, &self.dev.interrupt_status, .Or, virtio.IRQ_USED_BUFFER, .release);
 
         if (self.cfg.raise_irq) |f| f(self.cfg.raise_irq_ctx);
         return true;


### PR DESCRIPTION
## Summary

- Closes #230. **Not** a fix for #192 — that's the avail/used-ring memory-ordering bug (separate patch on `pp-validate-192-virtio-descriptor-stale`).
- Switches `Device.interrupt_status` accesses to `@atomicLoad` / `@atomicRmw` with paired acquire/release ordering across both HVF and KVM backends and the vsock bridge.
- 13 lines, 4 files. Full validation gate green (zig + agent-ci + vitest + smoke).

## Problem

`Device.interrupt_status` (`packages/microvm/src/virtio.zig:166`) is a plain `u32` mutated from both the vCPU thread (TX-kick paths, guest ACK at MMIO `0x064`) and the bridge poll thread (`Bridge.injectRx` after pushing an RX used-ring entry). Reads feed the post-MMIO IRQ resync (`hvf.Gic.setSpi` / `vm.setIrq`) on the vCPU thread without atomics.

That's UB in Zig and a real lost-update race: bridge thread's `|= IRQ_USED_BUFFER` and the vCPU thread's `&= ~v32` (guest ACK) can interleave so the bridge's set is dropped — bridge reads 0 just before guest writes 0, both write last, final value 0. The bridge then unconditionally raises the IRQ line, the guest takes the IRQ, reads `0x060`, sees 0, ACKs, and the just-pushed buffer sits unprocessed until the next event. That's a silent vsock wedge with no `rx:id` printk — same symptom class as #192 but a different mechanism.

Pre-existing on both HVF and KVM. The recent KVM vsock wire-up (#227) inherits it because both backends read the same field the same way after every MMIO.

## Solution

Switch all cross-thread sites to atomics with paired acquire/release ordering:

- `|= IRQ_USED_BUFFER` → `@atomicRmw(.Or, ..., .release)` at the `notify` / `injectRx` / `drainAvail` sites in `virtio.zig` and the bridge-thread RX path in `vsock.zig`.
- guest ACK `&= ~v32` at `0x064` → `@atomicRmw(.And, ..., .acq_rel)`.
- post-MMIO `interrupt_status != 0` reads (4 HVF + 3 KVM call sites) and the guest read at `0x060` → `@atomicLoad(..., .acquire)`.

The release on the bridge-thread set pairs with the acquire on the vCPU-thread read so the descriptor-ring writes preceding the set are visible to the vCPU when it decides whether to assert the IRQ line.

## Honest validation note

Same problem #192 hit: the race window is microscopic, the repro is statistical, and `pnpm repro-192` is unlikely to give a clean before/after signal. This lands on UB-cleanup and virtio-spec ordering grounds. #230 tracks the wedge-class soak alongside the in-flight #192 validation.

## Test plan

- [x] `cd packages/microvm && zig build test` → 45/45 pass
- [x] `npx agent-ci run --all -q -p` → 4/4 workflows pass (docs, base-assets/build, tests, workloads)
- [x] `npx vitest run` → 375/375 code tests pass (3 fixture-missing skips are pre-existing on this worktree)
- [x] `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` → all phases green: V1, V5, T1–T5, N1–N5, P1–P3, C1–C2, S1–S3. Vsock-heavy phases (T3/T5 FUSE live-mount, N2 exec, S1–S3 snapshot/fork via exec-agent) all pass on the patched VMM.
- [ ] Manual soak: weeks of dev-VM usage on Apple Silicon and KVM hosts without the silent wedge — same plan as #192
