### PR TITLE
chore(microvm): TigerStyle assertions for virtio/vsock/pl011/net_socket

### DIFF
--- a/packages/microvm/src/net_socket.zig
+++ b/packages/microvm/src/net_socket.zig
@@ -26,11 +26,23 @@ const std = @import("std");
 const builtin = @import("builtin");
 const virtio = @import("virtio.zig");
 const pl011 = @import("pl011.zig"); // for the shared PthreadMutex shim
+const assert = std.debug.assert;
 
 comptime {
     if (builtin.os.tag != .macos) {
         @compileError("net_socket.zig targets macOS (matches boot_hvf.zig)");
     }
+    // sockaddr_un layout the kernel expects (macOS): sun_len, sun_family,
+    // sun_path[104]. A mismatch would silently truncate the path during
+    // connect() and the socket dial would land somewhere else (or fail).
+    assert(@sizeOf(sockaddr_un) == 106);
+    assert(@offsetOf(sockaddr_un, "sun_len") == 0);
+    assert(@offsetOf(sockaddr_un, "sun_family") == 1);
+    assert(@offsetOf(sockaddr_un, "sun_path") == 2);
+    // The qemu-netdev wire format prefixes every frame with a 4-byte
+    // big-endian length; both writeInt sites below depend on this.
+    assert(AF_UNIX == 1);
+    assert(SHUT_RDWR == 2);
 }
 
 // ---- libc + sockaddr_un (macOS layout: u8 sun_len, u8 sun_family,
@@ -96,18 +108,22 @@ pub const NetSocket = struct {
     /// Dial gvproxy and spawn the RX thread. Heap-allocated because
     /// the RX thread and `on_rx_ctx` callers keep a stable pointer.
     pub fn connect(gpa: std.mem.Allocator, netdev: *virtio.Device, cfg: Config) !*NetSocket {
+        assert(cfg.socket_path.len > 0);
+        assert(netdev.size > 0);
         if (cfg.socket_path.len >= @sizeOf(@TypeOf(@as(sockaddr_un, undefined).sun_path))) {
             return error.SocketPathTooLong;
         }
 
         const fd = socket(AF_UNIX, SOCK_STREAM, 0);
         if (fd < 0) return error.SocketCreateFailed;
+        assert(fd >= 0);
         errdefer _ = close(fd);
 
         var addr: sockaddr_un = .{ .sun_len = 0, .sun_family = AF_UNIX, .sun_path = @splat(0) };
         @memcpy(addr.sun_path[0..cfg.socket_path.len], cfg.socket_path);
         // Total address length: 2 bytes (sun_len + sun_family) + path + NUL.
         const addrlen: u32 = @intCast(2 + cfg.socket_path.len + 1);
+        assert(addrlen <= @sizeOf(sockaddr_un));
         addr.sun_len = @intCast(addrlen);
 
         if (c_connect(fd, @ptrCast(&addr), addrlen) < 0) return error.ConnectFailed;
@@ -119,6 +135,7 @@ pub const NetSocket = struct {
     }
 
     pub fn destroy(self: *NetSocket) void {
+        assert(self.fd >= 0);
         self.stop.store(true, .release);
         // Wake the RX thread if it's parked in read().
         _ = shutdown(self.fd, SHUT_RDWR);
@@ -131,8 +148,10 @@ pub const NetSocket = struct {
     /// the kernel buffers the stream so this is effectively non-blocking
     /// under normal load.
     pub fn input(self: *NetSocket, frame: []const u8) void {
+        assert(self.fd >= 0);
         if (frame.len == 0 or frame.len > std.math.maxInt(u32)) return;
         var prefix: [4]u8 = undefined;
+        assert(prefix.len == 4);
         std.mem.writeInt(u32, &prefix, @intCast(frame.len), .big);
 
         self.tx_mutex.lock();
@@ -146,15 +165,18 @@ pub const NetSocket = struct {
     }
 
     fn rxLoop(self: *NetSocket) void {
+        assert(self.fd >= 0);
         // One buffer for the whole thread. MTU is 1500 on the gvproxy
         // tap; 16 KiB is plenty of headroom for a future jumbo config.
         var buf: [16 * 1024]u8 = undefined;
+        assert(buf.len >= 1500);
 
         while (!self.stop.load(.acquire)) {
             var prefix: [4]u8 = undefined;
             if (readAll(self.fd, &prefix) != 0) return;
             const len = std.mem.readInt(u32, &prefix, .big);
             if (len == 0 or len > buf.len) return;
+            assert(len > 0 and len <= buf.len);
 
             if (readAll(self.fd, buf[0..len]) != 0) return;
 
@@ -167,6 +189,8 @@ pub const NetSocket = struct {
 // ---- helpers -------------------------------------------------------
 
 fn writeAll(fd: c_int, data: []const u8) c_int {
+    assert(fd >= 0);
+    assert(data.len > 0);
     var remaining = data;
     while (remaining.len > 0) {
         const n = write(fd, remaining.ptr, remaining.len);
@@ -181,6 +205,8 @@ fn writeAll(fd: c_int, data: []const u8) c_int {
 }
 
 fn readAll(fd: c_int, into: []u8) c_int {
+    assert(fd >= 0);
+    assert(into.len > 0);
     var remaining = into;
     while (remaining.len > 0) {
         const n = read(fd, remaining.ptr, remaining.len);

--- a/packages/microvm/src/pl011.zig
+++ b/packages/microvm/src/pl011.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const assert = std.debug.assert;
 
 /// Platform-sized pthread mutex. Zig 0.16 moved `std.Thread.Mutex`
 /// under `std.Io` (it now requires an Io context), so we bind
@@ -63,6 +64,19 @@ pub const Pl011 = struct {
     // Bit 4 of RIS/MIS/ICR is RX interrupt.
     pub const RX_INT: u32 = 1 << 4;
 
+    comptime {
+        // PL011 wire constants — flipping these would silently break
+        // the guest driver's interrupt + framing logic.
+        assert(RX_INT == 0x10);
+        // The MMIO window must cover up through the PrimeCell IDs at
+        // 0xFFC; default size is 0x1000.
+        assert(0x1000 > 0xFFC);
+        // PthreadMutex blob must be >= every supported pthread_mutex_t.
+        assert(@sizeOf(PthreadMutex) >= 64);
+        assert(@sizeOf(PthreadMutex) >= PthreadMutex.macos_pad);
+        assert(@sizeOf(PthreadMutex) >= PthreadMutex.linux_pad);
+    }
+
     pub const init: Pl011 = .{
         .base = 0x0900_0000,
         .captured = .empty,
@@ -70,33 +84,46 @@ pub const Pl011 = struct {
     };
 
     pub fn withBase(base: u64) Pl011 {
+        // base 0 collides with the GIC distributor on the arm-virt
+        // machine; non-zero is a programmer invariant for every caller.
+        assert(base != 0);
         return .{ .base = base, .captured = .empty, .rx_buf = .empty };
     }
 
     pub fn deinit(self: *Pl011, gpa: std.mem.Allocator) void {
+        assert(self.size > 0);
         self.captured.deinit(gpa);
         self.rx_buf.deinit(gpa);
     }
 
     pub fn handles(self: *const Pl011, addr: u64) bool {
+        assert(self.size > 0);
+        // Window must cover the PrimeCell IDs.
+        assert(self.size >= 0x1000);
         return addr >= self.base and addr < self.base + self.size;
     }
 
     /// IRQ line should be asserted iff there's any masked interrupt pending.
     pub fn irqAsserted(self: *Pl011) bool {
+        assert(self.size > 0);
         self.mutex.lock();
         defer self.mutex.unlock();
         return (self.ris & self.imsc) != 0;
     }
 
     pub fn pushRx(self: *Pl011, gpa: std.mem.Allocator, bytes: []const u8) !void {
+        assert(self.size > 0);
         self.mutex.lock();
         defer self.mutex.unlock();
+        const before = self.rx_buf.items.len;
         try self.rx_buf.appendSlice(gpa, bytes);
+        assert(self.rx_buf.items.len == before + bytes.len);
         if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
     }
 
     pub fn write(self: *Pl011, gpa: std.mem.Allocator, addr: u64, value: u64) !void {
+        assert(self.size > 0);
+        assert(self.handles(addr));
         self.mutex.lock();
         defer self.mutex.unlock();
         const offset = addr - self.base;
@@ -112,15 +139,19 @@ pub const Pl011 = struct {
     }
 
     pub fn read(self: *Pl011, addr: u64) u64 {
+        assert(self.size > 0);
+        assert(self.handles(addr));
         self.mutex.lock();
         defer self.mutex.unlock();
         const offset = addr - self.base;
         switch (offset) {
             0x000 => {
                 if (self.rx_buf.items.len == 0) return 0;
+                const before = self.rx_buf.items.len;
                 const b = self.rx_buf.items[0];
                 std.mem.copyForwards(u8, self.rx_buf.items[0 .. self.rx_buf.items.len - 1], self.rx_buf.items[1..]);
                 self.rx_buf.items.len -= 1;
+                assert(self.rx_buf.items.len + 1 == before);
                 if (self.rx_buf.items.len == 0) self.ris &= ~RX_INT;
                 return b;
             },

--- a/packages/microvm/src/virtio.zig
+++ b/packages/microvm/src/virtio.zig
@@ -39,6 +39,7 @@
 //!   0x100+ Config space      RW  device-specific (e.g. virtio-net MAC lives here)
 
 const std = @import("std");
+const assert = std.debug.assert;
 
 pub const magic: u32 = 0x74726976; // 'v','i','r','t' little-endian
 pub const version: u32 = 2;
@@ -69,6 +70,33 @@ pub const Status = packed struct(u32) {
 /// Max number of queues we let the driver configure. virtio-net
 /// uses 2 (RX, TX); reserving extra room is cheap.
 pub const max_queues: u32 = 8;
+
+comptime {
+    // Wire-format layouts the guest driver writes / reads directly. A
+    // mismatch here means @memcpy at runtime would shred a parsed ring
+    // header. Pair with the @sizeOf-based length checks below.
+    assert(@sizeOf(VringDesc) == 16);
+    assert(@offsetOf(VringDesc, "addr") == 0);
+    assert(@offsetOf(VringDesc, "len") == 8);
+    assert(@offsetOf(VringDesc, "flags") == 12);
+    assert(@offsetOf(VringDesc, "next") == 14);
+    assert(@sizeOf(VringAvail) == 4);
+    assert(@offsetOf(VringAvail, "flags") == 0);
+    assert(@offsetOf(VringAvail, "idx") == 2);
+    assert(@sizeOf(VringUsedElem) == 8);
+    assert(@offsetOf(VringUsedElem, "id") == 0);
+    assert(@offsetOf(VringUsedElem, "len") == 4);
+    assert(@sizeOf(VringUsed) == 4);
+    assert(@offsetOf(VringUsed, "flags") == 0);
+    assert(@offsetOf(VringUsed, "idx") == 2);
+    // Status is u32-wide so it round-trips through the 0x070 register.
+    assert(@bitSizeOf(Status) == 32);
+    assert(@sizeOf(Status) == 4);
+    // skip_notify_queues is u32; queue index is shifted as u5. The
+    // hard cap is 32, but 8 is what we actually support.
+    assert(max_queues > 0);
+    assert(max_queues <= 32);
+}
 
 /// Interrupt-status bits the driver expects to see at 0x060.
 pub const IRQ_USED_BUFFER: u32 = 1 << 0; // VIRTIO_MMIO_INT_VRING
@@ -167,11 +195,16 @@ pub const Device = struct {
     queues: [max_queues]Queue = @splat(.{}),
 
     pub fn handles(self: *const Device, addr: u64) bool {
+        assert(self.size > 0);
+        // No address-space wraparound in the MMIO window.
+        assert(self.base +% self.size > self.base);
         return addr >= self.base and addr < self.base + self.size;
     }
 
     /// Handle an MMIO read. Returns the value the kernel should see.
     pub fn read(self: *Device, addr: u64) u64 {
+        assert(self.size > 0);
+        assert(self.handles(addr));
         const off = addr - self.base;
         return switch (off) {
             0x000 => magic,
@@ -196,6 +229,8 @@ pub const Device = struct {
     /// Handle an MMIO write. Updates internal state; returns void
     /// because the caller advances PC regardless.
     pub fn write(self: *Device, addr: u64, value: u64) void {
+        assert(self.size > 0);
+        assert(self.handles(addr));
         const off = addr - self.base;
         const v32: u32 = @truncate(value);
         switch (off) {
@@ -247,6 +282,9 @@ pub const Device = struct {
     }
 
     fn readConfig(self: *const Device, off: usize) u64 {
+        // Caller in `read` masks 0x100..0x1FF and subtracts 0x100, so
+        // off is bounded by the MMIO window — programmer error if not.
+        assert(off < 0x100);
         const cfg = self.config orelse return 0;
         if (off >= cfg.len) return 0;
         // Guests read config space with varied widths (byte, halfword,
@@ -255,6 +293,7 @@ pub const Device = struct {
         // of the destination register.
         var buf: [8]u8 = @splat(0);
         const n = @min(cfg.len - off, 8);
+        assert(n <= buf.len);
         @memcpy(buf[0..n], cfg[off..][0..n]);
         return std.mem.readInt(u64, &buf, .little);
     }
@@ -274,7 +313,10 @@ pub const Device = struct {
     /// — the kernel's TX path completes successfully, `tx_packets`
     /// counter increments, buffers get freed.
     pub fn notify(self: *Device, q_idx: u32) void {
+        assert(self.size > 0);
         if (q_idx >= max_queues) return;
+        // Inside the gate: q_idx fits a u5, so the shift below is well-defined.
+        assert(q_idx < 32);
         const q = &self.queues[q_idx];
         if (q.ready == 0 or q.num == 0) return;
 
@@ -306,6 +348,8 @@ pub const Device = struct {
     /// Read one descriptor from `q_idx` at index `idx`. Returns null
     /// on out-of-range or missing ram.
     pub fn queueDescriptor(self: *Device, q_idx: u32, idx: u16) ?VringDesc {
+        assert(self.size > 0);
+        assert(self.queue_num_max > 0);
         if (q_idx >= max_queues) return null;
         return self.readDescriptor(&self.queues[q_idx], idx);
     }
@@ -316,6 +360,8 @@ pub const Device = struct {
     /// provided data, since the guest cares about the byte count of
     /// data written BY the device).
     pub fn queuePushUsed(self: *Device, q_idx: u32, head: u16, len: u32) void {
+        assert(self.size > 0);
+        assert(self.queue_num_max > 0);
         if (q_idx >= max_queues) return;
         self.pushUsed(&self.queues[q_idx], head, len);
     }
@@ -336,6 +382,12 @@ pub const Device = struct {
     /// hasn't posted any receive buffers (drop). Call setSpi after
     /// this to match `interrupt_status`.
     pub fn injectRx(self: *Device, frame: []const u8) bool {
+        assert(self.size > 0);
+        // Programmer error to inject an empty frame; jumbo > 16K is
+        // larger than the TX scratch can ever produce, so the same
+        // bound applies in the other direction.
+        assert(frame.len > 0);
+        assert(frame.len <= 16 * 1024);
         const q = &self.queues[0]; // virtio-net: queue 0 is RX
         if (q.ready == 0 or q.num == 0) return false;
 
@@ -345,6 +397,7 @@ pub const Device = struct {
 
         // Build the payload: 12-byte header + frame bytes.
         const net_hdr = [_]u8{0} ** 12;
+        assert(net_hdr.len == 12);
         const total_len: u32 = @intCast(net_hdr.len + frame.len);
 
         // Walk descriptors, copying first the header then the frame.
@@ -386,6 +439,10 @@ pub const Device = struct {
     }
 
     fn drainAvail(self: *Device, q: *Queue) void {
+        // Caller (notify) gates on these; assert them so a bad caller
+        // doesn't quietly enter the loop body.
+        assert(q.ready != 0);
+        assert(q.num > 0);
         const avail = self.readAvailHeader(q) orelse return;
         while (q.last_avail_idx != avail.idx) {
             const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return;
@@ -406,8 +463,12 @@ pub const Device = struct {
     /// it before calling the handler — the handler gets a bare
     /// ethernet frame, which is what any backend wants to forward.
     fn walkAndEmit(self: *Device, q: *Queue, head: u16) u32 {
+        // Caller drains under notify, which has gated on q.num > 0.
+        // We use q.num as the loop bound below.
+        assert(q.num > 0);
         // Worst case: MTU 9000 + headers. 16 KiB is a comfortable cap.
         var scratch: [16 * 1024]u8 = undefined;
+        assert(scratch.len == 16 * 1024);
         var written: usize = 0;
 
         var idx: u16 = head;
@@ -425,6 +486,7 @@ pub const Device = struct {
             idx = desc.next;
         }
 
+        assert(written <= scratch.len);
         if (self.tx_handler) |h| {
             const net_hdr_size: usize = 12; // virtio_net_hdr_v1
             if (written > net_hdr_size) {
@@ -445,15 +507,21 @@ pub const Device = struct {
 
     fn readDescriptor(self: *Device, q: *const Queue, idx: u16) ?VringDesc {
         if (idx >= q.num) return null;
+        // Past the gate above: q.num > 0 (idx is a u16; idx >= 0 is
+        // tautological, so reaching here implies q.num >= 1).
+        assert(q.num > 0);
         const offset: u64 = q.desc_addr + @as(u64, idx) * @sizeOf(VringDesc);
         const bytes = self.guestSlice(offset, @sizeOf(VringDesc)) orelse return null;
+        assert(bytes.len == @sizeOf(VringDesc));
         var d: VringDesc = undefined;
         @memcpy(std.mem.asBytes(&d), bytes);
         return d;
     }
 
     pub fn readAvailHeader(self: *Device, q: *const Queue) ?VringAvail {
+        assert(self.size > 0);
         const bytes = self.guestSlice(q.driver_addr, @sizeOf(VringAvail)) orelse return null;
+        assert(bytes.len == @sizeOf(VringAvail));
         // The driver's smp_wmb() pairs `ring[idx] = head` (release)
         // with the `avail.idx` bump. We must acquire-load `avail.idx`
         // so the subsequent `ring[idx]` read can't be hoisted above
@@ -469,22 +537,30 @@ pub const Device = struct {
     }
 
     fn readAvailRingEntry(self: *Device, q: *const Queue, idx: u16) ?u16 {
+        // mod by q.num below — caller (notify / injectRx) has gated.
+        assert(q.num > 0);
         // avail.ring follows the 4-byte avail header.
         const slot: u32 = @as(u32, idx) % q.num;
+        assert(slot < q.num);
         const offset: u64 = q.driver_addr + @sizeOf(VringAvail) + @as(u64, slot) * @sizeOf(u16);
         const bytes = self.guestSlice(offset, @sizeOf(u16)) orelse return null;
         return std.mem.readInt(u16, bytes[0..2], .little);
     }
 
     fn pushUsed(self: *Device, q: *Queue, id: u16, len: u32) void {
+        // mod by q.num below — caller has already gated on this.
+        assert(q.num > 0);
         // used header (4 bytes) + used.ring[num] of VringUsedElem (8 bytes each)
         const used_bytes = self.guestSlice(q.device_addr, @sizeOf(VringUsed)) orelse return;
+        assert(used_bytes.len == @sizeOf(VringUsed));
         var header: VringUsed = undefined;
         @memcpy(std.mem.asBytes(&header), used_bytes);
         const slot: u32 = @as(u32, header.idx) % q.num;
+        assert(slot < q.num);
 
         const elem_off: u64 = q.device_addr + @sizeOf(VringUsed) + @as(u64, slot) * @sizeOf(VringUsedElem);
         const elem_bytes = self.guestSlice(elem_off, @sizeOf(VringUsedElem)) orelse return;
+        assert(elem_bytes.len == @sizeOf(VringUsedElem));
         const elem = VringUsedElem{ .id = id, .len = len };
         @memcpy(elem_bytes, std.mem.asBytes(&elem));
 

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -37,6 +37,7 @@
 
 const std = @import("std");
 const virtio = @import("virtio.zig");
+const assert = std.debug.assert;
 
 /// pthread-backed mutex. Zig 0.16 tucked std.Thread.Mutex behind an Io
 /// context; we already use this pattern in hvf.Pl011.
@@ -166,6 +167,43 @@ pub const rx_body_per_packet_max: usize = 3600;
 /// fewer credit updates. The guest driver caps its in-flight bytes to
 /// this before draining.
 pub const advertised_buf_alloc: u32 = 256 * 1024;
+
+comptime {
+    // Wire-format size: every encode/decode call assumes a 44-byte
+    // virtio_vsock_hdr. (@sizeOf(VsockHdr) is 48 because the u64s
+    // force 8-byte alignment — encode/decode is the wire authority,
+    // not the struct layout.)
+    assert(header_size == 44);
+    // Op enum values are wire constants; flipping any of these would
+    // silently mistype packets in dispatchGuestPacket.
+    assert(@intFromEnum(Op.invalid) == 0);
+    assert(@intFromEnum(Op.request) == 1);
+    assert(@intFromEnum(Op.response) == 2);
+    assert(@intFromEnum(Op.rst) == 3);
+    assert(@intFromEnum(Op.shutdown) == 4);
+    assert(@intFromEnum(Op.rw) == 5);
+    assert(@intFromEnum(Op.credit_update) == 6);
+    assert(@intFromEnum(Op.credit_request) == 7);
+    assert(@intFromEnum(Type.stream) == 1);
+    // Queue indices we route through virtio.Device must fit the
+    // device's queue table.
+    assert(Q_RX < virtio.max_queues);
+    assert(Q_TX < virtio.max_queues);
+    assert(Q_EVENT < virtio.max_queues);
+    assert(Q_RX != Q_TX and Q_TX != Q_EVENT and Q_RX != Q_EVENT);
+    // CIDs are protocol-fixed; mixing them up would mis-route packets.
+    assert(host_cid != default_guest_cid);
+    // RX body cap leaves room for the header inside the kernel-posted
+    // 4096-byte buffer (3776 observed - 44 header = 3732, rounded to 3600).
+    assert(rx_body_per_packet_max + header_size < 4096);
+    assert(rx_body_per_packet_max > 0);
+    assert(advertised_buf_alloc > 0);
+    assert(max_payload >= rx_body_per_packet_max);
+    // ShutdownFlag bit layout matches the wire spec.
+    assert(ShutdownFlag.recv == 1);
+    assert(ShutdownFlag.send == 2);
+    assert(ShutdownFlag.both == 3);
+}
 
 /// Parse a `MACHINEN_VSOCK` value into a `PortMap` list.
 ///
@@ -298,6 +336,10 @@ pub fn readPacket(
     head: u16,
     scratch: []u8,
 ) ?struct { hdr: VsockHdr, body: []const u8 } {
+    // Programmer-side preconditions: caller picks a real queue index
+    // and gives us a scratch large enough to hold at least the header.
+    assert(q_idx < virtio.max_queues);
+    assert(scratch.len >= header_size);
     // Gather the whole chain contents into scratch. The split between
     // "header" and "body" is fixed at header_size bytes, regardless of
     // how the descriptors fall.
@@ -317,6 +359,8 @@ pub fn readPacket(
         if ((d.flags & virtio.VringDesc.F_NEXT) == 0) break;
         idx = d.next;
     }
+    assert(steps <= 32);
+    assert(written <= scratch.len);
     if (written < header_size) return null;
 
     var hdr_bytes: [header_size]u8 = undefined;
@@ -324,6 +368,8 @@ pub fn readPacket(
     const hdr = VsockHdr.decode(&hdr_bytes);
 
     const body_end: usize = @min(scratch.len, header_size + @as(usize, hdr.len));
+    assert(body_end >= header_size);
+    assert(body_end <= scratch.len);
     const body = scratch[header_size..body_end];
     return .{ .hdr = hdr, .body = body };
 }
@@ -339,6 +385,10 @@ pub fn writePacket(
     hdr: VsockHdr,
     body: []const u8,
 ) ?u32 {
+    assert(q_idx < virtio.max_queues);
+    // The bridge never hands us > max_payload bytes; bigger means a
+    // caller bug, not a guest one.
+    assert(body.len <= max_payload);
     var hdr_bytes: [header_size]u8 = undefined;
     hdr.encode(&hdr_bytes);
 
@@ -374,7 +424,9 @@ pub fn writePacket(
         if ((d.flags & virtio.VringDesc.F_NEXT) == 0) return null; // chain too short
         idx = d.next;
     }
+    assert(steps <= 32);
     if (remaining_hdr.len != 0 or remaining_body.len != 0) return null;
+    assert(total == @as(u32, header_size) + @as(u32, @intCast(body.len)));
     return total;
 }
 
@@ -553,6 +605,9 @@ const SockaddrUn = extern struct {
 };
 
 fn makeSockaddrUn(path: []const u8) struct { sa: SockaddrUn, len: u32 } {
+    assert(path.len > 0);
+    // Leave room for sun_len/sun_family + NUL.
+    assert(path.len < 100);
     var sa = SockaddrUn{};
     if (@import("builtin").os.tag == .macos) {
         // sun_len (1 byte), sun_family (1 byte), sun_path (104 bytes on macOS)
@@ -575,12 +630,15 @@ fn makeSockaddrUn(path: []const u8) struct { sa: SockaddrUn, len: u32 } {
 }
 
 fn setNonblocking(fd: c_int) void {
+    assert(fd >= 0);
     _ = fcntl(fd, F_SETFL, O_NONBLOCK);
 }
 
 /// Connect (blocking) to a UDS at `path`. Returns the fd on success,
 /// -1 on any failure. Caller sets nonblocking and tracks the fd.
 fn connectUds(path: [:0]const u8) c_int {
+    assert(path.len > 0);
+    assert(path.len < 100);
     const fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) return -1;
     const made = makeSockaddrUn(path);
@@ -667,6 +725,8 @@ pub const Bridge = struct {
     thread: ?std.Thread = null,
 
     pub fn create(gpa: std.mem.Allocator, dev: *virtio.Device, cfg: BridgeConfig) !*Bridge {
+        assert(dev.size > 0);
+        assert(cfg.guest_cid != host_cid);
         const self = try gpa.create(Bridge);
         self.* = .{
             .gpa = gpa,
@@ -689,6 +749,9 @@ pub const Bridge = struct {
     }
 
     pub fn start(self: *Bridge) !void {
+        // No double-start: listeners + thread must be untouched.
+        assert(self.thread == null);
+        assert(self.listeners.items.len == 0);
         // Open a UDS listener for every INBOUND entry up front so a
         // failure here is visible before the guest boots. Outbound
         // entries don't open anything yet — we dial on-demand when
@@ -735,6 +798,9 @@ pub const Bridge = struct {
     }
 
     fn runThread(self: *Bridge) void {
+        // Self-pipe must be wired up by start() before this thread spawns.
+        assert(self.wake[0] >= 0);
+        assert(self.wake[1] >= 0);
         var scratch = self.gpa.alloc(PollFd, 64) catch return;
         defer self.gpa.free(scratch);
 
@@ -851,8 +917,11 @@ pub const Bridge = struct {
 
     // Must be called with self.mu held.
     fn startConnection(self: *Bridge, uds_fd: c_int, guest_port: u32) !void {
+        assert(uds_fd >= 0);
+        assert(guest_port != 0);
         const host_port = self.next_host_port;
         self.next_host_port += 1;
+        assert(host_port != 0);
         try self.conns.append(self.gpa, .{
             .guest_port = guest_port,
             .host_port = host_port,
@@ -891,7 +960,9 @@ pub const Bridge = struct {
 
     // Must be called with self.mu held.
     fn drainConnection(self: *Bridge, idx: usize) !void {
+        assert(idx < self.conns.items.len);
         const c = &self.conns.items[idx];
+        assert(c.uds_fd >= 0);
         if (c.state != .established) return; // wait for RESPONSE first
         const room = peerRoom(c);
         if (room == 0) {
@@ -945,7 +1016,9 @@ pub const Bridge = struct {
 
     // Must be called with self.mu held.
     fn closeConnection(self: *Bridge, idx: usize) void {
+        assert(idx < self.conns.items.len);
         const c = self.conns.swapRemove(idx);
+        assert(c.uds_fd >= 0);
         _ = close(c.uds_fd);
     }
 
@@ -954,6 +1027,10 @@ pub const Bridge = struct {
     // Claim the next posted RX descriptor chain, lay down hdr+body,
     // push used, and raise the virtio IRQ.
     fn injectRx(self: *Bridge, hdr: VsockHdr, body: []const u8) bool {
+        assert(self.dev.size > 0);
+        // Body is constructed on the host side; oversized means a
+        // bridge-internal bug, not a guest one.
+        assert(body.len <= rx_body_per_packet_max);
         const q = &self.dev.queues[Q_RX];
         if (q.ready == 0 or q.num == 0) return false;
 
@@ -984,7 +1061,10 @@ pub const Bridge = struct {
     /// Called from the vCPU thread when the guest kicks the TX queue.
     /// Signature matches virtio.Device.request_handler.
     pub fn handleTxChain(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
+        assert(ctx != null);
+        assert(q_idx < virtio.max_queues);
         const self: *Bridge = @ptrCast(@alignCast(ctx.?));
+        assert(self.dev == dev);
         if (q_idx != Q_TX) {
             // Event queue or unexpected: ack and move on.
             dev.queuePushUsed(q_idx, head, 0);
@@ -1006,6 +1086,9 @@ pub const Bridge = struct {
 
     // Must be called with self.mu held.
     fn dispatchGuestPacket(self: *Bridge, hdr: VsockHdr, body: []const u8) void {
+        // body is the slice readPacket carved out of its scratch; the
+        // caller bounded it to scratch.len = max_payload + header_size.
+        assert(body.len <= max_payload);
         // Match by (src_port = guest_port, dst_port = host_port).
         var match: ?usize = null;
         for (self.conns.items, 0..) |c, k| {
@@ -1127,6 +1210,8 @@ pub const Bridge = struct {
     }
 
     fn sendCreditUpdate(self: *Bridge, c: *Connection) void {
+        assert(c.uds_fd >= 0);
+        assert(c.host_port != 0);
         const credit = VsockHdr{
             .src_cid = host_cid,
             .dst_cid = self.cfg.guest_cid,


### PR DESCRIPTION
## Summary

Tier 1 of the TigerStyle assertion-density rollout. Pairs with #210's `blk.zig` pilot — together they cover every VMM file that parses or emits a wire format the guest reads verbatim.

| File | LOC | Functions | Asserts (incl. comptime) |
| --- | ---: | ---: | ---: |
| `virtio.zig` | 799 | 18 | 51 |
| `vsock.zig` | 1215 | 27 | 58 |
| `pl011.zig` | 148 | 10 | 17 |
| `net_socket.zig` | 196 | 7 | 20 |

Total: **+218 lines, ~146 asserts**. Same shape as the pilot in #210: `const assert = std.debug.assert;` import, a `comptime { ... }` block of layout asserts at the top, and `assert(...)` lines on every non-trivial public + private function.

## What's asserted

**`virtio.zig`** — comptime asserts for `VringDesc` / `VringAvail` / `VringUsedElem` / `VringUsed` / `Status` layouts (size + field offsets); per-fn pre/post on `read` / `write` / `handles` / `notify` / `queueDescriptor` / `queuePushUsed` / `injectRx` and the internal `drainAvail` / `walkAndEmit` / `readDescriptor` / `readAvailHeader` / `readAvailRingEntry` / `pushUsed` helpers (programmer invariants like `q.num > 0` before mod, slice lens matching `@sizeOf`, MMIO window non-degenerate).

**`vsock.zig`** — comptime asserts for `header_size == 44`, every `Op` enum value, `Q_RX` / `Q_TX` / `Q_EVENT < virtio.max_queues`, `host_cid != default_guest_cid`, `rx_body_per_packet_max + header_size < 4096`, `ShutdownFlag` bit layout; per-fn pre/post on `readPacket` / `writePacket`, `Bridge.create` / `start` / `runThread` (no-double-start, self-pipe wired), `startConnection` / `drainConnection` / `closeConnection` / `injectRx` / `handleTxChain` / `dispatchGuestPacket` / `sendCreditUpdate`.

**`pl011.zig`** — comptime asserts for `RX_INT == 0x10`, MMIO window covers the PrimeCell IDs at `0xFFC`, `PthreadMutex` blob big enough for every supported `pthread_mutex_t`; per-fn pre on `handles` / `read` / `write` / `pushRx` / `irqAsserted` / `deinit` plus a length-invariant on the `rx_buf` pop.

**`net_socket.zig`** — comptime asserts for `sockaddr_un` layout (size 106, `sun_len@0`, `sun_family@1`, `sun_path@2`) and `AF_UNIX` / `SHUT_RDWR` constants; per-fn pre on `connect` / `destroy` / `input` / `rxLoop` / `writeAll` / `readAll` (fd valid, path non-empty, `addrlen <= sockaddr_un`, frame-prefix is exactly 4 bytes, length-prefix bound enforced after the gate).

## What's *not* asserted (deliberately)

Guest-controlled values stay fail-soft: descriptor chain length > 32, oversized descriptors, `QueueNum` / `QueueReady` writes from the driver, vsock `Op` values that don't match the enum, RX frame contents, malformed avail rings. TigerStyle: **assertions are for programmer error, not operating error.** A buggy or hostile guest must not be able to crash the VMM.

## Test plan

- [x] `zig build`: clean.
- [x] `zig build test`: passes (same skip-on-no-fixture noise as main).
- [x] `npx vitest run`: 4 pre-existing fixture-missing failures + 1 pty.test.ts env flake — same set as main, none triggered by the new asserts.
- [x] `npx agent-ci run --all -q -p`: 4/4 workflows passed (2m37s).
- [ ] Smoke tests — left to reviewer (per branch handoff).

## Stacking

This branch is rebased on `main`. Tier 1 files are disjoint from `blk.zig` (#210), so the two PRs can land in either order; no rebase needed when #210 merges.
