### PR TITLE
fix(smoke): pipefail-safe rootfs capability probes

### DIFF
--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -116,18 +116,26 @@ ROOTFS_TAR="$ASSETS/rootfs-debian-arm64.tar.gz"
 ROOTFS_SUPPORTS_VSOCK_EXEC=1
 ROOTFS_SUPPORTS_CRIU=1
 ROOTFS_SUPPORTS_SNAPSHOT_HELPERS=1
+# Probe the rootfs tarball once. We can't `tar tzf | grep -q` directly
+# under `set -o pipefail`: grep -q exits as soon as it finds a match,
+# tar gets SIGPIPE on its next write and exits 141, and pipefail
+# surfaces that 141 — every probe lights up "missing" even when the
+# entry is right there. Linux GNU tar reproduces this; BSD tar on
+# darwin happens to absorb it, which is why this only manifests on
+# linux smoke runs and the regression went silent for a while.
+ROOTFS_ENTRIES=$(tar tzf "$ROOTFS_TAR" 2>/dev/null || true)
 # vsock support moved from /lib/modules into the kernel image (#119),
 # so the modern marker is /exec-agent in the rootfs (#93's vsock-using
 # helper) rather than the old `vmw_vsock_virtio_transport.ko` path.
-if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "^./exec-agent$"; then
+if ! grep -q "^./exec-agent$" <<<"$ROOTFS_ENTRIES"; then
   echo "smoke: WARN rootfs lacks /exec-agent — N-series (vm.exec) will be skipped"
   ROOTFS_SUPPORTS_VSOCK_EXEC=0
 fi
-if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "usr/sbin/criu"; then
+if ! grep -q "usr/sbin/criu" <<<"$ROOTFS_ENTRIES"; then
   echo "smoke: WARN rootfs lacks criu — P/C-series will be skipped"
   ROOTFS_SUPPORTS_CRIU=0
 fi
-if ! tar tzf "$ROOTFS_TAR" 2>/dev/null | grep -q "sbin/machinen-dump"; then
+if ! grep -q "sbin/machinen-dump" <<<"$ROOTFS_ENTRIES"; then
   echo "smoke: WARN rootfs lacks /sbin/machinen-dump — S-series (snapshot) will be skipped"
   ROOTFS_SUPPORTS_SNAPSHOT_HELPERS=0
 fi
@@ -281,7 +289,7 @@ fi
 # build-kernel-arm64.sh), so the previous `fuse.ko` gate would skip
 # forever. Stale tarballs from before #78 won't have fuse-agent.
 echo "T3: machinen boot --mount-live ./fixture:/mnt/live:ro -- cat /mnt/live/hello.txt"
-if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse-agent$'; then
+if ! grep -q 'fuse-agent$' <<<"$ROOTFS_ENTRIES"; then
   echo "  skip: fuse-agent not in $ROOTFS_TAR — rebuild base assets"
 else
   T3_MARKER="livemount-marker-$$"
@@ -318,7 +326,7 @@ fi
 # asserts the file appears on the host filesystem with the right
 # contents AFTER the VM exits. Same fuse-agent gate as T3.
 echo "T5: machinen boot --mount-live (default :rw) — guest write reaches the host"
-if ! tar -tzf "$ROOTFS_TAR" 2>/dev/null | grep -q 'fuse-agent$'; then
+if ! grep -q 'fuse-agent$' <<<"$ROOTFS_ENTRIES"; then
   echo "  skip: fuse-agent not in $ROOTFS_TAR — rebuild base assets"
 else
   T5_MARKER="livemount-rw-marker-$$"


### PR DESCRIPTION
## Problem

Five probes in `scripts/smoke-tests.sh` ran `tar tzf \"\$ROOTFS_TAR\" 2>/dev/null | grep -q PATTERN`. With `set -o pipefail` (line 28), `grep -q` exits as soon as it finds a match, `tar` gets SIGPIPE on its next write and exits 141, and pipefail surfaces that 141 as the pipeline status — so `! pipeline` is always true and the \"missing\" branch fires regardless of whether the entry is in the tarball.

**Effect on linux/KVM smoke runs:** every vsock-dependent phase silently skipped — N-series (`vm.exec`), P/C-series (criu, fnm cache), S-series (snapshot/fork), and T3/T5 (FUSE live-mount) — even though the rootfs had all the markers. The script still printed `all smoke tests passed` because the skips weren't fatal, so the regression went unnoticed for a while.

**Why darwin didn't expose it:** BSD tar absorbs the SIGPIPE without propagating a non-zero exit, so the same script behaves correctly there. GNU tar on Linux does propagate it, and that's where it bites.

## Repro

On friend@100.126.46.90 (Ampere, Ubuntu 24.04, GNU tar 1.35):

```
$ tar tzf release-assets/rootfs-debian-arm64.tar.gz \
    2>/dev/null | grep -q \"^./exec-agent\$\"; \
  echo \"PIPESTATUS=\${PIPESTATUS[@]}\"
PIPESTATUS=141 0   # tar SIGPIPE, grep matched
```

`PIPESTATUS` shows tar killed by SIGPIPE (141) and grep matched (0). With pipefail the pipeline returns 141; `! 141` is true; the predicate's \"WARN\" branch fires.

## Fix

Probe the tarball once into a string, then grep against a here-string (no pipe → no SIGPIPE → no pipefail interaction):

```
ROOTFS_ENTRIES=\$(tar tzf \"\$ROOTFS_TAR\" 2>/dev/null || true)
if ! grep -q \"^./exec-agent\$\" <<<\"\$ROOTFS_ENTRIES\"; then ...
```

Applies to all 5 probes (3 capability probes + 2 fuse-agent gates).

## Discovered while validating

I hit this trying to validate #231 (interrupt_status atomics) on friend's KVM hardware — the smoke run claimed \"all passed\" but every vsock-relevant phase was silently skipping. After this lands, re-running smoke-tests on friend will actually exercise the patch on KVM.

## Test plan

- [x] `bash -c 'set -euo pipefail; ENTRIES=\$(printf \"./a\\n./exec-agent\\n\"); if ! grep -q \"^./exec-agent\$\" <<<\"\$ENTRIES\"; then echo neg; else echo pos; fi'` → `pos` (predicate fires correctly under pipefail).
- [ ] `pnpm smoke-tests` on friend@100.126.46.90 (Ampere KVM) — N/P/C/S series and T3/T5 should now run instead of skipping. Will run after this PR + #231 land.
