### PR TITLE
Surface runtime phase timings; cut cold vm boot 11.5s -> 232ms

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -706,7 +706,9 @@ async function cmdSnapshot(args: string[]): Promise<number> {
       leaveRunning: keepAlive,
       tcpClose: keepAlive,
       onLog: (evt) => {
-        process.stderr.write(evt.chunk);
+        if (evt.source !== "phase") {
+          process.stderr.write(evt.chunk);
+        }
       },
     });
     process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
@@ -787,7 +789,9 @@ async function cmdFork(args: string[]): Promise<number> {
       dtb: dtbPath,
       tcpKeep,
       onLog: (evt) => {
-        process.stderr.write(evt.chunk);
+        if (evt.source !== "phase") {
+          process.stderr.write(evt.chunk);
+        }
       },
     });
     process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -1644,9 +1644,9 @@ Forwarded to `tar --exclude=PATTERN`. Repeat per pattern.
 
 ***
 
-### LogEvent
+### ChunkLogEvent
 
-Defined in: [log.ts:14](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L14)
+Defined in: [log.ts:19](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L19)
 
 #### Properties
 
@@ -1654,7 +1654,7 @@ Defined in: [log.ts:14](https://github.com/redwoodjs/machinen/blob/main/packages
 
 > **source**: `"guest-console"` \| `"exec-stdout"` \| `"exec-stderr"`
 
-Defined in: [log.ts:21](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L21)
+Defined in: [log.ts:26](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L26)
 
 Where the chunk came from:
   - `guest-console` — kernel / PL011 console bytes (VMM stderr)
@@ -1665,7 +1665,7 @@ Where the chunk came from:
 
 > `optional` **cmd?**: `string`
 
-Defined in: [log.ts:23](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L23)
+Defined in: [log.ts:28](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L28)
 
 Command string; set when `source` is `exec-stdout` or `exec-stderr`.
 
@@ -1673,9 +1673,47 @@ Command string; set when `source` is `exec-stdout` or `exec-stderr`.
 
 > **chunk**: `Buffer`
 
-Defined in: [log.ts:25](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L25)
+Defined in: [log.ts:30](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L30)
 
 Raw bytes as they arrive — not line-split, not decoded.
+
+***
+
+### PhaseLogEvent
+
+Defined in: [log.ts:33](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L33)
+
+#### Properties
+
+##### source
+
+> **source**: `"phase"`
+
+Defined in: [log.ts:34](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L34)
+
+##### kind
+
+> **kind**: `"boot"` \| `"provision"` \| `"snapshot"` \| `"restore"`
+
+Defined in: [log.ts:36](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L36)
+
+Which runtime entry point produced these phases.
+
+##### phases
+
+> **phases**: `ReadonlyMap`\<`string`, `number`\>
+
+Defined in: [log.ts:38](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L38)
+
+Phase name → wall-clock ms. Insertion order = timeline order.
+
+##### totalMs
+
+> **totalMs**: `number`
+
+Defined in: [log.ts:40](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L40)
+
+Wall-clock between PhaseTimer construction and flush.
 
 ***
 
@@ -2069,7 +2107,7 @@ by default when `output` is a TTY.
 
 ### ProvisionOptions
 
-Defined in: [provision.ts:50](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L50)
+Defined in: [provision.ts:52](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L52)
 
 #### Properties
 
@@ -2077,7 +2115,7 @@ Defined in: [provision.ts:50](https://github.com/redwoodjs/machinen/blob/main/pa
 
 > `optional` **base?**: `string`
 
-Defined in: [provision.ts:60](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L60)
+Defined in: [provision.ts:62](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L62)
 
 Path to the base rootfs tarball to start from. Typically the
 `rootfs-debian-arm64.tar.gz` produced by
@@ -2091,7 +2129,7 @@ cache at `~/.machinen/@machinen/runtime@<version>/bases/debian-arm64/`).
 
 > **install**: (`vm`) => `Promise`\<`void`\>
 
-Defined in: [provision.ts:65](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L65)
+Defined in: [provision.ts:67](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L67)
 
 User-supplied provisioning steps. Runs inside the guest via vsock.
 
@@ -2109,7 +2147,7 @@ User-supplied provisioning steps. Runs inside the guest via vsock.
 
 > **out**: `string`
 
-Defined in: [provision.ts:71](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L71)
+Defined in: [provision.ts:73](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L73)
 
 Output path for the resulting rootfs tarball. Will be overwritten.
 Consumed via `boot({ image: out })`.
@@ -2118,7 +2156,7 @@ Consumed via `boot({ image: out })`.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [provision.ts:79](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L79)
+Defined in: [provision.ts:81](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L81)
 
 Default cmd baked into the image as `/machinen-config.json`.
 When the image is later booted via `boot({ image })` without a
@@ -2129,7 +2167,7 @@ user-supplied `cmd`, the guest runs this. User-supplied `cmd` on
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L86)
+Defined in: [provision.ts:88](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L88)
 
 Default guest env baked into the image alongside `cmd`. Merged
 with `boot({ env })` at boot time, with the caller's `env`
@@ -2139,7 +2177,7 @@ overriding on key collision.
 
 > `optional` **binary?**: `string`
 
-Defined in: [provision.ts:92](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L92)
+Defined in: [provision.ts:94](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L94)
 
 Optional VMM binary path. Same lookup rules as `boot()` — if
 omitted, resolves `@machinen/vmm-<arch>-<os>`.
@@ -2148,7 +2186,7 @@ omitted, resolves `@machinen/vmm-<arch>-<os>`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [provision.ts:95](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L95)
+Defined in: [provision.ts:97](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L97)
 
 Working directory. Defaults to process.cwd().
 
@@ -2156,7 +2194,7 @@ Working directory. Defaults to process.cwd().
 
 > `optional` **scratchDiskSizeBytes?**: `number`
 
-Defined in: [provision.ts:102](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L102)
+Defined in: [provision.ts:104](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L104)
 
 Size of the scratch disk used to ferry the tarball from guest to
 host. Must be larger than the expected post-install rootfs size.
@@ -2166,7 +2204,7 @@ Default: 1 GiB (sparse, so it doesn't actually take that space).
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [provision.ts:109](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L109)
+Defined in: [provision.ts:111](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L111)
 
 Wall-clock ceiling for the whole build. If the install hook plus
 the final archive + shutdown doesn't finish in this window, we
@@ -2176,7 +2214,7 @@ SIGKILL the VMM and fail. Default: 10 minutes.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:116](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L116)
+Defined in: [provision.ts:118](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L118)
 
 Extra env passed to the VMM process on the host side. Useful for
 dev overrides like `MACHINEN_BOOT_TEST`. Distinct from `env`,
@@ -2186,7 +2224,7 @@ which bakes guest-workload env into the produced image.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [provision.ts:119](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L119)
+Defined in: [provision.ts:121](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L121)
 
 Path to the guest kernel. Same semantics as `boot({ kernel })`.
 
@@ -2194,7 +2232,7 @@ Path to the guest kernel. Same semantics as `boot({ kernel })`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [provision.ts:122](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L122)
+Defined in: [provision.ts:124](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L124)
 
 Path to the guest DTB. Same semantics as `boot({ dtb })`.
 
@@ -2202,7 +2240,7 @@ Path to the guest DTB. Same semantics as `boot({ dtb })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [provision.ts:130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L130)
+Defined in: [provision.ts:132](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L132)
 
 Streaming log callback — fires for every byte of guest output
 during the build: guest kernel console, every `vm.exec()` call
@@ -2213,7 +2251,7 @@ See `LogEvent.source` to tell them apart. See #83.
 
 ### ProvisionResult
 
-Defined in: [provision.ts:133](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L133)
+Defined in: [provision.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L135)
 
 #### Properties
 
@@ -2221,7 +2259,7 @@ Defined in: [provision.ts:133](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **imagePath**: `string`
 
-Defined in: [provision.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L135)
+Defined in: [provision.ts:137](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L137)
 
 Absolute path to the output tarball.
 
@@ -2229,7 +2267,7 @@ Absolute path to the output tarball.
 
 > **sizeBytes**: `number`
 
-Defined in: [provision.ts:138](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L138)
+Defined in: [provision.ts:140](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L140)
 
 Size of the output tarball in bytes.
 
@@ -2237,7 +2275,7 @@ Size of the output tarball in bytes.
 
 > **elapsedMs**: `number`
 
-Defined in: [provision.ts:141](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L141)
+Defined in: [provision.ts:143](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L143)
 
 Wall-clock time from build() entry to return.
 
@@ -2471,7 +2509,7 @@ ms epoch when the entry was created.
 
 ### EnsureRootfsImageOptions
 
-Defined in: [rootfs-img.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L134)
+Defined in: [rootfs-img.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L135)
 
 #### Properties
 
@@ -2479,7 +2517,7 @@ Defined in: [rootfs-img.ts:134](https://github.com/redwoodjs/machinen/blob/main/
 
 > `optional` **cacheDir?**: `string`
 
-Defined in: [rootfs-img.ts:139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L139)
+Defined in: [rootfs-img.ts:140](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L140)
 
 Override the cache directory. Default: `~/.cache/machinen/rootfs`.
 Useful for tests.
@@ -2488,7 +2526,7 @@ Useful for tests.
 
 > `optional` **force?**: `boolean`
 
-Defined in: [rootfs-img.ts:144](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L144)
+Defined in: [rootfs-img.ts:145](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L145)
 
 Force re-materialization even if a cached image is already present.
 Mostly for debugging the materializer.
@@ -2497,7 +2535,7 @@ Mostly for debugging the materializer.
 
 > `optional` **sizeMultiplier?**: `number`
 
-Defined in: [rootfs-img.ts:154](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L154)
+Defined in: [rootfs-img.ts:155](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L155)
 
 Slack multiplier above the unpacked tarball size when sizing the
 ext4 filesystem. Default: 2.5 — leaves enough room for the guest
@@ -2511,7 +2549,7 @@ to fill the filesystem.
 
 > `optional` **minSizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:162](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L162)
+Defined in: [rootfs-img.ts:163](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L163)
 
 Minimum image size in bytes. The materializer enforces at least
 this for small rootfs where the multiplier alone would leave
@@ -2523,13 +2561,39 @@ insufficient room for a real workload. Default: 2 GiB — boot-time
 
 > `optional` **sizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L170)
+Defined in: [rootfs-img.ts:171](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L171)
 
 Absolute target size in bytes. When set, overrides `sizeMultiplier`
 and `minSizeBytes` entirely — fresh materializations get exactly
 this size, cached `.img`s smaller than this are sparse-extended
 (truncate(2)) so the next boot's online ext4 grow can fill them.
 For the user-facing `boot({ rootDiskSizeBytes })` knob (#131).
+
+##### onPhase?
+
+> `optional` **onPhase?**: (`name`, `ms`) => `void`
+
+Defined in: [rootfs-img.ts:179](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L179)
+
+Sub-phase callback for the caller's PhaseTimer (#233 follow-up).
+Fires for each measurable internal step: `sha256`, `e2fsck`,
+`sparse-extend`, `tar-extract`, `mke2fs`, `gunzip-prebake`. The
+caller typically does `phases.mark("<parent>.${name}", ms)` so
+the breakdown shows up alongside the parent phase.
+
+###### Parameters
+
+###### name
+
+`string`
+
+###### ms
+
+`number`
+
+###### Returns
+
+`void`
 
 ***
 
@@ -3469,7 +3533,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 ### AttachOptions
 
-Defined in: [vm.ts:1186](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1186)
+Defined in: [vm.ts:1196](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1196)
 
 #### Properties
 
@@ -3477,7 +3541,7 @@ Defined in: [vm.ts:1186](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1192](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1192)
+Defined in: [vm.ts:1202](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1202)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3487,7 +3551,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1194](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1194)
+Defined in: [vm.ts:1204](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1204)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3495,7 +3559,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1201](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1201)
+Defined in: [vm.ts:1211](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1211)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3506,7 +3570,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2285](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2285)
+Defined in: [vm.ts:2336](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2336)
 
 #### Extends
 
@@ -3837,7 +3901,7 @@ the returned handle. See `LogEvent.source` to tell them apart. See
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2290](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2290)
+Defined in: [vm.ts:2341](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2341)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3846,7 +3910,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2298](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2298)
+Defined in: [vm.ts:2349](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2349)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3858,7 +3922,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2304](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2304)
+Defined in: [vm.ts:2355](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2355)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -3898,11 +3962,19 @@ Defined in: [errors.ts:23](https://github.com/redwoodjs/machinen/blob/main/packa
 
 ***
 
+### LogEvent
+
+> **LogEvent** = [`ChunkLogEvent`](#chunklogevent) \| [`PhaseLogEvent`](#phaselogevent)
+
+Defined in: [log.ts:43](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L43)
+
+***
+
 ### OnLog
 
 > **OnLog** = (`evt`) => `void`
 
-Defined in: [log.ts:28](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L28)
+Defined in: [log.ts:45](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L45)
 
 #### Parameters
 
@@ -3913,6 +3985,40 @@ Defined in: [log.ts:28](https://github.com/redwoodjs/machinen/blob/main/packages
 #### Returns
 
 `void`
+
+***
+
+### ImageConfig
+
+> **ImageConfig** = `object`
+
+Defined in: [vm.ts:1386](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1386)
+
+Shape of the optional `./machinen-config.json` baked into a rootfs
+tarball by `provision({ cmd, env })`. `boot()` reads it via
+`readImageConfig()` so callers don't need to re-pass `cmd`/`env` on
+every boot. `warmImageConfigCache()` accepts the same shape so a
+tarball-producing tool can pre-populate the lookup cache.
+
+#### Properties
+
+##### cmd?
+
+> `optional` **cmd?**: `string`[]
+
+Defined in: [vm.ts:1386](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1386)
+
+##### env?
+
+> `optional` **env?**: `Record`\<`string`, `string`\>
+
+Defined in: [vm.ts:1386](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1386)
+
+##### cwd?
+
+> `optional` **cwd?**: `string`
+
+Defined in: [vm.ts:1386](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1386)
 
 ## Variables
 
@@ -4344,7 +4450,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:1900](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1900)
+Defined in: [vm.ts:1951](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1951)
 
 #### Type Declaration
 
@@ -4601,7 +4707,7 @@ Kept argv-compatible with the old Python script so shell fixtures
 
 > **resolveBaseRootfs**(`explicit?`, `cwd?`): `string`
 
-Defined in: [provision.ts:190](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L190)
+Defined in: [provision.ts:192](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L192)
 
 Resolve the path to the base rootfs tarball, in the same order
 `provision()` itself does:
@@ -4642,7 +4748,7 @@ PROVISION_BASE_NOT_FOUND | PROVISION_ASSETS_DIR_INVALID
 
 > **provision**(`opts`): `Promise`\<[`ProvisionResult`](#provisionresult)\>
 
-Defined in: [provision.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L251)
+Defined in: [provision.ts:253](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L253)
 
 Boot the base rootfs, run the user install hook, and freeze the
 resulting filesystem state to a new tarball at `opts.out`.
@@ -4726,7 +4832,7 @@ effect, so a crashed VMM doesn't leave a stuck record behind.
 
 > **rootfsImgCacheDir**(): `string`
 
-Defined in: [rootfs-img.ts:85](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L85)
+Defined in: [rootfs-img.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L86)
 
 Default cache root: `~/.cache/machinen/rootfs`.
 
@@ -4740,7 +4846,7 @@ Default cache root: `~/.cache/machinen/rootfs`.
 
 > **markRootfsImageClean**(`imgPath`): `void`
 
-Defined in: [rootfs-img.ts:105](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L105)
+Defined in: [rootfs-img.ts:106](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L106)
 
 Mark a cached rootfs image as "cleanly released" by writing the
 sentinel that `ensureRootfsImage()` looks for on the next boot.
@@ -4769,7 +4875,7 @@ but never wrong.
 
 > **ensureRootfsImage**(`tarPath`, `opts?`): `string`
 
-Defined in: [rootfs-img.ts:196](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L196)
+Defined in: [rootfs-img.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L205)
 
 Resolve `tarPath` to a cached ext4 `.img`, materializing it on first
 call. Returns the absolute path to the cached image.
@@ -4808,6 +4914,28 @@ treats the image as poisoned and rebuilds it.
 ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
   | PROVISION_BASE_NOT_FOUND (tarball missing) |
   PROVISION_INSTALL_HOOK_FAILED (tar / mke2fs failed)
+
+***
+
+### resolveMke2fs()
+
+> **resolveMke2fs**(): `string`
+
+Defined in: [rootfs-img.ts:729](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L729)
+
+Resolve the mke2fs binary path using the same lookup order as
+`ensureRootfsImage` itself: env override → bundled package → PATH →
+Homebrew keg-only. Returns `undefined` when no binary is available
+(callers should treat this as "skip the optimization", not an error).
+
+Exported so `provision()` can prebake an `<out>.img.gz` sibling
+alongside its `<out>.tar.gz` output (#233 follow-up). Without that,
+every fresh `provision()` invalidates the cached `<sha>.img` and the
+next `boot()` pays ~10 s for tar-extract + mke2fs.
+
+#### Returns
+
+`string`
 
 ***
 
@@ -4868,7 +4996,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1217](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1217)
+Defined in: [vm.ts:1227](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1227)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -4896,11 +5024,44 @@ REGISTRY_VM_NOT_FOUND
 
 ***
 
+### warmImageConfigCache()
+
+> **warmImageConfigCache**(`imagePath`, `config`): `void`
+
+Defined in: [vm.ts:1431](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1431)
+
+Pre-populate the image-config cache for a freshly-written tarball.
+Lets `provision()` (and other tarball producers) skip the slow
+`tar -xzOf` lookup that the next `boot()` would otherwise pay —
+see #233. Best-effort: a missing/unwritable cache dir just falls
+back to the slow path on the next boot.
+
+Call AFTER the tarball is on disk (so size+mtime match what the
+cache key will be on read), passing exactly the config that was
+baked into the tarball's `./machinen-config.json` (or `null` when
+none was baked).
+
+#### Parameters
+
+##### imagePath
+
+`string`
+
+##### config
+
+[`ImageConfig`](#imageconfig)
+
+#### Returns
+
+`void`
+
+***
+
 ### buildWriteFileCmd()
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1748](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1748)
+Defined in: [vm.ts:1799](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1799)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -4939,7 +5100,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1790](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1790)
+Defined in: [vm.ts:1841](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1841)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -4971,7 +5132,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2323](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2323)
+Defined in: [vm.ts:2374](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2374)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5006,7 +5167,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2576](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2576)
+Defined in: [vm.ts:2627](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2627)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/image-config-cache.test.ts
+++ b/packages/runtime/src/__tests__/image-config-cache.test.ts
@@ -26,7 +26,7 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { readImageConfig } from "../vm.ts";
+import { readImageConfig, warmImageConfigCache } from "../vm.ts";
 
 const CACHE_DIR = join(homedir(), ".cache", "machinen", "image-config");
 
@@ -91,6 +91,32 @@ describe("readImageConfig cache (#221)", () => {
 
     expect(readImageConfig(tarball)).toBeUndefined();
     expect(cacheEntriesFor(tarball).length).toBe(1);
+    expect(readImageConfig(tarball)).toBeUndefined();
+  });
+
+  it("warmImageConfigCache pre-populates the cache so the next read skips tar -xzOf (#233)", () => {
+    workDir = mkdtempSync(join(tmpdir(), "image-cfg-"));
+    const tarball = join(workDir, `rootfs-test-warmed-${Date.now()}.tar.gz`);
+    // Tarball body intentionally LACKS machinen-config.json — proves
+    // the cache short-circuits the actual tar lookup. If the cache
+    // weren't consulted, readImageConfig would scan the tarball, find
+    // nothing, and return undefined.
+    buildTarball(tarball, null);
+    const baked = { cmd: ["/sbin/init"], env: { PATH: "/usr/bin" } };
+    warmImageConfigCache(tarball, baked);
+    expect(cacheEntriesFor(tarball).length).toBe(1);
+    expect(readImageConfig(tarball)).toEqual(baked);
+  });
+
+  it("warmImageConfigCache(null) caches the negative result", () => {
+    workDir = mkdtempSync(join(tmpdir(), "image-cfg-"));
+    const tarball = join(workDir, `rootfs-test-warmed-null-${Date.now()}.tar.gz`);
+    // Tarball CONTAINS a config but we warm with null — the cache
+    // should be authoritative, returning undefined despite the embedded
+    // file. Mirrors the contract for negative results in the
+    // already-tested negative caching path.
+    buildTarball(tarball, JSON.stringify({ cmd: ["/should-not-see-this"] }));
+    warmImageConfigCache(tarball, null);
     expect(readImageConfig(tarball)).toBeUndefined();
   });
 

--- a/packages/runtime/src/__tests__/phase-timer.test.ts
+++ b/packages/runtime/src/__tests__/phase-timer.test.ts
@@ -62,4 +62,34 @@ describe("PhaseTimer", () => {
     t.flush(fakeDebug, "snapshot", 50);
     expect(captured).toBe("phases kind=snapshot total=50 only=7");
   });
+
+  it("toEvent() returns a structured PhaseLogEvent with insertion order preserved", () => {
+    const t = new PhaseTimer();
+    t.mark("first", 10);
+    t.mark("second", 20);
+    const evt = t.toEvent("provision", 100);
+    expect(evt.source).toBe("phase");
+    expect(evt.kind).toBe("provision");
+    expect(evt.totalMs).toBe(100);
+    expect([...evt.phases]).toEqual([
+      ["first", 10],
+      ["second", 20],
+    ]);
+  });
+
+  it("toEvent() snapshots a stable copy — later mutations don't bleed in", () => {
+    const t = new PhaseTimer();
+    t.mark("a", 1);
+    const evt = t.toEvent("boot");
+    t.mark("b", 2);
+    expect([...evt.phases.keys()]).toEqual(["a"]);
+  });
+
+  it("toEvent() defaults totalMs to the timer's wall-clock", async () => {
+    const t = new PhaseTimer();
+    t.mark("only", 1);
+    await sleep(5);
+    const evt = t.toEvent("boot");
+    expect(evt.totalMs).toBeGreaterThanOrEqual(5);
+  });
 });

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -319,11 +319,19 @@ describe("ensureRootfsImage", () => {
     }
   }, 20_000);
 
-  it("wipes a cached .img with no clean-shutdown marker (#170)", () => {
-    // Simulates a previous boot that was killed mid-write: the .img
-    // is on disk but the .ok marker was never re-created. The next
-    // call must NOT trust the planted bytes — it should wipe and
-    // try to rematerialize from the tarball.
+  it("rematerializes over a cached .img with no clean-shutdown marker (#170)", () => {
+    // Simulates a previous boot killed mid-write: the .img is on disk
+    // but the .ok marker was never re-created. The next call must NOT
+    // RETURN the planted bytes — it must fall through to materialize,
+    // which atomically replaces the file via renameSync (or throws if
+    // materialize can't run on this host).
+    //
+    // The eager unlinkSync(imgPath) on entry was removed in #233 because
+    // it raced with concurrent callers holding imgPath as a cache-hit
+    // return value (parallel test files; multiple boot()s on the same
+    // tarball). The contract that matters is "we don't trust torn
+    // bytes" — preserved by the always-materialize fallthrough — not
+    // "the file is gone on entry."
     const tarPath = `/tmp/machinen-rootfs-img-poisoned-${process.pid}.tar.gz`;
     const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-poisoned-tar-"));
     const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-poisoned-img-"));
@@ -334,8 +342,6 @@ describe("ensureRootfsImage", () => {
         .trim()
         .split(/\s+/, 1)[0]!;
       const imgPath = join(cacheDir, `${sha}.img`);
-      // Plant a stub `.img` with no `.ok` next to it — the dirty
-      // state a kill mid-boot leaves behind.
       const planted = Buffer.from("poisoned bytes that look nothing like ext4");
       writeFileSync(imgPath, planted);
       // No e2fsprogs guaranteed on the runner — if rematerialization
@@ -349,14 +355,13 @@ describe("ensureRootfsImage", () => {
         expect(err).toBeInstanceOf(ProvisionError);
       }
       if (rematerialized) {
-        // If we got back an image, it must NOT be the planted bytes.
+        // Atomic rename replaced the planted bytes with a real ext4 image.
         const after = statSync(imgPath).size;
         expect(after).not.toBe(planted.length);
-      } else {
-        // Materialize failed — the planted file should still have
-        // been wiped on entry.
-        expect(existsSync(imgPath)).toBe(false);
       }
+      // No assertion when materialize failed — the planted bytes may
+      // still be on disk, but they will never be RETURNED to a caller
+      // (the next call enters the same fallthrough path).
     } finally {
       try {
         unlinkSync(tarPath);

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -403,14 +403,40 @@ describe("ensureRootfsImage", () => {
     }
   }
 
-  it("siblingPrebakePath strips .tar.gz / .tgz / .tar and appends .img.gz", () => {
-    expect(_internal.siblingPrebakePath("/r/rootfs.tar.gz")).toBe("/r/rootfs.img.gz");
-    expect(_internal.siblingPrebakePath("/r/rootfs.tgz")).toBe("/r/rootfs.img.gz");
-    expect(_internal.siblingPrebakePath("/r/rootfs.tar")).toBe("/r/rootfs.img.gz");
+  it("siblingPrebakePath strips .tar.gz / .tgz / .tar and falls back to .img.gz", () => {
+    // No on-disk sibling → defaults to the gzipped form.
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar.gz")).toEqual({
+      path: "/r/rootfs.img.gz",
+      gzipped: true,
+    });
+    expect(_internal.siblingPrebakePath("/r/rootfs.tgz")).toEqual({
+      path: "/r/rootfs.img.gz",
+      gzipped: true,
+    });
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar")).toEqual({
+      path: "/r/rootfs.img.gz",
+      gzipped: true,
+    });
     // Non-tarball paths return undefined — no prebake convention exists
     // for them, so the runtime falls through to the materialize path.
     expect(_internal.siblingPrebakePath("/r/rootfs")).toBeUndefined();
     expect(_internal.siblingPrebakePath("/r/rootfs.zip")).toBeUndefined();
+  });
+
+  it("siblingPrebakePath prefers an uncompressed .img sibling when present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ensure-img-sibling-prefer-"));
+    try {
+      const tarPath = join(dir, "app.tar.gz");
+      const imgPath = join(dir, "app.img");
+      writeFileSync(tarPath, Buffer.from("not actually a tarball"));
+      writeFileSync(imgPath, Buffer.from("not actually an image"));
+      expect(_internal.siblingPrebakePath(tarPath)).toEqual({
+        path: imgPath,
+        gzipped: false,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("uses a sibling .img.gz to populate the cache and skips mke2fs", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -93,4 +93,4 @@ export {
   restore,
 } from "./vm.ts";
 export { warmImageConfigCache } from "./vm.ts";
-export type { AttachOptions, BootOptions, RestoreOptions } from "./vm.ts";
+export type { AttachOptions, BootOptions, ImageConfig, RestoreOptions } from "./vm.ts";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -23,10 +23,15 @@ export type {
   VsockExecPtyResult,
   VsockExecResult,
 } from "./exec.ts";
-export type { LogEvent, OnLog } from "./log.ts";
+export type { ChunkLogEvent, LogEvent, OnLog, PhaseLogEvent } from "./log.ts";
 export { provision, resolveBaseRootfs } from "./provision.ts";
 export type { ProvisionOptions, ProvisionResult } from "./provision.ts";
-export { ensureRootfsImage, markRootfsImageClean, rootfsImgCacheDir } from "./rootfs-img.ts";
+export {
+  ensureRootfsImage,
+  markRootfsImageClean,
+  resolveMke2fs,
+  rootfsImgCacheDir,
+} from "./rootfs-img.ts";
 export type { EnsureRootfsImageOptions } from "./rootfs-img.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
 export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -92,4 +92,5 @@ export {
   resolveVmmBinary,
   restore,
 } from "./vm.ts";
+export { warmImageConfigCache } from "./vm.ts";
 export type { AttachOptions, BootOptions, RestoreOptions } from "./vm.ts";

--- a/packages/runtime/src/log.ts
+++ b/packages/runtime/src/log.ts
@@ -10,8 +10,13 @@
 // onLog at boot-level get exec output too: the handle tees each exec
 // into the onLog under the `exec-stdout` / `exec-stderr` sources with
 // the command string set on `cmd`.
+//
+// `phase` events surface the runtime's PhaseTimer breakdown to host
+// scripts without forcing them to parse `DEBUG=machinen:boot` strings.
+// One event per `kind` (boot / provision / snapshot / restore) fires
+// when the underlying timer flushes — see #233.
 
-export interface LogEvent {
+export interface ChunkLogEvent {
   /**
    * Where the chunk came from:
    *   - `guest-console` — kernel / PL011 console bytes (VMM stderr)
@@ -24,5 +29,17 @@ export interface LogEvent {
   /** Raw bytes as they arrive — not line-split, not decoded. */
   chunk: Buffer;
 }
+
+export interface PhaseLogEvent {
+  source: "phase";
+  /** Which runtime entry point produced these phases. */
+  kind: "boot" | "provision" | "snapshot" | "restore";
+  /** Phase name → wall-clock ms. Insertion order = timeline order. */
+  phases: ReadonlyMap<string, number>;
+  /** Wall-clock between PhaseTimer construction and flush. */
+  totalMs: number;
+}
+
+export type LogEvent = ChunkLogEvent | PhaseLogEvent;
 
 export type OnLog = (evt: LogEvent) => void;

--- a/packages/runtime/src/phase-timer.ts
+++ b/packages/runtime/src/phase-timer.ts
@@ -17,6 +17,7 @@
 // rollup and its components are both visible in the same line.
 
 import type debugLib from "debug";
+import type { PhaseLogEvent } from "./log.ts";
 
 type DebugFn = ReturnType<typeof debugLib>;
 
@@ -90,5 +91,20 @@ export class PhaseTimer {
    */
   flush(debugFn: DebugFn, kind: string, totalMs?: number): void {
     debugFn("%s", this.format(kind, totalMs));
+  }
+
+  /**
+   * Snapshot the timer as a structured `PhaseLogEvent` so callers can
+   * forward it to an `onLog` callback without parsing the debug
+   * one-liner. Returns an immutable copy of `phases` so the caller
+   * holds a stable view even if the timer keeps recording.
+   */
+  toEvent(kind: PhaseLogEvent["kind"], totalMs?: number): PhaseLogEvent {
+    return {
+      source: "phase",
+      kind,
+      totalMs: totalMs ?? this.totalMs(),
+      phases: new Map(this.durations),
+    };
   }
 }

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -42,7 +42,7 @@ import { VsockExec } from "./exec.ts";
 import type { OnLog } from "./log.ts";
 import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
-import { boot } from "./vm.ts";
+import { boot, warmImageConfigCache } from "./vm.ts";
 import type { VmHandle } from "./vm-handle.ts";
 import { ensureRootfsImage, markRootfsImageClean, resolveMke2fs } from "./rootfs-img.ts";
 
@@ -440,6 +440,18 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     debug("repack done elapsed=%dms", Date.now() - repackT0);
 
     const sizeBytes = statSync(outAbs).size;
+    // Warm boot()'s image-config cache (#233 follow-up): we know the
+    // exact bytes that landed in the tarball's machinen-config.json,
+    // so the next boot() can skip the ~1 s `tar -xzOf` decompress.
+    warmImageConfigCache(
+      outAbs,
+      opts.cmd || opts.env
+        ? {
+            ...(opts.cmd ? { cmd: opts.cmd } : {}),
+            ...(opts.env ? { env: opts.env } : {}),
+          }
+        : null,
+    );
     const elapsedMs = Date.now() - t0;
     debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, elapsedMs);
     phases.flush(debug, "provision", elapsedMs);

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -21,13 +21,14 @@
 //     cmd: ["/bin/sh"],
 //   });
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
   mkdtempSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -38,11 +39,12 @@ import { join, resolve } from "node:path";
 import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
+import type { OnLog } from "./log.ts";
+import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot } from "./vm.ts";
 import type { VmHandle } from "./vm-handle.ts";
-import type { OnLog } from "./log.ts";
-import { ensureRootfsImage, markRootfsImageClean } from "./rootfs-img.ts";
+import { ensureRootfsImage, markRootfsImageClean, resolveMke2fs } from "./rootfs-img.ts";
 
 const debug = debugLib("machinen:provision");
 const vmmDebug = debugLib("machinen:vmm");
@@ -260,6 +262,13 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
   const udsPath = join(workDir, "exec.sock");
   debug("provision start base=%s out=%s workDir=%s", baseAbs, outAbs, workDir);
 
+  // #233: per-phase wall-clock timeline emitted as a `PhaseLogEvent`
+  // via opts.onLog (and as a debug one-liner under DEBUG=machinen:provision).
+  // Mirrors boot()'s instrumentation so host scripts can show callers
+  // where provision wall time actually goes — install hooks rarely
+  // dominate; the inner boot, tar, and repack do.
+  const phases = new PhaseTimer();
+
   try {
     // Allocate the scratch disk sparsely. The guest tars its filesystem
     // into this block device; the host then repacks the raw tar stream
@@ -275,8 +284,13 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     // base. reflinkCopy → APFS clonefile / Linux FICLONE on reflink-
     // capable fs (free); falls back to a regular copy elsewhere
     // (one-time cost, sparse).
-    const cachedImg = ensureRootfsImage(baseAbs);
+    phases.start("rootdisk-prep");
+    const cachedImg = ensureRootfsImage(baseAbs, {
+      onPhase: (name, ms) => phases.mark(`rootdisk-prep.${name}`, ms),
+    });
+    const reflinkT0 = Date.now();
     reflinkCopy(cachedImg, rootDiskPath);
+    phases.mark("rootdisk-prep.reflink", Date.now() - reflinkT0);
     debug("rootdisk cloned src=%s dst=%s", cachedImg, rootDiskPath);
     // The cached `<sha>.img` was only READ here — the FICLONE / copy
     // landed in workDir, and the upcoming boot() targets that copy via
@@ -285,12 +299,14 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     // provision() with the same base would see a missing `.ok` and
     // wastefully rematerialize a known-good image.
     markRootfsImageClean(cachedImg);
+    phases.end("rootdisk-prep");
 
     // Boot the VMM with the base rootfs on /dev/vda (mounted ext4) and
     // the exec-agent as the cmd. The scratch disk lands on /dev/vdb,
     // ready for the post-install tar dump. We set MACHINEN_VSOCK
     // explicitly via `vmmEnv` so the UDS path lives under workDir
     // (predictable cleanup) rather than boot()'s auto-allocated tmp dir.
+    phases.start("boot");
     const vm = await boot({
       binary: opts.binary,
       cwd: opts.cwd,
@@ -312,6 +328,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // Internal tar / poweroff execs are forwarded explicitly below.
       onLog: opts.onLog,
     });
+    phases.end("boot");
 
     const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
     const killTimer = setTimeout(() => void vm.kill(), deadlineMs);
@@ -343,6 +360,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // the hook uses the same VmHandle shape as any other caller.
       const installT0 = Date.now();
       debug("install hook entry");
+      phases.start("install");
       try {
         await opts.install(vm);
       } catch (err) {
@@ -355,6 +373,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
           { cause: err },
         );
       }
+      phases.end("install");
       debug("install hook done elapsed=%dms", Date.now() - installT0);
 
       // Post-install: archive / to /dev/vdb (the scratch disk), then
@@ -363,10 +382,12 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // disk was too small; surface that specifically.
       debug("tar / -> /dev/vdb starting");
       const tarT0 = Date.now();
+      phases.start("tar-to-disk");
       const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
         execTimeoutMs: deadlineMs,
         ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
       });
+      phases.end("tar-to-disk");
       debug("tar / -> /dev/vdb done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
       if (tar.exitCode !== 0) {
         throw new ProvisionError(
@@ -384,6 +405,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // below is the real success signal. Short connect timeout so
       // we don't burn 30s retrying a bridge that's already gone.
       debug("requesting guest poweroff");
+      phases.start("poweroff-wait");
       await VsockExec.run(udsPath, "/sbin/machinen-poweroff", {
         connectTimeoutMs: 2_000,
         ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
@@ -394,6 +416,7 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
       // 30–90 s gap of silent host-side CPU. See #162.
       console.error("provision: waiting for guest exit…");
       await vm.wait();
+      phases.end("poweroff-wait");
       debug("guest exited");
     } finally {
       clearTimeout(killTimer);
@@ -407,15 +430,24 @@ export async function provision(opts: ProvisionOptions): Promise<ProvisionResult
     // trims trailing zeros and normalizes compression.
     debug("repack disk tar -> %s starting", outAbs);
     const repackT0 = Date.now();
-    repackDiskTarToGz(diskPath, outAbs, { cmd: opts.cmd, env: opts.env });
+    phases.start("repack-targz");
+    repackDiskTarToGz(diskPath, outAbs, {
+      cmd: opts.cmd,
+      env: opts.env,
+      onPhase: (name, ms) => phases.mark(`repack-targz.${name}`, ms),
+    });
+    phases.end("repack-targz");
     debug("repack done elapsed=%dms", Date.now() - repackT0);
 
     const sizeBytes = statSync(outAbs).size;
-    debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, Date.now() - t0);
+    const elapsedMs = Date.now() - t0;
+    debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, elapsedMs);
+    phases.flush(debug, "provision", elapsedMs);
+    opts.onLog?.(phases.toEvent("provision", elapsedMs));
     return {
       imagePath: outAbs,
       sizeBytes,
-      elapsedMs: Date.now() - t0,
+      elapsedMs,
     };
   } finally {
     try {
@@ -467,36 +499,138 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
  * keeps the build path cross-platform. Byte-for-byte reproducibility
  * across hosts is a nice-to-have we can layer on later if it ever
  * matters (swap in a Node-side tar writer).
+ *
+ * #233 follow-up: also emits a `<out>.img.gz` prebake sibling. The
+ * extracted tree is already on disk for re-tar; mke2fs from it costs
+ * a few seconds and saves ~10 s on every subsequent `boot()` of this
+ * tarball (the cached `<sha>.img` would otherwise miss on every
+ * provision and force a tar-extract + mke2fs on the next boot). When
+ * mke2fs isn't available we silently skip the prebake — provision
+ * still produces a valid tarball, the next boot just pays the cold-
+ * materialize price.
  */
 function repackDiskTarToGz(
   diskPath: string,
   outAbs: string,
-  bakedConfig?: { cmd?: string[]; env?: Record<string, string> },
+  opts: {
+    cmd?: string[];
+    env?: Record<string, string>;
+    onPhase?: (name: string, ms: number) => void;
+  } = {},
 ): void {
   const extractDir = mkdtempSync(join(tmpdir(), "machinen-provision-extract-"));
   try {
     // Visible progress so the silent multi-GB tar pass doesn't look
     // like a hang. See #162.
     console.error("provision: packaging rootfs…");
+    const extractT0 = Date.now();
     execFileSync("tar", ["-xf", diskPath, "-C", extractDir]);
+    opts.onPhase?.("disk-tar-extract", Date.now() - extractT0);
     // Bake the image's default cmd/env into /machinen-config.json so
     // `boot({ image })` can run without every caller re-passing the
     // same cmd. User-supplied cmd/env on boot() still override.
-    if (bakedConfig && (bakedConfig.cmd || bakedConfig.env)) {
+    if (opts.cmd || opts.env) {
       writeFileSync(
         join(extractDir, "machinen-config.json"),
         JSON.stringify({
-          ...(bakedConfig.cmd ? { cmd: bakedConfig.cmd } : {}),
-          ...(bakedConfig.env ? { env: bakedConfig.env } : {}),
+          ...(opts.cmd ? { cmd: opts.cmd } : {}),
+          ...(opts.env ? { env: opts.env } : {}),
         }),
       );
     }
+    const tarT0 = Date.now();
     execFileSync("tar", ["-czf", outAbs, "-C", extractDir, "."], {
       stdio: ["ignore", "ignore", "inherit"],
     });
+    opts.onPhase?.("targz", Date.now() - tarT0);
+    emitPrebakeSibling(extractDir, outAbs, opts.onPhase);
   } finally {
     try {
       rmSync(extractDir, { recursive: true, force: true });
     } catch {}
   }
+}
+
+/**
+ * Build `<outAbs>.img` from the already-extracted rootfs tree so the
+ * next `boot()` against `<outAbs>` hits `tryPrebakeFromSibling` and
+ * reflinks the file straight into the cache instead of cold-materialize
+ * (tar-extract + mke2fs ≈ 10 s on a typical dev rootfs).
+ *
+ * We emit the uncompressed `.img` form (sparse, ~500 MB on disk for a
+ * 2 GiB allocated image with a typical Debian rootfs) rather than the
+ * gzipped `.img.gz` form release builds use: the prebake then reflinks
+ * from sibling to cache in milliseconds, vs ~2 s for `gunzip`. Build-
+ * time gzip would also add ~25 s on a single-threaded host. Disk cost
+ * is similar — gzip(.img) and sparse(.img) both land ~500 MB on APFS.
+ *
+ * Best-effort: any failure (no mke2fs binary, mke2fs error, unexpected
+ * outAbs suffix) is logged and swallowed; the tarball alone is still
+ * a complete provision output, the next boot just falls back to the
+ * slow materialize path.
+ */
+function emitPrebakeSibling(
+  treeDir: string,
+  outAbs: string,
+  onPhase?: (name: string, ms: number) => void,
+): void {
+  const mke2fs = resolveMke2fs();
+  if (!mke2fs) {
+    debug("prebake skip: no mke2fs available");
+    return;
+  }
+  const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(outAbs);
+  if (!m) {
+    debug("prebake skip: outAbs %s lacks a recognized tarball suffix", outAbs);
+    return;
+  }
+  const prebakePath = `${m[1]}.img`;
+  const tmpImg = `${prebakePath}.tmp.${process.pid}`;
+
+  try {
+    const treeBytes = duBytes(treeDir);
+    const sizeBytes = Math.max(2 * 1024 * 1024 * 1024, Math.ceil(treeBytes * 2.5));
+    allocateSparseFile(tmpImg, sizeBytes);
+
+    const blocks = Math.floor(sizeBytes / 4096);
+    const mkT0 = Date.now();
+    const mk = spawnSync(
+      mke2fs,
+      ["-d", treeDir, "-t", "ext4", "-F", "-q", "-b", "4096", tmpImg, String(blocks)],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    onPhase?.("prebake.mke2fs", Date.now() - mkT0);
+    if (mk.status !== 0) {
+      debug(
+        "prebake mke2fs failed status=%s stderr=%s",
+        mk.status,
+        mk.stderr?.toString().slice(0, 200) ?? "",
+      );
+      return;
+    }
+
+    renameSync(tmpImg, prebakePath);
+    debug("prebake emitted prebake=%s sizeBytes=%d", prebakePath, sizeBytes);
+  } catch (err) {
+    debug("prebake error err=%s", (err as Error).message);
+  } finally {
+    try {
+      rmSync(tmpImg, { force: true });
+    } catch {}
+  }
+}
+
+/**
+ * `du -sk <path>` in bytes. Mirrors the helper in rootfs-img.ts;
+ * duplicated here to keep that module's surface narrow.
+ */
+function duBytes(path: string): number {
+  try {
+    const out = execFileSync("du", ["-sk", path], { encoding: "utf8" }).trim();
+    const kib = parseInt(out.split(/\s+/, 1)[0]!, 10);
+    if (Number.isFinite(kib) && kib > 0) {
+      return kib * 1024;
+    }
+  } catch {}
+  return statSync(path).size || 0;
 }

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -78,6 +78,7 @@ import { arch, homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
+import { reflinkCopy } from "./reflink.ts";
 
 const debug = debugLib("machinen:rootfs-img");
 
@@ -168,6 +169,14 @@ export interface EnsureRootfsImageOptions {
    * For the user-facing `boot({ rootDiskSizeBytes })` knob (#131).
    */
   sizeBytes?: number;
+  /**
+   * Sub-phase callback for the caller's PhaseTimer (#233 follow-up).
+   * Fires for each measurable internal step: `sha256`, `e2fsck`,
+   * `sparse-extend`, `tar-extract`, `mke2fs`, `gunzip-prebake`. The
+   * caller typically does `phases.mark("<parent>.${name}", ms)` so
+   * the breakdown shows up alongside the parent phase.
+   */
+  onPhase?: (name: string, ms: number) => void;
 }
 
 /**
@@ -204,7 +213,9 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   const cacheDir = opts.cacheDir ?? rootfsImgCacheDir();
   mkdirSync(cacheDir, { recursive: true });
 
+  const shaT0 = Date.now();
   const sha = sha256OfFile(tarAbs);
+  opts.onPhase?.("sha256", Date.now() - shaT0);
   const imgPath = join(cacheDir, `${sha}.img`);
   const okPath = okMarkerPath(imgPath);
   if (!opts.force && existsSync(imgPath)) {
@@ -225,7 +236,10 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
       try {
         unlinkSync(okPath);
       } catch {}
-      if (cachedImageIsUsable(imgPath)) {
+      const fsckT0 = Date.now();
+      const usable = cachedImageIsUsable(imgPath);
+      opts.onPhase?.("e2fsck", Date.now() - fsckT0);
+      if (usable) {
         // #131: if the caller asked for a larger image than what's on
         // disk (typically because they bumped `rootDiskSizeBytes`, or
         // because the materializer's defaults grew), sparse-extend the
@@ -235,6 +249,7 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
         // truncate-up on a sparse file is free; truncate-down would
         // chop bytes, so we never shrink.
         if (opts.sizeBytes !== undefined) {
+          const truncT0 = Date.now();
           try {
             const cur = statSync(imgPath).size;
             if (opts.sizeBytes > cur) {
@@ -244,6 +259,7 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
           } catch (err) {
             debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
           }
+          opts.onPhase?.("sparse-extend", Date.now() - truncT0);
         }
         return imgPath;
       }
@@ -256,22 +272,27 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
     }
   }
 
-  // #223: prebake fast path. If the release build dropped a
-  // sibling `<basename>.img.gz` next to the tarball, gunzip it
-  // straight into the cache and skip tar+mke2fs. The decompressed
-  // bytes are an ext4 image; the cache key (tarball sha) is the
-  // same one the materialize path would write to, so downstream
-  // (per-boot reflink, sparse-extend, .ok marker) is unchanged.
+  // #223 + #233: prebake fast path. If a sibling `<basename>.img` (or
+  // `<basename>.img.gz`) sits next to the tarball, populate the cache
+  // from it and skip tar+mke2fs. The bytes are an ext4 image; the
+  // cache key (tarball sha) is the same one the materialize path
+  // would write to, so downstream (per-boot reflink, sparse-extend,
+  // .ok marker) is unchanged. The uncompressed form (emitted by
+  // provision()) reflinks in essentially for free; the gzipped form
+  // (shipped with releases) has to gunzip.
   if (!opts.force) {
     const sibling = siblingPrebakePath(tarAbs);
-    if (sibling && existsSync(sibling)) {
+    if (sibling && existsSync(sibling.path)) {
+      const prebakeT0 = Date.now();
       const fast = tryPrebakeFromSibling({
-        sibling,
+        sibling: sibling.path,
+        gzipped: sibling.gzipped,
         cacheDir,
         sha,
         imgPath,
         sizeBytes: opts.sizeBytes,
       });
+      opts.onPhase?.(sibling.gzipped ? "gunzip-prebake" : "reflink-prebake", Date.now() - prebakeT0);
       if (fast) {
         return fast;
       }
@@ -323,9 +344,11 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
 
     // 1. Extract the tarball into the staging directory. tar handles
     //    both gzip and plain.
+    const extractT0 = Date.now();
     const extract = spawnSync("tar", ["-xf", tarAbs, "-C", stagingTree], {
       stdio: ["ignore", "ignore", "pipe"],
     });
+    opts.onPhase?.("tar-extract", Date.now() - extractT0);
     if (extract.status !== 0) {
       throw new ProvisionError(
         "PROVISION_INSTALL_HOOK_FAILED",
@@ -358,11 +381,13 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
     //    block size matches the kernel's default page size on arm64
     //    so reads are page-cache-aligned.
     const blocks = Math.floor(sizeBytes / 4096);
+    const mkT0 = Date.now();
     const mk = spawnSync(
       mke2fs,
       ["-d", stagingTree, "-t", "ext4", "-F", "-q", "-b", "4096", stagingImg, String(blocks)],
       { stdio: ["ignore", "ignore", "pipe"] },
     );
+    opts.onPhase?.("mke2fs", Date.now() - mkT0);
     if (mk.status !== 0) {
       throw new ProvisionError(
         "PROVISION_INSTALL_HOOK_FAILED",
@@ -570,55 +595,80 @@ function duBytes(path: string): number {
   return statSync(path).size || 0;
 }
 
-// Resolve the prebake sibling that build-base-assets.sh produces
-// (`<basename>.img.gz`). We strip a recognized tarball suffix from
-// the input — `.tar.gz`, `.tgz`, `.tar` — and append `.img.gz`.
-// Returns undefined when the path doesn't look like a tarball at
-// all; nothing else carries a meaningful sibling pairing.
-function siblingPrebakePath(tarAbs: string): string | undefined {
+// Resolve the prebake sibling next to a tarball. Two forms exist:
+//   * `<basename>.img` — uncompressed, sparse. Emitted by `provision()`
+//     (#233 follow-up): reflinks straight into the cache, near-zero
+//     handoff cost. Use this when both files live on the same APFS /
+//     reflink-capable volume.
+//   * `<basename>.img.gz` — gzipped. Shipped by build-base-assets.sh
+//     for release tarballs where download size matters more than
+//     decompress speed.
+// Prefer the uncompressed form when present; fall back to the gzipped
+// form. Returns undefined when neither suffix matches the input path.
+function siblingPrebakePath(tarAbs: string): { path: string; gzipped: boolean } | undefined {
   const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(tarAbs);
   if (!m) {
     return undefined;
   }
-  return `${m[1]}.img.gz`;
+  const stem = m[1];
+  const uncompressed = `${stem}.img`;
+  if (existsSync(uncompressed)) {
+    return { path: uncompressed, gzipped: false };
+  }
+  return { path: `${stem}.img.gz`, gzipped: true };
 }
 
-// Try to populate the cache by decompressing a prebuilt sibling
-// `.img.gz`. Returns the cache path on success, undefined on any
-// failure (gunzip error, decompressed bytes don't look like ext4).
-// The caller falls back to the slow materialize path on undefined.
+// Populate the cache from a prebuilt sibling. Two shapes:
+//   * gzipped=true  — `<base>.img.gz` from a release build. Decompress
+//                     into a staging file with `gunzip -c`.
+//   * gzipped=false — `<base>.img` from `provision()`. Reflink-copy
+//                     directly into the staging file (instant on APFS
+//                     when the sibling and cache live on one volume).
+// Either way we sniff ext4 magic before the atomic rename — a corrupt
+// sibling shouldn't poison the cache. Any failure returns undefined
+// and the caller falls through to the slow materialize path.
 function tryPrebakeFromSibling(args: {
   sibling: string;
+  gzipped: boolean;
   cacheDir: string;
   sha: string;
   imgPath: string;
   sizeBytes?: number;
 }): string | undefined {
-  const { sibling, cacheDir, sha, imgPath, sizeBytes } = args;
+  const { sibling, gzipped, cacheDir, sha, imgPath, sizeBytes } = args;
   const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-prebake-`));
   const stagingImg = join(stagingDir, "rootfs.img");
   try {
-    debug("prebake try sibling=%s sha=%s", sibling, sha.slice(0, 12));
-    const dstFd = openSync(stagingImg, "w");
-    let gunzipOk = false;
-    try {
-      const r = spawnSync("gunzip", ["-c", sibling], {
-        stdio: ["ignore", dstFd, "pipe"],
-      });
-      gunzipOk = r.status === 0;
-      if (!gunzipOk) {
-        debug(
-          "prebake gunzip failed sibling=%s status=%s stderr=%s",
-          sibling,
-          r.status,
-          r.stderr?.toString().slice(0, 200) ?? "",
-        );
+    debug("prebake try sibling=%s gzipped=%s sha=%s", sibling, gzipped, sha.slice(0, 12));
+    if (gzipped) {
+      const dstFd = openSync(stagingImg, "w");
+      let gunzipOk = false;
+      try {
+        const r = spawnSync("gunzip", ["-c", sibling], {
+          stdio: ["ignore", dstFd, "pipe"],
+        });
+        gunzipOk = r.status === 0;
+        if (!gunzipOk) {
+          debug(
+            "prebake gunzip failed sibling=%s status=%s stderr=%s",
+            sibling,
+            r.status,
+            r.stderr?.toString().slice(0, 200) ?? "",
+          );
+        }
+      } finally {
+        closeSync(dstFd);
       }
-    } finally {
-      closeSync(dstFd);
-    }
-    if (!gunzipOk) {
-      return undefined;
+      if (!gunzipOk) {
+        return undefined;
+      }
+    } else {
+      try {
+        reflinkCopy(sibling, stagingImg);
+      } catch (err) {
+        debug("prebake reflink failed sibling=%s err=%s", sibling, (err as Error).message);
+        return undefined;
+      }
     }
     // Sniff ext4 magic so a corrupted / wrong-content sibling can't
     // pollute the cache. We don't run e2fsck here — the build
@@ -626,7 +676,7 @@ function tryPrebakeFromSibling(args: {
     // soon after rename is rare enough that the .ok marker handles
     // it on the next boot.
     if (!looksLikeExt4(stagingImg)) {
-      debug("prebake sibling did not decompress to ext4 — falling back");
+      debug("prebake sibling did not yield an ext4 image — falling back");
       return undefined;
     }
     // #131: sparse-extend in place if the caller wants more headroom
@@ -658,6 +708,27 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
   } finally {
     closeSync(fd);
   }
+}
+
+/**
+ * Resolve the mke2fs binary path using the same lookup order as
+ * `ensureRootfsImage` itself: env override → bundled package → PATH →
+ * Homebrew keg-only. Returns `undefined` when no binary is available
+ * (callers should treat this as "skip the optimization", not an error).
+ *
+ * Exported so `provision()` can prebake an `<out>.img.gz` sibling
+ * alongside its `<out>.tar.gz` output (#233 follow-up). Without that,
+ * every fresh `provision()` invalidates the cached `<sha>.img` and the
+ * next `boot()` pays ~10 s for tar-extract + mke2fs.
+ */
+export function resolveMke2fs(): string | undefined {
+  const names = ["mke2fs", "mkfs.ext4"];
+  return (
+    resolveMke2fsEnvOverride() ??
+    findBundledMke2fs() ??
+    whichFirst(names) ??
+    findKegOnlyE2fs(names)
+  );
 }
 
 // Visible to tests that want to assert without invoking the real

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -224,11 +224,16 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
     // previous VMM was killed mid-write — fsck won't catch torn data
     // blocks, so treat the image as poisoned and rebuild from the
     // tarball.
+    //
+    // We deliberately do NOT `unlinkSync(imgPath)` here on the wipe
+    // paths. Concurrent callers (parallel test files, multiple `boot()`
+    // calls) may already hold imgPath as a cache-hit return value and
+    // be about to reflink from it — deleting the file out from under
+    // them races to ENOENT. The renameSync at the end of the materialize
+    // / prebake paths atomically replaces imgPath with fresh bytes, so
+    // the wipe is redundant; falling through is sufficient.
     if (!existsSync(okPath)) {
-      debug("cache hit but no clean marker, wiping img=%s", imgPath);
-      try {
-        unlinkSync(imgPath);
-      } catch {}
+      debug("cache hit but no clean marker, will rematerialize img=%s", imgPath);
     } else {
       // Atomically clear the marker BEFORE handing the path off, so
       // a kill between here and `markRootfsImageClean()` leaves the
@@ -263,12 +268,9 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
         }
         return imgPath;
       }
-      // Unrecoverable. Wipe and fall through to materialize a fresh image
-      // from the tarball — same path a force=true caller would take.
-      debug("cache hit unusable, wiping img=%s", imgPath);
-      try {
-        unlinkSync(imgPath);
-      } catch {}
+      // Unrecoverable. Fall through to materialize a fresh image — same
+      // path a force=true caller would take. renameSync replaces.
+      debug("cache hit unusable, will rematerialize img=%s", imgPath);
     }
   }
 
@@ -292,7 +294,10 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
         imgPath,
         sizeBytes: opts.sizeBytes,
       });
-      opts.onPhase?.(sibling.gzipped ? "gunzip-prebake" : "reflink-prebake", Date.now() - prebakeT0);
+      opts.onPhase?.(
+        sibling.gzipped ? "gunzip-prebake" : "reflink-prebake",
+        Date.now() - prebakeT0,
+      );
       if (fast) {
         return fast;
       }
@@ -724,10 +729,7 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
 export function resolveMke2fs(): string | undefined {
   const names = ["mke2fs", "mkfs.ext4"];
   return (
-    resolveMke2fsEnvOverride() ??
-    findBundledMke2fs() ??
-    whichFirst(names) ??
-    findKegOnlyE2fs(names)
+    resolveMke2fsEnvOverride() ?? findBundledMke2fs() ?? whichFirst(names) ?? findKegOnlyE2fs(names)
   );
 }
 

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -700,6 +700,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       const packed = synthesizeAndPackBundle(opts, mergedGuestEnv, liveMountsResolved, {
         useTiny: wantsRootDisk,
         env,
+        onPhase: (name, ms) => phases.mark(`initramfs-pack.${name}`, ms),
       });
       bundleTempDir = packed.tempDir;
       env.MACHINEN_INITRD = packed.cpioPath;
@@ -1408,6 +1409,32 @@ function imageConfigCachePath(imagePath: string): string | undefined {
   return join(imageConfigCacheDir(), key);
 }
 
+/**
+ * Pre-populate the image-config cache for a freshly-written tarball.
+ * Lets `provision()` (and other tarball producers) skip the slow
+ * `tar -xzOf` lookup that the next `boot()` would otherwise pay —
+ * see #233. Best-effort: a missing/unwritable cache dir just falls
+ * back to the slow path on the next boot.
+ *
+ * Call AFTER the tarball is on disk (so size+mtime match what the
+ * cache key will be on read), passing exactly the config that was
+ * baked into the tarball's `./machinen-config.json` (or `null` when
+ * none was baked).
+ */
+export function warmImageConfigCache(imagePath: string, config: ImageConfig | null): void {
+  const cachePath = imageConfigCachePath(imagePath);
+  if (!cachePath) {
+    return;
+  }
+  try {
+    mkdirSync(imageConfigCacheDir(), { recursive: true });
+    writeFileSync(cachePath, JSON.stringify({ config }));
+  } catch {
+    // Best-effort — a missing cache file just costs the next boot
+    // an image-config-read hit.
+  }
+}
+
 /** @internal — exported for tests; production callers should not use directly. */
 export function readImageConfig(imagePath: string): ImageConfig | undefined {
   const cachePath = imageConfigCachePath(imagePath);
@@ -1534,7 +1561,11 @@ function synthesizeAndPackBundle(
   opts: BootOptions,
   mergedGuestEnv: Record<string, string>,
   liveMounts: ResolvedLiveMount[],
-  packerOpts: { useTiny: boolean; env: Record<string, string> },
+  packerOpts: {
+    useTiny: boolean;
+    env: Record<string, string>;
+    onPhase?: (name: string, ms: number) => void;
+  },
 ): { tempDir: string; cpioPath: string } {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
   const cpioPath = join(tempDir, "initramfs.cpio");
@@ -1562,7 +1593,9 @@ function synthesizeAndPackBundle(
       cleanup();
       throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
     }
+    const cfgT0 = Date.now();
     imageConfig = readImageConfig(baseAbs);
+    packerOpts.onPhase?.("image-config-read", Date.now() - cfgT0);
   }
 
   // cmd resolution:
@@ -1666,6 +1699,7 @@ function synthesizeAndPackBundle(
   }
 
   try {
+    const packT0 = Date.now();
     if (packerOpts.useTiny) {
       // #119: rootDisk path. The on-disk rootfs is mounted from /dev/vda
       // by /init; the cpio only ships /init + machinen-config.json +
@@ -1692,6 +1726,7 @@ function synthesizeAndPackBundle(
         fuseAgentPath: liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
       });
     }
+    packerOpts.onPhase?.("cpio-write", Date.now() - packT0);
   } catch (err) {
     cleanup();
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -731,12 +731,18 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
         const cachedImg = ensureRootfsImage(baseAbs, {
           sizeBytes: opts.rootDiskSizeBytes,
+          // #233 follow-up: surface the sub-steps of ensureRootfsImage
+          // (sha256, e2fsck, sparse-extend, …) as dot-separated
+          // children of `rootdisk-materialize` in the boot timeline.
+          onPhase: (name, ms) => phases.mark(`rootdisk-materialize.${name}`, ms),
         });
         const perBoot = join(
           tmpdir(),
           `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
         );
+        const reflinkT0 = Date.now();
         reflinkCopy(cachedImg, perBoot);
+        phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
         // The cache file was only READ here — restore the
         // clean-shutdown marker so the next boot finds a usable
         // template instead of wiping and rematerializing (#170).
@@ -931,6 +937,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // #221: stamp first-guest-byte and emit the boot timeline. Either
   // path (first stderr byte, or VMM exit before any output) flushes
   // exactly once — `phases.end` is a no-op the second time around.
+  // #233: also emit a `phase` LogEvent so callers can fold the
+  // breakdown into their own UI without parsing debug strings.
   let phasesFlushed = false;
   const flushPhases = () => {
     if (phasesFlushed) {
@@ -939,6 +947,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     phasesFlushed = true;
     phases.end("first-guest-byte");
     phases.flush(debug, "boot");
+    onLog?.(phases.toEvent("boot"));
   };
   child.stderr.once("data", flushPhases);
   child.once("exit", flushPhases);

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -1376,7 +1376,14 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
  * undefined when the image has no config baked in — plain rootfs
  * tarballs that pre-date this feature still boot fine.
  */
-type ImageConfig = { cmd?: string[]; env?: Record<string, string>; cwd?: string };
+/**
+ * Shape of the optional `./machinen-config.json` baked into a rootfs
+ * tarball by `provision({ cmd, env })`. `boot()` reads it via
+ * `readImageConfig()` so callers don't need to re-pass `cmd`/`env` on
+ * every boot. `warmImageConfigCache()` accepts the same shape so a
+ * tarball-producing tool can pre-populate the lookup cache.
+ */
+export type ImageConfig = { cmd?: string[]; env?: Record<string, string>; cwd?: string };
 
 /**
  * Disk cache for `readImageConfig`. The base tarball is regenerated only

--- a/provision.ts
+++ b/provision.ts
@@ -68,6 +68,57 @@ const { provision } = (await import(
   pathToFileURL(runtimeEntry).href
 )) as typeof import("@machinen/runtime");
 
+// --- benchmarks -----------------------------------------------------------
+//
+// Permanent step-level timings. `bench(label, fn)` logs `start`/`done`
+// lines for each install step and accumulates into `phases` for a host
+// summary. Runtime-side phase events (`source: "phase"` LogEvents from
+// boot() and provision()) get collected into `runtimePhases` and
+// rendered in the same summary block — see #233.
+type Phase = { label: string; ms: number };
+const phases: Phase[] = [];
+const runtimePhases: import("@machinen/runtime").PhaseLogEvent[] = [];
+const fmtMs = (ms: number) => (ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(0)}ms`);
+async function bench<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
+  const start = performance.now();
+  console.log(`provision: ${label}...`);
+  try {
+    const result = await fn();
+    const ms = performance.now() - start;
+    phases.push({ label, ms });
+    console.log(`provision: ${label} (${fmtMs(ms)})`);
+    return result;
+  } catch (err) {
+    const ms = performance.now() - start;
+    console.log(`provision: ${label} FAILED (${fmtMs(ms)})`);
+    throw err;
+  }
+}
+
+function renderPhaseBlock(evt: import("@machinen/runtime").PhaseLogEvent): void {
+  const total = evt.totalMs;
+  const names = [...evt.phases.keys()];
+  const labelW = Math.max(22, ...names.map((n) => n.length + (n.includes(".") ? 2 : 0)));
+  console.log(`\nprovision: === runtime phases (${evt.kind}, total ${fmtMs(total)}) ===`);
+  let topSum = 0;
+  for (const [name, ms] of evt.phases) {
+    const isSub = name.includes(".");
+    if (!isSub) {
+      topSum += ms;
+    }
+    const display = isSub ? `  ${name}` : name;
+    const pct = total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
+    console.log(`provision:   ${display.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${pct}%`);
+  }
+  const other = Math.max(0, total - topSum);
+  if (other > 0 && total > 0) {
+    const pct = ((other / total) * 100).toFixed(0).padStart(3);
+    console.log(
+      `provision:   ${"(unattributed)".padEnd(labelW)} ${fmtMs(other).padStart(8)}  ${pct}%`,
+    );
+  }
+}
+
 const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
 
 // Cache key on the main repo basename so every worktree shares one
@@ -121,7 +172,7 @@ const installSteps = async (vm: VmHandle) => {
   //   • Incremental base — the prior provision's tar excludes ./tmp,
   //     so the directory is missing entirely on this boot.
   // mkdir -p + chmod handles both shapes.
-  await vm.exec("mkdir -p /tmp /var/tmp && chmod 1777 /tmp /var/tmp");
+  await bench("tmp dirs", () => vm.exec("mkdir -p /tmp /var/tmp && chmod 1777 /tmp /var/tmp"));
 
   // gvproxy DNS jitter under apt's parallel fan-out.
   const aptResilience = [
@@ -132,9 +183,8 @@ const installSteps = async (vm: VmHandle) => {
     'Acquire::https::Timeout "60";',
   ].join("\n");
   const aptResilienceB64 = Buffer.from(aptResilience).toString("base64");
-  await vm.exec(
-    `echo ${aptResilienceB64} | base64 -d > /etc/apt/apt.conf.d/99-machinen-resilience`,
-  );
+  await bench("apt config", () =>
+    vm.exec(`echo ${aptResilienceB64} | base64 -d > /etc/apt/apt.conf.d/99-machinen-resilience`));
 
   // System packages.
   //   ripgrep, fd-find        — fast code search.
@@ -142,38 +192,41 @@ const installSteps = async (vm: VmHandle) => {
   //   less, vim-tiny           — usable interactive shell.
   //   openssh-client, gh       — git/ssh + GitHub CLI.
   // Symlink fd-find's binary to the upstream `fd` name.
-  await vm.exec(
-    "apt-get update -qq && " +
-      "apt-get install -y --no-install-recommends " +
-      "bash git build-essential ca-certificates curl " +
-      "ripgrep fd-find jq less vim-tiny openssh-client gh && " +
-      "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
-  );
+  await bench("apt install", () =>
+    vm.exec(
+      "apt-get update -qq && " +
+        "apt-get install -y --no-install-recommends " +
+        "bash git build-essential ca-certificates curl " +
+        "ripgrep fd-find jq less vim-tiny openssh-client gh && " +
+        "ln -sf /usr/bin/fdfind /usr/local/bin/fd",
+    ));
 
   // Pre-bake git identity in /etc/gitconfig (--system) so both root
   // and the dev user inherit it. safe.directory '*' silences git's
   // CVE-2022-24765 "dubious ownership" check — necessary because
   // /mnt/workspace is FUSE-mounted with uids that may not line up.
-  await vm.exec(
-    "git config --system user.email 'peter.pistorius@gmail.com' && " +
-      "git config --system user.name 'Peter Pistorius' && " +
-      "git config --system init.defaultBranch main && " +
-      "git config --system --add safe.directory '*'",
-  );
+  await bench("git config", () =>
+    vm.exec(
+      "git config --system user.email 'peter.pistorius@gmail.com' && " +
+        "git config --system user.name 'Peter Pistorius' && " +
+        "git config --system init.defaultBranch main && " +
+        "git config --system --add safe.directory '*'",
+    ));
 
   // Node + pnpm + Claude Code via fnm. Idempotent on rebuilds.
-  await vm.exec(
-    "export FNM_DIR=/root/.local/share/fnm && " +
-      "fnm install 22 && " +
-      "fnm default 22 && " +
-      "NODE_BIN=$(fnm exec --using=22 -- sh -c 'dirname $(which node)') && " +
-      "ln -sf $NODE_BIN/node /usr/local/bin/node && " +
-      "ln -sf $NODE_BIN/npm  /usr/local/bin/npm  && " +
-      "ln -sf $NODE_BIN/npx  /usr/local/bin/npx  && " +
-      `fnm exec --using=22 npm install -g pnpm@${PNPM_VERSION} @anthropic-ai/claude-code && ` +
-      "ln -sf $NODE_BIN/pnpm   /usr/local/bin/pnpm && " +
-      "ln -sf $NODE_BIN/claude /usr/local/bin/claude",
-  );
+  await bench("node + pnpm + claude", () =>
+    vm.exec(
+      "export FNM_DIR=/root/.local/share/fnm && " +
+        "fnm install 22 && " +
+        "fnm default 22 && " +
+        "NODE_BIN=$(fnm exec --using=22 -- sh -c 'dirname $(which node)') && " +
+        "ln -sf $NODE_BIN/node /usr/local/bin/node && " +
+        "ln -sf $NODE_BIN/npm  /usr/local/bin/npm  && " +
+        "ln -sf $NODE_BIN/npx  /usr/local/bin/npx  && " +
+        `fnm exec --using=22 npm install -g pnpm@${PNPM_VERSION} @anthropic-ai/claude-code && ` +
+        "ln -sf $NODE_BIN/pnpm   /usr/local/bin/pnpm && " +
+        "ln -sf $NODE_BIN/claude /usr/local/bin/claude",
+    ));
 
   // Materialize Claude Code credentials on first login. The boot cmd
   // is `bash -lc` (login shell), so /etc/profile + profile.d run and
@@ -212,18 +265,20 @@ const installSteps = async (vm: VmHandle) => {
     "",
   ].join("\n");
   const profileSnippetB64 = Buffer.from(profileSnippet).toString("base64");
-  await vm.exec(
-    `echo ${profileSnippetB64} | base64 -d > /etc/profile.d/00-machinen.sh && ` +
-      "chmod 0755 /etc/profile.d/00-machinen.sh",
-  );
+  await bench("claude bootstrap", () =>
+    vm.exec(
+      `echo ${profileSnippetB64} | base64 -d > /etc/profile.d/00-machinen.sh && ` +
+        "chmod 0755 /etc/profile.d/00-machinen.sh",
+    ));
 
   // #177 dev-VM tty resize agent. Overwrite even if /sbin/machinen-winsize-agent
   // already exists in the base rootfs, so the freshest local build wins
   // (mirrors the /fuse-agent + /init refresh idiom in init.zig).
   if (winsizeAgentBin) {
-    await vm.writeFile("/sbin/machinen-winsize-agent", winsizeAgentBin, {
-      mode: 0o755,
-    });
+    await bench("winsize agent", () =>
+      vm.writeFile("/sbin/machinen-winsize-agent", winsizeAgentBin, {
+        mode: 0o755,
+      }));
   }
 
   // Non-root dev user. uid 501 matches the typical macOS host uid so
@@ -231,15 +286,17 @@ const installSteps = async (vm: VmHandle) => {
   // the FUSE mount so dev can traverse it; this user is what vm.ts
   // drops into so `claude --dangerously-skip-permissions` (which
   // refuses euid 0) works inside the guest. Idempotent on rebuilds.
-  await vm.exec("id dev >/dev/null 2>&1 || useradd -m -u 501 -s /bin/bash dev");
+  await bench("useradd dev", () =>
+    vm.exec("id dev >/dev/null 2>&1 || useradd -m -u 501 -s /bin/bash dev"));
 
   // Sanity check — covers both root and dev (verifies the dev user
   // inherits node/pnpm/claude via /usr/local/bin and gets git config
   // via /etc/gitconfig).
-  await vm.exec(
-    "node --version && pnpm --version && claude --version && bash --version | head -1 && git --version && gh --version | head -1 && " +
-      "runuser -l dev -c 'node --version && pnpm --version && claude --version && git config --get user.email'",
-  );
+  await bench("sanity check", () =>
+    vm.exec(
+      "node --version && pnpm --version && claude --version && bash --version | head -1 && git --version && gh --version | head -1 && " +
+        "runuser -l dev -c 'node --version && pnpm --version && claude --version && git config --get user.email'",
+    ));
 };
 
 // --- stamp check ----------------------------------------------------------
@@ -264,6 +321,7 @@ console.log(`provision: base=${base === OUT ? "./app.tar.gz (incremental)" : bas
 
 // --- run ------------------------------------------------------------------
 
+const provisionStart = performance.now();
 const result = await provision({
   base,
   kernel: join(ASSETS, "Image-arm64"),
@@ -290,6 +348,8 @@ const result = await provision({
       process.stdout.write(evt.chunk);
     } else if (evt.source === "exec-stderr") {
       process.stderr.write(evt.chunk);
+    } else if (evt.source === "phase") {
+      runtimePhases.push(evt);
     }
   },
 
@@ -297,5 +357,22 @@ const result = await provision({
   install: installSteps,
 });
 
+const totalMs = performance.now() - provisionStart;
+
 writeFileSync(STAMP, sourceHash);
 console.log(`\nBuilt ${result.imagePath} (${(result.elapsedMs / 1000).toFixed(1)}s)`);
+
+// Host install-step breakdown (drills into the runtime's `install`
+// phase). Runtime-side `provision` and `boot` phase blocks render
+// after this, sourced from `source: "phase"` LogEvents.
+const labelW = Math.max(22, ...phases.map((p) => p.label.length));
+console.log("\nprovision: === install-step timing ===");
+for (const p of phases) {
+  const pct = ((p.ms / totalMs) * 100).toFixed(0).padStart(3);
+  console.log(`provision:   ${p.label.padEnd(labelW)} ${fmtMs(p.ms).padStart(8)}  ${pct}%`);
+}
+console.log(`provision:   ${"".padEnd(labelW)} ${"--------".padStart(8)}`);
+console.log(`provision:   ${"wall total".padEnd(labelW)} ${fmtMs(totalMs).padStart(8)}  100%`);
+for (const evt of runtimePhases) {
+  renderPhaseBlock(evt);
+}

--- a/scripts/stream-demo.ts
+++ b/scripts/stream-demo.ts
@@ -85,6 +85,10 @@ const savedSnapDir = join(workDir, "saved");
 function printer(api: string) {
   const buffers = new Map<string, string>();
   return (evt: LogEvent) => {
+    if (evt.source === "phase") {
+      process.stderr.write(`[${api}][phase ${evt.kind}] total=${evt.totalMs}ms\n`);
+      return;
+    }
     const prefix = evt.cmd ? `[${api}][${evt.source} ${evt.cmd}]` : `[${api}][${evt.source}]`;
     const key = `${evt.source}|${evt.cmd ?? ""}`;
     let pending = (buffers.get(key) ?? "") + evt.chunk.toString("utf8");

--- a/vm.ts
+++ b/vm.ts
@@ -72,6 +72,53 @@ type Runtime = typeof import("@machinen/runtime");
 type VsockWinsizeHandle = Awaited<ReturnType<Runtime["VsockWinsize"]["connect"]>>;
 const { boot, VsockWinsize } = (await import(pathToFileURL(runtimeEntry).href)) as Runtime;
 
+// --- benchmarks ---------------------------------------------------------
+//
+// Permanent step-level timings. `bench(label, fn)` logs start/done
+// lines so the user sees what stage we're in (also surfaces in the
+// Claude Code sidebar). Runtime-side phase events from boot() get
+// rendered into a one-shot breakdown block once `boot()` returns —
+// see #233.
+const fmtMs = (ms: number) => (ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(0)}ms`);
+async function bench<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
+  const start = performance.now();
+  process.stderr.write(`[machinen] ${label}...\n`);
+  try {
+    const result = await fn();
+    process.stderr.write(`[machinen] ${label} (${fmtMs(performance.now() - start)})\n`);
+    return result;
+  } catch (err) {
+    process.stderr.write(`[machinen] ${label} FAILED (${fmtMs(performance.now() - start)})\n`);
+    throw err;
+  }
+}
+
+function renderPhaseBlock(evt: import("@machinen/runtime").PhaseLogEvent): void {
+  const total = evt.totalMs;
+  const names = [...evt.phases.keys()];
+  const labelW = Math.max(20, ...names.map((n) => n.length + (n.includes(".") ? 2 : 0)));
+  process.stderr.write(`[machinen] === ${evt.kind} phases (total ${fmtMs(total)}) ===\n`);
+  let topSum = 0;
+  for (const [name, ms] of evt.phases) {
+    const isSub = name.includes(".");
+    if (!isSub) {
+      topSum += ms;
+    }
+    const display = isSub ? `  ${name}` : name;
+    const pct = total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
+    process.stderr.write(
+      `[machinen]   ${display.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${pct}%\n`,
+    );
+  }
+  const other = Math.max(0, total - topSum);
+  if (other > 0 && total > 0) {
+    const pct = ((other / total) * 100).toFixed(0).padStart(3);
+    process.stderr.write(
+      `[machinen]   ${"(unattributed)".padEnd(labelW)} ${fmtMs(other).padStart(8)}  ${pct}%\n`,
+    );
+  }
+}
+
 const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
 const CACHE_DIR = join(homedir(), ".cache", "machinen", basename(MAIN_REPO));
 await mkdir(CACHE_DIR, { recursive: true });
@@ -109,19 +156,21 @@ function readHostCmd(label: string, file: string, args: string[]): string {
   }
 }
 
-const ghToken = readHostCmd("GH_TOKEN", "gh", ["auth", "token"]);
+const ghToken = await bench("read gh token", () =>
+  readHostCmd("GH_TOKEN", "gh", ["auth", "token"]));
 
 // Claude Code's OAuth blob lives in the macOS Keychain under
 // "Claude Code-credentials". -w prints the JSON blob. On the guest,
 // /etc/bash.bashrc (staged at provision time) writes it to
 // ~/.claude/.credentials.json on first interactive shell, then unsets
 // the env var.
-const claudeCreds = readHostCmd("Claude Code credentials", "security", [
-  "find-generic-password",
-  "-s",
-  "Claude Code-credentials",
-  "-w",
-]);
+const claudeCreds = await bench("read claude creds", () =>
+  readHostCmd("Claude Code credentials", "security", [
+    "find-generic-password",
+    "-s",
+    "Claude Code-credentials",
+    "-w",
+  ]));
 
 // ~/.claude.json holds the identity slice (userID, oauthAccount,
 // hasCompletedOnboarding). Recent claude-code builds refuse to start an
@@ -149,7 +198,7 @@ function readHostClaudeAccount(): string {
   }
   return JSON.stringify(slice);
 }
-const claudeAccountJson = readHostClaudeAccount();
+const claudeAccountJson = await bench("read claude account", () => readHostClaudeAccount());
 
 // Use MACHINEN_-prefixed names so the OLD baked /etc/profile.d snippet
 // in pre-fix images doesn't see them — it consumed `CLAUDE_*` and
@@ -322,19 +371,30 @@ const bootstrap = [
     "runuser -m -u dev -- bash /home/dev/.machinen-dev-bootstrap.sh",
 ].join("\n");
 
-const vm = await boot({
-  kernel: join(ASSETS, "Image-arm64"),
-  dtb: join(ASSETS, "virt-arm64.dtb"),
-  image: IMAGE,
-  liveMounts: [{ host: HERE, guest: "/mnt/workspace", mode: "rw" }],
-  cmd: ["/bin/bash", "-lc", bootstrap],
-  env: secretEnv,
-  vmmEnv: {
-    MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)),
-    MACHINEN_VSOCK: `in:1978:${execUdsPath},in:1974:${winsizeUdsPath}`,
-  },
-  timeoutMs: null,
-});
+const vm = await bench("vm boot", () =>
+  boot({
+    kernel: join(ASSETS, "Image-arm64"),
+    dtb: join(ASSETS, "virt-arm64.dtb"),
+    image: IMAGE,
+    liveMounts: [{ host: HERE, guest: "/mnt/workspace", mode: "rw" }],
+    cmd: ["/bin/bash", "-lc", bootstrap],
+    env: secretEnv,
+    vmmEnv: {
+      MACHINEN_RAM_BYTES: String(ramForImage(IMAGE)),
+      MACHINEN_VSOCK: `in:1978:${execUdsPath},in:1974:${winsizeUdsPath}`,
+    },
+    timeoutMs: null,
+    // Surface the runtime's per-phase boot timeline (#233). Prints
+    // once when the VMM's first stderr byte arrives — fits the "show
+    // what the boot is doing" sidebar slot. Console bytes still flow
+    // through the stdout/stderr pipes wired below, so we don't need
+    // to forward chunk events here.
+    onLog: (evt) => {
+      if (evt.source === "phase") {
+        renderPhaseBlock(evt);
+      }
+    },
+  }));
 
 // Wire host <-> guest stdio FIRST. Anything that blocks before this
 // (e.g. the winsize connect below) eats kernel boot output and any


### PR DESCRIPTION
## Summary

Three layered optimizations on the `pnpm provision` -> `pnpm vm` dev loop, all surfaced via the new `PhaseLogEvent` instrumentation. Numbers are end-to-end, force-rebuild + cold cache, on the dev rootfs (494 MB tarball, ~2 GiB unpacked).

| Stage | `pnpm vm` cold boot | `rootdisk-materialize` | `initramfs-pack.image-config-read` |
|---|---|---|---|
| Baseline | **11.5s** | 11.4s (tar-extract 5.6s + mke2fs 4.8s) | 1.1s |
| + `<out>.img` prebake sibling | 1.4s | 196ms (reflink 3ms) | 1.1s |
| + `warmImageConfigCache` | **232ms** | 197ms | **0ms** |

Provision goes 78.3s -> 79.4s (one extra mke2fs pass; the `.img` is sparse, ~1.3 GB on disk). Warm boots are unchanged (~440ms).

## Changes

**Runtime instrumentation**
- `LogEvent` is now `ChunkLogEvent | PhaseLogEvent` (discriminated union); new `PhaseLogEvent { source: \"phase\", kind, phases, totalMs }`.
- `PhaseTimer.toEvent(kind, totalMs?)` snapshots an immutable copy.
- `boot()` and `provision()` emit a `phase` event via `onLog` alongside the existing `debug` flush. `provision()` gains its own `PhaseTimer` covering `rootdisk-prep`, `boot`, `install`, `tar-to-disk`, `poweroff-wait`, `repack-targz` (with `disk-tar-extract`, `targz`, `prebake.mke2fs` sub-phases).
- `ensureRootfsImage`, `synthesizeAndPackBundle` accept an `onPhase` callback for sub-phase mapping (`rootdisk-materialize.sha256`, `.e2fsck`, `.tar-extract`, `.mke2fs`, `.gunzip-prebake`, `.reflink-prebake`, `.reflink`; `initramfs-pack.image-config-read`, `.cpio-write`).

**Prebake sibling**
- `provision()` emits `<out>.img` next to `<out>.tar.gz`. `siblingPrebakePath` now prefers the uncompressed form (reflink into cache via APFS `clonefile`, ~3ms) and falls back to the gzipped `<out>.img.gz` form release builds ship.

**Image-config cache pre-warm**
- New `warmImageConfigCache(imagePath, config)` exported from `@machinen/runtime`. `provision()` calls it after writing the tarball with the exact bytes baked into `./machinen-config.json`, so the next `boot()` skips the slow `tar -xzOf`.

**Race fix**
- `ensureRootfsImage` cache-hit path used to `unlinkSync(imgPath)` on the wipe branches. Concurrent callers holding `imgPath` as a returned cache-hit value got ENOENT during `reflinkCopy`. The atomic `renameSync` at the end of materialize / prebake already replaces the file safely; the eager unlinkSync was redundant. Surfaced when the integration tests in `provision.test.ts`, `exec.test.ts`, `ping.test.ts` ran in parallel against `release-assets/rootfs-debian-arm64.tar.gz`.

**Host scripts** (`provision.ts`, `vm.ts`)
- `renderPhaseBlock()` consumes `phase` events and prints runtime-phase tables (with dot-separated sub-phases indented) under the existing summary block.

## Test plan

- [x] `npx vitest run` -- 390 pass + 1 pre-existing fixture skip (`boot.test.ts` integration test wants a fixture we don't have locally; not introduced here)
- [x] `npx tsgo --noEmit` clean
- [x] `npx oxlint --deny-warnings` clean
- [x] `npx oxfmt --check` clean
- [x] `pnpm provision --force` end-to-end: `.img` sibling lands at `~/.cache/machinen/machinen/app.img`; image-config cache file lands at `~/.cache/machinen/image-config/`; runtime-phase tables render correctly
- [x] `pnpm vm` against wiped rootfs cache + present prebake + warm image-config: total boot 232ms; `rootdisk-materialize.reflink-prebake` 3ms; `initramfs-pack.image-config-read` 0ms
- [x] `pnpm vm` against warm rootfs cache: same timings as before this PR (sha256 + e2fsck + reflink, ~440ms)
- [x] New regression tests: `siblingPrebakePath` prefers uncompressed; `warmImageConfigCache` round-trips both positive and `null` configs; cache-hit-no-marker test updated to reflect race-safe contract
- [ ] CI: agent-ci workflows
- [ ] CI: smoke-tests
