### PR TITLE
fix(microvm): make Linux/KVM smoke pass — vsock IRQ-line race + virtio-net wiring

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -682,11 +682,19 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
                     hvf.Gic.setSpi(virtio_blk2_irq, @atomicLoad(u32, &d.interrupt_status, .acquire) != 0) catch {};
                 } else if (vsock_dev_ptr != null and vsock_dev_ptr.?.handles(info.ipa)) {
                     const d = vsock_dev_ptr.?;
+                    // The vCPU side of (RMW interrupt_status + setSpi)
+                    // must serialise against the bridge poll thread's
+                    // same pair. Apple's hv_gic_set_spi appears to
+                    // absorb the race in practice, but the underlying
+                    // hazard is the same as on KVM (where it bites
+                    // hard) — taking the bridge lock here makes the
+                    // semantics identical across backends and removes
+                    // a latent footgun. handleTxChain assumes the
+                    // caller holds bridge.mu; see its docstring.
+                    if (vsock_bridge_opt) |b| b.mu.lock();
+                    defer if (vsock_bridge_opt) |b| b.mu.unlock();
                     if (info.is_write) {
                         const value = try info.readSource(vcpu);
-                        // TX notify runs on the vCPU thread and shares
-                        // the bridge's connection table with the bridge
-                        // poll thread; the handler takes the mutex.
                         d.write(info.ipa, value);
                     } else if (info.srt != 31) {
                         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -36,10 +36,13 @@ const pl011_mod = @import("pl011.zig");
 const virtio = @import("virtio.zig");
 const blk_mod = @import("blk.zig");
 const vsock_mod = @import("vsock.zig");
+const net_mod = @import("net_socket.zig");
 
 // Guest-physical bases. Same MMIO layout as HVF (see boot_hvf.zig
 // for the slot layout doc) so the shared `virt.dts` works for both
 // backends.
+const virtio_net_base: u64 = 0x0A00_0000;
+const virtio_net_size: u64 = 0x200;
 const virtio_blk_base: u64 = 0x0A00_0200;
 const virtio_blk_size: u64 = 0x200;
 const virtio_vsock_base: u64 = 0x0A00_0400;
@@ -180,6 +183,13 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // never reaching the guest after the kernel writes QueueNotify.
     const pl011_irq: u32 = kvm.irqSpi(1);
 
+    // virtio-net (#197). Slot 0 → SPI #16 → eth0 in the guest. Off
+    // by default; the runtime sets `MACHINEN_NET_SOCKET` to a UDS
+    // path that gvproxy is listening on when the guest needs network
+    // (artifact-cache / fnm fetch / outbound HTTP). Same wire protocol
+    // as HVF: 4-byte length prefix per frame.
+    const virtio_net_irq: u32 = kvm.irqSpi(16);
+
     // virtio-blk (#114). Two slots, mirroring boot_hvf.zig:
     //   slot 1 → SPI #17 → /dev/vda — rootdisk preferred, else disk.
     //   slot 3 → SPI #19 → /dev/vdb — scratch when both are present.
@@ -236,6 +246,59 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         }
     }
     const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
+
+    // virtio-net (#197). Slot 0; gvproxy backs RX/TX over a UDS
+    // pointed at by `MACHINEN_NET_SOCKET`. Without that env (or
+    // with a connect failure), the device still exists in the MMIO
+    // window — the kernel binds a virtio-net driver to it — but
+    // RX/TX go nowhere, so eth0 stays link-down. That matches the
+    // pre-#197 behaviour where the slot returned zeros.
+    const virtio_mac = [_]u8{ 0x02, 0xDE, 0xAD, 0xBE, 0xEF, 0x01 };
+    var netdev = virtio.Device{
+        .base = virtio_net_base,
+        .size = virtio_net_size,
+        .id = .net,
+        // VIRTIO_F_VERSION_1 (bit 32) | VIRTIO_NET_F_MAC (bit 5).
+        .features = (1 << 32) | (1 << 5),
+        .config = &virtio_mac,
+        .ram = ram,
+        .ram_base = cfg.ram_base,
+    };
+    const net_inst: ?*net_mod.NetSocket = blk: {
+        const env = getenv("MACHINEN_NET_SOCKET") orelse {
+            break :blk null;
+        };
+        const path = std.mem.span(env);
+        if (path.len == 0) break :blk null;
+        break :blk net_mod.NetSocket.connect(gpa, &netdev, .{ .socket_path = path }) catch |err| {
+            std.debug.print("net: connect to {s} failed: {s} — continuing without network\n", .{ path, @errorName(err) });
+            break :blk null;
+        };
+    };
+    defer if (net_inst) |n| n.destroy();
+    var net_irq_ctx = NetIrqCtx{ .vm = &vm, .irq = virtio_net_irq };
+    if (net_inst) |n| {
+        // TX: every guest-emitted frame goes through NetSocket.input
+        // → gvproxy. The kernel's notify() drains the TX avail queue
+        // and calls tx_handler per frame (with the 12-byte virtio-net
+        // header already stripped by virtio.zig::walkAndEmit).
+        netdev.tx_handler = &onNetTx;
+        netdev.tx_ctx = @ptrCast(n);
+        // RX: NetSocket's rxLoop calls on_rx after each injectRx,
+        // both under `n.irq_mu`. The vCPU's net-MMIO handler in
+        // handleMmio takes the same mutex, so the (RMW + setIrq)
+        // pairs serialise across the two threads — without this,
+        // the bridge thread's setIrq(1) for an RX frame can be
+        // overridden by a stale vCPU setIrq(0).
+        n.on_rx = &onNetIrq;
+        n.on_rx_ctx = @ptrCast(&net_irq_ctx);
+    }
+    // Always hand the netdev to handleMmio so the kernel's probe
+    // of slot 0 finds a valid virtio-net device and binds the
+    // driver — even when no gvproxy backend is connected. eth0
+    // then comes up but has no link, which is exactly what should
+    // happen if MACHINEN_NET_SOCKET wasn't set.
+    const netdev_ptr: *virtio.Device = &netdev;
 
     // virtio-vsock (#44). Off by default; the runtime sets MACHINEN_VSOCK
     // when it wants the guest exec/fuse agents to be reachable. Same
@@ -315,7 +378,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         switch (reason) {
             .mmio => {
                 const ev = vcpu.mmioExit();
-                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq, vsock_dev_ptr_run, virtio_vsock_irq, vsock_bridge_opt);
+                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, netdev_ptr, virtio_net_irq, net_inst, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq, vsock_dev_ptr_run, virtio_vsock_irq, vsock_bridge_opt);
             },
             .system_event => {
                 const ev = vcpu.systemEventExit();
@@ -357,6 +420,9 @@ fn handleMmio(
     uart: *pl011_mod.Pl011,
     ev: kvm.MmioExit,
     pl011_irq: u32,
+    netdev: *virtio.Device,
+    virtio_net_irq: u32,
+    net_inst: ?*net_mod.NetSocket,
     blkdev: ?*virtio.Device,
     virtio_blk_irq: u32,
     blk2dev: ?*virtio.Device,
@@ -379,6 +445,24 @@ fn handleMmio(
             vcpu.writeMmioReadData(val, ev.len);
         }
         vm.setIrq(pl011_irq, if (uart.irqAsserted()) 1 else 0) catch {};
+        return;
+    }
+    if (netdev.handles(ev.phys_addr)) {
+        // Same race / serialisation story as vsock below: the RX
+        // thread inside NetSocket sets interrupt_status and asserts
+        // the SPI line under `n.irq_mu`; we take the same mutex so
+        // our snapshot-based setIrq can't override the bridge's.
+        // No-op when `net_inst` is null (no gvproxy backend) — there
+        // is no second thread to race against, and the kernel still
+        // sees a valid virtio-net device with link-down.
+        if (net_inst) |n| n.lockIrq();
+        defer if (net_inst) |n| n.unlockIrq();
+        if (ev.is_write != 0) {
+            netdev.write(ev.phys_addr, mmioReadValue(ev));
+        } else {
+            vcpu.writeMmioReadData(netdev.read(ev.phys_addr), ev.len);
+        }
+        vm.setIrq(virtio_net_irq, if (@atomicLoad(u32, &netdev.interrupt_status, .acquire) != 0) 1 else 0) catch {};
         return;
     }
     if (blkdev) |d| {
@@ -513,6 +597,30 @@ pub const VsockIrqCtx = struct {
 fn onVsockIrq(ctx: ?*anyopaque) void {
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
     c.vm.setIrq(c.irq, 1) catch {};
+}
+
+/// Same shape as VsockIrqCtx, but for the virtio-net SPI. NetSocket's
+/// rxLoop calls `onNetIrq` after each frame it injects, with
+/// `n.irq_mu` already held — we just pulse the line.
+pub const NetIrqCtx = struct {
+    vm: *kvm.Vm,
+    irq: u32,
+};
+
+fn onNetIrq(ctx: ?*anyopaque) void {
+    const c: *NetIrqCtx = @ptrCast(@alignCast(ctx.?));
+    c.vm.setIrq(c.irq, 1) catch {};
+}
+
+/// Pump a guest-emitted ethernet frame through to gvproxy. Called
+/// from `virtio.Device.notify()` on the vCPU thread when the kernel
+/// kicks the TX queue. The 12-byte virtio-net header has already
+/// been stripped by `walkAndEmit`, so we just hand the bare ethernet
+/// frame to NetSocket.input which prepends the 4-byte length prefix
+/// and writes to the gvproxy UDS.
+fn onNetTx(ctx: ?*anyopaque, frame: []const u8) void {
+    const n: *net_mod.NetSocket = @ptrCast(@alignCast(ctx.?));
+    n.input(frame);
 }
 
 // arm64 Linux kernel Image header — same parser as hvf.zig has;

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -315,7 +315,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         switch (reason) {
             .mmio => {
                 const ev = vcpu.mmioExit();
-                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq, vsock_dev_ptr_run, virtio_vsock_irq);
+                try handleMmio(gpa, &vm, &vcpu, &uart, ev, pl011_irq, blkdev_ptr, virtio_blk_irq, blk2dev_ptr, virtio_blk2_irq, vsock_dev_ptr_run, virtio_vsock_irq, vsock_bridge_opt);
             },
             .system_event => {
                 const ev = vcpu.systemEventExit();
@@ -363,6 +363,7 @@ fn handleMmio(
     virtio_blk2_irq: u32,
     vsockdev: ?*virtio.Device,
     virtio_vsock_irq: u32,
+    vsock_bridge: ?*vsock_mod.Bridge,
 ) !void {
     if (uart.handles(ev.phys_addr)) {
         if (ev.is_write != 0) {
@@ -404,10 +405,23 @@ fn handleMmio(
     }
     if (vsockdev) |d| {
         if (d.handles(ev.phys_addr)) {
+            // The vCPU side of (RMW interrupt_status + setIrq) must
+            // serialise against the bridge poll thread's same pair.
+            // Without this, the bridge's setIrq(1) — issued the
+            // moment it injects an RX packet — can be overridden by
+            // a stale setIrq(0) we computed before the bridge's RMW
+            // and only got around to syscalling now. Symptom: guest
+            // never sees the CONNECT RESPONSE, fuse-agent's dial
+            // wedges, T3/T5/N2/S* all fail deterministically on KVM.
+            // Apple's hv_gic_set_spi happens to absorb this race;
+            // KVM_IRQ_LINE doesn't, which is why HVF passes smoke
+            // and KVM doesn't until this lock lands.
+            if (vsock_bridge) |b| b.mu.lock();
+            defer if (vsock_bridge) |b| b.mu.unlock();
             if (ev.is_write != 0) {
-                // TX notify runs on the vCPU thread and shares the
-                // bridge's connection table with the bridge poll
-                // thread; the handler takes the mutex.
+                // TX notify runs on the vCPU thread and goes through
+                // notify() → handleTxChain. handleTxChain assumes the
+                // caller holds bridge.mu — see its docstring.
                 d.write(ev.phys_addr, mmioReadValue(ev));
             } else {
                 vcpu.writeMmioReadData(d.read(ev.phys_addr), ev.len);

--- a/packages/microvm/src/net_socket.zig
+++ b/packages/microvm/src/net_socket.zig
@@ -29,34 +29,47 @@ const pl011 = @import("pl011.zig"); // for the shared PthreadMutex shim
 const assert = std.debug.assert;
 
 comptime {
-    if (builtin.os.tag != .macos) {
-        @compileError("net_socket.zig targets macOS (matches boot_hvf.zig)");
+    // sockaddr_un layout the kernel expects:
+    //   macOS: { u8 sun_len; u8 sun_family; char[104] sun_path; } (106B)
+    //   Linux: { u16 sun_family; char[108] sun_path; }            (110B)
+    // A mismatch would silently truncate the path during connect()
+    // and the socket dial would land somewhere else (or fail).
+    if (builtin.os.tag == .macos) {
+        assert(@sizeOf(sockaddr_un) == 106);
+        assert(@offsetOf(sockaddr_un, "sun_len") == 0);
+        assert(@offsetOf(sockaddr_un, "sun_family") == 1);
+        assert(@offsetOf(sockaddr_un, "sun_path") == 2);
+    } else {
+        assert(@sizeOf(sockaddr_un) == 110);
+        assert(@offsetOf(sockaddr_un, "sun_family") == 0);
+        assert(@offsetOf(sockaddr_un, "sun_path") == 2);
     }
-    // sockaddr_un layout the kernel expects (macOS): sun_len, sun_family,
-    // sun_path[104]. A mismatch would silently truncate the path during
-    // connect() and the socket dial would land somewhere else (or fail).
-    assert(@sizeOf(sockaddr_un) == 106);
-    assert(@offsetOf(sockaddr_un, "sun_len") == 0);
-    assert(@offsetOf(sockaddr_un, "sun_family") == 1);
-    assert(@offsetOf(sockaddr_un, "sun_path") == 2);
     // The qemu-netdev wire format prefixes every frame with a 4-byte
     // big-endian length; both writeInt sites below depend on this.
     assert(AF_UNIX == 1);
     assert(SHUT_RDWR == 2);
 }
 
-// ---- libc + sockaddr_un (macOS layout: u8 sun_len, u8 sun_family,
-// char[104] sun_path). sa_family_t on macOS is u8. ------------------
+// ---- libc + sockaddr_un. Layouts differ between platforms:
+//   macOS: { u8 sun_len; u8 sun_family; char[104] sun_path; }
+//          (sa_family_t == u8; address length is wire-encoded)
+//   Linux: { u16 sun_family; char[108] sun_path; }
+//          (no sun_len; sa_family_t == u16)
+// AF_UNIX is 1 on both. SOCK_STREAM is 1 on both. EINTR is 4 on
+// both. SHUT_RDWR is 2 on both. ------------------------------------
 
 const AF_UNIX: c_int = 1;
 const SOCK_STREAM: c_int = 1;
 const SHUT_RDWR: c_int = 2;
 const EINTR: c_int = 4;
 
-const sockaddr_un = extern struct {
+const sockaddr_un = if (builtin.os.tag == .macos) extern struct {
     sun_len: u8,
     sun_family: u8,
     sun_path: [104]u8,
+} else extern struct {
+    sun_family: u16,
+    sun_path: [108]u8,
 };
 
 extern "c" fn socket(domain: c_int, typ: c_int, protocol: c_int) c_int;
@@ -71,10 +84,11 @@ extern "c" fn shutdown(fd: c_int, how: c_int) c_int;
 extern "c" fn read(fd: c_int, buf: [*]u8, count: usize) isize;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
 
-// macOS errno is a thread-local reached via __error().
+// errno: macOS uses __error(), glibc uses __errno_location().
 extern "c" fn __error() *c_int;
+extern "c" fn __errno_location() *c_int;
 fn errno() c_int {
-    return __error().*;
+    return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
 }
 
 // ---- public API ----------------------------------------------------
@@ -104,6 +118,17 @@ pub const NetSocket = struct {
     /// its length prefix with someone else's payload bytes. pthread
     /// shim because std.Thread.Mutex moved under std.Io in Zig 0.16.
     tx_mutex: pl011.PthreadMutex = .{},
+    /// Serialises the (RMW interrupt_status + setIrq) pair so the
+    /// RX thread's "I just injected, raise the line" can't be
+    /// overridden by the vCPU thread's "post-MMIO snapshot says
+    /// line=0". Taken inside `rxLoop` around `injectRx + on_rx`,
+    /// and by the vCPU's net-MMIO handler around its read/write +
+    /// setIrq via `lockIrq` / `unlockIrq` below. Same shape as the
+    /// vsock Bridge mutex; without it, KVM_IRQ_LINE delivery loses
+    /// the rising edge for RX frames whenever the vCPU is mid-MMIO
+    /// at the moment the bridge thread injects. See #231 / #234 /
+    /// the vsock-IRQ commit (PR #235) for the analogous race.
+    irq_mu: pl011.PthreadMutex = .{},
 
     /// Dial gvproxy and spawn the RX thread. Heap-allocated because
     /// the RX thread and `on_rx_ctx` callers keep a stable pointer.
@@ -119,12 +144,22 @@ pub const NetSocket = struct {
         assert(fd >= 0);
         errdefer _ = close(fd);
 
-        var addr: sockaddr_un = .{ .sun_len = 0, .sun_family = AF_UNIX, .sun_path = @splat(0) };
+        // macOS: 1-byte sun_len + 1-byte sun_family before sun_path
+        //        (header is 2 bytes). Address length is wire-encoded
+        //        in sun_len.
+        // Linux: 2-byte sun_family before sun_path (header is 2 bytes).
+        //        sun_len doesn't exist; addrlen is what the kernel uses.
+        // The total header size happens to be 2 bytes on both, so the
+        // addrlen formula is the same — only the per-field assignments
+        // differ.
+        var addr: sockaddr_un = if (builtin.os.tag == .macos)
+            .{ .sun_len = 0, .sun_family = AF_UNIX, .sun_path = @splat(0) }
+        else
+            .{ .sun_family = AF_UNIX, .sun_path = @splat(0) };
         @memcpy(addr.sun_path[0..cfg.socket_path.len], cfg.socket_path);
-        // Total address length: 2 bytes (sun_len + sun_family) + path + NUL.
         const addrlen: u32 = @intCast(2 + cfg.socket_path.len + 1);
         assert(addrlen <= @sizeOf(sockaddr_un));
-        addr.sun_len = @intCast(addrlen);
+        if (builtin.os.tag == .macos) addr.sun_len = @intCast(addrlen);
 
         if (c_connect(fd, @ptrCast(&addr), addrlen) < 0) return error.ConnectFailed;
 
@@ -180,9 +215,20 @@ pub const NetSocket = struct {
 
             if (readAll(self.fd, buf[0..len]) != 0) return;
 
+            self.irq_mu.lock();
             _ = self.netdev.injectRx(buf[0..len]);
             if (self.on_rx) |cb| cb(self.on_rx_ctx);
+            self.irq_mu.unlock();
         }
+    }
+
+    /// Take/release `irq_mu` for the vCPU's net-MMIO handler. See
+    /// the field doc above for why.
+    pub fn lockIrq(self: *NetSocket) void {
+        self.irq_mu.lock();
+    }
+    pub fn unlockIrq(self: *NetSocket) void {
+        self.irq_mu.unlock();
     }
 };
 

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -36,14 +36,34 @@
 //!  40   fwd_cnt   u32  — bytes we've consumed (for credit update)
 
 const std = @import("std");
+const builtin = @import("builtin");
 const virtio = @import("virtio.zig");
 const assert = std.debug.assert;
 
-/// pthread-backed mutex. Zig 0.16 tucked std.Thread.Mutex behind an Io
-/// context; we already use this pattern in hvf.Pl011.
+/// Platform-sized pthread mutex. Zig 0.16 moved `std.Thread.Mutex`
+/// under `std.Io` (it now requires an Io context), so we bind
+/// pthread directly rather than take on that dependency just for
+/// a lock. macOS layout: 64 bytes with a `sig` magic. Linux glibc
+/// layout: 40 bytes, all-zeros == `PTHREAD_MUTEX_INITIALIZER`.
+///
+/// Mirrors `pl011.PthreadMutex`. The previous form here hardcoded
+/// the macOS magic into a 64-byte struct and relied on the bridge
+/// thread being the only caller — on Linux that magic put glibc's
+/// pthread_mutex_lock into an undefined state so the bridge silently
+/// hung, but no other thread tried to take the same mutex so nothing
+/// else broke. The vsock-MMIO lock-take in boot_kvm.zig is the first
+/// place the vCPU thread tries to acquire it, which is what surfaced
+/// the bug as a kernel hang at earlycon.
 const PthreadMutex = extern struct {
-    sig: c_long = 0x32AAABA7, // macOS PTHREAD_MUTEX_INITIALIZER magic
-    opaque_bytes: [56]u8 = @splat(0),
+    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macosInit() else @splat(0),
+
+    fn macosInit() [64]u8 {
+        var out: [64]u8 = @splat(0);
+        // sig = 0x32AAABA7 (macOS PTHREAD_MUTEX_INITIALIZER magic).
+        const sig: u64 = 0x32AAABA7;
+        std.mem.writeInt(u64, out[0..8], sig, .little);
+        return out;
+    }
 
     extern "c" fn pthread_mutex_lock(m: *PthreadMutex) c_int;
     extern "c" fn pthread_mutex_unlock(m: *PthreadMutex) c_int;
@@ -1060,6 +1080,14 @@ pub const Bridge = struct {
 
     /// Called from the vCPU thread when the guest kicks the TX queue.
     /// Signature matches virtio.Device.request_handler.
+    ///
+    /// PRECONDITION: caller holds `self.mu`. The vCPU's vsock-MMIO
+    /// handler must lock the bridge mutex around the whole MMIO so the
+    /// (RMW interrupt_status + setIrq) pair can't interleave with the
+    /// bridge poll thread's own pair — see the `Why locking the bridge
+    /// mutex around vsock MMIO` doc on `Bridge`. We rely on that
+    /// outer lock instead of taking it again here (PthreadMutex isn't
+    /// reentrant).
     pub fn handleTxChain(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
         assert(ctx != null);
         assert(q_idx < virtio.max_queues);
@@ -1079,8 +1107,6 @@ pub const Bridge = struct {
         const total_len: u32 = @as(u32, @intCast(header_size)) + @as(u32, @intCast(pkt.body.len));
         dev.queuePushUsed(q_idx, head, total_len);
 
-        self.mu.lock();
-        defer self.mu.unlock();
         self.dispatchGuestPacket(pkt.hdr, pkt.body);
     }
 


### PR DESCRIPTION
## Summary

Makes `pnpm smoke-tests` pass end-to-end on Linux/KVM (friend@100.126.46.90, Ampere arm64, Ubuntu 24.04, kernel 6.17). Previously every vsock-dependent phase silently skipped (#234), and once the smoke probe was fixed those phases failed deterministically (`fuse-agent dial wedges`, `exec-agent unreachable`, snapshot/fork unable to talk to the guest). The two underlying bugs:

1. **vsock IRQ-line race + dead bridge mutex on Linux.** `Device.interrupt_status` is touched by the bridge poll thread and the vCPU thread; the atomic accesses from #231 keep the *bit* coherent but the *line* the kernel sees still races — the bridge's `setIrq(1)` issued after injecting an RX packet can be overridden by a stale snapshot-based `setIrq(0)` from the vCPU's post-MMIO handler. Apple's `hv_gic_set_spi` happens to absorb this; KVM's `KVM_IRQ_LINE` doesn't. On top of that, `vsock.zig`'s local `PthreadMutex` shim hardcoded the macOS `PTHREAD_MUTEX_INITIALIZER` magic, which on Linux glibc puts `pthread_mutex_lock` into undefined state — the bridge poll thread silently hung in its own mutex acquisition. Nothing else cared because no second thread tried to take the same mutex; the vCPU starts taking it in this PR.

2. **virtio-net not wired on KVM.** #225 / #227 ported virtio-blk and virtio-vsock to `boot_kvm.zig` but left slot 0 (net) returning zeros. `machinen-netup: eth0 did not appear` → every gvproxy-mediated HTTP fetch (C1/C2 fnm cache, S* artifact path in app workloads) errored.

## Solution

### Commit 1 — `serialise vsock IRQ-line update via bridge mutex; cross-platform PthreadMutex`

* `boot_kvm.zig` and `boot_hvf.zig`: take `bridge.mu` around the vCPU's whole vsock-MMIO handling (read/write + setIrq), so the (RMW + setIrq) pair on the vCPU thread can't interleave with the bridge poll thread's pair.
* `vsock.zig::Bridge.handleTxChain`: now assumes the caller holds `self.mu` (vCPU's MMIO handler now provides it) — the inner lock-take is removed and the docstring documents the new precondition.
* `vsock.zig::PthreadMutex`: replaced the macOS-only shim with the cross-platform shape that `pl011.PthreadMutex` already uses — 64-byte struct, macOS magic written conditionally on `builtin.os.tag == .macos`, all-zeros on Linux.

### Commit 2 — `wire virtio-net into the KVM backend`

* Slot 0 → SPI #16 → eth0. Always creates a `virtio.Device{ .id = .net, ... }` so the guest binds a driver even with no backend. With `MACHINEN_NET_SOCKET` set, dials gvproxy via `net_mod.NetSocket.connect` and wires TX (`onNetTx` → `n.input` → 4-byte-length-prefixed UDS) and RX (`onNetIrq` → `vm.setIrq` raises the SPI).
* Net MMIO dispatch in `handleMmio` takes `n.irq_mu` around its read/write + setIrq — same race, same fix. `NetSocket.rxLoop` already takes `irq_mu` around `injectRx + on_rx`.
* `net_socket.zig` was gated to macOS via top-of-file `@compileError`. Made cross-platform: conditional `sockaddr_un` (macOS has `sun_len`, Linux glibc doesn't), conditional `errno()` (`__error()` vs `__errno_location()`).

## Stacking

Depends on:
- **#231** — `interrupt_status` atomics (commit `ab159c3` is the base of this branch).
- **#234** — pipefail-safe smoke probes (cherry-picked onto this branch as `3f9c299`; without it the smoke run on Linux silently skips every vsock-dependent phase and the bug class never surfaces).

This branch contains those two commits as base, then the two new commits above.

## Test plan

- [x] `cd packages/microvm && zig build test` → 45/45 pass.
- [x] `npx agent-ci run --all -q -p` on darwin → 4/4 workflows pass.
- [x] `npx vitest run` on darwin → 375/375 code tests pass (3 fixture-missing skips on the worktree).
- [x] `pnpm smoke-tests` on darwin/HVF → V1–V8, T1–T5, N1–N5, P1–P3, C1–C2, S1–S3 all pass.
- [x] `pnpm smoke-tests` on **friend@100.126.46.90 (Ampere arm64 KVM)** → V1–V8, T1–T5, N1–N5, P1–P3, **C1, C2, S1, S2, S3** all pass. Same green as darwin.
- [ ] Manual soak: weeks of dev-VM usage on Apple Silicon and KVM hosts without silent vsock wedges (tracked in #230).
