### PR TITLE
chore(microvm): TigerStyle assertions for KVM + HVF backends

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -16,6 +16,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const assert = std.debug.assert;
+
 comptime {
     if (builtin.os.tag != .macos) {
         @compileError("boot_hvf.zig only builds on macOS (uses HVF)");
@@ -46,6 +48,19 @@ const virtio_vsock_base: u64 = 0x0A00_0400;
 const virtio_vsock_size: u64 = 0x200;
 const virtio_blk2_base: u64 = 0x0A00_0600;
 const virtio_blk2_size: u64 = 0x200;
+
+comptime {
+    // virtio-mmio slot layout — must stay byte-identical to virt.dts
+    // and to boot_kvm.zig's matching constants. Drift here means the
+    // kernel probes the wrong window and devices never bind.
+    assert(virtio_net_size == 0x200);
+    assert(virtio_blk_size == 0x200);
+    assert(virtio_vsock_size == 0x200);
+    assert(virtio_blk2_size == 0x200);
+    assert(virtio_blk_base == virtio_net_base + virtio_net_size);
+    assert(virtio_vsock_base == virtio_blk_base + virtio_blk_size);
+    assert(virtio_blk2_base == virtio_vsock_base + virtio_vsock_size);
+}
 
 pub const Error = error{
     FixtureMissing,
@@ -113,7 +128,9 @@ fn debugEnabled() bool {
 /// kernel spends real wall-clock walking the tail. Patching the end
 /// pointer to match the actual cpio eliminates that.
 fn patchDtbInitrdEnd(dtb: []u8, new_end: u32) !void {
+    assert(dtb.len > 0);
     if (dtb.len < 40) return error.DtbTooSmall;
+    assert(dtb.len >= 40);
 
     const magic = std.mem.readInt(u32, dtb[0..4], .big);
     if (magic != 0xd00dfeed) return error.DtbBadMagic;
@@ -124,6 +141,7 @@ fn patchDtbInitrdEnd(dtb: []u8, new_end: u32) !void {
 
     if (@as(usize, off_strings) + @as(usize, size_strings) > dtb.len) return error.DtbOutOfBounds;
     if (off_struct > dtb.len) return error.DtbOutOfBounds;
+    assert(size_strings > 0);
 
     // Find "linux,initrd-end" in the strings block; record its offset
     // within that block — the value FDT_PROP entries reference.
@@ -206,18 +224,34 @@ test "patchDtbInitrdEnd round-trips a minimal hand-built DTB" {
 }
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
+    // Caller-supplied layout must satisfy the basic geometry the boot
+    // protocol depends on. These are programmer errors at the call
+    // site, not anything the guest can influence.
+    assert(cfg.kernel_path.len > 0);
+    assert(cfg.dtb_path.len > 0);
+    assert(cfg.ram_size >= 16 * 1024 * 1024);
+    assert(cfg.ram_size % hvf.page_size == 0);
+    assert(cfg.ram_base % hvf.page_size == 0);
+    assert(cfg.dtb_offset % hvf.page_size == 0);
+    assert(cfg.initrd_offset % hvf.page_size == 0);
+    assert(cfg.dtb_offset < cfg.ram_size);
+    assert(cfg.initrd_offset < cfg.ram_size);
+    assert(cfg.max_exits > 0);
+
     // --- load fixture files off disk ------------------------------
     const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     defer gpa.free(kernel);
+    assert(kernel.len > 0);
 
     const dtb = readAll(gpa, cfg.dtb_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     defer gpa.free(dtb);
+    assert(dtb.len > 0);
 
     const img = try hvf.KernelImage.parse(kernel);
 
@@ -234,6 +268,8 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         0,
     );
     defer std.posix.munmap(ram);
+    assert(ram.len == cfg.ram_size);
+    assert(@intFromPtr(ram.ptr) % hvf.page_size == 0);
 
     // copy kernel and DTB into RAM
     @memcpy(ram[img.text_offset..][0..kernel.len], kernel);
@@ -324,11 +360,15 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     // arm64 Linux boot protocol: X0 = physical address of DTB.
     const dtb_phys = cfg.ram_base + cfg.dtb_offset;
+    const entry_phys = cfg.ram_base + img.text_offset;
+    assert(dtb_phys >= cfg.ram_base);
+    assert(entry_phys >= cfg.ram_base);
+    assert(entry_phys < cfg.ram_base + cfg.ram_size);
     try vcpu.setReg(.x0, dtb_phys);
     try vcpu.setReg(.x1, 0);
     try vcpu.setReg(.x2, 0);
     try vcpu.setReg(.x3, 0);
-    try vcpu.setReg(.pc, cfg.ram_base + img.text_offset);
+    try vcpu.setReg(.pc, entry_phys);
 
     // --- run loop -------------------------------------------------
     var uart: hvf.Pl011 = .init;
@@ -484,6 +524,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     //   virtio-mmio: interrupts = <0 16 1>  -> SPI #16
     // The absolute GIC id is `spi.base + <n>`.
     const spi = try hvf.Gic.spiRange();
+    // SPIs start at 32 on ARM GIC; HVF must report at least the four
+    // device IDs we wire up (1, 16, 17, 18, 19) past spi.base.
+    assert(spi.base >= 32);
+    assert(spi.count >= 20);
     const pl011_irq: u32 = spi.base + 1;
     // DTS interrupts = <0 N 1> for each virtio-mmio slot. Slots:
     //   slot 0 → SPI #16 (net)
@@ -775,6 +819,8 @@ pub const NetBridge = struct {
 };
 
 fn onTxFrameBridge(ctx: ?*anyopaque, frame: []const u8) void {
+    assert(ctx != null);
+    assert(frame.len > 0);
     const bridge: *NetBridge = @ptrCast(@alignCast(ctx.?));
     // Still log for smoke tests and diagnostics.
     onTxFrame(@ptrCast(bridge.stats), frame);
@@ -782,7 +828,9 @@ fn onTxFrameBridge(ctx: ?*anyopaque, frame: []const u8) void {
 }
 
 fn onNetRx(ctx: ?*anyopaque) void {
+    assert(ctx != null);
     const bridge: *NetBridge = @ptrCast(@alignCast(ctx.?));
+    assert(bridge.virtio_irq >= 32);
     // Device's interrupt_status was set inside injectRx. Sync the GIC
     // line so the guest sees a pending interrupt.
     hvf.Gic.setSpi(bridge.virtio_irq, true) catch {};
@@ -794,11 +842,14 @@ fn onNetRx(ctx: ?*anyopaque) void {
 pub const VsockIrqCtx = struct { irq: u32 };
 
 fn onVsockIrq(ctx: ?*anyopaque) void {
+    assert(ctx != null);
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
+    assert(c.irq >= 32);
     hvf.Gic.setSpi(c.irq, true) catch {};
 }
 
 fn onTxFrame(ctx: ?*anyopaque, frame: []const u8) void {
+    assert(ctx != null);
     const stats: *TxStats = @ptrCast(@alignCast(ctx.?));
     stats.frames += 1;
     stats.bytes += frame.len;
@@ -848,6 +899,7 @@ fn onTxFrame(ctx: ?*anyopaque, frame: []const u8) void {
 }
 
 fn stdinThreadMain(ctx: *StdinThread) void {
+    assert(ctx.irq >= 32);
     var buf: [256]u8 = undefined;
     while (!ctx.stop.load(.acquire)) {
         const n = read(0, &buf, buf.len);
@@ -856,6 +908,7 @@ fn stdinThreadMain(ctx: *StdinThread) void {
             // it just won't receive any more serial input.
             return;
         }
+        assert(@as(usize, @intCast(n)) <= buf.len);
         ctx.uart.pushRx(ctx.gpa, buf[0..@intCast(n)]) catch return;
         // Assert the IRQ so the vCPU wakes from WFI and services it.
         hvf.Gic.setSpi(ctx.irq, ctx.uart.irqAsserted()) catch {};
@@ -878,6 +931,7 @@ extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+    assert(path.len > 0);
     var path_buf: [4096]u8 = undefined;
     if (path.len >= path_buf.len) return error.NameTooLong;
     @memcpy(path_buf[0..path.len], path);
@@ -886,12 +940,14 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
 
     const fd = open(path_z, O_RDONLY);
     if (fd < 0) return error.OpenFailed;
+    assert(fd >= 0);
     defer _ = close(fd);
 
     const size_i = lseek(fd, 0, SEEK_END);
     if (size_i < 0) return error.SeekFailed;
     _ = lseek(fd, 0, SEEK_SET);
     const size: usize = @intCast(size_i);
+    assert(size > 0);
 
     const buf = try gpa.alloc(u8, size);
     errdefer gpa.free(buf);
@@ -902,6 +958,7 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
         if (n <= 0) return error.ShortRead;
         total += @intCast(n);
     }
+    assert(total == size);
     return buf;
 }
 

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -25,6 +25,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const assert = std.debug.assert;
+
 comptime {
     if (builtin.os.tag != .linux) {
         @compileError("boot_kvm.zig only builds on Linux (uses /dev/kvm)");
@@ -49,6 +51,19 @@ const virtio_vsock_base: u64 = 0x0A00_0400;
 const virtio_vsock_size: u64 = 0x200;
 const virtio_blk2_base: u64 = 0x0A00_0600;
 const virtio_blk2_size: u64 = 0x200;
+
+comptime {
+    // virtio-mmio slot layout — must stay byte-identical to virt.dts.
+    // Drift here means the kernel probes the wrong window and devices
+    // never bind, with no clear runtime signal.
+    assert(virtio_net_size == 0x200);
+    assert(virtio_blk_size == 0x200);
+    assert(virtio_vsock_size == 0x200);
+    assert(virtio_blk2_size == 0x200);
+    assert(virtio_blk_base == virtio_net_base + virtio_net_size);
+    assert(virtio_vsock_base == virtio_blk_base + virtio_blk_size);
+    assert(virtio_blk2_base == virtio_vsock_base + virtio_vsock_size);
+}
 
 pub const Error = error{
     FixtureMissing,
@@ -96,18 +111,35 @@ pub const Result = struct {
 };
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
+    // Caller-supplied layout must satisfy the basic geometry the boot
+    // protocol depends on. These are programmer errors at the call
+    // site, not anything the guest can influence.
+    assert(cfg.kernel_path.len > 0);
+    assert(cfg.dtb_path.len > 0);
+    assert(cfg.ram_size >= 16 * 1024 * 1024);
+    assert(cfg.ram_size % 4096 == 0);
+    assert(cfg.ram_base % 4096 == 0);
+    assert(cfg.dtb_offset % 4096 == 0);
+    assert(cfg.initrd_offset % 4096 == 0);
+    assert(cfg.dtb_offset < cfg.ram_size);
+    assert(cfg.initrd_offset < cfg.ram_size);
+    assert(cfg.gic_dist_addr != cfg.gic_redist_addr);
+    assert(cfg.max_exits > 0);
+
     // --- load fixture files --------------------------------------
     const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     defer gpa.free(kernel);
+    assert(kernel.len > 0);
 
     const dtb = readAll(gpa, cfg.dtb_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     defer gpa.free(dtb);
+    assert(dtb.len > 0);
 
     const img = try KernelImage.parse(kernel);
     if (img.text_offset + kernel.len > cfg.ram_size) return error.KernelTooLarge;
@@ -124,6 +156,8 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     ) catch return error.KvmSetMemoryFailed;
     defer std.posix.munmap(ram_ptr);
     const ram: []u8 = ram_ptr;
+    assert(ram.len == cfg.ram_size);
+    assert(@intFromPtr(ram.ptr) % 4096 == 0);
 
     @memcpy(ram[img.text_offset..][0..kernel.len], kernel);
     @memcpy(ram[cfg.dtb_offset..][0..dtb.len], dtb);
@@ -166,11 +200,15 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     // arm64 boot protocol: X0 = dtb phys addr, PC = kernel entry.
     const dtb_phys = cfg.ram_base + cfg.dtb_offset;
+    const entry_phys = cfg.ram_base + img.text_offset;
+    assert(dtb_phys >= cfg.ram_base);
+    assert(entry_phys >= cfg.ram_base);
+    assert(entry_phys < cfg.ram_base + cfg.ram_size);
     try vcpu.setReg(kvm.REG_X0, dtb_phys);
     try vcpu.setReg(kvm.REG_X1, 0);
     try vcpu.setReg(kvm.REG_X2, 0);
     try vcpu.setReg(kvm.REG_X3, 0);
-    try vcpu.setReg(kvm.REG_PC, cfg.ram_base + img.text_offset);
+    try vcpu.setReg(kvm.REG_PC, entry_phys);
 
     // --- run loop -------------------------------------------------
     var uart = pl011_mod.Pl011.init;
@@ -431,6 +469,17 @@ fn handleMmio(
     virtio_vsock_irq: u32,
     vsock_bridge: ?*vsock_mod.Bridge,
 ) !void {
+    // KVM never emits an MMIO exit with len outside [1,8]; values
+    // outside that mean we read the wrong kvm_run union slot.
+    assert(ev.len >= 1 and ev.len <= 8);
+    assert(ev.is_write <= 1);
+    // SPI encodings must include the SPI type bits — without them
+    // setIrq silently drops doorbells (see kvm.irqSpi docstring).
+    assert(pl011_irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
+    assert(virtio_net_irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
+    assert(virtio_blk_irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
+    assert(virtio_blk2_irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
+    assert(virtio_vsock_irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
     if (uart.handles(ev.phys_addr)) {
         if (ev.is_write != 0) {
             const val = mmioReadValue(ev);
@@ -524,8 +573,10 @@ fn handleMmio(
 /// Pack the up-to-8 little-endian bytes KVM hands us in `mmio.data`
 /// into a u64 the device handlers expect.
 fn mmioReadValue(ev: kvm.MmioExit) u64 {
+    assert(ev.len >= 1 and ev.len <= 8);
     var val: u64 = 0;
     const n = @min(@as(usize, ev.len), 8);
+    assert(n >= 1 and n <= 8);
     for (0..n) |i| {
         val |= @as(u64, ev.data[i]) << @as(u6, @intCast(i * 8));
     }
@@ -533,6 +584,7 @@ fn mmioReadValue(ev: kvm.MmioExit) u64 {
 }
 
 fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+    assert(path.len > 0);
     var path_buf: [4096]u8 = undefined;
     if (path.len >= path_buf.len) return error.NameTooLong;
     @memcpy(path_buf[0..path.len], path);
@@ -541,12 +593,14 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
 
     const fd = hostOpen(path_z, 0, 0);
     if (fd < 0) return error.OpenFailed;
+    assert(fd >= 0);
     defer _ = hostClose(fd);
 
     const size_i = hostLseek(fd, 0, 2);
     if (size_i < 0) return error.SeekFailed;
     _ = hostLseek(fd, 0, 0);
     const size: usize = @intCast(size_i);
+    assert(size > 0);
 
     const buf = try gpa.alloc(u8, size);
     errdefer gpa.free(buf);
@@ -556,6 +610,7 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
         if (n <= 0) return error.ShortRead;
         total += @intCast(n);
     }
+    assert(total == size);
     return buf;
 }
 
@@ -595,7 +650,9 @@ pub const VsockIrqCtx = struct {
 };
 
 fn onVsockIrq(ctx: ?*anyopaque) void {
+    assert(ctx != null);
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
+    assert(c.irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
     c.vm.setIrq(c.irq, 1) catch {};
 }
 
@@ -608,7 +665,9 @@ pub const NetIrqCtx = struct {
 };
 
 fn onNetIrq(ctx: ?*anyopaque) void {
+    assert(ctx != null);
     const c: *NetIrqCtx = @ptrCast(@alignCast(ctx.?));
+    assert(c.irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
     c.vm.setIrq(c.irq, 1) catch {};
 }
 
@@ -619,6 +678,8 @@ fn onNetIrq(ctx: ?*anyopaque) void {
 /// frame to NetSocket.input which prepends the 4-byte length prefix
 /// and writes to the gvproxy UDS.
 fn onNetTx(ctx: ?*anyopaque, frame: []const u8) void {
+    assert(ctx != null);
+    assert(frame.len > 0);
     const n: *net_mod.NetSocket = @ptrCast(@alignCast(ctx.?));
     n.input(frame);
 }
@@ -635,12 +696,16 @@ pub const KernelImage = struct {
     pub const Error = error{ TooSmall, BadMagic };
 
     pub fn parse(bytes: []const u8) KernelImage.Error!KernelImage {
+        assert(bytes.len > 0);
         if (bytes.len < 64) return error.TooSmall;
+        assert(bytes.len >= 0x40);
         const got_magic = std.mem.readInt(u32, bytes[0x38..0x3C], .little);
         if (got_magic != magic) return error.BadMagic;
+        const text_offset = std.mem.readInt(u64, bytes[0x08..0x10], .little);
+        const image_size = std.mem.readInt(u64, bytes[0x10..0x18], .little);
         return .{
-            .text_offset = std.mem.readInt(u64, bytes[0x08..0x10], .little),
-            .image_size = std.mem.readInt(u64, bytes[0x10..0x18], .little),
+            .text_offset = text_offset,
+            .image_size = image_size,
             .bytes = bytes,
         };
     }

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -6,6 +6,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const pl011_mod = @import("pl011.zig");
 
+const assert = std.debug.assert;
+
 comptime {
     if (builtin.os.tag != .macos) {
         @compileError("hvf.zig only builds on macOS");
@@ -67,15 +69,62 @@ pub const Vm = struct {
 
     /// Map host memory into the guest's physical address space.
     pub fn map(_: Vm, host_mem: []align(page_size) u8, guest_phys: u64, flags: MapFlags) Error!void {
+        // HVF requires page-aligned, page-sized regions. Host pointer
+        // alignment is enforced by the slice type; guest_phys + size
+        // alignment are runtime invariants.
+        assert(host_mem.len > 0);
+        assert(host_mem.len % page_size == 0);
+        assert(guest_phys % page_size == 0);
+        // Mapping an unreadable page is a programmer bug — the guest
+        // would trap on the first fetch with no useful diagnostic.
+        assert(flags.read or flags.write or flags.exec);
         try check(c.hv_vm_map(host_mem.ptr, guest_phys, host_mem.len, flags.bits()));
     }
 
     pub fn unmap(_: Vm, guest_phys: u64, size: usize) Error!void {
+        assert(size > 0);
+        assert(size % page_size == 0);
+        assert(guest_phys % page_size == 0);
         try check(c.hv_vm_unmap(guest_phys, size));
     }
 };
 
 pub const page_size = 0x4000; // 16 KiB pages on Apple Silicon arm64
+
+comptime {
+    // Apple Silicon arm64 mandates 16 KiB pages — anything else
+    // means the wrong target was selected for this build.
+    assert(page_size == 0x4000);
+
+    // HVF ABI struct layouts. ExitReason is u32 then ExitException
+    // (24 B, 8-aligned) → 4 B padding → total 32 B for VcpuExit.
+    assert(@sizeOf(ExitException) == 24);
+    assert(@offsetOf(ExitException, "syndrome") == 0);
+    assert(@offsetOf(ExitException, "virtual_address") == 8);
+    assert(@offsetOf(ExitException, "physical_address") == 16);
+    assert(@sizeOf(VcpuExit) == 32);
+    assert(@offsetOf(VcpuExit, "reason") == 0);
+    assert(@offsetOf(VcpuExit, "exception") == 8);
+
+    // Reg enum tags must match hv_reg_t values (X0..X30 contiguous,
+    // then PC=31, FPCR=32, FPSR=33, CPSR=34).
+    assert(@intFromEnum(Reg.x0) == 0);
+    assert(@intFromEnum(Reg.x30) == 30);
+    assert(@intFromEnum(Reg.pc) == 31);
+    assert(@intFromEnum(Reg.cpsr) == 34);
+
+    // ExceptionClass: top 6 bits of ESR_EL2.
+    assert(@intFromEnum(ExceptionClass.hvc_aarch64) == 0x16);
+    assert(@intFromEnum(ExceptionClass.data_abort_lower_el) == 0x24);
+    assert(@intFromEnum(ExceptionClass.brk_aarch64) == 0x3C);
+
+    // PSCI v1.1 function IDs (ARM DEN 0022).
+    assert(@intFromEnum(Psci.Function.version) == 0x84000000);
+    assert(@intFromEnum(Psci.Function.system_off) == 0x84000008);
+    assert(@intFromEnum(Psci.Function.system_reset) == 0x84000009);
+    // SMC64 entry points have the top nibble flipped from 0x8 to 0xC.
+    assert(@intFromEnum(Psci.Function.cpu_on_64) == 0xC4000003);
+}
 
 pub const MapFlags = packed struct {
     read: bool = false,
@@ -202,6 +251,12 @@ pub const Gic = struct {
     };
 
     pub fn enable(cfg: Config) Error!void {
+        // Distributor and redistributor MMIO windows must be distinct
+        // and non-zero; placing them at the same address silently
+        // breaks GIC routing.
+        assert(cfg.distributor_base != 0);
+        assert(cfg.redistributor_base != 0);
+        assert(cfg.distributor_base != cfg.redistributor_base);
         const config = hv_gic_config_create() orelse return error.NoResources;
         try check(hv_gic_config_set_distributor_base(config, cfg.distributor_base));
         try check(hv_gic_config_set_redistributor_base(config, cfg.redistributor_base));
@@ -223,6 +278,7 @@ pub const Gic = struct {
     pub fn redistributorBase(vcpu: Vcpu) Error!u64 {
         var b: u64 = 0;
         try check(hv_gic_get_redistributor_base(vcpu.handle, &b));
+        assert(b != 0);
         return b;
     }
 
@@ -273,6 +329,11 @@ pub const Gic = struct {
     /// on ARM GIC; the DTS number is 0-based within SPIs, so for a
     /// device that says `interrupts = <0 1 4>` call with intid = 33).
     pub fn setSpi(intid: u32, level: bool) Error!void {
+        // SPIs start at 32 on ARM GIC; values below that hit SGI/PPI
+        // ranges and silently drop on hv_gic_set_spi.
+        assert(intid >= 32);
+        // GICv3 caps SPI INTID at 1019 (hardware-defined).
+        assert(intid <= 1019);
         try check(hv_gic_set_spi(intid, level));
     }
 
@@ -385,6 +446,10 @@ pub const DataAbort = struct {
     /// Read the guest register holding the value the guest was storing.
     /// XZR reads as 0. Out-of-range is a bug.
     pub fn readSource(self: DataAbort, vcpu: Vcpu) Error!u64 {
+        // Only meaningful when the syndrome decoded a load/store
+        // operand; otherwise srt is whatever bits happened to land.
+        assert(self.isv);
+        assert(self.srt <= 31);
         if (self.srt == 31) return 0; // XZR
         const reg: Reg = @enumFromInt(@as(u32, self.srt));
         return vcpu.getReg(reg);
@@ -412,12 +477,16 @@ pub const KernelImage = struct {
 
     /// Parse the header. `bytes` is the entire kernel Image file.
     pub fn parse(bytes: []const u8) KernelImage.Error!KernelImage {
+        assert(bytes.len > 0);
         if (bytes.len < 64) return error.TooSmall;
+        assert(bytes.len >= 0x40);
         const got_magic = std.mem.readInt(u32, bytes[0x38..0x3C], .little);
         if (got_magic != magic) return error.BadMagic;
+        const text_offset = std.mem.readInt(u64, bytes[0x08..0x10], .little);
+        const image_size = std.mem.readInt(u64, bytes[0x10..0x18], .little);
         return .{
-            .text_offset = std.mem.readInt(u64, bytes[0x08..0x10], .little),
-            .image_size = std.mem.readInt(u64, bytes[0x10..0x18], .little),
+            .text_offset = text_offset,
+            .image_size = image_size,
             .bytes = bytes,
         };
     }

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -13,6 +13,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const assert = std.debug.assert;
+
 comptime {
     if (builtin.os.tag != .linux) {
         @compileError("kvm.zig only builds on Linux (uses /dev/kvm)");
@@ -164,7 +166,12 @@ pub const KVM_ARM_IRQ_TYPE_PPI: u32 = 2;
 /// call as a legacy CPU-line IRQ (type 0) and silently drops virtio
 /// doorbells, which manifests as guest hangs after QueueNotify.
 pub fn irqSpi(spi_id: u32) u32 {
-    return (KVM_ARM_IRQ_TYPE_SPI << KVM_ARM_IRQ_TYPE_SHIFT) | (32 + spi_id);
+    // INTID lives in bits 15:0 of the encoded value; anything wider
+    // would either collide with the type field or wrap silently.
+    assert(spi_id < (1 << 16) - 32);
+    const intid: u32 = 32 + spi_id;
+    assert(intid >= 32);
+    return (KVM_ARM_IRQ_TYPE_SPI << KVM_ARM_IRQ_TYPE_SHIFT) | intid;
 }
 
 // ---------------------------------------------------------------
@@ -335,6 +342,82 @@ pub const REG_PC = armCoreReg(0x100);
 pub const REG_PSTATE = armCoreReg(0x108);
 
 // ---------------------------------------------------------------
+// Layout asserts — KVM ABI is stable; if any of these trip, our
+// struct definitions drifted from <linux/kvm.h> and every ioctl in
+// this file will silently corrupt kernel memory.
+
+comptime {
+    // _IOC dir bits.
+    assert(IOC_NONE == 0);
+    assert(IOC_WRITE == 1);
+    assert(IOC_READ == 2);
+    assert(KVMIO == 0xAE);
+
+    // KVM_IRQ_LINE arm64 encoding constants.
+    assert(KVM_ARM_IRQ_TYPE_SHIFT == 24);
+    assert(KVM_ARM_IRQ_TYPE_CPU == 0);
+    assert(KVM_ARM_IRQ_TYPE_SPI == 1);
+    assert(KVM_ARM_IRQ_TYPE_PPI == 2);
+
+    // UserspaceMemoryRegion (32 B).
+    assert(@sizeOf(UserspaceMemoryRegion) == 32);
+    assert(@offsetOf(UserspaceMemoryRegion, "slot") == 0);
+    assert(@offsetOf(UserspaceMemoryRegion, "flags") == 4);
+    assert(@offsetOf(UserspaceMemoryRegion, "guest_phys_addr") == 8);
+    assert(@offsetOf(UserspaceMemoryRegion, "memory_size") == 16);
+    assert(@offsetOf(UserspaceMemoryRegion, "userspace_addr") == 24);
+
+    // VcpuInit (32 B: u32 target + 7 × u32 features).
+    assert(@sizeOf(VcpuInit) == 32);
+    assert(@offsetOf(VcpuInit, "target") == 0);
+    assert(@offsetOf(VcpuInit, "features") == 4);
+
+    // OneReg / IrqLevel.
+    assert(@sizeOf(OneReg) == 16);
+    assert(@offsetOf(OneReg, "id") == 0);
+    assert(@offsetOf(OneReg, "addr") == 8);
+    assert(@sizeOf(IrqLevel) == 8);
+    assert(@offsetOf(IrqLevel, "irq") == 0);
+    assert(@offsetOf(IrqLevel, "level") == 4);
+
+    // CreateDevice / DeviceAttr.
+    assert(@sizeOf(CreateDevice) == 12);
+    assert(@offsetOf(CreateDevice, "type") == 0);
+    assert(@offsetOf(CreateDevice, "fd") == 4);
+    assert(@offsetOf(CreateDevice, "flags") == 8);
+    assert(@sizeOf(DeviceAttr) == 24);
+    assert(@offsetOf(DeviceAttr, "flags") == 0);
+    assert(@offsetOf(DeviceAttr, "group") == 4);
+    assert(@offsetOf(DeviceAttr, "attr") == 8);
+    assert(@offsetOf(DeviceAttr, "addr") == 16);
+
+    // x86 register banks — sizes are baked into the ioctl numbers.
+    assert(@sizeOf(X86Regs) == 144);
+    assert(@sizeOf(X86Segment) == 24);
+    assert(@sizeOf(X86Dtable) == 16);
+    assert(@sizeOf(X86Sregs) == 312);
+
+    // kvm_run union payloads we touch (offsets relative to union base).
+    assert(@sizeOf(MmioExit) == 24);
+    assert(@offsetOf(MmioExit, "phys_addr") == 0);
+    assert(@offsetOf(MmioExit, "data") == 8);
+    assert(@offsetOf(MmioExit, "len") == 16);
+    assert(@offsetOf(MmioExit, "is_write") == 20);
+    assert(@sizeOf(SystemEventExit) == 136);
+    assert(@offsetOf(SystemEventExit, "type") == 0);
+    assert(@offsetOf(SystemEventExit, "ndata") == 4);
+    assert(@offsetOf(SystemEventExit, "data") == 8);
+
+    // arm64 core-reg encoding (see armCoreReg).
+    assert(REG_ARM64 == 0x6000_0000_0000_0000);
+    assert(REG_SIZE_U64 == 0x0030_0000_0000_0000);
+    assert(REG_ARM_CORE == 0x0010_0000);
+    assert(REG_PC == 0x6030_0000_0010_0040);
+    assert(REG_PSTATE == 0x6030_0000_0010_0042);
+    assert(REG_X0 == 0x6030_0000_0010_0000);
+}
+
+// ---------------------------------------------------------------
 // libc bindings. Kept narrow so we don't pull in std.posix's
 // ever-shifting Io surface.
 
@@ -386,6 +469,7 @@ pub const Kvm = struct {
         const fd = open("/dev/kvm", O_RDWR | O_CLOEXEC);
         if (fd < 0) return error.KvmDeviceOpenFailed;
         errdefer _ = close(fd);
+        assert(fd >= 0);
 
         // glibc's ioctl is declared `int ioctl(int, unsigned long,
         // ...)` — the third arg is variadic. Even for "no payload"
@@ -397,16 +481,23 @@ pub const Kvm = struct {
 
         const sz = ioctl(fd, @as(c_ulong, KVM_GET_VCPU_MMAP_SIZE), @as(c_ulong, 0));
         if (sz <= 0) return error.Unsupported;
+        // Mmap size must be at least one page; anything smaller is a
+        // kernel bug we can't safely cast or mmap.
+        assert(sz >= 4096);
         return .{ .kvm_fd = fd, .vcpu_mmap_size = @intCast(sz) };
     }
 
     pub fn close_(self: *Kvm) void {
+        assert(self.kvm_fd >= 0);
         _ = close(self.kvm_fd);
     }
 
     pub fn createVm(self: *Kvm) !Vm {
+        assert(self.kvm_fd >= 0);
+        assert(self.vcpu_mmap_size >= 4096);
         const fd = ioctl(self.kvm_fd, KVM_CREATE_VM, @as(c_ulong, 0));
         if (fd < 0) return error.KvmCreateVmFailed;
+        assert(fd != self.kvm_fd);
         return .{ .fd = fd, .parent = self };
     }
 };
@@ -416,6 +507,7 @@ pub const Vm = struct {
     parent: *Kvm,
 
     pub fn destroy(self: *Vm) void {
+        assert(self.fd >= 0);
         _ = close(self.fd);
     }
 
@@ -426,6 +518,16 @@ pub const Vm = struct {
         guest_phys_addr: u64,
         host_buf: []u8,
     ) !void {
+        assert(self.fd >= 0);
+        assert(host_buf.len > 0);
+        // KVM requires both the guest-physical address and the host
+        // userspace address to be page-aligned, and the size to be a
+        // multiple of the page size. Mis-aligned mappings are a
+        // programmer bug — KVM rejects with -EINVAL but we want a
+        // clearer signal in debug builds.
+        assert(guest_phys_addr % 4096 == 0);
+        assert(@intFromPtr(host_buf.ptr) % 4096 == 0);
+        assert(host_buf.len % 4096 == 0);
         const r = UserspaceMemoryRegion{
             .slot = slot,
             .flags = 0,
@@ -447,6 +549,14 @@ pub const Vm = struct {
         dist_addr: u64,
         redist_addr: u64,
     ) !Gic {
+        assert(self.fd >= 0);
+        // Distributor and redistributor MMIO windows must occupy
+        // distinct, non-zero, 64 KiB-aligned guest-physical regions.
+        assert(dist_addr != 0);
+        assert(redist_addr != 0);
+        assert(dist_addr != redist_addr);
+        assert(dist_addr % 0x10000 == 0);
+        assert(redist_addr % 0x10000 == 0);
         var args = CreateDevice{
             .type = KVM_DEV_TYPE_ARM_VGIC_V3,
             .fd = 0,
@@ -456,6 +566,8 @@ pub const Vm = struct {
             return error.KvmCreateIrqchipFailed;
         }
         const gic_fd: c_int = @intCast(args.fd);
+        assert(gic_fd >= 0);
+        assert(gic_fd != self.fd);
         errdefer _ = close(gic_fd);
 
         var dist = dist_addr;
@@ -496,13 +608,21 @@ pub const Vm = struct {
     /// the type bits, KVM treats the call as a CPU-line legacy IRQ
     /// (type 0) which silently drops virtio doorbells.
     pub fn setIrq(self: *Vm, irq: u32, level: u32) !void {
+        assert(self.fd >= 0);
+        // KVM_IRQ_LINE level is a boolean (0 = deassert, 1 = assert).
+        // Anything else is a programmer bug — the kernel ignores high
+        // bits but a non-{0,1} value usually means we forgot to mask.
+        assert(level <= 1);
         var lvl = IrqLevel{ .irq = irq, .level = level };
         if (ioctl(self.fd, KVM_IRQ_LINE, &lvl) != 0) return error.KvmIrqLineFailed;
     }
 
     pub fn createVcpu(self: *Vm, id: u32) !Vcpu {
+        assert(self.fd >= 0);
+        assert(self.parent.vcpu_mmap_size >= 4096);
         const fd = ioctl(self.fd, KVM_CREATE_VCPU, @as(c_ulong, id));
         if (fd < 0) return error.KvmCreateVcpuFailed;
+        assert(fd != self.fd);
         errdefer _ = close(fd);
         const run_ptr = mmap(null, self.parent.vcpu_mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
         if (run_ptr == MAP_FAILED or run_ptr == null) return error.KvmMmapRunFailed;
@@ -512,6 +632,7 @@ pub const Vm = struct {
     /// Fill in `out` with the host's preferred CPU target for this
     /// VM's arm64 vCPUs. Caller passes that to Vcpu.init.
     pub fn preferredTarget(self: *Vm) !VcpuInit {
+        assert(self.fd >= 0);
         var out: VcpuInit = .{ .target = 0, .features = @splat(0) };
         if (ioctl(self.fd, KVM_ARM_PREFERRED_TARGET, &out) != 0) {
             return error.KvmPreferredTargetFailed;
@@ -528,10 +649,15 @@ pub const Gic = struct {
     vm_fd: c_int,
 
     pub fn destroy(self: *Gic) void {
+        assert(self.fd >= 0);
+        assert(self.vm_fd >= 0);
+        assert(self.fd != self.vm_fd);
         _ = close(self.fd);
     }
 
     pub fn finalize(self: *Gic) !void {
+        assert(self.fd >= 0);
+        assert(self.vm_fd >= 0);
         var attr = DeviceAttr{
             .flags = 0,
             .group = KVM_DEV_ARM_VGIC_GRP_CTRL,
@@ -550,11 +676,14 @@ pub const Vcpu = struct {
     run_size: usize,
 
     pub fn destroy(self: *Vcpu) void {
+        assert(self.fd >= 0);
+        assert(self.run_size >= 4096);
         _ = munmap(self.run_page, self.run_size);
         _ = close(self.fd);
     }
 
     pub fn init(self: *Vcpu, vi: VcpuInit) !void {
+        assert(self.fd >= 0);
         var v = vi;
         if (ioctl(self.fd, KVM_ARM_VCPU_INIT, &v) != 0) {
             return error.KvmVcpuInitFailed;
@@ -562,6 +691,9 @@ pub const Vcpu = struct {
     }
 
     pub fn setReg(self: *Vcpu, id: u64, value: u64) !void {
+        assert(self.fd >= 0);
+        // Reg id 0 is reserved; KVM rejects with -ENOENT.
+        assert(id != 0);
         var v = value;
         const r = OneReg{ .id = id, .addr = @intFromPtr(&v) };
         if (ioctl(self.fd, KVM_SET_ONE_REG, &r) != 0) {
@@ -570,6 +702,8 @@ pub const Vcpu = struct {
     }
 
     pub fn getReg(self: *Vcpu, id: u64) !u64 {
+        assert(self.fd >= 0);
+        assert(id != 0);
         var v: u64 = 0;
         const r = OneReg{ .id = id, .addr = @intFromPtr(&v) };
         if (ioctl(self.fd, KVM_GET_ONE_REG, &r) != 0) {
@@ -579,6 +713,11 @@ pub const Vcpu = struct {
     }
 
     pub fn run(self: *Vcpu) !ExitReason {
+        assert(self.fd >= 0);
+        // We at minimum need to read exit_reason (offset 8, 4 bytes)
+        // and decode the union at offset 0x20. Anything smaller and
+        // the mmap is a kernel bug we can't safely indirect through.
+        assert(self.run_size >= 0x20 + @sizeOf(SystemEventExit));
         if (ioctl(self.fd, KVM_RUN, @as(c_ulong, 0)) != 0) {
             return error.KvmRunFailed;
         }
@@ -597,18 +736,26 @@ pub const Vcpu = struct {
     /// after `apic_base` at 0x18), on builds without the S390
     /// extension — which matches x86_64 and arm64.
     pub fn mmioExit(self: *Vcpu) MmioExit {
+        assert(self.run_size >= 0x20 + @sizeOf(MmioExit));
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: MmioExit = undefined;
         @memcpy(std.mem.asBytes(&out), base[0x20..][0..@sizeOf(MmioExit)]);
+        // The kernel never emits len > 8 (mmio.data is 8 bytes); a
+        // wider value means we read the wrong offset.
+        assert(out.len <= 8);
+        assert(out.is_write <= 1);
         return out;
     }
 
     /// Read the SYSTEM_EVENT exit payload. Used for PSCI SHUTDOWN /
     /// RESET. Same struct union as MMIO; offset 0x20 inside kvm_run.
     pub fn systemEventExit(self: *Vcpu) SystemEventExit {
+        assert(self.run_size >= 0x20 + @sizeOf(SystemEventExit));
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: SystemEventExit = undefined;
         @memcpy(std.mem.asBytes(&out), base[0x20..][0..@sizeOf(SystemEventExit)]);
+        // ndata bounds the populated portion of `data` and must fit.
+        assert(out.ndata <= out.data.len);
         return out;
     }
 
@@ -617,32 +764,39 @@ pub const Vcpu = struct {
     /// before the next `KVM_RUN`. `mmio.data` lives at 0x20 + 8 =
     /// 0x28 in the kvm_run page.
     pub fn writeMmioReadData(self: *Vcpu, value: u64, len: u32) void {
+        assert(self.run_size >= 0x28 + 8);
+        // mmio.data is 8 bytes; len > 8 would corrupt the next field.
+        assert(len <= 8);
+        assert(len > 0);
         const base: [*]u8 = @ptrCast(self.run_page);
         const slot: []u8 = base[0x28 .. 0x28 + 8];
         std.mem.writeInt(u64, slot[0..8], value, .little);
-        _ = len;
     }
 
     // x86-specific register access. arm64 uses setReg/getReg above.
 
     pub fn getRegsX86(self: *Vcpu) !X86Regs {
+        assert(self.fd >= 0);
         var r: X86Regs = undefined;
         if (ioctl(self.fd, KVM_GET_REGS, &r) != 0) return error.KvmGetRegFailed;
         return r;
     }
 
     pub fn setRegsX86(self: *Vcpu, r: X86Regs) !void {
+        assert(self.fd >= 0);
         var v = r;
         if (ioctl(self.fd, KVM_SET_REGS, &v) != 0) return error.KvmSetRegFailed;
     }
 
     pub fn getSregsX86(self: *Vcpu) !X86Sregs {
+        assert(self.fd >= 0);
         var s: X86Sregs = undefined;
         if (ioctl(self.fd, KVM_GET_SREGS, &s) != 0) return error.KvmGetRegFailed;
         return s;
     }
 
     pub fn setSregsX86(self: *Vcpu, s: X86Sregs) !void {
+        assert(self.fd >= 0);
         var v = s;
         if (ioctl(self.fd, KVM_SET_SREGS, &v) != 0) return error.KvmSetRegFailed;
     }

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -11,6 +11,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const microvm = @import("microvm");
 
+const assert = std.debug.assert;
+
 comptime {
     if (builtin.os.tag != .macos and builtin.os.tag != .linux) {
         @compileError("machinen-microvm only supports macOS (HVF) and arm64 Linux (KVM)");
@@ -69,19 +71,23 @@ pub fn main(init: std.process.Init) !void {
 }
 
 fn envRequired(comptime name: [:0]const u8) []const u8 {
+    comptime assert(name.len > 0);
     const raw = getenv(name.ptr) orelse dieUsage(name);
     const s = std.mem.span(raw);
     if (s.len == 0) dieUsage(name);
+    assert(s.len > 0);
     return s;
 }
 
 fn envOptional(comptime name: [:0]const u8) ?[]const u8 {
+    comptime assert(name.len > 0);
     const raw = getenv(name.ptr) orelse return null;
     const s = std.mem.span(raw);
     return if (s.len == 0) null else s;
 }
 
 fn dieUsage(missing: []const u8) noreturn {
+    assert(missing.len > 0);
     std.debug.print(
         "machinen-microvm: {s} is unset.\n" ++
             "  This binary is invoked by @machinen/runtime, not directly.\n" ++

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -12,6 +12,16 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const assert = std.debug.assert;
+
+comptime {
+    // The Backend enum is plumbed across both backends and the JS
+    // runtime; tag values are part of the cross-language ABI.
+    assert(@intFromEnum(Backend.hvf) == 0);
+    assert(@intFromEnum(Backend.kvm) == 1);
+    assert(@intFromEnum(Backend.none) == 2);
+}
+
 pub const hvf = if (builtin.os.tag == .macos) @import("hvf.zig") else struct {};
 pub const boot_hvf = if (builtin.os.tag == .macos) @import("boot_hvf.zig") else struct {};
 pub const net_socket = if (builtin.os.tag == .macos) @import("net_socket.zig") else struct {};


### PR DESCRIPTION
## Summary

Tier 2 of the TigerStyle assertion-density rollout. Follows #210 (`blk.zig` pilot, ~25 asserts) and #232 (Tier 1: `virtio.zig` / `vsock.zig` / `pl011.zig` / `net_socket.zig`, ~146 asserts). Together with this PR, every assertable file in `packages/microvm/src/` has a `const assert = std.debug.assert;` import, a comptime layout block, and per-fn pre/post asserts.

This tier covers the **hypervisor backends** — every file that talks to a KVM ioctl, an HVF `hv_*` call, or the arm64 boot protocol.

| File | LOC | Asserts added |
| --- | ---: | ---: |
| `kvm.zig` | 828 | ~80 |
| `boot_kvm.zig` | 712 | ~30 |
| `hvf.zig` | 992 | ~50 |
| `boot_hvf.zig` | 1008 | ~25 |
| `main.zig` | 97 | 4 |
| `root.zig` | 87 | 3 (comptime) |

Total: **+369 lines, ~190 asserts**.

## What's asserted

**`kvm.zig`** — comptime asserts for `_IOC` dir bits, `KVMIO == 0xAE`, the `KVM_IRQ_LINE` arm64 type encoding, and every ABI struct we hand to the kernel (`UserspaceMemoryRegion`, `VcpuInit`, `OneReg`, `IrqLevel`, `CreateDevice`, `DeviceAttr`, `X86Regs/Sregs/Segment/Dtable`, `MmioExit`, `SystemEventExit`) — sizes + field offsets locked. Per-fn pre/post on `Kvm.open_/close_/createVm`, `Vm.destroy/mapMemory/createGicV3/setIrq/createVcpu/preferredTarget`, `Gic.destroy/finalize`, `Vcpu.destroy/init/setReg/getReg/run/mmioExit/systemEventExit/writeMmioReadData` and the x86 register banks. `mapMemory` enforces page alignment of both `guest_phys` and `host_buf` (KVM rejects with `-EINVAL` otherwise but the asserts give a clearer signal). `irqSpi` gates `spi_id` so the encoded INTID can't collide with the type field.

**`boot_kvm.zig`** — comptime asserts that the virtio-mmio slot layout stays byte-identical to `virt.dts` (slots are contiguous 0x200 windows). Per-fn pre on `boot()` (RAM/DTB/initrd alignment, paths non-empty, `max_exits > 0`), `handleMmio` (MMIO `len in [1,8]`, every SPI irq carries the `KVM_ARM_IRQ_TYPE_SPI` bits — see #236 for why this matters), `readAll` (path non-empty, fd valid, `total == size` after the loop), `KernelImage.parse`, and the vsock/net irq + tx callbacks.

**`hvf.zig`** — comptime asserts for `page_size == 0x4000`, the `VcpuExit` / `ExitException` layouts, `Reg` enum tag values, `ExceptionClass` codes (ESR_EL2 EC values from the Arm ARM), and PSCI v1.1 function IDs (ARM DEN 0022). Per-fn pre on `Vm.map/unmap` (page alignment, non-empty, at least one of read/write/exec set), `Gic.enable` (distributor != redistributor, both non-zero), `Gic.setSpi` (intid in `[32, 1019]` per GICv3), `DataAbort.readSource` (isv set, srt <= 31), `KernelImage.parse`.

**`boot_hvf.zig`** — comptime asserts mirroring `boot_kvm.zig`'s slot layout. Per-fn pre on `boot()` (same caller-supplied geometry as the KVM twin, page-aligned to `hvf.page_size = 16 KiB`), `spi.base >= 32` with `count >= 20`, the irq + tx + stdin-thread callbacks, and `readAll`. `patchDtbInitrdEnd` asserts dtb non-empty + `size_strings > 0` before walking the structure block.

**`main.zig`** — `envRequired/envOptional` comptime-assert their name is non-empty; `envRequired` post-asserts the resolved value is non-empty.

**`root.zig`** — comptime-asserts the `Backend` enum tag values stay stable (0=hvf, 1=kvm, 2=none) since they're part of the cross-language ABI to the JS runtime.

## What's *not* asserted (deliberately)

Same fail-soft policy as #210/#232: **assertions are for programmer error, not operating error**. Anything the guest controls — descriptor chain length, MMIO offsets within a window, kernel-supplied register values, vsock `Op` values — stays as fail-soft early-returns rather than asserts. A buggy or hostile guest must not be able to crash the VMM.

A few asserts I prototyped and removed before pushing because they tripped on legitimate inputs:
- `text_offset % 0x200000 == 0` in `KernelImage.parse` — real arm64 kernels use `text_offset = 0x80000` (512 KiB), not 2 MiB. The arm64 boot protocol requires the *kernel base* to be 2 MiB-aligned, not `text_offset` itself.
- `vcpu.handle != 0` on the HVF path — `hv_vcpu_t` is a documented opaque `uint64_t`; HVF can legitimately return 0 for the first vCPU.

## Test plan

- [x] `zig build`: clean.
- [x] `zig build test`: 45/45 passed.
- [x] `npx vitest run`: 390/391 passed; the 1 failure is the same pre-existing fixture-missing failure as on `main` (`rootfs-debian-arm64.tar.gz` not provisioned locally).
- [x] `npx agent-ci run --all -q -p`: 4/4 workflows passed.
- [x] `pnpm smoke-tests`: all passed (T1–T5, N1–N5, P1–P3, C1–C2, S1–S3).

## Stacking

This branch is rebased directly on `origin/main` so the PR contains only the assertion work. Tier 2 files are disjoint from the Tier 1 set, so no rebase needed against #232 / #210.
