### PR TITLE
feat(runtime,cli): machinen gc + machinen stop (PR2 of #150 phase 2)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,7 +38,10 @@ import {
   isMachinenError,
   list,
   restore,
+  runGc,
+  validatePid,
 } from "@machinen/runtime";
+import type { RegistryEntry } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
@@ -596,6 +599,132 @@ function formatUptime(ms: number): string {
   return `${Math.floor(h / 24)}d`;
 }
 
+// `machinen gc` — drop registry entries whose VMM is dead (or whose
+// pid was recycled to some other process) and remove their per-boot
+// artifacts. Backstop for `--detached` boots, where the in-process
+// exit hook can't run because the parent is gone (issue #150 phase 2
+// PR2).
+async function cmdGc(args: string[]): Promise<number> {
+  let dryRun = false;
+  for (const a of args) {
+    if (a === "--dry-run" || a === "-n") {
+      dryRun = true;
+    } else {
+      die(`unknown flag: ${a}`);
+    }
+  }
+  const results = runGc({ dryRun });
+  if (results.length === 0) {
+    process.stdout.write("(nothing to clean up)\n");
+    return 0;
+  }
+  for (const r of results) {
+    const label = r.name ? `${r.name} (pid ${r.pid})` : `pid ${r.pid}`;
+    const verb = dryRun ? "would clean" : "cleaned";
+    process.stdout.write(`${verb} ${label} [${r.status}]: ${r.removedPaths.length} path(s)\n`);
+    for (const p of r.removedPaths) {
+      process.stdout.write(`  ${p}\n`);
+    }
+    for (const p of r.failedPaths) {
+      process.stdout.write(`  failed: ${p}\n`);
+    }
+  }
+  return 0;
+}
+
+// `machinen stop <name|pid>` — SIGTERM the VMM, escalate to SIGKILL
+// after 2s, then gc its entry. Resolves `--detached` boots' Ctrl-C
+// problem: the CLI no longer holds the VMM, so a separate `stop`
+// command is the only way to ask for a clean shutdown.
+async function cmdStop(args: string[]): Promise<number> {
+  let force = false;
+  const rest: string[] = [];
+  for (const a of args) {
+    if (a === "--force" || a === "-9") {
+      force = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  const target = parseTargetFlags(rest, "stop");
+  const entry = lookupEntry(target);
+  if (!entry) {
+    process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
+    return 1;
+  }
+  // Pid-validate before signalling — refuses to kill a recycled pid.
+  const status = validatePid(entry.pid, {
+    vmmExe: entry.vmmExe,
+    startedAt: entry.startedAt,
+  });
+  if (status === "recycled") {
+    process.stderr.write(
+      `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
+        "skipping kill and running gc.\n",
+    );
+    runGc({ pid: entry.pid });
+    return 0;
+  }
+  if (status === "dead") {
+    process.stderr.write(`machinen stop: pid ${entry.pid} already gone; running gc.\n`);
+    runGc({ pid: entry.pid });
+    return 0;
+  }
+  const sig = force ? "SIGKILL" : "SIGTERM";
+  try {
+    process.kill(entry.pid, sig);
+  } catch (err) {
+    process.stderr.write(
+      `machinen stop: failed to signal pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+  if (!force) {
+    // Wait up to 2s for graceful shutdown, then escalate. Polling
+    // beats kqueue/inotify here — the pid we're watching is *not*
+    // our child, so there's no SIGCHLD to listen for.
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      try {
+        process.kill(entry.pid, 0);
+      } catch {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    try {
+      process.kill(entry.pid, 0);
+      // Still alive — escalate.
+      try {
+        process.kill(entry.pid, "SIGKILL");
+      } catch {}
+    } catch {
+      // Already gone.
+    }
+  }
+  // Final gc to drop the registry entry + cleanupPaths.
+  runGc({ pid: entry.pid });
+  const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
+  process.stdout.write(`stopped ${label}\n`);
+  return 0;
+}
+
+function lookupEntry(target: { name: string } | { pid: number }): RegistryEntry | undefined {
+  for (const e of list()) {
+    if ("name" in target && e.name === target.name) {
+      return e;
+    }
+    if ("pid" in target && e.pid === target.pid) {
+      return e;
+    }
+  }
+  return undefined;
+}
+
+function describeTarget(target: { name: string } | { pid: number }): string {
+  return "name" in target ? `--name ${target.name}` : `--pid ${target.pid}`;
+}
+
 async function cmdExec(args: string[]): Promise<number> {
   // Pull --tty out before the `--` boundary so it isn't passed to the
   // workload. Auto-enable when stdin is a TTY and no --tty was passed
@@ -1015,7 +1144,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install ls ps exec snapshot fork attach repl completion --version --help -h -v"
+  local cmds="boot restore install ls ps exec snapshot fork attach repl gc stop completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -1035,8 +1164,12 @@ _machinen_completion() {
       ;;
   esac
   case "\${words[1]}" in
-    exec|snapshot|fork|attach|repl)
+    exec|snapshot|fork|attach|repl|stop)
       COMPREPLY=( $(compgen -W "--name --pid" -- "\${cur}") )
+      return
+      ;;
+    gc)
+      COMPREPLY=( $(compgen -W "--dry-run" -- "\${cur}") )
       return
       ;;
   esac
@@ -1048,7 +1181,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install ls ps exec snapshot fork attach repl completion)
+  cmds=(boot restore install ls ps exec snapshot fork attach repl gc stop completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -1068,8 +1201,12 @@ _machinen() {
       ;;
   esac
   case "\${words[2]}" in
-    exec|snapshot|fork|attach|repl)
+    exec|snapshot|fork|attach|repl|stop)
       _describe 'flag' '(--name --pid)'
+      return
+      ;;
+    gc)
+      _describe 'flag' '(--dry-run)'
       return
       ;;
   esac
@@ -1079,14 +1216,15 @@ compdef _machinen machinen
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install ls ps exec snapshot fork attach repl completion
+set -l cmds boot restore install ls ps exec snapshot fork attach repl gc stop completion
 complete -c machinen -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
-for sub in exec snapshot fork attach repl
+for sub in exec snapshot fork attach repl stop
   complete -c machinen -f -n "__fish_seen_subcommand_from $sub" -l name \\
     -a '(machinen ls 2>/dev/null | awk \\'NR>1 && $2!="-"{print $2}\\')'
   complete -c machinen -f -n "__fish_seen_subcommand_from $sub" -l pid \\
     -a '(machinen ls 2>/dev/null | awk \\'NR>1{print $1}\\')'
 end
+complete -c machinen -f -n "__fish_seen_subcommand_from gc" -l dry-run
 `;
 
 // ------------------------------------------------------------
@@ -1252,6 +1390,10 @@ async function main(): Promise<number> {
       return cmdRepl(rest);
     case "completion":
       return cmdCompletion(rest);
+    case "gc":
+      return cmdGc(rest);
+    case "stop":
+      return cmdStop(rest);
     default:
       die(`unknown command: ${sub}\nRun 'machinen --help' for usage.`);
   }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -1644,6 +1644,84 @@ Forwarded to `tar --exclude=PATTERN`. Repeat per pattern.
 
 ***
 
+### GcResult
+
+Defined in: [gc.ts:22](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L22)
+
+Per-entry record of what `runGc` did (or would do, with dryRun).
+
+#### Properties
+
+##### pid
+
+> **pid**: `number`
+
+Defined in: [gc.ts:23](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L23)
+
+##### name?
+
+> `optional` **name?**: `string`
+
+Defined in: [gc.ts:24](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L24)
+
+##### status
+
+> **status**: [`PidStatus`](#pidstatus)
+
+Defined in: [gc.ts:25](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L25)
+
+##### removedPaths
+
+> **removedPaths**: `string`[]
+
+Defined in: [gc.ts:27](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L27)
+
+Paths removed (or that would be removed under `dryRun`).
+
+##### failedPaths
+
+> **failedPaths**: `string`[]
+
+Defined in: [gc.ts:29](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L29)
+
+Paths the gc tried to rm but couldn't (already gone, EPERM, …).
+
+##### registryRemoved
+
+> **registryRemoved**: `boolean`
+
+Defined in: [gc.ts:31](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L31)
+
+True if the registry entry was (or would be) dropped.
+
+***
+
+### RunGcOptions
+
+Defined in: [gc.ts:34](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L34)
+
+#### Properties
+
+##### dryRun?
+
+> `optional` **dryRun?**: `boolean`
+
+Defined in: [gc.ts:39](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L39)
+
+When true, list what would be cleaned without touching the disk
+or registry. Used by `machinen gc --dry-run` and tests.
+
+##### pid?
+
+> `optional` **pid?**: `number`
+
+Defined in: [gc.ts:44](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L44)
+
+Only act on this single entry (skip everything else in the
+registry). Used by `machinen stop` after killing a specific VM.
+
+***
+
 ### ChunkLogEvent
 
 Defined in: [log.ts:19](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/log.ts#L19)
@@ -2509,11 +2587,36 @@ Path to the one-shot boot-console snapshot written at detach time
 floor (the VMM ignores SIGPIPE), so this file is the only record
 of the boot sequence on a detached VM.
 
+##### cleanupPaths?
+
+> `optional` **cleanupPaths?**: `string`[]
+
+Defined in: [registry.ts:76](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L76)
+
+Per-boot artifacts that need to be removed when the VMM exits.
+Today the in-process exit hook handles this for non-detached
+boots. After detach (#150 phase 2) the parent is gone before the
+VMM exits — `machinen gc` / `machinen stop` use this list to
+clean up afterward. Each entry is an absolute path to either a
+file (per-boot disk image) or a directory (bundle / vsock UDS).
+
+##### vmmExe?
+
+> `optional` **vmmExe?**: `string`
+
+Defined in: [registry.ts:84](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L84)
+
+Absolute path to the VMM binary that was spawned. `machinen gc`
+compares this against `/proc/<pid>/exe` (Linux) or `ps -o comm=`
+(macOS) before treating an entry as live — without it, a recycled
+pid that happens to belong to some other process would look alive
+to `kill(pid, 0)` and the entry would be kept around forever.
+
 ##### startedAt
 
 > **startedAt**: `number`
 
-Defined in: [registry.ts:69](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L69)
+Defined in: [registry.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L86)
 
 ms epoch when the entry was created.
 
@@ -3574,7 +3677,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ### AttachOptions
 
-Defined in: [vm.ts:1346](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1346)
+Defined in: [vm.ts:1375](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1375)
 
 #### Properties
 
@@ -3582,7 +3685,7 @@ Defined in: [vm.ts:1346](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1352](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1352)
+Defined in: [vm.ts:1381](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1381)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3592,7 +3695,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1354](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1354)
+Defined in: [vm.ts:1383](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1383)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3600,7 +3703,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1361](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1361)
+Defined in: [vm.ts:1390](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1390)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3611,7 +3714,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2486](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2486)
+Defined in: [vm.ts:2515](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2515)
 
 #### Extends
 
@@ -3975,7 +4078,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2491](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2491)
+Defined in: [vm.ts:2520](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2520)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -3984,7 +4087,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2499](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2499)
+Defined in: [vm.ts:2528](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2528)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -3996,7 +4099,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2505](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2505)
+Defined in: [vm.ts:2534](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2534)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4062,11 +4165,21 @@ Defined in: [log.ts:45](https://github.com/redwoodjs/machinen/blob/main/packages
 
 ***
 
+### PidStatus
+
+> **PidStatus** = `"alive"` \| `"dead"` \| `"recycled"`
+
+Defined in: [pid-validate.ts:40](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/pid-validate.ts#L40)
+
+Result of `validatePid` — easy to switch on at the call site.
+
+***
+
 ### ImageConfig
 
 > **ImageConfig** = `object`
 
-Defined in: [vm.ts:1536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1536)
+Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
 
 Shape of the optional `./machinen-config.json` baked into a rootfs
 tarball by `provision({ cmd, env })`. `boot()` reads it via
@@ -4080,19 +4193,19 @@ tarball-producing tool can pre-populate the lookup cache.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:1536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1536)
+Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
 
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:1536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1536)
+Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
 
 ##### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:1536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1536)
+Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
 
 ## Variables
 
@@ -4532,7 +4645,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:2101](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2101)
+Defined in: [vm.ts:2130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2130)
 
 #### Type Declaration
 
@@ -4720,6 +4833,28 @@ library callers can adopt the same format if they want to.
 
 ***
 
+### runGc()
+
+> **runGc**(`opts?`): [`GcResult`](#gcresult)[]
+
+Defined in: [gc.ts:52](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/gc.ts#L52)
+
+Walk the registry; for each entry that's dead or pid-recycled,
+remove its cleanupPaths + bootLog + registry entry. Returns one
+result per entry processed (live entries are skipped silently).
+
+#### Parameters
+
+##### opts?
+
+[`RunGcOptions`](#rungcoptions) = `{}`
+
+#### Returns
+
+[`GcResult`](#gcresult)[]
+
+***
+
 ### mkinitramfsBundle()
 
 > **mkinitramfsBundle**(`opts`): `void`
@@ -4849,6 +4984,47 @@ Kept argv-compatible with the old Python script so shell fixtures
 
 ***
 
+### validatePid()
+
+> **validatePid**(`pid`, `expected`): [`PidStatus`](#pidstatus)
+
+Defined in: [pid-validate.ts:56](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/pid-validate.ts#L56)
+
+Return whether the running process at `pid` is still our VMM.
+
+- `alive`     — pid is alive AND the exe + start-time match.
+- `dead`      — kill(pid, 0) failed (gone or permission-denied,
+                either way unreachable).
+- `recycled`  — pid is alive but the process isn't ours (different
+                exe, or start time outside skew).
+
+Falls back to `alive` when the recorded entry lacks `vmmExe` /
+`startedAt` (older entries from before PR2). Conservative on
+purpose: the gc decision then leans on `kill(pid, 0)` alone, same
+behaviour we had before.
+
+#### Parameters
+
+##### pid
+
+`number`
+
+##### expected
+
+###### vmmExe?
+
+`string`
+
+###### startedAt?
+
+`number`
+
+#### Returns
+
+[`PidStatus`](#pidstatus)
+
+***
+
 ### resolveBaseRootfs()
 
 > **resolveBaseRootfs**(`explicit?`, `cwd?`): `string`
@@ -4947,7 +5123,7 @@ registry can hold it.
 
 > **registryRoot**(): `string`
 
-Defined in: [registry.ts:78](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L78)
+Defined in: [registry.ts:95](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L95)
 
 Absolute path to the registry root. Honors `MACHINEN_REGISTRY_DIR`
 so tests can point at a scratch dir without stomping on real entries.
@@ -4962,7 +5138,7 @@ so tests can point at a scratch dir without stomping on real entries.
 
 > **list**(): [`RegistryEntry`](#registryentry)[]
 
-Defined in: [registry.ts:164](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L164)
+Defined in: [registry.ts:212](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L212)
 
 List all registry entries whose pid is still alive. Prunes stale
 entries (pid no longer alive) and orphaned name pins as a side
@@ -5142,7 +5318,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1377](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1377)
+Defined in: [vm.ts:1406](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1406)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -5174,7 +5350,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **warmImageConfigCache**(`imagePath`, `config`): `void`
 
-Defined in: [vm.ts:1581](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1581)
+Defined in: [vm.ts:1610](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1610)
 
 Pre-populate the image-config cache for a freshly-written tarball.
 Lets `provision()` (and other tarball producers) skip the slow
@@ -5207,7 +5383,7 @@ none was baked).
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1949](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1949)
+Defined in: [vm.ts:1978](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1978)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -5246,7 +5422,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:1991](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1991)
+Defined in: [vm.ts:2020](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2020)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -5278,7 +5454,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2524](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2524)
+Defined in: [vm.ts:2553](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2553)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5313,7 +5489,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2777](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2777)
+Defined in: [vm.ts:2806](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2806)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/gc.test.ts
+++ b/packages/runtime/src/__tests__/gc.test.ts
@@ -1,0 +1,178 @@
+// `runGc` + `validatePid` (issue #150 phase 2 PR2). The unit tests
+// don't boot a VMM — they fabricate registry entries on disk and
+// drive `runGc` against a scratch root. The end-to-end "stop a
+// detached VM and prove its files are gone" lives in the smoke
+// suite.
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runGc, validatePid } from "../index.ts";
+import { listAll, type RegistryEntry } from "../registry.ts";
+
+function makeEntry(root: string, e: RegistryEntry): void {
+  const dir = join(root, String(e.pid));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "meta.json"), JSON.stringify(e));
+  if (e.name) {
+    const namesDir = join(root, "names");
+    mkdirSync(namesDir, { recursive: true });
+    writeFileSync(join(namesDir, e.name), String(e.pid));
+  }
+}
+
+describe("validatePid", () => {
+  it("returns 'dead' for a pid that's gone", () => {
+    // 999999 is well outside the typical pid space + nothing's
+    // listening on it on a dev box; close enough to a guaranteed-
+    // dead pid for the purpose of this assertion.
+    expect(validatePid(999_999, {})).toBe("dead");
+  });
+
+  it("returns 'dead' for invalid pids", () => {
+    expect(validatePid(0, {})).toBe("dead");
+    expect(validatePid(-1, {})).toBe("dead");
+    expect(validatePid(1.5, {})).toBe("dead");
+  });
+
+  it("returns 'alive' for our own pid with no expectations", () => {
+    expect(validatePid(process.pid, {})).toBe("alive");
+  });
+
+  it("returns 'recycled' when exe basename doesn't match", () => {
+    // `node` is what Vitest runs the worker as; expecting
+    // "totally-other-binary" forces a mismatch.
+    expect(validatePid(process.pid, { vmmExe: "/nope/totally-other-binary" })).toBe("recycled");
+  });
+
+  it("returns 'recycled' when startedAt is far outside skew", () => {
+    // 1h in the past — well outside the 5s skew tolerance.
+    const longAgo = Date.now() - 60 * 60 * 1000;
+    expect(validatePid(process.pid, { startedAt: longAgo })).toBe("recycled");
+  });
+});
+
+describe("runGc", () => {
+  let root: string;
+  let prevRoot: string | undefined;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "machinen-gc-test-"));
+    prevRoot = process.env.MACHINEN_REGISTRY_DIR;
+    process.env.MACHINEN_REGISTRY_DIR = root;
+  });
+  afterEach(() => {
+    if (prevRoot === undefined) {
+      delete process.env.MACHINEN_REGISTRY_DIR;
+    } else {
+      process.env.MACHINEN_REGISTRY_DIR = prevRoot;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does nothing on an empty registry", () => {
+    expect(runGc()).toEqual([]);
+  });
+
+  it("leaves alive entries alone", () => {
+    makeEntry(root, {
+      pid: process.pid,
+      socketPath: join(root, "sock"),
+      startedAt: Date.now(),
+    });
+    expect(runGc()).toEqual([]);
+    expect(listAll().length).toBe(1);
+  });
+
+  it("reaps a dead-pid entry and rms its cleanupPaths", () => {
+    // Real layout: per-boot disks in tmpdir, boot snapshot in
+    // ~/.machinen/logs — separate trees. Mirror that here so the
+    // recursive rm of one doesn't accidentally hit the other.
+    const perBootDir = mkdtempSync(join(tmpdir(), "machinen-gc-disks-"));
+    const perBootFile = join(perBootDir, "perboot.img");
+    writeFileSync(perBootFile, "x");
+    const logDir = mkdtempSync(join(tmpdir(), "machinen-gc-logs-"));
+    const bootLog = join(logDir, "999999.boot.log");
+    writeFileSync(bootLog, "boot console");
+    makeEntry(root, {
+      pid: 999_999,
+      socketPath: "/nope",
+      cleanupPaths: [perBootFile, perBootDir],
+      bootLogPath: bootLog,
+      startedAt: Date.now(),
+    });
+    try {
+      const results = runGc();
+      expect(results).toHaveLength(1);
+      expect(results[0]!.status).toBe("dead");
+      expect(results[0]!.removedPaths.sort()).toEqual([bootLog, perBootDir, perBootFile].sort());
+      expect(existsSync(perBootFile)).toBe(false);
+      expect(existsSync(perBootDir)).toBe(false);
+      expect(existsSync(bootLog)).toBe(false);
+      expect(listAll()).toEqual([]);
+    } finally {
+      rmSync(logDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run reports without touching disk or registry", () => {
+    const scratchDir = mkdtempSync(join(tmpdir(), "machinen-gc-dry-"));
+    const scratchFile = join(scratchDir, "perboot.img");
+    writeFileSync(scratchFile, "x");
+    makeEntry(root, {
+      pid: 999_998,
+      socketPath: "/nope",
+      cleanupPaths: [scratchFile],
+      startedAt: Date.now(),
+    });
+    const results = runGc({ dryRun: true });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.removedPaths).toEqual([scratchFile]);
+    expect(existsSync(scratchFile)).toBe(true);
+    expect(listAll()).toHaveLength(1);
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it("filters by pid when opts.pid is set", () => {
+    makeEntry(root, { pid: 999_001, socketPath: "/a", startedAt: Date.now() });
+    makeEntry(root, { pid: 999_002, socketPath: "/b", startedAt: Date.now() });
+    const results = runGc({ pid: 999_001 });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.pid).toBe(999_001);
+    expect(
+      listAll()
+        .map((e) => e.pid)
+        .sort(),
+    ).toEqual([999_002]);
+  });
+
+  it("treats recycled pids the same as dead (rms cleanupPaths)", async () => {
+    // Spawn a short-lived `sleep` and use *its* pid. validatePid
+    // sees the process is alive but exe doesn't match the recorded
+    // VMM exe → "recycled" → reap.
+    const child = spawn("sleep", ["10"], { detached: true, stdio: "ignore" });
+    child.unref();
+    try {
+      // Ensure the child actually exists before we depend on its pid.
+      execFileSync("kill", ["-0", String(child.pid)]);
+      const scratch = mkdtempSync(join(tmpdir(), "machinen-gc-recycled-"));
+      makeEntry(root, {
+        pid: child.pid!,
+        socketPath: "/nope",
+        cleanupPaths: [scratch],
+        // Mismatched exe + ancient startedAt — both signal recycled.
+        vmmExe: "/usr/local/bin/machinen-vm-fake",
+        startedAt: Date.now() - 60 * 60 * 1000,
+      });
+      const results = runGc();
+      expect(results).toHaveLength(1);
+      expect(results[0]!.status).toBe("recycled");
+      expect(existsSync(scratch)).toBe(false);
+    } finally {
+      try {
+        process.kill(child.pid!, "SIGKILL");
+      } catch {}
+    }
+  });
+});

--- a/packages/runtime/src/gc.ts
+++ b/packages/runtime/src/gc.ts
@@ -1,0 +1,128 @@
+// `machinen gc` / `machinen stop` cleanup of registry entries whose
+// VMM is gone (issue #150 phase 2 PR2).
+//
+// Why this isn't just `kill(pid, 0)`: the boot()-side exit hook used
+// to handle every cleanup synchronously when the parent CLI was
+// pinned to the VMM. Detached boots break that — the parent exits
+// before the VMM does, so per-boot reflink disks, bundle dirs, and
+// vsock UDS dirs leak. `runGc` is the backstop: walk the registry,
+// drop entries whose pid is dead or has been recycled to some other
+// process, and rm their recorded cleanupPaths + bootLogPath.
+//
+// Pid recycling is handled by `validatePid` (see pid-validate.ts).
+
+import { existsSync, rmSync, statSync, unlinkSync } from "node:fs";
+import debugLib from "debug";
+import { validatePid, type PidStatus } from "./pid-validate.ts";
+import { listAll, removeEntry, type RegistryEntry } from "./registry.ts";
+
+const debug = debugLib("machinen:gc");
+
+/** Per-entry record of what `runGc` did (or would do, with dryRun). */
+export interface GcResult {
+  pid: number;
+  name?: string;
+  status: PidStatus;
+  /** Paths removed (or that would be removed under `dryRun`). */
+  removedPaths: string[];
+  /** Paths the gc tried to rm but couldn't (already gone, EPERM, …). */
+  failedPaths: string[];
+  /** True if the registry entry was (or would be) dropped. */
+  registryRemoved: boolean;
+}
+
+export interface RunGcOptions {
+  /**
+   * When true, list what would be cleaned without touching the disk
+   * or registry. Used by `machinen gc --dry-run` and tests.
+   */
+  dryRun?: boolean;
+  /**
+   * Only act on this single entry (skip everything else in the
+   * registry). Used by `machinen stop` after killing a specific VM.
+   */
+  pid?: number;
+}
+
+/**
+ * Walk the registry; for each entry that's dead or pid-recycled,
+ * remove its cleanupPaths + bootLog + registry entry. Returns one
+ * result per entry processed (live entries are skipped silently).
+ */
+export function runGc(opts: RunGcOptions = {}): GcResult[] {
+  const entries = listAll().filter((e) => opts.pid === undefined || e.pid === opts.pid);
+  const out: GcResult[] = [];
+  for (const entry of entries) {
+    const status = validatePid(entry.pid, {
+      vmmExe: entry.vmmExe,
+      startedAt: entry.startedAt,
+    });
+    if (status === "alive") {
+      continue;
+    }
+    out.push(reapEntry(entry, status, opts.dryRun ?? false));
+  }
+  return out;
+}
+
+function reapEntry(entry: RegistryEntry, status: PidStatus, dryRun: boolean): GcResult {
+  debug(
+    "reap pid=%d name=%s status=%s dryRun=%s",
+    entry.pid,
+    entry.name ?? "<unset>",
+    status,
+    dryRun,
+  );
+  const removedPaths: string[] = [];
+  const failedPaths: string[] = [];
+  const candidates: string[] = [];
+  if (entry.cleanupPaths) {
+    for (const p of entry.cleanupPaths) {
+      candidates.push(p);
+    }
+  }
+  if (entry.bootLogPath) {
+    candidates.push(entry.bootLogPath);
+  }
+  for (const p of candidates) {
+    if (!existsSync(p)) {
+      // Treat already-gone as success — the goal is that the path
+      // doesn't exist after gc runs.
+      continue;
+    }
+    if (dryRun) {
+      removedPaths.push(p);
+      continue;
+    }
+    if (rmPath(p)) {
+      removedPaths.push(p);
+    } else {
+      failedPaths.push(p);
+    }
+  }
+  if (!dryRun) {
+    removeEntry(entry.pid);
+  }
+  return {
+    pid: entry.pid,
+    name: entry.name,
+    status,
+    removedPaths,
+    failedPaths,
+    registryRemoved: true,
+  };
+}
+
+function rmPath(p: string): boolean {
+  try {
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      rmSync(p, { recursive: true, force: true });
+    } else {
+      unlinkSync(p);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -36,6 +36,10 @@ export type { EnsureRootfsImageOptions } from "./rootfs-img.ts";
 export { spawnArtifactCache, resolveCacheDir } from "./artifact-cache.ts";
 export type { ArtifactCacheHandle, ArtifactCacheOptions } from "./artifact-cache.ts";
 export { bootSnapshotPath, detachedLogRoot, writeBootSnapshot } from "./detached-log.ts";
+export { validatePid } from "./pid-validate.ts";
+export type { PidStatus } from "./pid-validate.ts";
+export { runGc } from "./gc.ts";
+export type { GcResult, RunGcOptions } from "./gc.ts";
 export { list, registryRoot } from "./registry.ts";
 export type { RegistryEntry } from "./registry.ts";
 export {

--- a/packages/runtime/src/pid-validate.ts
+++ b/packages/runtime/src/pid-validate.ts
@@ -1,0 +1,180 @@
+// Anti-recycling check for `machinen gc` / `machinen stop`.
+//
+// `kill(pid, 0)` only tells us "some process with this pid exists" —
+// the kernel happily recycles pids, so a long-dead VMM's pid can land
+// on an unrelated process. If gc trusts kill(0) alone, two things go
+// wrong: it leaves cleanupPaths around for the recycled-pid entry,
+// and `machinen stop <name>` ends up SIGTERM-ing whatever happened to
+// inherit that pid.
+//
+// The fix is to also confirm the process *is the original VMM*:
+//   - exe path matches the recorded `entry.vmmExe`, and
+//   - process start time is within a small skew of `entry.startedAt`.
+//
+// Linux: `/proc/<pid>/exe` is a symlink to the on-disk exe; readlink
+// is rock-solid. `/proc/<pid>/stat` field 22 (starttime in clock
+// ticks since boot) gives the start time we cross-check.
+//
+// macOS: no /proc. `ps -o comm=,lstart= -p <pid>` is the portable
+// answer; comm is the basename, lstart is a wall-clock human-readable
+// timestamp. Comparing basenames means we miss exe-replacement
+// attacks, but the threat model here is pid recycling on a
+// development laptop — comm + lstart-within-skew is enough.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readlinkSync } from "node:fs";
+import { platform } from "node:os";
+import { basename } from "node:path";
+
+/**
+ * Skew tolerance for start-time comparison. macOS `ps` only gives us
+ * second-level resolution and the registry records ms; allow a few
+ * seconds either way to absorb both. Smaller would be tighter but
+ * would false-positive on slow boots where Date.now() (in JS, after
+ * spawn) and ps's start time (in the kernel, before exec) differ by
+ * a noticeable amount.
+ */
+const STARTTIME_SKEW_MS = 5_000;
+
+/** Result of `validatePid` — easy to switch on at the call site. */
+export type PidStatus = "alive" | "dead" | "recycled";
+
+/**
+ * Return whether the running process at `pid` is still our VMM.
+ *
+ * - `alive`     — pid is alive AND the exe + start-time match.
+ * - `dead`      — kill(pid, 0) failed (gone or permission-denied,
+ *                 either way unreachable).
+ * - `recycled`  — pid is alive but the process isn't ours (different
+ *                 exe, or start time outside skew).
+ *
+ * Falls back to `alive` when the recorded entry lacks `vmmExe` /
+ * `startedAt` (older entries from before PR2). Conservative on
+ * purpose: the gc decision then leans on `kill(pid, 0)` alone, same
+ * behaviour we had before.
+ */
+export function validatePid(
+  pid: number,
+  expected: { vmmExe?: string; startedAt?: number },
+): PidStatus {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return "dead";
+  }
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return "dead";
+  }
+  // No way to distinguish — be conservative.
+  if (!expected.vmmExe && expected.startedAt === undefined) {
+    return "alive";
+  }
+  const observed = readProcessIdentity(pid);
+  if (!observed) {
+    // Couldn't read /proc or ps; don't lie that it's recycled — fall
+    // back to the kill(0) result.
+    return "alive";
+  }
+  if (expected.vmmExe) {
+    const expectedBase = basename(expected.vmmExe);
+    if (observed.exeBase !== expectedBase) {
+      return "recycled";
+    }
+  }
+  if (expected.startedAt !== undefined && observed.startedAtMs !== undefined) {
+    if (Math.abs(observed.startedAtMs - expected.startedAt) > STARTTIME_SKEW_MS) {
+      return "recycled";
+    }
+  }
+  return "alive";
+}
+
+interface ProcessIdentity {
+  exeBase: string;
+  startedAtMs?: number;
+}
+
+function readProcessIdentity(pid: number): ProcessIdentity | undefined {
+  if (platform() === "linux") {
+    return readLinuxIdentity(pid);
+  }
+  return readPsIdentity(pid);
+}
+
+function readLinuxIdentity(pid: number): ProcessIdentity | undefined {
+  let exeBase: string;
+  try {
+    exeBase = basename(readlinkSync(`/proc/${pid}/exe`));
+  } catch {
+    return undefined;
+  }
+  // /proc/<pid>/stat layout: pid (comm) state … starttime[22] (in
+  // clock ticks since boot). The comm field is parens-wrapped and
+  // can contain spaces, so split on the *last* `)` to skip it.
+  let startedAtMs: number | undefined;
+  try {
+    if (existsSync(`/proc/${pid}/stat`)) {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const lastParen = stat.lastIndexOf(")");
+      if (lastParen !== -1) {
+        const fields = stat.slice(lastParen + 2).split(" ");
+        // After the comm field, indices restart from 0 (state).
+        // starttime is the original field 22 → index 22 - 3 = 19.
+        const ticksRaw = fields[19];
+        const ticks = Number(ticksRaw);
+        const btime = readBootTimeSeconds();
+        if (Number.isFinite(ticks) && btime !== undefined) {
+          // SC_CLK_TCK is 100 on every Linux the runtime targets;
+          // not exposed by Node, hard-coded with this assumption.
+          startedAtMs = (btime + ticks / 100) * 1000;
+        }
+      }
+    }
+  } catch {
+    // start-time is best-effort — exe match alone is plenty signal.
+  }
+  return { exeBase, startedAtMs };
+}
+
+function readBootTimeSeconds(): number | undefined {
+  try {
+    const stat = readFileSync("/proc/stat", "utf8");
+    for (const line of stat.split("\n")) {
+      if (line.startsWith("btime ")) {
+        const v = Number(line.slice(6).trim());
+        return Number.isFinite(v) ? v : undefined;
+      }
+    }
+  } catch {}
+  return undefined;
+}
+
+function readPsIdentity(pid: number): ProcessIdentity | undefined {
+  let out: string;
+  try {
+    out = execFileSync("ps", ["-o", "comm=,lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return undefined;
+  }
+  const trimmed = out.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Format from `man ps`: comm is one whitespace-separated token; the
+  // rest is the lstart wall-clock string ("Sun May  3 07:13:52 2026"),
+  // which Date.parse can read directly (the locale-independent
+  // ctime-ish format ps uses).
+  const m = trimmed.match(/^(\S+)\s+(.+)$/);
+  if (!m) {
+    return undefined;
+  }
+  const exeBase = basename(m[1]!);
+  const lstartMs = Date.parse(m[2]!);
+  return {
+    exeBase,
+    startedAtMs: Number.isFinite(lstartMs) ? lstartMs : undefined,
+  };
+}

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -65,6 +65,23 @@ export interface RegistryEntry {
    * of the boot sequence on a detached VM.
    */
   bootLogPath?: string;
+  /**
+   * Per-boot artifacts that need to be removed when the VMM exits.
+   * Today the in-process exit hook handles this for non-detached
+   * boots. After detach (#150 phase 2) the parent is gone before the
+   * VMM exits — `machinen gc` / `machinen stop` use this list to
+   * clean up afterward. Each entry is an absolute path to either a
+   * file (per-boot disk image) or a directory (bundle / vsock UDS).
+   */
+  cleanupPaths?: string[];
+  /**
+   * Absolute path to the VMM binary that was spawned. `machinen gc`
+   * compares this against `/proc/<pid>/exe` (Linux) or `ps -o comm=`
+   * (macOS) before treating an entry as live — without it, a recycled
+   * pid that happens to belong to some other process would look alive
+   * to `kill(pid, 0)` and the entry would be kept around forever.
+   */
+  vmmExe?: string;
   /** ms epoch when the entry was created. */
   startedAt: number;
 }
@@ -154,6 +171,37 @@ export function isAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * List every registry entry on disk, including ones whose pid is
+ * dead. Side-effect-free: nothing is removed, no pins are pruned.
+ *
+ * `machinen gc` (issue #150 phase 2 PR2) needs this to see dead
+ * entries before deciding whether to drop their cleanupPaths —
+ * `list()` would have already removed the registry directory by the
+ * time gc looked, leaving no record of what to clean up.
+ */
+export function listAll(): RegistryEntry[] {
+  const root = registryRoot();
+  if (!existsSync(root)) {
+    return [];
+  }
+  const out: RegistryEntry[] = [];
+  for (const dirent of readdirSync(root, { withFileTypes: true })) {
+    if (!dirent.isDirectory() || dirent.name === "names") {
+      continue;
+    }
+    const pidNum = Number(dirent.name);
+    if (!Number.isInteger(pidNum) || pidNum <= 0) {
+      continue;
+    }
+    const entry = readEntry(pidNum);
+    if (entry) {
+      out.push(entry);
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -879,6 +879,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // and we throw REGISTRY_NAME_IN_USE. The just-spawned VMM has to
   // be torn down on conflict; otherwise it'd be an orphan no one
   // can reach.
+  //
+  // INVARIANT (#150 phase 2): this whole block must complete
+  // synchronously before any `await` — in particular, before the
+  // readiness gate further down can call `handle.detach()` and
+  // unref the child. Detaching a name-conflict losers' child means
+  // the SIGKILL above wouldn't reach an orphaned-to-PID-1 VMM.
+  // Today the structure enforces this (no awaits between here and
+  // the gate); don't reorder.
   const vmName = opts.name;
   const childPid = child.pid ?? -1;
   if (vmName && childPid > 0) {
@@ -896,6 +904,25 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // #150 phase 2: detached VMs record where the boot-console snapshot
   // will land so `attach` / `ls` / `gc` can find it later.
   const bootLogPath = opts.detached && childPid > 0 ? bootSnapshotPath(childPid) : undefined;
+  // #150 phase 2 PR2: persist per-boot artifacts in the registry so
+  // `machinen gc` / `machinen stop` can clean them up after the
+  // parent has exited (the in-process exit hook below stops firing
+  // once we detach). Recorded for *every* boot, not just detached —
+  // gc is a backstop, the inline rm still runs first for the common
+  // attached case.
+  const cleanupPaths: string[] = [];
+  if (perBootRootDisk) {
+    cleanupPaths.push(perBootRootDisk);
+  }
+  if (perBootSnapDisk) {
+    cleanupPaths.push(perBootSnapDisk);
+  }
+  if (bundleTempDir) {
+    cleanupPaths.push(bundleTempDir);
+  }
+  if (vsockTempDir) {
+    cleanupPaths.push(vsockTempDir);
+  }
   let registered = false;
   if (childPid > 0 && vsockUdsPath) {
     try {
@@ -907,6 +934,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         diskPath: diskAbs,
         forkedFrom: opts.forkedFrom,
         bootLogPath,
+        cleanupPaths: cleanupPaths.length > 0 ? cleanupPaths : undefined,
+        vmmExe: binary,
         startedAt: Date.now(),
       });
       registered = true;

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -525,8 +525,70 @@ else
   cat "$N2D_EXEC_LOG" >&2
   fail "N2D — post-detach 'machinen exec' exited non-zero"
 fi
+# Don't call cleanup_n2d here — N2S below uses `machinen stop` to
+# tear it down and asserts the cleanup actually happened. The EXIT
+# trap is still set, so a failure between here and the end of N2S
+# still kills the VMM.
 
-cleanup_n2d
+# ---- N2S: machinen stop <name> — clean SIGTERM + gc.
+# Issue #150 phase 2 PR2. Reuses the N2D-booted detached VM: now
+# tear it down via `machinen stop` instead of raw kill, and assert
+# both the registry entry and the per-boot artifacts are gone.
+echo "N2S: machinen stop $N2D_NAME"
+# Snapshot the cleanupPaths we expect gc to nuke. Pull them straight
+# from the registry's meta.json — gc has the source of truth.
+N2D_META="$MACHINEN_REGISTRY_DIR/$N2D_PID/meta.json"
+if [[ ! -s "$N2D_META" ]]; then
+  fail "N2S — meta.json missing for pid $N2D_PID"
+fi
+# `node -p` to extract cleanupPaths reliably without a JSON parser
+# in bash. Falls back to empty string if the field is absent.
+N2D_CLEANUP_PATHS=$(node -p "JSON.parse(require('fs').readFileSync('$N2D_META','utf8')).cleanupPaths?.join('\\n') ?? ''" 2>/dev/null || true)
+
+N2S_LOG="$FIXTURE/n2s.log"
+if cli stop --name "$N2D_NAME" >"$N2S_LOG" 2>&1; then
+  pass "machinen stop --name $N2D_NAME exited 0"
+else
+  cat "$N2S_LOG" >&2
+  fail "N2S — machinen stop exited non-zero"
+fi
+
+# Registry entry should be gone.
+if cli ls 2>/dev/null | grep -q "$N2D_NAME"; then
+  cli ls >&2
+  fail "N2S — '$N2D_NAME' still listed after machinen stop"
+fi
+pass "machinen ls no longer lists '$N2D_NAME'"
+
+# Each cleanupPath should now be gone too. Skip the loop body when
+# cleanupPaths was empty in the registry (e.g. snapshot: false boots).
+if [[ -n "$N2D_CLEANUP_PATHS" ]]; then
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    if [[ -e "$path" ]]; then
+      fail "N2S — cleanupPath survived gc: $path"
+    fi
+  done <<<"$N2D_CLEANUP_PATHS"
+  pass "machinen stop removed all recorded cleanupPaths"
+else
+  pass "no cleanupPaths recorded (nothing to verify)"
+fi
+
+# Stop is idempotent — calling it again on a missing name should
+# error cleanly, not crash.
+N2S_AGAIN_LOG="$FIXTURE/n2s-again.log"
+if cli stop --name "$N2D_NAME" >"$N2S_AGAIN_LOG" 2>&1; then
+  cat "$N2S_AGAIN_LOG" >&2
+  fail "N2S — second 'stop' on missing name should have failed"
+fi
+if grep -q "no running VM matched" "$N2S_AGAIN_LOG"; then
+  pass "second stop reports 'no running VM matched'"
+else
+  cat "$N2S_AGAIN_LOG" >&2
+  fail "N2S — expected 'no running VM matched' on missing name"
+fi
+
+# Already cleaned by `machinen stop`, so cleanup_n2d is a no-op now.
 trap 'rm -rf "$FIXTURE"' EXIT
 fi  # N2 rootfs-capability gate
 


### PR DESCRIPTION
## Summary

Stacked on #241. Closes the cleanup gap PR1 left behind: per-boot reflink disks, bundle dirs, and vsock UDS dirs from \`--detached\` boots no longer leak.

```
$ machinen ls
PID    NAME    UP   FORKED-FROM
12345  worker  3h   -
$ machinen stop --name worker
stopped worker (pid 12345)
$ machinen ls
(no running VMs)
$ machinen gc        # backstop after a crash
(nothing to clean up)
```

## Pieces

- **\`registry.ts\`** — \`RegistryEntry\` gains \`cleanupPaths: string[]\` (per-boot artifacts to rm) + \`vmmExe: string\` (recorded so gc can detect a recycled pid). New \`listAll()\` returns every entry without pruning, so gc can see dead-pid entries before \`list()\` drops them.
- **\`pid-validate.ts\`** — \`validatePid(pid, { vmmExe?, startedAt? })\` returns \`alive\` / \`dead\` / \`recycled\`. Linux uses \`/proc/<pid>/{exe,stat}\`; macOS uses \`ps -o comm=,lstart=\`. Without this, gc would trust \`kill(0)\` alone and either keep entries forever (recycled pid happens to be alive) or \`SIGTERM\` an unrelated process.
- **\`gc.ts\`** — \`runGc({ dryRun?, pid? })\` walks \`listAll()\`, reaps dead+recycled entries, rms each \`cleanupPaths\` entry + the boot-log snapshot + the registry record. Idempotent.
- **\`cli.ts\`** — \`machinen gc [--dry-run|-n]\` and \`machinen stop ( --name | --pid ) [--force|-9]\`. \`stop\` SIGTERMs, polls for exit, escalates to SIGKILL after 2s, then runs gc on that entry. Refuses to signal a recycled pid.
- **\`vm.ts\`** — registers \`cleanupPaths\` + \`vmmExe\` into the registry on every boot (gc is a backstop; the in-process exit hook still runs first for non-detached boots). Also tightens the name-claim INVARIANT comment so a future refactor can't accidentally insert an \`await\` between \`claimName\` and the readiness gate.
- **completion** — bash, zsh, fish all gain \`gc\` / \`stop\` plus their flags.

## Test plan

- [x] Unit: 11 new tests (5 \`validatePid\` covering dead / invalid / alive / exe-mismatch / starttime-skew; 6 \`runGc\` covering empty / alive-skip / dead+rm / dry-run / pid-filter / recycled-via-real-spawn).
- [x] Local: \`pnpm vitest run\` (407 pass / 7 skipped with \`MACHINEN_REQUIRE_FIXTURES=0\`).
- [x] Local: \`agent-ci run --all\` (4/4 workflows green in 1m33s).
- [x] Smoke (N2S, extends N2D): \`stop --name\` clears the registry entry AND every recorded \`cleanupPath\`; a second \`stop\` on the missing name errors cleanly.
- [ ] Smoke runner needs to execute N2S end-to-end against the real VMM.

## Recycled-pid threat model

The kernel happily reuses pids; \`kill(0)\` only says "some process exists." Without the validation step:
- \`gc\` would never reap an entry whose pid was recycled to (say) the user's editor — \`cleanupPaths\` leak forever.
- \`stop --name worker\` would \`SIGTERM\` whatever now holds that pid.

Both are real on a long-lived dev machine. \`validatePid\` requires both exe-name match AND start-time within 5s skew before treating an entry as live. Conservative when fields are missing (older entries from before this PR): falls back to \`alive\` so we never mis-signal.

## Closes the loop on #150 phase 2

PR1 made detach work; PR2 makes it cleanable. After this lands, the only remaining piece of phase 2 is **PR3**: gvproxy detach + \`attach\` log replay. Phase 3 (extracting the artifact cache + live-mount FUSE servers out of the JS supervisor so the \`BOOT_DETACHED_INCOMPATIBLE\` gates can be lifted) follows after that.
