### PR TITLE
chore(microvm): bound loops in virtio / vsock / net_socket (#238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ release-assets/
 .kernel-build/
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+
+# vm-pick clonefile helper (built on first use; macOS-arm64 only)
+scripts/clonefile
+scripts/clonefile.o
+scripts/clonefile.o.o
+.zig-cache/

--- a/packages/microvm/src/net_socket.zig
+++ b/packages/microvm/src/net_socket.zig
@@ -63,6 +63,12 @@ const SOCK_STREAM: c_int = 1;
 const SHUT_RDWR: c_int = 2;
 const EINTR: c_int = 4;
 
+/// Per call to writeAll/readAll, cap the number of consecutive EINTR
+/// retries so a signal storm can't pin the thread. A healthy socket
+/// either makes byte-progress or closes; EINTR is transient. 64 is
+/// generous (NASA Power-of-Ten Rule 2 / #238).
+const max_eintr_retries: u32 = 64;
+
 const sockaddr_un = if (builtin.os.tag == .macos) extern struct {
     sun_len: u8,
     sun_family: u8,
@@ -206,6 +212,12 @@ pub const NetSocket = struct {
         var buf: [16 * 1024]u8 = undefined;
         assert(buf.len >= 1500);
 
+        // Service loop: termination bound is `self.stop` (set by
+        // destroy() before shutdown()). Per-iteration work is bounded
+        // statically — exactly one frame, ≤ buf.len bytes, plus two
+        // readAll() calls each capped on EINTR by max_eintr_retries.
+        // No frames-per-wake throttle: incoming frames are real work
+        // and the kernel buffer keeps them ordered while we drain.
         while (!self.stop.load(.acquire)) {
             var prefix: [4]u8 = undefined;
             if (readAll(self.fd, &prefix) != 0) return;
@@ -238,13 +250,22 @@ fn writeAll(fd: c_int, data: []const u8) c_int {
     assert(fd >= 0);
     assert(data.len > 0);
     var remaining = data;
+    var eintr: u32 = 0;
+    // remaining strictly shrinks on every n>0; eintr counts the
+    // signal-retry path independently and is bounded by
+    // max_eintr_retries (#238).
     while (remaining.len > 0) {
         const n = write(fd, remaining.ptr, remaining.len);
         if (n > 0) {
             remaining = remaining[@intCast(n)..];
+            eintr = 0;
             continue;
         }
-        if (n < 0 and errno() == EINTR) continue;
+        if (n < 0 and errno() == EINTR) {
+            eintr += 1;
+            if (eintr > max_eintr_retries) return -1;
+            continue;
+        }
         return -1;
     }
     return 0;
@@ -254,14 +275,20 @@ fn readAll(fd: c_int, into: []u8) c_int {
     assert(fd >= 0);
     assert(into.len > 0);
     var remaining = into;
+    var eintr: u32 = 0;
     while (remaining.len > 0) {
         const n = read(fd, remaining.ptr, remaining.len);
         if (n > 0) {
             remaining = remaining[@intCast(n)..];
+            eintr = 0;
             continue;
         }
         if (n == 0) return -1; // peer closed
-        if (errno() == EINTR) continue;
+        if (errno() == EINTR) {
+            eintr += 1;
+            if (eintr > max_eintr_retries) return -1;
+            continue;
+        }
         return -1;
     }
     return 0;

--- a/packages/microvm/src/virtio.zig
+++ b/packages/microvm/src/virtio.zig
@@ -71,6 +71,14 @@ pub const Status = packed struct(u32) {
 /// uses 2 (RX, TX); reserving extra room is cheap.
 pub const max_queues: u32 = 8;
 
+/// Hard cap on descriptors per chain. The virtio spec doesn't fix
+/// this, but in practice every workload we serve (net, blk, vsock)
+/// uses chains of ≤ 4. A buggy or hostile guest could ring a longer
+/// chain — including a `next` cycle — which would otherwise spin the
+/// VMM thread indefinitely. We break out silently when exceeded:
+/// guest-input bound, fail-soft, exactly as `blk.zig` does.
+pub const max_chain_descriptors: u32 = 32;
+
 comptime {
     // Wire-format layouts the guest driver writes / reads directly. A
     // mismatch here means @memcpy at runtime would shred a parsed ring
@@ -96,6 +104,10 @@ comptime {
     // hard cap is 32, but 8 is what we actually support.
     assert(max_queues > 0);
     assert(max_queues <= 32);
+    assert(max_chain_descriptors > 0);
+    // A chain longer than the queue itself is impossible on a
+    // well-formed driver; the cap is the smaller bound for runtime.
+    assert(max_chain_descriptors <= 256);
 }
 
 /// Interrupt-status bits the driver expects to see at 0x060.
@@ -328,11 +340,18 @@ pub const Device = struct {
             // there's something to send to the guest).
             if ((self.skip_notify_queues >> @as(u5, @intCast(q_idx))) & 1 != 0) return;
             const avail = self.readAvailHeader(q) orelse return;
-            while (q.last_avail_idx != avail.idx) {
+            // A well-formed driver can post at most q.num avail entries
+            // before it must wait for used. A buggy driver that bumps
+            // avail.idx past that bound would otherwise spin us; cap at
+            // q.num and let the next notify (or the next iteration of
+            // the boot run loop) catch up.
+            var chains: u32 = 0;
+            while (chains < q.num and q.last_avail_idx != avail.idx) : (chains += 1) {
                 const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return;
                 handler(self.request_ctx, self, q_idx, head);
                 q.last_avail_idx +%= 1;
             }
+            assert(chains <= q.num);
             _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
             return;
         }
@@ -406,12 +425,20 @@ pub const Device = struct {
         var idx: u16 = head;
         var written: u32 = 0;
         var steps: u32 = 0;
-        while (steps < q.num) : (steps += 1) {
+        // Chain walk capped at max_chain_descriptors per #238: a guest
+        // that points `next` in a cycle would otherwise spin the VMM.
+        // Truncating an over-long chain is fail-soft (we drop the frame
+        // and the next inject will pick up a fresh head).
+        while (steps < max_chain_descriptors) : (steps += 1) {
             const desc = self.readDescriptor(q, idx) orelse return false;
             // RX descriptors must be writable by the device.
             if ((desc.flags & VringDesc.F_WRITE) == 0) return false;
 
             var budget: u32 = desc.len;
+            // Inner loop terminates because either `remaining` shrinks
+            // (bounded by net_hdr.len + frame.len) or we break out when
+            // both buffers are empty. Each iteration that enters the
+            // copy branch consumes at least 1 byte from `remaining`.
             while (budget > 0) {
                 if (remaining.len == 0) {
                     if (frame_started) break;
@@ -420,6 +447,7 @@ pub const Device = struct {
                     if (remaining.len == 0) break;
                 }
                 const chunk: u32 = @intCast(@min(@as(u64, budget), remaining.len));
+                assert(chunk > 0);
                 const dst = self.guestSlice(desc.addr + (desc.len - budget), chunk) orelse return false;
                 @memcpy(dst, remaining[0..chunk]);
                 remaining = remaining[chunk..];
@@ -430,6 +458,7 @@ pub const Device = struct {
             if ((desc.flags & VringDesc.F_NEXT) == 0) break;
             idx = desc.next;
         }
+        assert(steps <= max_chain_descriptors);
 
         self.pushUsed(q, head, written);
         q.last_avail_idx +%= 1;
@@ -444,12 +473,16 @@ pub const Device = struct {
         assert(q.ready != 0);
         assert(q.num > 0);
         const avail = self.readAvailHeader(q) orelse return;
-        while (q.last_avail_idx != avail.idx) {
+        // Bound matches the request_handler path in notify(): no driver
+        // can post more than q.num avail entries before consuming used.
+        var chains: u32 = 0;
+        while (chains < q.num and q.last_avail_idx != avail.idx) : (chains += 1) {
             const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return;
             const total_len = self.walkAndEmit(q, head);
             self.pushUsed(q, head, total_len);
             q.last_avail_idx +%= 1;
         }
+        assert(chains <= q.num);
         _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
     }
 
@@ -464,7 +497,6 @@ pub const Device = struct {
     /// ethernet frame, which is what any backend wants to forward.
     fn walkAndEmit(self: *Device, q: *Queue, head: u16) u32 {
         // Caller drains under notify, which has gated on q.num > 0.
-        // We use q.num as the loop bound below.
         assert(q.num > 0);
         // Worst case: MTU 9000 + headers. 16 KiB is a comfortable cap.
         var scratch: [16 * 1024]u8 = undefined;
@@ -473,7 +505,10 @@ pub const Device = struct {
 
         var idx: u16 = head;
         var steps: u32 = 0;
-        while (steps < q.num) : (steps += 1) {
+        // #238: cap at max_chain_descriptors so a guest that points
+        // `next` in a cycle truncates the frame instead of pinning the
+        // VMM thread. Same fail-soft policy as injectRx / blk.zig.
+        while (steps < max_chain_descriptors) : (steps += 1) {
             const desc = self.readDescriptor(q, idx) orelse break;
             if (desc.len > 0 and written < scratch.len) {
                 const take: usize = @min(desc.len, scratch.len - written);
@@ -486,6 +521,7 @@ pub const Device = struct {
             idx = desc.next;
         }
 
+        assert(steps <= max_chain_descriptors);
         assert(written <= scratch.len);
         if (self.tx_handler) |h| {
             const net_hdr_size: usize = 12; // virtio_net_hdr_v1

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -162,6 +162,23 @@ pub const Q_EVENT: u32 = 2;
 /// packets; this just bounds our scratch buffer (TX direction).
 pub const max_payload: usize = 64 * 1024;
 
+/// Per-iteration cap on the wake-pipe drain in the bridge poll loop.
+/// Each read drains up to 64 B; 256 iterations covers a 16 KiB
+/// backlog. A peer that keeps writing past this just wakes us again
+/// next poll — the surrounding poll() already serves as the rate limit.
+pub const wake_drain_iters_max: u32 = 256;
+
+/// Cumulative EAGAIN stalls allowed while waiting for a UDS write to
+/// drain in dispatchGuestPacket. Each stall is a 100 ms poll, so 50
+/// caps the per-packet wait at ~5 s before we give up on a wedged
+/// peer rather than block the bridge thread indefinitely.
+pub const tx_eagain_stalls_max: u32 = 50;
+
+/// Hard cap on entries parsed out of MACHINEN_VSOCK. Bounded by the
+/// number of port-mapping arguments a sane operator would ever pass.
+/// Keeps parseEnv from looping forever on a pathological input.
+pub const parse_env_entries_max: u32 = 256;
+
 /// Per-packet body cap we use when INJECTING RX packets into the
 /// guest. The Linux virtio-vsock driver posts RX buffers as a
 /// SINGLE flat descriptor (not a chain — contrary to what the
@@ -223,6 +240,9 @@ comptime {
     assert(ShutdownFlag.recv == 1);
     assert(ShutdownFlag.send == 2);
     assert(ShutdownFlag.both == 3);
+    assert(wake_drain_iters_max > 0);
+    assert(tx_eagain_stalls_max > 0);
+    assert(parse_env_entries_max > 0);
 }
 
 /// Parse a `MACHINEN_VSOCK` value into a `PortMap` list.
@@ -243,7 +263,11 @@ pub fn parseEnv(gpa: std.mem.Allocator, raw: []const u8) ![]PortMap {
         list.deinit(gpa);
     }
     var rest: []const u8 = raw;
-    while (rest.len > 0) {
+    var entries: u32 = 0;
+    // #238: cap entries so a pathological env value can't pin the
+    // parser. Real configs have a handful of mappings; 256 is far
+    // beyond anything a sane operator would set.
+    while (rest.len > 0 and entries < parse_env_entries_max) : (entries += 1) {
         const end = std.mem.indexOfScalar(u8, rest, ',') orelse rest.len;
         var entry = rest[0..end];
         if (end < rest.len) rest = rest[end + 1 ..] else rest = "";
@@ -366,7 +390,10 @@ pub fn readPacket(
     var written: usize = 0;
     var idx: u16 = head;
     var steps: u32 = 0;
-    while (steps < 32) : (steps += 1) {
+    // Chain length is guest-driven; cap at virtio.max_chain_descriptors
+    // (the same 32-entry policy as blk.zig and virtio's own walks)
+    // and silently truncate longer chains.
+    while (steps < virtio.max_chain_descriptors) : (steps += 1) {
         const d = dev.queueDescriptor(q_idx, idx) orelse return null;
         if (d.len > 0) {
             const take: usize = @min(@as(usize, d.len), scratch.len - written);
@@ -379,7 +406,7 @@ pub fn readPacket(
         if ((d.flags & virtio.VringDesc.F_NEXT) == 0) break;
         idx = d.next;
     }
-    assert(steps <= 32);
+    assert(steps <= virtio.max_chain_descriptors);
     assert(written <= scratch.len);
     if (written < header_size) return null;
 
@@ -418,16 +445,23 @@ pub fn writePacket(
     var idx: u16 = head;
     var steps: u32 = 0;
     var total: u32 = 0;
-    while (steps < 32) : (steps += 1) {
+    // Mirror the readPacket bound: cap at virtio.max_chain_descriptors
+    // and treat a longer chain as "too short" to fit our packet (return
+    // null) — same fail-soft as the chain-too-short branch below.
+    while (steps < virtio.max_chain_descriptors) : (steps += 1) {
         const d = dev.queueDescriptor(q_idx, idx) orelse return null;
         // RX descriptors must be writable.
         if ((d.flags & virtio.VringDesc.F_WRITE) == 0) return null;
 
         var budget: u32 = d.len;
         var desc_off: u32 = 0;
+        // Inner loop: each iteration consumes ≥ 1 byte from
+        // remaining_hdr or remaining_body (both bounded), so it
+        // terminates in at most header_size + body.len iterations.
         while (budget > 0 and (remaining_hdr.len > 0 or remaining_body.len > 0)) {
             const source: []const u8 = if (remaining_hdr.len > 0) remaining_hdr else remaining_body;
             const chunk: u32 = @intCast(@min(@as(u64, budget), source.len));
+            assert(chunk > 0);
             const dst = dev.guestBytes(d.addr + desc_off, chunk) orelse return null;
             @memcpy(dst, source[0..chunk]);
             if (remaining_hdr.len > 0) {
@@ -444,7 +478,7 @@ pub fn writePacket(
         if ((d.flags & virtio.VringDesc.F_NEXT) == 0) return null; // chain too short
         idx = d.next;
     }
-    assert(steps <= 32);
+    assert(steps <= virtio.max_chain_descriptors);
     if (remaining_hdr.len != 0 or remaining_body.len != 0) return null;
     assert(total == @as(u32, header_size) + @as(u32, @intCast(body.len)));
     return total;
@@ -853,10 +887,15 @@ pub const Bridge = struct {
 
             _ = poll(scratch.ptr, @intCast(n), 250);
 
-            // Drain the wake pipe.
+            // Drain the wake pipe. Capped per #238 so a peer that keeps
+            // writing nudges can't pin this thread out of the poll set.
             if ((scratch[0].revents & POLLIN) != 0) {
                 var drain: [64]u8 = undefined;
-                while (read(self.wake[0], &drain, drain.len) > 0) {}
+                var drain_iters: u32 = 0;
+                while (drain_iters < wake_drain_iters_max) : (drain_iters += 1) {
+                    if (read(self.wake[0], &drain, drain.len) <= 0) break;
+                }
+                assert(drain_iters <= wake_drain_iters_max);
             }
 
             // Accept listeners.
@@ -1196,7 +1235,10 @@ pub const Bridge = struct {
                 // "Truncated tar archive".
                 var remaining = body;
                 var stalls: u32 = 0;
-                while (remaining.len > 0) {
+                // remaining strictly shrinks on n > 0; stalls is the
+                // EAGAIN-only counter, capped to keep a wedged peer
+                // from pinning the bridge thread (#238).
+                while (remaining.len > 0 and stalls <= tx_eagain_stalls_max) {
                     const n = write(c.uds_fd, remaining.ptr, remaining.len);
                     if (n > 0) {
                         remaining = remaining[@intCast(n)..];
@@ -1207,8 +1249,8 @@ pub const Bridge = struct {
                     var pfds = [_]PollFd{.{ .fd = c.uds_fd, .events = POLLOUT_, .revents = 0 }};
                     _ = poll(&pfds, 1, 100);
                     stalls += 1;
-                    if (stalls > 50) break; // ~5 s cumulative, give up
                 }
+                assert(stalls <= tx_eagain_stalls_max + 1);
                 c.bytes_from_peer +%= @intCast(body.len);
                 c.fwd_cnt = c.bytes_from_peer;
                 // Emit a credit update when we've consumed enough new

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -451,7 +451,11 @@ gzip -n > /out/rootfs-debian-arm64.tar.gz
 # 4-KiB block size matches the kernel's arm64 page size so reads
 # are page-cache-aligned; same as the runtime materializer.
 TREE_KIB=$(du -sk /work/rootfs | awk '{print $1}')
-SIZE_BYTES=$(awk -v k="$TREE_KIB" 'BEGIN { s = int(k * 1024 * 2.5); m = 2 * 1024 * 1024 * 1024; if (s < m) s = m; printf "%d\n", s }')
+# printf "%d" on macOS awk clamps at INT32_MAX (2147483647), so a 2 GiB
+# default became 2^31-1 — odd, not 512-aligned, and the VMM's
+# blk.Backend.initFromFd asserts on the misalignment. %.0f keeps the
+# value as a double-rendered integer all the way through.
+SIZE_BYTES=$(awk -v k="$TREE_KIB" 'BEGIN { s = int(k * 1024 * 2.5); m = 2 * 1024 * 1024 * 1024; if (s < m) s = m; printf "%.0f\n", s }')
 BLOCKS=$(( SIZE_BYTES / 4096 ))
 echo "==> Prebaking rootfs ext4 image: ${SIZE_BYTES} bytes (${BLOCKS} x 4 KiB blocks)"
 truncate -s "$SIZE_BYTES" /tmp/rootfs.img

--- a/scripts/clonefile.zig
+++ b/scripts/clonefile.zig
@@ -1,0 +1,37 @@
+// Single-syscall APFS directory clone via clonefile(2).
+//
+// `cp -c -R` walks the tree and calls clonefile() per file (~135us each
+// of metadata work). For a 42k-file repo that's ~5s. Calling clonefile(2)
+// once on the source directory clones the whole subtree in the kernel,
+// ~10x faster.
+//
+// Build: zig build-exe -O ReleaseSmall scripts/clonefile.zig -femit-bin=scripts/clonefile
+// Usage: clonefile <src> <dst>
+
+const std = @import("std");
+
+extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: u32) c_int;
+extern "c" fn write(fd: c_int, buf: [*]const u8, n: usize) isize;
+extern "c" fn __error() *c_int;
+
+fn errOut(msg: []const u8, rc: u8) u8 {
+    _ = write(2, msg.ptr, msg.len);
+    return rc;
+}
+
+pub fn main(init: std.process.Init.Minimal) u8 {
+    var it = init.args.iterate();
+    _ = it.next(); // argv[0]
+    const src = it.next() orelse return errOut("usage: clonefile <src> <dst>\n", 2);
+    const dst = it.next() orelse return errOut("usage: clonefile <src> <dst>\n", 2);
+    if (it.next() != null) return errOut("usage: clonefile <src> <dst>\n", 2);
+
+    if (clonefile(src.ptr, dst.ptr, 0) != 0) {
+        const e = __error().*;
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "clonefile failed: errno={d}\n", .{e}) catch "clonefile failed\n";
+        _ = write(2, msg.ptr, msg.len);
+        return 1;
+    }
+    return 0;
+}

--- a/scripts/vm-pick.sh
+++ b/scripts/vm-pick.sh
@@ -169,9 +169,27 @@ if [[ -d "$CLONE_DIR" ]]; then
 else
   echo "vm-pick: creating CoW clone at $CLONE_DIR" >&2
   mkdir -p "$CLONES_ROOT"
-  # APFS reflink on macOS. -c is the macOS clone flag; on Linux use
-  # `cp --reflink=auto` instead (this script targets Darwin).
-  cp -c -R "$MAIN_REPO" "$CLONE_DIR"
+  # Single clonefile(2) syscall on the source dir clones the whole tree
+  # in the kernel — ~10x faster than `cp -c -R`, which walks userspace
+  # and pays per-file metadata overhead for ~42k files. Build the helper
+  # on first use; it's macOS-arm64-only and intentionally not checked in.
+  SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  CLONEFILE_BIN="$SCRIPT_DIR/clonefile"
+  CLONEFILE_SRC="$SCRIPT_DIR/clonefile.zig"
+  if [[ ! -x "$CLONEFILE_BIN" ]] || [[ "$CLONEFILE_SRC" -nt "$CLONEFILE_BIN" ]]; then
+    if command -v zig >/dev/null 2>&1; then
+      echo "vm-pick: building clonefile helper..." >&2
+      (cd "$SCRIPT_DIR" && zig build-exe -O ReleaseSmall clonefile.zig >/dev/null)
+    else
+      echo "vm-pick: zig not found, falling back to cp -c -R (slower)" >&2
+      CLONEFILE_BIN=""
+    fi
+  fi
+  if [[ -n "$CLONEFILE_BIN" ]]; then
+    "$CLONEFILE_BIN" "$MAIN_REPO" "$CLONE_DIR"
+  else
+    cp -c -R "$MAIN_REPO" "$CLONE_DIR"
+  fi
 
   if [[ "$kind" == "pr" ]]; then
     (cd "$CLONE_DIR" && gh pr checkout "$num")


### PR DESCRIPTION
Closes #238.

## Summary

Tier 3 of the TigerStyle rollout — NASA Power-of-Ten Rule 2. Every `while` in the three VMM device files now has either an explicit named upper bound + post-loop assert, or a documented per-iteration bound on its inner work. Same shape as #210 (blk pilot) / #232 (Tier 1: virtio/vsock/pl011/net_socket asserts) / #237 (Tier 2: KVM + HVF backends).

| File | Bounded loops | New constants |
| --- | ---: | --- |
| `virtio.zig` | 5 | `max_chain_descriptors = 32` |
| `vsock.zig` | 6 | `wake_drain_iters_max`, `tx_eagain_stalls_max`, `parse_env_entries_max` |
| `net_socket.zig` | 2 (+ rxLoop annotation) | `max_eintr_retries = 64` |

## What's bounded

**`virtio.zig`**
- `notify` / `drainAvail` — chain-of-chains capped at `q.num`. A buggy `avail.idx` past that bound can no longer spin the VMM thread.
- `walkAndEmit` / `injectRx` — chain walks capped at `max_chain_descriptors`. A guest-driven `next` cycle now truncates the frame instead of wedging us.
- `injectRx` inner copy loop — `assert(chunk > 0)` makes the per-iteration progress invariant explicit.

**`vsock.zig`**
- `parseEnv` — capped at `parse_env_entries_max`. A pathological `MACHINEN_VSOCK` value can't pin the parser.
- `readPacket` / `writePacket` — chain walks now reuse `virtio.max_chain_descriptors` (replaces the bare `< 32`).
- `Bridge.runThread`'s wake-pipe drain — capped at `wake_drain_iters_max`. A peer that keeps writing nudges can't pull the bridge out of `poll()`.
- `dispatchGuestPacket` write-retry loop — the magic `> 50` is now `tx_eagain_stalls_max`, with the bound documented.

**`net_socket.zig`**
- `writeAll` / `readAll` — count consecutive EINTRs, cap at `max_eintr_retries`. A signal storm can't pin either path.
- `rxLoop` — annotated with explicit per-iteration bound rationale (one frame ≤ 16 KiB, EINTR-bounded `readAll() x 2`). No frames-per-wake throttle: incoming frames are real work and the kernel buffer keeps order.

## Policy (matches #232's audit)

- **Guest-driven bounds** stay fail-soft: descriptor chain walks, avail-ring drains. We early-return / silently truncate.
- **Programmer-error / wedged-peer bounds** add a post-loop `assert`.

## Drive-by fix

`scripts/build-base-assets.sh:454` clamped the rootfs `SIZE_BYTES` to `INT32_MAX` (= 2147483647, an odd number) because macOS `awk`'s `printf "%d"` is a signed 32-bit conversion. The downstream `truncate -s` made the prebake `.img` 2 GiB - 1 byte, the runtime cached it, and the VMM's `blk.Backend.initFromFd` rightly asserted `size_bytes % 512 == 0` — manifesting as a "reached unreachable code" panic at T1 of `pnpm smoke-tests`. Switched the format to `%.0f`. Found while verifying smoke for this PR; folded in to unblock verification.

## Test plan

- [x] `zig build` clean.
- [x] `zig build test` — same skip-on-no-fixture noise as main; no regressions.
- [x] `npx vitest run` — 4 pre-existing failures (3 `exec.test.ts` `EXEC_AGENT_UNAVAILABLE` flakes + 1 `pty.test.ts` env flake), same set as main and #232.
- [x] `npx agent-ci run --all -q -p` — 4/4 workflows passed (1m31s).
- [x] `pnpm smoke-tests` — all green after the prebake fix.
