### PR TITLE
feat(runtime,cli): gvproxy detach + attach --tail (PR3 of #150 phase 2)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,6 +1,7 @@
 import { ParseError } from "@machinen/runtime";
 import { describe, expect, it } from "vitest";
 import { parseRunArgs } from "../parse-run-args.ts";
+import { tailLines } from "../tail-lines.ts";
 
 describe("parseRunArgs --env", () => {
   it("collects repeated --env flags into env", () => {
@@ -279,4 +280,41 @@ describe("parseRunArgs --detached", () => {
   // enforced by the runtime's BOOT_DETACHED_INCOMPATIBLE check, not
   // the parser — the parser is happy to capture both. The runtime
   // gate is covered in detached.test.ts.
+});
+
+describe("tailLines (machinen attach --tail slicing)", () => {
+  it("returns content unchanged when tail is 'all' and content ends with newline", () => {
+    expect(tailLines("a\nb\nc\n", "all")).toBe("a\nb\nc\n");
+  });
+
+  it("appends a trailing newline when content has none", () => {
+    expect(tailLines("a\nb\nc", "all")).toBe("a\nb\nc\n");
+  });
+
+  it("treats tail=0 as 'all' (preserves the legacy `--tail 0` quirk)", () => {
+    expect(tailLines("a\nb\nc\n", 0)).toBe("a\nb\nc\n");
+  });
+
+  it("returns the last N lines, terminated with a newline", () => {
+    expect(tailLines("a\nb\nc\nd\ne\n", 2)).toBe("d\ne\n");
+  });
+
+  it("doesn't double-count the trailing-newline empty in line counts", () => {
+    // Without the trim, a 3-line file with trailing \n would split
+    // into 4 elements and `tail=3` would return only 2 actual lines.
+    expect(tailLines("a\nb\nc\n", 3)).toBe("a\nb\nc\n");
+  });
+
+  it("handles content without a trailing newline", () => {
+    expect(tailLines("a\nb\nc", 2)).toBe("b\nc\n");
+  });
+
+  it("returns empty string for empty content", () => {
+    expect(tailLines("", "all")).toBe("");
+    expect(tailLines("", 5)).toBe("");
+  });
+
+  it("returns the whole content when tail >= line count", () => {
+    expect(tailLines("a\nb\n", 99)).toBe("a\nb\n");
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,6 +46,7 @@ import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
 import { parseRunArgs } from "./parse-run-args.ts";
+import { tailLines } from "./tail-lines.ts";
 
 const debug = debugLib("machinen:cli");
 
@@ -680,18 +681,7 @@ async function cmdStop(args: string[]): Promise<number> {
     return 1;
   }
   if (!force) {
-    // Wait up to 2s for graceful shutdown, then escalate. Polling
-    // beats kqueue/inotify here — the pid we're watching is *not*
-    // our child, so there's no SIGCHLD to listen for.
-    const deadline = Date.now() + 2_000;
-    while (Date.now() < deadline) {
-      try {
-        process.kill(entry.pid, 0);
-      } catch {
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
+    await waitForExit(entry.pid, 2_000);
     try {
       process.kill(entry.pid, 0);
       // Still alive — escalate.
@@ -702,11 +692,63 @@ async function cmdStop(args: string[]): Promise<number> {
       // Already gone.
     }
   }
-  // Final gc to drop the registry entry + cleanupPaths.
+  // #150 phase 2 PR3: signal gvproxy too. Detached gvproxy survives
+  // the parent's exit on its own (no pdeathsig); without this it'd
+  // outlive every `machinen stop`, holding host ports and leaking
+  // the qemu/control sockets. Anti-recycling guard mirrors the VMM
+  // path — basename match against the recorded gvproxy binary, so
+  // an unrelated pid that inherited gvproxy's slot weeks later
+  // doesn't get killed. Wait for it to exit so the test/user can
+  // assume "stop returned → process is gone" without a follow-up
+  // poll.
+  if (entry.gvproxyPid && entry.gvproxyExe) {
+    const gvStatus = validatePid(entry.gvproxyPid, { vmmExe: entry.gvproxyExe });
+    if (gvStatus === "alive") {
+      try {
+        process.kill(entry.gvproxyPid, sig);
+      } catch (err) {
+        process.stderr.write(
+          `machinen stop: failed to signal gvproxy pid ${entry.gvproxyPid}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+      if (!force) {
+        await waitForExit(entry.gvproxyPid, 2_000);
+        try {
+          process.kill(entry.gvproxyPid, 0);
+          try {
+            process.kill(entry.gvproxyPid, "SIGKILL");
+          } catch {}
+        } catch {}
+      }
+    } else if (gvStatus === "recycled") {
+      process.stderr.write(
+        `machinen stop: gvproxy pid ${entry.gvproxyPid} now held by an unrelated process; skipping.\n`,
+      );
+    }
+  }
+  // Final gc to drop the registry entry + cleanupPaths (including the
+  // gvproxy socket dir that PR3 added to the cleanup list).
   runGc({ pid: entry.pid });
   const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
   process.stdout.write(`stopped ${label}\n`);
   return 0;
+}
+
+/**
+ * Poll `kill(pid, 0)` until the process is gone or the deadline
+ * passes. Polling beats kqueue/inotify here — the pid we're watching
+ * is *not* our child, so there's no SIGCHLD to listen for.
+ */
+async function waitForExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
 }
 
 function lookupEntry(target: { name: string } | { pid: number }): RegistryEntry | undefined {
@@ -1012,11 +1054,12 @@ async function cmdFork(args: string[]): Promise<number> {
 }
 
 async function cmdAttach(args: string[]): Promise<number> {
-  // Pull `--shell` out before the target flags so unknown-arg checks
-  // in `parseTargetFlags` don't reject it. Default to `bash -i` —
-  // the Debian base rootfs ships bash, and `-i` gets job control,
-  // history, and a prompt.
+  // Pull `--shell` and `--tail` out before the target flags so the
+  // unknown-arg checks in `parseTargetFlags` don't reject them.
+  // `--shell` defaults to `bash -i` — the Debian base rootfs ships
+  // bash, and `-i` gets job control, history, and a prompt.
   let shell = "/bin/bash -i";
+  let tail: number | "all" | undefined;
   const filtered: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
@@ -1026,11 +1069,51 @@ async function cmdAttach(args: string[]): Promise<number> {
         die("--shell requires a value");
       }
       shell = v;
+    } else if (a === "--tail" || a.startsWith("--tail=")) {
+      // `--tail` (no value) prints the whole snapshot. `--tail N`
+      // prints the last N lines. The snapshot is capped at ~1 MiB so
+      // even the no-value form is bounded.
+      let v: string | undefined;
+      if (a === "--tail") {
+        const peek = args[i + 1];
+        if (peek && /^[0-9]+$/.test(peek)) {
+          v = peek;
+          i++;
+        }
+      } else {
+        v = a.slice("--tail=".length);
+      }
+      if (v === undefined) {
+        tail = "all";
+      } else {
+        const n = Number(v);
+        if (!Number.isInteger(n) || n < 0) {
+          die(`--tail: expected a non-negative integer, got '${v}'`);
+        }
+        tail = n;
+      }
     } else {
       filtered.push(a);
     }
   }
   const target = parseTargetFlags(filtered, "attach");
+  // #150 phase 2 PR3: --tail dumps the boot-console snapshot before
+  // (or instead of) the interactive shell. Look up the registry
+  // entry directly — `attach()` only returns a VmHandle, not the
+  // entry, and we need `bootLogPath` from the registry.
+  if (tail !== undefined) {
+    const entry = lookupEntry(target);
+    if (!entry) {
+      die(`machinen attach: no running VM matched ${describeTarget(target)}`);
+    }
+    if (!entry.bootLogPath) {
+      die(
+        `machinen attach --tail: VM was not booted with --detached, no snapshot exists. ` +
+          `Use 'machinen attach' (no --tail) for live console access.`,
+      );
+    }
+    printBootLogTail(entry.bootLogPath, tail);
+  }
   // Resolve the target before the TTY check: a typo in --name should
   // surface "no running VM found", not the TTY error. The TTY error
   // is only useful once we know the VM exists.
@@ -1045,6 +1128,19 @@ async function cmdAttach(args: string[]): Promise<number> {
   } finally {
     await vm.detach();
   }
+}
+
+function printBootLogTail(path: string, tail: number | "all"): void {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `machinen attach --tail: couldn't read ${path}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return;
+  }
+  process.stderr.write(tailLines(content, tail));
 }
 
 async function cmdRepl(args: string[]): Promise<number> {

--- a/packages/cli/src/tail-lines.ts
+++ b/packages/cli/src/tail-lines.ts
@@ -1,0 +1,26 @@
+// Tail-N pure helper for `machinen attach --tail`. Lives in its own
+// module so vitest can import the function without dragging in
+// `cli.ts`'s top-level `main()` call (which would `process.exit` on
+// load with the test runner's argv).
+
+/**
+ * Return the last `tail` lines of `content`, always terminated with a
+ * newline. `"all"` (or `0`) returns the whole content. Pure for tests.
+ */
+export function tailLines(content: string, tail: number | "all"): string {
+  if (tail === "all" || tail === 0) {
+    return content.endsWith("\n") || content.length === 0 ? content : `${content}\n`;
+  }
+  // Split on \n, drop the trailing empty produced by a terminating
+  // newline so "last N" counts real lines, then take the last N. Fine
+  // for the snapshot's ~1 MiB cap; a streaming reverse-reader would
+  // be overkill at this size.
+  const lines = content.split("\n");
+  const hadTrailingNl = lines.length > 0 && lines[lines.length - 1] === "";
+  const meaningful = hadTrailingNl ? lines.slice(0, -1) : lines;
+  if (meaningful.length === 0) {
+    return "";
+  }
+  const slice = meaningful.slice(Math.max(0, meaningful.length - tail));
+  return `${slice.join("\n")}\n`;
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2612,11 +2612,35 @@ compares this against `/proc/<pid>/exe` (Linux) or `ps -o comm=`
 pid that happens to belong to some other process would look alive
 to `kill(pid, 0)` and the entry would be kept around forever.
 
+##### gvproxyPid?
+
+> `optional` **gvproxyPid?**: `number`
+
+Defined in: [registry.ts:93](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L93)
+
+PID of the gvproxy process spawned alongside this VMM (issue #150
+phase 2 PR3). Recorded so `machinen stop` can SIGTERM gvproxy at
+the same time as the VMM, and so `machinen gc` can validate /
+reap it independently. Undefined when the VM was booted without
+networking (no gvproxy binary, or `MACHINEN_NET_SOCKET` was
+pre-set by the caller).
+
+##### gvproxyExe?
+
+> `optional` **gvproxyExe?**: `string`
+
+Defined in: [registry.ts:100](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L100)
+
+Absolute path to the gvproxy binary spawned for this VM. Used by
+`machinen stop` for the same anti-recycling check the VMM gets
+via `vmmExe` — we don't want to SIGTERM whatever process inherits
+gvproxy's pid weeks later.
+
 ##### startedAt
 
 > **startedAt**: `number`
 
-Defined in: [registry.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L86)
+Defined in: [registry.ts:102](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L102)
 
 ms epoch when the entry was created.
 
@@ -3677,7 +3701,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ### AttachOptions
 
-Defined in: [vm.ts:1375](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1375)
+Defined in: [vm.ts:1390](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1390)
 
 #### Properties
 
@@ -3685,7 +3709,7 @@ Defined in: [vm.ts:1375](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1381](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1381)
+Defined in: [vm.ts:1396](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1396)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3695,7 +3719,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1383](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1383)
+Defined in: [vm.ts:1398](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1398)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3703,7 +3727,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1390](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1390)
+Defined in: [vm.ts:1405](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1405)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3714,7 +3738,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2515](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2515)
+Defined in: [vm.ts:2530](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2530)
 
 #### Extends
 
@@ -4078,7 +4102,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2520](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2520)
+Defined in: [vm.ts:2535](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2535)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -4087,7 +4111,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2528](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2528)
+Defined in: [vm.ts:2543](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2543)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -4099,7 +4123,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2534](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2534)
+Defined in: [vm.ts:2549](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2549)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4179,7 +4203,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 > **ImageConfig** = `object`
 
-Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
+Defined in: [vm.ts:1580](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1580)
 
 Shape of the optional `./machinen-config.json` baked into a rootfs
 tarball by `provision({ cmd, env })`. `boot()` reads it via
@@ -4193,19 +4217,19 @@ tarball-producing tool can pre-populate the lookup cache.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
+Defined in: [vm.ts:1580](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1580)
 
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
+Defined in: [vm.ts:1580](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1580)
 
 ##### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:1565](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1565)
+Defined in: [vm.ts:1580](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1580)
 
 ## Variables
 
@@ -4645,7 +4669,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:2130](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2130)
+Defined in: [vm.ts:2145](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2145)
 
 #### Type Declaration
 
@@ -5123,7 +5147,7 @@ registry can hold it.
 
 > **registryRoot**(): `string`
 
-Defined in: [registry.ts:95](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L95)
+Defined in: [registry.ts:111](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L111)
 
 Absolute path to the registry root. Honors `MACHINEN_REGISTRY_DIR`
 so tests can point at a scratch dir without stomping on real entries.
@@ -5138,7 +5162,7 @@ so tests can point at a scratch dir without stomping on real entries.
 
 > **list**(): [`RegistryEntry`](#registryentry)[]
 
-Defined in: [registry.ts:212](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L212)
+Defined in: [registry.ts:228](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L228)
 
 List all registry entries whose pid is still alive. Prunes stale
 entries (pid no longer alive) and orphaned name pins as a side
@@ -5318,7 +5342,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1406](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1406)
+Defined in: [vm.ts:1421](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1421)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -5350,7 +5374,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **warmImageConfigCache**(`imagePath`, `config`): `void`
 
-Defined in: [vm.ts:1610](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1610)
+Defined in: [vm.ts:1625](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1625)
 
 Pre-populate the image-config cache for a freshly-written tarball.
 Lets `provision()` (and other tarball producers) skip the slow
@@ -5383,7 +5407,7 @@ none was baked).
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1978](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1978)
+Defined in: [vm.ts:1993](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1993)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -5422,7 +5446,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:2020](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2020)
+Defined in: [vm.ts:2035](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2035)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -5454,7 +5478,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2553](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2553)
+Defined in: [vm.ts:2568](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2568)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5489,7 +5513,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2806](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2806)
+Defined in: [vm.ts:2821](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2821)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/detached.test.ts
+++ b/packages/runtime/src/__tests__/detached.test.ts
@@ -84,27 +84,21 @@ describe("boot({ detached }) compatibility gate", () => {
     expect(err.message).toContain("liveMounts");
   });
 
-  it("rejects --portForward", async () => {
-    const err = await boot({
-      detached: true,
-      image: "/tmp/does-not-exist.tar.gz",
-      portForward: [{ hostPort: 8080, guestPort: 80 }],
-    }).catch((e) => e);
-    expect(isMachinenError(err, "BOOT_DETACHED_INCOMPATIBLE")).toBe(true);
-    expect(err.message).toContain("portForward");
-  });
+  // #150 phase 2 PR3 lifted the portForward gate: gvproxy now also
+  // detaches (its pid + socket dir are persisted in the registry so
+  // `machinen stop` reaps them). `--detached -p` is allowed; the
+  // failure modes that previously needed gating come from the
+  // mount-* options below.
 
-  it("lists every incompatible option in one error", async () => {
+  it("lists mount + liveMounts in one error", async () => {
     const err = await boot({
       detached: true,
       image: "/tmp/does-not-exist.tar.gz",
       mount: { host: "/tmp", guest: "/mnt/in" },
       liveMounts: [{ host: "/tmp", guest: "/mnt/live" }],
-      portForward: [{ hostPort: 8080, guestPort: 80 }],
     }).catch((e) => e);
     expect(isMachinenError(err, "BOOT_DETACHED_INCOMPATIBLE")).toBe(true);
     expect(err.message).toContain("mount");
     expect(err.message).toContain("liveMounts");
-    expect(err.message).toContain("portForward");
   });
 });

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -459,6 +459,12 @@ interface GvproxyHandle {
   controlSocketPath: string;
   /** The spawned gvproxy child. */
   child: ChildProcess;
+  /**
+   * Directory holding both unix sockets. `cleanupPaths` in the VMM's
+   * registry entry references this so `machinen gc` can rm it after
+   * a detached gvproxy exits (issue #150 phase 2 PR3).
+   */
+  socketDir: string;
   /** Kill gvproxy and clean up the socket + temp dir. Idempotent. */
   stop: () => void;
 }
@@ -466,10 +472,17 @@ interface GvproxyHandle {
 /**
  * Spawn gvproxy and block until its qemu-netdev socket is ready.
  * Throws if the socket doesn't appear within `timeoutMs`.
+ *
+ * `detached: true` (issue #150 phase 2 PR3) skips the parent-death
+ * shim and unrefs the child so the runtime parent can exit while
+ * gvproxy keeps running — required when `boot({ detached: true })`
+ * needs guest networking. Caller is responsible for persisting the
+ * child's pid in the VMM registry so `machinen stop` / `machinen gc`
+ * can clean it up later.
  */
 export async function spawnGvproxy(
   binary: string,
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; detached?: boolean } = {},
 ): Promise<GvproxyHandle> {
   const timeoutMs = opts.timeoutMs ?? 3000;
   // Short, unique dir so the socket path stays well under the ~104
@@ -506,7 +519,13 @@ export async function spawnGvproxy(
   // unavailable (no `cc` toolchain, opted-out, unsupported platform);
   // the BOOT_PORT_FORWARD_IN_USE pre-flight probe is the safety net
   // in that case. See #115.
-  const pdeathsig = await ensurePdeathsig();
+  //
+  // Detached mode (#150 phase 2 PR3) skips the shim — the whole
+  // point is the parent exits while gvproxy keeps running. The
+  // VMM's registry entry records gvproxy's pid + socket dir so
+  // `machinen stop` SIGTERMs both processes and `machinen gc` rms
+  // the socket dir.
+  const pdeathsig = opts.detached ? null : await ensurePdeathsig();
   const wrapped = wrapWithPdeathsig(pdeathsig, binary, args);
   // Small retry loop around exec() for `ETXTBSY`. On Linux this fires
   // briefly after a freshly-written binary gets exec'd while a peer
@@ -515,6 +534,13 @@ export async function spawnGvproxy(
   // test runners.
   const child = await spawnWithEtxtbsyRetry(wrapped.command, wrapped.args);
   debug("spawned pid=%d qemu=%s ctrl=%s", child.pid ?? -1, socketPath, controlSocketPath);
+  if (opts.detached) {
+    // Drop the event-loop pin so the runtime parent can exit while
+    // gvproxy keeps running. The default-piped stdio streams stay
+    // paused (nobody reads them), and a paused pipe doesn't keep the
+    // loop alive on its own.
+    child.unref();
+  }
 
   let stopped = false;
   const stop = () => {
@@ -570,7 +596,7 @@ export async function spawnGvproxy(
   }
   debug("ready elapsed=%dms", Date.now() - spawnT0);
 
-  return { socketPath, controlSocketPath, child, stop };
+  return { socketPath, controlSocketPath, child, socketDir: dir, stop };
 }
 
 /**

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -82,6 +82,22 @@ export interface RegistryEntry {
    * to `kill(pid, 0)` and the entry would be kept around forever.
    */
   vmmExe?: string;
+  /**
+   * PID of the gvproxy process spawned alongside this VMM (issue #150
+   * phase 2 PR3). Recorded so `machinen stop` can SIGTERM gvproxy at
+   * the same time as the VMM, and so `machinen gc` can validate /
+   * reap it independently. Undefined when the VM was booted without
+   * networking (no gvproxy binary, or `MACHINEN_NET_SOCKET` was
+   * pre-set by the caller).
+   */
+  gvproxyPid?: number;
+  /**
+   * Absolute path to the gvproxy binary spawned for this VM. Used by
+   * `machinen stop` for the same anti-recycling check the VMM gets
+   * via `vmmExe` — we don't want to SIGTERM whatever process inherits
+   * gvproxy's pid weeks later.
+   */
+  gvproxyExe?: string;
   /** ms epoch when the entry was created. */
   startedAt: number;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -398,9 +398,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // #150 phase 2: refuse `--detached` with options that keep helpers
   // alive in the JS supervisor. After detach the supervisor is gone;
   // any guest call back into one of these (a FUSE op, an artifact-
-  // cache fetch, a port-forward control change) would land on a dead
-  // socket. Phase 3 extracts these helpers into standalone daemons —
-  // until then, the gate is hard.
+  // cache fetch) would land on a dead socket. Phase 3 extracts those
+  // helpers into standalone daemons — until then, the gate is hard.
+  //
+  // PR3 lifted the `portForward` restriction: gvproxy now also
+  // detaches (its pid + socket dir are persisted in the registry so
+  // `machinen stop` reaps them), and `exposePort` runs *before*
+  // detach completes, so the forwards are configured by the time the
+  // parent exits.
   if (opts.detached) {
     const incompatible: string[] = [];
     if (opts.mount) {
@@ -408,9 +413,6 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     }
     if ((opts.liveMounts ?? []).length > 0) {
       incompatible.push("liveMounts");
-    }
-    if ((opts.portForward ?? []).length > 0) {
-      incompatible.push("portForward");
     }
     if (incompatible.length > 0) {
       throw new BootError(
@@ -656,6 +658,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // nodeSpawn failure), the outer catch shuts both supervisors back
   // down — otherwise a failed boot would leave orphans behind.
   let gvStop: (() => void) | undefined;
+  let gvPid: number | undefined;
+  let gvExe: string | undefined;
+  let gvSocketDir: string | undefined;
   let cacheStop: (() => Promise<void>) | undefined;
   const liveMountStops: Array<() => Promise<void>> = [];
   let bundleTempDir: string | undefined;
@@ -682,9 +687,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       const gvBin = await ensureGvproxy(binary);
       if (gvBin) {
         debug("starting gvproxy bin=%s", gvBin);
-        const gv = await spawnGvproxy(gvBin);
+        // Detach gvproxy alongside the VMM so the parent can exit
+        // without stranding the guest's networking (#150 phase 2 PR3).
+        const gv = await spawnGvproxy(gvBin, { detached: opts.detached });
         env.MACHINEN_NET_SOCKET = gv.socketPath;
         gvStop = gv.stop;
+        gvPid = gv.child.pid;
+        gvExe = gvBin;
+        gvSocketDir = gv.socketDir;
         for (const m of portForward) {
           await exposePort(gv.controlSocketPath, m);
         }
@@ -923,6 +933,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   if (vsockTempDir) {
     cleanupPaths.push(vsockTempDir);
   }
+  if (gvSocketDir) {
+    cleanupPaths.push(gvSocketDir);
+  }
   let registered = false;
   if (childPid > 0 && vsockUdsPath) {
     try {
@@ -936,6 +949,8 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         bootLogPath,
         cleanupPaths: cleanupPaths.length > 0 ? cleanupPaths : undefined,
         vmmExe: binary,
+        gvproxyPid: gvPid,
+        gvproxyExe: gvExe,
         startedAt: Date.now(),
       });
       registered = true;

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -544,6 +544,11 @@ fi
 # `node -p` to extract cleanupPaths reliably without a JSON parser
 # in bash. Falls back to empty string if the field is absent.
 N2D_CLEANUP_PATHS=$(node -p "JSON.parse(require('fs').readFileSync('$N2D_META','utf8')).cleanupPaths?.join('\\n') ?? ''" 2>/dev/null || true)
+# #150 phase 2 PR3: gvproxy is also detached for --detached boots,
+# its pid is recorded in the registry, and `machinen stop` should
+# SIGTERM it alongside the VMM. Capture it here so we can assert
+# it's gone post-stop.
+N2D_GVPROXY_PID=$(node -p "JSON.parse(require('fs').readFileSync('$N2D_META','utf8')).gvproxyPid ?? ''" 2>/dev/null || true)
 
 N2S_LOG="$FIXTURE/n2s.log"
 if cli stop --name "$N2D_NAME" >"$N2S_LOG" 2>&1; then
@@ -572,6 +577,19 @@ if [[ -n "$N2D_CLEANUP_PATHS" ]]; then
   pass "machinen stop removed all recorded cleanupPaths"
 else
   pass "no cleanupPaths recorded (nothing to verify)"
+fi
+
+# gvproxy should be reaped by `machinen stop`. Without PR3 it would
+# survive (no pdeathsig in detached mode → orphaned to PID 1, holding
+# the qemu/control sockets and any host port forwards).
+if [[ -n "$N2D_GVPROXY_PID" ]]; then
+  if kill -0 "$N2D_GVPROXY_PID" 2>/dev/null; then
+    ps -o pid=,comm=,lstart= -p "$N2D_GVPROXY_PID" >&2 || true
+    fail "N2S — gvproxy pid $N2D_GVPROXY_PID still alive after machinen stop"
+  fi
+  pass "machinen stop reaped gvproxy (pid $N2D_GVPROXY_PID)"
+else
+  pass "no gvproxy spawned for this VM (nothing to reap)"
 fi
 
 # Stop is idempotent — calling it again on a missing name should


### PR DESCRIPTION
## Summary

Stacked on #242 (which is stacked on #241). Closes the last two gaps from #150 phase 2:

1. **gvproxy was orphaning to PID 1 on every detach.** It still ran (so guest networking worked), but \`machinen stop\` couldn't reach it, host port forwards leaked, and the qemu/control sockets piled up under \`tmpdir()\`.
2. **No way to read a detached VM's boot console.** PR1 dumped a snapshot to \`~/.machinen/logs/<pid>.boot.log\`, but you had to find the file yourself.

```
$ machinen boot --name worker --detached -p 8080:80 -- /bin/sh -c "/exec-agent & sleep inf"
machinen: detached (worker). Reattach: machinen attach worker
$ curl localhost:8080  # works — gvproxy survived
$ machinen attach --tail 20 --name worker
[ 0.234] machinen-supervisor: ready
[ 0.512] starting workload...
attached to worker — exit the shell to detach.
$ ^D
$ machinen stop --name worker
stopped worker (pid 12345)
$ pgrep gvproxy  # gone
```

## Pieces

- **\`gvproxy.ts\`** — \`spawnGvproxy(bin, { detached })\` skips the \`pdeathsig\` shim and \`unref()\`s the child so the runtime parent can exit while gvproxy keeps running. Returns \`socketDir\` so the caller can put it in \`cleanupPaths\`.
- **\`registry.ts\`** — \`gvproxyPid\` + \`gvproxyExe\` persist alongside the VMM. \`stop\` SIGTERMs gvproxy with the same anti-recycling guard the VMM gets (basename match against \`gvproxyExe\`); \`gc\` rms the gvproxy socket dir via \`cleanupPaths\`. New \`waitForExit\` helper polls \`kill(pid, 0)\` so \`stop\` returns only after both processes are actually gone.
- **\`vm.ts\`** — passes \`{ detached }\` through to \`spawnGvproxy\`, persists the gvproxy fields on \`writeEntry\`, and **lifts the \`BOOT_DETACHED_INCOMPATIBLE\` gate against \`portForward\`**. \`exposePort\` already runs before the readiness gate, so port forwards are configured by the time the parent exits. \`mount\` + \`liveMounts\` still gated — Phase 3 lifts those.
- **\`cli.ts\`** — \`attach --tail [N]\` reads the entry's \`bootLogPath\` and prints the last \`N\` lines (or all of it if \`N\` omitted) to stderr before the interactive shell. Errors clearly when the VM wasn't booted with \`--detached\`.
- **\`tail-lines.ts\`** (new) — pure slicing helper. Lives in its own module so \`vitest\` can import it without dragging \`cli.ts\`'s top-level \`main()\` into the test runner (which would \`process.exit\` on load).

## Test plan

- [x] Unit: 8 new \`tailLines\` tests (all-content, tail=0, last-N, line count without double-counting trailing \\n, missing trailing \\n, empty, oversized N).
- [x] Unit (delta from PR1): the \`--portForward\` rejection test was removed (the gate is gone); the merged-error test was updated to expect only \`mount\` + \`liveMounts\`.
- [x] Local: \`pnpm vitest run\` (414 pass / 7 skipped with \`MACHINEN_REQUIRE_FIXTURES=0\`).
- [x] Local: \`agent-ci run --all\` (4/4 workflows green in 1m34s).
- [x] Smoke N2S extended: \`gvproxyPid\` is recorded in the registry, is dead immediately after \`machinen stop\` returns, and the gvproxy socket dir is gone.
- [ ] Smoke runner needs to execute the extended N2S end-to-end against the real VMM.

## Anti-recycling for gvproxy

\`stop\` validates gvproxy the same way it validates the VMM: \`kill(0)\` + basename match against the recorded binary path. Without this, a long-dead gvproxy whose pid was recycled to (say) the user's editor weeks later would get SIGTERMed by \`machinen stop\`. The exe-basename heuristic is enough — \`gvproxy\` isn't a generic name, and we don't need start-time correlation here because the threat model is "pid recycled to something else," not "exe replaced in place."

## What's left in #150

Phase 2 is fully done after this PR lands. **Phase 3** (the original "last tier" the user asked about) extracts the artifact cache and live-mount FUSE servers out of the JS supervisor so the remaining \`mount\` / \`liveMounts\` gates can be lifted and \`--detached\` becomes the default. That's a much larger change — Zig FUSE rewrite or sidecar daemon — and lives in followup issues.
