### PR TITLE
fix(test): bump phase-timer sleep to dodge scheduler early-return

### DIFF
--- a/packages/runtime/src/__tests__/phase-timer.test.ts
+++ b/packages/runtime/src/__tests__/phase-timer.test.ts
@@ -88,7 +88,12 @@ describe("PhaseTimer", () => {
   it("toEvent() defaults totalMs to the timer's wall-clock", async () => {
     const t = new PhaseTimer();
     t.mark("only", 1);
-    await sleep(5);
+    // setTimeout(5) + the >=5 assertion is racy on busy CI runners —
+    // Linux schedulers occasionally wake setTimeout up to ~1ms early
+    // (saw `expected 4 >= 5` on PR #245's hosted CI). Bumping to 25ms
+    // keeps the test fast while putting enough headroom on the
+    // schedule that "time elapsed" measures truthfully.
+    await sleep(25);
     const evt = t.toEvent("boot");
     expect(evt.totalMs).toBeGreaterThanOrEqual(5);
   });


### PR DESCRIPTION
## Problem

\`phase-timer.test.ts\`'s \`"toEvent() defaults totalMs to the timer's wall-clock"\` test did \`await sleep(5)\` then \`expect(totalMs).toBeGreaterThanOrEqual(5)\`. Linux schedulers occasionally wake setTimeout up to ~1ms early on busy runners — surfaced as \`expected 4 >= 5\` on the hosted CI run for PR #245.

The test wasn't exercising any new code; it just got unlucky on a contended GitHub Actions worker. The flake is intermittent, but it'll keep biting unrelated PRs the same way it bit #245.

## Fix

Bump the sleep to 25ms (still test-fast) so a 1ms early wake can't undershoot the \`>=5\` assertion. Test's intent — "elapsed wall-clock shows up in \`totalMs\`" — is preserved without ratcheting up the flakiness tolerance.

## Test plan

- [x] Local: \`vitest run packages/runtime/src/__tests__/phase-timer.test.ts\` (9/9 pass).
- [x] Lint + format clean.
