### PR TITLE
chore(microvm): audit + bound allocations on hot paths (#240)

### DIFF
--- a/.docs/learnings/microvm/allocations.md
+++ b/.docs/learnings/microvm/allocations.md
@@ -1,0 +1,62 @@
+# microvm allocations audit
+
+NASA Power-of-Ten Rule 3: avoid dynamic allocation in steady-state code.
+This file enumerates every `gpa.*` call in `packages/microvm/src/`,
+classifies it, and records the rationale where a call survives the
+audit.
+
+Categories:
+
+- **(a) one-shot at boot** — runs zero or one times during the VMM's
+  lifetime, before the run loop starts (or once after it ends).
+- **(b) per-event but bounded** — runs on a discrete event (a guest
+  packet, a host connection), but the rate is bounded by external
+  pressure and the buffer/list reuses memory after the first few
+  events.
+- **(c) per-event in a hot loop** — runs in the run loop or on every
+  packet/byte. The TigerStyle target is to eliminate these.
+
+| File             | Site                                       | Op                                                                                | Class       | Notes                                                                                                                                                                                                                                                                                                                           |
+| ---------------- | ------------------------------------------ | --------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `boot_hvf.zig`   | `loadFixtures`                             | `readAll(kernel)` + `readAll(dtb)`                                                | a           | One read per boot. `LoadedFixtures.deinit` frees both.                                                                                                                                                                                                                                                                          |
+| `boot_hvf.zig`   | `allocateAndPopulateRam`                   | `readAll(initrd)`                                                                 | a           | One read per boot when `initrd_path` is set; freed before run loop starts.                                                                                                                                                                                                                                                      |
+| `boot_hvf.zig`   | `runLoop` end                              | `gpa.dupe(uart.captured.items)`                                                   | a           | Once per boot, on shutdown. Caller (main.zig / tests) frees.                                                                                                                                                                                                                                                                    |
+| `boot_kvm.zig`   | same as boot_hvf                           | same                                                                              | a           | KVM twin; identical lifetimes.                                                                                                                                                                                                                                                                                                  |
+| `vsock.zig`      | `parseEnv`                                 | `gpa.allocSentinel(uds_path)` × N entries, `list.append` × N, `list.toOwnedSlice` | a           | Parses `MACHINEN_VSOCK` once at boot. N capped by `parse_env_entries_max` (256). Paths leak for the VMM's life by design.                                                                                                                                                                                                       |
+| `vsock.zig`      | `Bridge.create`                            | `gpa.create(Bridge)`                                                              | a           | One bridge per VM. `destroy` frees it.                                                                                                                                                                                                                                                                                          |
+| `vsock.zig`      | `Bridge.start`                             | `listeners.append`, `listener_port_idx.append`                                    | a           | One append per inbound port at boot; bounded by the operator-supplied `MACHINEN_VSOCK` map.                                                                                                                                                                                                                                     |
+| `vsock.zig`      | `Bridge.runThread` start                   | `gpa.alloc(PollFd, BRIDGE_INITIAL_POLL_CAP)`                                      | a           | One scratch alloc per bridge thread. **#240**: pre-sized to a cap that covers the steady-state pollset, so the realloc path below never fires under normal operation.                                                                                                                                                           |
+| `vsock.zig`      | `Bridge.runThread` loop                    | `gpa.realloc(scratch, want)`                                                      | b → never   | Was per-iteration on growth. **#240**: with the pre-sized scratch, this branch is now dead code under normal operation; kept as a safety valve for pathological port-map / connection counts.                                                                                                                                   |
+| `vsock.zig`      | `Bridge.startConnection`                   | `conns.append`                                                                    | b           | Per inbound UDS connection. Connection count is host-operator-controlled; ArrayList doubles, so amortised O(1) per `append`.                                                                                                                                                                                                    |
+| `vsock.zig`      | `Bridge.dispatchGuestPacket` (REQUEST arm) | `conns.append`                                                                    | b           | Per outbound REQUEST from the guest. Same shape as `startConnection`.                                                                                                                                                                                                                                                           |
+| `net_socket.zig` | `NetSocket.connect`                        | `gpa.create(NetSocket)`                                                           | a           | One per VM. `destroy` frees it.                                                                                                                                                                                                                                                                                                 |
+| `pl011.zig`      | `pushRx`                                   | `rx_buf.appendSlice(bytes)`                                                       | b           | Per stdin batch (≤ 256 B per batch). Drained as the guest reads DR; bounded in steady state. Stays a `(b)` because non-interactive boots never invoke it.                                                                                                                                                                       |
+| `pl011.zig`      | `write` (DR arm)                           | `captured.append(byte)`                                                           | (c) → gated | One append per byte the guest writes to the UART data register. **#240**: `Pl011.capture_enabled` (set false when `Config.unbounded_serial = true`) skips the append entirely in production boots, where main.zig frees the captured buffer unread anyway. Test boots leave it enabled (capped by `Config.capture_bytes` exit). |
+
+## Fixes landed in #240
+
+1. **`pl011.captured.append` → gated by `capture_enabled`.**
+   Production boots (set `Config.unbounded_serial = true`) frees
+   `Result.serial` immediately on shutdown without reading it (see
+   `main.zig`, comment at "result.serial buffer is the same bytes,
+   captured for tests — don't re-emit here"). Skipping the append
+   eliminates the per-byte `ArrayList` grow on the production hot
+   path. The same guest console bytes still echo to host stderr from
+   the `handlePl011Mmio` DR arm in both `boot_hvf.zig` and
+   `boot_kvm.zig`, so user-visible output is unchanged.
+
+2. **`vsock.Bridge.runThread` scratch pre-sized.**
+   The poll set is `1 + listeners + conns`. Pre-allocating to
+   `BRIDGE_INITIAL_POLL_CAP = 256` covers every realistic operator
+   config (the host UDS map is rarely more than a handful of ports,
+   and per-bridge connection counts in production stay in the
+   single digits). The `realloc` branch survives as a safety valve
+   for pathological cases.
+
+## Out of scope
+
+Switching the entire VMM to a static arena. Not warranted by what we
+see here — every survivor is one-shot at boot, bounded by an
+operator-supplied config, or a guest-driven event ring that ArrayList
+amortises. The remaining `(b)` cases would only become hot under
+adversarial workload patterns we don't have evidence of yet.

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -279,6 +279,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     // --- run loop -------------------------------------------------
     var uart: hvf.Pl011 = .init;
+    // Production boots discard Result.serial unread (main.zig); skip
+    // the per-byte capture allocations in that mode. See
+    // .docs/learnings/microvm/allocations.md (#240).
+    uart.capture_enabled = !cfg.unbounded_serial;
     defer uart.deinit(gpa);
 
     // virtio-net + gvproxy (#82). The Device is the "hardware"; gvproxy

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -153,6 +153,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     // --- run loop -------------------------------------------------
     var uart = pl011_mod.Pl011.init;
+    // Production boots discard Result.serial unread (main.zig); skip
+    // the per-byte capture allocations in that mode. See
+    // .docs/learnings/microvm/allocations.md (#240).
+    uart.capture_enabled = !cfg.unbounded_serial;
     defer uart.deinit(gpa);
 
     const irqs = IrqMap.init();

--- a/packages/microvm/src/pl011.zig
+++ b/packages/microvm/src/pl011.zig
@@ -55,6 +55,14 @@ pub const Pl011 = struct {
     size: u64 = 0x1000,
     captured: std.ArrayList(u8),
     rx_buf: std.ArrayList(u8),
+    /// Whether DR-write bytes are appended to `captured`. Test boots
+    /// rely on the captured buffer to assert on guest output; production
+    /// boots discard `Result.serial` immediately (see main.zig — the
+    /// same bytes already live-echo to host stderr from the boot loop's
+    /// PL011 handler). Skipping the append eliminates the per-byte
+    /// ArrayList grow on the production hot path. NASA Power-of-Ten
+    /// Rule 3, see .docs/learnings/microvm/allocations.md (#240).
+    capture_enabled: bool = true,
     // Interrupt mask/status. The kernel's PL011 IRQ handler reads MIS
     // (masked = RIS & IMSC) and clears matching bits via ICR.
     imsc: u32 = 0,
@@ -128,7 +136,7 @@ pub const Pl011 = struct {
         defer self.mutex.unlock();
         const offset = addr - self.base;
         switch (offset) {
-            0x000 => try self.captured.append(gpa, @truncate(value)),
+            0x000 => if (self.capture_enabled) try self.captured.append(gpa, @truncate(value)),
             0x038 => self.imsc = @truncate(value),
             0x044 => {
                 self.ris &= ~@as(u32, @truncate(value));

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -179,6 +179,14 @@ pub const tx_eagain_stalls_max: u32 = 50;
 /// Keeps parseEnv from looping forever on a pathological input.
 pub const parse_env_entries_max: u32 = 256;
 
+/// Initial capacity for `Bridge.runThread`'s pollset scratch slice.
+/// Sized to comfortably cover the steady-state pollset (one entry per
+/// listener + one per active connection + the wake-pipe head); chosen
+/// to keep the realloc branch in `runThread` from firing under any
+/// realistic operator config. NASA Power-of-Ten Rule 3, see
+/// .docs/learnings/microvm/allocations.md (#240).
+pub const bridge_initial_poll_cap: usize = 256;
+
 /// Per-packet body cap we use when INJECTING RX packets into the
 /// guest. The Linux virtio-vsock driver posts RX buffers as a
 /// SINGLE flat descriptor (not a chain — contrary to what the
@@ -243,6 +251,7 @@ comptime {
     assert(wake_drain_iters_max > 0);
     assert(tx_eagain_stalls_max > 0);
     assert(parse_env_entries_max > 0);
+    assert(bridge_initial_poll_cap > 0);
 }
 
 /// Parse a `MACHINEN_VSOCK` value into a `PortMap` list.
@@ -855,7 +864,10 @@ pub const Bridge = struct {
         // Self-pipe must be wired up by start() before this thread spawns.
         assert(self.wake[0] >= 0);
         assert(self.wake[1] >= 0);
-        var scratch = self.gpa.alloc(PollFd, 64) catch return;
+        // #240: pre-sized large enough that the realloc branch below
+        // is dead code under any realistic operator config. Kept as a
+        // safety valve for pathological port-map / connection counts.
+        var scratch = self.gpa.alloc(PollFd, bridge_initial_poll_cap) catch return;
         defer self.gpa.free(scratch);
 
         while (!self.stop_flag.load(.acquire)) {


### PR DESCRIPTION
Closes #240.

## Summary

Walk every `gpa.*` reachable from `boot()` / the run loop, classify each as (a) one-shot at boot, (b) per-event but bounded, or (c) per-event in a hot loop. Land the audit as a doc + fix the two (c) rows. NASA Power-of-Ten Rule 3.

## Audit doc

[`.docs/learnings/microvm/allocations.md`](.docs/learnings/microvm/allocations.md) enumerates every site, with class + rationale. Two cases were (c) before this PR:

1. **`pl011.captured.append(byte)`** — per byte of guest serial output. In production (`Config.unbounded_serial = true`), grows unbounded for the VM's lifetime. The captured bytes are then freed unread in `main.zig` — they exist only so test boots can assert on guest output, but the same bytes already live-echo to host stderr from the boot loop's PL011 DR-write handler.

2. **`vsock.Bridge.runThread` `realloc(scratch)`** — per iteration of the bridge poll loop, fired whenever the active connection count exceeds the prior pollset capacity. Settles after a few growths in steady state, but the realloc path is hit on every connection burst.

## Fixes

1. **`Pl011.capture_enabled`.** New bool field on `Pl011`, default `true` so test boots are unchanged. `boot_hvf::boot` and `boot_kvm::boot` set it to `!cfg.unbounded_serial` — production skips the per-byte append entirely.
2. **`vsock.Bridge.runThread` pre-sized scratch.** New `bridge_initial_poll_cap = 256` constant. The initial alloc covers the steady-state pollset under any realistic operator config; the realloc branch is now dead code in normal operation and survives only as a safety valve.

The remaining (b) rows (per-connection `conns.append`, per-stdin-batch `rx_buf.appendSlice`) stay as-is — bounded by external pressure, not hot loops.

Out of scope per the issue: switching the entire VMM to a static arena. The audit shows that's not warranted by current evidence.

## Test plan

- [x] `zig build` clean (native macOS).
- [x] `zig build -Dtarget=aarch64-linux-musl` clean (cross-compile to KVM target).
- [x] `zig build test` — same skip-on-no-fixture noise as main.
- [x] `npx vitest run` — 4 pre-existing failures, same set as main.
- [x] `npx agent-ci run --all -q -p` — 4/4 passed.
- [x] `pnpm smoke-tests` — V1..V8 + T1..T5 + N1, N2, N2D pass; S1..S3 (snapshot/chain/fork) pass. **Pre-existing flake**: N2S's "gvproxy reaped after machinen stop" check is a race between `machinen stop` returning and `gvproxy` actually exiting — reproduces on `origin/main` with a clean rebuild, unrelated to this PR.
