### PR TITLE
fix(runtime): preserve underlying errno on MKINITRAMFS_INIT_MISSING

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -4994,7 +4994,7 @@ Defined in: [mkinitramfs.ts:672](https://github.com/redwoodjs/machinen/blob/main
 
 > **mkinitramfsCli**(`argv`): `void`
 
-Defined in: [mkinitramfs.ts:826](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/mkinitramfs.ts#L826)
+Defined in: [mkinitramfs.ts:838](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/mkinitramfs.ts#L838)
 
 Invoked by the CLI shim at packages/microvm/test-fixtures/assets/mkinitramfs.ts.
 Kept argv-compatible with the old Python script so shell fixtures

--- a/packages/runtime/src/__tests__/mkinitramfs.test.ts
+++ b/packages/runtime/src/__tests__/mkinitramfs.test.ts
@@ -223,6 +223,31 @@ describe("packBundle mount", () => {
     }
   });
 
+  it("preserves the underlying ENOENT on the cause chain so EACCES/EISDIR don't get misreported", () => {
+    // The throw collapses every readFileSync failure into the same
+    // top-level message; without `cause` set, an EACCES on a chmod-0
+    // fixture or an EISDIR on a directory-shaped path would all read
+    // as "rebuild it" and send the user down the wrong rabbit hole.
+    // Pin the chain so formatMachinenError's "caused by:" walker has
+    // the real errno to surface.
+    const bundle = makeEmptyBundle();
+    const out = join(tmp, "no-init-cause.cpio");
+    const prev = process.env.MACHINEN_REQUIRE_FIXTURES;
+    delete process.env.MACHINEN_REQUIRE_FIXTURES;
+    try {
+      packTinyBundle({ bundle, out, initPath: join(tmp, "does-not-exist") });
+      throw new Error("expected MKINITRAMFS_INIT_MISSING");
+    } catch (err) {
+      const cause = (err as { cause?: unknown }).cause;
+      expect(cause).toBeInstanceOf(Error);
+      expect((cause as NodeJS.ErrnoException).code).toBe("ENOENT");
+    } finally {
+      if (prev !== undefined) {
+        process.env.MACHINEN_REQUIRE_FIXTURES = prev;
+      }
+    }
+  });
+
   it("packTinyBundle silently skips a missing /init when MACHINEN_REQUIRE_FIXTURES=0", () => {
     // Test-only escape hatch for fake-VMM tests (binary: "/bin/sh"),
     // where the cpio's contents don't matter because the spawn is

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -745,6 +745,7 @@ function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
           "MKINITRAMFS_INIT_MISSING",
           `mkinitramfs: /init binary not readable at ${opts.initPath} (${err instanceof Error ? err.message : String(err)}). ` +
             `Build it with scripts/build-base-assets.sh, or pass initPath to point at a custom one.`,
+          { cause: err },
         );
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #254. The new \`MKINITRAMFS_INIT_MISSING\` throw collapses every \`readFileSync\` failure into the same top-level message. Without \`cause\` set, \`EACCES\` on a chmod-0 fixture or \`EISDIR\` on a directory-shaped path reads as \"rebuild it\" and sends the user down the wrong rabbit hole.

This passes \`{ cause: err }\` so \`formatMachinenError\`'s \`caused by:\` walker has the real errno to surface.

## Test plan

- [x] \`pnpm vitest run packages/runtime/src/__tests__/mkinitramfs.test.ts\` — 14 pass (new case asserts \`err.cause.code === \"ENOENT\"\`).
- [x] \`npx agent-ci run --all -q -p\` — 4/4 workflows pass.
- [x] \`pnpm smoke-tests\` — pass.
- [x] \`pnpm run build:docs\` — API.md regenerated for the 1-line shift.
