### PR TITLE
feat(cli): add -p to fork; name the holding VM on port-conflict errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ independently. Use it to clone a warmed-up process: a database with caches
 loaded, a test fixture in exactly the right state, a long-running compute
 job branched into N parallel explorations.
 
+The fork doesn't inherit the source's `-p` host forwards — host ports are
+global, only one process can bind each one. Two ways to reach a fork:
+
+```bash
+# A) exec over vsock — works for any guest port, no host forward needed.
+npx machinen exec --name counter-b -- curl -s localhost:3000
+
+# B) -p with non-conflicting host ports — forwards on the host.
+npx machinen fork --name counter --new-name counter-b -p 3001:3000 --detach
+curl localhost:3001                                            # the fork
+curl localhost:3000                                            # still the source
+```
+
+Pass `-p` multiple times for multiple ports. If you pick a host port the
+source is already forwarding, `fork` errors with
+`BOOT_PORT_FORWARD_IN_USE` and names the VM that's holding it.
+
 From Node, same shape:
 
 ```ts

--- a/docs/guides/create-a-vm.md
+++ b/docs/guides/create-a-vm.md
@@ -77,7 +77,7 @@ and the VM keeps running in the background.
 Once it's running, you can find it again from any shell:
 
 ```bash
-npx machinen ls                              # see PID, NAME, uptime
+npx machinen ls                              # see PID, NAME, uptime, port forwards
 npx machinen exec --name worker -- ps aux    # run a one-off command
 npx machinen attach --name worker            # interactive shell with job control
 ```

--- a/docs/guides/create-a-vm.md
+++ b/docs/guides/create-a-vm.md
@@ -1,7 +1,7 @@
 # Create a VM
 
-This guide is about the trade-off between *getting started fast* and
-*having something reusable*. There are three points on that line, and which
+This guide is about the trade-off between _getting started fast_ and
+_having something reusable_. There are three points on that line, and which
 one's right depends on what you're doing right now.
 
 ## "I just want a Linux shell"
@@ -83,7 +83,7 @@ npx machinen attach --name worker            # interactive shell with job contro
 ```
 
 `exec` is for scripted use — pipes are line-buffered, the command runs
-to completion, exit code propagates. `attach` is for when *you* want a
+to completion, exit code propagates. `attach` is for when _you_ want a
 real terminal: tab completion, full-screen TUIs, Ctrl-C signalling the
 guest process and not the host CLI.
 

--- a/docs/guides/mount-files.md
+++ b/docs/guides/mount-files.md
@@ -142,7 +142,7 @@ the mount paths above are more efficient.
 ## Landing the workload inside the share
 
 A small ergonomic note: you'll often want the guest's entrypoint to
-run *inside* the directory you mounted, instead of starting in `/` and
+run _inside_ the directory you mounted, instead of starting in `/` and
 needing a `cd` in your wrapper script. Pass `--cwd` to set the guest's
 working directory:
 

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -106,20 +106,19 @@ when:
 For interactive use (a real terminal, full-screen TUIs), `machinen
 attach` is the right tool — same vsock channel, but with a PTY.
 
-## A current limitation: detached boots and port forwards
+## A current limitation: detached boots and mounts
 
-If you've used `--detached` before, you'll find that `-p`, `--mount`,
-and `--mount-live` all refuse to combine with it. The reason: each of
-those features keeps a helper running in the original Node process —
-gvproxy's port-forward setup, the mount FUSE relay — and `--detached`
-is meant to let that Node process exit. The VMM can outlive the parent;
-the helpers can't yet.
+If you've used `--detached` before, you'll find that `--mount` and
+`--mount-live` refuse to combine with it: those features keep a FUSE
+relay running in the original Node process, and `--detached` is meant
+to let that Node process exit. The VMM can outlive the parent; the
+mount helpers can't yet. Phase 3 will lift those helpers out into
+standalone daemons so detached boots can have everything.
 
-There's a phase 3 of this work that lifts the helpers out into
-standalone daemons so detached boots can have everything. Until then,
-if you need both a long-running VM and a port forward, run the boot
-under a process supervisor (systemd, pm2, tmux) so something keeps the
-helper alive.
+`-p` used to be in the same boat, but PR3 detached gvproxy too: its
+pid lives in the registry, `exposePort` runs before detach completes,
+and `machinen stop` reaps it on shutdown. So `boot --detached -p ...`
+and `fork --detach -p ...` both work today.
 
 ## Custom gvproxy
 

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -73,8 +73,8 @@ await boot({
   image,
   cmd,
   portForward: [
-    { hostPort: 3000, guestPort: 3000 },                       // localhost only
-    { hostPort: 5432, guestPort: 5432, hostAddr: "0.0.0.0" },   // all interfaces
+    { hostPort: 3000, guestPort: 3000 }, // localhost only
+    { hostPort: 5432, guestPort: 5432, hostAddr: "0.0.0.0" }, // all interfaces
   ],
 });
 ```

--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -2,8 +2,8 @@
 
 A snapshot is a complete picture of a running VM frozen to disk: every
 page of memory, every open file descriptor, every TCP listener, the
-program counter of every thread. Restoring it doesn't *start* the
-process — it *resumes* it, like waking a laptop from sleep.
+program counter of every thread. Restoring it doesn't _start_ the
+process — it _resumes_ it, like waking a laptop from sleep.
 
 Two patterns get a lot of mileage out of that:
 
@@ -37,7 +37,7 @@ snapshot.
 
 By default `snapshot` is destructive: the source VM exits as part of
 the dump. CRIU kills the workload tree once it has the images, and the
-VM shuts down cleanly. This is what you want for a *handoff* — the
+VM shuts down cleanly. This is what you want for a _handoff_ — the
 process should only be running in one place at a time.
 
 To move it:
@@ -71,7 +71,7 @@ Restored VMs without an explicit name get an auto-name shaped like
 
 ## Cloning a running process
 
-The same machinery, used differently. If you snapshot *without* killing
+The same machinery, used differently. If you snapshot _without_ killing
 the source and immediately restore, you get two VMs running the same
 process from the same instant. They share a heap up to that moment;
 from then on they diverge.
@@ -91,7 +91,7 @@ const fork = await vm.fork({ name: "counter-b" });
 ```
 
 There are two pieces of inherited state where the defaults are
-deliberately *unsafe* if you don't think about them:
+deliberately _unsafe_ if you don't think about them:
 
 **TCP connections.** The source had open sockets to clients; both VMs
 can't hold the same connection without racing on sequence numbers.
@@ -147,15 +147,17 @@ For now, two practical workarounds:
 
 - For transport, tar with `-S` so sparseness is preserved (a 2 GiB
   sparse image is typically well under 100 MiB on the wire):
+
   ```bash
   tar -czSf counter.snap.tar.gz counter.snap/
   ```
+
   Use `rsync -aS` instead of `scp -r` if you're going host-to-host —
   `scp` doesn't preserve sparseness.
 
 - If you know the workload only writes a few hundred MB, pre-size the
   scratch disk down via `boot({ snapshot: "<smaller pre-allocated
-  file>" })` so the bundle starts smaller.
+file>" })` so the bundle starts smaller.
 
 A `--compact` flag that trims unused blocks at snapshot time is tracked
 in [issue #261](https://github.com/redwoodjs/machinen/issues/261).

--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -104,7 +104,12 @@ same connection (rare; usually means a load test or a CRIU experiment).
 only one process can bind it. The source already does. So `fork`
 doesn't inherit port forwards by default; the new VM has no exposed
 ports. Either reach the fork via `machinen exec` (vsock, doesn't go
-through host networking), or pass new `portForward` entries explicitly:
+through host networking), or pass new forwards explicitly — both the
+CLI and Node API accept them:
+
+```bash
+npx machinen fork --name counter --new-name counter-b -p 3001:3000
+```
 
 ```ts
 await vm.fork({
@@ -112,6 +117,10 @@ await vm.fork({
   portForward: [{ hostPort: 3001, guestPort: 3000 }],
 });
 ```
+
+If you pick a host port the source is already forwarding, the bind
+probe fires `BOOT_PORT_FORWARD_IN_USE` with the holding VM's name —
+not advice to `kill` it — so you know to pick a different host port.
 
 ## When you need the source to survive the snapshot
 

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -62,7 +62,10 @@ Resolves base assets the same way `boot` does.
 
 ## `machinen ls` / `ps`
 
-Lists running VMs as `PID  NAME  UP  FORKED-FROM`. `ps` is an alias.
+Lists running VMs as `PID  NAME  UP  PORTS  FORKED-FROM`. `PORTS` is
+the host-port forwards configured at boot/fork time, rendered as
+`<hostPort>:<guestPort>` (comma-separated for multi-port VMs, `-` for
+none). `ps` is an alias.
 
 ## `machinen exec`
 

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -38,16 +38,16 @@ cache (populated by `machinen install`, or auto-fetched on first use).
   baked-in default cmd (set via `provision({ cmd })`), `-- <cmd>` is
   optional; pass it to override.
 
-| Flag                                            | What it does                                                                                                                              |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`)                                                                |
-| `--mount <host-dir>:<guest-path>`               | Copy-once host directory into the guest (`/mnt/...`)                                                                                      |
-| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Live-share via FUSE — guest reads stream in on demand. `rw` (default) or `ro`                                                             |
-| `--env KEY=VALUE`                               | Set an env var inside the guest (repeatable)                                                                                              |
-| `--cwd <abs-path>`                              | Start the guest cmd in this directory (must be absolute)                                                                                  |
-| `-p <hostPort>:<guestPort>`                     | Forward a host TCP port to the guest (repeatable)                                                                                         |
+| Flag                                            | What it does                                                                                                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`)                                                                 |
+| `--mount <host-dir>:<guest-path>`               | Copy-once host directory into the guest (`/mnt/...`)                                                                                       |
+| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Live-share via FUSE — guest reads stream in on demand. `rw` (default) or `ro`                                                              |
+| `--env KEY=VALUE`                               | Set an env var inside the guest (repeatable)                                                                                               |
+| `--cwd <abs-path>`                              | Start the guest cmd in this directory (must be absolute)                                                                                   |
+| `-p <hostPort>:<guestPort>`                     | Forward a host TCP port to the guest (repeatable)                                                                                          |
 | `--detached`                                    | Detach the VMM from the CLI on first-guest-byte readiness; reattach with `attach`. Mutually exclusive with `--mount`, `--mount-live`, `-p` |
-| `--snapshot <path>`                             | Attach `<path>` as `/dev/vda` — scratch disk for a future `vm.snapshot()`                                                                 |
+| `--snapshot <path>`                             | Attach `<path>` as `/dev/vda` — scratch disk for a future `vm.snapshot()`                                                                  |
 
 ## `machinen restore`
 
@@ -102,12 +102,12 @@ sibling VM, dropping the caller into the fork's interactive console.
 Pass `--detach` to hand the fork off and return immediately
 (CI / scripted use).
 
-| Flag             | What it does                                                              |
-| ---------------- | ------------------------------------------------------------------------- |
-| `--new-name <n>` | Name for the fork (defaults to `<source>/<fork-pid>`)                     |
-| `--out-dir <d>`  | Keep the snapshot bundle here. Without this, the bundle is temp-dir'd     |
-| `--tcp-keep`     | Inherit TCP socket state in the fork (rarely correct — both copies race)  |
-| `--detach`       | Don't attach the caller's stdio to the fork — return as soon as it's up   |
+| Flag             | What it does                                                             |
+| ---------------- | ------------------------------------------------------------------------ |
+| `--new-name <n>` | Name for the fork (defaults to `<source>/<fork-pid>`)                    |
+| `--out-dir <d>`  | Keep the snapshot bundle here. Without this, the bundle is temp-dir'd    |
+| `--tcp-keep`     | Inherit TCP socket state in the fork (rarely correct — both copies race) |
+| `--detach`       | Don't attach the caller's stdio to the fork — return as soon as it's up  |
 
 ## `machinen attach`
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,6 @@
 import { ParseError } from "@machinen/runtime";
 import { describe, expect, it } from "vitest";
+import { parseForkArgs } from "../parse-fork-args.ts";
 import { parseRunArgs } from "../parse-run-args.ts";
 import { tailLines } from "../tail-lines.ts";
 
@@ -280,6 +281,103 @@ describe("parseRunArgs --detached", () => {
   // enforced by the runtime's BOOT_DETACHED_INCOMPATIBLE check, not
   // the parser — the parser is happy to capture both. The runtime
   // gate is covered in detached.test.ts.
+});
+
+describe("parseForkArgs", () => {
+  it("captures --new-name and --out-dir", () => {
+    const parsed = parseForkArgs([
+      "--name",
+      "src",
+      "--new-name",
+      "fork-b",
+      "--out-dir",
+      "./bundle",
+    ]);
+    expect(parsed.newName).toBe("fork-b");
+    expect(parsed.outDir).toBe("./bundle");
+    expect(parsed.rest).toEqual(["--name", "src"]);
+  });
+
+  it("supports --new-name=<v> and --out-dir=<v>", () => {
+    const parsed = parseForkArgs(["--new-name=fork-b", "--out-dir=./bundle"]);
+    expect(parsed.newName).toBe("fork-b");
+    expect(parsed.outDir).toBe("./bundle");
+  });
+
+  it("captures --tcp-keep and --detach", () => {
+    const parsed = parseForkArgs(["--tcp-keep", "--detach"]);
+    expect(parsed.tcpKeep).toBe(true);
+    expect(parsed.detach).toBe(true);
+  });
+
+  it("defaults tcpKeep, detach, and portForward when no flags are given", () => {
+    const parsed = parseForkArgs(["--name", "src"]);
+    expect(parsed.tcpKeep).toBe(false);
+    expect(parsed.detach).toBe(false);
+    expect(parsed.portForward).toEqual([]);
+    expect(parsed.newName).toBeUndefined();
+    expect(parsed.outDir).toBeUndefined();
+  });
+
+  it("collects -p / --publish into portForward", () => {
+    const parsed = parseForkArgs([
+      "-p",
+      "3001:3000",
+      "--publish",
+      "5433:5432",
+      "--publish=8081:8080",
+    ]);
+    expect(parsed.portForward).toEqual([
+      { hostPort: 3001, guestPort: 3000 },
+      { hostPort: 5433, guestPort: 5432 },
+      { hostPort: 8081, guestPort: 8080 },
+    ]);
+  });
+
+  it("rejects duplicate hostPort across the same fork", () => {
+    expect(() => parseForkArgs(["-p", "3001:3000", "-p", "3001:3001"])).toThrow(
+      /duplicate hostPort 3001/,
+    );
+  });
+
+  it("rejects malformed -p", () => {
+    expect(() => parseForkArgs(["-p", "3001"])).toThrow(/expected <hostPort>:<guestPort>/);
+  });
+
+  it("rejects out-of-range -p ports", () => {
+    expect(() => parseForkArgs(["-p", "0:3000"])).toThrow(/hostPort must be in 1..65535/);
+    expect(() => parseForkArgs(["-p", "3001:70000"])).toThrow(/guestPort must be in 1..65535/);
+  });
+
+  it("rejects a bare -p with no following argument", () => {
+    expect(() => parseForkArgs(["-p"])).toThrow(/-p requires/);
+  });
+
+  it("rejects a bare --new-name with no following argument", () => {
+    expect(() => parseForkArgs(["--new-name"])).toThrow(/--new-name requires/);
+  });
+
+  it("rejects a bare --out-dir with no following argument", () => {
+    expect(() => parseForkArgs(["--out-dir"])).toThrow(/--out-dir requires/);
+  });
+
+  it("rejects a duplicate --new-name", () => {
+    expect(() => parseForkArgs(["--new-name", "a", "--new-name", "b"])).toThrow(/at most once/);
+  });
+
+  it("rejects a duplicate --out-dir", () => {
+    expect(() => parseForkArgs(["--out-dir", "a", "--out-dir", "b"])).toThrow(/at most once/);
+  });
+
+  it("throws ParseError (not generic Error) so the CLI can format it", () => {
+    expect(() => parseForkArgs(["-p"])).toThrow(ParseError);
+  });
+
+  it("preserves unknown args in rest for parseTargetFlags", () => {
+    const parsed = parseForkArgs(["--name", "src", "--pid", "1234", "--detach"]);
+    expect(parsed.rest).toEqual(["--name", "src", "--pid", "1234"]);
+    expect(parsed.detach).toBe(true);
+  });
 });
 
 describe("tailLines (machinen attach --tail slicing)", () => {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,6 @@
 import { ParseError } from "@machinen/runtime";
 import { describe, expect, it } from "vitest";
+import { formatPorts } from "../format-ports.ts";
 import { parseForkArgs } from "../parse-fork-args.ts";
 import { parseRunArgs } from "../parse-run-args.ts";
 import { tailLines } from "../tail-lines.ts";
@@ -377,6 +378,32 @@ describe("parseForkArgs", () => {
     const parsed = parseForkArgs(["--name", "src", "--pid", "1234", "--detach"]);
     expect(parsed.rest).toEqual(["--name", "src", "--pid", "1234"]);
     expect(parsed.detach).toBe(true);
+  });
+});
+
+describe("formatPorts (machinen ls PORTS column)", () => {
+  it("renders '-' when no forwards are configured", () => {
+    expect(formatPorts(undefined)).toBe("-");
+    expect(formatPorts([])).toBe("-");
+  });
+
+  it("renders a single forward as <hostPort>:<guestPort>", () => {
+    expect(formatPorts([{ hostPort: 3000, guestPort: 3000 }])).toBe("3000:3000");
+  });
+
+  it("comma-separates multiple forwards", () => {
+    expect(
+      formatPorts([
+        { hostPort: 3000, guestPort: 3000 },
+        { hostPort: 5432, guestPort: 5432 },
+      ]),
+    ).toBe("3000:3000,5432:5432");
+  });
+
+  it("ignores hostAddr in the rendered cell (kept terse for the table)", () => {
+    expect(formatPorts([{ hostPort: 5432, guestPort: 5432, hostAddr: "0.0.0.0" }])).toBe(
+      "5432:5432",
+    );
   });
 });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,6 +45,7 @@ import type { RegistryEntry } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
+import { parseForkArgs } from "./parse-fork-args.ts";
 import { parseRunArgs } from "./parse-run-args.ts";
 import { tailLines } from "./tail-lines.ts";
 
@@ -921,31 +922,13 @@ async function cmdFork(args: string[]): Promise<number> {
   // `machinen restore`). `--detach` keeps the fire-and-forget shape
   // (CI / scripted workflows): print identity, hand off, return.
   // Source keeps running either way.
-  let newName: string | undefined;
-  let outDir: string | undefined;
-  let tcpKeep = false;
-  let detach = false;
-  const rest: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--new-name" || a.startsWith("--new-name=")) {
-      newName = a === "--new-name" ? args[++i] : a.slice("--new-name=".length);
-      if (!newName) {
-        die("--new-name requires a value");
-      }
-    } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      outDir = a === "--out-dir" ? args[++i] : a.slice("--out-dir=".length);
-      if (!outDir) {
-        die("--out-dir requires a directory path");
-      }
-    } else if (a === "--tcp-keep") {
-      tcpKeep = true;
-    } else if (a === "--detach") {
-      detach = true;
-    } else {
-      rest.push(a);
-    }
+  let parsed;
+  try {
+    parsed = parseForkArgs(args);
+  } catch (err) {
+    handleError(err);
   }
+  const { newName, outDir, tcpKeep, detach, portForward, rest } = parsed;
   const target = parseTargetFlags(rest, "fork");
 
   // The fork is a fresh restore boot, so it needs the same base
@@ -979,6 +962,7 @@ async function cmdFork(args: string[]): Promise<number> {
       kernel: kernelPath,
       dtb: dtbPath,
       tcpKeep,
+      portForward: portForward.length > 0 ? portForward : undefined,
       onLog: (evt) => {
         if (evt.source !== "phase") {
           process.stderr.write(evt.chunk);
@@ -1403,7 +1387,7 @@ function printHelp(): void {
       `                                                 (and closes inherited TCP sockets to\n` +
       `                                                 avoid two live copies racing on shared\n` +
       `                                                 connection state).\n` +
-      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
+      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach] [-p ...]\n` +
       `                                                 Snapshot the source live (it keeps\n` +
       `                                                 running) and restore into a sibling VM,\n` +
       `                                                 dropping the caller into the fork's\n` +
@@ -1412,6 +1396,11 @@ function printHelp(): void {
       `                                                 (CI / scripted use).\n` +
       `                                                 Without --out-dir, the bundle is\n` +
       `                                                 ephemeral and removed when the fork exits.\n` +
+      `                                                 -p <hostPort>:<guestPort> forwards a host\n` +
+      `                                                 port into the fork; host forwards are NOT\n` +
+      `                                                 inherited from the source (host ports are\n` +
+      `                                                 global), so pick a host port the source\n` +
+      `                                                 isn't already using.\n` +
       `  machinen attach   <target-flag> [--shell <c>]  Drop into an interactive PTY shell\n` +
       `                                                 in the running VM (default \`bash -i\`).\n` +
       `                                                 \`cd\`, env vars, history, job control\n` +

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,6 +45,7 @@ import type { RegistryEntry } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
+import { formatPorts } from "./format-ports.ts";
 import { parseForkArgs } from "./parse-fork-args.ts";
 import { parseRunArgs } from "./parse-run-args.ts";
 import { tailLines } from "./tail-lines.ts";
@@ -567,13 +568,15 @@ async function cmdLs(_args: string[]): Promise<number> {
     return 0;
   }
   // Plain tabular output. PID is the runtime handle; NAME is the
-  // optional human label; FORKED-FROM lets you trace lineage when
-  // the VM was created via `machinen restore`.
-  const header = ["PID", "NAME", "UP", "FORKED-FROM"];
+  // optional human label; PORTS lists `<hostPort>:<guestPort>` pairs
+  // configured at boot/fork (comma-separated, `-` if none); FORKED-FROM
+  // lets you trace lineage when the VM was created via `machinen restore`.
+  const header = ["PID", "NAME", "UP", "PORTS", "FORKED-FROM"];
   const rows = entries.map((e) => [
     String(e.pid),
     e.name ?? "-",
     formatUptime(Date.now() - e.startedAt),
+    formatPorts(e.portForward),
     e.forkedFrom ?? "-",
   ]);
   const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
@@ -1366,7 +1369,7 @@ function printHelp(): void {
       `                                                 <source>/<pid>.\n` +
       `\n` +
       `  machinen ls   (alias: ps)                      List running VMs (PID, NAME, UP,\n` +
-      `                                                 FORKED-FROM)\n` +
+      `                                                 PORTS, FORKED-FROM)\n` +
       `\n` +
       `  Targeting a running VM:\n` +
       `    --name <name>     |  --pid <pid>             pick exactly one\n` +

--- a/packages/cli/src/format-ports.ts
+++ b/packages/cli/src/format-ports.ts
@@ -1,0 +1,21 @@
+// Render a registry entry's `portForward` array as a single PORTS cell
+// for `machinen ls`. Kept in its own module so the test can import it
+// without triggering cli.ts's top-level `main()` dispatch.
+//
+// Format:
+//   - undefined / empty → "-"
+//   - single forward    → "3000:3000"
+//   - multiple forwards → "3000:3000,5432:5432"
+//
+// `hostAddr` is intentionally elided — the table cell stays terse, and
+// the bind-address surfaces in `BOOT_PORT_FORWARD_IN_USE` errors when
+// it actually matters.
+
+export function formatPorts(
+  pf: Array<{ hostPort: number; guestPort: number; hostAddr?: string }> | undefined,
+): string {
+  if (!pf || pf.length === 0) {
+    return "-";
+  }
+  return pf.map((p) => `${p.hostPort}:${p.guestPort}`).join(",");
+}

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -50,10 +50,7 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
     } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
       const v = a === "--out-dir" ? argv[++i] : a.slice("--out-dir=".length);
       if (!v) {
-        throw new ParseError(
-          "PARSE_FLAG_MISSING_VALUE",
-          "--out-dir requires a directory path",
-        );
+        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--out-dir requires a directory path");
       }
       if (outDir !== undefined) {
         throw new ParseError(

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -1,0 +1,81 @@
+// Pure arg parser for `machinen fork`. Sibling of parse-run-args.ts —
+// split out so the parser is unit-testable without spawning the CLI.
+
+import { ParseError } from "@machinen/runtime";
+
+import { consumePortForward } from "./parse-run-args.ts";
+
+export interface ParsedForkArgs {
+  /** Optional name for the fork (`--new-name <n>`). */
+  newName?: string;
+  /** Where to write the snapshot bundle (`--out-dir <d>`). */
+  outDir?: string;
+  /** Inherit live TCP connections into the fork (`--tcp-keep`). */
+  tcpKeep: boolean;
+  /** Hand the fork off and return immediately (`--detach`). */
+  detach: boolean;
+  /**
+   * Host→guest port forwards (`-p <hostPort>:<guestPort>`). NOT
+   * inherited from the source — host ports are global, so the source
+   * already binds each one it forwarded. Pass new entries explicitly
+   * with non-conflicting host ports.
+   */
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  /** Args we didn't recognize — passed to `parseTargetFlags`. */
+  rest: string[];
+}
+
+export function parseForkArgs(argv: string[]): ParsedForkArgs {
+  let newName: string | undefined;
+  let outDir: string | undefined;
+  let tcpKeep = false;
+  let detach = false;
+  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
+  const seenHostPorts = new Set<number>();
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--new-name" || a.startsWith("--new-name=")) {
+      const v = a === "--new-name" ? argv[++i] : a.slice("--new-name=".length);
+      if (!v) {
+        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--new-name requires a value");
+      }
+      if (newName !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--new-name may be given at most once per invocation",
+        );
+      }
+      newName = v;
+    } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
+      const v = a === "--out-dir" ? argv[++i] : a.slice("--out-dir=".length);
+      if (!v) {
+        throw new ParseError(
+          "PARSE_FLAG_MISSING_VALUE",
+          "--out-dir requires a directory path",
+        );
+      }
+      if (outDir !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--out-dir may be given at most once per invocation",
+        );
+      }
+      outDir = v;
+    } else if (a === "--tcp-keep") {
+      tcpKeep = true;
+    } else if (a === "--detach") {
+      detach = true;
+    } else if (
+      a === "-p" ||
+      a === "--publish" ||
+      a.startsWith("-p=") ||
+      a.startsWith("--publish=")
+    ) {
+      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
+    } else {
+      rest.push(a);
+    }
+  }
+  return { newName, outDir, tcpKeep, detach, portForward, rest };
+}

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -142,35 +142,8 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       a.startsWith("-p=") ||
       a.startsWith("--publish=")
     ) {
-      let spec: string | undefined;
-      if (a === "-p" || a === "--publish") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError(
-            "PARSE_FLAG_MISSING_VALUE",
-            `${a} requires a <hostPort>:<guestPort> value`,
-          );
-        }
-        i++;
-      } else if (a.startsWith("-p=")) {
-        spec = a.slice("-p=".length);
-      } else {
-        spec = a.slice("--publish=".length);
-      }
-      const colon = spec!.indexOf(":");
-      if (colon <= 0 || colon === spec!.length - 1) {
-        throw new ParseError(
-          "PARSE_FLAG_MALFORMED",
-          `-p: expected <hostPort>:<guestPort>, got '${spec}'`,
-        );
-      }
-      const hostPort = parsePort(spec!.slice(0, colon), "hostPort");
-      const guestPort = parsePort(spec!.slice(colon + 1), "guestPort");
-      if (seenHostPorts.has(hostPort)) {
-        throw new ParseError("PARSE_FLAG_DUPLICATE", `-p: duplicate hostPort ${hostPort}`);
-      }
-      seenHostPorts.add(hostPort);
-      portForward.push({ hostPort, guestPort });
+      const consumed = consumePortForward(a, pre, i, seenHostPorts, portForward);
+      i = consumed;
     } else if (a === "--snapshot" || a.startsWith("--snapshot=")) {
       let spec: string | undefined;
       if (a === "--snapshot") {
@@ -262,4 +235,50 @@ function parsePort(raw: string, label: string): number {
     throw new ParseError("PARSE_PORT_INVALID", `-p: ${label} must be in 1..65535 (got ${n})`);
   }
   return n;
+}
+
+/**
+ * Consume one `-p`/`--publish` token (and the following value, if the
+ * flag was given without `=`). Pushes onto `portForward`, updates
+ * `seenHostPorts`, and returns the new loop index. Shared between
+ * `parseRunArgs` (boot) and the inline parser in `cmdFork`.
+ */
+export function consumePortForward(
+  flag: string,
+  args: string[],
+  i: number,
+  seenHostPorts: Set<number>,
+  portForward: Array<{ hostPort: number; guestPort: number }>,
+): number {
+  let spec: string | undefined;
+  let next = i;
+  if (flag === "-p" || flag === "--publish") {
+    spec = args[i + 1];
+    if (spec === undefined) {
+      throw new ParseError(
+        "PARSE_FLAG_MISSING_VALUE",
+        `${flag} requires a <hostPort>:<guestPort> value`,
+      );
+    }
+    next = i + 1;
+  } else if (flag.startsWith("-p=")) {
+    spec = flag.slice("-p=".length);
+  } else {
+    spec = flag.slice("--publish=".length);
+  }
+  const colon = spec.indexOf(":");
+  if (colon <= 0 || colon === spec.length - 1) {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `-p: expected <hostPort>:<guestPort>, got '${spec}'`,
+    );
+  }
+  const hostPort = parsePort(spec.slice(0, colon), "hostPort");
+  const guestPort = parsePort(spec.slice(colon + 1), "guestPort");
+  if (seenHostPorts.has(hostPort)) {
+    throw new ParseError("PARSE_FLAG_DUPLICATE", `-p: duplicate hostPort ${hostPort}`);
+  }
+  seenHostPorts.add(hostPort);
+  portForward.push({ hostPort, guestPort });
+  return next;
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2582,11 +2582,34 @@ Absolute path to the gvproxy binary spawned for this VM. Used by
 via `vmmExe` — we don't want to SIGTERM whatever process inherits
 gvproxy's pid weeks later.
 
+##### portForward?
+
+> `optional` **portForward?**: `object`[]
+
+Defined in: [registry.ts:107](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L107)
+
+Host→guest port forwards configured at boot/fork time. Surfaced
+in `machinen ls` so users can see which host port maps to which
+VM without re-reading the launch command. Undefined when the VM
+was booted without `-p` / `portForward: []`.
+
+###### hostPort
+
+> **hostPort**: `number`
+
+###### guestPort
+
+> **guestPort**: `number`
+
+###### hostAddr?
+
+> `optional` **hostAddr?**: `string`
+
 ##### startedAt
 
 > **startedAt**: `number`
 
-Defined in: [registry.ts:102](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L102)
+Defined in: [registry.ts:109](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L109)
 
 ms epoch when the entry was created.
 
@@ -3647,7 +3670,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ### AttachOptions
 
-Defined in: [vm.ts:1357](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1357)
+Defined in: [vm.ts:1358](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1358)
 
 #### Properties
 
@@ -3655,7 +3678,7 @@ Defined in: [vm.ts:1357](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1363](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1363)
+Defined in: [vm.ts:1364](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1364)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3665,7 +3688,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1365](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1365)
+Defined in: [vm.ts:1366](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1366)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3673,7 +3696,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1372](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1372)
+Defined in: [vm.ts:1373](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1373)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3684,7 +3707,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2497](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2497)
+Defined in: [vm.ts:2498](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2498)
 
 #### Extends
 
@@ -3887,7 +3910,7 @@ default `127.0.0.1`) to `guestPort` inside the guest.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`portForward`](#portforward-1)
+[`BootOptions`](#bootoptions).[`portForward`](#portforward-2)
 
 ##### binary?
 
@@ -4048,7 +4071,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2502](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2502)
+Defined in: [vm.ts:2503](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2503)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -4057,7 +4080,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2510](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2510)
+Defined in: [vm.ts:2511](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2511)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -4069,7 +4092,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2516](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2516)
+Defined in: [vm.ts:2517](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2517)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4149,7 +4172,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 > **ImageConfig** = `object`
 
-Defined in: [vm.ts:1547](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1547)
+Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
 
 Shape of the optional `./machinen-config.json` baked into a rootfs
 tarball by `provision({ cmd, env })`. `boot()` reads it via
@@ -4163,19 +4186,19 @@ tarball-producing tool can pre-populate the lookup cache.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:1547](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1547)
+Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
 
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:1547](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1547)
+Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
 
 ##### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:1547](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1547)
+Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
 
 ## Variables
 
@@ -4619,7 +4642,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:2112](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2112)
+Defined in: [vm.ts:2113](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2113)
 
 #### Type Declaration
 
@@ -5054,7 +5077,7 @@ registry can hold it.
 
 > **registryRoot**(): `string`
 
-Defined in: [registry.ts:111](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L111)
+Defined in: [registry.ts:118](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L118)
 
 Absolute path to the registry root. Honors `MACHINEN_REGISTRY_DIR`
 so tests can point at a scratch dir without stomping on real entries.
@@ -5069,7 +5092,7 @@ so tests can point at a scratch dir without stomping on real entries.
 
 > **list**(): [`RegistryEntry`](#registryentry)[]
 
-Defined in: [registry.ts:228](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L228)
+Defined in: [registry.ts:235](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L235)
 
 List all registry entries whose pid is still alive. Prunes stale
 entries (pid no longer alive) and orphaned name pins as a side
@@ -5249,7 +5272,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1388](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1388)
+Defined in: [vm.ts:1389](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1389)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -5281,7 +5304,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **warmImageConfigCache**(`imagePath`, `config`): `void`
 
-Defined in: [vm.ts:1592](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1592)
+Defined in: [vm.ts:1593](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1593)
 
 Pre-populate the image-config cache for a freshly-written tarball.
 Lets `provision()` (and other tarball producers) skip the slow
@@ -5314,7 +5337,7 @@ none was baked).
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1960](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1960)
+Defined in: [vm.ts:1961](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1961)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -5353,7 +5376,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:2002](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2002)
+Defined in: [vm.ts:2003](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2003)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -5385,7 +5408,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2535](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2535)
+Defined in: [vm.ts:2536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2536)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5420,7 +5443,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2788](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2788)
+Defined in: [vm.ts:2789](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2789)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -50,6 +50,21 @@ describe("registry primitives", () => {
     expect(readEntry(process.pid)).toEqual(entry);
   });
 
+  it("writeEntry → readEntry round-trips portForward", () => {
+    const entry: RegistryEntry = {
+      pid: process.pid,
+      name: "with-ports",
+      socketPath: "/tmp/fake.sock",
+      portForward: [
+        { hostPort: 3000, guestPort: 3000 },
+        { hostPort: 5432, guestPort: 5432, hostAddr: "0.0.0.0" },
+      ],
+      startedAt: 1_700_000_000_000,
+    };
+    writeEntry(entry);
+    expect(readEntry(process.pid)).toEqual(entry);
+  });
+
   it("removeEntry drops the directory + name pin", () => {
     writeEntry({
       pid: process.pid,

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -40,6 +40,7 @@ import { promisify } from "node:util";
 import debugLib from "debug";
 import { GvproxyError } from "./errors.ts";
 import { ensurePdeathsig, wrapWithPdeathsig } from "./pdeathsig.ts";
+import { listAll } from "./registry.ts";
 
 const debug = debugLib("machinen:gvproxy");
 
@@ -349,7 +350,8 @@ const execFileAsync = promisify(execFile);
  *
  * The returned string is meant to be appended verbatim to a port-in-use
  * error message; format is one of:
- *   - `held by machinen-owned gvproxy (pid 1234) — try \`kill 1234\` to clear it`
+ *   - `held by VM 'counter' (gvproxy pid 1234) — pick a different host port`
+ *   - `held by machinen-owned gvproxy (pid 1234, no live VM) — likely orphaned, try \`kill 1234\` to clear it`
  *   - `held by chrome (pid 5678)`
  */
 export async function describePortHolder(port: number): Promise<string | null> {
@@ -376,6 +378,7 @@ export async function describePortHolder(port: number): Promise<string | null> {
   if (!cmd || !pid || !/^\d+$/.test(pid)) {
     return null;
   }
+  const pidNum = Number(pid);
 
   let fullCmd = "";
   try {
@@ -392,9 +395,31 @@ export async function describePortHolder(port: number): Promise<string | null> {
   const looksMachinen =
     (fullCmd && fullCmd.includes(machinenDir)) || cmd === "gvproxy" || cmd === "microvm";
 
-  return looksMachinen
-    ? `held by machinen-owned ${cmd} (pid ${pid}) — try \`kill ${pid}\` to clear it`
-    : `held by ${cmd} (pid ${pid})`;
+  if (!looksMachinen) {
+    return `held by ${cmd} (pid ${pid})`;
+  }
+  // Machinen-owned. Walk the registry to see if the holding gvproxy
+  // belongs to a live VM — most common in fork: the source VM still
+  // forwards the port, and the user picked the same host port for the
+  // fork. In that case `kill <pid>` would take down the source, so
+  // route the user toward a different host port instead.
+  let owningVm: { name?: string; pid: number } | null = null;
+  try {
+    for (const entry of listAll()) {
+      if (entry.gvproxyPid === pidNum) {
+        owningVm = { name: entry.name, pid: entry.pid };
+        break;
+      }
+    }
+  } catch {
+    // Registry read is best-effort — if it throws, fall through to
+    // the orphan-fallback message.
+  }
+  if (owningVm) {
+    const label = owningVm.name ? `VM '${owningVm.name}'` : `VM (pid ${owningVm.pid})`;
+    return `held by ${label} (gvproxy pid ${pid}) — pick a different host port`;
+  }
+  return `held by machinen-owned ${cmd} (pid ${pid}, no live VM) — likely orphaned, try \`kill ${pid}\` to clear it`;
 }
 
 /**

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -98,6 +98,13 @@ export interface RegistryEntry {
    * gvproxy's pid weeks later.
    */
   gvproxyExe?: string;
+  /**
+   * Host→guest port forwards configured at boot/fork time. Surfaced
+   * in `machinen ls` so users can see which host port maps to which
+   * VM without re-reading the launch command. Undefined when the VM
+   * was booted without `-p` / `portForward: []`.
+   */
+  portForward?: Array<{ hostPort: number; guestPort: number; hostAddr?: string }>;
   /** ms epoch when the entry was created. */
   startedAt: number;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -921,6 +921,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         vmmExe: binary,
         gvproxyPid: gvPid,
         gvproxyExe: gvExe,
+        portForward: portForward.length > 0 ? portForward : undefined,
         startedAt: Date.now(),
       });
       registered = true;


### PR DESCRIPTION
## Problem

The CLI's `fork` command couldn't forward host ports. You could do it from Node (`vm.fork({ portForward })`), but `machinen fork` had no `-p` flag — so reaching a fork from the host meant writing Node code or falling back to `machinen exec` over vsock.

When two VMs did try to share a host port, the error said `held by machinen-owned gvproxy (pid 1234) — try \`kill 1234\` to clear it`. For the common case (forking onto a port the source already uses), following that advice would kill the source. The message gave the same hint whether the holder was a live VM or a real orphan, so the user couldn't tell.

## Solution

Add `-p <hostPort>:<guestPort>` to `machinen fork`, same parsing rules as `boot -p`. The runtime already accepts a `portForward` option on `vm.fork()`, so the flag just plumbs through.

Make the conflict error registry-aware. When the holding gvproxy belongs to a live VM, name that VM and tell the user to pick a different host port. Keep the `kill <pid>` hint only for actual orphans.

## Technical summary

- `parseForkArgs` (new) parses fork's flags. Shares port-spec parsing with `parseRunArgs` via a small extracted `consumePortForward` helper, so `boot -p` and `fork -p` stay aligned.
- `cmdFork` passes `portForward` through to `vm.fork()`. Existing pre-flight checks (`BOOT_PORT_FORWARD_INVALID`, `BOOT_PORT_FORWARD_CONFLICT`, `BOOT_PORT_FORWARD_IN_USE`) cover validation — no new error codes.
- `describePortHolder` walks the registry. If the holder pid matches a live entry's `gvproxyPid`, the message names the VM. If not, it falls through to the orphan message (which still suggests `kill`).
- Docs: README fork section, `snapshot-restore-fork.md` guide, and `networking.md` — that file's "detached + -p" limitation note was stale (PR3 of #150 already lifted it; `boot --detached -p` and `fork --detach -p` both work today).

## Test plan

- [x] 14 new `parseForkArgs` unit tests (`-p` success / malformed / missing / duplicate / out-of-range, plus `--new-name` / `--out-dir` / `--detach` / `--tcp-keep`).
- [x] Existing `parseRunArgs -p` and `describePortHolder` tests still pass after the helper extraction.
- [ ] Manual: fork with `-p 3001:3000` reaches the fork at `localhost:3001` while the source still serves `localhost:3000`.
- [ ] Manual: collision case (fork onto the source's host port) names the source VM, doesn't suggest `kill`.
- [ ] `npx agent-ci run --all -q -p` (kicked off, didn't wait for pause).
- [ ] `pnpm smoke-tests` (per CLAUDE.md — not yet run).

Two pre-existing vitest failures (`boot.test.ts > image + cmd` missing fixture; `mount-server-workloads.test.ts > tar -xf` macOS metadata quirk) are unrelated.