### PR TITLE
fix(runtime): release stale empty dir at name-pin path

### DIFF
--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -6,7 +6,7 @@
 // we don't need real HVF.
 
 import { createServer } from "node:net";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -141,6 +141,35 @@ describe("registry primitives", () => {
     expect(claimName("recycled", 999_999_999)).toBe(true);
     // The dead-pid pin should be replaced by our live one on retry.
     expect(claimName("recycled", process.pid)).toBe(true);
+  });
+
+  it("claimName self-heals an empty stale directory at the pin path", () => {
+    // Reproduces the leftover from a path-shaped child pin (pre-#268
+    // removeEntry didn't prune parents): names/<name>/ ends up empty.
+    mkdirSync(join(scratchDir, "names", "stranded"), { recursive: true });
+    expect(claimName("stranded", process.pid)).toBe(true);
+  });
+
+  it("claimName refuses when a non-empty directory holds nested pins", () => {
+    // A live child pin at names/parent/<pid> means the plain name is taken.
+    mkdirSync(join(scratchDir, "names", "parent"), { recursive: true });
+    writeFileSync(join(scratchDir, "names", "parent", "1234"), "1234");
+    expect(claimName("parent", process.pid)).toBe(false);
+  });
+
+  it("removeEntry prunes empty parent dirs of a path-shaped pin", () => {
+    writeEntry({
+      pid: process.pid,
+      name: "src/child",
+      socketPath: "/tmp/fake.sock",
+      startedAt: Date.now(),
+    });
+    expect(existsSync(join(scratchDir, "names", "src", "child"))).toBe(true);
+    removeEntry(process.pid);
+    // Both the leaf pin and the now-empty parent should be gone, so the
+    // plain name "src" is claimable again.
+    expect(existsSync(join(scratchDir, "names", "src"))).toBe(false);
+    expect(claimName("src", process.pid)).toBe(true);
   });
 });
 

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -27,6 +27,8 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  rmdirSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -159,13 +161,32 @@ export function removeEntry(pid: number): void {
   // Read meta first to recover the name (so we can drop the pin).
   const entry = readEntry(pid);
   if (entry?.name) {
+    const pin = pinPath(entry.name);
     try {
-      unlinkSync(pinPath(entry.name));
+      unlinkSync(pin);
     } catch {}
+    // For path-shaped names (`<src>/<pid>` chained restore — #208) the
+    // pin's parent dirs were created by `claimName`'s recursive mkdir.
+    // Walk up and rmdir any that are now empty, stopping at namesDir().
+    // rmdirSync errors on non-empty dirs, so siblings stay intact.
+    pruneEmptyParents(dirname(pin));
   }
   try {
     rmSync(join(root, String(pid)), { recursive: true, force: true });
   } catch {}
+}
+
+function pruneEmptyParents(dir: string): void {
+  const stop = namesDir();
+  let cur = dir;
+  while (cur.startsWith(stop) && cur !== stop) {
+    try {
+      rmdirSync(cur);
+    } catch {
+      return;
+    }
+    cur = dirname(cur);
+  }
 }
 
 /** Read an entry by pid. Returns undefined if the directory or file is missing. */
@@ -342,7 +363,25 @@ export function claimName(name: string, pid: number): boolean {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
         throw err;
       }
-      // EEXIST: someone holds the pin. If they're dead, drop it and retry.
+      // EEXIST: a file or a directory occupies the pin path. An empty
+      // directory is a leftover from a path-shaped child pin whose
+      // leaf was unlinked (pre-#268 removeEntry didn't prune parents).
+      // A non-empty directory is holding live nested pins — refuse.
+      let isDir = false;
+      try {
+        isDir = statSync(pin).isDirectory();
+      } catch {}
+      if (isDir) {
+        try {
+          rmdirSync(pin);
+          debug("claimName name=%s removed empty stale dir — retrying", name);
+          continue;
+        } catch {
+          debug("claimName name=%s dir holds live nested pins — refusing", name);
+          return false;
+        }
+      }
+      // Pin is a regular file. If the holding pid is dead, drop it and retry.
       let heldPid = -1;
       try {
         heldPid = Number(readFileSync(pin, "utf8").trim());


### PR DESCRIPTION
## Summary

`machinen boot --name counter` was failing with `REGISTRY_NAME_IN_USE` even though `machinen ps` showed no running VMs. Root cause: a path-shaped pin (`names/<src>/<pid>` from chained restore / fork — #208, #216) creates `<src>/` as a directory via the recursive mkdir in `claimName`. `removeEntry` only unlinked the leaf, so when the child VM exited, `<src>/` was left behind as an empty directory. Later, claiming the plain name `<src>` hit `writeFileSync(pin, ..., { flag: "wx" })` → `EEXIST` → the EEXIST handler tried to `readFileSync` the path (got `EISDIR`, swallowed) → `heldPid = -1`, so the live-pid check was skipped → `unlinkSync` failed on the directory (also swallowed) → returned false → bogus `REGISTRY_NAME_IN_USE`.

## Solution

Two-part fix in `packages/runtime/src/registry.ts`:

- **`removeEntry`** prunes empty parent dirs up to `namesDir()` after unlinking the leaf pin. `rmdirSync` errors on non-empty dirs, so siblings stay intact. This stops new path-shaped pins from leaking.
- **`claimName`** self-heals existing leakage: when EEXIST hits and the path is a directory, `rmdir` it (empty case → retry) or refuse cleanly (non-empty case → live nested pins, name is genuinely taken).

Plus three unit tests:
- `claimName` self-heals an empty stale directory at the pin path
- `claimName` refuses a non-empty directory holding nested pins
- `removeEntry` prunes empty parent dirs of a path-shaped pin

## Test plan

- [x] `npx vitest run packages/runtime/src/__tests__/registry.test.ts` — 19/19
- [x] `npx vitest run` (full suite) — 443/443
- [x] `npx agent-ci run --all -q -p` — 6/7 (the one failure is `release.yml > build-vmm-darwin-arm64 > codesign`, a Docker container HTTP 404 mid-run; unrelated to runtime changes)
- [x] Reproduced the original bug locally (stale `~/.machinen/vms/names/counter/` empty dir → `REGISTRY_NAME_IN_USE`); the new `claimName` path clears it and the boot succeeds
- [ ] Smoke tests (`pnpm smoke-tests`) not run in this session — registry-only change with no VM-boot path touched