### PR TITLE
fix(runtime): preserve workload state across snapshot/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,19 @@ Freeze it, copy the bundle to host B, thaw it:
 
 ```bash
 npx machinen snapshot --name counter --out-dir ./counter.snap
-scp -r ./counter.snap host-b:
+scp ./counter.tar.gz ./counter.snap host-b:
 ssh host-b npx machinen restore ./counter.snap &
 curl host-b:3000                           # { count: 3 }  ← same process
 ```
 
 Same arch only (arm64 ↔ arm64). Memory, file descriptors, and timers come
 back exactly as they were.
+
+The bundle remembers the absolute path of the rootfs tarball you booted
+from. On the same host that's all you need — `restore` reuses the same
+tarball so CRIU can re-open file-backed VMAs (executable, shared
+libraries) at the paths they were dumped from. Across hosts, copy the
+tarball to the same path or pass `--image <tarball>` to override.
 
 ## Fork
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "changeset": "changeset",
     "version": "changeset version && oxfmt",
     "release": "pnpm -F @machinen/runtime -F @machinen/cli build && changeset publish",
-    "premachinen": "pnpm -F @machinen/runtime -F @machinen/cli build",
+    "premachinen": "pnpm build",
     "machinen": "MACHINEN_ASSETS_DIR=${MACHINEN_ASSETS_DIR:-$PWD/release-assets} node packages/cli/dist/cli.js",
     "build:docs": "typedoc",
     "dev": "bash scripts/dev.sh",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -2,6 +2,7 @@ import { ParseError } from "@machinen/runtime";
 import { describe, expect, it } from "vitest";
 import { formatPorts } from "../format-ports.ts";
 import { parseForkArgs } from "../parse-fork-args.ts";
+import { parseRestoreArgs } from "../parse-restore-args.ts";
 import { parseRunArgs } from "../parse-run-args.ts";
 import { tailLines } from "../tail-lines.ts";
 
@@ -378,6 +379,88 @@ describe("parseForkArgs", () => {
     const parsed = parseForkArgs(["--name", "src", "--pid", "1234", "--detach"]);
     expect(parsed.rest).toEqual(["--name", "src", "--pid", "1234"]);
     expect(parsed.detach).toBe(true);
+  });
+});
+
+describe("parseRestoreArgs", () => {
+  it("captures the snap-dir positional", () => {
+    const parsed = parseRestoreArgs(["./warm"]);
+    expect(parsed.positional).toEqual(["./warm"]);
+    expect(parsed.name).toBeUndefined();
+    expect(parsed.image).toBeUndefined();
+    expect(parsed.portForward).toEqual([]);
+  });
+
+  it("captures --name and --image (space and = forms)", () => {
+    const a = parseRestoreArgs(["./warm", "--name", "restored", "--image", "./rootfs.tar.gz"]);
+    expect(a.name).toBe("restored");
+    expect(a.image).toBe("./rootfs.tar.gz");
+    const b = parseRestoreArgs(["--name=restored", "--image=./rootfs.tar.gz", "./warm"]);
+    expect(b.name).toBe("restored");
+    expect(b.image).toBe("./rootfs.tar.gz");
+  });
+
+  it("collects -p / --publish into portForward", () => {
+    const parsed = parseRestoreArgs([
+      "./warm",
+      "-p",
+      "3001:3000",
+      "--publish",
+      "5433:5432",
+      "--publish=8081:8080",
+    ]);
+    expect(parsed.portForward).toEqual([
+      { hostPort: 3001, guestPort: 3000 },
+      { hostPort: 5433, guestPort: 5432 },
+      { hostPort: 8081, guestPort: 8080 },
+    ]);
+  });
+
+  it("rejects duplicate hostPort across the same restore", () => {
+    expect(() => parseRestoreArgs(["./warm", "-p", "3001:3000", "-p", "3001:3001"])).toThrow(
+      /duplicate hostPort 3001/,
+    );
+  });
+
+  it("rejects malformed -p", () => {
+    expect(() => parseRestoreArgs(["./warm", "-p", "3001"])).toThrow(
+      /expected <hostPort>:<guestPort>/,
+    );
+  });
+
+  it("rejects out-of-range -p ports", () => {
+    expect(() => parseRestoreArgs(["./warm", "-p", "0:3000"])).toThrow(
+      /hostPort must be in 1..65535/,
+    );
+    expect(() => parseRestoreArgs(["./warm", "-p", "3001:70000"])).toThrow(
+      /guestPort must be in 1..65535/,
+    );
+  });
+
+  it("rejects a bare -p with no following argument", () => {
+    expect(() => parseRestoreArgs(["./warm", "-p"])).toThrow(/-p requires/);
+  });
+
+  it("rejects a bare --name / --image with no following argument", () => {
+    expect(() => parseRestoreArgs(["./warm", "--name"])).toThrow(/--name requires/);
+    expect(() => parseRestoreArgs(["./warm", "--image"])).toThrow(/--image requires/);
+  });
+
+  it("rejects a duplicate --name / --image", () => {
+    expect(() => parseRestoreArgs(["./warm", "--name", "a", "--name", "b"])).toThrow(
+      /at most once/,
+    );
+    expect(() => parseRestoreArgs(["./warm", "--image", "a", "--image", "b"])).toThrow(
+      /at most once/,
+    );
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseRestoreArgs(["./warm", "--bogus"])).toThrow(/unknown flag: --bogus/);
+  });
+
+  it("throws ParseError (not generic Error) so the CLI can format it", () => {
+    expect(() => parseRestoreArgs(["./warm", "-p"])).toThrow(ParseError);
   });
 });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@
 //
 // Surface:
 //   machinen boot [opts] -- <cmd>
-//   machinen restore <snap-dir> [--name <name>]
+//   machinen restore <snap-dir> [--name <name>] [-p <hostPort>:<guestPort>]
 //   machinen ls (alias: ps)
 //   machinen exec ( --name <name> | --pid <pid> ) -- <cmd>
 //   machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir>
@@ -47,6 +47,7 @@ import debugLib from "debug";
 import pkg from "../package.json" with { type: "json" };
 import { formatPorts } from "./format-ports.ts";
 import { parseForkArgs } from "./parse-fork-args.ts";
+import { parseRestoreArgs } from "./parse-restore-args.ts";
 import { parseRunArgs } from "./parse-run-args.ts";
 import { tailLines } from "./tail-lines.ts";
 
@@ -477,30 +478,38 @@ async function cmdInstall(args: string[]): Promise<number> {
 }
 
 async function cmdRestore(args: string[]): Promise<number> {
-  // `machinen restore <snap-dir> [--name <name>]`. The bundle dir
-  // (produced by `machinen snapshot`) holds disk.img + meta.json.
-  const positional: string[] = [];
-  let name: string | undefined;
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--name" || a.startsWith("--name=")) {
-      name = a === "--name" ? args[++i] : a.slice("--name=".length);
-      if (!name) {
-        die("--name requires a value");
-      }
-    } else if (a.startsWith("-")) {
-      die(`unknown flag: ${a}`);
-    } else {
-      positional.push(a);
-    }
+  // `machinen restore <snap-dir> [--image <tarball>] [--name <name>]`.
+  // The bundle dir (produced by `machinen snapshot`) holds disk.img +
+  // meta.json. The bundle carries CRIU's process images but not the
+  // workload's rootfs, so any process whose memory map references
+  // files outside the base debian rootfs (e.g. /usr/bin/node from a
+  // `provision()`d tarball) needs the same workload tarball passed
+  // here as `--image`. Without it, criu fails its file-backed VMA
+  // restore with "Can't open file <path> on restore: No such file
+  // or directory" and /sbin/machinen-restore exits 1, panicking the
+  // guest kernel ("Attempted to kill init!").
+  let parsed;
+  try {
+    parsed = parseRestoreArgs(args);
+  } catch (err) {
+    handleError(err);
   }
+  const { positional, name, image: imageOverride, portForward } = parsed;
   if (positional.length !== 1) {
-    die("usage: machinen restore <snap-dir> [--name <name>]");
+    die(
+      "usage: machinen restore <snap-dir> [--image <tarball>] [--name <name>] " +
+        "[-p <hostPort>:<guestPort>]",
+    );
   }
   const snapDir = resolve(positional[0]!);
 
-  // Restore needs the base rootfs in the initramfs (criu, machinen-
-  // restore, etc), so resolve it the same way `cmdBoot` does.
+  // Kernel + dtb always come from the base assets (the workload tarball
+  // doesn't carry them). The rootfs comes from --image when given, or
+  // falls back to meta.sourceImage inside restore() so the same-host
+  // quickstart works without a flag. The base release rootfs is no
+  // longer a silent default — workloads beyond a bare /bin/sh need
+  // their own tarball, and a confused-by-default restore that panics
+  // the guest kernel was the original bug we shipped this fix for.
   const assetsOverride = process.env.MACHINEN_ASSETS_DIR;
   if (assetsOverride) {
     validateAssetsDir(assetsOverride);
@@ -511,7 +520,14 @@ async function cmdRestore(args: string[]): Promise<number> {
   const baseDir = assetsOverride ? resolve(assetsOverride) : baseDirFor(RELEASE_TAG);
   const kernelPath = join(baseDir, assetsOverride ? "Image-arm64" : "Image");
   const dtbPath = join(baseDir, assetsOverride ? "virt-arm64.dtb" : "virt.dtb");
-  const imagePath = join(baseDir, assetsOverride ? "rootfs-debian-arm64.tar.gz" : "rootfs.tar.gz");
+
+  let imagePath: string | undefined;
+  if (imageOverride) {
+    imagePath = resolve(imageOverride);
+    if (!existsSync(imagePath)) {
+      die(`--image: file not found: ${imagePath}`);
+    }
+  }
 
   let vm;
   try {
@@ -521,6 +537,7 @@ async function cmdRestore(args: string[]): Promise<number> {
       kernel: kernelPath,
       dtb: dtbPath,
       name,
+      portForward: portForward.length > 0 ? portForward : undefined,
       timeoutMs: null,
     });
   } catch (err) {
@@ -1364,9 +1381,18 @@ function printHelp(): void {
       `                                                 (must be absolute).\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +
-      `  machinen restore <snap-dir> [--name <name>]    Restore a VM from a snapshot bundle.\n` +
+      `  machinen restore <snap-dir> [--image <tar.gz>] [--name <name>] [-p ...]\n` +
+      `                                                 Restore a VM from a snapshot bundle.\n` +
       `                                                 Anonymous restores auto-name as\n` +
-      `                                                 <source>/<pid>.\n` +
+      `                                                 <source>/<pid>. Pass --image with the\n` +
+      `                                                 same tarball used to boot the source VM\n` +
+      `                                                 when the workload references files\n` +
+      `                                                 outside the base rootfs (e.g. node).\n` +
+      `                                                 -p <hostPort>:<guestPort> forwards a host\n` +
+      `                                                 port into the restored VM; forwards are\n` +
+      `                                                 NOT inherited from the source (host ports\n` +
+      `                                                 are global), so pick host ports nothing\n` +
+      `                                                 else is binding.\n` +
       `\n` +
       `  machinen ls   (alias: ps)                      List running VMs (PID, NAME, UP,\n` +
       `                                                 PORTS, FORKED-FROM)\n` +

--- a/packages/cli/src/parse-restore-args.ts
+++ b/packages/cli/src/parse-restore-args.ts
@@ -1,0 +1,76 @@
+// Pure arg parser for `machinen restore`. Sibling of parse-run-args.ts
+// and parse-fork-args.ts — split out so the parser is unit-testable
+// without spawning the CLI.
+
+import { ParseError } from "@machinen/runtime";
+
+import { consumePortForward } from "./parse-run-args.ts";
+
+export interface ParsedRestoreArgs {
+  /**
+   * Positional args (the snapshot bundle directory). The CLI enforces
+   * exactly one — kept as an array here to match the parseRunArgs
+   * shape and let the CLI emit the canonical `usage:` line.
+   */
+  positional: string[];
+  /** Optional explicit name for the restored VM (`--name <name>`). */
+  name?: string;
+  /** Workload rootfs override (`--image <path>`). */
+  image?: string;
+  /**
+   * Host→guest port forwards (`-p <hostPort>:<guestPort>`). Like
+   * `fork`, restore does NOT inherit forwards from the source — host
+   * ports are global, so the source already binds each one it
+   * forwarded. Pass new entries explicitly with non-conflicting
+   * host ports.
+   */
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+}
+
+export function parseRestoreArgs(argv: string[]): ParsedRestoreArgs {
+  const positional: string[] = [];
+  let name: string | undefined;
+  let image: string | undefined;
+  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
+  const seenHostPorts = new Set<number>();
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--name" || a.startsWith("--name=")) {
+      const v = a === "--name" ? argv[++i] : a.slice("--name=".length);
+      if (!v) {
+        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
+      }
+      if (name !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--name may be given at most once per invocation",
+        );
+      }
+      name = v;
+    } else if (a === "--image" || a.startsWith("--image=")) {
+      const v = a === "--image" ? argv[++i] : a.slice("--image=".length);
+      if (!v) {
+        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--image requires a value");
+      }
+      if (image !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--image may be given at most once per invocation",
+        );
+      }
+      image = v;
+    } else if (
+      a === "-p" ||
+      a === "--publish" ||
+      a.startsWith("-p=") ||
+      a.startsWith("--publish=")
+    ) {
+      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
+    } else if (a.startsWith("-")) {
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, name, image, portForward };
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2465,7 +2465,7 @@ Alias of output() — a pty gives us one merged stream.
 
 ### RegistryEntry
 
-Defined in: [registry.ts:39](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L39)
+Defined in: [registry.ts:41](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L41)
 
 #### Properties
 
@@ -2473,7 +2473,7 @@ Defined in: [registry.ts:39](https://github.com/redwoodjs/machinen/blob/main/pac
 
 > **pid**: `number`
 
-Defined in: [registry.ts:41](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L41)
+Defined in: [registry.ts:43](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L43)
 
 PID of the VMM process on this host — primary key.
 
@@ -2481,7 +2481,7 @@ PID of the VMM process on this host — primary key.
 
 > `optional` **name?**: `string`
 
-Defined in: [registry.ts:43](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L43)
+Defined in: [registry.ts:45](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L45)
 
 Optional human-friendly name (from `boot({ name })`). Path-shaped allowed.
 
@@ -2489,7 +2489,7 @@ Optional human-friendly name (from `boot({ name })`). Path-shaped allowed.
 
 > **socketPath**: `string`
 
-Defined in: [registry.ts:45](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L45)
+Defined in: [registry.ts:47](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L47)
 
 Host-side vsock UDS the exec-agent is reachable on.
 
@@ -2497,7 +2497,7 @@ Host-side vsock UDS the exec-agent is reachable on.
 
 > `optional` **imagePath?**: `string`
 
-Defined in: [registry.ts:47](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L47)
+Defined in: [registry.ts:49](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L49)
 
 Path to the image the VM was booted from (diagnostic only).
 
@@ -2505,7 +2505,7 @@ Path to the image the VM was booted from (diagnostic only).
 
 > `optional` **diskPath?**: `string`
 
-Defined in: [registry.ts:54](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L54)
+Defined in: [registry.ts:56](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L56)
 
 Host-side path of the disk file attached as /dev/vda (from
 `boot({ snapshot: <path> })`). Required for `vm.snapshot()` —
@@ -2516,7 +2516,7 @@ file to copy after the guest dump completes.
 
 > `optional` **forkedFrom?**: `string`
 
-Defined in: [registry.ts:59](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L59)
+Defined in: [registry.ts:61](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L61)
 
 Absolute path to the snapshot directory this VM was forked from
 (set by `restore({ snapDir })`). Visible in `ls`; informational.
@@ -2525,7 +2525,7 @@ Absolute path to the snapshot directory this VM was forked from
 
 > `optional` **bootLogPath?**: `string`
 
-Defined in: [registry.ts:67](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L67)
+Defined in: [registry.ts:69](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L69)
 
 Path to the one-shot boot-console snapshot written at detach time
 (issue #150 phase 2). Only set on entries booted with
@@ -2537,7 +2537,7 @@ of the boot sequence on a detached VM.
 
 > `optional` **cleanupPaths?**: `string`[]
 
-Defined in: [registry.ts:76](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L76)
+Defined in: [registry.ts:78](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L78)
 
 Per-boot artifacts that need to be removed when the VMM exits.
 Today the in-process exit hook handles this for non-detached
@@ -2550,7 +2550,7 @@ file (per-boot disk image) or a directory (bundle / vsock UDS).
 
 > `optional` **vmmExe?**: `string`
 
-Defined in: [registry.ts:84](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L84)
+Defined in: [registry.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L86)
 
 Absolute path to the VMM binary that was spawned. `machinen gc`
 compares this against `/proc/<pid>/exe` (Linux) or `ps -o comm=`
@@ -2562,7 +2562,7 @@ to `kill(pid, 0)` and the entry would be kept around forever.
 
 > `optional` **gvproxyPid?**: `number`
 
-Defined in: [registry.ts:93](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L93)
+Defined in: [registry.ts:95](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L95)
 
 PID of the gvproxy process spawned alongside this VMM (issue #150
 phase 2 PR3). Recorded so `machinen stop` can SIGTERM gvproxy at
@@ -2575,7 +2575,7 @@ pre-set by the caller).
 
 > `optional` **gvproxyExe?**: `string`
 
-Defined in: [registry.ts:100](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L100)
+Defined in: [registry.ts:102](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L102)
 
 Absolute path to the gvproxy binary spawned for this VM. Used by
 `machinen stop` for the same anti-recycling check the VMM gets
@@ -2586,7 +2586,7 @@ gvproxy's pid weeks later.
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [registry.ts:107](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L107)
+Defined in: [registry.ts:109](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L109)
 
 Host→guest port forwards configured at boot/fork time. Surfaced
 in `machinen ls` so users can see which host port maps to which
@@ -2609,7 +2609,7 @@ was booted without `-p` / `portForward: []`.
 
 > **startedAt**: `number`
 
-Defined in: [registry.ts:109](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L109)
+Defined in: [registry.ts:111](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L111)
 
 ms epoch when the entry was created.
 
@@ -3208,11 +3208,24 @@ Defined in: [vm-handle.ts:227](https://github.com/redwoodjs/machinen/blob/main/p
 
 Name passed to `boot({ name })` when the source VM was started.
 
+##### sourceImage?
+
+> `optional` **sourceImage?**: `string`
+
+Defined in: [vm-handle.ts:236](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L236)
+
+Absolute path of the rootfs tarball the source VM was booted with
+(`boot({ image })` or its restored equivalent). `restore()` uses
+this as the default rootfs, so the same-host quickstart works
+without callers having to repeat the image path. Cross-host
+restores need either the path to resolve on the new host, or an
+explicit `image` override.
+
 ##### snappedAt
 
 > **snappedAt**: `number`
 
-Defined in: [vm-handle.ts:229](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L229)
+Defined in: [vm-handle.ts:238](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L238)
 
 ms epoch when `vm.snapshot()` returned.
 
@@ -3220,7 +3233,7 @@ ms epoch when `vm.snapshot()` returned.
 
 ### ForkOptions
 
-Defined in: [vm-handle.ts:232](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L232)
+Defined in: [vm-handle.ts:241](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L241)
 
 #### Properties
 
@@ -3228,7 +3241,7 @@ Defined in: [vm-handle.ts:232](https://github.com/redwoodjs/machinen/blob/main/p
 
 > `optional` **name?**: `string`
 
-Defined in: [vm-handle.ts:237](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L237)
+Defined in: [vm-handle.ts:246](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L246)
 
 Name for the forked VM. When omitted, the existing restore()
 auto-naming kicks in: `<sourceName>/<fork.pid>`.
@@ -3237,7 +3250,7 @@ auto-naming kicks in: `<sourceName>/<fork.pid>`.
 
 > `optional` **outDir?**: `string`
 
-Defined in: [vm-handle.ts:244](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L244)
+Defined in: [vm-handle.ts:253](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L253)
 
 If set, the snapshot bundle is written here and kept after the
 fork exits — re-restore from this path to spawn another sibling.
@@ -3248,7 +3261,7 @@ when the fork's VMM exits.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm-handle.ts:249](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L249)
+Defined in: [vm-handle.ts:258](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L258)
 
 Override the rootfs image used for the fork's restore boot.
 Same semantics as `restore({ image })`.
@@ -3257,7 +3270,7 @@ Same semantics as `restore({ image })`.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [vm-handle.ts:251](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L251)
+Defined in: [vm-handle.ts:260](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L260)
 
 Kernel path for the fork's boot. Same semantics as `boot({ kernel })`.
 
@@ -3265,7 +3278,7 @@ Kernel path for the fork's boot. Same semantics as `boot({ kernel })`.
 
 > `optional` **dtb?**: `string`
 
-Defined in: [vm-handle.ts:253](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L253)
+Defined in: [vm-handle.ts:262](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L262)
 
 DTB path for the fork's boot. Same semantics as `boot({ dtb })`.
 
@@ -3273,7 +3286,7 @@ DTB path for the fork's boot. Same semantics as `boot({ dtb })`.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm-handle.ts:259](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L259)
+Defined in: [vm-handle.ts:268](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L268)
 
 Wall-clock ceiling for the dump half. Default 90s (matches
 `vm.snapshot({ timeoutMs })`). Restore boot has its own
@@ -3283,7 +3296,7 @@ implicit deadlines via `boot()`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm-handle.ts:264](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L264)
+Defined in: [vm-handle.ts:273](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L273)
 
 Streaming log callback for the snapshot half. Same shape as
 `vm.snapshot({ onLog })`.
@@ -3292,7 +3305,7 @@ Streaming log callback for the snapshot half. Same shape as
 
 > `optional` **tcpKeep?**: `boolean`
 
-Defined in: [vm-handle.ts:271](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L271)
+Defined in: [vm-handle.ts:280](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L280)
 
 Default false: omit `--tcp-established` from the dump so the
 fork sees ECONNRESET on sockets the source had open. Set true
@@ -3303,7 +3316,7 @@ the same connection — only correct in narrow scenarios).
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm-handle.ts:277](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L277)
+Defined in: [vm-handle.ts:286](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L286)
 
 Host→guest port forwards for the fork. NOT inherited from the
 source — host ports are global and source + fork would race on
@@ -3670,7 +3683,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ### AttachOptions
 
-Defined in: [vm.ts:1358](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1358)
+Defined in: [vm.ts:1366](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1366)
 
 #### Properties
 
@@ -3678,7 +3691,7 @@ Defined in: [vm.ts:1358](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1364](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1364)
+Defined in: [vm.ts:1372](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1372)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3688,7 +3701,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1366](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1366)
+Defined in: [vm.ts:1374](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1374)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3696,7 +3709,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1373](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1373)
+Defined in: [vm.ts:1381](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1381)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3707,7 +3720,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2498](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2498)
+Defined in: [vm.ts:2521](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2521)
 
 #### Extends
 
@@ -4071,7 +4084,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2503](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2503)
+Defined in: [vm.ts:2526](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2526)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -4080,7 +4093,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2511](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2511)
+Defined in: [vm.ts:2534](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2534)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -4092,7 +4105,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2517](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2517)
+Defined in: [vm.ts:2540](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2540)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4172,7 +4185,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 > **ImageConfig** = `object`
 
-Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
+Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
 
 Shape of the optional `./machinen-config.json` baked into a rootfs
 tarball by `provision({ cmd, env })`. `boot()` reads it via
@@ -4186,19 +4199,19 @@ tarball-producing tool can pre-populate the lookup cache.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
+Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
 
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
+Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
 
 ##### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:1548](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1548)
+Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
 
 ## Variables
 
@@ -4642,7 +4655,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:2113](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2113)
+Defined in: [vm.ts:2123](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2123)
 
 #### Type Declaration
 
@@ -5077,7 +5090,7 @@ registry can hold it.
 
 > **registryRoot**(): `string`
 
-Defined in: [registry.ts:118](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L118)
+Defined in: [registry.ts:120](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L120)
 
 Absolute path to the registry root. Honors `MACHINEN_REGISTRY_DIR`
 so tests can point at a scratch dir without stomping on real entries.
@@ -5092,7 +5105,7 @@ so tests can point at a scratch dir without stomping on real entries.
 
 > **list**(): [`RegistryEntry`](#registryentry)[]
 
-Defined in: [registry.ts:235](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L235)
+Defined in: [registry.ts:256](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/registry.ts#L256)
 
 List all registry entries whose pid is still alive. Prunes stale
 entries (pid no longer alive) and orphaned name pins as a side
@@ -5272,7 +5285,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1389](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1389)
+Defined in: [vm.ts:1397](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1397)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -5304,7 +5317,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **warmImageConfigCache**(`imagePath`, `config`): `void`
 
-Defined in: [vm.ts:1593](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1593)
+Defined in: [vm.ts:1603](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1603)
 
 Pre-populate the image-config cache for a freshly-written tarball.
 Lets `provision()` (and other tarball producers) skip the slow
@@ -5337,7 +5350,7 @@ none was baked).
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1961](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1961)
+Defined in: [vm.ts:1971](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1971)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -5376,7 +5389,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:2003](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2003)
+Defined in: [vm.ts:2013](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2013)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -5408,7 +5421,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2536)
+Defined in: [vm.ts:2559](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2559)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5443,7 +5456,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2789](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2789)
+Defined in: [vm.ts:2856](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2856)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3683,7 +3683,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ### AttachOptions
 
-Defined in: [vm.ts:1366](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1366)
+Defined in: [vm.ts:1364](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1364)
 
 #### Properties
 
@@ -3691,7 +3691,7 @@ Defined in: [vm.ts:1366](https://github.com/redwoodjs/machinen/blob/main/package
 
 > `optional` **pid?**: `number`
 
-Defined in: [vm.ts:1372](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1372)
+Defined in: [vm.ts:1370](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1370)
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
 while alive; mutually exclusive with `name`. Exactly one of
@@ -3701,7 +3701,7 @@ while alive; mutually exclusive with `name`. Exactly one of
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:1374](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1374)
+Defined in: [vm.ts:1372](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1372)
 
 Look up a VM by the name passed to `boot({ name })`.
 
@@ -3709,7 +3709,7 @@ Look up a VM by the name passed to `boot({ name })`.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm.ts:1381](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1381)
+Defined in: [vm.ts:1379](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1379)
 
 Streaming log callback — fires for every byte of output from execs
 made through the returned handle. See #83. Guest kernel console is
@@ -3720,7 +3720,7 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 
 ### RestoreOptions
 
-Defined in: [vm.ts:2521](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2521)
+Defined in: [vm.ts:2523](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2523)
 
 #### Extends
 
@@ -4084,7 +4084,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Defined in: [vm.ts:2526](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2526)
+Defined in: [vm.ts:2528](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2528)
 
 Snapshot bundle directory produced by `vm.snapshot()`.
 Must contain `disk.img` and `meta.json`.
@@ -4093,7 +4093,7 @@ Must contain `disk.img` and `meta.json`.
 
 > `optional` **image?**: `string`
 
-Defined in: [vm.ts:2534](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2534)
+Defined in: [vm.ts:2536](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2536)
 
 Override the rootfs image used for the restore boot. Defaults
 to whatever caller passes through `image`-equivalent — but
@@ -4105,7 +4105,7 @@ release rootfs path here.
 
 > `optional` **name?**: `string`
 
-Defined in: [vm.ts:2540](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2540)
+Defined in: [vm.ts:2542](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2542)
 
 Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
@@ -4185,7 +4185,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 > **ImageConfig** = `object`
 
-Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
+Defined in: [vm.ts:1556](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1556)
 
 Shape of the optional `./machinen-config.json` baked into a rootfs
 tarball by `provision({ cmd, env })`. `boot()` reads it via
@@ -4199,19 +4199,19 @@ tarball-producing tool can pre-populate the lookup cache.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
+Defined in: [vm.ts:1556](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1556)
 
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
+Defined in: [vm.ts:1556](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1556)
 
 ##### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [vm.ts:1558](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1558)
+Defined in: [vm.ts:1556](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1556)
 
 ## Variables
 
@@ -4655,7 +4655,7 @@ the guest agent skips entries that don't match.
 
 > `const` **\_internal**: `object`
 
-Defined in: [vm.ts:2123](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2123)
+Defined in: [vm.ts:2125](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2125)
 
 #### Type Declaration
 
@@ -5285,7 +5285,7 @@ BOOT_VMM_MISSING | BOOT_VMM_PACKAGE_BROKEN |
 
 > **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:1397](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1397)
+Defined in: [vm.ts:1395](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1395)
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -5317,7 +5317,7 @@ REGISTRY_VM_NOT_FOUND
 
 > **warmImageConfigCache**(`imagePath`, `config`): `void`
 
-Defined in: [vm.ts:1603](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1603)
+Defined in: [vm.ts:1601](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1601)
 
 Pre-populate the image-config cache for a freshly-written tarball.
 Lets `provision()` (and other tarball producers) skip the slow
@@ -5350,7 +5350,7 @@ none was baked).
 
 > **buildWriteFileCmd**(`guestPath`, `contents`, `opts?`): `string`
 
-Defined in: [vm.ts:1971](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1971)
+Defined in: [vm.ts:1973](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L1973)
 
 Build the shell pipeline that `vm.writeFile()` ships through the
 exec-agent. Stays single-line so it works against the legacy EXEC
@@ -5389,7 +5389,7 @@ Returns a single cmd string. For payloads that would exceed Linux's
 
 > **buildWriteFileCmds**(`guestPath`, `contents`, `opts?`): `string`[]
 
-Defined in: [vm.ts:2013](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2013)
+Defined in: [vm.ts:2015](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2015)
 
 Plan the cmd sequence `vm.writeFile()` issues for `contents`.
 Small payloads (base64 ≤ `WRITE_FILE_B64_CHUNK_BYTES`) collapse to a
@@ -5421,7 +5421,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2559](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2559)
+Defined in: [vm.ts:2561](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2561)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5456,7 +5456,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/disk.img`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2856](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2856)
+Defined in: [vm.ts:2858](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2858)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -285,10 +285,7 @@ describe("snapshot option", () => {
       execSync(`tar -czf ${imgPath} -C ${imgDir} .`);
       const vm = await boot({
         binary: "/bin/sh",
-        args: [
-          "-c",
-          `cp "$(dirname "$MACHINEN_INITRD")/bundle/machinen-config.json" ${dumpPath}`,
-        ],
+        args: ["-c", `cp "$(dirname "$MACHINEN_INITRD")/bundle/machinen-config.json" ${dumpPath}`],
         image: imgPath,
         snapshot: snap,
         rootDisk: false,

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -11,6 +11,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   readdirSync,
   rmSync,
   statSync,
@@ -259,6 +260,54 @@ describe("snapshot option", () => {
       try {
         unlinkSync(snap);
       } catch {}
+    }
+  });
+
+  it("synthesizes /sbin/machinen-restore even when the image carries a baked cmd", async () => {
+    // Restore against an image whose tarball has a baked default cmd
+    // (e.g. `provision({ cmd })`). The snapshot helper must take
+    // precedence over the baked cmd — replaying the baked cmd would
+    // launch a fresh workload and silently drop the in-memory state
+    // CRIU was supposed to restore (counter starts back at 0). The
+    // /bin/sh stand-in copies the synthesized machinen-config.json
+    // out of the bundle dir (sibling of $MACHINEN_INITRD) so we can
+    // assert what /init would have run.
+    const imgDir = mkdtempSync(join(tmpdir(), "machinen-snap-baked-"));
+    const imgPath = `${imgDir}.tar.gz`;
+    const snap = `/tmp/machinen-runtime-snap-baked-${process.pid}`;
+    const dumpPath = `/tmp/machinen-runtime-config-dump-${process.pid}`;
+    writeFileSync(snap, "");
+    try {
+      writeFileSync(
+        join(imgDir, "machinen-config.json"),
+        JSON.stringify({ cmd: ["/usr/bin/node", "/opt/counter.mjs"] }),
+      );
+      execSync(`tar -czf ${imgPath} -C ${imgDir} .`);
+      const vm = await boot({
+        binary: "/bin/sh",
+        args: [
+          "-c",
+          `cp "$(dirname "$MACHINEN_INITRD")/bundle/machinen-config.json" ${dumpPath}`,
+        ],
+        image: imgPath,
+        snapshot: snap,
+        rootDisk: false,
+        timeoutMs: 3_000,
+      });
+      await vm.wait();
+      const config = JSON.parse(readFileSync(dumpPath, "utf8")) as { cmd: string[] };
+      expect(config.cmd).toEqual(["/sbin/machinen-restore"]);
+    } finally {
+      try {
+        unlinkSync(snap);
+      } catch {}
+      try {
+        unlinkSync(imgPath);
+      } catch {}
+      try {
+        unlinkSync(dumpPath);
+      } catch {}
+      rmSync(imgDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -225,6 +225,15 @@ export interface SnapshotResult {
 export interface SnapshotMeta {
   /** Name passed to `boot({ name })` when the source VM was started. */
   sourceName?: string;
+  /**
+   * Absolute path of the rootfs tarball the source VM was booted with
+   * (`boot({ image })` or its restored equivalent). `restore()` uses
+   * this as the default rootfs, so the same-host quickstart works
+   * without callers having to repeat the image path. Cross-host
+   * restores need either the path to resolve on the new host, or an
+   * explicit `image` override.
+   */
+  sourceImage?: string;
   /** ms epoch when `vm.snapshot()` returned. */
   snappedAt: number;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -868,6 +868,10 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // Today the structure enforces this (no awaits between here and
   // the gate); don't reorder.
   const vmName = opts.name;
+  // Resolved once: shared by the registry entry and any future snapshot
+  // ctx so the bundle's meta.json points at the same absolute path the
+  // source booted from. Cheap (just a path resolve), so unconditional.
+  const sourceImageAbs = opts.image ? resolve(opts.cwd ?? process.cwd(), opts.image) : undefined;
   const childPid = child.pid ?? -1;
   if (vmName && childPid > 0) {
     if (!claimName(vmName, childPid)) {
@@ -913,7 +917,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         pid: childPid,
         name: vmName,
         socketPath: vsockUdsPath,
-        imagePath: opts.image ? resolve(opts.cwd ?? process.cwd(), opts.image) : undefined,
+        imagePath: sourceImageAbs,
         diskPath: diskAbs,
         forkedFrom: opts.forkedFrom,
         bootLogPath,
@@ -1209,6 +1213,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         {
           pid: childPid,
           sourceName: vmName,
+          sourceImage: sourceImageAbs,
           diskPath: diskAbs,
           execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
           wait: () => this.wait(),
@@ -1241,6 +1246,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         {
           pid: childPid,
           sourceName: vmName,
+          sourceImage: sourceImageAbs,
           diskPath: diskAbs,
           execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
           wait: () => this.wait(),
@@ -1493,6 +1499,7 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
         {
           pid: entry.pid,
           sourceName: entry.name,
+          sourceImage: entry.imagePath,
           diskPath: entry.diskPath,
           execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
           wait: () => this.wait(),
@@ -1518,6 +1525,7 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
         {
           pid: entry.pid,
           sourceName: entry.name,
+          sourceImage: entry.imagePath,
           diskPath: entry.diskPath,
           execRaw: (cmd, execOpts) => this.execRaw(cmd, execOpts),
           wait: () => this.wait(),
@@ -1773,7 +1781,11 @@ function synthesizeAndPackBundle(
   //     /dev/vda, spawns a fresh exec-agent, and runs `criu restore`
   //     inside `unshare --pid --fork --mount-proc` so the dumped
   //     workload's PIDs don't collide with the restore-side helpers
-  //     on chained restores (#215).
+  //     on chained restores (#215). This MUST take precedence over
+  //     the rootfs's baked `imageConfig.cmd` — that field is the
+  //     fresh-boot default; replaying it on restore would launch a
+  //     brand-new workload instead of resuming the dumped one,
+  //     silently dropping all in-memory state.
   //   - Normal boot: user's cmd wins; fall back to image's baked
   //     default. Then wrap in /sbin/machinen-supervisor so the
   //     workload runs as a CRIU-dumpable child of /init and the
@@ -1784,14 +1796,14 @@ function synthesizeAndPackBundle(
   let effectiveCmd: string[] | undefined;
   if (opts.cmd) {
     effectiveCmd = opts.cmd;
-  } else if (imageConfig?.cmd) {
-    effectiveCmd = imageConfig.cmd;
   } else if (typeof opts.snapshot === "string") {
     // Only synthesize the restore helper when the caller explicitly
     // passed a snapshot path. The auto-allocated scratch (default
     // `snapshot: undefined`) is empty, so synthesizing here would feed
     // CRIU a bundle-less file and fail.
     effectiveCmd = ["/sbin/machinen-restore"];
+  } else if (imageConfig?.cmd) {
+    effectiveCmd = imageConfig.cmd;
   }
   if (!effectiveCmd) {
     cleanup();
@@ -2138,6 +2150,13 @@ interface SnapshotContext {
   pid: number;
   /** Optional source name (from `boot({ name })`); written into bundle meta.json. */
   sourceName?: string;
+  /**
+   * Absolute path of the rootfs tarball the source VM was booted with;
+   * written into bundle meta.json so `restore()` can default to the
+   * same image. Optional because attach handles may be looking at a
+   * registry entry that pre-dates `imagePath` tracking.
+   */
+  sourceImage?: string;
   /** Host file backing /dev/vda — what we copy into the bundle on success. */
   diskPath: string;
   execRaw: (cmd: string, opts?: VsockExecOptions) => Promise<VsockExecResult>;
@@ -2465,9 +2484,15 @@ async function performSnapshot(
   }
 
   // Drop the bundle metadata next to the image so `restore({ snapDir })`
-  // can recover the source name without poking at the disk.
+  // can recover the source name and rootfs path without poking at the
+  // disk. `sourceImage` is the absolute host path to the tarball the
+  // source VM booted from — restore uses it as the default rootfs so
+  // CRIU can re-open file-backed VMAs (executable, libraries) at the
+  // paths they were dumped from. Cross-host restores still need the
+  // path to resolve on the new host (or `--image` to override).
   const meta: SnapshotMeta = {
     sourceName: ctx.sourceName,
+    sourceImage: ctx.sourceImage,
     snappedAt: Date.now(),
   };
   writeFileSync(join(snapDir, "meta.json"), JSON.stringify(meta));
@@ -2558,12 +2583,56 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   }
   phases.end("snapshot-meta-read");
 
+  // Resolve the rootfs image: caller's `opts.image` wins; otherwise
+  // fall back to the path the source booted from (recorded in
+  // meta.json). Without a usable image, criu's file-backed VMA
+  // restore has nothing to reopen and PID 1 panics — so we throw
+  // here with a message the user can act on instead.
+  let resolvedImage: string | undefined;
+  if (opts.image) {
+    resolvedImage = resolve(opts.cwd ?? process.cwd(), opts.image);
+    if (!existsSync(resolvedImage)) {
+      throw new BootError("BOOT_IMAGE_NOT_FOUND", `restore: image not found: ${resolvedImage}`);
+    }
+  } else if (meta.sourceImage && existsSync(meta.sourceImage)) {
+    resolvedImage = meta.sourceImage;
+    debugRestore("using meta.sourceImage path=%s", resolvedImage);
+  } else if (meta.sourceImage) {
+    // The bundle remembers a path, but it's gone on this host (e.g.
+    // restored on a different machine, or the tarball was deleted).
+    // Surface it so the user can scp it over or pass --image.
+    throw new BootError(
+      "BOOT_IMAGE_NOT_FOUND",
+      `restore: source image not found at ${meta.sourceImage}\n` +
+        `  The snapshot was taken with this rootfs tarball, and CRIU needs\n` +
+        `  it to reopen the process's file-backed memory mappings (e.g.\n` +
+        `  /usr/bin/node, libc, etc).\n` +
+        `  • copy the tarball to that path on this host, OR\n` +
+        `  • pass an explicit override via the runtime's restore({ image })\n` +
+        `    or the CLI's \`machinen restore --image <tarball>\`.`,
+    );
+  } else {
+    // No --image, and the bundle's meta.json has no sourceImage (an
+    // old bundle predating this field, or one written without the
+    // source's image path). Without something to mount as /, criu
+    // can't reopen file-backed VMAs. Tell the user up front.
+    throw new BootError(
+      "BOOT_IMAGE_NOT_FOUND",
+      `restore: no rootfs image available for this bundle.\n` +
+        `  The snapshot's meta.json doesn't record a source image (likely\n` +
+        `  predates the field). Pass the same tarball you booted the\n` +
+        `  source VM with via the runtime's restore({ image }) or the\n` +
+        `  CLI's \`machinen restore --image <tarball>\`.`,
+    );
+  }
+
   // boot() doesn't know the pid until after the VMM is spawned, so
   // we can't pass `<sourceName>/<pid>` up front. Boot anonymous,
   // then claim the auto-name and patch the registry entry below.
   phases.start("boot");
   const vm = await boot({
     ...opts,
+    image: resolvedImage,
     snapshot: diskPath,
     forkedFrom: snapDir,
     name: opts.name,


### PR DESCRIPTION
## Summary

- `boot()`'s cmd-resolution preferred the rootfs's baked `imageConfig.cmd` over the synthesized `/sbin/machinen-restore` helper, so restoring a snapshot taken from an image with a baked cmd (e.g. `provision({ cmd })`) silently launched a fresh workload instead of replaying the CRIU dump — counter restarted at 0 instead of resuming from 5. Reordered so the restore helper wins when the caller passed a snapshot path.
- Bundle `meta.json` now records the source rootfs path so `restore()` can default to the same image (CRIU needs it to reopen file-backed VMAs).
- `machinen restore` gains `--image` / `-p` flags for cross-host restores and explicit overrides.

## Test plan

- [x] `npx vitest run` (455 tests pass)
- [x] New regression test: `synthesizes /sbin/machinen-restore even when the image carries a baked cmd` in `packages/runtime/src/__tests__/boot.test.ts`
- [ ] `npx agent-ci run --all -q -p`
- [ ] `pnpm smoke-tests` — manual round-trip: boot a baked-cmd image, hit it 5×, snapshot, restore, hit again — counter must continue from 6