### PR TITLE
feat(runtime,cli): unify fork's surface with restore + snapshot

### DIFF
--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -122,6 +122,33 @@ If you pick a host port the source is already forwarding, the bind
 probe fires `BOOT_PORT_FORWARD_IN_USE` with the holding VM's name —
 not advice to `kill` it — so you know to pick a different host port.
 
+### Boot-shaped flags work on the fork too
+
+`fork` is `snapshot --keep-alive` + `restore` rolled into one call, so
+anything you can pass at `boot` time also works on a fork — and lands
+on the _forked sibling_, not the source. That covers `--mount`,
+`--mount-live`, `--env`, `--cwd`, and `--memory`.
+
+The source's own `--mount` payload was baked into its rootdisk before
+the snapshot, so the fork inherits it via the disk image without you
+re-passing anything. Use these flags when you want the fork to differ
+from the source — e.g. layer in an additional input dir, set an env
+var that wasn't there before, or hand the fork more RAM:
+
+```bash
+npx machinen fork --name worker --new-name worker-eval \
+  --mount ./eval-fixtures:/mnt/in \
+  --env RUN_MODE=eval \
+  --memory 8192
+```
+
+Live mounts (`--mount-live`) on a fork establish a _fresh_ vsock FUSE
+channel on the sibling. The source must not have its own live mount
+active at fork time — vsock FUSE channels can't survive a CRIU dump,
+which is why `vm.fork` rejects sources with live mounts. Tear down the
+source's live mount, fork, and re-attach a new one if you need
+write-through on both copies.
+
 ## When you need the source to survive the snapshot
 
 Sometimes you want to snapshot a VM, hand someone the bundle for later

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -99,6 +99,8 @@ on shared connection state.
 
 ```
 machinen fork <target> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]
+              [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...
+              [--cwd <abs>] [--memory <mib>]
 ```
 
 Snapshots the source live (it keeps running) and restores into a
@@ -106,12 +108,25 @@ sibling VM, dropping the caller into the fork's interactive console.
 Pass `--detach` to hand the fork off and return immediately
 (CI / scripted use).
 
-| Flag             | What it does                                                             |
-| ---------------- | ------------------------------------------------------------------------ |
-| `--new-name <n>` | Name for the fork (defaults to `<source>/<fork-pid>`)                    |
-| `--out-dir <d>`  | Keep the snapshot bundle here. Without this, the bundle is temp-dir'd    |
-| `--tcp-keep`     | Inherit TCP socket state in the fork (rarely correct — both copies race) |
-| `--detach`       | Don't attach the caller's stdio to the fork — return as soon as it's up  |
+Fork = `snapshot --keep-alive` + `restore` rolled into one call, so
+the boot-shaped flags (`--mount`, `--mount-live`, `--env`, `--cwd`,
+`--memory`) take effect on the _forked sibling_, not the source. They
+default to "not set" — the source's own configuration is what's
+encoded in the snapshot, and the fork inherits whatever lived on the
+source's rootdisk at dump time.
+
+| Flag                                            | What it does                                                                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--new-name <n>`                                | Name for the fork (defaults to `<source>/<fork-pid>`)                                                                     |
+| `--out-dir <d>`                                 | Keep the snapshot bundle here. Without this, the bundle is temp-dir'd                                                     |
+| `--tcp-keep`                                    | Inherit TCP socket state in the fork (rarely correct — both copies race)                                                  |
+| `--detach`                                      | Don't attach the caller's stdio to the fork — return as soon as it's up                                                   |
+| `-p <hostPort>:<guestPort>`                     | Forward a host TCP port into the fork. NOT inherited from the source (host ports are global) — pick a non-conflicting one |
+| `--mount <host-dir>:<guest-path>`               | Overlay an additional copy-once host directory on the fork                                                                |
+| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Establish a fresh FUSE live-share on the fork. Source must NOT have its own live mount active (vsock FUSE ≠ CRIU)         |
+| `--env KEY=VALUE`                               | Set an env var inside the forked guest (repeatable)                                                                       |
+| `--cwd <abs-path>`                              | Working directory for the guest cmd in the fork (must be absolute)                                                        |
+| `--memory <mib>`                                | Guest RAM ceiling for the fork, decimal MiB. Debug knob                                                                   |
 
 ## `machinen attach`
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -415,6 +415,47 @@ describe("parseForkArgs", () => {
     expect(parsed.rest).toEqual(["--name", "src", "--pid", "1234"]);
     expect(parsed.detach).toBe(true);
   });
+
+  it("captures --mount and --mount-live", () => {
+    const parsed = parseForkArgs([
+      "--mount",
+      "/tmp/host:/mnt/in",
+      "--mount-live",
+      "/tmp/live:/mnt/live:ro",
+    ]);
+    expect(parsed.mount).toEqual({ host: "/tmp/host", guest: "/mnt/in" });
+    expect(parsed.liveMounts).toEqual([{ host: "/tmp/live", guest: "/mnt/live", mode: "ro" }]);
+  });
+
+  it("captures --env (repeatable) and --cwd", () => {
+    const parsed = parseForkArgs(["--env", "FOO=bar", "--env=BAZ=qux", "--cwd", "/mnt/in"]);
+    expect(parsed.env).toEqual({ FOO: "bar", BAZ: "qux" });
+    expect(parsed.guestCwd).toBe("/mnt/in");
+  });
+
+  it("captures --memory and rejects malformed values", () => {
+    expect(parseForkArgs(["--memory", "1024"]).memory).toBe(1024);
+    expect(parseForkArgs(["--memory=2048"]).memory).toBe(2048);
+    expect(() => parseForkArgs(["--memory", "1g"])).toThrow(/decimal integer/);
+    expect(() => parseForkArgs(["--memory", "0"])).toThrow(/must be > 0/);
+    expect(() => parseForkArgs(["--memory", "1024", "--memory", "2048"])).toThrow(/at most once/);
+  });
+
+  it("rejects a duplicate --mount but allows repeated --mount-live", () => {
+    expect(() => parseForkArgs(["--mount", "a:/m/a", "--mount", "b:/m/b"])).toThrow(/at most once/);
+    const parsed = parseForkArgs(["--mount-live", "a:/m/a", "--mount-live", "b:/m/b:ro"]);
+    expect(parsed.liveMounts).toHaveLength(2);
+  });
+
+  it("rejects an invalid --mount-live mode", () => {
+    expect(() => parseForkArgs(["--mount-live", "h:/m/x:bogus"])).toThrow(
+      /mode must be 'ro' or 'rw'/,
+    );
+  });
+
+  it("rejects a duplicate --cwd", () => {
+    expect(() => parseForkArgs(["--cwd", "/a", "--cwd", "/b"])).toThrow(/at most once/);
+  });
 });
 
 describe("parseRestoreArgs", () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -942,7 +942,9 @@ async function cmdSnapshot(args: string[]): Promise<number> {
 
 async function cmdFork(args: string[]): Promise<number> {
   // `machinen fork ( --name <src> | --pid <pid> ) [--new-name <dst>]
-  //                [--out-dir <dir>] [--tcp-keep] [--detach]`.
+  //                [--out-dir <dir>] [--tcp-keep] [--detach]
+  //                [-p ...] [--mount ...] [--mount-live ...]
+  //                [--env KEY=VALUE]... [--cwd <abs>] [--memory <mib>]`.
   //
   // Snapshots the source live (--leave-running), restores into a
   // sibling, and by default attaches the fork's console to host
@@ -950,13 +952,30 @@ async function cmdFork(args: string[]): Promise<number> {
   // `machinen restore`). `--detach` keeps the fire-and-forget shape
   // (CI / scripted workflows): print identity, hand off, return.
   // Source keeps running either way.
+  //
+  // The boot-shaped flags (`--mount`, `--mount-live`, `--env`, `--cwd`,
+  // `--memory`) take effect on the *forked* sibling, not the source.
+  // Fork = snapshot + restore, so anything you can pass to `boot` /
+  // `restore` works here too.
   let parsed;
   try {
     parsed = parseForkArgs(args);
   } catch (err) {
     handleError(err);
   }
-  const { newName, outDir, tcpKeep, detach, portForward, rest } = parsed;
+  const {
+    newName,
+    outDir,
+    tcpKeep,
+    detach,
+    portForward,
+    mount,
+    liveMounts,
+    env,
+    guestCwd,
+    memory,
+    rest,
+  } = parsed;
   const target = parseTargetFlags(rest, "fork");
 
   // The fork is a fresh restore boot, so it needs the same base
@@ -991,6 +1010,11 @@ async function cmdFork(args: string[]): Promise<number> {
       dtb: dtbPath,
       tcpKeep,
       portForward: portForward.length > 0 ? portForward : undefined,
+      mount,
+      liveMounts,
+      env,
+      guestCwd,
+      memory,
       onLog: (evt) => {
         if (evt.source !== "phase") {
           process.stderr.write(evt.chunk);
@@ -1424,7 +1448,9 @@ function printHelp(): void {
       `                                                 (and closes inherited TCP sockets to\n` +
       `                                                 avoid two live copies racing on shared\n` +
       `                                                 connection state).\n` +
-      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach] [-p ...]\n` +
+      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
+      `                    [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...\n` +
+      `                    [--cwd <abs>] [--memory <mib>]\n` +
       `                                                 Snapshot the source live (it keeps\n` +
       `                                                 running) and restore into a sibling VM,\n` +
       `                                                 dropping the caller into the fork's\n` +
@@ -1438,6 +1464,10 @@ function printHelp(): void {
       `                                                 inherited from the source (host ports are\n` +
       `                                                 global), so pick a host port the source\n` +
       `                                                 isn't already using.\n` +
+      `                                                 The boot-shaped flags (--mount,\n` +
+      `                                                 --mount-live, --env, --cwd, --memory)\n` +
+      `                                                 take effect on the forked sibling, not\n` +
+      `                                                 the source.\n` +
       `  machinen attach   <target-flag> [--shell <c>]  Drop into an interactive PTY shell\n` +
       `                                                 in the running VM (default \`bash -i\`).\n` +
       `                                                 \`cd\`, env vars, history, job control\n` +

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -1,9 +1,24 @@
 // Pure arg parser for `machinen fork`. Sibling of parse-run-args.ts —
 // split out so the parser is unit-testable without spawning the CLI.
+//
+// Fork is "snapshot live + restore" rolled into one call, so the flag
+// surface mirrors `machinen boot` for the most part: --mount,
+// --mount-live, --env, --memory, --cwd all take effect on the
+// restored sibling. Fork-only flags are --new-name, --out-dir,
+// --tcp-keep, --detach. The source target (`--name`/`--pid`) is
+// resolved by `parseTargetFlags` from the `rest` we pass through.
 
 import { ParseError } from "@machinen/runtime";
 
-import { consumePortForward } from "./parse-run-args.ts";
+import {
+  consumeEnv,
+  consumeGuestCwd,
+  consumeLiveMount,
+  consumeMemory,
+  consumeMount,
+  consumePortForward,
+  takeValue,
+} from "./parse-run-args.ts";
 
 export interface ParsedForkArgs {
   /** Optional name for the fork (`--new-name <n>`). */
@@ -21,6 +36,36 @@ export interface ParsedForkArgs {
    * with non-conflicting host ports.
    */
   portForward: Array<{ hostPort: number; guestPort: number }>;
+  /**
+   * Single host directory to copy into the fork at boot
+   * (`--mount <host>:<guest>`). Copy-once: same semantics as
+   * `boot --mount`. Independent of the source's mount — the source's
+   * `--mount` payload was baked into its rootdisk before snapshot,
+   * so the fork inherits it via the disk image. Use this flag to
+   * overlay an *additional* host dir on the fork.
+   */
+  mount?: { host: string; guest: string };
+  /**
+   * Live-share FUSE mounts (`--mount-live <host>:<guest>[:<mode>]`).
+   * Establishes a fresh vsock FUSE channel on the fork after restore.
+   * The source must NOT have its own live mount active at fork time
+   * (that's caught by the runtime — vsock FUSE channels can't survive
+   * CRIU dump). See #78, #151.
+   */
+  liveMounts?: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  /** Env vars exposed to the forked guest workload (`--env KEY=VALUE`). */
+  env?: Record<string, string>;
+  /**
+   * Working directory for the guest cmd in the fork (`--cwd <abs-path>`).
+   * Same shape as `boot --cwd`. Useful with `--mount` / `--mount-live`
+   * to land directly inside the share.
+   */
+  guestCwd?: string;
+  /**
+   * Guest RAM ceiling for the fork in MiB (`--memory <mib>`). Same
+   * shape as `boot --memory`. The runtime auto-sizes by default.
+   */
+  memory?: number;
   /** Args we didn't recognize — passed to `parseTargetFlags`. */
   rest: string[];
 }
@@ -32,33 +77,34 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
   let detach = false;
   const portForward: Array<{ hostPort: number; guestPort: number }> = [];
   const seenHostPorts = new Set<number>();
+  let mount: { host: string; guest: string } | undefined;
+  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
+  const env: Record<string, string> = {};
+  let guestCwd: string | undefined;
+  let memory: number | undefined;
   const rest: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
     if (a === "--new-name" || a.startsWith("--new-name=")) {
-      const v = a === "--new-name" ? argv[++i] : a.slice("--new-name=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--new-name requires a value");
-      }
       if (newName !== undefined) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--new-name may be given at most once per invocation",
         );
       }
-      newName = v;
+      const { spec, next } = takeValue(a, argv, i, "a value");
+      newName = spec;
+      i = next;
     } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      const v = a === "--out-dir" ? argv[++i] : a.slice("--out-dir=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--out-dir requires a directory path");
-      }
       if (outDir !== undefined) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--out-dir may be given at most once per invocation",
         );
       }
-      outDir = v;
+      const { spec, next } = takeValue(a, argv, i, "a directory path");
+      outDir = spec;
+      i = next;
     } else if (a === "--tcp-keep") {
       tcpKeep = true;
     } else if (a === "--detach") {
@@ -70,9 +116,59 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
       a.startsWith("--publish=")
     ) {
       i = consumePortForward(a, argv, i, seenHostPorts, portForward);
+    } else if (a === "--mount" || a.startsWith("--mount=")) {
+      if (mount) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--mount may be given at most once per invocation",
+        );
+      }
+      const r = consumeMount(a, argv, i);
+      mount = r.value;
+      i = r.next;
+    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
+      const r = consumeLiveMount(a, argv, i);
+      liveMounts.push(r.value);
+      i = r.next;
+    } else if (a === "--env" || a.startsWith("--env=")) {
+      const r = consumeEnv(a, argv, i);
+      env[r.key] = r.value;
+      i = r.next;
+    } else if (a === "--cwd" || a.startsWith("--cwd=")) {
+      if (guestCwd !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--cwd may be given at most once per invocation",
+        );
+      }
+      const r = consumeGuestCwd(a, argv, i);
+      guestCwd = r.value;
+      i = r.next;
+    } else if (a === "--memory" || a.startsWith("--memory=")) {
+      if (memory !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--memory may be given at most once per invocation",
+        );
+      }
+      const r = consumeMemory(a, argv, i);
+      memory = r.value;
+      i = r.next;
     } else {
       rest.push(a);
     }
   }
-  return { newName, outDir, tcpKeep, detach, portForward, rest };
+  return {
+    newName,
+    outDir,
+    tcpKeep,
+    detach,
+    portForward,
+    mount,
+    liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
+    env: Object.keys(env).length > 0 ? env : undefined,
+    guestCwd,
+    memory,
+    rest,
+  };
 }

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -63,149 +63,60 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
   for (let i = 0; i < pre.length; i++) {
     const a = pre[i]!;
     if (a === "--mount" || a.startsWith("--mount=")) {
-      let spec: string | undefined;
-      if (a === "--mount") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError(
-            "PARSE_FLAG_MISSING_VALUE",
-            "--mount requires a <host-dir>:<guest-path> value",
-          );
-        }
-        i++;
-      } else {
-        spec = a.slice("--mount=".length);
-      }
       if (mount) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--mount may be given at most once per invocation",
         );
       }
-      const colon = spec!.indexOf(":");
-      if (colon <= 0 || colon === spec!.length - 1) {
-        throw new ParseError(
-          "PARSE_FLAG_MALFORMED",
-          `--mount: expected <host-dir>:<guest-path>, got '${spec}'`,
-        );
-      }
-      mount = { host: spec!.slice(0, colon), guest: spec!.slice(colon + 1) };
+      const r = consumeMount(a, pre, i);
+      mount = r.value;
+      i = r.next;
     } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      let spec: string | undefined;
-      if (a === "--mount-live") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError(
-            "PARSE_FLAG_MISSING_VALUE",
-            "--mount-live requires a <host-dir>:<guest-path> value",
-          );
-        }
-        i++;
-      } else {
-        spec = a.slice("--mount-live=".length);
-      }
-      // Format: `<host>:<guest>[:<mode>]`. Mode defaults to `rw`
-      // (write-through, #151); pass `:ro` for read-only. A guest path
-      // containing a colon is rejected — same trade-off as `--mount`.
-      const parts = spec!.split(":");
-      if (parts.length < 2 || parts.length > 3 || !parts[0] || !parts[1]) {
-        throw new ParseError(
-          "PARSE_FLAG_MALFORMED",
-          `--mount-live: expected <host-dir>:<guest-path>[:<mode>], got '${spec}'`,
-        );
-      }
-      const modeRaw = parts[2];
-      if (modeRaw !== undefined && modeRaw !== "ro" && modeRaw !== "rw") {
-        throw new ParseError(
-          "PARSE_FLAG_MALFORMED",
-          `--mount-live: mode must be 'ro' or 'rw', got '${modeRaw}'`,
-        );
-      }
-      liveMounts.push({
-        host: parts[0]!,
-        guest: parts[1]!,
-        mode: (modeRaw as "ro" | "rw" | undefined) ?? "rw",
-      });
+      const r = consumeLiveMount(a, pre, i);
+      liveMounts.push(r.value);
+      i = r.next;
     } else if (a === "--env" || a.startsWith("--env=")) {
-      let spec: string | undefined;
-      if (a === "--env") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--env requires a KEY=VALUE value");
-        }
-        i++;
-      } else {
-        spec = a.slice("--env=".length);
-      }
-      const eq = spec!.indexOf("=");
-      if (eq <= 0) {
-        throw new ParseError("PARSE_FLAG_MALFORMED", `--env: expected KEY=VALUE, got '${spec}'`);
-      }
-      const key = spec!.slice(0, eq);
-      const value = spec!.slice(eq + 1);
-      env[key] = value;
+      const r = consumeEnv(a, pre, i);
+      env[r.key] = r.value;
+      i = r.next;
     } else if (
       a === "-p" ||
       a === "--publish" ||
       a.startsWith("-p=") ||
       a.startsWith("--publish=")
     ) {
-      const consumed = consumePortForward(a, pre, i, seenHostPorts, portForward);
-      i = consumed;
+      i = consumePortForward(a, pre, i, seenHostPorts, portForward);
     } else if (a === "--snapshot" || a.startsWith("--snapshot=")) {
-      let spec: string | undefined;
-      if (a === "--snapshot") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--snapshot requires a path value");
-        }
-        i++;
-      } else {
-        spec = a.slice("--snapshot=".length);
-      }
       if (snapshot) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--snapshot may be given at most once per invocation",
         );
       }
+      const { spec, next } = takeValue(a, pre, i, "a path value");
       snapshot = spec;
+      i = next;
     } else if (a === "--cwd" || a.startsWith("--cwd=")) {
-      let spec: string | undefined;
-      if (a === "--cwd") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--cwd requires an absolute path value");
-        }
-        i++;
-      } else {
-        spec = a.slice("--cwd=".length);
-      }
       if (guestCwd !== undefined) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--cwd may be given at most once per invocation",
         );
       }
-      guestCwd = spec;
+      const r = consumeGuestCwd(a, pre, i);
+      guestCwd = r.value;
+      i = r.next;
     } else if (a === "--name" || a.startsWith("--name=")) {
-      let spec: string | undefined;
-      if (a === "--name") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
-        }
-        i++;
-      } else {
-        spec = a.slice("--name=".length);
-      }
       if (name) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--name may be given at most once per invocation",
         );
       }
+      const { spec, next } = takeValue(a, pre, i, "a value");
       name = spec;
+      i = next;
     } else if (a === "--detached" || a === "--detach") {
       if (detached) {
         throw new ParseError(
@@ -218,36 +129,15 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
       // #263 phase A: decimal MiB, no unit suffix. Same shape as
       // MACHINEN_MEMORY. The runtime validates the floor; we only
       // reject syntactically bad values here.
-      let spec: string | undefined;
-      if (a === "--memory") {
-        spec = pre[i + 1];
-        if (spec === undefined) {
-          throw new ParseError(
-            "PARSE_FLAG_MISSING_VALUE",
-            "--memory requires a <mib> value (decimal integer, no unit suffix)",
-          );
-        }
-        i++;
-      } else {
-        spec = a.slice("--memory=".length);
-      }
       if (memory !== undefined) {
         throw new ParseError(
           "PARSE_FLAG_DUPLICATE",
           "--memory may be given at most once per invocation",
         );
       }
-      if (!/^[0-9]+$/.test(spec!)) {
-        throw new ParseError(
-          "PARSE_FLAG_MALFORMED",
-          `--memory: expected a decimal integer (MiB, no unit suffix), got '${spec}'`,
-        );
-      }
-      const n = Number(spec);
-      if (!Number.isFinite(n) || n <= 0) {
-        throw new ParseError("PARSE_FLAG_MALFORMED", `--memory: must be > 0 (got '${spec}')`);
-      }
-      memory = n;
+      const r = consumeMemory(a, pre, i);
+      memory = r.value;
+      i = r.next;
     } else if (a.startsWith("-")) {
       throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
     } else {
@@ -281,6 +171,32 @@ function parsePort(raw: string, label: string): number {
 }
 
 /**
+ * Pull the value attached to a flag, supporting both `--flag value` and
+ * `--flag=value` forms. Returns the spec string and the new loop index.
+ * Throws `PARSE_FLAG_MISSING_VALUE` when the space form has nothing
+ * following it.
+ *
+ * Shared between `parseRunArgs` (boot) and `parseForkArgs`. Each
+ * `consume*` helper below uses this to keep the dispatch loop short.
+ */
+export function takeValue(
+  flag: string,
+  args: string[],
+  i: number,
+  label: string,
+): { spec: string; next: number } {
+  if (flag.includes("=")) {
+    const eq = flag.indexOf("=");
+    return { spec: flag.slice(eq + 1), next: i };
+  }
+  const spec = args[i + 1];
+  if (spec === undefined) {
+    throw new ParseError("PARSE_FLAG_MISSING_VALUE", `${flag} requires ${label}`);
+  }
+  return { spec, next: i + 1 };
+}
+
+/**
  * Consume one `-p`/`--publish` token (and the following value, if the
  * flag was given without `=`). Pushes onto `portForward`, updates
  * `seenHostPorts`, and returns the new loop index. Shared between
@@ -293,22 +209,7 @@ export function consumePortForward(
   seenHostPorts: Set<number>,
   portForward: Array<{ hostPort: number; guestPort: number }>,
 ): number {
-  let spec: string | undefined;
-  let next = i;
-  if (flag === "-p" || flag === "--publish") {
-    spec = args[i + 1];
-    if (spec === undefined) {
-      throw new ParseError(
-        "PARSE_FLAG_MISSING_VALUE",
-        `${flag} requires a <hostPort>:<guestPort> value`,
-      );
-    }
-    next = i + 1;
-  } else if (flag.startsWith("-p=")) {
-    spec = flag.slice("-p=".length);
-  } else {
-    spec = flag.slice("--publish=".length);
-  }
+  const { spec, next } = takeValue(flag, args, i, "a <hostPort>:<guestPort> value");
   const colon = spec.indexOf(":");
   if (colon <= 0 || colon === spec.length - 1) {
     throw new ParseError(
@@ -324,4 +225,122 @@ export function consumePortForward(
   seenHostPorts.add(hostPort);
   portForward.push({ hostPort, guestPort });
   return next;
+}
+
+/**
+ * Consume one `--mount <host>:<guest>` token. Returns the parsed value
+ * and the new loop index. Caller enforces "at most once" against its
+ * own state — same shape as `consumePortForward`.
+ */
+export function consumeMount(
+  flag: string,
+  args: string[],
+  i: number,
+): { value: { host: string; guest: string }; next: number } {
+  const { spec, next } = takeValue(flag, args, i, "a <host-dir>:<guest-path> value");
+  const colon = spec.indexOf(":");
+  if (colon <= 0 || colon === spec.length - 1) {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `--mount: expected <host-dir>:<guest-path>, got '${spec}'`,
+    );
+  }
+  return { value: { host: spec.slice(0, colon), guest: spec.slice(colon + 1) }, next };
+}
+
+/**
+ * Consume one `--mount-live <host>:<guest>[:<mode>]` token. `mode`
+ * defaults to `"rw"` (write-through). Returns the parsed entry and
+ * the new loop index. Caller pushes onto its own array.
+ */
+export function consumeLiveMount(
+  flag: string,
+  args: string[],
+  i: number,
+): { value: { host: string; guest: string; mode: "ro" | "rw" }; next: number } {
+  const { spec, next } = takeValue(flag, args, i, "a <host-dir>:<guest-path> value");
+  // Format: `<host>:<guest>[:<mode>]`. A guest path containing a colon
+  // is rejected — same trade-off as `--mount`.
+  const parts = spec.split(":");
+  if (parts.length < 2 || parts.length > 3 || !parts[0] || !parts[1]) {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `--mount-live: expected <host-dir>:<guest-path>[:<mode>], got '${spec}'`,
+    );
+  }
+  const modeRaw = parts[2];
+  if (modeRaw !== undefined && modeRaw !== "ro" && modeRaw !== "rw") {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `--mount-live: mode must be 'ro' or 'rw', got '${modeRaw}'`,
+    );
+  }
+  return {
+    value: {
+      host: parts[0]!,
+      guest: parts[1]!,
+      mode: (modeRaw as "ro" | "rw" | undefined) ?? "rw",
+    },
+    next,
+  };
+}
+
+/**
+ * Consume one `--env KEY=VALUE` token. Returns the key/value pair and
+ * the new loop index. Caller assigns onto its own map (later entries
+ * win on duplicate keys, matching boot semantics).
+ */
+export function consumeEnv(
+  flag: string,
+  args: string[],
+  i: number,
+): { key: string; value: string; next: number } {
+  const { spec, next } = takeValue(flag, args, i, "a KEY=VALUE value");
+  const eq = spec.indexOf("=");
+  if (eq <= 0) {
+    throw new ParseError("PARSE_FLAG_MALFORMED", `--env: expected KEY=VALUE, got '${spec}'`);
+  }
+  return { key: spec.slice(0, eq), value: spec.slice(eq + 1), next };
+}
+
+/**
+ * Consume one `--memory <mib>` token. Returns the parsed integer and
+ * the new loop index. Caller enforces "at most once". The runtime
+ * validates the floor against host RAM.
+ */
+export function consumeMemory(
+  flag: string,
+  args: string[],
+  i: number,
+): { value: number; next: number } {
+  const { spec, next } = takeValue(
+    flag,
+    args,
+    i,
+    "a <mib> value (decimal integer, no unit suffix)",
+  );
+  if (!/^[0-9]+$/.test(spec)) {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `--memory: expected a decimal integer (MiB, no unit suffix), got '${spec}'`,
+    );
+  }
+  const n = Number(spec);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new ParseError("PARSE_FLAG_MALFORMED", `--memory: must be > 0 (got '${spec}')`);
+  }
+  return { value: n, next };
+}
+
+/**
+ * Consume one `--cwd <abs-path>` token. The runtime validates the
+ * absolute-path requirement; we only collect the spec here.
+ */
+export function consumeGuestCwd(
+  flag: string,
+  args: string[],
+  i: number,
+): { value: string; next: number } {
+  const { spec, next } = takeValue(flag, args, i, "an absolute path value");
+  return { value: spec, next };
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2730,7 +2730,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### VmHandle
 
-Defined in: [vm-handle.ts:15](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L15)
+Defined in: [vm-handle.ts:16](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L16)
 
 #### Properties
 
@@ -2738,7 +2738,7 @@ Defined in: [vm-handle.ts:15](https://github.com/redwoodjs/machinen/blob/main/pa
 
 > `readonly` **pid**: `number`
 
-Defined in: [vm-handle.ts:22](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L22)
+Defined in: [vm-handle.ts:23](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L23)
 
 PID of the host-side VMM process — primary identifier across
 boot/attach. Kernel-unique while alive; reused after exit, so
@@ -2749,7 +2749,7 @@ pass it to `attach({ pid })` while the VM is live (or use
 
 > `readonly` `optional` **name?**: `string`
 
-Defined in: [vm-handle.ts:24](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L24)
+Defined in: [vm-handle.ts:25](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L25)
 
 Optional human-friendly name passed to `boot({ name })`.
 
@@ -2757,19 +2757,19 @@ Optional human-friendly name passed to `boot({ name })`.
 
 > `readonly` **stdin**: `Writable`
 
-Defined in: [vm-handle.ts:25](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L25)
+Defined in: [vm-handle.ts:26](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L26)
 
 ##### stdout
 
 > `readonly` **stdout**: `Readable`
 
-Defined in: [vm-handle.ts:26](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L26)
+Defined in: [vm-handle.ts:27](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L27)
 
 ##### stderr
 
 > `readonly` **stderr**: `Readable`
 
-Defined in: [vm-handle.ts:27](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L27)
+Defined in: [vm-handle.ts:28](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L28)
 
 #### Methods
 
@@ -2777,7 +2777,7 @@ Defined in: [vm-handle.ts:27](https://github.com/redwoodjs/machinen/blob/main/pa
 
 > **wait**(): `Promise`\<\{ `code`: `number`; `signal`: `Signals`; \}\>
 
-Defined in: [vm-handle.ts:30](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L30)
+Defined in: [vm-handle.ts:31](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L31)
 
 Resolves when the VM process exits. Rejects on timeout.
 
@@ -2789,7 +2789,7 @@ Resolves when the VM process exits. Rejects on timeout.
 
 > **kill**(): `Promise`\<`void`\>
 
-Defined in: [vm-handle.ts:33](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L33)
+Defined in: [vm-handle.ts:34](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L34)
 
 Send SIGKILL to the VM. Resolves once it's really gone.
 
@@ -2801,7 +2801,7 @@ Send SIGKILL to the VM. Resolves once it's really gone.
 
 > **detach**(): `Promise`\<`void`\>
 
-Defined in: [vm-handle.ts:41](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L41)
+Defined in: [vm-handle.ts:42](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L42)
 
 Drop this host-side handle without killing the VMM. The VM keeps
 running and can be re-attached from another process. For locally-
@@ -2816,7 +2816,7 @@ booted handles this closes captured streams; `wait()` and
 
 > **output**(): `Promise`\<`string`\>
 
-Defined in: [vm-handle.ts:49](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L49)
+Defined in: [vm-handle.ts:50](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L50)
 
 Buffer stdout until the process exits; return it as a UTF-8 string.
 Capped at ~1 MiB tail — long-running VMs keep only the most recent
@@ -2831,7 +2831,7 @@ assertions; not a full transcript.
 
 > **errorOutput**(): `Promise`\<`string`\>
 
-Defined in: [vm-handle.ts:52](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L52)
+Defined in: [vm-handle.ts:53](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L53)
 
 Same as `output()` but for stderr (where guest console lands).
 
@@ -2843,7 +2843,7 @@ Same as `output()` but for stderr (where guest console lands).
 
 > **exec**(`cmd`, `opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
 
-Defined in: [vm-handle.ts:63](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L63)
+Defined in: [vm-handle.ts:64](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L64)
 
 Run a shell command inside the guest via the vsock exec-agent. Throws
 BootError on non-zero exit; callers who want to inspect failure
@@ -2871,7 +2871,7 @@ automatically by `boot()` unless the caller pre-set MACHINEN_VSOCK.
 
 > **execRaw**(`cmd`, `opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
 
-Defined in: [vm-handle.ts:66](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L66)
+Defined in: [vm-handle.ts:67](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L67)
 
 Like `exec()` but returns non-zero exit codes instead of throwing.
 
@@ -2893,7 +2893,7 @@ Like `exec()` but returns non-zero exit codes instead of throwing.
 
 > **execPty**(`cmd`, `opts`): [`VsockExecPtyHandle`](#vsockexecptyhandle)
 
-Defined in: [vm-handle.ts:79](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L79)
+Defined in: [vm-handle.ts:80](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L80)
 
 Run a shell command inside a pseudoterminal. Bidirectional bytes
 flow between `opts.stdin` and `opts.stdout`; the returned handle's
@@ -2923,7 +2923,7 @@ untranslated bytes. See #133.
 
 > **writeFile**(`guestPath`, `contents`, `opts?`): `Promise`\<`void`\>
 
-Defined in: [vm-handle.ts:100](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L100)
+Defined in: [vm-handle.ts:101](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L101)
 
 Write `contents` to `guestPath` inside the VM. Convenience over
 `vm.exec(...)` for the common "drop a config file from the host"
@@ -2967,7 +2967,7 @@ EXEC_VSOCK_UNAVAILABLE | EXEC_NONZERO_EXIT |
 
 > **snapshot**(`opts`): `Promise`\<[`SnapshotResult`](#snapshotresult)\>
 
-Defined in: [vm-handle.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L135)
+Defined in: [vm-handle.ts:136](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L136)
 
 Freeze this VM with CRIU and write a snapshot bundle into
 `opts.outDir`. The bundle is a directory containing:
@@ -3015,7 +3015,7 @@ and the bundle can be restored into a sibling VM (`vm.fork()`).
 
 > **fork**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm-handle.ts:158](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L158)
+Defined in: [vm-handle.ts:159](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L159)
 
 Snapshot this VM without killing it and immediately restore the
 bundle into a new sibling VM. Both source and fork keep running,
@@ -3051,7 +3051,7 @@ written to a temp dir and removed when the fork exits.
 
 ### WriteFileOptions
 
-Defined in: [vm-handle.ts:161](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L161)
+Defined in: [vm-handle.ts:162](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L162)
 
 #### Properties
 
@@ -3059,7 +3059,7 @@ Defined in: [vm-handle.ts:161](https://github.com/redwoodjs/machinen/blob/main/p
 
 > `optional` **mode?**: `number`
 
-Defined in: [vm-handle.ts:163](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L163)
+Defined in: [vm-handle.ts:164](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L164)
 
 Octal mode for the destination file (e.g. `0o755`). Default: leave as-is.
 
@@ -3067,7 +3067,7 @@ Octal mode for the destination file (e.g. `0o755`). Default: leave as-is.
 
 > `optional` **recursive?**: `boolean`
 
-Defined in: [vm-handle.ts:165](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L165)
+Defined in: [vm-handle.ts:166](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L166)
 
 `mkdir -p` the parent directory before writing. Default: true.
 
@@ -3075,7 +3075,7 @@ Defined in: [vm-handle.ts:165](https://github.com/redwoodjs/machinen/blob/main/p
 
 > `optional` **append?**: `boolean`
 
-Defined in: [vm-handle.ts:167](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L167)
+Defined in: [vm-handle.ts:168](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L168)
 
 Append to the file instead of overwriting. Default: false.
 
@@ -3083,7 +3083,7 @@ Append to the file instead of overwriting. Default: false.
 
 ### SnapshotOptions
 
-Defined in: [vm-handle.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L170)
+Defined in: [vm-handle.ts:171](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L171)
 
 #### Properties
 
@@ -3091,7 +3091,7 @@ Defined in: [vm-handle.ts:170](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **outDir**: `string`
 
-Defined in: [vm-handle.ts:176](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L176)
+Defined in: [vm-handle.ts:177](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L177)
 
 Directory the snapshot bundle is written to. Created if missing
 and required to be empty (or absent) so a previous snapshot
@@ -3101,7 +3101,7 @@ can't be silently overwritten.
 
 > `optional` **dumpCmd?**: `string`
 
-Defined in: [vm-handle.ts:181](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L181)
+Defined in: [vm-handle.ts:182](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L182)
 
 Command to run in the guest to trigger the CRIU dump. Defaults to
 `/sbin/machinen-dump`.
@@ -3110,7 +3110,7 @@ Command to run in the guest to trigger the CRIU dump. Defaults to
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [vm-handle.ts:186](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L186)
+Defined in: [vm-handle.ts:187](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L187)
 
 Wall-clock ceiling for the dump + shutdown. If the VMM hasn't exited
 in this window we SIGKILL it and fail. Default 90s.
@@ -3119,7 +3119,7 @@ in this window we SIGKILL it and fail. Default 90s.
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [vm-handle.ts:192](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L192)
+Defined in: [vm-handle.ts:193](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L193)
 
 Streaming log callback — fires for every byte the dump emits
 (guest console + the dump exec). See #83. When both the snapshot
@@ -3129,7 +3129,7 @@ call and `boot({ onLog })` have a callback set, both fire.
 
 > `optional` **leaveRunning?**: `boolean`
 
-Defined in: [vm-handle.ts:201](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L201)
+Defined in: [vm-handle.ts:202](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L202)
 
 Pass `--leave-running` to `criu dump` so the source workload
 survives the snapshot. The VMM stays up after the dump; success
@@ -3142,7 +3142,7 @@ Default: false (current destructive snapshot behavior).
 
 > `optional` **tcpClose?**: `boolean`
 
-Defined in: [vm-handle.ts:211](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L211)
+Defined in: [vm-handle.ts:212](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L212)
 
 Omit `--tcp-established` from `criu dump`. Restored sockets come
 back in CLOSED state — the workload sees ECONNRESET on first
@@ -3156,7 +3156,7 @@ Default: false (preserve TCP — current snapshot/restore behavior).
 
 ### SnapshotResult
 
-Defined in: [vm-handle.ts:214](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L214)
+Defined in: [vm-handle.ts:215](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L215)
 
 #### Properties
 
@@ -3164,7 +3164,7 @@ Defined in: [vm-handle.ts:214](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **snapDir**: `string`
 
-Defined in: [vm-handle.ts:216](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L216)
+Defined in: [vm-handle.ts:217](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L217)
 
 Absolute path to the snapshot bundle directory.
 
@@ -3172,7 +3172,7 @@ Absolute path to the snapshot bundle directory.
 
 > **imgDir**: `string`
 
-Defined in: [vm-handle.ts:218](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L218)
+Defined in: [vm-handle.ts:219](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L219)
 
 Absolute path to the CRIU image directory inside the bundle.
 
@@ -3180,7 +3180,7 @@ Absolute path to the CRIU image directory inside the bundle.
 
 > **elapsedMs**: `number`
 
-Defined in: [vm-handle.ts:220](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L220)
+Defined in: [vm-handle.ts:221](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L221)
 
 Time from `snapshot()` entry to VMM exit, in milliseconds.
 
@@ -3188,7 +3188,7 @@ Time from `snapshot()` entry to VMM exit, in milliseconds.
 
 > **consoleLog**: `string`
 
-Defined in: [vm-handle.ts:222](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L222)
+Defined in: [vm-handle.ts:223](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L223)
 
 Guest console output captured during the dump.
 
@@ -3196,7 +3196,7 @@ Guest console output captured during the dump.
 
 ### SnapshotMeta
 
-Defined in: [vm-handle.ts:229](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L229)
+Defined in: [vm-handle.ts:230](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L230)
 
 On-disk shape of the bundle's `meta.json`. Read by `restore()`
 to reconstruct the source VM's name when registering the fork.
@@ -3207,7 +3207,7 @@ to reconstruct the source VM's name when registering the fork.
 
 > `optional` **sourceName?**: `string`
 
-Defined in: [vm-handle.ts:231](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L231)
+Defined in: [vm-handle.ts:232](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L232)
 
 Name passed to `boot({ name })` when the source VM was started.
 
@@ -3215,7 +3215,7 @@ Name passed to `boot({ name })` when the source VM was started.
 
 > `optional` **sourceImage?**: `string`
 
-Defined in: [vm-handle.ts:240](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L240)
+Defined in: [vm-handle.ts:241](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L241)
 
 Absolute path of the rootfs tarball the source VM was booted with
 (`boot({ image })` or its restored equivalent). `restore()` uses
@@ -3228,7 +3228,7 @@ explicit `image` override.
 
 > **snappedAt**: `number`
 
-Defined in: [vm-handle.ts:242](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L242)
+Defined in: [vm-handle.ts:243](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L243)
 
 ms epoch when `vm.snapshot()` returned.
 
@@ -3236,90 +3236,68 @@ ms epoch when `vm.snapshot()` returned.
 
 ### ForkOptions
 
-Defined in: [vm-handle.ts:245](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L245)
+Defined in: [vm-handle.ts:261](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L261)
+
+Fork = `vm.snapshot({ leaveRunning: true })` + `restore(...)` rolled
+into one call. The shape mirrors `RestoreOptions` (so anything you
+could pass to `restore()` works on a fork) plus two fork-only knobs:
+`outDir` (where to write the bundle) and `tcpKeep` (snapshot half).
+
+Notably this means `mount`, `liveMounts`, `env`, `guestCwd`, `memory`,
+etc. are all settable on the fork — they take effect on the restored
+sibling, not the source.
+
+`snapDir` is omitted because `vm.fork()` produces the bundle itself.
+Re-included here are the fork-shaped docs for `name`, `portForward`,
+`timeoutMs`, and `onLog` so call sites see the fork-specific defaults
+instead of the boot/restore ones.
+
+#### Extends
+
+- `Omit`\<[`RestoreOptions`](#restoreoptions), `"snapDir"`\>
 
 #### Properties
-
-##### name?
-
-> `optional` **name?**: `string`
-
-Defined in: [vm-handle.ts:250](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L250)
-
-Name for the forked VM. When omitted, the existing restore()
-auto-naming kicks in: `<sourceName>/<fork.pid>`.
 
 ##### outDir?
 
 > `optional` **outDir?**: `string`
 
-Defined in: [vm-handle.ts:257](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L257)
+Defined in: [vm-handle.ts:268](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L268)
 
 If set, the snapshot bundle is written here and kept after the
 fork exits — re-restore from this path to spawn another sibling.
 If omitted, the bundle is written to a temp dir and removed
 when the fork's VMM exits.
 
-##### image?
-
-> `optional` **image?**: `string`
-
-Defined in: [vm-handle.ts:262](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L262)
-
-Override the rootfs image used for the fork's restore boot.
-Same semantics as `restore({ image })`.
-
-##### kernel?
-
-> `optional` **kernel?**: `string`
-
-Defined in: [vm-handle.ts:264](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L264)
-
-Kernel path for the fork's boot. Same semantics as `boot({ kernel })`.
-
-##### dtb?
-
-> `optional` **dtb?**: `string`
-
-Defined in: [vm-handle.ts:266](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L266)
-
-DTB path for the fork's boot. Same semantics as `boot({ dtb })`.
-
-##### timeoutMs?
-
-> `optional` **timeoutMs?**: `number`
-
-Defined in: [vm-handle.ts:272](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L272)
-
-Wall-clock ceiling for the dump half. Default 90s (matches
-`vm.snapshot({ timeoutMs })`). Restore boot has its own
-implicit deadlines via `boot()`.
-
-##### onLog?
-
-> `optional` **onLog?**: [`OnLog`](#onlog)
-
-Defined in: [vm-handle.ts:277](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L277)
-
-Streaming log callback for the snapshot half. Same shape as
-`vm.snapshot({ onLog })`.
-
 ##### tcpKeep?
 
 > `optional` **tcpKeep?**: `boolean`
 
-Defined in: [vm-handle.ts:284](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L284)
+Defined in: [vm-handle.ts:275](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L275)
 
 Default false: omit `--tcp-established` from the dump so the
 fork sees ECONNRESET on sockets the source had open. Set true
 to clone live TCP state into the fork (both VMs then race on
 the same connection — only correct in narrow scenarios).
 
+##### name?
+
+> `optional` **name?**: `string`
+
+Defined in: [vm-handle.ts:280](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L280)
+
+Name for the forked VM. When omitted, restore()'s auto-naming
+kicks in: `<sourceName>/<fork.pid>`.
+
+###### Overrides
+
+[`RestoreOptions`](#restoreoptions).[`name`](#name-7)
+
 ##### portForward?
 
 > `optional` **portForward?**: `object`[]
 
-Defined in: [vm-handle.ts:290](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L290)
+Defined in: [vm-handle.ts:286](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L286)
 
 Host→guest port forwards for the fork. NOT inherited from the
 source — host ports are global and source + fork would race on
@@ -3337,23 +3315,389 @@ the same bind. Pass explicitly when the fork needs forwards.
 
 > `optional` **hostAddr?**: `string`
 
+###### Overrides
+
+[`BootOptions`](#bootoptions).[`portForward`](#portforward-2)
+
+##### timeoutMs?
+
+> `optional` **timeoutMs?**: `number`
+
+Defined in: [vm-handle.ts:295](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L295)
+
+Wall-clock ceiling for the restored fork's `wait()`. Defaults to
+`null` (forever) — forks are typically long-lived sibling VMs and
+interactive sessions can sit idle. Set a finite deadline if you
+want the fork to be reaped after N ms of unresponsiveness. The
+dump half uses `performSnapshot`'s own 90s default and isn't
+configurable here.
+
+###### Overrides
+
+[`BootOptions`](#bootoptions).[`timeoutMs`](#timeoutms-5)
+
+##### onLog?
+
+> `optional` **onLog?**: [`OnLog`](#onlog)
+
+Defined in: [vm-handle.ts:300](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L300)
+
+Streaming log callback for the snapshot half. Same shape as
+`vm.snapshot({ onLog })`. Also used by the restore boot.
+
+###### Overrides
+
+[`BootOptions`](#bootoptions).[`onLog`](#onlog-4)
+
+##### env?
+
+> `optional` **env?**: `Record`\<`string`, `string`\>
+
+Defined in: [vm.ts:209](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L209)
+
+Env vars exposed to the guest workload. Packed into the synthesized
+`/machinen-config.json`. Distinct from `vmmEnv`, which only affects
+the host-side VMM process.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`env`](#env-5)
+
+##### guestCwd?
+
+> `optional` **guestCwd?**: `string`
+
+Defined in: [vm.ts:221](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L221)
+
+Working directory for the guest cmd. Lands as `cwd` in the
+synthesized `/machinen-config.json`; `/init` calls `chdir()` to
+this path before exec'ing the cmd. Useful with `mount` /
+`liveMounts` to land directly inside the share (e.g.
+`guestCwd: "/mnt/workspace"`).
+
+Must be absolute. Throws `BOOT_CWD_INVALID` for relative paths or
+paths containing NULs. Same precedence as `cmd`/`env`: an
+image-baked `cwd` is overridden by this field when both are set.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`guestCwd`](#guestcwd-1)
+
+##### rootDisk?
+
+> `optional` **rootDisk?**: `string` \| `boolean`
+
+Defined in: [vm.ts:266](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L266)
+
+Boot the guest with the rootfs on a virtio-blk device (`/dev/vda`)
+instead of inflating the whole rootfs into a RAM-backed tmpfs via
+the initramfs. See #114.
+
+Default: `true` whenever `image` is set. The runtime materializes
+an ext4 image from `image` (cached at
+`~/.cache/machinen/rootfs/<sha256>.img`) and attaches it as the
+rootdisk; the guest's `/init` mounts + chroots into it before
+running the user cmd. Materialization needs `mke2fs` (or
+`mkfs.ext4`) on PATH — `brew install e2fsprogs` on macOS, the
+`e2fsprogs` package on Linux.
+
+  - `string` — path to a pre-built ext4 `.img` file to attach
+               directly. Skips the materialize step + cache.
+  - `false`  — opt out: keep the cpio-as-rootfs path. The whole
+               rootfs lands in a tmpfs at boot (RAM scales ~8×
+               with rootfs size). Mostly an escape hatch for
+               tooling that doesn't need disk-backed semantics
+               (e.g. `provision()` itself).
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`rootDisk`](#rootdisk-1)
+
+##### rootDiskSizeBytes?
+
+> `optional` **rootDiskSizeBytes?**: `number`
+
+Defined in: [vm.ts:283](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L283)
+
+Absolute target size (bytes) for the materialized rootdisk image.
+Defaults to `max(2 GiB, treeBytes * 2.5)` — generous enough that
+boot-time `npm install -g <large package>` / `apt install ...`
+land without ENOSPC. Bump this for workloads that write more
+(e.g. 8 GiB for a build tree, 16 GiB for a model cache).
+
+The host file is sparse — unused capacity costs nothing on disk
+until the guest writes. The guest's online ext4 grow (in /init)
+resizes the on-disk filesystem to fill the file on every boot,
+so bumping this against an existing cached image works without
+a rematerialize.
+
+Ignored when `rootDisk` is a string path (the caller-provided
+image is taken as-is) or `rootDisk: false`. See #131.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`rootDiskSizeBytes`](#rootdisksizebytes-1)
+
+##### forkedFrom?
+
+> `optional` **forkedFrom?**: `string`
+
+Defined in: [vm.ts:296](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L296)
+
+Bookkeeping: absolute path to the snapshot bundle this VM was
+forked from. Set by `restore({ snapDir })`; visible in
+`machinen ls`. Plain `boot()` leaves it undefined.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`forkedFrom`](#forkedfrom-2)
+
+##### mount?
+
+> `optional` **mount?**: `object`
+
+Defined in: [vm.ts:310](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L310)
+
+A single host directory copied into the guest at boot. The guest
+path must live under `/mnt/`. Copy-once semantics: guest writes are
+discarded when the VM exits. See #64, #78.
+
+The payload rides through the initramfs cpio (overlaid under
+`/mnt/<guest>/` at pack time) and is then carried across the
+rootdisk pivot by `/init` into the on-disk rootfs. With
+`rootDisk: true` (the default) the mount briefly counts against
+the initramfs RAM ceiling at unpack — the same ceiling #114 was
+designed to relieve for the rootfs proper. For very large mounts
+prefer `liveMount` (FUSE pass-through, no copy). See #125.
+
+###### host
+
+> **host**: `string`
+
+###### guest
+
+> **guest**: `string`
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`mount`](#mount-3)
+
+##### liveMounts?
+
+> `optional` **liveMounts?**: `object`[]
+
+Defined in: [vm.ts:328](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L328)
+
+Host directories exposed to the guest as live-share FUSE mounts
+(#78). Unlike `mount` (copy-once into the boot rootfs), these stay
+connected to the host: the guest reads on demand via a vsock FUSE
+relay, and nothing is copied at boot. `mode` defaults to `"rw"` —
+guest writes land on the host (#151, #156). Set `"ro"` for a
+one-way share (host caches, untrusted guests).
+
+Each guest path must live under `/mnt/` (same rule as `mount`).
+Repeatable; each entry gets its own vsock port.
+
+Security note: a live-share mount gives a compromised guest a
+persistent channel back to the host filesystem. Containment keeps
+that bounded to the configured host root. `mount` (copy-once) has
+no such runtime channel and is strictly safer — prefer it for
+inputs you don't need write-through on.
+
+###### host
+
+> **host**: `string`
+
+###### guest
+
+> **guest**: `string`
+
+###### mode?
+
+> `optional` **mode?**: `"ro"` \| `"rw"`
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`liveMounts`](#livemounts-1)
+
+##### binary?
+
+> `optional` **binary?**: `string`
+
+Defined in: [vm.ts:342](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L342)
+
+Absolute or cwd-relative path to the VMM binary. Optional —
+if omitted, `boot()` resolves it via `resolveVmmBinary()`.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`binary`](#binary-3)
+
+##### cwd?
+
+> `optional` **cwd?**: `string`
+
+Defined in: [vm.ts:344](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L344)
+
+Working directory for the VMM (for finding fixture files).
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`cwd`](#cwd-3)
+
+##### args?
+
+> `optional` **args?**: `string`[]
+
+Defined in: [vm.ts:346](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L346)
+
+Extra argv for the VMM.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`args`](#args-2)
+
+##### kernel?
+
+> `optional` **kernel?**: `string`
+
+Defined in: [vm.ts:348](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L348)
+
+Path to the guest kernel Image. Forwarded as `MACHINEN_KERNEL`.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`kernel`](#kernel-2)
+
+##### dtb?
+
+> `optional` **dtb?**: `string`
+
+Defined in: [vm.ts:350](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L350)
+
+Path to the guest device-tree blob. Forwarded as `MACHINEN_DTB`.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`dtb`](#dtb-2)
+
+##### memory?
+
+> `optional` **memory?**: `number`
+
+Defined in: [vm.ts:363](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L363)
+
+Guest RAM ceiling, in MiB (decimal integer; no unit suffixes). The
+VMM reads this as `MACHINEN_MEMORY` (#263 phase A). Defaults to
+`min(host_ram_mib / 2, 16384)` with a floor of 512 — sized for
+typical dev workloads while leaving the host responsive. The
+ceiling is approximately free until the guest touches a page (see
+`packages/microvm/docs/memory.md`), so over-provisioning costs
+little until phase B's balloon lands and lets it actually shrink.
+
+This is documented as a debug knob — most workloads should never
+need to set it.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`memory`](#memory-1)
+
+##### pdeathsig?
+
+> `optional` **pdeathsig?**: `boolean`
+
+Defined in: [vm.ts:374](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L374)
+
+Wrap the VMM through the parent-death shim so it dies with this
+runtime process. Default true — the right answer for the common
+"boot, do work, exit" CLI flow.
+
+Set to false when the VMM is supposed to outlive the spawning
+process. `vm.fork()` (#216) sets this so the forked sibling
+survives `cli fork` returning. Without it, the kqueue-watching
+shim catches the CLI exit and SIGTERMs the fork mid-startup.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`pdeathsig`](#pdeathsig-1)
+
+##### vmmEnv?
+
+> `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
+
+Defined in: [vm.ts:384](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L384)
+
+Env passed to the VMM process on the host side (not exposed to the
+guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`vmmEnv`](#vmmenv-2)
+
+##### detached?
+
+> `optional` **detached?**: `boolean`
+
+Defined in: [vm.ts:417](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L417)
+
+Detach the VMM from the runtime parent so the parent can exit
+while the VM keeps running (issue #150 phase 2). When set, `boot()`
+blocks only until the guest produces its first console byte
+(readiness signal) and then resolves a handle whose `.wait()` /
+`.output()` no longer reflect the live VM — the parent has unrefed
+the child and is free to exit.
+
+Forces `pdeathsig: false` (otherwise the parent's exit kills the
+VMM, defeating the purpose). Refused in v1 alongside `liveMounts`,
+`mount`, and `portForward`: those all keep helpers in the JS
+process that the detached VMM still needs to call back into.
+Phase 3 lifts those gates by extracting the helpers into
+standalone daemons.
+
+Cleanup of per-boot reflink disks, bundle dirs, and vsock UDS
+directories normally happens in the parent's `child.once("exit")`
+hook. After detach the parent is gone, so those leak until the
+follow-up `machinen gc` / `machinen stop` commands (PR2 of #150)
+land. Use `--detached` only when you understand that trade-off.
+
+Reattach with `attach({ name | pid })` from another process —
+the registry entry stays live, the vsock UDS is still listening.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`detached`](#detached-1)
+
+##### image?
+
+> `optional` **image?**: `string`
+
+Defined in: [vm.ts:2564](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2564)
+
+Override the rootfs image used for the restore boot. Defaults
+to whatever caller passes through `image`-equivalent — but
+`restore()` always needs a base rootfs in the initramfs to
+carry /sbin/machinen-restore + criu. Most callers pass the
+release rootfs path here.
+
+###### Inherited from
+
+[`RestoreOptions`](#restoreoptions).[`image`](#image-2)
+
 ##### lazyPages?
 
 > `optional` **lazyPages?**: `boolean`
 
-Defined in: [vm-handle.ts:304](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L304)
+Defined in: [vm.ts:2578](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2578)
 
 Restore via CRIU lazy-pages with the bundle vsock-FUSE-mounted
-read-only into the guest (#266). The runtime live-mounts the
-bundle's `img/` dir at `/mnt/snap-src/img`; the in-guest
-`criu lazy-pages` daemon serves UFFD faults by reading from that
-mount, which streams bytes from the host on demand. Pages flow
-into the workload's anon only when actually touched, not
-eagerly at restore — that's what keeps RSS down when forking a
-snapshot of a large workload.
+read-only into the guest (#266). Pages flow into the workload's
+anon mappings only when faulted, streaming from the host bundle
+on demand — host RSS is proportional to the touched set rather
+than the full snapshot size. Default false (eager restore).
 
-Default false (eager restore). Requires the rootfs to ship a
-`criu lazy-pages`-capable binary (the rootfs we ship does).
+###### Inherited from
+
+[`RestoreOptions`](#restoreoptions).[`lazyPages`](#lazypages-1)
 
 ***
 
@@ -3780,7 +4124,7 @@ the host-side VMM process.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`env`](#env-4)
+[`BootOptions`](#bootoptions).[`env`](#env-5)
 
 ##### guestCwd?
 
@@ -3800,7 +4144,7 @@ image-baked `cwd` is overridden by this field when both are set.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`guestCwd`](#guestcwd)
+[`BootOptions`](#bootoptions).[`guestCwd`](#guestcwd-1)
 
 ##### rootDisk?
 
@@ -3830,7 +4174,7 @@ running the user cmd. Materialization needs `mke2fs` (or
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`rootDisk`](#rootdisk)
+[`BootOptions`](#bootoptions).[`rootDisk`](#rootdisk-1)
 
 ##### rootDiskSizeBytes?
 
@@ -3855,7 +4199,7 @@ image is taken as-is) or `rootDisk: false`. See #131.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`rootDiskSizeBytes`](#rootdisksizebytes)
+[`BootOptions`](#bootoptions).[`rootDiskSizeBytes`](#rootdisksizebytes-1)
 
 ##### forkedFrom?
 
@@ -3869,7 +4213,7 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`forkedFrom`](#forkedfrom-1)
+[`BootOptions`](#bootoptions).[`forkedFrom`](#forkedfrom-2)
 
 ##### mount?
 
@@ -3899,7 +4243,7 @@ prefer `liveMount` (FUSE pass-through, no copy). See #125.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`mount`](#mount-2)
+[`BootOptions`](#bootoptions).[`mount`](#mount-3)
 
 ##### liveMounts?
 
@@ -3937,7 +4281,7 @@ inputs you don't need write-through on.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`liveMounts`](#livemounts)
+[`BootOptions`](#bootoptions).[`liveMounts`](#livemounts-1)
 
 ##### portForward?
 
@@ -3976,7 +4320,7 @@ if omitted, `boot()` resolves it via `resolveVmmBinary()`.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`binary`](#binary-2)
+[`BootOptions`](#bootoptions).[`binary`](#binary-3)
 
 ##### cwd?
 
@@ -3988,7 +4332,7 @@ Working directory for the VMM (for finding fixture files).
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`cwd`](#cwd-2)
+[`BootOptions`](#bootoptions).[`cwd`](#cwd-3)
 
 ##### args?
 
@@ -4000,7 +4344,7 @@ Extra argv for the VMM.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`args`](#args-1)
+[`BootOptions`](#bootoptions).[`args`](#args-2)
 
 ##### kernel?
 
@@ -4045,7 +4389,7 @@ need to set it.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`memory`](#memory)
+[`BootOptions`](#bootoptions).[`memory`](#memory-1)
 
 ##### pdeathsig?
 
@@ -4064,7 +4408,7 @@ shim catches the CLI exit and SIGTERMs the fork mid-startup.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`pdeathsig`](#pdeathsig)
+[`BootOptions`](#bootoptions).[`pdeathsig`](#pdeathsig-1)
 
 ##### timeoutMs?
 
@@ -4090,7 +4434,7 @@ guest workload). Mostly for dev/test flags like `MACHINEN_BOOT_TEST`.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`vmmEnv`](#vmmenv-1)
+[`BootOptions`](#bootoptions).[`vmmEnv`](#vmmenv-2)
 
 ##### onLog?
 
@@ -4139,7 +4483,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 ###### Inherited from
 
-[`BootOptions`](#bootoptions).[`detached`](#detached)
+[`BootOptions`](#bootoptions).[`detached`](#detached-1)
 
 ##### snapDir
 
@@ -5568,7 +5912,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/img/`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:2999](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2999)
+Defined in: [vm.ts:3005](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3005)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -11,6 +11,7 @@ import type {
   VsockExecResult,
 } from "./exec.ts";
 import type { OnLog } from "./log.ts";
+import type { RestoreOptions } from "./vm.ts";
 
 export interface VmHandle {
   /**
@@ -242,12 +243,22 @@ export interface SnapshotMeta {
   snappedAt: number;
 }
 
-export interface ForkOptions {
-  /**
-   * Name for the forked VM. When omitted, the existing restore()
-   * auto-naming kicks in: `<sourceName>/<fork.pid>`.
-   */
-  name?: string;
+/**
+ * Fork = `vm.snapshot({ leaveRunning: true })` + `restore(...)` rolled
+ * into one call. The shape mirrors `RestoreOptions` (so anything you
+ * could pass to `restore()` works on a fork) plus two fork-only knobs:
+ * `outDir` (where to write the bundle) and `tcpKeep` (snapshot half).
+ *
+ * Notably this means `mount`, `liveMounts`, `env`, `guestCwd`, `memory`,
+ * etc. are all settable on the fork — they take effect on the restored
+ * sibling, not the source.
+ *
+ * `snapDir` is omitted because `vm.fork()` produces the bundle itself.
+ * Re-included here are the fork-shaped docs for `name`, `portForward`,
+ * `timeoutMs`, and `onLog` so call sites see the fork-specific defaults
+ * instead of the boot/restore ones.
+ */
+export interface ForkOptions extends Omit<RestoreOptions, "snapDir"> {
   /**
    * If set, the snapshot bundle is written here and kept after the
    * fork exits — re-restore from this path to spawn another sibling.
@@ -256,26 +267,6 @@ export interface ForkOptions {
    */
   outDir?: string;
   /**
-   * Override the rootfs image used for the fork's restore boot.
-   * Same semantics as `restore({ image })`.
-   */
-  image?: string;
-  /** Kernel path for the fork's boot. Same semantics as `boot({ kernel })`. */
-  kernel?: string;
-  /** DTB path for the fork's boot. Same semantics as `boot({ dtb })`. */
-  dtb?: string;
-  /**
-   * Wall-clock ceiling for the dump half. Default 90s (matches
-   * `vm.snapshot({ timeoutMs })`). Restore boot has its own
-   * implicit deadlines via `boot()`.
-   */
-  timeoutMs?: number;
-  /**
-   * Streaming log callback for the snapshot half. Same shape as
-   * `vm.snapshot({ onLog })`.
-   */
-  onLog?: OnLog;
-  /**
    * Default false: omit `--tcp-established` from the dump so the
    * fork sees ECONNRESET on sockets the source had open. Set true
    * to clone live TCP state into the fork (both VMs then race on
@@ -283,23 +274,28 @@ export interface ForkOptions {
    */
   tcpKeep?: boolean;
   /**
+   * Name for the forked VM. When omitted, restore()'s auto-naming
+   * kicks in: `<sourceName>/<fork.pid>`.
+   */
+  name?: string;
+  /**
    * Host→guest port forwards for the fork. NOT inherited from the
    * source — host ports are global and source + fork would race on
    * the same bind. Pass explicitly when the fork needs forwards.
    */
   portForward?: Array<{ hostPort: number; guestPort: number; hostAddr?: string }>;
   /**
-   * Restore via CRIU lazy-pages with the bundle vsock-FUSE-mounted
-   * read-only into the guest (#266). The runtime live-mounts the
-   * bundle's `img/` dir at `/mnt/snap-src/img`; the in-guest
-   * `criu lazy-pages` daemon serves UFFD faults by reading from that
-   * mount, which streams bytes from the host on demand. Pages flow
-   * into the workload's anon only when actually touched, not
-   * eagerly at restore — that's what keeps RSS down when forking a
-   * snapshot of a large workload.
-   *
-   * Default false (eager restore). Requires the rootfs to ship a
-   * `criu lazy-pages`-capable binary (the rootfs we ship does).
+   * Wall-clock ceiling for the restored fork's `wait()`. Defaults to
+   * `null` (forever) — forks are typically long-lived sibling VMs and
+   * interactive sessions can sit idle. Set a finite deadline if you
+   * want the fork to be reaped after N ms of unresponsiveness. The
+   * dump half uses `performSnapshot`'s own 90s default and isn't
+   * configurable here.
    */
-  lazyPages?: boolean;
+  timeoutMs?: number | null;
+  /**
+   * Streaming log callback for the snapshot half. Same shape as
+   * `vm.snapshot({ onLog })`. Also used by the restore boot.
+   */
+  onLog?: OnLog;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -2914,13 +2914,14 @@ async function performFork(ctx: SnapshotContext, opts: ForkOptions): Promise<VmH
   );
 
   // Snapshot half: source survives. tcpClose flips the spec's default.
+  // Uses performSnapshot's own 90s default ceiling — the dump half is
+  // not user-configurable through ForkOptions today.
   let snap: SnapshotResult;
   try {
     snap = await performSnapshot(ctx, {
       outDir: snapDir,
       leaveRunning: true,
       tcpClose: opts.tcpKeep !== true,
-      timeoutMs: opts.timeoutMs,
       onLog: opts.onLog,
     });
   } catch (err) {
@@ -2936,31 +2937,36 @@ async function performFork(ctx: SnapshotContext, opts: ForkOptions): Promise<VmH
 
   // Restore half: a fresh sibling VM. boot() inside restore() auto-
   // allocates its own vsock UDS and (if needed) gvproxy — vsock
-  // identity and L2 networking are isolated per-VM. portForward is
-  // intentionally NOT inherited from the source: host ports are
-  // global, so source + fork would race on the same bind.
+  // identity and L2 networking are isolated per-VM.
+  //
+  // Strip the two fork-only fields (outDir, tcpKeep) and forward the
+  // rest of `opts` straight to restore(). This is the "fork = snapshot
+  // + restore, no diverging path" surface: every BootOptions field the
+  // user could pass at boot time also works on a fork (mount,
+  // liveMounts, env, guestCwd, memory, kernel, dtb, …) and lands on
+  // the restored sibling.
+  //
+  // Two invariants we preserve regardless of caller input:
+  //   - portForward: NOT inherited from source. Host ports are global,
+  //     so source + fork would race on the same bind. Caller must
+  //     re-declare any forwards they want on the fork.
+  //   - pdeathsig: forced false. The fork outlives the process that
+  //     spawned it (CLI returns immediately; programmatic callers
+  //     detach()). The parent-death shim would SIGTERM the fork on
+  //     CLI exit otherwise.
+  //   - timeoutMs: defaults to null (forever) instead of boot()'s 60s.
+  //     Forks are long-lived siblings; an idle interactive console
+  //     would otherwise be reaped mid-shell. Caller can override.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { outDir: _outDir, tcpKeep: _tcpKeep, ...restoreOpts } = opts;
   let fork: VmHandle;
   try {
     fork = await restore({
+      ...restoreOpts,
       snapDir,
-      name: opts.name,
-      image: opts.image,
-      kernel: opts.kernel,
-      dtb: opts.dtb,
       portForward: opts.portForward ?? [],
-      lazyPages: opts.lazyPages,
-      // The fork outlives the process that spawned it (CLI returns
-      // immediately; programmatic callers detach() and move on).
-      // Skip the parent-death shim so the fork's VMM isn't SIGTERM'd
-      // when this process exits.
       pdeathsig: false,
-      // Disable the implicit 60s wait deadline that boot() applies
-      // by default. Forks are long-lived sibling VMs — `cmdFork`
-      // (and any caller that drops the user into the fork's console)
-      // calls `fork.wait()` with no time bound. Without this null,
-      // the wait throws BOOT_TIMEOUT after 60s of an idle interactive
-      // session, killing the fork mid-shell.
-      timeoutMs: null,
+      timeoutMs: opts.timeoutMs ?? null,
     });
   } catch (err) {
     if (ephemeral) {

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -477,5 +477,15 @@ for f in Image-arm64 virt-arm64.dtb rootfs-debian-arm64.tar.gz rootfs-debian-arm
   shasum -a 256 "$f" > "${f}.sha256"
 done
 
+# Input-hash sidecars consumed by scripts/check-asset-freshness.sh.
+# Source the checker so the file list lives in one place — drift
+# between "what we hash here" and "what the checker hashes" would
+# defeat the whole point of the staleness probe.
+echo "==> Writing input-hash sidecars"
+# shellcheck source=./check-asset-freshness.sh
+source "${ROOT}/scripts/check-asset-freshness.sh"
+rootfs_input_files | compute_sha > "${OUT}/rootfs-debian-arm64.tar.gz.inputs-sha256"
+kernel_input_files | compute_sha > "${OUT}/Image-arm64.inputs-sha256"
+
 ls -lh "$OUT"
 echo "==> Done."

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Detect when release-assets/ is stale relative to the source files
+# that produced it. Without this, an out-of-date rootfs.tar.gz looks
+# like a runtime bug at snapshot time (S1 hangs 10s in trying to talk
+# to a /sbin/machinen-dump that doesn't match the host's expectations)
+# rather than the asset-mismatch it actually is.
+#
+# How it works:
+#   - At build time, scripts/build-base-assets.sh hashes the input
+#     files and writes the digest to a sidecar:
+#       release-assets/rootfs-debian-arm64.tar.gz.inputs-sha256
+#       release-assets/Image-arm64.inputs-sha256
+#   - At check time (this script), the same input files are hashed
+#     and compared against the sidecar. A mismatch means the source
+#     has moved on since the binary was built.
+#
+# Sidecar absent = release-assets/ predates this checker. Treated as
+# a soft failure: warn, but don't block, so a checkout from before
+# the checker landed still smokes.
+#
+# Usage:
+#   scripts/check-asset-freshness.sh           # exit 1 if stale
+#   scripts/check-asset-freshness.sh --quiet   # suppress the ok line
+#
+# Sourceable: when sourced (`source check-asset-freshness.sh`) the
+# helper functions are exposed but `main` is not run. Used by
+# build-base-assets.sh to write the sidecars without re-implementing
+# the file list.
+
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ASSETS="${ROOT}/packages/microvm/assets"
+SCRIPTS="${ROOT}/scripts"
+OUT="${ROOT}/release-assets"
+
+# Files whose contents are baked into rootfs-debian-arm64.tar.gz.
+# - The .zig sources are compiled to /init, /exec-agent, /sbin/...
+#   inside the rootfs.
+# - The .sh scripts are copied verbatim under /sbin.
+# - machinen-netup.c is zig-cc'd into /sbin/machinen-netup.
+# - The build script itself is included so a change to install paths
+#   or Debian package pins triggers a rebuild even when no asset
+#   source moved.
+rootfs_input_files() {
+  printf '%s\n' \
+    "${ASSETS}/exec-agent.zig" \
+    "${ASSETS}/fuse-agent.zig" \
+    "${ASSETS}/init.zig" \
+    "${ASSETS}/lo-up.zig" \
+    "${ASSETS}/machinen-dump-preflight.sh" \
+    "${ASSETS}/machinen-dump.sh" \
+    "${ASSETS}/machinen-netup.c" \
+    "${ASSETS}/machinen-restore.sh" \
+    "${ASSETS}/machinen-supervisor.sh" \
+    "${ASSETS}/memdirty.zig" \
+    "${ASSETS}/net-bench-probe.zig" \
+    "${ASSETS}/no-iou.zig" \
+    "${ASSETS}/poweroff.zig" \
+    "${ASSETS}/winsize-agent.zig" \
+    "${SCRIPTS}/build-base-assets.sh"
+}
+
+# Files whose contents are baked into Image-arm64. The kernel itself
+# comes from upstream kernel.org pinned by version inside
+# build-kernel-arm64.sh — that single script captures version pin,
+# CONFIG_ overrides, and patch list, so it's the only input we track.
+# virt.dts contributes to virt-arm64.dtb (compiled alongside the
+# kernel) so it's listed here too.
+kernel_input_files() {
+  printf '%s\n' \
+    "${ASSETS}/virt.dts" \
+    "${SCRIPTS}/build-kernel-arm64.sh"
+}
+
+# Read filenames on stdin (one per line, in stable order from the
+# *_input_files producers above), `cat` the bytes through a single
+# sha256 stream. Concatenating the files (rather than per-file digest +
+# digest-of-digests) keeps the helper trivial; the file list is fixed
+# so this is reproducible across machines.
+compute_sha() {
+  local f
+  while IFS= read -r f; do
+    if [[ ! -f "$f" ]]; then
+      echo "asset-freshness: input file missing: $f" >&2
+      return 1
+    fi
+    cat "$f"
+  done | shasum -a 256 | awk '{print $1}'
+}
+
+# Compare a sidecar against a freshly-computed input hash. The third
+# argument is the function that lists the inputs (rootfs_input_files
+# or kernel_input_files).
+verify_sidecar() {
+  local label="$1"
+  local sidecar="$2"
+  local inputs_fn="$3"
+  if [[ ! -f "$sidecar" ]]; then
+    echo "asset-freshness: ${label}: sidecar ${sidecar##*/} missing" >&2
+    echo "  this release-assets/ was built before the freshness checker landed" >&2
+    echo "  rebuild to populate the sidecar: bash scripts/build-base-assets.sh" >&2
+    return 2
+  fi
+  local expected actual
+  expected=$(cat "$sidecar")
+  actual=$("$inputs_fn" | compute_sha)
+  if [[ "$expected" != "$actual" ]]; then
+    echo "asset-freshness: ${label}: STALE — inputs have changed since the binary was built" >&2
+    echo "  expected (from sidecar): $expected" >&2
+    echo "  actual   (from sources): $actual" >&2
+    echo "  fix: bash scripts/build-base-assets.sh" >&2
+    return 1
+  fi
+  return 0
+}
+
+main() {
+  local quiet=false
+  if [[ "${1:-}" == "--quiet" ]]; then
+    quiet=true
+  fi
+
+  # Treat "no release-assets at all" as a soft skip — the smoke-tests
+  # entry point handles building from scratch, and this checker is
+  # about catching drift, not about gating the first build.
+  if [[ ! -d "$OUT" ]]; then
+    if ! $quiet; then
+      echo "asset-freshness: ${OUT##*/} not present, skipping check"
+    fi
+    return 0
+  fi
+
+  local rootfs_rc=0 kernel_rc=0
+  verify_sidecar "rootfs" "${OUT}/rootfs-debian-arm64.tar.gz.inputs-sha256" rootfs_input_files \
+    || rootfs_rc=$?
+  verify_sidecar "kernel" "${OUT}/Image-arm64.inputs-sha256" kernel_input_files \
+    || kernel_rc=$?
+
+  # Stale (rc=1) is a hard failure. Missing sidecar (rc=2) is soft —
+  # warn but pass, so older checkouts can still run smoke-tests.
+  if (( rootfs_rc == 1 )) || (( kernel_rc == 1 )); then
+    return 1
+  fi
+  if ! $quiet; then
+    echo "asset-freshness: ok"
+  fi
+  return 0
+}
+
+# When run directly, dispatch to main. When sourced (BASH_SOURCE !=
+# $0, which happens under `source path/to/this`), only the helpers
+# get exposed. The `:-` defaults guard against `set -u` blowing up
+# in callers that source us before BASH_SOURCE has been populated
+# (e.g. zsh, where the array doesn't exist at all).
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  main "$@"
+fi

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -91,6 +91,17 @@ if [[ ! -f "$ASSETS/Image-arm64" ]]; then
   "$ROOT/scripts/build-base-assets.sh"
 fi
 
+# Catch a stale rootfs / kernel before booting. Without this, an
+# out-of-date /sbin/machinen-dump (e.g. release-assets/ predates a
+# host-side change to the snapshot protocol) produces a 10s vsock
+# timeout in S1 that looks like a runtime regression. The checker
+# diffs source-file hashes against sidecars baked at build time;
+# missing sidecars (older release-assets/) just warn.
+if ! "$ROOT/scripts/check-asset-freshness.sh" --quiet; then
+  echo "smoke: release-assets/ is stale — rebuild with bash $ROOT/scripts/build-base-assets.sh" >&2
+  exit 1
+fi
+
 if [[ ! -f "$CLI" ]]; then
   echo "=== building @machinen/runtime + @machinen/cli ==="
   pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null


### PR DESCRIPTION
## Problem

`vm.fork()` is mechanically `vm.snapshot({ leaveRunning: true })` followed by `restore(opts)`. The API didn't reflect that. `ForkOptions` declared a narrow subset of fields (`name`, `image`, `kernel`, `dtb`, `portForward`, `lazyPages`, `tcpKeep`, `outDir`), and `performFork` cherry-picked five of them when calling `restore()`, dropping the rest on the floor. The underlying `restore()` happily accepts `mount`, `mountLive`, `env`, `guestCwd`, `memory`, etc. — none of those reached the forked sibling. So you couldn't attach a fresh live-mount to a fork, set per-fork env vars, or hand it more RAM than the source had, without dropping into Node and bypassing the runtime fork helper entirely.

## Solution

Make the fork surface equal to restore's. `ForkOptions` now extends `Omit<RestoreOptions, "snapDir">` plus the two genuinely-fork-only knobs (`outDir` for the bundle, `tcpKeep` for the dump half). `performFork` destructures those two and spreads the rest straight into `restore()`. Three invariants stay enforced regardless of caller input:

- `portForward` defaults to `[]` — host ports are global; source + fork can't share a bind, so non-inheritance has to be explicit.
- `pdeathsig` is forced `false` — the fork outlives its parent process; the parent-death shim would SIGTERM it on CLI exit otherwise.
- `timeoutMs` defaults to `null` — forks are long-lived siblings; an idle interactive console shouldn't be reaped after 60s.

The CLI follows: `parse-run-args` exposes per-flag consumers, `parse-fork-args` reuses them, and `machinen fork` accepts `--mount`, `--mount-live`, `--env`, `--cwd`, `--memory` with identical semantics to `machinen boot`.

A second `chore(scripts):` commit adds an asset-freshness checker that surfaced while smoke-testing this change. The checked-in `release-assets/` rootfs predated #266's tar-on-stdout dump protocol, so S1 hung for 10 seconds into every snapshot — looking like a runtime regression rather than the asset-mismatch it actually was. The checker hashes the source files that bake into the rootfs and kernel against sidecars written at build time, so the next time a checked-in rootfs goes stale it fails fast with the rebuild command instead of looking like a snapshot bug.

## Technical summary

**`packages/runtime/src/vm-handle.ts`** — `ForkOptions` rewritten to `extends Omit<RestoreOptions, "snapDir">`, plus `outDir` and `tcpKeep`. A handful of fork-shaped overrides (`name`, `portForward`, `timeoutMs`, `onLog`) are re-declared so call-site docs reflect fork-specific defaults instead of the boot/restore ones.

**`packages/runtime/src/vm.ts`** — `performFork` destructures `outDir` and `tcpKeep`, then spreads `restoreOpts` into `restore()`. The snapshot half drops the now-unused `timeoutMs` plumbing; `performSnapshot`'s own 90s default covers the dump.

**`packages/cli/src/parse-run-args.ts`** — Per-flag consumer functions (`consumeMount`, `consumeLiveMount`, `consumeEnv`, `consumeMemory`, `consumeGuestCwd`) extracted as exports, plus a shared `takeValue` helper for the `--flag value` / `--flag=value` decode. `parseRunArgs` refactored to use them; behaviour unchanged.

**`packages/cli/src/parse-fork-args.ts`** — Adds `mount`, `liveMounts`, `env`, `guestCwd`, `memory` to `ParsedForkArgs` and uses the shared consumers. Existing fork-only flags (`--new-name`, `--out-dir`, `--tcp-keep`, `--detach`) untouched.

**`packages/cli/src/cli.ts`** — `cmdFork` threads the new fields into `vm.fork()` and the help text covers them.

**`scripts/check-asset-freshness.sh`** (new) — Sourceable bash that hashes the rootfs/kernel input files and compares against sidecars at `release-assets/{rootfs-debian-arm64.tar.gz,Image-arm64}.inputs-sha256`. Three behaviours: hash matches → pass; hash differs → exit 1 with the rebuild command; sidecar missing (older checkout) → soft-pass with a warning.

**`scripts/build-base-assets.sh`** — After the existing `*.sha256` step, sources `check-asset-freshness.sh` and writes the two new input-hash sidecars from the same file list the checker reads (single source of truth).

**`scripts/smoke-tests.sh`** — Calls the checker after the build/cache step, before any VMs boot. Stale → exits with the rebuild command; otherwise transparent.

**Docs** — `packages/cli/API.md`, `packages/runtime/API.md` (typedoc-regenerated), and `docs/guides/snapshot-restore-fork.md` reflect the new fork surface.