### PR TITLE
feat: on-demand memory for restore and fork (closes #263)

### DIFF
--- a/.changeset/lazy-restore-default.md
+++ b/.changeset/lazy-restore-default.md
@@ -1,0 +1,11 @@
+---
+"@machinen/runtime": minor
+"@machinen/cli": minor
+---
+
+Make lazy-pages restore the default for `restore()` and `fork()` (#263). Pages stream on-demand from the host via vsock-FUSE so a fork's host RSS stays proportional to what it actually touches, not the parent's high-water mark.
+
+Breaking surface change:
+
+- Runtime: `RestoreOptions.lazyPages` and `ForkOptions.lazyPages` are gone. The new opt-out is `eager: true`, which reinstates the pre-#266 tar-on-/dev/vdb path.
+- CLI: `machinen restore --lazy-pages` is gone. The default is now lazy; pass `--eager` to opt back into eager restore.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -347,13 +347,26 @@ describe("parseForkArgs", () => {
     expect(parsed.detach).toBe(true);
   });
 
-  it("defaults tcpKeep, detach, and portForward when no flags are given", () => {
+  it("defaults tcpKeep, detach, eager, and portForward when no flags are given", () => {
     const parsed = parseForkArgs(["--name", "src"]);
     expect(parsed.tcpKeep).toBe(false);
     expect(parsed.detach).toBe(false);
+    expect(parsed.eager).toBe(false);
     expect(parsed.portForward).toEqual([]);
     expect(parsed.newName).toBeUndefined();
     expect(parsed.outDir).toBeUndefined();
+  });
+
+  it("captures --eager", () => {
+    const parsed = parseForkArgs(["--eager"]);
+    expect(parsed.eager).toBe(true);
+    expect(parsed.detach).toBe(false);
+  });
+
+  it("forces eager when --detach is set (FUSE server can't survive detach yet)", () => {
+    const parsed = parseForkArgs(["--detach"]);
+    expect(parsed.detach).toBe(true);
+    expect(parsed.eager).toBe(true);
   });
 
   it("collects -p / --publish into portForward", () => {
@@ -465,6 +478,12 @@ describe("parseRestoreArgs", () => {
     expect(parsed.name).toBeUndefined();
     expect(parsed.image).toBeUndefined();
     expect(parsed.portForward).toEqual([]);
+    expect(parsed.eager).toBe(false);
+  });
+
+  it("captures --eager (opt out of the default lazy restore)", () => {
+    const parsed = parseRestoreArgs(["./warm", "--eager"]);
+    expect(parsed.eager).toBe(true);
   });
 
   it("captures --name and --image (space and = forms)", () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -481,7 +481,7 @@ async function cmdInstall(args: string[]): Promise<number> {
 
 async function cmdRestore(args: string[]): Promise<number> {
   // `machinen restore <snap-dir> [--image <tarball>] [--name <name>]
-  // [--lazy-pages] [-p <hostPort>:<guestPort>]`. The bundle dir
+  // [--eager] [-p <hostPort>:<guestPort>]`. The bundle dir
   // (produced by `machinen snapshot`) holds img/<criu-images> +
   // meta.json. The bundle carries CRIU's process images but not the
   // workload's rootfs, so any process whose memory map references
@@ -492,20 +492,23 @@ async function cmdRestore(args: string[]): Promise<number> {
   // or directory" and /sbin/machinen-restore exits 1, panicking the
   // guest kernel ("Attempted to kill init!").
   //
-  // `--lazy-pages` live-mounts the bundle into the guest and runs
-  // `criu restore --lazy-pages` so pages flow into the workload's
-  // anon mappings only when faulted — see #266 for the RSS argument.
+  // Restore is lazy by default (#263 / #266): the bundle is
+  // vsock-FUSE-mounted into the guest and `criu restore --lazy-pages`
+  // faults workload pages on demand, keeping host RSS proportional to
+  // what the restored VM actually touches. Pass `--eager` to force the
+  // pre-#266 behaviour (tar the bundle onto /dev/vdb, untar in guest,
+  // load every page up front).
   let parsed;
   try {
     parsed = parseRestoreArgs(args);
   } catch (err) {
     handleError(err);
   }
-  const { positional, name, image: imageOverride, portForward, lazyPages } = parsed;
+  const { positional, name, image: imageOverride, portForward, eager } = parsed;
   if (positional.length !== 1) {
     die(
       "usage: machinen restore <snap-dir> [--image <tarball>] [--name <name>] " +
-        "[--lazy-pages] [-p <hostPort>:<guestPort>]",
+        "[--eager] [-p <hostPort>:<guestPort>]",
     );
   }
   const snapDir = resolve(positional[0]!);
@@ -544,7 +547,7 @@ async function cmdRestore(args: string[]): Promise<number> {
       kernel: kernelPath,
       dtb: dtbPath,
       name,
-      lazyPages,
+      eager,
       portForward: portForward.length > 0 ? portForward : undefined,
       timeoutMs: null,
     });
@@ -968,6 +971,7 @@ async function cmdFork(args: string[]): Promise<number> {
     outDir,
     tcpKeep,
     detach,
+    eager,
     portForward,
     mount,
     liveMounts,
@@ -1009,6 +1013,7 @@ async function cmdFork(args: string[]): Promise<number> {
       kernel: kernelPath,
       dtb: dtbPath,
       tcpKeep,
+      eager,
       portForward: portForward.length > 0 ? portForward : undefined,
       mount,
       liveMounts,

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -30,6 +30,16 @@ export interface ParsedForkArgs {
   /** Hand the fork off and return immediately (`--detach`). */
   detach: boolean;
   /**
+   * `--eager` — opt out of the default lazy restore for this fork
+   * (#263). Forced to true whenever `--detach` is set: the lazy path
+   * relies on a host-side FUSE server (#266) that lives in the
+   * runtime supervisor process, and `--detach` exits that process,
+   * which would leave the in-guest `criu lazy-pages` daemon blocked
+   * on the now-dead FUSE channel. Lifting this constraint is #150
+   * phase 3 — until then, detach implies eager.
+   */
+  eager: boolean;
+  /**
    * Host→guest port forwards (`-p <hostPort>:<guestPort>`). NOT
    * inherited from the source — host ports are global, so the source
    * already binds each one it forwarded. Pass new entries explicitly
@@ -75,6 +85,7 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
   let outDir: string | undefined;
   let tcpKeep = false;
   let detach = false;
+  let eager = false;
   const portForward: Array<{ hostPort: number; guestPort: number }> = [];
   const seenHostPorts = new Set<number>();
   let mount: { host: string; guest: string } | undefined;
@@ -109,6 +120,8 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
       tcpKeep = true;
     } else if (a === "--detach") {
       detach = true;
+    } else if (a === "--eager") {
+      eager = true;
     } else if (
       a === "-p" ||
       a === "--publish" ||
@@ -158,11 +171,16 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
       rest.push(a);
     }
   }
+  // Detach exits the runtime supervisor, taking the host-side FUSE
+  // server with it — the in-guest lazy-pages daemon would then block
+  // on a dead FUSE channel. Force eager to keep --detach usable until
+  // the FUSE server gains its own detach handoff (#150 phase 3).
   return {
     newName,
     outDir,
     tcpKeep,
     detach,
+    eager: eager || detach,
     portForward,
     mount,
     liveMounts: liveMounts.length > 0 ? liveMounts : undefined,

--- a/packages/cli/src/parse-restore-args.ts
+++ b/packages/cli/src/parse-restore-args.ts
@@ -26,24 +26,26 @@ export interface ParsedRestoreArgs {
    */
   portForward: Array<{ hostPort: number; guestPort: number }>;
   /**
-   * `--lazy-pages` — live-mount the bundle into the guest and run
+   * `--eager` — opt out of the default lazy restore and load every
+   * page from the bundle into host RAM up front (#263). The default
+   * (lazy) live-mounts the bundle into the guest and runs
    * `criu restore --lazy-pages` so anon pages flow into the workload
-   * only when faulted (#266). Default false (eager restore).
+   * only when faulted (#266).
    */
-  lazyPages: boolean;
+  eager: boolean;
 }
 
 export function parseRestoreArgs(argv: string[]): ParsedRestoreArgs {
   const positional: string[] = [];
   let name: string | undefined;
   let image: string | undefined;
-  let lazyPages = false;
+  let eager = false;
   const portForward: Array<{ hostPort: number; guestPort: number }> = [];
   const seenHostPorts = new Set<number>();
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
-    if (a === "--lazy-pages") {
-      lazyPages = true;
+    if (a === "--eager") {
+      eager = true;
     } else if (a === "--name" || a.startsWith("--name=")) {
       const v = a === "--name" ? argv[++i] : a.slice("--name=".length);
       if (!v) {
@@ -81,5 +83,5 @@ export function parseRestoreArgs(argv: string[]): ParsedRestoreArgs {
       positional.push(a);
     }
   }
-  return { positional, name, image, portForward, lazyPages };
+  return { positional, name, image, portForward, eager };
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3349,6 +3349,31 @@ Streaming log callback for the snapshot half. Same shape as
 
 [`BootOptions`](#bootoptions).[`onLog`](#onlog-4)
 
+##### eager?
+
+> `optional` **eager?**: `boolean`
+
+Defined in: [vm-handle.ts:317](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm-handle.ts#L317)
+
+Force eager restore — load every page from the bundle into host
+RAM up front, the way restore worked before #266. Default false
+(lazy via vsock-FUSE-mounted bundle + `criu restore --lazy-pages`).
+
+The lazy default keeps fork RSS proportional to the pages the
+sibling actually touches, not the full snapshot size. Set this
+to true when:
+
+  - the runtime supervisor is about to exit while the fork keeps
+    running (lazy needs the host-side FUSE server alive for as
+    long as the guest may fault — see #150 phase 3),
+  - the workload is going to fault every page anyway and you want
+    to skip the per-page UFFD round-trips, or
+  - you're debugging a lazy-restore failure on a fresh rootfs.
+
+###### Overrides
+
+[`RestoreOptions`](#restoreoptions).[`eager`](#eager-1)
+
 ##### env?
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
@@ -3682,22 +3707,6 @@ release rootfs path here.
 ###### Inherited from
 
 [`RestoreOptions`](#restoreoptions).[`image`](#image-2)
-
-##### lazyPages?
-
-> `optional` **lazyPages?**: `boolean`
-
-Defined in: [vm.ts:2578](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2578)
-
-Restore via CRIU lazy-pages with the bundle vsock-FUSE-mounted
-read-only into the guest (#266). Pages flow into the workload's
-anon mappings only when faulted, streaming from the host bundle
-on demand — host RSS is proportional to the touched set rather
-than the full snapshot size. Default false (eager restore).
-
-###### Inherited from
-
-[`RestoreOptions`](#restoreoptions).[`lazyPages`](#lazypages-1)
 
 ***
 
@@ -4516,17 +4525,19 @@ Optional explicit name for the restored VM. When omitted, the
 fork is auto-named `<sourceName>/<pid>` after spawn so it stays
 unique under the source's namespace.
 
-##### lazyPages?
+##### eager?
 
-> `optional` **lazyPages?**: `boolean`
+> `optional` **eager?**: `boolean`
 
-Defined in: [vm.ts:2578](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2578)
+Defined in: [vm.ts:2580](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2580)
 
-Restore via CRIU lazy-pages with the bundle vsock-FUSE-mounted
-read-only into the guest (#266). Pages flow into the workload's
-anon mappings only when faulted, streaming from the host bundle
-on demand — host RSS is proportional to the touched set rather
-than the full snapshot size. Default false (eager restore).
+Force eager restore — load every page from the bundle into host
+RAM up front. Default false (lazy: bundle is vsock-FUSE-mounted
+read-only into the guest and `criu restore --lazy-pages` faults
+pages on demand, #266). The lazy default keeps host RSS
+proportional to the touched set rather than the full snapshot
+size; eager exists as an opt-out for debugging or for workloads
+that are about to fault every page anyway.
 
 ***
 
@@ -5874,7 +5885,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:2600](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2600)
+Defined in: [vm.ts:2602](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L2602)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -5912,7 +5923,7 @@ BOOT_SNAPSHOT_NOT_FOUND if `<snapDir>/img/`
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:3005](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3005)
+Defined in: [vm.ts:3011](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3011)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -298,4 +298,21 @@ export interface ForkOptions extends Omit<RestoreOptions, "snapDir"> {
    * `vm.snapshot({ onLog })`. Also used by the restore boot.
    */
   onLog?: OnLog;
+  /**
+   * Force eager restore — load every page from the bundle into host
+   * RAM up front, the way restore worked before #266. Default false
+   * (lazy via vsock-FUSE-mounted bundle + `criu restore --lazy-pages`).
+   *
+   * The lazy default keeps fork RSS proportional to the pages the
+   * sibling actually touches, not the full snapshot size. Set this
+   * to true when:
+   *
+   *   - the runtime supervisor is about to exit while the fork keeps
+   *     running (lazy needs the host-side FUSE server alive for as
+   *     long as the guest may fault — see #150 phase 3),
+   *   - the workload is going to fault every page anyway and you want
+   *     to skip the per-page UFFD round-trips, or
+   *   - you're debugging a lazy-restore failure on a fresh rootfs.
+   */
+  eager?: boolean;
 }

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -2569,13 +2569,15 @@ export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" |
    */
   name?: string;
   /**
-   * Restore via CRIU lazy-pages with the bundle vsock-FUSE-mounted
-   * read-only into the guest (#266). Pages flow into the workload's
-   * anon mappings only when faulted, streaming from the host bundle
-   * on demand — host RSS is proportional to the touched set rather
-   * than the full snapshot size. Default false (eager restore).
+   * Force eager restore — load every page from the bundle into host
+   * RAM up front. Default false (lazy: bundle is vsock-FUSE-mounted
+   * read-only into the guest and `criu restore --lazy-pages` faults
+   * pages on demand, #266). The lazy default keeps host RSS
+   * proportional to the touched set rather than the full snapshot
+   * size; eager exists as an opt-out for debugging or for workloads
+   * that are about to fault every page anyway.
    */
-  lazyPages?: boolean;
+  eager?: boolean;
 }
 
 /**
@@ -2672,15 +2674,17 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
     );
   }
 
-  // Lazy-pages mode (#266): mark every PE_PRESENT pagemap entry that
-  // lives in an anon-private VMA with PE_LAZY in place on the host
-  // before boot, so `criu restore --lazy-pages` actually registers
-  // UFFD on those entries instead of loading them eagerly. Dumps are
-  // taken without `--lazy-pages` (machinen-dump.sh keeps the dump
-  // path simple); without this rewrite the lazy-pages daemon would
-  // see no lazy entries and load the whole image up front. Idempotent.
-  // See packages/runtime/src/lazy-pagemap.ts.
-  if (opts.lazyPages) {
+  // Lazy-pages mode (#266, default — opt out via `eager: true`):
+  // mark every PE_PRESENT pagemap entry that lives in an anon-private
+  // VMA with PE_LAZY in place on the host before boot, so
+  // `criu restore --lazy-pages` actually registers UFFD on those
+  // entries instead of loading them eagerly. Dumps are taken without
+  // `--lazy-pages` (machinen-dump.sh keeps the dump path simple);
+  // without this rewrite the lazy-pages daemon would see no lazy
+  // entries and load the whole image up front. Idempotent. See
+  // packages/runtime/src/lazy-pagemap.ts.
+  const lazyPages = !opts.eager;
+  if (lazyPages) {
     phases.start("snapshot-mark-lazy");
     const marked = markPagemapsLazy(imgDir);
     debug(
@@ -2693,21 +2697,23 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   }
 
   // Bundle delivery split by mode:
-  //   - lazyPages: vsock-FUSE-mount `imgDir/` read-only at /mnt/snap-src/img.
-  //     CRIU restore reads pagemap-*.img + pages-*.img directly through FUSE;
-  //     bytes stream from the host on demand and never materialize in guest
-  //     tmpfs. This is the #266 path — it removes the duplicate-copy that
-  //     was eating ~workload-size of guest RAM.
-  //   - eager (default): pack `imgDir/` into a tar archive attached as
-  //     /dev/vdb. The guest's machinen-restore.sh untars into tmpfs and
-  //     CRIU does an eager load. We keep this path for non-lazy restores
-  //     because every pread through FUSE costs a vsock round-trip; eager
-  //     restore is many MB of preadv calls and would slow the restore.
+  //   - lazy (default): vsock-FUSE-mount `imgDir/` read-only at
+  //     /mnt/snap-src/img. CRIU restore reads pagemap-*.img +
+  //     pages-*.img directly through FUSE; bytes stream from the host
+  //     on demand and never materialize in guest tmpfs. This is the
+  //     #266 path — it removes the duplicate-copy that was eating
+  //     ~workload-size of guest RAM.
+  //   - eager (opt-in via `eager: true`): pack `imgDir/` into a tar
+  //     archive attached as /dev/vdb. The guest's machinen-restore.sh
+  //     untars into tmpfs and CRIU does an eager load. Kept as an
+  //     opt-out because every pread through FUSE costs a vsock
+  //     round-trip; eager wins when the workload is about to fault
+  //     every page anyway.
   phases.start("snapshot-pack");
   const restoreEnv: Record<string, string> = {};
   let scratchPath: string;
   let liveMounts: Array<{ host: string; guest: string; mode?: "ro" | "rw" }> | undefined;
-  if (opts.lazyPages) {
+  if (lazyPages) {
     scratchPath = join(
       tmpdir(),
       `machinen-restore-scratch-${process.pid}-${randomBytes(6).toString("hex")}.img`,

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -1540,10 +1540,11 @@ else
   wait "$S4_PID" 2>/dev/null || true
   pass "'machinen snapshot' returned 0"
 
-  # Lazy-pages restore in the background. The CLI's --lazy-pages flag
-  # live-mounts the bundle dir into the guest and starts the in-guest
-  # `criu lazy-pages` daemon to serve UFFD faults from the FUSE mount.
-  node "$CLI" restore --lazy-pages "$S4_SNAP_DIR" >"$S4_RESTORE_LOG" 2>&1 &
+  # Restore is lazy by default (#263). The runtime live-mounts the
+  # bundle dir into the guest and starts the in-guest `criu lazy-pages`
+  # daemon to serve UFFD faults from the FUSE mount. `--eager` would
+  # opt back into the pre-#266 tar-on-vdb path; we want lazy here.
+  node "$CLI" restore "$S4_SNAP_DIR" >"$S4_RESTORE_LOG" 2>&1 &
   S4_RESTORE_PID=$!
   cleanup_s4_restore() {
     kill -TERM "$S4_RESTORE_PID" 2>/dev/null || true
@@ -1675,11 +1676,12 @@ else
   wait "$S5_PID" 2>/dev/null || true
   pass "'machinen snapshot' returned 0"
 
-  # Lazy-pages restore. The bundle is live-mounted into the guest; the
-  # restored guest only faults the criu bring-up handful in. memdirty
-  # itself sits in pause(), so its dirty anon stays on the host bundle.
+  # Restore (lazy by default, #263). The bundle is live-mounted into
+  # the guest; the restored guest only faults the criu bring-up handful
+  # in. memdirty itself sits in pause(), so its dirty anon stays on the
+  # host bundle.
   S5_RESTORE_LOG="$FIXTURE/s5-restore.log"
-  node "$CLI" restore --lazy-pages "$S5_SNAP_DIR" >"$S5_RESTORE_LOG" 2>&1 &
+  node "$CLI" restore "$S5_SNAP_DIR" >"$S5_RESTORE_LOG" 2>&1 &
   S5_RESTORE_PID=$!
   cleanup_s5_restore() {
     kill -TERM "$S5_RESTORE_PID" 2>/dev/null || true


### PR DESCRIPTION
## Problem

When you copy a running virtual machine — we call this *forking* — the copy used to load the original's entire memory into your computer's RAM up front. If the original had used 8 GB at any point, every copy cost 8 GB on startup, even if the copy was about to do almost nothing. A script that made five copies could pin 40 GB before any of them did real work.

A previous change (issue #266) added an *on-demand* mode: a copy only loads a memory page when it actually touches it. That worked, but you had to opt in by passing `--lazy-pages` every time. The umbrella issue for this whole memory effort, #263, asks for on-demand to be the **default**, so the user never has to think about it.

## Solution

1. On-demand restore is now the default for both `restore()` and `fork()`. Memory pages stream into the copy only when it touches them, so a copy that does nothing costs almost nothing.
2. The opt-out is a single flag: `--eager` on the command line, or `eager: true` in code. When set, the copy loads everything up front, the way it used to.
3. The old `--lazy-pages` flag is removed. It was the opt-in for this same behaviour, and the behaviour is the default now.

## Known constraint

`machinen fork --detach` still uses the eager path. Here's why: on-demand mode needs a small server running in the host process to feed memory pages to the copy when it asks for them. `--detach` exits the host process by design, which would leave the copy stuck waiting on a server that no longer exists. The command-line tool catches this and quietly switches to eager whenever you pass `--detach`. Removing this restriction is part of issue #150 phase 3 (teaching the page server to outlive the process that started it). A note has been added to #263 explaining the gap.

## Test plan

- [x] Unit tests: `npx vitest run` — 479 pass.
- [x] Workflow checks: `npx agent-ci run --all -q -p` — 4 of 4 pass.
- [x] End-to-end smoke tests: `pnpm smoke-tests` — S0 through S5 all pass. The headline check forks a parent that dirtied 2048 MB of memory and shows the copy uses only 692 MB on the host, saving 1659 MB.

## Cleanup after merge

- Close #263. The remaining items on that issue (memory observability, fork backpressure) have been split into #274.