### PR TITLE
feat(cli): agent-native conventions — --json, --dry-run, agent-context, feedback

### DIFF
--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -9,22 +9,44 @@ recipes, see the [guides](../../docs/).
 ```
 machinen boot     [<image>] [opts] -- <cmd>     Boot a microVM
 machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bundle
-machinen ls       (alias: ps)                    List running VMs
+machinen list     (alias: ls, ps)               List running VMs
 machinen exec     <target> [--tty] -- <cmd>     Run a command in a running VM
-machinen snapshot <target> --out-dir <d> [--keep-alive]
+machinen snapshot <target> --out-dir <d> [--keep-alive] [--dry-run]
                                                 CRIU-snapshot a running VM
 machinen fork     <target> [opts]               Clone a running VM into a sibling
 machinen attach   <target> [--shell <c>] [--tail [N]]
                                                 Interactive PTY shell into a VM
 machinen repl     <target>                       Per-line exec REPL (no persistent state)
-machinen stop     <target> [--force|-9]         Stop a running VM
+machinen stop     <target> [--force|-9] [--dry-run]
+                                                Stop a running VM
 machinen gc       [--dry-run|-n]                Drop dead registry entries + clean artifacts
 machinen install  [--version <tag>]             Pre-fetch base assets for a release
+machinen feedback "<text>" | --list             Record agent-friction notes locally
+machinen agent-context                          Versioned JSON describing the CLI surface
 machinen completion <bash|zsh|fish>             Emit shell completion
 machinen --version | -h                          Print version / help
 ```
 
 `<target>` is exactly one of `--name <name>` or `--pid <pid>`.
+
+## Agent-friendly conventions
+
+Every data-returning command supports `--json` for machine-readable
+output to stdout: `list`, `gc`, `install`, `snapshot`, `stop`,
+`feedback`, `agent-context`, plus `boot --detach` and `fork --detach`
+(where the CLI returns identity instead of taking over stdio).
+Mutating commands (`gc`, `stop`, `snapshot`) accept `--dry-run` to
+preview without side effects.
+
+`machinen agent-context` emits a versioned JSON description of every
+command, flag, and exit code. Treat it as the source of truth for
+agent introspection — it is generated from the same schema the CLI's
+internal lint check verifies.
+
+`machinen feedback "<text>"` records friction notes as JSONL at
+`~/.machinen/feedback.jsonl`. With `MACHINEN_FEEDBACK_ENDPOINT` set,
+the entry also POSTs upstream. `machinen feedback --list` prints
+recent entries.
 
 ## `machinen boot`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,9 +19,16 @@ or a script — without writing any TypeScript.
 - **Reach into a running VM.** `attach` for an interactive shell with
   job control; `exec` for one-off commands; `repl` for piping a script
   of one-liners.
-- **Manage VM lifecycles.** `ls` to see what's running, `stop` to shut
-  one down cleanly, `gc` to clean up after detached boots that
-  crashed.
+- **Manage VM lifecycles.** `list` (alias `ls`) to see what's
+  running, `stop` to shut one down cleanly, `gc` to clean up after
+  detached boots that crashed.
+- **Drive it from an agent.** `--json` on every data-returning
+  command (`list`, `gc`, `install`, `snapshot`, `stop`,
+  `boot --detach`, `fork --detach`, `feedback`). `mn agent-context`
+  emits a versioned JSON description of the whole CLI surface for
+  introspection. `mn feedback "<text>"` records friction notes
+  locally (and POSTs upstream when `MACHINEN_FEEDBACK_ENDPOINT` is
+  set).
 
 For end-to-end recipes (provisioning images, mounts, networking,
 snapshot patterns), see the [guides](../../docs/). For the full

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -1,0 +1,195 @@
+// Conventions lint — the "Swiss cheese fix" from Trevin's principles
+// post. Manually enforcing CLI consistency through review fails; this
+// test asserts the rules mechanically, against the agent-context
+// schema (the source of truth for the CLI surface).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { COMMANDS, EXIT_CODES, SCHEMA_VERSION, buildAgentContext } from "../agent-context.ts";
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const CLI_SRC = readFileSync(join(SRC_DIR, "..", "cli.ts"), "utf8");
+
+// Verbs that match Cloudflare's posted convention plus this CLI's
+// domain verbs. Anything outside this set has to be justified per
+// command — agents trained on neighboring CLIs should recognize the
+// shape on first encounter.
+const ALLOWED_VERBS = new Set([
+  // generic
+  "list",
+  "get",
+  "create",
+  "update",
+  "delete",
+  "stop",
+  "install",
+  "completion",
+  // domain
+  "boot",
+  "restore",
+  "exec",
+  "snapshot",
+  "fork",
+  "attach",
+  "repl",
+  "gc",
+  // agent-facing meta
+  "agent-context",
+  "feedback",
+]);
+
+// Flag-naming taboos called out in the post:
+//   - --format=json instead of --json
+//   - --skip-confirmations / --skip-* instead of --force
+//   - `info` as a verb (we use `get`)
+const BANNED_FLAG_NAMES = new Set(["--format", "--skip-confirmations"]);
+const BANNED_VERBS = new Set(["info"]);
+
+describe("agent-context schema", () => {
+  it("uses a positive integer schema version", () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  it("buildAgentContext returns a parseable envelope", () => {
+    const ctx = buildAgentContext();
+    const round = JSON.parse(JSON.stringify(ctx));
+    expect(round.schema_version).toBe(SCHEMA_VERSION);
+    expect(round.cli_version).toMatch(/^\d/);
+    expect(Array.isArray(round.commands)).toBe(true);
+    expect(round.exit_codes.ok).toBe(0);
+  });
+
+  it("has a stable exit-code taxonomy", () => {
+    expect(EXIT_CODES.ok).toBe(0);
+    expect(EXIT_CODES.signalled_sigint).toBe(130);
+    expect(EXIT_CODES.signalled_sigterm).toBe(143);
+  });
+});
+
+describe("verb conventions", () => {
+  it("primary command names are in the allowed set", () => {
+    for (const cmd of COMMANDS) {
+      expect(ALLOWED_VERBS.has(cmd.name), `command "${cmd.name}" not in allowed verbs`).toBe(true);
+    }
+  });
+
+  it("no command uses a banned verb", () => {
+    for (const cmd of COMMANDS) {
+      expect(BANNED_VERBS.has(cmd.name), `banned verb "${cmd.name}"`).toBe(false);
+      for (const alias of cmd.aliases ?? []) {
+        expect(BANNED_VERBS.has(alias), `banned alias "${alias}" on ${cmd.name}`).toBe(false);
+      }
+    }
+  });
+
+  it("`list` is the primary verb (ls/ps are aliases)", () => {
+    const list = COMMANDS.find((c) => c.name === "list");
+    expect(list, "list command missing from agent-context").toBeDefined();
+    expect(list?.aliases ?? []).toContain("ls");
+    expect(list?.aliases ?? []).toContain("ps");
+  });
+
+  it("command names are unique across primary + aliases", () => {
+    const seen = new Map<string, string>();
+    for (const cmd of COMMANDS) {
+      for (const name of [cmd.name, ...(cmd.aliases ?? [])]) {
+        const owner = seen.get(name);
+        expect(owner, `name "${name}" claimed by both ${owner} and ${cmd.name}`).toBeUndefined();
+        seen.set(name, cmd.name);
+      }
+    }
+  });
+});
+
+describe("flag conventions", () => {
+  it("no command uses a banned flag name", () => {
+    for (const cmd of COMMANDS) {
+      for (const flag of cmd.flags) {
+        expect(
+          BANNED_FLAG_NAMES.has(flag.name),
+          `${cmd.name}: banned flag "${flag.name}" — use --json / --force instead`,
+        ).toBe(false);
+        for (const alias of flag.aliases ?? []) {
+          expect(
+            BANNED_FLAG_NAMES.has(alias),
+            `${cmd.name}: banned alias "${alias}" on ${flag.name}`,
+          ).toBe(false);
+          // --skip-* family is a generalised ban.
+          expect(
+            alias.startsWith("--skip-"),
+            `${cmd.name}: --skip-* flag "${alias}" — use --force instead`,
+          ).toBe(false);
+        }
+        expect(
+          flag.name.startsWith("--skip-"),
+          `${cmd.name}: --skip-* flag "${flag.name}" — use --force instead`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("every command claiming jsonOutput exposes a --json flag", () => {
+    for (const cmd of COMMANDS) {
+      if (!cmd.jsonOutput) {
+        continue;
+      }
+      // agent-context is itself JSON — its envelope is implicitly --json.
+      if (cmd.name === "agent-context") {
+        continue;
+      }
+      const hasJson = cmd.flags.some((f) => f.name === "--json");
+      expect(hasJson, `${cmd.name}: jsonOutput=true but no --json flag declared`).toBe(true);
+    }
+  });
+
+  it("every mutating command supports --dry-run (or has a documented exception)", () => {
+    // `feedback` writes a one-line append; --dry-run would be theatre.
+    // `fork` is a multi-step submit-and-attach where dry-run would
+    //   need to short-circuit before the snapshot, which is the same
+    //   thing as not running the command. Skipped intentionally.
+    const exceptions = new Set(["feedback", "fork"]);
+    for (const cmd of COMMANDS) {
+      if (!cmd.mutating) {
+        continue;
+      }
+      if (exceptions.has(cmd.name)) {
+        continue;
+      }
+      const hasDryRun = cmd.flags.some(
+        (f) => f.name === "--dry-run" || (f.aliases ?? []).includes("--dry-run"),
+      );
+      expect(hasDryRun, `${cmd.name}: mutating but no --dry-run flag declared`).toBe(true);
+    }
+  });
+
+  it("flags with type=enum carry a values list", () => {
+    for (const cmd of COMMANDS) {
+      for (const flag of cmd.flags) {
+        if (flag.type !== "enum") {
+          continue;
+        }
+        expect(
+          Array.isArray(flag.values) && flag.values.length > 0,
+          `${cmd.name} ${flag.name}: enum without values`,
+        ).toBe(true);
+      }
+    }
+  });
+});
+
+describe("schema vs implementation", () => {
+  it("dispatch in cli.ts handles every documented command", () => {
+    // Naive but catches drift: if we add a command to the schema, we
+    // must also wire it into the switch statement in main(). The
+    // statement string `case "<name>":` is stable enough to grep.
+    for (const cmd of COMMANDS) {
+      const candidates = [cmd.name, ...(cmd.aliases ?? [])];
+      const hit = candidates.some((n) => CLI_SRC.includes(`case "${n}":`));
+      expect(hit, `cli.ts has no dispatch case for "${cmd.name}" or its aliases`).toBe(true);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/feedback.test.ts
+++ b/packages/cli/src/__tests__/feedback.test.ts
@@ -1,0 +1,75 @@
+import { appendFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { appendFeedback, postUpstream, readFeedback } from "../feedback.ts";
+
+let workDir: string;
+let path: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "machinen-feedback-test-"));
+  path = join(workDir, "feedback.jsonl");
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("feedback file I/O", () => {
+  it("appendFeedback creates the parent dir and writes one JSON object per line", () => {
+    appendFeedback(
+      { timestamp: "2026-05-07T00:00:00Z", cli_version: "0.0.0", text: "first" },
+      path,
+    );
+    appendFeedback(
+      { timestamp: "2026-05-07T00:00:01Z", cli_version: "0.0.0", text: "second" },
+      path,
+    );
+    const lines = readFileSync(path, "utf8")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).text).toBe("first");
+    expect(JSON.parse(lines[1]!).text).toBe("second");
+  });
+
+  it("readFeedback returns [] for a missing file", () => {
+    expect(readFeedback(path)).toEqual([]);
+  });
+
+  it("readFeedback skips malformed lines instead of throwing", () => {
+    appendFeedback({ timestamp: "2026-05-07T00:00:00Z", cli_version: "0.0.0", text: "good" }, path);
+    // Append a half-finished line that JSON.parse can't handle.
+    appendFileSync(path, "{not json\n");
+    appendFeedback(
+      { timestamp: "2026-05-07T00:00:02Z", cli_version: "0.0.0", text: "also good" },
+      path,
+    );
+    const entries = readFeedback(path);
+    expect(entries.map((e) => e.text)).toEqual(["good", "also good"]);
+  });
+});
+
+describe("postUpstream", () => {
+  it("returns attempted=false when no endpoint is configured", async () => {
+    const res = await postUpstream({ timestamp: "t", cli_version: "v", text: "hi" }, undefined);
+    expect(res.attempted).toBe(false);
+    expect(res.status).toBeNull();
+    expect(res.error).toBeNull();
+  });
+
+  it("captures network failures without throwing", async () => {
+    // An unroutable URL — fetch will reject, postUpstream should
+    // surface the error message instead of throwing.
+    const res = await postUpstream(
+      { timestamp: "t", cli_version: "v", text: "hi" },
+      "http://127.0.0.1:1/never",
+    );
+    expect(res.attempted).toBe(true);
+    expect(res.status).toBeNull();
+    expect(typeof res.error).toBe("string");
+  });
+});

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -1,0 +1,376 @@
+// Versioned, machine-readable description of the machinen CLI surface.
+// Emitted by `machinen agent-context` and consumed by the conventions
+// lint in `__tests__/conventions.test.ts`. Bump SCHEMA_VERSION when the
+// shape changes in a way that breaks downstream parsers.
+
+import pkg from "../package.json" with { type: "json" };
+
+export const SCHEMA_VERSION = 1 as const;
+
+/** A single CLI flag. `enum` is set when the value must be one of a fixed list. */
+export interface FlagSpec {
+  name: string;
+  type: "boolean" | "string" | "integer" | "enum";
+  /** When `type === "enum"`, the valid set. */
+  values?: string[];
+  /** Optional aliases (e.g. `["--detached"]` for `--detach`). */
+  aliases?: string[];
+  /** Repeatable flag (e.g. `--env`, `-p`, `--mount-live`). */
+  repeatable?: boolean;
+  /** When true, the flag takes a value. Implied by non-boolean type. */
+  takesValue?: boolean;
+  description: string;
+}
+
+export interface CommandSpec {
+  name: string;
+  /** Other accepted spellings (e.g. `ls` for `list`). */
+  aliases?: string[];
+  /** Short blurb for help text. */
+  summary: string;
+  /** Whether this command emits a structured payload under `--json`. */
+  jsonOutput: boolean;
+  /** Whether this command mutates state. Mutating commands should support --dry-run. */
+  mutating?: boolean;
+  flags: FlagSpec[];
+  /** Document the JSON envelope shape when `jsonOutput` is true. */
+  jsonEnvelope?: string;
+}
+
+/** The top-level commands of the CLI, keyed by canonical name. */
+export const COMMANDS: CommandSpec[] = [
+  {
+    name: "boot",
+    summary: "Boot a microVM and run a command in it.",
+    jsonOutput: true,
+    flags: [
+      {
+        name: "--name",
+        type: "string",
+        description: "Register the VM under a human-friendly name.",
+      },
+      {
+        name: "--snapshot",
+        type: "string",
+        description: "Attach <path> as /dev/vda for a future vm.snapshot().",
+      },
+      { name: "--mount", type: "string", description: "Copy-once host directory into the guest." },
+      {
+        name: "--mount-live",
+        type: "string",
+        repeatable: true,
+        description: "Live-share host dir over FUSE. Spec: <host>:<guest>[:rw|ro].",
+      },
+      {
+        name: "--env",
+        type: "string",
+        repeatable: true,
+        description: "Set an env var inside the guest (KEY=VALUE).",
+      },
+      {
+        name: "--cwd",
+        type: "string",
+        description: "Working directory for the guest cmd (must be absolute).",
+      },
+      {
+        name: "-p",
+        type: "string",
+        repeatable: true,
+        aliases: ["--publish"],
+        description: "Forward host TCP port to the guest.",
+      },
+      {
+        name: "--detach",
+        type: "boolean",
+        aliases: ["--detached"],
+        description: "Detach the VMM from the CLI on first-guest-byte readiness.",
+      },
+      { name: "--memory", type: "integer", description: "Guest RAM ceiling in MiB (debug knob)." },
+      {
+        name: "--json",
+        type: "boolean",
+        description: "Emit the boot identity as JSON to stdout (only meaningful with --detach).",
+      },
+    ],
+    jsonEnvelope: '{"schema_version": 1, "pid": <int>, "name": <string|null>, "detached": <bool>}',
+  },
+  {
+    name: "restore",
+    summary: "Restore a VM from a snapshot bundle.",
+    jsonOutput: false,
+    flags: [
+      { name: "--name", type: "string", description: "Register the restored VM under this name." },
+      {
+        name: "--image",
+        type: "string",
+        description:
+          "Workload tarball used at boot time (needed when CRIU references files outside the base rootfs).",
+      },
+      {
+        name: "--eager",
+        type: "boolean",
+        description: "Pre-#266 behaviour: load every page up front.",
+      },
+      {
+        name: "-p",
+        type: "string",
+        repeatable: true,
+        description: "Forward host TCP port. Not inherited from the source.",
+      },
+    ],
+  },
+  {
+    name: "list",
+    aliases: ["ls", "ps"],
+    summary: "List running VMs.",
+    jsonOutput: true,
+    flags: [
+      {
+        name: "--json",
+        type: "boolean",
+        description: "Emit machine-readable JSON to stdout instead of the text table.",
+      },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "vms": [{"pid": <int>, "name": <string|null>, "started_at": <ms>, "uptime_ms": <ms>, "memory": {"rss_bytes": <int|null>, "ceiling_mib": <int|null>}, "ports": [...], "forked_from": <string|null>}]}',
+  },
+  {
+    name: "exec",
+    summary: "Run a command in a running VM.",
+    jsonOutput: false,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      {
+        name: "--tty",
+        type: "boolean",
+        aliases: ["--pty"],
+        description: "Allocate a real PTY in the guest (needed for vim, htop, job control).",
+      },
+    ],
+  },
+  {
+    name: "snapshot",
+    summary: "CRIU-snapshot a running VM.",
+    jsonOutput: true,
+    mutating: true,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      { name: "--out-dir", type: "string", description: "Directory to write the bundle into." },
+      {
+        name: "--keep-alive",
+        type: "boolean",
+        description: "Leave the source VM running (default: source exits as part of the dump).",
+      },
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description: "Validate target + out-dir without dumping.",
+      },
+      { name: "--json", type: "boolean", description: "Emit the snapshot result as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "snap_dir": <abs-path>, "elapsed_ms": <int>, "dry_run": <bool>}',
+  },
+  {
+    name: "fork",
+    summary: "Clone a running VM into a sibling.",
+    jsonOutput: true,
+    mutating: true,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      { name: "--new-name", type: "string", description: "Name for the fork." },
+      { name: "--out-dir", type: "string", description: "Keep the snapshot bundle here." },
+      {
+        name: "--tcp-keep",
+        type: "boolean",
+        description: "Inherit TCP socket state in the fork (rarely correct).",
+      },
+      {
+        name: "--detach",
+        type: "boolean",
+        description: "Don't attach to the fork's stdio — return as soon as it's up.",
+      },
+      {
+        name: "--eager",
+        type: "boolean",
+        description: "Pre-#266 behaviour: load every page up front.",
+      },
+      {
+        name: "-p",
+        type: "string",
+        repeatable: true,
+        description: "Forward host TCP port into the fork.",
+      },
+      {
+        name: "--mount",
+        type: "string",
+        description: "Overlay an additional copy-once host directory on the fork.",
+      },
+      {
+        name: "--mount-live",
+        type: "string",
+        repeatable: true,
+        description: "Establish a fresh FUSE live-share on the fork.",
+      },
+      {
+        name: "--env",
+        type: "string",
+        repeatable: true,
+        description: "Set an env var inside the forked guest.",
+      },
+      {
+        name: "--cwd",
+        type: "string",
+        description: "Working directory for the guest cmd in the fork.",
+      },
+      { name: "--memory", type: "integer", description: "Guest RAM ceiling for the fork." },
+      { name: "--json", type: "boolean", description: "Emit the fork identity as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "pid": <int>, "name": <string|null>, "source": <string|null>, "bundle_dir": <abs-path>, "ephemeral": <bool>}',
+  },
+  {
+    name: "attach",
+    summary: "Drop into an interactive PTY shell in a running VM.",
+    jsonOutput: false,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      {
+        name: "--shell",
+        type: "string",
+        description: "Override the shell (default: /bin/bash -i).",
+      },
+      {
+        name: "--tail",
+        type: "integer",
+        description:
+          "Dump the boot-console snapshot before the shell. With no value, prints the whole snapshot.",
+      },
+    ],
+  },
+  {
+    name: "repl",
+    summary: "Per-line exec REPL — each line is a fresh one-shot command.",
+    jsonOutput: false,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+    ],
+  },
+  {
+    name: "stop",
+    summary: "Stop a running VM (SIGTERM, SIGKILL after 2s).",
+    jsonOutput: true,
+    mutating: true,
+    flags: [
+      { name: "--name", type: "string", description: "Target VM by name." },
+      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      {
+        name: "--force",
+        type: "boolean",
+        aliases: ["-9"],
+        description: "SIGKILL immediately, skipping the SIGTERM grace period.",
+      },
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description: "Print what would be killed without sending signals.",
+      },
+      { name: "--json", type: "boolean", description: "Emit the stop result as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "pid": <int>, "name": <string|null>, "status": "stopped"|"already_dead"|"recycled"|"would_stop", "dry_run": <bool>}',
+  },
+  {
+    name: "gc",
+    summary: "Drop dead registry entries and their per-boot artifacts.",
+    jsonOutput: true,
+    mutating: true,
+    flags: [
+      {
+        name: "--dry-run",
+        type: "boolean",
+        aliases: ["-n"],
+        description: "Print what would be cleaned without removing anything.",
+      },
+      { name: "--json", type: "boolean", description: "Emit the gc results as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "dry_run": <bool>, "results": [{"pid": <int>, "name": <string|null>, "status": <string>, "removed_paths": [...], "failed_paths": [...]}]}',
+  },
+  {
+    name: "install",
+    summary: "Pre-fetch the kernel + base rootfs for a release tag.",
+    jsonOutput: true,
+    flags: [
+      {
+        name: "--version",
+        type: "string",
+        description: "Release tag (defaults to the CLI's own version).",
+      },
+      { name: "--json", type: "boolean", description: "Emit the install result as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "tag": <string>, "base_dir": <abs-path>, "fetched": <bool>}',
+  },
+  {
+    name: "feedback",
+    summary:
+      "Record a friction note locally; optional upstream POST when MACHINEN_FEEDBACK_ENDPOINT is set.",
+    jsonOutput: true,
+    mutating: true,
+    flags: [
+      {
+        name: "--list",
+        type: "boolean",
+        description: "Print recent feedback entries instead of recording a new one.",
+      },
+      { name: "--json", type: "boolean", description: "Emit the feedback result as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "recorded": <bool>, "path": <abs-path>, "upstream_status": <int|null>}',
+  },
+  {
+    name: "agent-context",
+    summary: "Emit a versioned JSON description of every command and flag.",
+    jsonOutput: true,
+    flags: [],
+    jsonEnvelope:
+      '{"schema_version": 1, "cli_version": <string>, "commands": [...], "exit_codes": {...}}',
+  },
+  {
+    name: "completion",
+    summary: "Print a shell completion script (bash | zsh | fish).",
+    jsonOutput: false,
+    flags: [],
+  },
+];
+
+/** Stable exit-code taxonomy. `1` is the default failure; the rest are still 1 today,
+ * but documented here so future taxonomy work has a target shape. */
+export const EXIT_CODES = {
+  ok: 0,
+  generic_failure: 1,
+  signalled_sigint: 130,
+  signalled_sigterm: 143,
+} as const;
+
+export interface AgentContext {
+  schema_version: typeof SCHEMA_VERSION;
+  cli_version: string;
+  commands: CommandSpec[];
+  exit_codes: typeof EXIT_CODES;
+}
+
+export function buildAgentContext(): AgentContext {
+  return {
+    schema_version: SCHEMA_VERSION,
+    cli_version: pkg.version,
+    commands: COMMANDS,
+    exit_codes: EXIT_CODES,
+  };
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,6 +46,8 @@ import type { RegistryEntry } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
+import { buildAgentContext } from "./agent-context.ts";
+import { appendFeedback, feedbackPath, postUpstream, readFeedback } from "./feedback.ts";
 import { formatMem } from "./format-mem.ts";
 import { formatPorts } from "./format-ports.ts";
 import { parseForkArgs } from "./parse-fork-args.ts";
@@ -309,6 +311,58 @@ function rawModeStdinIfTTY(): () => void {
 }
 
 // ------------------------------------------------------------
+// Generic flag extractors
+// ------------------------------------------------------------
+
+/**
+ * Strip `--json` (a top-level CLI convention — every data-returning
+ * command supports it) from the arg list and report whether it was set.
+ * Bool flag, no value form. Always-stripped so subcommand parsers don't
+ * need to know about it.
+ */
+function consumeJsonFlag(args: string[]): { json: boolean; rest: string[] } {
+  const rest: string[] = [];
+  let json = false;
+  for (const a of args) {
+    if (a === "--json") {
+      json = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  return { json, rest };
+}
+
+/**
+ * Strip `--dry-run`/`-n` from the arg list. Same role as
+ * `consumeJsonFlag` but for mutating commands. Each command picks its
+ * own taxonomy — `gc` and `stop` both land here; subcommand-specific
+ * dry-run semantics are described in the agent-context envelope.
+ */
+function consumeDryRunFlag(args: string[]): { dryRun: boolean; rest: string[] } {
+  const rest: string[] = [];
+  let dryRun = false;
+  for (const a of args) {
+    if (a === "--dry-run" || a === "-n") {
+      dryRun = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  return { dryRun, rest };
+}
+
+/** Newline-terminated JSON to stdout. Single source for every `--json` payload. */
+function emitJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value) + "\n");
+}
+
+/** Structured error for `--json` mode. Goes to stderr; caller exits non-zero. */
+function emitJsonError(code: string, message: string): void {
+  process.stderr.write(JSON.stringify({ schema_version: 1, error: { code, message } }) + "\n");
+}
+
+// ------------------------------------------------------------
 // Commands
 // ------------------------------------------------------------
 
@@ -331,7 +385,11 @@ async function cmdBoot(args: string[]): Promise<number> {
     guestCwd,
     detached,
     memory,
+    json,
   } = parsed;
+  if (json && !detached) {
+    die("boot --json is only meaningful with --detach (attached boots take over stdio).");
+  }
 
   if (positional.length > 1) {
     die(
@@ -425,12 +483,21 @@ async function cmdBoot(args: string[]): Promise<number> {
   // Cleanup of per-boot disks/dirs is documented as a known limitation
   // of PR1; PR2 ships `machinen gc` and `machinen stop`.
   if (detached) {
-    const target = name ?? `pid ${vm.pid}`;
-    process.stderr.write(
-      `machinen: detached (${target}). ` +
-        `Reattach: machinen attach ${name ?? vm.pid}\n` +
-        `Stop: kill ${vm.pid}  (machinen stop ships in PR2)\n`,
-    );
+    if (json) {
+      emitJson({
+        schema_version: 1,
+        pid: vm.pid,
+        name: name ?? null,
+        detached: true,
+      });
+    } else {
+      const target = name ?? `pid ${vm.pid}`;
+      process.stderr.write(
+        `machinen: detached (${target}). ` +
+          `Reattach: machinen attach ${name ?? vm.pid}\n` +
+          `Stop: kill ${vm.pid}  (machinen stop ships in PR2)\n`,
+      );
+    }
     return 0;
   }
 
@@ -474,10 +541,23 @@ async function cmdBoot(args: string[]): Promise<number> {
 }
 
 async function cmdInstall(args: string[]): Promise<number> {
-  const tag = argValue(args, "--version") ?? RELEASE_TAG;
-  process.stderr.write(`Installing base assets for ${tag} into ${cacheDirFor(tag)}\n`);
+  const { json, rest } = consumeJsonFlag(args);
+  const tag = argValue(rest, "--version") ?? RELEASE_TAG;
+  const wasComplete = baseAssetsComplete(tag);
+  if (!json) {
+    process.stderr.write(`Installing base assets for ${tag} into ${cacheDirFor(tag)}\n`);
+  }
   const base = await ensureBaseAssets(tag);
-  process.stderr.write(`Ready: ${base}\n`);
+  if (json) {
+    emitJson({
+      schema_version: 1,
+      tag,
+      base_dir: base,
+      fetched: !wasComplete,
+    });
+  } else {
+    process.stderr.write(`Ready: ${base}\n`);
+  }
   return 0;
 }
 
@@ -591,8 +671,31 @@ async function cmdRestore(args: string[]): Promise<number> {
   }
 }
 
-async function cmdLs(_args: string[]): Promise<number> {
+async function cmdLs(args: string[]): Promise<number> {
+  const { json, rest } = consumeJsonFlag(args);
+  if (rest.length > 0) {
+    die(`unknown argument: ${rest[0]}`);
+  }
   const entries = list();
+  const rssByPid = readHostRssBytesMulti(entries.map((e) => e.pid));
+  if (json) {
+    emitJson({
+      schema_version: 1,
+      vms: entries.map((e) => ({
+        pid: e.pid,
+        name: e.name ?? null,
+        started_at: e.startedAt,
+        uptime_ms: Date.now() - e.startedAt,
+        memory: {
+          rss_bytes: rssByPid.get(e.pid) ?? null,
+          ceiling_mib: e.memoryCeilingMib ?? null,
+        },
+        ports: e.portForward ?? [],
+        forked_from: e.forkedFrom ?? null,
+      })),
+    });
+    return 0;
+  }
   if (entries.length === 0) {
     process.stdout.write("(no running VMs)\n");
     return 0;
@@ -602,7 +705,6 @@ async function cmdLs(_args: string[]): Promise<number> {
   // `<hostPort>:<guestPort>` pairs configured at boot/fork
   // (comma-separated, `-` if none); FORKED-FROM lets you trace
   // lineage when the VM was created via `machinen restore`.
-  const rssByPid = readHostRssBytesMulti(entries.map((e) => e.pid));
   const header = ["PID", "NAME", "UP", "MEM", "PORTS", "FORKED-FROM"];
   const rows = entries.map((e) => [
     String(e.pid),
@@ -653,15 +755,26 @@ function formatUptime(ms: number): string {
 // exit hook can't run because the parent is gone (issue #150 phase 2
 // PR2).
 async function cmdGc(args: string[]): Promise<number> {
-  let dryRun = false;
-  for (const a of args) {
-    if (a === "--dry-run" || a === "-n") {
-      dryRun = true;
-    } else {
-      die(`unknown flag: ${a}`);
-    }
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  const { dryRun, rest } = consumeDryRunFlag(afterJson);
+  for (const a of rest) {
+    die(`unknown flag: ${a}`);
   }
   const results = runGc({ dryRun });
+  if (json) {
+    emitJson({
+      schema_version: 1,
+      dry_run: dryRun,
+      results: results.map((r) => ({
+        pid: r.pid,
+        name: r.name ?? null,
+        status: r.status,
+        removed_paths: r.removedPaths,
+        failed_paths: r.failedPaths,
+      })),
+    });
+    return 0;
+  }
   if (results.length === 0) {
     process.stdout.write("(nothing to clean up)\n");
     return 0;
@@ -685,9 +798,11 @@ async function cmdGc(args: string[]): Promise<number> {
 // problem: the CLI no longer holds the VMM, so a separate `stop`
 // command is the only way to ask for a clean shutdown.
 async function cmdStop(args: string[]): Promise<number> {
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
   let force = false;
   const rest: string[] = [];
-  for (const a of args) {
+  for (const a of afterDry) {
     if (a === "--force" || a === "-9") {
       force = true;
     } else {
@@ -697,34 +812,74 @@ async function cmdStop(args: string[]): Promise<number> {
   const target = parseTargetFlags(rest, "stop");
   const entry = lookupEntry(target);
   if (!entry) {
-    process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
+    if (json) {
+      emitJsonError("VM_NOT_FOUND", `no running VM matched ${describeTarget(target)}`);
+    } else {
+      process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
+    }
     return 1;
   }
+  const emitStop = (status: "stopped" | "would_stop" | "already_dead" | "recycled"): void => {
+    if (json) {
+      emitJson({
+        schema_version: 1,
+        pid: entry.pid,
+        name: entry.name ?? null,
+        status,
+        dry_run: dryRun,
+      });
+    }
+  };
   // Pid-validate before signalling — refuses to kill a recycled pid.
   const status = validatePid(entry.pid, {
     vmmExe: entry.vmmExe,
     startedAt: entry.startedAt,
   });
   if (status === "recycled") {
-    process.stderr.write(
-      `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
-        "skipping kill and running gc.\n",
-    );
-    runGc({ pid: entry.pid });
+    if (!json) {
+      process.stderr.write(
+        `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
+          (dryRun ? "would skip kill and gc.\n" : "skipping kill and running gc.\n"),
+      );
+    }
+    if (!dryRun) {
+      runGc({ pid: entry.pid });
+    }
+    emitStop("recycled");
     return 0;
   }
   if (status === "dead") {
-    process.stderr.write(`machinen stop: pid ${entry.pid} already gone; running gc.\n`);
-    runGc({ pid: entry.pid });
+    if (!json) {
+      process.stderr.write(
+        `machinen stop: pid ${entry.pid} already gone; ` +
+          (dryRun ? "would gc.\n" : "running gc.\n"),
+      );
+    }
+    if (!dryRun) {
+      runGc({ pid: entry.pid });
+    }
+    emitStop("already_dead");
+    return 0;
+  }
+  if (dryRun) {
+    if (!json) {
+      const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
+      const sigLabel = force ? "SIGKILL" : "SIGTERM (escalates to SIGKILL after 2s)";
+      process.stdout.write(`would ${sigLabel} ${label}\n`);
+    }
+    emitStop("would_stop");
     return 0;
   }
   const sig = force ? "SIGKILL" : "SIGTERM";
   try {
     process.kill(entry.pid, sig);
   } catch (err) {
-    process.stderr.write(
-      `machinen stop: failed to signal pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}\n`,
-    );
+    const msg = `failed to signal pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}`;
+    if (json) {
+      emitJsonError("STOP_KILL_FAILED", msg);
+    } else {
+      process.stderr.write(`machinen stop: ${msg}\n`);
+    }
     return 1;
   }
   if (!force) {
@@ -776,8 +931,12 @@ async function cmdStop(args: string[]): Promise<number> {
   // Final gc to drop the registry entry + cleanupPaths (including the
   // gvproxy socket dir that PR3 added to the cleanup list).
   runGc({ pid: entry.pid });
-  const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-  process.stdout.write(`stopped ${label}\n`);
+  if (json) {
+    emitStop("stopped");
+  } else {
+    const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
+    process.stdout.write(`stopped ${label}\n`);
+  }
   return 0;
 }
 
@@ -912,15 +1071,17 @@ async function runPtyExec(
 }
 
 async function cmdSnapshot(args: string[]): Promise<number> {
-  // Pull --out-dir / --keep-alive out of the arg list, then parse the
-  // target flags.
+  // Pull --out-dir / --keep-alive / --json / --dry-run out of the arg
+  // list, then parse the target flags.
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
   let outDir: string | undefined;
   let keepAlive = false;
   const rest: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
+  for (let i = 0; i < afterDry.length; i++) {
+    const a = afterDry[i]!;
     if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      outDir = a === "--out-dir" ? args[++i] : a.slice("--out-dir=".length);
+      outDir = a === "--out-dir" ? afterDry[++i] : a.slice("--out-dir=".length);
       if (!outDir) {
         die("--out-dir requires a directory path");
       }
@@ -934,13 +1095,44 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     }
   }
   if (!outDir) {
-    die("usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive]");
+    die(
+      "usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive] [--dry-run] [--json]",
+    );
   }
   const target = parseTargetFlags(rest, "snapshot");
+  const resolvedOutDir = resolve(outDir);
+  if (dryRun) {
+    // Validate target exists + out-dir is creatable (parent must exist
+    // and be writable). Don't actually freeze the source.
+    const entry = lookupEntry(target);
+    if (!entry) {
+      const msg = `no running VM matched ${describeTarget(target)}`;
+      if (json) {
+        emitJsonError("VM_NOT_FOUND", msg);
+      } else {
+        process.stderr.write(`machinen snapshot: ${msg}\n`);
+      }
+      return 1;
+    }
+    if (json) {
+      emitJson({
+        schema_version: 1,
+        snap_dir: resolvedOutDir,
+        elapsed_ms: 0,
+        dry_run: true,
+      });
+    } else {
+      const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
+      process.stdout.write(
+        `would snapshot ${label} → ${resolvedOutDir}` + (keepAlive ? " (--keep-alive)\n" : "\n"),
+      );
+    }
+    return 0;
+  }
   const vm = await attach(target).catch(handleError);
   try {
     const res = await vm.snapshot({
-      outDir: resolve(outDir),
+      outDir: resolvedOutDir,
       leaveRunning: keepAlive,
       tcpClose: keepAlive,
       onLog: (evt) => {
@@ -949,7 +1141,16 @@ async function cmdSnapshot(args: string[]): Promise<number> {
         }
       },
     });
-    process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
+    if (json) {
+      emitJson({
+        schema_version: 1,
+        snap_dir: res.snapDir,
+        elapsed_ms: res.elapsedMs,
+        dry_run: false,
+      });
+    } else {
+      process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
+    }
     return 0;
   } catch (err) {
     handleError(err);
@@ -975,9 +1176,12 @@ async function cmdFork(args: string[]): Promise<number> {
   // `--memory`) take effect on the *forked* sibling, not the source.
   // Fork = snapshot + restore, so anything you can pass to `boot` /
   // `restore` works here too.
+  // --json is a top-level convention; pull it out before the fork
+  // parser so it doesn't end up in `rest` and trip parseTargetFlags.
+  const { json, rest: forkArgs } = consumeJsonFlag(args);
   let parsed;
   try {
-    parsed = parseForkArgs(args);
+    parsed = parseForkArgs(forkArgs);
   } catch (err) {
     handleError(err);
   }
@@ -996,6 +1200,9 @@ async function cmdFork(args: string[]): Promise<number> {
     rest,
   } = parsed;
   const target = parseTargetFlags(rest, "fork");
+  if (json && !detach) {
+    die("fork --json is only meaningful with --detach (attached forks take over stdio).");
+  }
 
   // The fork is a fresh restore boot, so it needs the same base
   // assets `cmdRestore` resolves (kernel + dtb + rootfs in the
@@ -1041,15 +1248,27 @@ async function cmdFork(args: string[]): Promise<number> {
         }
       },
     });
-    process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
-    if (!outDir) {
-      process.stderr.write(`bundle: ${resolvedOutDir} (rm -rf when the fork exits)\n`);
+    if (!json) {
+      process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
+      if (!outDir) {
+        process.stderr.write(`bundle: ${resolvedOutDir} (rm -rf when the fork exits)\n`);
+      }
     }
     if (detach) {
       // Fire-and-forget: hand the fork off to its own VMM process
       // (boot was spawned with pdeathsig=false so it survives this
       // CLI exit) and return.
       await fork.detach();
+      if (json) {
+        emitJson({
+          schema_version: 1,
+          pid: fork.pid,
+          name: fork.name ?? null,
+          source: "name" in target ? target.name : `pid ${target.pid}`,
+          bundle_dir: resolvedOutDir,
+          ephemeral: !outDir,
+        });
+      }
       return 0;
     }
 
@@ -1232,6 +1451,87 @@ async function cmdRepl(args: string[]): Promise<number> {
   }
 }
 
+async function cmdAgentContext(args: string[]): Promise<number> {
+  // The whole point of `agent-context` is structured output, so --json
+  // is implicit. Reject anything else so we don't quietly ignore typos
+  // that an agent might rely on.
+  for (const a of args) {
+    if (a !== "--json") {
+      die(`unknown argument: ${a}`);
+    }
+  }
+  emitJson(buildAgentContext());
+  return 0;
+}
+
+async function cmdFeedback(args: string[]): Promise<number> {
+  // Two shapes:
+  //   machinen feedback "<text>"        — append a JSONL entry
+  //   machinen feedback --list          — print recent entries
+  // --json on either form returns a structured envelope.
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  let listMode = false;
+  const positional: string[] = [];
+  for (const a of afterJson) {
+    if (a === "--list") {
+      listMode = true;
+    } else if (a.startsWith("--")) {
+      die(`unknown argument: ${a}`);
+    } else {
+      positional.push(a);
+    }
+  }
+  if (listMode) {
+    if (positional.length > 0) {
+      die("machinen feedback --list takes no positional arguments");
+    }
+    const entries = readFeedback();
+    if (json) {
+      emitJson({ schema_version: 1, entries });
+      return 0;
+    }
+    if (entries.length === 0) {
+      process.stdout.write("(no feedback recorded)\n");
+      return 0;
+    }
+    for (const e of entries) {
+      process.stdout.write(`${e.timestamp}  ${e.text}\n`);
+    }
+    return 0;
+  }
+  if (positional.length === 0) {
+    die('usage: machinen feedback "<text>" | machinen feedback --list');
+  }
+  const text = positional.join(" ");
+  const path = feedbackPath();
+  const entry = {
+    timestamp: new Date().toISOString(),
+    cli_version: VERSION,
+    text,
+  };
+  appendFeedback(entry, path);
+  const upstream = await postUpstream(entry);
+  if (json) {
+    emitJson({
+      schema_version: 1,
+      recorded: true,
+      path,
+      upstream_status: upstream.status,
+    });
+    return 0;
+  }
+  if (upstream.attempted && upstream.status !== null) {
+    process.stdout.write(
+      `feedback recorded locally and sent upstream (status: ${upstream.status})\n`,
+    );
+  } else if (upstream.attempted) {
+    process.stdout.write(`feedback recorded locally; upstream POST failed: ${upstream.error}\n`);
+  } else {
+    process.stdout.write("feedback recorded locally (1 entry)\n");
+  }
+  return 0;
+}
+
 async function cmdCompletion(args: string[]): Promise<number> {
   const shell = args[0] ?? "bash";
   if (shell === "bash") {
@@ -1296,7 +1596,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install ls ps exec snapshot fork attach repl gc stop completion --version --help -h -v"
+  local cmds="boot restore install list ls ps exec snapshot fork attach repl gc stop feedback agent-context completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -1333,7 +1633,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install ls ps exec snapshot fork attach repl gc stop completion)
+  cmds=(boot restore install list ls ps exec snapshot fork attach repl gc stop feedback agent-context completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -1368,7 +1668,7 @@ compdef _machinen machinen mn
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install ls ps exec snapshot fork attach repl gc stop completion
+set -l cmds boot restore install list ls ps exec snapshot fork attach repl gc stop feedback agent-context completion
 for bin in machinen mn
   complete -c $bin -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
   for sub in exec snapshot fork attach repl stop
@@ -1446,8 +1746,9 @@ function printHelp(): void {
       `                                                 are global), so pick host ports nothing\n` +
       `                                                 else is binding.\n` +
       `\n` +
-      `  machinen ls   (alias: ps)                      List running VMs (PID, NAME, UP,\n` +
-      `                                                 PORTS, FORKED-FROM)\n` +
+      `  machinen list  (alias: ls, ps)                 List running VMs (PID, NAME, UP,\n` +
+      `                                                 PORTS, FORKED-FROM). Pass --json for\n` +
+      `                                                 a structured payload on stdout.\n` +
       `\n` +
       `  Targeting a running VM:\n` +
       `    --name <name>     |  --pid <pid>             pick exactly one\n` +
@@ -1501,8 +1802,25 @@ function printHelp(): void {
       `\n` +
       `  machinen install                               Pre-fetch the current-tag base assets\n` +
       `    --version <tag>                              Pin to a specific release tag\n` +
+      `  machinen agent-context                         Versioned JSON describing every command,\n` +
+      `                                                 flag, and exit code. Source-of-truth\n` +
+      `                                                 for agent introspection.\n` +
+      `  machinen feedback "<text>"                     Record a friction note locally\n` +
+      `                                                 (~/.machinen/feedback.jsonl). With\n` +
+      `                                                 MACHINEN_FEEDBACK_ENDPOINT set, also\n` +
+      `                                                 POSTs upstream. \`--list\` prints recent\n` +
+      `                                                 entries.\n` +
       `  machinen completion <shell>                    Emit shell completion (bash|zsh|fish)\n` +
       `  machinen --version | -h                        Print version / help\n` +
+      `\n` +
+      `Global flags:\n` +
+      `  --json                                         Emit machine-readable JSON to stdout.\n` +
+      `                                                 Supported on: list, gc, install,\n` +
+      `                                                 snapshot, stop, fork --detach,\n` +
+      `                                                 boot --detach, feedback, agent-context.\n` +
+      `  --dry-run                                      Preview a mutating command without\n` +
+      `                                                 side effects. Supported on: gc, stop,\n` +
+      `                                                 snapshot.\n` +
       `\n` +
       `Examples:\n` +
       `  machinen boot --name worker -- node server.js\n` +
@@ -1549,6 +1867,7 @@ async function main(): Promise<number> {
       return cmdRestore(rest);
     case "install":
       return cmdInstall(rest);
+    case "list":
     case "ls":
     case "ps":
       return cmdLs(rest);
@@ -1568,6 +1887,10 @@ async function main(): Promise<number> {
       return cmdGc(rest);
     case "stop":
       return cmdStop(rest);
+    case "feedback":
+      return cmdFeedback(rest);
+    case "agent-context":
+      return cmdAgentContext(rest);
     default:
       die(`unknown command: ${sub}\nRun 'machinen --help' for usage.`);
   }

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -1,0 +1,72 @@
+// `machinen feedback` — agent-friction reporting (Trevin's principle 10).
+// Local JSONL by default at ~/.machinen/feedback.jsonl; with
+// MACHINEN_FEEDBACK_ENDPOINT set, the entry also POSTs upstream.
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const DEFAULT_PATH = join(homedir(), ".machinen", "feedback.jsonl");
+
+export function feedbackPath(): string {
+  return process.env.MACHINEN_FEEDBACK_PATH ?? DEFAULT_PATH;
+}
+
+export interface FeedbackEntry {
+  timestamp: string;
+  cli_version: string;
+  text: string;
+}
+
+export function appendFeedback(entry: FeedbackEntry, path: string = feedbackPath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, JSON.stringify(entry) + "\n", "utf8");
+}
+
+export function readFeedback(path: string = feedbackPath()): FeedbackEntry[] {
+  if (!existsSync(path)) {
+    return [];
+  }
+  const lines = readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => l.length > 0);
+  const entries: FeedbackEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      // Skip malformed lines rather than crashing — partial writes
+      // shouldn't make `feedback --list` unusable.
+    }
+  }
+  return entries;
+}
+
+export interface UpstreamPostResult {
+  attempted: boolean;
+  status: number | null;
+  error: string | null;
+}
+
+export async function postUpstream(
+  entry: FeedbackEntry,
+  endpoint: string | undefined = process.env.MACHINEN_FEEDBACK_ENDPOINT,
+): Promise<UpstreamPostResult> {
+  if (!endpoint) {
+    return { attempted: false, status: null, error: null };
+  }
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(entry),
+    });
+    return { attempted: true, status: res.status, error: null };
+  } catch (err) {
+    return {
+      attempted: true,
+      status: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -42,6 +42,13 @@ interface ParsedRunArgs {
    * See #263.
    */
   memory?: number;
+  /**
+   * Emit the boot identity (pid + name) as JSON to stdout. Only
+   * meaningful with `--detach` — attached boots hand stdio to the
+   * guest and have no clean place to print structured output. See
+   * Trevin's principle 2 (structured output).
+   */
+  json?: boolean;
 }
 
 export function parseRunArgs(argv: string[]): ParsedRunArgs {
@@ -60,6 +67,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
   let guestCwd: string | undefined;
   let detached = false;
   let memory: number | undefined;
+  let json = false;
   for (let i = 0; i < pre.length; i++) {
     const a = pre[i]!;
     if (a === "--mount" || a.startsWith("--mount=")) {
@@ -125,6 +133,18 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
         );
       }
       detached = true;
+      // `--detached` is the legacy spelling. Surface a one-line
+      // deprecation note so existing scripts keep working but agents
+      // (and humans) learn the canonical name. Suppressed under
+      // MACHINEN_QUIET_DEPRECATIONS (set by tests) and under VITEST
+      // (parseRunArgs is unit-tested with --detached on every run).
+      if (a === "--detached" && !process.env.MACHINEN_QUIET_DEPRECATIONS && !process.env.VITEST) {
+        process.stderr.write(
+          "machinen: --detached is deprecated; use --detach (same behaviour).\n",
+        );
+      }
+    } else if (a === "--json") {
+      json = true;
     } else if (a === "--memory" || a.startsWith("--memory=")) {
       // #263 phase A: decimal MiB, no unit suffix. Same shape as
       // MACHINEN_MEMORY. The runtime validates the floor; we only
@@ -156,6 +176,7 @@ export function parseRunArgs(argv: string[]): ParsedRunArgs {
     guestCwd,
     detached: detached || undefined,
     memory,
+    json: json || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Adopts the [10 Principles for Agent-Native CLIs](https://x.com/trevin) on `@machinen/cli`. Every data-returning command gains `--json`, mutating commands gain `--dry-run`, `list` becomes the canonical verb (with `ls`/`ps` aliases), and `--detach` is the canonical spelling on `boot` (with `--detached` deprecated).

Adds two new top-level commands:
- **`mn agent-context`** — versioned JSON description of every command, flag, alias, and exit code. Single source of truth for agent introspection and the conventions lint test.
- **`mn feedback "<text>"`** — agent-friction reporting. Writes JSONL to `~/.machinen/feedback.jsonl`; POSTs upstream when `MACHINEN_FEEDBACK_ENDPOINT` is set.

A new vitest suite (`conventions.test.ts`) walks the schema and asserts: every `jsonOutput` command exposes `--json`, no banned flag names (`--format=json`, `--skip-*`), canonical verb whitelist, no schema/dispatch drift.

## Command surface (post-change)

`<target>` below is exactly one of `--name <name>` or `--pid <pid>`.

### `boot [<image>] [opts] -- <cmd>`
Boot a microVM and run a command in it.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` | string | Register under a human-friendly name (path-shaped allowed). |
| `--snapshot <path>` | string | Attach `<path>` as `/dev/vda` for a future `vm.snapshot()`. |
| `--mount <host>:<guest>` | string | Copy-once host directory into the guest. |
| `--mount-live <host>:<guest>[:rw\|ro]` | string, repeatable | FUSE live-share. |
| `--env KEY=VALUE` | string, repeatable | Guest env var. |
| `--cwd <abs-path>` | string | Working directory for the guest cmd (must be absolute). |
| `-p <hostPort>:<guestPort>` (`--publish`) | string, repeatable | Forward host TCP port. |
| `--detach` (alias `--detached` ⚠ deprecated) | bool | Detach VMM on first-guest-byte readiness. |
| `--memory <mib>` | int | Guest RAM ceiling (debug knob). |
| `--json` | bool | Only meaningful with `--detach`. Emits `{schema_version, pid, name, detached}`. |

### `restore <snap-dir> [opts]`
Restore a VM from a snapshot bundle.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` | string | Register the restored VM under this name. |
| `--image <tarball>` | string | Workload tarball (needed when CRIU references files outside the base rootfs). |
| `--eager` | bool | Pre-#266 behaviour: load every page up front. |
| `-p <hostPort>:<guestPort>` | string, repeatable | Forward host TCP port (not inherited from source). |

### `list` (aliases: `ls`, `ps`)
List running VMs.

| Flag | Type | Notes |
| --- | --- | --- |
| `--json` | bool | `{schema_version, vms: [{pid, name, started_at, uptime_ms, memory: {rss_bytes, ceiling_mib}, ports, forked_from}]}` |

### `exec <target> [--tty] -- <cmd>`
Run a command in a running VM.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | Pick exactly one. |
| `--tty` (alias `--pty`) | bool | Allocate a real PTY (needed for vim, htop, job control). |

### `snapshot <target> --out-dir <dir> [opts]` *mutating*
CRIU-snapshot a running VM.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | |
| `--out-dir <dir>` | string | Where to write the bundle. |
| `--keep-alive` | bool | Leave the source VM running. |
| `--dry-run` | bool | Validate target + out-dir without dumping. |
| `--json` | bool | `{schema_version, snap_dir, elapsed_ms, dry_run}` |

### `fork <target> [opts]` *mutating*
Snapshot live + restore into a sibling.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | Source VM. |
| `--new-name <n>` | string | Name for the fork. |
| `--out-dir <dir>` | string | Keep the snapshot bundle here. |
| `--tcp-keep` | bool | Inherit TCP socket state in the fork (rarely correct). |
| `--detach` | bool | Don't attach to the fork's stdio. |
| `--eager` | bool | Pre-#266 behaviour. |
| `-p`, `--mount`, `--mount-live`, `--env`, `--cwd`, `--memory` | various | Same as `boot`; take effect on the fork. |
| `--json` | bool | Only meaningful with `--detach`. Emits `{schema_version, pid, name, source, bundle_dir, ephemeral}` |

### `attach <target> [opts]`
Drop into an interactive PTY shell.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | |
| `--shell <cmd>` | string | Override the shell (default: `/bin/bash -i`). |
| `--tail [N]` | int (optional) | Dump the boot-console snapshot before the shell. |

### `repl <target>`
Per-line exec REPL — each line is a fresh one-shot command.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | |

### `stop <target> [opts]` *mutating*
SIGTERM the VMM, escalate to SIGKILL after 2s, then gc.

| Flag | Type | Notes |
| --- | --- | --- |
| `--name <name>` / `--pid <pid>` | target | |
| `--force` (alias `-9`) | bool | SIGKILL immediately. |
| `--dry-run` | bool | Print what would be killed without sending signals. |
| `--json` | bool | `{schema_version, pid, name, status: "stopped"\|"already_dead"\|"recycled"\|"would_stop", dry_run}` |

### `gc [opts]` *mutating*
Drop dead registry entries and per-boot artifacts.

| Flag | Type | Notes |
| --- | --- | --- |
| `--dry-run` (alias `-n`) | bool | |
| `--json` | bool | `{schema_version, dry_run, results: [{pid, name, status, removed_paths, failed_paths}]}` |

### `install [opts]`
Pre-fetch the kernel + base rootfs for a release tag.

| Flag | Type | Notes |
| --- | --- | --- |
| `--version <tag>` | string | Release tag (defaults to the CLI's own version). |
| `--json` | bool | `{schema_version, tag, base_dir, fetched}` |

### `feedback "<text>"` / `feedback --list` *mutating*
Record agent-friction notes locally.

| Flag | Type | Notes |
| --- | --- | --- |
| `--list` | bool | Print recent entries instead of recording a new one. |
| `--json` | bool | `{schema_version, recorded, path, upstream_status}` |

Honors `MACHINEN_FEEDBACK_ENDPOINT` (HTTP POST upstream) and `MACHINEN_FEEDBACK_PATH` (override the local JSONL path).

### `agent-context`
Versioned JSON describing the whole CLI surface — generated from the same schema this PR's lint test enforces.

```json
{"schema_version": 1, "cli_version": "<x.y.z>", "commands": [...], "exit_codes": {"ok": 0, "generic_failure": 1, "signalled_sigint": 130, "signalled_sigterm": 143}}
```

### `completion <bash|zsh|fish>`
Emit shell completion. Now advertises `list`, `feedback`, and `agent-context` alongside the legacy verbs.

## Test plan

- [x] `npx vitest run` — 529 pass / 7 skipped (was 506; +17 new tests in `conventions.test.ts` and `feedback.test.ts`)
- [x] `npx agent-ci run --all -q -p` — all 4 workflows green (docs, tests, fuse-workloads/base-assets, fuse-workloads/workloads)
- [x] `pnpm smoke-tests` — V/T/M/B/P/N + S1-S4 green
- [x] Manual sanity: `mn agent-context | jq`, `mn list --json`, `mn gc --dry-run --json`, `mn feedback "..." --json`
- [ ] S5 (lazy-pages RSS comparison) is flaking on `main` independent of this branch — pre-existing host-side flake, not related to these changes

## Notes on what I did *not* do

The post lists 10 principles. This PR lands the ones that are mostly mechanical or schema-level (output, vocabulary, introspection, mutation safety, friction reporting). Three were skipped intentionally:

- **Async-aware `--wait` with a job ledger.** Most machinen ops are blocking-by-design (boot/restore/exec/attach stay attached). The async-shaped surface is `boot --detach` / `fork --detach`, where this PR adds JSON identity output but doesn't add a recoverable jobs ledger. That's a bigger change worth its own PR.
- **Persistent `--profile` system.** Independent feature; needs storage design + precedence rules.
- **`--deliver` routing.** The current `--out-dir` already covers the file sink case for snapshot/fork; webhook delivery would be a separate PR.