### PR TITLE
fix(runtime): preserve /tmp sticky bit when materializing rootfs (#262)

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -6608,7 +6608,7 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveMke2fs**(): `string`
 
-Defined in: [rootfs-img.ts:729](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L729)
+Defined in: [rootfs-img.ts:744](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L744)
 
 Resolve the mke2fs binary path using the same lookup order as
 `ensureRootfsImage` itself: env override → bundled package → PATH →

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -458,7 +458,13 @@ describe("image + cmd", () => {
   });
 
   it("boots an image + cmd and the guest runs the cmd", async () => {
-    const debianRootfs = resolve(microvmRoot, "test-fixtures/rootfs-debian-arm64.tar.gz");
+    // Sibling tests (exec.test.ts, ping.test.ts, provision.test.ts) all
+    // resolve the base rootfs out of release-assets/, which is where
+    // build-base-assets.sh actually writes it. test-fixtures/ only ever
+    // gets the kernel + DTB synced in (vitest.setup.ts), never the
+    // rootfs tarball — pointing at it there made this test guaranteed
+    // to fail on every host.
+    const debianRootfs = resolve(microvmRoot, "../../release-assets/rootfs-debian-arm64.tar.gz");
     const { skip, binary } = requireFixturesOrSkip([debianRootfs]);
     if (skip) {
       return;

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -9,6 +9,7 @@
 
 import { execSync } from "node:child_process";
 import {
+  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -561,6 +562,40 @@ describe("ensureRootfsImage", () => {
       rmSync(cacheDir, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("preserves the sticky bit on /tmp during extract (#262)", () => {
+    // BSD tar (the macOS default) applies the host umask when extracting
+    // as non-root, which silently drops the sticky bit. Our base rootfs
+    // ships /tmp at 1777; without `tar -p` it lands as 0755 in the
+    // staging tree, gets baked into the ext4 image, and breaks
+    // `apt-get install` in the booted guest because apt drops to the
+    // _apt user for fetches and can't write to /tmp.
+    //
+    // Build a tiny tarball with /tmp at 1777 and run the extract helper
+    // ensureRootfsImage uses internally. The mode the helper wrote must
+    // match the archive byte-for-byte (1777, not 0755).
+    const stage = mkdtempSync(join(tmpdir(), "machinen-rootfs-tmp-perms-stage-"));
+    const dest = mkdtempSync(join(tmpdir(), "machinen-rootfs-tmp-perms-dest-"));
+    const tarPath = join(stage, "rootfs.tar.gz");
+    try {
+      const src = join(stage, "src");
+      mkdirSync(join(src, "tmp"), { recursive: true });
+      // mkdirSync applies the process umask, so set the mode explicitly
+      // — the test's invariant is "the archive declares 1777 and the
+      // extracted tree matches" and we need the source side to actually
+      // be 1777 before we tar it up.
+      chmodSync(join(src, "tmp"), 0o1777);
+      execSync(`tar -czf ${tarPath} -C ${src} .`);
+
+      _internal.extractTarball(tarPath, dest);
+
+      const mode = statSync(join(dest, "tmp")).mode & 0o7777;
+      expect(mode).toBe(0o1777);
+    } finally {
+      rmSync(stage, { recursive: true, force: true });
+      rmSync(dest, { recursive: true, force: true });
+    }
+  });
 
   it("never shrinks a cached .img — sizeBytes < existing is a no-op", () => {
     // Truncate-down would actually destroy data inside the ext4 fs, so

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -350,16 +350,8 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
     // 1. Extract the tarball into the staging directory. tar handles
     //    both gzip and plain.
     const extractT0 = Date.now();
-    const extract = spawnSync("tar", ["-xf", tarAbs, "-C", stagingTree], {
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+    extractTarball(tarAbs, stagingTree);
     opts.onPhase?.("tar-extract", Date.now() - extractT0);
-    if (extract.status !== 0) {
-      throw new ProvisionError(
-        "PROVISION_INSTALL_HOOK_FAILED",
-        `ensureRootfsImage: tar -xf failed (code ${extract.status}): ${extract.stderr?.toString() ?? ""}`,
-      );
-    }
 
     // 2. Size the image. Three-way:
     //    - sizeBytes wins outright when the caller passes it (the
@@ -705,6 +697,29 @@ function tryPrebakeFromSibling(args: {
   }
 }
 
+// Extract `tarPath` into `dest` with mode-bit fidelity.
+//
+// `-p` (--preserve-permissions) matters: BSD tar (the macOS default)
+// applies the host umask when extracting as non-root, which silently
+// drops the sticky bit and other "extra" mode bits declared in the
+// archive. /tmp ships at 1777 in our base rootfs but extracts as 0755
+// without -p, which bakes into the ext4 image and breaks `apt-get`
+// in the booted guest — apt drops to the `_apt` user for fetches and
+// can't write to /tmp, so apt-key fails and Release files look
+// unsigned (#262). GNU tar treats -p as a no-op for non-root (umask
+// is already not applied there), so adding it is safe on every host.
+function extractTarball(tarPath: string, dest: string): void {
+  const r = spawnSync("tar", ["-xpf", tarPath, "-C", dest], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  if (r.status !== 0) {
+    throw new ProvisionError(
+      "PROVISION_INSTALL_HOOK_FAILED",
+      `ensureRootfsImage: tar -xpf failed (code ${r.status}): ${r.stderr?.toString() ?? ""}`,
+    );
+  }
+}
+
 function allocateSparseFile(path: string, sizeBytes: number): void {
   const fd = openSync(path, "w");
   try {
@@ -745,4 +760,5 @@ export const _rootfsImgInternal = {
   resolveMke2fsEnvOverride,
   okMarkerPath,
   siblingPrebakePath,
+  extractTarball,
 };


### PR DESCRIPTION
## Problem

`apt-get install` fails inside provision install hooks on macOS:

```
W: GPG error: http://deb.debian.org/debian bookworm InRelease: Couldn't create temporary file /tmp/apt.conf.XXXXXX for passing config to apt-key
E: The repository '… bookworm InRelease' is not signed.
```

`apt` drops privileges to a built-in `_apt` user when it fetches packages. That user has very few permissions; the only place it can write is `/tmp`, which has a special "anyone can write here" mode (the sticky bit, mode `1777`). When `_apt` can't write to `/tmp`, the GPG check is skipped and the repository is rejected as unsigned.

The base rootfs ships `/tmp` with the right mode. But the runtime extracts the base rootfs tarball on the host before booting it, and on macOS that extraction silently drops the sticky bit. By the time the guest boots, `/tmp` is `0755` — owned by root, not writable by anyone else — and `apt` breaks.

The cause: macOS's default `tar` applies the host's "default permissions" mask when extracting as a non-root user. Without telling tar to keep the archive's permissions exactly, the sticky bit and other "extra" mode bits are filtered out.

Closes #262.

While debugging, I also found that one of the runtime's tests was looking for the base rootfs tarball in a directory where the build never puts it, so the test failed on every run. Sibling tests already look in the right place; this PR matches them.

## Solution

1. Pass `-p` (preserve permissions) to the `tar` invocation that extracts the base rootfs into the staging tree. With `-p`, tar honors the archive's mode bits exactly. On Linux this is a no-op for non-root callers; on macOS it stops the silent permission filtering. Pulled the tar call into a tiny helper so a regression test can drive it directly.

2. Added a regression test that builds a tarball with `/tmp` at `1777`, runs the helper, and asserts the extracted directory still has mode `1777`. Verified it fails (mode drops to `0755`) without the fix.

3. Pointed the `boot.test.ts` "boots an image + cmd" test at `release-assets/rootfs-debian-arm64.tar.gz`, which is where `scripts/build-base-assets.sh` actually writes the tarball. The test was looking under `packages/microvm/test-fixtures/`, where the rootfs tarball is never placed.

## Test plan

- [x] Unit tests pass: `npx vitest run` — 563 passed, 7 skipped, 0 failed.
- [x] New regression test catches the bug when the fix is reverted (verified locally).
- [x] End-to-end smoke tests pass: `pnpm smoke-tests` (V1–V8, T1–T8, M1–M3, B0–B1, N1–N5, P1–P3, S1–S6 all green).
- [ ] Reviewer check: `apt-get install` works in a `provision()` install hook on macOS without the documented `mkdir -p /tmp && chmod 1777 /tmp` workaround.