### PR TITLE
fix(microvm): drop VIRTIO_BALLOON_F_REPORTING — mmap reclaim corrupts guest

### DIFF
--- a/packages/microvm/src/balloon.zig
+++ b/packages/microvm/src/balloon.zig
@@ -11,13 +11,16 @@
 //!
 //! ## Mode
 //!
-//! We negotiate `VIRTIO_BALLOON_F_REPORTING` (bit 5) — the modern
-//! free-page-reporting variant added in Linux 5.7 (2020). With this
-//! feature the guest *continuously* reports free runs on a dedicated
-//! queue (queue 2, after inflate/deflate which are always present),
-//! without the inflate/deflate ceremony of the classic balloon. We
-//! never ask the guest to inflate, so `num_pages` in config space
-//! stays 0; the inflate/deflate queue handlers are minimal acks.
+//! Currently we advertise `VIRTIO_F_VERSION_1` only — no
+//! `VIRTIO_BALLOON_F_REPORTING`, no inflate/deflate driver. The
+//! guest's virtio-balloon driver instantiates with the always-present
+//! inflate + deflate queues; both queue handlers are minimal acks
+//! since `num_pages` stays 0 and we never ask the guest to inflate.
+//! The reporting handler is implemented (see `handleReporting`) but
+//! unreachable while bit 5 is off — kept so reintroducing reporting
+//! is a one-line change once we have a reclaim path that doesn't
+//! corrupt the guest. See the comment on `Backend.features` for the
+//! corruption story.
 //!
 //! ## Queues (driver order, with REPORTING + no STATS / FREE_PAGE_HINT)
 //!
@@ -131,9 +134,21 @@ pub const Backend = struct {
     /// Pairs with `request_handler` below — adding a feature bit
     /// without a matching queue handler will hang the driver at
     /// `find_vqs`.
+    ///
+    /// We DO NOT advertise `VIRTIO_BALLOON_F_REPORTING`. The reporting
+    /// handler reclaims pages via `mmap(MAP_FIXED|MAP_PRIVATE|MAP_ANONYMOUS)`
+    /// over guest RAM, and that races with the guest's own use of
+    /// reported pages — under load the guest reads zeros from pages
+    /// it still considers in-use, corrupting its own page cache (HTTP
+    /// stress reproduces it as binaries getting `Exec format error`
+    /// while the host-side rootdisk image stays clean). Until we have
+    /// a reclaim path that doesn't have this race, leave the bit off:
+    /// the guest never queues reporting chains, host RSS doesn't shrink
+    /// mid-run, but the VM stops corrupting itself. `handleReporting`
+    /// is kept around so reintroducing the bit is a one-line change.
     pub fn features() u64 {
-        // Bit 5 (REPORTING) + bit 32 (VERSION_1, required for v2 transport).
-        return (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING) | (@as(u64, 1) << 32);
+        // Bit 32 (VERSION_1, required for v2 transport).
+        return @as(u64, 1) << 32;
     }
 
     /// Wire-format config bytes for `virtio.Device.config`. Stable
@@ -374,10 +389,13 @@ const MAP_ANONYMOUS: c_int = if (builtin.os.tag == .macos) 0x1000 else 0x20;
 
 // --- tests ---
 
-test "Backend.features advertises REPORTING + VERSION_1" {
+test "Backend.features advertises VERSION_1 only (REPORTING off — see header)" {
     const f = Backend.features();
-    try std.testing.expect((f & (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING)) != 0);
     try std.testing.expect((f & (@as(u64, 1) << 32)) != 0); // VERSION_1
+    // REPORTING is intentionally off — the mmap-based reclaim races
+    // with the guest's use of reported pages and corrupts the page
+    // cache. See the comment on `Backend.features`.
+    try std.testing.expect((f & (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING)) == 0);
     // We must NOT advertise STATS_VQ or FREE_PAGE_HINT — those add
     // queues we don't implement, and the driver hangs at find_vqs
     // if we offer them.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -6510,7 +6510,7 @@ PROVISION_DTB_NOT_FOUND |
 
 > **provision**(`opts`): `Promise`\<[`ProvisionResult`](#provisionresult)\>
 
-Defined in: [provision.ts:322](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L322)
+Defined in: [provision.ts:325](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L325)
 
 Boot the base rootfs, run the user install hook, and freeze the
 resulting filesystem state to a new tarball at `opts.out`.

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -261,7 +261,10 @@ interface BaseAssetSpec {
   param: string;
   assetsDirName: string;
   cliCacheName: string;
-  missingCode: "PROVISION_BASE_NOT_FOUND" | "PROVISION_KERNEL_NOT_FOUND" | "PROVISION_DTB_NOT_FOUND";
+  missingCode:
+    | "PROVISION_BASE_NOT_FOUND"
+    | "PROVISION_KERNEL_NOT_FOUND"
+    | "PROVISION_DTB_NOT_FOUND";
 }
 
 function resolveBaseAsset(spec: BaseAssetSpec, explicit: string | undefined, cwd: string): string {

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -759,8 +759,15 @@ fi  # B0 rootfs gate
 # REPORT_GRACE seconds for the guest's page-reporting kthread to fire,
 # remeasure. A working balloon brings RSS back down (within tolerance);
 # without it, the post-spike RSS stays at the high-water mark.
+#
+# Currently SKIPPED: VIRTIO_BALLOON_F_REPORTING is intentionally off
+# in `balloon.zig` (mmap-based reclaim races with in-use guest RAM
+# and corrupts the page cache — see the comment on `Backend.features`).
+# Re-enable this test when a safe reclaim path lands.
 if [[ "$ROOTFS_SUPPORTS_VSOCK_EXEC" -eq 0 ]]; then
   echo "B1: skipped (rootfs lacks vsock-exec)"
+elif true; then
+  echo "B1: skipped (VIRTIO_BALLOON_F_REPORTING disabled — see balloon.zig)"
 else
 echo "B1: spike-and-idle reclaim — RSS drops after free-page-reporting fires"
 B1_NAME="balloon-smoke-$$"
@@ -854,6 +861,45 @@ pass "balloon reclaim: ${B1_RECLAIMED_DROP} MiB returned to host (spike ${B1_SPI
 cleanup_b1
 trap 'rm -rf "$FIXTURE"' EXIT
 fi  # B1 rootfs gate
+
+# ---- B2: VIRTIO_BALLOON_F_REPORTING stays disabled ----
+# Regression guard for the balloon-mmap-reclaim corruption (the reason
+# B1 is currently skipped). The fix lives in `Backend.features()` in
+# `packages/microvm/src/balloon.zig` — REPORTING (bit 5) is off so the
+# guest never queues reporting chains, eliminating the race that
+# zeroed in-use guest pages.
+#
+# Why a feature-bit check instead of a "page cache stays intact under
+# load" probe: the corruption is timing-sensitive and didn't reliably
+# reproduce in 60s of synthetic memory churn — the original repro
+# needed a long-lived workload (HTTP server + 30k requests) and even
+# then took most of a minute to surface. A behavioral smoke test that
+# only flags 80% of regressions is worse than a deterministic guard
+# on the feature bit, which catches the only way the bug can come
+# back: someone re-advertising REPORTING without fixing the reclaim
+# path. The Zig unit test in balloon.zig pins the same invariant from
+# the host side; this one pins it from the guest's POV after MMIO
+# negotiation actually happens.
+if [[ "$ROOTFS_SUPPORTS_VSOCK_EXEC" -eq 0 ]]; then
+  echo "B2: skipped (rootfs lacks vsock-exec)"
+else
+echo "B2: guest sees REPORTING bit unset on the balloon device"
+B2_LOG="$FIXTURE/b2.log"
+# /sys/bus/virtio/devices/virtio4/features is a 64-char ASCII bitmap
+# of the *negotiated* feature bits — char i = '1' iff bit i is set.
+# We read indices 5 (REPORTING) and 32 (VERSION_1) and assert the
+# expected pattern. virtio4 is the balloon slot per #263 phase B
+# (B0 above checks the device-id binding).
+run_timeout 60 node "$CLI" boot -- /bin/sh -c \
+  'F=$(cat /sys/bus/virtio/devices/virtio4/features); echo "REPORTING=$(echo "$F" | cut -c6)"; echo "VERSION_1=$(echo "$F" | cut -c33)"' \
+  >"$B2_LOG" 2>&1 || true
+if grep -q "^REPORTING=0" "$B2_LOG" && grep -q "^VERSION_1=1" "$B2_LOG"; then
+  pass "guest negotiated VERSION_1 with REPORTING off"
+else
+  tail -50 "$B2_LOG" >&2
+  fail "B2 — expected REPORTING=0 and VERSION_1=1 in negotiated features"
+fi
+fi  # B2 rootfs gate
 
 # ----------------------------------------------------------------
 # Phase-1 base-rootfs contract tests — verify #77 step 1 plumbing.


### PR DESCRIPTION
## Problem (plain)

When you ran a long-lived workload (like the counter HTTP server) inside a machinen VM, the guest's binaries would eventually start failing with `Exec format error` or segfaults. Running `ls`, `cat`, even `mkfs.ext4` — they'd all silently break, even though they were on disk just fine. Snapshots would fail because the binaries `machinen-dump.sh` needs (`mount`, `mkfs.ext4`) were among the casualties. The VM was effectively eating itself.

The disk image on the host was clean the whole time. The corruption was only in the guest's memory.

## Solution (plain)

Stop the guest from telling the host which pages it considers free. The mechanism that listened for those reports — and was clobbering them — is now disabled. Host RAM usage no longer drops mid-run when the guest frees memory, but the VM doesn't corrupt itself anymore. Acceptable trade for a hotfix.

---

## Problem (technical)

`virtio-balloon` with `VIRTIO_BALLOON_F_REPORTING` (Linux 5.7+) lets the guest continuously report runs of free physical pages on a dedicated virtqueue. Our handler in `packages/microvm/src/balloon.zig` reclaimed each reported run with:

```zig
mmap(host_va, len, PROT_READ|PROT_WRITE, MAP_FIXED|MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
```

`MAP_FIXED|MAP_PRIVATE|MAP_ANONYMOUS` is the only portable primitive that gives immediate RSS reclaim on both Linux and Darwin (per the comment in the file — `madvise(MADV_DONTNEED)` is advisory-only on Darwin). It works by atomically replacing the host VA's backing pages with fresh zero-fill anonymous pages.

Under sustained load — empirically reproducible with `examples/quickstart`'s `counter.mjs` + ~33,000 HTTP requests in ~60s — pages the **guest still considered in use** were getting zeroed by this reclaim. The fingerprint:

- ELF magic still intact at offset 0 of `/usr/bin/*` (the kernel's first read survived)
- Program text/data pages mid-binary read as zeros
- Result: `execve` returns `ENOEXEC` (→ "Exec format error") or the process SIGILLs on the first instruction in a zeroed page
- Host-side rootdisk image: e2fsck-clean. Disk was never wrong; **guest page cache was being silently wiped**

The race itself is unconfirmed. Linux's `page_reporting` framework keeps reported pages isolated from the buddy free list until the host ACKs the chain, and we ACK *after* `mmap` returns (`queuePushUsed` follows the reclaim loop in `handleReporting`), so the ordering looks correct on paper. Two viable suspects:

1. **HVF stage-2 invalidation** — after `MAP_FIXED` swaps the host VA's backing, HVF's stage-2 page-table entries for that guest physical address may still resolve to the *old* host pages (which the host kernel has reclaimed) instead of refaulting through the new anonymous mapping. Comment in `balloon.zig:276–279` claims faults re-resolve, but it's not verified.
2. **`page_reporting` ABA under heavy concurrency** — a guest-side window where a reported page makes it back into circulation before the host's `mmap` lands.

Either way, the host-side mitigation is the same: stop atomically replacing in-use page contents.

## Solution (technical)

`Backend.features()` in `balloon.zig` now advertises only `VIRTIO_F_VERSION_1`. With `VIRTIO_BALLOON_F_REPORTING` (bit 5) off, the guest's virtio-balloon driver doesn't instantiate the reporting queue, so no reporting chains are ever queued, so `handleReporting` never runs. We don't drive inflate either (`num_pages` stays 0), so the entire balloon device is effectively a no-op — the inflate/deflate handlers are minimal acks per the existing wiring.

`handleReporting` is left in place (now unreachable) so re-introducing reporting after a safe reclaim path lands is a one-line change in `features()`.

## Trade-offs

- **Lost**: host RSS no longer shrinks when the guest frees memory. A 2 GiB spike followed by `free()` keeps the host at the high-water mark for the VM's lifetime. The smoke test that asserted this reclaim (`B1` in `scripts/smoke-tests.sh`) is now skipped with an explicit pointer back to the corruption story.
- **Kept**: lazy commit on the way up still works (host RSS grows on first guest touch). The `bytesReported` counter in `MemoryStats` will read 0 for the VM's lifetime.

## Regression guards

Two layers, because feature-bit drift is the only way this bug can come back:

1. **Zig unit test** (`balloon.zig`) — asserts `features()` does *not* set bit 5. Catches a developer flipping the bit on the host side without thinking through the corruption.
2. **Smoke test B2** (`scripts/smoke-tests.sh`) — boots a guest, reads `/sys/bus/virtio/devices/virtio4/features`, verifies the *negotiated* bitmap from the guest's POV is `REPORTING=0, VERSION_1=1`. Catches the same drift after MMIO handshake actually happens — A/B-validated against this branch (passes with the fix, fails when REPORTING is re-enabled).

A behavioral smoke test ("page cache stays intact under load") would have been more satisfying, but the corruption is timing-sensitive — the original repro needed ~60s of HTTP traffic — and a synthetic `dd`-loop equivalent inside the smoke harness didn't reliably trigger it. A deterministic guard on the feature bit catches 100% of the only way the bug returns; a flaky behavioral test would catch ~80% and produce false-positive failures the rest of the time.

## Repro for posterity

`scripts/bisect-rootfs-corruption.sh` already existed for an earlier round of investigation into snapshot-induced corruption (which turned out to be a related symptom of the same balloon issue — corrupted in-flight binaries → corrupted snapshot bundle). The reliable user-load reproduction is `examples/quickstart`'s `counter.mjs` + sustained HTTP traffic; B2 is what fires deterministically in CI.

## Test plan

- [x] `npx vitest run` — 571 pass, 7 skip, 0 fail
- [x] Zig unit tests (`zig build test` in `packages/microvm`) — 58 pass
- [x] `pnpm smoke-tests` — all pass; B0 ✓, B1 skipped-with-reason, B2 ✓
- [x] A/B reproduction with `examples/quickstart`'s `counter.mjs`: corrupts before this change, clean after