### PR TITLE
feat(cli): take VM target as a positional arg

### DIFF
--- a/.changeset/cli-positional-target.md
+++ b/.changeset/cli-positional-target.md
@@ -1,0 +1,14 @@
+---
+"@machinen/cli": minor
+---
+
+`exec`, `snapshot`, `fork`, `attach`, `repl`, and `stop` now take the target VM as a positional argument instead of `--name <name>` / `--pid <pid>`. `snapshot` also takes its `<out-dir>` as a second positional. The legacy flags still work for one release with a one-time deprecation warning per `(command, flag)` pair.
+
+- `machinen exec worker -- ps aux`
+- `machinen snapshot worker ./warm`
+- `machinen fork worker --new-name worker-b --detach`
+- `machinen stop 12345` (digits resolve as pid; non-digits as name)
+
+A VM literally named `123` can't be targeted positionally — pass `--name 123` (with the deprecation warning) until renamed.
+
+`agent-context` schema bumps to version 2: `CommandSpec` gains a `positionals` field and `FlagSpec` gains a `deprecated` field. Existing v1 consumers that ignore unknown fields keep working; consumers that want the positional surface should bump to v2.

--- a/.changeset/cli-positional-target.md
+++ b/.changeset/cli-positional-target.md
@@ -2,13 +2,13 @@
 "@machinen/cli": minor
 ---
 
-`exec`, `snapshot`, `fork`, `attach`, `repl`, and `stop` now take the target VM as a positional argument instead of `--name <name>` / `--pid <pid>`. `snapshot` also takes its `<out-dir>` as a second positional. The legacy flags still work for one release with a one-time deprecation warning per `(command, flag)` pair.
+`exec`, `snapshot`, `fork`, `attach`, `repl`, and `stop` take the target VM as a positional argument. `snapshot` also takes its `<out-dir>` as a second positional. Digits-only resolves as a pid; everything else as a name.
 
 - `machinen exec worker -- ps aux`
 - `machinen snapshot worker ./warm`
 - `machinen fork worker --new-name worker-b --detach`
-- `machinen stop 12345` (digits resolve as pid; non-digits as name)
+- `machinen stop 12345`
 
-A VM literally named `123` can't be targeted positionally — pass `--name 123` (with the deprecation warning) until renamed.
+A VM literally named `123` can't be targeted positionally — it'd resolve as a pid. Rename the VM if you hit this; there's no flag escape hatch.
 
-`agent-context` schema bumps to version 2: `CommandSpec` gains a `positionals` field and `FlagSpec` gains a `deprecated` field. Existing v1 consumers that ignore unknown fields keep working; consumers that want the positional surface should bump to v2.
+`agent-context` schema bumps to version 2: `CommandSpec` gains a `positionals` field. v1 consumers that ignore unknown fields keep working.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The process is now sitting on host A with `count = 2` in its heap.
 Freeze it, copy the bundle to host B, thaw it:
 
 ```bash
-npx machinen snapshot --name counter --out-dir ./counter.snap
+npx machinen snapshot counter ./counter.snap
 scp ./counter.tar.gz ./counter.snap host-b:
 ssh host-b npx machinen restore ./counter.snap &
 curl host-b:3000                           # { count: 3 }  ← same process
@@ -110,12 +110,12 @@ copy-on-write disk. Both processes diverge from the same instant.
 Pick up from Step 2 above — `counter` is running with `count = 2`:
 
 ```bash
-npx machinen fork --name counter --new-name counter-b --detach
+npx machinen fork counter --new-name counter-b --detach
 
-npx machinen exec --name counter   -- curl -s localhost:3000   # { count: 3 }
-npx machinen exec --name counter-b -- curl -s localhost:3000   # { count: 3 }
-npx machinen exec --name counter-b -- curl -s localhost:3000   # { count: 4 }
-npx machinen exec --name counter   -- curl -s localhost:3000   # { count: 4 }
+npx machinen exec counter   -- curl -s localhost:3000   # { count: 3 }
+npx machinen exec counter-b -- curl -s localhost:3000   # { count: 3 }
+npx machinen exec counter-b -- curl -s localhost:3000   # { count: 4 }
+npx machinen exec counter   -- curl -s localhost:3000   # { count: 4 }
 ```
 
 Both VMs branched from the same `count = 2` heap and now count
@@ -128,10 +128,10 @@ global, only one process can bind each one. Two ways to reach a fork:
 
 ```bash
 # A) exec over vsock — works for any guest port, no host forward needed.
-npx machinen exec --name counter-b -- curl -s localhost:3000
+npx machinen exec counter-b -- curl -s localhost:3000
 
 # B) -p with non-conflicting host ports — forwards on the host.
-npx machinen fork --name counter --new-name counter-b -p 3001:3000 --detach
+npx machinen fork counter --new-name counter-b -p 3001:3000 --detach
 curl localhost:3001                                            # the fork
 curl localhost:3000                                            # still the source
 ```

--- a/docs/guides/create-a-vm.md
+++ b/docs/guides/create-a-vm.md
@@ -78,8 +78,8 @@ Once it's running, you can find it again from any shell:
 
 ```bash
 npx machinen ls                              # see PID, NAME, uptime, port forwards
-npx machinen exec --name worker -- ps aux    # run a one-off command
-npx machinen attach --name worker            # interactive shell with job control
+npx machinen exec worker -- ps aux           # run a one-off command
+npx machinen attach worker                   # interactive shell with job control
 ```
 
 `exec` is for scripted use — pipes are line-buffered, the command runs
@@ -90,7 +90,7 @@ guest process and not the host CLI.
 When you're done:
 
 ```bash
-npx machinen stop --name worker
+npx machinen stop worker
 ```
 
 `stop` SIGTERMs the VMM and waits for it to exit cleanly; it falls back

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -91,7 +91,7 @@ the network at all. `machinen exec` runs a command inside a VM over
 vsock — directly into the guest, bypassing TCP entirely:
 
 ```bash
-npx machinen exec --name worker -- curl -s localhost:3000
+npx machinen exec worker -- curl -s localhost:3000
 ```
 
 The guest runs the curl, and `localhost:3000` resolves to the guest's

--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -26,7 +26,7 @@ then snapshot:
 ```bash
 npx machinen boot --name counter -p 3000:3000 --detached ./counter.tar.gz
 # ... requests come in, the process builds up state ...
-npx machinen snapshot --name counter --out-dir ./counter.snap
+npx machinen snapshot counter ./counter.snap
 ```
 
 `./counter.snap` is a directory holding two files: `disk.img` (the
@@ -79,7 +79,7 @@ from then on they diverge.
 That's what `fork` does:
 
 ```bash
-npx machinen fork --name counter --new-name counter-b --detach
+npx machinen fork counter --new-name counter-b --detach
 ```
 
 The source `counter` is unaffected — briefly frozen during the dump,
@@ -108,7 +108,7 @@ through host networking), or pass new forwards explicitly — both the
 CLI and Node API accept them:
 
 ```bash
-npx machinen fork --name counter --new-name counter-b -p 3001:3000
+npx machinen fork counter --new-name counter-b -p 3001:3000
 ```
 
 ```ts
@@ -136,7 +136,7 @@ from the source — e.g. layer in an additional input dir, set an env
 var that wasn't there before, or hand the fork more RAM:
 
 ```bash
-npx machinen fork --name worker --new-name worker-eval \
+npx machinen fork worker --new-name worker-eval \
   --mount ./eval-fixtures:/mnt/in \
   --env RUN_MODE=eval \
   --memory 8192
@@ -155,7 +155,7 @@ Sometimes you want to snapshot a VM, hand someone the bundle for later
 restore, and keep the source running. Pass `--keep-alive`:
 
 ```bash
-npx machinen snapshot --name counter --out-dir ./counter.snap --keep-alive
+npx machinen snapshot counter ./counter.snap --keep-alive
 ```
 
 Same as fork's snapshot half: the source survives, and inherited TCP

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,7 +74,7 @@ file descriptors as a CRIU dump on an ext4 volume; `meta.json` is a small
 manifest.
 
 ```bash
-npx machinen snapshot --name counter --out-dir ./counter.snap
+npx machinen snapshot counter ./counter.snap
 scp -r ./counter.snap host-b:
 ssh host-b npx machinen restore ./counter.snap &
 curl host-b:3000                           # { count: 3 }

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -11,7 +11,7 @@ machinen boot     [<image>] [opts] -- <cmd>     Boot a microVM
 machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bundle
 machinen list     (alias: ls, ps)               List running VMs
 machinen exec     <target> [--tty] -- <cmd>     Run a command in a running VM
-machinen snapshot <target> --out-dir <d> [--keep-alive] [--dry-run]
+machinen snapshot <target> <out-dir> [--keep-alive] [--dry-run]
                                                 CRIU-snapshot a running VM
 machinen fork     <target> [opts]               Clone a running VM into a sibling
 machinen attach   <target> [--shell <c>] [--tail [N]]
@@ -27,7 +27,10 @@ machinen completion <bash|zsh|fish>             Emit shell completion
 machinen --version | -h                          Print version / help
 ```
 
-`<target>` is exactly one of `--name <name>` or `--pid <pid>`.
+`<target>` is the first positional after the subcommand. Pass a name
+(any non-digit string) or a host pid (digits-only). The legacy
+`--name <n>` / `--pid <p>` flags still work for one release with a
+deprecation warning.
 
 ## Agent-friendly conventions
 
@@ -102,17 +105,17 @@ line-buffered pipes (good for one-shot commands and piping). Pass
 htop, or anything that wants job control.
 
 ```bash
-machinen exec --name worker -- ps aux
-machinen exec --name worker --tty -- bash -i
+machinen exec worker -- ps aux
+machinen exec worker --tty -- bash -i
 ```
 
 ## `machinen snapshot`
 
 ```
-machinen snapshot <target> --out-dir <dir> [--keep-alive]
+machinen snapshot <target> <out-dir> [--keep-alive]
 ```
 
-CRIU-snapshots a running VM into `<dir>` (`disk.img` + `meta.json`).
+CRIU-snapshots a running VM into `<out-dir>` (`disk.img` + `meta.json`).
 The default freezes-and-exits the source. `--keep-alive` leaves it
 running and closes inherited TCP sockets so two live copies don't race
 on shared connection state.
@@ -173,7 +176,7 @@ machinen repl <target>
 
 Per-line exec REPL: every line is a fresh one-shot `exec`, so `cd`,
 env vars, and shell history do **not** carry over. Useful for piping a
-script of one-liners (`cat cmds.txt | machinen repl --name foo`). For
+script of one-liners (`cat cmds.txt | machinen repl foo`). For
 an actual interactive shell, use `machinen attach`.
 
 ## `machinen stop`

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -28,9 +28,7 @@ machinen --version | -h                          Print version / help
 ```
 
 `<target>` is the first positional after the subcommand. Pass a name
-(any non-digit string) or a host pid (digits-only). The legacy
-`--name <n>` / `--pid <p>` flags still work for one release with a
-deprecation warning.
+(any non-digit string) or a host pid (digits-only).
 
 ## Agent-friendly conventions
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,16 +64,18 @@ npx machinen boot ./image.tar.gz                 # boot a provisioned image
 npx machinen boot --name worker --detached ./image.tar.gz
                                                   # ... and reach it from another shell:
 npx machinen ls
-npx machinen exec --name worker -- ps aux
-npx machinen attach --name worker
-npx machinen snapshot --name worker --out-dir ./warm
+npx machinen exec worker -- ps aux
+npx machinen attach worker
+npx machinen snapshot worker ./warm
 npx machinen restore ./warm
-npx machinen fork --name worker --new-name worker-b --detach
-npx machinen stop --name worker
+npx machinen fork worker --new-name worker-b --detach
+npx machinen stop worker
 ```
 
-The `<name>` arg in any of those can be swapped for `--pid <pid>` if
-you'd rather identify the VM by host pid.
+After the subcommand, the first positional is the target VM. Pass a
+name for a registered VM, or a host pid (digits-only) to identify it
+by process. (Legacy `--name <n>` / `--pid <p>` flags still work for
+one release with a deprecation warning.)
 
 ## Reference
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,8 +74,7 @@ npx machinen stop worker
 
 After the subcommand, the first positional is the target VM. Pass a
 name for a registered VM, or a host pid (digits-only) to identify it
-by process. (Legacy `--name <n>` / `--pid <p>` flags still work for
-one release with a deprecation warning.)
+by process.
 
 ## Reference
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -708,13 +708,11 @@ describe("extractTarget", () => {
     const r = extractTarget(["worker"], "exec");
     expect(r.target).toEqual({ name: "worker" });
     expect(r.rest).toEqual([]);
-    expect(r.legacyFlags).toEqual([]);
   });
 
   it("treats an all-digits positional as a pid", () => {
     const r = extractTarget(["12345"], "stop");
     expect(r.target).toEqual({ pid: 12345 });
-    expect(r.legacyFlags).toEqual([]);
   });
 
   it("accepts path-shaped names (slash-separated)", () => {
@@ -728,67 +726,14 @@ describe("extractTarget", () => {
     expect(r.rest).toEqual(["./warm"]);
   });
 
-  it("flags legacy --name with legacyFlags", () => {
-    const r = extractTarget(["--name", "worker"], "exec");
-    expect(r.target).toEqual({ name: "worker" });
-    expect(r.legacyFlags).toEqual(["--name"]);
-  });
-
-  it("flags legacy --pid with legacyFlags", () => {
-    const r = extractTarget(["--pid", "999"], "stop");
-    expect(r.target).toEqual({ pid: 999 });
-    expect(r.legacyFlags).toEqual(["--pid"]);
-  });
-
-  it("supports --name=<v> form", () => {
-    const r = extractTarget(["--name=worker"], "exec");
-    expect(r.target).toEqual({ name: "worker" });
-    expect(r.legacyFlags).toEqual(["--name"]);
-  });
-
-  it("supports --pid=<v> form", () => {
-    const r = extractTarget(["--pid=42"], "stop");
-    expect(r.target).toEqual({ pid: 42 });
-  });
-
-  it("rejects positional + --name (over-specified)", () => {
-    expect(() => extractTarget(["worker", "--name", "other"], "exec")).toThrow(
-      /pass the target once/,
-    );
-  });
-
-  it("rejects positional + --pid (over-specified)", () => {
-    expect(() => extractTarget(["worker", "--pid", "1"], "exec")).toThrow(/pass the target once/);
-  });
-
-  it("rejects --name + --pid", () => {
-    expect(() => extractTarget(["--name", "x", "--pid", "1"], "exec")).toThrow(
-      /--name OR --pid, not both/,
-    );
-  });
-
   it("rejects no target at all", () => {
     expect(() => extractTarget([], "exec")).toThrow(/requires a target/);
   });
 
-  it("rejects unknown flags", () => {
+  it("rejects unknown flags (legacy --name/--pid no longer recognized)", () => {
+    expect(() => extractTarget(["--name", "worker"], "exec")).toThrow(/unknown argument: --name/);
+    expect(() => extractTarget(["--pid", "1234"], "stop")).toThrow(/unknown argument: --pid/);
     expect(() => extractTarget(["--bogus"], "exec")).toThrow(/unknown argument: --bogus/);
-  });
-
-  it("rejects non-numeric --pid", () => {
-    expect(() => extractTarget(["--pid", "abc"], "exec")).toThrow(/--pid requires a numeric/);
-  });
-
-  it("rejects bare --name with no value", () => {
-    expect(() => extractTarget(["--name"], "exec")).toThrow(/--name requires a value/);
-  });
-
-  it("rejects duplicate --name", () => {
-    expect(() => extractTarget(["--name", "a", "--name", "b"], "exec")).toThrow(/at most once/);
-  });
-
-  it("rejects duplicate --pid", () => {
-    expect(() => extractTarget(["--pid", "1", "--pid", "2"], "exec")).toThrow(/at most once/);
   });
 
   it("throws ParseError so the CLI can format it", () => {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -5,6 +5,7 @@ import { formatPorts } from "../format-ports.ts";
 import { parseForkArgs } from "../parse-fork-args.ts";
 import { parseRestoreArgs } from "../parse-restore-args.ts";
 import { parseRunArgs } from "../parse-run-args.ts";
+import { extractTarget } from "../parse-target.ts";
 import { tailLines } from "../tail-lines.ts";
 
 describe("parseRunArgs --env", () => {
@@ -699,5 +700,98 @@ describe("tailLines (machinen attach --tail slicing)", () => {
 
   it("returns the whole content when tail >= line count", () => {
     expect(tailLines("a\nb\n", 99)).toBe("a\nb\n");
+  });
+});
+
+describe("extractTarget", () => {
+  it("treats a non-digit positional as a name", () => {
+    const r = extractTarget(["worker"], "exec");
+    expect(r.target).toEqual({ name: "worker" });
+    expect(r.rest).toEqual([]);
+    expect(r.legacyFlags).toEqual([]);
+  });
+
+  it("treats an all-digits positional as a pid", () => {
+    const r = extractTarget(["12345"], "stop");
+    expect(r.target).toEqual({ pid: 12345 });
+    expect(r.legacyFlags).toEqual([]);
+  });
+
+  it("accepts path-shaped names (slash-separated)", () => {
+    const r = extractTarget(["a/b/c"], "exec");
+    expect(r.target).toEqual({ name: "a/b/c" });
+  });
+
+  it("returns extra positionals in rest (e.g. snapshot's out-dir)", () => {
+    const r = extractTarget(["worker", "./warm"], "snapshot");
+    expect(r.target).toEqual({ name: "worker" });
+    expect(r.rest).toEqual(["./warm"]);
+  });
+
+  it("flags legacy --name with legacyFlags", () => {
+    const r = extractTarget(["--name", "worker"], "exec");
+    expect(r.target).toEqual({ name: "worker" });
+    expect(r.legacyFlags).toEqual(["--name"]);
+  });
+
+  it("flags legacy --pid with legacyFlags", () => {
+    const r = extractTarget(["--pid", "999"], "stop");
+    expect(r.target).toEqual({ pid: 999 });
+    expect(r.legacyFlags).toEqual(["--pid"]);
+  });
+
+  it("supports --name=<v> form", () => {
+    const r = extractTarget(["--name=worker"], "exec");
+    expect(r.target).toEqual({ name: "worker" });
+    expect(r.legacyFlags).toEqual(["--name"]);
+  });
+
+  it("supports --pid=<v> form", () => {
+    const r = extractTarget(["--pid=42"], "stop");
+    expect(r.target).toEqual({ pid: 42 });
+  });
+
+  it("rejects positional + --name (over-specified)", () => {
+    expect(() => extractTarget(["worker", "--name", "other"], "exec")).toThrow(
+      /pass the target once/,
+    );
+  });
+
+  it("rejects positional + --pid (over-specified)", () => {
+    expect(() => extractTarget(["worker", "--pid", "1"], "exec")).toThrow(/pass the target once/);
+  });
+
+  it("rejects --name + --pid", () => {
+    expect(() => extractTarget(["--name", "x", "--pid", "1"], "exec")).toThrow(
+      /--name OR --pid, not both/,
+    );
+  });
+
+  it("rejects no target at all", () => {
+    expect(() => extractTarget([], "exec")).toThrow(/requires a target/);
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => extractTarget(["--bogus"], "exec")).toThrow(/unknown argument: --bogus/);
+  });
+
+  it("rejects non-numeric --pid", () => {
+    expect(() => extractTarget(["--pid", "abc"], "exec")).toThrow(/--pid requires a numeric/);
+  });
+
+  it("rejects bare --name with no value", () => {
+    expect(() => extractTarget(["--name"], "exec")).toThrow(/--name requires a value/);
+  });
+
+  it("rejects duplicate --name", () => {
+    expect(() => extractTarget(["--name", "a", "--name", "b"], "exec")).toThrow(/at most once/);
+  });
+
+  it("rejects duplicate --pid", () => {
+    expect(() => extractTarget(["--pid", "1", "--pid", "2"], "exec")).toThrow(/at most once/);
+  });
+
+  it("throws ParseError so the CLI can format it", () => {
+    expect(() => extractTarget([], "exec")).toThrow(ParseError);
   });
 });

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -5,10 +5,9 @@
 
 import pkg from "../package.json" with { type: "json" };
 
-// SCHEMA_VERSION 2: introduced `positionals` on CommandSpec and the
-// `deprecated` marker on FlagSpec. Adding the positional <target>
-// + <out-dir> shape on exec/snapshot/fork/attach/repl/stop and the
-// matching deprecation of --name/--pid/--out-dir.
+// SCHEMA_VERSION 2: introduced `positionals` on CommandSpec along
+// with the <target> positional on exec/snapshot/fork/attach/repl/stop
+// (and snapshot's <out-dir>).
 export const SCHEMA_VERSION = 2 as const;
 
 /** A single CLI flag. `enum` is set when the value must be one of a fixed list. */
@@ -23,12 +22,6 @@ export interface FlagSpec {
   repeatable?: boolean;
   /** When true, the flag takes a value. Implied by non-boolean type. */
   takesValue?: boolean;
-  /**
-   * Set to a free-text "use X instead" message when the flag is kept
-   * working for one release with a deprecation warning. Agents should
-   * prefer the replacement.
-   */
-  deprecated?: string;
   description: string;
 }
 
@@ -57,26 +50,11 @@ export interface CommandSpec {
   jsonEnvelope?: string;
 }
 
-// Shared shape for the seven commands that target a running VM. The
-// preferred form is a single positional (digits → pid, otherwise →
-// name); --name/--pid still work for one release with a deprecation
-// warning.
+// Shared shape for the seven commands that target a running VM:
+// a single positional, digits → pid, otherwise → name.
 const TARGET_POSITIONAL: PositionalSpec = {
   name: "target",
-  description:
-    "The VM to act on. Pass a registered name or a host pid (digits-only). Mutually exclusive with the deprecated --name/--pid flags.",
-};
-const LEGACY_NAME_FLAG: FlagSpec = {
-  name: "--name",
-  type: "string",
-  deprecated: "Pass the name as the first positional instead.",
-  description: "Target VM by name (deprecated; use the <target> positional).",
-};
-const LEGACY_PID_FLAG: FlagSpec = {
-  name: "--pid",
-  type: "integer",
-  deprecated: "Pass the pid as the first positional instead.",
-  description: "Target VM by VMM pid (deprecated; use the <target> positional).",
+  description: "The VM to act on. Pass a registered name or a host pid (digits-only).",
 };
 
 /** The top-level commands of the CLI, keyed by canonical name. */
@@ -189,8 +167,6 @@ export const COMMANDS: CommandSpec[] = [
     jsonOutput: false,
     positionals: [TARGET_POSITIONAL],
     flags: [
-      LEGACY_NAME_FLAG,
-      LEGACY_PID_FLAG,
       {
         name: "--tty",
         type: "boolean",
@@ -212,15 +188,6 @@ export const COMMANDS: CommandSpec[] = [
       },
     ],
     flags: [
-      LEGACY_NAME_FLAG,
-      LEGACY_PID_FLAG,
-      {
-        name: "--out-dir",
-        type: "string",
-        deprecated: "Pass the directory as the second positional instead.",
-        description:
-          "Directory to write the bundle into (deprecated; use the <out-dir> positional).",
-      },
       {
         name: "--keep-alive",
         type: "boolean",
@@ -243,8 +210,6 @@ export const COMMANDS: CommandSpec[] = [
     mutating: true,
     positionals: [TARGET_POSITIONAL],
     flags: [
-      LEGACY_NAME_FLAG,
-      LEGACY_PID_FLAG,
       { name: "--new-name", type: "string", description: "Name for the fork." },
       { name: "--out-dir", type: "string", description: "Keep the snapshot bundle here." },
       {
@@ -302,8 +267,6 @@ export const COMMANDS: CommandSpec[] = [
     jsonOutput: false,
     positionals: [TARGET_POSITIONAL],
     flags: [
-      LEGACY_NAME_FLAG,
-      LEGACY_PID_FLAG,
       {
         name: "--shell",
         type: "string",
@@ -322,7 +285,7 @@ export const COMMANDS: CommandSpec[] = [
     summary: "Per-line exec REPL — each line is a fresh one-shot command.",
     jsonOutput: false,
     positionals: [TARGET_POSITIONAL],
-    flags: [LEGACY_NAME_FLAG, LEGACY_PID_FLAG],
+    flags: [],
   },
   {
     name: "stop",
@@ -331,8 +294,6 @@ export const COMMANDS: CommandSpec[] = [
     mutating: true,
     positionals: [TARGET_POSITIONAL],
     flags: [
-      LEGACY_NAME_FLAG,
-      LEGACY_PID_FLAG,
       {
         name: "--force",
         type: "boolean",

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -5,7 +5,11 @@
 
 import pkg from "../package.json" with { type: "json" };
 
-export const SCHEMA_VERSION = 1 as const;
+// SCHEMA_VERSION 2: introduced `positionals` on CommandSpec and the
+// `deprecated` marker on FlagSpec. Adding the positional <target>
+// + <out-dir> shape on exec/snapshot/fork/attach/repl/stop and the
+// matching deprecation of --name/--pid/--out-dir.
+export const SCHEMA_VERSION = 2 as const;
 
 /** A single CLI flag. `enum` is set when the value must be one of a fixed list. */
 export interface FlagSpec {
@@ -19,6 +23,20 @@ export interface FlagSpec {
   repeatable?: boolean;
   /** When true, the flag takes a value. Implied by non-boolean type. */
   takesValue?: boolean;
+  /**
+   * Set to a free-text "use X instead" message when the flag is kept
+   * working for one release with a deprecation warning. Agents should
+   * prefer the replacement.
+   */
+  deprecated?: string;
+  description: string;
+}
+
+/** A positional argument. Order matches the order in the array. */
+export interface PositionalSpec {
+  name: string;
+  /** Required positional? Defaults to true. */
+  required?: boolean;
   description: string;
 }
 
@@ -32,10 +50,34 @@ export interface CommandSpec {
   jsonOutput: boolean;
   /** Whether this command mutates state. Mutating commands should support --dry-run. */
   mutating?: boolean;
+  /** Positional args, in order. */
+  positionals?: PositionalSpec[];
   flags: FlagSpec[];
   /** Document the JSON envelope shape when `jsonOutput` is true. */
   jsonEnvelope?: string;
 }
+
+// Shared shape for the seven commands that target a running VM. The
+// preferred form is a single positional (digits → pid, otherwise →
+// name); --name/--pid still work for one release with a deprecation
+// warning.
+const TARGET_POSITIONAL: PositionalSpec = {
+  name: "target",
+  description:
+    "The VM to act on. Pass a registered name or a host pid (digits-only). Mutually exclusive with the deprecated --name/--pid flags.",
+};
+const LEGACY_NAME_FLAG: FlagSpec = {
+  name: "--name",
+  type: "string",
+  deprecated: "Pass the name as the first positional instead.",
+  description: "Target VM by name (deprecated; use the <target> positional).",
+};
+const LEGACY_PID_FLAG: FlagSpec = {
+  name: "--pid",
+  type: "integer",
+  deprecated: "Pass the pid as the first positional instead.",
+  description: "Target VM by VMM pid (deprecated; use the <target> positional).",
+};
 
 /** The top-level commands of the CLI, keyed by canonical name. */
 export const COMMANDS: CommandSpec[] = [
@@ -145,9 +187,10 @@ export const COMMANDS: CommandSpec[] = [
     name: "exec",
     summary: "Run a command in a running VM.",
     jsonOutput: false,
+    positionals: [TARGET_POSITIONAL],
     flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      LEGACY_NAME_FLAG,
+      LEGACY_PID_FLAG,
       {
         name: "--tty",
         type: "boolean",
@@ -161,10 +204,23 @@ export const COMMANDS: CommandSpec[] = [
     summary: "CRIU-snapshot a running VM.",
     jsonOutput: true,
     mutating: true,
+    positionals: [
+      TARGET_POSITIONAL,
+      {
+        name: "out-dir",
+        description: "Directory to write the snapshot bundle into.",
+      },
+    ],
     flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
-      { name: "--out-dir", type: "string", description: "Directory to write the bundle into." },
+      LEGACY_NAME_FLAG,
+      LEGACY_PID_FLAG,
+      {
+        name: "--out-dir",
+        type: "string",
+        deprecated: "Pass the directory as the second positional instead.",
+        description:
+          "Directory to write the bundle into (deprecated; use the <out-dir> positional).",
+      },
       {
         name: "--keep-alive",
         type: "boolean",
@@ -185,9 +241,10 @@ export const COMMANDS: CommandSpec[] = [
     summary: "Clone a running VM into a sibling.",
     jsonOutput: true,
     mutating: true,
+    positionals: [TARGET_POSITIONAL],
     flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      LEGACY_NAME_FLAG,
+      LEGACY_PID_FLAG,
       { name: "--new-name", type: "string", description: "Name for the fork." },
       { name: "--out-dir", type: "string", description: "Keep the snapshot bundle here." },
       {
@@ -243,9 +300,10 @@ export const COMMANDS: CommandSpec[] = [
     name: "attach",
     summary: "Drop into an interactive PTY shell in a running VM.",
     jsonOutput: false,
+    positionals: [TARGET_POSITIONAL],
     flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      LEGACY_NAME_FLAG,
+      LEGACY_PID_FLAG,
       {
         name: "--shell",
         type: "string",
@@ -263,19 +321,18 @@ export const COMMANDS: CommandSpec[] = [
     name: "repl",
     summary: "Per-line exec REPL — each line is a fresh one-shot command.",
     jsonOutput: false,
-    flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
-    ],
+    positionals: [TARGET_POSITIONAL],
+    flags: [LEGACY_NAME_FLAG, LEGACY_PID_FLAG],
   },
   {
     name: "stop",
     summary: "Stop a running VM (SIGTERM, SIGKILL after 2s).",
     jsonOutput: true,
     mutating: true,
+    positionals: [TARGET_POSITIONAL],
     flags: [
-      { name: "--name", type: "string", description: "Target VM by name." },
-      { name: "--pid", type: "integer", description: "Target VM by VMM pid." },
+      LEGACY_NAME_FLAG,
+      LEGACY_PID_FLAG,
       {
         name: "--force",
         type: "boolean",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -977,7 +977,7 @@ function lookupEntry(target: { name: string } | { pid: number }): RegistryEntry 
 }
 
 function describeTarget(target: { name: string } | { pid: number }): string {
-  return "name" in target ? `--name ${target.name}` : `--pid ${target.pid}`;
+  return "name" in target ? `name ${target.name}` : `pid ${target.pid}`;
 }
 
 async function cmdExec(args: string[]): Promise<number> {
@@ -1078,30 +1078,15 @@ async function runPtyExec(
 }
 
 async function cmdSnapshot(args: string[]): Promise<number> {
-  // Preferred form: `machinen snapshot <target> <out-dir>`.
-  // Legacy: `--out-dir <dir>` (warned, accepted for one release).
-  // We strip --json / --dry-run / --keep-alive / --out-dir first;
-  // anything left feeds extractTarget which pulls the first positional
-  // as the target and returns leftovers as `rest`. The first leftover
-  // (if any) is the out-dir positional.
+  // Form: `machinen snapshot <target> <out-dir>`. We strip --json /
+  // --dry-run / --keep-alive first; the first two positionals left
+  // are the target and the out-dir.
   const { json, rest: afterJson } = consumeJsonFlag(args);
   const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
-  let outDirFromFlag: string | undefined;
   let keepAlive = false;
   const remaining: string[] = [];
-  for (let i = 0; i < afterDry.length; i++) {
-    const a = afterDry[i]!;
-    if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      const v = a === "--out-dir" ? afterDry[++i] : a.slice("--out-dir=".length);
-      if (!v) {
-        die("--out-dir requires a directory path");
-      }
-      outDirFromFlag = v;
-      warnLegacyOnce(
-        "snapshot:--out-dir",
-        "machinen snapshot: --out-dir is deprecated; pass the directory as the second positional (e.g. `machinen snapshot <name|pid> <out-dir>`)",
-      );
-    } else if (a === "--keep-alive") {
+  for (const a of afterDry) {
+    if (a === "--keep-alive") {
       // Source survives the dump (CRIU --leave-running). Default
       // closes inherited TCP sockets — two live copies sharing the
       // same connection state can't both talk to the peer cleanly.
@@ -1111,21 +1096,13 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     }
   }
   const { target, rest: afterTarget } = resolveTarget(remaining, "snapshot");
-  let outDir = outDirFromFlag;
-  if (afterTarget.length > 0) {
-    if (outDir !== undefined) {
-      die(
-        "machinen snapshot: pass the out-dir once — either as a positional or via --out-dir (deprecated), not both",
-      );
-    }
-    if (afterTarget.length > 1) {
-      die(`unknown argument: ${afterTarget[1]}`);
-    }
-    outDir = afterTarget[0];
-  }
-  if (!outDir) {
+  if (afterTarget.length === 0) {
     die("usage: machinen snapshot <name|pid> <out-dir> [--keep-alive] [--dry-run] [--json]");
   }
+  if (afterTarget.length > 1) {
+    die(`unknown argument: ${afterTarget[1]}`);
+  }
+  const outDir = afterTarget[0]!;
   const resolvedOutDir = resolve(outDir);
   if (dryRun) {
     // Validate target exists + out-dir is creatable (parent must exist
@@ -1576,43 +1553,17 @@ async function cmdCompletion(args: string[]): Promise<number> {
 }
 
 /**
- * Pull `--name <s>` / `--pid <n>` out of an arg list. Exactly one of
- * the two must be present; reject zero, both, or unknown flags. The
- * shape returned matches `AttachOptions` so callers can pass it
- * straight to `attach()`.
- */
-/**
- * Wrap the pure `extractTarget` parser with the CLI's deprecation-
- * warning + error-formatting glue. Callers either use this directly
- * (snapshot, which has a second positional <out-dir>) or via the
- * `parseTargetFlags` shim (everyone else).
+ * Wrap the pure `extractTarget` parser with the CLI's error
+ * formatting. Callers either use this directly (snapshot, which has a
+ * second positional <out-dir>) or via the `parseTargetFlags` shim
+ * (everyone else).
  */
 function resolveTarget(args: string[], cmd: string): { target: Target; rest: string[] } {
-  let parsed;
   try {
-    parsed = extractTarget(args, cmd);
+    return extractTarget(args, cmd);
   } catch (err) {
     handleError(err);
   }
-  for (const flag of parsed.legacyFlags) {
-    warnLegacyTargetFlag(cmd, flag);
-  }
-  return { target: parsed.target, rest: parsed.rest };
-}
-
-const legacyWarned = new Set<string>();
-function warnLegacyOnce(key: string, message: string): void {
-  if (legacyWarned.has(key)) {
-    return;
-  }
-  legacyWarned.add(key);
-  process.stderr.write(`${message}\n`);
-}
-function warnLegacyTargetFlag(cmd: string, flag: "--name" | "--pid"): void {
-  warnLegacyOnce(
-    `${cmd}:${flag}`,
-    `machinen ${cmd}: ${flag} is deprecated; pass the target as a positional (e.g. \`machinen ${cmd} <name|pid>\`)`,
-  );
 }
 
 /**
@@ -1629,8 +1580,7 @@ function parseTargetFlags(args: string[], cmd: string): Target {
 
 // Names live in column 2 of `machinen ls`; pids in column 1. Both
 // are completion candidates for the first positional on
-// exec/snapshot/fork/attach/repl/stop, and after legacy
-// --name/--pid flags.
+// exec/snapshot/fork/attach/repl/stop.
 const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bashrc, or:
 #   eval "$(machinen completion bash)"
 _machinen_completion() {
@@ -1641,20 +1591,6 @@ _machinen_completion() {
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
   fi
-  case "\${prev}" in
-    --name)
-      local names
-      names=$(machinen ls 2>/dev/null | awk 'NR>1 && $2!="-"{print $2}')
-      COMPREPLY=( $(compgen -W "\${names}" -- "\${cur}") )
-      return
-      ;;
-    --pid)
-      local pids
-      pids=$(machinen ls 2>/dev/null | awk 'NR>1{print $1}')
-      COMPREPLY=( $(compgen -W "\${pids}" -- "\${cur}") )
-      return
-      ;;
-  esac
   case "\${words[1]}" in
     exec|snapshot|fork|attach|repl|stop)
       # First positional after the subcommand is the target.
@@ -1683,20 +1619,6 @@ _machinen() {
     _describe 'command' cmds
     return
   fi
-  case "\${words[CURRENT-1]}" in
-    --name)
-      local -a names
-      names=(\${(f)"$(machinen ls 2>/dev/null | awk 'NR>1 && $2!="-"{print $2}')"})
-      _describe 'name' names
-      return
-      ;;
-    --pid)
-      local -a pids
-      pids=(\${(f)"$(machinen ls 2>/dev/null | awk 'NR>1{print $1}')"})
-      _describe 'pid' pids
-      return
-      ;;
-  esac
   case "\${words[2]}" in
     exec|snapshot|fork|attach|repl|stop)
       # First positional after the subcommand is the target.
@@ -1725,11 +1647,6 @@ for bin in machinen mn
     # First positional after the subcommand: complete with VM names + pids.
     complete -c $bin -f -n "__fish_seen_subcommand_from $sub" \\
       -a '(machinen ls 2>/dev/null | awk \\'NR>1{print $1; if ($2!="-") print $2}\\')'
-    # Legacy --name/--pid still work; complete after them too.
-    complete -c $bin -f -n "__fish_seen_subcommand_from $sub" -l name \\
-      -a '(machinen ls 2>/dev/null | awk \\'NR>1 && $2!="-"{print $2}\\')'
-    complete -c $bin -f -n "__fish_seen_subcommand_from $sub" -l pid \\
-      -a '(machinen ls 2>/dev/null | awk \\'NR>1{print $1}\\')'
   end
   complete -c $bin -f -n "__fish_seen_subcommand_from gc" -l dry-run
 end
@@ -1808,7 +1725,6 @@ function printHelp(): void {
       `  Targeting a running VM:\n` +
       `    Pass the name or pid as the first positional arg.\n` +
       `    Digits-only is interpreted as a pid; everything else as a name.\n` +
-      `    (--name/--pid still work for one release with a deprecation warning.)\n` +
       `\n` +
       `  machinen exec     <name|pid> [--tty] -- <cmd>\n` +
       `                                                 Run a command in a running VM. Pass\n` +

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,10 +6,10 @@
 //   machinen boot [opts] -- <cmd>
 //   machinen restore <snap-dir> [--name <name>] [-p <hostPort>:<guestPort>]
 //   machinen ls (alias: ps)
-//   machinen exec ( --name <name> | --pid <pid> ) -- <cmd>
-//   machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir>
-//   machinen attach ( --name <name> | --pid <pid> ) [--shell <cmd>]   # PTY shell
-//   machinen repl   ( --name <name> | --pid <pid> )                   # per-line exec
+//   machinen exec <name|pid> -- <cmd>
+//   machinen snapshot <name|pid> <out-dir>
+//   machinen attach <name|pid> [--shell <cmd>]   # PTY shell
+//   machinen repl   <name|pid>                   # per-line exec
 //   machinen install [--version <tag>]
 //   machinen completion <bash|zsh|fish>
 //   machinen --version | -h | --help
@@ -53,6 +53,7 @@ import { formatPorts } from "./format-ports.ts";
 import { parseForkArgs } from "./parse-fork-args.ts";
 import { parseRestoreArgs } from "./parse-restore-args.ts";
 import { parseRunArgs } from "./parse-run-args.ts";
+import { extractTarget, type Target } from "./parse-target.ts";
 import { tailLines } from "./tail-lines.ts";
 
 const debug = debugLib("machinen:cli");
@@ -982,7 +983,7 @@ function describeTarget(target: { name: string } | { pid: number }): string {
 async function cmdExec(args: string[]): Promise<number> {
   // Pull --tty out before the `--` boundary so it isn't passed to the
   // workload. Auto-enable when stdin is a TTY and no --tty was passed
-  // explicitly is *not* what we want — `machinen exec --name foo --
+  // explicitly is *not* what we want — `machinen exec foo --
   // ps aux` from a terminal should still be one-shot pipes, otherwise
   // every output gets line-discipline-translated. Caller opts in.
   let usePty = false;
@@ -996,7 +997,7 @@ async function cmdExec(args: string[]): Promise<number> {
   }
   const dashIdx = filtered.indexOf("--");
   if (dashIdx === -1 || dashIdx === filtered.length - 1) {
-    die("usage: machinen exec ( --name <name> | --pid <pid> ) [--tty] -- <cmd>");
+    die("usage: machinen exec <name|pid> [--tty] -- <cmd>");
   }
   const pre = filtered.slice(0, dashIdx);
   const cmdArgs = filtered.slice(dashIdx + 1);
@@ -1005,7 +1006,7 @@ async function cmdExec(args: string[]): Promise<number> {
   try {
     // Shell out via `sh -c` on the guest so caller can pass piped
     // commands naturally. Users who want raw exec of a single binary
-    // can quote it like `machinen exec --name foo -- /bin/ls`.
+    // can quote it like `machinen exec foo -- /bin/ls`.
     const joined = cmdArgs.join(" ");
     if (usePty) {
       if (!process.stdin.isTTY) {
@@ -1077,35 +1078,54 @@ async function runPtyExec(
 }
 
 async function cmdSnapshot(args: string[]): Promise<number> {
-  // Pull --out-dir / --keep-alive / --json / --dry-run out of the arg
-  // list, then parse the target flags.
+  // Preferred form: `machinen snapshot <target> <out-dir>`.
+  // Legacy: `--out-dir <dir>` (warned, accepted for one release).
+  // We strip --json / --dry-run / --keep-alive / --out-dir first;
+  // anything left feeds extractTarget which pulls the first positional
+  // as the target and returns leftovers as `rest`. The first leftover
+  // (if any) is the out-dir positional.
   const { json, rest: afterJson } = consumeJsonFlag(args);
   const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
-  let outDir: string | undefined;
+  let outDirFromFlag: string | undefined;
   let keepAlive = false;
-  const rest: string[] = [];
+  const remaining: string[] = [];
   for (let i = 0; i < afterDry.length; i++) {
     const a = afterDry[i]!;
     if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      outDir = a === "--out-dir" ? afterDry[++i] : a.slice("--out-dir=".length);
-      if (!outDir) {
+      const v = a === "--out-dir" ? afterDry[++i] : a.slice("--out-dir=".length);
+      if (!v) {
         die("--out-dir requires a directory path");
       }
+      outDirFromFlag = v;
+      warnLegacyOnce(
+        "snapshot:--out-dir",
+        "machinen snapshot: --out-dir is deprecated; pass the directory as the second positional (e.g. `machinen snapshot <name|pid> <out-dir>`)",
+      );
     } else if (a === "--keep-alive") {
       // Source survives the dump (CRIU --leave-running). Default
       // closes inherited TCP sockets — two live copies sharing the
       // same connection state can't both talk to the peer cleanly.
       keepAlive = true;
     } else {
-      rest.push(a);
+      remaining.push(a);
     }
   }
-  if (!outDir) {
-    die(
-      "usage: machinen snapshot ( --name <name> | --pid <pid> ) --out-dir <dir> [--keep-alive] [--dry-run] [--json]",
-    );
+  const { target, rest: afterTarget } = resolveTarget(remaining, "snapshot");
+  let outDir = outDirFromFlag;
+  if (afterTarget.length > 0) {
+    if (outDir !== undefined) {
+      die(
+        "machinen snapshot: pass the out-dir once — either as a positional or via --out-dir (deprecated), not both",
+      );
+    }
+    if (afterTarget.length > 1) {
+      die(`unknown argument: ${afterTarget[1]}`);
+    }
+    outDir = afterTarget[0];
   }
-  const target = parseTargetFlags(rest, "snapshot");
+  if (!outDir) {
+    die("usage: machinen snapshot <name|pid> <out-dir> [--keep-alive] [--dry-run] [--json]");
+  }
   const resolvedOutDir = resolve(outDir);
   if (dryRun) {
     // Validate target exists + out-dir is creatable (parent must exist
@@ -1436,7 +1456,7 @@ async function cmdRepl(args: string[]): Promise<number> {
   process.stderr.write(
     `each line is a fresh one-shot exec — cd / env vars / history do NOT persist.\n` +
       `for an interactive shell with job control + TUI support, use:\n` +
-      `  machinen attach ${vm.name ? `--name ${vm.name}` : `--pid ${vm.pid}`}\n` +
+      `  machinen attach ${vm.name ?? vm.pid}\n` +
       `Ctrl-D to exit.\n`,
   );
   try {
@@ -1561,42 +1581,56 @@ async function cmdCompletion(args: string[]): Promise<number> {
  * shape returned matches `AttachOptions` so callers can pass it
  * straight to `attach()`.
  */
-function parseTargetFlags(args: string[], cmd: string): { name: string } | { pid: number } {
-  let name: string | undefined;
-  let pid: number | undefined;
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--name" || a.startsWith("--name=")) {
-      const v = a === "--name" ? args[++i] : a.slice("--name=".length);
-      if (!v) {
-        die(`--name requires a value`);
-      }
-      name = v;
-    } else if (a === "--pid" || a.startsWith("--pid=")) {
-      const v = a === "--pid" ? args[++i] : a.slice("--pid=".length);
-      if (!v || !/^[0-9]+$/.test(v)) {
-        die(`--pid requires a numeric value`);
-      }
-      pid = Number(v);
-    } else {
-      die(`unknown argument: ${a}`);
-    }
+/**
+ * Wrap the pure `extractTarget` parser with the CLI's deprecation-
+ * warning + error-formatting glue. Callers either use this directly
+ * (snapshot, which has a second positional <out-dir>) or via the
+ * `parseTargetFlags` shim (everyone else).
+ */
+function resolveTarget(args: string[], cmd: string): { target: Target; rest: string[] } {
+  let parsed;
+  try {
+    parsed = extractTarget(args, cmd);
+  } catch (err) {
+    handleError(err);
   }
-  if (name && pid !== undefined) {
-    die(`machinen ${cmd}: pass --name OR --pid, not both`);
+  for (const flag of parsed.legacyFlags) {
+    warnLegacyTargetFlag(cmd, flag);
   }
-  if (!name && pid === undefined) {
-    die(`machinen ${cmd}: requires --name <name> or --pid <pid>`);
+  return { target: parsed.target, rest: parsed.rest };
+}
+
+const legacyWarned = new Set<string>();
+function warnLegacyOnce(key: string, message: string): void {
+  if (legacyWarned.has(key)) {
+    return;
   }
-  if (name) {
-    return { name };
+  legacyWarned.add(key);
+  process.stderr.write(`${message}\n`);
+}
+function warnLegacyTargetFlag(cmd: string, flag: "--name" | "--pid"): void {
+  warnLegacyOnce(
+    `${cmd}:${flag}`,
+    `machinen ${cmd}: ${flag} is deprecated; pass the target as a positional (e.g. \`machinen ${cmd} <name|pid>\`)`,
+  );
+}
+
+/**
+ * Shim for callers that don't accept extra positionals. Errors on any
+ * leftover args.
+ */
+function parseTargetFlags(args: string[], cmd: string): Target {
+  const { target, rest } = resolveTarget(args, cmd);
+  if (rest.length > 0) {
+    die(`unknown argument: ${rest[0]}`);
   }
-  return { pid: pid! };
+  return target;
 }
 
 // Names live in column 2 of `machinen ls`; pids in column 1. Both
-// are used as completion candidates after `--name`/`--pid` on
-// exec/snapshot/attach/repl.
+// are completion candidates for the first positional on
+// exec/snapshot/fork/attach/repl/stop, and after legacy
+// --name/--pid flags.
 const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bashrc, or:
 #   eval "$(machinen completion bash)"
 _machinen_completion() {
@@ -1623,8 +1657,13 @@ _machinen_completion() {
   esac
   case "\${words[1]}" in
     exec|snapshot|fork|attach|repl|stop)
-      COMPREPLY=( $(compgen -W "--name --pid" -- "\${cur}") )
-      return
+      # First positional after the subcommand is the target.
+      if [[ \${cword} -eq 2 ]]; then
+        local targets
+        targets=$(machinen ls 2>/dev/null | awk 'NR>1{print $1; if ($2!="-") print $2}')
+        COMPREPLY=( $(compgen -W "\${targets}" -- "\${cur}") )
+        return
+      fi
       ;;
     gc)
       COMPREPLY=( $(compgen -W "--dry-run" -- "\${cur}") )
@@ -1660,8 +1699,13 @@ _machinen() {
   esac
   case "\${words[2]}" in
     exec|snapshot|fork|attach|repl|stop)
-      _describe 'flag' '(--name --pid)'
-      return
+      # First positional after the subcommand is the target.
+      if (( CURRENT == 3 )); then
+        local -a targets
+        targets=(\${(f)"$(machinen ls 2>/dev/null | awk 'NR>1{print $1; if ($2!="-") print $2}')"})
+        _describe 'target' targets
+        return
+      fi
       ;;
     gc)
       _describe 'flag' '(--dry-run)'
@@ -1678,6 +1722,10 @@ set -l cmds boot restore install list ls ps exec snapshot fork attach repl gc st
 for bin in machinen mn
   complete -c $bin -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
   for sub in exec snapshot fork attach repl stop
+    # First positional after the subcommand: complete with VM names + pids.
+    complete -c $bin -f -n "__fish_seen_subcommand_from $sub" \\
+      -a '(machinen ls 2>/dev/null | awk \\'NR>1{print $1; if ($2!="-") print $2}\\')'
+    # Legacy --name/--pid still work; complete after them too.
     complete -c $bin -f -n "__fish_seen_subcommand_from $sub" -l name \\
       -a '(machinen ls 2>/dev/null | awk \\'NR>1 && $2!="-"{print $2}\\')'
     complete -c $bin -f -n "__fish_seen_subcommand_from $sub" -l pid \\
@@ -1758,9 +1806,11 @@ function printHelp(): void {
       `                                                 a structured payload on stdout.\n` +
       `\n` +
       `  Targeting a running VM:\n` +
-      `    --name <name>     |  --pid <pid>             pick exactly one\n` +
+      `    Pass the name or pid as the first positional arg.\n` +
+      `    Digits-only is interpreted as a pid; everything else as a name.\n` +
+      `    (--name/--pid still work for one release with a deprecation warning.)\n` +
       `\n` +
-      `  machinen exec     <target-flag> [--tty] -- <cmd>\n` +
+      `  machinen exec     <name|pid> [--tty] -- <cmd>\n` +
       `                                                 Run a command in a running VM. Pass\n` +
       `                                                 --tty for a real PTY session — needed\n` +
       `                                                 for an interactive shell, vim, htop,\n` +
@@ -1768,15 +1818,15 @@ function printHelp(): void {
       `                                                 Without --tty stdio is line-buffered\n` +
       `                                                 pipes (good for one-shot commands).\n` +
       `                                                 Example:\n` +
-      `                                                   machinen exec <target-flag> --tty -- bash -i\n` +
-      `  machinen snapshot <target-flag> --out-dir <d> [--keep-alive]\n` +
+      `                                                   machinen exec <name|pid> --tty -- bash -i\n` +
+      `  machinen snapshot <name|pid> <out-dir> [--keep-alive]\n` +
       `                                                 CRIU-snapshot a running VM into <d>.\n` +
       `                                                 Default: source VM exits as part of the\n` +
       `                                                 dump. --keep-alive leaves it running\n` +
       `                                                 (and closes inherited TCP sockets to\n` +
       `                                                 avoid two live copies racing on shared\n` +
       `                                                 connection state).\n` +
-      `  machinen fork     <target-flag> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
+      `  machinen fork     <name|pid> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
       `                    [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...\n` +
       `                    [--cwd <abs>] [--memory <mib>]\n` +
       `                                                 Snapshot the source live (it keeps\n` +
@@ -1796,12 +1846,12 @@ function printHelp(): void {
       `                                                 --mount-live, --env, --cwd, --memory)\n` +
       `                                                 take effect on the forked sibling, not\n` +
       `                                                 the source.\n` +
-      `  machinen attach   <target-flag> [--shell <c>]  Drop into an interactive PTY shell\n` +
+      `  machinen attach   <name|pid> [--shell <c>]    Drop into an interactive PTY shell\n` +
       `                                                 in the running VM (default \`bash -i\`).\n` +
       `                                                 \`cd\`, env vars, history, job control\n` +
       `                                                 and full-screen TUIs all work. Exit\n` +
       `                                                 the shell (Ctrl-D) to detach.\n` +
-      `  machinen repl     <target-flag>                Per-line exec REPL: each line is a\n` +
+      `  machinen repl     <name|pid>                   Per-line exec REPL: each line is a\n` +
       `                                                 fresh one-shot \`exec\`, no persistent\n` +
       `                                                 state. Useful for piping a script of\n` +
       `                                                 one-liners; for an interactive shell\n` +
@@ -1832,10 +1882,10 @@ function printHelp(): void {
       `Examples:\n` +
       `  machinen boot --name worker -- node server.js\n` +
       `  machinen ls\n` +
-      `  machinen exec --name worker -- ps aux                # one-off command\n` +
-      `  machinen exec --name worker --tty -- bash -i         # interactive shell w/ job control\n` +
-      `  machinen exec --name worker --tty -- vim /etc/passwd # full-screen TUI in a PTY\n` +
-      `  machinen snapshot --name worker --out-dir ./warm\n` +
+      `  machinen exec worker -- ps aux                       # one-off command\n` +
+      `  machinen exec worker --tty -- bash -i                # interactive shell w/ job control\n` +
+      `  machinen exec worker --tty -- vim /etc/passwd        # full-screen TUI in a PTY\n` +
+      `  machinen snapshot worker ./warm                      # CRIU snapshot bundle\n` +
       `  machinen restore ./warm\n` +
       `\n` +
       `Environment:\n` +

--- a/packages/cli/src/parse-target.ts
+++ b/packages/cli/src/parse-target.ts
@@ -2,11 +2,10 @@
 // attach/repl/stop. Sibling of parse-run-args.ts / parse-fork-args.ts
 // — extracted so tests don't need to spawn the CLI.
 //
-// Preferred form: a single positional. All-digits → pid; everything
-// else → name. Legacy `--name`/`--pid` flags are still accepted for
-// one release; callers warn the user via `legacyFlags`. Anything that
-// isn't the target lands in `rest` so callers with a second positional
-// (snapshot's <out-dir>) can read it without re-parsing.
+// The target is a single positional. All-digits → pid; everything
+// else → name. Anything that isn't the target lands in `rest` so
+// callers with a second positional (snapshot's <out-dir>) can read
+// it without re-parsing.
 
 import { ParseError } from "@machinen/runtime";
 
@@ -16,45 +15,13 @@ export interface ExtractedTarget {
   target: Target;
   /** Args we didn't consume — extra positionals or flags the caller handles. */
   rest: string[];
-  /** Legacy flags the user passed; the CLI prints a one-time warning per flag. */
-  legacyFlags: Array<"--name" | "--pid">;
 }
 
 export function extractTarget(args: string[], cmd: string): ExtractedTarget {
-  let name: string | undefined;
-  let pid: number | undefined;
   let positional: string | undefined;
   const rest: string[] = [];
-  const legacyFlags: Array<"--name" | "--pid"> = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--name" || a.startsWith("--name=")) {
-      const v = a === "--name" ? args[++i] : a.slice("--name=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
-      }
-      if (name !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--name may be given at most once per invocation",
-        );
-      }
-      name = v;
-      legacyFlags.push("--name");
-    } else if (a === "--pid" || a.startsWith("--pid=")) {
-      const v = a === "--pid" ? args[++i] : a.slice("--pid=".length);
-      if (!v || !/^[0-9]+$/.test(v)) {
-        throw new ParseError("PARSE_FLAG_MALFORMED", "--pid requires a numeric value");
-      }
-      if (pid !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--pid may be given at most once per invocation",
-        );
-      }
-      pid = Number(v);
-      legacyFlags.push("--pid");
-    } else if (!a.startsWith("-")) {
+  for (const a of args) {
+    if (!a.startsWith("-")) {
       if (positional === undefined) {
         positional = a;
       } else {
@@ -64,30 +31,17 @@ export function extractTarget(args: string[], cmd: string): ExtractedTarget {
       throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown argument: ${a}`);
     }
   }
-  if (positional !== undefined && (name !== undefined || pid !== undefined)) {
-    throw new ParseError(
-      "PARSE_FLAG_MALFORMED",
-      `machinen ${cmd}: pass the target once — either as a positional or via --name/--pid (deprecated), not both`,
-    );
-  }
-  if (name !== undefined && pid !== undefined) {
-    throw new ParseError("PARSE_FLAG_MALFORMED", `machinen ${cmd}: pass --name OR --pid, not both`);
-  }
-  let target: Target;
-  if (positional !== undefined) {
-    // Edge case: a VM literally named "123" can't be targeted
-    // positionally (resolves as pid). Use the legacy `--name 123` form
-    // until renamed.
-    target = /^[0-9]+$/.test(positional) ? { pid: Number(positional) } : { name: positional };
-  } else if (name !== undefined) {
-    target = { name };
-  } else if (pid !== undefined) {
-    target = { pid };
-  } else {
+  if (positional === undefined) {
     throw new ParseError(
       "PARSE_FLAG_MISSING_VALUE",
       `machinen ${cmd}: requires a target name or pid (e.g. \`machinen ${cmd} <name|pid>\`)`,
     );
   }
-  return { target, rest, legacyFlags };
+  // Edge case: a VM literally named "123" can't be targeted
+  // positionally (resolves as pid). Rename the VM if you hit this —
+  // there's no flag escape hatch.
+  const target: Target = /^[0-9]+$/.test(positional)
+    ? { pid: Number(positional) }
+    : { name: positional };
+  return { target, rest };
 }

--- a/packages/cli/src/parse-target.ts
+++ b/packages/cli/src/parse-target.ts
@@ -1,0 +1,93 @@
+// Pure arg parser for the VM target shared by exec/snapshot/fork/
+// attach/repl/stop. Sibling of parse-run-args.ts / parse-fork-args.ts
+// — extracted so tests don't need to spawn the CLI.
+//
+// Preferred form: a single positional. All-digits → pid; everything
+// else → name. Legacy `--name`/`--pid` flags are still accepted for
+// one release; callers warn the user via `legacyFlags`. Anything that
+// isn't the target lands in `rest` so callers with a second positional
+// (snapshot's <out-dir>) can read it without re-parsing.
+
+import { ParseError } from "@machinen/runtime";
+
+export type Target = { name: string } | { pid: number };
+
+export interface ExtractedTarget {
+  target: Target;
+  /** Args we didn't consume — extra positionals or flags the caller handles. */
+  rest: string[];
+  /** Legacy flags the user passed; the CLI prints a one-time warning per flag. */
+  legacyFlags: Array<"--name" | "--pid">;
+}
+
+export function extractTarget(args: string[], cmd: string): ExtractedTarget {
+  let name: string | undefined;
+  let pid: number | undefined;
+  let positional: string | undefined;
+  const rest: string[] = [];
+  const legacyFlags: Array<"--name" | "--pid"> = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--name" || a.startsWith("--name=")) {
+      const v = a === "--name" ? args[++i] : a.slice("--name=".length);
+      if (!v) {
+        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
+      }
+      if (name !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--name may be given at most once per invocation",
+        );
+      }
+      name = v;
+      legacyFlags.push("--name");
+    } else if (a === "--pid" || a.startsWith("--pid=")) {
+      const v = a === "--pid" ? args[++i] : a.slice("--pid=".length);
+      if (!v || !/^[0-9]+$/.test(v)) {
+        throw new ParseError("PARSE_FLAG_MALFORMED", "--pid requires a numeric value");
+      }
+      if (pid !== undefined) {
+        throw new ParseError(
+          "PARSE_FLAG_DUPLICATE",
+          "--pid may be given at most once per invocation",
+        );
+      }
+      pid = Number(v);
+      legacyFlags.push("--pid");
+    } else if (!a.startsWith("-")) {
+      if (positional === undefined) {
+        positional = a;
+      } else {
+        rest.push(a);
+      }
+    } else {
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown argument: ${a}`);
+    }
+  }
+  if (positional !== undefined && (name !== undefined || pid !== undefined)) {
+    throw new ParseError(
+      "PARSE_FLAG_MALFORMED",
+      `machinen ${cmd}: pass the target once — either as a positional or via --name/--pid (deprecated), not both`,
+    );
+  }
+  if (name !== undefined && pid !== undefined) {
+    throw new ParseError("PARSE_FLAG_MALFORMED", `machinen ${cmd}: pass --name OR --pid, not both`);
+  }
+  let target: Target;
+  if (positional !== undefined) {
+    // Edge case: a VM literally named "123" can't be targeted
+    // positionally (resolves as pid). Use the legacy `--name 123` form
+    // until renamed.
+    target = /^[0-9]+$/.test(positional) ? { pid: Number(positional) } : { name: positional };
+  } else if (name !== undefined) {
+    target = { name };
+  } else if (pid !== undefined) {
+    target = { pid };
+  } else {
+    throw new ParseError(
+      "PARSE_FLAG_MISSING_VALUE",
+      `machinen ${cmd}: requires a target name or pid (e.g. \`machinen ${cmd} <name|pid>\`)`,
+    );
+  }
+  return { target, rest, legacyFlags };
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2845,7 +2845,7 @@ runtime materialized a squashfs RO lower + ext4 RW upper. Persist
 those host paths so an attach-owned `vm.snapshot()` /
 `vm.fork()` can reflink them into the snapshot bundle exactly
 like the boot-owned handle does — without this, a CLI-side
-`machinen snapshot --name <vm>` produces a bundle missing
+`machinen snapshot <vm>` produces a bundle missing
 `mount-lower.sqfs` / `mount-upper.img` and a later `restore`
 silently boots without the overlay.
 

--- a/packages/runtime/src/__tests__/api-md-drift.test.ts
+++ b/packages/runtime/src/__tests__/api-md-drift.test.ts
@@ -13,19 +13,26 @@
 // agent-ci snapshot checkout messes with).
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
 const COMMITTED_API_MD = join(REPO_ROOT, "packages/runtime/API.md");
+// Resolve the typedoc binary in node_modules directly. We used to
+// shell out via `npx typedoc`, but `npx` invokes npm's config layer,
+// which trips on otherwise-fine settings like `min-release-age=7d`
+// (npm 11.12 derives an internal `before` date from it, gets `null`,
+// and exits with `Invalid time value` before typedoc ever starts).
+// pnpm's `node_modules/.bin/typedoc` shim has none of that surface.
+const TYPEDOC_BIN = join(REPO_ROOT, "node_modules/.bin/typedoc");
 
 // Vitest's default `testTimeout` is 5s. Typedoc cold-start + plugin
 // load is ~1s on a warm `node_modules` but ~10-15s on hosted CI
-// runners (slower disks, cold caches, npx resolution overhead), so
-// the default fires before typedoc finishes its first run. 60s gives
-// plenty of headroom; the inner `execFileSync` uses the same cap.
+// runners (slower disks, cold caches), so the default fires before
+// typedoc finishes its first run. 60s gives plenty of headroom; the
+// inner `execFileSync` uses the same cap.
 const TYPEDOC_TIMEOUT_MS = 60_000;
 
 /**
@@ -46,12 +53,20 @@ describe("API.md drift", () => {
   it(
     "matches `pnpm run build:docs` output (modulo line-number URLs)",
     () => {
+      if (!existsSync(TYPEDOC_BIN)) {
+        // Fresh checkout, deps not installed yet — let the dev know
+        // which command to run instead of failing inside execFileSync
+        // with a cryptic ENOENT.
+        expect.fail(
+          `typedoc binary missing at ${TYPEDOC_BIN}; run \`pnpm install\` from the repo root.`,
+        );
+      }
       const out = mkdtempSync(join(tmpdir(), "machinen-api-md-drift-"));
       try {
         // Run the same typedoc invocation `pnpm run build:docs` runs,
         // but redirect the output so we don't clobber the on-disk
         // committed file mid-test. Reads typedoc.json from REPO_ROOT.
-        execFileSync("npx", ["typedoc", "--out", out], {
+        execFileSync(TYPEDOC_BIN, ["--out", out], {
           cwd: REPO_ROOT,
           stdio: ["ignore", "ignore", "pipe"],
           timeout: TYPEDOC_TIMEOUT_MS,

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -261,7 +261,10 @@ interface BaseAssetSpec {
   param: string;
   assetsDirName: string;
   cliCacheName: string;
-  missingCode: "PROVISION_BASE_NOT_FOUND" | "PROVISION_KERNEL_NOT_FOUND" | "PROVISION_DTB_NOT_FOUND";
+  missingCode:
+    | "PROVISION_BASE_NOT_FOUND"
+    | "PROVISION_KERNEL_NOT_FOUND"
+    | "PROVISION_DTB_NOT_FOUND";
 }
 
 function resolveBaseAsset(spec: BaseAssetSpec, explicit: string | undefined, cwd: string): string {

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -146,7 +146,7 @@ export interface RegistryEntry {
    * those host paths so an attach-owned `vm.snapshot()` /
    * `vm.fork()` can reflink them into the snapshot bundle exactly
    * like the boot-owned handle does — without this, a CLI-side
-   * `machinen snapshot --name <vm>` produces a bundle missing
+   * `machinen snapshot <vm>` produces a bundle missing
    * `mount-lower.sqfs` / `mount-upper.img` and a later `restore`
    * silently boots without the overlay.
    */

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -1173,7 +1173,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         statsPath: statsFilePath,
         // #272: persist mount-overlay paths so an attach-owned
         // vm.snapshot()/fork() can reflink the lower+upper into the
-        // bundle. Without this, `machinen snapshot --name <vm>` from
+        // bundle. Without this, `machinen snapshot <vm>` from
         // the CLI produces a bundle that's missing the overlay halves.
         mountDisk: mountDiskPaths
           ? {

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -769,9 +769,9 @@ B1_PID=$(boot_bg "$B1_NAME" "$B1_BG_LOG" --memory 2048 -- \
   /bin/sh -c "/exec-agent & sleep 600")
 # B1 runs before the N-series which asserts an empty registry, so
 # cleanup MUST remove the registry entry, not just kill the VMM.
-# `machinen stop --name` does both (SIGTERM + writeEntry remove).
+# `machinen stop <name>` does both (SIGTERM + writeEntry remove).
 cleanup_b1() {
-  cli stop --name "$B1_NAME" >/dev/null 2>&1 || true
+  cli stop "$B1_NAME" >/dev/null 2>&1 || true
   kill -TERM "$B1_PID" 2>/dev/null || true
   wait "$B1_PID" 2>/dev/null || true
 }
@@ -807,7 +807,7 @@ echo "  baseline RSS=${B1_BASELINE} MiB (vmm pid $B1_VMM_PID)"
 # under `sh -c` in the guest — so we pass the command as one
 # already-shell-ready string, no extra `/bin/sh -c` wrapping.
 B1_SPIKE_LOG="$FIXTURE/b1-spike.log"
-if ! cli exec --name "$B1_NAME" -- \
+if ! cli exec "$B1_NAME" -- \
   'dd if=/dev/zero of=/tmp/big bs=1M count=1024 status=none && sync && echo SPIKE_DONE' \
   >"$B1_SPIKE_LOG" 2>&1; then
   cat "$B1_SPIKE_LOG" >&2
@@ -827,7 +827,7 @@ pass "spike added $(( B1_SPIKE - B1_BASELINE )) MiB to host RSS"
 # `page_reporting_period_ms` defaults to 2000; report budget is 16
 # 2-MiB blocks per cycle, so a 1 GiB free-run takes a few cycles to
 # fully drain. 30s is comfortable.
-if ! cli exec --name "$B1_NAME" -- \
+if ! cli exec "$B1_NAME" -- \
   'rm /tmp/big && sync && echo 3 > /proc/sys/vm/drop_caches && echo FREE_DONE' \
   >"$FIXTURE/b1-free.log" 2>&1; then
   cat "$FIXTURE/b1-free.log" >&2
@@ -914,9 +914,9 @@ else
   fail "N2 — 'machinen ls' missing '$N2_NAME'"
 fi
 
-# machinen exec --name <name> -- uname -m should return 0 + aarch64.
+# machinen exec <name> -- uname -m should return 0 + aarch64.
 N2_EXEC_LOG="$FIXTURE/n2-exec.log"
-if cli exec --name "$N2_NAME" -- uname -m >"$N2_EXEC_LOG" 2>&1; then
+if cli exec "$N2_NAME" -- uname -m >"$N2_EXEC_LOG" 2>&1; then
   if grep -qE "aarch64|arm64" "$N2_EXEC_LOG"; then
     pass "'machinen exec $N2_NAME -- uname -m' returned aarch64"
   else
@@ -978,7 +978,7 @@ fi
 # in main.zig is what keeps it alive once the parent's stderr pipe
 # breaks).
 N2D_EXEC_LOG="$FIXTURE/n2d-exec.log"
-if cli exec --name "$N2D_NAME" -- uname -m >"$N2D_EXEC_LOG" 2>&1; then
+if cli exec "$N2D_NAME" -- uname -m >"$N2D_EXEC_LOG" 2>&1; then
   if grep -qE "aarch64|arm64" "$N2D_EXEC_LOG"; then
     pass "post-detach 'exec $N2D_NAME -- uname -m' returned aarch64"
   else
@@ -1015,8 +1015,8 @@ N2D_CLEANUP_PATHS=$(node -p "JSON.parse(require('fs').readFileSync('$N2D_META','
 N2D_GVPROXY_PID=$(node -p "JSON.parse(require('fs').readFileSync('$N2D_META','utf8')).gvproxyPid ?? ''" 2>/dev/null || true)
 
 N2S_LOG="$FIXTURE/n2s.log"
-if cli stop --name "$N2D_NAME" >"$N2S_LOG" 2>&1; then
-  pass "machinen stop --name $N2D_NAME exited 0"
+if cli stop "$N2D_NAME" >"$N2S_LOG" 2>&1; then
+  pass "machinen stop $N2D_NAME exited 0"
 else
   cat "$N2S_LOG" >&2
   fail "N2S — machinen stop exited non-zero"
@@ -1059,7 +1059,7 @@ fi
 # Stop is idempotent — calling it again on a missing name should
 # error cleanly, not crash.
 N2S_AGAIN_LOG="$FIXTURE/n2s-again.log"
-if cli stop --name "$N2D_NAME" >"$N2S_AGAIN_LOG" 2>&1; then
+if cli stop "$N2D_NAME" >"$N2S_AGAIN_LOG" 2>&1; then
   cat "$N2S_AGAIN_LOG" >&2
   fail "N2S — second 'stop' on missing name should have failed"
 fi
@@ -1077,7 +1077,7 @@ fi  # N2 rootfs-capability gate
 # ---- N3: machinen attach <unknown> errors cleanly ----
 echo "N3: machinen attach against an unknown name"
 N3_LOG="$FIXTURE/n3.log"
-if cli attach --name "nope-does-not-exist-$$" >"$N3_LOG" 2>&1; then
+if cli attach "nope-does-not-exist-$$" >"$N3_LOG" 2>&1; then
   cat "$N3_LOG" >&2
   fail "N3 — attach to unknown name should have failed"
 fi
@@ -1188,7 +1188,7 @@ fi
 # Snapshot/restore round-trip (#50 M2). Uses the supervisor +
 # /sbin/machinen-dump + /sbin/machinen-restore baked into the rootfs:
 #   1. boot with a scratch /dev/vda + named VM
-#   2. `machinen snapshot --name <n> --out-dir <d>`   (attach-snapshot)
+#   2. `machinen snapshot <n> <d>`                     (attach-snapshot)
 #   3. `machinen restore <d>`                          (criu-ns restore)
 #   4. exec into the restored VM (auto-named <n>/<pid>) to prove the
 #      agent re-spawned
@@ -1223,7 +1223,7 @@ else
 
   # Confirm the supervisor's backgrounded exec-agent is live.
   S1_EXEC_LOG="$FIXTURE/s1-exec.log"
-  if cli exec --name "$S1_NAME" -- uname -m >"$S1_EXEC_LOG" 2>&1 \
+  if cli exec "$S1_NAME" -- uname -m >"$S1_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S1_EXEC_LOG"; then
     pass "exec-agent responds on the dump-side VM"
   else
@@ -1235,7 +1235,7 @@ else
   # Snapshot via the attach path. The bundle (img/<criu> + meta.json)
   # lands at $S1_SNAP_DIR; the VM exits as part of the dump.
   S1_DUMP_LOG="$FIXTURE/s1-dump.log"
-  if ! cli snapshot --name "$S1_NAME" --out-dir "$S1_SNAP_DIR" 2>"$S1_DUMP_LOG"; then
+  if ! cli snapshot "$S1_NAME" "$S1_SNAP_DIR" 2>"$S1_DUMP_LOG"; then
     tail -60 "$S1_BG_LOG" >&2
     cat "$S1_DUMP_LOG" >&2
     fail "S1 — 'machinen snapshot' failed"
@@ -1285,7 +1285,7 @@ else
   pass "restored VM auto-named as '$S1_RESTORED_NAME'"
 
   S1_RESTORE_EXEC_LOG="$FIXTURE/s1-restore-exec.log"
-  if cli exec --name "$S1_RESTORED_NAME" -- uname -m >"$S1_RESTORE_EXEC_LOG" 2>&1 \
+  if cli exec "$S1_RESTORED_NAME" -- uname -m >"$S1_RESTORE_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S1_RESTORE_EXEC_LOG"; then
     pass "exec-agent responds on the restored VM"
   else
@@ -1368,7 +1368,7 @@ else
 
   # Snapshot to bundle A.
   S2_DUMP_A_LOG="$FIXTURE/s2-dump-a.log"
-  if ! cli snapshot --name "$S2_NAME" --out-dir "$S2_SNAP_A" 2>"$S2_DUMP_A_LOG"; then
+  if ! cli snapshot "$S2_NAME" "$S2_SNAP_A" 2>"$S2_DUMP_A_LOG"; then
     tail -60 "$S2_BG_LOG" >&2
     cat "$S2_DUMP_A_LOG" >&2
     fail "S2 — first 'machinen snapshot' (to A) failed"
@@ -1412,7 +1412,7 @@ else
   # Snapshot the restored VM to bundle B. This is the operation that
   # used to fail with EBUSY on /dev/vdb and 'PID file missing'.
   S2_DUMP_B_LOG="$FIXTURE/s2-dump-b.log"
-  if ! cli snapshot --name "$S2_RESTORED_A" --out-dir "$S2_SNAP_B" 2>"$S2_DUMP_B_LOG"; then
+  if ! cli snapshot "$S2_RESTORED_A" "$S2_SNAP_B" 2>"$S2_DUMP_B_LOG"; then
     tail -80 "$S2_RESTORE_A_LOG" >&2
     cat "$S2_DUMP_B_LOG" >&2
     fail "S2 — chained 'machinen snapshot' (restored → B) failed"
@@ -1463,7 +1463,7 @@ else
   pass "restored bundle B as '$S2_RESTORED_B'"
 
   S2_RESTORE_B_EXEC_LOG="$FIXTURE/s2-restore-b-exec.log"
-  if cli exec --name "$S2_RESTORED_B" -- uname -m >"$S2_RESTORE_B_EXEC_LOG" 2>&1 \
+  if cli exec "$S2_RESTORED_B" -- uname -m >"$S2_RESTORE_B_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S2_RESTORE_B_EXEC_LOG"; then
     pass "exec-agent responds on the chain-restored VM (gen 2)"
   else
@@ -1478,7 +1478,7 @@ else
   # deepens, so a depth-3 restore is the canary for whether
   # /sbin/machinen-dump can dump across a sub-NS boundary.
   S2_DUMP_C_LOG="$FIXTURE/s2-dump-c.log"
-  if ! cli snapshot --name "$S2_RESTORED_B" --out-dir "$S2_SNAP_C" 2>"$S2_DUMP_C_LOG"; then
+  if ! cli snapshot "$S2_RESTORED_B" "$S2_SNAP_C" 2>"$S2_DUMP_C_LOG"; then
     tail -80 "$S2_RESTORE_B_LOG" >&2
     cat "$S2_DUMP_C_LOG" >&2
     fail "S2 — gen-3 'machinen snapshot' (restored-B → C) failed"
@@ -1516,7 +1516,7 @@ else
   pass "restored bundle C as '$S2_RESTORED_C'"
 
   S2_RESTORE_C_EXEC_LOG="$FIXTURE/s2-restore-c-exec.log"
-  if cli exec --name "$S2_RESTORED_C" -- uname -m >"$S2_RESTORE_C_EXEC_LOG" 2>&1 \
+  if cli exec "$S2_RESTORED_C" -- uname -m >"$S2_RESTORE_C_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S2_RESTORE_C_EXEC_LOG"; then
     pass "exec-agent responds on the gen-3 chain-restored VM"
   else
@@ -1574,7 +1574,7 @@ else
   # under `sh -c` in the guest. To get a real shell redirect inside the
   # guest we have to send `>` as a literal arg (single-quoted on the
   # host so the host bash doesn't interpret it as a redirect).
-  if ! cli exec --name "$S3_NAME" -- echo source '>' /tmp/who; then
+  if ! cli exec "$S3_NAME" -- echo source '>' /tmp/who; then
     tail -60 "$S3_BG_LOG" >&2
     fail "S3 — couldn't seed /tmp/who on source"
   fi
@@ -1583,7 +1583,7 @@ else
   # the standard restore() auto-naming.
   S3_FORK_LOG="$FIXTURE/s3-fork.log"
   S3_FORK_BUNDLE="$FIXTURE/s3-fork-bundle"
-  if ! cli fork --name "$S3_NAME" --out-dir "$S3_FORK_BUNDLE" --detach 2>"$S3_FORK_LOG"; then
+  if ! cli fork "$S3_NAME" --out-dir "$S3_FORK_BUNDLE" --detach 2>"$S3_FORK_LOG"; then
     cat "$S3_FORK_LOG" >&2
     tail -60 "$S3_BG_LOG" >&2
     fail "S3 — 'machinen fork' failed"
@@ -1621,12 +1621,12 @@ else
   # Independence check: write 'fork' on the fork's disk, 'source' is
   # already on the source. Re-read both — neither should see the
   # other's value.
-  if ! cli exec --name "$S3_FORK_NAME" -- echo fork '>' /tmp/who; then
+  if ! cli exec "$S3_FORK_NAME" -- echo fork '>' /tmp/who; then
     tail -60 "$S3_BG_LOG" >&2
     fail "S3 — couldn't write /tmp/who on fork"
   fi
-  S3_SRC_AFTER=$(cli exec --name "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
-  S3_FORK_AFTER=$(cli exec --name "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_SRC_AFTER=$(cli exec "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FORK_AFTER=$(cli exec "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
   if [[ "$S3_SRC_AFTER" != "source" || "$S3_FORK_AFTER" != "fork" ]]; then
     fail "S3 — disk state crossed between source ('$S3_SRC_AFTER') and fork ('$S3_FORK_AFTER')"
   fi
@@ -1638,7 +1638,7 @@ else
   # hits with destructive snapshots.
   S3_GRAND_LOG="$FIXTURE/s3-fork-of-fork.log"
   S3_GRAND_BUNDLE="$FIXTURE/s3-grand-bundle"
-  if ! cli fork --name "$S3_FORK_NAME" --out-dir "$S3_GRAND_BUNDLE" --detach 2>"$S3_GRAND_LOG"; then
+  if ! cli fork "$S3_FORK_NAME" --out-dir "$S3_GRAND_BUNDLE" --detach 2>"$S3_GRAND_LOG"; then
     cat "$S3_GRAND_LOG" >&2
     tail -60 "$S3_BG_LOG" >&2
     fail "S3 — 'machinen fork' on the fork (gen-2) failed"
@@ -1662,12 +1662,12 @@ else
 
   # Three-way independence: write 'grand' on the grandchild, then
   # check all three /tmp/who files are independent.
-  if ! cli exec --name "$S3_GRAND_NAME" -- echo grand '>' /tmp/who; then
+  if ! cli exec "$S3_GRAND_NAME" -- echo grand '>' /tmp/who; then
     fail "S3 — couldn't write /tmp/who on grand"
   fi
-  S3_FINAL_SRC=$(cli exec --name "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
-  S3_FINAL_FORK=$(cli exec --name "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
-  S3_FINAL_GRAND=$(cli exec --name "$S3_GRAND_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FINAL_SRC=$(cli exec "$S3_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FINAL_FORK=$(cli exec "$S3_FORK_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
+  S3_FINAL_GRAND=$(cli exec "$S3_GRAND_NAME" -- cat /tmp/who 2>/dev/null | tr -d '\r\n')
   if [[ "$S3_FINAL_SRC" != "source" || "$S3_FINAL_FORK" != "fork" || "$S3_FINAL_GRAND" != "grand" ]]; then
     fail "S3 — three-way independence broken: src='$S3_FINAL_SRC' fork='$S3_FINAL_FORK' grand='$S3_FINAL_GRAND'"
   fi
@@ -1675,8 +1675,8 @@ else
 
   # Tear down the forks (poweroff via vsock). The source goes down
   # with cleanup_s3 below.
-  cli exec --name "$S3_GRAND_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
-  cli exec --name "$S3_FORK_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
+  cli exec "$S3_GRAND_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
+  cli exec "$S3_FORK_NAME" -- /sbin/machinen-poweroff >/dev/null 2>&1 || true
   rm -rf "$S3_GRAND_BUNDLE" "$S3_FORK_BUNDLE" 2>/dev/null || true
   cleanup_s3
   trap 'rm -rf "$FIXTURE"' EXIT
@@ -1721,7 +1721,7 @@ else
   pass "boot --name --snapshot registered '$S4_NAME'"
 
   S4_DUMP_LOG="$FIXTURE/s4-dump.log"
-  if ! cli snapshot --name "$S4_NAME" --out-dir "$S4_SNAP_DIR" 2>"$S4_DUMP_LOG"; then
+  if ! cli snapshot "$S4_NAME" "$S4_SNAP_DIR" 2>"$S4_DUMP_LOG"; then
     tail -60 "$S4_BG_LOG" >&2
     cat "$S4_DUMP_LOG" >&2
     fail "S4 — 'machinen snapshot' failed"
@@ -1764,7 +1764,7 @@ else
   # protocol is broken or FUSE reads fail, the workload hangs on first
   # instruction and exec times out.
   S4_EXEC_LOG="$FIXTURE/s4-exec.log"
-  if cli exec --name "$S4_RESTORED_NAME" -- uname -m >"$S4_EXEC_LOG" 2>&1 \
+  if cli exec "$S4_RESTORED_NAME" -- uname -m >"$S4_EXEC_LOG" 2>&1 \
      && grep -qE "aarch64|arm64" "$S4_EXEC_LOG"; then
     pass "exec-agent responds on the lazy-pages restored VM"
   else
@@ -1857,7 +1857,7 @@ else
 
   # Snapshot — destructive. Parent dies after the dump.
   S5_DUMP_LOG="$FIXTURE/s5-dump.log"
-  if ! cli snapshot --name "$S5_NAME" --out-dir "$S5_SNAP_DIR" 2>"$S5_DUMP_LOG"; then
+  if ! cli snapshot "$S5_NAME" "$S5_SNAP_DIR" 2>"$S5_DUMP_LOG"; then
     tail -60 "$S5_BG_LOG" >&2
     cat "$S5_DUMP_LOG" >&2
     fail "S5 — 'machinen snapshot' failed"
@@ -1988,7 +1988,7 @@ else
   pass "boot with --mount-live registered '$S6_NAME'"
 
   # Verify the source's live mount works: guest write lands on host.
-  if ! cli exec --name "$S6_NAME" -- echo from-source '>' /mnt/share/source.txt; then
+  if ! cli exec "$S6_NAME" -- echo from-source '>' /mnt/share/source.txt; then
     tail -60 "$S6_BG_LOG" >&2
     fail "S6 — couldn't write through live mount on source"
   fi
@@ -2002,7 +2002,7 @@ else
   # Today: preflight unmounts, dump succeeds, meta.liveMounts records
   # the share-A path so restore can re-establish.
   S6_DUMP_LOG="$FIXTURE/s6-dump.log"
-  if ! cli snapshot --name "$S6_NAME" --out-dir "$S6_SNAP_DIR" 2>"$S6_DUMP_LOG"; then
+  if ! cli snapshot "$S6_NAME" "$S6_SNAP_DIR" 2>"$S6_DUMP_LOG"; then
     tail -60 "$S6_BG_LOG" >&2
     cat "$S6_DUMP_LOG" >&2
     fail "S6 — 'machinen snapshot' against --mount-live VM failed"
@@ -2049,7 +2049,7 @@ else
   pass "restored VM auto-named as '$S6_RESTORED'"
 
   S6_READ_LOG="$FIXTURE/s6-read.log"
-  if cli exec --name "$S6_RESTORED" -- cat /mnt/share/source.txt >"$S6_READ_LOG" 2>&1 \
+  if cli exec "$S6_RESTORED" -- cat /mnt/share/source.txt >"$S6_READ_LOG" 2>&1 \
      && grep -q "from-source" "$S6_READ_LOG"; then
     pass "restored VM reads through re-established live mount (host share-A)"
   else
@@ -2092,7 +2092,7 @@ else
   pass "remapped restore registered as '$S6_REMAPPED'"
 
   S6_REMAP_READ_LOG="$FIXTURE/s6-remap-read.log"
-  if cli exec --name "$S6_REMAPPED" -- cat /mnt/share/marker.txt >"$S6_REMAP_READ_LOG" 2>&1 \
+  if cli exec "$S6_REMAPPED" -- cat /mnt/share/marker.txt >"$S6_REMAP_READ_LOG" 2>&1 \
      && grep -q "from-share-b" "$S6_REMAP_READ_LOG"; then
     pass "override --mount-live remapped host dir on restore (share-B visible)"
   else

--- a/vm.ts
+++ b/vm.ts
@@ -217,7 +217,7 @@ const hostRows = stdoutAny.rows ?? 24;
 
 // #177: ask the VMM to bridge AF_VSOCK port 1974 (winsize agent) to a
 // host UDS. We ALSO wire up port 1978 (exec-agent) so `machinen exec
-// --pid <X>` and `machinen snapshot --pid <X>` work against this VM —
+// <pid>` and `machinen snapshot <pid> <out-dir>` work against this VM —
 // the runtime's registry stores the FIRST entry's UDS as the socket
 // path attach handles use, so put exec first and winsize second.
 // Without this the registered socketPath was the winsize UDS, which
@@ -334,7 +334,7 @@ const DEV_BOOTSTRAP = [
   // AF_VSOCK fd never appears inside the dumpable workload tree.
   // Putting the spawn here used to make the agent a workload descendant,
   // which broke `criu dump` ("BUG! Unknown socket collected (family 40)")
-  // and made `machinen snapshot --pid X` fail on every vm-pick'd VM.
+  // and made `machinen snapshot X <out-dir>` fail on every vm-pick'd VM.
   // CWD stays at /home/dev (set by env above) so snapshot/restore can
   // re-open it on the restored VM. ~/.bashrc.machinen handles the
   // convenience cd into /mnt/workspace for interactive shells — see the


### PR DESCRIPTION
## Problem

To do anything to a running virtual machine — run a command inside it, snapshot it, stop it, fork it — `machinen` made you spell out which one you meant with a flag. Either `--name worker` or `--pid 12345`. So stopping a virtual machine looked like `machinen stop --name worker`, when the thing you actually wanted to say was "stop worker."

Seven commands shared this shape. It is repetitive boilerplate that punishes the most common day-to-day operations. `snapshot` had the same issue with where to write the snapshot bundle: you wrote `--out-dir ./warm` instead of just `./warm`.

A separate annoyance turned up while running the test suite for this branch. One of the test files shells out to `npx`, and `npx` itself was crashing before it could reach the tool it was meant to run. The cause was a setting in my home `.npmrc` combined with a bug in npm version 11.12.

## Solution

1. Take the virtual machine as a plain positional argument — meaning you write it without a flag in front of it — on every command that targets a running virtual machine:
   - `machinen stop worker` (was `machinen stop --name worker`)
   - `machinen exec worker -- ps aux`
   - `machinen snapshot worker ./warm` (was `machinen snapshot --name worker --out-dir ./warm`)

   If the argument is digits-only, treat it as a host process id. Otherwise treat it as a registered virtual-machine name. The seven affected commands are `exec`, `snapshot`, `fork`, `attach`, `repl`, and `stop`.
2. Delete the old `--name`, `--pid`, and `--out-dir` flags entirely. `machinen` has not shipped a public release yet, so there are no users to migrate. Removing the flags lets us delete the deprecation code along with them.
3. Stop the test from calling `npx`. Call the documentation-generator binary directly out of `node_modules/.bin`, so the test does not pass through npm's configuration layer.

One edge case worth knowing: a virtual machine literally named `123` cannot be targeted positionally because the digits make it look like a process id. Rename the virtual machine if you hit this. The names the registry hands out by default look like `worker-1` or `redis-cache`, so only someone who deliberately picks a digit-only name will trip on it.

## Technical Summary

The argument-parsing logic for the target lives in a new pure parser at `packages/cli/src/parse-target.ts`. It returns the parsed target plus any leftover arguments, so `snapshot` (which has a second positional for the output directory) reads the leftovers itself, instead of every command duplicating positional logic.

The schema that describes the command surface to other tools — `packages/cli/src/agent-context.ts` — gains a new field called `positionals` on every command. The schema version bumps from 1 to 2. Tools that read version 1 and ignore unknown fields keep working.

Help text, every guide, every example, the shell completion scripts for bash, zsh, and fish, and the end-to-end smoke tests all switch to the positional form in the same change. A repository-wide search for the old form turns up zero remaining mentions.

The npm-related fix is a one-line swap in `api-md-drift.test.ts`: instead of `execFileSync("npx", ["typedoc", ...])` it now calls the typedoc binary at `node_modules/.bin/typedoc` directly. Same behavior, no dependency on npm's broken configuration handling.