### PR TITLE
Ctrl-D stops the VM in foreground sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ If any of the three fails, fix the issue and re-run.
 - Package manager is pnpm (pinned via `packageManager` in package.json).
 - The user authenticates via OAuth (`gh auth login`), never API keys.
 
+## arm64 builds
+
+When a step needs to run inside a `linux/arm64` docker image (rootfs,
+kernel, anything compiled in-container), set
+`MACHINEN_REMOTE_BUILDER=friend@100.126.46.90` and let the build
+script delegate over ssh. Native-arm64 there finishes in ~3 min vs.
+~15–20 min under qemu-arm64 emulation locally on an M-series mac.
+
 ## FUSE ops (mount-server)
 
 When you wire up a new FUSE opcode in `packages/runtime/src/mount-server.ts`,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -339,7 +339,9 @@ function pipeStdinToVm(vmStdin: NodeJS.WritableStream, onCtrlD: () => void): voi
         cb(null, chunk);
         return;
       }
-      if (idx > 0) this.push(chunk.subarray(0, idx));
+      if (idx > 0) {
+        this.push(chunk.subarray(0, idx));
+      }
       cb();
       if (!fired) {
         fired = true;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import {
@@ -286,13 +287,19 @@ function sha256OfFile(path: string): string {
   return hash.digest("hex");
 }
 
-// Boot/restore wire host stdin straight into the VMM's stdin pipe (the
-// guest serial console). In cooked mode the host kernel's tty driver
-// eats Ctrl-C as SIGINT before the byte reaches the guest, so killing
-// `ping` in the guest tears down the whole VM. Flip stdin to raw so
-// 0x03 / 0x04 / arrows pass through untranslated; the guest's own tty
-// turns Ctrl-C into SIGINT for its foreground process and Ctrl-D into
-// EOF on bash, which exits the shell and shuts the VM down cleanly.
+// Boot/restore wire host stdin into the VMM's stdin pipe (the guest
+// serial console). In cooked mode the host kernel's tty driver eats
+// Ctrl-C as SIGINT before the byte reaches the guest, so killing
+// `ping` in the guest would tear down the whole VM. Flip stdin to raw
+// so 0x03 / arrows pass through untranslated; the guest's own tty
+// turns Ctrl-C into SIGINT for its foreground process.
+//
+// Ctrl-D (0x04) is intercepted on the host side (see pipeStdinToVm)
+// and shuts the VM down cleanly. Raw-mode stdin means the host kernel
+// no longer turns it into EOF for us, and forwarding it to the guest
+// is rarely useful — most workloads don't read stdin, and the workloads
+// that do (interactive shells) already accept Ctrl-D as "log out", which
+// the VM-level shutdown is just a louder version of.
 function rawModeStdinIfTTY(): () => void {
   const stdin = process.stdin;
   if (stdin.isTTY !== true) {
@@ -309,6 +316,59 @@ function rawModeStdinIfTTY(): () => void {
       }
     }
   };
+}
+
+// Pipe host stdin to the VMM's stdin, intercepting Ctrl-D as a host
+// shutdown trigger. Pre-Ctrl-D bytes flow through verbatim; the 0x04
+// byte itself and anything after it in the same chunk are dropped.
+// onCtrlD fires once, on the first Ctrl-D seen.
+//
+// When stdin isn't a TTY (piped/redirected), Ctrl-D doesn't apply —
+// 0x04 in input is just data — so we wire stdin straight through.
+function pipeStdinToVm(vmStdin: NodeJS.WritableStream, onCtrlD: () => void): void {
+  const stdin = process.stdin;
+  if (stdin.isTTY !== true) {
+    stdin.pipe(vmStdin);
+    return;
+  }
+  let fired = false;
+  const intercept = new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      const idx = chunk.indexOf(0x04);
+      if (idx === -1) {
+        cb(null, chunk);
+        return;
+      }
+      if (idx > 0) this.push(chunk.subarray(0, idx));
+      cb();
+      if (!fired) {
+        fired = true;
+        onCtrlD();
+      }
+    },
+  });
+  stdin.pipe(intercept).pipe(vmStdin);
+}
+
+// Print the "press Ctrl-D to stop" hint and schedule a second print
+// `repeatAfterMs` later. The boot/restore output buries the first hint
+// under kernel logs and init checkpoints; reprinting once the scroll
+// settles puts it back where the user is most likely to read it.
+//
+// Returns a cancel function for the pending reprint — call from the
+// finally block so the timer doesn't fire after the VM has already
+// exited.
+function printCtrlDHint(repeatAfterMs = 3000): () => void {
+  if (process.stdin.isTTY !== true) {
+    return () => {};
+  }
+  const msg = "machinen: press Ctrl-D to stop\n";
+  process.stderr.write(msg);
+  const t = setTimeout(() => {
+    process.stderr.write(msg);
+  }, repeatAfterMs);
+  t.unref();
+  return () => clearTimeout(t);
 }
 
 // ------------------------------------------------------------
@@ -505,7 +565,7 @@ async function cmdBoot(args: string[]): Promise<number> {
   vm.stdout.pipe(process.stdout);
   vm.stderr.pipe(process.stderr);
   const restoreStdin = rawModeStdinIfTTY();
-  process.stdin.pipe(vm.stdin);
+  const cancelHintRepeat = printCtrlDHint();
 
   // Propagate SIGINT/SIGTERM to the VMM child. With stdin in raw mode
   // the host kernel no longer turns keyboard Ctrl-C into SIGINT (the
@@ -513,6 +573,9 @@ async function cmdBoot(args: string[]): Promise<number> {
   // is signalled directly — e.g. a supervisor sending SIGTERM to node,
   // or `kill -INT <cli-pid>` from another shell. Without this, the
   // VMM survives as an orphan.
+  //
+  // Ctrl-D from the user's terminal lands in pipeStdinToVm below and
+  // funnels into the same vm.kill() path with SIGTERM exit semantics.
   let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
   const onSigint = () => {
     forwardedSignal = "SIGINT";
@@ -524,6 +587,12 @@ async function cmdBoot(args: string[]): Promise<number> {
   };
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
+
+  pipeStdinToVm(vm.stdin, () => {
+    process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
+    forwardedSignal = "SIGTERM";
+    void vm.kill();
+  });
 
   try {
     const { code } = await vm.wait();
@@ -537,6 +606,7 @@ async function cmdBoot(args: string[]): Promise<number> {
   } finally {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
+    cancelHintRepeat();
     restoreStdin();
   }
 }
@@ -649,7 +719,7 @@ async function cmdRestore(args: string[]): Promise<number> {
   vm.stdout.pipe(process.stdout);
   vm.stderr.pipe(process.stderr);
   const restoreStdin = rawModeStdinIfTTY();
-  process.stdin.pipe(vm.stdin);
+  const cancelHintRepeat = printCtrlDHint();
 
   let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
   const onSigint = () => {
@@ -662,6 +732,13 @@ async function cmdRestore(args: string[]): Promise<number> {
   };
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
+
+  pipeStdinToVm(vm.stdin, () => {
+    process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
+    forwardedSignal = "SIGTERM";
+    void vm.kill();
+  });
+
   try {
     const { code } = await vm.wait();
     if (forwardedSignal === "SIGINT") {
@@ -674,6 +751,7 @@ async function cmdRestore(args: string[]): Promise<number> {
   } finally {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
+    cancelHintRepeat();
     restoreStdin();
   }
 }
@@ -1281,7 +1359,7 @@ async function cmdFork(args: string[]): Promise<number> {
     fork.stdout.pipe(process.stdout);
     fork.stderr.pipe(process.stderr);
     const restoreStdin = rawModeStdinIfTTY();
-    process.stdin.pipe(fork.stdin);
+    const cancelHintRepeat = printCtrlDHint();
     // The source shell printed PS1 to the source's tty before the
     // dump, so the restored shell starts up sitting in read() without
     // redrawing — without this nudge the user has to hit Enter
@@ -1310,6 +1388,12 @@ async function cmdFork(args: string[]): Promise<number> {
     };
     process.on("SIGINT", onSigint);
     process.on("SIGTERM", onSigterm);
+
+    pipeStdinToVm(fork.stdin, () => {
+      process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
+      forwardedSignal = "SIGTERM";
+      void fork.kill();
+    });
     try {
       const { code } = await fork.wait();
       if (forwardedSignal === "SIGINT") {
@@ -1322,6 +1406,7 @@ async function cmdFork(args: string[]): Promise<number> {
     } finally {
       process.off("SIGINT", onSigint);
       process.off("SIGTERM", onSigterm);
+      cancelHintRepeat();
       restoreStdin();
     }
   } catch (err) {

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -219,6 +219,13 @@ chmod +x "${STAGE}/machinen-supervisor.sh" "${STAGE}/machinen-dump.sh" \
          "${STAGE}/machinen-dump-preflight.sh" "${STAGE}/machinen-restore.sh" \
          "${STAGE}/machinen-remount.sh"
 
+# Stage CRIU patches (applied inside the rootfs container against the
+# upstream tarball before `make`). See packages/microvm/patches/criu/.
+# The directory is optional — most builds run without patches.
+if [ -d "${ROOT}/packages/microvm/patches" ]; then
+  cp -r "${ROOT}/packages/microvm/patches" "${STAGE}/patches"
+fi
+
 # ------------------------------------------------------------
 # 4. Rootfs — mmdebstrap minbase + aggressive strip + guest binaries
 # ------------------------------------------------------------
@@ -342,11 +349,29 @@ apt-get install -y --no-install-recommends \
   build-essential pkg-config \
   libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler \
   libnl-3-dev libnet-dev libcap-dev libnftables-dev uuid-dev \
-  curl ca-certificates \
+  curl ca-certificates patch \
   > /dev/null
 mkdir -p /tmp/criu-build
 curl -fsSL "https://github.com/checkpoint-restore/criu/archive/refs/tags/${CRIU_TAG}.tar.gz" \
   | tar -xzf - -C /tmp/criu-build --strip-components=1
+# Apply machinen patches (sorted lexically). Each is a unified diff
+# rooted at the criu source tree. See packages/microvm/patches/criu/
+# for descriptions.
+if [ -d /stage/patches/criu ]; then
+  for p in /stage/patches/criu/*.patch; do
+    [ -e "$p" ] || break
+    echo "==> Applying CRIU patch: $(basename "$p")"
+    # patch(1) with a malformed hunk prints an error, applies what
+    # it can, and exits 0 — silently shipping a partially patched
+    # binary. -F0 disables fuzzy matching and --dry-run lets us
+    # validate the whole file before committing changes.
+    if ! patch -d /tmp/criu-build -p1 -F0 --dry-run < "$p"; then
+      echo "patch dry-run failed for $(basename "$p")" >&2
+      exit 1
+    fi
+    patch -d /tmp/criu-build -p1 -F0 < "$p"
+  done
+fi
 make -C /tmp/criu-build -j"$(nproc)" PIE=1 NO_GNUTLS=1 criu > /tmp/criu-build.log 2>&1 || {
   echo "criu build failed; tail of log:"
   tail -60 /tmp/criu-build.log

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -68,6 +68,9 @@ rootfs_input_files() {
     "${ASSETS}/poweroff.zig" \
     "${ASSETS}/winsize-agent.zig" \
     "${SCRIPTS}/build-base-assets.sh"
+  # CRIU patches applied during the rootfs build. Sorted for stable
+  # ordering. Empty find output is fine (no patches → no extra lines).
+  find "${ROOT}/packages/microvm/patches" -type f -name "*.patch" 2>/dev/null | LC_ALL=C sort
 }
 
 # Files whose contents are baked into Image-arm64. The kernel itself


### PR DESCRIPTION
## Problem

When you run `machinen boot`, `machinen restore`, or `machinen fork --restore` in a terminal, the only ways to stop the VM are:

1. Press Ctrl+C and hope the guest workload reacts to SIGINT.
2. Open a second terminal and run `machinen stop <name>`.

Option 1 is unreliable for snapshot-restored Node.js workloads. Node's terminal-signal handler depends on a particular kernel one-shot flag firing during signal delivery, and that flag interacts badly with the on-demand page loading we use during restore. About one in four Ctrl+C presses leaves the workload alive but with the handler already disarmed, so the VM just sits there. The user sees Ctrl+C "do nothing" and has no obvious way out of the foreground session.

Option 2 means leaving the session, finding another terminal, and remembering the VM's name. That's a lot of friction for "I want to stop this thing."

## Solution

Use Ctrl+D as a host-side stop button.

1. Press Ctrl+D in any foreground `machinen` session and the CLI cleanly shuts the VM down. The host-side kill bypasses whatever the guest workload is doing — it doesn't depend on the workload reacting to a signal.
2. Ctrl+C is unchanged. It still passes through to the guest, so workloads that handle Ctrl+C themselves still see it.
3. The session prints a small reminder — `machinen: press Ctrl-D to stop` — when it starts, and again about three seconds later. The first print gets buried under kernel boot logs; the second print lands after the scroll settles, where it's actually visible.
4. Stops are wired into all three foreground commands: `boot`, `restore`, and `fork --restore`. The exit code is 143 (the same code we already use when the user kills the CLI from outside).

For pipelines (stdin redirected from a file), nothing changes — Ctrl+D doesn't apply, and a `0x04` byte in input data is treated as data, not a control code.

## Technical Summary

`packages/cli/src/cli.ts`:

- New `pipeStdinToVm(vmStdin, onCtrlD)` helper. When stdin is a TTY, it inserts a `Transform` between `process.stdin` and `vm.stdin` that watches for the byte `0x04`. On the first occurrence it forwards any pre-Ctrl-D bytes in the same chunk, drops the `0x04` and everything after it, and fires `onCtrlD` once. When stdin isn't a TTY it pipes straight through.
- Each foreground command's `onCtrlD` writes a "Ctrl-D — stopping VM" line to stderr, sets the existing `forwardedSignal = "SIGTERM"` so `vm.wait()` returns exit code 143, and calls `vm.kill()`.
- New `printCtrlDHint()` helper prints the reminder once at start and schedules an `unref()`-d second print after `~3000ms`. Returns a cancel function the `finally` block calls so a pending reprint doesn't fire after the VM exits.
- Wired into `cmdBoot`, `cmdRestore`, and the `fork --restore` path. Comments updated near `rawModeStdinIfTTY` to reflect that Ctrl-D is no longer expected to reach the guest.

`AGENTS.md`: added a short section pointing arm64-in-Docker steps at `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90`. Native arm64 builds there finish in ~3 minutes; qemu-arm64 emulation locally on an M-series Mac takes 15–20 minutes.

`scripts/build-base-assets.sh` and `scripts/check-asset-freshness.sh`: added a small CRIU-patch pipeline. If `packages/microvm/patches/criu/*.patch` exists, the build script copies it into the staging directory and applies each patch with `patch -p1 -F0 --dry-run` followed by the real apply. The freshness checker hashes the patch files alongside the other rootfs inputs. With no patches present (the current state) both changes are no-ops; the scaffolding stays in place because the debugging that produced this PR also surfaced a need to ship CRIU patches later.

## Verification

End-to-end quickstart suite (`/tmp/verify_quickstart.sh`): bake → boot → curl × 2 → snapshot → restore → curl-expects-count-3 → Ctrl-D-out. 13/13 pass on a clean stock-criu base.

Direct Ctrl-D suite: `boot + ^D` and `restore + ^D` both exit 143 with the message printed and no orphaned VMs. `restore + ^C only` confirms the host doesn't intercept Ctrl+C.