### PR TITLE
Park vsock bytes when the guest's RX ring is empty

### DIFF
--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -752,6 +752,14 @@ pub const Connection = struct {
     /// when the gap with `fwd_cnt` is big enough to emit a new
     /// CREDIT_UPDATE.
     last_credit_fwd_cnt: u32 = 0,
+    /// Bytes already read off the UDS that we couldn't inject because
+    /// the guest's virtio RX ring had no descriptor posted. Holding
+    /// them lets the next drain retry instead of dropping them — the
+    /// stream framing depends on every byte landing in order, and
+    /// drops were the root cause of the FUSE-agent "bad reply len"
+    /// crash class. `pending_rx_len == 0` means no pending data.
+    pending_rx_buf: [rx_body_per_packet_max]u8 = undefined,
+    pending_rx_len: usize = 0,
 };
 
 pub const BridgeConfig = struct {
@@ -958,6 +966,23 @@ pub const Bridge = struct {
                 }
                 self.mu.unlock();
             }
+
+            // Retry connections with parked bytes from a previous
+            // drain that couldn't inject (RX ring was empty). Without
+            // this, a connection whose host side has stopped sending
+            // would leave its tail bytes stuck — POLLIN never fires
+            // again, so drainConnection wouldn't get called even
+            // though pending_rx still has bytes to deliver.
+            self.mu.lock();
+            var k: usize = 0;
+            while (k < self.conns.items.len) : (k += 1) {
+                if (self.conns.items[k].pending_rx_len == 0) continue;
+                self.drainConnection(k) catch |err| {
+                    std.debug.print("vsock: pending drainConnection err {s}\n", .{@errorName(err)});
+                    self.closeConnection(k);
+                };
+            }
+            self.mu.unlock();
         }
     }
 
@@ -1035,6 +1060,38 @@ pub const Bridge = struct {
         const c = &self.conns.items[idx];
         assert(c.uds_fd >= 0);
         if (c.state != .established) return; // wait for RESPONSE first
+
+        // First try to flush any pending bytes from a prior drain that
+        // couldn't inject because the guest's RX ring was empty. The
+        // poll loop re-fires often enough that the guest will have
+        // refilled the ring by some later iteration.
+        if (c.pending_rx_len > 0) {
+            const room = peerRoom(c);
+            if (room == 0) {
+                c.paused = true;
+                return;
+            }
+            const hdr = VsockHdr{
+                .src_cid = host_cid,
+                .dst_cid = self.cfg.guest_cid,
+                .src_port = c.host_port,
+                .dst_port = c.guest_port,
+                .len = @intCast(c.pending_rx_len),
+                .type = @intFromEnum(Type.stream),
+                .op = @intFromEnum(Op.rw),
+                .flags = 0,
+                .buf_alloc = advertised_buf_alloc,
+                .fwd_cnt = c.fwd_cnt,
+            };
+            if (!self.injectRx(hdr, c.pending_rx_buf[0..c.pending_rx_len])) {
+                // Ring is still empty; keep the bytes parked, return,
+                // try again next poll cycle.
+                return;
+            }
+            c.bytes_to_peer +%= @intCast(c.pending_rx_len);
+            c.pending_rx_len = 0;
+        }
+
         const room = peerRoom(c);
         if (room == 0) {
             c.paused = true;
@@ -1082,7 +1139,14 @@ pub const Bridge = struct {
         };
         if (self.injectRx(hdr, payload)) {
             c.bytes_to_peer +%= @intCast(payload.len);
+            return;
         }
+        // Inject failed — ring's empty, no descriptor posted by the
+        // guest. We've already consumed these bytes from the UDS, so
+        // dropping them would corrupt the stream. Park them in
+        // pending_rx_buf; the next drain (or next nudge) retries.
+        @memcpy(c.pending_rx_buf[0..payload.len], payload);
+        c.pending_rx_len = payload.len;
     }
 
     // Must be called with self.mu held.


### PR DESCRIPTION
## Problem

When you restore a snapshot, the guest sometimes panics very early in boot with a kernel message like:

```
fuse-agent: bad reply len 305352434
fuse-agent: exiting
[    1.508264] reboot: Power down
```

The garbage number is different every time. About one in five restores hits this; under heavier traffic it's almost every time.

The trail starts at the host. `machinen` runs a small filesystem server in the host process and ships its bytes into the guest over a Unix socket → vsock bridge → guest agent path. Each message starts with a 4-byte length prefix; the agent reads exactly that many bytes, hands them to `/dev/fuse`, then reads the next 4-byte length, and so on.

Now look at the bridge. Every time it wakes up, it reads up to ~3.5KB off the host's Unix socket and tries to hand the bytes to the guest's incoming ring. Sometimes the guest hasn't posted an empty buffer yet. The current code throws those bytes on the floor:

```zig
const n = read(c.uds_fd, &buf, cap);
…
if (self.injectRx(hdr, payload)) {        // returns false → drop happens
    c.bytes_to_peer +%= @intCast(payload.len);
}
```

The bytes were already consumed off the Unix socket. There's no way to "unread" them; the next read pulls in fresh bytes. The wire stream now has a hole, and the agent on the other end reads four bytes from somewhere mid-payload, calls them a length, and panics.

A comment that already lives in this file flagged exactly this shape years ago — issue #57's "tar says This does not look like a tar archive" was the same drop. The earlier fix capped the per-packet body so it can't exceed the kernel's descriptor size, but it didn't address the broader case where `injectRx` fails because the guest's ring just happens to be empty.

## Solution

If `injectRx` can't deliver right now, park the bytes on the connection itself instead of dropping them. The next time the bridge runs `drainConnection`, the first thing it does is try to flush whatever's parked, before reading anything new. The host-side Unix socket gets backpressure — its read pauses until the parked bytes ship.

The poll loop also gets a follow-up pass that iterates connections with parked bytes, so a host that's finished sending doesn't leave the tail stuck.

## Technical Summary

`packages/microvm/src/vsock.zig`:

- `Connection` gains `pending_rx_buf: [rx_body_per_packet_max]u8` and `pending_rx_len: usize`. Sized to one packet's body — enough for whatever a single `drainConnection` call consumed.
- `drainConnection` flushes `pending_rx_buf` before any new `read(uds_fd)`. If the flush still can't inject, it returns without reading more.
- After each new `read`, if `injectRx` fails, copy the payload into `pending_rx_buf` and set `pending_rx_len`. The `read` already happened; this is the only place those bytes can live until the ring opens up.
- After the per-poll iteration over `revents`-flagged connections, the bridge thread now sweeps every connection whose `pending_rx_len > 0` and re-runs `drainConnection`. Closes the gap where a connection has parked bytes but no new POLLIN — `drainConnection` would otherwise never get called.

## Verification

Pre-fix: 1 of 5 restores from `examples/quickstart/snapshot-counter` died with `fuse-agent: bad reply len <garbage>`.

Post-fix: 10/10 restores clean. Full quickstart suite (`/tmp/verify_quickstart.sh`: bake → boot → 2× curl → snapshot → restore → curl-shows-count-3 → Ctrl-D) at 13/13.