### PR TITLE
Stop the runaway page-reporting cycle on lazy-restored guests (#290)

### DIFF
--- a/packages/microvm/docs/memory.md
+++ b/packages/microvm/docs/memory.md
@@ -143,7 +143,7 @@ guest:
 - **Eager (default).** The runtime packs `imgDir/` into a tar
   attached as `/dev/vdb`. The guest's `/sbin/machinen-restore`
   untars into tmpfs and CRIU loads every page up front. Simple,
-  robust, works under `--detach`, doesn't fight free-page-reporting.
+  robust, works under `--detach`.
 - **Lazy (`--lazy` / `restore({ lazy: true })`).** The bundle is
   vsock-FUSE-mounted into the guest and `criu restore --lazy-pages`
   faults workload pages on demand (#266). Keeps host RSS
@@ -153,20 +153,46 @@ guest:
      that. The runtime forces `lazy: false` when `--detach` is set
      to keep that combination usable. A standalone FUSE helper
      that survives supervisor exit is on the roadmap (#150 phase 3).
-  2. The `MADV_FREE_REUSABLE` reclaim path interacts badly with
-     free-page-reporting under lazy: the guest kernel's reporting
-     kthread reads each "free" page to confirm it's free, which is
-     exactly what userfaultfd UFFDIO_COPYs the page back from the
-     bundle for. The runtime sets
-     `MACHINEN_DISABLE_BALLOON_REPORTING=1` for lazy boots to
-     suppress that — at the cost of giving up reclaim on those VMs.
-  3. The promised RSS savings haven't been measurably reproduced on
+  2. The promised RSS savings haven't been measurably reproduced on
      Darwin/HVF for small-heap workloads (tracked separately).
 
 The default flipped to eager because the lazy savings only matter
 when the workload's anon is large enough to be worth deferring, and
-the failure modes (1) + (2) bite anything else. Pass `--lazy` when
-you have a >GiB heap that the restored process will only sample.
+failure mode (1) bites anything else. Pass `--lazy` when you have a
+
+> GiB heap that the restored process will only sample.
+
+### Free-page-reporting under lazy restore (#290)
+
+There used to be a third strike against `lazy`: with
+`VIRTIO_BALLOON_F_REPORTING` enabled, the guest kernel's
+`page_reporting` workqueue would re-report the same physical region
+every 2-second cycle, so `bytes_reported` climbed to many times
+the VM's RAM ceiling and `phys_footprint` crept up indefinitely.
+The original theory ("the reporting kthread reads pages and that
+read fires UFFD") turned out to be wrong on inspection — CRIU's
+`lazy-pages.log` stayed silent in steady state, and the reporting
+kthread doesn't actually read page contents.
+
+The real culprit was in `mm/page_alloc.c::__free_one_page`. When the
+buddy allocator merges a freed page with an adjacent free buddy,
+`__del_page_from_free_list` clears the buddy's `Reported` flag
+(correct for genuine allocations), and the merged block lands on
+the higher-order free list with no `Reported` flag at all — so
+the next reporting cycle picks it up as "unreported" and reports
+the same physical region again. On a typical workload this barely
+shows because freed pages rarely have a Reported buddy. After a
+CRIU lazy restore the workload's PE_LAZY anon range stays as huge
+contiguous free runs, so almost every free triggers a merge with a
+Reported buddy and almost every cycle re-reports.
+
+Fixed by an in-tree kernel patch that refuses to merge with a
+Reported buddy:
+`packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`.
+The cycle now terminates after a single warm-up sweep (~22 s on a
+1.5 GiB VM with a 128 MiB workload in the reproducer), and
+`phys_footprint` stays flat afterwards. Reporting is unconditionally
+on; there is no env-var override.
 
 ## Initramfs scan window: a related growth trap
 

--- a/packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch
+++ b/packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch
@@ -1,0 +1,87 @@
+From: Machinen <noreply@redwoodjs.com>
+Subject: [PATCH] mm: don't merge with a Reported buddy in __free_one_page()
+
+Free-page-reporting marks pages it has reported to the host (via
+__SetPageReported) so the next reporting cycle can skip them. The
+flag is cleared whenever the page is removed from the free list
+(__del_page_from_free_list -> __ClearPageReported), which is correct
+for genuine allocations: the page is being given to a user, so the
+host's view of "free, reclaimed" is no longer accurate.
+
+But the same clear path runs during a buddy MERGE inside
+__free_one_page: when the page being freed has a free buddy, the
+buddy is removed from the free list (clearing its Reported flag) and
+combined with the page into a higher-order block. The merged block
+is then added to the higher-order free list with no Reported flag,
+even though half of its physical extent has already been reported
+to (and reclaimed by) the host.
+
+Result: the next reporting cycle picks up the merged block as
+"unreported" and reports the same physical region again. The host
+re-receives a report for memory it already reclaimed, a fresh
+madvise(MADV_DONTNEED)/MADV_FREE_REUSABLE re-runs against pages
+that may since have been re-faulted by zero-fault, host RSS no
+longer settles, and the cycle repeats every PAGE_REPORTING_DELAY
+(2s) for as long as the kernel keeps churning small allocations.
+
+The pathology is benign on a typical workload — most of the time
+freed pages don't have a free buddy that's already Reported, so
+the merge isn't blocked and the reporting cycle stabilises within
+a couple of passes. It's pathological under a CRIU lazy-pages
+restore: the workload's PE_LAZY anon range stays as huge
+contiguous free runs (CRIU registered userfaultfd on the VMAs but
+never allocated the underlying physical pages), so almost every
+free has a Reported buddy and almost every merge produces a fresh
+unreported block. We've observed bytes_reported climbing to
+~12 GiB on a 1.5 GiB VM in 30 s, with zero workload activity.
+
+Fix: in __free_one_page, refuse to merge with a buddy that is
+already Reported. The merged block can't be reported atomically
+(only one of the two halves was), and the buddy's Reported state
+is a real signal that the host has already done work for that
+range. Keeping the two halves separate preserves the buddy's
+Reported flag, the page being freed gets reported on the next
+cycle, and the cycle settles.
+
+Cost: a small amount of fragmentation at the boundary between
+allocated-and-freed pages and the still-Reported neighbourhood.
+For the cases that drove this change (VMs idling on a lazy-restored
+heap), the host has already dropped the physical backing of
+Reported pages anyway, so consolidating them into larger contiguous
+blocks does not actually buy contiguous host memory — the next
+allocation that uses the merged block stage-2-faults each
+component page back in independently.
+
+Signed-off-by: Machinen kernel patch <noreply@redwoodjs.com>
+---
+ mm/page_alloc.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -800,6 +800,22 @@ static inline void __free_one_page(struct page *page,
+ 		if (!buddy)
+ 			goto done_merging;
+
++		/*
++		 * Don't merge with a buddy that's already been reported to
++		 * a free-page-reporting device (typically a hypervisor that
++		 * has reclaimed the buddy's host backing via madvise).
++		 * Merging would clear the buddy's Reported flag in
++		 * __del_page_from_free_list and the new larger block would
++		 * land on the higher-order free list unreported, so the
++		 * next reporting cycle would re-report the same physical
++		 * region. On guests with very large idle anon ranges (e.g.
++		 * after CRIU lazy-pages restore) this turns into an endless
++		 * report/reclaim cycle that never settles. Keep the buddy
++		 * isolated; the freshly freed half will be reported on its
++		 * own on the next pass.
++		 */
++		if (page_reported(buddy))
++			goto done_merging;
+ 		if (unlikely(order >= pageblock_order)) {
+ 			/*
+ 			 * We want to prevent merge between freepages on pageblock
+--
+2.43.0

--- a/packages/microvm/src/balloon.zig
+++ b/packages/microvm/src/balloon.zig
@@ -163,23 +163,13 @@ pub const Backend = struct {
     /// was registered against. `madvise` leaves the VMA intact —
     /// the kernel just drops physical pages — so the race goes away.
     pub fn features() u64 {
-        // Bit 32 (VERSION_1, required for v2 transport).
-        // REPORTING is on by default. The runtime sets
-        // `MACHINEN_DISABLE_BALLOON_REPORTING=1` for snapshot-restore
-        // boots: with REPORTING on the guest kernel's free-page-
-        // reporting kthread walks every page in the workload's anon
-        // range, the kernel reads each page to identify it as free,
-        // and *that read* is what userfaultfd UFFDIO_COPYs the page
-        // back from the bundle for — defeating the whole "lazy
-        // pages" promise of #266. Fresh boots leave it on so
-        // long-running idle VMs return memory to the host.
-        var bits: u64 = (@as(u64, 1) << 32);
-        const disable_env = getenv("MACHINEN_DISABLE_BALLOON_REPORTING");
-        const disabled = if (disable_env) |p| p[0] == '1' else false;
-        if (!disabled) {
-            bits |= (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING);
-        }
-        return bits;
+        // Bit 32: VERSION_1, required for v2 transport.
+        // Bit VIRTIO_BALLOON_F_REPORTING: free-page-reporting is
+        // unconditionally on. The lazy-restore × reporting cycle that
+        // used to motivate a runtime opt-out is fixed at the kernel
+        // level in #290
+        // (`packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`).
+        return (@as(u64, 1) << 32) | (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING);
     }
 
     /// Wire-format config bytes for `virtio.Device.config`. Stable
@@ -410,8 +400,7 @@ const MADVISE_RECLAIM: c_int = if (builtin.os.tag == .macos) MADV_FREE_REUSABLE 
 
 // --- tests ---
 
-test "Backend.features advertises VERSION_1 + REPORTING by default" {
-    // Tests run without MACHINEN_DISABLE_BALLOON_REPORTING set.
+test "Backend.features advertises VERSION_1 + REPORTING" {
     const f = Backend.features();
     try std.testing.expect((f & (@as(u64, 1) << 32)) != 0); // VERSION_1
     // REPORTING drives the reclaim path — see `handleReporting`.
@@ -421,18 +410,6 @@ test "Backend.features advertises VERSION_1 + REPORTING by default" {
     // if we offer them.
     try std.testing.expect((f & (@as(u64, 1) << VIRTIO_BALLOON_F_STATS_VQ)) == 0);
     try std.testing.expect((f & (@as(u64, 1) << VIRTIO_BALLOON_F_FREE_PAGE_HINT)) == 0);
-}
-
-test "Backend.features drops REPORTING when MACHINEN_DISABLE_BALLOON_REPORTING=1" {
-    const c_setenv = struct {
-        extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
-        extern "c" fn unsetenv(name: [*:0]const u8) c_int;
-    };
-    _ = c_setenv.setenv("MACHINEN_DISABLE_BALLOON_REPORTING", "1", 1);
-    defer _ = c_setenv.unsetenv("MACHINEN_DISABLE_BALLOON_REPORTING");
-    const f = Backend.features();
-    try std.testing.expect((f & (@as(u64, 1) << 32)) != 0); // VERSION_1 still on
-    try std.testing.expect((f & (@as(u64, 1) << VIRTIO_BALLOON_F_REPORTING)) == 0);
 }
 
 test "BalloonConfig has the v1.1 layout the driver expects" {

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -5233,7 +5233,7 @@ unique under the source's namespace.
 
 > `optional` **lazy?**: `boolean`
 
-Defined in: [vm.ts:3274](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3274)
+Defined in: [vm.ts:3272](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3272)
 
 Opt into lazy-pages restore — bundle is vsock-FUSE-mounted into
 the guest read-only and `criu restore --lazy-pages` faults pages
@@ -5242,14 +5242,12 @@ image into a tar on `/dev/vdb`, the guest's
 `/sbin/machinen-restore` untars it into tmpfs, and CRIU does an
 eager load.
 
-Eager is the default because the lazy path has subtle
-interactions with virtio-balloon free-page-reporting (the
-guest's reporting kthread reads pages to identify them as free,
-which is exactly what UFFDIO_COPY's them back from the bundle —
-defeating the lazy promise). The runtime sets
-`MACHINEN_DISABLE_BALLOON_REPORTING=1` to suppress that when
-`lazy: true` is requested, but for the common case eager is
-simpler and faster on small workloads.
+Eager is still the default because lazy bundles a host-side FUSE
+server that doesn't compose with `--detach` (#150 phase 3). The
+historical second blocker — runaway free-page-reporting under
+lazy — is fixed in #290 by the in-tree kernel patch that stops
+the buddy allocator from clearing the Reported flag during a
+merge.
 
 ***
 
@@ -6994,7 +6992,7 @@ end, so no individual cmd line approaches `MAX_ARG_STRLEN`.
 
 > **restore**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
-Defined in: [vm.ts:3311](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3311)
+Defined in: [vm.ts:3309](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3309)
 
 Restore a microVM from a snapshot bundle produced by
 `vm.snapshot({ outDir })`. Reads the bundle's `meta.json` to
@@ -7050,7 +7048,7 @@ BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN if an entry in
 
 > **measureFirstByte**(`vm`): `Promise`\<`number`\>
 
-Defined in: [vm.ts:3791](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3791)
+Defined in: [vm.ts:3788](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/vm.ts#L3788)
 
 Time-to-first-output-byte for a boot. Useful for measuring how
 much the snapshot path is (or isn't) buying us.

--- a/packages/runtime/src/vm.ts
+++ b/packages/runtime/src/vm.ts
@@ -3262,14 +3262,12 @@ export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" |
    * `/sbin/machinen-restore` untars it into tmpfs, and CRIU does an
    * eager load.
    *
-   * Eager is the default because the lazy path has subtle
-   * interactions with virtio-balloon free-page-reporting (the
-   * guest's reporting kthread reads pages to identify them as free,
-   * which is exactly what UFFDIO_COPY's them back from the bundle —
-   * defeating the lazy promise). The runtime sets
-   * `MACHINEN_DISABLE_BALLOON_REPORTING=1` to suppress that when
-   * `lazy: true` is requested, but for the common case eager is
-   * simpler and faster on small workloads.
+   * Eager is still the default because lazy bundles a host-side FUSE
+   * server that doesn't compose with `--detach` (#150 phase 3). The
+   * historical second blocker — runaway free-page-reporting under
+   * lazy — is fixed in #290 by the in-tree kernel patch that stops
+   * the buddy allocator from clearing the Reported flag during a
+   * merge.
    */
   lazy?: boolean;
 }
@@ -3426,11 +3424,10 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   //     pagemap-*.img + pages-*.img directly through FUSE; bytes
   //     stream from the host on demand and never materialize in
   //     guest tmpfs. This is the #266 path — it keeps host RSS
-  //     proportional to the touched set, but the path interacts
-  //     subtly with virtio-balloon free-page-reporting (see the
-  //     `MACHINEN_DISABLE_BALLOON_REPORTING` comment below) and
-  //     can't compose with `--detach` until the FUSE server learns
-  //     to hand off (#150 phase 3).
+  //     proportional to the touched set. The historical
+  //     virtio-balloon interaction is fixed in #290 (in-tree kernel
+  //     patch); the remaining gap is `--detach` composition, which
+  //     waits on the FUSE server to learn to hand off (#150 phase 3).
   phases.start("snapshot-pack");
   const restoreEnv: Record<string, string> = {};
   let scratchPath: string;
@@ -3443,16 +3440,16 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
     allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
     restoreEnv.MACHINEN_RESTORE_BUNDLE_LIVE = "1";
     restoreEnv.MACHINEN_RESTORE_LAZY_PAGES = "1";
-    // Suppress virtio-balloon free-page-reporting on lazy-pages
-    // restores. With REPORTING on, the guest kernel's reporting
-    // kthread walks every "free" page in the workload's anon range
-    // — and that walk reads each page to identify it as free, which
-    // is exactly what userfaultfd UFFDIO_COPYs the page back from
-    // the bundle for. The result is the entire workload getting
-    // eagerly faulted in within seconds of restore, which defeats
-    // the whole point of lazy-pages. Fresh boots and eager restores
-    // leave REPORTING on so long-running idle VMs return memory.
-    restoreEnv.MACHINEN_DISABLE_BALLOON_REPORTING = "1";
+    // #290: lazy-restore + virtio-balloon free-page-reporting used to
+    // get into a runaway re-report cycle — the workload's PE_LAZY anon
+    // range stays as huge contiguous free runs in the buddy allocator,
+    // and `__free_one_page`'s buddy merge clears the Reported flag on
+    // every neighbour it merges with, so the next reporting cycle sees
+    // the merged block as unreported and reports the same physical
+    // region again. Fixed in the guest kernel by
+    // `packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`,
+    // which refuses to merge a freshly-freed page with a Reported buddy
+    // so the cycle terminates after a single warm-up sweep.
     liveMounts = [
       ...(effectiveLiveMounts ?? []),
       { host: imgDir, guest: "/mnt/snap-src/img", mode: "ro" as const },

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -90,18 +90,25 @@ if [ -f "$OUT/Image-arm64" ]; then
 else
 echo "==> Building custom arm64 kernel with virtio_* + ext4 + vsock + fuse =y"
 
+KERNEL_PATCHES_DIR="${ROOT}/packages/microvm/patches/kernel"
 if [ -n "${MACHINEN_REMOTE_BUILDER:-}" ]; then
-  # Remote build: rsync the kernel build script over, run it, pull
-  # the Image back. The remote host owns its own kernel-source cache
-  # at $REMOTE_WORKDIR (defaults to ~/.cache/machinen/kernel) so
-  # repeated rebuilds reuse the unpacked source tree.
+  # Remote build: rsync the kernel build script + any kernel patches
+  # over, run it, pull the Image back. The remote host owns its own
+  # kernel-source cache at $REMOTE_WORKDIR (defaults to
+  # ~/.cache/machinen/kernel) so repeated rebuilds reuse the unpacked
+  # source tree (and re-extract on patch-set changes — see
+  # build-kernel-arm64.sh's PATCHES_DIR handling).
   REMOTE_WORKDIR="${MACHINEN_REMOTE_WORKDIR:-\$HOME/.cache/machinen/kernel}"
   echo "    via remote builder: $MACHINEN_REMOTE_BUILDER (workdir=$REMOTE_WORKDIR)"
-  ssh "$MACHINEN_REMOTE_BUILDER" "mkdir -p $REMOTE_WORKDIR"
+  ssh "$MACHINEN_REMOTE_BUILDER" "mkdir -p $REMOTE_WORKDIR/patches"
   rsync -az "${ROOT}/scripts/build-kernel-arm64.sh" \
     "$MACHINEN_REMOTE_BUILDER:$REMOTE_WORKDIR/build-kernel-arm64.sh"
+  if [ -d "$KERNEL_PATCHES_DIR" ]; then
+    rsync -az --delete "${KERNEL_PATCHES_DIR}/" \
+      "$MACHINEN_REMOTE_BUILDER:$REMOTE_WORKDIR/patches/"
+  fi
   ssh "$MACHINEN_REMOTE_BUILDER" \
-    "WORKDIR=$REMOTE_WORKDIR bash $REMOTE_WORKDIR/build-kernel-arm64.sh"
+    "WORKDIR=$REMOTE_WORKDIR PATCHES_DIR=$REMOTE_WORKDIR/patches bash $REMOTE_WORKDIR/build-kernel-arm64.sh"
   rsync -az \
     "$MACHINEN_REMOTE_BUILDER:$REMOTE_WORKDIR/Image-arm64" \
     "$OUT/Image-arm64"
@@ -110,6 +117,7 @@ elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ] && [ "$(uname 
   # on the host — no docker overhead, no emulation.
   WORKDIR="${MACHINEN_KERNEL_WORKDIR:-${ROOT}/.kernel-build}" \
   OUT="$OUT/Image-arm64" \
+  PATCHES_DIR="$KERNEL_PATCHES_DIR" \
     bash "${ROOT}/scripts/build-kernel-arm64.sh"
 else
   echo "build-base-assets: cannot build the kernel here." >&2

--- a/scripts/build-kernel-arm64.sh
+++ b/scripts/build-kernel-arm64.sh
@@ -6,10 +6,13 @@
 # longer has to ship /lib/modules + kmod + libc just to mount /dev/vda.
 #
 # Inputs (env vars):
-#   KVER     — kernel version (default: 6.12.20)
-#   WORKDIR  — host workdir (default: $HOME/.cache/machinen/kernel)
-#   OUT      — final Image-arm64 path (default: $WORKDIR/Image-arm64)
-#   JOBS     — parallel make jobs (default: $(nproc))
+#   KVER         — kernel version (default: 6.12.20)
+#   WORKDIR      — host workdir (default: $HOME/.cache/machinen/kernel)
+#   OUT          — final Image-arm64 path (default: $WORKDIR/Image-arm64)
+#   JOBS         — parallel make jobs (default: $(nproc))
+#   PATCHES_DIR  — optional dir of *.patch files applied with `patch -p1`
+#                  before build. Re-extracts the source tree on patch-set
+#                  change so every build starts from a clean tarball.
 #
 # Output:
 #   $OUT — uncompressed arm64 kernel `Image` (boots the same way the
@@ -45,11 +48,51 @@ if [ ! -f "$TARBALL" ]; then
   mv "$TARBALL.tmp" "$TARBALL"
 fi
 
+# Hash the patch set (if any) so we can re-extract the source tree
+# whenever the patches change. Without this the second build with a
+# different patch set would either skip the new patches (cached source
+# already patched) or fail (`patch` complains about previously-applied
+# hunks). Cheap: a few SHA-256s over a tiny patches dir.
+PATCHES_DIR="${PATCHES_DIR:-}"
+PATCH_HASH=""
+if [ -n "$PATCHES_DIR" ] && [ -d "$PATCHES_DIR" ]; then
+  PATCH_HASH=$(find "$PATCHES_DIR" -maxdepth 1 -name '*.patch' -type f -print0 \
+    | sort -z | xargs -0 sha256sum 2>/dev/null \
+    | sha256sum | cut -d' ' -f1)
+fi
+APPLIED_HASH_FILE="$WORKDIR/$SRC/.machinen-patch-hash"
+
+if [ -d "$SRC" ] && [ -n "$PATCH_HASH" ]; then
+  if [ ! -f "$APPLIED_HASH_FILE" ] || [ "$(cat "$APPLIED_HASH_FILE")" != "$PATCH_HASH" ]; then
+    echo "==> Patch set changed (hash $PATCH_HASH) — re-extracting source tree"
+    rm -rf "$SRC"
+  fi
+fi
+
 if [ ! -d "$SRC" ]; then
   tar -xf "$TARBALL"
 fi
 
 cd "$SRC"
+
+# Apply our kernel patches (if any) before configuring the tree. Each
+# patch is rooted at the kernel source root (-p1). Bail loudly on any
+# patch that doesn't apply cleanly — silent partial application is the
+# kind of bug that turns into a kernel oops three boots later.
+if [ -n "$PATCHES_DIR" ] && [ -d "$PATCHES_DIR" ]; then
+  shopt -s nullglob
+  for p in "$PATCHES_DIR"/*.patch; do
+    echo "==> Applying kernel patch: $(basename "$p")"
+    if ! patch -p1 -F0 --dry-run < "$p" >/dev/null 2>&1; then
+      echo "build-kernel-arm64: patch refused to apply: $p" >&2
+      patch -p1 -F0 --dry-run < "$p" >&2 || true
+      exit 1
+    fi
+    patch -p1 -F0 < "$p"
+  done
+  shopt -u nullglob
+  echo "$PATCH_HASH" > .machinen-patch-hash
+fi
 
 # Start from arm64 defconfig — sane Cortex-A baseline with PSCI, PL011
 # console, GICv3, devtmpfs, sysfs, procfs already enabled.

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -68,21 +68,30 @@ rootfs_input_files() {
     "${ASSETS}/poweroff.zig" \
     "${ASSETS}/winsize-agent.zig" \
     "${SCRIPTS}/build-base-assets.sh"
-  # CRIU patches applied during the rootfs build. Sorted for stable
-  # ordering. Empty find output is fine (no patches → no extra lines).
-  find "${ROOT}/packages/microvm/patches" -type f -name "*.patch" 2>/dev/null | LC_ALL=C sort
+  # CRIU patches applied during the rootfs build. Scoped to
+  # patches/criu/ so kernel patches under patches/kernel/ (consumed
+  # by the kernel build, see kernel_input_files) don't accidentally
+  # invalidate the rootfs sidecar. Sorted for stable ordering. Empty
+  # find output is fine (no patches → no extra lines).
+  find "${ROOT}/packages/microvm/patches/criu" -type f -name "*.patch" 2>/dev/null | LC_ALL=C sort
 }
 
 # Files whose contents are baked into Image-arm64. The kernel itself
 # comes from upstream kernel.org pinned by version inside
-# build-kernel-arm64.sh — that single script captures version pin,
-# CONFIG_ overrides, and patch list, so it's the only input we track.
-# virt.dts contributes to virt-arm64.dtb (compiled alongside the
-# kernel) so it's listed here too.
+# build-kernel-arm64.sh — that single script captures version pin and
+# CONFIG_ overrides. Patches in packages/microvm/patches/kernel/ are
+# applied on top by the same script, so changing or adding a patch
+# must also invalidate the sidecar. virt.dts contributes to
+# virt-arm64.dtb (compiled alongside the kernel) so it's listed here
+# too.
 kernel_input_files() {
   printf '%s\n' \
     "${ASSETS}/virt.dts" \
     "${SCRIPTS}/build-kernel-arm64.sh"
+  if [ -d "${ROOT}/packages/microvm/patches/kernel" ]; then
+    find "${ROOT}/packages/microvm/patches/kernel" -maxdepth 1 -type f \
+      -name '*.patch' -print | sort
+  fi
 }
 
 # Files whose contents are baked into

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -926,6 +926,152 @@ else
 fi
 fi  # B2 rootfs gate
 
+# ---- B3: page-reporting cycle terminates on a --lazy restored VM (#290) ----
+# Boot memdirty, snapshot, restore --lazy, then watch the VMM's
+# `bytes_reported` counter (cumulative, monotonic). Without the
+# in-tree kernel patch
+# (`packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`)
+# the guest kernel's page-reporting workqueue re-reports the same
+# physical pages every 2-second cycle indefinitely, because the
+# buddy allocator clears the Reported flag during merges; on a
+# 1.5 GiB lazy-restored VM we observed `bytes_reported` climbing
+# past 12 GiB before hitting the sample horizon. With the patch
+# the cycle terminates after a single warm-up sweep (~22 s) and
+# `bytes_reported` plateaus.
+#
+# We assert plateau by sampling twice with a 5-cycle (10 s) gap
+# *after* a 30 s settle. A non-terminating cycle would add ~1 GiB
+# per cycle to the second sample; we just assert equality, which
+# trips on any forward motion at all.
+if [[ "$ROOTFS_SUPPORTS_CRIU" -eq 0 || "$ROOTFS_SUPPORTS_SNAPSHOT_HELPERS" -eq 0 \
+      || "$ROOTFS_SUPPORTS_MEMDIRTY" -eq 0 ]]; then
+  echo "B3: skipped (rootfs lacks criu/snapshot/memdirty helpers)"
+else
+echo "B3: lazy-restored VM's page-reporting cycle reaches steady state"
+B3_NAME="lazy-balloon-smoke-$$"
+B3_BG_LOG="$FIXTURE/b3-bg.log"
+B3_SCRATCH="$FIXTURE/b3-scratch.img"
+B3_SNAP_DIR="$FIXTURE/b3-snap"
+B3_RESTORE_LOG="$FIXTURE/b3-restore.log"
+B3_DIRTY_MIB=128
+B3_RAM_MIB=$((B3_DIRTY_MIB + 1024))
+
+truncate -s 4G "$B3_SCRATCH"
+B3_PID=$(boot_bg "$B3_NAME" "$B3_BG_LOG" --memory "$B3_RAM_MIB" --snapshot "$B3_SCRATCH" -- \
+  /sbin/machinen-memdirty "$B3_DIRTY_MIB")
+cleanup_b3() {
+  cli stop "$B3_NAME" >/dev/null 2>&1 || true
+  kill -TERM "$B3_PID" 2>/dev/null || true
+  wait "$B3_PID" 2>/dev/null || true
+}
+trap 'cleanup_b3; rm -rf "$FIXTURE"' EXIT
+
+if ! wait_for_vm "$B3_NAME"; then
+  tail -80 "$B3_BG_LOG" >&2
+  fail "B3 — '$B3_NAME' never appeared in 'machinen ls'"
+fi
+
+deadline=$((SECONDS + 60))
+while (( SECONDS < deadline )); do
+  if grep -q "READY mib=$B3_DIRTY_MIB" "$B3_BG_LOG"; then
+    break
+  fi
+  sleep 1
+done
+if ! grep -q "READY mib=$B3_DIRTY_MIB" "$B3_BG_LOG"; then
+  tail -120 "$B3_BG_LOG" >&2
+  fail "B3 — memdirty never printed READY mib=$B3_DIRTY_MIB"
+fi
+sleep 2
+
+if ! cli snapshot "$B3_NAME" "$B3_SNAP_DIR" 2>"$FIXTURE/b3-dump.log"; then
+  cat "$FIXTURE/b3-dump.log" >&2
+  fail "B3 — 'machinen snapshot' failed"
+fi
+wait "$B3_PID" 2>/dev/null || true
+
+node "$CLI" restore "$B3_SNAP_DIR" --lazy >"$B3_RESTORE_LOG" 2>&1 &
+B3_RESTORE_PID=$!
+cleanup_b3_restore() {
+  kill -TERM "$B3_RESTORE_PID" 2>/dev/null || true
+  wait "$B3_RESTORE_PID" 2>/dev/null || true
+}
+trap 'cleanup_b3; cleanup_b3_restore; rm -rf "$FIXTURE"' EXIT
+
+B3_FORK_NAME=""
+deadline=$((SECONDS + 60))
+while (( SECONDS < deadline )); do
+  cand=$(cli ls 2>/dev/null | awk -v src="$B3_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+  if [[ -n "$cand" ]]; then
+    B3_FORK_NAME=$cand
+    break
+  fi
+  sleep 1
+done
+if [[ -z "$B3_FORK_NAME" ]]; then
+  tail -200 "$B3_RESTORE_LOG" >&2
+  fail "B3 — restored VM never registered"
+fi
+
+B3_FORK_VMM=$(cli ls 2>/dev/null | awk -v n="$B3_FORK_NAME" 'NR>1 && $2==n {print $1}')
+if [[ -z "$B3_FORK_VMM" ]]; then
+  fail "B3 — couldn't find VMM pid for '$B3_FORK_NAME'"
+fi
+
+# Resolve the restored VMM's stats binary path (registry meta records
+# `statsPath`). The 24-byte file's first u64 LE is `bytes_reported`,
+# which the balloon backend bumps on every reporting cycle. Smoke
+# tests pin MACHINEN_REGISTRY_DIR to the fixture so we don't pollute
+# ~/.machinen — read the meta from there.
+B3_META="$MACHINEN_REGISTRY_DIR/$B3_FORK_VMM/meta.json"
+if [[ ! -f "$B3_META" ]]; then
+  fail "B3 — registry meta not found at $B3_META (vmm=$B3_FORK_VMM)"
+fi
+B3_STATS=$(node -e '
+  process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).statsPath || "");
+' "$B3_META")
+if [[ -z "$B3_STATS" || ! -f "$B3_STATS" ]]; then
+  fail "B3 — couldn't resolve stats binary for '$B3_FORK_NAME' (vmm=$B3_FORK_VMM)"
+fi
+
+read_b3_reported() {
+  node -e '
+    const buf = require("fs").readFileSync(process.argv[1]);
+    process.stdout.write(String(buf.length >= 8 ? Number(buf.readBigUInt64LE(0)) : 0));
+  ' "$B3_STATS"
+}
+
+# Settle: warm-up sweep finished around t=23 in the issue-290
+# reproducer at this workload size; 30 s is comfortable.
+sleep 30
+B3_REPORTED_A=$(read_b3_reported)
+echo "  bytes_reported after 30s settle = $B3_REPORTED_A"
+
+# A==0 means REPORTING never fired — likely the feature got silently
+# disabled. Catch that explicitly so the equality check below can't
+# trivially pass.
+if (( B3_REPORTED_A == 0 )); then
+  tail -100 "$B3_RESTORE_LOG" >&2
+  fail "B3 — bytes_reported == 0 after 30 s; REPORTING didn't fire (#290 regression?)"
+fi
+
+# Re-sample after 5 reporting cycles (~10 s). A non-terminating
+# cycle would add hundreds of MiB to the value here.
+sleep 10
+B3_REPORTED_B=$(read_b3_reported)
+echo "  bytes_reported after +10s gap   = $B3_REPORTED_B"
+
+if (( B3_REPORTED_B != B3_REPORTED_A )); then
+  tail -100 "$B3_RESTORE_LOG" >&2
+  fail "B3 — bytes_reported still growing on lazy-restored VM ($B3_REPORTED_A → $B3_REPORTED_B); kernel page-reporting cycle isn't terminating (#290 regression?)"
+fi
+pass "lazy-restored VM's bytes_reported plateaued at $B3_REPORTED_A bytes (cycle terminated)"
+
+cleanup_b3_restore
+cleanup_b3
+trap 'rm -rf "$FIXTURE"' EXIT
+fi  # B3 rootfs-capability gate
+
 # ----------------------------------------------------------------
 # Phase-1 base-rootfs contract tests — verify #77 step 1 plumbing.
 # Each asserts one thing scripts/build-base-assets.sh claims to ship.


### PR DESCRIPTION
## Problem

When you restore a virtual machine from a snapshot with `--lazy`, the guest's memory is supposed to load on demand, page by page, as the workload touches it. That's the whole point of lazy restore — the host should only pay for memory the workload actually uses.

A separate feature called free-page reporting lets the guest tell the host which memory pages are free, so the host can reclaim them. With both features on, something went wrong. The host kept getting told about the same memory regions over and over, every two seconds, forever. In a small reproduction with a 128 MiB workload on a 1.5 GiB virtual machine, the host received reports adding up to **11.6 GiB** in 30 seconds. The host kept doing wasted reclaim work, and its measured memory usage crept up over time.

There was supposed to be a workaround in the runtime. It set an environment variable named `MACHINEN_DISABLE_BALLOON_REPORTING` whenever a lazy restore happened. But the assignment put the variable on the guest workload's environment, and the code that reads it lives in a different process — the VMM (the host process that runs the virtual machine). The VMM never inherited the variable. The workaround was a no-op the entire time. Lazy-restored virtual machines have been running with the broken cycle ever since the feature shipped; the cost just never tripped any test threshold.

Closes #290.

## Solution

1. **Patch the guest kernel to stop the cycle at its source.** Refuse to merge a freshly-freed page with an adjacent already-reported neighbour. That keeps the neighbour's reported state intact, the freshly-freed half gets reported on its own one time, and the cycle stops on its own.
2. **Remove the broken workaround from the runtime.** No more dead environment variable, no more dead branch in the balloon code that read it.
3. **Wire kernel patches into the build.** A new `packages/microvm/patches/kernel/` directory holds patches; the kernel build script picks them up automatically and the freshness checker treats a changed patch as a reason to rebuild.

## Technical Summary

**Kernel patch** (`packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`, applied to Linux 6.12.20). In `mm/page_alloc.c::__free_one_page`, when the page being freed has a free buddy, the kernel removes the buddy from the free list and merges them into a higher-order block. Removing the buddy from the free list also clears its `Reported` flag (this is correct for normal allocations — the page is being given to a user, so the host's "I reclaimed this" state is no longer accurate). But during a buddy merge it is wrong: the merged block lands on the higher-order free list unreported, and the next reporting cycle reports the same physical region again. This barely shows on a typical workload because freshly-freed pages rarely have a Reported buddy, but on a CRIU lazy-restored guest the workload's `PE_LAZY` anon range is one huge contiguous free run, so almost every free has a Reported buddy. The patch adds one check before the merge: `if (page_reported(buddy)) goto done_merging`. The cycle terminates after a single warm-up sweep.

**Runtime cleanup** (`packages/runtime/src/vm.ts`). Drop `restoreEnv.MACHINEN_DISABLE_BALLOON_REPORTING = "1"` from `restore()`. The guest workload's env doesn't reach the VMM process; the variable was never read.

**Balloon cleanup** (`packages/microvm/src/balloon.zig`). Drop the `getenv("MACHINEN_DISABLE_BALLOON_REPORTING")` branch from `Backend.features()`. With the kernel patch in place there's no caller and no reason for an opt-out. `features()` is now an unconditional `return (1<<32) | (1<<VIRTIO_BALLOON_F_REPORTING)`. The corresponding zig test for the removed branch is dropped.

**Build wiring**:
- `scripts/build-kernel-arm64.sh`: new `PATCHES_DIR` env var. Hashes the patch set and re-extracts the kernel source tree on patch-set change so applies are always against a clean source. Bails loudly if any patch refuses.
- `scripts/build-base-assets.sh`: rsyncs `packages/microvm/patches/kernel/` to the remote arm64 builder and forwards `PATCHES_DIR`.
- `scripts/check-asset-freshness.sh`: kernel patches are listed as kernel inputs (so a changed patch invalidates the kernel sidecar). The rootfs's existing `find` over `packages/microvm/patches` is scoped to `patches/criu/` so kernel patches don't cross-invalidate the rootfs sidecar.

**Docs** (`packages/microvm/docs/memory.md`, `packages/runtime/API.md`). Corrects the prior diagnosis (the "reporting kthread reads pages → fires UFFD" theory was mechanistically wrong — `criu lazy-pages.log` is silent in steady state, no userfaultfd events fire) and documents the actual root cause and fix.

## Test plan

- [x] `npx vitest run` — 597 pass, 7 skip
- [x] `npx agent-ci run --all -q -p` — 4/4 workflows
- [x] `pnpm smoke-tests` — all pass; B0/B1/B2 reclaim tests still green, S4/S5/S6 lazy-pages tests still green. S5's pre-existing fork-RSS WARN is unchanged from main (a separate, tracked issue).
- [x] Reproducer (`scripts/probe-issue-290.sh`, kept local; not committed): on the patched kernel, `bytes_reported` settles at a one-time warm-up ceiling around t=23 and `phys_footprint` stays flat for the remaining 67 s of a 90 s observation window. On the unpatched kernel the same reproducer keeps cycling.