### PR TITLE
refactor: extract sub-functions from six high-cognitive-complexity functions

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1516,66 +1516,21 @@ async function cmdFork(args: string[]): Promise<number> {
   }
 }
 
+interface AttachOpts {
+  shell: string;
+  tail: number | "all" | undefined;
+  filtered: string[];
+}
+
 async function cmdAttach(args: string[]): Promise<number> {
-  // Pull `--shell` and `--tail` out before the target flags so the
-  // unknown-arg checks in `parseTargetFlags` don't reject them.
-  // `--shell` defaults to `bash -i` — the Debian base rootfs ships
-  // bash, and `-i` gets job control, history, and a prompt.
-  let shell = "/bin/bash -i";
-  let tail: number | "all" | undefined;
-  const filtered: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--shell" || a.startsWith("--shell=")) {
-      const v = a === "--shell" ? args[++i] : a.slice("--shell=".length);
-      if (!v) {
-        die("--shell requires a value");
-      }
-      shell = v;
-    } else if (a === "--tail" || a.startsWith("--tail=")) {
-      // `--tail` (no value) prints the whole snapshot. `--tail N`
-      // prints the last N lines. The snapshot is capped at ~1 MiB so
-      // even the no-value form is bounded.
-      let v: string | undefined;
-      if (a === "--tail") {
-        const peek = args[i + 1];
-        if (peek && /^[0-9]+$/.test(peek)) {
-          v = peek;
-          i++;
-        }
-      } else {
-        v = a.slice("--tail=".length);
-      }
-      if (v === undefined) {
-        tail = "all";
-      } else {
-        const n = Number(v);
-        if (!Number.isInteger(n) || n < 0) {
-          die(`--tail: expected a non-negative integer, got '${v}'`);
-        }
-        tail = n;
-      }
-    } else {
-      filtered.push(a);
-    }
-  }
+  const { shell, tail, filtered } = parseAttachOpts(args);
   const target = parseTargetFlags(filtered, "attach");
   // #150 phase 2 PR3: --tail dumps the boot-console snapshot before
   // (or instead of) the interactive shell. Look up the registry
   // entry directly — `attach()` only returns a VmHandle, not the
   // entry, and we need `bootLogPath` from the registry.
   if (tail !== undefined) {
-    const entry = lookupEntry(target);
-    if (!entry) {
-      die(`machinen attach: no running VM matched ${describeTarget(target)}`);
-    }
-    if (!entry.bootLogPath) {
-      die(
-        `machinen attach --tail: VM was not booted with --detached, no snapshot exists. ` +
-          `Use 'machinen attach' (no --tail) for live console access.`,
-      );
-    }
-    printBootLogTail(entry.bootLogPath, tail);
+    dumpBootLogTail(target, tail);
   }
   // Resolve the target before the TTY check: a typo in --name should
   // surface "no running VM found", not the TTY error. The TTY error
@@ -1591,6 +1546,73 @@ async function cmdAttach(args: string[]): Promise<number> {
   } finally {
     await vm.detach();
   }
+}
+
+// Pull `--shell` and `--tail` out before the target flags so the
+// unknown-arg checks in `parseTargetFlags` don't reject them.
+// `--shell` defaults to `bash -i` — the Debian base rootfs ships
+// bash, and `-i` gets job control, history, and a prompt.
+function parseAttachOpts(args: string[]): AttachOpts {
+  let shell = "/bin/bash -i";
+  let tail: number | "all" | undefined;
+  const filtered: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--shell" || a.startsWith("--shell=")) {
+      const v = a === "--shell" ? args[++i] : a.slice("--shell=".length);
+      if (!v) {
+        die("--shell requires a value");
+      }
+      shell = v;
+    } else if (a === "--tail" || a.startsWith("--tail=")) {
+      const r = parseTailFlag(a, args, i);
+      tail = r.value;
+      i = r.next;
+    } else {
+      filtered.push(a);
+    }
+  }
+  return { shell, tail, filtered };
+}
+
+// `--tail` (no value) prints the whole snapshot. `--tail N`
+// prints the last N lines. The snapshot is capped at ~1 MiB so
+// even the no-value form is bounded.
+function parseTailFlag(
+  arg: string,
+  args: string[],
+  i: number,
+): { value: number | "all"; next: number } {
+  if (arg.startsWith("--tail=")) {
+    return { value: parseTailValue(arg.slice("--tail=".length)), next: i };
+  }
+  const peek = args[i + 1];
+  if (peek && /^[0-9]+$/.test(peek)) {
+    return { value: parseTailValue(peek), next: i + 1 };
+  }
+  return { value: "all", next: i };
+}
+
+function parseTailValue(v: string): number {
+  const n = Number(v);
+  if (!Number.isInteger(n) || n < 0) {
+    die(`--tail: expected a non-negative integer, got '${v}'`);
+  }
+  return n;
+}
+
+function dumpBootLogTail(target: { name: string } | { pid: number }, tail: number | "all"): void {
+  const entry = lookupEntry(target);
+  if (!entry) {
+    die(`machinen attach: no running VM matched ${describeTarget(target)}`);
+  }
+  if (!entry.bootLogPath) {
+    die(
+      `machinen attach --tail: VM was not booted with --detached, no snapshot exists. ` +
+        `Use 'machinen attach' (no --tail) for live console access.`,
+    );
+  }
+  printBootLogTail(entry.bootLogPath, tail);
 }
 
 function printBootLogTail(path: string, tail: number | "all"): void {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -888,7 +888,100 @@ async function cmdGc(args: string[]): Promise<number> {
 // after 2s, then gc its entry. Resolves `--detached` boots' Ctrl-C
 // problem: the CLI no longer holds the VMM, so a separate `stop`
 // command is the only way to ask for a clean shutdown.
+interface StopOpts {
+  json: boolean;
+  dryRun: boolean;
+  force: boolean;
+  target: { name: string } | { pid: number };
+}
+
+type StopStatus = "stopped" | "would_stop" | "already_dead" | "recycled";
+
 async function cmdStop(args: string[]): Promise<number> {
+  const opts = parseStopOpts(args);
+  const entry = lookupEntry(opts.target);
+  if (!entry) {
+    notifyVmNotFound(opts.json, opts.target);
+    return 1;
+  }
+  const emitStop = (status: StopStatus): void => {
+    if (opts.json) {
+      emitJson({
+        schema_version: 1,
+        pid: entry.pid,
+        name: entry.name ?? null,
+        status,
+        dry_run: opts.dryRun,
+      });
+    }
+  };
+  // Pid-validate before signalling — refuses to kill a recycled pid.
+  const status = validatePid(entry.pid, {
+    vmmExe: entry.vmmExe,
+    startedAt: entry.startedAt,
+  });
+  const earlyExit = handleNonAliveStatus(entry, status, opts, emitStop);
+  if (earlyExit !== undefined) {
+    return earlyExit;
+  }
+  if (opts.dryRun) {
+    if (!opts.json) {
+      const sigLabel = opts.force ? "SIGKILL" : "SIGTERM (escalates to SIGKILL after 2s)";
+      process.stdout.write(`would ${sigLabel} ${describeEntry(entry)}\n`);
+    }
+    emitStop("would_stop");
+    return 0;
+  }
+  const sig: "SIGKILL" | "SIGTERM" = opts.force ? "SIGKILL" : "SIGTERM";
+  const killResult = await killAndMaybeEscalate(entry.pid, sig, opts.force);
+  if (killResult.kind === "error") {
+    notifyKillFailure(opts.json, entry.pid, killResult.error);
+    return 1;
+  }
+  // #150 phase 2 PR3: signal gvproxy too. Detached gvproxy survives
+  // the parent's exit on its own (no pdeathsig); without this it'd
+  // outlive every `machinen stop`, holding host ports and leaking
+  // the qemu/control sockets. Anti-recycling guard mirrors the VMM
+  // path — basename match against the recorded gvproxy binary, so
+  // an unrelated pid that inherited gvproxy's slot weeks later
+  // doesn't get killed. Wait for it to exit so the test/user can
+  // assume "stop returned → process is gone" without a follow-up
+  // poll.
+  if (entry.gvproxyPid && entry.gvproxyExe) {
+    await signalAuxiliary({
+      pid: entry.gvproxyPid,
+      exe: entry.gvproxyExe,
+      sig,
+      force: opts.force,
+      label: "gvproxy",
+    });
+  }
+  // #150 phase 3: signal each detached live-mount helper too. They
+  // die with the VMM via pdeathsig already, but signaling explicitly
+  // lets us wait for clean exit and avoids a window where SIGTERM-on-
+  // VMM races the helper's own pdeathsig-triggered shutdown.
+  // Anti-recycling guard mirrors the gvproxy path.
+  for (const helper of entry.liveMountServers ?? []) {
+    await signalAuxiliary({
+      pid: helper.pid,
+      exe: helper.exe,
+      sig,
+      force: opts.force,
+      label: "mount-server",
+    });
+  }
+  // Final gc to drop the registry entry + cleanupPaths (including the
+  // gvproxy socket dir that PR3 added to the cleanup list).
+  runGc({ pid: entry.pid });
+  if (opts.json) {
+    emitStop("stopped");
+  } else {
+    process.stdout.write(`stopped ${describeEntry(entry)}\n`);
+  }
+  return 0;
+}
+
+function parseStopOpts(args: string[]): StopOpts {
   const { json, rest: afterJson } = consumeJsonFlag(args);
   const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
   let force = false;
@@ -901,164 +994,135 @@ async function cmdStop(args: string[]): Promise<number> {
     }
   }
   const target = parseTargetFlags(rest, "stop");
-  const entry = lookupEntry(target);
-  if (!entry) {
-    if (json) {
-      emitJsonError("VM_NOT_FOUND", `no running VM matched ${describeTarget(target)}`);
-    } else {
-      process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
-    }
-    return 1;
-  }
-  const emitStop = (status: "stopped" | "would_stop" | "already_dead" | "recycled"): void => {
-    if (json) {
-      emitJson({
-        schema_version: 1,
-        pid: entry.pid,
-        name: entry.name ?? null,
-        status,
-        dry_run: dryRun,
-      });
-    }
-  };
-  // Pid-validate before signalling — refuses to kill a recycled pid.
-  const status = validatePid(entry.pid, {
-    vmmExe: entry.vmmExe,
-    startedAt: entry.startedAt,
-  });
-  if (status === "recycled") {
-    if (!json) {
-      process.stderr.write(
-        `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
-          (dryRun ? "would skip kill and gc.\n" : "skipping kill and running gc.\n"),
-      );
-    }
-    if (!dryRun) {
-      runGc({ pid: entry.pid });
-    }
-    emitStop("recycled");
-    return 0;
-  }
-  if (status === "dead") {
-    if (!json) {
-      process.stderr.write(
-        `machinen stop: pid ${entry.pid} already gone; ` +
-          (dryRun ? "would gc.\n" : "running gc.\n"),
-      );
-    }
-    if (!dryRun) {
-      runGc({ pid: entry.pid });
-    }
-    emitStop("already_dead");
-    return 0;
-  }
-  if (dryRun) {
-    if (!json) {
-      const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-      const sigLabel = force ? "SIGKILL" : "SIGTERM (escalates to SIGKILL after 2s)";
-      process.stdout.write(`would ${sigLabel} ${label}\n`);
-    }
-    emitStop("would_stop");
-    return 0;
-  }
-  const sig = force ? "SIGKILL" : "SIGTERM";
-  try {
-    process.kill(entry.pid, sig);
-  } catch (err) {
-    const msg = `failed to signal pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}`;
-    if (json) {
-      emitJsonError("STOP_KILL_FAILED", msg);
-    } else {
-      process.stderr.write(`machinen stop: ${msg}\n`);
-    }
-    return 1;
-  }
-  if (!force) {
-    await waitForExit(entry.pid, 2_000);
-    try {
-      process.kill(entry.pid, 0);
-      // Still alive — escalate.
-      try {
-        process.kill(entry.pid, "SIGKILL");
-      } catch {}
-    } catch {
-      // Already gone.
-    }
-  }
-  // #150 phase 2 PR3: signal gvproxy too. Detached gvproxy survives
-  // the parent's exit on its own (no pdeathsig); without this it'd
-  // outlive every `machinen stop`, holding host ports and leaking
-  // the qemu/control sockets. Anti-recycling guard mirrors the VMM
-  // path — basename match against the recorded gvproxy binary, so
-  // an unrelated pid that inherited gvproxy's slot weeks later
-  // doesn't get killed. Wait for it to exit so the test/user can
-  // assume "stop returned → process is gone" without a follow-up
-  // poll.
-  if (entry.gvproxyPid && entry.gvproxyExe) {
-    const gvStatus = validatePid(entry.gvproxyPid, { vmmExe: entry.gvproxyExe });
-    if (gvStatus === "alive") {
-      try {
-        process.kill(entry.gvproxyPid, sig);
-      } catch (err) {
-        process.stderr.write(
-          `machinen stop: failed to signal gvproxy pid ${entry.gvproxyPid}: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      }
-      if (!force) {
-        await waitForExit(entry.gvproxyPid, 2_000);
-        try {
-          process.kill(entry.gvproxyPid, 0);
-          try {
-            process.kill(entry.gvproxyPid, "SIGKILL");
-          } catch {}
-        } catch {}
-      }
-    } else if (gvStatus === "recycled") {
-      process.stderr.write(
-        `machinen stop: gvproxy pid ${entry.gvproxyPid} now held by an unrelated process; skipping.\n`,
-      );
-    }
-  }
-  // #150 phase 3: signal each detached live-mount helper too. They
-  // die with the VMM via pdeathsig already, but signaling explicitly
-  // lets us wait for clean exit and avoids a window where SIGTERM-on-
-  // VMM races the helper's own pdeathsig-triggered shutdown.
-  // Anti-recycling guard mirrors the gvproxy path.
-  for (const helper of entry.liveMountServers ?? []) {
-    const status = validatePid(helper.pid, { vmmExe: helper.exe });
-    if (status === "alive") {
-      try {
-        process.kill(helper.pid, sig);
-      } catch (err) {
-        process.stderr.write(
-          `machinen stop: failed to signal mount-server pid ${helper.pid}: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      }
-      if (!force) {
-        await waitForExit(helper.pid, 2_000);
-        try {
-          process.kill(helper.pid, 0);
-          try {
-            process.kill(helper.pid, "SIGKILL");
-          } catch {}
-        } catch {}
-      }
-    } else if (status === "recycled") {
-      process.stderr.write(
-        `machinen stop: mount-server pid ${helper.pid} now held by an unrelated process; skipping.\n`,
-      );
-    }
-  }
-  // Final gc to drop the registry entry + cleanupPaths (including the
-  // gvproxy socket dir that PR3 added to the cleanup list).
-  runGc({ pid: entry.pid });
+  return { json, dryRun, force, target };
+}
+
+function notifyVmNotFound(json: boolean, target: { name: string } | { pid: number }): void {
   if (json) {
-    emitStop("stopped");
+    emitJsonError("VM_NOT_FOUND", `no running VM matched ${describeTarget(target)}`);
   } else {
-    const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-    process.stdout.write(`stopped ${label}\n`);
+    process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
   }
+}
+
+function describeEntry(entry: RegistryEntry): string {
+  return entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
+}
+
+// Map "recycled" / "dead" pid statuses to the appropriate exit code
+// and emit the matching message. Returns undefined when status is
+// "alive" (the caller should continue with the actual kill path).
+function handleNonAliveStatus(
+  entry: RegistryEntry,
+  status: "alive" | "dead" | "recycled",
+  opts: StopOpts,
+  emitStop: (status: StopStatus) => void,
+): number | undefined {
+  if (status === "alive") {
+    return undefined;
+  }
+  const isRecycled = status === "recycled";
+  const detail = isRecycled ? "registry entry pid" : "pid";
+  const action = isRecycled
+    ? opts.dryRun
+      ? "would skip kill and gc."
+      : "skipping kill and running gc."
+    : opts.dryRun
+      ? "would gc."
+      : "running gc.";
+  if (!opts.json) {
+    const lead = isRecycled
+      ? `${detail} ${entry.pid} is now held by an unrelated process;`
+      : `${detail} ${entry.pid} already gone;`;
+    process.stderr.write(`machinen stop: ${lead} ${action}\n`);
+  }
+  if (!opts.dryRun) {
+    runGc({ pid: entry.pid });
+  }
+  emitStop(isRecycled ? "recycled" : "already_dead");
   return 0;
+}
+
+type KillResult = { kind: "ok" } | { kind: "error"; error: unknown };
+
+// SIGTERM → 2s wait → SIGKILL escalation. `force: true` skips both
+// the SIGTERM step and the escalation (caller already chose SIGKILL).
+async function killAndMaybeEscalate(
+  pid: number,
+  sig: "SIGTERM" | "SIGKILL",
+  force: boolean,
+): Promise<KillResult> {
+  try {
+    process.kill(pid, sig);
+  } catch (err) {
+    return { kind: "error", error: err };
+  }
+  if (force) {
+    return { kind: "ok" };
+  }
+  await waitForExit(pid, 2_000);
+  try {
+    process.kill(pid, 0);
+    // Still alive — escalate.
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  } catch {
+    // Already gone.
+  }
+  return { kind: "ok" };
+}
+
+function notifyKillFailure(json: boolean, pid: number, err: unknown): void {
+  const msg = `failed to signal pid ${pid}: ${err instanceof Error ? err.message : String(err)}`;
+  if (json) {
+    emitJsonError("STOP_KILL_FAILED", msg);
+  } else {
+    process.stderr.write(`machinen stop: ${msg}\n`);
+  }
+}
+
+interface AuxiliarySignalArgs {
+  pid: number;
+  exe: string;
+  sig: "SIGTERM" | "SIGKILL";
+  force: boolean;
+  label: string;
+}
+
+// Signal a non-VMM helper (gvproxy, live-mount server). Pid-validates
+// to refuse killing a recycled pid, signals, optionally waits +
+// escalates. Soft errors (signal failure, recycled-pid skip) go to
+// stderr without propagating — auxiliary failures don't make `stop`
+// itself fail.
+async function signalAuxiliary(args: AuxiliarySignalArgs): Promise<void> {
+  const status = validatePid(args.pid, { vmmExe: args.exe });
+  if (status === "recycled") {
+    process.stderr.write(
+      `machinen stop: ${args.label} pid ${args.pid} now held by an unrelated process; skipping.\n`,
+    );
+    return;
+  }
+  if (status !== "alive") {
+    return;
+  }
+  try {
+    process.kill(args.pid, args.sig);
+  } catch (err) {
+    process.stderr.write(
+      `machinen stop: failed to signal ${args.label} pid ${args.pid}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+  if (args.force) {
+    return;
+  }
+  await waitForExit(args.pid, 2_000);
+  try {
+    process.kill(args.pid, 0);
+    try {
+      process.kill(args.pid, "SIGKILL");
+    } catch {}
+  } catch {}
 }
 
 /**

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -80,96 +80,57 @@ export interface ParsedForkArgs {
   rest: string[];
 }
 
+interface ParseState {
+  newName?: string;
+  outDir?: string;
+  tcpKeep: boolean;
+  detach: boolean;
+  lazy: boolean;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  seenHostPorts: Set<number>;
+  mount?: { host: string; guest: string };
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  env: Record<string, string>;
+  guestCwd?: string;
+  memory?: number;
+  rest: string[];
+}
+
+type FlagHandler = (state: ParseState, args: string[], i: number, flag: string) => number;
+
+const FLAG_HANDLERS: ReadonlyArray<readonly [readonly string[], FlagHandler]> = [
+  [["--new-name"], handleNewNameFlag],
+  [["--out-dir"], handleOutDirFlag],
+  [["--tcp-keep"], handleTcpKeepFlag],
+  [["--detach"], handleDetachFlag],
+  [["--lazy"], handleLazyFlag],
+  [["-p", "--publish"], handlePortForwardFlag],
+  [["--mount"], handleMountFlag],
+  [["--mount-live"], handleLiveMountFlag],
+  [["--env"], handleEnvFlag],
+  [["--cwd"], handleCwdFlag],
+  [["--memory"], handleMemoryFlag],
+];
+
 export function parseForkArgs(argv: string[]): ParsedForkArgs {
-  let newName: string | undefined;
-  let outDir: string | undefined;
-  let tcpKeep = false;
-  let detach = false;
-  let lazy = false;
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const seenHostPorts = new Set<number>();
-  let mount: { host: string; guest: string } | undefined;
-  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
-  const env: Record<string, string> = {};
-  let guestCwd: string | undefined;
-  let memory: number | undefined;
-  const rest: string[] = [];
+  const state: ParseState = {
+    tcpKeep: false,
+    detach: false,
+    lazy: false,
+    portForward: [],
+    seenHostPorts: new Set<number>(),
+    liveMounts: [],
+    env: {},
+    rest: [],
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
-    if (a === "--new-name" || a.startsWith("--new-name=")) {
-      if (newName !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--new-name may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, argv, i, "a value");
-      newName = spec;
+    const next = dispatchFlag(state, a, argv, i);
+    if (next !== undefined) {
       i = next;
-    } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      if (outDir !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--out-dir may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, argv, i, "a directory path");
-      outDir = spec;
-      i = next;
-    } else if (a === "--tcp-keep") {
-      tcpKeep = true;
-    } else if (a === "--detach") {
-      detach = true;
-    } else if (a === "--lazy") {
-      lazy = true;
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
-    } else if (a === "--mount" || a.startsWith("--mount=")) {
-      if (mount) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--mount may be given at most once per invocation",
-        );
-      }
-      const r = consumeMount(a, argv, i);
-      mount = r.value;
-      i = r.next;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const r = consumeLiveMount(a, argv, i);
-      liveMounts.push(r.value);
-      i = r.next;
-    } else if (a === "--env" || a.startsWith("--env=")) {
-      const r = consumeEnv(a, argv, i);
-      env[r.key] = r.value;
-      i = r.next;
-    } else if (a === "--cwd" || a.startsWith("--cwd=")) {
-      if (guestCwd !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--cwd may be given at most once per invocation",
-        );
-      }
-      const r = consumeGuestCwd(a, argv, i);
-      guestCwd = r.value;
-      i = r.next;
-    } else if (a === "--memory" || a.startsWith("--memory=")) {
-      if (memory !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--memory may be given at most once per invocation",
-        );
-      }
-      const r = consumeMemory(a, argv, i);
-      memory = r.value;
-      i = r.next;
-    } else {
-      rest.push(a);
+      continue;
     }
+    state.rest.push(a);
   }
   // Detach exits the runtime supervisor, taking the host-side FUSE
   // server with it — the in-guest lazy-pages daemon would then block
@@ -177,17 +138,108 @@ export function parseForkArgs(argv: string[]): ParsedForkArgs {
   // usable until the FUSE server gains its own detach handoff
   // (#150 phase 3).
   return {
-    newName,
-    outDir,
-    tcpKeep,
-    detach,
-    lazy: lazy && !detach,
-    portForward,
-    mount,
-    liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
-    env: Object.keys(env).length > 0 ? env : undefined,
-    guestCwd,
-    memory,
-    rest,
+    newName: state.newName,
+    outDir: state.outDir,
+    tcpKeep: state.tcpKeep,
+    detach: state.detach,
+    lazy: state.lazy && !state.detach,
+    portForward: state.portForward,
+    mount: state.mount,
+    liveMounts: state.liveMounts.length > 0 ? state.liveMounts : undefined,
+    env: Object.keys(state.env).length > 0 ? state.env : undefined,
+    guestCwd: state.guestCwd,
+    memory: state.memory,
+    rest: state.rest,
   };
+}
+
+function dispatchFlag(
+  state: ParseState,
+  arg: string,
+  args: string[],
+  i: number,
+): number | undefined {
+  for (const [flags, handler] of FLAG_HANDLERS) {
+    for (const flag of flags) {
+      if (arg === flag || arg.startsWith(`${flag}=`)) {
+        return handler(state, args, i, flag);
+      }
+    }
+  }
+  return undefined;
+}
+
+function assertNotSeen(predicate: boolean, flag: string): void {
+  if (predicate) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
+}
+
+function handleNewNameFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.newName !== undefined, flag);
+  const { spec, next } = takeValue(args[i]!, args, i, "a value");
+  state.newName = spec;
+  return next;
+}
+
+function handleOutDirFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.outDir !== undefined, flag);
+  const { spec, next } = takeValue(args[i]!, args, i, "a directory path");
+  state.outDir = spec;
+  return next;
+}
+
+function handleTcpKeepFlag(state: ParseState, _args: string[], i: number): number {
+  state.tcpKeep = true;
+  return i;
+}
+
+function handleDetachFlag(state: ParseState, _args: string[], i: number): number {
+  state.detach = true;
+  return i;
+}
+
+function handleLazyFlag(state: ParseState, _args: string[], i: number): number {
+  state.lazy = true;
+  return i;
+}
+
+function handlePortForwardFlag(state: ParseState, args: string[], i: number): number {
+  return consumePortForward(args[i]!, args, i, state.seenHostPorts, state.portForward);
+}
+
+function handleMountFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.mount !== undefined, flag);
+  const r = consumeMount(args[i]!, args, i);
+  state.mount = r.value;
+  return r.next;
+}
+
+function handleLiveMountFlag(state: ParseState, args: string[], i: number): number {
+  const r = consumeLiveMount(args[i]!, args, i);
+  state.liveMounts.push(r.value);
+  return r.next;
+}
+
+function handleEnvFlag(state: ParseState, args: string[], i: number): number {
+  const r = consumeEnv(args[i]!, args, i);
+  state.env[r.key] = r.value;
+  return r.next;
+}
+
+function handleCwdFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.guestCwd !== undefined, flag);
+  const r = consumeGuestCwd(args[i]!, args, i);
+  state.guestCwd = r.value;
+  return r.next;
+}
+
+function handleMemoryFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.memory !== undefined, flag);
+  const r = consumeMemory(args[i]!, args, i);
+  state.memory = r.value;
+  return r.next;
 }

--- a/packages/cli/src/parse-restore-args.ts
+++ b/packages/cli/src/parse-restore-args.ts
@@ -48,69 +48,131 @@ export interface ParsedRestoreArgs {
   liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
 }
 
+interface ParseState {
+  positional: string[];
+  name?: string;
+  image?: string;
+  lazy: boolean;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  seenLiveGuests: Set<string>;
+  seenHostPorts: Set<number>;
+}
+
+type FlagHandler = (state: ParseState, args: string[], i: number, flag: string) => number;
+
+const FLAG_HANDLERS: ReadonlyArray<readonly [readonly string[], FlagHandler]> = [
+  [["--lazy"], handleLazyFlag],
+  [["--name"], handleNameFlag],
+  [["--image"], handleImageFlag],
+  [["--mount-live"], handleLiveMountFlag],
+  [["-p", "--publish"], handlePortForwardFlag],
+];
+
 export function parseRestoreArgs(argv: string[]): ParsedRestoreArgs {
-  const positional: string[] = [];
-  let name: string | undefined;
-  let image: string | undefined;
-  let lazy = false;
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
-  const seenLiveGuests = new Set<string>();
-  const seenHostPorts = new Set<number>();
+  const state: ParseState = {
+    positional: [],
+    lazy: false,
+    portForward: [],
+    liveMounts: [],
+    seenLiveGuests: new Set<string>(),
+    seenHostPorts: new Set<number>(),
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
-    if (a === "--lazy") {
-      lazy = true;
-    } else if (a === "--name" || a.startsWith("--name=")) {
-      const v = a === "--name" ? argv[++i] : a.slice("--name=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
-      }
-      if (name !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--name may be given at most once per invocation",
-        );
-      }
-      name = v;
-    } else if (a === "--image" || a.startsWith("--image=")) {
-      const v = a === "--image" ? argv[++i] : a.slice("--image=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--image requires a value");
-      }
-      if (image !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--image may be given at most once per invocation",
-        );
-      }
-      image = v;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const { value, next } = consumeLiveMount(a, argv, i);
+    const next = dispatchFlag(state, a, argv, i);
+    if (next !== undefined) {
       i = next;
-      // CLI-side dedup: two overrides for the same guest is a typo,
-      // not a feature. Runtime would still accept the second one
-      // silently (last write wins on Map.set) — fail fast here.
-      if (seenLiveGuests.has(value.guest)) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          `--mount-live override for guest=${value.guest} given more than once`,
-        );
-      }
-      seenLiveGuests.add(value.guest);
-      liveMounts.push(value);
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
-    } else if (a.startsWith("-")) {
+      continue;
+    }
+    if (a.startsWith("-")) {
       throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
-    } else {
-      positional.push(a);
+    }
+    state.positional.push(a);
+  }
+  return {
+    positional: state.positional,
+    name: state.name,
+    image: state.image,
+    portForward: state.portForward,
+    lazy: state.lazy,
+    liveMounts: state.liveMounts,
+  };
+}
+
+function dispatchFlag(
+  state: ParseState,
+  arg: string,
+  args: string[],
+  i: number,
+): number | undefined {
+  for (const [flags, handler] of FLAG_HANDLERS) {
+    for (const flag of flags) {
+      if (arg === flag || arg.startsWith(`${flag}=`)) {
+        return handler(state, args, i, flag);
+      }
     }
   }
-  return { positional, name, image, portForward, lazy, liveMounts };
+  return undefined;
+}
+
+function assertNotSeen(predicate: boolean, flag: string): void {
+  if (predicate) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
+}
+
+function takeInlineValue(
+  arg: string,
+  args: string[],
+  i: number,
+  flag: string,
+): { v: string; i: number } {
+  const v = arg === flag ? args[i + 1] : arg.slice(`${flag}=`.length);
+  if (!v) {
+    throw new ParseError("PARSE_FLAG_MISSING_VALUE", `${flag} requires a value`);
+  }
+  return { v, i: arg === flag ? i + 1 : i };
+}
+
+function handleLazyFlag(state: ParseState, _args: string[], i: number): number {
+  state.lazy = true;
+  return i;
+}
+
+function handleNameFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.name !== undefined, flag);
+  const r = takeInlineValue(args[i]!, args, i, flag);
+  state.name = r.v;
+  return r.i;
+}
+
+function handleImageFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.image !== undefined, flag);
+  const r = takeInlineValue(args[i]!, args, i, flag);
+  state.image = r.v;
+  return r.i;
+}
+
+function handleLiveMountFlag(state: ParseState, args: string[], i: number): number {
+  const { value, next } = consumeLiveMount(args[i]!, args, i);
+  // CLI-side dedup: two overrides for the same guest is a typo,
+  // not a feature. Runtime would still accept the second one
+  // silently (last write wins on Map.set) — fail fast here.
+  if (state.seenLiveGuests.has(value.guest)) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `--mount-live override for guest=${value.guest} given more than once`,
+    );
+  }
+  state.seenLiveGuests.add(value.guest);
+  state.liveMounts.push(value);
+  return next;
+}
+
+function handlePortForwardFlag(state: ParseState, args: string[], i: number): number {
+  return consumePortForward(args[i]!, args, i, state.seenHostPorts, state.portForward);
 }

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -51,133 +51,177 @@ interface ParsedRunArgs {
   json?: boolean;
 }
 
+interface ParseState {
+  positional: string[];
+  mount?: { host: string; guest: string };
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  env: Record<string, string>;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  seenHostPorts: Set<number>;
+  snapshot?: string;
+  name?: string;
+  guestCwd?: string;
+  detached: boolean;
+  memory?: number;
+  json: boolean;
+}
+
+type FlagHandler = (state: ParseState, args: string[], i: number, flag: string) => number;
+
+// Flag → handler dispatch table. Order doesn't matter (each entry
+// matches by exact flag or `<flag>=` prefix). One row per logical
+// flag; aliases share a row.
+const FLAG_HANDLERS: ReadonlyArray<readonly [readonly string[], FlagHandler]> = [
+  [["--mount"], handleMountFlag],
+  [["--mount-live"], handleLiveMountFlag],
+  [["--env"], handleEnvFlag],
+  [["-p", "--publish"], handlePortForwardFlag],
+  [["--snapshot"], handleSnapshotFlag],
+  [["--cwd"], handleGuestCwdFlag],
+  [["--name"], handleNameFlag],
+  [["--detached", "--detach"], handleDetachedFlag],
+  [["--json"], handleJsonFlag],
+  [["--memory"], handleMemoryFlag],
+];
+
 export function parseRunArgs(argv: string[]): ParsedRunArgs {
   const idx = argv.indexOf("--");
   const pre = idx === -1 ? argv : argv.slice(0, idx);
   const double_dash_args = idx === -1 ? [] : argv.slice(idx + 1);
 
-  const positional: string[] = [];
-  let mount: { host: string; guest: string } | undefined;
-  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
-  const env: Record<string, string> = {};
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const seenHostPorts = new Set<number>();
-  let snapshot: string | undefined;
-  let name: string | undefined;
-  let guestCwd: string | undefined;
-  let detached = false;
-  let memory: number | undefined;
-  let json = false;
+  const state: ParseState = {
+    positional: [],
+    liveMounts: [],
+    env: {},
+    portForward: [],
+    seenHostPorts: new Set<number>(),
+    detached: false,
+    json: false,
+  };
   for (let i = 0; i < pre.length; i++) {
     const a = pre[i]!;
-    if (a === "--mount" || a.startsWith("--mount=")) {
-      if (mount) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--mount may be given at most once per invocation",
-        );
-      }
-      const r = consumeMount(a, pre, i);
-      mount = r.value;
-      i = r.next;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const r = consumeLiveMount(a, pre, i);
-      liveMounts.push(r.value);
-      i = r.next;
-    } else if (a === "--env" || a.startsWith("--env=")) {
-      const r = consumeEnv(a, pre, i);
-      env[r.key] = r.value;
-      i = r.next;
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, pre, i, seenHostPorts, portForward);
-    } else if (a === "--snapshot" || a.startsWith("--snapshot=")) {
-      if (snapshot) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--snapshot may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, pre, i, "a path value");
-      snapshot = spec;
+    const next = dispatchFlag(state, a, pre, i);
+    if (next !== undefined) {
       i = next;
-    } else if (a === "--cwd" || a.startsWith("--cwd=")) {
-      if (guestCwd !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--cwd may be given at most once per invocation",
-        );
-      }
-      const r = consumeGuestCwd(a, pre, i);
-      guestCwd = r.value;
-      i = r.next;
-    } else if (a === "--name" || a.startsWith("--name=")) {
-      if (name) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--name may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, pre, i, "a value");
-      name = spec;
-      i = next;
-    } else if (a === "--detached" || a === "--detach") {
-      if (detached) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--detached may be given at most once per invocation",
-        );
-      }
-      detached = true;
-      // `--detached` is the legacy spelling. Surface a one-line
-      // deprecation note so existing scripts keep working but agents
-      // (and humans) learn the canonical name. Suppressed under
-      // MACHINEN_QUIET_DEPRECATIONS (set by tests) and under VITEST
-      // (parseRunArgs is unit-tested with --detached on every run).
-      if (a === "--detached" && !process.env.MACHINEN_QUIET_DEPRECATIONS && !process.env.VITEST) {
-        process.stderr.write(
-          "machinen: --detached is deprecated; use --detach (same behaviour).\n",
-        );
-      }
-    } else if (a === "--json") {
-      json = true;
-    } else if (a === "--memory" || a.startsWith("--memory=")) {
-      // #263 phase A: decimal MiB, no unit suffix. Same shape as
-      // MACHINEN_MEMORY. The runtime validates the floor; we only
-      // reject syntactically bad values here.
-      if (memory !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--memory may be given at most once per invocation",
-        );
-      }
-      const r = consumeMemory(a, pre, i);
-      memory = r.value;
-      i = r.next;
-    } else if (a.startsWith("-")) {
-      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
-    } else {
-      positional.push(a);
+      continue;
     }
+    if (a.startsWith("-")) {
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
+    }
+    state.positional.push(a);
   }
   return {
-    positional,
+    positional: state.positional,
     double_dash_args,
-    mount,
-    liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
-    env: Object.keys(env).length > 0 ? env : undefined,
-    portForward: portForward.length > 0 ? portForward : undefined,
-    snapshot,
-    name,
-    guestCwd,
-    detached: detached || undefined,
-    memory,
-    json: json || undefined,
+    mount: state.mount,
+    liveMounts: state.liveMounts.length > 0 ? state.liveMounts : undefined,
+    env: Object.keys(state.env).length > 0 ? state.env : undefined,
+    portForward: state.portForward.length > 0 ? state.portForward : undefined,
+    snapshot: state.snapshot,
+    name: state.name,
+    guestCwd: state.guestCwd,
+    detached: state.detached || undefined,
+    memory: state.memory,
+    json: state.json || undefined,
   };
+}
+
+function dispatchFlag(
+  state: ParseState,
+  arg: string,
+  args: string[],
+  i: number,
+): number | undefined {
+  for (const [flags, handler] of FLAG_HANDLERS) {
+    for (const flag of flags) {
+      if (arg === flag || arg.startsWith(`${flag}=`)) {
+        return handler(state, args, i, flag);
+      }
+    }
+  }
+  return undefined;
+}
+
+function assertNotSeen(predicate: boolean, flag: string): void {
+  if (predicate) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
+}
+
+function handleMountFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.mount !== undefined, flag);
+  const r = consumeMount(args[i]!, args, i);
+  state.mount = r.value;
+  return r.next;
+}
+
+function handleLiveMountFlag(state: ParseState, args: string[], i: number): number {
+  const r = consumeLiveMount(args[i]!, args, i);
+  state.liveMounts.push(r.value);
+  return r.next;
+}
+
+function handleEnvFlag(state: ParseState, args: string[], i: number): number {
+  const r = consumeEnv(args[i]!, args, i);
+  state.env[r.key] = r.value;
+  return r.next;
+}
+
+function handlePortForwardFlag(state: ParseState, args: string[], i: number): number {
+  return consumePortForward(args[i]!, args, i, state.seenHostPorts, state.portForward);
+}
+
+function handleSnapshotFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.snapshot !== undefined, flag);
+  const { spec, next } = takeValue(args[i]!, args, i, "a path value");
+  state.snapshot = spec;
+  return next;
+}
+
+function handleGuestCwdFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.guestCwd !== undefined, flag);
+  const r = consumeGuestCwd(args[i]!, args, i);
+  state.guestCwd = r.value;
+  return r.next;
+}
+
+function handleNameFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  assertNotSeen(state.name !== undefined, flag);
+  const { spec, next } = takeValue(args[i]!, args, i, "a value");
+  state.name = spec;
+  return next;
+}
+
+function handleDetachedFlag(state: ParseState, args: string[], i: number): number {
+  assertNotSeen(state.detached, "--detached");
+  state.detached = true;
+  // `--detached` is the legacy spelling. Surface a one-line
+  // deprecation note so existing scripts keep working but agents
+  // (and humans) learn the canonical name. Suppressed under
+  // MACHINEN_QUIET_DEPRECATIONS (set by tests) and under VITEST
+  // (parseRunArgs is unit-tested with --detached on every run).
+  if (args[i] === "--detached" && !process.env.MACHINEN_QUIET_DEPRECATIONS && !process.env.VITEST) {
+    process.stderr.write("machinen: --detached is deprecated; use --detach (same behaviour).\n");
+  }
+  return i;
+}
+
+function handleJsonFlag(state: ParseState, _args: string[], i: number): number {
+  state.json = true;
+  return i;
+}
+
+function handleMemoryFlag(state: ParseState, args: string[], i: number, flag: string): number {
+  // #263 phase A: decimal MiB, no unit suffix. Same shape as
+  // MACHINEN_MEMORY. The runtime validates the floor; we only
+  // reject syntactically bad values here.
+  assertNotSeen(state.memory !== undefined, flag);
+  const r = consumeMemory(args[i]!, args, i);
+  state.memory = r.value;
+  return r.next;
 }
 
 function parsePort(raw: string, label: string): number {

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -485,20 +485,8 @@ function sweepEmptyPinDirs(dir: string): void {
  */
 export function claimName(name: string, pid: number): boolean {
   const pin = pinPath(name);
-  // Path-shaped names like `<src>/<pid>` (chained restore — #208) need
-  // their parent dir to exist. mkdir is idempotent for directories;
-  // it throws EEXIST when a regular file blocks the parent path —
-  // typical when the source VM is alive and pinned at `<src>` (the
-  // fork case, #216). Treat that as "name unavailable" so callers
-  // can fall back to a non-nested name rather than crash.
-  try {
-    mkdirSync(dirname(pin), { recursive: true });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      debug("claimName name=%s parent path is a live pin — refusing", name);
-      return false;
-    }
-    throw err;
+  if (!ensurePinParentDir(pin, name)) {
+    return false;
   }
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
@@ -509,51 +497,86 @@ export function claimName(name: string, pid: number): boolean {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
         throw err;
       }
-      // EEXIST: a file or a directory occupies the pin path. An empty
-      // directory is a leftover from a path-shaped child pin whose
-      // leaf was unlinked (pre-#268 removeEntry didn't prune parents).
-      // A non-empty directory is holding live nested pins — refuse.
-      let isDir = false;
-      try {
-        isDir = statSync(pin).isDirectory();
-      } catch {}
-      if (isDir) {
-        try {
-          rmdirSync(pin);
-          debug("claimName name=%s removed empty stale dir — retrying", name);
-          continue;
-        } catch {
-          debug("claimName name=%s dir holds live nested pins — refusing", name);
-          return false;
-        }
-      }
-      // Pin is a regular file. If the holder fails the recycling /
-      // orphan check, drop the pin (and any orphaned meta dir) and
-      // retry. `kill(pid,0)` alone isn't enough — a recycled pid will
-      // succeed it, leaving the pin pinned forever.
-      let heldPid = -1;
-      try {
-        heldPid = Number(readFileSync(pin, "utf8").trim());
-      } catch {}
-      if (heldPid > 0 && !pinIsStale(heldPid)) {
-        debug("claimName name=%s held by live pid=%d — refusing", name, heldPid);
+      if (reclaimExistingPin(pin, name) === "refuse") {
         return false;
       }
-      debug("claimName name=%s stale pin (heldPid=%d) — reaping", name, heldPid);
-      try {
-        unlinkSync(pin);
-      } catch {}
-      if (heldPid > 0) {
-        // If the meta dir lingered (orphaned writeEntry, or recycled
-        // pid), drop it now — otherwise the next list() would prune
-        // it but we want claimName to leave a clean slate either way.
-        try {
-          rmSync(join(registryRoot(), String(heldPid)), { recursive: true, force: true });
-        } catch {}
-      }
+      // "retry" — loop continues
     }
   }
   return false;
+}
+
+// Path-shaped names like `<src>/<pid>` (chained restore — #208) need
+// their parent dir to exist. mkdir is idempotent for directories;
+// it throws EEXIST when a regular file blocks the parent path —
+// typical when the source VM is alive and pinned at `<src>` (the
+// fork case, #216). Treat that as "name unavailable" so callers
+// can fall back to a non-nested name rather than crash.
+function ensurePinParentDir(pin: string, name: string): boolean {
+  try {
+    mkdirSync(dirname(pin), { recursive: true });
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      debug("claimName name=%s parent path is a live pin — refusing", name);
+      return false;
+    }
+    throw err;
+  }
+}
+
+type ReclaimOutcome = "retry" | "refuse";
+
+// EEXIST landed on the pin path: a file or a directory is in the way.
+// Dispatch to the directory-pin or file-pin reclaim path.
+function reclaimExistingPin(pin: string, name: string): ReclaimOutcome {
+  let isDir = false;
+  try {
+    isDir = statSync(pin).isDirectory();
+  } catch {}
+  return isDir ? reclaimStaleDirPin(pin, name) : reclaimStaleFilePin(pin, name);
+}
+
+// An empty directory is a leftover from a path-shaped child pin whose
+// leaf was unlinked (pre-#268 removeEntry didn't prune parents). A
+// non-empty directory is holding live nested pins — refuse.
+function reclaimStaleDirPin(pin: string, name: string): ReclaimOutcome {
+  try {
+    rmdirSync(pin);
+    debug("claimName name=%s removed empty stale dir — retrying", name);
+    return "retry";
+  } catch {
+    debug("claimName name=%s dir holds live nested pins — refusing", name);
+    return "refuse";
+  }
+}
+
+// Pin is a regular file. If the holder fails the recycling / orphan
+// check, drop the pin (and any orphaned meta dir) and retry.
+// `kill(pid,0)` alone isn't enough — a recycled pid will succeed it,
+// leaving the pin pinned forever.
+function reclaimStaleFilePin(pin: string, name: string): ReclaimOutcome {
+  let heldPid = -1;
+  try {
+    heldPid = Number(readFileSync(pin, "utf8").trim());
+  } catch {}
+  if (heldPid > 0 && !pinIsStale(heldPid)) {
+    debug("claimName name=%s held by live pid=%d — refusing", name, heldPid);
+    return "refuse";
+  }
+  debug("claimName name=%s stale pin (heldPid=%d) — reaping", name, heldPid);
+  try {
+    unlinkSync(pin);
+  } catch {}
+  if (heldPid > 0) {
+    // If the meta dir lingered (orphaned writeEntry, or recycled
+    // pid), drop it now — otherwise the next list() would prune
+    // it but we want claimName to leave a clean slate either way.
+    try {
+      rmSync(join(registryRoot(), String(heldPid)), { recursive: true, force: true });
+    } catch {}
+  }
+  return "retry";
 }
 
 /**

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -217,106 +217,136 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   const sha = sha256OfFile(tarAbs);
   opts.onPhase?.("sha256", Date.now() - shaT0);
   const imgPath = join(cacheDir, `${sha}.img`);
-  const okPath = okMarkerPath(imgPath);
-  if (!opts.force && existsSync(imgPath)) {
-    debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
-    // #170: require the clean-shutdown marker. Missing means the
-    // previous VMM was killed mid-write — fsck won't catch torn data
-    // blocks, so treat the image as poisoned and rebuild from the
-    // tarball.
-    //
-    // We deliberately do NOT `unlinkSync(imgPath)` here on the wipe
-    // paths. Concurrent callers (parallel test files, multiple `boot()`
-    // calls) may already hold imgPath as a cache-hit return value and
-    // be about to reflink from it — deleting the file out from under
-    // them races to ENOENT. The renameSync at the end of the materialize
-    // / prebake paths atomically replaces imgPath with fresh bytes, so
-    // the wipe is redundant; falling through is sufficient.
-    if (!existsSync(okPath)) {
-      debug("cache hit but no clean marker, will rematerialize img=%s", imgPath);
-    } else {
-      // Atomically clear the marker BEFORE handing the path off, so
-      // a kill between here and `markRootfsImageClean()` leaves the
-      // image flagged dirty for the next boot.
-      try {
-        unlinkSync(okPath);
-      } catch {}
-      const fsckT0 = Date.now();
-      const usable = cachedImageIsUsable(imgPath);
-      opts.onPhase?.("e2fsck", Date.now() - fsckT0);
-      if (usable) {
-        // #131: if the caller asked for a larger image than what's on
-        // disk (typically because they bumped `rootDiskSizeBytes`, or
-        // because the materializer's defaults grew), sparse-extend the
-        // file in place. The on-disk ext4 fs is still sized to the old
-        // file; /init's tryRootDiskPivot resizes it online via
-        // EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
-        // truncate-up on a sparse file is free; truncate-down would
-        // chop bytes, so we never shrink.
-        if (opts.sizeBytes !== undefined) {
-          const truncT0 = Date.now();
-          try {
-            const cur = statSync(imgPath).size;
-            if (opts.sizeBytes > cur) {
-              truncateSync(imgPath, opts.sizeBytes);
-              debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
-            }
-          } catch (err) {
-            debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
-          }
-          opts.onPhase?.("sparse-extend", Date.now() - truncT0);
-        }
-        return imgPath;
-      }
-      // Unrecoverable. Fall through to materialize a fresh image — same
-      // path a force=true caller would take. renameSync replaces.
-      debug("cache hit unusable, will rematerialize img=%s", imgPath);
-    }
-  }
 
-  // #223 + #233: prebake fast path. If a sibling `<basename>.img` (or
-  // `<basename>.img.gz`) sits next to the tarball, populate the cache
-  // from it and skip tar+mke2fs. The bytes are an ext4 image; the
-  // cache key (tarball sha) is the same one the materialize path
-  // would write to, so downstream (per-boot reflink, sparse-extend,
-  // .ok marker) is unchanged. The uncompressed form (emitted by
-  // provision()) reflinks in essentially for free; the gzipped form
-  // (shipped with releases) has to gunzip.
   if (!opts.force) {
-    const sibling = siblingPrebakePath(tarAbs);
-    if (sibling && existsSync(sibling.path)) {
-      const prebakeT0 = Date.now();
-      const fast = tryPrebakeFromSibling({
-        sibling: sibling.path,
-        gzipped: sibling.gzipped,
-        cacheDir,
-        sha,
-        imgPath,
-        sizeBytes: opts.sizeBytes,
-      });
-      opts.onPhase?.(
-        sibling.gzipped ? "gunzip-prebake" : "reflink-prebake",
-        Date.now() - prebakeT0,
-      );
-      if (fast) {
-        return fast;
-      }
-      // Fall through to materialize on any failure — same outcome
-      // as if the sibling weren't there. Slow but always correct.
+    const reused = tryReuseCachedImage(imgPath, sha, opts);
+    if (reused) {
+      return reused;
+    }
+    const prebaked = tryPrebakeFastPath(tarAbs, cacheDir, sha, imgPath, opts);
+    if (prebaked) {
+      return prebaked;
     }
   }
 
-  // Resolve mke2fs in four steps:
-  //   1. `MACHINEN_MKE2FS` env override — for users pinning a specific
-  //      build (e.g. a debug binary, or a vendored copy outside the
-  //      bundled package). Mirrors `MACHINEN_VMM` / `MACHINEN_GVPROXY`.
-  //   2. The bundled `@machinen/e2fsprogs-<arch>-<os>` package (zero
-  //      user setup, present in normal installs). Each arch package
-  //      declares matching `os` + `cpu` so npm/pnpm only installs the
-  //      one that fits the host.
-  //   3. PATH (for hosts that have e2fsprogs installed system-wide).
-  //   4. Homebrew's keg-only prefix on macOS (#124) — `brew install
-  //      e2fsprogs` deliberately doesn't symlink mke2fs onto PATH.
+  const mke2fs = resolveMke2fsBin();
+  return materializeFromTar(tarAbs, sha, mke2fs, cacheDir, imgPath, opts);
+}
+
+// #170 cache-hit path: require the clean-shutdown marker, then e2fsck
+// the image, then optionally sparse-extend. Returns the image path on
+// reuse, undefined on miss or unrecoverable image (the caller falls
+// through to prebake / materialize).
+//
+// We deliberately do NOT `unlinkSync(imgPath)` here on the wipe
+// paths. Concurrent callers (parallel test files, multiple `boot()`
+// calls) may already hold imgPath as a cache-hit return value and
+// be about to reflink from it — deleting the file out from under
+// them races to ENOENT. The renameSync at the end of the materialize
+// / prebake paths atomically replaces imgPath with fresh bytes, so
+// the wipe is redundant; falling through is sufficient.
+function tryReuseCachedImage(
+  imgPath: string,
+  sha: string,
+  opts: EnsureRootfsImageOptions,
+): string | undefined {
+  if (!existsSync(imgPath)) {
+    return undefined;
+  }
+  debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
+  const okPath = okMarkerPath(imgPath);
+  if (!existsSync(okPath)) {
+    debug("cache hit but no clean marker, will rematerialize img=%s", imgPath);
+    return undefined;
+  }
+  // Atomically clear the marker BEFORE handing the path off, so
+  // a kill between here and `markRootfsImageClean()` leaves the
+  // image flagged dirty for the next boot.
+  try {
+    unlinkSync(okPath);
+  } catch {}
+  const fsckT0 = Date.now();
+  const usable = cachedImageIsUsable(imgPath);
+  opts.onPhase?.("e2fsck", Date.now() - fsckT0);
+  if (!usable) {
+    debug("cache hit unusable, will rematerialize img=%s", imgPath);
+    return undefined;
+  }
+  growCachedImageIfRequested(imgPath, opts);
+  return imgPath;
+}
+
+// #131: if the caller asked for a larger image than what's on
+// disk (typically because they bumped `rootDiskSizeBytes`, or
+// because the materializer's defaults grew), sparse-extend the
+// file in place. The on-disk ext4 fs is still sized to the old
+// file; /init's tryRootDiskPivot resizes it online via
+// EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
+// truncate-up on a sparse file is free; truncate-down would
+// chop bytes, so we never shrink.
+function growCachedImageIfRequested(imgPath: string, opts: EnsureRootfsImageOptions): void {
+  if (opts.sizeBytes === undefined) {
+    return;
+  }
+  const truncT0 = Date.now();
+  try {
+    const cur = statSync(imgPath).size;
+    if (opts.sizeBytes > cur) {
+      truncateSync(imgPath, opts.sizeBytes);
+      debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
+    }
+  } catch (err) {
+    debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
+  }
+  opts.onPhase?.("sparse-extend", Date.now() - truncT0);
+}
+
+// #223 + #233: prebake fast path. If a sibling `<basename>.img` (or
+// `<basename>.img.gz`) sits next to the tarball, populate the cache
+// from it and skip tar+mke2fs. The bytes are an ext4 image; the
+// cache key (tarball sha) is the same one the materialize path
+// would write to, so downstream (per-boot reflink, sparse-extend,
+// .ok marker) is unchanged. The uncompressed form (emitted by
+// provision()) reflinks in essentially for free; the gzipped form
+// (shipped with releases) has to gunzip. Returns the image path on
+// success; undefined when there's no sibling or the prebake failed
+// (caller falls through to materialize — slow but always correct).
+function tryPrebakeFastPath(
+  tarAbs: string,
+  cacheDir: string,
+  sha: string,
+  imgPath: string,
+  opts: EnsureRootfsImageOptions,
+): string | undefined {
+  const sibling = siblingPrebakePath(tarAbs);
+  if (!sibling || !existsSync(sibling.path)) {
+    return undefined;
+  }
+  const prebakeT0 = Date.now();
+  const fast = tryPrebakeFromSibling({
+    sibling: sibling.path,
+    gzipped: sibling.gzipped,
+    cacheDir,
+    sha,
+    imgPath,
+    sizeBytes: opts.sizeBytes,
+  });
+  opts.onPhase?.(sibling.gzipped ? "gunzip-prebake" : "reflink-prebake", Date.now() - prebakeT0);
+  return fast ?? undefined;
+}
+
+// Resolve mke2fs in four steps:
+//   1. `MACHINEN_MKE2FS` env override — for users pinning a specific
+//      build (e.g. a debug binary, or a vendored copy outside the
+//      bundled package). Mirrors `MACHINEN_VMM` / `MACHINEN_GVPROXY`.
+//   2. The bundled `@machinen/e2fsprogs-<arch>-<os>` package (zero
+//      user setup, present in normal installs). Each arch package
+//      declares matching `os` + `cpu` so npm/pnpm only installs the
+//      one that fits the host.
+//   3. PATH (for hosts that have e2fsprogs installed system-wide).
+//   4. Homebrew's keg-only prefix on macOS (#124) — `brew install
+//      e2fsprogs` deliberately doesn't symlink mke2fs onto PATH.
+function resolveMke2fsBin(): string {
   const names = ["mke2fs", "mkfs.ext4"];
   const mke2fs =
     resolveMke2fsEnvOverride() ??
@@ -339,7 +369,20 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
         "initramfs-as-rootfs path.",
     );
   }
+  return mke2fs;
+}
 
+// Slow path: extract the tarball into a staging tree, size the image,
+// run mke2fs over the tree, atomically rename into the cache. Cleans
+// up the staging dir on any exit.
+function materializeFromTar(
+  tarAbs: string,
+  sha: string,
+  mke2fs: string,
+  cacheDir: string,
+  imgPath: string,
+  opts: EnsureRootfsImageOptions,
+): string {
   const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-staging-`));
   const stagingTree = join(stagingDir, "tree");
   const stagingImg = join(stagingDir, "rootfs.img");

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -171,6 +171,14 @@ export function resolveRestoreLiveMounts(
   });
 }
 
+type ImageConfig = { cmd?: string[]; env?: Record<string, string>; cwd?: string };
+type MountDisk = {
+  lowerPath: string;
+  upperPath: string;
+  guest: string;
+  upperSizeBytes: number;
+};
+
 export function synthesizeAndPackBundle(
   opts: BootOptions,
   mergedGuestEnv: Record<string, string>,
@@ -184,12 +192,7 @@ export function synthesizeAndPackBundle(
 ): {
   tempDir: string;
   cpioPath: string;
-  mountDisk?: {
-    lowerPath: string;
-    upperPath: string;
-    guest: string;
-    upperSizeBytes: number;
-  };
+  mountDisk?: MountDisk;
 } {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
   const cpioPath = join(tempDir, "initramfs.cpio");
@@ -200,135 +203,179 @@ export function synthesizeAndPackBundle(
     } catch {}
   };
 
-  if (opts.guestCwd !== undefined) {
-    try {
+  try {
+    if (opts.guestCwd !== undefined) {
       validateGuestCwd(opts.guestCwd);
-    } catch (err) {
-      cleanup();
-      throw err;
     }
+    const { baseAbs, imageConfig } = readBaseImage(opts, packerOpts.onPhase);
+    const effectiveCmd = resolveEffectiveCmd(opts, imageConfig);
+    const wrappedCmd = wrapCmdInSupervisor(effectiveCmd, opts.snapshot);
+    // env: image defaults overlaid by user + runtime-injected (gvproxy
+    // cache mirror, etc.). User + runtime wins on key collision. Shared
+    // between the synthesized config.json (read by /init) and the
+    // packer's runtime env injection (written into the cpio's
+    // env-overlay file).
+    const effectiveEnv = { ...imageConfig?.env, ...mergedGuestEnv };
+    writeBundleConfig({
+      synthBundleDir,
+      wrappedCmd,
+      effectiveEnv,
+      guestCwd: opts.guestCwd,
+      imageCwd: imageConfig?.cwd,
+      liveMounts,
+    });
+    const mount = resolveMount(opts);
+    packCpio({
+      useTiny: packerOpts.useTiny,
+      synthBundleDir,
+      cpioPath,
+      baseAbs,
+      mount,
+      restoreMountGuest: opts._restoreMountDisk?.guest,
+      effectiveEnv,
+      liveMounts,
+      onPhase: packerOpts.onPhase,
+    });
+    const mountDisk = resolveMountDiskPaths(opts, mount, packerOpts);
+    return { tempDir, cpioPath, mountDisk };
+  } catch (err) {
+    cleanup();
+    throw err;
   }
+}
 
-  let baseAbs: string | undefined;
-  let imageConfig: { cmd?: string[]; env?: Record<string, string>; cwd?: string } | undefined;
-  if (opts.image) {
-    baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
-    if (!existsSync(baseAbs)) {
-      cleanup();
-      throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
-    }
-    const cfgT0 = Date.now();
-    imageConfig = readImageConfig(baseAbs);
-    packerOpts.onPhase?.("image-config-read", Date.now() - cfgT0);
+function readBaseImage(
+  opts: BootOptions,
+  onPhase: ((name: string, ms: number) => void) | undefined,
+): { baseAbs: string | undefined; imageConfig: ImageConfig | undefined } {
+  if (!opts.image) {
+    return { baseAbs: undefined, imageConfig: undefined };
   }
+  const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
+  if (!existsSync(baseAbs)) {
+    throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
+  }
+  const cfgT0 = Date.now();
+  const imageConfig = readImageConfig(baseAbs);
+  onPhase?.("image-config-read", Date.now() - cfgT0);
+  return { baseAbs, imageConfig };
+}
 
-  // cmd resolution:
-  //   - Snapshot-only restore (`boot({ snapshot })` with no cmd):
-  //     synthesize `["/sbin/machinen-restore"]`. The helper mounts
-  //     /dev/vda, spawns a fresh exec-agent, and runs `criu restore`
-  //     inside `unshare --pid --fork --mount-proc` so the dumped
-  //     workload's PIDs don't collide with the restore-side helpers
-  //     on chained restores (#215). This MUST take precedence over
-  //     the rootfs's baked `imageConfig.cmd` — that field is the
-  //     fresh-boot default; replaying it on restore would launch a
-  //     brand-new workload instead of resuming the dumped one,
-  //     silently dropping all in-memory state.
-  //   - Normal boot: user's cmd wins; fall back to image's baked
-  //     default. Then wrap in /sbin/machinen-supervisor so the
-  //     workload runs as a CRIU-dumpable child of /init and the
-  //     exec-agent stays alive alongside it for vm.exec / vm.snapshot.
-  //     Exception: if the cmd is already `/exec-agent`, skip the
-  //     wrapper — the workload IS the agent (provision() flow).
-  //   - Neither snapshot nor cmd and no image default: error.
-  let effectiveCmd: string[] | undefined;
+// cmd resolution:
+//   - Snapshot-only restore (`boot({ snapshot })` with no cmd):
+//     synthesize `["/sbin/machinen-restore"]`. The helper mounts
+//     /dev/vda, spawns a fresh exec-agent, and runs `criu restore`
+//     inside `unshare --pid --fork --mount-proc` so the dumped
+//     workload's PIDs don't collide with the restore-side helpers
+//     on chained restores (#215). This MUST take precedence over
+//     the rootfs's baked `imageConfig.cmd` — that field is the
+//     fresh-boot default; replaying it on restore would launch a
+//     brand-new workload instead of resuming the dumped one,
+//     silently dropping all in-memory state.
+//   - Normal boot: user's cmd wins; fall back to image's baked
+//     default. Then wrap in /sbin/machinen-supervisor so the
+//     workload runs as a CRIU-dumpable child of /init and the
+//     exec-agent stays alive alongside it for vm.exec / vm.snapshot.
+//   - Neither snapshot nor cmd and no image default: error.
+function resolveEffectiveCmd(opts: BootOptions, imageConfig: ImageConfig | undefined): string[] {
   if (opts.cmd) {
-    effectiveCmd = opts.cmd;
-  } else if (typeof opts.snapshot === "string") {
+    return opts.cmd;
+  }
+  if (typeof opts.snapshot === "string") {
     // Only synthesize the restore helper when the caller explicitly
     // passed a snapshot path. The auto-allocated scratch (default
     // `snapshot: undefined`) is empty, so synthesizing here would feed
     // CRIU a bundle-less file and fail.
-    effectiveCmd = ["/sbin/machinen-restore"];
-  } else if (imageConfig?.cmd) {
-    effectiveCmd = imageConfig.cmd;
+    return ["/sbin/machinen-restore"];
   }
-  if (!effectiveCmd) {
-    cleanup();
+  if (imageConfig?.cmd) {
+    return imageConfig.cmd;
+  }
+  throw new BootError(
+    "BOOT_CMD_MISSING",
+    "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
+      "image via `provision({ cmd })`.",
+  );
+}
+
+// Wrap the cmd in the supervisor unless the caller is booting the
+// vsock agent directly (provision flow) or the runtime-synthesized
+// restore helper (which already manages the agent itself).
+//
+// `--session` is the legacy "run under setsid" toggle from when CRIU
+// dumps required it but interactive boots didn't. Both modes now go
+// through the same `setsid -c -w` path in the supervisor, so the flag
+// is just consumed for back-compat. Pass it whenever a caller-managed
+// snapshot path is present — purely cosmetic, mirrors how older
+// releases logged the boot.
+function wrapCmdInSupervisor(effectiveCmd: string[], snapshot: BootOptions["snapshot"]): string[] {
+  const cmdHead = effectiveCmd[0];
+  if (cmdHead === "/exec-agent" || cmdHead === "/sbin/machinen-restore") {
+    return effectiveCmd;
+  }
+  const supervisorArgs = typeof snapshot === "string" ? ["--session"] : [];
+  return ["/sbin/machinen-supervisor", ...supervisorArgs, ...effectiveCmd];
+}
+
+// Synthesize the bundle directory from the effective cmd + env. No
+// user-authored machinen-config.json; we generate it here and the
+// caller never sees it.
+function writeBundleConfig(args: {
+  synthBundleDir: string;
+  wrappedCmd: string[];
+  effectiveEnv: Record<string, string>;
+  guestCwd: string | undefined;
+  imageCwd: string | undefined;
+  liveMounts: ResolvedLiveMount[];
+}): void {
+  mkdirSync(join(args.synthBundleDir, "rootfs"), { recursive: true });
+  const configJson = buildMachinenConfig({
+    cmd: args.wrappedCmd,
+    env: args.effectiveEnv,
+    guestCwd: args.guestCwd,
+    imageCwd: args.imageCwd,
+    liveMounts: args.liveMounts,
+  });
+  writeFileSync(join(args.synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
+}
+
+function resolveMount(opts: BootOptions): { host: string; guest: string } | undefined {
+  if (!opts.mount) {
+    return undefined;
+  }
+  validateMountGuest(opts.mount.guest);
+  const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
+  if (!existsSync(hostAbs)) {
     throw new BootError(
-      "BOOT_CMD_MISSING",
-      "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
-        "image via `provision({ cmd })`.",
+      "BOOT_MOUNT_HOST_NOT_FOUND",
+      `mount host path not found: ${opts.mount.host}`,
     );
   }
-
-  // Wrap the cmd in the supervisor unless the caller is booting the
-  // vsock agent directly (provision flow) or the runtime-synthesized
-  // restore helper (which already manages the agent itself).
-  //
-  // `--session` is the legacy "run under setsid" toggle from when CRIU
-  // dumps required it but interactive boots didn't. Both modes now go
-  // through the same `setsid -c -w` path in the supervisor, so the flag
-  // is just consumed for back-compat. Pass it whenever a caller-managed
-  // snapshot path is present — purely cosmetic, mirrors how older
-  // releases logged the boot.
-  const cmdHead = effectiveCmd[0];
-  const isAgentDirect = cmdHead === "/exec-agent";
-  const isRestoreHelper = cmdHead === "/sbin/machinen-restore";
-  const supervisorArgs = typeof opts.snapshot === "string" ? ["--session"] : [];
-  const wrappedCmd =
-    isAgentDirect || isRestoreHelper
-      ? effectiveCmd
-      : ["/sbin/machinen-supervisor", ...supervisorArgs, ...effectiveCmd];
-
-  // env: image defaults overlaid by user + runtime-injected (gvproxy
-  // cache mirror, etc.). User + runtime wins on key collision. Shared
-  // between the synthesized config.json (read by /init) and the
-  // packer's runtime env injection (written into the cpio's
-  // env-overlay file).
-  const effectiveEnv = { ...imageConfig?.env, ...mergedGuestEnv };
-
-  // Synthesize the bundle directory from the effective cmd + env. No
-  // user-authored machinen-config.json; we generate it here and the
-  // caller never sees it.
-  mkdirSync(join(synthBundleDir, "rootfs"), { recursive: true });
-  const configJson = buildMachinenConfig({
-    cmd: wrappedCmd,
-    env: effectiveEnv,
-    guestCwd: opts.guestCwd,
-    imageCwd: imageConfig?.cwd,
-    liveMounts,
-  });
-  writeFileSync(join(synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
-
-  let mount: { host: string; guest: string } | undefined;
-  if (opts.mount) {
-    try {
-      validateMountGuest(opts.mount.guest);
-    } catch (err) {
-      cleanup();
-      throw err;
-    }
-    const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
-    if (!existsSync(hostAbs)) {
-      cleanup();
-      throw new BootError(
-        "BOOT_MOUNT_HOST_NOT_FOUND",
-        `mount host path not found: ${opts.mount.host}`,
-      );
-    }
-    if (!statSync(hostAbs).isDirectory()) {
-      cleanup();
-      throw new BootError(
-        "BOOT_MOUNT_INVALID",
-        `mount host path must be a directory (got a file): ${opts.mount.host}`,
-      );
-    }
-    mount = { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
+  if (!statSync(hostAbs).isDirectory()) {
+    throw new BootError(
+      "BOOT_MOUNT_INVALID",
+      `mount host path must be a directory (got a file): ${opts.mount.host}`,
+    );
   }
+  return { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
+}
 
+// Drive the mkinitramfs packer for tiny (rootDisk path) vs. legacy
+// fat-cpio mode. Wraps any underlying failure as BOOT_PACK_FAILED.
+function packCpio(args: {
+  useTiny: boolean;
+  synthBundleDir: string;
+  cpioPath: string;
+  baseAbs: string | undefined;
+  mount: { host: string; guest: string } | undefined;
+  restoreMountGuest: string | undefined;
+  effectiveEnv: Record<string, string>;
+  liveMounts: ResolvedLiveMount[];
+  onPhase: ((name: string, ms: number) => void) | undefined;
+}): void {
   try {
     const packT0 = Date.now();
-    if (packerOpts.useTiny) {
+    if (args.useTiny) {
       // #119: rootDisk path. The on-disk rootfs is mounted from /dev/vda
       // by /init; the cpio only ships /init + machinen-config.json +
       // boot-epoch + /dev/console (~500 KB). The custom kernel
@@ -341,15 +388,15 @@ export function synthesizeAndPackBundle(
       // bytes ride on virtio-blk slots 5+6 (set up further down in
       // boot()).
       mkinitramfsPackTinyBundle({
-        bundle: synthBundleDir,
-        out: cpioPath,
+        bundle: args.synthBundleDir,
+        out: args.cpioPath,
         // The cpio just carries the guest mountpoint string for /init
         // to read. The actual payload (whether materialized fresh or
         // sourced from a snapshot bundle) rides on virtio-blk slots
         // 5+6, attached further down in boot().
-        mountGuest: mount?.guest ?? opts._restoreMountDisk?.guest,
-        env: effectiveEnv,
-        fuseAgentPath: liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
+        mountGuest: args.mount?.guest ?? args.restoreMountGuest,
+        env: args.effectiveEnv,
+        fuseAgentPath: args.liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
       });
     } else {
       // Legacy fat cpio: explicit `rootDisk: false` opt-out. Drags the
@@ -359,94 +406,100 @@ export function synthesizeAndPackBundle(
       // does not get the virtio-blk mount overlay, since the kernel
       // would have to wait for the rootdisk pivot anyway.
       mkinitramfsPackBundle({
-        bundle: synthBundleDir,
-        out: cpioPath,
-        base: baseAbs,
-        mount,
-        env: effectiveEnv,
-        fuseAgentPath: liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
+        bundle: args.synthBundleDir,
+        out: args.cpioPath,
+        base: args.baseAbs,
+        mount: args.mount,
+        env: args.effectiveEnv,
+        fuseAgentPath: args.liveMounts.length > 0 ? defaultFuseAgentPath() : undefined,
       });
     }
-    packerOpts.onPhase?.("cpio-write", Date.now() - packT0);
+    args.onPhase?.("cpio-write", Date.now() - packT0);
   } catch (err) {
-    cleanup();
     const msg = err instanceof Error ? err.message : String(err);
     throw new BootError("BOOT_PACK_FAILED", `mkinitramfs pack failed: ${msg}`, { cause: err });
   }
-  // #272: the rootDisk path also needs the squashfs+ext4 payload
-  // built and fd-passed to the VMM. Two paths:
-  //   - fresh boot with `mount`: materialize a content-addressed
-  //     squashfs lower from the host source dir + a per-VM ext4 upper.
-  //   - restore from a snapshot bundle (`_restoreMountDisk`): reuse
-  //     the bundle's lower as-is (it's already content-addressed and
-  //     immutable), but reflink the bundle's upper into a per-VM
-  //     path so guest writes don't mutate the bundle in-place.
-  //
-  // Materialize here so a missing mksquashfs fails fast at boot rather
-  // than mid-spawn.
-  let mountDisk:
-    | { lowerPath: string; upperPath: string; guest: string; upperSizeBytes: number }
-    | undefined;
-  if (packerOpts.useTiny) {
-    if (opts._restoreMountDisk) {
-      try {
-        const r = opts._restoreMountDisk;
-        if (!existsSync(r.lowerPath)) {
-          throw new BootError(
-            "BOOT_SNAPSHOT_NOT_FOUND",
-            `restore: bundle is missing mount-lower at ${r.lowerPath}`,
-          );
-        }
-        if (!existsSync(r.upperPath)) {
-          throw new BootError(
-            "BOOT_SNAPSHOT_NOT_FOUND",
-            `restore: bundle is missing mount-upper at ${r.upperPath}`,
-          );
-        }
-        // Reflink the upper so writes accumulate per-fork instead of
-        // mutating the bundle. APFS clonefile / Linux FICLONE on
-        // capable fs (free, shared blocks until guest writes); falls
-        // back to a regular copy elsewhere.
-        const perVMUpper = join(
-          tmpdir(),
-          `machinen-mountdisk-upper-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-        );
-        reflinkCopy(r.upperPath, perVMUpper);
-        const upperSize = statSync(perVMUpper).size;
-        mountDisk = {
-          lowerPath: r.lowerPath,
-          upperPath: perVMUpper,
-          guest: r.guest,
-          upperSizeBytes: upperSize,
-        };
-      } catch (err) {
-        cleanup();
-        throw err;
-      }
-    } else if (mount) {
-      try {
-        const lower = ensureMountDiskImage(mount.host, {
-          onPhase: (name, ms) => packerOpts.onPhase?.(`mountdisk.${name}`, ms),
-        });
-        // markMountDiskImageClean is idempotent and safe to call here —
-        // we only READ the cached file; the per-boot boot() flow takes
-        // ownership of the .ok marker via the same lifecycle the
-        // rootdisk uses.
-        const upper = ensureMountDiskUpper({
-          sizeBytes: packerOpts.mountDiskUpperSizeBytes,
-        });
-        mountDisk = {
-          lowerPath: lower.lowerPath,
-          upperPath: upper.upperPath,
-          guest: mount.guest,
-          upperSizeBytes: upper.sizeBytes,
-        };
-        markMountDiskImageClean(lower.lowerPath);
-      } catch (err) {
-        cleanup();
-        throw err;
-      }
-    }
+}
+
+// #272: the rootDisk path also needs the squashfs+ext4 payload
+// built and fd-passed to the VMM. Two paths:
+//   - fresh boot with `mount`: materialize a content-addressed
+//     squashfs lower from the host source dir + a per-VM ext4 upper.
+//   - restore from a snapshot bundle (`_restoreMountDisk`): reuse
+//     the bundle's lower as-is (it's already content-addressed and
+//     immutable), but reflink the bundle's upper into a per-VM
+//     path so guest writes don't mutate the bundle in-place.
+//
+// Materialize here so a missing mksquashfs fails fast at boot rather
+// than mid-spawn.
+function resolveMountDiskPaths(
+  opts: BootOptions,
+  mount: { host: string; guest: string } | undefined,
+  packerOpts: {
+    useTiny: boolean;
+    mountDiskUpperSizeBytes?: number;
+    onPhase?: (name: string, ms: number) => void;
+  },
+): MountDisk | undefined {
+  if (!packerOpts.useTiny) {
+    return undefined;
   }
-  return { tempDir, cpioPath, mountDisk };
+  if (opts._restoreMountDisk) {
+    return reflinkRestoreMountDisk(opts._restoreMountDisk);
+  }
+  if (mount) {
+    return materializeFreshMountDisk(mount, packerOpts);
+  }
+  return undefined;
+}
+
+function reflinkRestoreMountDisk(r: NonNullable<BootOptions["_restoreMountDisk"]>): MountDisk {
+  if (!existsSync(r.lowerPath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle is missing mount-lower at ${r.lowerPath}`,
+    );
+  }
+  if (!existsSync(r.upperPath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle is missing mount-upper at ${r.upperPath}`,
+    );
+  }
+  // Reflink the upper so writes accumulate per-fork instead of
+  // mutating the bundle. APFS clonefile / Linux FICLONE on
+  // capable fs (free, shared blocks until guest writes); falls
+  // back to a regular copy elsewhere.
+  const perVMUpper = join(
+    tmpdir(),
+    `machinen-mountdisk-upper-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  reflinkCopy(r.upperPath, perVMUpper);
+  return {
+    lowerPath: r.lowerPath,
+    upperPath: perVMUpper,
+    guest: r.guest,
+    upperSizeBytes: statSync(perVMUpper).size,
+  };
+}
+
+function materializeFreshMountDisk(
+  mount: { host: string; guest: string },
+  packerOpts: { mountDiskUpperSizeBytes?: number; onPhase?: (name: string, ms: number) => void },
+): MountDisk {
+  const lower = ensureMountDiskImage(mount.host, {
+    onPhase: (name, ms) => packerOpts.onPhase?.(`mountdisk.${name}`, ms),
+  });
+  // markMountDiskImageClean is idempotent and safe to call here —
+  // we only READ the cached file; the per-boot boot() flow takes
+  // ownership of the .ok marker via the same lifecycle the
+  // rootdisk uses.
+  const upper = ensureMountDiskUpper({ sizeBytes: packerOpts.mountDiskUpperSizeBytes });
+  markMountDiskImageClean(lower.lowerPath);
+  return {
+    lowerPath: lower.lowerPath,
+    upperPath: upper.upperPath,
+    guest: mount.guest,
+    upperSizeBytes: upper.sizeBytes,
+  };
 }

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -117,96 +117,11 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   const phases = new PhaseTimer();
   const snapDir = resolve(opts.snapDir);
   const imgDir = join(snapDir, "img");
-  const metaPath = join(snapDir, "meta.json");
-  if (!existsSync(imgDir) || !statSync(imgDir).isDirectory()) {
-    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${imgDir} not found`);
-  }
-  const imgEntries = readdirSync(imgDir);
-  if (!imgEntries.some((name) => /^core-\d+\.img$/.test(name))) {
-    throw new BootError(
-      "BOOT_SNAPSHOT_NOT_FOUND",
-      `restore: ${imgDir} has no core-*.img — is this a snapshot bundle?`,
-    );
-  }
-  phases.start("snapshot-meta-read");
-  let meta: SnapshotMeta = { snappedAt: 0 };
-  if (existsSync(metaPath)) {
-    try {
-      meta = JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
-    } catch {
-      // Bundle predates metadata or got corrupted; fall through with
-      // an anonymous source name. The fork still boots; it just won't
-      // have a memorable auto-name.
-    }
-  }
-  phases.end("snapshot-meta-read");
 
-  // Resolve the rootfs image: caller's `opts.image` wins; otherwise
-  // fall back to the path the source booted from (recorded in
-  // meta.json). Without a usable image, criu's file-backed VMA
-  // restore has nothing to reopen and PID 1 panics — so we throw
-  // here with a message the user can act on instead.
-  let resolvedImage: string | undefined;
-  if (opts.image) {
-    resolvedImage = resolve(opts.cwd ?? process.cwd(), opts.image);
-    if (!existsSync(resolvedImage)) {
-      throw new BootError("BOOT_IMAGE_NOT_FOUND", `restore: image not found: ${resolvedImage}`);
-    }
-  } else if (meta.sourceImage && existsSync(meta.sourceImage)) {
-    resolvedImage = meta.sourceImage;
-    debugRestore("using meta.sourceImage path=%s", resolvedImage);
-  } else if (meta.sourceImage) {
-    // The bundle remembers a path, but it's gone on this host (e.g.
-    // restored on a different machine, or the tarball was deleted).
-    // Surface it so the user can scp it over or pass --image.
-    throw new BootError(
-      "BOOT_IMAGE_NOT_FOUND",
-      `restore: source image not found at ${meta.sourceImage}\n` +
-        `  The snapshot was taken with this rootfs tarball, and CRIU needs\n` +
-        `  it to reopen the process's file-backed memory mappings (e.g.\n` +
-        `  /usr/bin/node, libc, etc).\n` +
-        `  • copy the tarball to that path on this host, OR\n` +
-        `  • pass an explicit override via the runtime's restore({ image })\n` +
-        `    or the CLI's \`machinen restore --image <tarball>\`.`,
-    );
-  } else {
-    // No --image, and the bundle's meta.json has no sourceImage (an
-    // old bundle predating this field, or one written without the
-    // source's image path). Without something to mount as /, criu
-    // can't reopen file-backed VMAs. Tell the user up front.
-    throw new BootError(
-      "BOOT_IMAGE_NOT_FOUND",
-      `restore: no rootfs image available for this bundle.\n` +
-        `  The snapshot's meta.json doesn't record a source image (likely\n` +
-        `  predates the field). Pass the same tarball you booted the\n` +
-        `  source VM with via the runtime's restore({ image }) or the\n` +
-        `  CLI's \`machinen restore --image <tarball>\`.`,
-    );
-  }
-
-  // Lazy-pages mode (#266, opt-in via `lazy: true`): mark every
-  // PE_PRESENT pagemap entry that lives in an anon-private VMA with
-  // PE_LAZY in place on the host before boot, so
-  // `criu restore --lazy-pages` actually registers UFFD on those
-  // entries instead of loading them eagerly. Dumps are taken without
-  // `--lazy-pages` (machinen-dump.sh keeps the dump path simple);
-  // without this rewrite the lazy-pages daemon would see no lazy
-  // entries and load the whole image up front. Idempotent. See
-  // packages/runtime/src/lazy-pagemap.ts.
-  const lazyPages = opts.lazy === true;
-  let lazyPagesTotal: number | undefined;
-  if (lazyPages) {
-    phases.start("snapshot-mark-lazy");
-    const marked = markPagemapsLazy(imgDir);
-    lazyPagesTotal = marked.entriesFlagged + marked.entriesAlreadyLazy;
-    debug(
-      "lazy-pages mark: files=%d entriesFlagged=%d alreadyLazy=%d",
-      marked.filesRewritten,
-      marked.entriesFlagged,
-      marked.entriesAlreadyLazy,
-    );
-    phases.end("snapshot-mark-lazy");
-  }
+  validateBundleDir(imgDir);
+  const meta = readSnapshotMeta(snapDir, phases);
+  const resolvedImage = resolveRestoreImage(opts, meta);
+  const lazyPagesTotal = applyLazyPagesMode(opts, imgDir, phases);
 
   // #273: live-share FUSE mounts the source had at snapshot time.
   // Re-establish them on the restored VM so the workload's view of
@@ -214,105 +129,15 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   // map keyed by `guest` (see resolveRestoreLiveMounts).
   const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
 
-  // Bundle delivery split by mode:
-  //   - eager (default): pack `imgDir/` into a tar archive attached
-  //     as /dev/vdb. The guest's machinen-restore.sh untars into
-  //     tmpfs and CRIU does an eager load. Simple, robust, no FUSE
-  //     vsock channel to keep alive — and on the workloads we
-  //     actually ship for (small JS heaps, short-lived MicroVMs)
-  //     the workload faults every page within the first second
-  //     anyway, so the lazy save is moot.
-  //   - lazy (opt-in via `lazy: true`): vsock-FUSE-mount `imgDir/`
-  //     read-only at /mnt/snap-src/img. CRIU restore reads
-  //     pagemap-*.img + pages-*.img directly through FUSE; bytes
-  //     stream from the host on demand and never materialize in
-  //     guest tmpfs. This is the #266 path — it keeps host RSS
-  //     proportional to the touched set. The historical
-  //     virtio-balloon interaction is fixed in #290 (in-tree kernel
-  //     patch); the remaining gap is `--detach` composition, which
-  //     waits on the FUSE server to learn to hand off (#150 phase 3).
   phases.start("snapshot-pack");
-  const restoreEnv: Record<string, string> = {};
-  let scratchPath: string;
-  let liveMounts: Array<{ host: string; guest: string; mode?: "ro" | "rw" }> | undefined;
-  if (lazyPages) {
-    scratchPath = join(
-      tmpdir(),
-      `machinen-restore-scratch-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-    );
-    allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
-    restoreEnv.MACHINEN_RESTORE_BUNDLE_LIVE = "1";
-    restoreEnv.MACHINEN_RESTORE_LAZY_PAGES = "1";
-    // #290: lazy-restore + virtio-balloon free-page-reporting used to
-    // get into a runaway re-report cycle — the workload's PE_LAZY anon
-    // range stays as huge contiguous free runs in the buddy allocator,
-    // and `__free_one_page`'s buddy merge clears the Reported flag on
-    // every neighbour it merges with, so the next reporting cycle sees
-    // the merged block as unreported and reports the same physical
-    // region again. Fixed in the guest kernel by
-    // `packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`,
-    // which refuses to merge a freshly-freed page with a Reported buddy
-    // so the cycle terminates after a single warm-up sweep.
-    liveMounts = [
-      ...(effectiveLiveMounts ?? []),
-      { host: imgDir, guest: "/mnt/snap-src/img", mode: "ro" as const },
-    ];
-  } else {
-    // Pack the bundle into a tar so machinen-restore.sh can untar it
-    // off /dev/vdb. tar is `bsdtar` on darwin and `gnu tar` on linux;
-    // both produce archives the guest's `tar -xmf` reads. The trailing
-    // sparse extension keeps /dev/vdb at SNAP_SCRATCH_BYTES so chained
-    // `vm.snapshot()` against this VM has scratch room (its mkfs.ext4
-    // happily ignores tar bytes at the front).
-    scratchPath = join(
-      tmpdir(),
-      `machinen-restore-bundle-${process.pid}-${randomBytes(6).toString("hex")}.tar`,
-    );
-    try {
-      execFileSync("tar", ["-cf", scratchPath, "-C", imgDir, "."]);
-      const fd = openSync(scratchPath, "r+");
-      try {
-        const buf = Buffer.alloc(1);
-        writeSync(fd, buf, 0, 1, SNAP_SCRATCH_BYTES - 1);
-      } finally {
-        closeSync(fd);
-      }
-    } catch (err) {
-      try {
-        unlinkSync(scratchPath);
-      } catch {}
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: failed to pack bundle from ${imgDir}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-    liveMounts = effectiveLiveMounts;
-  }
+  const { scratchPath, liveMounts, restoreEnv } = packRestoreBundle({
+    imgDir,
+    lazyPages: opts.lazy === true,
+    effectiveLiveMounts,
+  });
   phases.end("snapshot-pack");
 
-  // #272: when the snapshot bundle includes a `--mount` overlay,
-  // hand the lower/upper paths through to boot() so it can fd-pass
-  // them to the VMM without re-running mksquashfs on the host source
-  // dir. Each fork reflinks the upper into a per-VM file so guest
-  // writes accumulate per-fork, not in the bundle.
-  let restoreMountDisk: BootOptions["_restoreMountDisk"];
-  if (meta.mountDisk) {
-    const lowerAbs = join(snapDir, meta.mountDisk.lower);
-    const upperAbs = join(snapDir, meta.mountDisk.upper);
-    if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
-      );
-    }
-    restoreMountDisk = {
-      guest: meta.mountDisk.guest,
-      lowerPath: lowerAbs,
-      upperPath: upperAbs,
-    };
-  }
+  const restoreMountDisk = resolveRestoreMountDiskRefs(meta, snapDir);
 
   // boot() doesn't know the pid until after the VMM is spawned, so
   // we can't pass `<sourceName>/<pid>` up front. Boot anonymous,
@@ -341,41 +166,10 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
   phases.end("boot");
 
   if (!opts.name && meta.sourceName) {
-    // Default auto-name nests under the source: `<src>/<pid>`.
-    // claimName refuses (returns false) when `<src>` exists as a live
-    // pin file blocking the parent dir — the fork case (#216), where
-    // the source VM is still running. In that case fall back to a
-    // flat sibling name `<src>~<pid>` so the fork still gets a
-    // meaningful auto-id in `machinen ls`.
-    const candidates = [`${meta.sourceName}/${vm.pid}`, `${meta.sourceName}~${vm.pid}`];
-    for (const candidate of candidates) {
-      if (claimName(candidate, vm.pid)) {
-        // Promote the registry entry to carry the auto-name.
-        const cur = findEntry({ pid: vm.pid });
-        if (cur) {
-          writeEntry({ ...cur, name: candidate });
-        }
-        // Mutate the handle so `vm.name` reflects the resolved name.
-        (vm as { name?: string }).name = candidate;
-        break;
-      }
-    }
+    assignAutoNameFromSource(vm, meta.sourceName);
   }
-
-  // #274: persist lazy-restore bookkeeping so `vm.memoryStats()` can
-  // approximate `lazyPagesPending` without re-reading the bundle.
-  // Boot-owned handles read this back through the registry on every
-  // call; attach handles read it for the same reason but can't
-  // observe the FUSE counter half (no in-process mount-server).
   if (lazyPagesTotal !== undefined) {
-    const cur = findEntry({ pid: vm.pid });
-    if (cur) {
-      writeEntry({
-        ...cur,
-        lazyPagesTotal,
-        lazyPagesMountRoot: imgDir,
-      });
-    }
+    persistLazyPagesBookkeeping(vm, lazyPagesTotal, imgDir);
   }
 
   // CRIU restores the dumped UTS namespace, which means the hostname
@@ -395,4 +189,278 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
     phases.flush(debugRestore, "restore");
   });
   return vm;
+}
+
+function validateBundleDir(imgDir: string): void {
+  if (!existsSync(imgDir) || !statSync(imgDir).isDirectory()) {
+    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${imgDir} not found`);
+  }
+  const imgEntries = readdirSync(imgDir);
+  if (!imgEntries.some((name) => /^core-\d+\.img$/.test(name))) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: ${imgDir} has no core-*.img — is this a snapshot bundle?`,
+    );
+  }
+}
+
+function readSnapshotMeta(snapDir: string, phases: PhaseTimer): SnapshotMeta {
+  const metaPath = join(snapDir, "meta.json");
+  phases.start("snapshot-meta-read");
+  let meta: SnapshotMeta = { snappedAt: 0 };
+  if (existsSync(metaPath)) {
+    try {
+      meta = JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
+    } catch {
+      // Bundle predates metadata or got corrupted; fall through with
+      // an anonymous source name. The fork still boots; it just won't
+      // have a memorable auto-name.
+    }
+  }
+  phases.end("snapshot-meta-read");
+  return meta;
+}
+
+// Resolve the rootfs image: caller's `opts.image` wins; otherwise
+// fall back to the path the source booted from (recorded in
+// meta.json). Without a usable image, criu's file-backed VMA
+// restore has nothing to reopen and PID 1 panics — so we throw
+// here with a message the user can act on instead.
+function resolveRestoreImage(opts: RestoreOptions, meta: SnapshotMeta): string {
+  if (opts.image) {
+    const resolved = resolve(opts.cwd ?? process.cwd(), opts.image);
+    if (!existsSync(resolved)) {
+      throw new BootError("BOOT_IMAGE_NOT_FOUND", `restore: image not found: ${resolved}`);
+    }
+    return resolved;
+  }
+  if (meta.sourceImage && existsSync(meta.sourceImage)) {
+    debugRestore("using meta.sourceImage path=%s", meta.sourceImage);
+    return meta.sourceImage;
+  }
+  if (meta.sourceImage) {
+    // The bundle remembers a path, but it's gone on this host (e.g.
+    // restored on a different machine, or the tarball was deleted).
+    // Surface it so the user can scp it over or pass --image.
+    throw new BootError(
+      "BOOT_IMAGE_NOT_FOUND",
+      `restore: source image not found at ${meta.sourceImage}\n` +
+        `  The snapshot was taken with this rootfs tarball, and CRIU needs\n` +
+        `  it to reopen the process's file-backed memory mappings (e.g.\n` +
+        `  /usr/bin/node, libc, etc).\n` +
+        `  • copy the tarball to that path on this host, OR\n` +
+        `  • pass an explicit override via the runtime's restore({ image })\n` +
+        `    or the CLI's \`machinen restore --image <tarball>\`.`,
+    );
+  }
+  // No --image, and the bundle's meta.json has no sourceImage (an
+  // old bundle predating this field, or one written without the
+  // source's image path). Without something to mount as /, criu
+  // can't reopen file-backed VMAs. Tell the user up front.
+  throw new BootError(
+    "BOOT_IMAGE_NOT_FOUND",
+    `restore: no rootfs image available for this bundle.\n` +
+      `  The snapshot's meta.json doesn't record a source image (likely\n` +
+      `  predates the field). Pass the same tarball you booted the\n` +
+      `  source VM with via the runtime's restore({ image }) or the\n` +
+      `  CLI's \`machinen restore --image <tarball>\`.`,
+  );
+}
+
+// Lazy-pages mode (#266, opt-in via `lazy: true`): mark every
+// PE_PRESENT pagemap entry that lives in an anon-private VMA with
+// PE_LAZY in place on the host before boot, so
+// `criu restore --lazy-pages` actually registers UFFD on those
+// entries instead of loading them eagerly. Dumps are taken without
+// `--lazy-pages` (machinen-dump.sh keeps the dump path simple);
+// without this rewrite the lazy-pages daemon would see no lazy
+// entries and load the whole image up front. Idempotent. See
+// packages/runtime/src/lazy-pagemap.ts.
+function applyLazyPagesMode(
+  opts: RestoreOptions,
+  imgDir: string,
+  phases: PhaseTimer,
+): number | undefined {
+  if (opts.lazy !== true) {
+    return undefined;
+  }
+  phases.start("snapshot-mark-lazy");
+  const marked = markPagemapsLazy(imgDir);
+  debug(
+    "lazy-pages mark: files=%d entriesFlagged=%d alreadyLazy=%d",
+    marked.filesRewritten,
+    marked.entriesFlagged,
+    marked.entriesAlreadyLazy,
+  );
+  phases.end("snapshot-mark-lazy");
+  return marked.entriesFlagged + marked.entriesAlreadyLazy;
+}
+
+interface PackedRestoreBundle {
+  scratchPath: string;
+  liveMounts: Array<{ host: string; guest: string; mode?: "ro" | "rw" }> | undefined;
+  restoreEnv: Record<string, string>;
+}
+
+// Bundle delivery split by mode:
+//   - eager (default): pack `imgDir/` into a tar archive attached
+//     as /dev/vdb. The guest's machinen-restore.sh untars into
+//     tmpfs and CRIU does an eager load. Simple, robust, no FUSE
+//     vsock channel to keep alive — and on the workloads we
+//     actually ship for (small JS heaps, short-lived MicroVMs)
+//     the workload faults every page within the first second
+//     anyway, so the lazy save is moot.
+//   - lazy (opt-in via `lazy: true`): vsock-FUSE-mount `imgDir/`
+//     read-only at /mnt/snap-src/img. CRIU restore reads
+//     pagemap-*.img + pages-*.img directly through FUSE; bytes
+//     stream from the host on demand and never materialize in
+//     guest tmpfs. This is the #266 path — it keeps host RSS
+//     proportional to the touched set. The historical
+//     virtio-balloon interaction is fixed in #290 (in-tree kernel
+//     patch); the remaining gap is `--detach` composition, which
+//     waits on the FUSE server to learn to hand off (#150 phase 3).
+function packRestoreBundle(args: {
+  imgDir: string;
+  lazyPages: boolean;
+  effectiveLiveMounts: ReturnType<typeof resolveRestoreLiveMounts>;
+}): PackedRestoreBundle {
+  if (args.lazyPages) {
+    return packLazyRestoreBundle(args.imgDir, args.effectiveLiveMounts);
+  }
+  return packEagerRestoreBundle(args.imgDir, args.effectiveLiveMounts);
+}
+
+function packLazyRestoreBundle(
+  imgDir: string,
+  effectiveLiveMounts: ReturnType<typeof resolveRestoreLiveMounts>,
+): PackedRestoreBundle {
+  const scratchPath = join(
+    tmpdir(),
+    `machinen-restore-scratch-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
+  // #290: lazy-restore + virtio-balloon free-page-reporting used to
+  // get into a runaway re-report cycle — the workload's PE_LAZY anon
+  // range stays as huge contiguous free runs in the buddy allocator,
+  // and `__free_one_page`'s buddy merge clears the Reported flag on
+  // every neighbour it merges with, so the next reporting cycle sees
+  // the merged block as unreported and reports the same physical
+  // region again. Fixed in the guest kernel by
+  // `packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`,
+  // which refuses to merge a freshly-freed page with a Reported buddy
+  // so the cycle terminates after a single warm-up sweep.
+  return {
+    scratchPath,
+    liveMounts: [
+      ...(effectiveLiveMounts ?? []),
+      { host: imgDir, guest: "/mnt/snap-src/img", mode: "ro" as const },
+    ],
+    restoreEnv: {
+      MACHINEN_RESTORE_BUNDLE_LIVE: "1",
+      MACHINEN_RESTORE_LAZY_PAGES: "1",
+    },
+  };
+}
+
+function packEagerRestoreBundle(
+  imgDir: string,
+  effectiveLiveMounts: ReturnType<typeof resolveRestoreLiveMounts>,
+): PackedRestoreBundle {
+  // Pack the bundle into a tar so machinen-restore.sh can untar it
+  // off /dev/vdb. tar is `bsdtar` on darwin and `gnu tar` on linux;
+  // both produce archives the guest's `tar -xmf` reads. The trailing
+  // sparse extension keeps /dev/vdb at SNAP_SCRATCH_BYTES so chained
+  // `vm.snapshot()` against this VM has scratch room (its mkfs.ext4
+  // happily ignores tar bytes at the front).
+  const scratchPath = join(
+    tmpdir(),
+    `machinen-restore-bundle-${process.pid}-${randomBytes(6).toString("hex")}.tar`,
+  );
+  try {
+    execFileSync("tar", ["-cf", scratchPath, "-C", imgDir, "."]);
+    const fd = openSync(scratchPath, "r+");
+    try {
+      const buf = Buffer.alloc(1);
+      writeSync(fd, buf, 0, 1, SNAP_SCRATCH_BYTES - 1);
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    try {
+      unlinkSync(scratchPath);
+    } catch {}
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: failed to pack bundle from ${imgDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return { scratchPath, liveMounts: effectiveLiveMounts, restoreEnv: {} };
+}
+
+// #272: when the snapshot bundle includes a `--mount` overlay,
+// hand the lower/upper paths through to boot() so it can fd-pass
+// them to the VMM without re-running mksquashfs on the host source
+// dir. Each fork reflinks the upper into a per-VM file so guest
+// writes accumulate per-fork, not in the bundle.
+function resolveRestoreMountDiskRefs(
+  meta: SnapshotMeta,
+  snapDir: string,
+): BootOptions["_restoreMountDisk"] {
+  if (!meta.mountDisk) {
+    return undefined;
+  }
+  const lowerAbs = join(snapDir, meta.mountDisk.lower);
+  const upperAbs = join(snapDir, meta.mountDisk.upper);
+  if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
+    );
+  }
+  return {
+    guest: meta.mountDisk.guest,
+    lowerPath: lowerAbs,
+    upperPath: upperAbs,
+  };
+}
+
+// Default auto-name nests under the source: `<src>/<pid>`.
+// claimName refuses (returns false) when `<src>` exists as a live
+// pin file blocking the parent dir — the fork case (#216), where
+// the source VM is still running. In that case fall back to a
+// flat sibling name `<src>~<pid>` so the fork still gets a
+// meaningful auto-id in `machinen ls`.
+function assignAutoNameFromSource(vm: VmHandle, sourceName: string): void {
+  const candidates = [`${sourceName}/${vm.pid}`, `${sourceName}~${vm.pid}`];
+  for (const candidate of candidates) {
+    if (!claimName(candidate, vm.pid)) {
+      continue;
+    }
+    // Promote the registry entry to carry the auto-name.
+    const cur = findEntry({ pid: vm.pid });
+    if (cur) {
+      writeEntry({ ...cur, name: candidate });
+    }
+    // Mutate the handle so `vm.name` reflects the resolved name.
+    (vm as { name?: string }).name = candidate;
+    return;
+  }
+}
+
+// #274: persist lazy-restore bookkeeping so `vm.memoryStats()` can
+// approximate `lazyPagesPending` without re-reading the bundle.
+// Boot-owned handles read this back through the registry on every
+// call; attach handles read it for the same reason but can't
+// observe the FUSE counter half (no in-process mount-server).
+function persistLazyPagesBookkeeping(vm: VmHandle, lazyPagesTotal: number, imgDir: string): void {
+  const cur = findEntry({ pid: vm.pid });
+  if (cur) {
+    writeEntry({
+      ...cur,
+      lazyPagesTotal,
+      lazyPagesMountRoot: imgDir,
+    });
+  }
 }


### PR DESCRIPTION
## Problem

After pull request #293 cut the two biggest functions in the runtime down to size, the codebase analyzer (`fallow`) flagged nine more functions that were still too complex to follow in one read:

| Function | Where it lives | Cognitive complexity |
|---|---|---|
| `cmdStop` | command-line tool | 96 |
| `parseRunArgs` | command-line tool | 52 |
| `synthesizeAndPackBundle` | runtime | 48 |
| `ensureRootfsImage` | runtime | 45 |
| `restore` | runtime | 45 |
| `parseForkArgs` | command-line tool | 40 |
| `cmdAttach` | command-line tool | 38 |
| `claimName` | registry | 36 |
| `parseRestoreArgs` | command-line tool | 34 |

Cognitive complexity is a score for "how many branches and nested loops a reader has to hold in their head at once." Above about 25, a function stops fitting in working memory; above 50, you need a flowchart.

Each of these mixed three or four unrelated jobs (argument parsing, validation, the actual work, error reporting) inside a single function body. Adding a feature meant reading the whole thing first to find the right place to plug in.

## Solution

Extract one or more named helper functions from each of the nine targets. The orchestrator stays at the top, reads top-to-bottom, and calls the helpers in order. Each helper is now small enough to understand on its own.

Three patterns came out of doing this nine times:

1. **For the four argument parsers** (`parseRunArgs`, `parseForkArgs`, `parseRestoreArgs`, plus the attach options inside `cmdAttach`), the long if/else cascade became a small dispatch table. Each flag has its own tiny handler that updates a shared state object. The duplicate-flag check moved to one shared `assertNotSeen` helper.
2. **For `cmdStop`**, the kill-then-wait-then-escalate logic that was duplicated three times — once for the virtual machine, once for the network proxy, once per live-share helper — now lives in one `signalAuxiliary` helper.
3. **For `synthesizeAndPackBundle`**, the five separate try/catch blocks that each called the same `cleanup()` collapsed into one outer try/catch with a single `cleanup()` in the catch.

## Technical Summary

Cognitive complexity drops on the nine targeted functions:

| Function | Before | After |
|---|---|---|
| `cli.ts::cmdStop` | 96 | ~15 |
| `parseRunArgs` | 52 | ~10 |
| `synthesizeAndPackBundle` | 48 | ~10 |
| `ensureRootfsImage` | 45 | ~10 |
| `restore` | 45 | ~8 |
| `parseForkArgs` | 40 | ~8 |
| `cmdAttach` | 38 | ~6 |
| `claimName` | 36 | ~10 |
| `parseRestoreArgs` | 34 | ~8 |

After this pull request, the only remaining production-code targets on the analyzer's list are the existing `boot → fork → restore → boot` import cycle (left as-is, see #293) and `boot()` itself at 55 (already cut from 242 in #293; further reduction has diminishing returns).

Two smaller targets surface because the bigger ones came down: `scripts/bench-boot.ts::main` and `scripts/test-claude-bootstrap.mjs::run`. Both are dev scripts, not production code.

### Validation

- TypeScript compile clean.
- Formatter (`oxfmt`) clean.
- Unit tests: 604 of 604 pass.
- All 9 local CI workflows pass (one transient flake on a stats-file race in a test this pull request does not touch; passed on retry).
- End-to-end smoke tests pass.

### Stacking

This pull request is stacked on top of #293. The GitHub UI will retarget the base to `main` automatically once #293 merges, and the CI workflows (which only run on pull requests against `main`) will start at that point.