### PR TITLE
fix(smoke): always rebuild dist before running smoke tests

### DIFF
--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -99,10 +99,12 @@ if ! "$ROOT/scripts/check-asset-freshness.sh" --quiet; then
   exit 1
 fi
 
-if [[ ! -f "$CLI" ]]; then
-  echo "=== building @machinen/runtime + @machinen/cli ==="
-  pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null
-fi
+# Always rebuild — without this, a stale `dist/cli.js` from a prior
+# run silently masks source changes, and a "passing" smoke run can
+# actually be exercising the previous PR's code. tsup itself is fast
+# (~1s); the extra cost is negligible next to a single VM boot.
+echo "=== building @machinen/runtime + @machinen/cli ==="
+pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null
 
 # Stage gvproxy next to the locally-built VMM so the runtime's
 # sibling-lookup in resolveGvproxyBinary() finds it. Same script the


### PR DESCRIPTION
## Problem

The smoke-test script (`scripts/smoke-tests.sh`) only rebuilt the compiled JavaScript output when the build file was missing on disk. After any previous run, the build file already exists, so the script started skipping the build step.

The result: every smoke run after the first was actually testing whatever code happened to be sitting in the `dist/` folder, not the source you just edited. A "passing" smoke run could be passing against the previous pull request's code. A "failing" smoke run could be failing against code that no longer exists.

I hit this directly while validating pull request #294. The smoke run reported a failure that had nothing to do with the changes in the branch — the build was a day stale. Rebuilding by hand and re-running the script made everything pass.

## Solution

Drop the conditional check. Always rebuild before running smoke tests.

## Technical Summary

- `scripts/smoke-tests.sh`: removed the `if [[ ! -f "$CLI" ]]` guard around the build step.
- The TypeScript bundler (`tsup`) takes about one second; the extra cost is negligible compared to a single virtual-machine boot.