### PR TITLE
Quieter boot/restore UX with diagnostics on failure (#286)

### DIFF
--- a/packages/cli/src/__tests__/quiet.test.ts
+++ b/packages/cli/src/__tests__/quiet.test.ts
@@ -1,0 +1,321 @@
+// Tests for the quiet UX helper — #286.
+
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BUFFER_BYTES,
+  formatElapsed,
+  isBootNoiseLine,
+  isQuiet,
+  NoiseFilter,
+  printDiagnostics,
+  printHeadline,
+  RingBuffer,
+} from "../quiet.ts";
+
+describe("RingBuffer", () => {
+  it("appends and concatenates strings + buffers", () => {
+    const rb = new RingBuffer(64);
+    rb.push("hello ");
+    rb.push(Buffer.from("world"));
+    expect(rb.toString()).toBe("hello world");
+    expect(rb.byteLength()).toBe(11);
+    expect(rb.isEmpty()).toBe(false);
+  });
+
+  it("drops oldest chunks when capacity is exceeded", () => {
+    const rb = new RingBuffer(10);
+    rb.push("aaaa");
+    rb.push("bbbb");
+    rb.push("cccc"); // total 12 > 10 — first chunk drops
+    expect(rb.toString()).toBe("bbbbcccc");
+    expect(rb.byteLength()).toBe(8);
+  });
+
+  it("keeps the most recent chunk even when it alone exceeds capacity", () => {
+    // The implementation keeps at least one chunk so callers always
+    // see *some* tail rather than an empty buffer when a single
+    // chunk is larger than the cap. Common when CRIU writes a huge
+    // single line on failure.
+    const rb = new RingBuffer(4);
+    rb.push("aaaa");
+    rb.push("xxxxxxxx");
+    expect(rb.toString()).toBe("xxxxxxxx");
+  });
+
+  it("treats empty pushes as no-ops", () => {
+    const rb = new RingBuffer();
+    rb.push("");
+    rb.push(Buffer.alloc(0));
+    expect(rb.isEmpty()).toBe(true);
+  });
+
+  it("default capacity matches the exported constant", () => {
+    const rb = new RingBuffer();
+    rb.push("x".repeat(BUFFER_BYTES + 100));
+    expect(rb.byteLength()).toBeLessThanOrEqual(BUFFER_BYTES + 100);
+  });
+});
+
+describe("isBootNoiseLine", () => {
+  const noiseSamples = [
+    "[    0.123456] Booting Linux on physical CPU 0x0",
+    "[ 1234.567] EXT4-fs (vda): mounted",
+    "init: machinen-netup exited non-zero — network may not be up",
+    "checkpoint: post-tryRootDiskPivot",
+    "checkpoint: post-bringUpNetwork",
+    "mountdisk: mkfs.ext4 ok",
+    "machinen-restore: lazy-pages daemon pid=42",
+    "machinen-supervisor: spawning workload",
+    "machinen-dump: criu exit=0",
+    "machinen-netup: gvproxy ready",
+  ];
+
+  it.each(noiseSamples)("classifies %s as boot noise", (line) => {
+    expect(isBootNoiseLine(line)).toBe(true);
+  });
+
+  const workloadSamples = [
+    "hello-world",
+    "Listening on http://localhost:3000",
+    "node:fs:1234 fs.readFile()",
+    "Error: ENOENT: no such file or directory",
+    "",
+    "    indented log line",
+  ];
+
+  it.each(workloadSamples)("classifies %s as workload output", (line) => {
+    expect(isBootNoiseLine(line)).toBe(false);
+  });
+});
+
+describe("NoiseFilter", () => {
+  it("routes noise lines to buffer, workload lines to out, and fires onReady once", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    let outBytes = "";
+    out.on("data", (chunk: Buffer) => {
+      outBytes += chunk.toString();
+    });
+    const onReady = vi.fn();
+
+    const f = new NoiseFilter({ buffer, out, onReady });
+    f.push(Buffer.from("[    0.001] Booting Linux\n"));
+    f.push(Buffer.from("checkpoint: post-tryRootDiskPivot\n"));
+    f.push(Buffer.from("hello workload\n"));
+    f.push(Buffer.from("another workload line\n"));
+
+    expect(buffer.toString()).toContain("Booting Linux");
+    expect(buffer.toString()).toContain("post-tryRootDiskPivot");
+    // Post-ready lines are rolling-buffered too so a late workload
+    // crash still has context for the dump.
+    expect(buffer.toString()).toContain("hello workload");
+    expect(outBytes).toContain("hello workload");
+    expect(outBytes).toContain("another workload line");
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(f.ready).toBe(true);
+  });
+
+  it("handles chunks split mid-line", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    let outBytes = "";
+    out.on("data", (chunk: Buffer) => {
+      outBytes += chunk.toString();
+    });
+
+    const f = new NoiseFilter({ buffer, out });
+    f.push(Buffer.from("checkpoint: po"));
+    f.push(Buffer.from("st-bringUpNetwork\nhel"));
+    f.push(Buffer.from("lo\n"));
+    expect(buffer.toString()).toContain("post-bringUpNetwork");
+    expect(outBytes).toBe("hello\n");
+  });
+
+  it("flush() drains a trailing residual line as noise pre-ready", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    let outBytes = "";
+    out.on("data", (chunk: Buffer) => {
+      outBytes += chunk.toString();
+    });
+
+    const f = new NoiseFilter({ buffer, out });
+    f.push(Buffer.from("checkpoint: ha"));
+    f.push(Buffer.from("lf-line-no-newline"));
+    f.flush();
+    expect(buffer.toString()).toBe("checkpoint: half-line-no-newline");
+    expect(outBytes).toBe("");
+  });
+
+  it("blank pre-ready lines stay buffered and don't flip the gate", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    const onReady = vi.fn();
+
+    const f = new NoiseFilter({ buffer, out, onReady });
+    f.push(Buffer.from("checkpoint: x\n\n\n"));
+    expect(onReady).not.toHaveBeenCalled();
+    expect(f.ready).toBe(false);
+  });
+});
+
+describe("isQuiet", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.DEBUG;
+    delete process.env.DEBUG;
+  });
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = saved;
+    }
+  });
+
+  it("returns true with no DEBUG set", () => {
+    expect(isQuiet()).toBe(true);
+  });
+
+  it("respects DEBUG=machinen:* as an opt-out (operator mode)", () => {
+    process.env.DEBUG = "machinen:*";
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("respects DEBUG=machinen:boot (single namespace)", () => {
+    process.env.DEBUG = "machinen:boot";
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("respects DEBUG=machinen (bare namespace)", () => {
+    process.env.DEBUG = "machinen";
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("respects DEBUG=* (catch-all wildcard)", () => {
+    process.env.DEBUG = "*";
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("stays quiet for unrelated DEBUG namespaces", () => {
+    process.env.DEBUG = "express:*";
+    expect(isQuiet()).toBe(true);
+  });
+
+  it("recognises a machinen entry alongside others", () => {
+    process.env.DEBUG = "express:*,machinen:boot";
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("treats `-machinen:*` (negation) as not-opted-in", () => {
+    process.env.DEBUG = "express:*,-machinen:*";
+    expect(isQuiet()).toBe(true);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats ms as seconds with 2 decimals", () => {
+    expect(formatElapsed(1450)).toBe("1.45s");
+    expect(formatElapsed(623)).toBe("0.62s");
+    expect(formatElapsed(0)).toBe("0.00s");
+    expect(formatElapsed(-5)).toBe("0.00s");
+  });
+});
+
+describe("printHeadline", () => {
+  let written = "";
+  let savedDebug: string | undefined;
+  const origWrite = process.stderr.write.bind(process.stderr);
+  beforeEach(() => {
+    savedDebug = process.env.DEBUG;
+    delete process.env.DEBUG;
+    written = "";
+    // @ts-ignore monkeypatch for test
+    process.stderr.write = (chunk: string | Buffer) => {
+      written += typeof chunk === "string" ? chunk : chunk.toString();
+      return true;
+    };
+  });
+  afterEach(() => {
+    process.stderr.write = origWrite;
+    if (savedDebug === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = savedDebug;
+    }
+  });
+
+  it("writes a single newline-terminated line in quiet mode", () => {
+    printHeadline("booting counter…");
+    expect(written).toBe("booting counter…\n");
+  });
+
+  it("is silent when DEBUG=machinen:* is set", () => {
+    process.env.DEBUG = "machinen:*";
+    printHeadline("booting counter…");
+    expect(written).toBe("");
+  });
+});
+
+describe("printDiagnostics", () => {
+  let written = "";
+  let savedDebug: string | undefined;
+  const origWrite = process.stderr.write.bind(process.stderr);
+  beforeEach(() => {
+    savedDebug = process.env.DEBUG;
+    delete process.env.DEBUG;
+    written = "";
+    // @ts-ignore monkeypatch for test
+    process.stderr.write = (chunk: string | Buffer) => {
+      written += typeof chunk === "string" ? chunk : chunk.toString();
+      return true;
+    };
+  });
+  afterEach(() => {
+    process.stderr.write = origWrite;
+    if (savedDebug === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = savedDebug;
+    }
+  });
+
+  it("emits summary + envelope + hint when there's buffered content", () => {
+    const rb = new RingBuffer();
+    rb.push("checkpoint: post-bringUpNetwork\n");
+    rb.push("init: panic\n");
+    printDiagnostics("boot counter failed: guest did not respond", { buffer: rb });
+    expect(written).toContain("boot counter failed: guest did not respond");
+    expect(written).toContain("--- diagnostics ---");
+    expect(written).toContain("checkpoint: post-bringUpNetwork");
+    expect(written).toContain("init: panic");
+    expect(written).toContain("--------------------");
+    expect(written).toContain("run with DEBUG=machinen:* for live output");
+  });
+
+  it("skips the envelope when the buffer is empty (still prints summary + hint)", () => {
+    printDiagnostics("install failed: 404");
+    expect(written).toContain("install failed: 404");
+    expect(written).not.toContain("--- diagnostics ---");
+    expect(written).toContain("run with DEBUG=machinen:* for live output");
+  });
+
+  it("renders labeled tails inside the envelope", () => {
+    printDiagnostics("restore counter failed: criu", {
+      buffer: "lazy-pages daemon died\n",
+      tails: { "restore.log": "criu: cannot open img/core.img\n" },
+    });
+    expect(written).toContain("[restore.log]");
+    expect(written).toContain("criu: cannot open img/core.img");
+  });
+
+  it("in operator mode emits just the summary line, no envelope, no hint", () => {
+    process.env.DEBUG = "machinen:*";
+    const rb = new RingBuffer();
+    rb.push("checkpoint: x\n");
+    printDiagnostics("boot counter failed: x", { buffer: rb });
+    expect(written).toBe("boot counter failed: x\n");
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -43,7 +43,7 @@ import {
   runGc,
   validatePid,
 } from "@machinen/runtime";
-import type { RegistryEntry } from "@machinen/runtime";
+import type { LogEvent, RegistryEntry } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
@@ -55,6 +55,14 @@ import { parseForkArgs } from "./parse-fork-args.ts";
 import { parseRestoreArgs } from "./parse-restore-args.ts";
 import { parseRunArgs } from "./parse-run-args.ts";
 import { extractTarget, type Target } from "./parse-target.ts";
+import {
+  formatElapsed,
+  isQuiet,
+  NoiseFilter,
+  printDiagnostics,
+  printHeadline,
+  RingBuffer,
+} from "./quiet.ts";
 import { tailLines } from "./tail-lines.ts";
 
 const debug = debugLib("machinen:cli");
@@ -219,7 +227,13 @@ async function downloadWithChecksum(
 ): Promise<void> {
   const tmp = `${dest}.partial`;
 
-  process.stderr.write(`  fetch ${asset}\n`);
+  // Per-asset progress is useful detail when an operator is
+  // debugging a fetch (slow network, asset name typo) but noise
+  // for everyone else. Suppressed in quiet mode (#286); the caller
+  // prints one headline + "ready in <t>s" instead.
+  if (!isQuiet()) {
+    process.stderr.write(`  fetch ${asset}\n`);
+  }
   await downloadAssetById(asset, tmp, index, token);
 
   const sha = (await fetchAssetText(`${asset}.sha256`, index, token)).trim().split(/\s+/)[0];
@@ -352,10 +366,12 @@ function pipeStdinToVm(vmStdin: NodeJS.WritableStream, onCtrlD: () => void): voi
   stdin.pipe(intercept).pipe(vmStdin);
 }
 
-// Print the "press Ctrl-D to stop" hint and schedule a second print
-// `repeatAfterMs` later. The boot/restore output buries the first hint
-// under kernel logs and init checkpoints; reprinting once the scroll
-// settles puts it back where the user is most likely to read it.
+// Print the "press Ctrl-D to stop" hint. In operator mode
+// (DEBUG=machinen:*) the boot/restore output buries the first hint
+// under kernel logs and init checkpoints; we reprint once the scroll
+// settles to put it back where the user is most likely to read it.
+// In quiet mode (#286) the headline lines are short and stable, so
+// one hint right after them is enough — no reprint, no clutter.
 //
 // Returns a cancel function for the pending reprint — call from the
 // finally block so the timer doesn't fire after the VM has already
@@ -366,6 +382,9 @@ function printCtrlDHint(repeatAfterMs = 3000): () => void {
   }
   const msg = "machinen: press Ctrl-D to stop\n";
   process.stderr.write(msg);
+  if (isQuiet()) {
+    return () => {};
+  }
   const t = setTimeout(() => {
     process.stderr.write(msg);
   }, repeatAfterMs);
@@ -511,6 +530,46 @@ async function cmdBoot(args: string[]): Promise<number> {
   // back to that automatically.
   const cmd = double_dash_args.length > 0 ? ["/usr/bin/env", ...double_dash_args] : undefined;
 
+  // #286: quiet headline UX + diagnostics-on-failure. Buffer the
+  // chatty boot/restore lines (init checkpoints, kernel printk,
+  // machinen-restore.sh mechanics) and only flush them on failure.
+  // Operator mode (DEBUG=machinen:*) bypasses the filter — `onLog`
+  // is unset so vm.stderr stays raw via the runtime's own
+  // vmmDebug.enabled tee, and the CLI's `.pipe(process.stderr)`
+  // below carries the rest. JSON detached output skips headlines
+  // (the caller is scripting against the structured payload).
+  const headlineName = name ?? deriveBootName(imageOverride);
+  const showHeadlines = isQuiet() && !(detached && json);
+  const bootT0 = Date.now();
+  const buffer = new RingBuffer();
+  let filter: NoiseFilter | null = null;
+  if (showHeadlines) {
+    printHeadline(`booting ${headlineName}…`);
+    if (!detached) {
+      filter = new NoiseFilter({
+        buffer,
+        out: process.stderr,
+        onReady: () => {
+          printHeadline("guest ready");
+          printHeadline(`ready in ${formatElapsed(Date.now() - bootT0)}`);
+        },
+      });
+    }
+  }
+  const onLog = filter
+    ? (evt: LogEvent) => {
+        if (evt.source === "guest-console") {
+          filter!.push(evt.chunk);
+        }
+      }
+    : showHeadlines
+      ? (evt: LogEvent) => {
+          if (evt.source === "guest-console") {
+            buffer.push(evt.chunk);
+          }
+        }
+      : undefined;
+
   let vm;
   try {
     vm = await boot({
@@ -530,6 +589,7 @@ async function cmdBoot(args: string[]): Promise<number> {
       guestCwd,
       detached,
       memory,
+      onLog,
       // Interactive CLI: the session lives as long as the guest does.
       // Don't impose the default 60s cap. Detached boots fall back to
       // the runtime's own readiness timeout (60s) so the CLI can't
@@ -537,6 +597,12 @@ async function cmdBoot(args: string[]): Promise<number> {
       timeoutMs: detached ? undefined : null,
     });
   } catch (err) {
+    filter?.flush();
+    if (showHeadlines) {
+      failQuiet(`boot ${headlineName} failed: ${describeError(err)}`, {
+        buffer,
+      });
+    }
     handleError(err);
   }
 
@@ -565,7 +631,14 @@ async function cmdBoot(args: string[]): Promise<number> {
   }
 
   vm.stdout.pipe(process.stdout);
-  vm.stderr.pipe(process.stderr);
+  // Quiet mode: the NoiseFilter already routes vm.stderr (via the
+  // `onLog` hook installed by boot()) into the ring buffer + stderr,
+  // splitting boot noise from workload output. Piping vm.stderr
+  // directly here would double-print every line. Operator mode
+  // (filter === null) keeps the legacy raw passthrough.
+  if (!filter) {
+    vm.stderr.pipe(process.stderr);
+  }
   const restoreStdin = rawModeStdinIfTTY();
   const cancelHintRepeat = printCtrlDHint();
 
@@ -598,11 +671,20 @@ async function cmdBoot(args: string[]): Promise<number> {
 
   try {
     const { code } = await vm.wait();
+    filter?.flush();
     if (forwardedSignal === "SIGINT") {
       return 130;
     }
     if (forwardedSignal === "SIGTERM") {
       return 143;
+    }
+    // Pre-ready non-zero exit: the workload never reached the
+    // readiness boundary, so the buffered boot noise IS the only
+    // post-mortem signal the user has. Flush it under the
+    // diagnostics envelope. Post-ready exits skip the dump — the
+    // workload printed its own error to stderr already.
+    if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
+      printDiagnostics(`boot ${headlineName} exited ${code} before reaching ready`, { buffer });
     }
     return code ?? 0;
   } finally {
@@ -617,10 +699,25 @@ async function cmdInstall(args: string[]): Promise<number> {
   const { json, rest } = consumeJsonFlag(args);
   const tag = argValue(rest, "--version") ?? RELEASE_TAG;
   const wasComplete = baseAssetsComplete(tag);
+  const t0 = Date.now();
   if (!json) {
-    process.stderr.write(`Installing base assets for ${tag} into ${cacheDirFor(tag)}\n`);
+    process.stderr.write(`installing base assets for ${tag}…\n`);
+    // Only show the cache target in operator mode — the path is
+    // useful to know when you're debugging where downloads landed,
+    // noise otherwise.
+    if (!isQuiet()) {
+      process.stderr.write(`  into ${cacheDirFor(tag)}\n`);
+    }
   }
-  const base = await ensureBaseAssets(tag);
+  let base: string;
+  try {
+    base = await ensureBaseAssets(tag);
+  } catch (err) {
+    if (isQuiet() && !json) {
+      failQuiet(`install ${tag} failed: ${describeError(err)}`);
+    }
+    throw err;
+  }
   if (json) {
     emitJson({
       schema_version: 1,
@@ -628,8 +725,10 @@ async function cmdInstall(args: string[]): Promise<number> {
       base_dir: base,
       fetched: !wasComplete,
     });
+  } else if (wasComplete) {
+    process.stderr.write(`ready: ${base} (cached)\n`);
   } else {
-    process.stderr.write(`Ready: ${base}\n`);
+    process.stderr.write(`ready in ${formatElapsed(Date.now() - t0)}: ${base}\n`);
   }
   return 0;
 }
@@ -697,6 +796,37 @@ async function cmdRestore(args: string[]): Promise<number> {
     }
   }
 
+  // #286: quiet headline UX + diagnostics-on-failure. The restore
+  // path is much chattier than boot — machinen-restore.sh emits the
+  // lazy-pages daemon pid, UDS bind, untar progress, criu's exit
+  // notes — and most of it is noise for end-users. Same buffer +
+  // NoiseFilter shape as cmdBoot; only the verbs differ.
+  const headlineName = name ?? deriveBootName(snapDir);
+  const showHeadlines = isQuiet();
+  const restoreT0 = Date.now();
+  const buffer = new RingBuffer();
+  let filter: NoiseFilter | null = null;
+  if (showHeadlines) {
+    printHeadline(`restoring ${headlineName}…`);
+    // onReady fires on the first non-noise line — typically the
+    // restored workload's first stdout/stderr write. We print the
+    // "restored" headline there so timing is wall-clock honest.
+    filter = new NoiseFilter({
+      buffer,
+      out: process.stderr,
+      onReady: () => {
+        printHeadline(`restored in ${formatElapsed(Date.now() - restoreT0)}`);
+      },
+    });
+  }
+  const onLog = filter
+    ? (evt: LogEvent) => {
+        if (evt.source === "guest-console") {
+          filter!.push(evt.chunk);
+        }
+      }
+    : undefined;
+
   let vm;
   try {
     vm = await restore({
@@ -713,15 +843,26 @@ async function cmdRestore(args: string[]): Promise<number> {
       // host/mode (BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN if no match).
       liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
       timeoutMs: null,
+      onLog,
     });
   } catch (err) {
+    filter?.flush();
+    if (showHeadlines) {
+      failQuiet(`restore ${headlineName} failed: ${describeError(err)}`, {
+        buffer,
+      });
+    }
     handleError(err);
   }
 
-  process.stderr.write(`restored as: ${vm.name ?? "<anonymous>"} (pid ${vm.pid})\n`);
+  if (!showHeadlines) {
+    process.stderr.write(`restored as: ${vm.name ?? "<anonymous>"} (pid ${vm.pid})\n`);
+  }
 
   vm.stdout.pipe(process.stdout);
-  vm.stderr.pipe(process.stderr);
+  if (!filter) {
+    vm.stderr.pipe(process.stderr);
+  }
   const restoreStdin = rawModeStdinIfTTY();
   const cancelHintRepeat = printCtrlDHint();
 
@@ -745,11 +886,15 @@ async function cmdRestore(args: string[]): Promise<number> {
 
   try {
     const { code } = await vm.wait();
+    filter?.flush();
     if (forwardedSignal === "SIGINT") {
       return 130;
     }
     if (forwardedSignal === "SIGTERM") {
       return 143;
+    }
+    if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
+      printDiagnostics(`restore ${headlineName} exited ${code} before reaching ready`, { buffer });
     }
     return code ?? 0;
   } finally {
@@ -1247,13 +1392,28 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     return 0;
   }
   const vm = await attach(target).catch(handleError);
+  // #286: quiet snapshot UX. Snapshot's onLog stream is the CRIU
+  // dump-side chatter (machinen-dump.sh + criu's per-phase
+  // progress); buffer it under the diagnostics envelope, surface
+  // only the final "snapshot: <dir>" line on success.
+  const snapHeadlineName = vm.name ?? `pid ${vm.pid}`;
+  const showHeadlines = isQuiet() && !json;
+  const buffer = new RingBuffer();
+  if (showHeadlines) {
+    printHeadline(`snapshotting ${snapHeadlineName}…`);
+  }
   try {
     const res = await vm.snapshot({
       outDir: resolvedOutDir,
       leaveRunning: keepAlive,
       tcpClose: keepAlive,
       onLog: (evt) => {
-        if (evt.source !== "phase") {
+        if (evt.source === "phase") {
+          return;
+        }
+        if (showHeadlines) {
+          buffer.push(evt.chunk);
+        } else {
           process.stderr.write(evt.chunk);
         }
       },
@@ -1270,6 +1430,11 @@ async function cmdSnapshot(args: string[]): Promise<number> {
     }
     return 0;
   } catch (err) {
+    if (showHeadlines) {
+      failQuiet(`snapshot ${snapHeadlineName} failed: ${describeError(err)}`, {
+        buffer,
+      });
+    }
     handleError(err);
   } finally {
     await vm.detach();
@@ -1344,28 +1509,78 @@ async function cmdFork(args: string[]): Promise<number> {
   // is responsible for `rm -rf`-ing the printed path.
   const resolvedOutDir = outDir ? resolve(outDir) : mkdtempSync(join(tmpdir(), "machinen-fork-"));
   const vm = await attach(target).catch(handleError);
-  try {
-    const fork = await vm.fork({
-      name: newName,
-      outDir: resolvedOutDir,
-      image: imagePath,
-      kernel: kernelPath,
-      dtb: dtbPath,
-      tcpKeep,
-      lazy,
-      portForward: portForward.length > 0 ? portForward : undefined,
-      mount,
-      liveMounts,
-      env,
-      guestCwd,
-      memory,
-      onLog: (evt) => {
-        if (evt.source !== "phase") {
-          process.stderr.write(evt.chunk);
+  // #286: quiet fork UX. The fork path is snapshot+restore back to
+  // back, so it's the noisiest of the three — both the source-side
+  // CRIU dump chunks and the restore-side guest console land on the
+  // same onLog. Buffer them; on failure dump under the diagnostics
+  // envelope so the user has something to read.
+  const sourceLabel = "name" in target ? target.name : `pid ${target.pid}`;
+  const forkHeadlineName = newName ?? sourceLabel;
+  const showHeadlines = isQuiet() && !(detach && json);
+  const forkT0 = Date.now();
+  const buffer = new RingBuffer();
+  let filter: NoiseFilter | null = null;
+  if (showHeadlines) {
+    printHeadline(`forking ${sourceLabel} → ${forkHeadlineName}…`);
+    if (!detach) {
+      filter = new NoiseFilter({
+        buffer,
+        out: process.stderr,
+        onReady: () => {
+          printHeadline(`fork ready in ${formatElapsed(Date.now() - forkT0)}`);
+        },
+      });
+    }
+  }
+  const onLog = filter
+    ? (evt: LogEvent) => {
+        if (evt.source === "guest-console") {
+          filter!.push(evt.chunk);
         }
-      },
-    });
-    if (!json) {
+      }
+    : showHeadlines
+      ? (evt: LogEvent) => {
+          if (evt.source === "guest-console") {
+            buffer.push(evt.chunk);
+          }
+        }
+      : (evt: LogEvent) => {
+          // Operator mode: legacy live-stream of every non-phase chunk
+          // (the runtime emits phase events too — those are timing
+          // metadata, not console output, so they're filtered out).
+          if (evt.source !== "phase") {
+            process.stderr.write(evt.chunk);
+          }
+        };
+  try {
+    let fork;
+    try {
+      fork = await vm.fork({
+        name: newName,
+        outDir: resolvedOutDir,
+        image: imagePath,
+        kernel: kernelPath,
+        dtb: dtbPath,
+        tcpKeep,
+        lazy,
+        portForward: portForward.length > 0 ? portForward : undefined,
+        mount,
+        liveMounts,
+        env,
+        guestCwd,
+        memory,
+        onLog,
+      });
+    } catch (err) {
+      filter?.flush();
+      if (showHeadlines) {
+        failQuiet(`fork ${forkHeadlineName} failed: ${describeError(err)}`, {
+          buffer,
+        });
+      }
+      throw err;
+    }
+    if (!showHeadlines && !json) {
       process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
       if (!outDir) {
         process.stderr.write(`bundle: ${resolvedOutDir} (rm -rf when the fork exits)\n`);
@@ -1393,7 +1608,9 @@ async function cmdFork(args: string[]): Promise<number> {
     // as `cmdRestore`. The source VM keeps running in the background,
     // owned by whoever booted it; we never had its console fd.
     fork.stdout.pipe(process.stdout);
-    fork.stderr.pipe(process.stderr);
+    if (!filter) {
+      fork.stderr.pipe(process.stderr);
+    }
     const restoreStdin = rawModeStdinIfTTY();
     const cancelHintRepeat = printCtrlDHint();
     // The source shell printed PS1 to the source's tty before the
@@ -1432,11 +1649,17 @@ async function cmdFork(args: string[]): Promise<number> {
     });
     try {
       const { code } = await fork.wait();
+      filter?.flush();
       if (forwardedSignal === "SIGINT") {
         return 130;
       }
       if (forwardedSignal === "SIGTERM") {
         return 143;
+      }
+      if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
+        printDiagnostics(`fork ${forkHeadlineName} exited ${code} before reaching ready`, {
+          buffer,
+        });
       }
       return code ?? 0;
     } finally {
@@ -1794,6 +2017,11 @@ function die(msg: string): never {
  * Unified error handler. MachinenError gets a formatted `(CODE): message`
  * + cause chain and an exit(1). Anything else re-throws so Node prints
  * the full stack — those are genuine surprises we want to see.
+ *
+ * In quiet mode (#286) the same line lands inside the caller's
+ * `printDiagnostics()` envelope when the failure has a buffered tail
+ * to dump. Callers route through `failQuiet()` in that case; this
+ * stays the fall-through for everything else.
  */
 function handleError(err: unknown): never {
   if (isMachinenError(err)) {
@@ -1801,6 +2029,49 @@ function handleError(err: unknown): never {
     process.exit(1);
   }
   throw err;
+}
+
+/**
+ * Print a failure summary + diagnostics envelope and exit non-zero.
+ * Used by boot/restore/fork/snapshot/install when a buffered tail of
+ * suppressed output would otherwise be lost. In operator mode
+ * (DEBUG=machinen:*) the envelope is a no-op — the user has already
+ * seen the live stream — but the summary line still prints.
+ */
+function failQuiet(
+  summary: string,
+  opts: { buffer?: RingBuffer | string; tails?: Record<string, string> } = {},
+): never {
+  printDiagnostics(summary, opts);
+  process.exit(1);
+}
+
+function describeError(err: unknown): string {
+  if (isMachinenError(err)) {
+    return formatMachinenError(err);
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Derive the headline name for a VM when `--name` wasn't passed.
+ * Strips the tarball extensions (`.tar.gz`, `.tgz`, `.tar`) and any
+ * directory components so `./counter.tar.gz` shows as `counter`.
+ * Falls back to `vm` for image-less boots (e.g. `boot -- bash`).
+ */
+function deriveBootName(imageOverride: string | undefined): string {
+  if (!imageOverride) {
+    return "vm";
+  }
+  const base = imageOverride.split("/").pop() ?? imageOverride;
+  return base
+    .replace(/\.tar\.gz$/i, "")
+    .replace(/\.tgz$/i, "")
+    .replace(/\.tar$/i, "")
+    .replace(/\.gz$/i, "");
 }
 
 function printHelp(): void {

--- a/packages/cli/src/quiet.ts
+++ b/packages/cli/src/quiet.ts
@@ -1,0 +1,323 @@
+// Quiet boot/restore UX with diagnostics-on-failure — #286.
+//
+// The cold boot and snapshot-restore paths stream a lot of detail
+// (kernel printk, init.zig checkpoints, machinen-restore.sh
+// mechanics) that's useful when building or debugging a VM but
+// noise for an end-user just trying to run one. This module
+// implements the "quiet headline + dump-on-failure" envelope used by
+// every command in the CLI:
+//
+//   1. `isQuiet()` — true unless any DEBUG=machinen:* namespace is
+//      live. The runtime's `debug` calls already self-gate, so this
+//      mirrors that gate at the CLI layer: with DEBUG set the user
+//      opted into noise and we get out of the way.
+//
+//   2. `RingBuffer` — capped FIFO of stderr chunks. Feed it from an
+//      `onLog` (or a manual `.push()`) so failure paths have the
+//      relevant tail context regardless of how much output came
+//      before. Capped at 64 KiB which holds ~roughly the last 1k
+//      lines — enough for a CRIU restore failure or a panicking
+//      guest, well under the 1 MiB the runtime's own collect() caps.
+//
+//   3. `NoiseFilter` — a line splitter over guest-console bytes that
+//      routes each line to either the ring buffer (boot noise) or
+//      stderr (workload output). Recognises the prefixes the guest
+//      init and restore scripts emit. The first non-noise line is
+//      the readiness boundary — that's when we print "guest ready"
+//      / "ready in <t>s" and from there it's pure pass-through.
+//      Content-based rather than vsock-probe-based because one-shot
+//      workloads (e.g. `boot -- echo hello`) can exit before any
+//      probe could fire.
+//
+//   4. `printDiagnostics()` — the "--- diagnostics ---" envelope.
+//      Dumps the buffer + any labeled tails the caller hands in
+//      (e.g. restore.log) and tails the escape-hatch hint.
+//
+// DEBUG=machinen:* bypasses every quiet path — `vm.stderr.pipe`
+// stays direct, headlines are skipped, and the diagnostics dumper
+// turns into a no-op. This is the operator escape hatch the issue
+// calls out: "it's stuck, show me now."
+
+import debugLib from "debug";
+
+const cliDebug = debugLib("machinen:cli");
+
+/**
+ * Quiet mode is on unless any `machinen:*` debug namespace is
+ * enabled. Mirrors the runtime's own debug gate so users who
+ * opted into verbose runtime logs also get verbose CLI flow.
+ *
+ * Implementation: scan `process.env.DEBUG` for any positive entry
+ * that targets a `machinen` namespace (or `*`, the wildcard that
+ * catches every namespace). The `debug` library reads DEBUG once
+ * at require time; reading it again here lets tests flip behavior
+ * via `vi.stubEnv("DEBUG", …)` without restarting the process.
+ */
+export function isQuiet(): boolean {
+  const env = process.env.DEBUG;
+  if (!env) {
+    return true;
+  }
+  for (const raw of env.split(/[\s,]+/)) {
+    const entry = raw.trim();
+    if (!entry) {
+      continue;
+    }
+    // Leading `-` disables a namespace (e.g. `*,-machinen:*` to
+    // enable everything *except* machinen). Those don't count as
+    // an opt-in for the namespace.
+    if (entry.startsWith("-")) {
+      continue;
+    }
+    if (entry === "*") {
+      return false;
+    }
+    if (entry === "machinen" || entry.startsWith("machinen:")) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// 64 KiB holds ~1k typical kernel/init lines on the noisy boot
+// path, which is well over what a failure dump needs. Below the
+// runtime-side `CONSOLE_TAIL_BYTES` (1 MiB) so we never duplicate
+// its work — the runtime collector remains the source of truth for
+// post-mortem tails on a thrown error.
+export const BUFFER_BYTES = 64 * 1024;
+
+export class RingBuffer {
+  private chunks: Buffer[] = [];
+  private size = 0;
+
+  constructor(private cap = BUFFER_BYTES) {}
+
+  push(chunk: Buffer | string): void {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+    if (buf.length === 0) {
+      return;
+    }
+    this.chunks.push(buf);
+    this.size += buf.length;
+    while (this.size > this.cap && this.chunks.length > 1) {
+      const drop = this.chunks.shift()!;
+      this.size -= drop.length;
+    }
+  }
+
+  isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  byteLength(): number {
+    return this.size;
+  }
+
+  toString(): string {
+    return Buffer.concat(this.chunks, this.size).toString("utf8");
+  }
+}
+
+// Lines that match these prefixes are boot-time noise: kernel
+// printk, guest /init checkpoints, the machinen-* userspace
+// helpers. Everything else is treated as workload output and
+// passes through to the user immediately.
+const NOISE_PREFIXES: ReadonlyArray<RegExp> = [
+  /^\[\s*\d+\.\d+\]/, // kernel printk: "[    0.123456] ..."
+  /^init:/,
+  /^checkpoint:/,
+  /^mountdisk:/,
+  /^machinen-restore:/,
+  /^machinen-supervisor:/,
+  /^machinen-dump:/,
+  /^machinen-netup:/,
+];
+
+export function isBootNoiseLine(line: string): boolean {
+  return NOISE_PREFIXES.some((re) => re.test(line));
+}
+
+export interface NoiseFilterOpts {
+  /** Sink for boot-noise lines. */
+  buffer: RingBuffer;
+  /** Stream to write pass-through (workload) lines to. */
+  out: NodeJS.WritableStream;
+  /**
+   * Fires once, on the first line that isn't boot noise — the
+   * readiness boundary. Caller uses this to print the "guest ready"
+   * headline before the workload's first line lands.
+   */
+  onReady?: () => void;
+}
+
+/**
+ * Line-buffered filter over guest-console chunks. Each complete
+ * line (LF-terminated, or the residual on flush) is classified as
+ * boot noise (→ buffer) or workload output (→ stderr). The first
+ * workload line flips the gate and triggers `onReady`.
+ *
+ * Chunks may split lines mid-byte; the filter holds the residual
+ * until the next chunk completes it. Call `.flush()` once on VM
+ * exit to drain any trailing partial line — guest output that
+ * ended without a newline (rare but real for early panics).
+ */
+export class NoiseFilter {
+  private residual = "";
+  private readyFired = false;
+
+  constructor(private readonly opts: NoiseFilterOpts) {}
+
+  push(chunk: Buffer): void {
+    const combined = this.residual + chunk.toString("utf8");
+    const nlIdx = combined.lastIndexOf("\n");
+    if (nlIdx === -1) {
+      this.residual = combined;
+      return;
+    }
+    const complete = combined.slice(0, nlIdx + 1);
+    this.residual = combined.slice(nlIdx + 1);
+    for (const line of splitLines(complete)) {
+      this.routeLine(line, "\n");
+    }
+  }
+
+  /**
+   * Flush any residual partial line. Treats it as a boot-noise line
+   * if we're still pre-ready, otherwise passes it through. Idempotent.
+   */
+  flush(): void {
+    if (this.residual.length === 0) {
+      return;
+    }
+    const tail = this.residual;
+    this.residual = "";
+    this.routeLine(tail, "");
+  }
+
+  private routeLine(line: string, terminator: string): void {
+    if (line.length === 0 && terminator === "") {
+      return;
+    }
+    if (!this.readyFired && isBootNoiseLine(line)) {
+      this.opts.buffer.push(line + terminator);
+      return;
+    }
+    // First non-noise line flips the gate. Empty lines pre-ready
+    // (a stray blank line in init.zig output) stay buffered so we
+    // don't fire ready on whitespace.
+    if (!this.readyFired) {
+      if (line.length === 0) {
+        this.opts.buffer.push(line + terminator);
+        return;
+      }
+      this.readyFired = true;
+      try {
+        this.opts.onReady?.();
+      } catch (err) {
+        cliDebug("NoiseFilter onReady threw err=%o", err);
+      }
+    }
+    // Post-ready: pass through AND keep buffering (rolling tail)
+    // so a workload that crashes minutes in still has context
+    // for the failure dump.
+    this.opts.out.write(line + terminator);
+    this.opts.buffer.push(line + terminator);
+  }
+
+  get ready(): boolean {
+    return this.readyFired;
+  }
+}
+
+function splitLines(text: string): string[] {
+  // Preserve LF-terminated splits without trailing empty entries
+  // when `text` itself ends with LF (which is the common case here).
+  const parts = text.split("\n");
+  if (parts[parts.length - 1] === "") {
+    parts.pop();
+  }
+  return parts;
+}
+
+/**
+ * Headline writer. No-op when quiet mode is off — operator runs
+ * (DEBUG=machinen:*) want the legacy raw stream without a banner
+ * on top.
+ */
+export function printHeadline(line: string): void {
+  if (!isQuiet()) {
+    return;
+  }
+  process.stderr.write(`${line}\n`);
+}
+
+export function formatElapsed(ms: number): string {
+  if (ms < 0) {
+    ms = 0;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+const ESCAPE_HINT = "run with DEBUG=machinen:* for live output\n";
+
+export interface DiagnosticsOpts {
+  /** Suppressed boot/restore output. Skip when there's nothing to dump. */
+  buffer?: RingBuffer | string;
+  /**
+   * Extra labeled tail blocks (e.g. `{ "restore.log": "...", "guest console": "..." }`).
+   * Each renders under its own bracketed header inside the diagnostics envelope.
+   */
+  tails?: Record<string, string>;
+  /**
+   * Override the escape-hatch hint. Defaults to the standard
+   * "run with DEBUG=…" line; pass an empty string to suppress.
+   */
+  hint?: string;
+}
+
+/**
+ * Print the failure summary + diagnostics envelope. In operator
+ * mode (DEBUG=machinen:*) the envelope is skipped — the user has
+ * already seen the full live stream — but the summary line still
+ * prints so the error is recognisable in the same place either way.
+ */
+export function printDiagnostics(summary: string, opts: DiagnosticsOpts = {}): void {
+  process.stderr.write(`${summary}\n`);
+  if (!isQuiet()) {
+    return;
+  }
+
+  const bufStr = typeof opts.buffer === "string" ? opts.buffer : (opts.buffer?.toString() ?? "");
+  const tails = opts.tails ?? {};
+  const hasBuf = bufStr.trim().length > 0;
+  const hasTails = Object.values(tails).some((t) => t && t.trim().length > 0);
+
+  if (hasBuf || hasTails) {
+    process.stderr.write("\n--- diagnostics ---\n");
+    if (hasBuf) {
+      process.stderr.write(bufStr);
+      if (!bufStr.endsWith("\n")) {
+        process.stderr.write("\n");
+      }
+    }
+    for (const [label, content] of Object.entries(tails)) {
+      if (!content || content.trim().length === 0) {
+        continue;
+      }
+      if (hasBuf) {
+        process.stderr.write("\n");
+      }
+      process.stderr.write(`[${label}]\n`);
+      process.stderr.write(content);
+      if (!content.endsWith("\n")) {
+        process.stderr.write("\n");
+      }
+    }
+    process.stderr.write("--------------------\n\n");
+  }
+
+  const hint = opts.hint ?? ESCAPE_HINT;
+  if (hint.length > 0) {
+    process.stderr.write(hint);
+  }
+}


### PR DESCRIPTION
## Problem

When you run `machinen boot ./counter.tar.gz` or `machinen restore ./snapshot-counter`, the screen fills with dozens of low-level lines: kernel boot messages, internal checkpoints from the guest's startup script, lazy-page daemon details, untar progress, and per-phase timing notes. All of that detail is useful when you're building or debugging the virtual-machine layer — but for someone who just wants to run a workload, it buries the parts they actually care about: "is it starting? is it ready? did it work?"

When something goes wrong, the opposite problem appears. A single error message at the bottom doesn't carry enough context for the user to act on, or for us to look at if they file a bug.

Closes #286.

## Solution

On the happy path the CLI now prints three short headlines:

1. A "starting" line, e.g. `booting counter…` or `restoring snapshot-counter…`.
2. A "ready" line that fires the moment the guest workload produces its first output.
3. A "took N seconds" line.

All of the kernel and startup-script lines that used to scroll past are captured into a memory buffer in the background. On a successful run they are never shown. If the command fails — either because the runtime threw an error or because the workload exited before ever reaching ready — the captured tail is printed under a `--- diagnostics ---` block alongside the failure summary, so the user has something to read and we have something to look at in bug reports.

The same shape applies to every command in the CLI that runs a long noisy operation: boot, restore, fork, snapshot, and install. The base-assets installer also collapses its per-file fetch lines into one "installing… / ready in 4.2s" pair.

Setting `DEBUG=machinen:*` (or any other `machinen` debug namespace) bypasses every quiet path and restores the legacy live-stream output. This is the operator escape hatch the issue explicitly called for.

## Technical Summary

A new `packages/cli/src/quiet.ts` module owns the shared pieces:

- `isQuiet()` scans `process.env.DEBUG` for any positive entry that targets a `machinen` namespace, or the catch-all `*`. It honours the `debug` library's negation syntax (`*,-machinen:*` is treated as quiet).
- `RingBuffer` is a fixed-capacity (64 KiB) byte buffer. It keeps the most recent chunk even when a single write exceeds capacity — CRIU prints multi-kilobyte single-line failures and the user needs to see them.
- `NoiseFilter` is a line splitter over the guest console. Each complete line is classified against a prefix list (`[N.N]` kernel printk, `init:`, `checkpoint:`, `mountdisk:`, and the `machinen-restore` / `machinen-supervisor` / `machinen-dump` / `machinen-netup` helpers). Boot noise goes to the buffer; everything else passes through to stderr. The first non-noise line flips a "ready" gate and fires a callback the CLI uses to print the "ready in <t>s" headline.
- `printDiagnostics()` writes the `--- diagnostics ---` envelope, with optional labeled tail blocks for log files and the escape-hatch hint.

The four chatty CLI commands (boot, restore, fork, snapshot) install an `onLog` hook that funnels guest-console chunks through `NoiseFilter`. On success the filter passes workload output straight through; on a thrown error or a pre-ready non-zero exit, the buffered tail is dumped through `printDiagnostics` and the CLI exits non-zero. The runtime is unchanged — all of this lives at the CLI layer.

A content-based line filter is deliberately picked over a vsock-based readiness probe. One-shot workloads like `boot -- echo hello` exit before a probe could fire, so the readiness boundary has to be derivable from the byte stream alone.

40 new unit tests in `packages/cli/src/__tests__/quiet.test.ts` cover ring-buffer capping, noise classification, chunk reassembly across line boundaries, every `isQuiet` env-var permutation including negation, and the `printDiagnostics` envelope in both quiet and operator modes.

## Test plan

- [x] `pnpm exec vitest run packages/cli/` — 174 / 174 passing
- [x] `npx agent-ci run --all -q -p` — 4 / 4 workflows passing (docs, tests, fuse-workloads × 2)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — clean
- [x] Manual exercise of the failure path (`boot /nonexistent.tar.gz` with and without `DEBUG=machinen:vmm`) — headlines + diagnostics envelope appear in quiet mode, raw passthrough in operator mode
- [ ] `pnpm smoke-tests` — not run on the dev box (the arm64 base-assets build needs `MACHINEN_REMOTE_BUILDER`); please run locally before merging