### PR TITLE
chore(microvm): name local byte counts with explicit `_bytes` suffix

### DIFF
--- a/packages/microvm/src/blk.zig
+++ b/packages/microvm/src/blk.zig
@@ -188,7 +188,7 @@ pub const Backend = struct {
 
         // Parse outhdr.
         var status: u8 = VIRTIO_BLK_S_OK;
-        var written: u32 = 0;
+        var bytes_written: u32 = 0;
 
         if (hdr == null or status_desc == null) {
             // Malformed; nothing to write back. Still ack the chain.
@@ -212,15 +212,15 @@ pub const Backend = struct {
                         status = VIRTIO_BLK_S_IOERR;
                         break;
                     };
-                    const n = pread(self.fd, dst.ptr, dst.len, @as(i64, @intCast(sector)) * 512);
-                    if (n < 0) {
+                    const n_bytes = pread(self.fd, dst.ptr, dst.len, @as(i64, @intCast(sector)) * 512);
+                    if (n_bytes < 0) {
                         status = VIRTIO_BLK_S_IOERR;
                         break;
                     }
-                    written += @intCast(n);
+                    bytes_written += @intCast(n_bytes);
                     sector += dst.len / 512;
                 }
-                traceBlk("read", out_hdr.sector, data_count, written);
+                traceBlk("read", out_hdr.sector, data_count, bytes_written);
             },
             .out => {
                 if (self.read_only) {
@@ -231,22 +231,22 @@ pub const Backend = struct {
                     status = VIRTIO_BLK_S_IOERR;
                     traceBlk("write-rejected-ro", out_hdr.sector, data_count, 0);
                 } else {
-                    var total: u32 = 0;
+                    var total_bytes: u32 = 0;
                     var sector = out_hdr.sector;
                     for (data[0..data_count]) |d| {
                         const src = dev.guestBytes(d.addr, d.len) orelse {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         };
-                        const n = pwrite(self.fd, src.ptr, src.len, @as(i64, @intCast(sector)) * 512);
-                        if (n < 0) {
+                        const n_bytes = pwrite(self.fd, src.ptr, src.len, @as(i64, @intCast(sector)) * 512);
+                        if (n_bytes < 0) {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         }
-                        total += @intCast(n);
+                        total_bytes += @intCast(n_bytes);
                         sector += src.len / 512;
                     }
-                    traceBlk("write", out_hdr.sector, data_count, total);
+                    traceBlk("write", out_hdr.sector, data_count, total_bytes);
                 }
             },
             .flush => {
@@ -301,7 +301,7 @@ pub const Backend = struct {
                     assert(dst.len <= 20);
                     @memset(dst, 0);
                     @memcpy(dst[0..@min(dst.len, id_str.len)], id_str[0..@min(dst.len, id_str.len)]);
-                    written = @intCast(dst.len);
+                    bytes_written = @intCast(dst.len);
                 }
             },
             else => status = VIRTIO_BLK_S_UNSUPP,
@@ -319,7 +319,7 @@ pub const Backend = struct {
 
         // virtio-blk reports used `len` as the number of bytes the
         // DEVICE wrote into the chain (read data + the status byte).
-        dev.queuePushUsed(0, head, written + 1);
+        dev.queuePushUsed(0, head, bytes_written + 1);
     }
 };
 

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -777,19 +777,19 @@ fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod
     // SEEK_END to discover size — same trick `openFile` uses. The
     // file-scope `lseek` extern further down in this file resolves
     // against libc; both squashfs and ext4 images are seekable.
-    const sz = lseek(f, 0, SEEK_END);
-    if (sz <= 0) {
-        std.debug.print("virtio-blk {s} disabled: lseek(fd={d}) returned {d}\n", .{ label, f, sz });
+    const size_bytes = lseek(f, 0, SEEK_END);
+    if (size_bytes <= 0) {
+        std.debug.print("virtio-blk {s} disabled: lseek(fd={d}) returned {d}\n", .{ label, f, size_bytes });
         return null;
     }
-    if (@rem(sz, 512) != 0) {
+    if (@rem(size_bytes, 512) != 0) {
         std.debug.print(
             "virtio-blk {s} disabled: size {d} is not a multiple of 512 (fd={d})\n",
-            .{ label, sz, f },
+            .{ label, size_bytes, f },
         );
         return null;
     }
-    return blk_mod.Backend.initFromFdWithMode(f, @intCast(sz), read_only);
+    return blk_mod.Backend.initFromFdWithMode(f, @intCast(size_bytes), read_only);
 }
 
 /// Wrap a `blk_mod.Backend` as a virtio-mmio device. `backend` must
@@ -1162,22 +1162,22 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     assert(fd >= 0);
     defer _ = close(fd);
 
-    const size_i = lseek(fd, 0, SEEK_END);
-    if (size_i < 0) return error.SeekFailed;
+    const size_signed = lseek(fd, 0, SEEK_END);
+    if (size_signed < 0) return error.SeekFailed;
     _ = lseek(fd, 0, SEEK_SET);
-    const size: usize = @intCast(size_i);
-    assert(size > 0);
+    const size_bytes: usize = @intCast(size_signed);
+    assert(size_bytes > 0);
 
-    const buf = try gpa.alloc(u8, size);
+    const buf = try gpa.alloc(u8, size_bytes);
     errdefer gpa.free(buf);
 
-    var total: usize = 0;
-    while (total < size) {
-        const n = read(fd, buf[total..].ptr, size - total);
-        if (n <= 0) return error.ShortRead;
-        total += @intCast(n);
+    var total_bytes: usize = 0;
+    while (total_bytes < size_bytes) {
+        const n_bytes = read(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
+        if (n_bytes <= 0) return error.ShortRead;
+        total_bytes += @intCast(n_bytes);
     }
-    assert(total == size);
+    assert(total_bytes == size_bytes);
     return buf;
 }
 

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -457,19 +457,19 @@ fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
 fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
     const f = fd orelse return null;
     if (f < 0) return null;
-    const sz = lseek(f, 0, 2);
-    if (sz <= 0) {
-        std.debug.print("virtio-blk {s} disabled: lseek(fd={d}) returned {d}\n", .{ label, f, sz });
+    const size_bytes = lseek(f, 0, 2);
+    if (size_bytes <= 0) {
+        std.debug.print("virtio-blk {s} disabled: lseek(fd={d}) returned {d}\n", .{ label, f, size_bytes });
         return null;
     }
-    if (@rem(sz, 512) != 0) {
+    if (@rem(size_bytes, 512) != 0) {
         std.debug.print(
             "virtio-blk {s} disabled: size {d} is not a multiple of 512 (fd={d})\n",
-            .{ label, sz, f },
+            .{ label, size_bytes, f },
         );
         return null;
     }
-    return blk_mod.Backend.initFromFdWithMode(f, @intCast(sz), read_only);
+    return blk_mod.Backend.initFromFdWithMode(f, @intCast(size_bytes), read_only);
 }
 
 /// Wrap a `blk_mod.Backend` as a virtio-mmio device. `backend` must
@@ -847,21 +847,21 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     assert(fd >= 0);
     defer _ = hostClose(fd);
 
-    const size_i = hostLseek(fd, 0, 2);
-    if (size_i < 0) return error.SeekFailed;
+    const size_signed = hostLseek(fd, 0, 2);
+    if (size_signed < 0) return error.SeekFailed;
     _ = hostLseek(fd, 0, 0);
-    const size: usize = @intCast(size_i);
-    assert(size > 0);
+    const size_bytes: usize = @intCast(size_signed);
+    assert(size_bytes > 0);
 
-    const buf = try gpa.alloc(u8, size);
+    const buf = try gpa.alloc(u8, size_bytes);
     errdefer gpa.free(buf);
-    var total: usize = 0;
-    while (total < size) {
-        const n = hostRead(fd, buf[total..].ptr, size - total);
-        if (n <= 0) return error.ShortRead;
-        total += @intCast(n);
+    var total_bytes: usize = 0;
+    while (total_bytes < size_bytes) {
+        const n_bytes = hostRead(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
+        if (n_bytes <= 0) return error.ShortRead;
+        total_bytes += @intCast(n_bytes);
     }
-    assert(total == size);
+    assert(total_bytes == size_bytes);
     return buf;
 }
 

--- a/packages/microvm/src/net_socket.zig
+++ b/packages/microvm/src/net_socket.zig
@@ -221,14 +221,14 @@ pub const NetSocket = struct {
         while (!self.stop.load(.acquire)) {
             var prefix: [4]u8 = undefined;
             if (readAll(self.fd, &prefix) != 0) return;
-            const len = std.mem.readInt(u32, &prefix, .big);
-            if (len == 0 or len > buf.len) return;
-            assert(len > 0 and len <= buf.len);
+            const frame_len_bytes = std.mem.readInt(u32, &prefix, .big);
+            if (frame_len_bytes == 0 or frame_len_bytes > buf.len) return;
+            assert(frame_len_bytes > 0 and frame_len_bytes <= buf.len);
 
-            if (readAll(self.fd, buf[0..len]) != 0) return;
+            if (readAll(self.fd, buf[0..frame_len_bytes]) != 0) return;
 
             self.irq_mu.lock();
-            _ = self.netdev.injectRx(buf[0..len]);
+            _ = self.netdev.injectRx(buf[0..frame_len_bytes]);
             if (self.on_rx) |cb| cb(self.on_rx_ctx);
             self.irq_mu.unlock();
         }

--- a/packages/microvm/src/virtio.zig
+++ b/packages/microvm/src/virtio.zig
@@ -447,13 +447,13 @@ pub const Device = struct {
                     frame_started = true;
                     if (remaining.len == 0) break;
                 }
-                const chunk: u32 = @intCast(@min(@as(u64, budget), remaining.len));
-                assert(chunk > 0);
-                const dst = self.guestSlice(desc.addr + (desc.len - budget), chunk) orelse return false;
-                @memcpy(dst, remaining[0..chunk]);
-                remaining = remaining[chunk..];
-                budget -= chunk;
-                written += chunk;
+                const chunk_bytes: u32 = @intCast(@min(@as(u64, budget), remaining.len));
+                assert(chunk_bytes > 0);
+                const dst = self.guestSlice(desc.addr + (desc.len - budget), chunk_bytes) orelse return false;
+                @memcpy(dst, remaining[0..chunk_bytes]);
+                remaining = remaining[chunk_bytes..];
+                budget -= chunk_bytes;
+                written += chunk_bytes;
             }
 
             if ((desc.flags & VringDesc.F_NEXT) == 0) break;
@@ -512,10 +512,10 @@ pub const Device = struct {
         while (steps < max_chain_descriptors) : (steps += 1) {
             const desc = self.readDescriptor(q, idx) orelse break;
             if (desc.len > 0 and written < scratch.len) {
-                const take: usize = @min(desc.len, scratch.len - written);
-                if (self.guestSlice(desc.addr, take)) |bytes| {
-                    @memcpy(scratch[written..][0..take], bytes);
-                    written += take;
+                const take_bytes: usize = @min(desc.len, scratch.len - written);
+                if (self.guestSlice(desc.addr, take_bytes)) |bytes| {
+                    @memcpy(scratch[written..][0..take_bytes], bytes);
+                    written += take_bytes;
                 }
             }
             if ((desc.flags & VringDesc.F_NEXT) == 0) break;


### PR DESCRIPTION
## Problem

A handful of local variables in the VM monitor track byte counts but don't say so in their name. Variables like `n`, `size`, `total`, `written`, and `chunk` could in principle be sectors, pages, or array indices — and the sectors-vs-bytes boundary is right there in `blk.zig`'s read and write handlers. A future change that copy-pastes one of these names into the wrong arithmetic would compile cleanly and produce a silent off-by-512 corruption.

This is the next step in the TigerStyle hardening of the VM monitor (after #298). Adding asserts and bounded loops guards against malformed inputs at runtime; naming with units guards against the same class of bugs at *read time*.

## Solution

Rename local variables to carry their unit in the name (`_bytes` for bytes, `_signed` for the intermediate signed return that becomes a `usize`). No behaviour change, no public API change, no field rename — only locals inside function bodies.

The sweep is intentionally narrow:
1. Skip wire-format struct fields (`VringDesc.len`, `BlkOutHdr.sector`, etc.) — they mirror the Linux uapi / virtio spec and a rename would break ABI compatibility.
2. Skip slice variables of `[]u8` — the type already says bytes.
3. Skip trivial loop indices (`i`, `j`, `k`).
4. Pick variables at unit boundaries: a `size` from `lseek` that gets divided by 512 to make sectors; a `total` accumulating `pwrite` returns; a `len` read off the wire that gates a buffer allocation.

## Technical Summary

Five files touched, all in `packages/microvm/src/`. Net change is zero lines (renames only).

- **`blk.zig`** — the `handleRequest` switch arms had three implicit-byte-count locals next to the `sectors` accumulator. Renamed: `written` → `bytes_written` (the outer used-len accumulator), `total` → `total_bytes` (the `.out` write-path mirror), `n` → `n_bytes` (the `pread`/`pwrite` syscall returns in both arms).
- **`virtio.zig`** — `injectRx` and `walkAndEmit` each had one ambiguous local: `chunk` → `chunk_bytes` (capped `@min(budget, remaining.len)` where both terms are bytes), `take` → `take_bytes` (capped `@min(desc.len, scratch.len - written)`).
- **`net_socket.zig`** — the length-prefixed framing reader had `const len = std.mem.readInt(u32, &prefix, .big);` shadowing slice `.len` and gating `buf[0..len]`. Renamed to `frame_len_bytes` so the wire-derived count never gets confused with a slice length.
- **`boot_hvf.zig`** and **`boot_kvm.zig`** — `openBlkBackendFromFd` and the in-file `readAll` helper each had `sz` / `size_i` / `size` / `total` / `n` from `lseek` and `read`. Renamed `sz`, `size_i`, `size` → `size_signed` and `size_bytes` (intermediate signed lseek return + the final usize byte count); `total` → `total_bytes`; `n` → `n_bytes`. The two boot files mirror each other so the rename is consistent across both.

### Skipped on purpose

- `dtb_patch.zig`, `balloon.zig`, `stats.zig`, `main.zig` are in the open #298 PR; touching them here would conflict on merge.
- `vsock.zig`'s suggested renames (`body_end`, `payload`) were marginal — both slice into `[]u8`, where the type already conveys bytes.
- `pl011.zig`, `kvm.zig`, `hvf.zig`, `root.zig` had no good candidates — variables are either already disambiguated or are obvious `idx` / `addr` / `offset` patterns.

### Tests

All 60 microvm Zig tests pass. `vitest run` 644/644. `agent-ci run --all` green. `pnpm smoke-tests` pass.