### PR TITLE
chore(microvm): split the longest boot functions into named helpers

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -153,10 +153,10 @@ fn debugEnabled() bool {
 // DTB patching (initrd-end + memory@ size) lives in `dtb_patch.zig`,
 // shared with boot_kvm.zig. See that file for the FDT walker + tests.
 
-pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
-    // Caller-supplied layout must satisfy the basic geometry the boot
-    // protocol depends on. These are programmer errors at the call
-    // site, not anything the guest can influence.
+/// Caller-supplied layout must satisfy the basic geometry the boot
+/// protocol depends on. These are programmer errors at the call site,
+/// not anything the guest can influence — assert hard.
+fn validateConfig(cfg: Config) void {
     assert(cfg.kernel_path.len > 0);
     assert(cfg.dtb_path.len > 0);
     assert(cfg.ram_size >= 16 * 1024 * 1024);
@@ -167,24 +167,15 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     assert(cfg.dtb_offset < cfg.ram_size);
     assert(cfg.initrd_offset < cfg.ram_size);
     assert(cfg.max_exits > 0);
+}
 
-    var fx = try loadFixtures(gpa, cfg);
-    defer fx.deinit(gpa);
-
-    const ram = try allocateAndPopulateRam(gpa, cfg, fx);
-    defer std.posix.munmap(ram);
-
-    const vm = try hvf.Vm.create();
-    defer vm.destroy();
-
-    // Turn on HVF's in-kernel GIC v3 at the addresses the device tree
-    // advertises (distributor at 0x0800_0000, redistributor at
-    // 0x080A_0000 per a QEMU `virt,gic-version=3` DTB dump). Without
-    // this the kernel has nowhere to register interrupts and the
-    // virtual timer has nothing to deliver to.
+/// Turn on HVF's in-kernel GIC v3 at the addresses the device tree
+/// advertises (distributor at 0x0800_0000, redistributor at
+/// 0x080A_0000 per a QEMU `virt,gic-version=3` DTB dump). Without
+/// this the kernel has nowhere to register interrupts and the virtual
+/// timer has nothing to deliver to.
+fn enableGic() !void {
     try hvf.Gic.enable(.{});
-
-    // Diagnostic: print GIC alignment + size requirements.
     if (debugEnabled()) {
         std.debug.print(
             "GIC dist align=0x{x} size=0x{x}; rdist align=0x{x} size=0x{x} region=0x{x}\n",
@@ -197,6 +188,21 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
             },
         );
     }
+}
+
+pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
+    validateConfig(cfg);
+
+    var fx = try loadFixtures(gpa, cfg);
+    defer fx.deinit(gpa);
+
+    const ram = try allocateAndPopulateRam(gpa, cfg, fx);
+    defer std.posix.munmap(ram);
+
+    const vm = try hvf.Vm.create();
+    defer vm.destroy();
+
+    try enableGic();
 
     // Give the guest full read/write/execute on this region. Stage-2
     // permissions; the guest's own MMU still decides what it does at

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -132,10 +132,10 @@ pub const Result = struct {
     exits: usize,
 };
 
-pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
-    // Caller-supplied layout must satisfy the basic geometry the boot
-    // protocol depends on. These are programmer errors at the call
-    // site, not anything the guest can influence.
+/// Caller-supplied layout must satisfy the basic geometry the boot
+/// protocol depends on. These are programmer errors at the call site,
+/// not anything the guest can influence — assert hard.
+fn validateConfig(cfg: Config) void {
     assert(cfg.kernel_path.len > 0);
     assert(cfg.dtb_path.len > 0);
     assert(cfg.ram_size >= 16 * 1024 * 1024);
@@ -147,6 +147,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     assert(cfg.initrd_offset < cfg.ram_size);
     assert(cfg.gic_dist_addr != cfg.gic_redist_addr);
     assert(cfg.max_exits > 0);
+}
+
+pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
+    validateConfig(cfg);
 
     var fx = try loadFixtures(gpa, cfg);
     defer fx.deinit(gpa);
@@ -761,16 +765,7 @@ fn routeMmio(
         return;
     }
     if (devs.netdev.handles(ev.phys_addr)) {
-        // Same race / serialisation story as vsock below: the RX
-        // thread inside NetSocket sets interrupt_status and asserts
-        // the SPI line under `n.irq_mu`; we take the same mutex so
-        // our snapshot-based setIrq can't override the bridge's.
-        // No-op when `net_inst` is null (no gvproxy backend) — there
-        // is no second thread to race against, and the kernel still
-        // sees a valid virtio-net device with link-down.
-        if (devs.net_inst) |n| n.lockIrq();
-        defer if (devs.net_inst) |n| n.unlockIrq();
-        try handleVirtioMmio(vm, vcpu, devs.netdev, irqs.net, ev);
+        try dispatchNetMmio(vm, vcpu, devs, irqs, ev);
         return;
     }
     if (devs.blk_dev) |d| if (d.handles(ev.phys_addr)) {
@@ -790,21 +785,7 @@ fn routeMmio(
         return;
     };
     if (devs.vsock_dev) |d| if (d.handles(ev.phys_addr)) {
-        // The vCPU side of (RMW interrupt_status + setIrq) must
-        // serialise against the bridge poll thread's same pair.
-        // Without this, the bridge's setIrq(1) — issued the moment
-        // it injects an RX packet — can be overridden by a stale
-        // setIrq(0) we computed before the bridge's RMW and only
-        // got around to syscalling now. Symptom: guest never sees
-        // the CONNECT RESPONSE, fuse-agent's dial wedges, T3/T5/N2
-        // /S* all fail deterministically on KVM. Apple's
-        // hv_gic_set_spi happens to absorb this race; KVM_IRQ_LINE
-        // doesn't, which is why HVF passes smoke and KVM doesn't
-        // until this lock lands. handleTxChain assumes the caller
-        // holds bridge.mu — see its docstring.
-        if (devs.vsock_bridge) |b| b.mu.lock();
-        defer if (devs.vsock_bridge) |b| b.mu.unlock();
-        try handleVirtioMmio(vm, vcpu, d, irqs.vsock, ev);
+        try dispatchVsockMmio(vm, vcpu, devs, d, irqs.vsock, ev);
         return;
     };
     if (devs.balloon_dev) |d| if (d.handles(ev.phys_addr)) {
@@ -816,6 +797,49 @@ fn routeMmio(
     // untouched kvm_run bytes is already zero, but be explicit so a
     // future non-zero lingerer doesn't bite).
     if (ev.is_write == 0) vcpu.writeMmioReadData(0, ev.len);
+}
+
+/// Run a virtio-net MMIO event under `net_inst.irq_mu`. The RX thread
+/// inside NetSocket sets interrupt_status and asserts the SPI line
+/// under `irq_mu`; we take the same mutex so our snapshot-based setIrq
+/// can't override the bridge's. No-op when `net_inst` is null (no
+/// gvproxy backend) — there is no second thread to race against, and
+/// the kernel still sees a valid virtio-net device with link-down.
+fn dispatchNetMmio(
+    vm: *kvm.Vm,
+    vcpu: *kvm.Vcpu,
+    devs: *const Devices,
+    irqs: IrqMap,
+    ev: kvm.MmioExit,
+) !void {
+    if (devs.net_inst) |n| n.lockIrq();
+    defer if (devs.net_inst) |n| n.unlockIrq();
+    try handleVirtioMmio(vm, vcpu, devs.netdev, irqs.net, ev);
+}
+
+/// Run a virtio-vsock MMIO event under `vsock_bridge.mu`. The vCPU
+/// side of (RMW interrupt_status + setIrq) must serialise against the
+/// bridge poll thread's same pair. Without this, the bridge's
+/// setIrq(1) — issued the moment it injects an RX packet — can be
+/// overridden by a stale setIrq(0) we computed before the bridge's
+/// RMW and only got around to syscalling now. Symptom: guest never
+/// sees the CONNECT RESPONSE, fuse-agent's dial wedges, T3/T5/N2/S*
+/// all fail deterministically on KVM. Apple's `hv_gic_set_spi`
+/// happens to absorb this race; `KVM_IRQ_LINE` doesn't, which is why
+/// HVF passes smoke and KVM doesn't until this lock lands.
+/// `handleTxChain` assumes the caller holds `bridge.mu` — see its
+/// docstring.
+fn dispatchVsockMmio(
+    vm: *kvm.Vm,
+    vcpu: *kvm.Vcpu,
+    devs: *const Devices,
+    dev: *virtio.Device,
+    irq: u32,
+    ev: kvm.MmioExit,
+) !void {
+    if (devs.vsock_bridge) |b| b.mu.lock();
+    defer if (devs.vsock_bridge) |b| b.mu.unlock();
+    try handleVirtioMmio(vm, vcpu, dev, irq, ev);
 }
 
 /// Pack the up-to-8 little-endian bytes KVM hands us in `mmio.data`


### PR DESCRIPTION
## Problem

TigerStyle prefers functions that fit on one screen — roughly 70 lines or fewer. Three functions in the VM monitor were well over that cap and have been hard to read for a while:

- `boot_hvf.zig:boot()` at **229 lines** — the HVF entry point that wires up every backend before the run loop.
- `boot_kvm.zig:boot()` at **176 lines** — the KVM mirror of the above.
- `boot_kvm.zig:routeMmio()` at **74 lines** — the per-device MMIO dispatcher, mostly long comments explaining lock acquisition order.

Long entry points are a documented TigerStyle anti-pattern: they hide control flow, mix concerns, and make per-line reviews harder. This pull request takes the **safe** extractions — ones that don't reshape lifetimes or defer ordering — and is honest about what it leaves on the table.

## Solution

Three single-purpose helpers, each one a contained extraction with no behaviour change.

1. **`validateConfig(cfg)`** — extract the 12-line assert block at the top of `boot()` in both boot files. Pure function, zero state, identical shape across the two backends.
2. **`dispatchNetMmio` and `dispatchVsockMmio`** in `boot_kvm.zig` — extract the `irq_mu` and `bridge.mu` locking dances out of `routeMmio`. The long inline comments explaining the race against the bridge poll thread move with their helpers, where readers see them next to the lock call.
3. **`enableGic()`** in `boot_hvf.zig` — extract the GIC v3 enable plus optional debug-print block from `boot()`. Pure I/O, no state captured.

### Function lengths after the pass

| function | before | after | under cap |
|---|---:|---:|:---:|
| `boot_hvf.zig:boot()` | 229 | 198 | no |
| `boot_kvm.zig:boot()` | 176 | 163 | no |
| `boot_kvm.zig:routeMmio()` | 74 | 51 | yes |

`routeMmio` is now under the cap. The two `boot()` functions are still over.

### Why `boot()` isn't fully split here

Cutting `boot()` further means moving the per-backend setup (virtio-blk slots 1/3/5/6, virtio-net + gvproxy, virtio-vsock + bridge, virtio-balloon, stats mmap, stdin reader thread) into helpers. Every one of those backends has a `defer backend.deinit()` and a captured-by-pointer `&local` that has to outlive the run loop. Pulling them into helpers means either:

- The helpers can't own the `defer` (caller still writes it for each backend, which doesn't actually shorten `boot()` much), or
- A `DeviceBundle` struct owns every backend's lifetime, exposes pointers, and collapses the per-device `defer` tail into one — a real architectural change with subtle correctness implications around partial-init failure paths.

A `DeviceBundle` refactor is the right way to bring these under cap, but it's substantial enough that it deserves its own PR with its own design discussion. The safe extractions in this PR are real wins on their own and don't risk the lifetime / defer ordering that the bundle refactor would.

## Technical Summary

Two files changed, three helper functions added, no behaviour change.

### `packages/microvm/src/boot_hvf.zig`

- New `fn validateConfig(cfg: Config) void` — consolidates the 12 cfg-shape `assert(...)` calls that previously sat at the top of `boot()`.
- New `fn enableGic() !void` — wraps `hvf.Gic.enable(.{})` plus the optional `debugEnabled()`-gated diagnostic print of distributor / redistributor alignment + size + region.
- `boot()` body trimmed from 229 to 198 lines; both callsites become `try enableGic();` and `validateConfig(cfg);`.

### `packages/microvm/src/boot_kvm.zig`

- New `fn validateConfig(cfg: Config) void` — same shape as the HVF version, asserting the KVM-side cfg invariants (notice `gic_dist_addr != gic_redist_addr`).
- New `fn dispatchNetMmio(...) !void` — owns the `net_inst.lockIrq()` / `unlockIrq()` pair around `handleVirtioMmio`. The race-explanation comment moves to the helper's docstring.
- New `fn dispatchVsockMmio(...) !void` — owns the `vsock_bridge.mu.lock()` / `unlock()` pair around `handleVirtioMmio`. The long KVM-vs-HVF race-condition explanation (the original wedged-CONNECT-RESPONSE bug) moves to the helper's docstring.
- `routeMmio()` body trimmed from 74 to 51 lines.

### Tests

All 60 microvm Zig tests pass. `vitest run` 644/644. `agent-ci run --all` green. `pnpm smoke-tests` pass.