### PR TITLE
chore(microvm): replace PL011 ArrayList with fixed-capacity rings

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -210,10 +210,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // --- run loop -------------------------------------------------
     var uart: hvf.Pl011 = .init;
     // Production boots discard Result.serial unread (main.zig); skip
-    // the per-byte capture allocations in that mode. See
+    // the per-byte capture writes in that mode. See
     // .docs/learnings/microvm/allocations.md (#240).
     uart.capture_enabled = !cfg.unbounded_serial;
-    defer uart.deinit(gpa);
 
     // virtio-net + gvproxy (#82). The Device is the "hardware"; gvproxy
     // (containers/gvisor-tap-vsock) runs out-of-process as a user-mode
@@ -361,7 +360,6 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var stdin_ctx = StdinThread{
         .uart = &uart,
         .irq = irqs.pl011,
-        .gpa = gpa,
     };
     const stdin_thread = try std.Thread.spawn(.{}, stdinThreadMain, .{&stdin_ctx});
     defer {
@@ -423,7 +421,7 @@ fn runLoop(
             },
             .data_abort_lower_el => {
                 const info = hvf.DataAbort.decode(vcpu.exit.exception);
-                try routeDataAbort(gpa, vcpu, devs, irqs, info);
+                try routeDataAbort(vcpu, devs, irqs, info);
             },
             else => {
                 // Unhandled exception — record and stop.
@@ -435,12 +433,12 @@ fn runLoop(
         // be confident the kernel booted far enough to prove our point.
         // Production boots set `unbounded_serial` so the loop ends only
         // on PSCI SYSTEM_OFF (or max_exits).
-        if (!cfg.unbounded_serial and devs.uart.captured.items.len >= cfg.capture_bytes) break;
+        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
     }
 
     if (exits >= cfg.max_exits) return error.RanTooLong;
 
-    const serial = try gpa.dupe(u8, devs.uart.captured.items);
+    const serial = try gpa.dupe(u8, devs.uart.capturedBytes());
     return .{
         .serial = serial,
         .saw_psci_shutdown = saw_off,
@@ -452,7 +450,6 @@ fn runLoop(
 const StdinThread = struct {
     uart: *hvf.Pl011,
     irq: u32,
-    gpa: std.mem.Allocator,
     stop: std.atomic.Value(bool) = .init(false),
 };
 
@@ -979,14 +976,13 @@ const Devices = struct {
 /// advance PC past the faulting load/store. This is the dispatch table
 /// — the per-device helpers do the actual read/write.
 fn routeDataAbort(
-    gpa: std.mem.Allocator,
     vcpu: hvf.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
     info: hvf.DataAbort,
 ) !void {
     if (devs.uart.handles(info.ipa)) {
-        try handlePl011Mmio(devs.uart, gpa, vcpu, info, irqs.pl011);
+        try handlePl011Mmio(devs.uart, vcpu, info, irqs.pl011);
     } else if (info.ipa >= 0x0800_0000 and info.ipa < 0x0801_0000) {
         try handleGicDistMmio(vcpu, info);
     } else if (devs.netdev.handles(info.ipa)) {
@@ -1035,7 +1031,6 @@ fn syncPl011Irq(uart: *hvf.Pl011, irq: u32) void {
 /// console output live; every access resyncs the IRQ line.
 fn handlePl011Mmio(
     uart: *hvf.Pl011,
-    gpa: std.mem.Allocator,
     vcpu: hvf.Vcpu,
     info: hvf.DataAbort,
     irq: u32,
@@ -1043,7 +1038,7 @@ fn handlePl011Mmio(
     assert(uart.handles(info.ipa));
     if (info.is_write) {
         const value = try info.readSource(vcpu);
-        try uart.write(gpa, info.ipa, value);
+        uart.write(info.ipa, value);
         if ((info.ipa - uart.base) == 0) {
             const byte: [1]u8 = .{@truncate(value)};
             _ = write(2, &byte, 1);
@@ -1128,7 +1123,7 @@ fn stdinThreadMain(ctx: *StdinThread) void {
             return;
         }
         assert(@as(usize, @intCast(n)) <= buf.len);
-        ctx.uart.pushRx(ctx.gpa, buf[0..@intCast(n)]) catch return;
+        ctx.uart.pushRx(buf[0..@intCast(n)]);
         // Assert the IRQ so the vCPU wakes from WFI and services it.
         hvf.Gic.setSpi(ctx.irq, ctx.uart.irqAsserted()) catch {};
     }

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -176,10 +176,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // --- run loop -------------------------------------------------
     var uart = pl011_mod.Pl011.init;
     // Production boots discard Result.serial unread (main.zig); skip
-    // the per-byte capture allocations in that mode. See
+    // the per-byte capture writes in that mode. See
     // .docs/learnings/microvm/allocations.md (#240).
     uart.capture_enabled = !cfg.unbounded_serial;
-    defer uart.deinit(gpa);
 
     const irqs = IrqMap.init();
 
@@ -620,7 +619,7 @@ fn runLoop(
         switch (reason) {
             .mmio => {
                 const ev = vcpu.mmioExit();
-                try routeMmio(gpa, vm, vcpu, devs, irqs, ev);
+                try routeMmio(vm, vcpu, devs, irqs, ev);
             },
             .system_event => {
                 const ev = vcpu.systemEventExit();
@@ -640,18 +639,18 @@ fn runLoop(
                 return error.GuestCrashed;
             },
         }
-        if (!cfg.unbounded_serial and devs.uart.captured.items.len >= cfg.capture_bytes) break;
+        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
     }
 
     if (exits >= cfg.max_exits) {
         std.debug.print(
             "kvm boot: RanTooLong after {d} exits. Captured serial ({d} bytes):\n{s}\n",
-            .{ exits, devs.uart.captured.items.len, devs.uart.captured.items },
+            .{ exits, devs.uart.captured_len, devs.uart.capturedBytes() },
         );
         return error.RanTooLong;
     }
 
-    const serial = try gpa.dupe(u8, devs.uart.captured.items);
+    const serial = try gpa.dupe(u8, devs.uart.capturedBytes());
     return .{ .serial = serial, .saw_psci_shutdown = saw_off, .exits = exits };
 }
 
@@ -702,7 +701,6 @@ const Devices = struct {
 /// PL011 MMIO. Console-byte writes echo to host stderr; every access
 /// resyncs the SPI line based on `irqAsserted()`.
 fn handlePl011Mmio(
-    gpa: std.mem.Allocator,
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     uart: *pl011_mod.Pl011,
@@ -712,7 +710,7 @@ fn handlePl011Mmio(
     assert(uart.handles(ev.phys_addr));
     if (ev.is_write != 0) {
         const val = mmioReadValue(ev);
-        try uart.write(gpa, ev.phys_addr, val);
+        uart.write(ev.phys_addr, val);
         if ((ev.phys_addr - uart.base) == 0 and ev.len > 0) {
             const byte: [1]u8 = .{ev.data[0]};
             _ = hostWrite(2, &byte, 1);
@@ -747,7 +745,6 @@ fn handleVirtioMmio(
 /// Route an MMIO exit to the device that owns the IPA. Each cross-
 /// thread arm wraps `handleVirtioMmio` in the appropriate mutex.
 fn routeMmio(
-    gpa: std.mem.Allocator,
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
@@ -760,7 +757,7 @@ fn routeMmio(
     assert(ev.is_write <= 1);
 
     if (devs.uart.handles(ev.phys_addr)) {
-        try handlePl011Mmio(gpa, vm, vcpu, devs.uart, ev, irqs.pl011);
+        try handlePl011Mmio(vm, vcpu, devs.uart, ev, irqs.pl011);
         return;
     }
     if (devs.netdev.handles(ev.phys_addr)) {

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -829,9 +829,7 @@ test "guest writes bytes to PL011 UART, host captures them" {
     try vcpu.setSysReg(.sctlr_el1, 1 << 12);
     try vcpu.setReg(.pc, guest_base);
 
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
     const max_iters: usize = 32;
     var iters: usize = 0;
@@ -847,7 +845,7 @@ test "guest writes bytes to PL011 UART, host captures them" {
                 if (uart.handles(info.ipa)) {
                     if (info.is_write) {
                         const value = try info.readSource(vcpu);
-                        try uart.write(gpa, info.ipa, value);
+                        uart.write(info.ipa, value);
                     }
                     // (reads not exercised in this test)
                 }
@@ -860,10 +858,10 @@ test "guest writes bytes to PL011 UART, host captures them" {
     }
     try std.testing.expect(iters < max_iters);
 
-    try std.testing.expectEqualStrings("Hi\n", uart.captured.items);
+    try std.testing.expectEqualStrings("Hi\n", uart.capturedBytes());
     std.debug.print(
         "PL011 captured {d} bytes: \"{s}\"",
-        .{ uart.captured.items.len, uart.captured.items },
+        .{ uart.captured_len, uart.capturedBytes() },
     );
 }
 
@@ -878,39 +876,33 @@ test "guest writes bytes to PL011 UART, host captures them" {
 // return the standard PL011 values so the AMBA bus binds.
 
 test "Pl011: pushRx buffers bytes and sets RX_INT in RIS" {
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
-    try uart.pushRx(gpa, "abc");
-    try std.testing.expectEqual(@as(usize, 3), uart.rx_buf.items.len);
+    uart.pushRx("abc");
+    try std.testing.expectEqual(@as(usize, 3), uart.rx_len);
     try std.testing.expect((uart.ris & Pl011.RX_INT) != 0);
 }
 
 test "Pl011: irqAsserted is gated on IMSC" {
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
-    try uart.pushRx(gpa, "x");
+    uart.pushRx("x");
     // RIS has RX_INT set, but the kernel hasn't enabled the mask yet.
     try std.testing.expect(!uart.irqAsserted());
 
     // Kernel enables RX interrupt (IMSC bit 4 = 0x10).
-    try uart.write(gpa, uart.base + 0x038, 0x10);
+    uart.write(uart.base + 0x038, 0x10);
     try std.testing.expect(uart.irqAsserted());
 
     // Kernel masks everything — IRQ line should drop even though bytes remain.
-    try uart.write(gpa, uart.base + 0x038, 0x00);
+    uart.write(uart.base + 0x038, 0x00);
     try std.testing.expect(!uart.irqAsserted());
 }
 
 test "Pl011: ICR clears selected RIS bits, preserves RX_INT while FIFO has bytes" {
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
-    try uart.pushRx(gpa, "y");
+    uart.pushRx("y");
     // Enable + assert: the RT (receive-timeout) bit too, so we can see
     // ICR clear it without clearing RX_INT.
     uart.ris |= (1 << 6); // RT
@@ -919,35 +911,31 @@ test "Pl011: ICR clears selected RIS bits, preserves RX_INT while FIFO has bytes
 
     // Kernel writes ICR=0x50 (RX | RT). RT should clear permanently;
     // RX_INT should re-latch because rx_buf still holds a byte.
-    try uart.write(gpa, uart.base + 0x044, 0x50);
+    uart.write(uart.base + 0x044, 0x50);
     try std.testing.expectEqual(@as(u32, 0x10), uart.ris);
 }
 
 test "Pl011: DR read pops a byte; RX_INT clears when FIFO drains" {
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
-    try uart.pushRx(gpa, "hi");
+    uart.pushRx("hi");
     const a = uart.read(uart.base + 0x000); // DR
     try std.testing.expectEqual(@as(u64, 'h'), a);
     try std.testing.expect((uart.ris & Pl011.RX_INT) != 0); // still one byte left
 
     const b = uart.read(uart.base + 0x000);
     try std.testing.expectEqual(@as(u64, 'i'), b);
-    try std.testing.expectEqual(@as(usize, 0), uart.rx_buf.items.len);
+    try std.testing.expectEqual(@as(usize, 0), uart.rx_len);
     try std.testing.expect((uart.ris & Pl011.RX_INT) == 0); // drained → clear
 }
 
 test "Pl011: FR.RXFE flips with FIFO occupancy" {
-    const gpa = std.testing.allocator;
     var uart: Pl011 = .init;
-    defer uart.deinit(gpa);
 
     // Empty: bit 4 (RXFE) set.
     try std.testing.expect((uart.read(uart.base + 0x018) & (1 << 4)) != 0);
 
-    try uart.pushRx(gpa, "z");
+    uart.pushRx("z");
     // Not empty: RXFE clear.
     try std.testing.expect((uart.read(uart.base + 0x018) & (1 << 4)) == 0);
 

--- a/packages/microvm/src/pl011.zig
+++ b/packages/microvm/src/pl011.zig
@@ -50,18 +50,40 @@ pub const PthreadMutex = extern struct {
     }
 };
 
+/// Cap on captured DR-write bytes. Tests inspect Result.serial,
+/// runLoop breaks once `captured_len >= cfg.capture_bytes` (default
+/// 256 KiB) so the bound is reached cleanly without allocator
+/// involvement. Production boots run with `capture_enabled = false`,
+/// so this buffer never grows past 0 in production.
+pub const captured_capacity: usize = 256 * 1024;
+
+/// Cap on the RX FIFO. Real PL011 hardware has a 32-byte FIFO; we
+/// give the guest much more headroom so a slow ISR can't drop
+/// pasted-in commands. Bytes that don't fit are dropped at the tail
+/// — same fail-soft policy a real UART uses on FIFO overflow.
+pub const rx_capacity: usize = 4096;
+
 pub const Pl011 = struct {
     base: u64,
     size: u64 = 0x1000,
-    captured: std.ArrayList(u8),
-    rx_buf: std.ArrayList(u8),
+    /// Captured DR-write bytes. Pre-sized; never grows. The vCPU
+    /// hot-path (`write` at offset 0x000) writes one byte per call
+    /// without touching the allocator. NASA Power-of-Ten Rule 3
+    /// (no dynamic alloc after init), see
+    /// .docs/learnings/microvm/allocations.md (#240).
+    captured: [captured_capacity]u8 = undefined,
+    captured_len: usize = 0,
+    /// RX FIFO bytes from host stdin. Pre-sized; pushRx drops at the
+    /// tail when full.
+    rx_buf: [rx_capacity]u8 = undefined,
+    rx_len: usize = 0,
     /// Whether DR-write bytes are appended to `captured`. Test boots
-    /// rely on the captured buffer to assert on guest output; production
-    /// boots discard `Result.serial` immediately (see main.zig — the
-    /// same bytes already live-echo to host stderr from the boot loop's
-    /// PL011 handler). Skipping the append eliminates the per-byte
-    /// ArrayList grow on the production hot path. NASA Power-of-Ten
-    /// Rule 3, see .docs/learnings/microvm/allocations.md (#240).
+    /// rely on the captured buffer to assert on guest output;
+    /// production boots discard `Result.serial` immediately (see
+    /// main.zig — the same bytes already live-echo to host stderr
+    /// from the boot loop's PL011 handler). Skipping the append
+    /// eliminates the per-byte buffer churn on the production hot
+    /// path even though the buffer itself is allocator-free.
     capture_enabled: bool = true,
     // Interrupt mask/status. The kernel's PL011 IRQ handler reads MIS
     // (masked = RIS & IMSC) and clears matching bits via ICR.
@@ -83,25 +105,24 @@ pub const Pl011 = struct {
         assert(@sizeOf(PthreadMutex) >= 64);
         assert(@sizeOf(PthreadMutex) >= PthreadMutex.macos_pad);
         assert(@sizeOf(PthreadMutex) >= PthreadMutex.linux_pad);
+        // Pl011 holds both rings inline. Sanity-check the expected
+        // struct size so a future cap bump catches the stack-pressure
+        // cost explicitly. ~260 KiB sits comfortably on the boot
+        // thread's default ~8 MiB stack.
+        assert(@sizeOf(Pl011) >= captured_capacity + rx_capacity);
+        assert(captured_capacity > 0);
+        assert(rx_capacity > 0);
     }
 
     pub const init: Pl011 = .{
         .base = 0x0900_0000,
-        .captured = .empty,
-        .rx_buf = .empty,
     };
 
     pub fn withBase(base: u64) Pl011 {
         // base 0 collides with the GIC distributor on the arm-virt
         // machine; non-zero is a programmer invariant for every caller.
         assert(base != 0);
-        return .{ .base = base, .captured = .empty, .rx_buf = .empty };
-    }
-
-    pub fn deinit(self: *Pl011, gpa: std.mem.Allocator) void {
-        assert(self.size > 0);
-        self.captured.deinit(gpa);
-        self.rx_buf.deinit(gpa);
+        return .{ .base = base };
     }
 
     pub fn handles(self: *const Pl011, addr: u64) bool {
@@ -119,28 +140,48 @@ pub const Pl011 = struct {
         return (self.ris & self.imsc) != 0;
     }
 
-    pub fn pushRx(self: *Pl011, gpa: std.mem.Allocator, bytes: []const u8) !void {
+    /// Slice over the captured DR-write bytes. The returned slice
+    /// aliases the inline buffer — copy it (e.g. via `gpa.dupe`) if
+    /// you need it to outlive the Pl011.
+    pub fn capturedBytes(self: *const Pl011) []const u8 {
+        assert(self.captured_len <= captured_capacity);
+        return self.captured[0..self.captured_len];
+    }
+
+    /// Drop bytes that don't fit. Real PL011 hardware does the same
+    /// when its 32-byte RX FIFO is full; the kernel's driver expects
+    /// to lose data on overrun rather than block the producer.
+    pub fn pushRx(self: *Pl011, bytes: []const u8) void {
         assert(self.size > 0);
         self.mutex.lock();
         defer self.mutex.unlock();
-        const before = self.rx_buf.items.len;
-        try self.rx_buf.appendSlice(gpa, bytes);
-        assert(self.rx_buf.items.len == before + bytes.len);
-        if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
+        const room = rx_capacity - self.rx_len;
+        const n = @min(room, bytes.len);
+        if (n == 0) return;
+        @memcpy(self.rx_buf[self.rx_len..][0..n], bytes[0..n]);
+        self.rx_len += n;
+        assert(self.rx_len <= rx_capacity);
+        self.ris |= RX_INT;
     }
 
-    pub fn write(self: *Pl011, gpa: std.mem.Allocator, addr: u64, value: u64) !void {
+    pub fn write(self: *Pl011, addr: u64, value: u64) void {
         assert(self.size > 0);
         assert(self.handles(addr));
         self.mutex.lock();
         defer self.mutex.unlock();
         const offset = addr - self.base;
         switch (offset) {
-            0x000 => if (self.capture_enabled) try self.captured.append(gpa, @truncate(value)),
+            0x000 => {
+                if (self.capture_enabled and self.captured_len < captured_capacity) {
+                    self.captured[self.captured_len] = @truncate(value);
+                    self.captured_len += 1;
+                    assert(self.captured_len <= captured_capacity);
+                }
+            },
             0x038 => self.imsc = @truncate(value),
             0x044 => {
                 self.ris &= ~@as(u32, @truncate(value));
-                if (self.rx_buf.items.len > 0) self.ris |= RX_INT;
+                if (self.rx_len > 0) self.ris |= RX_INT;
             },
             else => {},
         }
@@ -154,17 +195,17 @@ pub const Pl011 = struct {
         const offset = addr - self.base;
         switch (offset) {
             0x000 => {
-                if (self.rx_buf.items.len == 0) return 0;
-                const before = self.rx_buf.items.len;
-                const b = self.rx_buf.items[0];
-                std.mem.copyForwards(u8, self.rx_buf.items[0 .. self.rx_buf.items.len - 1], self.rx_buf.items[1..]);
-                self.rx_buf.items.len -= 1;
-                assert(self.rx_buf.items.len + 1 == before);
-                if (self.rx_buf.items.len == 0) self.ris &= ~RX_INT;
+                if (self.rx_len == 0) return 0;
+                const before = self.rx_len;
+                const b = self.rx_buf[0];
+                std.mem.copyForwards(u8, self.rx_buf[0 .. self.rx_len - 1], self.rx_buf[1..self.rx_len]);
+                self.rx_len -= 1;
+                assert(self.rx_len + 1 == before);
+                if (self.rx_len == 0) self.ris &= ~RX_INT;
                 return b;
             },
             0x018 => {
-                const rxfe: u64 = if (self.rx_buf.items.len == 0) (1 << 4) else 0;
+                const rxfe: u64 = if (self.rx_len == 0) (1 << 4) else 0;
                 return 0x80 | rxfe;
             },
             0x038 => return self.imsc,


### PR DESCRIPTION
## Problem

A recent no-allocator-on-hot-paths audit of the VM monitor found that **every byte the guest writes to its console, and every byte the host types into the guest, calls the heap allocator**.

The audit picked PL011 (the serial port the guest uses for console output and stdin) as the worst offender. Two pieces of state — captured guest output and the host-to-guest receive buffer — were both backed by growing arrays:

1. The vCPU thread runs `uart.write(...)` once per byte the guest prints (every `printk`, every shell prompt, every test banner). When the boot is configured to capture serial for test assertions, that write appends to a growing array. The allocator gets called on the vCPU thread, on every byte.
2. The stdin reader thread runs `uart.pushRx(...)` once per read from host stdin. Every paste, every keystroke, every line. Same growing array, same per-byte allocator call.

Production boots already side-step the captured-output path with a flag (`capture_enabled = false`) because we figured out it was hot. But it still costs the allocator in every test, and the receive path stays hot in every environment. More importantly, having a growable array on the vCPU thread is the kind of code that quietly turns into a memory-limit problem under load — there's no upper bound, no surprise, no warning.

TigerBeetle's coding rule for this kind of work is "no dynamic memory after init." Tail latency stops moving around, OOM windows close, the allocator stops appearing in vCPU stack traces.

## Solution

Replace the two growing arrays with fixed-capacity buffers, sized once at compile time, embedded directly in the PL011 struct. No allocator anywhere in the PL011 hot path.

1. **Captured serial buffer:** a 256 KiB inline buffer plus a length counter. 256 KiB matches the default capture-budget setting, and the run loop already breaks out before it fills.
2. **Receive FIFO:** a 4 KiB inline buffer plus a length counter. A real PL011 chip has a 32-byte FIFO; 4 KiB is far past any realistic typed-input or pasted-command burst. Bytes that don't fit are dropped at the tail — the same fail-soft policy a real UART uses when its FIFO overruns.

The PL011 struct grows from about 100 bytes to about 260 KB. It lives on the boot thread's stack, which is 8 MB on every supported platform, so there's plenty of headroom. A compile-time check documents the expected size so a future buffer-size bump catches the stack-pressure cost explicitly.

## Technical Summary

Four files changed. No behaviour change observable from outside the VMM.

### `packages/microvm/src/pl011.zig`

- New top-level constants `captured_capacity = 256 * 1024` and `rx_capacity = 4096`.
- `Pl011.captured: std.ArrayList(u8)` → `captured: [captured_capacity]u8 = undefined` + `captured_len: usize = 0`.
- `Pl011.rx_buf: std.ArrayList(u8)` → `rx_buf: [rx_capacity]u8 = undefined` + `rx_len: usize = 0`.
- `pushRx(self, gpa, bytes) !void` → `pushRx(self, bytes) void`. Drops bytes that don't fit, sets `RX_INT` in RIS iff any byte landed.
- `write(self, gpa, addr, value) !void` → `write(self, addr, value) void`. The DR-write path silently caps at `captured_capacity` (runLoop's break check fires first in practice).
- `read` and `irqAsserted` switch from `*.items.len` / `*.items` to `rx_len` / `rx_buf`.
- New `capturedBytes()` accessor returns `captured[0..captured_len]`; replaces every `captured.items` callsite.
- `deinit` removed (no-op without ArrayList).
- New comptime asserts: `@sizeOf(Pl011) >= captured_capacity + rx_capacity`, plus the existing wire-constant asserts.

### `packages/microvm/src/boot_hvf.zig` and `packages/microvm/src/boot_kvm.zig`

- `defer uart.deinit(gpa);` removed in both.
- `try uart.write(gpa, ...)` → `uart.write(...)` everywhere.
- `try uart.pushRx(gpa, ...)` → `uart.pushRx(...)` (and the surrounding `catch return;` drops).
- `devs.uart.captured.items.len` → `devs.uart.captured_len`; `devs.uart.captured.items` → `devs.uart.capturedBytes()`.
- `handlePl011Mmio` sheds its `gpa` parameter in both files; `routeDataAbort` (HVF) and `routeMmio` (KVM) also shed `gpa` because that was the only place they used it.
- `StdinThread` struct (HVF) sheds its `.gpa` field — only ever forwarded to `pushRx`.

### `packages/microvm/src/hvf.zig`

The boot test and the five PL011 RX-path unit tests all update to the new no-allocator API. Their previous `const gpa = std.testing.allocator;` declarations were only used for `deinit` / `write` / `pushRx` and become unreferenced — removed. `uart.captured.items` becomes `uart.capturedBytes()`; `uart.rx_buf.items.len` becomes `uart.rx_len`.

### Why this is safe

- The captured cap is reached cleanly: the run loop already breaks at `captured_len >= cfg.capture_bytes`, and both values default to 256 KiB. Production sets `capture_enabled = false`, so the buffer never fills there anyway.
- The RX cap is far above any realistic input: the kernel's PL011 driver reads bytes within microseconds of the RX interrupt firing. A 4 KB ring would only overflow under a stuck driver, which is exactly the case where dropping bytes is the right fail-soft.
- The Pl011 struct still uses `pub const init: Pl011 = .{ .base = ... }` — Zig's `undefined` initialiser leaves the buffer bytes unspecified, but they're never read past `len`.

### Tests

All 60 microvm Zig tests pass — including the existing HVF boot test, the five PL011 RX / IRQ / FIFO / PrimeCell-ID unit tests, and the AMBA bus-binding test. `vitest run` 644/644. `agent-ci run --all` green. `pnpm smoke-tests` pass.