### PR TITLE
refactor(runtime): write rootfs prebake into the runtime cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,7 @@ scripts/clonefile.o.o
 # Quickstart bake outputs and snapshot bundles. The example sources
 # (bake.ts, counter.mjs) are tracked; everything `node bake.ts` and
 # `mn-dev snapshot` produce is regenerable from those.
-examples/quickstart/counter.tar.gz
-examples/quickstart/counter.img
-examples/quickstart/snapshot-counter/
+examples/quickstart/artifacts/
 examples/quickstart/.claude/
 counter-snap/
 

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,57 @@
+# examples/quickstart
+
+Runnable companion to [docs/quickstart.md](../../docs/quickstart.md).
+Builds a Node HTTP server that counts requests in memory, boots it in
+a microVM, snapshots the running process, and restores it.
+
+The point of the demo: the counter only lives in the Node process's
+heap. After a snapshot/restore round-trip the next request still
+returns `{ count: N+1 }` — same heap, same TCP listener, same process,
+different VM.
+
+## 1. Bake the image
+
+```sh
+pnpm install
+pnpm -F @machinen/example-quickstart start
+```
+
+`bake.ts` calls `provision({ install })`, which boots the base Debian
+rootfs, runs `apt-get install nodejs` inside, drops `counter.mjs` at
+`/opt/counter.mjs`, and archives the result to
+`./artifacts/rootfs.tar.gz`. First run takes a couple of minutes; the
+bake script is a no-op after that.
+
+## 2. Boot it and give it state
+
+```sh
+npx machinen boot --name counter -p 3000:3000 --detach ./artifacts/rootfs.tar.gz
+curl localhost:3000     # { "count": 1 }
+curl localhost:3000     # { "count": 2 }
+```
+
+`--name counter` registers the VM under a stable handle. `-p 3000:3000`
+forwards the host port to the guest. `--detach` returns once the guest
+is up instead of holding the terminal.
+
+## 3. Snapshot and restore
+
+```sh
+npx machinen snapshot counter ./artifacts/snapshot
+npx machinen restore ./artifacts/snapshot -p 3000:3000 --detach
+curl localhost:3000     # { "count": 3 }
+```
+
+The third `curl` returns `{ count: 3 }` because the Node process picked
+up exactly where it left off — same heap, same listening socket. To
+move it to another host instead, `scp -r ./artifacts/snapshot host-b:`
+and run the restore there. Host architectures have to match (arm64 to
+arm64).
+
+## Files
+
+- `counter.mjs` — the trivial HTTP server. Gets copied into the rootfs
+  during the bake.
+- `bake.ts` — the `provision()` call that produces the rootfs tarball.
+- `artifacts/rootfs.tar.gz` — the baked rootfs (gitignored, ~100 MiB).
+- `artifacts/snapshot/` — written by `machinen snapshot` (gitignored).

--- a/examples/quickstart/bake.ts
+++ b/examples/quickstart/bake.ts
@@ -1,0 +1,40 @@
+// Step 1 of docs/quickstart.md — bake a Node + counter.mjs image.
+//
+//   pnpm -F @machinen/example-quickstart start
+//
+// Boots the base Debian rootfs, installs nodejs into it, drops
+// counter.mjs at /opt/counter.mjs, and writes the archived rootfs to
+// ./artifacts/rootfs.tar.gz. Idempotent: if the rootfs already exists
+// this is a no-op.
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { provision } from "@machinen/runtime";
+
+const here = dirname(new URL(import.meta.url).pathname);
+const artifactsDir = resolve(here, "artifacts");
+const rootfsPath = resolve(artifactsDir, "rootfs.tar.gz");
+const counterPath = resolve(here, "counter.mjs");
+
+if (existsSync(rootfsPath)) {
+  process.stderr.write(`bake: ${rootfsPath} already exists, skipping\n`);
+  process.exit(0);
+}
+
+mkdirSync(artifactsDir, { recursive: true });
+
+process.stderr.write("bake: installing nodejs into base rootfs (first run)\n");
+
+const result = await provision({
+  install: async (vm) => {
+    await vm.exec("apt-get update && apt-get install -y nodejs");
+    await vm.writeFile("/opt/counter.mjs", readFileSync(counterPath));
+  },
+  cmd: ["/usr/bin/node", "/opt/counter.mjs"],
+  out: rootfsPath,
+});
+
+process.stderr.write(
+  `bake: done in ${Math.round(result.elapsedMs / 1000)}s ` +
+    `(${Math.round(result.sizeBytes / 1024 / 1024)} MiB) → ${rootfsPath}\n`,
+);

--- a/examples/quickstart/counter.mjs
+++ b/examples/quickstart/counter.mjs
@@ -1,0 +1,10 @@
+import { createServer } from "node:http";
+
+let count = 0;
+
+createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ count: ++count }) + "\n");
+}).listen(3000, "0.0.0.0", () => {
+  console.log("counter: listening on 0.0.0.0:3000");
+});

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@machinen/example-quickstart",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --conditions=source --import tsx bake.ts"
+  },
+  "dependencies": {
+    "@machinen/runtime": "workspace:*"
+  }
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2348,7 +2348,7 @@ pids that aren't machinen-managed; those fall back to ps.
 
 ### ProvisionOptions
 
-Defined in: [provision.ts:52](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L52)
+Defined in: [provision.ts:55](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L55)
 
 #### Properties
 
@@ -2356,7 +2356,7 @@ Defined in: [provision.ts:52](https://github.com/redwoodjs/machinen/blob/main/pa
 
 > `optional` **base?**: `string`
 
-Defined in: [provision.ts:62](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L62)
+Defined in: [provision.ts:65](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L65)
 
 Path to the base rootfs tarball to start from. Typically the
 `rootfs-debian-arm64.tar.gz` produced by
@@ -2370,7 +2370,7 @@ cache at `~/.machinen/@machinen/runtime@<version>/bases/debian-arm64/`).
 
 > **install**: (`vm`) => `Promise`\<`void`\>
 
-Defined in: [provision.ts:67](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L67)
+Defined in: [provision.ts:70](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L70)
 
 User-supplied provisioning steps. Runs inside the guest via vsock.
 
@@ -2388,7 +2388,7 @@ User-supplied provisioning steps. Runs inside the guest via vsock.
 
 > **out**: `string`
 
-Defined in: [provision.ts:73](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L73)
+Defined in: [provision.ts:76](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L76)
 
 Output path for the resulting rootfs tarball. Will be overwritten.
 Consumed via `boot({ image: out })`.
@@ -2397,7 +2397,7 @@ Consumed via `boot({ image: out })`.
 
 > `optional` **cmd?**: `string`[]
 
-Defined in: [provision.ts:81](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L81)
+Defined in: [provision.ts:84](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L84)
 
 Default cmd baked into the image as `/machinen-config.json`.
 When the image is later booted via `boot({ image })` without a
@@ -2408,7 +2408,7 @@ user-supplied `cmd`, the guest runs this. User-supplied `cmd` on
 
 > `optional` **env?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:88](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L88)
+Defined in: [provision.ts:91](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L91)
 
 Default guest env baked into the image alongside `cmd`. Merged
 with `boot({ env })` at boot time, with the caller's `env`
@@ -2418,7 +2418,7 @@ overriding on key collision.
 
 > `optional` **binary?**: `string`
 
-Defined in: [provision.ts:94](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L94)
+Defined in: [provision.ts:97](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L97)
 
 Optional VMM binary path. Same lookup rules as `boot()` — if
 omitted, resolves `@machinen/vmm-<arch>-<os>`.
@@ -2427,7 +2427,7 @@ omitted, resolves `@machinen/vmm-<arch>-<os>`.
 
 > `optional` **cwd?**: `string`
 
-Defined in: [provision.ts:97](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L97)
+Defined in: [provision.ts:100](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L100)
 
 Working directory. Defaults to process.cwd().
 
@@ -2435,7 +2435,7 @@ Working directory. Defaults to process.cwd().
 
 > `optional` **scratchDiskSizeBytes?**: `number`
 
-Defined in: [provision.ts:104](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L104)
+Defined in: [provision.ts:107](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L107)
 
 Size of the scratch disk used to ferry the tarball from guest to
 host. Must be larger than the expected post-install rootfs size.
@@ -2445,7 +2445,7 @@ Default: 1 GiB (sparse, so it doesn't actually take that space).
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [provision.ts:111](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L111)
+Defined in: [provision.ts:114](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L114)
 
 Wall-clock ceiling for the whole build. If the install hook plus
 the final archive + shutdown doesn't finish in this window, we
@@ -2455,7 +2455,7 @@ SIGKILL the VMM and fail. Default: 10 minutes.
 
 > `optional` **vmmEnv?**: `Record`\<`string`, `string`\>
 
-Defined in: [provision.ts:118](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L118)
+Defined in: [provision.ts:121](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L121)
 
 Extra env passed to the VMM process on the host side. Useful for
 dev overrides like `MACHINEN_BOOT_TEST`. Distinct from `env`,
@@ -2465,7 +2465,7 @@ which bakes guest-workload env into the produced image.
 
 > `optional` **kernel?**: `string`
 
-Defined in: [provision.ts:126](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L126)
+Defined in: [provision.ts:129](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L129)
 
 Path to the guest kernel. Optional — when omitted, `provision()`
 resolves it via `resolveBaseKernel()` (MACHINEN_ASSETS_DIR override,
@@ -2476,7 +2476,7 @@ falling back to the `@machinen/cli` cache). Same semantics as
 
 > `optional` **dtb?**: `string`
 
-Defined in: [provision.ts:132](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L132)
+Defined in: [provision.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L135)
 
 Path to the guest DTB. Optional — when omitted, resolved via
 `resolveBaseDtb()` from the same fallback chain as `kernel`.
@@ -2485,7 +2485,7 @@ Path to the guest DTB. Optional — when omitted, resolved via
 
 > `optional` **onLog?**: [`OnLog`](#onlog)
 
-Defined in: [provision.ts:140](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L140)
+Defined in: [provision.ts:143](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L143)
 
 Streaming log callback — fires for every byte of guest output
 during the build: guest kernel console, every `vm.exec()` call
@@ -2496,7 +2496,7 @@ See `LogEvent.source` to tell them apart. See #83.
 
 ### ProvisionResult
 
-Defined in: [provision.ts:143](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L143)
+Defined in: [provision.ts:146](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L146)
 
 #### Properties
 
@@ -2504,7 +2504,7 @@ Defined in: [provision.ts:143](https://github.com/redwoodjs/machinen/blob/main/p
 
 > **imagePath**: `string`
 
-Defined in: [provision.ts:145](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L145)
+Defined in: [provision.ts:148](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L148)
 
 Absolute path to the output tarball.
 
@@ -2512,7 +2512,7 @@ Absolute path to the output tarball.
 
 > **sizeBytes**: `number`
 
-Defined in: [provision.ts:148](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L148)
+Defined in: [provision.ts:151](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L151)
 
 Size of the output tarball in bytes.
 
@@ -2520,7 +2520,7 @@ Size of the output tarball in bytes.
 
 > **elapsedMs**: `number`
 
-Defined in: [provision.ts:151](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L151)
+Defined in: [provision.ts:154](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L154)
 
 Wall-clock time from build() entry to return.
 
@@ -2965,7 +2965,7 @@ ms epoch when the entry was created.
 
 ### EnsureRootfsImageOptions
 
-Defined in: [rootfs-img.ts:135](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L135)
+Defined in: [rootfs-img.ts:134](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L134)
 
 #### Properties
 
@@ -2973,7 +2973,7 @@ Defined in: [rootfs-img.ts:135](https://github.com/redwoodjs/machinen/blob/main/
 
 > `optional` **cacheDir?**: `string`
 
-Defined in: [rootfs-img.ts:140](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L140)
+Defined in: [rootfs-img.ts:139](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L139)
 
 Override the cache directory. Default: `~/.cache/machinen/rootfs`.
 Useful for tests.
@@ -2982,7 +2982,7 @@ Useful for tests.
 
 > `optional` **force?**: `boolean`
 
-Defined in: [rootfs-img.ts:145](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L145)
+Defined in: [rootfs-img.ts:144](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L144)
 
 Force re-materialization even if a cached image is already present.
 Mostly for debugging the materializer.
@@ -2991,7 +2991,7 @@ Mostly for debugging the materializer.
 
 > `optional` **sizeMultiplier?**: `number`
 
-Defined in: [rootfs-img.ts:155](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L155)
+Defined in: [rootfs-img.ts:154](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L154)
 
 Slack multiplier above the unpacked tarball size when sizing the
 ext4 filesystem. Default: 2.5 — leaves enough room for the guest
@@ -3005,7 +3005,7 @@ to fill the filesystem.
 
 > `optional` **minSizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:163](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L163)
+Defined in: [rootfs-img.ts:162](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L162)
 
 Minimum image size in bytes. The materializer enforces at least
 this for small rootfs where the multiplier alone would leave
@@ -3017,7 +3017,7 @@ insufficient room for a real workload. Default: 2 GiB — boot-time
 
 > `optional` **sizeBytes?**: `number`
 
-Defined in: [rootfs-img.ts:171](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L171)
+Defined in: [rootfs-img.ts:170](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L170)
 
 Absolute target size in bytes. When set, overrides `sizeMultiplier`
 and `minSizeBytes` entirely — fresh materializations get exactly
@@ -3029,7 +3029,7 @@ For the user-facing `boot({ rootDiskSizeBytes })` knob (#131).
 
 > `optional` **onPhase?**: (`name`, `ms`) => `void`
 
-Defined in: [rootfs-img.ts:179](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L179)
+Defined in: [rootfs-img.ts:178](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L178)
 
 Sub-phase callback for the caller's PhaseTimer (#233 follow-up).
 Fires for each measurable internal step: `sha256`, `e2fsck`,
@@ -6475,7 +6475,7 @@ readonly (`number` \| [`RssTarget`](#rsstarget))[]
 
 > **resolveBaseRootfs**(`explicit?`, `cwd?`): `string`
 
-Defined in: [provision.ts:200](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L200)
+Defined in: [provision.ts:203](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L203)
 
 Resolve the path to the base rootfs tarball, in the same order
 `provision()` itself does:
@@ -6516,7 +6516,7 @@ PROVISION_BASE_NOT_FOUND | PROVISION_ASSETS_DIR_INVALID
 
 > **resolveBaseKernel**(`explicit?`, `cwd?`): `string`
 
-Defined in: [provision.ts:223](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L223)
+Defined in: [provision.ts:226](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L226)
 
 Resolve the path to the guest kernel Image. Same fallback chain as
 `resolveBaseRootfs`: explicit → `MACHINEN_ASSETS_DIR/Image-arm64` →
@@ -6548,7 +6548,7 @@ PROVISION_KERNEL_NOT_FOUND |
 
 > **resolveBaseDtb**(`explicit?`, `cwd?`): `string`
 
-Defined in: [provision.ts:245](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L245)
+Defined in: [provision.ts:248](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L248)
 
 Resolve the path to the guest DTB. Same fallback chain as
 `resolveBaseRootfs`: explicit → `MACHINEN_ASSETS_DIR/virt-arm64.dtb` →
@@ -6579,7 +6579,7 @@ PROVISION_DTB_NOT_FOUND |
 
 > **provision**(`opts`): `Promise`\<[`ProvisionResult`](#provisionresult)\>
 
-Defined in: [provision.ts:325](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L325)
+Defined in: [provision.ts:328](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/provision.ts#L328)
 
 Boot the base rootfs, run the user install hook, and freeze the
 resulting filesystem state to a new tarball at `opts.out`.
@@ -6664,7 +6664,7 @@ effect, so a crashed VMM doesn't leave a stuck record behind.
 
 > **rootfsImgCacheDir**(): `string`
 
-Defined in: [rootfs-img.ts:86](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L86)
+Defined in: [rootfs-img.ts:85](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L85)
 
 Default cache root: `~/.cache/machinen/rootfs`.
 
@@ -6678,7 +6678,7 @@ Default cache root: `~/.cache/machinen/rootfs`.
 
 > **markRootfsImageClean**(`imgPath`): `void`
 
-Defined in: [rootfs-img.ts:106](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L106)
+Defined in: [rootfs-img.ts:105](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L105)
 
 Mark a cached rootfs image as "cleanly released" by writing the
 sentinel that `ensureRootfsImage()` looks for on the next boot.
@@ -6707,7 +6707,7 @@ but never wrong.
 
 > **ensureRootfsImage**(`tarPath`, `opts?`): `string`
 
-Defined in: [rootfs-img.ts:205](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L205)
+Defined in: [rootfs-img.ts:204](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L204)
 
 Resolve `tarPath` to a cached ext4 `.img`, materializing it on first
 call. Returns the absolute path to the cached image.
@@ -6753,17 +6753,15 @@ ROOTFS_IMG_TOOL_MISSING (no e2fsprogs found)
 
 > **resolveMke2fs**(): `string`
 
-Defined in: [rootfs-img.ts:744](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L744)
+Defined in: [rootfs-img.ts:717](https://github.com/redwoodjs/machinen/blob/main/packages/runtime/src/rootfs-img.ts#L717)
 
 Resolve the mke2fs binary path using the same lookup order as
 `ensureRootfsImage` itself: env override → bundled package → PATH →
 Homebrew keg-only. Returns `undefined` when no binary is available
 (callers should treat this as "skip the optimization", not an error).
 
-Exported so `provision()` can prebake an `<out>.img.gz` sibling
-alongside its `<out>.tar.gz` output (#233 follow-up). Without that,
-every fresh `provision()` invalidates the cached `<sha>.img` and the
-next `boot()` pays ~10 s for tar-extract + mke2fs.
+Exported so other tools that need to run mke2fs (e.g. `mountdisk-img`)
+resolve the binary through the same lookup chain.
 
 #### Returns
 

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -32,7 +32,7 @@ import {
   markRootfsImageClean,
   ProvisionError,
 } from "../index.ts";
-import { _rootfsImgInternal as _internal } from "../rootfs-img.ts";
+import { _rootfsImgInternal as _internal, prebakeRootfsImageFromTree } from "../rootfs-img.ts";
 
 describe("ensureRootfsImage", () => {
   it("throws PROVISION_BASE_NOT_FOUND when the tarball is missing", () => {
@@ -409,40 +409,16 @@ describe("ensureRootfsImage", () => {
     }
   }
 
-  it("siblingPrebakePath strips .tar.gz / .tgz / .tar and falls back to .img.gz", () => {
-    // No on-disk sibling → defaults to the gzipped form.
-    expect(_internal.siblingPrebakePath("/r/rootfs.tar.gz")).toEqual({
-      path: "/r/rootfs.img.gz",
-      gzipped: true,
-    });
-    expect(_internal.siblingPrebakePath("/r/rootfs.tgz")).toEqual({
-      path: "/r/rootfs.img.gz",
-      gzipped: true,
-    });
-    expect(_internal.siblingPrebakePath("/r/rootfs.tar")).toEqual({
-      path: "/r/rootfs.img.gz",
-      gzipped: true,
-    });
+  it("siblingPrebakePath strips .tar.gz / .tgz / .tar and points at .img.gz", () => {
+    // Only the gzipped release-build sibling form is recognized;
+    // provision() writes its prebake into the runtime cache directly.
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar.gz")).toBe("/r/rootfs.img.gz");
+    expect(_internal.siblingPrebakePath("/r/rootfs.tgz")).toBe("/r/rootfs.img.gz");
+    expect(_internal.siblingPrebakePath("/r/rootfs.tar")).toBe("/r/rootfs.img.gz");
     // Non-tarball paths return undefined — no prebake convention exists
     // for them, so the runtime falls through to the materialize path.
     expect(_internal.siblingPrebakePath("/r/rootfs")).toBeUndefined();
     expect(_internal.siblingPrebakePath("/r/rootfs.zip")).toBeUndefined();
-  });
-
-  it("siblingPrebakePath prefers an uncompressed .img sibling when present", () => {
-    const dir = mkdtempSync(join(tmpdir(), "ensure-img-sibling-prefer-"));
-    try {
-      const tarPath = join(dir, "app.tar.gz");
-      const imgPath = join(dir, "app.img");
-      writeFileSync(tarPath, Buffer.from("not actually a tarball"));
-      writeFileSync(imgPath, Buffer.from("not actually an image"));
-      expect(_internal.siblingPrebakePath(tarPath)).toEqual({
-        path: imgPath,
-        gzipped: false,
-      });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
   });
 
   it("uses a sibling .img.gz to populate the cache and skips mke2fs", () => {
@@ -562,6 +538,71 @@ describe("ensureRootfsImage", () => {
       rmSync(cacheDir, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("prebakeRootfsImageFromTree leaves an existing cache image untouched", () => {
+    // Don't clobber a `<sha>.img` that a concurrent boot() might have
+    // open via virtio-blk. Renaming over an in-use inode would leave
+    // that boot writing dead bytes while the next boot reads ours.
+    const tarPath = `/tmp/machinen-rootfs-prebake-skip-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-skip-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-skip-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-skip-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const imgPath = join(cacheDir, `${sha}.img`);
+      const sentinel = Buffer.from("do not overwrite me");
+      writeFileSync(imgPath, sentinel);
+
+      prebakeRootfsImageFromTree({ tarPath, treeDir: tmpDir, cacheDir });
+
+      // File is byte-identical — no mke2fs ran.
+      expect(readFileSync(imgPath)).toEqual(sentinel);
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prebakeRootfsImageFromTree no-ops when no mke2fs is available", () => {
+    // Best-effort contract: missing tooling logs and returns, never
+    // throws. We point MACHINEN_MKE2FS at a non-existent path —
+    // resolveMke2fsEnvOverride() throws ProvisionError in that case,
+    // and prebakeRootfsImageFromTree must swallow it.
+    const tarPath = `/tmp/machinen-rootfs-prebake-nomke-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-nomke-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-nomke-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-nomke-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      expect(() =>
+        prebakeRootfsImageFromTree({ tarPath, treeDir: tmpDir, cacheDir }),
+      ).not.toThrow();
+      // No cache file produced.
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      expect(existsSync(join(cacheDir, `${sha}.img`))).toBe(false);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
 
   it("preserves the sticky bit on /tmp during extract (#262)", () => {
     // BSD tar (the macOS default) applies the host umask when extracting

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -21,14 +21,13 @@
 //     cmd: ["/bin/sh"],
 //   });
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
   mkdtempSync,
   openSync,
   readFileSync,
-  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -44,7 +43,11 @@ import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot, warmImageConfigCache } from "./vm/index.ts";
 import type { VmHandle } from "./vm-handle.ts";
-import { ensureRootfsImage, markRootfsImageClean, resolveMke2fs } from "./rootfs-img.ts";
+import {
+  ensureRootfsImage,
+  markRootfsImageClean,
+  prebakeRootfsImageFromTree,
+} from "./rootfs-img.ts";
 
 const debug = debugLib("machinen:provision");
 const vmmDebug = debugLib("machinen:vmm");
@@ -586,7 +589,7 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
  * across hosts is a nice-to-have we can layer on later if it ever
  * matters (swap in a Node-side tar writer).
  *
- * #233 follow-up: also emits a `<out>.img.gz` prebake sibling. The
+ * #233 follow-up: also prebakes the runtime cache image. The
  * extracted tree is already on disk for re-tar; mke2fs from it costs
  * a few seconds and saves ~10 s on every subsequent `boot()` of this
  * tarball (the cached `<sha>.img` would otherwise miss on every
@@ -629,94 +632,14 @@ function repackDiskTarToGz(
       stdio: ["ignore", "ignore", "inherit"],
     });
     opts.onPhase?.("targz", Date.now() - tarT0);
-    emitPrebakeSibling(extractDir, outAbs, opts.onPhase);
+    prebakeRootfsImageFromTree({
+      tarPath: outAbs,
+      treeDir: extractDir,
+      onPhase: opts.onPhase,
+    });
   } finally {
     try {
       rmSync(extractDir, { recursive: true, force: true });
     } catch {}
   }
-}
-
-/**
- * Build `<outAbs>.img` from the already-extracted rootfs tree so the
- * next `boot()` against `<outAbs>` hits `tryPrebakeFromSibling` and
- * reflinks the file straight into the cache instead of cold-materialize
- * (tar-extract + mke2fs ≈ 10 s on a typical dev rootfs).
- *
- * We emit the uncompressed `.img` form (sparse, ~500 MB on disk for a
- * 2 GiB allocated image with a typical Debian rootfs) rather than the
- * gzipped `.img.gz` form release builds use: the prebake then reflinks
- * from sibling to cache in milliseconds, vs ~2 s for `gunzip`. Build-
- * time gzip would also add ~25 s on a single-threaded host. Disk cost
- * is similar — gzip(.img) and sparse(.img) both land ~500 MB on APFS.
- *
- * Best-effort: any failure (no mke2fs binary, mke2fs error, unexpected
- * outAbs suffix) is logged and swallowed; the tarball alone is still
- * a complete provision output, the next boot just falls back to the
- * slow materialize path.
- */
-function emitPrebakeSibling(
-  treeDir: string,
-  outAbs: string,
-  onPhase?: (name: string, ms: number) => void,
-): void {
-  const mke2fs = resolveMke2fs();
-  if (!mke2fs) {
-    debug("prebake skip: no mke2fs available");
-    return;
-  }
-  const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(outAbs);
-  if (!m) {
-    debug("prebake skip: outAbs %s lacks a recognized tarball suffix", outAbs);
-    return;
-  }
-  const prebakePath = `${m[1]}.img`;
-  const tmpImg = `${prebakePath}.tmp.${process.pid}`;
-
-  try {
-    const treeBytes = duBytes(treeDir);
-    const sizeBytes = Math.max(2 * 1024 * 1024 * 1024, Math.ceil(treeBytes * 2.5));
-    allocateSparseFile(tmpImg, sizeBytes);
-
-    const blocks = Math.floor(sizeBytes / 4096);
-    const mkT0 = Date.now();
-    const mk = spawnSync(
-      mke2fs,
-      ["-d", treeDir, "-t", "ext4", "-F", "-q", "-b", "4096", tmpImg, String(blocks)],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
-    onPhase?.("prebake.mke2fs", Date.now() - mkT0);
-    if (mk.status !== 0) {
-      debug(
-        "prebake mke2fs failed status=%s stderr=%s",
-        mk.status,
-        mk.stderr?.toString().slice(0, 200) ?? "",
-      );
-      return;
-    }
-
-    renameSync(tmpImg, prebakePath);
-    debug("prebake emitted prebake=%s sizeBytes=%d", prebakePath, sizeBytes);
-  } catch (err) {
-    debug("prebake error err=%s", (err as Error).message);
-  } finally {
-    try {
-      rmSync(tmpImg, { force: true });
-    } catch {}
-  }
-}
-
-/**
- * `du -sk <path>` in bytes. Mirrors the helper in rootfs-img.ts;
- * duplicated here to keep that module's surface narrow.
- */
-function duBytes(path: string): number {
-  try {
-    const out = execFileSync("du", ["-sk", path], { encoding: "utf8" }).trim();
-    const kib = parseInt(out.split(/\s+/, 1)[0]!, 10);
-    if (Number.isFinite(kib) && kib > 0) {
-      return kib * 1024;
-    }
-  } catch {}
-  return statSync(path).size || 0;
 }

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -78,7 +78,6 @@ import { arch, homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
-import { reflinkCopy } from "./reflink.ts";
 
 const debug = debugLib("machinen:rootfs-img");
 
@@ -274,30 +273,26 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
     }
   }
 
-  // #223 + #233: prebake fast path. If a sibling `<basename>.img` (or
-  // `<basename>.img.gz`) sits next to the tarball, populate the cache
-  // from it and skip tar+mke2fs. The bytes are an ext4 image; the
-  // cache key (tarball sha) is the same one the materialize path
+  // #223: prebake fast path. If a sibling `<basename>.img.gz` sits
+  // next to the tarball (shipped with release builds), gunzip it
+  // into the cache and skip tar+mke2fs. The bytes are an ext4 image;
+  // the cache key (tarball sha) is the same one the materialize path
   // would write to, so downstream (per-boot reflink, sparse-extend,
-  // .ok marker) is unchanged. The uncompressed form (emitted by
-  // provision()) reflinks in essentially for free; the gzipped form
-  // (shipped with releases) has to gunzip.
+  // .ok marker) is unchanged. Locally `provision()`-built tarballs
+  // skip this branch — provision() writes the cache image directly
+  // via prebakeRootfsImageFromTree() instead of staging a sibling.
   if (!opts.force) {
     const sibling = siblingPrebakePath(tarAbs);
-    if (sibling && existsSync(sibling.path)) {
+    if (sibling && existsSync(sibling)) {
       const prebakeT0 = Date.now();
       const fast = tryPrebakeFromSibling({
-        sibling: sibling.path,
-        gzipped: sibling.gzipped,
+        sibling,
         cacheDir,
         sha,
         imgPath,
         sizeBytes: opts.sizeBytes,
       });
-      opts.onPhase?.(
-        sibling.gzipped ? "gunzip-prebake" : "reflink-prebake",
-        Date.now() - prebakeT0,
-      );
+      opts.onPhase?.("gunzip-prebake", Date.now() - prebakeT0);
       if (fast) {
         return fast;
       }
@@ -592,80 +587,60 @@ function duBytes(path: string): number {
   return statSync(path).size || 0;
 }
 
-// Resolve the prebake sibling next to a tarball. Two forms exist:
-//   * `<basename>.img` — uncompressed, sparse. Emitted by `provision()`
-//     (#233 follow-up): reflinks straight into the cache, near-zero
-//     handoff cost. Use this when both files live on the same APFS /
-//     reflink-capable volume.
-//   * `<basename>.img.gz` — gzipped. Shipped by build-base-assets.sh
-//     for release tarballs where download size matters more than
-//     decompress speed.
-// Prefer the uncompressed form when present; fall back to the gzipped
-// form. Returns undefined when neither suffix matches the input path.
-function siblingPrebakePath(tarAbs: string): { path: string; gzipped: boolean } | undefined {
+// Resolve the prebake sibling next to a tarball. Only one form is
+// supported: `<basename>.img.gz` — gzipped ext4 image, shipped by
+// build-base-assets.sh for release tarballs where download size
+// matters more than decompress speed. Returns undefined when the
+// input path doesn't end in a recognized tarball suffix.
+//
+// `provision()` no longer emits an uncompressed sibling; it writes
+// the prebake straight into the runtime cache via
+// `prebakeRootfsImageFromTree()` instead.
+function siblingPrebakePath(tarAbs: string): string | undefined {
   const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(tarAbs);
   if (!m) {
     return undefined;
   }
-  const stem = m[1];
-  const uncompressed = `${stem}.img`;
-  if (existsSync(uncompressed)) {
-    return { path: uncompressed, gzipped: false };
-  }
-  return { path: `${stem}.img.gz`, gzipped: true };
+  return `${m[1]}.img.gz`;
 }
 
-// Populate the cache from a prebuilt sibling. Two shapes:
-//   * gzipped=true  — `<base>.img.gz` from a release build. Decompress
-//                     into a staging file with `gunzip -c`.
-//   * gzipped=false — `<base>.img` from `provision()`. Reflink-copy
-//                     directly into the staging file (instant on APFS
-//                     when the sibling and cache live on one volume).
-// Either way we sniff ext4 magic before the atomic rename — a corrupt
-// sibling shouldn't poison the cache. Any failure returns undefined
-// and the caller falls through to the slow materialize path.
+// Populate the cache from a release-built `<base>.img.gz` sibling.
+// Decompresses into a staging file with `gunzip -c`, sniffs ext4
+// magic so a corrupt sibling can't poison the cache, then atomically
+// renames into place. Any failure returns undefined and the caller
+// falls through to the slow materialize path.
 function tryPrebakeFromSibling(args: {
   sibling: string;
-  gzipped: boolean;
   cacheDir: string;
   sha: string;
   imgPath: string;
   sizeBytes?: number;
 }): string | undefined {
-  const { sibling, gzipped, cacheDir, sha, imgPath, sizeBytes } = args;
+  const { sibling, cacheDir, sha, imgPath, sizeBytes } = args;
   const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-prebake-`));
   const stagingImg = join(stagingDir, "rootfs.img");
   try {
-    debug("prebake try sibling=%s gzipped=%s sha=%s", sibling, gzipped, sha.slice(0, 12));
-    if (gzipped) {
-      const dstFd = openSync(stagingImg, "w");
-      let gunzipOk = false;
-      try {
-        const r = spawnSync("gunzip", ["-c", sibling], {
-          stdio: ["ignore", dstFd, "pipe"],
-        });
-        gunzipOk = r.status === 0;
-        if (!gunzipOk) {
-          debug(
-            "prebake gunzip failed sibling=%s status=%s stderr=%s",
-            sibling,
-            r.status,
-            r.stderr?.toString().slice(0, 200) ?? "",
-          );
-        }
-      } finally {
-        closeSync(dstFd);
-      }
+    debug("prebake try sibling=%s sha=%s", sibling, sha.slice(0, 12));
+    const dstFd = openSync(stagingImg, "w");
+    let gunzipOk = false;
+    try {
+      const r = spawnSync("gunzip", ["-c", sibling], {
+        stdio: ["ignore", dstFd, "pipe"],
+      });
+      gunzipOk = r.status === 0;
       if (!gunzipOk) {
-        return undefined;
+        debug(
+          "prebake gunzip failed sibling=%s status=%s stderr=%s",
+          sibling,
+          r.status,
+          r.stderr?.toString().slice(0, 200) ?? "",
+        );
       }
-    } else {
-      try {
-        reflinkCopy(sibling, stagingImg);
-      } catch (err) {
-        debug("prebake reflink failed sibling=%s err=%s", sibling, (err as Error).message);
-        return undefined;
-      }
+    } finally {
+      closeSync(dstFd);
+    }
+    if (!gunzipOk) {
+      return undefined;
     }
     // Sniff ext4 magic so a corrupted / wrong-content sibling can't
     // pollute the cache. We don't run e2fsck here — the build
@@ -736,16 +711,101 @@ function allocateSparseFile(path: string, sizeBytes: number): void {
  * Homebrew keg-only. Returns `undefined` when no binary is available
  * (callers should treat this as "skip the optimization", not an error).
  *
- * Exported so `provision()` can prebake an `<out>.img.gz` sibling
- * alongside its `<out>.tar.gz` output (#233 follow-up). Without that,
- * every fresh `provision()` invalidates the cached `<sha>.img` and the
- * next `boot()` pays ~10 s for tar-extract + mke2fs.
+ * Exported so other tools that need to run mke2fs (e.g. `mountdisk-img`)
+ * resolve the binary through the same lookup chain.
  */
 export function resolveMke2fs(): string | undefined {
   const names = ["mke2fs", "mkfs.ext4"];
   return (
     resolveMke2fsEnvOverride() ?? findBundledMke2fs() ?? whichFirst(names) ?? findKegOnlyE2fs(names)
   );
+}
+
+/**
+ * Pre-populate the runtime cache image for `tarPath` from an already-
+ * extracted source `treeDir`, skipping the materialize path on the
+ * next `ensureRootfsImage()` for the same tarball. Called by
+ * `provision()` right after it writes the tarball — re-uses the
+ * staging tree it has on hand so the cost is just one mke2fs pass
+ * (~3 s) instead of tar-extract + mke2fs (~10 s) on first boot.
+ *
+ * Hashes the tarball to derive the cache key, runs mke2fs on
+ * `treeDir` directly into a staging file under the cache, atomically
+ * renames into `<cacheDir>/<sha>.img`, then writes the `.ok` clean-
+ * shutdown marker (the freshly-built fs has never been mounted, so
+ * it's clean by definition).
+ *
+ * Best-effort: no mke2fs binary, mke2fs error, or hash failure is
+ * logged and swallowed; the next boot just pays the cold materialize
+ * cost. Skipped entirely when a usable cache image already exists
+ * for this sha — avoids racing a concurrent `boot()` that has the
+ * file open via virtio-blk.
+ */
+export function prebakeRootfsImageFromTree(args: {
+  tarPath: string;
+  treeDir: string;
+  cacheDir?: string;
+  onPhase?: (name: string, ms: number) => void;
+}): void {
+  const { tarPath, treeDir, onPhase } = args;
+  const cacheDir = args.cacheDir ?? rootfsImgCacheDir();
+
+  try {
+    const mke2fs = resolveMke2fs();
+    if (!mke2fs) {
+      debug("prebake skip: no mke2fs available");
+      return;
+    }
+
+    mkdirSync(cacheDir, { recursive: true });
+    const shaT0 = Date.now();
+    const sha = sha256OfFile(tarPath);
+    onPhase?.("prebake.sha256", Date.now() - shaT0);
+    const imgPath = join(cacheDir, `${sha}.img`);
+    if (existsSync(imgPath)) {
+      // Skip when the cache is already populated — a concurrent boot()
+      // may have the file open via virtio-blk, and renaming over it
+      // would leave that boot writing to a dead inode while the next
+      // boot reads our fresh bytes.
+      debug("prebake skip: cache already populated sha=%s", sha.slice(0, 12));
+      return;
+    }
+
+    const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-prebake-tree-`));
+    const stagingImg = join(stagingDir, "rootfs.img");
+    try {
+      const treeBytes = duBytes(treeDir);
+      const sizeBytes = Math.max(2 * 1024 * 1024 * 1024, Math.ceil(treeBytes * 2.5));
+      allocateSparseFile(stagingImg, sizeBytes);
+
+      const blocks = Math.floor(sizeBytes / 4096);
+      const mkT0 = Date.now();
+      const mk = spawnSync(
+        mke2fs,
+        ["-d", treeDir, "-t", "ext4", "-F", "-q", "-b", "4096", stagingImg, String(blocks)],
+        { stdio: ["ignore", "ignore", "pipe"] },
+      );
+      onPhase?.("prebake.mke2fs", Date.now() - mkT0);
+      if (mk.status !== 0) {
+        debug(
+          "prebake mke2fs failed status=%s stderr=%s",
+          mk.status,
+          mk.stderr?.toString().slice(0, 200) ?? "",
+        );
+        return;
+      }
+
+      renameSync(stagingImg, imgPath);
+      markRootfsImageClean(imgPath);
+      debug("prebake emitted cache=%s sizeBytes=%d", imgPath, sizeBytes);
+    } finally {
+      try {
+        rmSync(stagingDir, { recursive: true, force: true });
+      } catch {}
+    }
+  } catch (err) {
+    debug("prebake error err=%s", (err as Error).message);
+  }
 }
 
 // Visible to tests that want to assert without invoking the real

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -264,12 +264,19 @@ export async function restore(opts: RestoreOptions): Promise<VmHandle> {
     // sparse extension keeps /dev/vdb at SNAP_SCRATCH_BYTES so chained
     // `vm.snapshot()` against this VM has scratch room (its mkfs.ext4
     // happily ignores tar bytes at the front).
+    //
+    // --no-xattrs: on darwin, Gatekeeper auto-tags files extracted by
+    // `machinen snapshot` with `com.apple.provenance`, and bsdtar then
+    // embeds them as `LIBARCHIVE.xattr.*` extended headers — which
+    // GNU tar in the guest warns about once per file ("Ignoring
+    // unknown extended header keyword"). CRIU images don't need
+    // xattrs, so drop them at pack time.
     scratchPath = join(
       tmpdir(),
       `machinen-restore-bundle-${process.pid}-${randomBytes(6).toString("hex")}.tar`,
     );
     try {
-      execFileSync("tar", ["-cf", scratchPath, "-C", imgDir, "."]);
+      execFileSync("tar", ["--no-xattrs", "-cf", scratchPath, "-C", imgDir, "."]);
       const fd = openSync(scratchPath, "r+");
       try {
         const buf = Buffer.alloc(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtime
 
+  examples/quickstart:
+    dependencies:
+      '@machinen/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+
   packages/cli:
     dependencies:
       '@machinen/runtime':


### PR DESCRIPTION
## Problem

Running `provision()` left behind a 2 GB sparse `rootfs.img` file sitting next to the `rootfs.tar.gz` it produced. For the quickstart example, that meant a giant unexplained file in `examples/quickstart/artifacts/` right next to the tarball — users would notice it and wonder why a build output was so large. The `.img` was actually a cache: a pre-built ext4 filesystem image so the next `boot()` could skip about ten seconds of unpacking the tarball and running `mke2fs`. The optimization was fine, but it had no business living in the user-facing artifacts directory.

## Solution

Write the cache image straight into the runtime cache at `~/.cache/machinen/rootfs/<sha>.img` — the same place the runtime would have built it on the first boot anyway. Nothing is left next to the tarball.

1. After `provision()` writes the tarball, hash the tarball to derive the cache key, then build the cache image from the staging tree it already has on hand. The next `boot()` for that tarball gets a cache hit and skips the slow materialize step.
2. Skip the build entirely when the cache already has an image for this tarball. This avoids the case where a concurrent `boot()` is holding the cache file open and we'd otherwise rename a fresh file in over it.
3. Delete the old code that wrote the sibling `.img` next to the tarball, and the lookup branch in the runtime that picked it up. Release tarballs still ship a separate gzipped `.img.gz` sibling for fast first-boot on a fresh machine, and that path is unchanged.

## Technical Summary

- `prebakeRootfsImageFromTree({ tarPath, treeDir, cacheDir?, onPhase? })` added to `packages/runtime/src/rootfs-img.ts`. Hashes the tarball, runs `mke2fs -d` from the staging tree into a temp file inside the cache directory, atomically renames to `<sha>.img`, then writes the `.ok` clean-shutdown marker so the next boot treats the cache as trustworthy. Best-effort: any failure (no `mke2fs` available, `mke2fs` error, hash failure, missing `MACHINEN_MKE2FS` override) is logged and swallowed — the tarball alone is still a valid provision output and the next boot just pays the cold cost.
- `repackDiskTarToGz` in `packages/runtime/src/provision.ts` calls the new helper with the same staging tree it already used to re-tar the rootfs. `emitPrebakeSibling` and the duplicated `duBytes` helper are removed, along with the now-unused `spawnSync` and `renameSync` imports.
- `siblingPrebakePath` in `rootfs-img.ts` no longer looks for an uncompressed `.img` sibling — only the release-build `.img.gz` form. Return type collapses from `{ path, gzipped } | undefined` to `string | undefined`. `tryPrebakeFromSibling` drops its `reflink` branch and the unused `reflinkCopy` import; only the `gunzip` path remains.
- Two new tests in `rootfs-img.test.ts`: one asserts `prebakeRootfsImageFromTree` leaves an existing cache file byte-for-byte untouched (the concurrency safety property), and one asserts it no-ops without throwing when `MACHINEN_MKE2FS` points at a non-existent path (the best-effort contract). The old "prefers uncompressed sibling" test is removed; the gzipped-fallback test stays.
- `packages/runtime/API.md` regenerated by `pnpm run build:docs` to track the JSDoc rename of `resolveMke2fs`'s comment.

## Verification

- `npx vitest run`: 645 / 645 passing.
- `npx agent-ci run --all -q -p`: 9 / 9 workflows pass.
- `pnpm smoke-tests`: T1 fails with `boot vm exited 137 before reaching ready`. Reproduced on a stashed clean `main` checkout — pre-existing VMM/HVF codesigning issue, not caused by this change.