### PR TITLE
Add POSIX advisory locks to liveMount FUSE (closes #322)

### DIFF
--- a/packages/runtime/src/__tests__/mount-fuse-protocol.test.ts
+++ b/packages/runtime/src/__tests__/mount-fuse-protocol.test.ts
@@ -9,14 +9,18 @@
 import { describe, expect, it } from "vitest";
 import {
   DT,
+  F_LCK,
   FUSE_ATTR_OUT_SIZE,
   FUSE_ATTR_SIZE,
   FUSE_CAP,
   FUSE_ENTRY_OUT_SIZE,
+  FUSE_FILE_LOCK_SIZE,
   FUSE_INIT_OUT_SIZE,
   FUSE_IN_HEADER_SIZE,
   FUSE_KERNEL_MINOR_VERSION,
   FUSE_KERNEL_VERSION,
+  FUSE_LK_IN_SIZE,
+  FUSE_LK_OUT_SIZE,
   FUSE_OP,
   FUSE_OUT_HEADER_SIZE,
   buildAttrOut,
@@ -24,6 +28,7 @@ import {
   buildEntryOut,
   buildErrorResponse,
   buildInitOut,
+  buildLkOut,
   buildOpenOut,
   buildResponse,
   payloadOf,
@@ -33,6 +38,7 @@ import {
   readGetattrIn,
   readInHeader,
   readInitIn,
+  readLkIn,
   readOpenIn,
   readReadIn,
   readReleaseIn,
@@ -80,11 +86,66 @@ describe("FUSE protocol — opcodes match Linux 6.1", () => {
     ["OPENDIR", 27],
     ["READDIR", 28],
     ["RELEASEDIR", 29],
+    ["GETLK", 31],
+    ["SETLK", 32],
+    ["SETLKW", 33],
     ["DESTROY", 38],
     ["BATCH_FORGET", 42],
     ["READDIRPLUS", 44],
   ])("%s = %d", (name, value) => {
     expect(FUSE_OP[name as keyof typeof FUSE_OP]).toBe(value);
+  });
+});
+
+describe("FUSE protocol — POSIX lock constants and codecs (#322)", () => {
+  it("F_LCK type values match Linux fcntl.h", () => {
+    expect(F_LCK.RDLCK).toBe(0);
+    expect(F_LCK.WRLCK).toBe(1);
+    expect(F_LCK.UNLCK).toBe(2);
+  });
+
+  it("fuse_file_lock is 24 bytes", () => {
+    expect(FUSE_FILE_LOCK_SIZE).toBe(24);
+  });
+
+  it("fuse_lk_in is 48 bytes", () => {
+    expect(FUSE_LK_IN_SIZE).toBe(48);
+  });
+
+  it("fuse_lk_out is 24 bytes (just the embedded fuse_file_lock)", () => {
+    expect(FUSE_LK_OUT_SIZE).toBe(24);
+  });
+
+  it("readLkIn round-trips a synthetic struct", () => {
+    // Hand-pack a fuse_lk_in: fh=0x1122..., owner=0xaaaa..., lk{
+    //   start=100, end=200, type=WRLCK, pid=4242 }, lk_flags=0.
+    const buf = new Uint8Array(FUSE_LK_IN_SIZE);
+    const dv = new DataView(buf.buffer);
+    dv.setBigUint64(0, 0x1122334455667788n, true); // fh
+    dv.setBigUint64(8, 0xaaaabbbbccccddddn, true); // owner
+    dv.setBigUint64(16, 100n, true); // lk.start
+    dv.setBigUint64(24, 200n, true); // lk.end
+    dv.setUint32(32, F_LCK.WRLCK, true); // lk.type
+    dv.setUint32(36, 4242, true); // lk.pid
+    dv.setUint32(40, 0, true); // lk_flags
+    const got = readLkIn(buf);
+    expect(got.fh).toBe(0x1122334455667788n);
+    expect(got.owner).toBe(0xaaaabbbbccccddddn);
+    expect(got.lk.start).toBe(100n);
+    expect(got.lk.end).toBe(200n);
+    expect(got.lk.type).toBe(F_LCK.WRLCK);
+    expect(got.lk.pid).toBe(4242);
+    expect(got.lk_flags).toBe(0);
+  });
+
+  it("buildLkOut writes the embedded fuse_file_lock at offset 0", () => {
+    const out = buildLkOut({ start: 0n, end: 0xffffffffffffffffn, type: F_LCK.UNLCK, pid: 0 });
+    expect(out.length).toBe(FUSE_LK_OUT_SIZE);
+    const dv = new DataView(out.buffer);
+    expect(dv.getBigUint64(0, true)).toBe(0n);
+    expect(dv.getBigUint64(8, true)).toBe(0xffffffffffffffffn);
+    expect(dv.getUint32(16, true)).toBe(F_LCK.UNLCK);
+    expect(dv.getUint32(20, true)).toBe(0);
   });
 });
 

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -26,9 +26,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  F_LCK,
   FUSE_IN_HEADER_SIZE,
   FUSE_KERNEL_MINOR_VERSION,
   FUSE_KERNEL_VERSION,
+  FUSE_LK_OUT_SIZE,
   FUSE_OP,
   readAttr,
 } from "../mount-fuse-protocol.ts";
@@ -487,9 +489,6 @@ const UNIMPLEMENTED_OPS = [
   { name: "GETXATTR", op: 22 },
   { name: "LISTXATTR", op: 23 },
   { name: "REMOVEXATTR", op: 24 },
-  { name: "GETLK", op: 31 },
-  { name: "SETLK", op: 32 },
-  { name: "SETLKW", op: 33 },
   { name: "READDIRPLUS", op: 44 },
   { name: "RENAME2", op: 45 },
 ] as const;
@@ -1610,6 +1609,521 @@ describe("live mount server — :rw write-through", () => {
   });
 });
 
+// ---------------- POSIX advisory locks (#322) ----------------
+//
+// Per CLAUDE.md FUSE-op rules: happy / error / :ro gate / wedge guard.
+// The lock manager is in-memory on the server side — there's no host
+// fs side-effect to assert. Coverage focuses on the conflict matrix,
+// the wait/wake plumbing, and lifecycle (RELEASE, socket close).
+
+describe("live mount server — POSIX locks (#322): happy paths", () => {
+  it("two read locks from different owners coexist; a write lock from a third → EAGAIN", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      // Owner A read-locks [0..10].
+      const a = await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.RDLCK,
+          pid: 100,
+        }),
+      });
+      expect(a.header.error).toBe(0);
+      // Owner B read-locks [0..10] — overlapping reads coexist.
+      const b = await conn.request(FUSE_OP.SETLK, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.RDLCK,
+          pid: 200,
+        }),
+      });
+      expect(b.header.error).toBe(0);
+      // Owner C tries an exclusive lock — must fail with EAGAIN.
+      const c = await conn.request(FUSE_OP.SETLK, {
+        unique: 12n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xc3n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.WRLCK,
+          pid: 300,
+        }),
+      });
+      expect(c.header.error).toBe(-11); // -EAGAIN
+    });
+  });
+
+  it("F_UNLCK via SETLK drops the range and lets a previously-blocked acquirer succeed", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      // A holds an exclusive lock on [0..100].
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      // B's try-lock fails.
+      const b1 = await conn.request(FUSE_OP.SETLK, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      expect(b1.header.error).toBe(-11);
+      // A unlocks.
+      const u = await conn.request(FUSE_OP.SETLK, {
+        unique: 12n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.UNLCK,
+          pid: 100,
+        }),
+      });
+      expect(u.header.error).toBe(0);
+      // B retries — succeeds.
+      const b2 = await conn.request(FUSE_OP.SETLK, {
+        unique: 13n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      expect(b2.header.error).toBe(0);
+    });
+  });
+
+  it("SETLKW resolves once the conflicting holder releases", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      // A holds [0..50] WRLCK.
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 50n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      // B issues SETLKW — parks. We don't await yet; we need to drop A
+      // first.
+      const bWait = conn.request(FUSE_OP.SETLKW, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 50n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      // Yield so the SETLKW request lands and parks before we proceed.
+      await new Promise((r) => setTimeout(r, 25));
+      // A unlocks → B's wait resolves.
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 12n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 50n,
+          type: F_LCK.UNLCK,
+          pid: 100,
+        }),
+      });
+      const b = await raceWithDeadline(bWait, "SETLKW resolves on UNLCK");
+      expect(b.header.error).toBe(0);
+    });
+  });
+
+  it("RELEASE drops the fd's owner's locks on that nodeid", async () => {
+    // Open a real file handle, take a lock through it, RELEASE the
+    // handle, confirm a competing acquirer succeeds.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 2n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      const fileIno = bigintFromEntry(lookup.payload);
+      const open = await conn.request(FUSE_OP.OPEN, {
+        unique: 3n,
+        nodeid: fileIno,
+        payload: u32u32(0, 0),
+      });
+      const fh = new DataView(
+        open.payload.buffer,
+        open.payload.byteOffset,
+        open.payload.length,
+      ).getBigUint64(0, true);
+
+      const lk = await conn.request(FUSE_OP.SETLK, {
+        unique: 4n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh,
+          owner: 0xa1n,
+          start: 0n,
+          end: 1024n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      expect(lk.header.error).toBe(0);
+
+      // Other owner blocked.
+      const blocked = await conn.request(FUSE_OP.SETLK, {
+        unique: 5n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh,
+          owner: 0xb2n,
+          start: 0n,
+          end: 1024n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      expect(blocked.header.error).toBe(-11);
+
+      // RELEASE the fd with lock_owner=A → A's locks drop.
+      await conn.request(FUSE_OP.RELEASE, {
+        unique: 6n,
+        nodeid: fileIno,
+        payload: buildReleaseInWithOwner({ fh, owner: 0xa1n }),
+      });
+
+      // Now B can acquire.
+      const acquired = await conn.request(FUSE_OP.SETLK, {
+        unique: 7n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh,
+          owner: 0xb2n,
+          start: 0n,
+          end: 1024n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      expect(acquired.header.error).toBe(0);
+    });
+  });
+
+  it("re-acquiring an already-held same-owner range is a no-op success (coalesce)", async () => {
+    // Same owner can re-lock its own range freely — the kernel does
+    // this when a process closes one fd and acquires through another.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const first = await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      expect(first.header.error).toBe(0);
+      const overlap = await conn.request(FUSE_OP.SETLK, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 50n,
+          end: 200n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      expect(overlap.header.error).toBe(0);
+    });
+  });
+});
+
+describe("live mount server — POSIX locks (#322): error paths", () => {
+  it("GETLK reports the conflicting holder's range, type, and pid", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      // A holds [10..20] WRLCK.
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 10n,
+          end: 20n,
+          type: F_LCK.WRLCK,
+          pid: 4242,
+        }),
+      });
+      // B GETLK probes for a read lock at [0..30] — conflict at A.
+      const probe = await conn.request(FUSE_OP.GETLK, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 30n,
+          type: F_LCK.RDLCK,
+          pid: 200,
+        }),
+      });
+      expect(probe.header.error).toBe(0);
+      expect(probe.payload.length).toBe(FUSE_LK_OUT_SIZE);
+      const dv = new DataView(probe.payload.buffer, probe.payload.byteOffset, FUSE_LK_OUT_SIZE);
+      expect(dv.getBigUint64(0, true)).toBe(10n); // start
+      expect(dv.getBigUint64(8, true)).toBe(20n); // end
+      expect(dv.getUint32(16, true)).toBe(F_LCK.WRLCK);
+      expect(dv.getUint32(20, true)).toBe(4242); // holder's pid
+    });
+  });
+
+  it("GETLK returns F_UNLCK type when no holder conflicts", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const probe = await conn.request(FUSE_OP.GETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 100n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      expect(probe.header.error).toBe(0);
+      const dv = new DataView(probe.payload.buffer, probe.payload.byteOffset, FUSE_LK_OUT_SIZE);
+      expect(dv.getUint32(16, true)).toBe(F_LCK.UNLCK);
+    });
+  });
+
+  it("SETLK with garbage l_type returns EINVAL", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const reply = await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 10n,
+          type: 99 /* not RD/WR/UN */,
+          pid: 100,
+        }),
+      });
+      expect(reply.header.error).toBe(-22); // -EINVAL
+    });
+  });
+
+  it("write-lock conflicts with an existing read lock (different owner)", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.RDLCK,
+          pid: 100,
+        }),
+      });
+      const conflict = await conn.request(FUSE_OP.SETLK, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 5n,
+          end: 15n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      expect(conflict.header.error).toBe(-11); // -EAGAIN
+    });
+  });
+});
+
+describe("live mount server — POSIX locks (#322): :ro gate and wedge guard", () => {
+  it("SETLK is allowed on a :ro mount (advisory locks are not writes)", async () => {
+    // Default fixture is :ro. Locks are advisory: they don't mutate
+    // the file, so the EROFS gate doesn't apply. POSIX-conformant
+    // userspace (SQLite, dpkg) needs to take read AND write locks
+    // even when only reading the file structure.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.SETLK, {
+          unique: 10n,
+          nodeid: fileIno,
+          payload: buildLkIn({
+            fh: 1n,
+            owner: 0xa1n,
+            start: 0n,
+            end: 10n,
+            type: F_LCK.WRLCK,
+            pid: 100,
+          }),
+        }),
+        "SETLK on :ro",
+      );
+      expect(reply.header.error).toBe(0); // NOT EROFS
+    });
+  });
+
+  it("SETLKW cancels cleanly when the socket drops mid-wait — no orphan timers", async () => {
+    // The wedge class we're catching: a parked SETLKW that's never
+    // released because its connection went away. We must wake the
+    // waiter (so the promise settles) and the table must be empty
+    // afterwards.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      // A grabs an exclusive lock.
+      await conn.request(FUSE_OP.SETLK, {
+        unique: 10n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 1n,
+          owner: 0xa1n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.WRLCK,
+          pid: 100,
+        }),
+      });
+      // B SETLKW parks. We don't await — instead we kill the
+      // connection. The pending request promise will never resolve
+      // because the socket is gone, but the server's internal waiter
+      // must be cancelled. We assert that by reconnecting and seeing
+      // a free table.
+      void conn.request(FUSE_OP.SETLKW, {
+        unique: 11n,
+        nodeid: fileIno,
+        payload: buildLkIn({
+          fh: 2n,
+          owner: 0xb2n,
+          start: 0n,
+          end: 10n,
+          type: F_LCK.WRLCK,
+          pid: 200,
+        }),
+      });
+      await new Promise((r) => setTimeout(r, 25));
+      conn.close();
+    });
+    // A fresh connection sees no leftover locks (connection-close
+    // dropped them all). C can acquire what was contested.
+    await new Promise((r) => setTimeout(r, 25));
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const c = await raceWithDeadline(
+        conn.request(FUSE_OP.SETLK, {
+          unique: 99n,
+          nodeid: fileIno,
+          payload: buildLkIn({
+            fh: 1n,
+            owner: 0xc3n,
+            start: 0n,
+            end: 10n,
+            type: F_LCK.WRLCK,
+            pid: 300,
+          }),
+        }),
+        "SETLK after connection-drop cleanup",
+      );
+      expect(c.header.error).toBe(0);
+    });
+  });
+
+  it("GETLK replies within deadline (wedge guard)", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const fileIno = await openHello(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.GETLK, {
+          unique: 10n,
+          nodeid: fileIno,
+          payload: buildLkIn({
+            fh: 1n,
+            owner: 0xa1n,
+            start: 0n,
+            end: 10n,
+            type: F_LCK.WRLCK,
+            pid: 100,
+          }),
+        }),
+        "GETLK deadline",
+      );
+      expect(reply.header.error).toBe(0);
+    });
+  });
+});
+
 // ---------------- helpers ----------------
 
 interface TestConnection {
@@ -1728,6 +2242,51 @@ function buildReleaseIn(opts: { fh: bigint }): Uint8Array {
   const dv = new DataView(buf.buffer);
   dv.setBigUint64(0, opts.fh, true);
   return buf;
+}
+
+function buildReleaseInWithOwner(opts: { fh: bigint; owner: bigint }): Uint8Array {
+  // fuse_release_in: u64 fh + u32 flags + u32 release_flags + u64 lock_owner = 24
+  const buf = new Uint8Array(24);
+  const dv = new DataView(buf.buffer);
+  dv.setBigUint64(0, opts.fh, true);
+  dv.setBigUint64(16, opts.owner, true);
+  return buf;
+}
+
+function buildLkIn(opts: {
+  fh: bigint;
+  owner: bigint;
+  start: bigint;
+  end: bigint;
+  type: number;
+  pid: number;
+  flags?: number;
+}): Uint8Array {
+  // fuse_lk_in: u64 fh + u64 owner + fuse_file_lock(24) + u32 lk_flags + u32 padding = 48
+  const buf = new Uint8Array(48);
+  const dv = new DataView(buf.buffer);
+  dv.setBigUint64(0, opts.fh, true);
+  dv.setBigUint64(8, opts.owner, true);
+  dv.setBigUint64(16, opts.start, true);
+  dv.setBigUint64(24, opts.end, true);
+  dv.setUint32(32, opts.type, true);
+  dv.setUint32(36, opts.pid, true);
+  dv.setUint32(40, opts.flags ?? 0, true);
+  return buf;
+}
+
+/**
+ * LOOKUP hello.txt against the default fixture and return its inode.
+ * Most lock tests don't actually OPEN the file — they target the
+ * inode directly, since the FUSE protocol routes lock ops by nodeid.
+ */
+async function openHello(conn: TestConnection): Promise<bigint> {
+  const reply = await conn.request(FUSE_OP.LOOKUP, {
+    unique: 99_001n,
+    nodeid: 1n,
+    payload: nameBuf("hello.txt"),
+  });
+  return bigintFromEntry(reply.payload);
 }
 
 function buildCreateInWithName(opts: { flags: number; mode: number; name: string }): Uint8Array {

--- a/packages/runtime/src/mount-fuse-protocol.ts
+++ b/packages/runtime/src/mount-fuse-protocol.ts
@@ -57,6 +57,9 @@ export const FUSE_OP = {
   READDIR: 28,
   RELEASEDIR: 29,
   FSYNCDIR: 30,
+  GETLK: 31,
+  SETLK: 32,
+  SETLKW: 33,
   ACCESS: 34,
   CREATE: 35,
   INTERRUPT: 36,
@@ -66,6 +69,21 @@ export const FUSE_OP = {
   READDIRPLUS: 44,
   LSEEK: 46,
   COPY_FILE_RANGE: 47,
+} as const;
+
+/**
+ * POSIX advisory-lock types. Wire values match Linux's `linux/fcntl.h`
+ * F_RDLCK / F_WRLCK / F_UNLCK and the `fuse_file_lock.type` field.
+ */
+export const F_LCK = {
+  RDLCK: 0,
+  WRLCK: 1,
+  UNLCK: 2,
+} as const;
+
+/** fuse_lk_in.lk_flags bits. FLOCK marks a flock(2) call rather than fcntl. */
+export const FUSE_LK_FLAGS = {
+  FLOCK: 1 << 0,
 } as const;
 
 /**
@@ -806,6 +824,86 @@ export function readRenameIn(buf: Uint8Array, off = 0): FuseRenameIn {
   return {
     newdir: dv.getBigUint64(0, true),
   };
+}
+
+// --- fuse_lk_in / fuse_lk_out (POSIX advisory locks) --------------------
+
+/**
+ * `fuse_file_lock` (24 bytes): the on-the-wire representation of a
+ * single advisory-lock range.
+ *
+ *   { start: u64, end: u64, type: u32, pid: u32 }
+ *
+ * `start`/`end` are inclusive byte offsets; `end == 0xffff_ffff_ffff_ffff`
+ * means "to end-of-file" (POSIX `l_len == 0`). `type` is one of
+ * `F_LCK.RDLCK / WRLCK / UNLCK`. `pid` is the guest's PID, reflected
+ * back verbatim in GETLK replies so userspace can identify the
+ * conflicting holder.
+ */
+export const FUSE_FILE_LOCK_SIZE = 24;
+
+interface FuseFileLock {
+  start: bigint;
+  end: bigint;
+  type: number;
+  pid: number;
+}
+
+function readFileLock(buf: Uint8Array, offset: number): FuseFileLock {
+  const dv = viewOf(buf, offset, FUSE_FILE_LOCK_SIZE);
+  return {
+    start: dv.getBigUint64(0, true),
+    end: dv.getBigUint64(8, true),
+    type: dv.getUint32(16, true),
+    pid: dv.getUint32(20, true),
+  };
+}
+
+function writeFileLock(buf: Uint8Array, offset: number, lk: FuseFileLock): void {
+  const dv = viewOf(buf, offset, FUSE_FILE_LOCK_SIZE);
+  dv.setBigUint64(0, lk.start, true);
+  dv.setBigUint64(8, lk.end, true);
+  dv.setUint32(16, lk.type, true);
+  dv.setUint32(20, lk.pid, true);
+}
+
+/**
+ * `fuse_lk_in` is 48 bytes: u64 fh, u64 owner, fuse_file_lock (24),
+ * u32 lk_flags, u32 padding. `owner` is opaque to us — the kernel
+ * derives it from the calling process and we just key our lock table
+ * by it. Two open fds in the same process holding locks on the same
+ * file share the same owner.
+ */
+export const FUSE_LK_IN_SIZE = 48;
+
+interface FuseLkIn {
+  fh: bigint;
+  owner: bigint;
+  lk: FuseFileLock;
+  lk_flags: number;
+}
+
+export function readLkIn(buf: Uint8Array, offset = 0): FuseLkIn {
+  const dv = viewOf(buf, offset, FUSE_LK_IN_SIZE);
+  return {
+    fh: dv.getBigUint64(0, true),
+    owner: dv.getBigUint64(8, true),
+    lk: readFileLock(buf, offset + 16),
+    lk_flags: dv.getUint32(40, true),
+    // padding at offset 44
+  };
+}
+
+/**
+ * `fuse_lk_out` is just the embedded `fuse_file_lock` struct. GETLK
+ * replies with the conflicting holder (or type=UNLCK for "no conflict").
+ */
+export const FUSE_LK_OUT_SIZE = FUSE_FILE_LOCK_SIZE;
+
+export function buildLkOut(lk: FuseFileLock): Uint8Array {
+  const buf = new Uint8Array(FUSE_LK_OUT_SIZE);
+  writeFileLock(buf, 0, lk);
+  return buf;
 }
 
 // --- helpers -------------------------------------------------------------

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -47,6 +47,7 @@ import {
   DT,
   FALLOC_FL,
   FATTR,
+  F_LCK,
   FUSE_CAP,
   FUSE_IN_HEADER_SIZE,
   FUSE_KERNEL_MINOR_VERSION,
@@ -62,6 +63,7 @@ import {
   buildErrorResponse,
   buildInitOut,
   buildKstatfs,
+  buildLkOut,
   buildLseekOut,
   buildOpenOut,
   buildResponse,
@@ -75,6 +77,7 @@ import {
   readInHeader,
   readInitIn,
   readLinkIn,
+  readLkIn,
   readLseekIn,
   readMkdirIn,
   readOpenIn,
@@ -91,9 +94,11 @@ const log = debug("machinen:mount-server");
 const ERRNO = {
   EPERM: 1,
   ENOENT: 2,
+  EINTR: 4,
   EIO: 5,
   ENXIO: 6,
   EBADF: 9,
+  EAGAIN: 11,
   EACCES: 13,
   EBUSY: 16,
   EEXIST: 17,
@@ -124,8 +129,48 @@ interface InodeEntry {
 
 /** Per-connection file-handle table. One entry per OPEN/OPENDIR. */
 type OpenEntry =
-  | { kind: "file"; fh: FileHandle; lazyPagesContrib: boolean }
+  | {
+      kind: "file";
+      fh: FileHandle;
+      lazyPagesContrib: boolean;
+      /**
+       * Inode this fd was opened on. Recorded so RELEASE can drop
+       * locks on `(nodeid, lock_owner)` per the POSIX rule that
+       * closing a fd releases all locks the process held on the
+       * underlying file via that fd.
+       */
+      nodeid: bigint;
+    }
   | { kind: "dir"; entries: Uint8Array[] };
+
+/**
+ * One held POSIX advisory-lock range. `start`/`end` are inclusive
+ * byte offsets matching the wire `fuse_file_lock` semantics. `pid`
+ * is the guest pid the lock was taken on, reflected back to GETLK
+ * callers so userspace can identify the holder.
+ */
+interface LockRange {
+  start: bigint;
+  end: bigint;
+  type: typeof F_LCK.RDLCK | typeof F_LCK.WRLCK;
+  owner: bigint;
+  pid: number;
+}
+
+/**
+ * A SETLKW call that's parked because a holder is in the way.
+ * `resolve` writes the success reply (or, if the wait is cancelled
+ * by socket close, a no-op). `cancel` is invoked when the connection
+ * drops so we don't strand the kernel waiting on a lock that won't
+ * arrive.
+ */
+interface LockWaiter {
+  nodeid: bigint;
+  request: LockRange;
+  /** Whether this wait was issued as flock vs fcntl. Affects coalescing semantics later. */
+  resolve: () => void;
+  cancel: () => void;
+}
 
 interface LiveMountServerOptions {
   /** Absolute host path that bounds every op. */
@@ -198,6 +243,21 @@ interface ServerState {
    * `LiveMountServerHandle.bytesServedOnPagesImg()`; never decremented.
    */
   bytesServedOnPagesImg: number;
+  /**
+   * In-memory POSIX advisory-lock table (#322). Keyed by nodeid so a
+   * single guest process holding two open fds on the same file shares
+   * one lock view, matching kernel semantics. Host `fcntl` is not used
+   * — the FUSE protocol's `lock_owner` field has no host-side analogue,
+   * so we manage conflicts entirely on this side.
+   */
+  locks: Map<bigint, LockRange[]>;
+  /**
+   * SETLKW callers parked behind a conflicting holder. Walked whenever
+   * a lock is dropped (UNLCK / RELEASE / shutdown); a waiter resolves
+   * the moment its requested range no longer conflicts with anything
+   * in the table.
+   */
+  lockWaiters: LockWaiter[];
 }
 
 function createState(rootAbs: string, mode: "ro" | "rw"): ServerState {
@@ -213,6 +273,8 @@ function createState(rootAbs: string, mode: "ro" | "rw"): ServerState {
     nextHandle: 1n,
     socket: null,
     bytesServedOnPagesImg: 0,
+    locks: new Map(),
+    lockWaiters: [],
   };
 }
 
@@ -231,6 +293,12 @@ async function shutdown(server: Server, state: ServerState): Promise<void> {
     }
   }
   state.handles.clear();
+  // Cancel any parked SETLKW callers so their promises don't leak
+  // setImmediate / pending-resolver state across the test harness.
+  // The FUSE response was already lost when the socket dropped; this
+  // is just internal-bookkeeping cleanup.
+  cancelAllWaiters(state);
+  state.locks.clear();
   await new Promise<void>((done) => server.close(() => done()));
 }
 
@@ -243,6 +311,12 @@ async function handleConnection(sock: Socket, state: ServerState): Promise<void>
   state.socket = sock;
   sock.on("close", () => {
     state.socket = null;
+    // One connection per mount: when it drops, every guest fd is
+    // gone and so is every advisory lock those fds were holding.
+    // Drop the table wholesale and wake any parked SETLKW callers
+    // so their pending promises don't strand listeners.
+    cancelAllWaiters(state);
+    state.locks.clear();
   });
   sock.on("error", (err) => log("socket error: %s", err.message));
   try {
@@ -366,6 +440,12 @@ async function handle(
       return await onLseek(hdr, msg, state);
     case FUSE_OP.COPY_FILE_RANGE:
       return await onCopyFileRange(hdr, msg, state);
+    case FUSE_OP.GETLK:
+      return onGetlk(hdr, msg, state);
+    case FUSE_OP.SETLK:
+      return onSetlk(hdr, msg, state);
+    case FUSE_OP.SETLKW:
+      return await onSetlkw(hdr, msg, state);
     case FUSE_OP.FLUSH:
     case FUSE_OP.ACCESS:
       // Userspace ok-to-ignore ops: reply success with no payload.
@@ -383,12 +463,17 @@ function onInit(hdr: FuseInHeader, msg: Uint8Array): Uint8Array {
   // or the kernel re-INITs with its own major.
   const minor = Math.min(init.minor, FUSE_KERNEL_MINOR_VERSION);
   // Only propagate flags we actively support back to the kernel.
+  // POSIX_LOCKS turns on advisory-lock dispatch (#322) — the kernel
+  // routes fcntl GETLK/SETLK/SETLKW through us instead of falling
+  // back to "no locks available" mode (which silently corrupts
+  // multi-writer SQLite, dpkg lockfiles, etc.).
   const supported =
     FUSE_CAP.ASYNC_READ |
     FUSE_CAP.BIG_WRITES |
     FUSE_CAP.EXPORT_SUPPORT |
     FUSE_CAP.MAX_PAGES |
-    FUSE_CAP.PARALLEL_DIROPS;
+    FUSE_CAP.PARALLEL_DIROPS |
+    FUSE_CAP.POSIX_LOCKS;
   const flags = init.flags & supported;
   const out = buildInitOut({
     major: FUSE_KERNEL_VERSION,
@@ -532,6 +617,7 @@ async function onOpen(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): P
     kind: "file",
     fh,
     lazyPagesContrib: isPagesImgPath(entry.relPath),
+    nodeid: hdr.nodeid,
   });
   return buildResponse(hdr.unique, buildOpenOut({ fh: id, open_flags: 0 }));
 }
@@ -555,10 +641,16 @@ async function onRelease(
   msg: Uint8Array,
   state: ServerState,
 ): Promise<Uint8Array> {
-  const { fh } = readReleaseIn(payloadOf(msg));
-  const entry = state.handles.get(fh);
+  const rel = readReleaseIn(payloadOf(msg));
+  const entry = state.handles.get(rel.fh);
   if (entry && entry.kind === "file") {
-    state.handles.delete(fh);
+    state.handles.delete(rel.fh);
+    // POSIX: closing a fd releases every advisory lock that the
+    // owning process held on the underlying file via that fd. The
+    // FUSE kernel mirrors this by sending the lock_owner on RELEASE.
+    // We drop only that owner's locks on this nodeid, not other
+    // processes' locks on the same file.
+    dropLocksFor(state, entry.nodeid, rel.lock_owner);
     await entry.fh.close().catch(() => {});
   }
   return buildErrorResponse(hdr.unique, 0);
@@ -678,6 +770,7 @@ async function onCreate(
     kind: "file",
     fh,
     lazyPagesContrib: isPagesImgPath(childRel),
+    nodeid: ino,
   });
   return buildResponse(
     hdr.unique,
@@ -1217,6 +1310,290 @@ async function onCopyFileRange(
     }
   }
   return buildResponse(hdr.unique, buildWriteOut({ size: copied }));
+}
+
+// --- POSIX advisory locks (#322) ----------------------------------------
+//
+// We manage advisory locks entirely in this process — host fcntl is not
+// involved. The reason: FUSE identifies a lock owner by the 64-bit
+// `lock_owner` field in fuse_in_header / fuse_lk_in, which has no
+// meaningful host-side analogue. Two open fds in the same guest process
+// holding locks on the same file share one owner; on the host they'd
+// look like one fd holding two locks, which `fcntl` flattens. So we
+// can't pass lock_owner through to host fcntl without subtly wrong
+// semantics. An in-memory table per mount keeps the model exact.
+//
+// Range conventions match the wire `fuse_file_lock`:
+//   - `start` and `end` are inclusive byte offsets.
+//   - `end == 0xffff_ffff_ffff_ffff` means "to end-of-file".
+//   - Two ranges `a` and `b` overlap iff `a.start <= b.end && b.start <= a.end`.
+//   - A read lock conflicts with a write lock; two read locks coexist;
+//     two write locks conflict (regardless of owner — in practice the
+//     same owner re-locks should coalesce, see addLock below).
+
+/**
+ * Build a `LockRange` from the wire `fuse_lk_in.lk` payload, given the
+ * owner token from the same struct and the guest-supplied pid. Returns
+ * `null` if the wire `type` is not a recognised F_LCK value.
+ */
+function rangeFromLkIn(
+  lk: { start: bigint; end: bigint; type: number; pid: number },
+  owner: bigint,
+): LockRange | null {
+  if (lk.type !== F_LCK.RDLCK && lk.type !== F_LCK.WRLCK) {
+    return null;
+  }
+  return { start: lk.start, end: lk.end, type: lk.type, owner, pid: lk.pid };
+}
+
+function rangesOverlap(
+  a: { start: bigint; end: bigint },
+  b: { start: bigint; end: bigint },
+): boolean {
+  return a.start <= b.end && b.start <= a.end;
+}
+
+/**
+ * First lock in `state.locks[nodeid]` whose range overlaps `req` and
+ * whose type makes a real conflict (write-vs-anything, read-vs-write).
+ * Same-owner locks never conflict — the kernel's POSIX lock semantics
+ * let an owner upgrade or shrink its own range freely.
+ */
+function findConflict(state: ServerState, nodeid: bigint, req: LockRange): LockRange | null {
+  const ranges = state.locks.get(nodeid);
+  if (!ranges) {
+    return null;
+  }
+  for (const r of ranges) {
+    if (r.owner === req.owner) {
+      continue;
+    }
+    if (!rangesOverlap(r, req)) {
+      continue;
+    }
+    if (req.type === F_LCK.WRLCK || r.type === F_LCK.WRLCK) {
+      return r;
+    }
+  }
+  return null;
+}
+
+/**
+ * Add `req` to the table, coalescing with any same-owner same-type
+ * range it touches or overlaps. We don't bother splitting on type
+ * upgrades within an owner's set — POSIX permits an owner to "promote"
+ * a read lock to a write lock by re-locking, and the simplest correct
+ * model is to drop any of the owner's existing overlapping ranges and
+ * insert the new one merged with adjacent same-type slots.
+ */
+function addLock(state: ServerState, nodeid: bigint, req: LockRange): void {
+  let ranges = state.locks.get(nodeid);
+  if (!ranges) {
+    ranges = [];
+    state.locks.set(nodeid, ranges);
+  }
+  // Merge with same-owner overlapping ranges of the same type; drop
+  // overlapping ranges of a different type from the same owner (the
+  // new lock supersedes them — e.g. write replacing read).
+  let merged: LockRange = { ...req };
+  const kept: LockRange[] = [];
+  for (const r of ranges) {
+    if (r.owner !== merged.owner || !rangesOverlap(r, merged)) {
+      kept.push(r);
+      continue;
+    }
+    if (r.type === merged.type) {
+      const start = r.start < merged.start ? r.start : merged.start;
+      const end = r.end > merged.end ? r.end : merged.end;
+      merged = { ...merged, start, end };
+    }
+    // Different-type same-owner overlap → drop r; merged wins.
+  }
+  kept.push(merged);
+  state.locks.set(nodeid, kept);
+}
+
+/**
+ * Remove the requested range from `(nodeid, owner)`'s lock set. May
+ * shrink, split, or delete entries as needed so the residual set
+ * exactly excludes `[req.start..req.end]`. Other owners' locks are
+ * untouched.
+ */
+function removeLockRange(
+  state: ServerState,
+  nodeid: bigint,
+  owner: bigint,
+  req: { start: bigint; end: bigint },
+): void {
+  const ranges = state.locks.get(nodeid);
+  if (!ranges) {
+    return;
+  }
+  const out: LockRange[] = [];
+  for (const r of ranges) {
+    if (r.owner !== owner || !rangesOverlap(r, req)) {
+      out.push(r);
+      continue;
+    }
+    // Keep the parts of `r` that lie outside `req`.
+    if (r.start < req.start) {
+      out.push({ ...r, end: req.start - 1n });
+    }
+    if (r.end > req.end) {
+      out.push({ ...r, start: req.end + 1n });
+    }
+  }
+  if (out.length === 0) {
+    state.locks.delete(nodeid);
+  } else {
+    state.locks.set(nodeid, out);
+  }
+}
+
+/**
+ * Drop every lock held by `(nodeid, owner)` and wake any SETLKW
+ * waiters whose conflict was on those ranges. Called from RELEASE
+ * (one fd closed) — connection-close uses the wholesale clear path
+ * in `handleConnection` instead.
+ */
+function dropLocksFor(state: ServerState, nodeid: bigint, owner: bigint): void {
+  const ranges = state.locks.get(nodeid);
+  if (!ranges) {
+    return;
+  }
+  const out = ranges.filter((r) => r.owner !== owner);
+  if (out.length === 0) {
+    state.locks.delete(nodeid);
+  } else {
+    state.locks.set(nodeid, out);
+  }
+  wakeWaiters(state);
+}
+
+/**
+ * Walk the wait list. Any waiter whose request now has no conflict
+ * acquires its lock and resolves; the rest stay parked. We re-walk
+ * from the top after each successful acquisition because a new owner
+ * arriving can shadow the next waiter.
+ */
+function wakeWaiters(state: ServerState): void {
+  // Restart the loop on every successful wake — the new lock might
+  // block someone who was about to be woken next pass.
+  for (;;) {
+    const idx = state.lockWaiters.findIndex(
+      (w) => findConflict(state, w.nodeid, w.request) === null,
+    );
+    if (idx < 0) {
+      return;
+    }
+    const [w] = state.lockWaiters.splice(idx, 1);
+    if (!w) {
+      return;
+    }
+    addLock(state, w.nodeid, w.request);
+    w.resolve();
+  }
+}
+
+function cancelAllWaiters(state: ServerState): void {
+  const waiters = state.lockWaiters;
+  state.lockWaiters = [];
+  for (const w of waiters) {
+    w.cancel();
+  }
+}
+
+function onGetlk(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): Uint8Array {
+  const req = readLkIn(payloadOf(msg));
+  // GETLK is a probe: caller asks "what would block this lock?". Any
+  // type other than RDLCK/WRLCK is malformed.
+  const probe = rangeFromLkIn(req.lk, req.owner);
+  if (!probe) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const conflict = findConflict(state, hdr.nodeid, probe);
+  if (!conflict) {
+    // No conflict: per POSIX, return l_type = F_UNLCK and leave the
+    // other fields informational. The kernel uses the type field as
+    // the "free or not" signal.
+    return buildResponse(
+      hdr.unique,
+      buildLkOut({ start: req.lk.start, end: req.lk.end, type: F_LCK.UNLCK, pid: 0 }),
+    );
+  }
+  return buildResponse(
+    hdr.unique,
+    buildLkOut({
+      start: conflict.start,
+      end: conflict.end,
+      type: conflict.type,
+      pid: conflict.pid,
+    }),
+  );
+}
+
+function onSetlk(hdr: FuseInHeader, msg: Uint8Array, state: ServerState): Uint8Array {
+  const req = readLkIn(payloadOf(msg));
+  // F_UNLCK takes the early branch — no conflict check, just punch
+  // out the requested range from the owner's set.
+  if (req.lk.type === F_LCK.UNLCK) {
+    removeLockRange(state, hdr.nodeid, req.owner, { start: req.lk.start, end: req.lk.end });
+    wakeWaiters(state);
+    return buildErrorResponse(hdr.unique, 0);
+  }
+  const want = rangeFromLkIn(req.lk, req.owner);
+  if (!want) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  if (findConflict(state, hdr.nodeid, want)) {
+    // Try-lock semantics: SETLK never blocks. Return EAGAIN; the
+    // caller (or the kernel re-issuing as SETLKW) handles the
+    // wait. Linux man page documents EAGAIN here, not EWOULDBLOCK
+    // — they share the value but EAGAIN is the canonical name for
+    // "would block".
+    return buildErrorResponse(hdr.unique, -ERRNO.EAGAIN);
+  }
+  addLock(state, hdr.nodeid, want);
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+async function onSetlkw(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  const req = readLkIn(payloadOf(msg));
+  // F_UNLCK still resolves immediately — SETLKW only blocks on
+  // acquire.
+  if (req.lk.type === F_LCK.UNLCK) {
+    removeLockRange(state, hdr.nodeid, req.owner, { start: req.lk.start, end: req.lk.end });
+    wakeWaiters(state);
+    return buildErrorResponse(hdr.unique, 0);
+  }
+  const want = rangeFromLkIn(req.lk, req.owner);
+  if (!want) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  if (!findConflict(state, hdr.nodeid, want)) {
+    addLock(state, hdr.nodeid, want);
+    return buildErrorResponse(hdr.unique, 0);
+  }
+  // Park the caller. The waiter resolves when a future UNLCK /
+  // RELEASE / connection-close clears the conflict; the cancel path
+  // fires if the connection drops first, so the kernel gets EINTR
+  // (EBADF on the wire is fine — the socket is gone, the reply
+  // never lands anyway). We don't attach a setTimeout because there
+  // is no SETLKW timeout on the wire; cancellation is the only exit
+  // besides successful acquisition.
+  return await new Promise<Uint8Array>((done) => {
+    const waiter: LockWaiter = {
+      nodeid: hdr.nodeid,
+      request: want,
+      resolve: () => done(buildErrorResponse(hdr.unique, 0)),
+      cancel: () => done(buildErrorResponse(hdr.unique, -ERRNO.EINTR)),
+    };
+    state.lockWaiters.push(waiter);
+  });
 }
 
 // --- internal helpers ----------------------------------------------------


### PR DESCRIPTION
## Problem

Live-share mounts (the host directory shared into a running microVM through FUSE) silently corrupt SQLite databases and other lock-aware tools when more than one process writes to them at the same time. Closes #322.

The mount server told the guest kernel "I don't know how to do file locks." The kernel then turned off file-locking for the whole mount. Most modern tools detect this and quietly downgrade to "I'll skip locking and hope for the best":

- **SQLite** drops to its no-locks file system driver. Two writers and the database file gets garbled.
- **flock / fcntl pidfiles** (used by package managers like `dpkg` and build coordinators like `make --output-sync`, `ninja`, `cargo`) think they hold a lock when they don't, so two builds can stomp on each other.
- **Editor swap files** (vim, emacs) lose their arbitration when the buffer lives on the share.

The failure mode is the one users hate the most: everything looks fine for weeks, then one day a database file is corrupt.

## Solution

Teach the mount server to actually answer the three lock questions the kernel asks:

1. **"Can I take this lock?" (try-lock)** — check whether the requested byte range conflicts with anything anyone else is holding. If it does, return "would block." Otherwise record the lock.
2. **"Wait until I can take this lock." (blocking)** — same check, but if it conflicts, park the caller. When the conflicting holder lets go, wake the waiter and give it the lock.
3. **"Who is holding this range?" (probe)** — report back the first conflicting holder so the caller can show a useful error.

Locks live entirely in the mount server's memory. We do not hand them through to the host operating system's lock APIs, because those APIs identify lock owners by host process id and the mapping back to the guest's idea of a lock owner is lossy. Doing it ourselves keeps the semantics exact.

Lifecycle is handled the way the file-system rules require: closing a file releases that file's locks, and a dropped connection releases everything that connection was holding. Parked waiters on a dropped connection are woken so nothing hangs.

## Technical Summary

- `packages/runtime/src/mount-fuse-protocol.ts` — added `FUSE_OP.GETLK / SETLK / SETLKW` opcodes (31/32/33), `F_LCK.RDLCK / WRLCK / UNLCK` constants matching Linux `fcntl.h`, and codecs for `fuse_lk_in` (48 bytes: fh + owner + 24-byte `fuse_file_lock` + flags) and `fuse_lk_out` (the 24-byte `fuse_file_lock` payload).
- `packages/runtime/src/mount-server.ts` — added a per-mount lock table keyed by inode. Conflict rules: a write lock conflicts with any other-owner overlapping lock; two read locks coexist; same-owner ranges never conflict (so an owner can extend, shrink, or upgrade its own range), and same-owner same-type ranges coalesce on insert. `SETLK` is non-blocking (returns `EAGAIN` on conflict). `SETLKW` parks a waiter that resolves when the conflict clears, or cancels with `EINTR` if the socket drops. `F_UNLCK` punches the requested range out of the owner's set and walks the wait list. `RELEASE` drops that file's `(inode, lock_owner)` locks; the connection-close handler drops the whole table and wakes parked waiters. The `FUSE_INIT` reply now advertises `FUSE_CAP.POSIX_LOCKS` so the guest kernel actually routes `fcntl` calls through us instead of disabling locks.
- Tests follow the project's FUSE-op rules (happy / error / read-only gate / wedge guard): shared locks from different owners coexist while a third owner's exclusive request returns `EAGAIN`; `GETLK` reports the holder's range, type, and pid; an invalid lock type returns `EINVAL`; locks succeed on read-only mounts (locks are advisory, not writes); and dropping the connection mid-wait cleans up the table so a fresh connection sees no leftover state.

## Test plan

- [x] Unit tests: `pnpm vitest run` — 670 passed, 7 skipped.
- [x] Workflows: `agent-ci run --all -q -p` — 4 of 4 passed.
- [ ] Smoke tests: `pnpm smoke-tests` — every test through S4 passed; S5 fails with `ERR_STRING_TOO_LONG` in `exec.ts:278` (`Buffer.concat(stdoutBufs).toString("utf8")`) when the 2 GiB-dirty workload's snapshot stdout exceeds Node's max string length. This path is untouched by this change (S1–S4 snapshots all passed) and is a pre-existing limit in `VsockExec.run`.