### PR TITLE
feat(runtime): implement xattr ops in the live-mount FUSE server

### DIFF
--- a/.changeset/xattr-fuse-ops.md
+++ b/.changeset/xattr-fuse-ops.md
@@ -1,0 +1,69 @@
+---
+"@machinen/runtime": minor
+---
+
+Implement xattr ops in the live-mount FUSE server (#321).
+
+Closes #321.
+
+The mount-server previously returned `ENOSYS` for `SETXATTR` (21),
+`GETXATTR` (22), `LISTXATTR` (23), and `REMOVEXATTR` (24). Tools never
+crashed but every extended attribute written or read by the guest
+inside a live mount silently vanished — `setcap` no-op'd, `rsync -X`
+quietly lost data, `getfattr -d` came back empty regardless of what
+the host actually stored. This change wires up all four ops end to
+end against the host filesystem.
+
+**Strategy.** Per-call shell-out to the platform-native tools, matching
+issue #321's "Option A":
+
+- darwin: `xattr -p -s -x` / `xattr -w -s -x` / `xattr -s` / `xattr -d -s`
+- linux: `getfattr --only-values` / `setfattr -v 0sBASE64` /
+  `getfattr --match=.` / `setfattr -x`
+
+`-s` (darwin) and `--no-dereference` (linux) keep the call on the
+symlink itself rather than its target, mirroring the rest of the
+mount-server's existing `lstat`-shaped ops. Per-op cost is ~5–20 ms;
+acceptable for the workloads the live-mount path was built for
+(install-time `setcap`, occasional SELinux relabel, tar extracts with
+xattrs). A future native-binding replacement can swap the internals
+without changing the wire-side handlers.
+
+**Namespace handling.** Names round-trip verbatim — no Linux
+`user.*` / `security.*` / `trusted.*` translation. On a Linux host
+the kernel polices the privileged namespaces, so a guest's `setcap`
+lands as `EPERM` unless the host is root, which is closer-to-correct
+degradation than the previous silent loss. On a darwin host names
+aren't gated at all, so every name stores and reads cleanly inside the
+mount — only invisible to Linux-specific host tools (`getcap` etc.),
+which is the documented trade-off in the issue.
+
+**XATTR_CREATE / XATTR_REPLACE.** The flag bits in `fuse_setxattr_in`
+are honoured by a pre-existence check before the write, returning
+`EEXIST` / `ENODATA` respectively. There's a TOCTOU race against
+direct host-side activity outside the guest's view, but inside the
+single mount the FUSE channel serialises every op, so the window only
+matters when a third party writes through the host fs directly.
+
+**ENODATA / ERANGE.** Both are added to the mount-server's `ERRNO`
+table. macOS's `ENOATTR` (errno 93) is normalised to Linux's `ENODATA`
+(61) on the wire so the guest kernel sees the canonical "no such
+attribute" code regardless of host.
+
+**Tests** in `mount-server.test.ts` follow the project's FUSE-op rules
+in `CLAUDE.md`:
+
+- Happy round-trip: set → probe → fetch → list → remove → re-get
+  yields `-ENODATA`.
+- Error: `-ENODATA` on get of an unset attribute; `-ERANGE` when the
+  caller's fetch buffer is smaller than the value.
+- `:ro` gate: `SETXATTR` and `REMOVEXATTR` return `-EROFS` and never
+  touch the host; `GETXATTR` and `LISTXATTR` are allowed.
+- Wedge guard: every assertion goes through `raceWithDeadline()` so a
+  hang becomes a fast, specific test failure.
+
+The four opcodes are removed from `UNIMPLEMENTED_OPS` in the same
+file. Tests skip automatically when the host has neither
+`getfattr`/`setfattr` (Linux) nor `xattr` (darwin) on `PATH` — a
+developer without `attr` installed still gets a green local suite,
+CI installs the package.

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -8,6 +8,7 @@
 // guest kernel in the loop. The guest smoke test (follow-up commit)
 // exercises the actual mount → read path.
 
+import { execFileSync } from "node:child_process";
 import { connect as netConnect } from "node:net";
 import {
   existsSync,
@@ -485,10 +486,6 @@ describe("live mount server — symlink semantics", () => {
 // in the same change (per AGENTS.md).
 const UNIMPLEMENTED_OPS = [
   { name: "MKNOD", op: 8 },
-  { name: "SETXATTR", op: 21 },
-  { name: "GETXATTR", op: 22 },
-  { name: "LISTXATTR", op: 23 },
-  { name: "REMOVEXATTR", op: 24 },
   { name: "READDIRPLUS", op: 44 },
   { name: "RENAME2", op: 45 },
 ] as const;
@@ -2124,6 +2121,310 @@ describe("live mount server — POSIX locks (#322): :ro gate and wedge guard", (
   });
 });
 
+// ---------------- xattr ops (#321) ----------------
+//
+// The mount-server shells out to `setfattr`/`getfattr` on Linux and
+// `xattr` on darwin. The tests round-trip a `user.machinen.test` attr
+// through a :rw mount and check the wire-reply errno on the documented
+// failure modes — same shape as #322's lock-ops coverage block above.
+//
+// We skip the whole describe if neither tool family is available on
+// PATH so a developer without `attr` installed (`apt install attr`)
+// still gets a green local suite. CI installs `attr` so these run in
+// the pipeline. On darwin `/usr/bin/xattr` ships with the OS.
+
+const HOST_HAS_XATTR_TOOLS = (() => {
+  try {
+    if (process.platform === "darwin") {
+      execFileSync("/usr/bin/xattr", ["--help"], { stdio: "ignore" });
+      return true;
+    }
+    execFileSync("setfattr", ["--version"], { stdio: "ignore" });
+    execFileSync("getfattr", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!HOST_HAS_XATTR_TOOLS)("live mount server — xattr ops (#321)", () => {
+  let xScratch: string;
+  let xRoot: string;
+  let xUds: string;
+  let xHandle: LiveMountServerHandle | undefined;
+
+  beforeEach(async () => {
+    xScratch = mkdtempSync(join(tmpdir(), "machinen-mount-server-xattr-"));
+    xRoot = join(xScratch, "root");
+    mkdirSync(xRoot);
+    writeFileSync(join(xRoot, "target.txt"), "hello\n");
+    xUds = join(xScratch, "fuse.sock");
+    xHandle = await serveLiveMount(xUds, { rootAbs: xRoot, mode: "rw" });
+  });
+
+  afterEach(async () => {
+    await xHandle?.stop();
+    xHandle = undefined;
+    rmSync(xScratch, { recursive: true, force: true });
+  });
+
+  async function xConn(fn: (c: TestConnection) => Promise<void>): Promise<void> {
+    await withConnectionTo(xUds, fn);
+  }
+
+  /** Look up target.txt under root and return its inode. */
+  async function lookupTarget(conn: TestConnection): Promise<bigint> {
+    const reply = await conn.request(FUSE_OP.LOOKUP, {
+      unique: 7_000n,
+      nodeid: 1n,
+      payload: nameBuf("target.txt"),
+    });
+    expect(reply.header.error).toBe(0);
+    return bigintFromEntry(reply.payload);
+  }
+
+  it("happy path: set → probe → fetch → list → remove → get returns ENODATA", async () => {
+    await xConn(async (conn) => {
+      await doInit(conn);
+      const ino = await lookupTarget(conn);
+
+      const setReply = await raceWithDeadline(
+        conn.request(FUSE_OP.SETXATTR, {
+          unique: 7_001n,
+          nodeid: ino,
+          payload: buildSetxattrIn({ name: "user.machinen.test", value: "hello world", flags: 0 }),
+        }),
+        "SETXATTR",
+      );
+      expect(setReply.header.error).toBe(0);
+
+      // Probe (size=0): expect fuse_getxattr_out carrying the value length.
+      const probe = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_002n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 0, name: "user.machinen.test" }),
+        }),
+        "GETXATTR probe",
+      );
+      expect(probe.header.error).toBe(0);
+      expect(probe.payload.length).toBe(8);
+      expect(new DataView(probe.payload.buffer, probe.payload.byteOffset, 8).getUint32(0, true)).toBe(
+        "hello world".length,
+      );
+
+      // Fetch (size=N): expect the raw value bytes.
+      const fetch = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_003n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 64, name: "user.machinen.test" }),
+        }),
+        "GETXATTR fetch",
+      );
+      expect(fetch.header.error).toBe(0);
+      expect(new TextDecoder().decode(fetch.payload)).toBe("hello world");
+
+      // LISTXATTR probe → size header, then fetch → NUL-separated names.
+      const listProbe = await raceWithDeadline(
+        conn.request(FUSE_OP.LISTXATTR, {
+          unique: 7_004n,
+          nodeid: ino,
+          payload: buildGetxattrIn({ size: 0 }),
+        }),
+        "LISTXATTR probe",
+      );
+      expect(listProbe.header.error).toBe(0);
+      const listProbeLen = new DataView(
+        listProbe.payload.buffer,
+        listProbe.payload.byteOffset,
+        8,
+      ).getUint32(0, true);
+      // At least our attribute's NUL-terminated name fits. macOS quietly
+      // stamps `com.apple.provenance` (and on some configs other system
+      // xattrs) on every file the host process touches, so the probe
+      // length is often larger than 19 in practice. The fetch below
+      // asserts our attr is present in the listing — that's the real
+      // contract.
+      expect(listProbeLen).toBeGreaterThanOrEqual("user.machinen.test\0".length);
+
+      const listFetch = await raceWithDeadline(
+        conn.request(FUSE_OP.LISTXATTR, {
+          unique: 7_005n,
+          nodeid: ino,
+          payload: buildGetxattrIn({ size: 256 }),
+        }),
+        "LISTXATTR fetch",
+      );
+      expect(listFetch.header.error).toBe(0);
+      const listed = new TextDecoder()
+        .decode(listFetch.payload)
+        .split("\0")
+        .filter((n) => n.length > 0);
+      expect(listed).toContain("user.machinen.test");
+
+      // Remove and confirm subsequent GETXATTR yields ENODATA.
+      const rm = await raceWithDeadline(
+        conn.request(FUSE_OP.REMOVEXATTR, {
+          unique: 7_006n,
+          nodeid: ino,
+          payload: nameBuf("user.machinen.test"),
+        }),
+        "REMOVEXATTR",
+      );
+      expect(rm.header.error).toBe(0);
+
+      const after = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_007n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 0, name: "user.machinen.test" }),
+        }),
+        "GETXATTR after remove",
+      );
+      expect(after.header.error).toBe(-61); // -ENODATA
+    });
+  });
+
+  it("GETXATTR on an unset attribute returns -ENODATA", async () => {
+    await xConn(async (conn) => {
+      await doInit(conn);
+      const ino = await lookupTarget(conn);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_010n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 0, name: "user.never.set" }),
+        }),
+        "GETXATTR missing",
+      );
+      expect(reply.header.error).toBe(-61); // -ENODATA
+    });
+  });
+
+  it("GETXATTR with a too-small fetch buffer returns -ERANGE", async () => {
+    await xConn(async (conn) => {
+      await doInit(conn);
+      const ino = await lookupTarget(conn);
+      const set = await raceWithDeadline(
+        conn.request(FUSE_OP.SETXATTR, {
+          unique: 7_020n,
+          nodeid: ino,
+          payload: buildSetxattrIn({
+            name: "user.machinen.test",
+            value: "this value is longer than the probe size below",
+            flags: 0,
+          }),
+        }),
+        "SETXATTR",
+      );
+      expect(set.header.error).toBe(0);
+
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_021n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 4, name: "user.machinen.test" }),
+        }),
+        "GETXATTR ERANGE",
+      );
+      expect(reply.header.error).toBe(-34); // -ERANGE
+    });
+  });
+
+  it(":ro gate: SETXATTR returns -EROFS and never touches the host attr", async () => {
+    // The default top-level fixture is :ro — reuse it instead of
+    // spinning up a third server.
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 7_030n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      const ino = bigintFromEntry(lookup.payload);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.SETXATTR, {
+          unique: 7_031n,
+          nodeid: ino,
+          payload: buildSetxattrIn({
+            name: "user.should.not.land",
+            value: "nope",
+            flags: 0,
+          }),
+        }),
+        "SETXATTR on :ro",
+      );
+      expect(reply.header.error).toBe(-30); // -EROFS
+    });
+  });
+
+  it(":ro gate: REMOVEXATTR returns -EROFS", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 7_040n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      const ino = bigintFromEntry(lookup.payload);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.REMOVEXATTR, {
+          unique: 7_041n,
+          nodeid: ino,
+          payload: nameBuf("user.anything"),
+        }),
+        "REMOVEXATTR on :ro",
+      );
+      expect(reply.header.error).toBe(-30); // -EROFS
+    });
+  });
+
+  it(":ro gate: GETXATTR is allowed (returns -ENODATA on a clean file)", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 7_050n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      const ino = bigintFromEntry(lookup.payload);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.GETXATTR, {
+          unique: 7_051n,
+          nodeid: ino,
+          payload: buildGetxattrInWithName({ size: 0, name: "user.absent" }),
+        }),
+        "GETXATTR on :ro",
+      );
+      expect(reply.header.error).toBe(-61); // -ENODATA
+    });
+  });
+
+  it(":ro gate: LISTXATTR is allowed and replies within deadline", async () => {
+    await withConnection(async (conn) => {
+      await doInit(conn);
+      const lookup = await conn.request(FUSE_OP.LOOKUP, {
+        unique: 7_060n,
+        nodeid: 1n,
+        payload: nameBuf("hello.txt"),
+      });
+      const ino = bigintFromEntry(lookup.payload);
+      const reply = await raceWithDeadline(
+        conn.request(FUSE_OP.LISTXATTR, {
+          unique: 7_061n,
+          nodeid: ino,
+          payload: buildGetxattrIn({ size: 0 }),
+        }),
+        "LISTXATTR on :ro",
+      );
+      // Either zero attrs (size==0 in the probe header) or some set —
+      // either way the call shouldn't EROFS.
+      expect(reply.header.error).toBe(0);
+    });
+  });
+});
+
 // ---------------- helpers ----------------
 
 interface TestConnection {
@@ -2395,6 +2696,39 @@ function buildCopyFileRangeIn(opts: {
   dv.setBigUint64(32, opts.offOut, true);
   dv.setBigUint64(40, opts.len, true);
   dv.setBigUint64(48, opts.flags, true);
+  return buf;
+}
+
+function buildSetxattrIn(opts: { name: string; value: string | Uint8Array; flags: number }): Uint8Array {
+  // fuse_setxattr_in: u32 size, u32 flags. Then NUL-terminated name,
+  // then the raw value bytes (no terminator).
+  const valueBytes =
+    typeof opts.value === "string" ? new TextEncoder().encode(opts.value) : opts.value;
+  const nameBytes = new TextEncoder().encode(opts.name);
+  const buf = new Uint8Array(8 + nameBytes.length + 1 + valueBytes.length);
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(0, valueBytes.length, true);
+  dv.setUint32(4, opts.flags, true);
+  buf.set(nameBytes, 8);
+  // trailing NUL on the name is already zero
+  buf.set(valueBytes, 8 + nameBytes.length + 1);
+  return buf;
+}
+
+function buildGetxattrIn(opts: { size: number }): Uint8Array {
+  // fuse_getxattr_in: u32 size, u32 padding. LISTXATTR uses the same
+  // struct with no name appended.
+  const buf = new Uint8Array(8);
+  new DataView(buf.buffer).setUint32(0, opts.size, true);
+  return buf;
+}
+
+function buildGetxattrInWithName(opts: { size: number; name: string }): Uint8Array {
+  // fuse_getxattr_in followed by a NUL-terminated name (GETXATTR form).
+  const nameBytes = new TextEncoder().encode(opts.name);
+  const buf = new Uint8Array(8 + nameBytes.length + 1);
+  new DataView(buf.buffer).setUint32(0, opts.size, true);
+  buf.set(nameBytes, 8);
   return buf;
 }
 

--- a/packages/runtime/src/__tests__/mount-server.test.ts
+++ b/packages/runtime/src/__tests__/mount-server.test.ts
@@ -2209,9 +2209,9 @@ describe.skipIf(!HOST_HAS_XATTR_TOOLS)("live mount server — xattr ops (#321)",
       );
       expect(probe.header.error).toBe(0);
       expect(probe.payload.length).toBe(8);
-      expect(new DataView(probe.payload.buffer, probe.payload.byteOffset, 8).getUint32(0, true)).toBe(
-        "hello world".length,
-      );
+      expect(
+        new DataView(probe.payload.buffer, probe.payload.byteOffset, 8).getUint32(0, true),
+      ).toBe("hello world".length);
 
       // Fetch (size=N): expect the raw value bytes.
       const fetch = await raceWithDeadline(
@@ -2699,7 +2699,11 @@ function buildCopyFileRangeIn(opts: {
   return buf;
 }
 
-function buildSetxattrIn(opts: { name: string; value: string | Uint8Array; flags: number }): Uint8Array {
+function buildSetxattrIn(opts: {
+  name: string;
+  value: string | Uint8Array;
+  flags: number;
+}): Uint8Array {
   // fuse_setxattr_in: u32 size, u32 flags. Then NUL-terminated name,
   // then the raw value bytes (no terminator).
   const valueBytes =

--- a/packages/runtime/src/mount-fuse-protocol.ts
+++ b/packages/runtime/src/mount-fuse-protocol.ts
@@ -51,6 +51,10 @@ export const FUSE_OP = {
   STATFS: 17,
   RELEASE: 18,
   FSYNC: 20,
+  SETXATTR: 21,
+  GETXATTR: 22,
+  LISTXATTR: 23,
+  REMOVEXATTR: 24,
   FLUSH: 25,
   INIT: 26,
   OPENDIR: 27,
@@ -903,6 +907,74 @@ export const FUSE_LK_OUT_SIZE = FUSE_FILE_LOCK_SIZE;
 export function buildLkOut(lk: FuseFileLock): Uint8Array {
   const buf = new Uint8Array(FUSE_LK_OUT_SIZE);
   writeFileLock(buf, 0, lk);
+  return buf;
+}
+
+// --- xattr ops (#321) ---------------------------------------------------
+
+/**
+ * `fuse_setxattr_in` is 8 bytes: u32 size, u32 flags. The body that
+ * follows is the NUL-terminated attribute name then `size` value bytes
+ * (the value itself is **not** NUL-terminated and may contain NULs).
+ *
+ * `flags` carries Linux's `XATTR_CREATE` (1) / `XATTR_REPLACE` (2)
+ * bits — the caller's `setxattr(2)` 4th argument.
+ */
+export const FUSE_SETXATTR_IN_SIZE = 8;
+
+interface FuseSetxattrIn {
+  size: number;
+  flags: number;
+}
+
+export function readSetxattrIn(buf: Uint8Array, off = 0): FuseSetxattrIn {
+  const dv = viewOf(buf, off, FUSE_SETXATTR_IN_SIZE);
+  return {
+    size: dv.getUint32(0, true),
+    flags: dv.getUint32(4, true),
+  };
+}
+
+/** Linux `XATTR_CREATE` / `XATTR_REPLACE` semantics for SETXATTR.flags. */
+export const XATTR = {
+  CREATE: 1,
+  REPLACE: 2,
+} as const;
+
+/**
+ * `fuse_getxattr_in` is 8 bytes: u32 size, u32 padding. `size == 0` is
+ * the kernel's probe form: reply with `fuse_getxattr_out` carrying the
+ * value's length so the caller can allocate. `size > 0` is the fetch
+ * form: reply with the raw value bytes (no header) when it fits, or
+ * `-ERANGE` when it doesn't.
+ *
+ * LISTXATTR shares the exact same wire layout (the body has no name) —
+ * we reuse this codec for both.
+ */
+export const FUSE_GETXATTR_IN_SIZE = 8;
+
+interface FuseGetxattrIn {
+  size: number;
+}
+
+export function readGetxattrIn(buf: Uint8Array, off = 0): FuseGetxattrIn {
+  const dv = viewOf(buf, off, FUSE_GETXATTR_IN_SIZE);
+  return {
+    size: dv.getUint32(0, true),
+    // padding at offset 4
+  };
+}
+
+/**
+ * `fuse_getxattr_out` — the size-probe reply for GETXATTR / LISTXATTR.
+ * Lives in 8 bytes: u32 size, u32 padding.
+ */
+export const FUSE_GETXATTR_OUT_SIZE = 8;
+
+export function buildGetxattrOut(size: number): Uint8Array {
+  const buf = new Uint8Array(FUSE_GETXATTR_OUT_SIZE);
+  new DataView(buf.buffer).setUint32(0, size, true);
+  // padding at 4
   return buf;
 }
 

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -16,6 +16,7 @@
 // mount root. See mount-resolver.ts.
 
 import { createServer, type Server, type Socket } from "node:net";
+import { execFile as execFileCb } from "node:child_process";
 import {
   chmod,
   lchmod,
@@ -40,6 +41,7 @@ import type { FileHandle } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import type { Stats } from "node:fs";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import debug from "debug";
 import { MountError, isMachinenError } from "./errors.ts";
 import { resolveUnderRoot } from "./mount-resolver.ts";
@@ -53,14 +55,17 @@ import {
   FUSE_KERNEL_MINOR_VERSION,
   FUSE_KERNEL_VERSION,
   FUSE_OP,
+  FUSE_SETXATTR_IN_SIZE,
   FUSE_WRITE_IN_SIZE,
   SEEK,
+  XATTR,
   type FuseInHeader,
   buildAttrOut,
   buildCreateOut,
   buildDirent,
   buildEntryOut,
   buildErrorResponse,
+  buildGetxattrOut,
   buildInitOut,
   buildKstatfs,
   buildLkOut,
@@ -74,6 +79,7 @@ import {
   readCreateIn,
   readFallocateIn,
   readForgetIn,
+  readGetxattrIn,
   readInHeader,
   readInitIn,
   readLinkIn,
@@ -85,8 +91,11 @@ import {
   readReleaseIn,
   readRenameIn,
   readSetattrIn,
+  readSetxattrIn,
   readWriteIn,
 } from "./mount-fuse-protocol.ts";
+
+const execFile = promisify(execFileCb);
 
 const log = debug("machinen:mount-server");
 
@@ -105,9 +114,14 @@ const ERRNO = {
   ENOTDIR: 20,
   EISDIR: 21,
   EINVAL: 22,
+  ERANGE: 34,
   EROFS: 30,
   ENOSYS: 38,
   ENOTEMPTY: 39,
+  // "Attribute not found" — Linux errno for getxattr/removexattr on a
+  // name that doesn't exist. macOS calls the same condition ENOATTR
+  // (errno 93) and our shell-out translates it to ENODATA on the wire.
+  ENODATA: 61,
   // ENOTSUP / EOPNOTSUPP share value 95 on Linux. Some macOS-host
   // ops (lchmod on filesystems without symlink-mode support, lutimes
   // on older APFS) throw ENOTSUP; pass it through verbatim so tar
@@ -440,6 +454,14 @@ async function handle(
       return await onLseek(hdr, msg, state);
     case FUSE_OP.COPY_FILE_RANGE:
       return await onCopyFileRange(hdr, msg, state);
+    case FUSE_OP.SETXATTR:
+      return await onSetxattr(hdr, msg, state);
+    case FUSE_OP.GETXATTR:
+      return await onGetxattr(hdr, msg, state);
+    case FUSE_OP.LISTXATTR:
+      return await onListxattr(hdr, msg, state);
+    case FUSE_OP.REMOVEXATTR:
+      return await onRemovexattr(hdr, msg, state);
     case FUSE_OP.GETLK:
       return onGetlk(hdr, msg, state);
     case FUSE_OP.SETLK:
@@ -1310,6 +1332,353 @@ async function onCopyFileRange(
     }
   }
   return buildResponse(hdr.unique, buildWriteOut({ size: copied }));
+}
+
+// --- extended attributes (#321) -----------------------------------------
+//
+// We shell out to `setfattr` / `getfattr` (Linux) or `xattr` (darwin) —
+// one subprocess per call. Per-op spawn cost is ~5–20 ms, which is fine
+// for the workloads the FUSE-over-vsock path was built for (apt installs
+// stamping file capabilities, occasional `setcap`, tar archives with
+// xattrs, infrequent SELinux relabels). It's painful for `rsync -X`'s
+// per-file listxattr / getxattr storm but still correct — a future
+// switch to a native binding can replace these internals without
+// changing the wire-side handlers below.
+//
+// Namespace handling: we pass names through verbatim, no translation.
+// On a Linux host the kernel polices `user.*` (unprivileged) vs
+// `security.*` / `trusted.*` (root-only), so a guest's `setcap` lands
+// as EPERM unless the host happens to be running as root — closer-to-
+// correct degradation than silent loss. On a darwin host there's no
+// namespace concept at all, so every name round-trips cleanly within
+// the mount, only invisible to Linux-specific host tools (`getcap` etc.)
+// which is the documented trade-off in issue #321.
+
+const IS_DARWIN = process.platform === "darwin";
+
+interface XattrError {
+  /** errno to send back on the wire (positive — caller negates). */
+  errno: number;
+}
+
+function isXattrError(e: unknown): e is XattrError {
+  return typeof e === "object" && e !== null && "errno" in e && typeof (e as XattrError).errno === "number";
+}
+
+/**
+ * Decode the stderr of a failed `setfattr`/`getfattr`/`xattr` call into
+ * a wire errno. The tool exits 1 for every error class and stuffs the
+ * actual cause into a free-form message, so we pattern-match the
+ * canonical strings each tool prints.
+ *
+ * The default is EIO — anything we don't recognise becomes a hard error
+ * rather than a silent miss, since silently returning ENODATA on an
+ * unrecognised failure would let bugs hide.
+ */
+function decodeXattrStderr(stderr: string): number {
+  // "No such xattr" (darwin), "No such attribute" (Linux getfattr),
+  // "No data available" (Linux setfattr -x on missing attr).
+  if (/no such (xattr|attribute)|no data available/i.test(stderr)) {
+    return ERRNO.ENODATA;
+  }
+  if (/operation not permitted|permission denied/i.test(stderr)) {
+    return ERRNO.EACCES;
+  }
+  if (/not supported|operation not supported/i.test(stderr)) {
+    return ERRNO.ENOTSUP;
+  }
+  if (/file name too long|argument list too long/i.test(stderr)) {
+    return ERRNO.EINVAL;
+  }
+  return ERRNO.EIO;
+}
+
+/**
+ * Map a thrown `execFile` rejection to a wire errno. `code === "ENOENT"`
+ * (Node's spawn-time errno) means the host doesn't have the tool
+ * installed at all — `attr` on a Linux box, `xattr` on darwin (always
+ * present by default). Surface that as ENOTSUP rather than ENODATA so
+ * the guest knows the op didn't no-op silently.
+ */
+function xattrErrorFromExec(err: unknown): XattrError {
+  const e = err as { code?: string | number; stderr?: string | Buffer };
+  if (e.code === "ENOENT") {
+    return { errno: ERRNO.ENOTSUP };
+  }
+  const stderr = typeof e.stderr === "string" ? e.stderr : (e.stderr?.toString("utf8") ?? "");
+  return { errno: decodeXattrStderr(stderr) };
+}
+
+/**
+ * Fetch a single xattr value as a Buffer. Returns `null` when the
+ * attribute is absent — the caller distinguishes "absent → ENODATA"
+ * from "present but empty value → 0-byte Buffer".
+ */
+async function hostGetxattr(absPath: string, name: string): Promise<Buffer | null> {
+  try {
+    if (IS_DARWIN) {
+      // `xattr -p -s -x` prints the value as hex pairs (whitespace
+      // separated, may wrap). -s targets the symlink itself when the
+      // path is a link, mirroring `--no-dereference` on Linux. -x is
+      // mandatory for binary values; the default string-decode would
+      // mangle anything that isn't UTF-8.
+      const { stdout } = await execFile("xattr", ["-p", "-s", "-x", name, absPath], {
+        encoding: "utf8",
+      });
+      return Buffer.from(stdout.replace(/\s+/g, ""), "hex");
+    }
+    const { stdout } = await execFile(
+      "getfattr",
+      ["--no-dereference", "--absolute-names", "--only-values", "-n", name, absPath],
+      { encoding: "buffer" },
+    );
+    return stdout as Buffer;
+  } catch (err) {
+    const xe = xattrErrorFromExec(err);
+    if (xe.errno === ERRNO.ENODATA) {
+      return null;
+    }
+    throw xe;
+  }
+}
+
+/** Whether an xattr already exists. Used to enforce XATTR_CREATE/REPLACE. */
+async function hostXattrExists(absPath: string, name: string): Promise<boolean> {
+  return (await hostGetxattr(absPath, name)) !== null;
+}
+
+async function hostSetxattr(
+  absPath: string,
+  name: string,
+  value: Uint8Array,
+): Promise<void> {
+  try {
+    if (IS_DARWIN) {
+      // -wx accepts the value as a hex string. Pair with -s to act on
+      // the symlink itself.
+      const hex = Buffer.from(value.buffer, value.byteOffset, value.length).toString("hex");
+      await execFile("xattr", ["-w", "-s", "-x", name, hex, absPath]);
+      return;
+    }
+    // setfattr's `-v` recognises `0sBASE64` as a base64-encoded value,
+    // which is the safe channel for binary data. The base64 alphabet is
+    // ASCII so argv passes it through verbatim.
+    const b64 = Buffer.from(value.buffer, value.byteOffset, value.length).toString("base64");
+    await execFile(
+      "setfattr",
+      ["--no-dereference", "-n", name, "-v", `0s${b64}`, absPath],
+    );
+  } catch (err) {
+    throw xattrErrorFromExec(err);
+  }
+}
+
+async function hostListxattr(absPath: string): Promise<string[]> {
+  try {
+    if (IS_DARWIN) {
+      // `xattr -s` lists names, one per line. -s = symlink-itself.
+      const { stdout } = await execFile("xattr", ["-s", absPath], { encoding: "utf8" });
+      return stdout.split("\n").filter((n) => n.length > 0);
+    }
+    // getfattr's listing is verbose: a "# file: <path>" comment header,
+    // then one name per line, then a blank line. --match=. is a regex
+    // that matches every name (the default would skip names not in the
+    // `user.*` namespace). --no-dereference targets the link itself.
+    const { stdout } = await execFile(
+      "getfattr",
+      ["--no-dereference", "--absolute-names", "--match=.", absPath],
+      { encoding: "utf8" },
+    );
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"));
+  } catch (err) {
+    const xe = xattrErrorFromExec(err);
+    // Linux getfattr exits 0 with empty output for "no attrs"; if we
+    // get ENODATA here it means the host considers the file absent.
+    if (xe.errno === ERRNO.ENODATA) {
+      return [];
+    }
+    throw xe;
+  }
+}
+
+async function hostRemovexattr(absPath: string, name: string): Promise<void> {
+  try {
+    if (IS_DARWIN) {
+      await execFile("xattr", ["-d", "-s", name, absPath]);
+      return;
+    }
+    await execFile("setfattr", ["--no-dereference", "-x", name, absPath]);
+  } catch (err) {
+    throw xattrErrorFromExec(err);
+  }
+}
+
+/**
+ * Wire-encoding for a LISTXATTR reply: every name followed by a NUL
+ * byte, concatenated. Matches the kernel's `listxattr(2)` ABI.
+ */
+function packListxattrNames(names: string[]): Uint8Array {
+  const encoded = names.map((n) => Buffer.from(`${n}\0`, "utf8"));
+  const total = encoded.reduce((sum, b) => sum + b.length, 0);
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const b of encoded) {
+    out.set(b, cursor);
+    cursor += b.length;
+  }
+  return out;
+}
+
+async function onSetxattr(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const body = payloadOf(msg);
+  const req = readSetxattrIn(body);
+  const after = body.subarray(FUSE_SETXATTR_IN_SIZE);
+  // Name is NUL-terminated; the value bytes (length = req.size) follow
+  // immediately after the terminator and are NOT NUL-terminated.
+  const nulAt = after.indexOf(0);
+  if (nulAt < 0) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const name = new TextDecoder("utf-8", { fatal: false }).decode(after.subarray(0, nulAt));
+  if (name === "" || name.length > 255) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const valueStart = nulAt + 1;
+  if (valueStart + req.size > after.length) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const value = after.subarray(valueStart, valueStart + req.size);
+  const entry = requireInode(state, hdr.nodeid);
+  const abs = await absPathForLstat(state, entry);
+  // XATTR_CREATE: fail with EEXIST when the attr already exists.
+  // XATTR_REPLACE: fail with ENODATA when it doesn't. Both pre-checks
+  // race against concurrent host-side writers, but inside a single
+  // mount the FUSE channel serialises every op so the only window is
+  // direct host-fs activity outside the guest's view — acceptable.
+  if ((req.flags & XATTR.CREATE) && (await hostXattrExists(abs, name))) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EEXIST);
+  }
+  if ((req.flags & XATTR.REPLACE) && !(await hostXattrExists(abs, name))) {
+    return buildErrorResponse(hdr.unique, -ERRNO.ENODATA);
+  }
+  try {
+    await hostSetxattr(abs, name, value);
+  } catch (err) {
+    if (isXattrError(err)) {
+      return buildErrorResponse(hdr.unique, -err.errno);
+    }
+    throw err;
+  }
+  // SETXATTR reply is the bare success header — no payload.
+  return buildErrorResponse(hdr.unique, 0);
+}
+
+async function onGetxattr(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  const body = payloadOf(msg);
+  const req = readGetxattrIn(body);
+  const after = body.subarray(8);
+  const nulAt = after.indexOf(0);
+  if (nulAt < 0) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const name = new TextDecoder("utf-8", { fatal: false }).decode(after.subarray(0, nulAt));
+  if (name === "" || name.length > 255) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const entry = requireInode(state, hdr.nodeid);
+  const abs = await absPathForLstat(state, entry);
+  let value: Buffer | null;
+  try {
+    value = await hostGetxattr(abs, name);
+  } catch (err) {
+    if (isXattrError(err)) {
+      return buildErrorResponse(hdr.unique, -err.errno);
+    }
+    throw err;
+  }
+  if (value === null) {
+    return buildErrorResponse(hdr.unique, -ERRNO.ENODATA);
+  }
+  // Two reply forms. Probe (`size == 0`): caller wants the value's
+  // length so they can size a buffer — reply is `fuse_getxattr_out`.
+  // Fetch (`size > 0`): reply is the raw value bytes when it fits, or
+  // -ERANGE when the caller's buffer is too small.
+  if (req.size === 0) {
+    return buildResponse(hdr.unique, buildGetxattrOut(value.length));
+  }
+  if (value.length > req.size) {
+    return buildErrorResponse(hdr.unique, -ERRNO.ERANGE);
+  }
+  return buildResponse(hdr.unique, new Uint8Array(value.buffer, value.byteOffset, value.length));
+}
+
+async function onListxattr(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  const req = readGetxattrIn(payloadOf(msg));
+  const entry = requireInode(state, hdr.nodeid);
+  const abs = await absPathForLstat(state, entry);
+  let names: string[];
+  try {
+    names = await hostListxattr(abs);
+  } catch (err) {
+    if (isXattrError(err)) {
+      return buildErrorResponse(hdr.unique, -err.errno);
+    }
+    throw err;
+  }
+  const packed = packListxattrNames(names);
+  // Same probe/fetch dance as GETXATTR. The probe reply carries the
+  // packed total length; the fetch reply is the raw NUL-separated
+  // names buffer.
+  if (req.size === 0) {
+    return buildResponse(hdr.unique, buildGetxattrOut(packed.length));
+  }
+  if (packed.length > req.size) {
+    return buildErrorResponse(hdr.unique, -ERRNO.ERANGE);
+  }
+  return buildResponse(hdr.unique, packed);
+}
+
+async function onRemovexattr(
+  hdr: FuseInHeader,
+  msg: Uint8Array,
+  state: ServerState,
+): Promise<Uint8Array> {
+  if (state.mode === "ro") {
+    return buildErrorResponse(hdr.unique, -ERRNO.EROFS);
+  }
+  const name = decodeName(payloadOf(msg));
+  if (name === "" || name.length > 255) {
+    return buildErrorResponse(hdr.unique, -ERRNO.EINVAL);
+  }
+  const entry = requireInode(state, hdr.nodeid);
+  const abs = await absPathForLstat(state, entry);
+  try {
+    await hostRemovexattr(abs, name);
+  } catch (err) {
+    if (isXattrError(err)) {
+      return buildErrorResponse(hdr.unique, -err.errno);
+    }
+    throw err;
+  }
+  return buildErrorResponse(hdr.unique, 0);
 }
 
 // --- POSIX advisory locks (#322) ----------------------------------------

--- a/packages/runtime/src/mount-server.ts
+++ b/packages/runtime/src/mount-server.ts
@@ -1362,7 +1362,12 @@ interface XattrError {
 }
 
 function isXattrError(e: unknown): e is XattrError {
-  return typeof e === "object" && e !== null && "errno" in e && typeof (e as XattrError).errno === "number";
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "errno" in e &&
+    typeof (e as XattrError).errno === "number"
+  );
 }
 
 /**
@@ -1447,11 +1452,7 @@ async function hostXattrExists(absPath: string, name: string): Promise<boolean> 
   return (await hostGetxattr(absPath, name)) !== null;
 }
 
-async function hostSetxattr(
-  absPath: string,
-  name: string,
-  value: Uint8Array,
-): Promise<void> {
+async function hostSetxattr(absPath: string, name: string, value: Uint8Array): Promise<void> {
   try {
     if (IS_DARWIN) {
       // -wx accepts the value as a hex string. Pair with -s to act on
@@ -1464,10 +1465,7 @@ async function hostSetxattr(
     // which is the safe channel for binary data. The base64 alphabet is
     // ASCII so argv passes it through verbatim.
     const b64 = Buffer.from(value.buffer, value.byteOffset, value.length).toString("base64");
-    await execFile(
-      "setfattr",
-      ["--no-dereference", "-n", name, "-v", `0s${b64}`, absPath],
-    );
+    await execFile("setfattr", ["--no-dereference", "-n", name, "-v", `0s${b64}`, absPath]);
   } catch (err) {
     throw xattrErrorFromExec(err);
   }
@@ -1565,10 +1563,10 @@ async function onSetxattr(
   // race against concurrent host-side writers, but inside a single
   // mount the FUSE channel serialises every op so the only window is
   // direct host-fs activity outside the guest's view — acceptable.
-  if ((req.flags & XATTR.CREATE) && (await hostXattrExists(abs, name))) {
+  if (req.flags & XATTR.CREATE && (await hostXattrExists(abs, name))) {
     return buildErrorResponse(hdr.unique, -ERRNO.EEXIST);
   }
-  if ((req.flags & XATTR.REPLACE) && !(await hostXattrExists(abs, name))) {
+  if (req.flags & XATTR.REPLACE && !(await hostXattrExists(abs, name))) {
     return buildErrorResponse(hdr.unique, -ERRNO.ENODATA);
   }
   try {


### PR DESCRIPTION
## Problem

When the guest in a `--mount-live` mount tries to write or read an
extended attribute — the small named labels filesystems attach to
files for things like Linux's file capabilities, SELinux security
contexts, or arbitrary user-defined tags — nothing happens. The
mount server replies "I don't know how to do that" to all four
extended-attribute requests (set, get, list, remove). Tools tolerate
the reply and don't crash, so the failure is silent: a `setcap` no-ops,
a `rsync -X` quietly loses data, a `getfattr -d` comes back empty
regardless of what the host actually stores.

Filed as issue #321.

## Solution

Wire all four extended-attribute operations through to the host
filesystem. The mount server now shells out to the platform's
standard tool — `xattr` on macOS, `getfattr`/`setfattr` on Linux —
once per call, with one subprocess per request. Cost is a handful
of milliseconds per call, which is fine for the things this matters
for: install-time file capabilities, occasional SELinux relabels,
the odd `tar` extract that carries xattrs.

Concretely:

1. **Four new request handlers** (`SETXATTR`, `GETXATTR`, `LISTXATTR`,
   `REMOVEXATTR`) in the mount server, plus the protocol-side
   structures they speak.
2. **No name translation.** Names go through verbatim. On Linux the
   host kernel polices the privileged `security.*` / `trusted.*`
   namespaces — so a guest's `setcap` against a non-root host returns
   "permission denied" instead of silently losing data, which is the
   closest-to-correct behavior we can give. On macOS there's no
   namespace concept at all, so every name round-trips inside the
   mount; it's only invisible to Linux-specific host tools, which is
   the documented trade-off in issue #321.
3. **Create / replace flags** in `SETXATTR` are honored by a quick
   "does this attribute already exist" check before the write.
4. **Read-only mounts** continue to reject mutations: writes and
   deletes return the read-only-filesystem error; reads and listings
   are allowed.
5. **Tests** in `mount-server.test.ts` follow the project's per-op
   convention: happy round-trip (set → probe → fetch → list → remove
   → re-get returns "no such attribute"); error paths (the same "no
   such attribute" reply on an unset name; a "value too big" reply
   when the caller's fetch buffer is smaller than the value); the
   read-only gate on the two mutating ops; and every assertion goes
   through the wedge-deadline helper so a hang becomes a fast,
   specific failure. The xattr test block skips when neither tool
   family is on `PATH`.
6. **Changeset** as a `minor` bump on `@machinen/runtime` (new
   capability, no breaking changes).

Closes #321.

## Technical Summary

**`mount-fuse-protocol.ts`**

- Add opcodes `SETXATTR` (21), `GETXATTR` (22), `LISTXATTR` (23),
  `REMOVEXATTR` (24) to `FUSE_OP`.
- Add codecs for `fuse_setxattr_in` (8 bytes: `size`, `flags`) and
  `fuse_getxattr_in` (8 bytes: `size`, `padding`); both are followed
  on the wire by a NUL-terminated name (and for `SETXATTR`, the raw
  value bytes immediately after the name terminator — no value
  terminator, length is in `size`).
- Add a builder for `fuse_getxattr_out` (8 bytes: `size`, `padding`)
  — the size-probe reply both `GETXATTR` and `LISTXATTR` share.
- Export `XATTR.CREATE` (1) / `XATTR.REPLACE` (2) flag bits.

**`mount-server.ts`**

- Add `ENODATA` (61) and `ERANGE` (34) to the `ERRNO` table. macOS's
  `ENOATTR` (errno 93) is normalized to `ENODATA` (61) on the wire so
  the guest kernel sees the canonical "no such attribute" code
  regardless of host.
- Wire the four new opcodes into the dispatch switch.
- Add four handlers:
  - `onSetxattr`: `EROFS` on `:ro`; parses name + value out of the
    body; pre-check `XATTR_CREATE` / `XATTR_REPLACE` against the
    current state (returning `EEXIST` / `ENODATA` respectively);
    shells out via the host helper.
  - `onGetxattr`: parses name; fetches value from host; for
    `req.size == 0` replies with a `fuse_getxattr_out` carrying the
    length, for `req.size > 0` replies with raw value bytes when it
    fits or `ERANGE` when it doesn't.
  - `onListxattr`: probes (size header) or returns the
    NUL-separated names buffer, same shape as `GETXATTR`.
  - `onRemovexattr`: `EROFS` on `:ro`; parses name; shells out.
- Add four host helpers — `hostGetxattr`, `hostSetxattr`,
  `hostListxattr`, `hostRemovexattr` — that branch on `process.platform`:
  - macOS uses `xattr -p -s -x` / `xattr -w -s -x` / `xattr -s` /
    `xattr -d -s`. `-s` targets the symlink itself when the path is
    a link (mirroring `lstat`-shaped ops elsewhere in the server).
    `-x` is mandatory for binary values — the default string decoder
    would mangle anything that isn't UTF-8.
  - Linux uses `getfattr --only-values` / `setfattr -v 0sBASE64` /
    `getfattr --match=.` / `setfattr -x`. `--no-dereference` is the
    Linux equivalent of `-s`. Binary values pass through as base64
    (`0s` prefix tells `setfattr` to base64-decode).
- Add `decodeXattrStderr` to translate the tools' free-form error
  strings into wire errno values, and `xattrErrorFromExec` to
  separate the "tool not installed" case (`ENOENT` at spawn time,
  surfaced as `ENOTSUP`) from real errors so the guest knows the op
  didn't silently no-op.

**`__tests__/mount-server.test.ts`**

- Remove `SETXATTR` / `GETXATTR` / `LISTXATTR` / `REMOVEXATTR` from
  `UNIMPLEMENTED_OPS` so the "always-`ENOSYS`-within-deadline"
  assertion no longer covers them.
- Add an `xattr ops (#321)` describe block with a `:rw` fixture and
  six tests: happy round-trip, missing-attr `ENODATA`, small-buffer
  `ERANGE`, `:ro` `EROFS` on `SETXATTR`, `:ro` `EROFS` on
  `REMOVEXATTR`, `:ro` allow on `GETXATTR` / `LISTXATTR`.
- Add `buildSetxattrIn`, `buildGetxattrIn`, `buildGetxattrInWithName`
  wire builders.
- Probe-length check on `LISTXATTR` uses `>=` rather than `===` since
  macOS quietly stamps `com.apple.provenance` on every file the host
  process touches; the fetch step's content check is the real
  contract.

**`.changeset/xattr-fuse-ops.md`** — `minor` bump on
`@machinen/runtime` describing the new capability.