### PR TITLE
fix(runtime): VsockExec stops double-collecting stdout when streamed

### DIFF
--- a/.changeset/exec-streaming-no-double-collect.md
+++ b/.changeset/exec-streaming-no-double-collect.md
@@ -1,0 +1,30 @@
+---
+"@machinen/runtime": patch
+---
+
+Fix `VsockExec.run` collecting a parallel buffered copy of every
+chunk when the caller passes `onStdout` / `onStderr`. The buffered
+copy was concatenated and decoded as UTF-8 at finish time, so any
+streaming caller whose cumulative output crossed V8's ~512 MiB max
+string length crashed with `ERR_STRING_TOO_LONG` from
+`Buffer.concat(...).toString("utf8")` in `finish()`.
+
+The snapshot path uses `onStdout` to pump criu tar bytes into a
+host-side `tar -x`. For workloads with more than ~512 MiB of dirty
+pages the dump produces enough stdout to trip the limit, so every
+such snapshot failed with a V8 internal error instead of completing.
+The S5 smoke test (`scripts/smoke-tests.sh`, 2 GiB-dirty workload)
+was the most visible victim — closing #325.
+
+Fix: when `onStdout` is set, skip pushing chunks into `stdoutBufs`;
+same for `onStderr` / `stderrBufs`. The result's `stdout` / `stderr`
+fields come back as empty strings for streaming callers, which is
+documented in `VsockExecResult` and is what those callers want
+anyway — they already have the bytes via the callback.
+
+Adds `__tests__/exec-streaming.test.ts` covering: streamed-stdout
+result is empty + callback sees every byte, same for stderr, the
+existing buffered path still collects when no callback is set, and
+the mixed case (one channel streamed, the other buffered).
+
+Closes #325.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -1448,9 +1448,16 @@ Called with each stderr chunk as it arrives (pass-through tee).
 
 > **stdout**: `string`
 
+Concatenated stdout bytes, decoded as UTF-8. Always `""` when the
+caller passed `onStdout` — streaming callers already have the
+bytes and a parallel buffered copy would defeat the streaming
+(and at multi-GB volumes would crash with ERR_STRING_TOO_LONG).
+
 ##### stderr
 
 > **stderr**: `string`
+
+Same shape as `stdout` for the stderr channel + `onStderr`.
 
 ***
 

--- a/packages/runtime/src/__tests__/exec-streaming.test.ts
+++ b/packages/runtime/src/__tests__/exec-streaming.test.ts
@@ -1,0 +1,166 @@
+// Regression: when a caller passes `onStdout` / `onStderr` to
+// `VsockExec.run`, the implementation should NOT also collect those
+// chunks into the buffered `stdout` / `stderr` fields of the result.
+//
+// History: the chunk handler was unconditionally pushing every byte
+// into `stdoutBufs` / `stderrBufs` alongside the user-visible callback.
+// At `finish()` the buffered copy was concatenated with
+// `Buffer.concat(...).toString("utf8")`, which throws
+// `ERR_STRING_TOO_LONG` once the cumulative output crosses V8's max
+// string length (~512 MiB). The snapshot-dump path streams ~2 GiB of
+// criu tar bytes through `onStdout` into a host-side `tar -x`, so
+// every snapshot of a workload over ~512 MiB of dirty pages was
+// failing with an unhelpful V8 error.
+//
+// We drive the protocol directly over a Unix-socket pair — no VM, no
+// agent binary. That keeps the test cheap and the regression specific
+// to the exec.ts contract.
+
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VsockExec } from "../exec.ts";
+
+let scratch: string;
+let server: Server | undefined;
+let udsPath: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "machinen-exec-streaming-"));
+  udsPath = join(scratch, "exec.sock");
+});
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((done) => server!.close(() => done()));
+    server = undefined;
+  }
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+/**
+ * Bring up a one-shot fake exec-agent. On the first connection it
+ * reads (and discards) the EXEC header line, then writes the supplied
+ * sequence of stdout / stderr chunks framed in the exec-agent wire
+ * format (`O <byte-len>\n<bytes>` / `E <byte-len>\n<bytes>`), then
+ * `X 0\n`, then closes.
+ */
+async function startFakeAgent(chunks: Array<{ stream: "O" | "E"; bytes: Buffer }>): Promise<void> {
+  server = createServer((sock: Socket) => {
+    let header = Buffer.alloc(0);
+    sock.on("data", (chunk: Buffer) => {
+      header = Buffer.concat([header, chunk]);
+      const nl = header.indexOf(0x0a);
+      if (nl < 0) {
+        return;
+      }
+      sock.removeAllListeners("data");
+      for (const { stream, bytes } of chunks) {
+        sock.write(`${stream} ${bytes.length}\n`);
+        sock.write(bytes);
+      }
+      sock.write("X 0\n");
+      sock.end();
+    });
+  });
+  await new Promise<void>((done, fail) => {
+    server!.once("error", fail);
+    server!.listen(udsPath, () => {
+      server!.off("error", fail);
+      done();
+    });
+  });
+}
+
+describe("VsockExec — streaming callback drops buffered collection", () => {
+  it("stdout result is empty when onStdout is provided; callback sees every byte", async () => {
+    // 4 chunks × 64 KiB = 256 KiB total — large enough to exercise the
+    // chunk loop, small enough to keep the test cheap. The regression
+    // bug surfaces at hundreds of MB; we don't try to reproduce the
+    // V8 limit itself (memory expensive in CI) — we lock down the
+    // contract that prevents it.
+    const chunkBytes = Buffer.alloc(64 * 1024, 0x41);
+    const chunks = Array.from({ length: 4 }, () => ({
+      stream: "O" as const,
+      bytes: chunkBytes,
+    }));
+    await startFakeAgent(chunks);
+
+    let streamed = 0;
+    const result = await VsockExec.run(udsPath, "echo hi", {
+      onStdout: (chunk) => {
+        streamed += chunk.length;
+      },
+      connectTimeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    // The contract: streaming callers get bytes on the callback, the
+    // buffered result fields stay empty. Without this guard the
+    // implementation collects a parallel copy, which is the root
+    // cause of the >512 MiB ERR_STRING_TOO_LONG crash.
+    expect(result.stdout).toBe("");
+    expect(streamed).toBe(chunkBytes.length * chunks.length);
+  });
+
+  it("stderr result is empty when onStderr is provided; callback sees every byte", async () => {
+    const chunkBytes = Buffer.alloc(8 * 1024, 0x42);
+    const chunks = Array.from({ length: 3 }, () => ({
+      stream: "E" as const,
+      bytes: chunkBytes,
+    }));
+    await startFakeAgent(chunks);
+
+    let streamed = 0;
+    const result = await VsockExec.run(udsPath, "echo hi", {
+      onStderr: (chunk) => {
+        streamed += chunk.length;
+      },
+      connectTimeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(streamed).toBe(chunkBytes.length * chunks.length);
+  });
+
+  it("without callbacks, both result fields buffer the full output (existing contract)", async () => {
+    // Sanity that the non-streaming path still collects normally —
+    // otherwise the fix would over-correct and break every existing
+    // caller that relies on `result.stdout`.
+    await startFakeAgent([
+      { stream: "O", bytes: Buffer.from("hello-stdout") },
+      { stream: "E", bytes: Buffer.from("hello-stderr") },
+    ]);
+
+    const result = await VsockExec.run(udsPath, "echo hi", {
+      connectTimeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hello-stdout");
+    expect(result.stderr).toBe("hello-stderr");
+  });
+
+  it("mixed: onStdout set, onStderr unset — only the streamed side is empty", async () => {
+    await startFakeAgent([
+      { stream: "O", bytes: Buffer.from("streamed-stdout") },
+      { stream: "E", bytes: Buffer.from("buffered-stderr") },
+    ]);
+
+    let streamed = "";
+    const result = await VsockExec.run(udsPath, "echo hi", {
+      onStdout: (chunk) => {
+        streamed += chunk.toString("utf8");
+      },
+      connectTimeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(streamed).toBe("streamed-stdout");
+    expect(result.stderr).toBe("buffered-stderr");
+  });
+});

--- a/packages/runtime/src/__tests__/streaming.test.ts
+++ b/packages/runtime/src/__tests__/streaming.test.ts
@@ -60,7 +60,12 @@ describe("VsockExec streaming", () => {
     });
 
     expect(res.exitCode).toBe(0);
-    expect(res.stdout).toBe("early\nlate\n");
+    // Streaming-caller contract: when `onStdout` is set the result's
+    // `stdout` field comes back empty — the caller already has every
+    // byte via the callback, and a parallel buffered copy here would
+    // crash with ERR_STRING_TOO_LONG at multi-GB volumes (see
+    // exec-streaming.test.ts).
+    expect(res.stdout).toBe("");
 
     // Two streamed chunks, not one merged one.
     expect(chunks.length).toBe(2);

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -55,7 +55,14 @@ export interface VsockExecOptions {
 
 export interface VsockExecResult {
   exitCode: number;
+  /**
+   * Concatenated stdout bytes, decoded as UTF-8. Always `""` when the
+   * caller passed `onStdout` — streaming callers already have the
+   * bytes and a parallel buffered copy would defeat the streaming
+   * (and at multi-GB volumes would crash with ERR_STRING_TOO_LONG).
+   */
   stdout: string;
+  /** Same shape as `stdout` for the stderr channel + `onStderr`. */
   stderr: string;
 }
 
@@ -293,12 +300,27 @@ async function runOnSocket(
           const chunk = buf.subarray(0, take);
           buf = buf.subarray(take);
           awaitingBytes -= take;
+          // Buffer for the resolved-result string field only when no
+          // streaming callback is set. Callers that pass `onStdout` /
+          // `onStderr` already have the bytes — keeping a parallel copy
+          // here costs RAM and, at >~512 MiB cumulative, breaks
+          // `Buffer.concat(...).toString("utf8")` in `finish()` with
+          // ERR_STRING_TOO_LONG (V8's max string length). Streaming
+          // callers see `stdout` / `stderr` come back as empty strings,
+          // which is the contract: opt into the callback, take the
+          // bytes there.
           if (payloadTag === "O") {
-            stdoutBufs.push(chunk);
-            opts.onStdout?.(chunk);
+            if (opts.onStdout) {
+              opts.onStdout(chunk);
+            } else {
+              stdoutBufs.push(chunk);
+            }
           } else if (payloadTag === "E") {
-            stderrBufs.push(chunk);
-            opts.onStderr?.(chunk);
+            if (opts.onStderr) {
+              opts.onStderr(chunk);
+            } else {
+              stderrBufs.push(chunk);
+            }
           }
           if (awaitingBytes === 0) {
             payloadTag = null;


### PR DESCRIPTION
## Problem

The host-side primitive that runs shell commands inside a guest can
hand the output back two ways: as one big string at the end, or as
small chunks delivered to a callback as they arrive. The streaming
form is what the snapshot path uses — it pipes tar bytes from a
guest-side dump straight into a host-side `tar -x`, never wanting to
hold the whole stream in memory.

The implementation was doing both at the same time. Every chunk
went to the user's callback *and* into a parallel buffer that the
result object materialised as a string at the end. For small commands
nobody noticed. For the snapshot of a workload with a couple of
gigabytes of dirty memory, the parallel buffer crossed the limit on
how big a single string can be in Node — about 512 MiB on V8's
default build — and the whole snapshot failed with an unhelpful
internal error: `ERR_STRING_TOO_LONG`.

The most visible victim was the project's own S5 smoke test, which
dirties 2 GiB on purpose and then snapshots. Filed as
[machinen#325](https://github.com/redwoodjs/machinen/issues/325).

## Solution

When the caller asks for streaming — by passing `onStdout` or
`onStderr` — stop also keeping a parallel buffered copy. Streaming
callers already have every byte through their callback; a second
buffered copy is wasted memory at small sizes and a hard crash at
large ones.

1. **The fix itself is small.** In the chunk handler in
   `packages/runtime/src/exec.ts`, push into the buffer *or* call the
   callback, not both.
2. **The result fields are now empty for streaming callers.** When a
   caller passes `onStdout`, the `stdout` field on the result comes
   back as the empty string. The contract is documented on the
   `VsockExecResult` interface. Every in-tree caller that passes a
   callback already ignored the result fields (verified by reading
   the call sites in `cli.ts`, `vm/snapshot.ts`, and `provision.ts`),
   so no production caller breaks.
3. **Regression test.** A new file
   `__tests__/exec-streaming.test.ts` stands up a fake exec agent on
   a Unix socket and asserts the contract in four shapes: streamed
   stdout → result is empty, streamed stderr → result is empty,
   no-callback → both result fields collect normally, and the mixed
   case where one channel is streamed and the other isn't.
4. **Existing test updated.** The pre-existing `streaming.test.ts`
   was asserting both the callback and the buffered field — implicitly
   documenting the broken dual-collect behaviour. Its result-field
   assertion is updated to expect the empty string. The streaming
   guarantee (the chunk arrives before the next one is written) is
   unchanged.
5. **Changeset** as a `patch` bump on `@machinen/runtime` (bug fix,
   behaviour change visible only to callers that were relying on the
   undocumented dual-collect).

Closes #325.

## Technical Summary

**`packages/runtime/src/exec.ts`**

In the `runOnSocket` chunk loop, the bug was this block:

```ts
if (payloadTag === "O") {
  stdoutBufs.push(chunk);     // always
  opts.onStdout?.(chunk);     // also
}
```

The chunk was pushed to the buffer regardless of whether the caller
had asked for streaming. At `finish()`,
`Buffer.concat(stdoutBufs).toString("utf8")` is called to populate
`result.stdout`. Once `stdoutBufs` totals more than V8's
`String::kMaxLength` (`~512 MiB` on most builds, exact value depends
on pointer compression), that call throws `ERR_STRING_TOO_LONG` and
the whole `run()` promise rejects.

The fix flips the push into an else-branch on the callback:

```ts
if (payloadTag === "O") {
  if (opts.onStdout) {
    opts.onStdout(chunk);
  } else {
    stdoutBufs.push(chunk);
  }
}
```

Same shape for the `"E"` (stderr) branch. JSDoc on the
`VsockExecResult.stdout` / `.stderr` fields now documents the
empty-string contract.

**`packages/runtime/src/__tests__/exec-streaming.test.ts`** (new)

Stands up a `node:net` Unix-socket server that mimics the wire format
the guest's exec-agent speaks: read-and-discard the `EXEC` header
line, write a sequence of `O <len>\n<bytes>` or `E <len>\n<bytes>`
frames, then `X 0\n`, then close. Drives `VsockExec.run` against it
with four scenarios:

- 256 KiB across four `O` frames, `onStdout` set: assert
  `result.stdout === ""` and the callback sum equals total.
- 24 KiB across three `E` frames, `onStderr` set: same contract for
  the stderr channel.
- Two frames, no callbacks: assert `result.stdout` /
  `result.stderr` carry the expected text.
- Mixed: `onStdout` set, `onStderr` not: streamed channel empty in
  result, buffered channel populated.

We don't reproduce the V8 limit directly — 512 MiB+ in a unit test
is too memory-expensive for CI. The "result is empty when callback
is set" assertion is the regression guard: anyone who re-introduces
the unconditional push immediately fails the first two tests.

**`packages/runtime/src/__tests__/streaming.test.ts`**

The `expect(res.stdout).toBe("early\nlate\n")` assertion is replaced
with `expect(res.stdout).toBe("")` and a comment pointing at the new
test. The streaming-timing assertions (`chunks[0].t` arrives before
`chunks[1]` is written) are untouched — that's the actual point of
this test, and it still works.

**`packages/runtime/API.md`**

Regenerated via `pnpm build:docs` to pick up the new JSDoc on
`VsockExecResult.stdout` / `.stderr`. Required to keep the API.md
drift test green.

**`.changeset/exec-streaming-no-double-collect.md`** — `patch` bump
on `@machinen/runtime`.