### PR TITLE
Fix VM interactive prompt

### DIFF
--- a/packages/cli/src/__tests__/quiet.test.ts
+++ b/packages/cli/src/__tests__/quiet.test.ts
@@ -62,6 +62,8 @@ describe("isBootNoiseLine", () => {
   const noiseSamples = [
     "[    0.123456] Booting Linux on physical CPU 0x0",
     "[ 1234.567] EXT4-fs (vda): mounted",
+    "=== machinen /init: reading /machinen-config.json ===",
+    "\r\r=== machinen /init: reading /machinen-config.json ===",
     "init: machinen-netup exited non-zero — network may not be up",
     "checkpoint: post-tryRootDiskPivot",
     "checkpoint: post-bringUpNetwork",
@@ -70,6 +72,10 @@ describe("isBootNoiseLine", () => {
     "machinen-supervisor: spawning workload",
     "machinen-dump: criu exit=0",
     "machinen-netup: gvproxy ready",
+    "topology: 31750dad25ded0f50100a9340063397ae73868c1ddf9b5996e89049b007a5cbd",
+    "vsock: in 1978 <-> /tmp/machinen/exec.sock",
+    "hvf boot: starting snapshot watcher (vcpu=0)",
+    "hvf watcher: thread started, vcpu=0",
   ];
 
   it.each(noiseSamples)("classifies %s as boot noise", (line) => {
@@ -81,6 +87,7 @@ describe("isBootNoiseLine", () => {
     "Listening on http://localhost:3000",
     "node:fs:1234 fs.readFile()",
     "Error: ENOENT: no such file or directory",
+    "[    0.123456] reboot: Power down",
     "",
     "    indented log line",
   ];
@@ -133,6 +140,43 @@ describe("NoiseFilter", () => {
     expect(outBytes).toBe("hello\n");
   });
 
+  it("passes an interactive prompt through even without a newline", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    let outBytes = "";
+    out.on("data", (chunk: Buffer) => {
+      outBytes += chunk.toString();
+    });
+    const onReady = vi.fn();
+
+    const f = new NoiseFilter({ buffer, out, onReady });
+    f.push(Buffer.from("supervisor: starting cmd=/usr/bin/env bash -i\n"));
+    f.push(Buffer.from("\x1b[?2004hroot@worker-pid-1234:/# "));
+
+    expect(buffer.toString()).toContain("supervisor: starting");
+    expect(outBytes).toBe("\x1b[?2004hroot@worker-pid-1234:/# ");
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(f.ready).toBe(true);
+  });
+
+  it("streams post-ready echo bytes without waiting for a newline", () => {
+    const buffer = new RingBuffer();
+    const out = new PassThrough();
+    let outBytes = "";
+    out.on("data", (chunk: Buffer) => {
+      outBytes += chunk.toString();
+    });
+
+    const f = new NoiseFilter({ buffer, out });
+    f.push(Buffer.from("\x1b[?2004hroot@worker-pid-1234:/# "));
+    f.push(Buffer.from("e"));
+    f.push(Buffer.from("c"));
+    f.push(Buffer.from("ho"));
+
+    expect(outBytes).toBe("\x1b[?2004hroot@worker-pid-1234:/# echo");
+    expect(buffer.toString()).toContain("echo");
+  });
+
   it("flush() drains a trailing residual line as noise pre-ready", () => {
     const buffer = new RingBuffer();
     const out = new PassThrough();
@@ -149,13 +193,13 @@ describe("NoiseFilter", () => {
     expect(outBytes).toBe("");
   });
 
-  it("blank pre-ready lines stay buffered and don't flip the gate", () => {
+  it("blank/control-only pre-ready lines stay buffered and don't flip the gate", () => {
     const buffer = new RingBuffer();
     const out = new PassThrough();
     const onReady = vi.fn();
 
     const f = new NoiseFilter({ buffer, out, onReady });
-    f.push(Buffer.from("checkpoint: x\n\n\n"));
+    f.push(Buffer.from("checkpoint: x\n\n\r\r\n"));
     expect(onReady).not.toHaveBeenCalled();
     expect(f.ready).toBe(false);
   });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { Transform } from "node:stream";
+import { PassThrough, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import {
@@ -457,12 +457,14 @@ async function cmdBoot(args: string[]): Promise<number> {
   const bootT0 = Date.now();
   const buffer = new RingBuffer();
   let filter: NoiseFilter | null = null;
+  let filterOut: PassThrough | null = null;
   if (showHeadlines) {
     printHeadline(`booting ${headlineName}…`);
     if (!detached) {
+      filterOut = new PassThrough();
       filter = new NoiseFilter({
         buffer,
-        out: process.stderr,
+        out: filterOut,
         onReady: () => {
           printHeadline("guest ready");
           printHeadline(`ready in ${formatElapsed(Date.now() - bootT0)}`);
@@ -582,6 +584,12 @@ async function cmdBoot(args: string[]): Promise<number> {
     forwardedSignal = "SIGTERM";
     void vm.kill();
   });
+  // In quiet mode, don't display the workload's first prompt until
+  // stdin is in raw mode and piped to the VM. Bash prompts are partial
+  // (no trailing LF); showing them during boot made the terminal look
+  // ready while host stdin was still canonical, so typed characters
+  // appeared only after Enter and early input could be lost.
+  filterOut?.pipe(process.stderr);
 
   try {
     const { code } = await vm.wait();

--- a/packages/cli/src/quiet.ts
+++ b/packages/cli/src/quiet.ts
@@ -124,17 +124,47 @@ export class RingBuffer {
 // passes through to the user immediately.
 const NOISE_PREFIXES: ReadonlyArray<RegExp> = [
   /^\[\s*\d+\.\d+\]/, // kernel printk: "[    0.123456] ..."
+  /^=== machinen \/init:/,
   /^init:/,
   /^checkpoint:/,
   /^mountdisk:/,
   /^machinen-restore:/,
   /^machinen-supervisor:/,
+  /^supervisor:/,
   /^machinen-dump:/,
   /^machinen-netup:/,
+  /^topology:/,
+  /^vsock:/,
+  /^(?:hvf|kvm)(?: [^:]+)?:/,
 ];
 
 export function isBootNoiseLine(line: string): boolean {
-  return NOISE_PREFIXES.some((re) => re.test(line));
+  const visible = stripAnsiControl(line).trimStart();
+  if (visible.includes("reboot: Power down")) {
+    return false;
+  }
+  return NOISE_PREFIXES.some((re) => re.test(visible));
+}
+
+const ESC = String.fromCharCode(27);
+const CR = String.fromCharCode(13);
+const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function stripAnsiControl(text: string): string {
+  return text.replace(CSI_RE, "").split(CR).join("");
+}
+
+function isLikelyInteractivePrompt(text: string): boolean {
+  // Bash prompts are intentionally not newline-terminated. In quiet
+  // mode, waiting for LF means the user sees only the final boot-noise
+  // line (`supervisor: starting ...`) until they press Enter, at which
+  // point the prompt finally flushes. Detect the common Debian/root
+  // prompt shape (`root@host:/#`, `dev@host:/path$`) and pass it
+  // through immediately while still keeping arbitrary partial boot
+  // noise line-buffered. Readline may prefix the prompt with ANSI CSI
+  // controls such as bracketed-paste enable (`\x1b[?2004h`), so match
+  // against the visible text but pass the original bytes through.
+  return /^[^\s@]+@[^\s:]+:[^\n\r]*[#$] ?$/.test(stripAnsiControl(text));
 }
 
 export interface NoiseFilterOpts {
@@ -151,14 +181,16 @@ export interface NoiseFilterOpts {
 }
 
 /**
- * Line-buffered filter over guest-console chunks. Each complete
- * line (LF-terminated, or the residual on flush) is classified as
- * boot noise (→ buffer) or workload output (→ stderr). The first
- * workload line flips the gate and triggers `onReady`.
+ * Pre-ready line-buffered filter over guest-console chunks. Each
+ * complete line (LF-terminated, or the residual on flush) is
+ * classified as boot noise (→ buffer) or workload output (→ stderr).
+ * The first workload line flips the gate and triggers `onReady`; after
+ * that, bytes pass through immediately so interactive echo is not held
+ * until Enter.
  *
- * Chunks may split lines mid-byte; the filter holds the residual
- * until the next chunk completes it. Call `.flush()` once on VM
- * exit to drain any trailing partial line — guest output that
+ * Chunks may split lines mid-byte before readiness; the filter holds
+ * the residual until the next chunk completes it. Call `.flush()` once
+ * on VM exit to drain any trailing partial line — guest output that
  * ended without a newline (rare but real for early panics).
  */
 export class NoiseFilter {
@@ -168,9 +200,20 @@ export class NoiseFilter {
   constructor(private readonly opts: NoiseFilterOpts) {}
 
   push(chunk: Buffer): void {
-    const combined = this.residual + chunk.toString("utf8");
+    const text = chunk.toString("utf8");
+    if (this.readyFired) {
+      this.passThrough(text);
+      return;
+    }
+
+    const combined = this.residual + text;
     const nlIdx = combined.lastIndexOf("\n");
     if (nlIdx === -1) {
+      if (isLikelyInteractivePrompt(combined)) {
+        this.residual = "";
+        this.routeLine(combined, "");
+        return;
+      }
       this.residual = combined;
       return;
     }
@@ -178,6 +221,11 @@ export class NoiseFilter {
     this.residual = combined.slice(nlIdx + 1);
     for (const line of splitLines(complete)) {
       this.routeLine(line, "\n");
+    }
+    if (this.readyFired && this.residual.length > 0) {
+      const tail = this.residual;
+      this.residual = "";
+      this.passThrough(tail);
     }
   }
 
@@ -202,11 +250,12 @@ export class NoiseFilter {
       this.opts.buffer.push(line + terminator);
       return;
     }
-    // First non-noise line flips the gate. Empty lines pre-ready
-    // (a stray blank line in init.zig output) stay buffered so we
-    // don't fire ready on whitespace.
+    // First non-noise line flips the gate. Empty / control-only lines
+    // pre-ready (a stray blank line in init.zig output, or CR padding
+    // from the serial console) stay buffered so we don't fire ready on
+    // whitespace.
     if (!this.readyFired) {
-      if (line.length === 0) {
+      if (stripAnsiControl(line).trim().length === 0) {
         this.opts.buffer.push(line + terminator);
         return;
       }
@@ -220,8 +269,12 @@ export class NoiseFilter {
     // Post-ready: pass through AND keep buffering (rolling tail)
     // so a workload that crashes minutes in still has context
     // for the failure dump.
-    this.opts.out.write(line + terminator);
-    this.opts.buffer.push(line + terminator);
+    this.passThrough(line + terminator);
+  }
+
+  private passThrough(text: string): void {
+    this.opts.out.write(text);
+    this.opts.buffer.push(text);
   }
 
   get ready(): boolean {

--- a/packages/microvm/assets/machinen-supervisor.sh
+++ b/packages/microvm/assets/machinen-supervisor.sh
@@ -49,14 +49,27 @@ if [ -x /sbin/machinen-winsize-agent ]; then
     WINSIZE_PID=$!
 fi
 
-# Label the guest with the VM's name so an interactive shell prompt
-# (\h in bash's default Debian PS1) shows which VM is attached. The
-# runtime injects MACHINEN_VM_NAME via machinen-config.json when the
-# caller passed --name; nameless boots leave the hostname unchanged.
-# `hostname` here is a no-op if the binary is missing or the value
-# fails validation — we never want a prompt cosmetic to break boot.
+# Label the guest so an interactive shell prompt (\h in bash's default
+# Debian PS1) shows which VM is attached. MACHINEN_VM_NAME is only an
+# early fallback: the runtime does not know the host VMM pid until after
+# spawn, so the host later sets the final `<name>-pid-<host_pid>` (or
+# `vm-pid-<host_pid>`) over exec-agent. When requested, wait briefly for
+# that final hostname before starting the workload; otherwise bash may
+# cache the kernel's initial `(none)` and keep showing it until the user
+# starts a new shell.
 if [ -n "${MACHINEN_VM_NAME:-}" ]; then
     hostname "$MACHINEN_VM_NAME" 2>/dev/null || true
+fi
+if [ "${MACHINEN_VM_HOSTNAME_WAIT:-}" = "1" ]; then
+    i=0
+    while [ "$i" -lt 100 ]; do
+        h=$(hostname 2>/dev/null || true)
+        case "$h" in
+            *-pid-[0-9]*|vm-pid-[0-9]*) break ;;
+        esac
+        i=$((i + 1))
+        sleep 0.05 2>/dev/null || break
+    done
 fi
 
 mkdir -p /run 2>/dev/null || true

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -23,6 +23,7 @@ import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { BootError, ExecError, buildMachinenConfig, measureFirstByte, boot } from "../index.ts";
 import { ensurePdeathsig } from "../pdeathsig.ts";
+import { buildGuestHostname } from "../vm/helpers.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
 
@@ -598,6 +599,18 @@ describe("mount option", () => {
         unlinkSync(fakeImage);
       } catch {}
     }
+  });
+});
+
+describe("guest hostname labels", () => {
+  it("include the host VMM pid for named and nameless VMs", () => {
+    expect(buildGuestHostname(1234, "worker")).toBe("worker-pid-1234");
+    expect(buildGuestHostname(1234)).toBe("vm-pid-1234");
+  });
+
+  it("sanitizes VM names before adding the pid suffix", () => {
+    expect(buildGuestHostname(99, "src/name~fork")).toBe("src-name-fork-pid-99");
+    expect(buildGuestHostname(99, "///")).toBe("vm-pid-99");
   });
 });
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -517,15 +517,18 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   let perBootRootDisk: string | undefined;
   const mergedGuestEnv: Record<string, string> = { ...opts.env };
 
-  // Surface the VM name in the guest so an interactive shell prompt
-  // (\h in bash's default Debian PS1) tells the user which VM they're
-  // attached to. machinen-supervisor.sh consumes this and calls
-  // sethostname() before spawning the workload. We don't have the host
-  // VMM pid yet — that's only known after spawn — so the name-less case
-  // simply doesn't set a hostname; users who want a labelled prompt
-  // pass --name.
+  // Surface the VM name in the guest as an early fallback so an
+  // interactive shell prompt (\h in bash's default Debian PS1) can tell
+  // the user which VM they're attached to. The final prompt label must
+  // also include the host VMM pid, which isn't known until after spawn;
+  // when vsock-exec is available, machinen-supervisor.sh waits briefly
+  // before starting the workload while the host-side setGuestHostname()
+  // below installs `<name>-pid-<host_pid>` (or `vm-pid-<host_pid>`).
   if (opts.name && !mergedGuestEnv.MACHINEN_VM_NAME) {
     mergedGuestEnv.MACHINEN_VM_NAME = opts.name;
+  }
+  if (vsockUdsPath && !mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT) {
+    mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT = "1";
   }
 
   try {


### PR DESCRIPTION
## Problem

Interactive VM boots could show `root@(none):/#` instead of a useful name. The prompt could also stay hidden behind `supervisor: starting ...` until you pressed Enter. After that, typed characters could be buffered, so you only saw what you typed after pressing Return.

## Solution

The guest now waits briefly for the host to set a hostname that includes the VM name and host pid. The CLI quiet filter now recognizes the real shell prompt, hides more boot noise, and streams input echo right away once the VM is ready. This keeps the prompt useful and makes interactive typing feel normal.

## Testing

- `pnpm run lint`
- `pnpm run format:check`
- `MACHINEN_REQUIRE_FIXTURES=0 npm_config_userconfig=/dev/null npx vitest run packages/cli/src/__tests__/quiet.test.ts`
- `npm_config_userconfig=/dev/null npx agent-ci run --all -q -p`
- `pnpm smoke-tests`

Note: full local `vitest` still hits the existing `vcpu-xload.test.ts` vector-register mismatch on this machine.
