### PR TITLE
Write vmstate snapshots asynchronously

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -33,6 +33,7 @@ const virtiofs_mod = @import("virtiofs.zig");
 const balloon_mod = @import("balloon.zig");
 const stats_mod = @import("stats.zig");
 const dtb_patch = @import("dtb_patch.zig");
+const vmstate_writer = @import("vmstate_writer.zig");
 
 // Guest-physical bases. Each virtio-MMIO device lives in a 0x200
 // window. The DTS has slots at 0x0A000000 + i*0x200; we wire up the
@@ -157,7 +158,8 @@ pub const Config = struct {
     /// Snapshot integration mirroring boot_kvm.zig's Config. Set
     /// `restore_path` to load .vmstate bytes at boot before the first
     /// vcpu.run(). Set `snapshot_path` to enable SIGUSR1-triggered
-    /// dump during the run loop.
+    /// capture during the run loop; compression/write continue on a
+    /// background thread while the guest resumes.
     restore_path: ?[]const u8 = null,
     snapshot_path: ?[]const u8 = null,
 };
@@ -166,7 +168,7 @@ pub const Result = struct {
     serial: []u8, // owned, free with allocator
     saw_psci_shutdown: bool,
     exits: usize,
-    /// True iff the run loop exited via SIGUSR1-triggered snapshot.
+    /// True iff a SIGUSR1-triggered snapshot was accepted.
     snapshotted: bool = false,
 };
 
@@ -553,54 +555,28 @@ fn startSnapshotWatcher(vcpu_handle: u64) void {
 const snap_c = struct {
     extern "c" fn open(path: [*:0]const u8, flags: c_int, mode: c_int) c_int;
     extern "c" fn close(fd: c_int) c_int;
-    extern "c" fn write(fd: c_int, buf: *const anyopaque, count: usize) isize;
     extern "c" fn read(fd: c_int, buf: *anyopaque, count: usize) isize;
     extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
-    extern "c" fn chmod(path: [*:0]const u8, mode: c_int) c_int;
-    extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
 };
 
 const SNAP_O_RDONLY: c_int = 0;
-const SNAP_O_WRONLY: c_int = 1;
-const SNAP_O_CREAT: c_int = 0x200; // macOS
-const SNAP_O_TRUNC: c_int = 0x400;
 const SNAP_SEEK_END: c_int = 2;
 const SNAP_SEEK_SET: c_int = 0;
 
-fn writeSnapshotFile(
+fn captureSnapshotJob(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: hvf.Vcpu,
     ram: []const u8,
     cfg: Config,
     devs: *const Devices,
-) !void {
+) !*vmstate_writer.Job {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
-
-    const vcpu_payload = try vcpu_dump.dumpHvf(gpa, vcpu.handle);
-    defer gpa.free(vcpu_payload);
-    const ram_payload = try ram_dump.encode(gpa, cfg.ram_base, ram);
-    defer gpa.free(ram_payload);
-    // GICv3 distributor + per-vCPU redistributor state. Without these
-    // a cross-VMM restore lands the guest on a fresh GIC: interrupts
-    // the kernel thinks are enabled (the vtimer PPI especially) are
-    // silently disabled, and the resumed guest never makes progress.
-    const gic_dist_payload = try gic_state.dumpHvfDist(gpa);
-    defer gpa.free(gic_dist_payload);
-    const gic_redist_payload = try gic_state.dumpHvfRedist(gpa, vcpu.handle);
-    defer gpa.free(gic_redist_payload);
-    // CPU interface (ICC_*) — captured via hv_gic_get_icc_reg. This
-    // gates whether interrupts the distributor marks pending actually
-    // reach the resumed vCPU; without a real capture the restored
-    // interface sits at reset (IGRPEN1=0, PMR=0) and the guest never
-    // wakes from its idle WFI.
-    const gic_cpuif_payload = try gic_state.dumpHvfCpuIf(gpa, vcpu.handle);
-    defer gpa.free(gic_cpuif_payload);
 
     const topo: topology.Topology = .{
         .ram_base = cfg.ram_base,
@@ -609,6 +585,25 @@ fn writeSnapshotFile(
         .gic_redist_base = 0x1000_0000,
     };
 
+    const job = try vmstate_writer.Job.create(gpa, "hvf", path, topo.hash());
+    errdefer job.destroy();
+    const a = job.arenaAllocator();
+
+    const vcpu_payload = try vcpu_dump.dumpHvf(a, vcpu.handle);
+    const ram_payload = try ram_dump.encode(a, cfg.ram_base, ram);
+    // GICv3 distributor + per-vCPU redistributor state. Without these
+    // a cross-VMM restore lands the guest on a fresh GIC: interrupts
+    // the kernel thinks are enabled (the vtimer PPI especially) are
+    // silently disabled, and the resumed guest never makes progress.
+    const gic_dist_payload = try gic_state.dumpHvfDist(a);
+    const gic_redist_payload = try gic_state.dumpHvfRedist(a, vcpu.handle);
+    // CPU interface (ICC_*) — captured via hv_gic_get_icc_reg. This
+    // gates whether interrupts the distributor marks pending actually
+    // reach the resumed vCPU; without a real capture the restored
+    // interface sits at reset (IGRPEN1=0, PMR=0) and the guest never
+    // wakes from its idle WFI.
+    const gic_cpuif_payload = try gic_state.dumpHvfCpuIf(a, vcpu.handle);
+
     // One `.virtio` section per present device — the section `id` is
     // the device's MMIO base so restore can match it back. Without
     // this the resumed guest's in-RAM virtio drivers point at a
@@ -616,19 +611,16 @@ fn writeSnapshotFile(
     // dropped — the exec-agent's vsock goes silent.
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
     const vdevs = devs.virtioDevices(&vbufs);
-    var varena = std.heap.ArenaAllocator.init(gpa);
-    defer varena.deinit();
 
     var sections = std.ArrayList(snapshot.Section).empty;
-    defer sections.deinit(gpa);
-    try sections.append(gpa, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
-    try sections.append(gpa, .{ .tag = .ram, .id = 0, .payload = ram_payload });
-    try sections.append(gpa, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
-    try sections.append(gpa, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
-    try sections.append(gpa, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
+    try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
+    try sections.append(a, .{ .tag = .ram, .id = 0, .payload = ram_payload });
+    try sections.append(a, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
+    try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
+    try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
     for (vdevs) |d| {
-        const vp = try virtio_dump.dumpDevice(varena.allocator(), d);
-        try sections.append(gpa, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
+        const vp = try virtio_dump.dumpDevice(a, d);
+        try sections.append(a, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
     }
     // virtio-fs FUSE backend state — the nodeid→path map and the open
     // handle table. The `.virtio` loop above captured each virtio-fs
@@ -640,41 +632,11 @@ fn writeSnapshotFile(
     for (vdevs) |d| {
         if (d.id != .virtio_fs) continue;
         const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-        const fp = try backend.state.dumpState(varena.allocator());
-        try sections.append(gpa, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
+        const fp = try backend.state.dumpState(a);
+        try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
-
-    const bytes = try snapshot.encode(gpa, topo.hash(), sections.items);
-    defer gpa.free(bytes);
-    // gzip the whole container — guest RAM is mostly zero pages, so
-    // this routinely shrinks the .vmstate by an order of magnitude.
-    const out = try @import("vmstate_zip.zig").compress(gpa, bytes);
-    defer gpa.free(out);
-    std.debug.print("hvf: snapshot {d} bytes -> {d} compressed\n", .{ bytes.len, out.len });
-
-    // Write atomically: dump into `<path>.tmp`, then rename() onto the
-    // final path. The runtime's `performSnapshotVmstate` polls for the
-    // final path's existence as the "dump complete" signal, so a
-    // partially-written file must never be observable there.
-    const path_z = try gpa.dupeZ(u8, path);
-    defer gpa.free(path_z);
-    const tmp_z = try std.fmt.allocPrintSentinel(gpa, "{s}.tmp", .{path}, 0);
-    defer gpa.free(tmp_z);
-    const fd = snap_c.open(tmp_z, SNAP_O_WRONLY | SNAP_O_CREAT | SNAP_O_TRUNC, 0o644);
-    if (fd < 0) return error.OpenFailed;
-    {
-        defer _ = snap_c.close(fd);
-        var off: usize = 0;
-        while (off < out.len) {
-            const rc = snap_c.write(fd, out.ptr + off, out.len - off);
-            if (rc <= 0) return error.WriteFailed;
-            off += @intCast(rc);
-        }
-    }
-    // open()'s variadic mode arg doesn't reliably stick on macOS;
-    // post-chmod is the safe path.
-    _ = snap_c.chmod(tmp_z, 0o644);
-    if (snap_c.rename(tmp_z, path_z) != 0) return error.WriteFailed;
+    job.sections = try sections.toOwnedSlice(a);
+    return job;
 }
 
 fn applyRestoreFile(
@@ -863,27 +825,26 @@ fn runLoop(
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
+    var snapshot_writer_state: vmstate_writer.Writer = .{};
+    defer snapshot_writer_state.wait();
     while (exits < cfg.max_exits) : (exits += 1) {
         try vcpu.run();
 
         // Async exit from hv_vcpus_exit (watcher thread, snapshot
         // trigger). Don't treat as a guest fault; check the flag and
-        // either dump or resume.
+        // either capture a snapshot or resume.
         if (vcpu.exit.reason == .canceled) {
             if (snapshot_requested_hvf.load(.seq_cst)) {
                 if (cfg.snapshot_path) |path| {
-                    std.debug.print("hvf: writing snapshot to {s}\n", .{path});
-                    writeSnapshotFile(gpa, path, vcpu, ram, cfg, devs) catch |err| {
-                        std.debug.print("hvf boot: snapshot write failed: {s}\n", .{@errorName(err)});
-                    };
-                    std.debug.print("hvf: snapshot write done\n", .{});
-                    snapshotted = true;
+                    if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs)) {
+                        snapshotted = true;
+                    }
                     // Clear the flag and RESUME — the snapshot engine
                     // (`performSnapshotVmstate`) decides destructiveness
                     // itself: a plain `snapshot` powers the source off
                     // afterward, `fork` leaves it running. Keep the
                     // watcher thread alive so a later SIGUSR1 (chained
-                    // snapshot / fork-the-fork) triggers another dump.
+                    // snapshot / fork-the-fork) triggers another capture.
                     snapshot_requested_hvf.store(false, .seq_cst);
                 }
             }
@@ -930,13 +891,12 @@ fn runLoop(
 
         // Snapshot trigger fallback — for the rare case the watcher's
         // hv_vcpus_exit() landed as a plain exception exit rather than
-        // `.canceled`. Same write-and-resume contract as above.
+        // `.canceled`. Same capture-and-resume contract as above.
         if (snapshot_requested_hvf.load(.seq_cst)) {
             if (cfg.snapshot_path) |path| {
-                writeSnapshotFile(gpa, path, vcpu, ram, cfg, devs) catch |err| {
-                    std.debug.print("hvf boot: snapshot write failed: {s}\n", .{@errorName(err)});
-                };
-                snapshotted = true;
+                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs)) {
+                    snapshotted = true;
+                }
                 snapshot_requested_hvf.store(false, .seq_cst);
             }
         }
@@ -951,6 +911,40 @@ fn runLoop(
         .exits = exits,
         .snapshotted = snapshotted,
     };
+}
+
+fn queueSnapshotWrite(
+    writer: *vmstate_writer.Writer,
+    gpa: std.mem.Allocator,
+    path: []const u8,
+    vcpu: hvf.Vcpu,
+    ram: []const u8,
+    cfg: Config,
+    devs: *const Devices,
+) bool {
+    if (writer.busy()) {
+        std.debug.print("hvf: snapshot requested while previous write is still in flight\n", .{});
+        return false;
+    }
+
+    std.debug.print("hvf: writing snapshot to {s}\n", .{path});
+    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, devs) catch |err| {
+        std.debug.print("hvf boot: snapshot capture failed: {s}\n", .{@errorName(err)});
+        return false;
+    };
+    writer.start(job) catch |err| {
+        std.debug.print(
+            "hvf: snapshot async writer spawn failed: {s}; writing synchronously\n",
+            .{@errorName(err)},
+        );
+        vmstate_writer.writeAndDestroy(job) catch |write_err| {
+            std.debug.print("hvf boot: snapshot write failed: {s}\n", .{@errorName(write_err)});
+            return false;
+        };
+        return true;
+    };
+    std.debug.print("hvf: snapshot capture done; async write started\n", .{});
+    return true;
 }
 
 // Context shared between the vCPU thread and the stdin-reader thread.

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -43,6 +43,7 @@ const net_mod = @import("net_socket.zig");
 const dtb_patch = @import("dtb_patch.zig");
 const balloon_mod = @import("balloon.zig");
 const stats_mod = @import("stats.zig");
+const vmstate_writer = @import("vmstate_writer.zig");
 
 // Guest-physical bases. Same MMIO layout as HVF (see boot_hvf.zig
 // for the slot layout doc) so the shared `virt.dts` works for both
@@ -147,8 +148,9 @@ pub const Config = struct {
     /// is set, the .vmstate at that path is loaded and applied to the
     /// vCPU + RAM before the run loop starts. While running, SIGUSR1
     /// flips an atomic flag that the run loop checks after each exit;
-    /// when raised, the vCPU + RAM are dumped to `snapshot_path` and
-    /// the loop exits cleanly with `Result.snapshotted = true`.
+    /// when raised, live state is captured while the vCPU is stopped,
+    /// then compression/write continue on a background thread while
+    /// the guest resumes.
     restore_path: ?[]const u8 = null,
     snapshot_path: ?[]const u8 = null,
 };
@@ -157,8 +159,7 @@ pub const Result = struct {
     serial: []u8,
     saw_psci_shutdown: bool,
     exits: usize,
-    /// True iff the run loop exited via SIGUSR1-triggered snapshot
-    /// (state has been written to cfg.snapshot_path).
+    /// True iff a SIGUSR1-triggered snapshot was accepted.
     snapshotted: bool = false,
 };
 
@@ -833,6 +834,8 @@ fn runLoop(
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
+    var snapshot_writer_state: vmstate_writer.Writer = .{};
+    defer snapshot_writer_state.wait();
     while (exits < cfg.max_exits) : (exits += 1) {
         const reason = try vcpu.run();
         switch (reason) {
@@ -859,18 +862,18 @@ fn runLoop(
             },
         }
         if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
-        // Snapshot trigger: SIGUSR1 set the flag. Write the whole-VM
-        // state to cfg.snapshot_path and RESUME — destructiveness is
-        // the snapshot engine's call (`performSnapshotVmstate` powers
-        // the source off for a plain `snapshot`, leaves it running for
-        // `fork`). The SIGUSR1 handler stays installed so a later
-        // signal (chained snapshot / fork-the-fork) triggers another.
+        // Snapshot trigger: SIGUSR1 set the flag. Capture whole-VM
+        // state, queue compression/write, and RESUME — destructiveness
+        // is the snapshot engine's call (`performSnapshotVmstate`
+        // powers the source off for a plain `snapshot`, leaves it
+        // running for `fork`). The SIGUSR1 handler stays installed so
+        // a later signal (chained snapshot / fork-the-fork) triggers
+        // another capture.
         if (snapshot_requested.load(.seq_cst)) {
             if (cfg.snapshot_path) |path| {
-                writeSnapshotFile(gpa, path, vcpu, ram, cfg, gic_fd, devs) catch |err| {
-                    std.debug.print("kvm boot: snapshot write failed: {s}\n", .{@errorName(err)});
-                };
-                snapshotted = true;
+                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, gic_fd, devs)) {
+                    snapshotted = true;
+                }
                 snapshot_requested.store(false, .seq_cst);
             }
         }
@@ -893,23 +896,49 @@ fn runLoop(
     };
 }
 
+fn queueSnapshotWrite(
+    writer: *vmstate_writer.Writer,
+    gpa: std.mem.Allocator,
+    path: []const u8,
+    vcpu: *kvm.Vcpu,
+    ram: []const u8,
+    cfg: Config,
+    gic_fd: c_int,
+    devs: *const Devices,
+) bool {
+    if (writer.busy()) {
+        std.debug.print("kvm: snapshot requested while previous write is still in flight\n", .{});
+        return false;
+    }
+
+    std.debug.print("kvm: writing snapshot to {s}\n", .{path});
+    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, gic_fd, devs) catch |err| {
+        std.debug.print("kvm boot: snapshot capture failed: {s}\n", .{@errorName(err)});
+        return false;
+    };
+    writer.start(job) catch |err| {
+        std.debug.print(
+            "kvm: snapshot async writer spawn failed: {s}; writing synchronously\n",
+            .{@errorName(err)},
+        );
+        vmstate_writer.writeAndDestroy(job) catch |write_err| {
+            std.debug.print("kvm boot: snapshot write failed: {s}\n", .{@errorName(write_err)});
+            return false;
+        };
+        return true;
+    };
+    std.debug.print("kvm: snapshot capture done; async write started\n", .{});
+    return true;
+}
+
 const snap_c = struct {
     extern "c" fn open(path: [*:0]const u8, flags: c_int, mode: c_int) c_int;
     extern "c" fn close(fd: c_int) c_int;
-    extern "c" fn write(fd: c_int, buf: *const anyopaque, count: usize) isize;
     extern "c" fn read(fd: c_int, buf: *anyopaque, count: usize) isize;
     extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
-    extern "c" fn chmod(path: [*:0]const u8, mode: c_int) c_int;
-    extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
 };
 
-// O_RDONLY=0, O_WRONLY=1, O_RDWR=2, O_CREAT=64 (Linux) / 0x200 (macOS)
-// O_TRUNC=512 (Linux) / 0x400 (macOS). We bake target-specific flags
-// at comptime instead of dragging libc headers in.
 const O_RDONLY: c_int = 0;
-const O_WRONLY: c_int = 1;
-const O_CREAT: c_int = if (@import("builtin").os.tag == .macos) 0x200 else 64;
-const O_TRUNC: c_int = if (@import("builtin").os.tag == .macos) 0x400 else 512;
 const SEEK_END: c_int = 2;
 const SEEK_SET: c_int = 0;
 
@@ -927,7 +956,7 @@ fn kvmVcpuMpidr(vcpu: *kvm.Vcpu) u64 {
     return vcpu.getReg(KVM_REG_MPIDR_EL1) catch 0;
 }
 
-fn writeSnapshotFile(
+fn captureSnapshotJob(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: *kvm.Vcpu,
@@ -935,28 +964,13 @@ fn writeSnapshotFile(
     cfg: Config,
     gic_fd: c_int,
     devs: *const Devices,
-) !void {
+) !*vmstate_writer.Job {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
-
-    const vcpu_payload = try vcpu_dump.dumpKvm(gpa, vcpu.fd);
-    defer gpa.free(vcpu_payload);
-    const ram_payload = try ram_dump.encode(gpa, cfg.ram_base, ram);
-    defer gpa.free(ram_payload);
-    // GICv3 distributor + per-vCPU redistributor + CPU interface —
-    // see the matching block in boot_hvf.zig for why a cross-VMM
-    // restore can't resume without it.
-    const mpidr = kvmVcpuMpidr(vcpu);
-    const gic_dist_payload = try gic_state.dumpKvmDist(gpa, gic_fd);
-    defer gpa.free(gic_dist_payload);
-    const gic_redist_payload = try gic_state.dumpKvmRedist(gpa, gic_fd, mpidr);
-    defer gpa.free(gic_redist_payload);
-    const gic_cpuif_payload = try gic_state.dumpKvmCpuIf(gpa, gic_fd, mpidr);
-    defer gpa.free(gic_cpuif_payload);
 
     const topo: topology.Topology = .{
         .ram_base = cfg.ram_base,
@@ -965,24 +979,35 @@ fn writeSnapshotFile(
         .gic_redist_base = cfg.gic_redist_addr,
     };
 
+    const job = try vmstate_writer.Job.create(gpa, "kvm", path, topo.hash());
+    errdefer job.destroy();
+    const a = job.arenaAllocator();
+
+    const vcpu_payload = try vcpu_dump.dumpKvm(a, vcpu.fd);
+    const ram_payload = try ram_dump.encode(a, cfg.ram_base, ram);
+    // GICv3 distributor + per-vCPU redistributor + CPU interface —
+    // see the matching block in boot_hvf.zig for why a cross-VMM
+    // restore can't resume without it.
+    const mpidr = kvmVcpuMpidr(vcpu);
+    const gic_dist_payload = try gic_state.dumpKvmDist(a, gic_fd);
+    const gic_redist_payload = try gic_state.dumpKvmRedist(a, gic_fd, mpidr);
+    const gic_cpuif_payload = try gic_state.dumpKvmCpuIf(a, gic_fd, mpidr);
+
     // One `.virtio` section per present device (section `id` = the
     // device's MMIO base). See boot_hvf.zig's matching block for why
     // a restored guest's virtio drivers need this.
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
     const vdevs = devs.virtioDevices(&vbufs);
-    var varena = std.heap.ArenaAllocator.init(gpa);
-    defer varena.deinit();
 
     var sections = std.ArrayList(snapshot.Section).empty;
-    defer sections.deinit(gpa);
-    try sections.append(gpa, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
-    try sections.append(gpa, .{ .tag = .ram, .id = 0, .payload = ram_payload });
-    try sections.append(gpa, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
-    try sections.append(gpa, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
-    try sections.append(gpa, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
+    try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
+    try sections.append(a, .{ .tag = .ram, .id = 0, .payload = ram_payload });
+    try sections.append(a, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
+    try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
+    try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
     for (vdevs) |d| {
-        const vp = try virtio_dump.dumpDevice(varena.allocator(), d);
-        try sections.append(gpa, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
+        const vp = try virtio_dump.dumpDevice(a, d);
+        try sections.append(a, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
     }
     // virtio-fs FUSE backend state — the nodeid→path map and the open
     // handle table. The `.virtio` loop above captured each virtio-fs
@@ -994,39 +1019,11 @@ fn writeSnapshotFile(
     for (vdevs) |d| {
         if (d.id != .virtio_fs) continue;
         const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-        const fp = try backend.state.dumpState(varena.allocator());
-        try sections.append(gpa, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
+        const fp = try backend.state.dumpState(a);
+        try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
-
-    const bytes = try snapshot.encode(gpa, topo.hash(), sections.items);
-    defer gpa.free(bytes);
-    // gzip the whole container — guest RAM is mostly zero pages, so
-    // this routinely shrinks the .vmstate by an order of magnitude.
-    const out = try @import("vmstate_zip.zig").compress(gpa, bytes);
-    defer gpa.free(out);
-    std.debug.print("kvm: snapshot {d} bytes -> {d} compressed\n", .{ bytes.len, out.len });
-
-    // Write atomically: dump into `<path>.tmp`, then rename() onto the
-    // final path. The runtime's `performSnapshotVmstate` polls for the
-    // final path's existence as the "dump complete" signal, so a
-    // partially-written file must never be observable there.
-    const path_z = try gpa.dupeZ(u8, path);
-    defer gpa.free(path_z);
-    const tmp_z = try std.fmt.allocPrintSentinel(gpa, "{s}.tmp", .{path}, 0);
-    defer gpa.free(tmp_z);
-    const fd = snap_c.open(tmp_z, O_WRONLY | O_CREAT | O_TRUNC, 0o644);
-    if (fd < 0) return error.OpenFailed;
-    {
-        defer _ = snap_c.close(fd);
-        var off: usize = 0;
-        while (off < out.len) {
-            const rc = snap_c.write(fd, out.ptr + off, out.len - off);
-            if (rc <= 0) return error.WriteFailed;
-            off += @intCast(rc);
-        }
-    }
-    _ = snap_c.chmod(tmp_z, 0o644);
-    if (snap_c.rename(tmp_z, path_z) != 0) return error.WriteFailed;
+    job.sections = try sections.toOwnedSlice(a);
+    return job;
 }
 
 fn applyRestoreFile(

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -66,7 +66,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Snapshot/restore plumbing — host orchestrator drives via env.
     // MACHINEN_RESTORE_PATH: load .vmstate at boot before vcpu.run().
-    // MACHINEN_SNAPSHOT_PATH: dump on SIGUSR1, exit cleanly.
+    // MACHINEN_SNAPSHOT_PATH: capture on SIGUSR1, write .vmstate, then resume.
     const restore_path = envOptional("MACHINEN_RESTORE_PATH");
     const snapshot_path = envOptional("MACHINEN_SNAPSHOT_PATH");
 

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -36,6 +36,7 @@ pub const pl011 = @import("pl011.zig"); // pure Zig PL011 UART (shared HVF/KVM)
 pub const dtb_patch = @import("dtb_patch.zig"); // FDT memory/initrd patcher
 pub const snapshot = @import("snapshot.zig"); // .vmstate format codec
 pub const vmstate_zip = @import("vmstate_zip.zig"); // .vmstate gzip transport
+pub const vmstate_writer = @import("vmstate_writer.zig"); // async .vmstate encode/compress/write
 pub const topology = @import("topology.zig"); // IPA layout fingerprint
 pub const sysreg_names = @import("sysreg_names.zig"); // name<->encoding table
 pub const sysreg_classify = @import("sysreg_classify.zig"); // portability decisions
@@ -113,6 +114,7 @@ test {
     _ = @import("dtb_patch.zig");
     _ = @import("snapshot.zig");
     _ = @import("vmstate_zip.zig");
+    _ = @import("vmstate_writer.zig");
     _ = @import("topology.zig");
     _ = @import("sysreg_classify.zig");
     _ = @import("vcpu_dump.zig");

--- a/packages/microvm/src/vmstate_writer.zig
+++ b/packages/microvm/src/vmstate_writer.zig
@@ -1,0 +1,211 @@
+//! Async `.vmstate` writer.
+//!
+//! The backend run loops must stop the vCPU while they capture live
+//! state (registers, sparse RAM payload, GIC, virtio transport state),
+//! but compression and disk I/O only need an immutable copy of that
+//! captured state. This helper owns that copy in a per-snapshot arena
+//! and writes it on a joinable background thread so the guest can
+//! resume as soon as capture finishes.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const snapshot = @import("snapshot.zig");
+const vmstate_zip = @import("vmstate_zip.zig");
+
+pub const Job = struct {
+    allocator: std.mem.Allocator,
+    arena: std.heap.ArenaAllocator,
+    label: []const u8,
+    path: []const u8,
+    topology_hash: [32]u8,
+    sections: []const snapshot.Section,
+
+    /// Allocate a job and copy the output path into the job arena.
+    /// Backend-specific capture code should allocate every section
+    /// payload and the final `sections` slice from `arenaAllocator()`;
+    /// the writer thread deinitializes the arena after the atomic
+    /// rename completes (or fails).
+    pub fn create(
+        allocator: std.mem.Allocator,
+        label: []const u8,
+        path: []const u8,
+        topology_hash: [32]u8,
+    ) !*Job {
+        const job = try allocator.create(Job);
+        job.* = .{
+            .allocator = allocator,
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .label = label,
+            .path = undefined,
+            .topology_hash = topology_hash,
+            .sections = &.{},
+        };
+        errdefer {
+            job.arena.deinit();
+            allocator.destroy(job);
+        }
+        job.path = try job.arena.allocator().dupe(u8, path);
+        return job;
+    }
+
+    pub fn arenaAllocator(self: *Job) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+
+    pub fn destroy(self: *Job) void {
+        self.arena.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
+pub const Writer = struct {
+    handle: ?std.Thread = null,
+    done: std.atomic.Value(bool) = .init(true),
+
+    pub const StartError = std.Thread.SpawnError || error{SnapshotInFlight};
+
+    /// Start a background encode/compress/write. Takes ownership of
+    /// `job` on success; on error, the caller still owns it and can
+    /// fall back to `writeAndDestroy(job)`.
+    pub fn start(self: *Writer, job: *Job) StartError!void {
+        self.reapFinished();
+        if (self.handle != null) return error.SnapshotInFlight;
+
+        self.done.store(false, .release);
+        const handle = std.Thread.spawn(.{}, workerMain, .{ job, &self.done }) catch |err| {
+            self.done.store(true, .release);
+            return err;
+        };
+        self.handle = handle;
+    }
+
+    /// Join a completed worker without blocking the vCPU thread. Call
+    /// this opportunistically before accepting a new snapshot request.
+    pub fn reapFinished(self: *Writer) void {
+        if (self.handle) |handle| {
+            if (self.done.load(.acquire)) {
+                handle.join();
+                self.handle = null;
+            }
+        }
+    }
+
+    pub fn busy(self: *Writer) bool {
+        self.reapFinished();
+        return self.handle != null;
+    }
+
+    /// Block until the in-flight write exits. Used only when the VMM is
+    /// about to leave the run loop; otherwise a process exit could kill
+    /// the writer before it renames the complete `.vmstate` into place.
+    pub fn wait(self: *Writer) void {
+        if (self.handle) |handle| {
+            handle.join();
+            self.handle = null;
+        }
+    }
+};
+
+fn workerMain(job: *Job, done: *std.atomic.Value(bool)) void {
+    const label = job.label;
+    write(job) catch |err| {
+        std.debug.print("{s}: snapshot async write failed: {s}\n", .{ label, @errorName(err) });
+    };
+    job.destroy();
+    done.store(true, .release);
+}
+
+/// Synchronous fallback used if the background thread cannot be
+/// spawned. Consumes `job` either way.
+pub fn writeAndDestroy(job: *Job) !void {
+    defer job.destroy();
+    try write(job);
+}
+
+fn write(job: *Job) !void {
+    const allocator = job.arena.allocator();
+    const bytes = try snapshot.encode(allocator, job.topology_hash, job.sections);
+    // gzip the whole container — guest RAM is mostly zero pages, so
+    // this routinely shrinks the .vmstate by an order of magnitude.
+    const out = try vmstate_zip.compress(allocator, bytes);
+    std.debug.print("{s}: snapshot {d} bytes -> {d} compressed\n", .{ job.label, bytes.len, out.len });
+    try writeAtomic(allocator, job.path, out);
+    std.debug.print("{s}: snapshot write done\n", .{job.label});
+}
+
+const c = struct {
+    extern "c" fn open(path: [*:0]const u8, flags: c_int, mode: c_int) c_int;
+    extern "c" fn close(fd: c_int) c_int;
+    extern "c" fn write(fd: c_int, buf: *const anyopaque, count: usize) isize;
+    extern "c" fn chmod(path: [*:0]const u8, mode: c_int) c_int;
+    extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
+};
+
+const O_WRONLY: c_int = 1;
+const O_CREAT: c_int = if (builtin.os.tag == .macos) 0x200 else 64;
+const O_TRUNC: c_int = if (builtin.os.tag == .macos) 0x400 else 512;
+
+fn writeAtomic(allocator: std.mem.Allocator, path: []const u8, data: []const u8) !void {
+    // Write atomically: dump into `<path>.tmp`, then rename() onto the
+    // final path. The runtime polls for the final path's existence as
+    // the "dump complete" signal, so a partial file must never be
+    // observable there.
+    const path_z = try allocator.dupeZ(u8, path);
+    const tmp_z = try std.fmt.allocPrintSentinel(allocator, "{s}.tmp", .{path}, 0);
+
+    const fd = c.open(tmp_z, O_WRONLY | O_CREAT | O_TRUNC, 0o644);
+    if (fd < 0) return error.OpenFailed;
+    {
+        defer _ = c.close(fd);
+        var off: usize = 0;
+        while (off < data.len) {
+            const rc = c.write(fd, data.ptr + off, data.len - off);
+            if (rc <= 0) return error.WriteFailed;
+            off += @intCast(rc);
+        }
+    }
+    // open()'s variadic mode arg doesn't reliably stick on macOS;
+    // post-chmod is the safe path.
+    _ = c.chmod(tmp_z, 0o644);
+    if (c.rename(tmp_z, path_z) != 0) return error.WriteFailed;
+}
+
+fn testTmpPath(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir, name: []const u8) ![]u8 {
+    const cwd = try std.process.currentPathAlloc(std.testing.io, gpa);
+    defer gpa.free(cwd);
+    return std.fs.path.join(gpa, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path, name });
+}
+
+test "Writer writes a complete gzip-compressed vmstate asynchronously" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try testTmpPath(gpa, &tmp, "state.vmstate");
+    defer gpa.free(path);
+
+    const topo: [32]u8 = @splat(0xAB);
+    const job = try Job.create(gpa, "test", path, topo);
+    const a = job.arenaAllocator();
+    const payload = try a.dupe(u8, "payload");
+    var sections = std.ArrayList(snapshot.Section).empty;
+    try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = payload });
+    job.sections = try sections.toOwnedSlice(a);
+
+    var writer: Writer = .{};
+    try writer.start(job);
+    writer.wait();
+
+    try tmp.dir.access(std.testing.io, "state.vmstate", .{});
+    const raw = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, path, gpa, .limited(1 << 20));
+    defer gpa.free(raw);
+    const plain = try vmstate_zip.decompress(gpa, raw);
+    defer gpa.free(plain);
+    var decoded = try snapshot.decode(gpa, plain);
+    defer decoded.deinit();
+
+    try std.testing.expectEqual(@as(u32, 1), decoded.header.section_count);
+    try std.testing.expectEqualSlices(u8, &topo, &decoded.header.topology_hash);
+    try std.testing.expectEqual(snapshot.SectionTag.vcpu, decoded.sections[0].tag);
+    try std.testing.expectEqualSlices(u8, "payload", decoded.sections[0].payload);
+}

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -564,9 +564,9 @@ function formatDumpOutcomeHint(outcome: DumpOutcome | undefined): string {
 /**
  * Whole-VM snapshot via the `.vmstate` engine. The source VM was
  * booted with `MACHINEN_SNAPSHOT_PATH` set (boot.ts does this when the
- * engine is vmstate), so its VMM carries a SIGUSR1 handler that dumps
- * vCPU + RAM + GIC + virtio device state to that path and then
- * resumes the guest. Steps:
+ * engine is vmstate), so its VMM carries a SIGUSR1 handler that
+ * captures vCPU + RAM + GIC + virtio device state, resumes the guest,
+ * then compresses/writes that immutable capture asynchronously. Steps:
  *   1. clear any stale state file at `ctx.vmstatePath`,
  *   2. SIGUSR1 the VMM pid,
  *   3. wait for the file to (re)appear — the VMM writes it atomically
@@ -576,11 +576,12 @@ function formatDumpOutcomeHint(outcome: DumpOutcome | undefined): string {
  *   6. write `meta.json` (with `engine: "vmstate"`),
  *   7. destructive snapshot (`!leaveRunning`) → power the source off;
  *      fork (`leaveRunning`) leaves it running (the VMM already
- *      resumed the guest after the dump).
+ *      resumed the guest after capturing state).
  *
  * Destructiveness is the runtime's call, mirroring the CRIU path's
  * `--leave-running` + host-poweroff split — the VMM itself always
- * resumes after writing.
+ * resumes after capture, while the `.vmstate` writer finishes in the
+ * background.
  */
 async function performSnapshotVmstate(
   ctx: SnapshotContext,
@@ -630,9 +631,10 @@ async function performSnapshotVmstate(
     );
   }
 
-  // Trigger the dump. SIGUSR1 → the VMM's handler dumps the whole VM
-  // to ctx.vmstatePath and resumes the guest. Works for boot- and
-  // attach-owned handles alike — it's just a signal to the VMM pid.
+  // Trigger the dump. SIGUSR1 → the VMM captures whole-VM state,
+  // resumes the guest, then writes ctx.vmstatePath from a background
+  // writer. Works for boot- and attach-owned handles alike — it's just
+  // a signal to the VMM pid.
   try {
     process.kill(ctx.pid, "SIGUSR1");
   } catch (err) {


### PR DESCRIPTION
## Problem

Taking a whole-VM snapshot paused the guest until the snapshot was compressed and written to disk. That made the machine look frozen longer than needed. The guest only needs to stop while we copy a safe, matching view of its state.

## Solution

The VMM now captures the VM state while the guest is stopped, then lets the guest run again. A new async writer compresses and writes `state.vmstate` in the background, using the same atomic rename as before. This is wired into both HVF and KVM snapshot paths.

## Testing

- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `pnpm smoke-tests`
