### PR TITLE
Speed up vmstate restore

### DIFF
--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -646,11 +646,14 @@ fn writeSnapshotFile(
 
     const bytes = try snapshot.encode(gpa, topo.hash(), sections.items);
     defer gpa.free(bytes);
-    // gzip the whole container — guest RAM is mostly zero pages, so
-    // this routinely shrinks the .vmstate by an order of magnitude.
-    const out = try @import("vmstate_zip.zig").compress(gpa, bytes);
-    defer gpa.free(out);
-    std.debug.print("hvf: snapshot {d} bytes -> {d} compressed\n", .{ bytes.len, out.len });
+    const vmstate_zip = @import("vmstate_zip.zig");
+    const compression = vmstate_zip.writeCompression();
+    const out: []const u8 = switch (compression) {
+        .none => bytes,
+        .gzip => try vmstate_zip.compress(gpa, bytes),
+    };
+    defer if (compression == .gzip) gpa.free(@constCast(out));
+    std.debug.print("hvf: snapshot {d} bytes -> {d} {s}\n", .{ bytes.len, out.len, @tagName(compression) });
 
     // Write atomically: dump into `<path>.tmp`, then rename() onto the
     // final path. The runtime's `performSnapshotVmstate` polls for the
@@ -691,6 +694,7 @@ fn applyRestoreFile(
     const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
+    const vmstate_timing = @import("vmstate_timing.zig");
 
     const path_z = try gpa.dupeZ(u8, path);
     defer gpa.free(path_z);
@@ -704,18 +708,24 @@ fn applyRestoreFile(
 
     const raw = try gpa.alloc(u8, @intCast(size));
     defer gpa.free(raw);
+    var timing = vmstate_timing.RestoreTimer.start("hvf", raw.len, ram.len);
+
     var off: usize = 0;
     while (off < raw.len) {
         const rc = snap_c.read(fd, raw.ptr + off, raw.len - off);
         if (rc <= 0) return error.ReadFailed;
         off += @intCast(rc);
     }
-    // gunzip if the file is compressed; a plain .vmstate passes through.
-    const bytes = try @import("vmstate_zip.zig").decompress(gpa, raw);
-    defer gpa.free(bytes);
+    timing.mark("read-file");
 
-    var snap = try snapshot.decode(gpa, bytes);
+    // gunzip if the file is compressed; a plain .vmstate borrows `raw`.
+    const decoded = try @import("vmstate_zip.zig").decompressMaybeOwned(gpa, raw);
+    defer decoded.deinit(gpa);
+    timing.mark("decompress");
+
+    var snap = try snapshot.decode(gpa, decoded.bytes);
     defer snap.deinit();
+    timing.mark("container-decode");
 
     // A resumed normal VM needs interrupts: the vtimer PPI to drive
     // the scheduler, the virtio SPIs to wake blocked drivers (the
@@ -729,12 +739,13 @@ fn applyRestoreFile(
     const vdevs = devs.virtioDevices(&vbufs);
     var gic_cpuif_applied = false;
     for (snap.sections) |s| {
+        const section_t0 = timing.sectionStart();
         switch (s.tag) {
             .vcpu => try vcpu_dump.loadHvf(gpa, vcpu.handle, s.payload),
             .ram => {
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
-                _ = try ram_dump.decodeInto(s.payload, ram);
+                _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
             },
             .gic_dist => gic_state.loadHvfDist(gpa, s.payload) catch |err| {
                 std.debug.print("hvf boot: gic_dist restore failed: {s}\n", .{@errorName(err)});
@@ -788,7 +799,9 @@ fn applyRestoreFile(
             },
             else => {},
         }
+        timing.section(s.tag, s.id, s.payload.len, section_t0);
     }
+    timing.mark("apply-sections");
 
     // If the snapshot carried a real `gic_cpuif` section it was just
     // replayed (the captured ICC_* values are always correct). Only
@@ -797,6 +810,7 @@ fn applyRestoreFile(
     // without *some* programming the interface stays at reset and the
     // resumed guest never wakes from its idle WFI.
     if (!gic_cpuif_applied) gic_state.applyHvfCpuIfDefaults(vcpu.handle);
+    timing.mark("gic-cpuif-fallback");
 
     // Virtual-timer fixup. loadHvf restored CNTV_CVAL_EL0 — an absolute
     // point on the guest's virtual-counter timeline — but a fresh HVF
@@ -846,6 +860,8 @@ fn applyRestoreFile(
             );
         }
     }
+    timing.mark("timer-fixup");
+    timing.done();
 }
 
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exception, the
@@ -1117,6 +1133,13 @@ fn allocateAndPopulateRam(
     errdefer std.posix.munmap(ram);
     assert(ram.len == cfg.ram_size);
     assert(@intFromPtr(ram.ptr) % hvf.page_size == 0);
+
+    if (cfg.restore_path != null) {
+        // Restore snapshots cover guest RAM themselves. Leave the fresh
+        // anonymous mmap untouched so sparse RAM restore can rely on
+        // demand-zero pages instead of clearing the full RAM ceiling.
+        return ram;
+    }
 
     @memcpy(ram[fx.img.text_offset..][0..fx.kernel.len], fx.kernel);
     @memcpy(ram[cfg.dtb_offset..][0..fx.dtb.len], fx.dtb);

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -451,6 +451,13 @@ fn allocateAndPopulateRam(
     assert(ram.len == cfg.ram_size);
     assert(@intFromPtr(ram.ptr) % 4096 == 0);
 
+    if (cfg.restore_path != null) {
+        // Restore snapshots cover guest RAM themselves. Leave the fresh
+        // anonymous mmap untouched so sparse RAM restore can rely on
+        // demand-zero pages instead of clearing the full RAM ceiling.
+        return ram;
+    }
+
     @memcpy(ram[fx.img.text_offset..][0..fx.kernel.len], fx.kernel);
     @memcpy(ram[cfg.dtb_offset..][0..fx.dtb.len], fx.dtb);
 
@@ -1000,11 +1007,14 @@ fn writeSnapshotFile(
 
     const bytes = try snapshot.encode(gpa, topo.hash(), sections.items);
     defer gpa.free(bytes);
-    // gzip the whole container — guest RAM is mostly zero pages, so
-    // this routinely shrinks the .vmstate by an order of magnitude.
-    const out = try @import("vmstate_zip.zig").compress(gpa, bytes);
-    defer gpa.free(out);
-    std.debug.print("kvm: snapshot {d} bytes -> {d} compressed\n", .{ bytes.len, out.len });
+    const vmstate_zip = @import("vmstate_zip.zig");
+    const compression = vmstate_zip.writeCompression();
+    const out: []const u8 = switch (compression) {
+        .none => bytes,
+        .gzip => try vmstate_zip.compress(gpa, bytes),
+    };
+    defer if (compression == .gzip) gpa.free(@constCast(out));
+    std.debug.print("kvm: snapshot {d} bytes -> {d} {s}\n", .{ bytes.len, out.len, @tagName(compression) });
 
     // Write atomically: dump into `<path>.tmp`, then rename() onto the
     // final path. The runtime's `performSnapshotVmstate` polls for the
@@ -1044,6 +1054,7 @@ fn applyRestoreFile(
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
+    const vmstate_timing = @import("vmstate_timing.zig");
 
     const path_z = try gpa.dupeZ(u8, path);
     defer gpa.free(path_z);
@@ -1057,18 +1068,24 @@ fn applyRestoreFile(
 
     const raw = try gpa.alloc(u8, @intCast(size));
     defer gpa.free(raw);
+    var timing = vmstate_timing.RestoreTimer.start("kvm", raw.len, ram.len);
+
     var off: usize = 0;
     while (off < raw.len) {
         const rc = snap_c.read(fd, raw.ptr + off, raw.len - off);
         if (rc <= 0) return error.ReadFailed;
         off += @intCast(rc);
     }
-    // gunzip if the file is compressed; a plain .vmstate passes through.
-    const bytes = try @import("vmstate_zip.zig").decompress(gpa, raw);
-    defer gpa.free(bytes);
+    timing.mark("read-file");
 
-    var snap = try snapshot.decode(gpa, bytes);
+    // gunzip if the file is compressed; a plain .vmstate borrows `raw`.
+    const decoded = try @import("vmstate_zip.zig").decompressMaybeOwned(gpa, raw);
+    defer decoded.deinit(gpa);
+    timing.mark("decompress");
+
+    var snap = try snapshot.decode(gpa, decoded.bytes);
     defer snap.deinit();
+    timing.mark("container-decode");
 
     const topo: topology.Topology = .{
         .ram_base = cfg.ram_base,
@@ -1079,6 +1096,7 @@ fn applyRestoreFile(
     if (!std.mem.eql(u8, &topo.hash(), &snap.header.topology_hash)) {
         return error.TopologyMismatch;
     }
+    timing.mark("topology-check");
 
     const mpidr = kvmVcpuMpidr(vcpu);
 
@@ -1102,17 +1120,19 @@ fn applyRestoreFile(
         // An empty gic_cpuif payload is exactly the 4-byte entry count.
         if (s.tag == .gic_cpuif and s.payload.len > 4) apply_gic = true;
     }
+    timing.mark("gic-scan");
 
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
     const vdevs = devs.virtioDevices(&vbufs);
     var cpuif_applied: usize = 0;
     for (snap.sections) |s| {
+        const section_t0 = timing.sectionStart();
         switch (s.tag) {
             .vcpu => try vcpu_dump.loadKvm(gpa, vcpu.fd, s.payload),
             .ram => {
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
-                _ = try ram_dump.decodeInto(s.payload, ram);
+                _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
             },
             .gic_dist => if (apply_gic) try gic_state.loadKvmDist(gpa, gic_fd, s.payload),
             .gic_redist => if (apply_gic) try gic_state.loadKvmRedist(gpa, gic_fd, mpidr, s.payload),
@@ -1155,7 +1175,9 @@ fn applyRestoreFile(
             },
             else => {},
         }
+        timing.section(s.tag, s.id, s.payload.len, section_t0);
     }
+    timing.mark("apply-sections");
     std.debug.print(
         "kvm boot: GIC sections {s} (cpuif entries present={})\n",
         .{ if (apply_gic) "applied" else "skipped (HVF-sourced)", apply_gic },
@@ -1182,6 +1204,7 @@ fn applyRestoreFile(
             std.debug.print("kvm boot: timer comparator fixup failed: {s}\n", .{@errorName(err)});
         };
     }
+    timing.mark("timer-fixup");
 
     // Restore diagnostics — the cheapest signal for a guest that
     // won't resume. PC/PSTATE should match the snapshot's EL/PC; a
@@ -1196,6 +1219,8 @@ fn applyRestoreFile(
         "kvm boot: restore readback PC=0x{x} PSTATE=0x{x} SCTLR_EL1=0x{x} TTBR0=0x{x} TTBR1=0x{x} cpuif_regs={d} timer_cval=0x{x}\n",
         .{ pc, pstate, sctlr, ttbr0, ttbr1, cpuif_applied, guest_cval },
     );
+    timing.mark("diagnostics");
+    timing.done();
 }
 
 /// SPI ids encoded for KVM_IRQ_LINE (with KVM_ARM_IRQ_TYPE_SPI in

--- a/packages/microvm/src/ram_dump.zig
+++ b/packages/microvm/src/ram_dump.zig
@@ -161,6 +161,21 @@ pub const DecodedMeta = struct {
 /// top. The SHA256 over the extent stream is checked first — a flipped
 /// bit fails loudly here instead of scrambling the restored guest.
 pub fn decodeInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+    return decodeIntoMode(payload, dest, .zero_dest_first);
+}
+
+/// Same sparse-RAM decoder, but assumes the leading `ram_size` bytes of
+/// `dest` are already zero. This is for the VMM restore path: guest RAM
+/// is a fresh anonymous mmap, so the kernel provides zero pages lazily.
+/// Avoiding an eager `@memset` keeps restore proportional to the saved
+/// extents instead of the configured guest RAM ceiling.
+pub fn decodeIntoZeroed(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+    return decodeIntoMode(payload, dest, .dest_already_zero);
+}
+
+const DecodeMode = enum { zero_dest_first, dest_already_zero };
+
+fn decodeIntoMode(payload: []const u8, dest: []u8, mode: DecodeMode) DecodeError!DecodedMeta {
     if (payload.len < HEADER_SIZE) return error.Truncated;
     var hdr: RamHeader = undefined;
     @memcpy(std.mem.asBytes(&hdr), payload[0..HEADER_SIZE]);
@@ -176,7 +191,9 @@ pub fn decodeInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
     const ram_size = std.math.cast(usize, hdr.ram_size) orelse return error.SizeMismatch;
     if (ram_size > dest.len) return error.SizeMismatch;
 
-    @memset(dest[0..ram_size], 0);
+    if (mode == .zero_dest_first) {
+        @memset(dest[0..ram_size], 0);
+    }
 
     var c: usize = 0;
     while (c < body.len) {
@@ -248,6 +265,31 @@ test "encode/decode round-trip on an all-zero buffer" {
     @memset(dest, 0xFF);
     _ = try decodeInto(payload, dest);
     try std.testing.expectEqualSlices(u8, ram, dest);
+}
+
+test "decodeIntoZeroed reconstructs without clearing implicit zero pages" {
+    const a = std.testing.allocator;
+    const ram = try a.alloc(u8, 4 * PAGE);
+    defer a.free(ram);
+    @memset(ram, 0);
+    @memset(ram[PAGE..][0..PAGE], 0x7E);
+
+    const payload = try encode(a, 0, ram);
+    defer a.free(payload);
+
+    const zeroed = try a.alloc(u8, 4 * PAGE);
+    defer a.free(zeroed);
+    @memset(zeroed, 0);
+    _ = try decodeIntoZeroed(payload, zeroed);
+    try std.testing.expectEqualSlices(u8, ram, zeroed);
+
+    const poisoned = try a.alloc(u8, 4 * PAGE);
+    defer a.free(poisoned);
+    @memset(poisoned, 0xA5);
+    _ = try decodeIntoZeroed(payload, poisoned);
+    try std.testing.expectEqualSlices(u8, ram[PAGE..][0..PAGE], poisoned[PAGE..][0..PAGE]);
+    // Precondition is real: omitted pages are not cleared by this fast path.
+    try std.testing.expectEqual(@as(u8, 0xA5), poisoned[0]);
 }
 
 test "encode/decode handles a non-page-aligned tail" {

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -36,6 +36,7 @@ pub const pl011 = @import("pl011.zig"); // pure Zig PL011 UART (shared HVF/KVM)
 pub const dtb_patch = @import("dtb_patch.zig"); // FDT memory/initrd patcher
 pub const snapshot = @import("snapshot.zig"); // .vmstate format codec
 pub const vmstate_zip = @import("vmstate_zip.zig"); // .vmstate gzip transport
+pub const vmstate_timing = @import("vmstate_timing.zig"); // .vmstate restore timing logs
 pub const topology = @import("topology.zig"); // IPA layout fingerprint
 pub const sysreg_names = @import("sysreg_names.zig"); // name<->encoding table
 pub const sysreg_classify = @import("sysreg_classify.zig"); // portability decisions
@@ -113,6 +114,7 @@ test {
     _ = @import("dtb_patch.zig");
     _ = @import("snapshot.zig");
     _ = @import("vmstate_zip.zig");
+    _ = @import("vmstate_timing.zig");
     _ = @import("topology.zig");
     _ = @import("sysreg_classify.zig");
     _ = @import("vcpu_dump.zig");

--- a/packages/microvm/src/vmstate_timing.zig
+++ b/packages/microvm/src/vmstate_timing.zig
@@ -1,0 +1,145 @@
+//! Lightweight timing logs for whole-VM `.vmstate` restore.
+//!
+//! The restore path runs inside the VMM before the first vCPU run, so
+//! runtime-side `PhaseTimer` can only see "VMM spawned → first stderr
+//! byte". This module adds opt-in, per-phase timing from inside the
+//! VMM for the expensive parts: file read, gzip inflate, container
+//! decode, RAM reconstruction, and post-restore fixups.
+//!
+//! Enabled when any of these are set:
+//!   - MACHINEN_VMSTATE_TIMING=1
+//!   - MACHINEN_DEBUG=1
+//!   - DEBUG includes machinen:vmstate, machinen:restore, or machinen:*
+
+const std = @import("std");
+const snapshot = @import("snapshot.zig");
+
+const libc = struct {
+    extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+};
+
+pub const RestoreTimer = struct {
+    enabled: bool,
+    backend: []const u8,
+    start_us: i128,
+    last_us: i128,
+
+    pub fn start(backend: []const u8, file_bytes: usize, ram_bytes: usize) RestoreTimer {
+        const e = enabled();
+        const now = if (e) nowUs() else 0;
+        if (e) {
+            std.debug.print(
+                "vmstate restore timing backend={s} event=start file_bytes={d} ram_bytes={d}\n",
+                .{ backend, file_bytes, ram_bytes },
+            );
+        }
+        return .{ .enabled = e, .backend = backend, .start_us = now, .last_us = now };
+    }
+
+    pub fn mark(self: *RestoreTimer, phase: []const u8) void {
+        if (!self.enabled) return;
+        const now = nowUs();
+        std.debug.print(
+            "vmstate restore timing backend={s} phase={s} delta_ms={d} total_ms={d}\n",
+            .{ self.backend, phase, ms(now - self.last_us), ms(now - self.start_us) },
+        );
+        self.last_us = now;
+    }
+
+    pub fn sectionStart(self: *const RestoreTimer) i128 {
+        if (!self.enabled) return 0;
+        return nowUs();
+    }
+
+    pub fn section(
+        self: *const RestoreTimer,
+        tag: snapshot.SectionTag,
+        id: u32,
+        payload_bytes: usize,
+        section_start_us: i128,
+    ) void {
+        if (!self.enabled) return;
+        const now = nowUs();
+        std.debug.print(
+            "vmstate restore timing backend={s} section={s} id={d} bytes={d} ms={d} total_ms={d}\n",
+            .{ self.backend, tagName(tag), id, payload_bytes, ms(now - section_start_us), ms(now - self.start_us) },
+        );
+    }
+
+    pub fn done(self: *RestoreTimer) void {
+        if (!self.enabled) return;
+        const now = nowUs();
+        std.debug.print(
+            "vmstate restore timing backend={s} event=done total_ms={d}\n",
+            .{ self.backend, ms(now - self.start_us) },
+        );
+        self.enabled = false;
+    }
+};
+
+fn enabled() bool {
+    if (libc.getenv("MACHINEN_VMSTATE_TIMING") != null) return true;
+    if (libc.getenv("MACHINEN_DEBUG") != null) return true;
+    const debug_raw = libc.getenv("DEBUG") orelse return false;
+    return debugSpecEnablesTiming(std.mem.span(debug_raw));
+}
+
+pub fn debugSpecEnablesTiming(spec: []const u8) bool {
+    var vmstate = false;
+    var restore = false;
+
+    var it = std.mem.tokenizeAny(u8, spec, ", ");
+    while (it.next()) |raw_token| {
+        if (raw_token.len == 0) continue;
+        const negated = raw_token[0] == '-';
+        const token = if (negated) raw_token[1..] else raw_token;
+        if (token.len == 0) continue;
+
+        if (debugTokenMatches(token, "machinen:vmstate")) vmstate = !negated;
+        if (debugTokenMatches(token, "machinen:restore")) restore = !negated;
+    }
+
+    return vmstate or restore;
+}
+
+fn debugTokenMatches(token: []const u8, namespace: []const u8) bool {
+    if (std.mem.eql(u8, token, "*")) return true;
+    if (std.mem.endsWith(u8, token, "*")) {
+        return std.mem.startsWith(u8, namespace, token[0 .. token.len - 1]);
+    }
+    return std.mem.eql(u8, token, namespace);
+}
+
+fn tagName(tag: snapshot.SectionTag) []const u8 {
+    return switch (tag) {
+        .ram => "ram",
+        .vcpu => "vcpu",
+        .gic_dist => "gic_dist",
+        .gic_redist => "gic_redist",
+        .virtio => "virtio",
+        .gic_cpuif => "gic_cpuif",
+        .virtiofs_state => "virtiofs_state",
+        else => "unknown",
+    };
+}
+
+fn nowUs() i128 {
+    var tv: std.c.timeval = undefined;
+    _ = std.c.gettimeofday(&tv, null);
+    return @as(i128, tv.sec) * 1_000_000 + @as(i128, tv.usec);
+}
+
+fn ms(us: i128) i128 {
+    return @divTrunc(us, 1000);
+}
+
+// -- tests --------------------------------------------------------
+
+test "DEBUG spec enables vmstate restore timing" {
+    try std.testing.expect(debugSpecEnablesTiming("machinen:vmstate"));
+    try std.testing.expect(debugSpecEnablesTiming("machinen:restore"));
+    try std.testing.expect(debugSpecEnablesTiming("machinen:*"));
+    try std.testing.expect(debugSpecEnablesTiming("*,other"));
+    try std.testing.expect(!debugSpecEnablesTiming("machinen:boot"));
+    try std.testing.expect(!debugSpecEnablesTiming("machinen:*,-machinen:vmstate,-machinen:restore"));
+}

--- a/packages/microvm/src/vmstate_zip.zig
+++ b/packages/microvm/src/vmstate_zip.zig
@@ -1,22 +1,49 @@
-//! gzip transport wrapping for .vmstate files.
+//! Transport wrapping for .vmstate files.
 //!
-//! The snapshot codec (snapshot.zig) stays oblivious to compression —
-//! this module just shrinks the bytes on the way to disk and restores
-//! them on the way back. A guest's RAM section is mostly zero pages,
-//! so gzip routinely takes a ~540 MiB .vmstate down by an order of
-//! magnitude.
+//! The snapshot codec (snapshot.zig) stays oblivious to compression.
+//! This module can gzip bytes for storage, and it can read both gzip
+//! and plain .vmstate files. New snapshots default to plain bytes so
+//! restore doesn't spend hundreds of milliseconds inflating the whole
+//! container before the first vCPU run; set
+//! `MACHINEN_VMSTATE_COMPRESSION=gzip` to opt back into the smaller
+//! historical transport.
 //!
-//! Backward compatible: `decompress` sniffs the gzip magic and passes
-//! a plain (already-uncompressed) .vmstate straight through, so files
-//! written before compression landed still load.
+//! Backward compatible: readers sniff the gzip magic and pass a plain
+//! (already-uncompressed) .vmstate straight through, so old and new
+//! files both load.
 
 const std = @import("std");
 const flate = std.compress.flate;
 
 const assert = std.debug.assert;
 
+const libc = struct {
+    extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+};
+
 /// gzip magic — the first two bytes of every gzip member.
 pub const gzip_magic = [2]u8{ 0x1f, 0x8b };
+
+/// On-disk transport used for newly-written snapshots.
+pub const Compression = enum { none, gzip };
+
+pub fn writeCompression() Compression {
+    const raw = libc.getenv("MACHINEN_VMSTATE_COMPRESSION") orelse return .none;
+    return parseCompression(std.mem.span(raw)) orelse .none;
+}
+
+pub fn parseCompression(raw: []const u8) ?Compression {
+    const v = std.mem.trim(u8, raw, " \t\r\n");
+    if (std.ascii.eqlIgnoreCase(v, "gzip") or
+        std.ascii.eqlIgnoreCase(v, "gz") or
+        std.ascii.eqlIgnoreCase(v, "true") or
+        std.mem.eql(u8, v, "1")) return .gzip;
+    if (std.ascii.eqlIgnoreCase(v, "none") or
+        std.ascii.eqlIgnoreCase(v, "plain") or
+        std.ascii.eqlIgnoreCase(v, "false") or
+        std.mem.eql(u8, v, "0")) return .none;
+    return null;
+}
 
 /// gzip-compress `input`. Caller owns the returned bytes.
 pub fn compress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
@@ -47,12 +74,23 @@ pub fn compress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
     return out;
 }
 
-/// Inverse of `compress`. A buffer that doesn't start with the gzip
-/// magic is assumed to be a plain .vmstate and returned as an owned
-/// copy unchanged. Caller owns the returned bytes either way.
-pub fn decompress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
+/// Decompression result that may borrow the caller's input when the
+/// file is already plain. Call `deinit` once done.
+pub const Decompressed = struct {
+    bytes: []const u8,
+    owned: bool,
+
+    pub fn deinit(self: Decompressed, gpa: std.mem.Allocator) void {
+        if (self.owned) gpa.free(@constCast(self.bytes));
+    }
+};
+
+/// Inverse of `compress`, optimized for restore: gzip input is inflated
+/// into an owned buffer; plain input is returned as a borrowed slice so
+/// restore avoids an extra full-container copy.
+pub fn decompressMaybeOwned(gpa: std.mem.Allocator, input: []const u8) !Decompressed {
     if (input.len < 2 or !std.mem.eql(u8, input[0..2], &gzip_magic)) {
-        return gpa.dupe(u8, input);
+        return .{ .bytes = input, .owned = false };
     }
     var in: std.Io.Reader = .fixed(input);
     var aw: std.Io.Writer.Allocating = .init(gpa);
@@ -60,7 +98,16 @@ pub fn decompress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
 
     var dc: flate.Decompress = .init(&in, .gzip, &.{});
     _ = try dc.reader.streamRemaining(&aw.writer);
-    return aw.toOwnedSlice();
+    return .{ .bytes = try aw.toOwnedSlice(), .owned = true };
+}
+
+/// Inverse of `compress`. A buffer that doesn't start with the gzip
+/// magic is assumed to be a plain .vmstate and returned as an owned
+/// copy unchanged. Caller owns the returned bytes either way.
+pub fn decompress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
+    const decoded = try decompressMaybeOwned(gpa, input);
+    if (decoded.owned) return @constCast(decoded.bytes);
+    return gpa.dupe(u8, decoded.bytes);
 }
 
 // -- tests --------------------------------------------------------
@@ -102,6 +149,32 @@ test "decompress passes a non-gzip buffer through unchanged" {
     const back = try decompress(a, plain);
     defer a.free(back);
     try std.testing.expectEqualSlices(u8, plain, back);
+}
+
+test "decompressMaybeOwned borrows plain buffers and owns gzip buffers" {
+    const a = std.testing.allocator;
+    var plain = [_]u8{ 'V', 'M', 'S', 'T', 'A', 'T', 'E', 0 };
+    const plain_back = try decompressMaybeOwned(a, &plain);
+    defer plain_back.deinit(a);
+    try std.testing.expect(!plain_back.owned);
+    try std.testing.expectEqual(@intFromPtr(plain[0..].ptr), @intFromPtr(plain_back.bytes.ptr));
+
+    const zipped = try compress(a, &plain);
+    defer a.free(zipped);
+    const zipped_back = try decompressMaybeOwned(a, zipped);
+    defer zipped_back.deinit(a);
+    try std.testing.expect(zipped_back.owned);
+    try std.testing.expectEqualSlices(u8, &plain, zipped_back.bytes);
+}
+
+test "parseCompression accepts documented values" {
+    try std.testing.expectEqual(Compression.none, parseCompression("none").?);
+    try std.testing.expectEqual(Compression.none, parseCompression("plain").?);
+    try std.testing.expectEqual(Compression.none, parseCompression("0").?);
+    try std.testing.expectEqual(Compression.gzip, parseCompression("gzip").?);
+    try std.testing.expectEqual(Compression.gzip, parseCompression("GZ").?);
+    try std.testing.expectEqual(Compression.gzip, parseCompression("1").?);
+    try std.testing.expect(parseCompression("surprise") == null);
 }
 
 test "decompress handles an empty/short buffer as plain" {

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -63,6 +63,8 @@ import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
 
 const debug = debugLib("machinen:boot");
 const vmmDebug = debugLib("machinen:vmm");
+const vmstateDebug = debugLib("machinen:vmstate");
+const restoreDebug = debugLib("machinen:restore");
 
 export interface BootOptions {
   /**
@@ -482,6 +484,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   }
   if (opts._vmstateRestorePath) {
     env.MACHINEN_RESTORE_PATH = opts._vmstateRestorePath;
+    if ((vmstateDebug.enabled || restoreDebug.enabled) && !env.MACHINEN_VMSTATE_TIMING) {
+      env.MACHINEN_VMSTATE_TIMING = "1";
+    }
   }
 
   // #78 / #332: resolve live-share mounts. We compute these here so the
@@ -736,6 +741,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       process.stderr.write(chunk);
     });
   }
+  installVmstateTimingRelay(child);
   installFlushPhases(child, phases, onLog);
 
   // #150 phase 2: in-flight ring buffer of stderr captured *only* for
@@ -1561,6 +1567,33 @@ function installVmExitCleanup(state: ExitCleanupState): void {
 // exactly once — `phases.end` is a no-op the second time around. Also
 // emits a `phase` LogEvent so callers can fold the breakdown into
 // their own UI without parsing debug strings.
+function installVmstateTimingRelay(child: ChildProcessWithoutNullStreams): void {
+  if (!vmstateDebug.enabled && !restoreDebug.enabled) {
+    return;
+  }
+  const timingDebug = vmstateDebug.enabled ? vmstateDebug : restoreDebug;
+  let carry = "";
+  const flushLine = (line: string) => {
+    if (line.startsWith("vmstate restore timing ")) {
+      timingDebug("%s", line);
+    }
+  };
+  child.stderr.on("data", (chunk: Buffer) => {
+    const text = carry + chunk.toString("utf8");
+    const lines = text.split("\n");
+    carry = lines.pop() ?? "";
+    for (const line of lines) {
+      flushLine(line);
+    }
+  });
+  child.once("exit", () => {
+    if (carry) {
+      flushLine(carry);
+      carry = "";
+    }
+  });
+}
+
 function installFlushPhases(
   child: ChildProcessWithoutNullStreams,
   phases: PhaseTimer,


### PR DESCRIPTION
## Problem

Restoring a whole-VM `state.vmstate` snapshot was slower than it needed to be. The VMM copied and inflated the whole snapshot before the guest could run, and it also cleared the full guest RAM size even when most pages were already zero. On a 12 GiB VM, that made restore spend about 1.5 seconds before the first guest instruction.

## Solution

The restore path now treats fresh VM memory as already zero, so it only writes the RAM pages that are actually in the snapshot. New vmstate snapshots are also stored plain by default, which avoids the gzip inflate cost during restore; old gzip snapshots still load, and `MACHINEN_VMSTATE_COMPRESSION=gzip` keeps the old small-file behavior. I also added `DEBUG=machinen:vmstate` timing logs so we can see where restore time goes.

## Validation

- `MACHINEN_REQUIRE_FIXTURES=0 NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `pnpm -F @machinen/microvm test`

Closes #345
