### PR TITLE
Guard base asset releases

### DIFF
--- a/.github/workflows/_build-base-assets.yml
+++ b/.github/workflows/_build-base-assets.yml
@@ -88,6 +88,34 @@ jobs:
         if: steps.prebuilt.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true'
         run: ./scripts/build-base-assets.sh
 
+      # Guard the artifact boundary: whether release-assets/ came from a
+      # fresh build, a cache restore, or a developer-provided prebuild, every
+      # payload must match the sidecar we are about to hand to release.yml.
+      # This catches the stale-sidecar shape from redwoodjs/machinen.dev#9
+      # before any public upload can happen.
+      - name: Verify base asset checksums
+        if: steps.prebuilt.outputs.skip != 'true' || hashFiles('release-assets/Image-arm64') != ''
+        run: |
+          set -euo pipefail
+          cd release-assets
+          assets=(
+            Image-arm64
+            virt-arm64.dtb
+            rootfs-debian-arm64.tar.gz
+            rootfs-debian-arm64.img.gz
+          )
+          for asset in "${assets[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "missing release asset: release-assets/$asset" >&2
+              exit 1
+            fi
+            if [ ! -f "$asset.sha256" ]; then
+              echo "missing checksum sidecar: release-assets/$asset.sha256" >&2
+              exit 1
+            fi
+            shasum -a 256 -c "$asset.sha256"
+          done
+
       # Skip the upload when the build was short-circuited and
       # release-assets/ is empty — `if-no-files-found: error` would
       # otherwise fail the job on agent-ci local without prebuilt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,30 +265,19 @@ jobs:
       # to a Release on the public `redwoodjs/machinen.dev` repo. The CLI's
       # `ensureBaseAssets()` fetches them anonymously from that public URL
       # so consumers don't need a GitHub token (the source repo is private).
-      # Tag must match `RELEASE_TAG = runtime-v${VERSION}` in @machinen/cli.
       #
-      # release-assets/ is already populated from the earlier
-      # `Download base assets (for guest binaries)` step, with the three
-      # guest binaries stripped out — so this glob ships exactly kernel
-      # + dtb + rootfs + sha256 sidecars.
-      - name: Publish base assets to redwoodjs/machinen.dev
+      # The Node script is also the manual release path (`gh auth login`, then
+      # run it locally): it rewrites .sha256 sidecars from the exact payload
+      # bytes, uploads only the public base assets, and fetches everything back
+      # through the public URLs as a release-health gate. This prevents the
+      # stale-sidecar shape that broke runtime-v0.3.3 (redwoodjs/machinen.dev#9).
+      - name: Publish and verify base assets to redwoodjs/machinen.dev
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.MACHINEN_DEV_PUBLISH_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./packages/runtime/package.json').version")
-          TAG="runtime-v${VERSION}"
-          # Create-if-missing then always upload with --clobber so retries
-          # of the same release pick up rebuilt assets cleanly.
-          gh release create "$TAG" \
-            --repo redwoodjs/machinen.dev \
-            --title "$TAG" \
-            --notes "Base assets for @machinen/runtime@${VERSION}." \
-            2>/dev/null || true
-          gh release upload "$TAG" \
-            --repo redwoodjs/machinen.dev \
-            release-assets/* --clobber
+          MACHINEN_RELEASE_VERIFY_TRIES: "6"
+          MACHINEN_RELEASE_VERIFY_SLEEP: "10"
+        run: node scripts/release-base-assets.mjs publish
 
       # Mirror README + examples into the public machinen.dev repo so the
       # landing-page content tracks the source repo. scripts/sync-machinen-dev.mjs

--- a/packages/cli/src/__tests__/release-assets.test.ts
+++ b/packages/cli/src/__tests__/release-assets.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const SCRIPT = join(ROOT, "scripts/release-base-assets.mjs");
+const ROOTFS = "rootfs-debian-arm64.tar.gz";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "machinen-release-assets-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function sha256(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function writeAsset(dir: string, name: string, body: string, sidecarBody = body): void {
+  writeFileSync(join(dir, name), body);
+  writeFileSync(join(dir, `${name}.sha256`), `${sha256(sidecarBody)}  ${name}\n`);
+}
+
+function runVerify(remoteDir: string, assets = [ROOTFS], env: Record<string, string> = {}) {
+  return spawnSync(
+    "node",
+    [SCRIPT, "verify", "--tag", "runtime-vtest", ...assets.flatMap((asset) => ["--asset", asset])],
+    {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        MACHINEN_RELEASE_ASSETS_BASE_URL: `file://${remoteDir}`,
+        MACHINEN_RELEASE_VERIFY_TRIES: "1",
+        MACHINEN_RELEASE_VERIFY_SLEEP: "0",
+        ...env,
+      },
+      encoding: "utf8",
+    },
+  );
+}
+
+describe("scripts/release-base-assets.mjs verify", () => {
+  it("passes when a published asset matches its sidecar", () => {
+    const remote = tempDir();
+    writeAsset(remote, ROOTFS, "rootfs bytes\n");
+
+    const result = runVerify(remote);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`ok ${ROOTFS}`);
+    expect(result.stdout).toContain("release-assets: verified 1 asset(s) for runtime-vtest");
+  });
+
+  it("reproduces #9 by failing when published bytes do not match the published sidecar", () => {
+    const remote = tempDir();
+    writeAsset(
+      remote,
+      ROOTFS,
+      "actual rootfs bytes\n",
+      "sidecar was generated for different bytes\n",
+    );
+
+    const result = runVerify(remote);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain(`checksum mismatch for ${ROOTFS}`);
+    expect(output).toContain(sha256("sidecar was generated for different bytes\n"));
+    expect(output).toContain(sha256("actual rootfs bytes\n"));
+  });
+
+  it("fails when the public release is stale relative to the just-uploaded local sidecar", () => {
+    const remote = tempDir();
+    const local = tempDir();
+    writeAsset(remote, ROOTFS, "old but internally consistent rootfs\n");
+    writeAsset(local, ROOTFS, "new rootfs from this release job\n");
+
+    const result = runVerify(remote, [ROOTFS], {
+      MACHINEN_RELEASE_ASSETS_DIR: local,
+    });
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain(`published checksum sidecar mismatch for ${ROOTFS}`);
+    expect(output).toContain(sha256("new rootfs from this release job\n"));
+    expect(output).toContain(sha256("old but internally consistent rootfs\n"));
+  });
+});

--- a/scripts/release-base-assets.mjs
+++ b/scripts/release-base-assets.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+// Publish and verify the public base assets that @machinen/cli downloads
+// from redwoodjs/machinen.dev. This is intentionally a single Node entrypoint
+// (usable by CI and by a human with `gh auth login`) so manual asset releases
+// go through the same checksum refresh + fetch-back guard as automated ones.
+//
+// Guardrail for redwoodjs/machinen.dev#9: runtime-v0.3.3 shipped rootfs bytes
+// that did not match the published .sha256 sidecar. `publish` always rewrites
+// checksums from the exact payload bytes it is about to upload, uploads with
+// --clobber, then verifies by downloading through the public URLs the CLI uses.
+
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const DEFAULT_REPO = "redwoodjs/machinen.dev";
+const DEFAULT_ASSETS_DIR = resolve(REPO_ROOT, "release-assets");
+const PAYLOAD_ASSETS = [
+  "Image-arm64",
+  "virt-arm64.dtb",
+  "rootfs-debian-arm64.tar.gz",
+  "rootfs-debian-arm64.img.gz",
+];
+const OPTIONAL_UPLOAD_ASSETS = [
+  "Image-arm64.inputs-sha256",
+  "rootfs-debian-arm64.tar.gz.inputs-sha256",
+];
+
+function usage(exitCode = 2) {
+  const text = `usage:
+  node scripts/release-base-assets.mjs publish [options]
+  node scripts/release-base-assets.mjs verify  [options]
+  node scripts/release-base-assets.mjs checksums [options]
+
+commands:
+  checksums  Rewrite release-assets/*.sha256 for required payloads and verify locally.
+  verify     Download public assets + .sha256 sidecars and verify them.
+  publish    checksums -> gh release create/upload -> verify.
+
+options:
+  --tag <tag>           Release tag. Defaults to runtime-v<packages/runtime version>.
+  --repo <owner/repo>   Target repo. Default: ${DEFAULT_REPO}
+  --assets-dir <dir>    Local assets dir. Default: release-assets
+  --base-url <url>      Verification URL base. Default: GitHub release download URL.
+  --asset <name>        Payload to verify/publish. Repeatable. Default: required payloads.
+  --tries <n>           Verification attempts. Default: env or 6.
+  --sleep <seconds>     Seconds between verification attempts. Default: env or 10.
+  --dry-run             For publish: refresh/check local checksums, print upload plan only.
+
+Environment mirrors the options for manual use:
+  MACHINEN_RELEASE_ASSETS_DIR, MACHINEN_RELEASE_ASSETS_BASE_URL,
+  MACHINEN_RELEASE_VERIFY_TRIES, MACHINEN_RELEASE_VERIFY_SLEEP
+`;
+  console.error(text.trimEnd());
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const command = argv.shift();
+  if (!command || command === "-h" || command === "--help") {
+    usage(command ? 0 : 2);
+  }
+  if (!["publish", "verify", "checksums"].includes(command)) {
+    usage(2);
+  }
+
+  const envAssetsDir = process.env.MACHINEN_RELEASE_ASSETS_DIR;
+  const opts = {
+    command,
+    repo: DEFAULT_REPO,
+    assetsDir: envAssetsDir ?? DEFAULT_ASSETS_DIR,
+    compareLocal: command !== "verify" || Boolean(envAssetsDir),
+    baseUrl: process.env.MACHINEN_RELEASE_ASSETS_BASE_URL,
+    assets: [],
+    tries: Number(process.env.MACHINEN_RELEASE_VERIFY_TRIES ?? 6),
+    sleepSeconds: Number(process.env.MACHINEN_RELEASE_VERIFY_SLEEP ?? 10),
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (!value) {
+        usage(2);
+      }
+      return value;
+    };
+    if (arg === "--tag") {
+      opts.tag = next();
+    } else if (arg?.startsWith("--tag=")) {
+      opts.tag = arg.slice("--tag=".length);
+    } else if (arg === "--repo") {
+      opts.repo = next();
+    } else if (arg?.startsWith("--repo=")) {
+      opts.repo = arg.slice("--repo=".length);
+    } else if (arg === "--assets-dir") {
+      opts.assetsDir = next();
+      opts.compareLocal = true;
+    } else if (arg?.startsWith("--assets-dir=")) {
+      opts.assetsDir = arg.slice("--assets-dir=".length);
+      opts.compareLocal = true;
+    } else if (arg === "--base-url") {
+      opts.baseUrl = next();
+    } else if (arg?.startsWith("--base-url=")) {
+      opts.baseUrl = arg.slice("--base-url=".length);
+    } else if (arg === "--asset") {
+      opts.assets.push(next());
+    } else if (arg?.startsWith("--asset=")) {
+      opts.assets.push(arg.slice("--asset=".length));
+    } else if (arg === "--tries") {
+      opts.tries = Number(next());
+    } else if (arg?.startsWith("--tries=")) {
+      opts.tries = Number(arg.slice("--tries=".length));
+    } else if (arg === "--sleep") {
+      opts.sleepSeconds = Number(next());
+    } else if (arg?.startsWith("--sleep=")) {
+      opts.sleepSeconds = Number(arg.slice("--sleep=".length));
+    } else if (arg === "--dry-run") {
+      opts.dryRun = true;
+    } else {
+      usage(2);
+    }
+  }
+
+  opts.assetsDir = resolve(opts.assetsDir);
+  opts.assets = opts.assets.length > 0 ? opts.assets : [...PAYLOAD_ASSETS];
+  if (!Number.isInteger(opts.tries) || opts.tries < 1) {
+    throw new Error("--tries must be a positive integer");
+  }
+  if (!Number.isFinite(opts.sleepSeconds) || opts.sleepSeconds < 0) {
+    throw new Error("--sleep must be a non-negative number");
+  }
+  return opts;
+}
+
+async function defaultTag() {
+  const raw = await readFile(resolve(REPO_ROOT, "packages/runtime/package.json"), "utf8");
+  const pkg = JSON.parse(raw);
+  return `runtime-v${pkg.version}`;
+}
+
+function releaseBaseUrl(repo, tag) {
+  return `https://github.com/${repo}/releases/download/${encodeURIComponent(tag)}`;
+}
+
+function assetUrl(baseUrl, asset) {
+  return `${baseUrl.replace(/\/$/, "")}/${encodeURIComponent(asset)}`;
+}
+
+async function exists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+async function sha256File(path) {
+  const hash = createHash("sha256");
+  const file = createReadStream(path);
+  for await (const chunk of file) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function parseSidecar(text, label) {
+  const sha = text.trim().split(/\s+/)[0]?.toLowerCase();
+  if (!sha || !/^[0-9a-f]{64}$/.test(sha)) {
+    throw new Error(`invalid sha256 sidecar for ${label}`);
+  }
+  return sha;
+}
+
+async function localPayloadSha(assetsDir, asset) {
+  const payload = join(assetsDir, asset);
+  if (!(await exists(payload))) {
+    throw new Error(`missing release asset: ${payload}`);
+  }
+  return sha256File(payload);
+}
+
+async function rewriteChecksums(assetsDir, assets) {
+  console.log(`refresh checksums in ${assetsDir}`);
+  for (const asset of assets) {
+    const sha = await localPayloadSha(assetsDir, asset);
+    await writeFile(join(assetsDir, `${asset}.sha256`), `${sha}  ${asset}\n`);
+    console.log(`  ${sha}  ${asset}`);
+  }
+  await verifyLocalChecksums(assetsDir, assets);
+}
+
+async function verifyLocalChecksums(assetsDir, assets) {
+  for (const asset of assets) {
+    const sidecarPath = join(assetsDir, `${asset}.sha256`);
+    if (!(await exists(sidecarPath))) {
+      throw new Error(`missing checksum sidecar: ${sidecarPath}`);
+    }
+    const expected = parseSidecar(await readFile(sidecarPath, "utf8"), sidecarPath);
+    const got = await localPayloadSha(assetsDir, asset);
+    if (got !== expected) {
+      throw new Error(
+        `local checksum sidecar mismatch for ${asset}: expected ${expected}, got ${got}`,
+      );
+    }
+  }
+}
+
+async function downloadToFile(urlString, dest) {
+  const url = new URL(urlString);
+  await mkdir(dirname(dest), { recursive: true });
+  if (url.protocol === "file:") {
+    await copyFile(fileURLToPath(url), dest);
+    return;
+  }
+
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok || !res.body) {
+    throw new Error(`fetch failed: ${urlString}: ${res.status} ${res.statusText}`);
+  }
+  await pipeline(Readable.fromWeb(res.body), createWriteStream(dest));
+}
+
+async function fetchText(urlString) {
+  const url = new URL(urlString);
+  if (url.protocol === "file:") {
+    return readFile(fileURLToPath(url), "utf8");
+  }
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`fetch failed: ${urlString}: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+async function verifyPublishedOnce({ baseUrl, assets, assetsDir, compareLocal }) {
+  const tmp = await mkdtemp(join(tmpdir(), "machinen-release-assets-"));
+  try {
+    for (const asset of assets) {
+      console.log(`verify ${asset}`);
+      const sidecarUrl = assetUrl(baseUrl, `${asset}.sha256`);
+      const payloadUrl = assetUrl(baseUrl, asset);
+      const remoteExpected = parseSidecar(await fetchText(sidecarUrl), sidecarUrl);
+
+      let expected = remoteExpected;
+      if (compareLocal) {
+        const localSidecar = join(assetsDir, `${asset}.sha256`);
+        const localExpected = parseSidecar(await readFile(localSidecar, "utf8"), localSidecar);
+        const localGot = await localPayloadSha(assetsDir, asset);
+        if (localGot !== localExpected) {
+          throw new Error(
+            `local checksum sidecar mismatch for ${asset}: expected ${localExpected}, got ${localGot}`,
+          );
+        }
+        if (remoteExpected !== localExpected) {
+          throw new Error(
+            `published checksum sidecar mismatch for ${asset}: expected ${localExpected}, got ${remoteExpected}`,
+          );
+        }
+        expected = localExpected;
+      }
+
+      const downloaded = join(tmp, asset.replace(/[/:]/g, "_"));
+      await downloadToFile(payloadUrl, downloaded);
+      const got = await sha256File(downloaded);
+      if (got !== expected) {
+        throw new Error(`checksum mismatch for ${asset}: expected ${expected}, got ${got}`);
+      }
+      console.log(`  ok ${asset} ${got}`);
+    }
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+async function verifyPublished(opts) {
+  let lastError;
+  for (let attempt = 1; attempt <= opts.tries; attempt++) {
+    try {
+      await verifyPublishedOnce(opts);
+      console.log(`release-assets: verified ${opts.assets.length} asset(s) for ${opts.tag}`);
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < opts.tries) {
+        console.error(
+          `release-assets: verification attempt ${attempt}/${opts.tries} failed: ${err.message}`,
+        );
+        await new Promise((resolveSleep) =>
+          setTimeout(resolveSleep, Math.round(opts.sleepSeconds * 1000)),
+        );
+      }
+    }
+  }
+  throw new Error(
+    `release-assets: verification failed after ${opts.tries} attempt(s): ${lastError?.message}`,
+  );
+}
+
+function runGh(args, { allowFailure = false } = {}) {
+  const result = spawnSync("gh", args, {
+    cwd: REPO_ROOT,
+    stdio: allowFailure ? "ignore" : "inherit",
+    env: process.env,
+  });
+  if (!allowFailure && result.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+  return result.status ?? 1;
+}
+
+async function uploadList(assetsDir, assets) {
+  const files = [];
+  for (const asset of assets) {
+    files.push(join(assetsDir, asset), join(assetsDir, `${asset}.sha256`));
+  }
+  for (const asset of OPTIONAL_UPLOAD_ASSETS) {
+    const path = join(assetsDir, asset);
+    if (await exists(path)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+async function publish(opts) {
+  await rewriteChecksums(opts.assetsDir, opts.assets);
+  const files = await uploadList(opts.assetsDir, opts.assets);
+
+  console.log(`publish ${opts.tag} -> ${opts.repo}`);
+  for (const file of files) {
+    console.log(`  upload ${basename(file)}`);
+  }
+  if (opts.dryRun) {
+    console.log("dry-run: not creating or uploading release assets");
+    return;
+  }
+
+  if (runGh(["release", "view", opts.tag, "--repo", opts.repo], { allowFailure: true }) !== 0) {
+    runGh([
+      "release",
+      "create",
+      opts.tag,
+      "--repo",
+      opts.repo,
+      "--title",
+      opts.tag,
+      "--notes",
+      `Base assets for @machinen/runtime@${opts.tag.replace(/^runtime-v/, "")}.`,
+    ]);
+  }
+  runGh(["release", "upload", opts.tag, "--repo", opts.repo, ...files, "--clobber"]);
+
+  await verifyPublished(opts);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  opts.tag ??= await defaultTag();
+  opts.baseUrl ??= releaseBaseUrl(opts.repo, opts.tag);
+
+  if (opts.command === "checksums") {
+    await rewriteChecksums(opts.assetsDir, opts.assets);
+  } else if (opts.command === "verify") {
+    await verifyPublished(opts);
+  } else {
+    await publish(opts);
+  }
+}
+
+main().catch((err) => {
+  console.error(err?.message ?? String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

A release asset can be uploaded with an old `.sha256` file next to it. That is what happened to `runtime-v0.3.3`: the rootfs download was real, but the checksum file pointed at different bytes. New users then hit a checksum error on first install.

## Solution

This adds one Node script for releasing base assets, so CI and manual releases use the same safe path. The script rewrites checksums from the files it is about to upload, uploads only the expected public assets, then downloads them back through the public URLs and checks them again. The workflows now call this script and also check cached or prebuilt assets before passing them to the release job.

## Testing

- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `pnpm smoke-tests`
- `node scripts/release-base-assets.mjs verify --tag runtime-v0.3.3 --tries 1 ...`
