### PR TITLE
Fix Linux virtio-fs live mounts

### DIFF
--- a/.changeset/clean-lions-fix.md
+++ b/.changeset/clean-lions-fix.md
@@ -1,0 +1,8 @@
+---
+"@machinen/native-arm64-linux": patch
+"@machinen/native-arm64-darwin": patch
+---
+
+Fix virtio-fs live mounts on Linux/KVM.
+
+Linux arm64 now reads host file metadata with the right `stat` layout, so `--mount-live` no longer crashes the VMM during `GETATTR`. Appends through a live mount now honor the guest's write offset instead of duplicating bytes on Linux hosts.

--- a/docs/guides/mount-files.md
+++ b/docs/guides/mount-files.md
@@ -13,8 +13,9 @@ A quick decision sketch before the details:
   `--mount`. The data rides into the VM at boot and the guest sees a
   copy.
 - **A directory you want the guest and host to share live**, with
-  changes flowing in either direction? `--mount-live`. It's a FUSE
-  pass-through — no copy, just a vsock pipe back to the host.
+  changes flowing in either direction? `--mount-live`. It's a
+  FUSE-style filesystem served by the VMM over virtio-fs — no copy,
+  just live access to the host directory.
 
 ## A workspace you're actively editing — `--mount-live`
 
@@ -29,9 +30,9 @@ npx machinen boot --mount-live ./workspace:/mnt/workspace -- bash
 ```
 
 In the guest, `/mnt/workspace` is your host's `./workspace` directory.
-Reads stream over vsock on demand — nothing was copied at boot, so the
-mount is essentially free even if the workspace is huge. Writes land
-back on the host immediately. If the guest builds a binary into
+Reads stream through virtio-fs on demand — nothing was copied at boot,
+so the mount is essentially free even if the workspace is huge. Writes
+land back on the host immediately. If the guest builds a binary into
 `./workspace/dist/`, you'll see it in your editor.
 
 Default mode is read-write. If you want to share something the guest
@@ -43,7 +44,7 @@ npx machinen boot --mount-live ./fixtures:/mnt/fixtures:ro -- ./run-tests.sh
 ```
 
 You can pass `--mount-live` multiple times for separate shares; each
-one gets its own vsock port:
+one gets its own virtio-fs device slot:
 
 ```bash
 npx machinen boot \
@@ -51,6 +52,12 @@ npx machinen boot \
   --mount-live ./fixtures:/mnt/fixtures:ro \
   -- bash
 ```
+
+Common filesystem operations work through the live mount: read, write,
+append, truncate, rename, symlink, hardlink, `chmod +x`, and large file
+reads or writes. The same behavior is tested on macOS/HVF and
+Linux/KVM, so a workspace should behave the same whether the VM runs on
+your laptop or on a Linux builder.
 
 A security note worth being aware of: a `rw` live mount is a
 persistent channel from inside the guest back to the host filesystem,

--- a/packages/mount-server/src/fuse.zig
+++ b/packages/mount-server/src/fuse.zig
@@ -107,7 +107,7 @@ const StatDarwin = extern struct {
     qspare: [2]i64,
 };
 
-const StatLinux = extern struct {
+const StatLinuxX64 = extern struct {
     dev: u64,
     ino: u64,
     nlink: u64,
@@ -123,6 +123,34 @@ const StatLinux = extern struct {
     mtim: timespec_c,
     ctim: timespec_c,
     _spare: [3]i64,
+};
+
+// glibc's aarch64 `struct stat` is not the same as x86_64's: `mode`
+// and 32-bit `nlink` precede uid/gid, with padding around rdev/blksize.
+// The VMM's linux package ships for arm64, so using the x86_64 layout
+// here corrupts attrs and can panic on GETATTR under KVM.
+const StatLinuxAarch64 = extern struct {
+    dev: u64,
+    ino: u64,
+    mode: u32,
+    nlink: u32,
+    uid: u32,
+    gid: u32,
+    rdev: u64,
+    _pad1: u64,
+    size: i64,
+    blksize: i32,
+    _pad2: i32,
+    blocks: i64,
+    atim: timespec_c,
+    mtim: timespec_c,
+    ctim: timespec_c,
+    _spare: [2]u32,
+};
+
+const StatLinux = switch (builtin.cpu.arch) {
+    .aarch64 => StatLinuxAarch64,
+    else => StatLinuxX64,
 };
 
 const Stat = if (builtin.os.tag == .macos) StatDarwin else StatLinux;
@@ -1775,7 +1803,11 @@ fn linuxOpenToHost(linux_flags: u32) c_int {
     else
         O_RDONLY;
     if (linux_flags & LINUX_O_TRUNC != 0) host |= O_TRUNC;
-    if (linux_flags & LINUX_O_APPEND != 0) host |= O_APPEND;
+    // Do not mirror O_APPEND to the host fd. FUSE WRITE requests carry
+    // explicit offsets, and with WRITEBACK_CACHE the guest may send a
+    // whole rewritten page at offset 0 for `>> file`. Linux makes
+    // pwrite(2) append anyway on an O_APPEND fd, which duplicates the
+    // old bytes. Honor the guest-supplied offset instead.
     return host;
 }
 
@@ -2066,6 +2098,31 @@ fn testTmpRootAbs(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 
     return std.fs.path.join(gpa, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
 }
 
+test "dispatch: GETATTR returns sane attrs for the host stat layout" {
+    const gpa = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    defer state.deinit();
+
+    const frame = try testBuildFrame(gpa, @intFromEnum(Op.GETATTR), 9, 1, &.{});
+    defer gpa.free(frame);
+    const r = (try dispatch(&state, frame)) orelse return error.ExpectedReply;
+    defer gpa.free(r);
+
+    try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, r[4..8], .little));
+    try testing.expectEqual(@as(usize, FUSE_OUT_HEADER_SIZE + FUSE_ATTR_OUT_SIZE), r.len);
+
+    const attr = r[FUSE_OUT_HEADER_SIZE + 16 ..];
+    const mode = std.mem.readInt(u32, attr[60..64], .little);
+    const nlink = std.mem.readInt(u32, attr[64..68], .little);
+    const blksize = std.mem.readInt(u32, attr[80..84], .little);
+    try testing.expectEqual(@as(u32, 0o040000), mode & 0o170000);
+    try testing.expect(nlink > 0);
+    try testing.expect(blksize > 0);
+}
+
 /// CREATE `name` under the root inode; returns its (nodeid, fh).
 fn testCreate(state: *State, name: []const u8) !struct { nodeid: u64, fh: u64 } {
     var body: [16 + 96]u8 = @splat(0);
@@ -2140,6 +2197,38 @@ test "dispatch: OPEN O_WRONLY handles writeback-cache read fill then WRITE exist
     const got = try tmp.dir.readFileAlloc(std.testing.io, "existing.txt", gpa, .limited(1024));
     defer gpa.free(got);
     try testing.expectEqualStrings("new", got);
+}
+
+test "dispatch: O_APPEND writes honor guest offsets, not host append mode" {
+    const gpa = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "append.txt", .data = "append-base\n" });
+
+    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    defer state.deinit();
+    const nodeid = try testLookup(&state, "append.txt");
+    const fh = try testOpen(&state, nodeid, LINUX_O_WRONLY | LINUX_O_APPEND);
+
+    // With WRITEBACK_CACHE, the guest can satisfy `echo x >> file` by
+    // sending the rewritten page at offset 0. If the host fd also has
+    // O_APPEND, Linux pwrite(2) appends this whole page and duplicates
+    // the old bytes. The FUSE offset is authoritative.
+    const data = "append-base\nappended\n";
+    var wbody: [FUSE_WRITE_IN_SIZE + data.len]u8 = @splat(0);
+    std.mem.writeInt(u64, wbody[0..8], fh, .little);
+    std.mem.writeInt(u64, wbody[8..16], 0, .little);
+    std.mem.writeInt(u32, wbody[16..20], data.len, .little);
+    @memcpy(wbody[FUSE_WRITE_IN_SIZE..], data);
+    const wf = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 3, nodeid, &wbody);
+    defer gpa.free(wf);
+    const wr = (try dispatch(&state, wf)) orelse return error.ExpectedReply;
+    defer gpa.free(wr);
+    try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, wr[4..8], .little));
+
+    const got = try tmp.dir.readFileAlloc(std.testing.io, "append.txt", gpa, .limited(1024));
+    defer gpa.free(got);
+    try testing.expectEqualStrings(data, got);
 }
 
 test "dispatch: SETATTR FATTR_SIZE truncates an existing file and honors :ro" {

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -97,12 +97,12 @@ kernel_input_files() {
 
 # Files whose contents are baked into
 # packages/native-arm64-darwin/vmm/bin/machinen-vm. We `find` every .zig
-# under packages/microvm/src so a newly added source file
-# automatically invalidates the sidecar — listing them explicitly (as
-# rootfs_input_files does for assets/) would silently miss new files
-# and give us back the exact bug this checker is supposed to prevent.
-# Sort for stable order across find implementations (BSD find on
-# darwin doesn't sort by default).
+# under packages/microvm/src and the in-VMM virtio-fs FUSE handlers under
+# packages/mount-server/src so a newly added source file automatically
+# invalidates the sidecar — listing them explicitly (as rootfs_input_files
+# does for assets/) would silently miss new files and give us back the
+# exact bug this checker is supposed to prevent. Sort for stable order
+# across find implementations (BSD find on darwin doesn't sort by default).
 #
 # Also pulled in:
 #   - build.zig + build.zig.zon: build graph + dep pins.
@@ -111,6 +111,7 @@ kernel_input_files() {
 #     invalidate the sidecar even when no .zig source moved.
 vmm_input_files() {
   find "${ROOT}/packages/microvm/src" -type f -name '*.zig' -print | sort
+  find "${ROOT}/packages/mount-server/src" -type f -name '*.zig' -print | sort
   printf '%s\n' \
     "${ROOT}/packages/microvm/build.zig" \
     "${ROOT}/packages/microvm/build.zig.zon" \


### PR DESCRIPTION
## Problem

While testing the snapshot work on the Linux/KVM host, the live-mount smoke test exposed a separate Linux bug.

The VMM was reading Linux arm64 file details with the wrong memory layout. That could make `--mount-live` crash when the guest asked for file metadata. Appending through a live mount could also write the old contents twice on Linux hosts.

## Solution

The FUSE handler now uses the correct Linux arm64 `stat` layout. It also stops opening host files with `O_APPEND`, because FUSE writes already include the exact offset the guest wants.

This PR adds tests for both cases, updates the live-mount docs, and makes VMM freshness checks notice changes to the shared FUSE handlers.

## Testing

- `NPM_CONFIG_MIN_RELEASE_AGE=0 npx vitest run`
- `NPM_CONFIG_MIN_RELEASE_AGE=0 npx agent-ci run --all -q -p`
- `pnpm build`
- `pnpm exec tsgo --noEmit`
- `zig build test --summary all` in `packages/mount-server`
- `zig build test --summary all` in `packages/microvm`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-test-snapshot-restore-fork`
- Linux/KVM `pnpm smoke-tests` on `friend@100.126.46.90`
- Linux/KVM `pnpm smoke-test-snapshot-restore-fork` on `friend@100.126.46.90`
