### PR TITLE
Add incremental vmstate checkpoints

### DIFF
--- a/docs/snapshot/vmstate-portability.md
+++ b/docs/snapshot/vmstate-portability.md
@@ -11,9 +11,13 @@ Current policy:
   source backend (`hvf`/`kvm`), topology hash, guest RAM ceiling
   (the memory layout, not current host usage), guest PAuth state, and
   the exact root block image identity.
-- The exact root block image is copied into the bundle as
-  `rootdisk.img`. Restore reflink-clones it into a per-VM temp file so
-  the restored guest never mutates the bundle in place.
+- The first vmstate checkpoint in a VM chain carries a full sparse RAM
+  section and copies the exact root block image into the bundle as
+  `rootdisk.img`. Later checkpoints carry RAM/rootdisk delta sections
+  plus full non-diffable device/vCPU state. Restore walks parent
+  pointers, materializes a flat vmstate/rootdisk pair in a temp bundle,
+  then boots through the normal vmstate restore path so the restored
+  guest never mutates checkpoint bundles in place.
 - Cross-HVF/KVM restore is refused when guest PAuth is active or
   unknown. The default DTB includes `arm64.nopauth` so newly booted
   guests are portable by default; older active-PAuth snapshots must be

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -12,7 +12,7 @@ machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bun
 machinen list     (alias: ls, ps)               List running VMs
 machinen exec     <target> [--tty] -- <cmd>     Run a command in a running VM
 machinen snapshot <target> <out-dir> [--keep-alive] [--dry-run]
-                                                CRIU-snapshot a running VM
+                                                Checkpoint a running VM
 machinen fork     <target> [opts]               Clone a running VM into a sibling
 machinen attach   <target> [--shell <c>] [--tail [N]]
                                                 Interactive PTY shell into a VM
@@ -113,10 +113,13 @@ machinen exec worker --tty -- bash -i
 machinen snapshot <target> <out-dir> [--keep-alive]
 ```
 
-CRIU-snapshots a running VM into `<out-dir>` (`disk.img` + `meta.json`).
-The default freezes-and-exits the source. `--keep-alive` leaves it
-running and closes inherited TCP sockets so two live copies don't race
-on shared connection state.
+Checkpoints a running VM into `<out-dir>`. With the default vmstate
+engine this is incremental and non-destructive: the source keeps
+running, and later snapshots from the same VM store RAM/rootdisk deltas
+against the previous checkpoint. CRIU-engine snapshots remain
+non-incremental; there `--keep-alive` leaves the source running and
+closes inherited TCP sockets so two live copies don't race on shared
+connection state.
 
 ## `machinen fork`
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2020,12 +2020,11 @@ function printHelp(): void {
       `                                                 Example:\n` +
       `                                                   machinen exec <name|pid> --tty -- bash -i\n` +
       `  machinen snapshot <name|pid> <out-dir> [--keep-alive]\n` +
-      `                                                 CRIU-snapshot a running VM into <d>.\n` +
-      `                                                 Default: source VM exits as part of the\n` +
-      `                                                 dump. --keep-alive leaves it running\n` +
-      `                                                 (and closes inherited TCP sockets to\n` +
-      `                                                 avoid two live copies racing on shared\n` +
-      `                                                 connection state).\n` +
+      `                                                 Checkpoint a running VM into <d>.\n` +
+      `                                                 Default vmstate snapshots are incremental\n` +
+      `                                                 and non-destructive. CRIU snapshots stay\n` +
+      `                                                 non-incremental; --keep-alive leaves them\n` +
+      `                                                 running and closes inherited TCP sockets.\n` +
       `  machinen fork     <name|pid> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
       `                    [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...\n` +
       `                    [--cwd <abs>] [--memory <mib>]\n` +

--- a/packages/microvm/src/blk.zig
+++ b/packages/microvm/src/blk.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const virtio = @import("virtio.zig");
+const rootdisk_delta = @import("rootdisk_delta.zig");
 const assert = std.debug.assert;
 
 comptime {
@@ -58,6 +59,42 @@ pub const BlkDiscardSeg = extern struct {
 pub const VIRTIO_BLK_S_OK: u8 = 0;
 pub const VIRTIO_BLK_S_IOERR: u8 = 1;
 pub const VIRTIO_BLK_S_UNSUPP: u8 = 2;
+
+pub const DirtyTracker = struct {
+    allocator: std.mem.Allocator,
+    disk_size: u64,
+    bits: []u64,
+
+    pub fn init(allocator: std.mem.Allocator, disk_size: u64) !DirtyTracker {
+        assert(disk_size > 0);
+        const block_count = 1 + ((disk_size - 1) / rootdisk_delta.BLOCK);
+        const word_count: usize = @intCast((block_count + 63) / 64);
+        const bits = try allocator.alloc(u64, word_count);
+        @memset(bits, 0);
+        return .{ .allocator = allocator, .disk_size = disk_size, .bits = bits };
+    }
+
+    pub fn deinit(self: *DirtyTracker) void {
+        self.allocator.free(self.bits);
+        self.bits = &.{};
+    }
+
+    pub fn clear(self: *DirtyTracker) void {
+        @memset(self.bits, 0);
+    }
+
+    pub fn mark(self: *DirtyTracker, offset: u64, len: u64) void {
+        if (len == 0 or offset >= self.disk_size) return;
+        const end = if (len > self.disk_size - offset) self.disk_size else offset + len;
+        var block = offset / rootdisk_delta.BLOCK;
+        const end_block = (end + rootdisk_delta.BLOCK - 1) / rootdisk_delta.BLOCK;
+        while (block < end_block) : (block += 1) {
+            const word: usize = @intCast(block / 64);
+            const bit: u6 = @intCast(block % 64);
+            if (word < self.bits.len) self.bits[word] |= @as(u64, 1) << bit;
+        }
+    }
+};
 
 // virtio-blk-specific feature bits worth knowing.
 pub const VIRTIO_BLK_F_SIZE_MAX: u6 = 1;
@@ -111,6 +148,9 @@ pub const Backend = struct {
     /// driver can't corrupt the content-addressed cache file the
     /// runtime hands us read-only.
     read_only: bool = false,
+    /// Dirty-block bitmap for incremental vmstate checkpoints. Enabled
+    /// only for the rootdisk backend; scratch/mount disks leave it null.
+    dirty: ?DirtyTracker = null,
     /// The backing config space. Keep it here so the virtio.Device
     /// can hand out a stable slice reference.
     config: BlkConfig,
@@ -144,8 +184,29 @@ pub const Backend = struct {
     }
 
     pub fn deinit(self: *Backend) void {
+        if (self.dirty) |*d| d.deinit();
         assert(self.fd >= 0);
         _ = close(self.fd);
+    }
+
+    pub fn enableDirtyTracking(self: *Backend, allocator: std.mem.Allocator) !void {
+        if (self.dirty != null) return;
+        self.dirty = try DirtyTracker.init(allocator, self.capacity_sectors * 512);
+    }
+
+    pub fn clearDirty(self: *Backend) void {
+        if (self.dirty) |*d| d.clear();
+    }
+
+    pub fn encodeDirtyDelta(self: *Backend, allocator: std.mem.Allocator) ![]u8 {
+        if (self.dirty) |*d| {
+            return rootdisk_delta.encodeFromFd(allocator, self.fd, d.disk_size, d.bits);
+        }
+        return rootdisk_delta.encodeFromFd(allocator, self.fd, self.capacity_sectors * 512, &.{});
+    }
+
+    fn markDirtyBytes(self: *Backend, offset: u64, len: u64) void {
+        if (self.dirty) |*d| d.mark(offset, len);
     }
 
     /// The request-handler callback to feed `virtio.Device.request_handler`.
@@ -238,11 +299,13 @@ pub const Backend = struct {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         };
-                        const n_bytes = pwrite(self.fd, src.ptr, src.len, @as(i64, @intCast(sector)) * 512);
+                        const byte_off = sector * 512;
+                        const n_bytes = pwrite(self.fd, src.ptr, src.len, @as(i64, @intCast(byte_off)));
                         if (n_bytes < 0) {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         }
+                        self.markDirtyBytes(byte_off, @intCast(n_bytes));
                         total_bytes += @intCast(n_bytes);
                         sector += src.len / 512;
                     }
@@ -277,6 +340,7 @@ pub const Backend = struct {
                             const offset_bytes: i64 = @as(i64, @intCast(seg.sector)) * 512;
                             const len_bytes: i64 = @as(i64, @intCast(seg.num_sectors)) * 512;
                             if (len_bytes <= 0) continue;
+                            self.markDirtyBytes(@intCast(offset_bytes), @intCast(len_bytes));
                             const rc = punchHole(self.fd, offset_bytes, len_bytes);
                             if (rc != 0) {
                                 // EOPNOTSUPP / EINVAL on hosts that

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -28,6 +28,7 @@ const hvf = @import("hvf.zig");
 const virtio = @import("virtio.zig");
 const net_mod = @import("net_socket.zig");
 const blk_mod = @import("blk.zig");
+const ram_dump = @import("ram_dump.zig");
 const vsock_mod = @import("vsock.zig");
 const virtiofs_mod = @import("virtiofs.zig");
 const balloon_mod = @import("balloon.zig");
@@ -296,6 +297,11 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     var blk_backend_opt: ?blk_mod.Backend = openBlkBackend(slot1_path, "slot 1");
     defer if (blk_backend_opt) |*b| b.deinit();
+    if (cfg.rootdisk_path != null and cfg.snapshot_path != null) {
+        if (blk_backend_opt) |*b| b.enableDirtyTracking(gpa) catch |err| {
+            std.debug.print("blk: rootdisk dirty tracking disabled: {s}\n", .{@errorName(err)});
+        };
+    }
     var blkdev_opt: ?virtio.Device = if (blk_backend_opt) |*b|
         makeBlkDevice(virtio_blk_base, virtio_blk_size, ram, cfg, b)
     else
@@ -451,6 +457,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     const devs = Devices{
         .uart = &uart,
         .netdev = &netdev,
+        .root_blk = if (cfg.rootdisk_path != null) (if (blk_backend_opt) |_| &blk_backend_opt.? else null) else null,
         .blk_dev = blkdev_ptr,
         .blk2_dev = blk2dev_ptr,
         .blk3_dev = blk3dev_ptr,
@@ -474,15 +481,19 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         startSnapshotWatcher(vcpu.handle);
     }
 
-    return try runLoop(gpa, cfg, vcpu, &devs, irqs, ram);
+    return try runLoop(gpa, cfg, vm, vcpu, &devs, irqs, ram);
 }
 
 // SIGUSR1 atomic + watcher-thread plumbing. macOS HVF doesn't return
 // from hv_vcpu_run on signal, so the signal handler alone isn't
 // enough: we spawn a watcher pthread that polls the atomic and calls
 // hv_vcpus_exit() to force the vCPU out of its run when set. The run
-// loop then sees the flag on its next iteration and dumps.
+// loop then sees the flag on its next iteration and dumps. SIGUSR2 is
+// the matching runtime acknowledgment: after it has copied rootdisk /
+// mount-overlay sidecars that must match the captured CPU/RAM point, it
+// lets the paused vCPU resume.
 var snapshot_requested_hvf: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var snapshot_resume_requested_hvf: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var snapshot_watcher_running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var snapshot_watcher_vcpu: u64 = 0;
 
@@ -499,12 +510,38 @@ fn sigusr1HandlerHvf(sig: c_int) callconv(.c) void {
     _ = c.write(2, msg.ptr, msg.len);
 }
 
+fn sigusr2HandlerHvf(sig: c_int) callconv(.c) void {
+    _ = sig;
+    snapshot_resume_requested_hvf.store(true, .seq_cst);
+}
+
 fn installSnapshotSignal() void {
     const c = struct {
         extern "c" fn signal(sig: c_int, handler: usize) usize;
     };
     const SIGUSR1: c_int = 30; // macOS SIGUSR1; differs from Linux (10)
+    const SIGUSR2: c_int = 31; // macOS SIGUSR2; differs from Linux (12)
     _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1HandlerHvf));
+    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2HandlerHvf));
+}
+
+fn waitForSnapshotResumeHvf() void {
+    const c = struct {
+        extern "c" fn usleep(usec: u32) c_int;
+    };
+    const poll_us: u32 = 1_000;
+    const timeout_us: u64 = 120 * 1_000_000;
+    var waited_us: u64 = 0;
+    std.debug.print("hvf: snapshot captured; waiting for runtime resume\n", .{});
+    while (!snapshot_resume_requested_hvf.load(.seq_cst) and waited_us < timeout_us) : (waited_us += poll_us) {
+        _ = c.usleep(poll_us);
+    }
+    if (snapshot_resume_requested_hvf.load(.seq_cst)) {
+        snapshot_resume_requested_hvf.store(false, .seq_cst);
+        std.debug.print("hvf: snapshot resume received\n", .{});
+    } else {
+        std.debug.print("hvf: snapshot resume timed out after {d}us; resuming fail-open\n", .{waited_us});
+    }
 }
 
 fn snapshotWatcherThread(arg: ?*anyopaque) callconv(.c) ?*anyopaque {
@@ -570,10 +607,11 @@ fn captureSnapshotJob(
     ram: []const u8,
     cfg: Config,
     devs: *const Devices,
+    full_ram: bool,
+    dirty_bits: ?[]const u64,
 ) !*vmstate_writer.Job {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
-    const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
@@ -590,7 +628,10 @@ fn captureSnapshotJob(
     const a = job.arenaAllocator();
 
     const vcpu_payload = try vcpu_dump.dumpHvf(a, vcpu.handle);
-    const ram_payload = try ram_dump.encode(a, cfg.ram_base, ram);
+    const ram_payload = if (full_ram)
+        try ram_dump.encode(a, cfg.ram_base, ram)
+    else
+        try ram_dump.encodeDelta(a, cfg.ram_base, ram, dirty_bits.?);
     // GICv3 distributor + per-vCPU redistributor state. Without these
     // a cross-VMM restore lands the guest on a fresh GIC: interrupts
     // the kernel thinks are enabled (the vtimer PPI especially) are
@@ -614,7 +655,7 @@ fn captureSnapshotJob(
 
     var sections = std.ArrayList(snapshot.Section).empty;
     try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
-    try sections.append(a, .{ .tag = .ram, .id = 0, .payload = ram_payload });
+    try sections.append(a, .{ .tag = if (full_ram) .ram else .ram_delta, .id = 0, .payload = ram_payload });
     try sections.append(a, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
     try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
     try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
@@ -635,6 +676,12 @@ fn captureSnapshotJob(
         const fp = try backend.state.dumpState(a);
         try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
+    if (!full_ram) {
+        if (devs.root_blk) |b| {
+            const dp = try b.encodeDirtyDelta(a);
+            try sections.append(a, .{ .tag = .rootdisk_delta, .id = 0, .payload = dp });
+        }
+    }
     job.sections = try sections.toOwnedSlice(a);
     return job;
 }
@@ -649,7 +696,6 @@ fn applyRestoreFile(
 ) !void {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
-    const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
@@ -716,6 +762,11 @@ fn applyRestoreFile(
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
                 _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
+            },
+            .ram_delta => {
+                // Overlay a checkpoint delta onto the RAM reconstructed
+                // from its parent section(s).
+                _ = try ram_dump.decodeDeltaInto(s.payload, ram);
             },
             .gic_dist => gic_state.loadHvfDist(gpa, s.payload) catch |err| {
                 std.debug.print("hvf boot: gic_dist restore failed: {s}\n", .{@errorName(err)});
@@ -834,6 +885,54 @@ fn applyRestoreFile(
     timing.done();
 }
 
+const RamDirtyTracker = struct {
+    allocator: std.mem.Allocator,
+    vm: hvf.Vm,
+    ram_base: u64,
+    ram_size: usize,
+    bits: []u64,
+    active: bool = false,
+
+    fn init(allocator: std.mem.Allocator, vm: hvf.Vm, cfg: Config) !RamDirtyTracker {
+        const page_count = cfg.ram_size / ram_dump.PAGE;
+        const word_count = (page_count + 63) / 64;
+        const bits = try allocator.alloc(u64, word_count);
+        @memset(bits, 0);
+        return .{ .allocator = allocator, .vm = vm, .ram_base = cfg.ram_base, .ram_size = cfg.ram_size, .bits = bits };
+    }
+
+    fn deinit(self: *RamDirtyTracker) void {
+        self.allocator.free(self.bits);
+        self.bits = &.{};
+    }
+
+    fn activateClean(self: *RamDirtyTracker) !void {
+        @memset(self.bits, 0);
+        try self.vm.protect(self.ram_base, self.ram_size, hvf.MapFlags.rx);
+        self.active = true;
+    }
+
+    fn handleWriteFault(self: *RamDirtyTracker, info: hvf.DataAbort) !bool {
+        if (!self.active or !info.is_write) return false;
+        if (info.ipa < self.ram_base) return false;
+        const rel = info.ipa - self.ram_base;
+        if (rel >= self.ram_size) return false;
+        const hv_page_rel = (rel / hvf.page_size) * hvf.page_size;
+        const hv_page_ipa = self.ram_base + hv_page_rel;
+        const first_page = hv_page_rel / ram_dump.PAGE;
+        const subpages = hvf.page_size / ram_dump.PAGE;
+        for (0..subpages) |i| {
+            const page = first_page + i;
+            if (page * ram_dump.PAGE >= self.ram_size) break;
+            const word = page / 64;
+            const bit: u6 = @intCast(page % 64);
+            if (word < self.bits.len) self.bits[word] |= @as(u64, 1) << bit;
+        }
+        try self.vm.protect(hv_page_ipa, hvf.page_size, hvf.MapFlags.rwx);
+        return true;
+    }
+};
+
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exception, the
 /// configured serial-capture threshold, or `max_exits`. Each exit is
 /// classified and dispatched to the appropriate handler; the loop
@@ -841,6 +940,7 @@ fn applyRestoreFile(
 fn runLoop(
     gpa: std.mem.Allocator,
     cfg: Config,
+    vm: hvf.Vm,
     vcpu: hvf.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
@@ -849,6 +949,12 @@ fn runLoop(
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
+    var checkpoint_delta_mode = cfg.restore_path != null;
+    var ram_dirty = try RamDirtyTracker.init(gpa, vm, cfg);
+    defer ram_dirty.deinit();
+    if (checkpoint_delta_mode and cfg.snapshot_path != null) {
+        try ram_dirty.activateClean();
+    }
     var snapshot_writer_state: vmstate_writer.Writer = .{};
     defer snapshot_writer_state.wait();
     while (exits < cfg.max_exits) : (exits += 1) {
@@ -856,20 +962,30 @@ fn runLoop(
 
         // Async exit from hv_vcpus_exit (watcher thread, snapshot
         // trigger). Don't treat as a guest fault; check the flag and
-        // either capture a snapshot or resume.
+        // either capture a snapshot or resume after the runtime sends
+        // SIGUSR2.
         if (vcpu.exit.reason == .canceled) {
             if (snapshot_requested_hvf.load(.seq_cst)) {
                 if (cfg.snapshot_path) |path| {
-                    if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs)) {
+                    snapshot_resume_requested_hvf.store(false, .seq_cst);
+                    const full_ram = !checkpoint_delta_mode;
+                    const dirty_bits: ?[]const u64 = if (full_ram) null else ram_dirty.bits;
+                    if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
                         snapshotted = true;
+                        checkpoint_delta_mode = true;
+                        try ram_dirty.activateClean();
+                        if (devs.root_blk) |b| b.clearDirty();
+                        // Clear the flag and wait for the runtime's
+                        // SIGUSR2 before RESUME so sidecar files are
+                        // point-in-time consistent with CPU/RAM. Keep
+                        // the watcher thread alive so a later SIGUSR1
+                        // (chained snapshot / fork-the-fork) triggers
+                        // another capture.
+                        snapshot_requested_hvf.store(false, .seq_cst);
+                        waitForSnapshotResumeHvf();
+                    } else {
+                        snapshot_requested_hvf.store(false, .seq_cst);
                     }
-                    // Clear the flag and RESUME — the snapshot engine
-                    // (`performSnapshotVmstate`) decides destructiveness
-                    // itself: a plain `snapshot` powers the source off
-                    // afterward, `fork` leaves it running. Keep the
-                    // watcher thread alive so a later SIGUSR1 (chained
-                    // snapshot / fork-the-fork) triggers another capture.
-                    snapshot_requested_hvf.store(false, .seq_cst);
                 }
             }
             continue;
@@ -911,7 +1027,9 @@ fn runLoop(
             },
             .data_abort_lower_el => {
                 const info = hvf.DataAbort.decode(vcpu.exit.exception);
-                try routeDataAbort(vcpu, devs, irqs, info);
+                if (!try ram_dirty.handleWriteFault(info)) {
+                    try routeDataAbort(vcpu, devs, irqs, info);
+                }
             },
             else => {
                 logUnhandledException(vcpu, ec, "unhandled exception class");
@@ -927,13 +1045,23 @@ fn runLoop(
 
         // Snapshot trigger fallback — for the rare case the watcher's
         // hv_vcpus_exit() landed as a plain exception exit rather than
-        // `.canceled`. Same capture-and-resume contract as above.
+        // `.canceled`. Same capture-and-SIGUSR2-resume contract as
+        // above.
         if (snapshot_requested_hvf.load(.seq_cst)) {
             if (cfg.snapshot_path) |path| {
-                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs)) {
+                snapshot_resume_requested_hvf.store(false, .seq_cst);
+                const full_ram = !checkpoint_delta_mode;
+                const dirty_bits: ?[]const u64 = if (full_ram) null else ram_dirty.bits;
+                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
                     snapshotted = true;
+                    checkpoint_delta_mode = true;
+                    try ram_dirty.activateClean();
+                    if (devs.root_blk) |b| b.clearDirty();
+                    snapshot_requested_hvf.store(false, .seq_cst);
+                    waitForSnapshotResumeHvf();
+                } else {
+                    snapshot_requested_hvf.store(false, .seq_cst);
                 }
-                snapshot_requested_hvf.store(false, .seq_cst);
             }
         }
     }
@@ -1091,6 +1219,8 @@ fn queueSnapshotWrite(
     ram: []const u8,
     cfg: Config,
     devs: *const Devices,
+    full_ram: bool,
+    dirty_bits: ?[]const u64,
 ) bool {
     if (writer.busy()) {
         std.debug.print("hvf: snapshot requested while previous write is still in flight\n", .{});
@@ -1098,7 +1228,7 @@ fn queueSnapshotWrite(
     }
 
     std.debug.print("hvf: writing snapshot to {s}\n", .{path});
-    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, devs) catch |err| {
+    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits) catch |err| {
         std.debug.print("hvf boot: snapshot capture failed: {s}\n", .{@errorName(err)});
         return false;
     };
@@ -1740,6 +1870,7 @@ fn handlePsci(vcpu: hvf.Vcpu) !PsciOutcome {
 const Devices = struct {
     uart: *hvf.Pl011,
     netdev: *virtio.Device,
+    root_blk: ?*blk_mod.Backend,
     blk_dev: ?*virtio.Device,
     blk2_dev: ?*virtio.Device,
     blk3_dev: ?*virtio.Device,

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -37,6 +37,7 @@ const kvm = @import("kvm.zig");
 const pl011_mod = @import("pl011.zig");
 const virtio = @import("virtio.zig");
 const blk_mod = @import("blk.zig");
+const ram_dump = @import("ram_dump.zig");
 const vsock_mod = @import("vsock.zig");
 const virtiofs_mod = @import("virtiofs.zig");
 const net_mod = @import("net_socket.zig");
@@ -212,7 +213,8 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var vm = try k.createVm();
     defer vm.destroy();
 
-    try vm.mapMemory(0, cfg.ram_base, ram);
+    const ram_flags: u32 = if (cfg.snapshot_path != null) kvm.KVM_MEM_LOG_DIRTY_PAGES else 0;
+    try vm.mapMemoryWithFlags(0, cfg.ram_base, ram, ram_flags);
 
     // vGIC BEFORE vCPU creation (KVM requires it).
     var gic = try vm.createGicV3(cfg.gic_dist_addr, cfg.gic_redist_addr);
@@ -244,6 +246,11 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     var blk_backend_opt: ?blk_mod.Backend = openBlkBackend(slot1_path, "slot 1");
     defer if (blk_backend_opt) |*b| b.deinit();
+    if (cfg.rootdisk_path != null and cfg.snapshot_path != null) {
+        if (blk_backend_opt) |*b| b.enableDirtyTracking(gpa) catch |err| {
+            std.debug.print("blk: rootdisk dirty tracking disabled: {s}\n", .{@errorName(err)});
+        };
+    }
     var blkdev_opt: ?virtio.Device = if (blk_backend_opt) |*b|
         makeBlkDevice(virtio_blk_base, virtio_blk_size, ram, cfg, b)
     else
@@ -371,6 +378,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .uart = &uart,
         .netdev = &netdev,
         .net_inst = net_inst,
+        .root_blk = if (cfg.rootdisk_path != null) (if (blk_backend_opt) |_| &blk_backend_opt.? else null) else null,
         .blk_dev = blkdev_ptr,
         .blk2_dev = blk2dev_ptr,
         .blk3_dev = blk3dev_ptr,
@@ -806,15 +814,22 @@ fn startVsockBridge(
     return bridge;
 }
 
-/// SIGUSR1 atomic — set by the signal handler, polled by the run
-/// loop after every vCPU exit. File-static because signal handlers
-/// can't take closures; one VMM per process means there's at most
-/// one boot loop reading this.
+/// SIGUSR1 requests a snapshot; SIGUSR2 resumes the vCPU after the
+/// runtime has copied the sidecar files that must match the captured
+/// CPU/RAM point-in-time (rootdisk, mount overlay, metadata). Keep the
+/// handlers intentionally tiny: async-signal-safe atomic stores only;
+/// one boot loop reads these.
 var snapshot_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var snapshot_resume_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
 fn sigusr1Handler(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_requested.store(true, .seq_cst);
+}
+
+fn sigusr2Handler(sig: c_int) callconv(.c) void {
+    _ = sig;
+    snapshot_resume_requested.store(true, .seq_cst);
 }
 
 fn installSnapshotSignal() void {
@@ -822,7 +837,28 @@ fn installSnapshotSignal() void {
         extern "c" fn signal(sig: c_int, handler: usize) usize;
     };
     const SIGUSR1: c_int = 10;
+    const SIGUSR2: c_int = 12;
     _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1Handler));
+    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2Handler));
+}
+
+fn waitForSnapshotResume() void {
+    const c = struct {
+        extern "c" fn usleep(usec: u32) c_int;
+    };
+    const poll_us: u32 = 1_000;
+    const timeout_us: u64 = 120 * 1_000_000;
+    var waited_us: u64 = 0;
+    std.debug.print("kvm: snapshot captured; waiting for runtime resume\n", .{});
+    while (!snapshot_resume_requested.load(.seq_cst) and waited_us < timeout_us) : (waited_us += poll_us) {
+        _ = c.usleep(poll_us);
+    }
+    if (snapshot_resume_requested.load(.seq_cst)) {
+        snapshot_resume_requested.store(false, .seq_cst);
+        std.debug.print("kvm: snapshot resume received\n", .{});
+    } else {
+        std.debug.print("kvm: snapshot resume timed out after {d}us; resuming fail-open\n", .{waited_us});
+    }
 }
 
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exit, the
@@ -841,6 +877,7 @@ fn runLoop(
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
+    var checkpoint_delta_mode = cfg.restore_path != null;
     var snapshot_writer_state: vmstate_writer.Writer = .{};
     defer snapshot_writer_state.wait();
     while (exits < cfg.max_exits) : (exits += 1) {
@@ -870,18 +907,34 @@ fn runLoop(
         }
         if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
         // Snapshot trigger: SIGUSR1 set the flag. Capture whole-VM
-        // state, queue compression/write, and RESUME — destructiveness
-        // is the snapshot engine's call (`performSnapshotVmstate`
-        // powers the source off for a plain `snapshot`, leaves it
-        // running for `fork`). The SIGUSR1 handler stays installed so
-        // a later signal (chained snapshot / fork-the-fork) triggers
-        // another capture.
+        // state, queue compression/write, then wait for SIGUSR2 from
+        // the runtime before resuming so sidecar copies (rootdisk,
+        // mount overlay, metadata) match the captured CPU/RAM point.
+        // The SIGUSR1 handler stays installed so a later signal
+        // (chained snapshot / fork-the-fork) triggers another capture.
         if (snapshot_requested.load(.seq_cst)) {
             if (cfg.snapshot_path) |path| {
-                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, gic_fd, devs)) {
-                    snapshotted = true;
+                snapshot_resume_requested.store(false, .seq_cst);
+                var dirty_bits: ?[]u64 = null;
+                const page_count = ram.len / ram_dump.PAGE;
+                if (cfg.snapshot_path != null) {
+                    dirty_bits = vm.getDirtyLog(gpa, 0, page_count) catch |err| blk: {
+                        std.debug.print("kvm: dirty-log read failed: {s}; writing a full RAM section\n", .{@errorName(err)});
+                        break :blk null;
+                    };
                 }
-                snapshot_requested.store(false, .seq_cst);
+                defer if (dirty_bits) |bits| gpa.free(bits);
+                const full_ram = !checkpoint_delta_mode or dirty_bits == null;
+                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits)) {
+                    snapshotted = true;
+                    checkpoint_delta_mode = true;
+                    if (dirty_bits) |bits| vm.clearDirtyLog(0, bits, page_count);
+                    if (devs.root_blk) |b| b.clearDirty();
+                    snapshot_requested.store(false, .seq_cst);
+                    waitForSnapshotResume();
+                } else {
+                    snapshot_requested.store(false, .seq_cst);
+                }
             }
         }
     }
@@ -912,6 +965,8 @@ fn queueSnapshotWrite(
     cfg: Config,
     gic_fd: c_int,
     devs: *const Devices,
+    full_ram: bool,
+    dirty_bits: ?[]const u64,
 ) bool {
     if (writer.busy()) {
         std.debug.print("kvm: snapshot requested while previous write is still in flight\n", .{});
@@ -919,7 +974,7 @@ fn queueSnapshotWrite(
     }
 
     std.debug.print("kvm: writing snapshot to {s}\n", .{path});
-    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, gic_fd, devs) catch |err| {
+    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits) catch |err| {
         std.debug.print("kvm boot: snapshot capture failed: {s}\n", .{@errorName(err)});
         return false;
     };
@@ -971,10 +1026,11 @@ fn captureSnapshotJob(
     cfg: Config,
     gic_fd: c_int,
     devs: *const Devices,
+    full_ram: bool,
+    dirty_bits: ?[]const u64,
 ) !*vmstate_writer.Job {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
-    const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
@@ -991,7 +1047,10 @@ fn captureSnapshotJob(
     const a = job.arenaAllocator();
 
     const vcpu_payload = try vcpu_dump.dumpKvm(a, vcpu.fd);
-    const ram_payload = try ram_dump.encode(a, cfg.ram_base, ram);
+    const ram_payload = if (full_ram)
+        try ram_dump.encode(a, cfg.ram_base, ram)
+    else
+        try ram_dump.encodeDelta(a, cfg.ram_base, ram, dirty_bits.?);
     // GICv3 distributor + per-vCPU redistributor + CPU interface —
     // see the matching block in boot_hvf.zig for why a cross-VMM
     // restore can't resume without it.
@@ -1008,7 +1067,7 @@ fn captureSnapshotJob(
 
     var sections = std.ArrayList(snapshot.Section).empty;
     try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
-    try sections.append(a, .{ .tag = .ram, .id = 0, .payload = ram_payload });
+    try sections.append(a, .{ .tag = if (full_ram) .ram else .ram_delta, .id = 0, .payload = ram_payload });
     try sections.append(a, .{ .tag = .gic_dist, .id = 0, .payload = gic_dist_payload });
     try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
     try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
@@ -1029,6 +1088,12 @@ fn captureSnapshotJob(
         const fp = try backend.state.dumpState(a);
         try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
+    if (!full_ram) {
+        if (devs.root_blk) |b| {
+            const dp = try b.encodeDirtyDelta(a);
+            try sections.append(a, .{ .tag = .rootdisk_delta, .id = 0, .payload = dp });
+        }
+    }
     job.sections = try sections.toOwnedSlice(a);
     return job;
 }
@@ -1044,7 +1109,6 @@ fn applyRestoreFile(
 ) !void {
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
-    const ram_dump = @import("ram_dump.zig");
     const gic_state = @import("gic_state.zig");
     const virtio_dump = @import("virtio_dump.zig");
     const topology = @import("topology.zig");
@@ -1127,6 +1191,11 @@ fn applyRestoreFile(
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
                 _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
+            },
+            .ram_delta => {
+                // Overlay a checkpoint delta onto the RAM reconstructed
+                // from its parent section(s).
+                _ = try ram_dump.decodeDeltaInto(s.payload, ram);
             },
             .gic_dist => if (apply_gic) try gic_state.loadKvmDist(gpa, gic_fd, s.payload),
             .gic_redist => if (apply_gic) try gic_state.loadKvmRedist(gpa, gic_fd, mpidr, s.payload),
@@ -1259,6 +1328,7 @@ const Devices = struct {
     uart: *pl011_mod.Pl011,
     netdev: *virtio.Device,
     net_inst: ?*net_mod.NetSocket,
+    root_blk: ?*blk_mod.Backend,
     blk_dev: ?*virtio.Device,
     blk2_dev: ?*virtio.Device,
     blk3_dev: ?*virtio.Device,

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -87,6 +87,14 @@ pub const Vm = struct {
         assert(guest_phys % page_size == 0);
         try check(c.hv_vm_unmap(guest_phys, size));
     }
+
+    pub fn protect(_: Vm, guest_phys: u64, size: usize, flags: MapFlags) Error!void {
+        assert(size > 0);
+        assert(size % page_size == 0);
+        assert(guest_phys % page_size == 0);
+        assert(flags.read or flags.write or flags.exec);
+        try check(c.hv_vm_protect(guest_phys, size, flags.bits()));
+    }
 };
 
 pub const page_size = 0x4000; // 16 KiB pages on Apple Silicon arm64

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -58,9 +58,11 @@ pub const KVM_CHECK_EXTENSION = io_(KVMIO, 0x03);
 pub const KVM_GET_VCPU_MMAP_SIZE = io_(KVMIO, 0x04);
 
 pub const KVM_CREATE_VCPU = io_(KVMIO, 0x41);
+pub const KVM_GET_DIRTY_LOG = iow(KVMIO, 0x42, @sizeOf(DirtyLog));
 pub const KVM_RUN = io_(KVMIO, 0x80);
 
 pub const KVM_SET_USER_MEMORY_REGION = iow(KVMIO, 0x46, @sizeOf(UserspaceMemoryRegion));
+pub const KVM_CLEAR_DIRTY_LOG = iowr(KVMIO, 0xC0, @sizeOf(ClearDirtyLog));
 pub const KVM_CREATE_IRQCHIP = io_(KVMIO, 0x60);
 pub const KVM_IRQ_LINE = iow(KVMIO, 0x61, @sizeOf(IrqLevel));
 pub const KVM_GET_IRQCHIP = iowr(KVMIO, 0x62, @sizeOf(Irqchip));
@@ -91,12 +93,27 @@ pub const KVM_HAS_DEVICE_ATTR = iow(KVMIO, 0xE3, @sizeOf(DeviceAttr));
 // Flat structs — all have a KVM-stable layout across arm64/x86_64
 // but we only build on arm64 for our guest.
 
+pub const KVM_MEM_LOG_DIRTY_PAGES: u32 = 1 << 0;
+
 pub const UserspaceMemoryRegion = extern struct {
     slot: u32,
     flags: u32,
     guest_phys_addr: u64,
     memory_size: u64,
     userspace_addr: u64,
+};
+
+pub const DirtyLog = extern struct {
+    slot: u32,
+    padding1: u32 = 0,
+    dirty_bitmap: u64,
+};
+
+pub const ClearDirtyLog = extern struct {
+    slot: u32,
+    num_pages: u32,
+    first_page: u64,
+    dirty_bitmap: u64,
 };
 
 pub const VcpuInit = extern struct {
@@ -526,6 +543,16 @@ pub const Vm = struct {
         guest_phys_addr: u64,
         host_buf: []u8,
     ) !void {
+        return self.mapMemoryWithFlags(slot, guest_phys_addr, host_buf, 0);
+    }
+
+    pub fn mapMemoryWithFlags(
+        self: *Vm,
+        slot: u32,
+        guest_phys_addr: u64,
+        host_buf: []u8,
+        flags: u32,
+    ) !void {
         assert(self.fd >= 0);
         assert(host_buf.len > 0);
         // KVM requires both the guest-physical address and the host
@@ -538,7 +565,7 @@ pub const Vm = struct {
         assert(host_buf.len % 4096 == 0);
         const r = UserspaceMemoryRegion{
             .slot = slot,
-            .flags = 0,
+            .flags = flags,
             .guest_phys_addr = guest_phys_addr,
             .memory_size = host_buf.len,
             .userspace_addr = @intFromPtr(host_buf.ptr),
@@ -546,6 +573,30 @@ pub const Vm = struct {
         if (ioctl(self.fd, KVM_SET_USER_MEMORY_REGION, &r) != 0) {
             return error.KvmSetMemoryFailed;
         }
+    }
+
+    pub fn getDirtyLog(self: *Vm, allocator: std.mem.Allocator, slot: u32, page_count: usize) ![]u64 {
+        assert(page_count > 0);
+        const word_count = (page_count + 63) / 64;
+        const bits = try allocator.alloc(u64, word_count);
+        errdefer allocator.free(bits);
+        @memset(bits, 0);
+        var log = DirtyLog{ .slot = slot, .dirty_bitmap = @intFromPtr(bits.ptr) };
+        if (ioctl(self.fd, KVM_GET_DIRTY_LOG, &log) != 0) return error.KvmGetDirtyLogFailed;
+        return bits;
+    }
+
+    pub fn clearDirtyLog(self: *Vm, slot: u32, bits: []const u64, page_count: usize) void {
+        if (bits.len == 0 or page_count == 0) return;
+        var clear = ClearDirtyLog{
+            .slot = slot,
+            .num_pages = @intCast(page_count),
+            .first_page = 0,
+            .dirty_bitmap = @intFromPtr(bits.ptr),
+        };
+        // Older kernels either clear on KVM_GET_DIRTY_LOG or lack this
+        // ioctl. Best effort: correctness survives as cumulative deltas.
+        _ = ioctl(self.fd, KVM_CLEAR_DIRTY_LOG, &clear);
     }
 
     /// Create an in-kernel vgic-v3 and place its distributor +

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -66,7 +66,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Snapshot/restore plumbing — host orchestrator drives via env.
     // MACHINEN_RESTORE_PATH: load .vmstate at boot before vcpu.run().
-    // MACHINEN_SNAPSHOT_PATH: capture on SIGUSR1, write .vmstate, then resume.
+    // MACHINEN_SNAPSHOT_PATH: capture on SIGUSR1, write .vmstate, then resume after SIGUSR2.
     const restore_path = envOptional("MACHINEN_RESTORE_PATH");
     const snapshot_path = envOptional("MACHINEN_SNAPSHOT_PATH");
 

--- a/packages/microvm/src/ram_dump.zig
+++ b/packages/microvm/src/ram_dump.zig
@@ -36,7 +36,7 @@ pub const HEADER_SIZE: usize = 48;
 /// Zero-page scan granularity. 4 KiB is the finest guest page size on
 /// arm64, so a guest free page is always caught regardless of whether
 /// the guest kernel runs a 4 KiB or 16 KiB granule.
-const PAGE: usize = 4096;
+pub const PAGE: usize = 4096;
 
 /// Per-extent prefix: offset u64 + length u64.
 const EXTENT_HEADER_SIZE: usize = 16;
@@ -57,6 +57,28 @@ pub const DecodeError = error{
     Truncated,
     SizeMismatch,
     HashMismatch,
+};
+
+/// Delta RAM payload header. Same extent stream shape as the full
+/// sparse codec, but the extent bytes are overlaid onto an existing
+/// destination instead of zero-filling first. Dirty zero pages are
+/// therefore stored explicitly as zero bytes so a child checkpoint can
+/// clear data inherited from its parent.
+pub const DELTA_HEADER_SIZE: usize = 64;
+
+pub const RamDeltaHeader = extern struct {
+    ram_base: u64,
+    ram_size: u64,
+    page_size: u32,
+    reserved: u32 = 0,
+    sha256: [32]u8,
+    reserved2: [8]u8 = @splat(0),
+
+    comptime {
+        if (@sizeOf(RamDeltaHeader) != DELTA_HEADER_SIZE) {
+            @compileError("RamDeltaHeader must be exactly 64 bytes");
+        }
+    }
 };
 
 /// True if every byte of `buf` is zero. Word-wise so the multi-GiB
@@ -148,6 +170,78 @@ pub fn encode(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8) ![]u
     return out;
 }
 
+fn dirtyBitSet(bits: []const u64, page_idx: usize) bool {
+    const word = page_idx / 64;
+    if (word >= bits.len) return false;
+    const bit: u6 = @intCast(page_idx % 64);
+    return (bits[word] & (@as(u64, 1) << bit)) != 0;
+}
+
+fn nextDirtyExtent(ram_len: usize, dirty_bits: []const u64, from: usize) ?struct { start: usize, end: usize } {
+    std.debug.assert(from <= ram_len);
+    var page = from / PAGE;
+    const page_count = if (ram_len == 0) 0 else 1 + ((ram_len - 1) / PAGE);
+    while (page < page_count and !dirtyBitSet(dirty_bits, page)) : (page += 1) {}
+    if (page >= page_count) return null;
+    const start_page = page;
+    while (page < page_count and dirtyBitSet(dirty_bits, page)) : (page += 1) {}
+    const start = start_page * PAGE;
+    const end = @min(page * PAGE, ram_len);
+    std.debug.assert(start < end and end <= ram_len);
+    return .{ .start = start, .end = end };
+}
+
+/// Build a RAM-delta payload from a bitmap of dirty 4 KiB pages. The
+/// destination restore buffer is expected to already contain the
+/// parent checkpoint's RAM; decodeDeltaInto overlays these extents.
+/// Unlike the full sparse encoder, dirty zero pages are stored too.
+pub fn encodeDelta(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8, dirty_bits: []const u64) ![]u8 {
+    std.debug.assert(ram.len > 0);
+    std.debug.assert(ram_base % PAGE == 0);
+
+    var body_len: usize = 0;
+    {
+        var cursor: usize = 0;
+        while (nextDirtyExtent(ram.len, dirty_bits, cursor)) |e| {
+            body_len += EXTENT_HEADER_SIZE + (e.end - e.start);
+            cursor = e.end;
+        }
+    }
+
+    const out = try allocator.alloc(u8, DELTA_HEADER_SIZE + body_len);
+    errdefer allocator.free(out);
+
+    var w: usize = DELTA_HEADER_SIZE;
+    {
+        var cursor: usize = 0;
+        while (nextDirtyExtent(ram.len, dirty_bits, cursor)) |e| {
+            const ext_len = e.end - e.start;
+            std.mem.writeInt(u64, out[w..][0..8], e.start, .little);
+            w += 8;
+            std.mem.writeInt(u64, out[w..][0..8], ext_len, .little);
+            w += 8;
+            @memcpy(out[w..][0..ext_len], ram[e.start..e.end]);
+            w += ext_len;
+            cursor = e.end;
+        }
+    }
+    std.debug.assert(w == out.len);
+
+    var sha = std.crypto.hash.sha2.Sha256.init(.{});
+    sha.update(out[DELTA_HEADER_SIZE..]);
+    var digest: [32]u8 = undefined;
+    sha.final(&digest);
+
+    const hdr: RamDeltaHeader = .{
+        .ram_base = ram_base,
+        .ram_size = ram.len,
+        .page_size = PAGE,
+        .sha256 = digest,
+    };
+    @memcpy(out[0..DELTA_HEADER_SIZE], std.mem.asBytes(&hdr));
+    return out;
+}
+
 /// Metadata recovered from a payload — the bytes themselves are
 /// reconstructed straight into the caller's destination buffer.
 pub const DecodedMeta = struct {
@@ -223,6 +317,46 @@ fn decodeIntoMode(payload: []const u8, dest: []u8, mode: DecodeMode) DecodeError
     return .{ .ram_base = hdr.ram_base, .ram_size = hdr.ram_size };
 }
 
+/// Apply a RAM-delta payload onto an existing destination buffer.
+/// Unlike decodeInto(), this does not zero-fill first: the caller must
+/// have already reconstructed the parent checkpoint's RAM.
+pub fn decodeDeltaInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+    if (payload.len < DELTA_HEADER_SIZE) return error.Truncated;
+    var hdr: RamDeltaHeader = undefined;
+    @memcpy(std.mem.asBytes(&hdr), payload[0..DELTA_HEADER_SIZE]);
+    if (hdr.page_size != PAGE) return error.SizeMismatch;
+
+    const body = payload[DELTA_HEADER_SIZE..];
+    var sha = std.crypto.hash.sha2.Sha256.init(.{});
+    sha.update(body);
+    var digest: [32]u8 = undefined;
+    sha.final(&digest);
+    if (!std.mem.eql(u8, &digest, &hdr.sha256)) return error.HashMismatch;
+
+    const ram_size = std.math.cast(usize, hdr.ram_size) orelse return error.SizeMismatch;
+    if (ram_size > dest.len) return error.SizeMismatch;
+
+    var c: usize = 0;
+    while (c < body.len) {
+        std.debug.assert(c <= body.len);
+        if (body.len - c < EXTENT_HEADER_SIZE) return error.Truncated;
+        const off64 = std.mem.readInt(u64, body[c..][0..8], .little);
+        const len64 = std.mem.readInt(u64, body[c..][8..16], .little);
+        c += EXTENT_HEADER_SIZE;
+
+        const off = std.math.cast(usize, off64) orelse return error.SizeMismatch;
+        const len = std.math.cast(usize, len64) orelse return error.SizeMismatch;
+        if (len > body.len - c) return error.Truncated;
+        if (off > ram_size or len > ram_size - off) return error.SizeMismatch;
+        std.debug.assert(off + len <= ram_size and ram_size <= dest.len);
+
+        @memcpy(dest[off..][0..len], body[c..][0..len]);
+        c += len;
+    }
+    std.debug.assert(c == body.len);
+    return .{ .ram_base = hdr.ram_base, .ram_size = hdr.ram_size };
+}
+
 // --- tests ---
 
 test "encode/decode round-trip reconstructs a sparse buffer" {
@@ -265,6 +399,30 @@ test "encode/decode round-trip on an all-zero buffer" {
     @memset(dest, 0xFF);
     _ = try decodeInto(payload, dest);
     try std.testing.expectEqualSlices(u8, ram, dest);
+}
+
+test "RAM delta overlays dirty pages including zeroed pages" {
+    const a = std.testing.allocator;
+    const parent = try a.alloc(u8, 4 * PAGE);
+    defer a.free(parent);
+    @memset(parent, 0x11);
+
+    const child = try a.dupe(u8, parent);
+    defer a.free(child);
+    @memset(child[PAGE..][0..PAGE], 0); // dirty-to-zero must be explicit
+    @memset(child[3 * PAGE ..][0..PAGE], 0x33);
+
+    var bits = [_]u64{0};
+    bits[0] |= (@as(u64, 1) << 1) | (@as(u64, 1) << 3);
+    const payload = try encodeDelta(a, 0x4000_0000, child, &bits);
+    defer a.free(payload);
+
+    const dest = try a.dupe(u8, parent);
+    defer a.free(dest);
+    const meta = try decodeDeltaInto(payload, dest);
+    try std.testing.expectEqual(@as(u64, 0x4000_0000), meta.ram_base);
+    try std.testing.expectEqual(@as(u64, 4 * PAGE), meta.ram_size);
+    try std.testing.expectEqualSlices(u8, child, dest);
 }
 
 test "decodeIntoZeroed reconstructs without clearing implicit zero pages" {

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -43,6 +43,7 @@ pub const sysreg_names = @import("sysreg_names.zig"); // name<->encoding table
 pub const sysreg_classify = @import("sysreg_classify.zig"); // portability decisions
 pub const vcpu_dump = @import("vcpu_dump.zig"); // vCPU dump/load (KVM + HVF)
 pub const ram_dump = @import("ram_dump.zig"); // RAM section codec
+pub const rootdisk_delta = @import("rootdisk_delta.zig"); // rootdisk checkpoint delta codec
 pub const pl011_dump = @import("pl011_dump.zig"); // PL011 UART snapshot
 pub const gic_dump = @import("gic_dump.zig"); // GICv3 distributor/redistributor codec
 pub const gic_state = @import("gic_state.zig"); // GICv3 register dump/load (KVM + HVF)
@@ -121,6 +122,7 @@ test {
     _ = @import("sysreg_classify.zig");
     _ = @import("vcpu_dump.zig");
     _ = @import("ram_dump.zig");
+    _ = @import("rootdisk_delta.zig");
     _ = @import("pl011_dump.zig");
     _ = @import("gic_dump.zig");
     _ = @import("gic_state.zig");

--- a/packages/microvm/src/rootdisk_delta.zig
+++ b/packages/microvm/src/rootdisk_delta.zig
@@ -1,0 +1,132 @@
+//! Rootdisk delta payload for incremental vmstate checkpoints.
+//!
+//! The live virtio-blk backend tracks 4 KiB blocks written since the
+//! previous checkpoint. While the vCPU is stopped for a vmstate capture
+//! we copy those dirty blocks into this payload, then clear the dirty
+//! map before the guest resumes. Restore starts from the nearest parent
+//! checkpoint that carries a full `rootdisk.img` and overlays these
+//! extents in chain order to materialize a normal raw rootdisk image.
+
+const std = @import("std");
+
+pub const BLOCK: usize = 4096;
+pub const HEADER_SIZE: usize = 56;
+const EXTENT_HEADER_SIZE: usize = 16;
+
+pub const Header = extern struct {
+    disk_size: u64,
+    block_size: u32,
+    reserved: u32 = 0,
+    sha256: [32]u8,
+    reserved2: [8]u8 = @splat(0),
+
+    comptime {
+        if (@sizeOf(Header) != HEADER_SIZE) {
+            @compileError("rootdisk_delta.Header must be exactly 56 bytes");
+        }
+    }
+};
+
+fn bitSet(bits: []const u64, block_idx: usize) bool {
+    const word = block_idx / 64;
+    if (word >= bits.len) return false;
+    const bit: u6 = @intCast(block_idx % 64);
+    return (bits[word] & (@as(u64, 1) << bit)) != 0;
+}
+
+fn nextDirtyExtent(disk_size: u64, bits: []const u64, from: u64) ?struct { start: u64, end: u64 } {
+    std.debug.assert(from <= disk_size);
+    const block_count = if (disk_size == 0) 0 else 1 + ((disk_size - 1) / BLOCK);
+    var block = from / BLOCK;
+    while (block < block_count and !bitSet(bits, @intCast(block))) : (block += 1) {}
+    if (block >= block_count) return null;
+    const start_block = block;
+    while (block < block_count and bitSet(bits, @intCast(block))) : (block += 1) {}
+    const start = start_block * BLOCK;
+    const end = @min(block * BLOCK, disk_size);
+    std.debug.assert(start < end and end <= disk_size);
+    return .{ .start = start, .end = end };
+}
+
+pub fn encodeFromFd(
+    allocator: std.mem.Allocator,
+    fd: c_int,
+    disk_size: u64,
+    dirty_bits: []const u64,
+) ![]u8 {
+    std.debug.assert(fd >= 0);
+    std.debug.assert(disk_size > 0);
+
+    var body_len: usize = 0;
+    {
+        var cursor: u64 = 0;
+        while (nextDirtyExtent(disk_size, dirty_bits, cursor)) |e| {
+            body_len += EXTENT_HEADER_SIZE + @as(usize, @intCast(e.end - e.start));
+            cursor = e.end;
+        }
+    }
+
+    const out = try allocator.alloc(u8, HEADER_SIZE + body_len);
+    errdefer allocator.free(out);
+
+    var w: usize = HEADER_SIZE;
+    {
+        var cursor: u64 = 0;
+        while (nextDirtyExtent(disk_size, dirty_bits, cursor)) |e| {
+            const len: usize = @intCast(e.end - e.start);
+            std.mem.writeInt(u64, out[w..][0..8], e.start, .little);
+            w += 8;
+            std.mem.writeInt(u64, out[w..][0..8], len, .little);
+            w += 8;
+            try preadAll(fd, out[w..][0..len], e.start);
+            w += len;
+            cursor = e.end;
+        }
+    }
+    std.debug.assert(w == out.len);
+
+    var sha = std.crypto.hash.sha2.Sha256.init(.{});
+    sha.update(out[HEADER_SIZE..]);
+    var digest: [32]u8 = undefined;
+    sha.final(&digest);
+
+    const hdr: Header = .{ .disk_size = disk_size, .block_size = BLOCK, .sha256 = digest };
+    @memcpy(out[0..HEADER_SIZE], std.mem.asBytes(&hdr));
+    return out;
+}
+
+fn preadAll(fd: c_int, dst: []u8, offset: u64) !void {
+    var done: usize = 0;
+    while (done < dst.len) {
+        const rc = pread(fd, dst[done..].ptr, dst.len - done, @as(i64, @intCast(offset + done)));
+        if (rc <= 0) return error.ReadFailed;
+        done += @intCast(rc);
+    }
+}
+
+extern "c" fn pread(fd: c_int, buf: [*]u8, count: usize, offset: i64) isize;
+
+test "encodeFromFd stores contiguous dirty block extents" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const file = try tmp.dir.createFile(std.testing.io, "disk.img", .{ .read = true });
+    defer file.close(std.testing.io);
+    var block: [BLOCK]u8 = undefined;
+    for (0..4) |i| {
+        @memset(&block, @intCast(0x10 + i));
+        try file.writeStreamingAll(std.testing.io, &block);
+    }
+
+    var bits = [_]u64{0};
+    bits[0] |= (@as(u64, 1) << 1) | (@as(u64, 1) << 2);
+    const payload = try encodeFromFd(a, file.handle, 4 * BLOCK, &bits);
+    defer a.free(payload);
+
+    try std.testing.expectEqual(HEADER_SIZE + EXTENT_HEADER_SIZE + 2 * BLOCK, payload.len);
+    try std.testing.expectEqual(@as(u64, BLOCK), std.mem.readInt(u64, payload[HEADER_SIZE..][0..8], .little));
+    try std.testing.expectEqual(@as(u64, 2 * BLOCK), std.mem.readInt(u64, payload[HEADER_SIZE + 8 ..][0..8], .little));
+    try std.testing.expectEqual(@as(u8, 0x11), payload[HEADER_SIZE + EXTENT_HEADER_SIZE]);
+    try std.testing.expectEqual(@as(u8, 0x12), payload[HEADER_SIZE + EXTENT_HEADER_SIZE + BLOCK]);
+}

--- a/packages/microvm/src/snapshot.zig
+++ b/packages/microvm/src/snapshot.zig
@@ -56,6 +56,12 @@ pub const SectionTag = enum(u32) {
     /// section `id` is the virtio-fs device's MMIO base (same keying
     /// as `.virtio`). Payload schema: fuse_state.zig.
     virtiofs_state = 7,
+    /// Incremental RAM overlay against this checkpoint's parent.
+    /// Payload schema: ram_dump.encodeDelta.
+    ram_delta = 8,
+    /// Incremental rootdisk overlay against this checkpoint's parent.
+    /// Payload schema: rootdisk_delta.zig.
+    rootdisk_delta = 9,
     _,
 };
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2435,6 +2435,24 @@ with). Persisted so an attach-owned `vm.snapshot()` / `vm.fork()`
 can SIGUSR1 the VMM and pick the state file up. Undefined for VMs
 booted without the vmstate engine.
 
+##### vmstateChainId?
+
+> `optional` **vmstateChainId?**: `string`
+
+Per-VM incremental checkpoint chain id. New on every fresh boot/restore.
+
+##### vmstateCheckpointParent?
+
+> `optional` **vmstateCheckpointParent?**: `string`
+
+Absolute bundle path the next vmstate checkpoint should parent to.
+
+##### vmstateCheckpointSequence?
+
+> `optional` **vmstateCheckpointSequence?**: `number`
+
+Per-chain checkpoint sequence already written by this VM.
+
 ##### forkedFrom?
 
 > `optional` **forkedFrom?**: `string`
@@ -2906,48 +2924,31 @@ EXEC_VSOCK_UNAVAILABLE | EXEC_NONZERO_EXIT |
 
 > **snapshot**(`opts`): `Promise`\<[`SnapshotResult`](#snapshotresult)\>
 
-Freeze this VM with CRIU and write a snapshot bundle into
-`opts.outDir`. The bundle is a directory containing:
+Write a snapshot bundle into `opts.outDir`.
 
-  <outDir>/img/                ← CRIU image files (pages-*.img,
-                                 pagemap-*.img, core-*.img,
-                                 dump.log, ...)
-  <outDir>/meta.json           ← source name + timestamp +
-                                 optional mountDisk pointers
-  <outDir>/mount-lower.sqfs    ← squashfs RO lower (only when
-                                 the source VM had `mount` set)
-  <outDir>/mount-upper.img     ← ext4 RW upper (only when
-                                 the source VM had `mount` set)
+With the default vmstate engine this is an incremental checkpoint:
+the source VM keeps running, the first checkpoint in the VM's
+chain carries full sparse RAM + `rootdisk.img`, and later
+checkpoints carry RAM/rootdisk delta sections plus full vCPU,
+GIC, virtio queue, and virtio-fs backend state. `restore()` walks
+parent pointers and materializes a flat vmstate/rootdisk pair
+before booting through the normal vmstate restore path.
+
+With `MACHINEN_SNAPSHOT_ENGINE=criu`, this keeps the historical
+process-tree behavior: CRIU image files live under `<outDir>/img/`,
+`opts.leaveRunning: true` keeps the source alive, and the default
+destructive CRIU snapshot powers the source off after the dump.
 
 `mount-lower.sqfs` and `mount-upper.img` are reflinked from the
 runtime's per-VM materialization (#272), so on APFS / btrfs / xfs
 the snapshot is essentially free space-wise even for a large
 mount payload — blocks stay shared until either side writes.
 
-The caller must have booted the VM with a scratch disk (`snapshot:
-'<path>'` or default auto-allocation) so the guest had `/dev/vdb`
-to dump into; otherwise this throws `SNAPSHOT_NO_DISK`.
+`SNAPSHOT_TIMEOUT` if the dump doesn't complete within
+`opts.timeoutMs`; `SNAPSHOT_DUMP_FAILED` if the engine reports a
+failed/incomplete dump.
 
-Guest contract: the rootfs ships a dump helper callable via
-vsock exec — default `/sbin/machinen-dump`, override via
-`opts.dumpCmd`. The helper runs `criu dump --leave-running` and
-tars the resulting image set out on stdout, which the host
-extracts into `<outDir>/img/`. For destructive snapshots (default)
-the runtime then issues `/sbin/machinen-poweroff` over vsock to
-bring the VMM down; `opts.leaveRunning: true` skips that step
-and the source VM keeps running.
-
-`SNAPSHOT_TIMEOUT` if the dump exec doesn't return within
-`opts.timeoutMs`; `SNAPSHOT_DUMP_FAILED` if it returns non-zero
-or the streamed bundle is empty.
-
-Supported on both boot-owned and attach handles — attach uses
-the `diskPath` stored in the VM registry entry at boot time.
-
-By default the VM exits as part of the dump (CRIU kills the
-dumped tree on success). Pass `opts.leaveRunning: true` to keep
-the source VM alive — the workload resumes from the dump point
-and the bundle can be restored into a sibling VM (`vm.fork()`).
+Supported on both boot-owned and attach handles.
 
 ###### Parameters
 
@@ -3134,8 +3135,7 @@ Command to run in the guest to trigger the CRIU dump. Defaults to
 
 > `optional` **timeoutMs?**: `number`
 
-Wall-clock ceiling for the dump + shutdown. If the VMM hasn't exited
-in this window we SIGKILL it and fail. Default 90s.
+Wall-clock ceiling for the dump/checkpoint. Default 90s.
 
 ##### onLog?
 
@@ -3149,12 +3149,11 @@ call and `boot({ onLog })` have a callback set, both fire.
 
 > `optional` **leaveRunning?**: `boolean`
 
-Pass `--leave-running` to `criu dump` so the source workload
-survives the snapshot. The VMM stays up after the dump; success
-is signalled by the dump exec returning 0 instead of by VMM exit.
-Used by `vm.fork()` (#216).
+CRIU engine only: pass `--leave-running` to `criu dump` so the
+source workload survives the snapshot. Vmstate checkpoints are
+always non-destructive and ignore this flag.
 
-Default: false (current destructive snapshot behavior).
+Default under CRIU: false (destructive CRIU snapshot behavior).
 
 ##### tcpClose?
 
@@ -3204,7 +3203,7 @@ bundle. Set by the vmstate engine only; undefined for criu bundles.
 
 > **elapsedMs**: `number`
 
-Time from `snapshot()` entry to VMM exit, in milliseconds.
+Time from `snapshot()` entry to completed bundle, in milliseconds.
 
 ##### consoleLog
 
@@ -3276,9 +3275,9 @@ Pointer-auth state inferred from SCTLR_EL1 at snapshot time.
 
 ##### rootDisk?
 
-> `optional` **rootDisk?**: `object` & [`SnapshotFileIdentity`](#snapshotfileidentity) \| \{ `mode`: `"none"`; \}
+> `optional` **rootDisk?**: `object` & [`SnapshotFileIdentity`](#snapshotfileidentity) \| \{ `mode`: `"delta"`; \} \| \{ `mode`: `"none"`; \}
 
-Exact root block image needed by the resumed guest, or explicit absence.
+Exact root block image needed by the resumed guest, a parent-relative delta, or explicit absence.
 
 ##### kernel?
 
@@ -3291,6 +3290,42 @@ Kernel image identity when the source boot used an explicit kernel.
 > `optional` **dtb?**: [`SnapshotFileIdentity`](#snapshotfileidentity)
 
 DTB identity when the source boot used an explicit DTB.
+
+##### checkpoint?
+
+> `optional` **checkpoint?**: `object`
+
+Incremental checkpoint chain metadata for vmstate snapshots.
+
+###### chainId
+
+> **chainId**: `string`
+
+New random chain id for this VM's lifetime.
+
+###### sequence
+
+> **sequence**: `number`
+
+Per-chain checkpoint number, starting at 1.
+
+###### parent?
+
+> `optional` **parent?**: `string`
+
+Relative path from this bundle to its parent bundle, absent for a base checkpoint.
+
+###### ram
+
+> **ram**: `"delta"` \| `"full"`
+
+RAM section shape carried by this bundle.
+
+###### rootDisk
+
+> **rootDisk**: `"none"` \| `"delta"` \| `"full"`
+
+Rootdisk section shape carried by this bundle.
 
 ***
 

--- a/packages/runtime/src/__tests__/vmstate-chain.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-chain.test.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SnapshotMeta } from "../vm-handle.ts";
+import {
+  materializeVmstateChain,
+  readVmstate,
+  VMSTATE_SECTION,
+  writeVmstate,
+} from "../vm/vmstate-chain.ts";
+
+let TMP: string;
+
+beforeAll(() => {
+  TMP = mkdtempSync(join(tmpdir(), "vmstate-chain-"));
+});
+
+afterAll(() => {
+  if (TMP) {
+    rmSync(TMP, { recursive: true, force: true });
+  }
+});
+
+const TOPO = Buffer.alloc(32, 0x42);
+
+function writeMeta(dir: string, meta: SnapshotMeta): void {
+  writeFileSync(join(dir, "meta.json"), JSON.stringify(meta));
+}
+
+function rootdiskDelta(offset: number, bytes: Buffer, diskSize: number): Buffer {
+  const bodyHeader = Buffer.alloc(16);
+  bodyHeader.writeBigUInt64LE(BigInt(offset), 0);
+  bodyHeader.writeBigUInt64LE(BigInt(bytes.length), 8);
+  const body = Buffer.concat([bodyHeader, bytes]);
+  const header = Buffer.alloc(56);
+  header.writeBigUInt64LE(BigInt(diskSize), 0);
+  header.writeUInt32LE(4096, 8);
+  createHash("sha256").update(body).digest().copy(header, 16);
+  return Buffer.concat([header, body]);
+}
+
+describe("vmstate checkpoint chain materialization", () => {
+  it("combines RAM sections and applies rootdisk deltas into a flat restore bundle", () => {
+    const base = join(TMP, "base");
+    const child = join(TMP, "child");
+    rmSync(base, { recursive: true, force: true });
+    rmSync(child, { recursive: true, force: true });
+    mkdirSync(base, { recursive: true });
+    mkdirSync(child, { recursive: true });
+
+    writeVmstate(join(base, "state.vmstate"), {
+      topologyHash: TOPO,
+      sections: [
+        { tag: VMSTATE_SECTION.ram, id: 0, payload: Buffer.from("base-ram") },
+        { tag: VMSTATE_SECTION.vcpu, id: 0, payload: Buffer.from("base-vcpu") },
+      ],
+    });
+    const baseDisk = Buffer.concat([Buffer.alloc(4096, 0x11), Buffer.alloc(4096, 0x22)]);
+    writeFileSync(join(base, "rootdisk.img"), baseDisk);
+    const baseMeta: SnapshotMeta = {
+      engine: "vmstate",
+      sourceImage: join(TMP, "rootfs.tar.gz"),
+      snappedAt: 1,
+      vmstate: {
+        rootDisk: {
+          mode: "block",
+          file: "rootdisk.img",
+          sizeBytes: baseDisk.length,
+          sha256: "base",
+        },
+        checkpoint: { chainId: "chain", sequence: 1, ram: "full", rootDisk: "full" },
+      },
+    };
+    writeMeta(base, baseMeta);
+
+    const newBlock = Buffer.alloc(4096, 0x33);
+    writeVmstate(join(child, "state.vmstate"), {
+      topologyHash: TOPO,
+      sections: [
+        { tag: VMSTATE_SECTION.ramDelta, id: 0, payload: Buffer.from("child-ram-delta") },
+        { tag: VMSTATE_SECTION.vcpu, id: 0, payload: Buffer.from("child-vcpu") },
+        {
+          tag: VMSTATE_SECTION.rootdiskDelta,
+          id: 0,
+          payload: rootdiskDelta(4096, newBlock, baseDisk.length),
+        },
+      ],
+    });
+    const childMeta: SnapshotMeta = {
+      ...baseMeta,
+      snappedAt: 2,
+      vmstate: {
+        ...baseMeta.vmstate,
+        rootDisk: { mode: "delta" },
+        checkpoint: {
+          chainId: "chain",
+          sequence: 2,
+          parent: "../base",
+          ram: "delta",
+          rootDisk: "delta",
+        },
+      },
+    };
+    writeMeta(child, childMeta);
+
+    const materialized = materializeVmstateChain(child, childMeta);
+    try {
+      const flat = readVmstate(materialized.statePath);
+      expect(flat.sections.map((s) => s.tag)).toEqual([
+        VMSTATE_SECTION.ram,
+        VMSTATE_SECTION.ramDelta,
+        VMSTATE_SECTION.vcpu,
+      ]);
+      expect(flat.sections[2]!.payload.toString()).toBe("child-vcpu");
+      expect(readFileSync(join(materialized.snapDir, "rootdisk.img"))).toEqual(
+        Buffer.concat([Buffer.alloc(4096, 0x11), newBlock]),
+      );
+      expect(materialized.meta.vmstate?.rootDisk?.mode).toBe("block");
+    } finally {
+      rmSync(materialized.tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed rootdisk deltas and cleans materialization temp dirs", () => {
+    const before = new Set(
+      readdirSync(tmpdir()).filter((name) =>
+        name.startsWith(`machinen-vmstate-chain-${process.pid}-`),
+      ),
+    );
+    const base = join(TMP, "bad-base");
+    const child = join(TMP, "bad-child");
+    rmSync(base, { recursive: true, force: true });
+    rmSync(child, { recursive: true, force: true });
+    mkdirSync(base, { recursive: true });
+    mkdirSync(child, { recursive: true });
+
+    writeVmstate(join(base, "state.vmstate"), {
+      topologyHash: TOPO,
+      sections: [{ tag: VMSTATE_SECTION.ram, id: 0, payload: Buffer.from("base-ram") }],
+    });
+    const baseDisk = Buffer.alloc(4096, 0x11);
+    writeFileSync(join(base, "rootdisk.img"), baseDisk);
+    const baseMeta: SnapshotMeta = {
+      engine: "vmstate",
+      sourceImage: join(TMP, "rootfs.tar.gz"),
+      snappedAt: 1,
+      vmstate: {
+        rootDisk: {
+          mode: "block",
+          file: "rootdisk.img",
+          sizeBytes: baseDisk.length,
+          sha256: "base",
+        },
+        checkpoint: { chainId: "bad-chain", sequence: 1, ram: "full", rootDisk: "full" },
+      },
+    };
+    writeMeta(base, baseMeta);
+
+    writeVmstate(join(child, "state.vmstate"), {
+      topologyHash: TOPO,
+      sections: [
+        { tag: VMSTATE_SECTION.ramDelta, id: 0, payload: Buffer.alloc(64) },
+        {
+          tag: VMSTATE_SECTION.rootdiskDelta,
+          id: 0,
+          payload: rootdiskDelta(4096, Buffer.alloc(4096, 0x22), baseDisk.length),
+        },
+      ],
+    });
+    const childMeta: SnapshotMeta = {
+      ...baseMeta,
+      snappedAt: 2,
+      vmstate: {
+        ...baseMeta.vmstate,
+        rootDisk: { mode: "delta" },
+        checkpoint: {
+          chainId: "bad-chain",
+          sequence: 2,
+          parent: "../bad-base",
+          ram: "delta",
+          rootDisk: "delta",
+        },
+      },
+    };
+    writeMeta(child, childMeta);
+
+    expect(() => materializeVmstateChain(child, childMeta)).toThrow(
+      /invalid rootdisk delta extent/,
+    );
+    const after = readdirSync(tmpdir()).filter(
+      (name) => name.startsWith(`machinen-vmstate-chain-${process.pid}-`) && !before.has(name),
+    );
+    expect(after).toEqual([]);
+  });
+});

--- a/packages/runtime/src/pdeathsig.ts
+++ b/packages/runtime/src/pdeathsig.ts
@@ -53,7 +53,7 @@ const debug = debugLib("machinen:pdeathsig");
  * Bumped whenever the C source below changes in a way that changes
  * behavior. Recompiles instead of silently reusing a stale binary.
  */
-const PDEATHSIG_VERSION = "v4";
+const PDEATHSIG_VERSION = "v5";
 
 let warnedNoCompiler = false;
 // Keyed by the resolved cache path. Two reasons it has to be a map and
@@ -262,18 +262,19 @@ static int run_watch_pid_macos(pid_t watch_pid, char **target) {
     // delivers the event, leaving the target alive and orphaned to
     // PID 1 — defeating the whole point of the shim.
     //
-    // SIGUSR1 is included for the vmstate snapshot trigger: the
-    // runtime signals the wrapped VMM's pid, which on macOS is *this*
-    // shim (the watch loop forks). Blocking + kqueue-ing it lets us
-    // forward it to the VMM instead of dying by the default
+    // SIGUSR1/SIGUSR2 are included for the vmstate snapshot protocol:
+    // the runtime signals the wrapped VMM's pid, which on macOS is
+    // *this* shim (the watch loop forks). Blocking + kqueue-ing them
+    // lets us forward them to the VMM instead of dying by the default
     // disposition. The child unblocks the whole mask before execvp,
-    // so the VMM's own SIGUSR1 handler still fires.
+    // so the VMM's own handlers still fire.
     sigset_t mask;
     sigemptyset(&mask);
     sigaddset(&mask, SIGTERM);
     sigaddset(&mask, SIGINT);
     sigaddset(&mask, SIGHUP);
     sigaddset(&mask, SIGUSR1);
+    sigaddset(&mask, SIGUSR2);
     sigprocmask(SIG_BLOCK, &mask, NULL);
 
     pid_t child = fork();
@@ -298,7 +299,7 @@ static int run_watch_pid_macos(pid_t watch_pid, char **target) {
         return reap_then_exit(child, 127);
     }
 
-    struct kevent changes[6];
+    struct kevent changes[7];
     EV_SET(&changes[0], watch_pid, EVFILT_PROC, EV_ADD | EV_ONESHOT,
            NOTE_EXIT, 0, NULL);
     EV_SET(&changes[1], child, EVFILT_PROC, EV_ADD | EV_ONESHOT,
@@ -307,7 +308,8 @@ static int run_watch_pid_macos(pid_t watch_pid, char **target) {
     EV_SET(&changes[3], SIGINT,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
     EV_SET(&changes[4], SIGHUP,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
     EV_SET(&changes[5], SIGUSR1, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    if (kevent(kq, changes, 6, NULL, 0, NULL) == -1) {
+    EV_SET(&changes[6], SIGUSR2, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    if (kevent(kq, changes, 7, NULL, 0, NULL) == -1) {
         perror("pdeathsig: kevent register");
         kill(child, SIGTERM);
         return reap_then_exit(child, 127);
@@ -332,11 +334,11 @@ static int run_watch_pid_macos(pid_t watch_pid, char **target) {
         }
         if (n == 0) continue;
         if (ev.filter == EVFILT_SIGNAL) {
-            if ((int)ev.ident == SIGUSR1) {
-                // Vmstate snapshot trigger. Forward to the VMM and
-                // keep watching — the VMM dumps its whole-VM state
-                // and resumes the guest; it is NOT a shutdown signal.
-                kill(child, SIGUSR1);
+            if ((int)ev.ident == SIGUSR1 || (int)ev.ident == SIGUSR2) {
+                // Vmstate snapshot trigger / resume ack. Forward to
+                // the VMM and keep watching — neither is a shutdown
+                // signal for the pdeathsig guard.
+                kill(child, (int)ev.ident);
                 continue;
             }
             // Runtime is signaling us (typical: child.kill('SIGTERM')

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -70,6 +70,12 @@ export interface RegistryEntry {
    * booted without the vmstate engine.
    */
   vmstatePath?: string;
+  /** Per-VM incremental checkpoint chain id. New on every fresh boot/restore. */
+  vmstateChainId?: string;
+  /** Absolute bundle path the next vmstate checkpoint should parent to. */
+  vmstateCheckpointParent?: string;
+  /** Per-chain checkpoint sequence already written by this VM. */
+  vmstateCheckpointSequence?: number;
   /**
    * Absolute path to the snapshot directory this VM was forked from
    * (set by `restore({ snapDir })`). Visible in `ls`; informational.

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -102,48 +102,31 @@ export interface VmHandle {
   writeFile(guestPath: string, contents: Buffer | string, opts?: WriteFileOptions): Promise<void>;
 
   /**
-   * Freeze this VM with CRIU and write a snapshot bundle into
-   * `opts.outDir`. The bundle is a directory containing:
+   * Write a snapshot bundle into `opts.outDir`.
    *
-   *   <outDir>/img/                ← CRIU image files (pages-*.img,
-   *                                  pagemap-*.img, core-*.img,
-   *                                  dump.log, ...)
-   *   <outDir>/meta.json           ← source name + timestamp +
-   *                                  optional mountDisk pointers
-   *   <outDir>/mount-lower.sqfs    ← squashfs RO lower (only when
-   *                                  the source VM had `mount` set)
-   *   <outDir>/mount-upper.img     ← ext4 RW upper (only when
-   *                                  the source VM had `mount` set)
+   * With the default vmstate engine this is an incremental checkpoint:
+   * the source VM keeps running, the first checkpoint in the VM's
+   * chain carries full sparse RAM + `rootdisk.img`, and later
+   * checkpoints carry RAM/rootdisk delta sections plus full vCPU,
+   * GIC, virtio queue, and virtio-fs backend state. `restore()` walks
+   * parent pointers and materializes a flat vmstate/rootdisk pair
+   * before booting through the normal vmstate restore path.
+   *
+   * With `MACHINEN_SNAPSHOT_ENGINE=criu`, this keeps the historical
+   * process-tree behavior: CRIU image files live under `<outDir>/img/`,
+   * `opts.leaveRunning: true` keeps the source alive, and the default
+   * destructive CRIU snapshot powers the source off after the dump.
    *
    * `mount-lower.sqfs` and `mount-upper.img` are reflinked from the
    * runtime's per-VM materialization (#272), so on APFS / btrfs / xfs
    * the snapshot is essentially free space-wise even for a large
    * mount payload — blocks stay shared until either side writes.
    *
-   * The caller must have booted the VM with a scratch disk (`snapshot:
-   * '<path>'` or default auto-allocation) so the guest had `/dev/vdb`
-   * to dump into; otherwise this throws `SNAPSHOT_NO_DISK`.
+   * `SNAPSHOT_TIMEOUT` if the dump doesn't complete within
+   * `opts.timeoutMs`; `SNAPSHOT_DUMP_FAILED` if the engine reports a
+   * failed/incomplete dump.
    *
-   * Guest contract: the rootfs ships a dump helper callable via
-   * vsock exec — default `/sbin/machinen-dump`, override via
-   * `opts.dumpCmd`. The helper runs `criu dump --leave-running` and
-   * tars the resulting image set out on stdout, which the host
-   * extracts into `<outDir>/img/`. For destructive snapshots (default)
-   * the runtime then issues `/sbin/machinen-poweroff` over vsock to
-   * bring the VMM down; `opts.leaveRunning: true` skips that step
-   * and the source VM keeps running.
-   *
-   * `SNAPSHOT_TIMEOUT` if the dump exec doesn't return within
-   * `opts.timeoutMs`; `SNAPSHOT_DUMP_FAILED` if it returns non-zero
-   * or the streamed bundle is empty.
-   *
-   * Supported on both boot-owned and attach handles — attach uses
-   * the `diskPath` stored in the VM registry entry at boot time.
-   *
-   * By default the VM exits as part of the dump (CRIU kills the
-   * dumped tree on success). Pass `opts.leaveRunning: true` to keep
-   * the source VM alive — the workload resumes from the dump point
-   * and the bundle can be restored into a sibling VM (`vm.fork()`).
+   * Supported on both boot-owned and attach handles.
    */
   snapshot(opts: SnapshotOptions): Promise<SnapshotResult>;
 
@@ -271,8 +254,7 @@ export interface SnapshotOptions {
    */
   dumpCmd?: string;
   /**
-   * Wall-clock ceiling for the dump + shutdown. If the VMM hasn't exited
-   * in this window we SIGKILL it and fail. Default 90s.
+   * Wall-clock ceiling for the dump/checkpoint. Default 90s.
    */
   timeoutMs?: number;
   /**
@@ -282,12 +264,11 @@ export interface SnapshotOptions {
    */
   onLog?: OnLog;
   /**
-   * Pass `--leave-running` to `criu dump` so the source workload
-   * survives the snapshot. The VMM stays up after the dump; success
-   * is signalled by the dump exec returning 0 instead of by VMM exit.
-   * Used by `vm.fork()` (#216).
+   * CRIU engine only: pass `--leave-running` to `criu dump` so the
+   * source workload survives the snapshot. Vmstate checkpoints are
+   * always non-destructive and ignore this flag.
    *
-   * Default: false (current destructive snapshot behavior).
+   * Default under CRIU: false (destructive CRIU snapshot behavior).
    */
   leaveRunning?: boolean;
   /**
@@ -317,7 +298,7 @@ export interface SnapshotResult {
    * bundle. Set by the vmstate engine only; undefined for criu bundles.
    */
   vmstatePath?: string;
-  /** Time from `snapshot()` entry to VMM exit, in milliseconds. */
+  /** Time from `snapshot()` entry to completed bundle, in milliseconds. */
   elapsedMs: number;
   /** Guest console output captured during the dump. */
   consoleLog: string;
@@ -350,12 +331,28 @@ export interface VmstateSnapshotMeta {
     active?: boolean;
     sctlrEl1?: string;
   };
-  /** Exact root block image needed by the resumed guest, or explicit absence. */
-  rootDisk?: ({ mode: "block"; file: string } & SnapshotFileIdentity) | { mode: "none" };
+  /** Exact root block image needed by the resumed guest, a parent-relative delta, or explicit absence. */
+  rootDisk?:
+    | ({ mode: "block"; file: string } & SnapshotFileIdentity)
+    | { mode: "delta" }
+    | { mode: "none" };
   /** Kernel image identity when the source boot used an explicit kernel. */
   kernel?: SnapshotFileIdentity;
   /** DTB identity when the source boot used an explicit DTB. */
   dtb?: SnapshotFileIdentity;
+  /** Incremental checkpoint chain metadata for vmstate snapshots. */
+  checkpoint?: {
+    /** New random chain id for this VM's lifetime. */
+    chainId: string;
+    /** Per-chain checkpoint number, starting at 1. */
+    sequence: number;
+    /** Relative path from this bundle to its parent bundle, absent for a base checkpoint. */
+    parent?: string;
+    /** RAM section shape carried by this bundle. */
+    ram: "full" | "delta";
+    /** Rootdisk section shape carried by this bundle. */
+    rootDisk: "full" | "delta" | "none";
+  };
 }
 
 export interface SnapshotMeta {

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -7,7 +7,7 @@ import { ExecError, RegistryError, SnapshotError } from "../errors.ts";
 import { VsockExec } from "../exec.ts";
 import type { OnLog } from "../log.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
-import { findEntry, isAlive } from "../registry.ts";
+import { findEntry, isAlive, writeEntry } from "../registry.ts";
 import { performFork } from "./fork.ts";
 import type { MemoryStats, VmHandle } from "../vm-handle.ts";
 import { buildWriteFileCmds, teeOnLog } from "./helpers.ts";
@@ -49,7 +49,7 @@ export interface AttachOptions {
  */
 export async function attach(opts: AttachOptions): Promise<VmHandle> {
   debugAttach("attach lookup pid=%s name=%s", opts.pid ?? "<unset>", opts.name ?? "<unset>");
-  const entry = findEntry(opts);
+  let entry = findEntry(opts);
   if (!entry) {
     const q = opts.pid !== undefined ? `pid ${opts.pid}` : `name ${opts.name}`;
     debugAttach("attach miss for %s", q);
@@ -202,6 +202,24 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
       // Vmstate engine: the VMM's whole-VM state-file path, persisted
       // at boot. performSnapshotVmstate SIGUSR1s the VMM and reads it.
       vmstatePath: entry.vmstatePath,
+      vmstateChain: entry.vmstatePath
+        ? {
+            chainId: entry.vmstateChainId ?? `attached-${entry.pid}`,
+            parentDir: entry.vmstateCheckpointParent,
+            sequence: entry.vmstateCheckpointSequence ?? 0,
+          }
+        : undefined,
+      updateVmstateChain: entry.vmstatePath
+        ? ({ parentDir, sequence }) => {
+            entry = {
+              ...entry!,
+              vmstateChainId: entry!.vmstateChainId ?? `attached-${entry!.pid}`,
+              vmstateCheckpointParent: parentDir,
+              vmstateCheckpointSequence: sequence,
+            };
+            writeEntry(entry);
+          }
+        : undefined,
       execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
       wait: () => handle.wait(),
       kill: () => handle.kill(),

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -486,6 +486,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // wiring entirely so the VMM never installs the SIGUSR1 handler —
   // the VM is genuinely un-snapshottable, the same as under criu.
   let vmstateStatePath: string | undefined;
+  const vmstateChainId = randomBytes(16).toString("hex");
+  let vmstateCheckpointParent = opts._vmstateRestorePath ? opts.forkedFrom : undefined;
+  let vmstateCheckpointSequence = 0;
   if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
     if (!vsockTempDir) {
       vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
@@ -716,6 +719,9 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
           mountDiskPaths,
           liveMountsResolved,
           vmstateStatePath,
+          vmstateChainId: vmstateStatePath ? vmstateChainId : undefined,
+          vmstateCheckpointParent: vmstateStatePath ? vmstateCheckpointParent : undefined,
+          vmstateCheckpointSequence: vmstateStatePath ? vmstateCheckpointSequence : undefined,
         })
       : false;
 
@@ -932,6 +938,28 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
         : undefined,
       liveMounts: liveMountsForCtx,
       vmstatePath: vmstateStatePath,
+      vmstateChain: vmstateStatePath
+        ? {
+            chainId: vmstateChainId,
+            parentDir: vmstateCheckpointParent,
+            sequence: vmstateCheckpointSequence,
+          }
+        : undefined,
+      updateVmstateChain: vmstateStatePath
+        ? ({ parentDir, sequence }) => {
+            vmstateCheckpointParent = parentDir;
+            vmstateCheckpointSequence = sequence;
+            const cur = findEntry({ pid: childPid });
+            if (cur) {
+              writeEntry({
+                ...cur,
+                vmstateChainId,
+                vmstateCheckpointParent,
+                vmstateCheckpointSequence,
+              });
+            }
+          }
+        : undefined,
       execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
       wait: () => handle.wait(),
       kill: () => handle.kill(),
@@ -1463,6 +1491,9 @@ interface RegisterArgs {
   mountDiskPaths: MountDiskPaths | undefined;
   liveMountsResolved: ResolvedLiveMount[];
   vmstateStatePath: string | undefined;
+  vmstateChainId: string | undefined;
+  vmstateCheckpointParent: string | undefined;
+  vmstateCheckpointSequence: number | undefined;
 }
 
 // Write the registry entry. Returns true on success; registry-write
@@ -1518,6 +1549,9 @@ function registerInRegistry(args: RegisterArgs): boolean {
       // an attach-owned `vm.snapshot()` / `vm.fork()` can SIGUSR1 the
       // VMM and pick the .vmstate up. Undefined for criu-engine VMs.
       vmstatePath: args.vmstateStatePath,
+      vmstateChainId: args.vmstateChainId,
+      vmstateCheckpointParent: args.vmstateCheckpointParent,
+      vmstateCheckpointSequence: args.vmstateCheckpointSequence,
       // #272: persist mount-overlay paths so an attach-owned
       // vm.snapshot()/fork() can reflink the lower+upper into the
       // bundle. Without this, `machinen snapshot <vm>` from

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -12,6 +12,7 @@ import {
   openSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeSync,
@@ -27,6 +28,7 @@ import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { boot, type BootOptions } from "./boot.ts";
 import { resolveRestoreLiveMounts } from "./bundle.ts";
 import { VMSTATE_FILE } from "./snapshot-engine.ts";
+import { materializeVmstateChain } from "./vmstate-chain.ts";
 import type {
   SnapshotFileIdentity,
   SnapshotMeta,
@@ -556,6 +558,12 @@ function resolveVmstateRootDisk(
         "  restore({ rootDisk: <exact-image> }) to opt into caller-managed bytes.",
     );
   }
+  if (recorded.mode === "delta") {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: vmstate rootdisk delta was not materialized. This is a checkpoint-chain bug.",
+    );
+  }
   if (recorded.mode === "none") {
     if (typeof opts.rootDisk === "string") {
       throw new BootError(
@@ -620,7 +628,9 @@ function validateIdentity(label: string, path: string, expected: SnapshotFileIde
  * rematerializing a tarball into a fresh ext4 image is not safe.
  */
 async function restoreVmstate(opts: RestoreOptions, snapDir: string): Promise<VmHandle> {
-  const statePath = join(snapDir, VMSTATE_FILE);
+  let statePath = join(snapDir, VMSTATE_FILE);
+  let effectiveSnapDir = snapDir;
+  let materializedTempDir: string | undefined;
   const metaPath = join(snapDir, "meta.json");
 
   let meta: SnapshotMeta = { snappedAt: 0 };
@@ -634,39 +644,56 @@ async function restoreVmstate(opts: RestoreOptions, snapDir: string): Promise<Vm
     }
   }
 
-  const resolvedImage = resolveRestoreImage(opts, meta);
-  const vmstatePlan = planVmstateRestore(opts, meta, snapDir, statePath);
-  const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
-
-  // Re-attach a `--mount` overlay recorded in the bundle (same shape
-  // and per-fork reflink semantics as the CRIU path).
-  let restoreMountDisk: BootOptions["_restoreMountDisk"];
-  if (meta.mountDisk) {
-    const lowerAbs = join(snapDir, meta.mountDisk.lower);
-    const upperAbs = join(snapDir, meta.mountDisk.upper);
-    if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
-      );
+  let vm: VmHandle;
+  try {
+    if (meta.vmstate?.checkpoint?.parent) {
+      const materialized = materializeVmstateChain(snapDir, meta);
+      materializedTempDir = materialized.tempDir;
+      effectiveSnapDir = materialized.snapDir;
+      statePath = materialized.statePath;
+      meta = materialized.meta;
     }
-    restoreMountDisk = { guest: meta.mountDisk.guest, lowerPath: lowerAbs, upperPath: upperAbs };
+
+    const resolvedImage = resolveRestoreImage(opts, meta);
+    const vmstatePlan = planVmstateRestore(opts, meta, effectiveSnapDir, statePath);
+    const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
+
+    // Re-attach a `--mount` overlay recorded in the bundle (same shape
+    // and per-fork reflink semantics as the CRIU path).
+    let restoreMountDisk: BootOptions["_restoreMountDisk"];
+    if (meta.mountDisk) {
+      const lowerAbs = join(snapDir, meta.mountDisk.lower);
+      const upperAbs = join(snapDir, meta.mountDisk.upper);
+      if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
+        throw new BootError(
+          "BOOT_SNAPSHOT_NOT_FOUND",
+          `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
+        );
+      }
+      restoreMountDisk = { guest: meta.mountDisk.guest, lowerPath: lowerAbs, upperPath: upperAbs };
+    }
+
+    debugRestore("vmstate restore snapDir=%s state=%s image=%s", snapDir, statePath, resolvedImage);
+
+    vm = await boot({
+      ...opts,
+      image: resolvedImage,
+      forkedFrom: snapDir,
+      name: opts.name,
+      liveMounts: effectiveLiveMounts,
+      memory: vmstatePlan.memoryCeiling ?? opts.memory,
+      rootDisk: vmstatePlan.rootDisk ?? opts.rootDisk,
+      _restoreMountDisk: restoreMountDisk,
+      _vmstateRestorePath: statePath,
+      _rootDiskRestorePath: vmstatePlan.rootDiskRestorePath,
+    });
+  } finally {
+    if (materializedTempDir) {
+      try {
+        rmSync(materializedTempDir, { recursive: true, force: true });
+      } catch {}
+    }
   }
-
-  debugRestore("vmstate restore snapDir=%s state=%s image=%s", snapDir, statePath, resolvedImage);
-
-  const vm = await boot({
-    ...opts,
-    image: resolvedImage,
-    forkedFrom: snapDir,
-    name: opts.name,
-    liveMounts: effectiveLiveMounts,
-    memory: vmstatePlan.memoryCeiling ?? opts.memory,
-    rootDisk: vmstatePlan.rootDisk ?? opts.rootDisk,
-    _restoreMountDisk: restoreMountDisk,
-    _vmstateRestorePath: statePath,
-    _rootDiskRestorePath: vmstatePlan.rootDiskRestorePath,
-  });
 
   autoNameRestoredFork(vm, opts, meta);
   // The restored guest's kernel hostname is whatever the source had;

--- a/packages/runtime/src/vm/snapshot-engine.ts
+++ b/packages/runtime/src/vm/snapshot-engine.ts
@@ -7,7 +7,9 @@
 //                hypervisor-agnostic wire format. The only path that
 //                can move a live guest across VMMs (HVF<->KVM) when
 //                invariants match. Bundle layout:
-//                `<dir>/state.vmstate` + `<dir>/rootdisk.img`.
+//                `<dir>/state.vmstate` + `<dir>/rootdisk.img` for a
+//                base checkpoint; later checkpoints carry RAM/rootdisk
+//                delta sections and parent pointers in meta.json.
 //   - "criu"   — checkpoints the guest *process tree* from inside the
 //                guest via CRIU. Same-host, Linux-process-level.
 //                Bundle layout: `<dir>/img/core-*.img`.

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -35,6 +35,7 @@ import type {
   VmstateSnapshotMeta,
 } from "../vm-handle.ts";
 import { resolveSnapshotEngine, VMSTATE_FILE, VMSTATE_ROOTDISK_FILE } from "./snapshot-engine.ts";
+import { relativeCheckpointParent, VMSTATE_SECTION, vmstateSectionTags } from "./vmstate-chain.ts";
 import { currentVmstateBackend, fileIdentity, readVmstateFacts } from "./vmstate-metadata.ts";
 
 const debugSnapshot = debugLib("machinen:snapshot");
@@ -107,6 +108,14 @@ export interface SnapshotContext {
    * message.
    */
   vmstatePath?: string;
+  /** Incremental vmstate checkpoint chain state for this VM. */
+  vmstateChain?: {
+    chainId: string;
+    parentDir?: string;
+    sequence: number;
+  };
+  /** Persist the next parent pointer after a successful vmstate checkpoint. */
+  updateVmstateChain?: (next: { parentDir: string; sequence: number }) => void;
   execRaw: (cmd: string, opts?: VsockExecOptions) => Promise<VsockExecResult>;
   wait: () => Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   kill: () => Promise<void>;
@@ -583,24 +592,22 @@ function formatDumpOutcomeHint(outcome: DumpOutcome | undefined): string {
  * Whole-VM snapshot via the `.vmstate` engine. The source VM was
  * booted with `MACHINEN_SNAPSHOT_PATH` set (boot.ts does this when the
  * engine is vmstate), so its VMM carries a SIGUSR1 handler that
- * captures vCPU + RAM + GIC + virtio device state, resumes the guest,
- * then compresses/writes that immutable capture asynchronously. Steps:
+ * captures vCPU + RAM + GIC + virtio device state, queues the state
+ * file write, then waits paused for SIGUSR2 from the runtime. Steps:
  *   1. clear any stale state file at `ctx.vmstatePath`,
  *   2. SIGUSR1 the VMM pid,
  *   3. wait for the file to (re)appear — the VMM writes it atomically
  *      (tmp + rename), so existence == a complete dump,
  *   4. copy it into the bundle as `state.vmstate`,
- *   5. copy the exact root block image as `rootdisk.img`,
+ *   5. copy the exact root block image as `rootdisk.img` (or record
+ *      that the vmstate file carries a rootdisk delta),
  *   6. reflink any `--mount` overlay into the bundle (same as CRIU),
  *   7. write `meta.json` (with `engine: "vmstate"` + invariants),
- *   8. destructive snapshot (`!leaveRunning`) → power the source off;
- *      fork (`leaveRunning`) leaves it running (the VMM already
- *      resumed the guest after capturing state).
+ *   8. SIGUSR2 the VMM so the source VM resumes.
  *
- * Destructiveness is the runtime's call, mirroring the CRIU path's
- * `--leave-running` + host-poweroff split — the VMM itself always
- * resumes after capture, while the `.vmstate` writer finishes in the
- * background.
+ * Vmstate snapshots are non-destructive checkpoints. The SIGUSR2
+ * handshake keeps sidecar files point-in-time consistent while still
+ * letting the source continue after the bundle is complete.
  */
 async function performSnapshotVmstate(
   ctx: SnapshotContext,
@@ -608,7 +615,11 @@ async function performSnapshotVmstate(
 ): Promise<SnapshotResult> {
   const t0 = Date.now();
   const deadlineMs = opts.timeoutMs ?? 90_000;
-  const leaveRunning = opts.leaveRunning === true;
+  // Vmstate snapshots are now incremental checkpoints. A checkpoint is
+  // non-destructive by definition: the source VM resumes after the VMM
+  // captures the paused state, and future checkpoints in the same VM
+  // chain delta against this bundle.
+  const leaveRunning = true;
 
   if (!ctx.vmstatePath) {
     throw new SnapshotError(
@@ -651,76 +662,104 @@ async function performSnapshotVmstate(
   }
 
   // Trigger the dump. SIGUSR1 → the VMM captures whole-VM state,
-  // resumes the guest, then writes ctx.vmstatePath from a background
-  // writer. Works for boot- and attach-owned handles alike — it's just
-  // a signal to the VMM pid.
+  // queues ctx.vmstatePath from a background writer, and then waits
+  // paused until this runtime sends SIGUSR2. Keeping the vCPU stopped
+  // while we copy sidecars makes the rootdisk and mount overlay match
+  // the captured CPU/RAM point even though vmstate checkpoints are
+  // non-destructive.
+  let signaled = false;
   try {
-    process.kill(ctx.pid, "SIGUSR1");
+    try {
+      process.kill(ctx.pid, "SIGUSR1");
+      signaled = true;
+    } catch (err) {
+      throw new SnapshotError(
+        "SNAPSHOT_DUMP_FAILED",
+        `vm.snapshot: failed to signal the VMM (pid ${ctx.pid}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
+      );
+    }
+
+    await waitForVmstateFile(ctx.vmstatePath, deadlineMs);
+
+    // Copy the state file into the bundle — an independent copy so the
+    // source VM can be snapshotted again (overwriting ctx.vmstatePath)
+    // without disturbing this bundle.
+    const bundleStatePath = join(snapDir, VMSTATE_FILE);
+    try {
+      copyFileSync(ctx.vmstatePath, bundleStatePath);
+    } catch (err) {
+      throw new SnapshotError(
+        "SNAPSHOT_DUMP_FAILED",
+        `vm.snapshot: failed to copy the .vmstate into the bundle: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
+      );
+    }
+
+    const parentDir = ctx.vmstateChain?.parentDir;
+    const nextSequence = (ctx.vmstateChain?.sequence ?? 0) + 1;
+    const vmstateMeta = buildVmstateMeta(ctx, bundleStatePath, snapDir, parentDir, nextSequence);
+
+    // Reflink a `--mount` overlay into the bundle, same as the CRIU path.
+    const mountDiskMeta = await reflinkMountOverlay(ctx, snapDir, deadlineMs);
+
+    writeSnapshotMeta(ctx, snapDir, mountDiskMeta, "vmstate", vmstateMeta);
+
+    ctx.updateVmstateChain?.({ parentDir: snapDir, sequence: nextSequence });
+
+    const elapsedMs = Date.now() - t0;
+    const stateBytes = statSync(bundleStatePath).size;
+    debugVmstate(
+      "vmstate snapshot done snapDir=%s stateBytes=%d elapsedMs=%d",
+      snapDir,
+      stateBytes,
+      elapsedMs,
+    );
+    return {
+      engine: "vmstate",
+      snapDir,
+      vmstatePath: bundleStatePath,
+      elapsedMs,
+      // Vmstate checkpoints are non-destructive, so a boot-owned VMM's
+      // stderr stream stays open. Do not await ctx.errorOutput() here;
+      // attach-owned snapshots couldn't see it anyway.
+      consoleLog: "",
+    };
+  } finally {
+    if (signaled) {
+      resumeVmstateSource(ctx.pid);
+    }
+  }
+}
+
+function resumeVmstateSource(pid: number): void {
+  try {
+    process.kill(pid, "SIGUSR2");
   } catch (err) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      `vm.snapshot: failed to signal the VMM (pid ${ctx.pid}): ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { cause: err },
+    debugVmstate(
+      "vmstate snapshot: failed to resume VMM pid=%d after snapshot: %s",
+      pid,
+      err instanceof Error ? err.message : String(err),
     );
   }
-
-  await waitForVmstateFile(ctx.vmstatePath, deadlineMs);
-
-  // Copy the state file into the bundle — an independent copy so the
-  // source VM can be snapshotted again (overwriting ctx.vmstatePath)
-  // without disturbing this bundle.
-  const bundleStatePath = join(snapDir, VMSTATE_FILE);
-  try {
-    copyFileSync(ctx.vmstatePath, bundleStatePath);
-  } catch (err) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      `vm.snapshot: failed to copy the .vmstate into the bundle: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { cause: err },
-    );
-  }
-
-  const vmstateMeta = buildVmstateMeta(ctx, bundleStatePath, snapDir);
-
-  // Reflink a `--mount` overlay into the bundle, same as the CRIU path.
-  const mountDiskMeta = await reflinkMountOverlay(ctx, snapDir, deadlineMs);
-
-  writeSnapshotMeta(ctx, snapDir, mountDiskMeta, "vmstate", vmstateMeta);
-
-  // Destructive snapshot: bring the source down — its state is fully
-  // captured in the bundle. Fork (leaveRunning) leaves it running.
-  if (!leaveRunning) {
-    await powerOffSourceVm(ctx, deadlineMs);
-  }
-
-  const elapsedMs = Date.now() - t0;
-  const stateBytes = statSync(bundleStatePath).size;
-  debugVmstate(
-    "vmstate snapshot done snapDir=%s stateBytes=%d elapsedMs=%d",
-    snapDir,
-    stateBytes,
-    elapsedMs,
-  );
-  return {
-    engine: "vmstate",
-    snapDir,
-    vmstatePath: bundleStatePath,
-    elapsedMs,
-    consoleLog: await ctx.errorOutput(),
-  };
 }
 
 function buildVmstateMeta(
   ctx: SnapshotContext,
   statePath: string,
   snapDir: string,
+  parentDir: string | undefined,
+  sequence: number,
 ): VmstateSnapshotMeta {
   const facts = readVmstateFacts(statePath);
-  const rootDisk = copyVmstateRootDisk(ctx, snapDir);
+  const tags = vmstateSectionTags(statePath);
+  const hasRamDelta = tags.includes(VMSTATE_SECTION.ramDelta);
+  const hasRootdiskDelta = tags.includes(VMSTATE_SECTION.rootdiskDelta);
+  const rootDisk = copyVmstateRootDisk(ctx, snapDir, parentDir !== undefined && hasRootdiskDelta);
   return {
     sourceBackend: currentVmstateBackend(),
     topologyHash: facts.topologyHash,
@@ -732,12 +771,20 @@ function buildVmstateMeta(
     rootDisk,
     kernel: ctx.kernelPath ? fileIdentity(ctx.kernelPath) : undefined,
     dtb: ctx.dtbPath ? fileIdentity(ctx.dtbPath) : undefined,
+    checkpoint: {
+      chainId: ctx.vmstateChain?.chainId ?? `pid-${ctx.pid}`,
+      sequence,
+      parent: relativeCheckpointParent(snapDir, parentDir),
+      ram: hasRamDelta ? "delta" : "full",
+      rootDisk: ctx.rootDiskMode === "none" ? "none" : hasRootdiskDelta ? "delta" : "full",
+    },
   };
 }
 
 function copyVmstateRootDisk(
   ctx: SnapshotContext,
   snapDir: string,
+  deltaOnly: boolean,
 ): VmstateSnapshotMeta["rootDisk"] {
   if (ctx.rootDiskMode === "none") {
     return { mode: "none" };
@@ -749,6 +796,9 @@ function copyVmstateRootDisk(
         "  Reboot it with the current runtime so the registry records /dev/vda,\n" +
         "  or boot with rootDisk:false if the guest intentionally has no root block device.",
     );
+  }
+  if (deltaOnly) {
+    return { mode: "delta" };
   }
   const dest = join(snapDir, VMSTATE_ROOTDISK_FILE);
   try {

--- a/packages/runtime/src/vm/vmstate-chain.ts
+++ b/packages/runtime/src/vm/vmstate-chain.ts
@@ -1,0 +1,418 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import { BootError } from "../errors.ts";
+import type { SnapshotMeta, VmstateSnapshotMeta } from "../vm-handle.ts";
+import { reflinkCopy } from "../reflink.ts";
+import { VMSTATE_FILE, VMSTATE_ROOTDISK_FILE } from "./snapshot-engine.ts";
+import { fileIdentity } from "./vmstate-metadata.ts";
+
+export const VMSTATE_SECTION = {
+  ram: 1,
+  vcpu: 2,
+  gicDist: 3,
+  gicRedist: 4,
+  virtio: 5,
+  gicCpuif: 6,
+  virtiofsState: 7,
+  ramDelta: 8,
+  rootdiskDelta: 9,
+} as const;
+
+const MAGIC = Buffer.from("VMSTATE\0");
+const HEADER_SIZE = 64;
+const SECTION_HEADER_SIZE = 16;
+const ROOTDISK_DELTA_HEADER_SIZE = 56;
+const ROOTDISK_DELTA_BLOCK_SIZE = 4096;
+
+export interface VmstateSection {
+  tag: number;
+  id: number;
+  payload: Buffer;
+}
+
+export interface DecodedVmstate {
+  topologyHash: Buffer;
+  sections: VmstateSection[];
+}
+
+export interface MaterializedVmstateChain {
+  tempDir: string;
+  snapDir: string;
+  statePath: string;
+  meta: SnapshotMeta;
+}
+
+export function readVmstate(path: string): DecodedVmstate {
+  const raw = readFileSync(path);
+  const bytes = maybeGunzip(raw);
+  if (bytes.length < HEADER_SIZE) {
+    throw new Error(`vmstate: truncated header (${bytes.length} bytes)`);
+  }
+  if (!bytes.subarray(0, MAGIC.length).equals(MAGIC)) {
+    throw new Error("vmstate: bad magic");
+  }
+  const version = bytes.readUInt32LE(8);
+  if (version !== 1) {
+    throw new Error(`vmstate: unsupported version ${version}`);
+  }
+  const arch = bytes.readUInt32LE(12);
+  if (arch !== 1) {
+    throw new Error(`vmstate: unsupported arch ${arch}`);
+  }
+  const sectionCount = bytes.readUInt32LE(16);
+  const topologyHash = Buffer.from(bytes.subarray(24, 56));
+  const sections: VmstateSection[] = [];
+  let off = HEADER_SIZE;
+  for (let i = 0; i < sectionCount; i++) {
+    if (off + SECTION_HEADER_SIZE > bytes.length) {
+      throw new Error("vmstate: truncated section header");
+    }
+    const tag = bytes.readUInt32LE(off);
+    const id = bytes.readUInt32LE(off + 4);
+    const len = Number(bytes.readBigUInt64LE(off + 8));
+    off += SECTION_HEADER_SIZE;
+    if (!Number.isSafeInteger(len) || len < 0 || off + len > bytes.length) {
+      throw new Error("vmstate: section overflows file");
+    }
+    sections.push({ tag, id, payload: Buffer.from(bytes.subarray(off, off + len)) });
+    off += len;
+  }
+  return { topologyHash, sections };
+}
+
+export function writeVmstate(path: string, vmstate: DecodedVmstate): void {
+  let total = HEADER_SIZE;
+  for (const s of vmstate.sections) {
+    total += SECTION_HEADER_SIZE + s.payload.length;
+  }
+  const out = Buffer.alloc(total);
+  MAGIC.copy(out, 0);
+  out.writeUInt32LE(1, 8);
+  out.writeUInt32LE(1, 12);
+  out.writeUInt32LE(vmstate.sections.length, 16);
+  vmstate.topologyHash.copy(out, 24);
+  let off = HEADER_SIZE;
+  for (const s of vmstate.sections) {
+    out.writeUInt32LE(s.tag, off);
+    out.writeUInt32LE(s.id, off + 4);
+    out.writeBigUInt64LE(BigInt(s.payload.length), off + 8);
+    off += SECTION_HEADER_SIZE;
+    s.payload.copy(out, off);
+    off += s.payload.length;
+  }
+  writeFileSync(path, out);
+}
+
+export function vmstateSectionTags(path: string): number[] {
+  return readVmstate(path).sections.map((s) => s.tag);
+}
+
+export function isVmstateCheckpointMeta(meta: SnapshotMeta): boolean {
+  return meta.vmstate?.checkpoint !== undefined;
+}
+
+export function relativeCheckpointParent(
+  snapDir: string,
+  parentDir: string | undefined,
+): string | undefined {
+  if (!parentDir) {
+    return undefined;
+  }
+  const rel = relative(snapDir, parentDir);
+  return rel === "" ? "." : rel;
+}
+
+export function resolveCheckpointParent(snapDir: string, parent: string): string {
+  return isAbsolute(parent) ? parent : resolve(snapDir, parent);
+}
+
+export function materializeVmstateChain(
+  targetDir: string,
+  targetMeta: SnapshotMeta,
+): MaterializedVmstateChain {
+  const chain = readCheckpointChain(targetDir, targetMeta);
+  if (chain.length === 1 && !stateHasDeltaSections(join(targetDir, VMSTATE_FILE))) {
+    throw new Error("materializeVmstateChain called for a non-incremental vmstate bundle");
+  }
+
+  const tempDir = join(
+    tmpdir(),
+    `machinen-vmstate-chain-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  mkdirSync(tempDir, { recursive: true });
+
+  try {
+    const statePath = join(tempDir, VMSTATE_FILE);
+    const combined = combineVmstateRam(chain);
+    writeVmstate(statePath, combined);
+
+    const targetRootMode = targetMeta.vmstate?.rootDisk?.mode;
+    const meta: SnapshotMeta = {
+      ...targetMeta,
+      vmstate: {
+        ...targetMeta.vmstate,
+        rootDisk:
+          targetRootMode === "none" ? { mode: "none" } : materializeRootdisk(chain, tempDir),
+      },
+    };
+
+    return { tempDir, snapDir: tempDir, statePath, meta };
+  } catch (err) {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+    throw err;
+  }
+}
+
+function readCheckpointChain(
+  targetDir: string,
+  targetMeta: SnapshotMeta,
+): Array<{ dir: string; meta: SnapshotMeta; state: DecodedVmstate }> {
+  const out: Array<{ dir: string; meta: SnapshotMeta; state: DecodedVmstate }> = [];
+  const seen = new Set<string>();
+  let dir = targetDir;
+  let meta = targetMeta;
+  while (true) {
+    const real = resolve(dir);
+    if (seen.has(real)) {
+      throw new BootError(
+        "BOOT_VMSTATE_UNSUPPORTED",
+        `restore: vmstate checkpoint parent cycle at ${real}`,
+      );
+    }
+    seen.add(real);
+    const statePath = join(real, VMSTATE_FILE);
+    if (!existsSync(statePath)) {
+      throw new BootError(
+        "BOOT_SNAPSHOT_NOT_FOUND",
+        `restore: vmstate checkpoint state missing: ${statePath}`,
+      );
+    }
+    out.push({ dir: real, meta, state: readVmstate(statePath) });
+    const parent = meta.vmstate?.checkpoint?.parent;
+    if (!parent) {
+      break;
+    }
+    dir = resolveCheckpointParent(real, parent);
+    meta = readMeta(dir);
+  }
+  out.reverse();
+  return out;
+}
+
+function readMeta(dir: string): SnapshotMeta {
+  const metaPath = join(dir, "meta.json");
+  if (!existsSync(metaPath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: checkpoint parent meta missing: ${metaPath}`,
+    );
+  }
+  try {
+    return JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
+  } catch (err) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: failed to read checkpoint parent meta: ${metaPath}`,
+      { cause: err },
+    );
+  }
+}
+
+function stateHasDeltaSections(statePath: string): boolean {
+  const tags = vmstateSectionTags(statePath);
+  return tags.includes(VMSTATE_SECTION.ramDelta) || tags.includes(VMSTATE_SECTION.rootdiskDelta);
+}
+
+function combineVmstateRam(
+  chain: Array<{ dir: string; meta: SnapshotMeta; state: DecodedVmstate }>,
+): DecodedVmstate {
+  const target = chain[chain.length - 1]!;
+  const ramBaseIndex = findLatestRamBaseIndex(chain);
+  if (ramBaseIndex < 0) {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: vmstate checkpoint chain has no full RAM base",
+    );
+  }
+  const ramSections: VmstateSection[] = [];
+  const baseRam = chain[ramBaseIndex]!.state.sections.find((s) => s.tag === VMSTATE_SECTION.ram);
+  if (!baseRam) {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: vmstate checkpoint chain has no full RAM base",
+    );
+  }
+  ramSections.push(baseRam);
+  for (const item of chain.slice(ramBaseIndex + 1)) {
+    ramSections.push(...item.state.sections.filter((s) => s.tag === VMSTATE_SECTION.ramDelta));
+  }
+
+  const targetNonRam = target.state.sections.filter(
+    (s) =>
+      s.tag !== VMSTATE_SECTION.ram &&
+      s.tag !== VMSTATE_SECTION.ramDelta &&
+      s.tag !== VMSTATE_SECTION.rootdiskDelta,
+  );
+  return {
+    topologyHash: target.state.topologyHash,
+    sections: [...ramSections, ...targetNonRam],
+  };
+}
+
+function findLatestRamBaseIndex(chain: Array<{ state: DecodedVmstate }>): number {
+  for (let i = chain.length - 1; i >= 0; i--) {
+    if (chain[i]!.state.sections.some((s) => s.tag === VMSTATE_SECTION.ram)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function materializeRootdisk(
+  chain: Array<{ dir: string; meta: SnapshotMeta; state: DecodedVmstate }>,
+  tempDir: string,
+): VmstateSnapshotMeta["rootDisk"] {
+  const baseIndex = findLatestRootdiskBaseIndex(chain);
+  if (baseIndex < 0) {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: vmstate checkpoint chain has no full rootdisk base",
+    );
+  }
+
+  const dest = join(tempDir, VMSTATE_ROOTDISK_FILE);
+  const base = chain[baseIndex]!;
+  const root = base.meta.vmstate?.rootDisk;
+  if (!root || root.mode !== "block") {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: invalid vmstate rootdisk base metadata",
+    );
+  }
+  const basePath = join(base.dir, root.file);
+  if (!existsSync(basePath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: vmstate rootdisk base missing: ${basePath}`,
+    );
+  }
+  reflinkCopy(basePath, dest);
+
+  const fd = openSync(dest, "r+");
+  try {
+    for (const item of chain.slice(baseIndex + 1)) {
+      for (const section of item.state.sections) {
+        if (section.tag === VMSTATE_SECTION.rootdiskDelta) {
+          applyRootdiskDelta(fd, dest, section.payload);
+        }
+      }
+    }
+  } finally {
+    closeSync(fd);
+  }
+
+  const identity = fileIdentity(dest);
+  return {
+    mode: "block",
+    file: VMSTATE_ROOTDISK_FILE,
+    path: dest,
+    sizeBytes: identity.sizeBytes,
+    sha256: identity.sha256,
+  };
+}
+
+function findLatestRootdiskBaseIndex(chain: Array<{ meta: SnapshotMeta }>): number {
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const root = chain[i]!.meta.vmstate?.rootDisk;
+    if (root?.mode === "block") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function applyRootdiskDelta(fd: number, destPath: string, payload: Buffer): void {
+  if (payload.length < ROOTDISK_DELTA_HEADER_SIZE) {
+    throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: truncated rootdisk delta header");
+  }
+  const diskSize = Number(payload.readBigUInt64LE(0));
+  const blockSize = payload.readUInt32LE(8);
+  if (!Number.isSafeInteger(diskSize) || diskSize < 0) {
+    throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: invalid rootdisk delta size");
+  }
+  if (blockSize !== ROOTDISK_DELTA_BLOCK_SIZE) {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      `restore: unsupported rootdisk delta block size ${blockSize}`,
+    );
+  }
+  const actualSize = statSync(destPath).size;
+  if (actualSize !== diskSize) {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      `restore: rootdisk delta size mismatch (base=${actualSize}, delta=${diskSize})`,
+    );
+  }
+  const body = payload.subarray(ROOTDISK_DELTA_HEADER_SIZE);
+  const expected = payload.subarray(16, 48).toString("hex");
+  const actual = createHash("sha256").update(body).digest("hex");
+  if (actual !== expected) {
+    throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: rootdisk delta hash mismatch");
+  }
+
+  let off = 0;
+  while (off < body.length) {
+    if (body.length - off < 16) {
+      throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: truncated rootdisk delta extent");
+    }
+    const extentOff = Number(body.readBigUInt64LE(off));
+    const len = Number(body.readBigUInt64LE(off + 8));
+    off += 16;
+    if (
+      !Number.isSafeInteger(extentOff) ||
+      !Number.isSafeInteger(len) ||
+      extentOff < 0 ||
+      len < 0 ||
+      len > diskSize - extentOff ||
+      len > body.length - off
+    ) {
+      throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: invalid rootdisk delta extent");
+    }
+    writeAllAt(fd, body.subarray(off, off + len), extentOff);
+    off += len;
+  }
+}
+
+function writeAllAt(fd: number, bytes: Buffer, position: number): void {
+  let off = 0;
+  while (off < bytes.length) {
+    const n = writeSync(fd, bytes, off, bytes.length - off, position + off);
+    if (n <= 0) {
+      throw new Error("short write applying rootdisk delta");
+    }
+    off += n;
+  }
+}
+
+function maybeGunzip(raw: Buffer): Buffer {
+  if (raw.length >= 2 && raw[0] === 0x1f && raw[1] === 0x8b) {
+    return gunzipSync(raw);
+  }
+  return raw;
+}

--- a/scripts/smoke-test-snapshot-restore-fork.sh
+++ b/scripts/smoke-test-snapshot-restore-fork.sh
@@ -224,6 +224,16 @@ wait_for_vm() {
   return 1
 }
 
+# Helper: find the first auto-named restore child for a source name.
+# Destructive CRIU snapshots free the source name path, so restore can
+# claim `<src>/<pid>`. Vmstate checkpoints are non-destructive; while
+# the source pin is live restore falls back to `<src>~<pid>`.
+find_restore_child() {
+  local src=$1
+  cli ls 2>/dev/null | awk -v slash="$src/" -v tilde="$src~" \
+    'NR>1 && (index($2, slash)==1 || index($2, tilde)==1) {print $2; exit}'
+}
+
 # Helper: assert a snapshot bundle has the engine-appropriate shape.
 # criu bundles carry a process-tree checkpoint under `img/core-*.img`;
 # vmstate bundles carry a whole-VM `state.vmstate`. Both always carry
@@ -260,6 +270,45 @@ bundle_probe_file() {
   else
     ls "$dir"/img/core-*.img | head -1
   fi
+}
+
+assert_vmstate_checkpoint_shape() {
+  local dir=$1
+  local label=$2
+  local expected_ram=$3
+  local expected_root=$4
+  local expected_parent=$5
+  if [[ "$ENGINE" != "vmstate" ]]; then
+    return 0
+  fi
+  if ! node - "$dir" "$expected_ram" "$expected_root" "$expected_parent" <<'NODE'
+const fs = require('node:fs');
+const [dir, expectedRam, expectedRoot, expectedParent] = process.argv.slice(2);
+const meta = JSON.parse(fs.readFileSync(`${dir}/meta.json`, 'utf8'));
+const cp = meta.vmstate?.checkpoint;
+if (!cp) throw new Error('missing vmstate.checkpoint metadata');
+if (cp.ram !== expectedRam) throw new Error(`ram shape ${cp.ram} !== ${expectedRam}`);
+if (cp.rootDisk !== expectedRoot) throw new Error(`rootDisk shape ${cp.rootDisk} !== ${expectedRoot}`);
+const hasParent = cp.parent !== undefined;
+if (String(hasParent) !== expectedParent) throw new Error(`parent presence ${hasParent} !== ${expectedParent}`);
+const state = fs.readFileSync(`${dir}/state.vmstate`);
+const count = state.readUInt32LE(16);
+let off = 64;
+const tags = [];
+for (let i = 0; i < count; i++) {
+  tags.push(state.readUInt32LE(off));
+  const len = Number(state.readBigUInt64LE(off + 8));
+  off += 16 + len;
+}
+if (expectedRam === 'full' && !tags.includes(1)) throw new Error('missing full RAM section');
+if (expectedRam === 'delta' && !tags.includes(8)) throw new Error('missing RAM delta section');
+if (expectedRoot === 'full' && !fs.existsSync(`${dir}/rootdisk.img`)) throw new Error('missing full rootdisk.img');
+if (expectedRoot === 'delta' && !tags.includes(9)) throw new Error('missing rootdisk delta section');
+NODE
+  then
+    fail "$label — vmstate checkpoint shape mismatch"
+  fi
+  pass "$label vmstate checkpoint shape is $expected_ram/$expected_root"
 }
 
 # Helper: resolve the actual VMM pid from a registry-recorded pid.
@@ -358,8 +407,9 @@ for ENGINE in criu vmstate; do
       fail "S1 — exec against dump-side VM didn't return arch"
     fi
 
-    # Snapshot via the attach path. The bundle (img/<criu> + meta.json)
-    # lands at $S1_SNAP_DIR; the VM exits as part of the dump.
+    # Snapshot via the attach path. The bundle lands at $S1_SNAP_DIR.
+    # CRIU snapshots are destructive by default; vmstate checkpoints
+    # are non-destructive and keep the source VM running.
     S1_DUMP_LOG="$FIXTURE/s1-dump-$ENGINE.log"
     if ! cli snapshot "$S1_NAME" "$S1_SNAP_DIR" 2>"$S1_DUMP_LOG"; then
       tail -60 "$S1_BG_LOG" >&2
@@ -370,6 +420,7 @@ for ENGINE in criu vmstate; do
     pass "'machinen snapshot' returned 0"
 
     assert_bundle "$S1_SNAP_DIR" "S1"
+    assert_vmstate_checkpoint_shape "$S1_SNAP_DIR" "S1" full full false
 
     # Restore in the background. The auto-name is "<source>/<pid>";
     # find the restored VM by listing names that start with the source.
@@ -384,7 +435,7 @@ for ENGINE in criu vmstate; do
     S1_RESTORED_NAME=""
     deadline=$((SECONDS + 45))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S1_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      cand=$(find_restore_child "$S1_NAME")
       if [[ -n "$cand" ]]; then
         S1_RESTORED_NAME=$cand
         break
@@ -487,10 +538,15 @@ for ENGINE in criu vmstate; do
       cat "$S2_DUMP_A_LOG" >&2
       fail "S2 — first 'machinen snapshot' (to A) failed"
     fi
+    if [[ "$ENGINE" == "vmstate" ]]; then
+      cli stop "$S2_NAME" >/dev/null 2>&1 || true
+      kill -TERM "$S2_PID" 2>/dev/null || true
+    fi
     wait "$S2_PID" 2>/dev/null || true
     pass "snapshot → bundle A"
 
     assert_bundle "$S2_SNAP_A" "S2 (bundle A)"
+    assert_vmstate_checkpoint_shape "$S2_SNAP_A" "S2 bundle A" full full false
     S2_BUNDLE_A_PROBE=$(bundle_probe_file "$S2_SNAP_A")
     S2_BUNDLE_A_BEFORE=$(stat -c '%Y' "$S2_BUNDLE_A_PROBE" 2>/dev/null \
       || stat -f '%m' "$S2_BUNDLE_A_PROBE")
@@ -507,7 +563,7 @@ for ENGINE in criu vmstate; do
     S2_RESTORED_A=""
     deadline=$((SECONDS + 45))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S2_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      cand=$(find_restore_child "$S2_NAME")
       if [[ -n "$cand" ]]; then
         S2_RESTORED_A=$cand
         break
@@ -529,10 +585,15 @@ for ENGINE in criu vmstate; do
       cat "$S2_DUMP_B_LOG" >&2
       fail "S2 — chained 'machinen snapshot' (restored → B) failed"
     fi
+    if [[ "$ENGINE" == "vmstate" ]]; then
+      cli stop "$S2_RESTORED_A" >/dev/null 2>&1 || true
+      kill -TERM "$S2_RESTORE_A_PID" 2>/dev/null || true
+    fi
     wait "$S2_RESTORE_A_PID" 2>/dev/null || true
     pass "chained snapshot → bundle B"
 
     assert_bundle "$S2_SNAP_B" "S2 (chained bundle B)"
+    assert_vmstate_checkpoint_shape "$S2_SNAP_B" "S2 bundle B" delta delta true
 
     # Bundle A must NOT have been mutated by the chained dump. Restore
     # tars a temp copy on the host before attaching, so the source
@@ -557,8 +618,9 @@ for ENGINE in criu vmstate; do
     deadline=$((SECONDS + 45))
     while (( SECONDS < deadline )); do
       # The restored-from-B VM's source name is "<S2_RESTORED_A>", so
-      # the auto-name is "<S2_RESTORED_A>/<pid>".
-      cand=$(cli ls 2>/dev/null | awk -v src="$S2_RESTORED_A/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      # the auto-name is "<S2_RESTORED_A>/<pid>" or, while that source
+      # is still live under vmstate checkpoints, "<S2_RESTORED_A>~<pid>".
+      cand=$(find_restore_child "$S2_RESTORED_A")
       if [[ -n "$cand" ]]; then
         S2_RESTORED_B=$cand
         break
@@ -593,10 +655,15 @@ for ENGINE in criu vmstate; do
       cat "$S2_DUMP_C_LOG" >&2
       fail "S2 — gen-3 'machinen snapshot' (restored-B → C) failed"
     fi
+    if [[ "$ENGINE" == "vmstate" ]]; then
+      cli stop "$S2_RESTORED_B" >/dev/null 2>&1 || true
+      kill -TERM "$S2_RESTORE_B_PID" 2>/dev/null || true
+    fi
     wait "$S2_RESTORE_B_PID" 2>/dev/null || true
     pass "gen-3 chained snapshot → bundle C"
 
     assert_bundle "$S2_SNAP_C" "S2 (gen-3 bundle C)"
+    assert_vmstate_checkpoint_shape "$S2_SNAP_C" "S2 bundle C" delta delta true
 
     node "$CLI" restore "$S2_SNAP_C" >"$S2_RESTORE_C_LOG" 2>&1 &
     S2_RESTORE_C_PID=$!
@@ -609,7 +676,7 @@ for ENGINE in criu vmstate; do
     S2_RESTORED_C=""
     deadline=$((SECONDS + 45))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S2_RESTORED_B/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      cand=$(find_restore_child "$S2_RESTORED_B")
       if [[ -n "$cand" ]]; then
         S2_RESTORED_C=$cand
         break
@@ -700,9 +767,9 @@ for ENGINE in criu vmstate; do
     deadline=$((SECONDS + 30))
     while (( SECONDS < deadline )); do
       # Fork's auto-name is `<src>~<pid>` when source is alive (#216),
-      # falling back from the chained-restore convention `<src>/<pid>`
-      # which collides on the live source's pin file.
-      cand=$(cli ls 2>/dev/null | awk -v src="$S3_NAME~" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      # but vmstate's non-destructive checkpoints can also race the
+      # restore name claim into the chained-restore form `<src>/<pid>`.
+      cand=$(cli ls 2>/dev/null | awk -v src="$S3_NAME" 'NR>1 && (index($2, src "/")==1 || index($2, src "~")==1) {print $2; exit}')
       if [[ -n "$cand" ]]; then
         S3_FORK_NAME=$cand
         break
@@ -754,7 +821,7 @@ for ENGINE in criu vmstate; do
     S3_GRAND_NAME=""
     deadline=$((SECONDS + 30))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S3_FORK_NAME~" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      cand=$(cli ls 2>/dev/null | awk -v src="$S3_FORK_NAME" 'NR>1 && (index($2, src "/")==1 || index($2, src "~")==1) {print $2; exit}')
       if [[ -n "$cand" ]]; then
         S3_GRAND_NAME=$cand
         break
@@ -855,7 +922,7 @@ for ENGINE in criu vmstate; do
       S4_RESTORED_NAME=""
       deadline=$((SECONDS + 60))
       while (( SECONDS < deadline )); do
-        cand=$(cli ls 2>/dev/null | awk -v src="$S4_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+        cand=$(find_restore_child "$S4_NAME")
         if [[ -n "$cand" ]]; then
           S4_RESTORED_NAME=$cand
           break
@@ -994,7 +1061,7 @@ for ENGINE in criu vmstate; do
       S5_FORK_NAME=""
       deadline=$((SECONDS + 90))
       while (( SECONDS < deadline )); do
-        cand=$(cli ls 2>/dev/null | awk -v src="$S5_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+        cand=$(find_restore_child "$S5_NAME")
         if [[ -n "$cand" ]]; then
           S5_FORK_NAME=$cand
           break
@@ -1162,7 +1229,7 @@ for ENGINE in criu vmstate; do
     S6_RESTORED=""
     deadline=$((SECONDS + 60))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S6_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+      cand=$(find_restore_child "$S6_NAME")
       if [[ -n "$cand" ]]; then
         S6_RESTORED=$cand
         break
@@ -1206,7 +1273,8 @@ for ENGINE in criu vmstate; do
     S6_REMAPPED=""
     deadline=$((SECONDS + 60))
     while (( SECONDS < deadline )); do
-      cand=$(cli ls 2>/dev/null | awk -v src="$S6_NAME/" 'NR>1 && index($2, src)==1 && $2!=src"REPLACED" {print $2; exit}')
+      cand=$(cli ls 2>/dev/null | awk -v slash="$S6_NAME/" -v tilde="$S6_NAME~" -v seen="$S6_RESTORED" \
+        'NR>1 && (index($2, slash)==1 || index($2, tilde)==1) && $2!=seen {print $2; exit}')
       if [[ -n "$cand" && "$cand" != "$S6_RESTORED" ]]; then
         S6_REMAPPED=$cand
         break

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -605,13 +605,15 @@ else
     cleanup_t7
     fail "T7 — couldn't write to /mnt/data from the guest"
   fi
-  # Snapshot. Default destructive — VM exits when the dump finishes,
-  # so we don't need cleanup_t7 afterwards.
+  # Snapshot. Vmstate checkpoints are non-destructive, so explicitly
+  # stop the source after the bundle is written; CRIU snapshots may
+  # already have exited, making cleanup_t7 a no-op.
   if ! node "$CLI" snapshot "$T7_NAME" "$T7_BUNDLE" >>"$T7_BG_LOG" 2>&1; then
     tail -50 "$T7_BG_LOG" >&2
     cleanup_t7
     fail "T7 — machinen snapshot failed"
   fi
+  cleanup_t7
   # Now make the original host source disappear. The bundle's
   # mount-lower.sqfs and mount-upper.img must carry the data forward.
   rm -rf "$T7_HOST"
@@ -1130,7 +1132,7 @@ trap 'cleanup_b3; cleanup_b3_restore; rm -rf "$FIXTURE"' EXIT
 B3_FORK_NAME=""
 deadline=$((SECONDS + 60))
 while (( SECONDS < deadline )); do
-  cand=$(cli ls 2>/dev/null | awk -v src="$B3_NAME/" 'NR>1 && index($2, src)==1 {print $2; exit}')
+  cand=$(cli ls 2>/dev/null | awk -v src="$B3_NAME" 'NR>1 && (index($2, src "/")==1 || index($2, src "~")==1) {print $2; exit}')
   if [[ -n "$cand" ]]; then
     B3_FORK_NAME=$cand
     break


### PR DESCRIPTION
## Problem

Vmstate snapshots used to save a full copy every time. That made repeated snapshots bigger than they needed to be. It also meant restore only handled one bundle at a time, not a chain of checkpoints.

## Solution

Vmstate snapshots now form an incremental checkpoint chain. The first checkpoint stores full RAM and root disk bytes. Later checkpoints store only changed RAM pages and changed root disk blocks, plus fresh CPU and device state. Restore follows the parent links, builds a temporary flat bundle, and then uses the normal vmstate restore path. CRIU snapshots stay full and unchanged.

Closes #359.

## Validation

- `NPM_CONFIG_USERCONFIG=/dev/null MACHINEN_REQUIRE_FIXTURES=0 npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-test-snapshot-restore-fork`
- Remote Linux/KVM build and focused Zig tests on `friend@100.126.46.90`
