### PR TITLE
Reduce fallow health complexity

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -10,6 +10,12 @@
     "examples/live-mount/shared/server.mjs",
     "examples/quickstart/counter.mjs"
   ],
+  "duplicates": {
+    "ignore": ["**/__tests__/**", "**/*.{test,spec}.{js,jsx,ts,tsx,mjs,cjs}"]
+  },
+  "health": {
+    "ignore": ["**/__tests__/**", "**/*.{test,spec}.{js,jsx,ts,tsx,mjs,cjs}"]
+  },
   "ignoreDependencies": [
     "@homebridge/node-pty-prebuilt-multiarch",
     "@nkzw/oxlint-config",

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -184,12 +184,14 @@ describe("flag conventions", () => {
 describe("schema vs implementation", () => {
   it("dispatch in cli.ts handles every documented command", () => {
     // Naive but catches drift: if we add a command to the schema, we
-    // must also wire it into the switch statement in main(). The
-    // statement string `case "<name>":` is stable enough to grep.
+    // must also wire it into main()'s dispatch table. Keep the legacy
+    // switch marker too so the test still guides future rewrites.
     for (const cmd of COMMANDS) {
       const candidates = [cmd.name, ...(cmd.aliases ?? [])];
-      const hit = candidates.some((n) => CLI_SRC.includes(`case "${n}":`));
-      expect(hit, `cli.ts has no dispatch case for "${cmd.name}" or its aliases`).toBe(true);
+      const hit = candidates.some(
+        (n) => CLI_SRC.includes(`case "${n}":`) || CLI_SRC.includes(`["${n}",`),
+      );
+      expect(hit, `cli.ts has no dispatch entry for "${cmd.name}" or its aliases`).toBe(true);
     }
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,7 +42,7 @@ import {
   runGc,
   validatePid,
 } from "@machinen/runtime";
-import type { LogEvent, RegistryEntry } from "@machinen/runtime";
+import type { LogEvent, RegistryEntry, VmHandle } from "@machinen/runtime";
 import debugLib from "debug";
 
 import pkg from "../package.json" with { type: "json" };
@@ -151,33 +151,56 @@ function validateAssetsDir(dir: string): void {
 async function ensureBaseAssets(tag: string): Promise<string> {
   const spec = baseAssetSpec();
   const base = baseDirFor(tag, "debian", spec.cpu);
-  const kernel = join(base, "Image");
-  const dtb = spec.dtbAsset ? join(base, "virt.dtb") : undefined;
-  const tarball = join(base, "rootfs.tar.gz");
-
-  if (existsSync(kernel) && (!dtb || existsSync(dtb)) && existsSync(tarball)) {
+  if (cachedBaseAssetsReady(base, spec)) {
     return base;
   }
 
   mkdirSync(base, { recursive: true });
+  await downloadBaseAssets(tag, base, spec);
+  replaceCurrentBaseSymlink(tag);
+  return base;
+}
 
-  const assets = [
-    { name: spec.kernelAsset, dest: kernel },
-    ...(spec.dtbAsset && dtb ? [{ name: spec.dtbAsset, dest: dtb }] : []),
-    { name: spec.rootfsAsset, dest: tarball },
-  ];
+function cachedBaseAssetsReady(base: string, spec: BaseAssetSpec): boolean {
+  if (!existsSync(join(base, "Image"))) {
+    return false;
+  }
+  if (spec.dtbAsset && !existsSync(join(base, "virt.dtb"))) {
+    return false;
+  }
+  return existsSync(join(base, "rootfs.tar.gz"));
+}
 
-  await Promise.all(assets.map((a) => downloadWithChecksum(a.name, a.dest, tag)));
+async function downloadBaseAssets(tag: string, base: string, spec: BaseAssetSpec): Promise<void> {
+  await Promise.all(
+    baseAssetDownloads(base, spec).map((a) => downloadWithChecksum(a.name, a.dest, tag)),
+  );
+}
 
+function baseAssetDownloads(
+  base: string,
+  spec: BaseAssetSpec,
+): Array<{ name: string; dest: string }> {
+  const assets = [{ name: spec.kernelAsset, dest: join(base, "Image") }];
+  if (spec.dtbAsset) {
+    assets.push({ name: spec.dtbAsset, dest: join(base, "virt.dtb") });
+  }
+  assets.push({ name: spec.rootfsAsset, dest: join(base, "rootfs.tar.gz") });
+  return assets;
+}
+
+function replaceCurrentBaseSymlink(tag: string): void {
   const current = join(CACHE_ROOT, "current");
   try {
-    if (existsSync(current) || isSymlink(current)) {
-      unlinkSync(current);
-    }
+    unlinkCurrentSymlink(current);
   } catch {}
   symlinkSync(tag, current, "dir");
+}
 
-  return base;
+function unlinkCurrentSymlink(current: string): void {
+  if (existsSync(current) || isSymlink(current)) {
+    unlinkSync(current);
+  }
 }
 
 function isSymlink(p: string): boolean {
@@ -393,49 +416,14 @@ function emitJsonError(code: string, message: string): void {
 // Commands
 // ------------------------------------------------------------
 
-async function cmdBoot(args: string[]): Promise<number> {
-  let parsed;
-  try {
-    parsed = parseRunArgs(args);
-  } catch (err) {
-    handleError(err);
-  }
-  const {
-    positional,
-    double_dash_args,
-    mount,
-    liveMounts,
-    env,
-    portForward,
-    snapshot,
-    nested,
-    name,
-    guestCwd,
-    detached,
-    memory,
-    json,
-  } = parsed;
-  if (json && !detached) {
-    die("boot --json is only meaningful with --detach (attached boots take over stdio).");
-  }
+interface CliBaseAssetPaths {
+  kernelPath: string;
+  dtbPath?: string;
+  defaultImagePath: string;
+  baseDir: string;
+}
 
-  if (positional.length > 1) {
-    die(
-      "usage: machinen boot [<image>] [--snapshot <path>] [--name <name>] " +
-        "[--cwd <abs-path>] " +
-        "[--mount ...] [--mount-live ...] [--env KEY=VALUE]... [--detached] " +
-        "[--nested] [--memory <mib>] [-- <cmd> [args...]]",
-    );
-  }
-  const imageOverride = positional[0];
-
-  // Base assets (kernel + dtb + rootfs) are needed to boot.
-  //
-  // MACHINEN_ASSETS_DIR overrides the cache entirely — used for local
-  // dev against `./scripts/build-base-assets.sh` output, airgapped
-  // installs, and anywhere a GitHub Releases fetch isn't possible.
-  // Otherwise auto-download them on first run so users don't have to
-  // remember `machinen install`.
+async function resolveCliBaseAssets(): Promise<CliBaseAssetPaths> {
   const assetsOverride = process.env.MACHINEN_ASSETS_DIR;
   if (assetsOverride) {
     validateAssetsDir(assetsOverride);
@@ -443,428 +431,631 @@ async function cmdBoot(args: string[]): Promise<number> {
     process.stderr.write(`machinen: fetching base assets for ${RELEASE_TAG} (first run)\n`);
     await ensureBaseAssets(RELEASE_TAG);
   }
+  return cliBaseAssetPaths(assetsOverride);
+}
 
-  // Resolve the kernel, DTB, and base rootfs tarball.
-  // MACHINEN_ASSETS_DIR uses the unrenamed build-base-assets.sh output
-  // names; the cache renames on download (see `ensureBaseAssets`'s
-  // `assets` array). When the caller passes an image positional, it
-  // replaces the default base rootfs; kernel + DTB still come from
-  // the cache.
+function cliBaseAssetPaths(assetsOverride: string | undefined): CliBaseAssetPaths {
   const spec = baseAssetSpec();
-  const baseDir = assetsOverride
-    ? resolve(assetsOverride)
-    : baseDirFor(RELEASE_TAG, "debian", spec.cpu);
-  const kernelPath = join(baseDir, assetsOverride ? spec.kernelAsset : "Image");
-  const dtbPath = spec.dtbAsset
-    ? join(baseDir, assetsOverride ? spec.dtbAsset : "virt.dtb")
-    : undefined;
-  const defaultImagePath = join(baseDir, assetsOverride ? spec.rootfsAsset : "rootfs.tar.gz");
-  const imagePath = imageOverride ? resolve(imageOverride) : defaultImagePath;
+  const baseDir = cliBaseDir(assetsOverride, spec.cpu);
+  return {
+    baseDir,
+    kernelPath: cliKernelPath(baseDir, assetsOverride, spec),
+    dtbPath: cliDtbPath(baseDir, assetsOverride, spec),
+    defaultImagePath: cliRootfsPath(baseDir, assetsOverride, spec),
+  };
+}
+
+function cliBaseDir(assetsOverride: string | undefined, cpu: GuestCpu): string {
+  if (assetsOverride) {
+    return resolve(assetsOverride);
+  }
+  return baseDirFor(RELEASE_TAG, "debian", cpu);
+}
+
+function cliKernelPath(
+  baseDir: string,
+  assetsOverride: string | undefined,
+  spec: BaseAssetSpec,
+): string {
+  return join(baseDir, assetsOverride ? spec.kernelAsset : "Image");
+}
+
+function cliDtbPath(
+  baseDir: string,
+  assetsOverride: string | undefined,
+  spec: BaseAssetSpec,
+): string | undefined {
+  if (!spec.dtbAsset) {
+    return undefined;
+  }
+  return join(baseDir, assetsOverride ? spec.dtbAsset : "virt.dtb");
+}
+
+function cliRootfsPath(
+  baseDir: string,
+  assetsOverride: string | undefined,
+  spec: BaseAssetSpec,
+): string {
+  return join(baseDir, assetsOverride ? spec.rootfsAsset : "rootfs.tar.gz");
+}
+
+function resolveOptionalImageOverride(imageOverride: string | undefined): string | undefined {
+  if (!imageOverride) {
+    return undefined;
+  }
+  const imagePath = resolve(imageOverride);
+  if (!existsSync(imagePath)) {
+    die(`--image: file not found: ${imagePath}`);
+  }
+  return imagePath;
+}
+
+interface QuietRunState {
+  headlineName: string;
+  showHeadlines: boolean;
+  buffer: RingBuffer;
+  filter: NoiseFilter | null;
+  filterOut: PassThrough | null;
+  onLog?: (evt: LogEvent) => void;
+}
+
+interface AttachedSessionOptions {
+  filter: NoiseFilter | null;
+  filterOut?: PassThrough | null;
+  buffer: RingBuffer;
+  preReadyExitSummary: (code: number) => string;
+}
+
+async function runAttachedVmSession(vm: VmHandle, opts: AttachedSessionOptions): Promise<number> {
+  vm.stdout.pipe(process.stdout);
+  if (!opts.filter) {
+    vm.stderr.pipe(process.stderr);
+  }
+  const restoreStdin = rawModeStdinIfTTY();
+  const cancelHintRepeat = printCtrlDHint();
+  const signalState = installVmSignalHandlers(vm);
+
+  pipeStdinToVm(vm.stdin, () => {
+    process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
+    signalState.forwardedSignal = "SIGTERM";
+    void vm.kill();
+  });
+  opts.filterOut?.pipe(process.stderr);
+
+  try {
+    return await waitForAttachedVm(vm, opts, signalState);
+  } finally {
+    signalState.remove();
+    cancelHintRepeat();
+    restoreStdin();
+  }
+}
+
+type ForwardedSignal = "SIGINT" | "SIGTERM" | null;
+
+interface VmSignalState {
+  forwardedSignal: ForwardedSignal;
+  remove: () => void;
+}
+
+function installVmSignalHandlers(vm: VmHandle): VmSignalState {
+  const state: VmSignalState = { forwardedSignal: null, remove: () => {} };
+  const onSigint = () => {
+    state.forwardedSignal = "SIGINT";
+    void vm.kill();
+  };
+  const onSigterm = () => {
+    state.forwardedSignal = "SIGTERM";
+    void vm.kill();
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  state.remove = () => {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  };
+  return state;
+}
+
+async function waitForAttachedVm(
+  vm: VmHandle,
+  opts: AttachedSessionOptions,
+  signalState: VmSignalState,
+): Promise<number> {
+  const { code } = await vm.wait();
+  opts.filter?.flush();
+  const signalExitCode = forwardedSignalExitCode(signalState.forwardedSignal);
+  if (signalExitCode !== undefined) {
+    return signalExitCode;
+  }
+  if (shouldPrintPreReadyDiagnostics(opts.filter, code, signalState.forwardedSignal)) {
+    printDiagnostics(opts.preReadyExitSummary(code!), { buffer: opts.buffer });
+  }
+  return code ?? 0;
+}
+
+function forwardedSignalExitCode(signal: ForwardedSignal): number | undefined {
+  if (signal === "SIGINT") {
+    return 130;
+  }
+  if (signal === "SIGTERM") {
+    return 143;
+  }
+  return undefined;
+}
+
+function shouldPrintPreReadyDiagnostics(
+  filter: NoiseFilter | null,
+  code: number | null,
+  forwardedSignal: ForwardedSignal,
+): boolean {
+  if (!filter) {
+    return false;
+  }
+  if (filter.ready || forwardedSignal) {
+    return false;
+  }
+  return isNonZeroExit(code);
+}
+
+function isNonZeroExit(code: number | null): boolean {
+  if (code === null) {
+    return false;
+  }
+  return code !== 0;
+}
+
+type ParsedBootArgs = ReturnType<typeof parseRunArgs>;
+
+async function cmdBoot(args: string[]): Promise<number> {
+  const parsed = parseBootCommandArgs(args);
+  validateBootCommandArgs(parsed);
+
+  const imageOverride = parsed.positional[0];
+  const paths = await resolveCliBaseAssets();
+  const imagePath = imageOverride ? resolve(imageOverride) : paths.defaultImagePath;
+  logBootPlan(paths, imagePath, parsed);
+
+  const quiet = createBootQuietState(parsed, imageOverride);
+  const vm = await startBootVm(parsed, paths, imagePath, bootEnvCommand(parsed), quiet);
+  if (parsed.detached) {
+    reportDetachedBoot(vm, parsed);
+    return 0;
+  }
+  return runBootAttachedSession(vm, quiet);
+}
+
+function parseBootCommandArgs(args: string[]): ParsedBootArgs {
+  try {
+    return parseRunArgs(args);
+  } catch (err) {
+    handleError(err);
+  }
+}
+
+function validateBootCommandArgs(parsed: ParsedBootArgs): void {
+  if (parsed.json && !parsed.detached) {
+    die("boot --json is only meaningful with --detach (attached boots take over stdio).");
+  }
+  if (parsed.positional.length > 1) {
+    die(bootUsage());
+  }
+}
+
+function bootUsage(): string {
+  return (
+    "usage: machinen boot [<image>] [--snapshot <path>] [--name <name>] " +
+    "[--cwd <abs-path>] " +
+    "[--mount ...] [--mount-live ...] [--env KEY=VALUE]... [--detached] " +
+    "[--nested] [--memory <mib>] [-- <cmd> [args...]]"
+  );
+}
+
+function logBootPlan(paths: CliBaseAssetPaths, imagePath: string, parsed: ParsedBootArgs): void {
   debug(
     "boot baseDir=%s kernel=%s dtb=%s image=%s snapshot=%s name=%s",
-    baseDir,
-    kernelPath,
-    dtbPath,
+    paths.baseDir,
+    paths.kernelPath,
+    paths.dtbPath,
     imagePath,
-    snapshot ?? "<none>",
-    name ?? "<unset>",
+    parsed.snapshot ?? "<none>",
+    parsed.name ?? "<unset>",
   );
+}
 
+function bootEnvCommand(parsed: ParsedBootArgs): string[] | undefined {
   // Wrap the user cmd in /usr/bin/env so bare names like `node` or
   // `bash` are PATH-resolved. The guest init uses execve(), which
   // needs an absolute path for argv[0]; /usr/bin/env is the standard
   // shim for this. When the caller passes no `-- cmd`, the image may
   // carry a baked-in default (see `provision({ cmd })`); boot() falls
   // back to that automatically.
-  const cmd = double_dash_args.length > 0 ? ["/usr/bin/env", ...double_dash_args] : undefined;
-
-  // #286: quiet headline UX + diagnostics-on-failure. Buffer the
-  // chatty boot/restore lines (init checkpoints, kernel printk,
-  // machinen-restore.sh mechanics) and only flush them on failure.
-  // Operator mode (DEBUG=machinen:*) bypasses the filter — `onLog`
-  // is unset so vm.stderr stays raw via the runtime's own
-  // vmmDebug.enabled tee, and the CLI's `.pipe(process.stderr)`
-  // below carries the rest. JSON detached output skips headlines
-  // (the caller is scripting against the structured payload).
-  const headlineName = name ?? deriveBootName(imageOverride);
-  const showHeadlines = isQuiet() && !(detached && json);
-  const bootT0 = Date.now();
-  const buffer = new RingBuffer();
-  let filter: NoiseFilter | null = null;
-  let filterOut: PassThrough | null = null;
-  if (showHeadlines) {
-    printHeadline(`booting ${headlineName}…`);
-    if (!detached) {
-      filterOut = new PassThrough();
-      filter = new NoiseFilter({
-        buffer,
-        out: filterOut,
-        onReady: () => {
-          printHeadline("guest ready");
-          printHeadline(`ready in ${formatElapsed(Date.now() - bootT0)}`);
-        },
-      });
-    }
+  if (parsed.double_dash_args.length === 0) {
+    return undefined;
   }
-  const onLog = filter
-    ? (evt: LogEvent) => {
-        if (evt.source === "guest-console") {
-          filter!.push(evt.chunk);
-        }
-      }
-    : showHeadlines
-      ? (evt: LogEvent) => {
-          if (evt.source === "guest-console") {
-            buffer.push(evt.chunk);
-          }
-        }
-      : undefined;
+  return ["/usr/bin/env", ...parsed.double_dash_args];
+}
 
-  let vm;
+function createBootQuietState(
+  parsed: ParsedBootArgs,
+  imageOverride: string | undefined,
+): QuietRunState {
+  const headlineName = parsed.name ?? deriveBootName(imageOverride);
+  const showHeadlines = shouldShowBootHeadlines(parsed);
+  const buffer = new RingBuffer();
+  if (!showHeadlines) {
+    return { headlineName, showHeadlines, buffer, filter: null, filterOut: null };
+  }
+  return createVisibleBootQuietState(parsed, headlineName, showHeadlines, buffer);
+}
+
+function shouldShowBootHeadlines(parsed: ParsedBootArgs): boolean {
+  if (!isQuiet()) {
+    return false;
+  }
+  if (parsed.detached && parsed.json) {
+    return false;
+  }
+  return true;
+}
+
+function createVisibleBootQuietState(
+  parsed: ParsedBootArgs,
+  headlineName: string,
+  showHeadlines: boolean,
+  buffer: RingBuffer,
+): QuietRunState {
+  printHeadline(`booting ${headlineName}…`);
+  if (parsed.detached) {
+    return bootBufferOnlyQuietState(headlineName, showHeadlines, buffer);
+  }
+  return bootFilteredQuietState(headlineName, showHeadlines, buffer, Date.now());
+}
+
+function bootBufferOnlyQuietState(
+  headlineName: string,
+  showHeadlines: boolean,
+  buffer: RingBuffer,
+): QuietRunState {
+  return {
+    headlineName,
+    showHeadlines,
+    buffer,
+    filter: null,
+    filterOut: null,
+    onLog: guestConsoleOnLog((chunk) => buffer.push(chunk)),
+  };
+}
+
+function bootFilteredQuietState(
+  headlineName: string,
+  showHeadlines: boolean,
+  buffer: RingBuffer,
+  bootT0: number,
+): QuietRunState {
+  const filterOut = new PassThrough();
+  const filter = new NoiseFilter({
+    buffer,
+    out: filterOut,
+    onReady: () => {
+      printHeadline("guest ready");
+      printHeadline(`ready in ${formatElapsed(Date.now() - bootT0)}`);
+    },
+  });
+  return {
+    headlineName,
+    showHeadlines,
+    buffer,
+    filter,
+    filterOut,
+    onLog: guestConsoleOnLog((chunk) => filter.push(chunk)),
+  };
+}
+
+function guestConsoleOnLog(push: (chunk: Buffer) => void): (evt: LogEvent) => void {
+  return (evt) => {
+    if (evt.source === "guest-console") {
+      push(evt.chunk);
+    }
+  };
+}
+
+async function startBootVm(
+  parsed: ParsedBootArgs,
+  paths: CliBaseAssetPaths,
+  imagePath: string,
+  cmd: string[] | undefined,
+  quiet: QuietRunState,
+): Promise<VmHandle> {
   try {
-    vm = await boot({
+    return await boot({
       // Always pass the base rootfs so /sbin/machinen-restore and
       // friends are in the initramfs even on a bare `machinen restore
       // <snap>` (no --image, no -- cmd).
       image: imagePath,
       cmd,
-      env,
-      kernel: kernelPath,
-      dtb: dtbPath,
-      mount,
-      liveMounts,
-      portForward,
-      snapshot,
-      nested,
-      name,
-      guestCwd,
-      detached,
-      memory,
-      onLog,
+      env: parsed.env,
+      kernel: paths.kernelPath,
+      dtb: paths.dtbPath,
+      mount: parsed.mount,
+      liveMounts: parsed.liveMounts,
+      portForward: parsed.portForward,
+      snapshot: parsed.snapshot,
+      nested: parsed.nested,
+      name: parsed.name,
+      guestCwd: parsed.guestCwd,
+      detached: parsed.detached,
+      memory: parsed.memory,
+      onLog: quiet.onLog,
       // Interactive CLI: the session lives as long as the guest does.
       // Don't impose the default 60s cap. Detached boots fall back to
       // the runtime's own readiness timeout (60s) so the CLI can't
       // hang forever waiting for first-guest-byte.
-      timeoutMs: detached ? undefined : null,
+      timeoutMs: parsed.detached ? undefined : null,
     });
   } catch (err) {
-    filter?.flush();
-    if (showHeadlines) {
-      failQuiet(`boot ${headlineName} failed: ${describeError(err)}`, {
-        buffer,
-      });
-    }
-    handleError(err);
+    handleBootFailure(err, quiet);
   }
+}
 
+function handleBootFailure(err: unknown, quiet: QuietRunState): never {
+  quiet.filter?.flush();
+  if (quiet.showHeadlines) {
+    failQuiet(`boot ${quiet.headlineName} failed: ${describeError(err)}`, {
+      buffer: quiet.buffer,
+    });
+  }
+  handleError(err);
+}
+
+function reportDetachedBoot(vm: VmHandle, parsed: ParsedBootArgs): void {
   // #150 phase 2: detached boot — VMM is already unrefed inside boot()
   // and the registry entry stays live for `machinen attach`. Print a
   // short hint so users know how to reach the VM and exit cleanly.
-  // Cleanup of per-boot disks/dirs is documented as a known limitation
-  // of PR1; PR2 ships `machinen gc` and `machinen stop`.
-  if (detached) {
-    if (json) {
-      emitJson({
-        schema_version: 1,
-        pid: vm.pid,
-        name: name ?? null,
-        detached: true,
-      });
-    } else {
-      const target = name ?? `pid ${vm.pid}`;
-      process.stderr.write(
-        `machinen: detached (${target}). ` +
-          `Reattach: machinen attach ${name ?? vm.pid}\n` +
-          `Stop: kill ${vm.pid}  (machinen stop ships in PR2)\n`,
-      );
-    }
-    return 0;
+  if (parsed.json) {
+    emitDetachedBootJson(vm, parsed);
+    return;
   }
+  printDetachedBootHint(vm, parsed);
+}
 
-  vm.stdout.pipe(process.stdout);
+function emitDetachedBootJson(vm: VmHandle, parsed: ParsedBootArgs): void {
+  emitJson({ schema_version: 1, pid: vm.pid, name: parsed.name ?? null, detached: true });
+}
+
+function printDetachedBootHint(vm: VmHandle, parsed: ParsedBootArgs): void {
+  const target = parsed.name ?? `pid ${vm.pid}`;
+  process.stderr.write(
+    `machinen: detached (${target}). ` +
+      `Reattach: machinen attach ${parsed.name ?? vm.pid}\n` +
+      `Stop: kill ${vm.pid}  (machinen stop ships in PR2)\n`,
+  );
+}
+
+function runBootAttachedSession(vm: VmHandle, quiet: QuietRunState): Promise<number> {
   // Quiet mode: the NoiseFilter already routes vm.stderr (via the
   // `onLog` hook installed by boot()) into the ring buffer + stderr,
-  // splitting boot noise from workload output. Piping vm.stderr
-  // directly here would double-print every line. Operator mode
+  // splitting boot noise from workload output. Operator mode
   // (filter === null) keeps the legacy raw passthrough.
-  if (!filter) {
-    vm.stderr.pipe(process.stderr);
-  }
-  const restoreStdin = rawModeStdinIfTTY();
-  const cancelHintRepeat = printCtrlDHint();
-
-  // Propagate SIGINT/SIGTERM to the VMM child. With stdin in raw mode
-  // the host kernel no longer turns keyboard Ctrl-C into SIGINT (the
-  // byte goes through to the guest), so this only fires when the CLI
-  // is signalled directly — e.g. a supervisor sending SIGTERM to node,
-  // or `kill -INT <cli-pid>` from another shell. Without this, the
-  // VMM survives as an orphan.
-  //
-  // Ctrl-D from the user's terminal lands in pipeStdinToVm below and
-  // funnels into the same vm.kill() path with SIGTERM exit semantics.
-  let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
-  const onSigint = () => {
-    forwardedSignal = "SIGINT";
-    void vm.kill();
-  };
-  const onSigterm = () => {
-    forwardedSignal = "SIGTERM";
-    void vm.kill();
-  };
-  process.on("SIGINT", onSigint);
-  process.on("SIGTERM", onSigterm);
-
-  pipeStdinToVm(vm.stdin, () => {
-    process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
-    forwardedSignal = "SIGTERM";
-    void vm.kill();
-  });
   // In quiet mode, don't display the workload's first prompt until
-  // stdin is in raw mode and piped to the VM. Bash prompts are partial
-  // (no trailing LF); showing them during boot made the terminal look
-  // ready while host stdin was still canonical, so typed characters
-  // appeared only after Enter and early input could be lost.
-  filterOut?.pipe(process.stderr);
-
-  try {
-    const { code } = await vm.wait();
-    filter?.flush();
-    if (forwardedSignal === "SIGINT") {
-      return 130;
-    }
-    if (forwardedSignal === "SIGTERM") {
-      return 143;
-    }
-    // Pre-ready non-zero exit: the workload never reached the
-    // readiness boundary, so the buffered boot noise IS the only
-    // post-mortem signal the user has. Flush it under the
-    // diagnostics envelope. Post-ready exits skip the dump — the
-    // workload printed its own error to stderr already.
-    if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
-      printDiagnostics(`boot ${headlineName} exited ${code} before reaching ready`, { buffer });
-    }
-    return code ?? 0;
-  } finally {
-    process.off("SIGINT", onSigint);
-    process.off("SIGTERM", onSigterm);
-    cancelHintRepeat();
-    restoreStdin();
-  }
+  // stdin is in raw mode and piped to the VM.
+  return runAttachedVmSession(vm, {
+    filter: quiet.filter,
+    filterOut: quiet.filterOut,
+    buffer: quiet.buffer,
+    preReadyExitSummary: (code) =>
+      `boot ${quiet.headlineName} exited ${code} before reaching ready`,
+  });
 }
 
 async function cmdInstall(args: string[]): Promise<number> {
-  const { json, rest } = consumeJsonFlag(args);
-  const tag = argValue(rest, "--version") ?? RELEASE_TAG;
-  const wasComplete = baseAssetsComplete(tag);
-  const t0 = Date.now();
-  if (!json) {
-    process.stderr.write(`installing base assets for ${tag}…\n`);
-    // Only show the cache target in operator mode — the path is
-    // useful to know when you're debugging where downloads landed,
-    // noise otherwise.
-    if (!isQuiet()) {
-      process.stderr.write(`  into ${cacheDirFor(tag)}\n`);
-    }
-  }
-  let base: string;
-  try {
-    base = await ensureBaseAssets(tag);
-  } catch (err) {
-    if (isQuiet() && !json) {
-      failQuiet(`install ${tag} failed: ${describeError(err)}`);
-    }
-    throw err;
-  }
-  if (json) {
-    emitJson({
-      schema_version: 1,
-      tag,
-      base_dir: base,
-      fetched: !wasComplete,
-    });
-  } else if (wasComplete) {
-    process.stderr.write(`ready: ${base} (cached)\n`);
-  } else {
-    process.stderr.write(`ready in ${formatElapsed(Date.now() - t0)}: ${base}\n`);
-  }
+  const opts = parseInstallOptions(args);
+  const result = await installBaseAssets(opts);
+  reportInstallResult(opts, result);
   return 0;
 }
 
+interface InstallOptions {
+  json: boolean;
+  tag: string;
+}
+
+interface InstallResult {
+  base: string;
+  wasComplete: boolean;
+  elapsedMs: number;
+}
+
+function parseInstallOptions(args: string[]): InstallOptions {
+  const { json, rest } = consumeJsonFlag(args);
+  return { json, tag: argValue(rest, "--version") ?? RELEASE_TAG };
+}
+
+async function installBaseAssets(opts: InstallOptions): Promise<InstallResult> {
+  const wasComplete = baseAssetsComplete(opts.tag);
+  const t0 = Date.now();
+  printInstallStart(opts);
+  try {
+    const base = await ensureBaseAssets(opts.tag);
+    return { base, wasComplete, elapsedMs: Date.now() - t0 };
+  } catch (err) {
+    reportInstallFailure(opts, err);
+    throw err;
+  }
+}
+
+function printInstallStart(opts: InstallOptions): void {
+  if (opts.json) {
+    return;
+  }
+  process.stderr.write(`installing base assets for ${opts.tag}…\n`);
+  if (!isQuiet()) {
+    process.stderr.write(`  into ${cacheDirFor(opts.tag)}\n`);
+  }
+}
+
+function reportInstallFailure(opts: InstallOptions, err: unknown): void {
+  if (isQuiet() && !opts.json) {
+    failQuiet(`install ${opts.tag} failed: ${describeError(err)}`);
+  }
+}
+
+function reportInstallResult(opts: InstallOptions, result: InstallResult): void {
+  if (opts.json) {
+    emitInstallJson(opts, result);
+    return;
+  }
+  printInstallReady(result);
+}
+
+function emitInstallJson(opts: InstallOptions, result: InstallResult): void {
+  emitJson({
+    schema_version: 1,
+    tag: opts.tag,
+    base_dir: result.base,
+    fetched: !result.wasComplete,
+  });
+}
+
+function printInstallReady(result: InstallResult): void {
+  if (result.wasComplete) {
+    process.stderr.write(`ready: ${result.base} (cached)\n`);
+    return;
+  }
+  process.stderr.write(`ready in ${formatElapsed(result.elapsedMs)}: ${result.base}\n`);
+}
+
+type ParsedRestoreCommandArgs = ReturnType<typeof parseRestoreArgs>;
+
 async function cmdRestore(args: string[]): Promise<number> {
   // `machinen restore <snap-dir> [--image <tarball>] [--name <name>]
-  // [--lazy] [-p <hostPort>:<guestPort>]`. The bundle dir
-  // (produced by `machinen snapshot`) holds img/<criu-images> +
-  // meta.json. The bundle carries CRIU's process images but not the
-  // workload's rootfs, so any process whose memory map references
-  // files outside the base debian rootfs (e.g. /usr/bin/node from a
-  // `provision()`d tarball) needs the same workload tarball passed
-  // here as `--image`. Without it, criu fails its file-backed VMA
-  // restore with "Can't open file <path> on restore: No such file
-  // or directory" and /sbin/machinen-restore exits 1, panicking the
-  // guest kernel ("Attempted to kill init!").
-  //
-  // Restore is eager by default: the runtime packs the CRIU image
-  // as a tar on /dev/vdb, the guest's /sbin/machinen-restore untars
-  // into tmpfs, and CRIU loads everything up front. Pass `--lazy`
-  // to opt into the #266 path — vsock-FUSE-mount the bundle into
-  // the guest and run `criu restore --lazy-pages` so workload pages
-  // flow in only when faulted. Lazy keeps host RSS proportional to
-  // the touched set but doesn't compose with `--detach` and trades
-  // simplicity for a per-page UFFD round-trip cost.
-  let parsed;
+  // [--lazy] [-p <hostPort>:<guestPort>]`. Restore is eager by
+  // default; `--lazy` opts into the #266 vsock-FUSE lazy-pages path.
+  const parsed = parseRestoreCommandArgs(args);
+  validateRestoreCommandArgs(parsed);
+  const snapDir = resolve(parsed.positional[0]!);
+  const paths = await resolveCliBaseAssets();
+  const quiet = createRestoreQuietState(parsed, snapDir);
+  const vm = await startRestoreVm(parsed, snapDir, paths, quiet);
+  reportRestoreSuccess(vm, quiet);
+  return runRestoreAttachedSession(vm, quiet);
+}
+
+function parseRestoreCommandArgs(args: string[]): ParsedRestoreCommandArgs {
   try {
-    parsed = parseRestoreArgs(args);
+    return parseRestoreArgs(args);
   } catch (err) {
     handleError(err);
   }
-  const { positional, name, image: imageOverride, portForward, lazy, liveMounts } = parsed;
-  if (positional.length !== 1) {
-    die(
-      "usage: machinen restore <snap-dir> [--image <tarball>] [--name <name>] " +
-        "[--lazy] [-p <hostPort>:<guestPort>] " +
-        "[--mount-live <host>:<guest>[:<mode>]]",
-    );
-  }
-  const snapDir = resolve(positional[0]!);
+}
 
-  // Kernel + dtb always come from the base assets (the workload tarball
-  // doesn't carry them). The rootfs comes from --image when given, or
-  // falls back to meta.sourceImage inside restore() so the same-host
-  // quickstart works without a flag. The base release rootfs is no
-  // longer a silent default — workloads beyond a bare /bin/sh need
-  // their own tarball, and a confused-by-default restore that panics
-  // the guest kernel was the original bug we shipped this fix for.
-  const assetsOverride = process.env.MACHINEN_ASSETS_DIR;
-  if (assetsOverride) {
-    validateAssetsDir(assetsOverride);
-  } else if (!baseAssetsComplete(RELEASE_TAG)) {
-    process.stderr.write(`machinen: fetching base assets for ${RELEASE_TAG} (first run)\n`);
-    await ensureBaseAssets(RELEASE_TAG);
+function validateRestoreCommandArgs(parsed: ParsedRestoreCommandArgs): void {
+  if (parsed.positional.length !== 1) {
+    die(restoreUsage());
   }
-  const spec = baseAssetSpec();
-  const baseDir = assetsOverride
-    ? resolve(assetsOverride)
-    : baseDirFor(RELEASE_TAG, "debian", spec.cpu);
-  const kernelPath = join(baseDir, assetsOverride ? spec.kernelAsset : "Image");
-  const dtbPath = spec.dtbAsset
-    ? join(baseDir, assetsOverride ? spec.dtbAsset : "virt.dtb")
-    : undefined;
+}
 
-  let imagePath: string | undefined;
-  if (imageOverride) {
-    imagePath = resolve(imageOverride);
-    if (!existsSync(imagePath)) {
-      die(`--image: file not found: ${imagePath}`);
-    }
-  }
+function restoreUsage(): string {
+  return (
+    "usage: machinen restore <snap-dir> [--image <tarball>] [--name <name>] " +
+    "[--lazy] [-p <hostPort>:<guestPort>] " +
+    "[--mount-live <host>:<guest>[:<mode>]]"
+  );
+}
 
-  // #286: quiet headline UX + diagnostics-on-failure. The restore
-  // path is much chattier than boot — machinen-restore.sh emits the
-  // lazy-pages daemon pid, UDS bind, untar progress, criu's exit
-  // notes — and most of it is noise for end-users. Same buffer +
-  // NoiseFilter shape as cmdBoot; only the verbs differ.
-  const headlineName = name ?? deriveBootName(snapDir);
-  const showHeadlines = isQuiet();
-  const restoreT0 = Date.now();
+function createRestoreQuietState(parsed: ParsedRestoreCommandArgs, snapDir: string): QuietRunState {
+  const headlineName = parsed.name ?? deriveBootName(snapDir);
   const buffer = new RingBuffer();
-  let filter: NoiseFilter | null = null;
-  if (showHeadlines) {
-    printHeadline(`restoring ${headlineName}…`);
-    // onReady fires on the first non-noise line — typically the
-    // restored workload's first stdout/stderr write. We print the
-    // "restored" headline there so timing is wall-clock honest.
-    filter = new NoiseFilter({
-      buffer,
-      out: process.stderr,
-      onReady: () => {
-        printHeadline(`restored in ${formatElapsed(Date.now() - restoreT0)}`);
-      },
-    });
+  if (!isQuiet()) {
+    return { headlineName, showHeadlines: false, buffer, filter: null, filterOut: null };
   }
-  const onLog = filter
-    ? (evt: LogEvent) => {
-        if (evt.source === "guest-console") {
-          filter!.push(evt.chunk);
-        }
-      }
-    : undefined;
+  printHeadline(`restoring ${headlineName}…`);
+  return restoreFilteredQuietState(headlineName, buffer, Date.now());
+}
 
-  let vm;
+function restoreFilteredQuietState(
+  headlineName: string,
+  buffer: RingBuffer,
+  restoreT0: number,
+): QuietRunState {
+  // onReady fires on the first non-noise line — typically the
+  // restored workload's first stdout/stderr write. We print the
+  // "restored" headline there so timing is wall-clock honest.
+  const filter = new NoiseFilter({
+    buffer,
+    out: process.stderr,
+    onReady: () => {
+      printHeadline(`restored in ${formatElapsed(Date.now() - restoreT0)}`);
+    },
+  });
+  return {
+    headlineName,
+    showHeadlines: true,
+    buffer,
+    filter,
+    filterOut: null,
+    onLog: guestConsoleOnLog((chunk) => filter.push(chunk)),
+  };
+}
+
+async function startRestoreVm(
+  parsed: ParsedRestoreCommandArgs,
+  snapDir: string,
+  paths: CliBaseAssetPaths,
+  quiet: QuietRunState,
+): Promise<VmHandle> {
   try {
-    vm = await restore({
+    return await restore({
       snapDir,
-      image: imagePath,
-      kernel: kernelPath,
-      dtb: dtbPath,
-      name,
-      lazy,
-      portForward: portForward.length > 0 ? portForward : undefined,
+      image: resolveOptionalImageOverride(parsed.image),
+      kernel: paths.kernelPath,
+      dtb: paths.dtbPath,
+      name: parsed.name,
+      lazy: parsed.lazy,
+      portForward: optionalList(parsed.portForward),
       // #273: per-guest overrides for the bundle's recorded
       // liveMounts. Empty list = use the bundle's recorded mounts
       // verbatim; non-empty entries replace the matching guest's
       // host/mode (BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN if no match).
-      liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
+      liveMounts: optionalList(parsed.liveMounts),
       timeoutMs: null,
-      onLog,
+      onLog: quiet.onLog,
     });
   } catch (err) {
-    filter?.flush();
-    if (showHeadlines) {
-      failQuiet(`restore ${headlineName} failed: ${describeError(err)}`, {
-        buffer,
-      });
-    }
-    handleError(err);
+    handleRestoreFailure(err, quiet);
   }
+}
 
-  if (!showHeadlines) {
+function optionalList<T>(items: T[]): T[] | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+  return items;
+}
+
+function handleRestoreFailure(err: unknown, quiet: QuietRunState): never {
+  quiet.filter?.flush();
+  if (quiet.showHeadlines) {
+    failQuiet(`restore ${quiet.headlineName} failed: ${describeError(err)}`, {
+      buffer: quiet.buffer,
+    });
+  }
+  handleError(err);
+}
+
+function reportRestoreSuccess(vm: VmHandle, quiet: QuietRunState): void {
+  if (!quiet.showHeadlines) {
     process.stderr.write(`restored as: ${vm.name ?? "<anonymous>"} (pid ${vm.pid})\n`);
   }
+}
 
-  vm.stdout.pipe(process.stdout);
-  if (!filter) {
-    vm.stderr.pipe(process.stderr);
-  }
-  const restoreStdin = rawModeStdinIfTTY();
-  const cancelHintRepeat = printCtrlDHint();
-
-  let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
-  const onSigint = () => {
-    forwardedSignal = "SIGINT";
-    void vm.kill();
-  };
-  const onSigterm = () => {
-    forwardedSignal = "SIGTERM";
-    void vm.kill();
-  };
-  process.on("SIGINT", onSigint);
-  process.on("SIGTERM", onSigterm);
-
-  pipeStdinToVm(vm.stdin, () => {
-    process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
-    forwardedSignal = "SIGTERM";
-    void vm.kill();
+function runRestoreAttachedSession(vm: VmHandle, quiet: QuietRunState): Promise<number> {
+  return runAttachedVmSession(vm, {
+    filter: quiet.filter,
+    buffer: quiet.buffer,
+    preReadyExitSummary: (code) =>
+      `restore ${quiet.headlineName} exited ${code} before reaching ready`,
   });
-
-  try {
-    const { code } = await vm.wait();
-    filter?.flush();
-    if (forwardedSignal === "SIGINT") {
-      return 130;
-    }
-    if (forwardedSignal === "SIGTERM") {
-      return 143;
-    }
-    if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
-      printDiagnostics(`restore ${headlineName} exited ${code} before reaching ready`, { buffer });
-    }
-    return code ?? 0;
-  } finally {
-    process.off("SIGINT", onSigint);
-    process.off("SIGTERM", onSigterm);
-    cancelHintRepeat();
-    restoreStdin();
-  }
 }
 
 async function cmdLs(args: string[]): Promise<number> {
@@ -873,62 +1064,111 @@ async function cmdLs(args: string[]): Promise<number> {
     die(`unknown argument: ${rest[0]}`);
   }
   const entries = list();
-  const rssByPid = readHostRssBytesMulti(
-    entries.map((e) => ({ pid: e.pid, statsPath: e.statsPath })),
-  );
+  const rssByPid = rssByRegistryPid(entries);
   if (json) {
-    emitJson({
-      schema_version: 1,
-      vms: entries.map((e) => ({
-        pid: e.pid,
-        name: e.name ?? null,
-        started_at: e.startedAt,
-        uptime_ms: Date.now() - e.startedAt,
-        memory: {
-          rss_bytes: rssByPid.get(e.pid) ?? null,
-          ceiling_mib: e.memoryCeilingMib ?? null,
-        },
-        ports: e.portForward ?? [],
-        forked_from: e.forkedFrom ?? null,
-      })),
-    });
-    return 0;
+    emitLsJson(entries, rssByPid);
+  } else {
+    printLsTable(entries, rssByPid);
   }
+  return 0;
+}
+
+function rssByRegistryPid(entries: RegistryEntry[]): Map<number, number> {
+  return readHostRssBytesMulti(
+    entries.map((entry) => ({ pid: entry.pid, statsPath: entry.statsPath })),
+  );
+}
+
+function emitLsJson(entries: RegistryEntry[], rssByPid: Map<number, number>): void {
+  emitJson({
+    schema_version: 1,
+    vms: entries.map((entry) => vmJson(entry, rssByPid)),
+  });
+}
+
+function vmJson(entry: RegistryEntry, rssByPid: Map<number, number>): unknown {
+  return {
+    pid: entry.pid,
+    name: nullable(entry.name),
+    started_at: entry.startedAt,
+    uptime_ms: Date.now() - entry.startedAt,
+    memory: vmMemoryJson(entry, rssByPid),
+    ports: portsJson(entry),
+    forked_from: nullable(entry.forkedFrom),
+  };
+}
+
+function portsJson(entry: RegistryEntry): NonNullable<RegistryEntry["portForward"]> {
+  if (entry.portForward === undefined) {
+    return [];
+  }
+  return entry.portForward;
+}
+
+function vmMemoryJson(entry: RegistryEntry, rssByPid: Map<number, number>): unknown {
+  return {
+    rss_bytes: nullable(rssByPid.get(entry.pid)),
+    ceiling_mib: nullable(entry.memoryCeilingMib),
+  };
+}
+
+function nullable<T>(value: T | undefined): T | null {
+  if (value === undefined) {
+    return null;
+  }
+  return value;
+}
+
+function printLsTable(entries: RegistryEntry[], rssByPid: Map<number, number>): void {
   if (entries.length === 0) {
     process.stdout.write("(no running VMs)\n");
-    return 0;
+    return;
   }
-  // Plain tabular output. PID is the runtime handle; NAME is the
-  // optional human label; MEM is `hostRss/ceiling` (#274); PORTS lists
-  // `<hostPort>:<guestPort>` pairs configured at boot/fork
-  // (comma-separated, `-` if none); FORKED-FROM lets you trace
-  // lineage when the VM was created via `machinen restore`.
   const header = ["PID", "NAME", "UP", "MEM", "PORTS", "FORKED-FROM"];
-  const rows = entries.map((e) => [
-    String(e.pid),
-    e.name ?? "-",
-    formatUptime(Date.now() - e.startedAt),
-    formatMem(rssByPid.get(e.pid) ?? null, e.memoryCeilingMib),
-    formatPorts(e.portForward),
-    e.forkedFrom ?? "-",
+  const rows = lsRows(entries, rssByPid);
+  const widths = tableWidths(header, rows);
+  const visible = visibleLsColumns(header, widths);
+  printTable(header, rows, widths, visible);
+}
+
+function lsRows(entries: RegistryEntry[], rssByPid: Map<number, number>): string[][] {
+  return entries.map((entry) => [
+    String(entry.pid),
+    entry.name ?? "-",
+    formatUptime(Date.now() - entry.startedAt),
+    formatMem(rssByPid.get(entry.pid) ?? null, entry.memoryCeilingMib),
+    formatPorts(entry.portForward),
+    entry.forkedFrom ?? "-",
   ]);
-  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
+}
+
+function tableWidths(header: string[], rows: string[][]): number[] {
+  return header.map((heading, index) =>
+    Math.max(heading.length, ...rows.map((row) => row[index]!.length)),
+  );
+}
+
+function visibleLsColumns(header: string[], widths: number[]): number[] {
   const gap = "  ";
-  const fullWidth = widths.reduce((sum, w) => sum + w, 0) + gap.length * (widths.length - 1);
+  const fullWidth =
+    widths.reduce((sum, width) => sum + width, 0) + gap.length * (widths.length - 1);
   // Hide MEM (column index 3) on terminals that can't fit the full
   // line. Pipes / non-TTY stdout report `process.stdout.columns`
   // undefined — keep the column there so scripts get a stable shape.
   const cols = process.stdout.columns;
   const includeMem = cols === undefined || fullWidth <= cols;
-  const visible = includeMem
-    ? header.map((_, i) => i)
-    : header.map((_, i) => i).filter((i) => i !== 3);
-  const line = (cells: string[]) => visible.map((i) => cells[i]!.padEnd(widths[i]!)).join(gap);
-  process.stdout.write(line(header) + "\n");
+  return includeMem ? header.map((_, i) => i) : header.map((_, i) => i).filter((i) => i !== 3);
+}
+
+function printTable(header: string[], rows: string[][], widths: number[], visible: number[]): void {
+  process.stdout.write(formatTableLine(header, widths, visible) + "\n");
   for (const row of rows) {
-    process.stdout.write(line(row) + "\n");
+    process.stdout.write(formatTableLine(row, widths, visible) + "\n");
   }
-  return 0;
+}
+
+function formatTableLine(cells: string[], widths: number[], visible: number[]): string {
+  return visible.map((index) => cells[index]!.padEnd(widths[index]!)).join("  ");
 }
 
 function formatUptime(ms: number): string {
@@ -953,42 +1193,67 @@ function formatUptime(ms: number): string {
 // exit hook can't run because the parent is gone (issue #150 phase 2
 // PR2).
 async function cmdGc(args: string[]): Promise<number> {
-  const { json, rest: afterJson } = consumeJsonFlag(args);
-  const { dryRun, rest } = consumeDryRunFlag(afterJson);
-  for (const a of rest) {
-    die(`unknown flag: ${a}`);
-  }
+  const { json, dryRun, rest } = parseGcOptions(args);
+  dieOnUnexpectedArgs(rest);
   const results = runGc({ dryRun });
   if (json) {
-    emitJson({
-      schema_version: 1,
-      dry_run: dryRun,
-      results: results.map((r) => ({
-        pid: r.pid,
-        name: r.name ?? null,
-        status: r.status,
-        removed_paths: r.removedPaths,
-        failed_paths: r.failedPaths,
-      })),
-    });
-    return 0;
-  }
-  if (results.length === 0) {
-    process.stdout.write("(nothing to clean up)\n");
-    return 0;
-  }
-  for (const r of results) {
-    const label = r.name ? `${r.name} (pid ${r.pid})` : `pid ${r.pid}`;
-    const verb = dryRun ? "would clean" : "cleaned";
-    process.stdout.write(`${verb} ${label} [${r.status}]: ${r.removedPaths.length} path(s)\n`);
-    for (const p of r.removedPaths) {
-      process.stdout.write(`  ${p}\n`);
-    }
-    for (const p of r.failedPaths) {
-      process.stdout.write(`  failed: ${p}\n`);
-    }
+    emitGcJson(dryRun, results);
+  } else {
+    printGcResults(results, dryRun);
   }
   return 0;
+}
+
+function parseGcOptions(args: string[]): { json: boolean; dryRun: boolean; rest: string[] } {
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  const { dryRun, rest } = consumeDryRunFlag(afterJson);
+  return { json, dryRun, rest };
+}
+
+function dieOnUnexpectedArgs(args: string[]): void {
+  for (const arg of args) {
+    die(`unknown flag: ${arg}`);
+  }
+}
+
+function emitGcJson(dryRun: boolean, results: ReturnType<typeof runGc>): void {
+  emitJson({
+    schema_version: 1,
+    dry_run: dryRun,
+    results: results.map((r) => ({
+      pid: r.pid,
+      name: r.name ?? null,
+      status: r.status,
+      removed_paths: r.removedPaths,
+      failed_paths: r.failedPaths,
+    })),
+  });
+}
+
+function printGcResults(results: ReturnType<typeof runGc>, dryRun: boolean): void {
+  if (results.length === 0) {
+    process.stdout.write("(nothing to clean up)\n");
+    return;
+  }
+  for (const result of results) {
+    printGcResult(result, dryRun);
+  }
+}
+
+function printGcResult(result: ReturnType<typeof runGc>[number], dryRun: boolean): void {
+  const label = result.name ? `${result.name} (pid ${result.pid})` : `pid ${result.pid}`;
+  const verb = dryRun ? "would clean" : "cleaned";
+  process.stdout.write(
+    `${verb} ${label} [${result.status}]: ${result.removedPaths.length} path(s)\n`,
+  );
+  printIndentedPaths(result.removedPaths, "");
+  printIndentedPaths(result.failedPaths, "failed: ");
+}
+
+function printIndentedPaths(paths: string[], prefix: string): void {
+  for (const path of paths) {
+    process.stdout.write(`  ${prefix}${path}\n`);
+  }
 }
 
 // `machinen stop <name|pid>` — SIGTERM the VMM, escalate to SIGKILL
@@ -996,146 +1261,265 @@ async function cmdGc(args: string[]): Promise<number> {
 // problem: the CLI no longer holds the VMM, so a separate `stop`
 // command is the only way to ask for a clean shutdown.
 async function cmdStop(args: string[]): Promise<number> {
-  const { json, rest: afterJson } = consumeJsonFlag(args);
-  const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
-  let force = false;
-  const rest: string[] = [];
-  for (const a of afterDry) {
-    if (a === "--force" || a === "-9") {
-      force = true;
-    } else {
-      rest.push(a);
-    }
-  }
-  const target = parseTargetFlags(rest, "stop");
-  const entry = lookupEntry(target);
+  const opts = parseStopOptions(args);
+  const entry = lookupEntry(opts.target);
   if (!entry) {
-    if (json) {
-      emitJsonError("VM_NOT_FOUND", `no running VM matched ${describeTarget(target)}`);
-    } else {
-      process.stderr.write(`machinen stop: no running VM matched ${describeTarget(target)}\n`);
-    }
+    reportStopMissingTarget(opts);
     return 1;
   }
-  const emitStop = (status: "stopped" | "would_stop" | "already_dead" | "recycled"): void => {
-    if (json) {
-      emitJson({
-        schema_version: 1,
-        pid: entry.pid,
-        name: entry.name ?? null,
-        status,
-        dry_run: dryRun,
-      });
+  return stopExistingEntry(entry, opts);
+}
+
+async function stopExistingEntry(entry: RegistryEntry, opts: StopOptions): Promise<number> {
+  const status = validateStopEntry(entry);
+  if (await handleInactiveStopEntry(entry, status, opts)) {
+    return 0;
+  }
+  if (opts.dryRun) {
+    reportStopDryRun(entry, opts);
+    return 0;
+  }
+  return stopLiveEntry(entry, opts);
+}
+
+async function stopLiveEntry(entry: RegistryEntry, opts: StopOptions): Promise<number> {
+  const sig = stopSignal(opts.force);
+  if (!signalStopProcess(entry.pid, sig, opts, "STOP_KILL_FAILED")) {
+    return 1;
+  }
+  await escalateIfNeeded(entry.pid, opts.force);
+  await stopGvproxy(entry, sig, opts.force);
+  finishStoppedEntry(entry, opts);
+  return 0;
+}
+
+type StopStatus = "stopped" | "would_stop" | "already_dead" | "recycled";
+
+interface StopOptions {
+  json: boolean;
+  dryRun: boolean;
+  force: boolean;
+  target: Target;
+}
+
+function parseStopOptions(args: string[]): StopOptions {
+  const { json, rest: afterJson } = consumeJsonFlag(args);
+  const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
+  const { force, rest } = consumeForceFlag(afterDry);
+  return { json, dryRun, force, target: parseTargetFlags(rest, "stop") };
+}
+
+function consumeForceFlag(args: string[]): { force: boolean; rest: string[] } {
+  const rest: string[] = [];
+  let force = false;
+  for (const arg of args) {
+    if (arg === "--force" || arg === "-9") {
+      force = true;
+    } else {
+      rest.push(arg);
     }
-  };
+  }
+  return { force, rest };
+}
+
+function reportStopMissingTarget(opts: StopOptions): void {
+  const message = `no running VM matched ${describeTarget(opts.target)}`;
+  if (opts.json) {
+    emitJsonError("VM_NOT_FOUND", message);
+  } else {
+    process.stderr.write(`machinen stop: ${message}\n`);
+  }
+}
+
+function emitStop(entry: RegistryEntry, opts: StopOptions, status: StopStatus): void {
+  if (!opts.json) {
+    return;
+  }
+  emitJson({
+    schema_version: 1,
+    pid: entry.pid,
+    name: entry.name ?? null,
+    status,
+    dry_run: opts.dryRun,
+  });
+}
+
+function validateStopEntry(entry: RegistryEntry) {
   // Pid-validate before signalling — refuses to kill a recycled pid.
-  const status = validatePid(entry.pid, {
+  return validatePid(entry.pid, {
     vmmExe: entry.vmmExe,
     startedAt: entry.startedAt,
   });
+}
+
+async function handleInactiveStopEntry(
+  entry: RegistryEntry,
+  status: ReturnType<typeof validateStopEntry>,
+  opts: StopOptions,
+): Promise<boolean> {
   if (status === "recycled") {
-    if (!json) {
-      process.stderr.write(
-        `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
-          (dryRun ? "would skip kill and gc.\n" : "skipping kill and running gc.\n"),
-      );
-    }
-    if (!dryRun) {
-      runGc({ pid: entry.pid });
-    }
-    emitStop("recycled");
-    return 0;
+    reportRecycledStopEntry(entry, opts);
+    gcStoppedEntry(entry, opts.dryRun);
+    emitStop(entry, opts, "recycled");
+    return true;
   }
   if (status === "dead") {
-    if (!json) {
-      process.stderr.write(
-        `machinen stop: pid ${entry.pid} already gone; ` +
-          (dryRun ? "would gc.\n" : "running gc.\n"),
-      );
-    }
-    if (!dryRun) {
-      runGc({ pid: entry.pid });
-    }
-    emitStop("already_dead");
-    return 0;
+    reportDeadStopEntry(entry, opts);
+    gcStoppedEntry(entry, opts.dryRun);
+    emitStop(entry, opts, "already_dead");
+    return true;
   }
-  if (dryRun) {
-    if (!json) {
-      const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-      const sigLabel = force ? "SIGKILL" : "SIGTERM (escalates to SIGKILL after 2s)";
-      process.stdout.write(`would ${sigLabel} ${label}\n`);
-    }
-    emitStop("would_stop");
-    return 0;
+  return false;
+}
+
+function reportRecycledStopEntry(entry: RegistryEntry, opts: StopOptions): void {
+  if (opts.json) {
+    return;
   }
-  const sig = force ? "SIGKILL" : "SIGTERM";
+  process.stderr.write(
+    `machinen stop: registry entry pid ${entry.pid} is now held by an unrelated process; ` +
+      (opts.dryRun ? "would skip kill and gc.\n" : "skipping kill and running gc.\n"),
+  );
+}
+
+function reportDeadStopEntry(entry: RegistryEntry, opts: StopOptions): void {
+  if (opts.json) {
+    return;
+  }
+  process.stderr.write(
+    `machinen stop: pid ${entry.pid} already gone; ` +
+      (opts.dryRun ? "would gc.\n" : "running gc.\n"),
+  );
+}
+
+function gcStoppedEntry(entry: RegistryEntry, dryRun: boolean): void {
+  if (!dryRun) {
+    runGc({ pid: entry.pid });
+  }
+}
+
+function reportStopDryRun(entry: RegistryEntry, opts: StopOptions): void {
+  if (!opts.json) {
+    const sigLabel = opts.force ? "SIGKILL" : "SIGTERM (escalates to SIGKILL after 2s)";
+    process.stdout.write(`would ${sigLabel} ${entryLabel(entry)}\n`);
+  }
+  emitStop(entry, opts, "would_stop");
+}
+
+function stopSignal(force: boolean): NodeJS.Signals {
+  return force ? "SIGKILL" : "SIGTERM";
+}
+
+function signalStopProcess(
+  pid: number,
+  signal: NodeJS.Signals,
+  opts: Pick<StopOptions, "json">,
+  errorCode: string,
+): boolean {
   try {
-    process.kill(entry.pid, sig);
+    process.kill(pid, signal);
+    return true;
   } catch (err) {
-    const msg = `failed to signal pid ${entry.pid}: ${err instanceof Error ? err.message : String(err)}`;
-    if (json) {
-      emitJsonError("STOP_KILL_FAILED", msg);
-    } else {
-      process.stderr.write(`machinen stop: ${msg}\n`);
-    }
-    return 1;
+    reportStopSignalError(pid, err, opts, errorCode);
+    return false;
   }
-  if (!force) {
-    await waitForExit(entry.pid, 2_000);
-    try {
-      process.kill(entry.pid, 0);
-      // Still alive — escalate.
-      try {
-        process.kill(entry.pid, "SIGKILL");
-      } catch {}
-    } catch {
-      // Already gone.
-    }
+}
+
+function reportStopSignalError(
+  pid: number,
+  err: unknown,
+  opts: Pick<StopOptions, "json">,
+  errorCode: string,
+): void {
+  const msg = `failed to signal pid ${pid}: ${describeError(err)}`;
+  if (opts.json) {
+    emitJsonError(errorCode, msg);
+  } else {
+    process.stderr.write(`machinen stop: ${msg}\n`);
   }
+}
+
+async function escalateIfNeeded(pid: number, force: boolean): Promise<void> {
+  if (force) {
+    return;
+  }
+  await waitForExit(pid, 2_000);
+  if (pidIsAlive(pid)) {
+    tryKill(pid, "SIGKILL");
+  }
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryKill(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch {}
+}
+
+async function stopGvproxy(
+  entry: RegistryEntry,
+  signal: NodeJS.Signals,
+  force: boolean,
+): Promise<void> {
   // #150 phase 2 PR3: signal gvproxy too. Detached gvproxy survives
   // the parent's exit on its own (no pdeathsig); without this it'd
   // outlive every `machinen stop`, holding host ports and leaking
   // the qemu/control sockets. Anti-recycling guard mirrors the VMM
-  // path — basename match against the recorded gvproxy binary, so
-  // an unrelated pid that inherited gvproxy's slot weeks later
-  // doesn't get killed. Wait for it to exit so the test/user can
-  // assume "stop returned → process is gone" without a follow-up
-  // poll.
-  if (entry.gvproxyPid && entry.gvproxyExe) {
-    const gvStatus = validatePid(entry.gvproxyPid, { vmmExe: entry.gvproxyExe });
-    if (gvStatus === "alive") {
-      try {
-        process.kill(entry.gvproxyPid, sig);
-      } catch (err) {
-        process.stderr.write(
-          `machinen stop: failed to signal gvproxy pid ${entry.gvproxyPid}: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      }
-      if (!force) {
-        await waitForExit(entry.gvproxyPid, 2_000);
-        try {
-          process.kill(entry.gvproxyPid, 0);
-          try {
-            process.kill(entry.gvproxyPid, "SIGKILL");
-          } catch {}
-        } catch {}
-      }
-    } else if (gvStatus === "recycled") {
-      process.stderr.write(
-        `machinen stop: gvproxy pid ${entry.gvproxyPid} now held by an unrelated process; skipping.\n`,
-      );
-    }
+  // path — basename match against the recorded gvproxy binary.
+  if (!entry.gvproxyPid || !entry.gvproxyExe) {
+    return;
   }
+  await handleGvproxyStatus(
+    entry.gvproxyPid,
+    validatePid(entry.gvproxyPid, { vmmExe: entry.gvproxyExe }),
+    signal,
+    force,
+  );
+}
+
+async function handleGvproxyStatus(
+  pid: number,
+  status: ReturnType<typeof validatePid>,
+  signal: NodeJS.Signals,
+  force: boolean,
+): Promise<void> {
+  if (status === "alive") {
+    await signalGvproxy(pid, signal, force);
+  } else if (status === "recycled") {
+    process.stderr.write(
+      `machinen stop: gvproxy pid ${pid} now held by an unrelated process; skipping.\n`,
+    );
+  }
+}
+
+async function signalGvproxy(pid: number, signal: NodeJS.Signals, force: boolean): Promise<void> {
+  if (!signalStopProcess(pid, signal, { json: false }, "STOP_GVPROXY_KILL_FAILED")) {
+    return;
+  }
+  await escalateIfNeeded(pid, force);
+}
+
+function finishStoppedEntry(entry: RegistryEntry, opts: StopOptions): void {
   // Final gc to drop the registry entry + cleanupPaths (including the
   // gvproxy socket dir that PR3 added to the cleanup list).
   runGc({ pid: entry.pid });
-  if (json) {
-    emitStop("stopped");
+  if (opts.json) {
+    emitStop(entry, opts, "stopped");
   } else {
-    const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-    process.stdout.write(`stopped ${label}\n`);
+    process.stdout.write(`stopped ${entryLabel(entry)}\n`);
   }
-  return 0;
+}
+
+function entryLabel(entry: RegistryEntry): string {
+  return entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
 }
 
 /**
@@ -1156,15 +1540,17 @@ async function waitForExit(pid: number, timeoutMs: number): Promise<void> {
 }
 
 function lookupEntry(target: { name: string } | { pid: number }): RegistryEntry | undefined {
-  for (const e of list()) {
-    if ("name" in target && e.name === target.name) {
-      return e;
-    }
-    if ("pid" in target && e.pid === target.pid) {
-      return e;
-    }
+  return list().find((entry) => entryMatchesTarget(entry, target));
+}
+
+function entryMatchesTarget(
+  entry: RegistryEntry,
+  target: { name: string } | { pid: number },
+): boolean {
+  if ("name" in target) {
+    return entry.name === target.name;
   }
-  return undefined;
+  return entry.pid === target.pid;
 }
 
 function describeTarget(target: { name: string } | { pid: number }): string {
@@ -1172,58 +1558,75 @@ function describeTarget(target: { name: string } | { pid: number }): string {
 }
 
 async function cmdExec(args: string[]): Promise<number> {
-  // Pull --tty out before the `--` boundary so it isn't passed to the
-  // workload. Auto-enable when stdin is a TTY and no --tty was passed
-  // explicitly is *not* what we want — `machinen exec foo --
-  // ps aux` from a terminal should still be one-shot pipes, otherwise
-  // every output gets line-discipline-translated. Caller opts in.
-  let usePty = false;
-  const filtered: string[] = [];
-  for (const a of args) {
-    if (a === "--tty" || a === "--pty") {
-      usePty = true;
-    } else {
-      filtered.push(a);
-    }
-  }
-  const dashIdx = filtered.indexOf("--");
-  if (dashIdx === -1 || dashIdx === filtered.length - 1) {
-    die("usage: machinen exec <name|pid> [--tty] -- <cmd>");
-  }
-  const pre = filtered.slice(0, dashIdx);
-  const cmdArgs = filtered.slice(dashIdx + 1);
-  const target = parseTargetFlags(pre, "exec");
-  const vm = await attach(target).catch(handleError);
+  const parsed = parseExecArgs(args);
+  const vm = await attach(parsed.target).catch(handleError);
   try {
-    // Shell out via `sh -c` on the guest so caller can pass piped
-    // commands naturally. Users who want raw exec of a single binary
-    // can quote it like `machinen exec foo -- /bin/ls`.
-    const joined = cmdArgs.join(" ");
-    if (usePty) {
-      if (!process.stdin.isTTY) {
-        die("machinen exec --tty: stdin is not a TTY; pass via terminal or drop --tty");
-      }
-      return await runPtyExec(vm, joined);
-    }
-    const res = await vm.execRaw(joined, {
-      onStdout: (chunk) => process.stdout.write(chunk),
-      onStderr: (chunk) => process.stderr.write(chunk),
-    });
-    return res.exitCode;
+    return await runExecCommand(vm, parsed);
   } finally {
     await vm.detach();
   }
 }
 
-async function runPtyExec(
-  vm: {
-    execPty: (
-      cmd: string,
-      opts: import("@machinen/runtime").VsockExecPtyOptions,
-    ) => import("@machinen/runtime").VsockExecPtyHandle;
-  },
-  cmd: string,
-): Promise<number> {
+interface ParsedExecArgs {
+  target: Target;
+  cmd: string;
+  usePty: boolean;
+}
+
+function parseExecArgs(args: string[]): ParsedExecArgs {
+  const { usePty, filtered } = consumeExecPtyFlag(args);
+  const dashIdx = filtered.indexOf("--");
+  if (dashIdx === -1 || dashIdx === filtered.length - 1) {
+    die("usage: machinen exec <name|pid> [--tty] -- <cmd>");
+  }
+  return {
+    usePty,
+    target: parseTargetFlags(filtered.slice(0, dashIdx), "exec"),
+    cmd: filtered.slice(dashIdx + 1).join(" "),
+  };
+}
+
+function consumeExecPtyFlag(args: string[]): { usePty: boolean; filtered: string[] } {
+  // Pull --tty out before the `--` boundary so it isn't passed to the
+  // workload. Caller opts into line-discipline translation explicitly.
+  const filtered: string[] = [];
+  let usePty = false;
+  for (const arg of args) {
+    if (arg === "--tty" || arg === "--pty") {
+      usePty = true;
+    } else {
+      filtered.push(arg);
+    }
+  }
+  return { usePty, filtered };
+}
+
+async function runExecCommand(vm: VmHandle, parsed: ParsedExecArgs): Promise<number> {
+  if (parsed.usePty) {
+    assertExecPtyTty();
+    return runPtyExec(vm, parsed.cmd);
+  }
+  return runRawExec(vm, parsed.cmd);
+}
+
+function assertExecPtyTty(): void {
+  if (!process.stdin.isTTY) {
+    die("machinen exec --tty: stdin is not a TTY; pass via terminal or drop --tty");
+  }
+}
+
+async function runRawExec(vm: VmHandle, cmd: string): Promise<number> {
+  // Shell out via `sh -c` on the guest so caller can pass piped
+  // commands naturally. Users who want raw exec of a single binary
+  // can quote it like `machinen exec foo -- /bin/ls`.
+  const res = await vm.execRaw(cmd, {
+    onStdout: (chunk) => process.stdout.write(chunk),
+    onStderr: (chunk) => process.stderr.write(chunk),
+  });
+  return res.exitCode;
+}
+
+async function runPtyExec(vm: VmHandle, cmd: string): Promise<number> {
   // PTY mode (#133): bidirectional bytes between this terminal and a
   // guest pseudoterminal. Flip stdin to raw so Ctrl-C, arrows, and
   // function keys reach the guest as untranslated bytes; restore on
@@ -1231,452 +1634,588 @@ async function runPtyExec(
   // Caller is responsible for asserting stdin is a TTY (the right
   // error message depends on whether you got here via `attach` or
   // `exec --tty`).
-  const stdin = process.stdin;
-  const stdout = process.stdout;
-  const initialCols = stdout.columns ?? 80;
-  const initialRows = stdout.rows ?? 24;
-
-  const wasRaw = stdin.isRaw === true;
-  stdin.setRawMode(true);
-  stdin.resume();
-
+  const tty = enterPtyRawMode();
   const handle = vm.execPty(cmd, {
-    cols: initialCols,
-    rows: initialRows,
-    stdin,
-    stdout,
+    cols: tty.cols,
+    rows: tty.rows,
+    stdin: process.stdin,
+    stdout: process.stdout,
   });
-
-  const onResize = () => {
-    handle.resize(stdout.columns ?? initialCols, stdout.rows ?? initialRows);
-  };
-  stdout.on("resize", onResize);
-
+  const onResize = () =>
+    handle.resize(process.stdout.columns ?? tty.cols, process.stdout.rows ?? tty.rows);
+  process.stdout.on("resize", onResize);
   try {
     const { exitCode } = await handle.result;
     return exitCode;
   } finally {
-    stdout.removeListener("resize", onResize);
-    if (!wasRaw) {
-      try {
-        stdin.setRawMode(false);
-      } catch {
-        // Already restored or stream destroyed; ignore.
-      }
-    }
-    // Don't .pause() — the parent process will exit shortly.
+    process.stdout.removeListener("resize", onResize);
+    tty.restore();
+  }
+}
+
+function enterPtyRawMode(): { cols: number; rows: number; restore: () => void } {
+  const wasRaw = process.stdin.isRaw === true;
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  return {
+    cols: process.stdout.columns ?? 80,
+    rows: process.stdout.rows ?? 24,
+    restore: () => restorePtyRawMode(wasRaw),
+  };
+}
+
+function restorePtyRawMode(wasRaw: boolean): void {
+  if (wasRaw) {
+    return;
+  }
+  try {
+    process.stdin.setRawMode(false);
+  } catch {
+    // Already restored or stream destroyed; ignore.
   }
 }
 
 async function cmdSnapshot(args: string[]): Promise<number> {
+  const opts = parseSnapshotOptions(args);
+  if (opts.dryRun) {
+    return snapshotDryRun(opts);
+  }
+  return runSnapshot(opts);
+}
+
+interface SnapshotOptionsCli {
+  json: boolean;
+  dryRun: boolean;
+  keepAlive: boolean;
+  target: Target;
+  outDir: string;
+  resolvedOutDir: string;
+}
+
+function parseSnapshotOptions(args: string[]): SnapshotOptionsCli {
   // Form: `machinen snapshot <target> <out-dir>`. We strip --json /
   // --dry-run / --keep-alive first; the first two positionals left
   // are the target and the out-dir.
   const { json, rest: afterJson } = consumeJsonFlag(args);
   const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
+  const { keepAlive, rest } = consumeKeepAliveFlag(afterDry);
+  const { target, rest: afterTarget } = resolveTarget(rest, "snapshot");
+  const outDir = parseSnapshotOutDir(afterTarget);
+  return { json, dryRun, keepAlive, target, outDir, resolvedOutDir: resolve(outDir) };
+}
+
+function consumeKeepAliveFlag(args: string[]): { keepAlive: boolean; rest: string[] } {
+  const rest: string[] = [];
   let keepAlive = false;
-  const remaining: string[] = [];
-  for (const a of afterDry) {
-    if (a === "--keep-alive") {
-      // Source survives the dump (CRIU --leave-running). Default
-      // closes inherited TCP sockets — two live copies sharing the
-      // same connection state can't both talk to the peer cleanly.
+  for (const arg of args) {
+    if (arg === "--keep-alive") {
       keepAlive = true;
     } else {
-      remaining.push(a);
+      rest.push(arg);
     }
   }
-  const { target, rest: afterTarget } = resolveTarget(remaining, "snapshot");
-  if (afterTarget.length === 0) {
+  return { keepAlive, rest };
+}
+
+function parseSnapshotOutDir(args: string[]): string {
+  if (args.length === 0) {
     die("usage: machinen snapshot <name|pid> <out-dir> [--keep-alive] [--dry-run] [--json]");
   }
-  if (afterTarget.length > 1) {
-    die(`unknown argument: ${afterTarget[1]}`);
+  if (args.length > 1) {
+    die(`unknown argument: ${args[1]}`);
   }
-  const outDir = afterTarget[0]!;
-  const resolvedOutDir = resolve(outDir);
-  if (dryRun) {
-    // Validate target exists + out-dir is creatable (parent must exist
-    // and be writable). Don't actually freeze the source.
-    const entry = lookupEntry(target);
-    if (!entry) {
-      const msg = `no running VM matched ${describeTarget(target)}`;
-      if (json) {
-        emitJsonError("VM_NOT_FOUND", msg);
-      } else {
-        process.stderr.write(`machinen snapshot: ${msg}\n`);
-      }
-      return 1;
-    }
-    if (json) {
-      emitJson({
-        schema_version: 1,
-        snap_dir: resolvedOutDir,
-        elapsed_ms: 0,
-        dry_run: true,
-      });
-    } else {
-      const label = entry.name ? `${entry.name} (pid ${entry.pid})` : `pid ${entry.pid}`;
-      process.stdout.write(
-        `would snapshot ${label} → ${resolvedOutDir}` + (keepAlive ? " (--keep-alive)\n" : "\n"),
-      );
-    }
-    return 0;
+  return args[0]!;
+}
+
+function snapshotDryRun(opts: SnapshotOptionsCli): number {
+  // Validate target exists + out-dir is creatable (parent must exist
+  // and be writable). Don't actually freeze the source.
+  const entry = lookupEntry(opts.target);
+  if (!entry) {
+    reportSnapshotMissingTarget(opts);
+    return 1;
   }
-  const vm = await attach(target).catch(handleError);
-  // #286: quiet snapshot UX. Snapshot's onLog stream is the CRIU
-  // dump-side chatter (machinen-dump.sh + criu's per-phase
-  // progress); buffer it under the diagnostics envelope, surface
-  // only the final "snapshot: <dir>" line on success.
-  const snapHeadlineName = vm.name ?? `pid ${vm.pid}`;
-  const showHeadlines = isQuiet() && !json;
-  const buffer = new RingBuffer();
-  if (showHeadlines) {
-    printHeadline(`snapshotting ${snapHeadlineName}…`);
+  reportSnapshotDryRun(entry, opts);
+  return 0;
+}
+
+function reportSnapshotMissingTarget(opts: SnapshotOptionsCli): void {
+  const msg = `no running VM matched ${describeTarget(opts.target)}`;
+  if (opts.json) {
+    emitJsonError("VM_NOT_FOUND", msg);
+  } else {
+    process.stderr.write(`machinen snapshot: ${msg}\n`);
   }
+}
+
+function reportSnapshotDryRun(entry: RegistryEntry, opts: SnapshotOptionsCli): void {
+  if (opts.json) {
+    emitSnapshotJson(opts.resolvedOutDir, 0, true);
+    return;
+  }
+  const suffix = opts.keepAlive ? " (--keep-alive)\n" : "\n";
+  process.stdout.write(`would snapshot ${entryLabel(entry)} → ${opts.resolvedOutDir}${suffix}`);
+}
+
+async function runSnapshot(opts: SnapshotOptionsCli): Promise<number> {
+  const vm = await attach(opts.target).catch(handleError);
+  const quiet = createSnapshotQuietState(vm, opts);
   try {
     const res = await vm.snapshot({
-      outDir: resolvedOutDir,
-      leaveRunning: keepAlive,
-      tcpClose: keepAlive,
-      onLog: (evt) => {
-        if (evt.source === "phase") {
-          return;
-        }
-        if (showHeadlines) {
-          buffer.push(evt.chunk);
-        } else {
-          process.stderr.write(evt.chunk);
-        }
-      },
+      outDir: opts.resolvedOutDir,
+      leaveRunning: opts.keepAlive,
+      tcpClose: opts.keepAlive,
+      onLog: snapshotOnLog(quiet),
     });
-    if (json) {
-      emitJson({
-        schema_version: 1,
-        snap_dir: res.snapDir,
-        elapsed_ms: res.elapsedMs,
-        dry_run: false,
-      });
-    } else {
-      process.stdout.write(`snapshot: ${res.snapDir} (${res.elapsedMs}ms)\n`);
-    }
+    reportSnapshotSuccess(res.snapDir, res.elapsedMs, opts);
     return 0;
   } catch (err) {
-    if (showHeadlines) {
-      failQuiet(`snapshot ${snapHeadlineName} failed: ${describeError(err)}`, {
-        buffer,
-      });
+    handleSnapshotFailure(err, quiet);
+  } finally {
+    await vm.detach();
+  }
+}
+
+function createSnapshotQuietState(vm: VmHandle, opts: SnapshotOptionsCli): QuietRunState {
+  // #286: quiet snapshot UX. Snapshot's onLog stream is the CRIU
+  // dump-side chatter (machinen-dump.sh + criu's per-phase progress).
+  const headlineName = vm.name ?? `pid ${vm.pid}`;
+  const showHeadlines = isQuiet() && !opts.json;
+  const buffer = new RingBuffer();
+  if (showHeadlines) {
+    printHeadline(`snapshotting ${headlineName}…`);
+  }
+  return { headlineName, showHeadlines, buffer, filter: null, filterOut: null };
+}
+
+function snapshotOnLog(quiet: QuietRunState): (evt: LogEvent) => void {
+  return (evt) => {
+    if (evt.source === "phase") {
+      return;
     }
+    if (quiet.showHeadlines) {
+      quiet.buffer.push(evt.chunk);
+    } else {
+      process.stderr.write(evt.chunk);
+    }
+  };
+}
+
+function reportSnapshotSuccess(snapDir: string, elapsedMs: number, opts: SnapshotOptionsCli): void {
+  if (opts.json) {
+    emitSnapshotJson(snapDir, elapsedMs, false);
+    return;
+  }
+  process.stdout.write(`snapshot: ${snapDir} (${elapsedMs}ms)\n`);
+}
+
+function emitSnapshotJson(snapDir: string, elapsedMs: number, dryRun: boolean): void {
+  emitJson({ schema_version: 1, snap_dir: snapDir, elapsed_ms: elapsedMs, dry_run: dryRun });
+}
+
+function handleSnapshotFailure(err: unknown, quiet: QuietRunState): never {
+  if (quiet.showHeadlines) {
+    failQuiet(`snapshot ${quiet.headlineName} failed: ${describeError(err)}`, {
+      buffer: quiet.buffer,
+    });
+  }
+  handleError(err);
+}
+
+type ParsedForkCommandArgs = ReturnType<typeof parseForkArgs>;
+
+async function cmdFork(args: string[]): Promise<number> {
+  const opts = await prepareForkCommand(args);
+  const vm = await attach(opts.target).catch(handleError);
+  try {
+    const fork = await startForkVm(vm, opts);
+    reportForkStarted(fork, opts);
+    if (opts.parsed.detach) {
+      return detachFork(fork, opts);
+    }
+    return runForkAttachedSession(fork, opts.quiet);
+  } catch (err) {
     handleError(err);
   } finally {
     await vm.detach();
   }
 }
 
-async function cmdFork(args: string[]): Promise<number> {
-  // `machinen fork ( --name <src> | --pid <pid> ) [--new-name <dst>]
-  //                [--out-dir <dir>] [--tcp-keep] [--detach]
-  //                [-p ...] [--mount ...] [--mount-live ...]
-  //                [--env KEY=VALUE]... [--cwd <abs>] [--memory <mib>]`.
-  //
-  // Snapshots the source live (--leave-running), restores into a
-  // sibling, and by default attaches the fork's console to host
-  // stdio so the user lands inside the new VM (same shape as
-  // `machinen restore`). `--detach` keeps the fire-and-forget shape
-  // (CI / scripted workflows): print identity, hand off, return.
-  // Source keeps running either way.
-  //
-  // The boot-shaped flags (`--mount`, `--mount-live`, `--env`, `--cwd`,
-  // `--memory`) take effect on the *forked* sibling, not the source.
-  // Fork = snapshot + restore, so anything you can pass to `boot` /
-  // `restore` works here too.
-  // --json is a top-level convention; pull it out before the fork
-  // parser so it doesn't end up in `rest` and trip parseTargetFlags.
-  const { json, rest: forkArgs } = consumeJsonFlag(args);
-  let parsed;
+interface ForkCommandOptions {
+  json: boolean;
+  target: Target;
+  parsed: ParsedForkCommandArgs;
+  paths: CliBaseAssetPaths;
+  resolvedOutDir: string;
+  quiet: QuietRunState;
+}
+
+async function prepareForkCommand(args: string[]): Promise<ForkCommandOptions> {
+  const { json, rest } = consumeJsonFlag(args);
+  const parsed = parseForkCommandArgs(rest);
+  const target = parseTargetFlags(parsed.rest, "fork");
+  validateForkCommand(json, parsed);
+  const paths = await resolveCliBaseAssets();
+  const resolvedOutDir = resolveForkOutDir(parsed.outDir);
+  return {
+    json,
+    target,
+    parsed,
+    paths,
+    resolvedOutDir,
+    quiet: createForkQuietState(json, parsed, target),
+  };
+}
+
+function parseForkCommandArgs(args: string[]): ParsedForkCommandArgs {
   try {
-    parsed = parseForkArgs(forkArgs);
+    return parseForkArgs(args);
   } catch (err) {
     handleError(err);
   }
-  const {
-    newName,
-    outDir,
-    tcpKeep,
-    detach,
-    lazy,
-    portForward,
-    mount,
-    liveMounts,
-    env,
-    guestCwd,
-    memory,
-    rest,
-  } = parsed;
-  const target = parseTargetFlags(rest, "fork");
-  if (json && !detach) {
+}
+
+function validateForkCommand(json: boolean, parsed: ParsedForkCommandArgs): void {
+  if (json && !parsed.detach) {
     die("fork --json is only meaningful with --detach (attached forks take over stdio).");
   }
+}
 
-  // The fork is a fresh restore boot, so it needs the same base
-  // assets `cmdRestore` resolves (kernel + dtb + rootfs in the
-  // initramfs for /sbin/machinen-restore + criu).
-  const assetsOverride = process.env.MACHINEN_ASSETS_DIR;
-  if (assetsOverride) {
-    validateAssetsDir(assetsOverride);
-  } else if (!baseAssetsComplete(RELEASE_TAG)) {
-    process.stderr.write(`machinen: fetching base assets for ${RELEASE_TAG} (first run)\n`);
-    await ensureBaseAssets(RELEASE_TAG);
-  }
-  const spec = baseAssetSpec();
-  const baseDir = assetsOverride
-    ? resolve(assetsOverride)
-    : baseDirFor(RELEASE_TAG, "debian", spec.cpu);
-  const kernelPath = join(baseDir, assetsOverride ? spec.kernelAsset : "Image");
-  const dtbPath = spec.dtbAsset
-    ? join(baseDir, assetsOverride ? spec.dtbAsset : "virt.dtb")
-    : undefined;
-  const imagePath = join(baseDir, assetsOverride ? spec.rootfsAsset : "rootfs.tar.gz");
-
+function resolveForkOutDir(outDir: string | undefined): string {
   // The runtime's ephemeral-bundle cleanup hangs off `fork.wait()`,
   // which the CLI can't await — `cmdFork` returns as soon as the
   // fork is registered. So the CLI always materializes an explicit
   // outDir (caller-supplied or a temp dir we print) and skips the
-  // runtime's ephemeral mode. When --out-dir was omitted the user
-  // is responsible for `rm -rf`-ing the printed path.
-  const resolvedOutDir = outDir ? resolve(outDir) : mkdtempSync(join(tmpdir(), "machinen-fork-"));
-  const vm = await attach(target).catch(handleError);
-  // #286: quiet fork UX. The fork path is snapshot+restore back to
-  // back, so it's the noisiest of the three — both the source-side
-  // CRIU dump chunks and the restore-side guest console land on the
-  // same onLog. Buffer them; on failure dump under the diagnostics
-  // envelope so the user has something to read.
-  const sourceLabel = "name" in target ? target.name : `pid ${target.pid}`;
-  const forkHeadlineName = newName ?? sourceLabel;
-  const showHeadlines = isQuiet() && !(detach && json);
-  const forkT0 = Date.now();
-  const buffer = new RingBuffer();
-  let filter: NoiseFilter | null = null;
-  if (showHeadlines) {
-    printHeadline(`forking ${sourceLabel} → ${forkHeadlineName}…`);
-    if (!detach) {
-      filter = new NoiseFilter({
-        buffer,
-        out: process.stderr,
-        onReady: () => {
-          printHeadline(`fork ready in ${formatElapsed(Date.now() - forkT0)}`);
-        },
-      });
-    }
+  // runtime's ephemeral mode.
+  if (outDir) {
+    return resolve(outDir);
   }
-  const onLog = filter
-    ? (evt: LogEvent) => {
-        if (evt.source === "guest-console") {
-          filter!.push(evt.chunk);
-        }
-      }
-    : showHeadlines
-      ? (evt: LogEvent) => {
-          if (evt.source === "guest-console") {
-            buffer.push(evt.chunk);
-          }
-        }
-      : (evt: LogEvent) => {
-          // Operator mode: legacy live-stream of every non-phase chunk
-          // (the runtime emits phase events too — those are timing
-          // metadata, not console output, so they're filtered out).
-          if (evt.source !== "phase") {
-            process.stderr.write(evt.chunk);
-          }
-        };
+  return mkdtempSync(join(tmpdir(), "machinen-fork-"));
+}
+
+function createForkQuietState(
+  json: boolean,
+  parsed: ParsedForkCommandArgs,
+  target: Target,
+): QuietRunState {
+  const sourceLabel = describeForkSource(target);
+  const headlineName = parsed.newName ?? sourceLabel;
+  const buffer = new RingBuffer();
+  if (!shouldShowForkHeadlines(json, parsed)) {
+    return forkOperatorQuietState(headlineName, buffer);
+  }
+  return createVisibleForkQuietState(parsed, sourceLabel, headlineName, buffer);
+}
+
+function shouldShowForkHeadlines(json: boolean, parsed: ParsedForkCommandArgs): boolean {
+  if (!isQuiet()) {
+    return false;
+  }
+  if (parsed.detach && json) {
+    return false;
+  }
+  return true;
+}
+
+function createVisibleForkQuietState(
+  parsed: ParsedForkCommandArgs,
+  sourceLabel: string,
+  headlineName: string,
+  buffer: RingBuffer,
+): QuietRunState {
+  printHeadline(`forking ${sourceLabel} → ${headlineName}…`);
+  if (parsed.detach) {
+    return bootBufferOnlyQuietState(headlineName, true, buffer);
+  }
+  return forkFilteredQuietState(headlineName, true, buffer, Date.now());
+}
+
+function describeForkSource(target: Target): string {
+  return "name" in target ? target.name : `pid ${target.pid}`;
+}
+
+function forkOperatorQuietState(headlineName: string, buffer: RingBuffer): QuietRunState {
+  return {
+    headlineName,
+    showHeadlines: false,
+    buffer,
+    filter: null,
+    filterOut: null,
+    onLog: operatorForkOnLog,
+  };
+}
+
+function operatorForkOnLog(evt: LogEvent): void {
+  // Operator mode: legacy live-stream of every non-phase chunk (the
+  // runtime emits phase events too — those are timing metadata, not
+  // console output, so they're filtered out).
+  if (evt.source !== "phase") {
+    process.stderr.write(evt.chunk);
+  }
+}
+
+function forkFilteredQuietState(
+  headlineName: string,
+  showHeadlines: boolean,
+  buffer: RingBuffer,
+  forkT0: number,
+): QuietRunState {
+  const filter = new NoiseFilter({
+    buffer,
+    out: process.stderr,
+    onReady: () => {
+      printHeadline(`fork ready in ${formatElapsed(Date.now() - forkT0)}`);
+    },
+  });
+  return {
+    headlineName,
+    showHeadlines,
+    buffer,
+    filter,
+    filterOut: null,
+    onLog: guestConsoleOnLog((chunk) => filter.push(chunk)),
+  };
+}
+
+async function startForkVm(vm: VmHandle, opts: ForkCommandOptions): Promise<VmHandle> {
   try {
-    let fork;
-    try {
-      fork = await vm.fork({
-        name: newName,
-        outDir: resolvedOutDir,
-        image: imagePath,
-        kernel: kernelPath,
-        dtb: dtbPath,
-        tcpKeep,
-        lazy,
-        portForward: portForward.length > 0 ? portForward : undefined,
-        mount,
-        liveMounts,
-        env,
-        guestCwd,
-        memory,
-        onLog,
-      });
-    } catch (err) {
-      filter?.flush();
-      if (showHeadlines) {
-        failQuiet(`fork ${forkHeadlineName} failed: ${describeError(err)}`, {
-          buffer,
-        });
-      }
-      throw err;
-    }
-    if (!showHeadlines && !json) {
-      process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
-      if (!outDir) {
-        process.stderr.write(`bundle: ${resolvedOutDir} (rm -rf when the fork exits)\n`);
-      }
-    }
-    if (detach) {
-      // Fire-and-forget: hand the fork off to its own VMM process
-      // (boot was spawned with pdeathsig=false so it survives this
-      // CLI exit) and return.
-      await fork.detach();
-      if (json) {
-        emitJson({
-          schema_version: 1,
-          pid: fork.pid,
-          name: fork.name ?? null,
-          source: "name" in target ? target.name : `pid ${target.pid}`,
-          bundle_dir: resolvedOutDir,
-          ephemeral: !outDir,
-        });
-      }
-      return 0;
-    }
-
-    // Drop the user into the fork's interactive console — same shape
-    // as `cmdRestore`. The source VM keeps running in the background,
-    // owned by whoever booted it; we never had its console fd.
-    fork.stdout.pipe(process.stdout);
-    if (!filter) {
-      fork.stderr.pipe(process.stderr);
-    }
-    const restoreStdin = rawModeStdinIfTTY();
-    const cancelHintRepeat = printCtrlDHint();
-    // The source shell printed PS1 to the source's tty before the
-    // dump, so the restored shell starts up sitting in read() without
-    // redrawing — without this nudge the user has to hit Enter
-    // themselves to see anything past `machinen-restore: starting…`.
-    // The CR makes bash treat it as an empty Enter and reprints the
-    // prompt. Wait ~1.5s before sending: at `vm.fork()`-resolve the
-    // VMM's just spawned and the kernel is still booting; bytes sent
-    // earlier get dropped before bash starts reading from the tty.
-    const promptNudge = setTimeout(() => {
-      try {
-        fork.stdin.write("\r");
-      } catch {
-        // fork already exited / pipe closed — nothing to nudge.
-      }
-    }, 1500);
-    promptNudge.unref();
-
-    let forwardedSignal: "SIGINT" | "SIGTERM" | null = null;
-    const onSigint = () => {
-      forwardedSignal = "SIGINT";
-      void fork.kill();
-    };
-    const onSigterm = () => {
-      forwardedSignal = "SIGTERM";
-      void fork.kill();
-    };
-    process.on("SIGINT", onSigint);
-    process.on("SIGTERM", onSigterm);
-
-    pipeStdinToVm(fork.stdin, () => {
-      process.stderr.write("\nmachinen: Ctrl-D — stopping VM\n");
-      forwardedSignal = "SIGTERM";
-      void fork.kill();
+    return await vm.fork({
+      name: opts.parsed.newName,
+      outDir: opts.resolvedOutDir,
+      image: opts.paths.defaultImagePath,
+      kernel: opts.paths.kernelPath,
+      dtb: opts.paths.dtbPath,
+      tcpKeep: opts.parsed.tcpKeep,
+      lazy: opts.parsed.lazy,
+      portForward: optionalList(opts.parsed.portForward),
+      mount: opts.parsed.mount,
+      liveMounts: opts.parsed.liveMounts,
+      env: opts.parsed.env,
+      guestCwd: opts.parsed.guestCwd,
+      memory: opts.parsed.memory,
+      onLog: opts.quiet.onLog,
     });
-    try {
-      const { code } = await fork.wait();
-      filter?.flush();
-      if (forwardedSignal === "SIGINT") {
-        return 130;
-      }
-      if (forwardedSignal === "SIGTERM") {
-        return 143;
-      }
-      if (filter && !filter.ready && code != null && code !== 0 && !forwardedSignal) {
-        printDiagnostics(`fork ${forkHeadlineName} exited ${code} before reaching ready`, {
-          buffer,
-        });
-      }
-      return code ?? 0;
-    } finally {
-      process.off("SIGINT", onSigint);
-      process.off("SIGTERM", onSigterm);
-      cancelHintRepeat();
-      restoreStdin();
-    }
   } catch (err) {
-    handleError(err);
+    handleForkFailure(err, opts.quiet);
+  }
+}
+
+function handleForkFailure(err: unknown, quiet: QuietRunState): never {
+  quiet.filter?.flush();
+  if (quiet.showHeadlines) {
+    failQuiet(`fork ${quiet.headlineName} failed: ${describeError(err)}`, {
+      buffer: quiet.buffer,
+    });
+  }
+  handleError(err);
+}
+
+function reportForkStarted(fork: VmHandle, opts: ForkCommandOptions): void {
+  if (!shouldPrintForkStarted(opts)) {
+    return;
+  }
+  process.stderr.write(`forked: ${fork.name ?? "<anonymous>"} (pid ${fork.pid})\n`);
+  printForkBundleHint(opts);
+}
+
+function shouldPrintForkStarted(opts: ForkCommandOptions): boolean {
+  if (opts.quiet.showHeadlines) {
+    return false;
+  }
+  return !opts.json;
+}
+
+function printForkBundleHint(opts: ForkCommandOptions): void {
+  if (!opts.parsed.outDir) {
+    process.stderr.write(`bundle: ${opts.resolvedOutDir} (rm -rf when the fork exits)\n`);
+  }
+}
+
+async function detachFork(fork: VmHandle, opts: ForkCommandOptions): Promise<number> {
+  // Fire-and-forget: hand the fork off to its own VMM process
+  // (boot was spawned with pdeathsig=false so it survives this CLI exit) and return.
+  await fork.detach();
+  if (opts.json) {
+    emitJson({
+      schema_version: 1,
+      pid: fork.pid,
+      name: fork.name ?? null,
+      source: describeForkSource(opts.target),
+      bundle_dir: opts.resolvedOutDir,
+      ephemeral: !opts.parsed.outDir,
+    });
+  }
+  return 0;
+}
+
+async function runForkAttachedSession(fork: VmHandle, quiet: QuietRunState): Promise<number> {
+  const cancelPromptNudge = scheduleForkPromptNudge(fork);
+  try {
+    return await runAttachedVmSession(fork, {
+      filter: quiet.filter,
+      buffer: quiet.buffer,
+      preReadyExitSummary: (code) =>
+        `fork ${quiet.headlineName} exited ${code} before reaching ready`,
+    });
   } finally {
-    await vm.detach();
+    cancelPromptNudge();
+  }
+}
+
+function scheduleForkPromptNudge(fork: VmHandle): () => void {
+  // The source shell printed PS1 to the source's tty before the dump,
+  // so the restored shell starts up sitting in read() without redrawing.
+  const promptNudge = setTimeout(() => tryWriteForkPromptNudge(fork), 1500);
+  promptNudge.unref();
+  return () => clearTimeout(promptNudge);
+}
+
+function tryWriteForkPromptNudge(fork: VmHandle): void {
+  try {
+    fork.stdin.write("\r");
+  } catch {
+    // fork already exited / pipe closed — nothing to nudge.
   }
 }
 
 async function cmdAttach(args: string[]): Promise<number> {
-  // Pull `--shell` and `--tail` out before the target flags so the
-  // unknown-arg checks in `parseTargetFlags` don't reject them.
-  // `--shell` defaults to `bash -i` — the Debian base rootfs ships
-  // bash, and `-i` gets job control, history, and a prompt.
-  let shell = "/bin/bash -i";
-  let tail: number | "all" | undefined;
-  const filtered: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--shell" || a.startsWith("--shell=")) {
-      const v = a === "--shell" ? args[++i] : a.slice("--shell=".length);
-      if (!v) {
-        die("--shell requires a value");
-      }
-      shell = v;
-    } else if (a === "--tail" || a.startsWith("--tail=")) {
-      // `--tail` (no value) prints the whole snapshot. `--tail N`
-      // prints the last N lines. The snapshot is capped at ~1 MiB so
-      // even the no-value form is bounded.
-      let v: string | undefined;
-      if (a === "--tail") {
-        const peek = args[i + 1];
-        if (peek && /^[0-9]+$/.test(peek)) {
-          v = peek;
-          i++;
-        }
-      } else {
-        v = a.slice("--tail=".length);
-      }
-      if (v === undefined) {
-        tail = "all";
-      } else {
-        const n = Number(v);
-        if (!Number.isInteger(n) || n < 0) {
-          die(`--tail: expected a non-negative integer, got '${v}'`);
-        }
-        tail = n;
-      }
-    } else {
-      filtered.push(a);
-    }
-  }
-  const target = parseTargetFlags(filtered, "attach");
-  // #150 phase 2 PR3: --tail dumps the boot-console snapshot before
-  // (or instead of) the interactive shell. Look up the registry
-  // entry directly — `attach()` only returns a VmHandle, not the
-  // entry, and we need `bootLogPath` from the registry.
-  if (tail !== undefined) {
-    const entry = lookupEntry(target);
-    if (!entry) {
-      die(`machinen attach: no running VM matched ${describeTarget(target)}`);
-    }
-    if (!entry.bootLogPath) {
-      die(
-        `machinen attach --tail: VM was not booted with --detached, no snapshot exists. ` +
-          `Use 'machinen attach' (no --tail) for live console access.`,
-      );
-    }
-    printBootLogTail(entry.bootLogPath, tail);
-  }
+  const opts = parseAttachOptions(args);
+  printAttachTailIfRequested(opts);
   // Resolve the target before the TTY check: a typo in --name should
   // surface "no running VM found", not the TTY error. The TTY error
   // is only useful once we know the VM exists.
-  const vm = await attach(target).catch(handleError);
+  const vm = await attach(opts.target).catch(handleError);
+  return runAttachedPty(vm, opts.shell);
+}
+
+interface AttachOptionsCli {
+  shell: string;
+  tail?: number | "all";
+  target: Target;
+}
+
+function parseAttachOptions(args: string[]): AttachOptionsCli {
+  const state = {
+    shell: "/bin/bash -i",
+    tail: undefined as number | "all" | undefined,
+    rest: [] as string[],
+  };
+  for (let i = 0; i < args.length; i++) {
+    i = consumeAttachArg(args, i, state);
+  }
+  return { shell: state.shell, tail: state.tail, target: parseTargetFlags(state.rest, "attach") };
+}
+
+type AttachArgHandler = (
+  args: string[],
+  index: number,
+  arg: string,
+  state: { shell: string; tail?: number | "all"; rest: string[] },
+) => number;
+
+function consumeAttachArg(
+  args: string[],
+  index: number,
+  state: { shell: string; tail?: number | "all"; rest: string[] },
+): number {
+  const arg = args[index]!;
+  const handler = attachArgHandler(arg);
+  if (handler) {
+    return handler(args, index, arg, state);
+  }
+  state.rest.push(arg);
+  return index;
+}
+
+const ATTACH_ARG_HANDLERS: Array<[(arg: string) => boolean, AttachArgHandler]> = [
+  [(arg) => arg === "--shell" || arg.startsWith("--shell="), consumeAttachShell],
+  [(arg) => arg === "--tail" || arg.startsWith("--tail="), consumeAttachTail],
+];
+
+function attachArgHandler(arg: string): AttachArgHandler | undefined {
+  return ATTACH_ARG_HANDLERS.find(([matches]) => matches(arg))?.[1];
+}
+
+function consumeAttachShell(
+  args: string[],
+  index: number,
+  arg: string,
+  state: { shell: string },
+): number {
+  const value = arg === "--shell" ? args[index + 1] : arg.slice("--shell=".length);
+  if (!value) {
+    die("--shell requires a value");
+  }
+  state.shell = value;
+  return arg === "--shell" ? index + 1 : index;
+}
+
+function consumeAttachTail(
+  args: string[],
+  index: number,
+  arg: string,
+  state: { tail?: number | "all" },
+): number {
+  const { value, nextIndex } = attachTailValue(args, index, arg);
+  state.tail = parseAttachTail(value);
+  return nextIndex;
+}
+
+function attachTailValue(
+  args: string[],
+  index: number,
+  arg: string,
+): { value: string | undefined; nextIndex: number } {
+  if (arg !== "--tail") {
+    return { value: arg.slice("--tail=".length), nextIndex: index };
+  }
+  const peek = args[index + 1];
+  if (peek && /^[0-9]+$/.test(peek)) {
+    return { value: peek, nextIndex: index + 1 };
+  }
+  return { value: undefined, nextIndex: index };
+}
+
+function parseAttachTail(value: string | undefined): number | "all" {
+  // `--tail` (no value) prints the whole snapshot. `--tail N`
+  // prints the last N lines. The snapshot is capped at ~1 MiB so
+  // even the no-value form is bounded.
+  if (value === undefined) {
+    return "all";
+  }
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    die(`--tail: expected a non-negative integer, got '${value}'`);
+  }
+  return n;
+}
+
+function printAttachTailIfRequested(opts: AttachOptionsCli): void {
+  // #150 phase 2 PR3: --tail dumps the boot-console snapshot before
+  // (or instead of) the interactive shell. Look up the registry entry
+  // directly — `attach()` only returns a VmHandle, not the registry row.
+  if (opts.tail === undefined) {
+    return;
+  }
+  const entry = lookupAttachTailEntry(opts.target);
+  printBootLogTail(entry.bootLogPath!, opts.tail);
+}
+
+function lookupAttachTailEntry(target: Target): RegistryEntry {
+  const entry = lookupEntry(target);
+  if (!entry) {
+    die(`machinen attach: no running VM matched ${describeTarget(target)}`);
+  }
+  if (!entry.bootLogPath) {
+    die(
+      `machinen attach --tail: VM was not booted with --detached, no snapshot exists. ` +
+        `Use 'machinen attach' (no --tail) for live console access.`,
+    );
+  }
+  return entry;
+}
+
+async function runAttachedPty(vm: VmHandle, shell: string): Promise<number> {
   if (!process.stdin.isTTY) {
     await vm.detach();
     die("machinen attach: stdin is not a TTY (pipe scripts via `machinen repl` instead)");
@@ -1710,6 +2249,16 @@ async function cmdRepl(args: string[]): Promise<number> {
   // For an actual interactive shell, use `machinen attach`.
   const target = parseTargetFlags(args, "repl");
   const vm = await attach(target).catch(handleError);
+  printReplIntro(vm);
+  try {
+    await runReplLoop(vm);
+    return 0;
+  } finally {
+    await vm.detach();
+  }
+}
+
+function printReplIntro(vm: VmHandle): void {
   process.stderr.write(`repl: ${vm.name ?? `pid ${vm.pid}`}\n`);
   process.stderr.write(
     `each line is a fresh one-shot exec — cd / env vars / history do NOT persist.\n` +
@@ -1717,22 +2266,24 @@ async function cmdRepl(args: string[]): Promise<number> {
       `  machinen attach ${vm.name ?? vm.pid}\n` +
       `Ctrl-D to exit.\n`,
   );
-  try {
-    const { createInterface } = await import("node:readline");
-    const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
-    for await (const line of rl) {
-      if (line.length === 0) {
-        continue;
-      }
-      await vm.execRaw(line, {
-        onStdout: (chunk) => process.stdout.write(chunk),
-        onStderr: (chunk) => process.stderr.write(chunk),
-      });
-    }
-    return 0;
-  } finally {
-    await vm.detach();
+}
+
+async function runReplLoop(vm: VmHandle): Promise<void> {
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+  for await (const line of rl) {
+    await runReplLine(vm, line);
   }
+}
+
+async function runReplLine(vm: VmHandle, line: string): Promise<void> {
+  if (line.length === 0) {
+    return;
+  }
+  await vm.execRaw(line, {
+    onStdout: (chunk) => process.stdout.write(chunk),
+    onStderr: (chunk) => process.stderr.write(chunk),
+  });
 }
 
 async function cmdAgentContext(args: string[]): Promise<number> {
@@ -1753,84 +2304,120 @@ async function cmdFeedback(args: string[]): Promise<number> {
   //   machinen feedback "<text>"        — append a JSONL entry
   //   machinen feedback --list          — print recent entries
   // --json on either form returns a structured envelope.
-  const { json, rest: afterJson } = consumeJsonFlag(args);
-  let listMode = false;
-  const positional: string[] = [];
-  for (const a of afterJson) {
-    if (a === "--list") {
-      listMode = true;
-    } else if (a.startsWith("--")) {
-      die(`unknown argument: ${a}`);
-    } else {
-      positional.push(a);
-    }
+  const opts = parseFeedbackOptions(args);
+  if (opts.listMode) {
+    return listFeedback(opts);
   }
-  if (listMode) {
-    if (positional.length > 0) {
-      die("machinen feedback --list takes no positional arguments");
-    }
-    const entries = readFeedback();
-    if (json) {
-      emitJson({ schema_version: 1, entries });
-      return 0;
-    }
-    if (entries.length === 0) {
-      process.stdout.write("(no feedback recorded)\n");
-      return 0;
-    }
-    for (const e of entries) {
-      process.stdout.write(`${e.timestamp}  ${e.text}\n`);
-    }
+  return recordFeedback(opts);
+}
+
+interface FeedbackOptions {
+  json: boolean;
+  listMode: boolean;
+  positional: string[];
+}
+
+function parseFeedbackOptions(args: string[]): FeedbackOptions {
+  const { json, rest } = consumeJsonFlag(args);
+  const opts: FeedbackOptions = { json, listMode: false, positional: [] };
+  for (const arg of rest) {
+    consumeFeedbackArg(opts, arg);
+  }
+  return opts;
+}
+
+function consumeFeedbackArg(opts: FeedbackOptions, arg: string): void {
+  if (arg === "--list") {
+    opts.listMode = true;
+    return;
+  }
+  if (arg.startsWith("--")) {
+    die(`unknown argument: ${arg}`);
+  }
+  opts.positional.push(arg);
+}
+
+function listFeedback(opts: FeedbackOptions): number {
+  if (opts.positional.length > 0) {
+    die("machinen feedback --list takes no positional arguments");
+  }
+  const entries = readFeedback();
+  if (opts.json) {
+    emitJson({ schema_version: 1, entries });
     return 0;
   }
-  if (positional.length === 0) {
+  printFeedbackEntries(entries);
+  return 0;
+}
+
+function printFeedbackEntries(entries: ReturnType<typeof readFeedback>): void {
+  if (entries.length === 0) {
+    process.stdout.write("(no feedback recorded)\n");
+    return;
+  }
+  for (const entry of entries) {
+    process.stdout.write(`${entry.timestamp}  ${entry.text}\n`);
+  }
+}
+
+async function recordFeedback(opts: FeedbackOptions): Promise<number> {
+  if (opts.positional.length === 0) {
     die('usage: machinen feedback "<text>" | machinen feedback --list');
   }
-  const text = positional.join(" ");
   const path = feedbackPath();
-  const entry = {
+  const entry = newFeedbackEntry(opts.positional.join(" "));
+  appendFeedback(entry, path);
+  const upstream = await postUpstream(entry);
+  reportFeedbackRecorded(opts, path, upstream);
+  return 0;
+}
+
+function newFeedbackEntry(text: string): Parameters<typeof appendFeedback>[0] {
+  return {
     timestamp: new Date().toISOString(),
     cli_version: VERSION,
     text,
   };
-  appendFeedback(entry, path);
-  const upstream = await postUpstream(entry);
-  if (json) {
-    emitJson({
-      schema_version: 1,
-      recorded: true,
-      path,
-      upstream_status: upstream.status,
-    });
-    return 0;
+}
+
+function reportFeedbackRecorded(
+  opts: FeedbackOptions,
+  path: string,
+  upstream: Awaited<ReturnType<typeof postUpstream>>,
+): void {
+  if (opts.json) {
+    emitJson({ schema_version: 1, recorded: true, path, upstream_status: upstream.status });
+    return;
   }
+  process.stdout.write(feedbackRecordedMessage(upstream));
+}
+
+function feedbackRecordedMessage(upstream: Awaited<ReturnType<typeof postUpstream>>): string {
   if (upstream.attempted && upstream.status !== null) {
-    process.stdout.write(
-      `feedback recorded locally and sent upstream (status: ${upstream.status})\n`,
-    );
-  } else if (upstream.attempted) {
-    process.stdout.write(`feedback recorded locally; upstream POST failed: ${upstream.error}\n`);
-  } else {
-    process.stdout.write("feedback recorded locally (1 entry)\n");
+    return `feedback recorded locally and sent upstream (status: ${upstream.status})\n`;
   }
-  return 0;
+  if (upstream.attempted) {
+    return `feedback recorded locally; upstream POST failed: ${upstream.error}\n`;
+  }
+  return "feedback recorded locally (1 entry)\n";
 }
 
 async function cmdCompletion(args: string[]): Promise<number> {
   const shell = args[0] ?? "bash";
-  if (shell === "bash") {
-    process.stdout.write(BASH_COMPLETION);
-    return 0;
+  const completion = completionForShell(shell);
+  if (completion === undefined) {
+    die(`unsupported shell: ${shell} (expected bash | zsh | fish)`);
   }
-  if (shell === "zsh") {
-    process.stdout.write(ZSH_COMPLETION);
-    return 0;
-  }
-  if (shell === "fish") {
-    process.stdout.write(FISH_COMPLETION);
-    return 0;
-  }
-  die(`unsupported shell: ${shell} (expected bash | zsh | fish)`);
+  process.stdout.write(completion);
+  return 0;
+}
+
+function completionForShell(shell: string): string | undefined {
+  return new Map([
+    ["bash", BASH_COMPLETION],
+    ["zsh", ZSH_COMPLETION],
+    ["fish", FISH_COMPLETION],
+  ]).get(shell);
 }
 
 /**
@@ -2151,53 +2738,90 @@ function printHelp(): void {
 // Entry
 // ------------------------------------------------------------
 
+type CommandHandler = (args: string[]) => number | Promise<number>;
+
+const COMMAND_HANDLERS = new Map<string, CommandHandler>([
+  ["boot", cmdBoot],
+  ["restore", cmdRestore],
+  ["install", cmdInstall],
+  ["list", cmdLs],
+  ["ls", cmdLs],
+  ["ps", cmdLs],
+  ["exec", cmdExec],
+  ["snapshot", cmdSnapshot],
+  ["fork", cmdFork],
+  ["attach", cmdAttach],
+  ["repl", cmdRepl],
+  ["completion", cmdCompletion],
+  ["gc", cmdGc],
+  ["stop", cmdStop],
+  ["feedback", cmdFeedback],
+  ["agent-context", cmdAgentContext],
+]);
+
 async function main(): Promise<number> {
   const [sub, ...rest] = process.argv.slice(2);
-  debug("dispatch sub=%s argc=%d", sub ?? "<empty>", rest.length);
+  debug("dispatch sub=%s argc=%d", commandLabel(sub), rest.length);
 
-  if (!sub || sub === "-h" || sub === "--help") {
-    printHelp();
-    return sub ? 0 : 1;
+  const topLevelCode = maybeHandleTopLevelCommand(sub);
+  if (topLevelCode !== undefined) {
+    return topLevelCode;
   }
-  if (sub === "--version" || sub === "-v") {
-    process.stdout.write(`${VERSION}\n`);
+  return dispatchSubcommand(sub!, rest);
+}
+
+function commandLabel(sub: string | undefined): string {
+  if (sub === undefined) {
+    return "<empty>";
+  }
+  return sub;
+}
+
+function maybeHandleTopLevelCommand(sub: string | undefined): number | undefined {
+  const helpCode = maybePrintTopLevelHelp(sub);
+  if (helpCode !== undefined) {
+    return helpCode;
+  }
+  return maybePrintVersion(sub);
+}
+
+function dispatchSubcommand(sub: string, rest: string[]): number | Promise<number> {
+  const handler = COMMAND_HANDLERS.get(sub);
+  if (handler) {
+    return handler(rest);
+  }
+  die(`unknown command: ${sub}\nRun 'machinen --help' for usage.`);
+}
+
+function maybePrintTopLevelHelp(sub: string | undefined): number | undefined {
+  if (!sub) {
+    printHelp();
+    return 1;
+  }
+  if (sub === "-h") {
+    printHelp();
     return 0;
   }
-
-  switch (sub) {
-    case "boot":
-      return cmdBoot(rest);
-    case "restore":
-      return cmdRestore(rest);
-    case "install":
-      return cmdInstall(rest);
-    case "list":
-    case "ls":
-    case "ps":
-      return cmdLs(rest);
-    case "exec":
-      return cmdExec(rest);
-    case "snapshot":
-      return cmdSnapshot(rest);
-    case "fork":
-      return cmdFork(rest);
-    case "attach":
-      return cmdAttach(rest);
-    case "repl":
-      return cmdRepl(rest);
-    case "completion":
-      return cmdCompletion(rest);
-    case "gc":
-      return cmdGc(rest);
-    case "stop":
-      return cmdStop(rest);
-    case "feedback":
-      return cmdFeedback(rest);
-    case "agent-context":
-      return cmdAgentContext(rest);
-    default:
-      die(`unknown command: ${sub}\nRun 'machinen --help' for usage.`);
+  if (sub === "--help") {
+    printHelp();
+    return 0;
   }
+  return undefined;
+}
+
+function maybePrintVersion(sub: string | undefined): number | undefined {
+  if (sub === "--version") {
+    return printVersion();
+  }
+  if (sub === "-v") {
+    return printVersion();
+  }
+  return undefined;
+}
+
+function printVersion(): number {
+  process.stdout.write(`${VERSION}\n`);
+  return 0;
 }
 
 main().then(

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -82,118 +82,254 @@ interface ParsedForkArgs {
   rest: string[];
 }
 
+type ForkFlag =
+  | "newName"
+  | "outDir"
+  | "tcpKeep"
+  | "detach"
+  | "lazy"
+  | "portForward"
+  | "mount"
+  | "liveMount"
+  | "env"
+  | "guestCwd"
+  | "memory";
+
+type ForkFlagHandler = (
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+) => number;
+
+interface ForkParseState {
+  newName?: string;
+  outDir?: string;
+  tcpKeep: boolean;
+  detach: boolean;
+  lazy: boolean;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  seenHostPorts: Set<number>;
+  mount?: { host: string; guest: string };
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  env: Record<string, string>;
+  guestCwd?: string;
+  memory?: number;
+  rest: string[];
+}
+
+const FORK_VALUE_FLAGS = new Map<string, ForkFlag>([
+  ["--new-name", "newName"],
+  ["--out-dir", "outDir"],
+  ["-p", "portForward"],
+  ["--publish", "portForward"],
+  ["--mount", "mount"],
+  ["--mount-live", "liveMount"],
+  ["--env", "env"],
+  ["--cwd", "guestCwd"],
+  ["--memory", "memory"],
+]);
+
+const FORK_BARE_FLAGS = new Map<string, ForkFlag>([
+  ["--tcp-keep", "tcpKeep"],
+  ["--detach", "detach"],
+  ["--lazy", "lazy"],
+]);
+
+const FORK_FLAG_HANDLERS: Record<ForkFlag, ForkFlagHandler> = {
+  newName: handleForkNewName,
+  outDir: handleForkOutDir,
+  tcpKeep: handleForkTcpKeep,
+  detach: handleForkDetach,
+  lazy: handleForkLazy,
+  portForward: handleForkPortForward,
+  mount: handleForkMount,
+  liveMount: handleForkLiveMount,
+  env: handleForkEnv,
+  guestCwd: handleForkGuestCwd,
+  memory: handleForkMemory,
+};
+
 export function parseForkArgs(argv: string[]): ParsedForkArgs {
-  let newName: string | undefined;
-  let outDir: string | undefined;
-  let tcpKeep = false;
-  let detach = false;
-  let lazy = false;
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const seenHostPorts = new Set<number>();
-  let mount: { host: string; guest: string } | undefined;
-  const liveMounts: Array<{
-    host: string;
-    guest: string;
-    mode: "ro" | "rw";
-  }> = [];
-  const env: Record<string, string> = {};
-  let guestCwd: string | undefined;
-  let memory: number | undefined;
-  const rest: string[] = [];
+  const state = newForkParseState();
+
   for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
-    if (a === "--new-name" || a.startsWith("--new-name=")) {
-      if (newName !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--new-name may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, argv, i, "a value");
-      newName = spec;
-      i = next;
-    } else if (a === "--out-dir" || a.startsWith("--out-dir=")) {
-      if (outDir !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--out-dir may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, argv, i, "a directory path");
-      outDir = spec;
-      i = next;
-    } else if (a === "--tcp-keep") {
-      tcpKeep = true;
-    } else if (a === "--detach") {
-      detach = true;
-    } else if (a === "--lazy") {
-      lazy = true;
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
-    } else if (a === "--mount" || a.startsWith("--mount=")) {
-      if (mount) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--mount may be given at most once per invocation",
-        );
-      }
-      const r = consumeMount(a, argv, i);
-      mount = r.value;
-      i = r.next;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const r = consumeLiveMount(a, argv, i);
-      liveMounts.push(r.value);
-      i = r.next;
-    } else if (a === "--env" || a.startsWith("--env=")) {
-      const r = consumeEnv(a, argv, i);
-      env[r.key] = r.value;
-      i = r.next;
-    } else if (a === "--cwd" || a.startsWith("--cwd=")) {
-      if (guestCwd !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--cwd may be given at most once per invocation",
-        );
-      }
-      const r = consumeGuestCwd(a, argv, i);
-      guestCwd = r.value;
-      i = r.next;
-    } else if (a === "--memory" || a.startsWith("--memory=")) {
-      if (memory !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--memory may be given at most once per invocation",
-        );
-      }
-      const r = consumeMemory(a, argv, i);
-      memory = r.value;
-      i = r.next;
-    } else {
-      rest.push(a);
+    const arg = argv[i]!;
+    const flag = forkFlagFor(arg);
+    if (flag) {
+      i = FORK_FLAG_HANDLERS[flag](state, arg, argv, i);
+      continue;
     }
+    state.rest.push(arg);
   }
+
+  return finishForkArgs(state);
+}
+
+function newForkParseState(): ForkParseState {
+  return {
+    tcpKeep: false,
+    detach: false,
+    lazy: false,
+    portForward: [],
+    seenHostPorts: new Set<number>(),
+    liveMounts: [],
+    env: {},
+    rest: [],
+  };
+}
+
+function forkFlagFor(arg: string): ForkFlag | undefined {
+  const eq = arg.indexOf("=");
+  if (eq !== -1) {
+    return FORK_VALUE_FLAGS.get(arg.slice(0, eq));
+  }
+  return FORK_BARE_FLAGS.get(arg) ?? FORK_VALUE_FLAGS.get(arg);
+}
+
+function finishForkArgs(state: ForkParseState): ParsedForkArgs {
   // Detach exits the runtime supervisor, taking the host-side FUSE
   // server with it — the in-guest lazy-pages daemon would then block
   // on a dead FUSE channel. Force eager (lazy=false) to keep --detach
   // usable until the FUSE server gains its own detach handoff
   // (#150 phase 3).
   return {
-    newName,
-    outDir,
-    tcpKeep,
-    detach,
-    lazy: lazy && !detach,
-    portForward,
-    mount,
-    liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
-    env: Object.keys(env).length > 0 ? env : undefined,
-    guestCwd,
-    memory,
-    rest,
+    newName: state.newName,
+    outDir: state.outDir,
+    tcpKeep: state.tcpKeep,
+    detach: state.detach,
+    lazy: state.lazy && !state.detach,
+    portForward: state.portForward,
+    mount: state.mount,
+    liveMounts: state.liveMounts.length > 0 ? state.liveMounts : undefined,
+    env: Object.keys(state.env).length > 0 ? state.env : undefined,
+    guestCwd: state.guestCwd,
+    memory: state.memory,
+    rest: state.rest,
   };
+}
+
+function handleForkNewName(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertForkFlagUnused(state.newName !== undefined, "--new-name");
+  const { spec, next } = takeValue(flag, args, index, "a value");
+  state.newName = spec;
+  return next;
+}
+
+function handleForkOutDir(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertForkFlagUnused(state.outDir !== undefined, "--out-dir");
+  const { spec, next } = takeValue(flag, args, index, "a directory path");
+  state.outDir = spec;
+  return next;
+}
+
+function handleForkTcpKeep(
+  state: ForkParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  state.tcpKeep = true;
+  return index;
+}
+
+function handleForkDetach(
+  state: ForkParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  state.detach = true;
+  return index;
+}
+
+function handleForkLazy(
+  state: ForkParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  state.lazy = true;
+  return index;
+}
+
+function handleForkPortForward(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  return consumePortForward(flag, args, index, state.seenHostPorts, state.portForward);
+}
+
+function handleForkMount(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertForkFlagUnused(state.mount !== undefined, "--mount");
+  const result = consumeMount(flag, args, index);
+  state.mount = result.value;
+  return result.next;
+}
+
+function handleForkLiveMount(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  const result = consumeLiveMount(flag, args, index);
+  state.liveMounts.push(result.value);
+  return result.next;
+}
+
+function handleForkEnv(state: ForkParseState, flag: string, args: string[], index: number): number {
+  const result = consumeEnv(flag, args, index);
+  state.env[result.key] = result.value;
+  return result.next;
+}
+
+function handleForkGuestCwd(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertForkFlagUnused(state.guestCwd !== undefined, "--cwd");
+  const result = consumeGuestCwd(flag, args, index);
+  state.guestCwd = result.value;
+  return result.next;
+}
+
+function handleForkMemory(
+  state: ForkParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertForkFlagUnused(state.memory !== undefined, "--memory");
+  const result = consumeMemory(flag, args, index);
+  state.memory = result.value;
+  return result.next;
+}
+
+function assertForkFlagUnused(used: boolean, flag: string): void {
+  if (used) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
 }

--- a/packages/cli/src/parse-restore-args.ts
+++ b/packages/cli/src/parse-restore-args.ts
@@ -4,7 +4,7 @@
 
 import { ParseError } from "@machinen/runtime";
 
-import { consumeLiveMount, consumePortForward } from "./parse-run-args.ts";
+import { consumeLiveMount, consumePortForward, takeValue } from "./parse-run-args.ts";
 
 interface ParsedRestoreArgs {
   /**
@@ -52,73 +52,180 @@ interface ParsedRestoreArgs {
   }>;
 }
 
+type RestoreFlag = "lazy" | "name" | "image" | "liveMount" | "portForward";
+
+type RestoreFlagHandler = (
+  state: RestoreParseState,
+  flag: string,
+  args: string[],
+  index: number,
+) => number;
+
+interface RestoreParseState {
+  positional: string[];
+  name?: string;
+  image?: string;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  lazy: boolean;
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  seenLiveGuests: Set<string>;
+  seenHostPorts: Set<number>;
+}
+
+const RESTORE_VALUE_FLAGS = new Map<string, RestoreFlag>([
+  ["--name", "name"],
+  ["--image", "image"],
+  ["--mount-live", "liveMount"],
+  ["-p", "portForward"],
+  ["--publish", "portForward"],
+]);
+
+const RESTORE_BARE_FLAGS = new Map<string, RestoreFlag>([["--lazy", "lazy"]]);
+
+const RESTORE_FLAG_HANDLERS: Record<RestoreFlag, RestoreFlagHandler> = {
+  lazy: handleRestoreLazy,
+  name: handleRestoreName,
+  image: handleRestoreImage,
+  liveMount: handleRestoreLiveMount,
+  portForward: handleRestorePortForward,
+};
+
 export function parseRestoreArgs(argv: string[]): ParsedRestoreArgs {
-  const positional: string[] = [];
-  let name: string | undefined;
-  let image: string | undefined;
-  let lazy = false;
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const liveMounts: Array<{
-    host: string;
-    guest: string;
-    mode: "ro" | "rw";
-  }> = [];
-  const seenLiveGuests = new Set<string>();
-  const seenHostPorts = new Set<number>();
+  const state = newRestoreParseState();
+
   for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
-    if (a === "--lazy") {
-      lazy = true;
-    } else if (a === "--name" || a.startsWith("--name=")) {
-      const v = a === "--name" ? argv[++i] : a.slice("--name=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--name requires a value");
-      }
-      if (name !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--name may be given at most once per invocation",
-        );
-      }
-      name = v;
-    } else if (a === "--image" || a.startsWith("--image=")) {
-      const v = a === "--image" ? argv[++i] : a.slice("--image=".length);
-      if (!v) {
-        throw new ParseError("PARSE_FLAG_MISSING_VALUE", "--image requires a value");
-      }
-      if (image !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--image may be given at most once per invocation",
-        );
-      }
-      image = v;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const { value, next } = consumeLiveMount(a, argv, i);
-      i = next;
-      // CLI-side dedup: two overrides for the same guest is a typo,
-      // not a feature. Runtime would still accept the second one
-      // silently (last write wins on Map.set) — fail fast here.
-      if (seenLiveGuests.has(value.guest)) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          `--mount-live override for guest=${value.guest} given more than once`,
-        );
-      }
-      seenLiveGuests.add(value.guest);
-      liveMounts.push(value);
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, argv, i, seenHostPorts, portForward);
-    } else if (a.startsWith("-")) {
-      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
-    } else {
-      positional.push(a);
+    const arg = argv[i]!;
+    const flag = restoreFlagFor(arg);
+    if (flag) {
+      i = RESTORE_FLAG_HANDLERS[flag](state, arg, argv, i);
+      continue;
     }
+    if (arg.startsWith("-")) {
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${arg}`);
+    }
+    state.positional.push(arg);
   }
-  return { positional, name, image, portForward, lazy, liveMounts };
+
+  return finishRestoreArgs(state);
+}
+
+function newRestoreParseState(): RestoreParseState {
+  return {
+    positional: [],
+    portForward: [],
+    lazy: false,
+    liveMounts: [],
+    seenLiveGuests: new Set<string>(),
+    seenHostPorts: new Set<number>(),
+  };
+}
+
+function restoreFlagFor(arg: string): RestoreFlag | undefined {
+  const eq = arg.indexOf("=");
+  if (eq !== -1) {
+    return RESTORE_VALUE_FLAGS.get(arg.slice(0, eq));
+  }
+  return RESTORE_BARE_FLAGS.get(arg) ?? RESTORE_VALUE_FLAGS.get(arg);
+}
+
+function finishRestoreArgs(state: RestoreParseState): ParsedRestoreArgs {
+  return {
+    positional: state.positional,
+    name: state.name,
+    image: state.image,
+    portForward: state.portForward,
+    lazy: state.lazy,
+    liveMounts: state.liveMounts,
+  };
+}
+
+function handleRestoreLazy(
+  state: RestoreParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  state.lazy = true;
+  return index;
+}
+
+function handleRestoreName(
+  state: RestoreParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  const { spec, next } = takeRestoreValue(flag, args, index, "a value", "--name");
+  assertRestoreFlagUnused(state.name !== undefined, "--name");
+  state.name = spec;
+  return next;
+}
+
+function handleRestoreImage(
+  state: RestoreParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  const { spec, next } = takeRestoreValue(flag, args, index, "a value", "--image");
+  assertRestoreFlagUnused(state.image !== undefined, "--image");
+  state.image = spec;
+  return next;
+}
+
+function handleRestoreLiveMount(
+  state: RestoreParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  const { value, next } = consumeLiveMount(flag, args, index);
+  assertRestoreLiveGuestUnused(state, value.guest);
+  state.seenLiveGuests.add(value.guest);
+  state.liveMounts.push(value);
+  return next;
+}
+
+function handleRestorePortForward(
+  state: RestoreParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  return consumePortForward(flag, args, index, state.seenHostPorts, state.portForward);
+}
+
+function takeRestoreValue(
+  flag: string,
+  args: string[],
+  index: number,
+  label: string,
+  displayFlag: string,
+): { spec: string; next: number } {
+  const result = takeValue(flag, args, index, label);
+  if (!result.spec) {
+    throw new ParseError("PARSE_FLAG_MISSING_VALUE", `${displayFlag} requires ${label}`);
+  }
+  return result;
+}
+
+function assertRestoreFlagUnused(used: boolean, flag: string): void {
+  if (used) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
+}
+
+function assertRestoreLiveGuestUnused(state: RestoreParseState, guest: string): void {
+  // CLI-side dedup: two overrides for the same guest is a typo,
+  // not a feature. Runtime would still accept the second one
+  // silently (last write wins on Map.set) — fail fast here.
+  if (state.seenLiveGuests.has(guest)) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `--mount-live override for guest=${guest} given more than once`,
+    );
+  }
 }

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -59,145 +59,277 @@ interface ParsedRunArgs {
   json?: boolean;
 }
 
-export function parseRunArgs(argv: string[]): ParsedRunArgs {
-  const idx = argv.indexOf("--");
-  const pre = idx === -1 ? argv : argv.slice(0, idx);
-  const double_dash_args = idx === -1 ? [] : argv.slice(idx + 1);
+type RunFlag =
+  | "mount"
+  | "liveMount"
+  | "env"
+  | "portForward"
+  | "snapshot"
+  | "nested"
+  | "nestedValue"
+  | "guestCwd"
+  | "name"
+  | "detach"
+  | "json"
+  | "memory";
 
-  const positional: string[] = [];
-  let mount: { host: string; guest: string } | undefined;
-  const liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }> = [];
-  const env: Record<string, string> = {};
-  const portForward: Array<{ hostPort: number; guestPort: number }> = [];
-  const seenHostPorts = new Set<number>();
-  let snapshot: string | undefined;
-  let nested = false;
-  let name: string | undefined;
-  let guestCwd: string | undefined;
-  let detached = false;
-  let memory: number | undefined;
-  let json = false;
+type RunFlagHandler = (state: RunParseState, flag: string, args: string[], index: number) => number;
+
+interface RunParseState {
+  positional: string[];
+  mount?: { host: string; guest: string };
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  env: Record<string, string>;
+  portForward: Array<{ hostPort: number; guestPort: number }>;
+  seenHostPorts: Set<number>;
+  snapshot?: string;
+  nested: boolean;
+  name?: string;
+  guestCwd?: string;
+  detached: boolean;
+  memory?: number;
+  json: boolean;
+}
+
+const RUN_VALUE_FLAGS = new Map<string, RunFlag>([
+  ["--mount", "mount"],
+  ["--mount-live", "liveMount"],
+  ["--env", "env"],
+  ["-p", "portForward"],
+  ["--publish", "portForward"],
+  ["--snapshot", "snapshot"],
+  ["--cwd", "guestCwd"],
+  ["--name", "name"],
+  ["--memory", "memory"],
+]);
+
+const RUN_BARE_FLAGS = new Map<string, RunFlag>([
+  ["--nested", "nested"],
+  ["--detached", "detach"],
+  ["--detach", "detach"],
+  ["--json", "json"],
+]);
+
+const RUN_FLAG_HANDLERS: Record<RunFlag, RunFlagHandler> = {
+  mount: handleRunMount,
+  liveMount: handleRunLiveMount,
+  env: handleRunEnv,
+  portForward: handleRunPortForward,
+  snapshot: handleRunSnapshot,
+  nested: handleRunNested,
+  nestedValue: handleRunNestedValue,
+  guestCwd: handleRunGuestCwd,
+  name: handleRunName,
+  detach: handleRunDetach,
+  json: handleRunJson,
+  memory: handleRunMemory,
+};
+
+export function parseRunArgs(argv: string[]): ParsedRunArgs {
+  const { pre, double_dash_args } = splitCommandArgs(argv);
+  const state = newRunParseState();
+
   for (let i = 0; i < pre.length; i++) {
-    const a = pre[i]!;
-    if (a === "--mount" || a.startsWith("--mount=")) {
-      if (mount) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--mount may be given at most once per invocation",
-        );
-      }
-      const r = consumeMount(a, pre, i);
-      mount = r.value;
-      i = r.next;
-    } else if (a === "--mount-live" || a.startsWith("--mount-live=")) {
-      const r = consumeLiveMount(a, pre, i);
-      liveMounts.push(r.value);
-      i = r.next;
-    } else if (a === "--env" || a.startsWith("--env=")) {
-      const r = consumeEnv(a, pre, i);
-      env[r.key] = r.value;
-      i = r.next;
-    } else if (
-      a === "-p" ||
-      a === "--publish" ||
-      a.startsWith("-p=") ||
-      a.startsWith("--publish=")
-    ) {
-      i = consumePortForward(a, pre, i, seenHostPorts, portForward);
-    } else if (a === "--snapshot" || a.startsWith("--snapshot=")) {
-      if (snapshot) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--snapshot may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, pre, i, "a path value");
-      snapshot = spec;
-      i = next;
-    } else if (a === "--nested") {
-      if (nested) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--nested may be given at most once per invocation",
-        );
-      }
-      nested = true;
-    } else if (a.startsWith("--nested=")) {
-      throw new ParseError("PARSE_FLAG_MALFORMED", "--nested does not take a value");
-    } else if (a === "--cwd" || a.startsWith("--cwd=")) {
-      if (guestCwd !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--cwd may be given at most once per invocation",
-        );
-      }
-      const r = consumeGuestCwd(a, pre, i);
-      guestCwd = r.value;
-      i = r.next;
-    } else if (a === "--name" || a.startsWith("--name=")) {
-      if (name) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--name may be given at most once per invocation",
-        );
-      }
-      const { spec, next } = takeValue(a, pre, i, "a value");
-      name = spec;
-      i = next;
-    } else if (a === "--detached" || a === "--detach") {
-      if (detached) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--detached may be given at most once per invocation",
-        );
-      }
-      detached = true;
-      // `--detached` is the legacy spelling. Surface a one-line
-      // deprecation note so existing scripts keep working but agents
-      // (and humans) learn the canonical name. Suppressed under
-      // MACHINEN_QUIET_DEPRECATIONS (set by tests) and under VITEST
-      // (parseRunArgs is unit-tested with --detached on every run).
-      if (a === "--detached" && !process.env.MACHINEN_QUIET_DEPRECATIONS && !process.env.VITEST) {
-        process.stderr.write(
-          "machinen: --detached is deprecated; use --detach (same behaviour).\n",
-        );
-      }
-    } else if (a === "--json") {
-      json = true;
-    } else if (a === "--memory" || a.startsWith("--memory=")) {
-      // #263 phase A: decimal MiB, no unit suffix. Same shape as
-      // MACHINEN_MEMORY. The runtime validates the floor; we only
-      // reject syntactically bad values here.
-      if (memory !== undefined) {
-        throw new ParseError(
-          "PARSE_FLAG_DUPLICATE",
-          "--memory may be given at most once per invocation",
-        );
-      }
-      const r = consumeMemory(a, pre, i);
-      memory = r.value;
-      i = r.next;
-    } else if (a.startsWith("-")) {
-      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${a}`);
-    } else {
-      positional.push(a);
+    const arg = pre[i]!;
+    const flag = runFlagFor(arg);
+    if (flag) {
+      i = RUN_FLAG_HANDLERS[flag](state, arg, pre, i);
+      continue;
     }
+    if (arg.startsWith("-")) {
+      throw new ParseError("PARSE_FLAG_UNKNOWN", `unknown flag: ${arg}`);
+    }
+    state.positional.push(arg);
   }
+
+  return finishRunArgs(state, double_dash_args);
+}
+
+function splitCommandArgs(argv: string[]): { pre: string[]; double_dash_args: string[] } {
+  const idx = argv.indexOf("--");
+  if (idx === -1) {
+    return { pre: argv, double_dash_args: [] };
+  }
+  return { pre: argv.slice(0, idx), double_dash_args: argv.slice(idx + 1) };
+}
+
+function newRunParseState(): RunParseState {
   return {
-    positional,
-    double_dash_args,
-    mount,
-    liveMounts: liveMounts.length > 0 ? liveMounts : undefined,
-    env: Object.keys(env).length > 0 ? env : undefined,
-    portForward: portForward.length > 0 ? portForward : undefined,
-    snapshot,
-    nested: nested || undefined,
-    name,
-    guestCwd,
-    detached: detached || undefined,
-    memory,
-    json: json || undefined,
+    positional: [],
+    liveMounts: [],
+    env: {},
+    portForward: [],
+    seenHostPorts: new Set<number>(),
+    nested: false,
+    detached: false,
+    json: false,
   };
+}
+
+function runFlagFor(arg: string): RunFlag | undefined {
+  const eq = arg.indexOf("=");
+  if (eq !== -1) {
+    const head = arg.slice(0, eq);
+    if (head === "--nested") {
+      return "nestedValue";
+    }
+    return RUN_VALUE_FLAGS.get(head);
+  }
+  return RUN_BARE_FLAGS.get(arg) ?? RUN_VALUE_FLAGS.get(arg);
+}
+
+function finishRunArgs(state: RunParseState, double_dash_args: string[]): ParsedRunArgs {
+  return {
+    positional: state.positional,
+    double_dash_args,
+    mount: state.mount,
+    liveMounts: state.liveMounts.length > 0 ? state.liveMounts : undefined,
+    env: Object.keys(state.env).length > 0 ? state.env : undefined,
+    portForward: state.portForward.length > 0 ? state.portForward : undefined,
+    snapshot: state.snapshot,
+    nested: state.nested || undefined,
+    name: state.name,
+    guestCwd: state.guestCwd,
+    detached: state.detached || undefined,
+    memory: state.memory,
+    json: state.json || undefined,
+  };
+}
+
+function handleRunMount(state: RunParseState, flag: string, args: string[], index: number): number {
+  assertRunFlagUnused(state.mount !== undefined, "--mount");
+  const result = consumeMount(flag, args, index);
+  state.mount = result.value;
+  return result.next;
+}
+
+function handleRunLiveMount(
+  state: RunParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  const result = consumeLiveMount(flag, args, index);
+  state.liveMounts.push(result.value);
+  return result.next;
+}
+
+function handleRunEnv(state: RunParseState, flag: string, args: string[], index: number): number {
+  const result = consumeEnv(flag, args, index);
+  state.env[result.key] = result.value;
+  return result.next;
+}
+
+function handleRunPortForward(
+  state: RunParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  return consumePortForward(flag, args, index, state.seenHostPorts, state.portForward);
+}
+
+function handleRunSnapshot(
+  state: RunParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertRunFlagUnused(state.snapshot !== undefined, "--snapshot");
+  const { spec, next } = takeValue(flag, args, index, "a path value");
+  state.snapshot = spec;
+  return next;
+}
+
+function handleRunNested(
+  state: RunParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  assertRunFlagUnused(state.nested, "--nested");
+  state.nested = true;
+  return index;
+}
+
+function handleRunNestedValue(): number {
+  throw new ParseError("PARSE_FLAG_MALFORMED", "--nested does not take a value");
+}
+
+function handleRunGuestCwd(
+  state: RunParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  assertRunFlagUnused(state.guestCwd !== undefined, "--cwd");
+  const result = consumeGuestCwd(flag, args, index);
+  state.guestCwd = result.value;
+  return result.next;
+}
+
+function handleRunName(state: RunParseState, flag: string, args: string[], index: number): number {
+  assertRunFlagUnused(state.name !== undefined, "--name");
+  const { spec, next } = takeValue(flag, args, index, "a value");
+  state.name = spec;
+  return next;
+}
+
+function handleRunDetach(
+  state: RunParseState,
+  flag: string,
+  _args: string[],
+  index: number,
+): number {
+  assertRunFlagUnused(state.detached, "--detached");
+  state.detached = true;
+  warnDeprecatedDetached(flag);
+  return index;
+}
+
+function handleRunJson(
+  state: RunParseState,
+  _flag: string,
+  _args: string[],
+  index: number,
+): number {
+  state.json = true;
+  return index;
+}
+
+function handleRunMemory(
+  state: RunParseState,
+  flag: string,
+  args: string[],
+  index: number,
+): number {
+  // #263 phase A: decimal MiB, no unit suffix. Same shape as
+  // MACHINEN_MEMORY. The runtime validates the floor; we only
+  // reject syntactically bad values here.
+  assertRunFlagUnused(state.memory !== undefined, "--memory");
+  const result = consumeMemory(flag, args, index);
+  state.memory = result.value;
+  return result.next;
+}
+
+function assertRunFlagUnused(used: boolean, flag: string): void {
+  if (used) {
+    throw new ParseError(
+      "PARSE_FLAG_DUPLICATE",
+      `${flag} may be given at most once per invocation`,
+    );
+  }
+}
+
+function warnDeprecatedDetached(flag: string): void {
+  // `--detached` is the legacy spelling. Surface a one-line
+  // deprecation note so existing scripts keep working but agents
+  // (and humans) learn the canonical name. Suppressed under
+  // MACHINEN_QUIET_DEPRECATIONS (set by tests) and under VITEST
+  // (parseRunArgs is unit-tested with --detached on every run).
+  if (flag === "--detached" && !process.env.MACHINEN_QUIET_DEPRECATIONS && !process.env.VITEST) {
+    process.stderr.write("machinen: --detached is deprecated; use --detach (same behaviour).\n");
+  }
 }
 
 function parsePort(raw: string, label: string): number {

--- a/packages/cli/src/quiet.ts
+++ b/packages/cli/src/quiet.ts
@@ -340,37 +340,75 @@ export function printDiagnostics(summary: string, opts: DiagnosticsOpts = {}): v
     return;
   }
 
-  const bufStr = typeof opts.buffer === "string" ? opts.buffer : (opts.buffer?.toString() ?? "");
+  const buffer = diagnosticsBuffer(opts.buffer);
   const tails = opts.tails ?? {};
-  const hasBuf = bufStr.trim().length > 0;
-  const hasTails = Object.values(tails).some((t) => t && t.trim().length > 0);
+  printDiagnosticsEnvelope(buffer, tails);
+  printDiagnosticsHint(opts.hint);
+}
 
-  if (hasBuf || hasTails) {
-    process.stderr.write("\n--- diagnostics ---\n");
-    if (hasBuf) {
-      process.stderr.write(bufStr);
-      if (!bufStr.endsWith("\n")) {
-        process.stderr.write("\n");
-      }
-    }
-    for (const [label, content] of Object.entries(tails)) {
-      if (!content || content.trim().length === 0) {
-        continue;
-      }
-      if (hasBuf) {
-        process.stderr.write("\n");
-      }
-      process.stderr.write(`[${label}]\n`);
-      process.stderr.write(content);
-      if (!content.endsWith("\n")) {
-        process.stderr.write("\n");
-      }
-    }
-    process.stderr.write("--------------------\n\n");
+function diagnosticsBuffer(buffer: DiagnosticsOpts["buffer"]): string {
+  if (typeof buffer === "string") {
+    return buffer;
   }
+  if (buffer === undefined) {
+    return "";
+  }
+  return buffer.toString();
+}
 
-  const hint = opts.hint ?? ESCAPE_HINT;
-  if (hint.length > 0) {
-    process.stderr.write(hint);
+function printDiagnosticsEnvelope(buffer: string, tails: Record<string, string>): void {
+  const hasBuffer = hasDiagnosticsContent(buffer);
+  if (!hasBuffer && !hasDiagnosticsTails(tails)) {
+    return;
+  }
+  process.stderr.write("\n--- diagnostics ---\n");
+  printDiagnosticsBuffer(buffer, hasBuffer);
+  printDiagnosticsTails(tails, hasBuffer);
+  process.stderr.write("--------------------\n\n");
+}
+
+function hasDiagnosticsContent(content: string | undefined): boolean {
+  if (!content) {
+    return false;
+  }
+  return content.trim().length > 0;
+}
+
+function hasDiagnosticsTails(tails: Record<string, string>): boolean {
+  return Object.values(tails).some(hasDiagnosticsContent);
+}
+
+function printDiagnosticsBuffer(buffer: string, hasBuffer: boolean): void {
+  if (!hasBuffer) {
+    return;
+  }
+  process.stderr.write(buffer);
+  writeTrailingNewline(buffer);
+}
+
+function printDiagnosticsTails(tails: Record<string, string>, afterBuffer: boolean): void {
+  for (const [label, content] of Object.entries(tails)) {
+    if (!hasDiagnosticsContent(content)) {
+      continue;
+    }
+    if (afterBuffer) {
+      process.stderr.write("\n");
+    }
+    process.stderr.write(`[${label}]\n`);
+    process.stderr.write(content);
+    writeTrailingNewline(content);
+  }
+}
+
+function writeTrailingNewline(content: string): void {
+  if (!content.endsWith("\n")) {
+    process.stderr.write("\n");
+  }
+}
+
+function printDiagnosticsHint(hint: string | undefined): void {
+  const text = hint ?? ESCAPE_HINT;
+  if (text.length > 0) {
+    process.stderr.write(text);
   }
 }

--- a/packages/runtime/src/bin/supervise.ts
+++ b/packages/runtime/src/bin/supervise.ts
@@ -12,28 +12,49 @@
 import { Sandboxes, Supervisor, bootPty } from "../index.ts";
 
 async function main() {
-  const count = Number.parseInt(process.argv[2] ?? "2", 10) || 2;
   const sandboxes = new Sandboxes();
-  const kids = [] as ReturnType<typeof bootPty>[];
-  for (let i = 0; i < count; i++) {
-    const shell = process.env.SHELL || "/bin/bash";
-    const vm = bootPty({
-      binary: shell,
-      args: ["-i"],
-      env: { PS1: `sandbox-${i}> ` },
-    });
-    sandboxes.add(String(i), vm as unknown as Parameters<Sandboxes["add"]>[1]);
-    kids.push(vm);
-  }
+  const kids = bootDemoSandboxes(sandboxes, supervisorCount());
 
   // Supervisor picks up rawTtyOnAttach and forwardResize automatically
   // when process.stdin / process.stdout are real TTYs.
   process.stdin.resume();
   const sup = new Supervisor({ sandboxes });
   await sup.run();
+  await killDemoSandboxes(kids);
+}
 
-  for (const k of kids) {
-    await k.kill();
+function supervisorCount(): number {
+  const parsed = Number.parseInt(process.argv[2] ?? "2", 10);
+  if (parsed) {
+    return parsed;
+  }
+  return 2;
+}
+
+function bootDemoSandboxes(sandboxes: Sandboxes, count: number): ReturnType<typeof bootPty>[] {
+  const kids = [] as ReturnType<typeof bootPty>[];
+  for (let i = 0; i < count; i++) {
+    const vm = bootPty({
+      binary: supervisorShell(),
+      args: ["-i"],
+      env: { PS1: `sandbox-${i}> ` },
+    });
+    sandboxes.add(String(i), vm as unknown as Parameters<Sandboxes["add"]>[1]);
+    kids.push(vm);
+  }
+  return kids;
+}
+
+function supervisorShell(): string {
+  if (process.env.SHELL) {
+    return process.env.SHELL;
+  }
+  return "/bin/bash";
+}
+
+async function killDemoSandboxes(kids: ReturnType<typeof bootPty>[]): Promise<void> {
+  for (const kid of kids) {
+    await kid.kill();
   }
 }
 

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -231,16 +231,15 @@ async function runOnSocket(
   }
 
   return new Promise<VsockExecResult>((done, fail) => {
-    const stdoutBufs: Buffer[] = [];
-    const stderrBufs: Buffer[] = [];
-    let exitCode: number | null = null;
-
-    // Parser state.
-    let buf: Buffer = Buffer.alloc(0);
-    // When in a payload phase, `awaitingBytes` > 0; otherwise we're
-    // looking for the next header line.
-    let awaitingBytes = 0;
-    let payloadTag: "O" | "E" | null = null;
+    const parser: ExecFrameParserState = {
+      stdoutBufs: [],
+      stderrBufs: [],
+      exitCode: null,
+      buf: Buffer.alloc(0),
+      awaitingBytes: 0,
+      payloadTag: null,
+      opts,
+    };
 
     // `null` (or `Infinity`) disables the wall-clock ceiling — the
     // command lives until it exits on its own or the VM goes away. The
@@ -271,7 +270,7 @@ async function runOnSocket(
       if (timer) {
         clearTimeout(timer);
       }
-      if (exitCode === null) {
+      if (parser.exitCode === null) {
         fail(
           new ExecError(
             "EXEC_AGENT_UNAVAILABLE",
@@ -281,89 +280,17 @@ async function runOnSocket(
         );
       } else {
         done({
-          exitCode,
-          stdout: Buffer.concat(stdoutBufs).toString("utf8"),
-          stderr: Buffer.concat(stderrBufs).toString("utf8"),
+          exitCode: parser.exitCode,
+          stdout: Buffer.concat(parser.stdoutBufs).toString("utf8"),
+          stderr: Buffer.concat(parser.stderrBufs).toString("utf8"),
         });
       }
     };
 
-    const step = () => {
-      // Consume as much of the buffer as we can. Loop until we need
-      // more bytes to make progress.
-      while (true) {
-        if (awaitingBytes > 0) {
-          if (buf.length === 0) {
-            return;
-          }
-          const take = Math.min(awaitingBytes, buf.length);
-          const chunk = buf.subarray(0, take);
-          buf = buf.subarray(take);
-          awaitingBytes -= take;
-          // Buffer for the resolved-result string field only when no
-          // streaming callback is set. Callers that pass `onStdout` /
-          // `onStderr` already have the bytes — keeping a parallel copy
-          // here costs RAM and, at >~512 MiB cumulative, breaks
-          // `Buffer.concat(...).toString("utf8")` in `finish()` with
-          // ERR_STRING_TOO_LONG (V8's max string length). Streaming
-          // callers see `stdout` / `stderr` come back as empty strings,
-          // which is the contract: opt into the callback, take the
-          // bytes there.
-          if (payloadTag === "O") {
-            if (opts.onStdout) {
-              opts.onStdout(chunk);
-            } else {
-              stdoutBufs.push(chunk);
-            }
-          } else if (payloadTag === "E") {
-            if (opts.onStderr) {
-              opts.onStderr(chunk);
-            } else {
-              stderrBufs.push(chunk);
-            }
-          }
-          if (awaitingBytes === 0) {
-            payloadTag = null;
-          }
-          continue;
-        }
-        // Header phase: look for \n.
-        const nl = buf.indexOf(0x0a);
-        if (nl === -1) {
-          return;
-        }
-        const line = buf.subarray(0, nl).toString("ascii");
-        buf = buf.subarray(nl + 1);
-        const [tag, nStr] = line.split(" ");
-        if (tag === "X") {
-          exitCode = Number.parseInt(nStr ?? "0", 10);
-          return;
-        }
-        if (tag !== "O" && tag !== "E") {
-          // Unknown frame tag — treat as protocol error and end.
-          fail(
-            new ExecError("EXEC_PROTOCOL", `VsockExec: unknown frame tag ${JSON.stringify(tag)}`),
-          );
-          socket.destroy();
-          return;
-        }
-        const n = Number.parseInt(nStr ?? "", 10);
-        if (!Number.isFinite(n) || n < 0) {
-          fail(
-            new ExecError("EXEC_PROTOCOL", `VsockExec: bad frame length ${JSON.stringify(nStr)}`),
-          );
-          socket.destroy();
-          return;
-        }
-        awaitingBytes = n;
-        payloadTag = tag;
-      }
-    };
-
     socket.on("data", (data: Buffer) => {
-      buf = buf.length === 0 ? data : Buffer.concat([buf, data]);
+      parser.buf = parser.buf.length === 0 ? data : Buffer.concat([parser.buf, data]);
       try {
-        step();
+        stepExecParser(parser);
       } catch (e) {
         fail(e as Error);
         socket.destroy();
@@ -381,37 +308,187 @@ async function runOnSocket(
   });
 }
 
-async function connectWithRetry(udsPath: string, opts: VsockExecOptions): Promise<Socket> {
-  const totalMs = opts.connectTimeoutMs ?? 30_000;
-  const deadline = Date.now() + totalMs;
-  const retryMs = opts.retryMs ?? 250;
-  let lastErr: Error | null = null;
-  let attempt = 0;
-  while (Date.now() < deadline) {
-    attempt++;
-    try {
-      const s = await connectOnce(udsPath);
-      if (attempt > 1) {
-        debug("connect ok after attempt=%d", attempt);
+type ExecPayloadTag = "O" | "E";
+
+interface ExecFrameParserState {
+  stdoutBufs: Buffer[];
+  stderrBufs: Buffer[];
+  exitCode: number | null;
+  buf: Buffer;
+  awaitingBytes: number;
+  payloadTag: ExecPayloadTag | null;
+  opts: VsockExecOptions;
+}
+
+function stepExecParser(state: ExecFrameParserState): void {
+  while (true) {
+    if (state.awaitingBytes > 0) {
+      if (!consumeExecPayload(state)) {
+        return;
       }
-      return s;
-    } catch (err) {
-      lastErr = err as Error;
-      await new Promise((r) => setTimeout(r, retryMs));
+      continue;
+    }
+    const header = readExecHeader(state);
+    if (!header) {
+      return;
+    }
+    if (header.tag === "X") {
+      state.exitCode = header.exitCode;
+      return;
+    }
+    state.awaitingBytes = header.length;
+    state.payloadTag = header.tag;
+  }
+}
+
+function consumeExecPayload(state: ExecFrameParserState): boolean {
+  if (state.buf.length === 0) {
+    return false;
+  }
+  const take = Math.min(state.awaitingBytes, state.buf.length);
+  const chunk = state.buf.subarray(0, take);
+  state.buf = state.buf.subarray(take);
+  state.awaitingBytes -= take;
+  deliverExecPayload(state, chunk);
+  clearPayloadTagIfComplete(state);
+  return true;
+}
+
+function deliverExecPayload(state: ExecFrameParserState, chunk: Buffer): void {
+  if (state.payloadTag === "O") {
+    pushExecPayload(chunk, state.opts.onStdout, state.stdoutBufs);
+    return;
+  }
+  if (state.payloadTag === "E") {
+    pushExecPayload(chunk, state.opts.onStderr, state.stderrBufs);
+  }
+}
+
+function pushExecPayload(
+  chunk: Buffer,
+  onChunk: ((chunk: Buffer) => void) | undefined,
+  sink: Buffer[],
+): void {
+  if (onChunk) {
+    onChunk(chunk);
+  } else {
+    sink.push(chunk);
+  }
+}
+
+function clearPayloadTagIfComplete(state: ExecFrameParserState): void {
+  if (state.awaitingBytes === 0) {
+    state.payloadTag = null;
+  }
+}
+
+type ExecFrameHeader = { tag: "X"; exitCode: number } | { tag: ExecPayloadTag; length: number };
+
+function readExecHeader(state: ExecFrameParserState): ExecFrameHeader | undefined {
+  const nl = state.buf.indexOf(0x0a);
+  if (nl === -1) {
+    return undefined;
+  }
+  const line = state.buf.subarray(0, nl).toString("ascii");
+  state.buf = state.buf.subarray(nl + 1);
+  return parseExecHeaderLine(line);
+}
+
+function parseExecHeaderLine(line: string): ExecFrameHeader {
+  const [tag, nStr] = line.split(" ");
+  if (tag === "X") {
+    return { tag, exitCode: Number.parseInt(nStr ?? "0", 10) };
+  }
+  if (tag !== "O" && tag !== "E") {
+    throw new ExecError("EXEC_PROTOCOL", `VsockExec: unknown frame tag ${JSON.stringify(tag)}`);
+  }
+  const length = parseExecFrameLength(nStr);
+  return { tag, length };
+}
+
+function parseExecFrameLength(nStr: string | undefined): number {
+  const length = Number.parseInt(nStr ?? "", 10);
+  if (!Number.isFinite(length) || length < 0) {
+    throw new ExecError("EXEC_PROTOCOL", `VsockExec: bad frame length ${JSON.stringify(nStr)}`);
+  }
+  return length;
+}
+
+interface ConnectRetrySettings {
+  totalMs: number;
+  deadline: number;
+  retryMs: number;
+}
+
+interface ConnectRetryState {
+  attempt: number;
+  lastErr: Error | null;
+}
+
+async function connectWithRetry(udsPath: string, opts: VsockExecOptions): Promise<Socket> {
+  const settings = connectRetrySettings(opts);
+  const state: ConnectRetryState = { attempt: 0, lastErr: null };
+  while (Date.now() < settings.deadline) {
+    const socket = await tryConnectAttempt(udsPath, settings.retryMs, state);
+    if (socket) {
+      return socket;
     }
   }
+  throw connectRetryError(udsPath, settings.totalMs, state);
+}
+
+function connectRetrySettings(opts: VsockExecOptions): ConnectRetrySettings {
+  const totalMs = opts.connectTimeoutMs ?? 30_000;
+  return {
+    totalMs,
+    deadline: Date.now() + totalMs,
+    retryMs: opts.retryMs ?? 250,
+  };
+}
+
+async function tryConnectAttempt(
+  udsPath: string,
+  retryMs: number,
+  state: ConnectRetryState,
+): Promise<Socket | null> {
+  state.attempt++;
+  try {
+    const socket = await connectOnce(udsPath);
+    logRetriedConnect(state.attempt);
+    return socket;
+  } catch (err) {
+    state.lastErr = err as Error;
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, retryMs));
+    return null;
+  }
+}
+
+function logRetriedConnect(attempt: number): void {
+  if (attempt > 1) {
+    debug("connect ok after attempt=%d", attempt);
+  }
+}
+
+function connectRetryError(udsPath: string, totalMs: number, state: ConnectRetryState): ExecError {
   debug(
     "connect gave up uds=%s after %dms attempts=%d lastErr=%s",
     udsPath,
     totalMs,
-    attempt,
-    lastErr?.message,
+    state.attempt,
+    state.lastErr?.message,
   );
-  throw new ExecError(
+  return new ExecError(
     "EXEC_AGENT_UNAVAILABLE",
-    `VsockExec: could not reach ${udsPath} within ${totalMs}ms: ${lastErr?.message ?? "no error"}`,
-    { retryable: true, cause: lastErr ?? undefined },
+    `VsockExec: could not reach ${udsPath} within ${totalMs}ms: ${connectRetryMessage(state.lastErr)}`,
+    { retryable: true, cause: state.lastErr ?? undefined },
   );
+}
+
+function connectRetryMessage(lastErr: Error | null): string {
+  if (lastErr === null) {
+    return "no error";
+  }
+  return lastErr.message;
 }
 
 function connectOnce(udsPath: string): Promise<Socket> {
@@ -441,6 +518,106 @@ function endSocket(s: Socket): Promise<void> {
   });
 }
 
+interface PtyParserState {
+  buffer: Buffer;
+  awaitingBytes: number;
+}
+
+interface PtyParserHandlers {
+  stdout: Writable;
+  onExit: (code: number) => void;
+  onError: (err: Error) => void;
+}
+
+type PtyFrameHeader =
+  | { kind: "exit"; code: number }
+  | { kind: "stdout"; bytes: number }
+  | { kind: "error"; error: ExecError };
+
+function createPtyParserState(): PtyParserState {
+  return { buffer: Buffer.alloc(0), awaitingBytes: 0 };
+}
+
+function ingestPtyOutput(state: PtyParserState, data: Buffer, handlers: PtyParserHandlers): void {
+  state.buffer = state.buffer.length === 0 ? data : Buffer.concat([state.buffer, data]);
+  while (consumeNextPtyFrame(state, handlers)) {}
+}
+
+function consumeNextPtyFrame(state: PtyParserState, handlers: PtyParserHandlers): boolean {
+  if (state.awaitingBytes > 0) {
+    return consumePtyPayload(state, handlers.stdout);
+  }
+  const line = takePtyHeaderLine(state);
+  return line === undefined ? false : handlePtyHeaderLine(state, line, handlers);
+}
+
+function consumePtyPayload(state: PtyParserState, stdout: Writable): boolean {
+  if (state.buffer.length === 0) {
+    return false;
+  }
+  const take = Math.min(state.awaitingBytes, state.buffer.length);
+  stdout.write(state.buffer.subarray(0, take));
+  state.buffer = state.buffer.subarray(take);
+  state.awaitingBytes -= take;
+  return true;
+}
+
+function takePtyHeaderLine(state: PtyParserState): string | undefined {
+  const nl = state.buffer.indexOf(0x0a);
+  if (nl === -1) {
+    return undefined;
+  }
+  const line = state.buffer.subarray(0, nl).toString("ascii");
+  state.buffer = state.buffer.subarray(nl + 1);
+  return line;
+}
+
+function handlePtyHeaderLine(
+  state: PtyParserState,
+  line: string,
+  handlers: PtyParserHandlers,
+): boolean {
+  const header = parsePtyHeaderLine(line);
+  if (header.kind === "error") {
+    handlers.onError(header.error);
+    return false;
+  }
+  if (header.kind === "exit") {
+    handlers.onExit(header.code);
+    return false;
+  }
+  state.awaitingBytes = header.bytes;
+  return true;
+}
+
+function parsePtyHeaderLine(line: string): PtyFrameHeader {
+  const [tag, nStr] = line.split(" ");
+  if (tag === "X") {
+    return { kind: "exit", code: Number.parseInt(nStr ?? "0", 10) };
+  }
+  if (tag === "O") {
+    return parsePtyOutputHeader(nStr);
+  }
+  return {
+    kind: "error",
+    error: new ExecError("EXEC_PROTOCOL", `VsockExec.startPty: unknown PTY frame tag ${tag}`),
+  };
+}
+
+function parsePtyOutputHeader(nStr: string | undefined): PtyFrameHeader {
+  const bytes = Number.parseInt(nStr ?? "", 10);
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return {
+      kind: "error",
+      error: new ExecError(
+        "EXEC_PROTOCOL",
+        `VsockExec.startPty: bad O frame length ${JSON.stringify(nStr)}`,
+      ),
+    };
+  }
+  return { kind: "stdout", bytes };
+}
+
 // Wire `cols`/`rows` + the existing `cmd` into the PTY opcode header,
 // then plug bidirectional pumps onto an already-connected socket. Why
 // a separate helper: keeps `startPty` readable — the public method is
@@ -457,11 +634,7 @@ function startPtyImpl(udsPath: string, cmd: string, opts: VsockExecPtyOptions): 
     rejectResult = rej;
   });
 
-  // O-frame parser state: we may receive partial frames across
-  // socket data events. `awaitingBytes` > 0 means we're inside an
-  // O payload; otherwise we're scanning for the next header line.
-  let parseBuf: Buffer = Buffer.alloc(0);
-  let awaitingBytes = 0;
+  const parser = createPtyParserState();
 
   const reject = (err: Error) => {
     if (settled) {
@@ -491,48 +664,13 @@ function startPtyImpl(udsPath: string, cmd: string, opts: VsockExecPtyOptions): 
   };
 
   const onSocketData = (data: Buffer) => {
-    parseBuf = parseBuf.length === 0 ? data : Buffer.concat([parseBuf, data]);
-    while (true) {
-      if (awaitingBytes > 0) {
-        if (parseBuf.length === 0) {
-          return;
-        }
-        const take = Math.min(awaitingBytes, parseBuf.length);
-        const chunk = parseBuf.subarray(0, take);
-        parseBuf = parseBuf.subarray(take);
-        awaitingBytes -= take;
-        opts.stdout.write(chunk);
-        continue;
-      }
-      const nl = parseBuf.indexOf(0x0a);
-      if (nl === -1) {
-        return;
-      }
-      const line = parseBuf.subarray(0, nl).toString("ascii");
-      parseBuf = parseBuf.subarray(nl + 1);
-      const [tag, nStr] = line.split(" ");
-      if (tag === "X") {
-        exitCode = Number.parseInt(nStr ?? "0", 10);
-        // Agent will close right after; wait for `close` event so we
-        // don't race the rest of the buffered O bytes.
-        return;
-      }
-      if (tag !== "O") {
-        reject(new ExecError("EXEC_PROTOCOL", `VsockExec.startPty: unknown PTY frame tag ${tag}`));
-        return;
-      }
-      const n = Number.parseInt(nStr ?? "", 10);
-      if (!Number.isFinite(n) || n < 0) {
-        reject(
-          new ExecError(
-            "EXEC_PROTOCOL",
-            `VsockExec.startPty: bad O frame length ${JSON.stringify(nStr)}`,
-          ),
-        );
-        return;
-      }
-      awaitingBytes = n;
-    }
+    ingestPtyOutput(parser, data, {
+      stdout: opts.stdout,
+      onExit: (code) => {
+        exitCode = code;
+      },
+      onError: reject,
+    });
   };
 
   const onStdinData = (chunk: Buffer | string) => {

--- a/packages/runtime/src/gc.ts
+++ b/packages/runtime/src/gc.ts
@@ -66,43 +66,13 @@ export function runGc(opts: RunGcOptions = {}): GcResult[] {
 }
 
 function reapEntry(entry: RegistryEntry, status: PidStatus, dryRun: boolean): GcResult {
-  debug(
-    "reap pid=%d name=%s status=%s dryRun=%s",
-    entry.pid,
-    entry.name ?? "<unset>",
-    status,
-    dryRun,
-  );
+  debugReapEntry(entry, status, dryRun);
   const removedPaths: string[] = [];
   const failedPaths: string[] = [];
-  const candidates: string[] = [];
-  if (entry.cleanupPaths) {
-    for (const p of entry.cleanupPaths) {
-      candidates.push(p);
-    }
+  for (const path of cleanupCandidates(entry)) {
+    reapPath(path, dryRun, removedPaths, failedPaths);
   }
-  if (entry.bootLogPath) {
-    candidates.push(entry.bootLogPath);
-  }
-  for (const p of candidates) {
-    if (!existsSync(p)) {
-      // Treat already-gone as success — the goal is that the path
-      // doesn't exist after gc runs.
-      continue;
-    }
-    if (dryRun) {
-      removedPaths.push(p);
-      continue;
-    }
-    if (rmPath(p)) {
-      removedPaths.push(p);
-    } else {
-      failedPaths.push(p);
-    }
-  }
-  if (!dryRun) {
-    removeEntry(entry.pid);
-  }
+  removeRegistryEntry(entry, dryRun);
   return {
     pid: entry.pid,
     name: entry.name,
@@ -111,6 +81,56 @@ function reapEntry(entry: RegistryEntry, status: PidStatus, dryRun: boolean): Gc
     failedPaths,
     registryRemoved: true,
   };
+}
+
+function debugReapEntry(entry: RegistryEntry, status: PidStatus, dryRun: boolean): void {
+  debug(
+    "reap pid=%d name=%s status=%s dryRun=%s",
+    entry.pid,
+    entry.name ?? "<unset>",
+    status,
+    dryRun,
+  );
+}
+
+function cleanupCandidates(entry: RegistryEntry): string[] {
+  const candidates = [...(entry.cleanupPaths ?? [])];
+  if (entry.bootLogPath) {
+    candidates.push(entry.bootLogPath);
+  }
+  return candidates;
+}
+
+function reapPath(
+  path: string,
+  dryRun: boolean,
+  removedPaths: string[],
+  failedPaths: string[],
+): void {
+  if (!existsSync(path)) {
+    // Treat already-gone as success — the goal is that the path
+    // doesn't exist after gc runs.
+    return;
+  }
+  if (dryRun) {
+    removedPaths.push(path);
+    return;
+  }
+  recordRmPath(path, removedPaths, failedPaths);
+}
+
+function recordRmPath(path: string, removedPaths: string[], failedPaths: string[]): void {
+  if (rmPath(path)) {
+    removedPaths.push(path);
+  } else {
+    failedPaths.push(path);
+  }
+}
+
+function removeRegistryEntry(entry: RegistryEntry, dryRun: boolean): void {
+  if (!dryRun) {
+    removeEntry(entry.pid);
+  }
 }
 
 function rmPath(p: string): boolean {

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -60,42 +60,67 @@ let installInFlight: Promise<string | null> | null = null;
  * an absolute path, or `null` if gvproxy isn't available on this host.
  */
 function resolveGvproxyBinary(vmmBinary: string): string | null {
-  const envOverride = process.env.MACHINEN_GVPROXY;
-  if (envOverride) {
-    // Sentinel values — opt out of gvproxy entirely without fabricating
-    // a fake path. Used by the test harness so stub-binary boots don't
-    // pay the auto-install cost.
-    if (isGvproxyDisabledSentinel(envOverride)) {
-      return null;
-    }
-    if (existsSync(envOverride)) {
-      debug("resolved via MACHINEN_GVPROXY=%s", envOverride);
-      return envOverride;
-    }
-    // Explicit override that points at nothing is a user mistake —
-    // surface it rather than silently falling through.
-    throw new GvproxyError(
-      "GVPROXY_NOT_FOUND",
-      `MACHINEN_GVPROXY=${envOverride} is set but that file does not exist.`,
-    );
+  const envOverride = resolveGvproxyEnvOverride();
+  if (envOverride !== undefined) {
+    return envOverride;
   }
+  return resolveGvproxyFromDisk(vmmBinary);
+}
 
+function resolveGvproxyEnvOverride(): string | null | undefined {
+  const envOverride = process.env.MACHINEN_GVPROXY;
+  if (!envOverride) {
+    return undefined;
+  }
+  // Sentinel values — opt out of gvproxy entirely without fabricating
+  // a fake path. Used by the test harness so stub-binary boots don't
+  // pay the auto-install cost.
+  if (isGvproxyDisabledSentinel(envOverride)) {
+    return null;
+  }
+  if (existsSync(envOverride)) {
+    debug("resolved via MACHINEN_GVPROXY=%s", envOverride);
+    return envOverride;
+  }
+  // Explicit override that points at nothing is a user mistake —
+  // surface it rather than silently falling through.
+  throw new GvproxyError(
+    "GVPROXY_NOT_FOUND",
+    `MACHINEN_GVPROXY=${envOverride} is set but that file does not exist.`,
+  );
+}
+
+function resolveGvproxyFromDisk(vmmBinary: string): string | null {
+  const sibling = resolveGvproxySibling(vmmBinary);
+  if (sibling) {
+    return sibling;
+  }
+  const cached = resolveCachedGvproxy();
+  if (cached) {
+    return cached;
+  }
+  return resolveGvproxyFromPath();
+}
+
+function resolveGvproxySibling(vmmBinary: string): string | null {
   const sibling = join(dirname(vmmBinary), "gvproxy");
   if (existsSync(sibling)) {
     debug("resolved via VMM sibling=%s", sibling);
     return sibling;
   }
+  return null;
+}
 
+function resolveCachedGvproxy(): string | null {
   const cached = gvproxyCachePath();
   if (existsSync(cached)) {
     return cached;
   }
+  return null;
+}
 
-  const pathDirs = (process.env.PATH ?? "").split(pathSep);
-  for (const dir of pathDirs) {
-    if (!dir) {
-      continue;
-    }
+function resolveGvproxyFromPath(): string | null {
+  for (const dir of pathDirs()) {
     const candidate = join(dir, "gvproxy");
     if (existsSync(candidate)) {
       debug("resolved via PATH=%s", candidate);
@@ -104,6 +129,10 @@ function resolveGvproxyBinary(vmmBinary: string): string | null {
   }
   debug("not found (env, sibling, PATH all missed)");
   return null;
+}
+
+function pathDirs(): string[] {
+  return (process.env.PATH ?? "").split(pathSep).filter(Boolean);
 }
 
 /**

--- a/packages/runtime/src/lazy-pagemap.ts
+++ b/packages/runtime/src/lazy-pagemap.ts
@@ -228,7 +228,38 @@ interface RewriteResult {
  * fits inside one of the ranges get PE_LAZY OR'd in. Pass an empty
  * array to leave the pagemap untouched. Exported for tests.
  */
+interface PagemapMessage {
+  msg: Buffer;
+  isFirst: boolean;
+}
+
+interface PagemapRewriteState {
+  out: Buffer[];
+  changed: boolean;
+  entriesFlagged: number;
+  entriesAlreadyLazy: number;
+}
+
 export function rewritePagemap(input: Buffer, lazyRanges: VmaRange[] = []): RewriteResult {
+  validatePagemapHeader(input);
+  const state: PagemapRewriteState = {
+    out: [input.subarray(0, 8)],
+    changed: false,
+    entriesFlagged: 0,
+    entriesAlreadyLazy: 0,
+  };
+  for (const message of pagemapMessages(input)) {
+    appendRewrittenPagemapMessage(state, message, lazyRanges);
+  }
+  return {
+    out: Buffer.concat(state.out),
+    changed: state.changed,
+    entriesFlagged: state.entriesFlagged,
+    entriesAlreadyLazy: state.entriesAlreadyLazy,
+  };
+}
+
+function validatePagemapHeader(input: Buffer): void {
   if (input.length < 8) {
     throw new Error("pagemap: file too short for magic header");
   }
@@ -238,46 +269,64 @@ export function rewritePagemap(input: Buffer, lazyRanges: VmaRange[] = []): Rewr
   if (input.readUInt32LE(4) !== PAGEMAP_MAGIC) {
     throw new Error(`pagemap: bad pagemap magic 0x${input.readUInt32LE(4).toString(16)}`);
   }
+}
 
-  const out: Buffer[] = [input.subarray(0, 8)];
+function* pagemapMessages(input: Buffer): Generator<PagemapMessage> {
   let pos = 8;
-  let entriesFlagged = 0;
-  let entriesAlreadyLazy = 0;
-  let changed = false;
-  let isFirstMessage = true;
-
+  let isFirst = true;
   while (pos < input.length) {
-    if (pos + 4 > input.length) {
-      throw new Error("pagemap: truncated size prefix");
-    }
-    const size = input.readUInt32LE(pos);
-    pos += 4;
-    if (pos + size > input.length) {
-      throw new Error("pagemap: truncated message body");
-    }
-    const msg = input.subarray(pos, pos + size);
-    pos += size;
-
-    let outMsg: Buffer = msg;
-    if (!isFirstMessage) {
-      const result = rewriteEntry(msg, lazyRanges);
-      if (result.alreadyLazy) {
-        entriesAlreadyLazy++;
-      }
-      if (result.changed) {
-        outMsg = result.out;
-        entriesFlagged++;
-        changed = true;
-      }
-    }
-    isFirstMessage = false;
-
-    const sizeBuf = Buffer.alloc(4);
-    sizeBuf.writeUInt32LE(outMsg.length, 0);
-    out.push(sizeBuf, outMsg);
+    const read = readPagemapMessage(input, pos);
+    yield { msg: read.msg, isFirst };
+    pos = read.next;
+    isFirst = false;
   }
+}
 
-  return { out: Buffer.concat(out), changed, entriesFlagged, entriesAlreadyLazy };
+function readPagemapMessage(input: Buffer, pos: number): { msg: Buffer; next: number } {
+  if (pos + 4 > input.length) {
+    throw new Error("pagemap: truncated size prefix");
+  }
+  const size = input.readUInt32LE(pos);
+  const msgStart = pos + 4;
+  const next = msgStart + size;
+  if (next > input.length) {
+    throw new Error("pagemap: truncated message body");
+  }
+  return { msg: input.subarray(msgStart, next), next };
+}
+
+function appendRewrittenPagemapMessage(
+  state: PagemapRewriteState,
+  message: PagemapMessage,
+  lazyRanges: VmaRange[],
+): void {
+  const outMsg = message.isFirst
+    ? message.msg
+    : rewritePagemapEntryMessage(state, message.msg, lazyRanges);
+  appendPagemapMessage(state.out, outMsg);
+}
+
+function rewritePagemapEntryMessage(
+  state: PagemapRewriteState,
+  msg: Buffer,
+  lazyRanges: VmaRange[],
+): Buffer {
+  const result = rewriteEntry(msg, lazyRanges);
+  if (result.alreadyLazy) {
+    state.entriesAlreadyLazy++;
+  }
+  if (result.changed) {
+    state.entriesFlagged++;
+    state.changed = true;
+    return result.out;
+  }
+  return msg;
+}
+
+function appendPagemapMessage(out: Buffer[], msg: Buffer): void {
+  const sizeBuf = Buffer.alloc(4);
+  sizeBuf.writeUInt32LE(msg.length, 0);
+  out.push(sizeBuf, msg);
 }
 
 interface EntryRewriteResult {
@@ -286,67 +335,106 @@ interface EntryRewriteResult {
   alreadyLazy: boolean;
 }
 
+interface PagemapEntryFields {
+  flagsValPos: number;
+  flagsValLen: number;
+  flags: number;
+  vaddr: bigint | null;
+  nrPages: bigint | null;
+  compatNrPages: bigint | null;
+}
+
 function rewriteEntry(msg: Buffer, lazyRanges: VmaRange[]): EntryRewriteResult {
-  // Walk the entry's protobuf fields. We need: vaddr (1), nr_pages (5),
-  // compat_nr_pages (2) as fallback, flags (4). nr_pages * 4096 sets
-  // the byte length of this entry's range.
+  const fields = parsePagemapEntryFields(msg);
+  if (entryIsAlreadyLazy(fields)) {
+    return unchangedEntry(msg, true);
+  }
+  if (!entryShouldBecomeLazy(fields, lazyRanges)) {
+    return unchangedEntry(msg, false);
+  }
+  return rewriteEntryFlags(msg, fields);
+}
+
+function parsePagemapEntryFields(msg: Buffer): PagemapEntryFields {
+  const fields: PagemapEntryFields = {
+    flagsValPos: -1,
+    flagsValLen: 0,
+    flags: 0,
+    vaddr: null,
+    nrPages: null,
+    compatNrPages: null,
+  };
   let pos = 0;
-  let flagsValPos = -1;
-  let flagsValLen = 0;
-  let flags = 0;
-  let vaddr: bigint | null = null;
-  let nrPages: bigint | null = null;
-  let compatNrPages: bigint | null = null;
-
   while (pos < msg.length) {
-    const t = readVarint(msg, pos);
-    const wireType = Number(t.value & 0x7n);
-    const field = Number(t.value >> 3n);
-    pos = t.next;
+    pos = readPagemapEntryField(msg, pos, fields);
+  }
+  return fields;
+}
 
-    if (wireType !== 0) {
-      pos = skipField(msg, pos, wireType);
-      continue;
-    }
-    const fStart = pos;
-    const v = readVarint(msg, pos);
-    pos = v.next;
-    if (field === 1) {
-      vaddr = v.value;
-    } else if (field === 2) {
-      compatNrPages = v.value;
-    } else if (field === 4) {
-      flagsValPos = fStart;
-      flagsValLen = v.next - fStart;
-      flags = Number(v.value);
-    } else if (field === 5) {
-      nrPages = v.value;
-    }
+function readPagemapEntryField(msg: Buffer, pos: number, fields: PagemapEntryFields): number {
+  const tag = readVarint(msg, pos);
+  const wireType = Number(tag.value & 0x7n);
+  const field = Number(tag.value >> 3n);
+  if (wireType !== 0) {
+    return skipField(msg, tag.next, wireType);
   }
+  const valueStart = tag.next;
+  const value = readVarint(msg, valueStart);
+  applyPagemapEntryField(fields, field, value.value, valueStart, value.next);
+  return value.next;
+}
 
-  const isPresent = (flags & PE_PRESENT) !== 0;
-  const isLazy = (flags & PE_LAZY) !== 0;
-  if (!isPresent) {
-    return { out: msg, changed: false, alreadyLazy: false };
+function applyPagemapEntryField(
+  fields: PagemapEntryFields,
+  field: number,
+  value: bigint,
+  valueStart: number,
+  valueNext: number,
+): void {
+  if (field === 1) {
+    fields.vaddr = value;
+  } else if (field === 2) {
+    fields.compatNrPages = value;
+  } else if (field === 4) {
+    fields.flagsValPos = valueStart;
+    fields.flagsValLen = valueNext - valueStart;
+    fields.flags = Number(value);
+  } else if (field === 5) {
+    fields.nrPages = value;
   }
-  if (isLazy) {
-    return { out: msg, changed: false, alreadyLazy: true };
-  }
-  if (vaddr === null) {
-    return { out: msg, changed: false, alreadyLazy: false };
-  }
-  const pages = nrPages ?? compatNrPages ?? 0n;
-  const len = pages * 4096n;
-  if (lazyRanges.length === 0 || !vaddrInLazyRange(vaddr, len, lazyRanges)) {
-    return { out: msg, changed: false, alreadyLazy: false };
-  }
+}
 
-  const newFlags = flags | PE_LAZY;
+function entryIsAlreadyLazy(fields: PagemapEntryFields): boolean {
+  return (fields.flags & PE_LAZY) !== 0;
+}
+
+function entryShouldBecomeLazy(fields: PagemapEntryFields, lazyRanges: VmaRange[]): boolean {
+  if (!entryIsPresentWithAddress(fields)) {
+    return false;
+  }
+  const len = entryPageCount(fields) * 4096n;
+  return lazyRanges.length > 0 && vaddrInLazyRange(fields.vaddr!, len, lazyRanges);
+}
+
+function entryIsPresentWithAddress(fields: PagemapEntryFields): boolean {
+  return (fields.flags & PE_PRESENT) !== 0 && fields.vaddr !== null;
+}
+
+function entryPageCount(fields: PagemapEntryFields): bigint {
+  return fields.nrPages ?? fields.compatNrPages ?? 0n;
+}
+
+function unchangedEntry(msg: Buffer, alreadyLazy: boolean): EntryRewriteResult {
+  return { out: msg, changed: false, alreadyLazy };
+}
+
+function rewriteEntryFlags(msg: Buffer, fields: PagemapEntryFields): EntryRewriteResult {
+  const newFlags = fields.flags | PE_LAZY;
   const newFlagsBytes = Buffer.from(encodeVarint(newFlags));
   const out = Buffer.concat([
-    msg.subarray(0, flagsValPos),
+    msg.subarray(0, fields.flagsValPos),
     newFlagsBytes,
-    msg.subarray(flagsValPos + flagsValLen),
+    msg.subarray(fields.flagsValPos + fields.flagsValLen),
   ]);
   return { out, changed: true, alreadyLazy: false };
 }

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -78,58 +78,95 @@ const DEFAULT_WORKSPACE_EXCLUDES = new Set<string>([
 
 // --- newc cpio encoder ---------------------------------------------
 
-/** Emit one newc cpio entry as a Buffer. */
-function newc(
-  name: string,
-  mode: number,
-  opts: {
-    uid?: number;
-    gid?: number;
-    nlink?: number;
-    mtime?: number;
-    rmajor?: number;
-    rminor?: number;
-    data?: Buffer;
-  } = {},
-): Buffer {
-  const uid = opts.uid ?? 0;
-  const gid = opts.gid ?? 0;
-  const nlink = opts.nlink ?? 1;
-  const mtime = opts.mtime ?? 0;
-  const rmajor = opts.rmajor ?? 0;
-  const rminor = opts.rminor ?? 0;
-  const data = opts.data ?? Buffer.alloc(0);
+interface NewcOptions {
+  uid?: number;
+  gid?: number;
+  nlink?: number;
+  mtime?: number;
+  rmajor?: number;
+  rminor?: number;
+  data?: Buffer;
+}
 
-  const nameBytes = Buffer.concat([Buffer.from(name, "utf8"), Buffer.from([0])]);
-  const fields = [
+interface NormalizedNewcOptions {
+  uid: number;
+  gid: number;
+  nlink: number;
+  mtime: number;
+  rmajor: number;
+  rminor: number;
+  data: Buffer;
+}
+
+/** Emit one newc cpio entry as a Buffer. */
+function newc(name: string, mode: number, opts: NewcOptions = {}): Buffer {
+  const normalized = normalizeNewcOptions(opts);
+  const nameBytes = newcNameBytes(name);
+  const header = Buffer.from(newcHeader(mode, normalized, nameBytes.length), "ascii");
+  return newcEntryBuffer(header, nameBytes, normalized.data);
+}
+
+function normalizeNewcOptions(opts: NewcOptions): NormalizedNewcOptions {
+  return {
+    uid: opts.uid ?? 0,
+    gid: opts.gid ?? 0,
+    nlink: opts.nlink ?? 1,
+    mtime: opts.mtime ?? 0,
+    rmajor: opts.rmajor ?? 0,
+    rminor: opts.rminor ?? 0,
+    data: opts.data ?? Buffer.alloc(0),
+  };
+}
+
+function newcNameBytes(name: string): Buffer {
+  return Buffer.concat([Buffer.from(name, "utf8"), Buffer.from([0])]);
+}
+
+function newcHeader(mode: number, opts: NormalizedNewcOptions, nameSize: number): string {
+  return "070701" + newcFields(mode, opts, nameSize).map(newcHexField).join("");
+}
+
+function newcFields(mode: number, opts: NormalizedNewcOptions, nameSize: number): number[] {
+  return [
     0,
     mode,
-    uid,
-    gid,
-    nlink,
-    mtime,
-    data.length,
+    opts.uid,
+    opts.gid,
+    opts.nlink,
+    opts.mtime,
+    opts.data.length,
     0, // devmajor
     0, // devminor
-    rmajor,
-    rminor,
-    nameBytes.length,
+    opts.rmajor,
+    opts.rminor,
+    nameSize,
     0, // check
   ];
-  let hdr = "070701";
-  for (const v of fields) {
-    hdr += v.toString(16).padStart(8, "0");
-  }
+}
 
-  let out = Buffer.concat([Buffer.from(hdr, "ascii"), nameBytes]);
-  while (out.length % 4 !== 0) {
-    out = Buffer.concat([out, Buffer.from([0])]);
-  }
-  out = Buffer.concat([out, data]);
-  while (out.length % 4 !== 0) {
-    out = Buffer.concat([out, Buffer.from([0])]);
-  }
-  return out;
+function newcHexField(value: number): string {
+  return value.toString(16).padStart(8, "0");
+}
+
+function newcEntryBuffer(header: Buffer, nameBytes: Buffer, data: Buffer): Buffer {
+  return Buffer.concat([
+    padNewcPart(Buffer.concat([header, nameBytes])),
+    data,
+    newcPadding(data.length),
+  ]);
+}
+
+function padNewcPart(buf: Buffer): Buffer {
+  const padding = newcPadding(buf.length);
+  return padding.length === 0 ? buf : Buffer.concat([buf, padding]);
+}
+
+function newcPadding(length: number): Buffer {
+  return Buffer.alloc(newcPaddingLength(length));
+}
+
+function newcPaddingLength(length: number): number {
+  return (4 - (length % 4)) % 4;
 }
 
 // --- excludes ------------------------------------------------------
@@ -152,46 +189,74 @@ function fnmatchCase(name: string, pat: string): boolean {
   return fnmatchRegex(pat).test(name);
 }
 
+interface FnmatchToken {
+  source: string;
+  nextIndex: number;
+}
+
+const SIMPLE_FNMATCH_TOKENS: Record<string, string> = {
+  "*": ".*",
+  "?": ".",
+};
+
 function fnmatchRegex(pat: string): RegExp {
   let re = "^";
-  let i = 0;
-  while (i < pat.length) {
-    const c = pat[i]!;
-    if (c === "*") {
-      re += ".*";
-    } else if (c === "?") {
-      re += ".";
-    } else if (c === "[") {
-      let j = i + 1;
-      if (pat[j] === "!") {
-        j++;
-      }
-      if (pat[j] === "]") {
-        j++;
-      }
-      while (j < pat.length && pat[j] !== "]") {
-        j++;
-      }
-      if (j >= pat.length) {
-        re += "\\[";
-      } else {
-        let cls = pat.slice(i, j + 1);
-        if (cls.startsWith("[!")) {
-          cls = "[^" + cls.slice(2);
-        }
-        re += cls;
-        i = j;
-      }
-    } else if (/[\\^$.+()|{}]/.test(c)) {
-      re += "\\" + c;
-    } else {
-      re += c;
-    }
-    i++;
+  for (let i = 0; i < pat.length; i++) {
+    const token = translateFnmatchToken(pat, i);
+    re += token.source;
+    i = token.nextIndex;
   }
-  re += "$";
-  return new RegExp(re);
+  return new RegExp(re + "$");
 }
+
+function translateFnmatchToken(pat: string, index: number): FnmatchToken {
+  const c = pat[index]!;
+  const simple = SIMPLE_FNMATCH_TOKENS[c];
+  if (simple !== undefined) {
+    return { source: simple, nextIndex: index };
+  }
+  if (c === "[") {
+    return translateFnmatchClass(pat, index);
+  }
+  return { source: regexLiteral(c), nextIndex: index };
+}
+
+function translateFnmatchClass(pat: string, index: number): FnmatchToken {
+  const end = findFnmatchClassEnd(pat, index);
+  if (end === -1) {
+    return { source: "\\[", nextIndex: index };
+  }
+  return { source: normalizeFnmatchClass(pat.slice(index, end + 1)), nextIndex: end };
+}
+
+function findFnmatchClassEnd(pat: string, index: number): number {
+  let j = fnmatchClassBodyStart(pat, index);
+  while (j < pat.length && pat[j] !== "]") {
+    j++;
+  }
+  return j >= pat.length ? -1 : j;
+}
+
+function fnmatchClassBodyStart(pat: string, index: number): number {
+  let j = index + 1;
+  if (pat[j] === "!") {
+    j++;
+  }
+  if (pat[j] === "]") {
+    j++;
+  }
+  return j;
+}
+
+function normalizeFnmatchClass(cls: string): string {
+  return cls.startsWith("[!") ? "[^" + cls.slice(2) : cls;
+}
+
+function regexLiteral(c: string): string {
+  return REGEX_SPECIAL_CHARS.test(c) ? "\\" + c : c;
+}
+
+const REGEX_SPECIAL_CHARS = /[\\^$.+()|{}]/;
 
 // --- filesystem walk ----------------------------------------------
 
@@ -220,6 +285,8 @@ function* entriesFromRootfs(
   yield* walkRootfs(root, "", excludes, counts);
 }
 
+type FsStats = import("node:fs").Stats;
+
 function* walkRootfs(
   root: string,
   rel: string,
@@ -227,47 +294,79 @@ function* walkRootfs(
   counts: WalkCounts,
 ): Generator<Buffer> {
   const full = rel ? join(root, rel) : root;
-  let entries: string[];
-  try {
-    entries = readdirSync(full).sort();
-  } catch {
+  const entries = readSortedDir(full);
+  if (!entries) {
     return;
   }
 
   for (const name of entries) {
-    const childRel = rel ? join(rel, name) : name;
-    const childFull = join(full, name);
-
-    if (excludes.some((pat) => fnmatchCase(childRel, pat))) {
-      try {
-        const st = lstatSync(childFull);
-        if (st.isFile()) {
-          counts.files += 1;
-          counts.bytes += st.size;
-        }
-      } catch {}
-      continue;
-    }
-
-    let st;
-    try {
-      st = lstatSync(childFull);
-    } catch {
-      continue;
-    }
-    const m = st.mode;
-
-    if (st.isSymbolicLink()) {
-      const target = readlinkSync(childFull);
-      yield newc(childRel, 0o120000 | (m & 0o7777), { data: Buffer.from(target, "utf8") });
-    } else if (st.isDirectory()) {
-      yield newc(childRel, 0o40000 | (m & 0o7777));
-      yield* walkRootfs(root, childRel, excludes, counts);
-    } else if (st.isFile()) {
-      yield newc(childRel, 0o100000 | (m & 0o7777), { data: readFileSync(childFull) });
-    }
-    // Device/fifo/socket nodes are skipped — added by hand below.
+    yield* walkRootfsChild(root, rel, full, name, excludes, counts);
   }
+}
+
+function* walkRootfsChild(
+  root: string,
+  rel: string,
+  parentFull: string,
+  name: string,
+  excludes: string[],
+  counts: WalkCounts,
+): Generator<Buffer> {
+  const childRel = rel ? join(rel, name) : name;
+  const childFull = join(parentFull, name);
+  if (isExcludedRootfsEntry(childRel, childFull, excludes, counts)) {
+    return;
+  }
+  const st = tryLstat(childFull);
+  if (!st) {
+    return;
+  }
+  yield* rootfsEntryFromStats(root, childRel, childFull, st, excludes, counts);
+}
+
+function isExcludedRootfsEntry(
+  childRel: string,
+  childFull: string,
+  excludes: string[],
+  counts: WalkCounts,
+): boolean {
+  if (!excludes.some((pat) => fnmatchCase(childRel, pat))) {
+    return false;
+  }
+  countExcludedRootfsFile(childFull, counts);
+  return true;
+}
+
+function countExcludedRootfsFile(childFull: string, counts: WalkCounts): void {
+  const st = tryLstat(childFull);
+  if (st?.isFile()) {
+    counts.files += 1;
+    counts.bytes += st.size;
+  }
+}
+
+function* rootfsEntryFromStats(
+  root: string,
+  childRel: string,
+  childFull: string,
+  st: FsStats,
+  excludes: string[],
+  counts: WalkCounts,
+): Generator<Buffer> {
+  const mode = st.mode & 0o7777;
+  if (st.isSymbolicLink()) {
+    yield newc(childRel, 0o120000 | mode, { data: Buffer.from(readlinkSync(childFull), "utf8") });
+    return;
+  }
+  if (st.isDirectory()) {
+    yield newc(childRel, 0o40000 | mode);
+    yield* walkRootfs(root, childRel, excludes, counts);
+    return;
+  }
+  if (st.isFile()) {
+    yield newc(childRel, 0o100000 | mode, { data: readFileSync(childFull) });
+  }
+  // Device/fifo/socket nodes are skipped — added by hand below.
 }
 
 function* workspaceEntries(
@@ -288,40 +387,86 @@ function* walkWorkspace(
   counts: WalkCounts,
 ): Generator<Buffer> {
   const full = rel ? join(root, rel) : root;
-  let entries: string[];
-  try {
-    entries = readdirSync(full).sort();
-  } catch {
+  const entries = readSortedDir(full);
+  if (!entries) {
     return;
   }
 
   for (const name of entries) {
-    if (excludes.has(name)) {
-      continue;
-    }
-    const childRel = rel ? join(rel, name) : name;
-    const childFull = join(full, name);
-    const arcName = `${mountpoint}/${childRel}`;
+    yield* walkWorkspaceChild(root, rel, full, name, mountpoint, excludes, counts);
+  }
+}
 
-    let st;
-    try {
-      st = lstatSync(childFull);
-    } catch {
-      continue;
-    }
-    const m = st.mode;
+function* walkWorkspaceChild(
+  root: string,
+  rel: string,
+  parentFull: string,
+  name: string,
+  mountpoint: string,
+  excludes: Set<string>,
+  counts: WalkCounts,
+): Generator<Buffer> {
+  if (excludes.has(name)) {
+    return;
+  }
+  const childRel = rel ? join(rel, name) : name;
+  const childFull = join(parentFull, name);
+  const st = tryLstat(childFull);
+  if (!st) {
+    return;
+  }
+  yield* workspaceEntryFromStats(root, childRel, childFull, mountpoint, st, excludes, counts);
+}
 
-    if (st.isSymbolicLink()) {
-      const target = readlinkSync(childFull);
-      yield newc(arcName, 0o120000 | (m & 0o7777), { data: Buffer.from(target, "utf8") });
-    } else if (st.isDirectory()) {
-      yield newc(arcName, 0o40000 | (m & 0o7777));
-      yield* walkWorkspace(root, childRel, mountpoint, excludes, counts);
-    } else if (st.isFile()) {
-      const data = readFileSync(childFull);
-      counts.bytes += data.length;
-      yield newc(arcName, 0o100000 | (m & 0o7777), { data });
-    }
+function* workspaceEntryFromStats(
+  root: string,
+  childRel: string,
+  childFull: string,
+  mountpoint: string,
+  st: FsStats,
+  excludes: Set<string>,
+  counts: WalkCounts,
+): Generator<Buffer> {
+  const arcName = `${mountpoint}/${childRel}`;
+  const mode = st.mode & 0o7777;
+  if (st.isSymbolicLink()) {
+    yield newc(arcName, 0o120000 | mode, { data: Buffer.from(readlinkSync(childFull), "utf8") });
+    return;
+  }
+  if (st.isDirectory()) {
+    yield newc(arcName, 0o40000 | mode);
+    yield* walkWorkspace(root, childRel, mountpoint, excludes, counts);
+    return;
+  }
+  if (st.isFile()) {
+    yield* workspaceFileEntry(arcName, childFull, mode, counts);
+  }
+}
+
+function* workspaceFileEntry(
+  arcName: string,
+  childFull: string,
+  mode: number,
+  counts: WalkCounts,
+): Generator<Buffer> {
+  const data = readFileSync(childFull);
+  counts.bytes += data.length;
+  yield newc(arcName, 0o100000 | mode, { data });
+}
+
+function readSortedDir(full: string): string[] | undefined {
+  try {
+    return readdirSync(full).sort();
+  } catch {
+    return undefined;
+  }
+}
+
+function tryLstat(path: string): FsStats | undefined {
+  try {
+    return lstatSync(path);
+  } catch {
+    return undefined;
   }
 }
 
@@ -360,8 +505,28 @@ export interface PackBundleOptions {
   execAgentPath?: string;
 }
 
+interface PackBundlePaths {
+  rootfsDir: string;
+  cfgPath: string;
+}
+
+interface PackBundleSource {
+  packSrc: string;
+  mergeTmp?: string;
+}
+
 export function packBundle(opts: PackBundleOptions): void {
   const t0 = Date.now();
+  const paths = validatePackBundleInputs(opts);
+  const source = preparePackBundleSource(opts, paths.rootfsDir);
+  try {
+    writePackedBundle(opts, paths.cfgPath, source.packSrc, t0);
+  } finally {
+    cleanupMergedPackSource(source.mergeTmp);
+  }
+}
+
+function validatePackBundleInputs(opts: PackBundleOptions): PackBundlePaths {
   const rootfsDir = join(opts.bundle, "rootfs");
   const cfgPath = join(opts.bundle, "machinen-config.json");
   if (!statSync(rootfsDir).isDirectory()) {
@@ -370,8 +535,19 @@ export function packBundle(opts: PackBundleOptions): void {
   if (!statSync(cfgPath).isFile()) {
     throw new MkinitramfsError("MKINITRAMFS_BUNDLE_INVALID", `--bundle: missing ${cfgPath}`);
   }
+  return { rootfsDir, cfgPath };
+}
 
+function preparePackBundleSource(opts: PackBundleOptions, rootfsDir: string): PackBundleSource {
   const needsMerge = Boolean(opts.base) || Boolean(opts.mount);
+  debugPackBundleStart(opts, needsMerge);
+  if (!needsMerge) {
+    return { packSrc: rootfsDir };
+  }
+  return prepareMergedPackSource(opts, rootfsDir);
+}
+
+function debugPackBundleStart(opts: PackBundleOptions, needsMerge: boolean): void {
   debug(
     "packBundle bundle=%s out=%s base=%s mount=%s needsMerge=%s",
     opts.bundle,
@@ -380,76 +556,82 @@ export function packBundle(opts: PackBundleOptions): void {
     opts.mount ? `${opts.mount.host}->${opts.mount.guest}` : "<none>",
     needsMerge,
   );
+}
 
-  let packSrc = rootfsDir;
-  let mergeTmp: string | undefined;
-  if (needsMerge) {
-    mergeTmp = mkdtempSync(join(tmpdir(), "machinen-mkinitramfs-"));
-    if (opts.base) {
-      const extractT0 = Date.now();
-      const res = spawnSync("tar", ["-xzf", opts.base, "-C", mergeTmp]);
-      if (res.status !== 0) {
-        rmSync(mergeTmp, { recursive: true, force: true });
-        throw new MkinitramfsError(
-          "MKINITRAMFS_BASE_EXTRACT_FAILED",
-          `tar -xzf ${opts.base} failed: ${res.stderr?.toString() ?? ""}`,
-        );
-      }
-      debug("base extracted elapsed=%dms", Date.now() - extractT0);
-    }
-    if (opts.mount) {
-      overlayMount(mergeTmp, opts.mount.host, opts.mount.guest);
-    }
-    // Overlay the bundle's rootfs/ on top. Node's cp with recursive
-    // preserves symlinks via `verbatimSymlinks`; `force: true` mirrors
-    // shutil.copytree's dirs_exist_ok + overwrite semantics.
-    cpSync(rootfsDir, mergeTmp, {
-      recursive: true,
-      force: true,
-      verbatimSymlinks: true,
-    });
-    packSrc = mergeTmp;
-  }
-
+function prepareMergedPackSource(opts: PackBundleOptions, rootfsDir: string): PackBundleSource {
+  const mergeTmp = mkdtempSync(join(tmpdir(), "machinen-mkinitramfs-"));
   try {
-    const counts: WalkCounts = { files: 0, bytes: 0 };
-    const parts: Buffer[] = [];
-    for (const e of entriesFromRootfs(packSrc, opts.excludes ?? [], counts)) {
-      parts.push(e);
-    }
-    appendFinalEntries(parts, {
-      initPath: opts.initPath ?? defaultInitPath(),
-      config: patchConfigEnv(readFileSync(cfgPath), opts.env),
-      // Always inject the fresh /init AFTER walking the rootfs.
-      // `provision()` flows feed the previous run's frozen rootfs back
-      // in as `base`, and that capture has /init at root. The walked
-      // copy is whatever was captured the last time provision ran;
-      // injecting machinen's current /init here means the cpio carries
-      // duplicate /init entries with the latest one last — Linux's
-      // initramfs unpacker resolves duplicates by overwriting earlier
-      // entries with later ones, so the fresh /init wins. Without
-      // this, fixes that land in init.zig (e.g. the /run tmpfs mount
-      // from #146) silently regress on every provision-cached image.
-      injectInit: true,
-      // Same dedup trick for /exec-agent: the user's frozen rootfs
-      // captures whatever /exec-agent was running at provision time,
-      // and that gets re-walked back into the cpio on the next round.
-      // Inject the fresh one so changes to exec-agent.zig (env
-      // defaults like HOME=/root, new opcodes) actually reach the
-      // running binary.
-      execAgentPath: opts.execAgentPath ?? defaultExecAgentPath(),
-    });
-    writeFileSync(opts.out, Buffer.concat(parts));
-    debug(
-      "packBundle done files=%d bytes=%d elapsed=%dms",
-      counts.files,
-      counts.bytes,
-      Date.now() - t0,
+    extractBaseIfPresent(opts, mergeTmp);
+    overlayMountIfPresent(opts, mergeTmp);
+    copyBundleRootfs(rootfsDir, mergeTmp);
+    return { packSrc: mergeTmp, mergeTmp };
+  } catch (err) {
+    cleanupMergedPackSource(mergeTmp);
+    throw err;
+  }
+}
+
+function extractBaseIfPresent(opts: PackBundleOptions, mergeTmp: string): void {
+  if (opts.base) {
+    extractBaseRootfs(opts.base, mergeTmp);
+  }
+}
+
+function extractBaseRootfs(base: string, mergeTmp: string): void {
+  const extractT0 = Date.now();
+  const res = spawnSync("tar", ["-xzf", base, "-C", mergeTmp]);
+  if (res.status !== 0) {
+    throw new MkinitramfsError(
+      "MKINITRAMFS_BASE_EXTRACT_FAILED",
+      `tar -xzf ${base} failed: ${res.stderr?.toString() ?? ""}`,
     );
-  } finally {
-    if (mergeTmp) {
-      rmSync(mergeTmp, { recursive: true, force: true });
-    }
+  }
+  debug("base extracted elapsed=%dms", Date.now() - extractT0);
+}
+
+function overlayMountIfPresent(opts: PackBundleOptions, mergeTmp: string): void {
+  if (opts.mount) {
+    overlayMount(mergeTmp, opts.mount.host, opts.mount.guest);
+  }
+}
+
+function copyBundleRootfs(rootfsDir: string, mergeTmp: string): void {
+  cpSync(rootfsDir, mergeTmp, {
+    recursive: true,
+    force: true,
+    verbatimSymlinks: true,
+  });
+}
+
+function writePackedBundle(
+  opts: PackBundleOptions,
+  cfgPath: string,
+  packSrc: string,
+  t0: number,
+): void {
+  const counts: WalkCounts = { files: 0, bytes: 0 };
+  const parts: Buffer[] = [];
+  for (const e of entriesFromRootfs(packSrc, opts.excludes ?? [], counts)) {
+    parts.push(e);
+  }
+  appendFinalEntries(parts, {
+    initPath: opts.initPath ?? defaultInitPath(),
+    config: patchConfigEnv(readFileSync(cfgPath), opts.env),
+    injectInit: true,
+    execAgentPath: opts.execAgentPath ?? defaultExecAgentPath(),
+  });
+  writeFileSync(opts.out, Buffer.concat(parts));
+  debug(
+    "packBundle done files=%d bytes=%d elapsed=%dms",
+    counts.files,
+    counts.bytes,
+    Date.now() - t0,
+  );
+}
+
+function cleanupMergedPackSource(mergeTmp: string | undefined): void {
+  if (mergeTmp) {
+    rmSync(mergeTmp, { recursive: true, force: true });
   }
 }
 
@@ -662,51 +844,78 @@ interface FinalOptions {
 }
 
 function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
-  if (opts.injectInit) {
-    let initBytes: Buffer | null = null;
-    try {
-      initBytes = readFileSync(opts.initPath);
-    } catch (err) {
-      // packTinyBundle / packBundle both rely on /init mounting
-      // /dev/vda — without it the kernel falls through to
-      // prepare_namespace() with no `root=` and panics with
-      // "Can't open blockdev". A silent skip here turned a missing
-      // fixture into an opaque kernel panic, so fail loudly.
-      //
-      // Tests that don't actually boot a real VMM (binary: "/bin/sh"
-      // and friends) opt out via MACHINEN_REQUIRE_FIXTURES=0 — the
-      // same flag the integration suites use to skip when fixtures
-      // are absent. Hosted CI sets it; local dev with `pretest`
-      // doesn't, so this still fires for anyone whose worktree is
-      // missing the build-base-assets.sh artifacts.
-      if (process.env.MACHINEN_REQUIRE_FIXTURES !== "0") {
-        throw new MkinitramfsError(
-          "MKINITRAMFS_INIT_MISSING",
-          `mkinitramfs: /init binary not readable at ${opts.initPath} (${err instanceof Error ? err.message : String(err)}). ` +
-            `Build it with scripts/build-base-assets.sh, or pass initPath to point at a custom one.`,
-          { cause: err },
-        );
-      }
-    }
-    if (initBytes !== null) {
-      parts.push(newc("init", 0o100755, { data: initBytes }));
-    }
+  appendInitIfRequested(parts, opts);
+  appendExecAgentIfPresent(parts, opts.execAgentPath);
+  appendConfigIfPresent(parts, opts.config);
+  appendBootEpoch(parts);
+  appendMountGuestIfPresent(parts, opts.mountGuest);
+  appendFixedDeviceEntries(parts);
+  parts.push(newc("TRAILER!!!", 0));
+}
+
+function appendInitIfRequested(parts: Buffer[], opts: FinalOptions): void {
+  if (!opts.injectInit) {
+    return;
   }
-  if (opts.execAgentPath) {
-    try {
-      const bytes = readFileSync(opts.execAgentPath);
-      parts.push(newc("exec-agent", 0o100755, { data: bytes }));
-    } catch {
-      // Optional — if the build hasn't produced one yet (fresh
-      // checkout, first run before build-base-assets.sh), boots that
-      // didn't need exec-agent (no vm.exec, no provision) keep
-      // working. The provision flow itself depends on it and will
-      // fail downstream with a clearer error if it's truly absent.
+  const initBytes = readInitBytes(opts.initPath);
+  if (initBytes) {
+    parts.push(newc("init", 0o100755, { data: initBytes }));
+  }
+}
+
+function readInitBytes(initPath: string): Buffer | undefined {
+  try {
+    return readFileSync(initPath);
+  } catch (err) {
+    if (process.env.MACHINEN_REQUIRE_FIXTURES === "0") {
+      return undefined;
     }
+    throw missingInitError(initPath, err);
   }
-  if (opts.config) {
-    parts.push(newc("machinen-config.json", 0o100644, { data: opts.config }));
+}
+
+function missingInitError(initPath: string, err: unknown): MkinitramfsError {
+  // packTinyBundle / packBundle both rely on /init mounting /dev/vda —
+  // without it the kernel falls through to prepare_namespace() with no
+  // `root=` and panics with "Can't open blockdev". A silent skip here
+  // turned a missing fixture into an opaque kernel panic, so fail loudly.
+  //
+  // Tests that don't actually boot a real VMM (binary: "/bin/sh" and
+  // friends) opt out via MACHINEN_REQUIRE_FIXTURES=0 — the same flag the
+  // integration suites use to skip when fixtures are absent. Hosted CI
+  // sets it; local dev with `pretest` doesn't, so this still fires for
+  // anyone whose worktree is missing the build-base-assets.sh artifacts.
+  return new MkinitramfsError(
+    "MKINITRAMFS_INIT_MISSING",
+    `mkinitramfs: /init binary not readable at ${initPath} (${mkinitramfsErrorMessage(err)}). ` +
+      `Build it with scripts/build-base-assets.sh, or pass initPath to point at a custom one.`,
+    { cause: err },
+  );
+}
+
+function appendExecAgentIfPresent(parts: Buffer[], execAgentPath: string | undefined): void {
+  if (!execAgentPath) {
+    return;
   }
+  try {
+    const bytes = readFileSync(execAgentPath);
+    parts.push(newc("exec-agent", 0o100755, { data: bytes }));
+  } catch {
+    // Optional — if the build hasn't produced one yet (fresh checkout,
+    // first run before build-base-assets.sh), boots that didn't need
+    // exec-agent (no vm.exec, no provision) keep working. The provision
+    // flow itself depends on it and will fail downstream with a clearer
+    // error if it's truly absent.
+  }
+}
+
+function appendConfigIfPresent(parts: Buffer[], config: Buffer | undefined): void {
+  if (config) {
+    parts.push(newc("machinen-config.json", 0o100644, { data: config }));
+  }
+}
+
+function appendBootEpoch(parts: Buffer[]): void {
   // Bake the host's current epoch so /init can set the guest clock.
   // Without this the guest boots at 1970-01-01 and TLS + apt Release
   // date validation break.
@@ -716,16 +925,23 @@ function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
       data: Buffer.from(String(Math.floor(Date.now() / 1000)), "ascii"),
     }),
   );
+}
+
+function appendMountGuestIfPresent(parts: Buffer[], mountGuest: string | undefined): void {
+  if (!mountGuest) {
+    return;
+  }
   // #272: tell /init which guest path to mount the `--mount` overlay
   // at. The actual squashfs+ext4 payload rides on virtio-blk slots 5
   // and 6 — only the target path lives in the cpio.
-  if (opts.mountGuest) {
-    parts.push(
-      newc("etc/machinen-mountdisk-guest", 0o100644, {
-        data: Buffer.from(opts.mountGuest + "\n", "ascii"),
-      }),
-    );
-  }
+  parts.push(
+    newc("etc/machinen-mountdisk-guest", 0o100644, {
+      data: Buffer.from(mountGuest + "\n", "ascii"),
+    }),
+  );
+}
+
+function appendFixedDeviceEntries(parts: Buffer[]): void {
   parts.push(newc("dev", 0o40755));
   parts.push(newc("dev/console", 0o20600, { rmajor: 5, rminor: 1 }));
   // Force /tmp to the canonical sticky-world-writable (1777). The base
@@ -733,7 +949,10 @@ function appendFinalEntries(parts: Buffer[], opts: FinalOptions): void {
   // when extracting as non-root, so apt (which drops privs to _apt for
   // downloads) fails with "Couldn't create temporary file".
   parts.push(newc("tmp", 0o41777));
-  parts.push(newc("TRAILER!!!", 0));
+}
+
+function mkinitramfsErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 interface VmmGuestPaths {
@@ -808,85 +1027,137 @@ function defaultExecAgentPath(): string {
  */
 export function cli(argv: string[]): void {
   if (argv[0] === "--workspace") {
-    const src = argv[1];
-    if (!src) {
-      die("--workspace requires <dir>");
-    }
-    let out: string | undefined;
-    const extraEx = new Set<string>();
-    let maxMb = 500;
-    let i = 2;
-    while (i < argv.length) {
-      const flag = argv[i];
-      if (flag === "--out") {
-        out = argv[i + 1];
-        i += 2;
-      } else if (flag === "--exclude") {
-        extraEx.add(argv[i + 1]!);
-        i += 2;
-      } else if (flag === "--max-mb") {
-        maxMb = parseInt(argv[i + 1]!, 10);
-        i += 2;
-      } else {
-        die(`unknown flag: ${flag}`);
-      }
-    }
-    if (!out) {
-      die("--workspace requires --out <path>");
-    }
-    process.stderr.write(`packing workspace: ${src} -> ${out}\n`);
-    const excludes = new Set<string>([...DEFAULT_WORKSPACE_EXCLUDES, ...extraEx]);
-    packWorkspace({ workspace: src!, out: out!, excludes, maxMb });
-    const st = statSync(out!);
-    process.stderr.write(`wrote ${out} (${st.size} bytes)\n`);
+    runWorkspaceCli(argv);
     return;
   }
 
-  // Parse shared flags.
+  const flags = parseSharedCliFlags(argv);
+  if (flags.args[0] === "--bundle") {
+    runBundleCli(flags);
+    return;
+  }
+  if (flags.args[0] === "--rootfs") {
+    runRootfsCli(flags);
+    return;
+  }
+  runMinimalCli(flags);
+}
+
+interface SharedCliFlags {
+  args: string[];
+  outOverride: string | undefined;
+  configFlag: string | undefined;
+  excludes: string[];
+  baseFlag: string | undefined;
+}
+
+function runWorkspaceCli(argv: string[]): void {
+  const opts = parseWorkspaceCli(argv);
+  process.stderr.write(`packing workspace: ${opts.src} -> ${opts.out}\n`);
+  const excludes = new Set<string>([...DEFAULT_WORKSPACE_EXCLUDES, ...opts.extraEx]);
+  packWorkspace({ workspace: opts.src, out: opts.out, excludes, maxMb: opts.maxMb });
+  reportWrote(opts.out, process.stderr);
+}
+
+function parseWorkspaceCli(argv: string[]): {
+  src: string;
+  out: string;
+  extraEx: Set<string>;
+  maxMb: number;
+} {
+  const src = argv[1];
+  if (!src) {
+    die("--workspace requires <dir>");
+  }
+  const opts = parseWorkspaceCliFlags(argv.slice(2));
+  if (!opts.out) {
+    die("--workspace requires --out <path>");
+  }
+  return { src, out: opts.out, extraEx: opts.extraEx, maxMb: opts.maxMb };
+}
+
+function parseWorkspaceCliFlags(args: string[]): {
+  out: string | undefined;
+  extraEx: Set<string>;
+  maxMb: number;
+} {
+  let out: string | undefined;
+  const extraEx = new Set<string>();
+  let maxMb = 500;
+  for (let i = 0; i < args.length; ) {
+    const parsed = parseWorkspaceCliFlag(args, i, { out, extraEx, maxMb });
+    out = parsed.out;
+    maxMb = parsed.maxMb;
+    i = parsed.next;
+  }
+  return { out, extraEx, maxMb };
+}
+
+function parseWorkspaceCliFlag(
+  args: string[],
+  i: number,
+  state: { out: string | undefined; extraEx: Set<string>; maxMb: number },
+): { out: string | undefined; extraEx: Set<string>; maxMb: number; next: number } {
+  const flag = args[i];
+  if (flag === "--out") {
+    return { ...state, out: args[i + 1], next: i + 2 };
+  }
+  if (flag === "--exclude") {
+    state.extraEx.add(args[i + 1]!);
+    return { ...state, next: i + 2 };
+  }
+  if (flag === "--max-mb") {
+    return { ...state, maxMb: parseInt(args[i + 1]!, 10), next: i + 2 };
+  }
+  die(`unknown flag: ${flag}`);
+}
+
+function parseSharedCliFlags(argv: string[]): SharedCliFlags {
   const args = [...argv];
   const outOverride = takeFlag(args, "--out");
   const configFlag = takeFlag(args, "--config");
   const excludeFromFlag = takeFlag(args, "--exclude-from");
   const baseFlag = takeFlag(args, "--base");
+  return {
+    args,
+    outOverride,
+    configFlag,
+    excludes: excludeFromFlag ? loadExcludes(excludeFromFlag) : [],
+    baseFlag,
+  };
+}
 
-  const excludes = excludeFromFlag ? loadExcludes(excludeFromFlag) : [];
-
-  if (args[0] === "--bundle") {
-    const bundle = args[1];
-    if (!bundle) {
-      die("--bundle requires <dir>");
-    }
-    const out = outOverride ?? defaultOut();
-    process.stdout.write(`packing bundle: ${bundle}\n`);
-    packBundle({ bundle: bundle!, out, base: baseFlag, excludes });
-    const st = statSync(out);
-    process.stdout.write(`wrote ${out} (${st.size} bytes)\n`);
-    return;
+function runBundleCli(flags: SharedCliFlags): void {
+  const bundle = flags.args[1];
+  if (!bundle) {
+    die("--bundle requires <dir>");
   }
+  const out = flags.outOverride ?? defaultOut();
+  process.stdout.write(`packing bundle: ${bundle}\n`);
+  packBundle({ bundle, out, base: flags.baseFlag, excludes: flags.excludes });
+  reportWrote(out, process.stdout);
+}
 
-  if (args[0] === "--rootfs") {
-    const rootfs = args[1];
-    if (!rootfs) {
-      die("--rootfs requires <dir>");
-    }
-    const out = outOverride ?? defaultOut();
-    process.stdout.write(`packing rootfs: ${rootfs}\n`);
-    packRootfs({
-      rootfs: rootfs!,
-      out,
-      config: configFlag,
-      excludes,
-    });
-    const st = statSync(out);
-    process.stdout.write(`wrote ${out} (${st.size} bytes)\n`);
-    return;
+function runRootfsCli(flags: SharedCliFlags): void {
+  const rootfs = flags.args[1];
+  if (!rootfs) {
+    die("--rootfs requires <dir>");
   }
+  const out = flags.outOverride ?? defaultOut();
+  process.stdout.write(`packing rootfs: ${rootfs}\n`);
+  packRootfs({ rootfs, out, config: flags.configFlag, excludes: flags.excludes });
+  reportWrote(out, process.stdout);
+}
 
-  // Minimal mode.
-  const out = outOverride ?? defaultOut();
-  packMinimal({ out, config: configFlag });
+function runMinimalCli(flags: SharedCliFlags): void {
+  const out = flags.outOverride ?? defaultOut();
+  packMinimal({ out, config: flags.configFlag });
+  reportWrote(out, process.stdout);
+}
+
+function reportWrote(out: string, stream: NodeJS.WritableStream): void {
   const st = statSync(out);
-  process.stdout.write(`wrote ${out} (${st.size} bytes)\n`);
+  stream.write(`wrote ${out} (${st.size} bytes)\n`);
 }
 
 function takeFlag(args: string[], flag: string): string | undefined {

--- a/packages/runtime/src/mountdisk-img.ts
+++ b/packages/runtime/src/mountdisk-img.ts
@@ -454,47 +454,104 @@ export function treeManifestHash(root: string): string {
   return h.digest("hex");
 }
 
+type ManifestStats = import("node:fs").Stats & { mtimeNs?: bigint };
+
 function walkForManifest(root: string, rel: string, out: string[]): void {
   const here = rel ? join(root, rel) : root;
-  let entries: string[];
-  try {
-    entries = readdirSync(here).sort();
-  } catch {
+  const entries = readManifestDir(here);
+  if (!entries) {
     return;
   }
   for (const name of entries) {
-    const childRel = rel ? `${rel}/${name}` : name;
-    const childAbs = join(here, name);
-    let st;
-    try {
-      st = lstatSync(childAbs);
-    } catch {
-      continue;
-    }
-    const mode = (st.mode & 0o7777).toString(8);
-    // mtimeMs is a non-integer float on some platforms; mtimeNs is a
-    // bigint when bigint=true and unset otherwise. Either way, we
-    // need a stable string. Floor to ms when nanoseconds aren't
-    // available — same precision Node 18+ exposes anyway.
-    const mtimeNs = String(st.mtimeNs ?? BigInt(Math.floor(st.mtimeMs)) * BigInt(1_000_000));
-    if (st.isSymbolicLink()) {
-      let target = "";
-      try {
-        target = readlinkSync(childAbs);
-      } catch {}
-      out.push(`${childRel}\0L\0${mode}\0${target.length}\0${mtimeNs}\0${target}`);
-    } else if (st.isDirectory()) {
-      out.push(`${childRel}\0D\0${mode}\0\0${mtimeNs}\0`);
-      walkForManifest(root, childRel, out);
-    } else if (st.isFile()) {
-      const sha = sha256OfFile(childAbs);
-      out.push(`${childRel}\0F\0${mode}\0${st.size}\0${mtimeNs}\0${sha}`);
-    } else {
-      // sockets, pipes, device nodes — squashfs would refuse those
-      // on a regular host fs anyway. Hash a placeholder so the key
-      // changes when they appear/disappear.
-      out.push(`${childRel}\0?\0${mode}\0\0${mtimeNs}\0`);
-    }
+    appendManifestChild(root, rel, here, name, out);
+  }
+}
+
+function appendManifestChild(
+  root: string,
+  rel: string,
+  parentAbs: string,
+  name: string,
+  out: string[],
+): void {
+  const childRel = rel ? `${rel}/${name}` : name;
+  const childAbs = join(parentAbs, name);
+  const st = tryManifestLstat(childAbs);
+  if (!st) {
+    return;
+  }
+  out.push(manifestLineForStats(childRel, childAbs, st));
+  walkManifestDirectoryIfNeeded(root, childRel, st, out);
+}
+
+function manifestLineForStats(childRel: string, childAbs: string, st: ManifestStats): string {
+  const mode = (st.mode & 0o7777).toString(8);
+  const mtimeNs = manifestMtimeNs(st);
+  if (st.isSymbolicLink()) {
+    return symlinkManifestLine(childRel, childAbs, mode, mtimeNs);
+  }
+  if (st.isDirectory()) {
+    return `${childRel}\0D\0${mode}\0\0${mtimeNs}\0`;
+  }
+  if (st.isFile()) {
+    return `${childRel}\0F\0${mode}\0${st.size}\0${mtimeNs}\0${sha256OfFile(childAbs)}`;
+  }
+  // sockets, pipes, device nodes — squashfs would refuse those on a
+  // regular host fs anyway. Hash a placeholder so the key changes when
+  // they appear/disappear.
+  return `${childRel}\0?\0${mode}\0\0${mtimeNs}\0`;
+}
+
+function symlinkManifestLine(
+  childRel: string,
+  childAbs: string,
+  mode: string,
+  mtimeNs: string,
+): string {
+  const target = tryReadlink(childAbs);
+  return `${childRel}\0L\0${mode}\0${target.length}\0${mtimeNs}\0${target}`;
+}
+
+function manifestMtimeNs(st: ManifestStats): string {
+  // mtimeMs is a non-integer float on some platforms; mtimeNs is a
+  // bigint when bigint=true and unset otherwise. Either way, we need a
+  // stable string. Floor to ms when nanoseconds aren't available — same
+  // precision Node 18+ exposes anyway.
+  return String(st.mtimeNs ?? BigInt(Math.floor(st.mtimeMs)) * BigInt(1_000_000));
+}
+
+function walkManifestDirectoryIfNeeded(
+  root: string,
+  childRel: string,
+  st: ManifestStats,
+  out: string[],
+): void {
+  if (st.isDirectory()) {
+    walkForManifest(root, childRel, out);
+  }
+}
+
+function readManifestDir(here: string): string[] | undefined {
+  try {
+    return readdirSync(here).sort();
+  } catch {
+    return undefined;
+  }
+}
+
+function tryManifestLstat(childAbs: string): ManifestStats | undefined {
+  try {
+    return lstatSync(childAbs);
+  } catch {
+    return undefined;
+  }
+}
+
+function tryReadlink(childAbs: string): string {
+  try {
+    return readlinkSync(childAbs);
+  } catch {
+    return "";
   }
 }
 

--- a/packages/runtime/src/multiplex.ts
+++ b/packages/runtime/src/multiplex.ts
@@ -328,40 +328,75 @@ export class Supervisor {
 
   private ingest(chunk: Buffer): void {
     if (this.attachedId) {
-      // Scan for the double-Ctrl-] detach sequence and forward the
-      // rest to the attached sandbox.
-      let start = 0;
-      for (let i = 0; i < chunk.length; i++) {
-        const b = chunk[i]!;
-        if (b === 0x1d /* Ctrl-] */) {
-          if (this.lastGs) {
-            // Second in a row — detach, drop the two bytes, keep the
-            // tail for the next command.
-            const toSend = chunk.subarray(start, i - 1);
-            if (toSend.length > 0) {
-              this.sandboxes.send(this.attachedId, toSend);
-            }
-            this.detach();
-            const remainder = chunk.subarray(i + 1);
-            if (remainder.length > 0) {
-              this.ingest(remainder);
-            }
-            return;
-          }
-          this.lastGs = true;
-        } else {
-          this.lastGs = false;
-        }
-      }
-      this.sandboxes.send(this.attachedId, chunk.subarray(start));
+      this.ingestAttached(chunk);
       return;
     }
+    this.ingestDetached(chunk);
+  }
 
+  private ingestAttached(chunk: Buffer): void {
+    // Scan for the double-Ctrl-] detach sequence and forward the rest
+    // to the attached sandbox.
+    const detachAt = this.findDetachSequence(chunk);
+    if (detachAt === null) {
+      this.sendAttached(chunk);
+      return;
+    }
+    this.sendAttachedIfNonEmpty(chunk.subarray(0, detachAt - 1));
+    this.detach();
+    this.ingestRemainderAfterDetach(chunk, detachAt);
+  }
+
+  private findDetachSequence(chunk: Buffer): number | null {
+    for (let i = 0; i < chunk.length; i++) {
+      if (this.markCtrlRightBracket(chunk[i]! === 0x1d /* Ctrl-] */)) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  private markCtrlRightBracket(isCtrlRightBracket: boolean): boolean {
+    if (!isCtrlRightBracket) {
+      this.lastGs = false;
+      return false;
+    }
+    if (this.lastGs) {
+      return true;
+    }
+    this.lastGs = true;
+    return false;
+  }
+
+  private ingestRemainderAfterDetach(chunk: Buffer, detachAt: number): void {
+    const remainder = chunk.subarray(detachAt + 1);
+    if (remainder.length > 0) {
+      this.ingest(remainder);
+    }
+  }
+
+  private sendAttachedIfNonEmpty(chunk: Buffer): void {
+    if (chunk.length > 0) {
+      this.sendAttached(chunk);
+    }
+  }
+
+  private sendAttached(chunk: Buffer): void {
+    const id = this.attachedId;
+    if (id) {
+      this.sandboxes.send(id, chunk);
+    }
+  }
+
+  private ingestDetached(chunk: Buffer): void {
     // Detached: buffer lines and parse them as commands.
     for (const line of chunk.toString("utf8").split(/\r?\n/)) {
-      if (!line) {
-        continue;
-      }
+      this.handleDetachedLine(line);
+    }
+  }
+
+  private handleDetachedLine(line: string): void {
+    if (line) {
       this.handleCommand(line);
     }
   }

--- a/packages/runtime/src/proc-rss.ts
+++ b/packages/runtime/src/proc-rss.ts
@@ -67,43 +67,65 @@ export function readHostRssBytes(pid: number, statsPath?: string): number | null
 export function readHostRssBytesMulti(
   targets: ReadonlyArray<RssTarget | number>,
 ): Map<number, number> {
-  const out = new Map<number, number>();
-  if (targets.length === 0) {
-    return out;
+  const normalised = normaliseRssTargets(targets);
+  if (normalised.length === 0) {
+    return new Map<number, number>();
   }
-  const normalised: RssTarget[] = targets.map((t) => (typeof t === "number" ? { pid: t } : t));
   if (osPlatform() === "linux") {
-    for (const { pid } of normalised) {
-      const v = readVmRssLinux(pid);
-      if (v !== null) {
-        out.set(pid, v);
-      }
-    }
-    return out;
+    return readHostRssBytesLinuxMulti(normalised);
   }
   if (osPlatform() === "darwin") {
-    // Per-VM phys_footprint from the stats file is free (one
-    // readFileSync per VM, ~µs). Anything that doesn't have a
-    // statsPath, or whose stats file hasn't been written to yet,
-    // falls through to a single bulk `ps` call.
-    const fallbackPids: number[] = [];
-    for (const { pid, statsPath } of normalised) {
-      const fromStats = readPhysFootprintFromStats(statsPath);
-      if (fromStats !== null) {
-        out.set(pid, fromStats);
-      } else {
-        fallbackPids.push(pid);
-      }
+    return readHostRssBytesDarwinMulti(normalised);
+  }
+  return new Map<number, number>();
+}
+
+function normaliseRssTargets(targets: ReadonlyArray<RssTarget | number>): RssTarget[] {
+  return targets.map((target) => (typeof target === "number" ? { pid: target } : target));
+}
+
+function readHostRssBytesLinuxMulti(targets: RssTarget[]): Map<number, number> {
+  const out = new Map<number, number>();
+  for (const { pid } of targets) {
+    const value = readVmRssLinux(pid);
+    if (value !== null) {
+      out.set(pid, value);
     }
-    if (fallbackPids.length > 0) {
-      const psResults = readPsRssDarwin(fallbackPids);
-      for (const [pid, rss] of psResults) {
-        out.set(pid, rss);
-      }
-    }
-    return out;
   }
   return out;
+}
+
+function readHostRssBytesDarwinMulti(targets: RssTarget[]): Map<number, number> {
+  // Per-VM phys_footprint from the stats file is free (one
+  // readFileSync per VM, ~µs). Anything that doesn't have a
+  // statsPath, or whose stats file hasn't been written to yet,
+  // falls through to a single bulk `ps` call.
+  const out = new Map<number, number>();
+  const fallbackPids = collectDarwinRssFromStats(targets, out);
+  appendDarwinPsFallback(out, fallbackPids);
+  return out;
+}
+
+function collectDarwinRssFromStats(targets: RssTarget[], out: Map<number, number>): number[] {
+  const fallbackPids: number[] = [];
+  for (const { pid, statsPath } of targets) {
+    const fromStats = readPhysFootprintFromStats(statsPath);
+    if (fromStats !== null) {
+      out.set(pid, fromStats);
+    } else {
+      fallbackPids.push(pid);
+    }
+  }
+  return fallbackPids;
+}
+
+function appendDarwinPsFallback(out: Map<number, number>, fallbackPids: number[]): void {
+  if (fallbackPids.length === 0) {
+    return;
+  }
+  for (const [pid, rss] of readPsRssDarwin(fallbackPids)) {
+    out.set(pid, rss);
+  }
 }
 
 function readVmRssLinux(pid: number): number | null {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -355,6 +355,26 @@ function cliCachedBaseDir(): string {
   return join(homedir(), ".machinen", `runtime-v${version}`, "bases", `debian-${spec.cpu}`);
 }
 
+interface ProvisionContext {
+  cwd: string;
+  baseAbs: string;
+  kernelAbs: string;
+  dtbAbs: string | undefined;
+  outAbs: string;
+  t0: number;
+  workDir: string;
+  diskPath: string;
+  rootDiskPath: string;
+  udsPath: string;
+  phases: PhaseTimer;
+}
+
+interface ProvisionStderrTail {
+  tail: () => string;
+}
+
+const PROVISION_STDERR_TAIL_MAX = 128 * 1024;
+
 /**
  * Boot the base rootfs, run the user install hook, and freeze the
  * resulting filesystem state to a new tarball at `opts.out`.
@@ -366,227 +386,242 @@ function cliCachedBaseDir(): string {
  * @throws {BootError} see `boot()` — propagated from the inner boot
  */
 export async function provision(opts: ProvisionOptions): Promise<ProvisionResult> {
+  const ctx = createProvisionContext(opts);
+  try {
+    prepareProvisionDisks(opts, ctx);
+    const vm = await bootProvisionVm(opts, ctx);
+    await runProvisionVmWorkload(opts, ctx, vm);
+    repackProvisionOutput(opts, ctx);
+    return finishProvision(opts, ctx);
+  } finally {
+    cleanupProvisionWorkDir(ctx.workDir);
+  }
+}
+
+function createProvisionContext(opts: ProvisionOptions): ProvisionContext {
   const cwd = opts.cwd ?? process.cwd();
   const baseAbs = resolveBaseRootfs(opts.base, cwd);
   const kernelAbs = resolveBaseKernel(opts.kernel, cwd);
   const dtbAbs = resolveBaseDtb(opts.dtb, cwd);
   const outAbs = resolve(cwd, opts.out);
-  // Ensure the parent dir exists so `out: "./artifacts/rootfs.tar.gz"`
-  // works without the caller having to mkdir it first. mkdtemp / tar
-  // below would otherwise fail with ENOENT on a missing parent.
   mkdirSync(dirname(outAbs), { recursive: true });
 
-  const t0 = Date.now();
   const workDir = mkdtempSync(join(tmpdir(), "machinen-provision-"));
-  const diskPath = join(workDir, "scratch.img");
-  const rootDiskPath = join(workDir, "rootfs.img");
-  const udsPath = join(workDir, "exec.sock");
+  const ctx = {
+    cwd,
+    baseAbs,
+    kernelAbs,
+    dtbAbs,
+    outAbs,
+    t0: Date.now(),
+    workDir,
+    diskPath: join(workDir, "scratch.img"),
+    rootDiskPath: join(workDir, "rootfs.img"),
+    udsPath: join(workDir, "exec.sock"),
+    phases: new PhaseTimer(),
+  };
   debug("provision start base=%s out=%s workDir=%s", baseAbs, outAbs, workDir);
+  return ctx;
+}
 
-  // #233: per-phase wall-clock timeline emitted as a `PhaseLogEvent`
-  // via opts.onLog (and as a debug one-liner under DEBUG=machinen:provision).
-  // Mirrors boot()'s instrumentation so host scripts can show callers
-  // where provision wall time actually goes — install hooks rarely
-  // dominate; the inner boot, tar, and repack do.
-  const phases = new PhaseTimer();
+function prepareProvisionDisks(opts: ProvisionOptions, ctx: ProvisionContext): void {
+  allocateProvisionScratch(opts, ctx);
+  cloneProvisionRootDisk(ctx);
+}
 
+function allocateProvisionScratch(opts: ProvisionOptions, ctx: ProvisionContext): void {
+  const scratchBytes = opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024;
+  allocateSparseFile(ctx.diskPath, scratchBytes);
+  debug("scratch disk allocated path=%s sizeBytes=%d", ctx.diskPath, scratchBytes);
+}
+
+function cloneProvisionRootDisk(ctx: ProvisionContext): void {
+  ctx.phases.start("rootdisk-prep");
+  const cachedImg = ensureRootfsImage(ctx.baseAbs, {
+    onPhase: (name, ms) => ctx.phases.mark(`rootdisk-prep.${name}`, ms),
+  });
+  const reflinkT0 = Date.now();
+  reflinkCopy(cachedImg, ctx.rootDiskPath);
+  ctx.phases.mark("rootdisk-prep.reflink", Date.now() - reflinkT0);
+  debug("rootdisk cloned src=%s dst=%s", cachedImg, ctx.rootDiskPath);
+  markRootfsImageClean(cachedImg);
+  ctx.phases.end("rootdisk-prep");
+}
+
+async function bootProvisionVm(opts: ProvisionOptions, ctx: ProvisionContext): Promise<VmHandle> {
+  ctx.phases.start("boot");
+  const vm = await boot({
+    binary: opts.binary,
+    cwd: opts.cwd,
+    vmmEnv: {
+      ...opts.vmmEnv,
+      MACHINEN_VSOCK: `in:1978:${ctx.udsPath}`,
+    },
+    kernel: ctx.kernelAbs,
+    ...(ctx.dtbAbs ? { dtb: ctx.dtbAbs } : {}),
+    image: ctx.baseAbs,
+    cmd: ["/exec-agent"],
+    env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+    snapshot: ctx.diskPath,
+    rootDisk: ctx.rootDiskPath,
+    timeoutMs: null,
+    onLog: opts.onLog,
+  });
+  ctx.phases.end("boot");
+  return vm;
+}
+
+async function runProvisionVmWorkload(
+  opts: ProvisionOptions,
+  ctx: ProvisionContext,
+  vm: VmHandle,
+): Promise<void> {
+  const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
+  const killTimer = setTimeout(() => void vm.kill(), deadlineMs);
+  killTimer.unref();
+  const stderrTail = captureProvisionStderrTail(vm);
   try {
-    // Allocate the scratch disk sparsely. The guest tars its filesystem
-    // into this block device; the host then repacks the raw tar stream
-    // into the output tarball.
-    const scratchBytes = opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024;
-    allocateSparseFile(diskPath, scratchBytes);
-    debug("scratch disk allocated path=%s sizeBytes=%d", diskPath, scratchBytes);
-
-    // Materialize the base tarball into an ext4 image and COW-clone it
-    // into the workDir. The install hook mutates this throwaway copy, so
-    // the persistent ~/.cache/machinen/rootfs/<sha>.img cache stays
-    // pristine for normal `boot({ image })` callers that share the same
-    // base. reflinkCopy → APFS clonefile / Linux FICLONE on reflink-
-    // capable fs (free); falls back to a regular copy elsewhere
-    // (one-time cost, sparse).
-    phases.start("rootdisk-prep");
-    const cachedImg = ensureRootfsImage(baseAbs, {
-      onPhase: (name, ms) => phases.mark(`rootdisk-prep.${name}`, ms),
-    });
-    const reflinkT0 = Date.now();
-    reflinkCopy(cachedImg, rootDiskPath);
-    phases.mark("rootdisk-prep.reflink", Date.now() - reflinkT0);
-    debug("rootdisk cloned src=%s dst=%s", cachedImg, rootDiskPath);
-    // The cached `<sha>.img` was only READ here — the FICLONE / copy
-    // landed in workDir, and the upcoming boot() targets that copy via
-    // `rootDisk: rootDiskPath`. Restore the clean-shutdown marker the
-    // cache entry semantics expect (#170): without this the next
-    // provision() with the same base would see a missing `.ok` and
-    // wastefully rematerialize a known-good image.
-    markRootfsImageClean(cachedImg);
-    phases.end("rootdisk-prep");
-
-    // Boot the VMM with the base rootfs on /dev/vda (mounted ext4) and
-    // the exec-agent as the cmd. The scratch disk lands on /dev/vdb,
-    // ready for the post-install tar dump. We set MACHINEN_VSOCK
-    // explicitly via `vmmEnv` so the UDS path lives under workDir
-    // (predictable cleanup) rather than boot()'s auto-allocated tmp dir.
-    phases.start("boot");
-    const vm = await boot({
-      binary: opts.binary,
-      cwd: opts.cwd,
-      vmmEnv: {
-        ...opts.vmmEnv,
-        MACHINEN_VSOCK: `in:1978:${udsPath}`,
-      },
-      kernel: kernelAbs,
-      ...(dtbAbs ? { dtb: dtbAbs } : {}),
-      image: baseAbs,
-      cmd: ["/exec-agent"],
-      env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
-      snapshot: diskPath,
-      rootDisk: rootDiskPath,
-      // We drive the guest to exit via /sbin/machinen-poweroff at the
-      // end; wait() has its own ceiling below.
-      timeoutMs: null,
-      // Forward guest console + install-hook exec output to the caller.
-      // Internal tar / poweroff execs are forwarded explicitly below.
-      onLog: opts.onLog,
-    });
-    phases.end("boot");
-
-    const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
-    const killTimer = setTimeout(() => void vm.kill(), deadlineMs);
-    killTimer.unref();
-
-    // Buffer stderr so a timed-out VsockExec can surface the VMM's
-    // actual complaint instead of a bare ENOENT on the UDS. Keep up to
-    // 128 KB so we catch kernel boot output + vsock bridge messages,
-    // not just the zig unit-test tail.
-    const tailBuf: Buffer[] = [];
-    let tailBytes = 0;
-    const TAIL_MAX = 128 * 1024;
-    vm.stderr.on("data", (chunk: Buffer) => {
-      tailBuf.push(chunk);
-      tailBytes += chunk.length;
-      while (tailBytes > TAIL_MAX && tailBuf.length > 1) {
-        tailBytes -= tailBuf[0]!.length;
-        tailBuf.shift();
-      }
-      if (vmmDebug.enabled) {
-        process.stderr.write(chunk);
-      }
-    });
-    const stderrTail = () => Buffer.concat(tailBuf).slice(-TAIL_MAX).toString("utf8");
-
-    try {
-      // Hand control to the install hook. The spawned VM already has
-      // exec()/execRaw() hooked up to the vsock UDS we set via env, so
-      // the hook uses the same VmHandle shape as any other caller.
-      const installT0 = Date.now();
-      debug("install hook entry");
-      phases.start("install");
-      try {
-        await opts.install(vm);
-      } catch (err) {
-        const tail = stderrTail();
-        const msg = err instanceof Error ? err.message : String(err);
-        debug("install hook failed err=%s tailBytes=%d", msg, tail.length);
-        throw new ProvisionError(
-          "PROVISION_INSTALL_HOOK_FAILED",
-          `install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`,
-          { cause: err },
-        );
-      }
-      phases.end("install");
-      debug("install hook done elapsed=%dms", Date.now() - installT0);
-
-      // Post-install: archive / to /dev/vdb (the scratch disk), then
-      // tell the guest to power off cleanly (PSCI SYSTEM_OFF via
-      // /sbin/machinen-poweroff). A failed tar here means our scratch
-      // disk was too small; surface that specifically.
-      debug("tar / -> /dev/vdb starting");
-      const tarT0 = Date.now();
-      phases.start("tar-to-disk");
-      const tar = await VsockExec.run(udsPath, TAR_TO_DISK_CMD, {
-        execTimeoutMs: deadlineMs,
-        ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
-      });
-      phases.end("tar-to-disk");
-      debug("tar / -> /dev/vdb done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
-      if (tar.exitCode !== 0) {
-        throw new ProvisionError(
-          "PROVISION_DISK_TOO_SMALL",
-          `tar / to /dev/vdb failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
-            `Bump scratchDiskSizeBytes. stderr:\n${tar.stderr}`,
-        );
-      }
-
-      // Poweroff. /sbin/machinen-poweroff syncs, calls reboot(POWER_OFF),
-      // and the VMM exits on PSCI SYSTEM_OFF. The connection can fail in
-      // several equivalent ways (ECONNRESET mid-transaction, "agent
-      // closed before X frame", or a fast-retry hitting ECONNREFUSED
-      // after the VMM has already exited) — all are fine; vm.wait()
-      // below is the real success signal. Short connect timeout so
-      // we don't burn 30s retrying a bridge that's already gone.
-      debug("requesting guest poweroff");
-      phases.start("poweroff-wait");
-      await VsockExec.run(udsPath, "/sbin/machinen-poweroff", {
-        connectTimeoutMs: 2_000,
-        ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
-      }).catch(() => {});
-
-      // Surface progress without requiring DEBUG. The kernel's last
-      // visible line is `reboot: Power down`, after which there's a
-      // 30–90 s gap of silent host-side CPU. See #162.
-      console.error("provision: waiting for guest exit…");
-      await vm.wait();
-      phases.end("poweroff-wait");
-      debug("guest exited");
-    } finally {
-      clearTimeout(killTimer);
-      if (vm.pid > 0) {
-        await vm.kill().catch(() => {});
-      }
-    }
-
-    // Scratch disk now holds a raw tar stream (padded with zeros up to
-    // the scratch size). Repack it as a gzipped tarball at `out`, which
-    // trims trailing zeros and normalizes compression.
-    debug("repack disk tar -> %s starting", outAbs);
-    const repackT0 = Date.now();
-    phases.start("repack-targz");
-    repackDiskTarToGz(diskPath, outAbs, {
-      cmd: opts.cmd,
-      env: opts.env,
-      onPhase: (name, ms) => phases.mark(`repack-targz.${name}`, ms),
-    });
-    phases.end("repack-targz");
-    debug("repack done elapsed=%dms", Date.now() - repackT0);
-
-    const sizeBytes = statSync(outAbs).size;
-    // Warm boot()'s image-config cache (#233 follow-up): we know the
-    // exact bytes that landed in the tarball's machinen-config.json,
-    // so the next boot() can skip the ~1 s `tar -xzOf` decompress.
-    warmImageConfigCache(
-      outAbs,
-      opts.cmd || opts.env
-        ? {
-            ...(opts.cmd ? { cmd: opts.cmd } : {}),
-            ...(opts.env ? { env: opts.env } : {}),
-          }
-        : null,
-    );
-    const elapsedMs = Date.now() - t0;
-    debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, elapsedMs);
-    phases.flush(debug, "provision", elapsedMs);
-    opts.onLog?.(phases.toEvent("provision", elapsedMs));
-    return {
-      imagePath: outAbs,
-      sizeBytes,
-      elapsedMs,
-    };
+    await runInstallHook(opts, ctx, vm, stderrTail);
+    await tarProvisionRootfsToDisk(opts, ctx, deadlineMs);
+    await poweroffProvisionGuest(opts, ctx, vm);
   } finally {
-    try {
-      rmSync(workDir, { recursive: true, force: true });
-    } catch {}
+    clearTimeout(killTimer);
+    await killProvisionVm(vm);
   }
+}
+
+function captureProvisionStderrTail(vm: VmHandle): ProvisionStderrTail {
+  const tailBuf: Buffer[] = [];
+  let tailBytes = 0;
+  vm.stderr.on("data", (chunk: Buffer) => {
+    tailBuf.push(chunk);
+    tailBytes += chunk.length;
+    while (tailBytes > PROVISION_STDERR_TAIL_MAX && tailBuf.length > 1) {
+      tailBytes -= tailBuf[0]!.length;
+      tailBuf.shift();
+    }
+    if (vmmDebug.enabled) {
+      process.stderr.write(chunk);
+    }
+  });
+  return {
+    tail: () => Buffer.concat(tailBuf).slice(-PROVISION_STDERR_TAIL_MAX).toString("utf8"),
+  };
+}
+
+async function runInstallHook(
+  opts: ProvisionOptions,
+  ctx: ProvisionContext,
+  vm: VmHandle,
+  stderrTail: ProvisionStderrTail,
+): Promise<void> {
+  const installT0 = Date.now();
+  debug("install hook entry");
+  ctx.phases.start("install");
+  try {
+    await opts.install(vm);
+  } catch (err) {
+    throw installHookError(err, stderrTail.tail());
+  }
+  ctx.phases.end("install");
+  debug("install hook done elapsed=%dms", Date.now() - installT0);
+}
+
+function installHookError(err: unknown, tail: string): ProvisionError {
+  const msg = err instanceof Error ? err.message : String(err);
+  debug("install hook failed err=%s tailBytes=%d", msg, tail.length);
+  return new ProvisionError(
+    "PROVISION_INSTALL_HOOK_FAILED",
+    `install hook failed: ${msg}\n--- VMM stderr (last 8 KB) ---\n${tail}`,
+    { cause: err },
+  );
+}
+
+async function tarProvisionRootfsToDisk(
+  opts: ProvisionOptions,
+  ctx: ProvisionContext,
+  deadlineMs: number,
+): Promise<void> {
+  debug("tar / -> /dev/vdb starting");
+  const tarT0 = Date.now();
+  ctx.phases.start("tar-to-disk");
+  const tar = await VsockExec.run(ctx.udsPath, TAR_TO_DISK_CMD, {
+    execTimeoutMs: deadlineMs,
+    ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
+  });
+  ctx.phases.end("tar-to-disk");
+  debug("tar / -> /dev/vdb done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
+  if (tar.exitCode !== 0) {
+    throw new ProvisionError(
+      "PROVISION_DISK_TOO_SMALL",
+      `tar / to /dev/vdb failed (code ${tar.exitCode}) — scratch disk may be too small.\n` +
+        `Bump scratchDiskSizeBytes. stderr:\n${tar.stderr}`,
+    );
+  }
+}
+
+async function poweroffProvisionGuest(
+  opts: ProvisionOptions,
+  ctx: ProvisionContext,
+  vm: VmHandle,
+): Promise<void> {
+  debug("requesting guest poweroff");
+  ctx.phases.start("poweroff-wait");
+  await VsockExec.run(ctx.udsPath, "/sbin/machinen-poweroff", {
+    connectTimeoutMs: 2_000,
+    ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
+  }).catch(() => {});
+  console.error("provision: waiting for guest exit…");
+  await vm.wait();
+  ctx.phases.end("poweroff-wait");
+  debug("guest exited");
+}
+
+async function killProvisionVm(vm: VmHandle): Promise<void> {
+  if (vm.pid > 0) {
+    await vm.kill().catch(() => {});
+  }
+}
+
+function repackProvisionOutput(opts: ProvisionOptions, ctx: ProvisionContext): void {
+  debug("repack disk tar -> %s starting", ctx.outAbs);
+  const repackT0 = Date.now();
+  ctx.phases.start("repack-targz");
+  repackDiskTarToGz(ctx.diskPath, ctx.outAbs, {
+    cmd: opts.cmd,
+    env: opts.env,
+    onPhase: (name, ms) => ctx.phases.mark(`repack-targz.${name}`, ms),
+  });
+  ctx.phases.end("repack-targz");
+  debug("repack done elapsed=%dms", Date.now() - repackT0);
+}
+
+function finishProvision(opts: ProvisionOptions, ctx: ProvisionContext): ProvisionResult {
+  const sizeBytes = statSync(ctx.outAbs).size;
+  warmImageConfigCache(ctx.outAbs, provisionImageConfig(opts));
+  const elapsedMs = Date.now() - ctx.t0;
+  debug("provision complete sizeBytes=%d totalElapsed=%dms", sizeBytes, elapsedMs);
+  ctx.phases.flush(debug, "provision", elapsedMs);
+  opts.onLog?.(ctx.phases.toEvent("provision", elapsedMs));
+  return { imagePath: ctx.outAbs, sizeBytes, elapsedMs };
+}
+
+function provisionImageConfig(
+  opts: ProvisionOptions,
+): { cmd?: string[]; env?: Record<string, string> } | null {
+  if (!opts.cmd && !opts.env) {
+    return null;
+  }
+  return {
+    ...(opts.cmd ? { cmd: opts.cmd } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
+  };
+}
+
+function cleanupProvisionWorkDir(workDir: string): void {
+  try {
+    rmSync(workDir, { recursive: true, force: true });
+  } catch {}
 }
 
 /**

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -493,16 +493,29 @@ function sweepEmptyPinDirs(dir: string): void {
  * but Node's `writeFileSync(..., { flag: "wx" })` is the equivalent
  * and works on every platform we ship.
  */
+type ClaimAttempt = "claimed" | "retry" | "refuse";
+
 export function claimName(name: string, pid: number): boolean {
   const pin = pinPath(name);
-  // Path-shaped names like `<src>/<pid>` (chained restore — #208) need
-  // their parent dir to exist. mkdir is idempotent for directories;
-  // it throws EEXIST when a regular file blocks the parent path —
-  // typical when the source VM is alive and pinned at `<src>` (the
-  // fork case, #216). Treat that as "name unavailable" so callers
-  // can fall back to a non-nested name rather than crash.
+  if (!ensurePinParent(name, pin)) {
+    return false;
+  }
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const result = claimPinOnce(name, pid, pin, attempt);
+    if (result === "claimed") {
+      return true;
+    }
+    if (result === "refuse") {
+      return false;
+    }
+  }
+  return false;
+}
+
+function ensurePinParent(name: string, pin: string): boolean {
   try {
     mkdirSync(dirname(pin), { recursive: true });
+    return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") {
       debug("claimName name=%s parent path is a live pin — refusing", name);
@@ -510,60 +523,75 @@ export function claimName(name: string, pid: number): boolean {
     }
     throw err;
   }
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      writeFileSync(pin, String(pid), { flag: "wx" });
-      debug("claimName name=%s pid=%d (attempt=%d)", name, pid, attempt);
-      return true;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw err;
-      }
-      // EEXIST: a file or a directory occupies the pin path. An empty
-      // directory is a leftover from a path-shaped child pin whose
-      // leaf was unlinked (pre-#268 removeEntry didn't prune parents).
-      // A non-empty directory is holding live nested pins — refuse.
-      let isDir = false;
-      try {
-        isDir = statSync(pin).isDirectory();
-      } catch {}
-      if (isDir) {
-        try {
-          rmdirSync(pin);
-          debug("claimName name=%s removed empty stale dir — retrying", name);
-          continue;
-        } catch {
-          debug("claimName name=%s dir holds live nested pins — refusing", name);
-          return false;
-        }
-      }
-      // Pin is a regular file. If the holder fails the recycling /
-      // orphan check, drop the pin (and any orphaned meta dir) and
-      // retry. `kill(pid,0)` alone isn't enough — a recycled pid will
-      // succeed it, leaving the pin pinned forever.
-      let heldPid = -1;
-      try {
-        heldPid = Number(readFileSync(pin, "utf8").trim());
-      } catch {}
-      if (heldPid > 0 && !pinIsStale(heldPid)) {
-        debug("claimName name=%s held by live pid=%d — refusing", name, heldPid);
-        return false;
-      }
-      debug("claimName name=%s stale pin (heldPid=%d) — reaping", name, heldPid);
-      try {
-        unlinkSync(pin);
-      } catch {}
-      if (heldPid > 0) {
-        // If the meta dir lingered (orphaned writeEntry, or recycled
-        // pid), drop it now — otherwise the next list() would prune
-        // it but we want claimName to leave a clean slate either way.
-        try {
-          rmSync(join(registryRoot(), String(heldPid)), { recursive: true, force: true });
-        } catch {}
-      }
+}
+
+function claimPinOnce(name: string, pid: number, pin: string, attempt: number): ClaimAttempt {
+  try {
+    writeFileSync(pin, String(pid), { flag: "wx" });
+    debug("claimName name=%s pid=%d (attempt=%d)", name, pid, attempt);
+    return "claimed";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
     }
+    return handleExistingPin(name, pin);
   }
-  return false;
+}
+
+function handleExistingPin(name: string, pin: string): ClaimAttempt {
+  if (pinPathIsDirectory(pin)) {
+    return handleDirectoryPin(name, pin);
+  }
+  return handleFilePin(name, pin);
+}
+
+function pinPathIsDirectory(pin: string): boolean {
+  try {
+    return statSync(pin).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function handleDirectoryPin(name: string, pin: string): ClaimAttempt {
+  try {
+    rmdirSync(pin);
+    debug("claimName name=%s removed empty stale dir — retrying", name);
+    return "retry";
+  } catch {
+    debug("claimName name=%s dir holds live nested pins — refusing", name);
+    return "refuse";
+  }
+}
+
+function handleFilePin(name: string, pin: string): ClaimAttempt {
+  const heldPid = readPinPid(pin);
+  if (heldPid > 0 && !pinIsStale(heldPid)) {
+    debug("claimName name=%s held by live pid=%d — refusing", name, heldPid);
+    return "refuse";
+  }
+  debug("claimName name=%s stale pin (heldPid=%d) — reaping", name, heldPid);
+  reapStalePin(pin, heldPid);
+  return "retry";
+}
+
+function readPinPid(pin: string): number {
+  try {
+    return Number(readFileSync(pin, "utf8").trim());
+  } catch {
+    return -1;
+  }
+}
+
+function reapStalePin(pin: string, heldPid: number): void {
+  try {
+    unlinkSync(pin);
+  } catch {}
+  if (heldPid > 0) {
+    try {
+      rmSync(join(registryRoot(), String(heldPid)), { recursive: true, force: true });
+    } catch {}
+  }
 }
 
 /**

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -178,6 +178,20 @@ export interface EnsureRootfsImageOptions {
   onPhase?: (name: string, ms: number) => void;
 }
 
+interface RootfsCachePaths {
+  tarAbs: string;
+  cacheDir: string;
+  sha: string;
+  imgPath: string;
+  okPath: string;
+}
+
+interface RootfsStagingPaths {
+  stagingDir: string;
+  stagingTree: string;
+  stagingImg: string;
+}
+
 /**
  * Resolve `tarPath` to a cached ext4 `.img`, materializing it on first
  * call. Returns the absolute path to the cached image.
@@ -202,6 +216,18 @@ export interface EnsureRootfsImageOptions {
  *   PROVISION_INSTALL_HOOK_FAILED (tar / mke2fs failed)
  */
 export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOptions = {}): string {
+  const paths = resolveRootfsCachePaths(tarPath, opts);
+  return (
+    tryReusableCachedRootfs(paths, opts) ??
+    tryPrebakedRootfs(paths, opts) ??
+    materializeRootfsFromTar(paths, opts, resolveMke2fsOrThrow())
+  );
+}
+
+function resolveRootfsCachePaths(
+  tarPath: string,
+  opts: EnsureRootfsImageOptions,
+): RootfsCachePaths {
   const tarAbs = resolve(tarPath);
   if (!existsSync(tarAbs)) {
     throw new ProvisionError(
@@ -216,188 +242,192 @@ export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOption
   const sha = sha256OfFile(tarAbs);
   opts.onPhase?.("sha256", Date.now() - shaT0);
   const imgPath = join(cacheDir, `${sha}.img`);
-  const okPath = okMarkerPath(imgPath);
-  if (!opts.force && existsSync(imgPath)) {
-    debug("cache hit sha=%s img=%s", sha.slice(0, 12), imgPath);
-    // #170: require the clean-shutdown marker. Missing means the
-    // previous VMM was killed mid-write — fsck won't catch torn data
-    // blocks, so treat the image as poisoned and rebuild from the
-    // tarball.
-    //
-    // We deliberately do NOT `unlinkSync(imgPath)` here on the wipe
-    // paths. Concurrent callers (parallel test files, multiple `boot()`
-    // calls) may already hold imgPath as a cache-hit return value and
-    // be about to reflink from it — deleting the file out from under
-    // them races to ENOENT. The renameSync at the end of the materialize
-    // / prebake paths atomically replaces imgPath with fresh bytes, so
-    // the wipe is redundant; falling through is sufficient.
-    if (!existsSync(okPath)) {
-      debug("cache hit but no clean marker, will rematerialize img=%s", imgPath);
-    } else {
-      // Atomically clear the marker BEFORE handing the path off, so
-      // a kill between here and `markRootfsImageClean()` leaves the
-      // image flagged dirty for the next boot.
-      try {
-        unlinkSync(okPath);
-      } catch {}
-      const fsckT0 = Date.now();
-      const usable = cachedImageIsUsable(imgPath);
-      opts.onPhase?.("e2fsck", Date.now() - fsckT0);
-      if (usable) {
-        // #131: if the caller asked for a larger image than what's on
-        // disk (typically because they bumped `rootDiskSizeBytes`, or
-        // because the materializer's defaults grew), sparse-extend the
-        // file in place. The on-disk ext4 fs is still sized to the old
-        // file; /init's tryRootDiskPivot resizes it online via
-        // EXT4_IOC_RESIZE_FS so the guest sees the new capacity.
-        // truncate-up on a sparse file is free; truncate-down would
-        // chop bytes, so we never shrink.
-        if (opts.sizeBytes !== undefined) {
-          const truncT0 = Date.now();
-          try {
-            const cur = statSync(imgPath).size;
-            if (opts.sizeBytes > cur) {
-              truncateSync(imgPath, opts.sizeBytes);
-              debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
-            }
-          } catch (err) {
-            debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
-          }
-          opts.onPhase?.("sparse-extend", Date.now() - truncT0);
-        }
-        return imgPath;
-      }
-      // Unrecoverable. Fall through to materialize a fresh image — same
-      // path a force=true caller would take. renameSync replaces.
-      debug("cache hit unusable, will rematerialize img=%s", imgPath);
-    }
-  }
+  return { tarAbs, cacheDir, sha, imgPath, okPath: okMarkerPath(imgPath) };
+}
 
-  // #223: prebake fast path. If a sibling `<basename>.img.gz` sits
-  // next to the tarball (shipped with release builds), gunzip it
-  // into the cache and skip tar+mke2fs. The bytes are an ext4 image;
-  // the cache key (tarball sha) is the same one the materialize path
-  // would write to, so downstream (per-boot reflink, sparse-extend,
-  // .ok marker) is unchanged. Locally `provision()`-built tarballs
-  // skip this branch — provision() writes the cache image directly
-  // via prebakeRootfsImageFromTree() instead of staging a sibling.
-  if (!opts.force) {
-    const sibling = siblingPrebakePath(tarAbs);
-    if (sibling && existsSync(sibling)) {
-      const prebakeT0 = Date.now();
-      const fast = tryPrebakeFromSibling({
-        sibling,
-        cacheDir,
-        sha,
-        imgPath,
-        sizeBytes: opts.sizeBytes,
-      });
-      opts.onPhase?.("gunzip-prebake", Date.now() - prebakeT0);
-      if (fast) {
-        return fast;
-      }
-      // Fall through to materialize on any failure — same outcome
-      // as if the sibling weren't there. Slow but always correct.
-    }
+function tryReusableCachedRootfs(
+  paths: RootfsCachePaths,
+  opts: EnsureRootfsImageOptions,
+): string | undefined {
+  if (opts.force || !existsSync(paths.imgPath)) {
+    return undefined;
   }
-
-  // Resolve mke2fs in four steps:
-  //   1. `MACHINEN_MKE2FS` env override — for users pinning a specific
-  //      build (e.g. a debug binary, or a vendored copy outside the
-  //      bundled package). Mirrors `MACHINEN_VMM` / `MACHINEN_GVPROXY`.
-  //   2. The bundled `@machinen/e2fsprogs-<arch>-<os>` package (zero
-  //      user setup, present in normal installs). Each arch package
-  //      declares matching `os` + `cpu` so npm/pnpm only installs the
-  //      one that fits the host.
-  //   3. PATH (for hosts that have e2fsprogs installed system-wide).
-  //   4. Homebrew's keg-only prefix on macOS (#124) — `brew install
-  //      e2fsprogs` deliberately doesn't symlink mke2fs onto PATH.
-  const names = ["mke2fs", "mkfs.ext4"];
-  const mke2fs =
-    resolveMke2fsEnvOverride() ??
-    findBundledMke2fs() ??
-    whichFirst(names) ??
-    findKegOnlyE2fs(names);
-  if (!mke2fs) {
-    throw new ProvisionError(
-      "ROOTFS_IMG_TOOL_MISSING",
-      "ensureRootfsImage: no e2fsprogs binary found (no bundled package " +
-        "for this platform; looked for mke2fs / mkfs.ext4 on PATH and in " +
-        "Homebrew's keg-only prefix). Install it:\n" +
-        "  • macOS:  brew install e2fsprogs\n" +
-        "            (e2fsprogs is keg-only on Homebrew; machinen also " +
-        "probes /opt/homebrew/opt/e2fsprogs/sbin and " +
-        "/usr/local/opt/e2fsprogs/sbin automatically)\n" +
-        "  • Linux:  apt-get install -y e2fsprogs (or your distro's package)\n" +
-        "  • or set MACHINEN_MKE2FS=/abs/path/to/mke2fs to point at a vendored copy\n" +
-        "  • or skip virtio-blk root and let boot() use the legacy " +
-        "initramfs-as-rootfs path.",
-    );
+  debug("cache hit sha=%s img=%s", paths.sha.slice(0, 12), paths.imgPath);
+  if (!cachedImageHasCleanMarker(paths)) {
+    return undefined;
   }
+  markCachedImageInUse(paths.okPath);
+  if (!fsckCachedRootfs(paths.imgPath, opts)) {
+    debug("cache hit unusable, will rematerialize img=%s", paths.imgPath);
+    return undefined;
+  }
+  growCachedRootfsIfRequested(paths.imgPath, opts);
+  return paths.imgPath;
+}
 
-  const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-staging-`));
-  const stagingTree = join(stagingDir, "tree");
-  const stagingImg = join(stagingDir, "rootfs.img");
-  mkdirSync(stagingTree, { recursive: true });
+function cachedImageHasCleanMarker(paths: RootfsCachePaths): boolean {
+  if (existsSync(paths.okPath)) {
+    return true;
+  }
+  debug("cache hit but no clean marker, will rematerialize img=%s", paths.imgPath);
+  return false;
+}
+
+function markCachedImageInUse(okPath: string): void {
+  // Atomically clear the marker BEFORE handing the path off, so a kill
+  // before markRootfsImageClean() leaves the image flagged dirty.
   try {
-    debug("materialize sha=%s tar=%s", sha.slice(0, 12), tarAbs);
+    unlinkSync(okPath);
+  } catch {}
+}
 
-    // 1. Extract the tarball into the staging directory. tar handles
-    //    both gzip and plain.
-    const extractT0 = Date.now();
-    extractTarball(tarAbs, stagingTree);
-    opts.onPhase?.("tar-extract", Date.now() - extractT0);
+function fsckCachedRootfs(imgPath: string, opts: EnsureRootfsImageOptions): boolean {
+  const fsckT0 = Date.now();
+  const usable = cachedImageIsUsable(imgPath);
+  opts.onPhase?.("e2fsck", Date.now() - fsckT0);
+  return usable;
+}
 
-    // 2. Size the image. Three-way:
-    //    - sizeBytes wins outright when the caller passes it (the
-    //      user-facing rootDiskSizeBytes override; #131).
-    //    - Otherwise, max(minSizeBytes, treeBytes * sizeMultiplier).
-    //    Sparse files cost nothing on disk until written, so over-
-    //    provisioning the upper bound here is essentially free; the
-    //    guest's online ext4 grow (in /init) makes any extra capacity
-    //    visible without a rematerialize.
-    const treeBytes = duBytes(stagingTree);
-    const multiplier = opts.sizeMultiplier ?? 2.5;
-    const minBytes = opts.minSizeBytes ?? 2 * 1024 * 1024 * 1024;
-    const sizeBytes = opts.sizeBytes ?? Math.max(minBytes, Math.ceil(treeBytes * multiplier));
-    debug(
-      "size tree=%d size=%d multiplier=%s explicit=%s",
-      treeBytes,
-      sizeBytes,
-      multiplier,
-      opts.sizeBytes !== undefined,
-    );
-    allocateSparseFile(stagingImg, sizeBytes);
-
-    // 3. mke2fs -d <tree> -t ext4 -F <img> <size-in-blocks>. The 4-KiB
-    //    block size matches the kernel's default page size on arm64
-    //    so reads are page-cache-aligned.
-    const blocks = Math.floor(sizeBytes / 4096);
-    const mkT0 = Date.now();
-    const mk = spawnSync(
-      mke2fs,
-      ["-d", stagingTree, "-t", "ext4", "-F", "-q", "-b", "4096", stagingImg, String(blocks)],
-      { stdio: ["ignore", "ignore", "pipe"] },
-    );
-    opts.onPhase?.("mke2fs", Date.now() - mkT0);
-    if (mk.status !== 0) {
-      throw new ProvisionError(
-        "PROVISION_INSTALL_HOOK_FAILED",
-        `ensureRootfsImage: ${mke2fs} failed (code ${mk.status}): ${mk.stderr?.toString() ?? ""}`,
-      );
+function growCachedRootfsIfRequested(imgPath: string, opts: EnsureRootfsImageOptions): void {
+  if (opts.sizeBytes === undefined) {
+    return;
+  }
+  const truncT0 = Date.now();
+  try {
+    const cur = statSync(imgPath).size;
+    if (opts.sizeBytes > cur) {
+      truncateSync(imgPath, opts.sizeBytes);
+      debug("cache hit grew img=%s from=%d to=%d", imgPath, cur, opts.sizeBytes);
     }
+  } catch (err) {
+    debug("cache hit grow failed img=%s err=%s", imgPath, (err as Error).message);
+  }
+  opts.onPhase?.("sparse-extend", Date.now() - truncT0);
+}
 
-    // 4. Atomic rename into the cache. Concurrent materializers can
-    //    race here; the second `rename` clobbers the first, but both
-    //    files have identical content (same sha), so it doesn't
-    //    matter who wins.
-    renameSync(stagingImg, imgPath);
-    debug("materialize done sha=%s img=%s sizeBytes=%d", sha.slice(0, 12), imgPath, sizeBytes);
-    return imgPath;
+function tryPrebakedRootfs(
+  paths: RootfsCachePaths,
+  opts: EnsureRootfsImageOptions,
+): string | undefined {
+  if (opts.force) {
+    return undefined;
+  }
+  const sibling = siblingPrebakePath(paths.tarAbs);
+  if (!sibling || !existsSync(sibling)) {
+    return undefined;
+  }
+  const prebakeT0 = Date.now();
+  const fast = tryPrebakeFromSibling({
+    sibling,
+    cacheDir: paths.cacheDir,
+    sha: paths.sha,
+    imgPath: paths.imgPath,
+    sizeBytes: opts.sizeBytes,
+  });
+  opts.onPhase?.("gunzip-prebake", Date.now() - prebakeT0);
+  return fast;
+}
+
+function resolveMke2fsOrThrow(): string {
+  const mke2fs = resolveMke2fs();
+  if (mke2fs) {
+    return mke2fs;
+  }
+  throw new ProvisionError(
+    "ROOTFS_IMG_TOOL_MISSING",
+    "ensureRootfsImage: no e2fsprogs binary found (no bundled package " +
+      "for this platform; looked for mke2fs / mkfs.ext4 on PATH and in " +
+      "Homebrew's keg-only prefix). Install it:\n" +
+      "  • macOS:  brew install e2fsprogs\n" +
+      "            (e2fsprogs is keg-only on Homebrew; machinen also " +
+      "probes /opt/homebrew/opt/e2fsprogs/sbin and " +
+      "/usr/local/opt/e2fsprogs/sbin automatically)\n" +
+      "  • Linux:  apt-get install -y e2fsprogs (or your distro's package)\n" +
+      "  • or set MACHINEN_MKE2FS=/abs/path/to/mke2fs to point at a vendored copy\n" +
+      "  • or skip virtio-blk root and let boot() use the legacy " +
+      "initramfs-as-rootfs path.",
+  );
+}
+
+function materializeRootfsFromTar(
+  paths: RootfsCachePaths,
+  opts: EnsureRootfsImageOptions,
+  mke2fs: string,
+): string {
+  const staging = createRootfsStaging(paths);
+  try {
+    debug("materialize sha=%s tar=%s", paths.sha.slice(0, 12), paths.tarAbs);
+    extractRootfsTarball(paths.tarAbs, staging.stagingTree, opts);
+    const sizeBytes = sizeRootfsImage(staging.stagingTree, opts);
+    allocateSparseFile(staging.stagingImg, sizeBytes);
+    runMke2fs(mke2fs, staging.stagingTree, staging.stagingImg, sizeBytes, opts);
+    renameSync(staging.stagingImg, paths.imgPath);
+    debug(
+      "materialize done sha=%s img=%s sizeBytes=%d",
+      paths.sha.slice(0, 12),
+      paths.imgPath,
+      sizeBytes,
+    );
+    return paths.imgPath;
   } finally {
     try {
-      rmSync(stagingDir, { recursive: true, force: true });
+      rmSync(staging.stagingDir, { recursive: true, force: true });
     } catch {}
+  }
+}
+
+function createRootfsStaging(paths: RootfsCachePaths): RootfsStagingPaths {
+  const stagingDir = mkdtempSync(join(paths.cacheDir, `${paths.sha.slice(0, 12)}-staging-`));
+  const stagingTree = join(stagingDir, "tree");
+  mkdirSync(stagingTree, { recursive: true });
+  return { stagingDir, stagingTree, stagingImg: join(stagingDir, "rootfs.img") };
+}
+
+function extractRootfsTarball(
+  tarAbs: string,
+  stagingTree: string,
+  opts: EnsureRootfsImageOptions,
+): void {
+  const extractT0 = Date.now();
+  extractTarball(tarAbs, stagingTree);
+  opts.onPhase?.("tar-extract", Date.now() - extractT0);
+}
+
+function sizeRootfsImage(stagingTree: string, opts: EnsureRootfsImageOptions): number {
+  const treeBytes = duBytes(stagingTree);
+  const multiplier = opts.sizeMultiplier ?? 2.5;
+  const minBytes = opts.minSizeBytes ?? 2 * 1024 * 1024 * 1024;
+  const sizeBytes = opts.sizeBytes ?? Math.max(minBytes, Math.ceil(treeBytes * multiplier));
+  debug(
+    "size tree=%d size=%d multiplier=%s explicit=%s",
+    treeBytes,
+    sizeBytes,
+    multiplier,
+    opts.sizeBytes !== undefined,
+  );
+  return sizeBytes;
+}
+
+function runMke2fs(
+  mke2fs: string,
+  stagingTree: string,
+  stagingImg: string,
+  sizeBytes: number,
+  opts: EnsureRootfsImageOptions,
+): void {
+  const blocks = Math.floor(sizeBytes / 4096);
+  const mkT0 = Date.now();
+  const mk = spawnSync(
+    mke2fs,
+    ["-d", stagingTree, "-t", "ext4", "-F", "-q", "-b", "4096", stagingImg, String(blocks)],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+  opts.onPhase?.("mke2fs", Date.now() - mkT0);
+  if (mk.status !== 0) {
+    throw new ProvisionError(
+      "PROVISION_INSTALL_HOOK_FAILED",
+      `ensureRootfsImage: ${mke2fs} failed (code ${mk.status}): ${mk.stderr?.toString() ?? ""}`,
+    );
   }
 }
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -48,7 +48,7 @@ import { claimName, findEntry, removeEntry, writeEntry } from "../registry.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
 import { resolveLiveMounts, type ResolvedLiveMount, synthesizeAndPackBundle } from "./bundle.ts";
 import { performForkWithRestore } from "./fork-core.ts";
-import type { MemoryStats, VmHandle } from "../vm-handle.ts";
+import type { VmHandle } from "../vm-handle.ts";
 import {
   allocateSparseFile,
   autoSizeMemoryMib,
@@ -436,328 +436,31 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     opts.mount ? `${opts.mount.host}->${opts.mount.guest}` : "<none>",
   );
 
-  phases.start("asset-resolve");
-  // #150: detached boots are compatible with every boot option. gvproxy
-  // and each live-mount FUSE server spawn as detached daemons wrapped
-  // through `pdeathsig --watch-pid <vmm>`; `mount` (squashfs+ext4) is
-  // fd-passed to the VMM at spawn so the supervisor holds no live state
-  // after that. Per-boot artifacts are tracked in the registry so
-  // `machinen gc` / `machinen stop` reap them after supervisor exit.
-  const portForward = opts.portForward ?? [];
-  await validatePortForwardOpts(opts, portForward);
-
-  const binaryInput = opts.binary ?? resolveVmmBinary();
-  const binary = resolve(opts.cwd ?? process.cwd(), binaryInput);
-  if (!existsSync(binary)) {
-    throw new BootError("BOOT_VMM_MISSING", `VMM binary not found at ${binary}`);
-  }
-  // `cmd` requires an image to run against. `image` alone is allowed
-  // — the image may carry a baked-in default cmd (see
-  // `provision({ cmd })`); if it doesn't and the user didn't pass
-  // one, `synthesizeAndPackBundle` errors with a clear message.
-  if (opts.cmd && !opts.image) {
-    throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
-  }
-  phases.end("asset-resolve");
-
-  const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    ...opts.vmmEnv,
-  };
-  configureNestedVirtualization(opts, binary, env);
-  const memoryCeilingMib = setMemoryCeiling(opts, env);
-
-  phases.start("disk-prep");
-  const { diskAbs, perBootSnapDisk } = prepareScratchDisk(opts, env);
-  phases.end("disk-prep");
-
-  // #114: rootdisk-by-default. Boot mounts the rootfs from a
-  // virtio-blk device (/dev/vda) instead of inflating the whole tree
-  // into a RAM-backed tmpfs at boot. The user passes `rootDisk: false`
-  // to opt back into the legacy cpio-as-rootfs path (rare — mostly for
-  // tests that need to assert the initramfs path explicitly).
-  // Resolution + materialization happens later, alongside packBundle,
-  // so per-arg validation (mount paths, liveMount, baked-cmd) fires
-  // before we spend time hashing the tarball.
-  const wantsRootDisk =
-    opts.rootDisk !== false &&
-    (opts._rootDiskRestorePath !== undefined || opts.rootDisk !== undefined || !!opts.image);
-  if (wantsRootDisk && typeof opts.rootDisk !== "string" && !opts.image) {
-    throw new BootError(
-      "BOOT_CMD_WITHOUT_IMAGE",
-      "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
-    );
-  }
-  validateKernelDtb(opts, env);
-
-  let { vsockUdsPath, vsockTempDir } = setupVsockBridge(env);
-  const { statsFilePath, statsTempDir } = setupStatsFile(env, vsockTempDir);
-
-  // Vmstate engine wiring. Every VM booted under
-  // MACHINEN_SNAPSHOT_ENGINE=vmstate — except those that opt out with
-  // `snapshot: false` — gets a per-VM whole-VM state file the VMM
-  // dumps to on SIGUSR1 — `performSnapshotVmstate` (driven by
-  // `machinen snapshot` / `fork`) signals the VMM and picks the file
-  // up. Restore is the mirror: `restore()` hands the bundle's
-  // `state.vmstate` down via `_vmstateRestorePath`, which we forward
-  // to the VMM as MACHINEN_RESTORE_PATH so it loads that whole-VM
-  // state before the first vCPU run. `snapshot: false` skips the
-  // wiring entirely so the VMM never installs the SIGUSR1 handler —
-  // the VM is genuinely un-snapshottable, the same as under criu.
-  let vmstateStatePath: string | undefined;
-  const vmstateChainId = randomBytes(16).toString("hex");
-  let vmstateCheckpointParent = opts._vmstateRestorePath ? opts.forkedFrom : undefined;
-  let vmstateCheckpointSequence = 0;
-  if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
-    if (!vsockTempDir) {
-      vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
-    }
-    vmstateStatePath = join(vsockTempDir, VMSTATE_FILE);
-    env.MACHINEN_SNAPSHOT_PATH = vmstateStatePath;
-  }
-  if (opts._vmstateRestorePath) {
-    env.MACHINEN_RESTORE_PATH = opts._vmstateRestorePath;
-    if ((vmstateDebug.enabled || restoreDebug.enabled) && !env.MACHINEN_VMSTATE_TIMING) {
-      env.MACHINEN_VMSTATE_TIMING = "1";
-    }
-  }
-
-  // #78 / #332: resolve live-share mounts. We compute these here so the
-  // per-mount tag can be baked into machinen-config.json at pack time —
-  // the guest's /init reads the same entries. Each mount is served by
-  // an in-VMM virtio-fs device (slots 7..10); MACHINEN_VIRTIOFS_<i>
-  // carries `<tag>:<mode>:<host_path>` for slot i. No vsock port, no
-  // detached server, no guest fuse-agent (all removed in #338).
-  let liveMountsResolved: ResolvedLiveMount[] = [];
-  if ((opts.liveMounts ?? []).length > 0) {
-    liveMountsResolved = resolveLiveMounts(opts.liveMounts!, opts.cwd);
-    liveMountsResolved.forEach((lm, i) => {
-      env[`MACHINEN_VIRTIOFS_${i}`] = `${lm.tag}:${lm.mode}:${lm.host}`;
-    });
-  }
-
-  // gvproxy + host→guest port forwards (#87) are set up before the
-  // VMM boots so packBundle sees a populated MACHINEN_NET_SOCKET. If
-  // anything downstream throws (packBundle validation, exposePort
-  // failure, nodeSpawn failure), the outer catch shuts gvproxy back
-  // down — otherwise a failed boot would leave orphans behind.
-  let gvStop: (() => void) | undefined;
-  let gvPid: number | undefined;
-  let gvExe: string | undefined;
-  let gvSocketDir: string | undefined;
-  let bundleTempDir: string | undefined;
-  // #272: paths to the materialized squashfs lower + per-VM ext4
-  // upper for the `--mount` overlay. The lower lives in the host
-  // cache and survives this boot; the upper is per-VM and gets
-  // unlinked on VM exit unless a snapshot reflinks it first.
-  let mountDiskPaths: MountDiskPaths | undefined;
-  let perBootMountUpper: string | undefined;
-  let perBootRootDisk: string | undefined;
-  const mergedGuestEnv: Record<string, string> = { ...opts.env };
-
-  // Surface the VM name in the guest as an early fallback so an
-  // interactive shell prompt (\h in bash's default Debian PS1) can tell
-  // the user which VM they're attached to. The final prompt label must
-  // also include the host VMM pid, which isn't known until after spawn;
-  // when vsock-exec is available, machinen-supervisor.sh waits briefly
-  // before starting the workload while the host-side setGuestHostname()
-  // below installs `<name>-pid-<host_pid>` (or `vm-pid-<host_pid>`).
-  if (opts.name && !mergedGuestEnv.MACHINEN_VM_NAME) {
-    mergedGuestEnv.MACHINEN_VM_NAME = opts.name;
-  }
-  if (vsockUdsPath && !mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT) {
-    mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT = "1";
-  }
-
-  try {
-    phases.start("net-services");
-    phases.start("net-services.gvproxy");
-    const gv = await bringUpGvproxy(opts, binary, env, portForward);
-    gvStop = gv.gvStop;
-    gvPid = gv.gvPid;
-    gvExe = gv.gvExe;
-    gvSocketDir = gv.gvSocketDir;
-    phases.end("net-services.gvproxy");
-    // #338: live-share mounts are served by in-VMM virtio-fs devices —
-    // there's no host-side server process to spawn. The runtime just
-    // bakes the per-mount tags into machinen-config.json + the
-    // MACHINEN_VIRTIOFS_<i> env; the VMM wires the devices itself.
-    phases.end("net-services");
-
-    // Pack an initramfs whenever the guest needs userspace (image +
-    // cmd + snapshot-only restore all need /init + synthesized
-    // machinen-config.json). Test-mode zig boots fall through with no
-    // INITRD env set — the VMM uses its own fixture initramfs.
-    if (opts.image || opts.cmd || opts.snapshot) {
-      phases.start("initramfs-pack");
-      const packed = synthesizeAndPackBundle(opts, mergedGuestEnv, liveMountsResolved, {
-        useTiny: wantsRootDisk,
-        env,
-        mountDiskUpperSizeBytes: opts.mountDiskUpperSizeBytes,
-        onPhase: (name, ms) => phases.mark(`initramfs-pack.${name}`, ms),
-      });
-      bundleTempDir = packed.tempDir;
-      env.MACHINEN_INITRD = packed.cpioPath;
-      // #272: stash the materialized squashfs lower / ext4 upper so
-      // the spawn block can openSync + fd-pass them. The per-VM upper
-      // gets unlinked on VM exit alongside the per-boot rootdisk
-      // reflink; the lower stays in the host cache.
-      mountDiskPaths = packed.mountDisk;
-      const packMs = phases.end("initramfs-pack");
-      debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
-    }
-
-    // #114: rootDisk materialization. After all input validation has
-    // passed (so a bad mount path or missing image fails before we
-    // hash a multi-GB tarball). On a cache hit this is a few ms.
-    phases.start("rootdisk-materialize");
-    if (wantsRootDisk) {
-      perBootRootDisk = materializeRootdisk(opts, env, phases);
-    }
-    phases.end("rootdisk-materialize");
-  } catch (err) {
-    // Only the gv + per-boot disks need rolling back here — live-share
-    // mounts are wired by the VMM itself, with no host-side process.
-    // The post-VMM failure path below has its own inline cleanup that
-    // includes SIGKILLing the VMM.
-    rollbackPreSpawn({
-      gvStop,
-      bundleTempDir,
-      vsockTempDir,
-      perBootRootDisk,
-      perBootSnapDisk,
-      perBootMountUpper,
-    });
-    throw err;
-  }
-
-  // Wrap through the parent-death shim so the VMM dies with the
-  // runtime instead of orphaning to PID 1 holding the rootdisk fd and
-  // ~1.7 GiB RSS (#200). Mirrors `spawnGvproxy`. Falls through to a
-  // direct spawn if the shim is unavailable (no `cc`, opted-out,
-  // unsupported platform).
-  //
-  // Detached mode (#150) explicitly wants the orphan: the parent CLI
-  // exits while the VMM keeps running. Force pdeathsig off, ignoring
-  // any caller value, since both `pdeathsig: true` and the default
-  // `undefined` would otherwise SIGTERM the VMM the moment the parent
-  // exits.
-  phases.start("vmm-spawn");
-  const vmmPdeathsig = opts.detached || opts.pdeathsig === false ? null : await ensurePdeathsig();
-  const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, binary, opts.args ?? []);
-  const stdio: Array<"pipe" | number> = ["pipe", "pipe", "pipe"];
-  const mountDiskFds = mountDiskPaths ? openMountDiskFds(mountDiskPaths, env, stdio) : undefined;
-  if (mountDiskPaths) {
-    perBootMountUpper = mountDiskPaths.upperPath;
-  }
-  const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
-    cwd: opts.cwd,
+  const plan = await prepareBootPlan(opts, phases);
+  const {
     env,
-    stdio,
-  }) as ChildProcessWithoutNullStreams;
-  // The child has dup'd both fds; close our copies in the parent so
-  // the file isn't held open beyond what the child needs. Closing
-  // here is safe — the child has its own dup'd fd via posix_spawn /
-  // libuv's fd inheritance.
-  if (mountDiskFds) {
-    closeFds(mountDiskFds.lowerFd, mountDiskFds.upperFd);
-  }
-  phases.end("vmm-spawn");
-  // first-guest-byte starts ticking from VMM-spawn — that's the point
-  // after which any console output is real guest progress.
-  phases.start("first-guest-byte");
-  debug(
-    "VMM spawned pid=%d binary=%s wrapped=%s elapsedSinceEntry=%dms",
-    child.pid ?? -1,
-    binary,
-    vmmPdeathsig ? "yes" : "no",
-    Date.now() - bootT0,
-  );
+    memoryCeilingMib,
+    diskAbs,
+    vsockUdsPath,
+    statsFilePath,
+    vmstate,
+    liveMountsResolved,
+  } = plan;
 
-  // #98: register the running VM so another process can attach. The
-  // entry is keyed by pid (kernel-unique while alive); optional name
-  // lets `attach({ name })` look it up by something memorable.
-  //
-  // INVARIANT (#150 phase 2): name claim + registry write must
-  // complete synchronously before any `await` — in particular,
-  // before the readiness gate further down can call `handle.detach()`
-  // and unref the child. Detaching a name-conflict losers' child
-  // means the SIGKILL above wouldn't reach an orphaned-to-PID-1 VMM.
-  // Today the structure enforces this (no awaits between here and
-  // the gate); don't reorder.
-  const vmName = opts.name;
-  // Resolved once: shared by the registry entry and any future snapshot
-  // ctx so the bundle's meta.json points at the same absolute path the
-  // source booted from. Cheap (just a path resolve), so unconditional.
-  const sourceImageAbs = opts.image ? resolve(opts.cwd ?? process.cwd(), opts.image) : undefined;
-  const rootDiskPathForRegistry =
-    perBootRootDisk ??
-    (typeof opts.rootDisk === "string"
-      ? resolve(opts.cwd ?? process.cwd(), opts.rootDisk)
-      : undefined);
-  const rootDiskModeForRegistry = rootDiskPathForRegistry ? "block" : "none";
-  const childPid = child.pid ?? -1;
-  if (vmName && childPid > 0) {
-    claimNameOrThrow(vmName, childPid, child);
-  }
-  // #150 phase 2: detached VMs record where the boot-console snapshot
-  // will land so `attach` / `ls` / `gc` can find it later.
-  const bootLogPath = opts.detached && childPid > 0 ? bootSnapshotPath(childPid) : undefined;
-  // #150 phase 2 PR2: persist per-boot artifacts in the registry so
-  // `machinen gc` / `machinen stop` can clean them up after the
-  // parent has exited.
-  const cleanupPaths = collectCleanupPaths({
-    perBootRootDisk,
-    perBootSnapDisk,
-    perBootMountUpper,
-    bundleTempDir,
-    vsockTempDir,
-    statsTempDir,
-    gvSocketDir,
-  });
-  const registered =
-    childPid > 0 && vsockUdsPath
-      ? registerInRegistry({
-          childPid,
-          vmName,
-          vsockUdsPath,
-          sourceImageAbs,
-          rootDiskPath: rootDiskPathForRegistry,
-          rootDiskMode: rootDiskModeForRegistry,
-          diskAbs,
-          forkedFrom: opts.forkedFrom,
-          bootLogPath,
-          cleanupPaths,
-          binary,
-          vmmPdeathsig,
-          gvPid,
-          gvExe,
-          portForward,
-          memoryCeilingMib,
-          statsFilePath,
-          mountDiskPaths,
-          liveMountsResolved,
-          vmstateStatePath,
-          vmstateChainId: vmstateStatePath ? vmstateChainId : undefined,
-          vmstateCheckpointParent: vmstateStatePath ? vmstateCheckpointParent : undefined,
-          vmstateCheckpointSequence: vmstateStatePath ? vmstateCheckpointSequence : undefined,
-          nested: opts.nested,
-        })
-      : false;
+  const resources = await prepareBootResources(opts, plan, phases);
+  const { mountDiskPaths } = resources;
 
-  installVmExitCleanup({
-    child,
+  const spawned = await spawnBootVmm({ opts, plan, resources, phases, bootT0 });
+  const child = spawned.child;
+  const registry = registerSpawnedBoot({ opts, plan, resources, spawned, bootT0 });
+  const {
     childPid,
-    bootT0,
-    perBootRootDisk,
-    perBootSnapDisk,
-    perBootMountUpper,
-    bundleTempDir,
-    vsockTempDir,
-    statsTempDir,
-    gvStop,
-    registered,
-  });
+    vmName,
+    sourceImageAbs,
+    rootDiskPath: rootDiskPathForRegistry,
+    rootDiskMode: rootDiskModeForRegistry,
+    bootLogPath,
+  } = registry;
 
   const timeoutMs = opts.timeoutMs === undefined ? 60_000 : opts.timeoutMs;
 
@@ -800,204 +503,35 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     installDetachedBootCapture(child, detachedBootChunks);
   }
 
-  const handle: VmHandle = {
-    pid: childPid,
-    name: vmName,
-    stdin: child.stdin,
-    stdout: child.stdout,
-    stderr: child.stderr,
-    wait: makeWait(child, timeoutMs),
-    kill: makeKill(child),
-    output: () => outputCollector,
-    errorOutput: () => errorCollector,
-
-    async detach() {
-      // Drop the locally-booted process's hold without killing it:
-      // unref stdio and unregister from the registry. The VMM keeps
-      // running; `attach({ name | id })` from another process can
-      // pick it back up via the vsock UDS, which is *not* cleaned up
-      // on detach (only on VMM exit).
-      child.stdin.end();
-      child.unref();
-      // Intentionally leave the registry entry in place — detach means
-      // "someone else will attach," not "this VM is gone."
-    },
-
-    async exec(cmd, execOpts) {
-      if (!vsockUdsPath) {
-        throw new ExecError(
-          "EXEC_VSOCK_UNAVAILABLE",
-          "vm.exec: no vsock UDS available — MACHINEN_VSOCK was set to an " +
-            "unrecognized spec. Expected `in:<port>:<uds-path>`.",
-        );
-      }
-      const res = await VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
-      if (res.exitCode !== 0) {
-        throw new ExecError(
-          "EXEC_NONZERO_EXIT",
-          `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
-        );
-      }
-      return res;
-    },
-
-    execRaw(cmd, execOpts) {
-      if (!vsockUdsPath) {
-        return Promise.reject(
-          new ExecError(
-            "EXEC_VSOCK_UNAVAILABLE",
-            "vm.execRaw: no vsock UDS available — MACHINEN_VSOCK was set to " +
-              "an unrecognized spec. Expected `in:<port>:<uds-path>`.",
-          ),
-        );
-      }
-      return VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
-    },
-
-    execPty(cmd, ptyOpts) {
-      if (!vsockUdsPath) {
-        // Synchronous-handle API can't reject like execRaw — surface
-        // a handle whose `result` is already a rejected promise.
-        const err = new ExecError(
-          "EXEC_VSOCK_UNAVAILABLE",
-          "vm.execPty: no vsock UDS available — MACHINEN_VSOCK was set to " +
-            "an unrecognized spec. Expected `in:<port>:<uds-path>`.",
-        );
-        return {
-          result: Promise.reject(err),
-          resize: () => {},
-          cancel: () => {},
-        };
-      }
-      return VsockExec.startPty(vsockUdsPath, cmd, ptyOpts);
-    },
-
-    async writeFile(guestPath, contents, writeOpts) {
-      for (const cmd of buildWriteFileCmds(guestPath, contents, writeOpts)) {
-        await this.exec(cmd);
-      }
-    },
-
-    async memoryStats(): Promise<MemoryStats> {
-      const balloon = statsFilePath ? readBalloonStats(statsFilePath) : null;
-      // Re-read the registry for lazy bookkeeping — restore() patches
-      // the entry with `lazyPagesTotal` after boot returns, and the
-      // handle was constructed before that patch.
-      const cur = findEntry({ pid: childPid });
-      const lazyTotal = cur?.lazyPagesTotal ?? 0;
-      return {
-        ceilingMib: memoryCeilingMib ?? null,
-        hostRssBytes: readHostRssBytes(childPid, statsFilePath),
-        balloonInflatedBytes: balloon?.bytesReported ?? 0,
-        lazyPagesPending: lazyTotal,
-      };
-    },
-
-    async snapshot(snapshotOpts) {
-      // A VM can be snapshotted only if its resolved engine has a
-      // backing store: the criu engine writes its images onto the
-      // guest-side scratch disk; the vmstate engine dumps the whole VM
-      // to a host state file. `snapshot: false` provisions neither, so
-      // the guard fires for whichever engine is in effect.
-      const engine = resolveSnapshotEngine();
-      if ((engine === "criu" && !diskAbs) || (engine === "vmstate" && !vmstateStatePath)) {
-        throw new SnapshotError(
-          "SNAPSHOT_NO_DISK",
-          "vm.snapshot: this VM was booted with `snapshot: false` (no scratch " +
-            "disk attached). Re-boot without that flag — the runtime will " +
-            "auto-allocate a sparse scratch — or pass `snapshot: '<path>'`.",
-        );
-      }
-      return performSnapshot(buildBootSnapshotContext(), snapshotOpts);
-    },
-
-    async fork(forkOpts) {
-      const engine = resolveSnapshotEngine();
-      if ((engine === "criu" && !diskAbs) || (engine === "vmstate" && !vmstateStatePath)) {
-        throw new SnapshotError(
-          "SNAPSHOT_NO_DISK",
-          "vm.fork: source VM has no scratch disk (booted with `snapshot: false`). " +
-            "Re-boot the source without that flag so it can be snapshotted.",
-        );
-      }
-      return performForkWithRestore(
-        buildBootSnapshotContext(),
-        forkOpts ?? {},
-        async (restoreOpts) => {
-          const runtimeEntryPath = runtimeEntryImportPath();
-          const { restore } = await import(runtimeEntryPath);
-          return restore(restoreOpts);
-        },
-      );
-    },
-  };
-
-  // #273: shared snapshot-context builder for the boot-owned
-  // `snapshot()` and `fork()` paths. Threads the live-share mount
-  // config through to performSnapshot so it can record `liveMounts`
-  // in the bundle's meta.json. Since #338 the in-VMM virtio-fs device
-  // is carried across the CRIU dump by the VMM itself, so there are no
-  // host-side mount-server instances to stop/respawn.
-  function buildBootSnapshotContext(): SnapshotContext {
-    const liveMountsForCtx =
-      liveMountsResolved.length > 0
-        ? liveMountsResolved.map((lm) => ({
-            host: lm.host,
-            guest: lm.guest,
-            mode: lm.mode,
-          }))
-        : undefined;
-    return {
-      pid: childPid,
-      sourceName: vmName,
-      sourceImage: sourceImageAbs,
+  const handle = createBootVmHandle({
+    child,
+    childPid,
+    vmName,
+    timeoutMs,
+    outputCollector,
+    errorCollector,
+    vsockUdsPath,
+    onLog,
+    statsFilePath,
+    memoryCeilingMib,
+    diskAbs,
+    vmstateStatePath: vmstate.statePath,
+    snapshot: {
+      child,
+      childPid,
+      vmName,
+      sourceImageAbs,
       rootDiskPath: rootDiskPathForRegistry,
       rootDiskMode: rootDiskModeForRegistry,
-      memoryCeilingMib: memoryCeilingMib,
-      kernelPath: env.MACHINEN_KERNEL,
-      dtbPath: env.MACHINEN_DTB,
-      diskPath: diskAbs!,
-      mountDisk: mountDiskPaths
-        ? {
-            guest: mountDiskPaths.guest,
-            lowerPath: mountDiskPaths.lowerPath,
-            upperPath: mountDiskPaths.upperPath,
-          }
-        : undefined,
-      liveMounts: liveMountsForCtx,
-      vmstatePath: vmstateStatePath,
-      vmstateChain: vmstateStatePath
-        ? {
-            chainId: vmstateChainId,
-            parentDir: vmstateCheckpointParent,
-            sequence: vmstateCheckpointSequence,
-          }
-        : undefined,
-      updateVmstateChain: vmstateStatePath
-        ? ({ parentDir, sequence }) => {
-            vmstateCheckpointParent = parentDir;
-            vmstateCheckpointSequence = sequence;
-            const cur = findEntry({ pid: childPid });
-            if (cur) {
-              writeEntry({
-                ...cur,
-                vmstateChainId,
-                vmstateCheckpointParent,
-                vmstateCheckpointSequence,
-              });
-            }
-          }
-        : undefined,
+      memoryCeilingMib,
+      env,
+      diskAbs,
+      mountDiskPaths,
+      liveMountsResolved,
       nested: opts.nested,
-      execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
-      wait: () => handle.wait(),
-      kill: () => handle.kill(),
-      teeGuestConsole: (onChunk) => {
-        child.stderr.on("data", onChunk);
-      },
-      errorOutput: () => handle.errorOutput(),
-    };
-  }
+      vmstate,
+    },
+  });
 
   // Set a per-VM kernel hostname so `\h` prompts and other
   // hostname-aware tooling can tell VMs apart. Fire-and-forget
@@ -1027,6 +561,526 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 // Helpers
 // =============================================================
 
+interface BootPlan {
+  portForward: NonNullable<BootOptions["portForward"]>;
+  binary: string;
+  env: Record<string, string>;
+  memoryCeilingMib: number | undefined;
+  diskAbs: string | undefined;
+  perBootSnapDisk: string | undefined;
+  wantsRootDisk: boolean;
+  vsockUdsPath: string | undefined;
+  vsockTempDir: string | undefined;
+  statsFilePath: string | undefined;
+  statsTempDir: string | undefined;
+  vmstate: BootVmstateRuntime;
+  liveMountsResolved: ResolvedLiveMount[];
+  mergedGuestEnv: Record<string, string>;
+}
+
+interface BootResources {
+  gvStop: (() => void) | undefined;
+  gvPid: number | undefined;
+  gvExe: string | undefined;
+  gvSocketDir: string | undefined;
+  bundleTempDir: string | undefined;
+  mountDiskPaths: MountDiskPaths | undefined;
+  perBootRootDisk: string | undefined;
+}
+
+async function prepareBootResources(
+  opts: BootOptions,
+  plan: BootPlan,
+  phases: PhaseTimer,
+): Promise<BootResources> {
+  let resources: BootResources = emptyBootResources();
+  try {
+    resources = {
+      ...resources,
+      ...(await setupBootNetServices(opts, plan, phases)),
+      ...packBootInitramfsIfNeeded(opts, plan, phases),
+    };
+    resources.perBootRootDisk = materializeRootdiskIfNeeded(opts, plan, phases);
+    return resources;
+  } catch (err) {
+    rollbackPreSpawn({
+      gvStop: resources.gvStop,
+      bundleTempDir: resources.bundleTempDir,
+      vsockTempDir: plan.vsockTempDir,
+      perBootRootDisk: resources.perBootRootDisk,
+      perBootSnapDisk: plan.perBootSnapDisk,
+      perBootMountUpper: undefined,
+    });
+    throw err;
+  }
+}
+
+function emptyBootResources(): BootResources {
+  return {
+    gvStop: undefined,
+    gvPid: undefined,
+    gvExe: undefined,
+    gvSocketDir: undefined,
+    bundleTempDir: undefined,
+    mountDiskPaths: undefined,
+    perBootRootDisk: undefined,
+  };
+}
+
+async function setupBootNetServices(
+  opts: BootOptions,
+  plan: BootPlan,
+  phases: PhaseTimer,
+): Promise<Pick<BootResources, "gvStop" | "gvPid" | "gvExe" | "gvSocketDir">> {
+  phases.start("net-services");
+  phases.start("net-services.gvproxy");
+  const gv = await bringUpGvproxy(opts, plan.binary, plan.env, plan.portForward);
+  phases.end("net-services.gvproxy");
+  phases.end("net-services");
+  return gv;
+}
+
+function packBootInitramfsIfNeeded(
+  opts: BootOptions,
+  plan: BootPlan,
+  phases: PhaseTimer,
+): Pick<BootResources, "bundleTempDir" | "mountDiskPaths"> {
+  if (!bootNeedsInitramfs(opts)) {
+    return { bundleTempDir: undefined, mountDiskPaths: undefined };
+  }
+  phases.start("initramfs-pack");
+  const packed = synthesizeAndPackBundle(opts, plan.mergedGuestEnv, plan.liveMountsResolved, {
+    useTiny: plan.wantsRootDisk,
+    env: plan.env,
+    mountDiskUpperSizeBytes: opts.mountDiskUpperSizeBytes,
+    onPhase: (name, ms) => phases.mark(`initramfs-pack.${name}`, ms),
+  });
+  plan.env.MACHINEN_INITRD = packed.cpioPath;
+  const packMs = phases.end("initramfs-pack");
+  debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
+  return { bundleTempDir: packed.tempDir, mountDiskPaths: packed.mountDisk };
+}
+
+function bootNeedsInitramfs(opts: BootOptions): boolean {
+  return Boolean(opts.image || opts.cmd || opts.snapshot);
+}
+
+function materializeRootdiskIfNeeded(
+  opts: BootOptions,
+  plan: BootPlan,
+  phases: PhaseTimer,
+): string | undefined {
+  phases.start("rootdisk-materialize");
+  const perBootRootDisk = plan.wantsRootDisk
+    ? materializeRootdisk(opts, plan.env, phases)
+    : undefined;
+  phases.end("rootdisk-materialize");
+  return perBootRootDisk;
+}
+
+interface SpawnBootArgs {
+  opts: BootOptions;
+  plan: BootPlan;
+  resources: BootResources;
+  phases: PhaseTimer;
+  bootT0: number;
+}
+
+interface SpawnedBootVmm {
+  child: ChildProcessWithoutNullStreams;
+  vmmPdeathsig: string | null;
+  perBootMountUpper: string | undefined;
+}
+
+async function spawnBootVmm(args: SpawnBootArgs): Promise<SpawnedBootVmm> {
+  args.phases.start("vmm-spawn");
+  const vmmPdeathsig = await resolveVmmPdeathsig(args.opts);
+  const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, args.plan.binary, args.opts.args ?? []);
+  const stdio: Array<"pipe" | number> = ["pipe", "pipe", "pipe"];
+  const mountDiskFds = maybeOpenMountDiskFds(args.resources.mountDiskPaths, args.plan.env, stdio);
+  const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
+    cwd: args.opts.cwd,
+    env: args.plan.env,
+    stdio,
+  }) as ChildProcessWithoutNullStreams;
+  closeMountDiskFds(mountDiskFds);
+  args.phases.end("vmm-spawn");
+  args.phases.start("first-guest-byte");
+  logVmmSpawn(child, args.plan.binary, vmmPdeathsig, args.bootT0);
+  return { child, vmmPdeathsig, perBootMountUpper: args.resources.mountDiskPaths?.upperPath };
+}
+
+async function resolveVmmPdeathsig(opts: BootOptions): Promise<string | null> {
+  if (opts.detached || opts.pdeathsig === false) {
+    return null;
+  }
+  return ensurePdeathsig();
+}
+
+function maybeOpenMountDiskFds(
+  mountDiskPaths: MountDiskPaths | undefined,
+  env: Record<string, string>,
+  stdio: Array<"pipe" | number>,
+): { lowerFd: number; upperFd: number } | undefined {
+  return mountDiskPaths ? openMountDiskFds(mountDiskPaths, env, stdio) : undefined;
+}
+
+function closeMountDiskFds(fds: { lowerFd: number; upperFd: number } | undefined): void {
+  if (fds) {
+    closeFds(fds.lowerFd, fds.upperFd);
+  }
+}
+
+function logVmmSpawn(
+  child: ChildProcessWithoutNullStreams,
+  binary: string,
+  vmmPdeathsig: string | null,
+  bootT0: number,
+): void {
+  debug(
+    "VMM spawned pid=%d binary=%s wrapped=%s elapsedSinceEntry=%dms",
+    child.pid ?? -1,
+    binary,
+    vmmPdeathsig ? "yes" : "no",
+    Date.now() - bootT0,
+  );
+}
+
+interface BootRegistryState {
+  childPid: number;
+  vmName: string | undefined;
+  sourceImageAbs: string | undefined;
+  rootDiskPath: string | undefined;
+  rootDiskMode: "block" | "none";
+  bootLogPath: string | undefined;
+}
+
+function registerSpawnedBoot(args: {
+  opts: BootOptions;
+  plan: BootPlan;
+  resources: BootResources;
+  spawned: SpawnedBootVmm;
+  bootT0: number;
+}): BootRegistryState {
+  const state = buildBootRegistryState(args.opts, args.resources, args.spawned);
+  claimBootNameIfNeeded(state, args.spawned.child);
+  const registered = writeBootRegistryIfPossible(args, state);
+  installBootExitCleanup(args, state, registered);
+  return state;
+}
+
+function buildBootRegistryState(
+  opts: BootOptions,
+  resources: BootResources,
+  spawned: SpawnedBootVmm,
+): BootRegistryState {
+  const childPid = spawned.child.pid ?? -1;
+  const rootDiskPath = registryRootDiskPath(opts, resources.perBootRootDisk);
+  return {
+    childPid,
+    vmName: opts.name,
+    sourceImageAbs: registrySourceImage(opts),
+    rootDiskPath,
+    rootDiskMode: rootDiskPath ? "block" : "none",
+    bootLogPath: registryBootLogPath(opts, childPid),
+  };
+}
+
+function registrySourceImage(opts: BootOptions): string | undefined {
+  return opts.image ? resolve(opts.cwd ?? process.cwd(), opts.image) : undefined;
+}
+
+function registryRootDiskPath(
+  opts: BootOptions,
+  perBootRootDisk: string | undefined,
+): string | undefined {
+  if (perBootRootDisk) {
+    return perBootRootDisk;
+  }
+  return typeof opts.rootDisk === "string"
+    ? resolve(opts.cwd ?? process.cwd(), opts.rootDisk)
+    : undefined;
+}
+
+function registryBootLogPath(opts: BootOptions, childPid: number): string | undefined {
+  return opts.detached && childPid > 0 ? bootSnapshotPath(childPid) : undefined;
+}
+
+function claimBootNameIfNeeded(
+  state: BootRegistryState,
+  child: ChildProcessWithoutNullStreams,
+): void {
+  if (state.vmName && state.childPid > 0) {
+    claimNameOrThrow(state.vmName, state.childPid, child);
+  }
+}
+
+function writeBootRegistryIfPossible(
+  args: {
+    opts: BootOptions;
+    plan: BootPlan;
+    resources: BootResources;
+    spawned: SpawnedBootVmm;
+  },
+  state: BootRegistryState,
+): boolean {
+  if (state.childPid <= 0 || !args.plan.vsockUdsPath) {
+    return false;
+  }
+  return registerInRegistry(buildRegisterArgs(args, state));
+}
+
+function buildRegisterArgs(
+  args: {
+    opts: BootOptions;
+    plan: BootPlan;
+    resources: BootResources;
+    spawned: SpawnedBootVmm;
+  },
+  state: BootRegistryState,
+): RegisterArgs {
+  return {
+    childPid: state.childPid,
+    vmName: state.vmName,
+    vsockUdsPath: args.plan.vsockUdsPath!,
+    sourceImageAbs: state.sourceImageAbs,
+    rootDiskPath: state.rootDiskPath,
+    rootDiskMode: state.rootDiskMode,
+    diskAbs: args.plan.diskAbs,
+    forkedFrom: args.opts.forkedFrom,
+    bootLogPath: state.bootLogPath,
+    cleanupPaths: cleanupPathsForBoot(args.plan, args.resources, args.spawned),
+    binary: args.plan.binary,
+    vmmPdeathsig: args.spawned.vmmPdeathsig,
+    gvPid: args.resources.gvPid,
+    gvExe: args.resources.gvExe,
+    portForward: args.plan.portForward,
+    memoryCeilingMib: args.plan.memoryCeilingMib,
+    statsFilePath: args.plan.statsFilePath,
+    mountDiskPaths: args.resources.mountDiskPaths,
+    liveMountsResolved: args.plan.liveMountsResolved,
+    vmstateStatePath: args.plan.vmstate.statePath,
+    vmstateChainId: vmstateValue(args.plan.vmstate, args.plan.vmstate.chainId),
+    vmstateCheckpointParent: vmstateValue(args.plan.vmstate, args.plan.vmstate.checkpointParent),
+    vmstateCheckpointSequence: vmstateValue(
+      args.plan.vmstate,
+      args.plan.vmstate.checkpointSequence,
+    ),
+    nested: args.opts.nested,
+  };
+}
+
+function vmstateValue<T>(vmstate: BootVmstateRuntime, value: T): T | undefined {
+  return vmstate.statePath ? value : undefined;
+}
+
+function cleanupPathsForBoot(
+  plan: BootPlan,
+  resources: BootResources,
+  spawned: SpawnedBootVmm,
+): string[] {
+  return collectCleanupPaths({
+    perBootRootDisk: resources.perBootRootDisk,
+    perBootSnapDisk: plan.perBootSnapDisk,
+    perBootMountUpper: spawned.perBootMountUpper,
+    bundleTempDir: resources.bundleTempDir,
+    vsockTempDir: plan.vsockTempDir,
+    statsTempDir: plan.statsTempDir,
+    gvSocketDir: resources.gvSocketDir,
+  });
+}
+
+function installBootExitCleanup(
+  args: {
+    plan: BootPlan;
+    resources: BootResources;
+    spawned: SpawnedBootVmm;
+    bootT0: number;
+  },
+  state: BootRegistryState,
+  registered: boolean,
+): void {
+  installVmExitCleanup({
+    child: args.spawned.child,
+    childPid: state.childPid,
+    bootT0: args.bootT0,
+    perBootRootDisk: args.resources.perBootRootDisk,
+    perBootSnapDisk: args.plan.perBootSnapDisk,
+    perBootMountUpper: args.spawned.perBootMountUpper,
+    bundleTempDir: args.resources.bundleTempDir,
+    vsockTempDir: args.plan.vsockTempDir,
+    statsTempDir: args.plan.statsTempDir,
+    gvStop: args.resources.gvStop,
+    registered,
+  });
+}
+
+async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<BootPlan> {
+  const assets = await resolveBootAssets(opts, phases);
+  const env = buildVmmEnv(opts);
+  configureNestedVirtualization(opts, assets.binary, env);
+  const memoryCeilingMib = setMemoryCeiling(opts, env);
+  const scratch = prepareBootScratchDisk(opts, env, phases);
+  const wantsRootDisk = wantsRootDiskBoot(opts);
+  validateRootDiskRequest(opts, wantsRootDisk);
+  validateKernelDtb(opts, env);
+  const vsock = setupVsockBridge(env);
+  const stats = setupStatsFile(env, vsock.vsockTempDir);
+  const vmstateSetup = setupVmstateBoot(opts, env, vsock.vsockTempDir);
+  const liveMountsResolved = setupLiveMountEnv(opts, env);
+  return {
+    ...assets,
+    env,
+    memoryCeilingMib,
+    ...scratch,
+    wantsRootDisk,
+    vsockUdsPath: vsock.vsockUdsPath,
+    vsockTempDir: vmstateSetup.vsockTempDir,
+    ...stats,
+    vmstate: vmstateSetup.vmstate,
+    liveMountsResolved,
+    mergedGuestEnv: buildMergedGuestEnv(opts, vsock.vsockUdsPath),
+  };
+}
+
+async function resolveBootAssets(
+  opts: BootOptions,
+  phases: PhaseTimer,
+): Promise<Pick<BootPlan, "portForward" | "binary">> {
+  phases.start("asset-resolve");
+  const portForward = opts.portForward ?? [];
+  await validatePortForwardOpts(opts, portForward);
+  const binary = resolveBootBinary(opts);
+  validateBootCommandPair(opts);
+  phases.end("asset-resolve");
+  return { portForward, binary };
+}
+
+function resolveBootBinary(opts: BootOptions): string {
+  const binaryInput = opts.binary ?? resolveVmmBinary();
+  const binary = resolve(opts.cwd ?? process.cwd(), binaryInput);
+  if (!existsSync(binary)) {
+    throw new BootError("BOOT_VMM_MISSING", `VMM binary not found at ${binary}`);
+  }
+  return binary;
+}
+
+function validateBootCommandPair(opts: BootOptions): void {
+  if (opts.cmd && !opts.image) {
+    throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
+  }
+}
+
+function buildVmmEnv(opts: BootOptions): Record<string, string> {
+  return {
+    ...(process.env as Record<string, string>),
+    ...opts.vmmEnv,
+  };
+}
+
+function prepareBootScratchDisk(
+  opts: BootOptions,
+  env: Record<string, string>,
+  phases: PhaseTimer,
+): Pick<BootPlan, "diskAbs" | "perBootSnapDisk"> {
+  phases.start("disk-prep");
+  const scratch = prepareScratchDisk(opts, env);
+  phases.end("disk-prep");
+  return scratch;
+}
+
+function wantsRootDiskBoot(opts: BootOptions): boolean {
+  return (
+    opts.rootDisk !== false &&
+    (opts._rootDiskRestorePath !== undefined || opts.rootDisk !== undefined || !!opts.image)
+  );
+}
+
+function validateRootDiskRequest(opts: BootOptions, wantsRootDisk: boolean): void {
+  if (wantsRootDisk && typeof opts.rootDisk !== "string" && !opts.image) {
+    throw new BootError(
+      "BOOT_CMD_WITHOUT_IMAGE",
+      "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
+    );
+  }
+}
+
+function setupVmstateBoot(
+  opts: BootOptions,
+  env: Record<string, string>,
+  inputVsockTempDir: string | undefined,
+): { vmstate: BootVmstateRuntime; vsockTempDir: string | undefined } {
+  let vsockTempDir = inputVsockTempDir;
+  const vmstate: BootVmstateRuntime = {
+    statePath: undefined,
+    chainId: randomBytes(16).toString("hex"),
+    checkpointParent: opts._vmstateRestorePath ? opts.forkedFrom : undefined,
+    checkpointSequence: 0,
+  };
+  if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
+    vsockTempDir = ensureVsockTempDir(vsockTempDir);
+    vmstate.statePath = join(vsockTempDir, VMSTATE_FILE);
+    env.MACHINEN_SNAPSHOT_PATH = vmstate.statePath;
+  }
+  configureVmstateRestoreEnv(opts, env);
+  return { vmstate, vsockTempDir };
+}
+
+function ensureVsockTempDir(vsockTempDir: string | undefined): string {
+  return vsockTempDir ?? mkdtempSync(join(tmpdir(), "machinen-vsock-"));
+}
+
+function configureVmstateRestoreEnv(opts: BootOptions, env: Record<string, string>): void {
+  if (!opts._vmstateRestorePath) {
+    return;
+  }
+  env.MACHINEN_RESTORE_PATH = opts._vmstateRestorePath;
+  if (shouldEnableVmstateTiming(env)) {
+    env.MACHINEN_VMSTATE_TIMING = "1";
+  }
+}
+
+function shouldEnableVmstateTiming(env: Record<string, string>): boolean {
+  return (vmstateDebug.enabled || restoreDebug.enabled) && !env.MACHINEN_VMSTATE_TIMING;
+}
+
+function setupLiveMountEnv(opts: BootOptions, env: Record<string, string>): ResolvedLiveMount[] {
+  const liveMounts = opts.liveMounts ?? [];
+  if (liveMounts.length === 0) {
+    return [];
+  }
+  const resolved = resolveLiveMounts(liveMounts, opts.cwd);
+  resolved.forEach((lm, i) => {
+    env[`MACHINEN_VIRTIOFS_${i}`] = `${lm.tag}:${lm.mode}:${lm.host}`;
+  });
+  return resolved;
+}
+
+function buildMergedGuestEnv(
+  opts: BootOptions,
+  vsockUdsPath: string | undefined,
+): Record<string, string> {
+  const mergedGuestEnv: Record<string, string> = { ...opts.env };
+  applyGuestNameFallback(opts, mergedGuestEnv);
+  applyHostnameWait(vsockUdsPath, mergedGuestEnv);
+  return mergedGuestEnv;
+}
+
+function applyGuestNameFallback(opts: BootOptions, mergedGuestEnv: Record<string, string>): void {
+  if (opts.name && !mergedGuestEnv.MACHINEN_VM_NAME) {
+    mergedGuestEnv.MACHINEN_VM_NAME = opts.name;
+  }
+}
+
+function applyHostnameWait(
+  vsockUdsPath: string | undefined,
+  mergedGuestEnv: Record<string, string>,
+): void {
+  if (vsockUdsPath && !mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT) {
+    mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT = "1";
+  }
+}
+
 // Validate portForward up front — before resolving the binary or
 // touching the filesystem — so caller-input errors surface with a
 // clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
@@ -1038,6 +1092,12 @@ async function validatePortForwardOpts(
   if (portForward.length === 0) {
     return;
   }
+  rejectPresetNetSocket(opts);
+  validatePortForwardShape(portForward);
+  await validatePortForwardAvailability(portForward);
+}
+
+function rejectPresetNetSocket(opts: BootOptions): void {
   const preSetNetSock =
     (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET;
   if (preSetNetSock) {
@@ -1048,53 +1108,80 @@ async function validatePortForwardOpts(
         "against your gvproxy's control API.",
     );
   }
+}
+
+function validatePortForwardShape(portForward: NonNullable<BootOptions["portForward"]>): void {
   const seen = new Set<number>();
-  for (const m of portForward) {
-    for (const [label, port] of [
-      ["hostPort", m.hostPort],
-      ["guestPort", m.guestPort],
-    ] as const) {
-      if (!Number.isInteger(port) || port < 1 || port > 65535) {
-        throw new BootError(
-          "BOOT_PORT_FORWARD_INVALID",
-          `portForward: ${label} must be an integer in 1..65535 (got ${port})`,
-        );
-      }
-    }
-    if (seen.has(m.hostPort)) {
+  for (const mapping of portForward) {
+    validatePortMappingNumbers(mapping);
+    rejectDuplicateHostPort(mapping.hostPort, seen);
+  }
+}
+
+function validatePortMappingNumbers(
+  mapping: NonNullable<BootOptions["portForward"]>[number],
+): void {
+  for (const [label, port] of portMappingPorts(mapping)) {
+    if (!validTcpPort(port)) {
       throw new BootError(
-        "BOOT_PORT_FORWARD_CONFLICT",
-        `portForward: duplicate hostPort ${m.hostPort}`,
+        "BOOT_PORT_FORWARD_INVALID",
+        `portForward: ${label} must be an integer in 1..65535 (got ${port})`,
       );
     }
-    seen.add(m.hostPort);
   }
-  // Pre-flight bind probe per requested host port. Without this,
-  // gvproxy's control API surfaces `address already in use` as an
-  // opaque GVPROXY_EXPOSE_FAILED 500 *after* we've spawned it. The
-  // common cause is an orphaned gvproxy from a prior `kill -9` of
-  // the runtime — the kernel reparents it to PID 1 and it keeps
-  // holding the host port. Surface the orphan hypothesis directly
-  // so the user knows what to clean up. See #115.
-  for (const m of portForward) {
-    const host = m.hostAddr ?? "127.0.0.1";
-    const errno = await probeHostPortFree(host, m.hostPort);
-    if (!errno) {
-      continue;
-    }
-    // Best-effort: name the offending PID and flag whether it's
-    // machinen-owned. lsof failures are non-fatal — fall back to the
-    // generic orphan-gvproxy hypothesis so the message still helps.
-    const holder = await describePortHolder(m.hostPort).catch(() => null);
-    const detail = holder
-      ? `${holder}.`
-      : "Common cause: an orphaned gvproxy from a prior `kill -9` of the VMM. " +
-        "Try `pkill -f gvproxy` to clear it, or pick a different host port.";
+}
+
+function portMappingPorts(
+  mapping: NonNullable<BootOptions["portForward"]>[number],
+): Array<readonly ["hostPort" | "guestPort", number]> {
+  return [
+    ["hostPort", mapping.hostPort],
+    ["guestPort", mapping.guestPort],
+  ];
+}
+
+function validTcpPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
+function rejectDuplicateHostPort(hostPort: number, seen: Set<number>): void {
+  if (seen.has(hostPort)) {
     throw new BootError(
-      "BOOT_PORT_FORWARD_IN_USE",
-      `portForward: host port ${host}:${m.hostPort} is already in use (${errno}). ${detail}`,
+      "BOOT_PORT_FORWARD_CONFLICT",
+      `portForward: duplicate hostPort ${hostPort}`,
     );
   }
+  seen.add(hostPort);
+}
+
+async function validatePortForwardAvailability(
+  portForward: NonNullable<BootOptions["portForward"]>,
+): Promise<void> {
+  for (const mapping of portForward) {
+    await validateHostPortFree(mapping);
+  }
+}
+
+async function validateHostPortFree(
+  mapping: NonNullable<BootOptions["portForward"]>[number],
+): Promise<void> {
+  const host = mapping.hostAddr ?? "127.0.0.1";
+  const errno = await probeHostPortFree(host, mapping.hostPort);
+  if (!errno) {
+    return;
+  }
+  throw new BootError(
+    "BOOT_PORT_FORWARD_IN_USE",
+    `portForward: host port ${host}:${mapping.hostPort} is already in use (${errno}). ${await portHolderDetail(mapping.hostPort)}`,
+  );
+}
+
+async function portHolderDetail(hostPort: number): Promise<string> {
+  const holder = await describePortHolder(hostPort).catch(() => null);
+  return holder
+    ? `${holder}.`
+    : "Common cause: an orphaned gvproxy from a prior `kill -9` of the VMM. " +
+        "Try `pkill -f gvproxy` to clear it, or pick a different host port.";
 }
 
 // #263 phase A: forward the guest RAM ceiling so the VMM doesn't
@@ -1557,85 +1644,7 @@ interface RegisterArgs {
 // boot-and-use still works fine).
 function registerInRegistry(args: RegisterArgs): boolean {
   try {
-    writeEntry({
-      pid: args.childPid,
-      name: args.vmName,
-      socketPath: args.vsockUdsPath,
-      imagePath: args.sourceImageAbs,
-      rootDiskPath: args.rootDiskPath,
-      rootDiskMode: args.rootDiskMode,
-      diskPath: args.diskAbs,
-      forkedFrom: args.forkedFrom,
-      bootLogPath: args.bootLogPath,
-      cleanupPaths: args.cleanupPaths.length > 0 ? args.cleanupPaths : undefined,
-      // The pdeathsig shim works differently per platform, and that
-      // changes what `child.pid` actually IS:
-      //   - Linux: shim does `prctl(PR_SET_PDEATHSIG); execvp(target)`
-      //     in-place, so once the kernel runs `execvp` `child.pid`
-      //     is the target binary. /proc/<pid>/exe stabilizes at the
-      //     target's path.
-      //   - macOS: shim forks (parent is the long-lived kqueue
-      //     watcher; the child execvp's the target), so `child.pid`
-      //     is *the watcher* forever, and `ps` reports the shim's
-      //     own argv[0] for that pid.
-      // For the registry's vmmExe field we want whatever the OS
-      // will keep reporting for `child.pid` once everything settles.
-      // On macOS that's the shim ("pdeathsig"), so snapshot it now.
-      // On Linux that's the target — and we deliberately *don't*
-      // snapshot, because there's a race between Node's `spawn()`
-      // returning and the shim's execvp firing where /proc/<pid>/exe
-      // still resolves to the shim path. Storing the snapshot in
-      // that window persists "pdeathsig" and validatePid later sees
-      // "yes" / the real VMM and reports `recycled` forever —
-      // exactly what ate two CI tests when this code first landed.
-      vmmExe:
-        process.platform === "darwin" && args.vmmPdeathsig
-          ? (readProcessIdentity(args.childPid)?.exeBase ?? args.binary)
-          : args.binary,
-      gvproxyPid: args.gvPid,
-      // Same Linux-vs-macOS shim semantics as `vmmExe` above.
-      gvproxyExe:
-        process.platform === "darwin" && args.gvPid !== undefined && args.gvPid > 0
-          ? (readProcessIdentity(args.gvPid)?.exeBase ?? args.gvExe)
-          : args.gvExe,
-      portForward: args.portForward.length > 0 ? args.portForward : undefined,
-      memoryCeilingMib: args.memoryCeilingMib,
-      statsPath: args.statsFilePath,
-      // Vmstate engine: persist the VMM's whole-VM state-file path so
-      // an attach-owned `vm.snapshot()` / `vm.fork()` can SIGUSR1 the
-      // VMM and pick the .vmstate up. Undefined for criu-engine VMs.
-      vmstatePath: args.vmstateStatePath,
-      vmstateChainId: args.vmstateChainId,
-      vmstateCheckpointParent: args.vmstateCheckpointParent,
-      vmstateCheckpointSequence: args.vmstateCheckpointSequence,
-      // #271: record nested-EL2 opt-in so attach-owned snapshots can
-      // apply the same provider-level safety gate as boot-owned ones.
-      nested: args.nested || undefined,
-      // #272: persist mount-overlay paths so an attach-owned
-      // vm.snapshot()/fork() can reflink the lower+upper into the
-      // bundle. Without this, `machinen snapshot <vm>` from
-      // the CLI produces a bundle that's missing the overlay halves.
-      mountDisk: args.mountDiskPaths
-        ? {
-            guest: args.mountDiskPaths.guest,
-            lowerPath: args.mountDiskPaths.lowerPath,
-            upperPath: args.mountDiskPaths.upperPath,
-          }
-        : undefined,
-      // #273: persist live-share mount config so an attach-owned
-      // snapshot/fork can write the same `meta.liveMounts` block. The
-      // per-mount virtio-fs tag isn't carried — it's re-derived from
-      // the resolved order on restore.
-      liveMounts:
-        args.liveMountsResolved.length > 0
-          ? args.liveMountsResolved.map(({ guest, host, mode }) => ({
-              guest,
-              host,
-              mode,
-            }))
-          : undefined,
-      startedAt: Date.now(),
-    });
+    writeEntry(buildRegistryEntry(args));
     debug("registered pid=%d name=%s", args.childPid, args.vmName ?? "<unset>");
     return true;
   } catch (err) {
@@ -1645,6 +1654,77 @@ function registerInRegistry(args: RegisterArgs): boolean {
     );
     return false;
   }
+}
+
+function buildRegistryEntry(args: RegisterArgs) {
+  return {
+    pid: args.childPid,
+    name: args.vmName,
+    socketPath: args.vsockUdsPath,
+    imagePath: args.sourceImageAbs,
+    rootDiskPath: args.rootDiskPath,
+    rootDiskMode: args.rootDiskMode,
+    diskPath: args.diskAbs,
+    forkedFrom: args.forkedFrom,
+    bootLogPath: args.bootLogPath,
+    cleanupPaths: nonEmptyList(args.cleanupPaths),
+    vmmExe: registryVmmExe(args),
+    gvproxyPid: args.gvPid,
+    gvproxyExe: registryGvproxyExe(args),
+    portForward: nonEmptyList(args.portForward),
+    memoryCeilingMib: args.memoryCeilingMib,
+    statsPath: args.statsFilePath,
+    vmstatePath: args.vmstateStatePath,
+    vmstateChainId: args.vmstateChainId,
+    vmstateCheckpointParent: args.vmstateCheckpointParent,
+    vmstateCheckpointSequence: args.vmstateCheckpointSequence,
+    nested: args.nested || undefined,
+    mountDisk: registryMountDisk(args.mountDiskPaths),
+    liveMounts: registryLiveMounts(args.liveMountsResolved),
+    startedAt: Date.now(),
+  };
+}
+
+function nonEmptyList<T>(items: T[]): T[] | undefined {
+  return items.length > 0 ? items : undefined;
+}
+
+function registryVmmExe(args: RegisterArgs): string {
+  // The pdeathsig shim works differently per platform. On macOS child.pid
+  // is the watcher, so snapshot its identity now; on Linux the shim execs in
+  // place, so deferring avoids recording the shim during the exec race.
+  if (process.platform === "darwin" && args.vmmPdeathsig) {
+    return readProcessIdentity(args.childPid)?.exeBase ?? args.binary;
+  }
+  return args.binary;
+}
+
+function registryGvproxyExe(args: RegisterArgs): string | undefined {
+  if (process.platform === "darwin" && args.gvPid !== undefined && args.gvPid > 0) {
+    return readProcessIdentity(args.gvPid)?.exeBase ?? args.gvExe;
+  }
+  return args.gvExe;
+}
+
+function registryMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
+  if (!mountDiskPaths) {
+    return undefined;
+  }
+  return {
+    guest: mountDiskPaths.guest,
+    lowerPath: mountDiskPaths.lowerPath,
+    upperPath: mountDiskPaths.upperPath,
+  };
+}
+
+function registryLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
+  return nonEmptyList(
+    liveMountsResolved.map(({ guest, host, mode }) => ({
+      guest,
+      host,
+      mode,
+    })),
+  );
 }
 
 interface ExitCleanupState {
@@ -1761,6 +1841,308 @@ function installDetachedBootCapture(child: ChildProcessWithoutNullStreams, sink:
       bytes -= sink.shift()!.length;
     }
   });
+}
+
+interface BootHandleArgs {
+  child: ChildProcessWithoutNullStreams;
+  childPid: number;
+  vmName: string | undefined;
+  timeoutMs: number | null;
+  outputCollector: Promise<string>;
+  errorCollector: Promise<string>;
+  vsockUdsPath: string | undefined;
+  onLog: OnLog | undefined;
+  statsFilePath: string | undefined;
+  memoryCeilingMib: number | undefined;
+  diskAbs: string | undefined;
+  vmstateStatePath: string | undefined;
+  snapshot: BootSnapshotContextArgs;
+}
+
+interface BootSnapshotContextArgs {
+  child: ChildProcessWithoutNullStreams;
+  childPid: number;
+  vmName: string | undefined;
+  sourceImageAbs: string | undefined;
+  rootDiskPath: string | undefined;
+  rootDiskMode: "block" | "none";
+  memoryCeilingMib: number | undefined;
+  env: Record<string, string>;
+  diskAbs: string | undefined;
+  mountDiskPaths: MountDiskPaths | undefined;
+  liveMountsResolved: ResolvedLiveMount[];
+  nested: boolean | undefined;
+  vmstate: BootVmstateRuntime;
+}
+
+interface BootVmstateRuntime {
+  statePath: string | undefined;
+  chainId: string;
+  checkpointParent: string | undefined;
+  checkpointSequence: number;
+}
+
+function createBootVmHandle(args: BootHandleArgs): VmHandle {
+  let handle: VmHandle;
+  handle = {
+    pid: args.childPid,
+    name: args.vmName,
+    stdin: args.child.stdin,
+    stdout: args.child.stdout,
+    stderr: args.child.stderr,
+    wait: makeWait(args.child, args.timeoutMs),
+    kill: makeKill(args.child),
+    detach: makeDetach(args.child),
+    output: () => args.outputCollector,
+    errorOutput: () => args.errorCollector,
+    exec: makeExec(args.vsockUdsPath, args.onLog),
+    execRaw: makeExecRaw(args.vsockUdsPath, args.onLog),
+    execPty: makeExecPty(args.vsockUdsPath),
+    writeFile: makeWriteFile(() => handle),
+    memoryStats: makeMemoryStats(args.childPid, args.statsFilePath, args.memoryCeilingMib),
+    snapshot: makeSnapshot(args, () => buildBootSnapshotContext(args.snapshot, handle)),
+    fork: makeFork(args, () => buildBootSnapshotContext(args.snapshot, handle)),
+  };
+  return handle;
+}
+
+function makeDetach(child: ChildProcessWithoutNullStreams): VmHandle["detach"] {
+  return async () => {
+    child.stdin.end();
+    child.unref();
+  };
+}
+
+function makeExec(vsockUdsPath: string | undefined, onLog: OnLog | undefined): VmHandle["exec"] {
+  return async (cmd, execOpts) => {
+    const udsPath = requireVsockPath(vsockUdsPath, "exec");
+    const res = await VsockExec.run(udsPath, cmd, teeOnLog(cmd, execOpts, onLog));
+    if (res.exitCode !== 0) {
+      throw new ExecError(
+        "EXEC_NONZERO_EXIT",
+        `vm.exec failed (code ${res.exitCode}): ${cmd}\nstderr:\n${res.stderr}`,
+      );
+    }
+    return res;
+  };
+}
+
+function makeExecRaw(
+  vsockUdsPath: string | undefined,
+  onLog: OnLog | undefined,
+): VmHandle["execRaw"] {
+  return (cmd, execOpts) => {
+    if (!vsockUdsPath) {
+      return Promise.reject(missingVsockError("execRaw"));
+    }
+    return VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
+  };
+}
+
+function makeExecPty(vsockUdsPath: string | undefined): VmHandle["execPty"] {
+  return (cmd, ptyOpts) => {
+    if (!vsockUdsPath) {
+      return rejectedPtyHandle(missingVsockError("execPty"));
+    }
+    return VsockExec.startPty(vsockUdsPath, cmd, ptyOpts);
+  };
+}
+
+function rejectedPtyHandle(err: Error): ReturnType<VmHandle["execPty"]> {
+  return {
+    result: Promise.reject(err),
+    resize: () => {},
+    cancel: () => {},
+  };
+}
+
+function requireVsockPath(vsockUdsPath: string | undefined, method: string): string {
+  if (!vsockUdsPath) {
+    throw missingVsockError(method);
+  }
+  return vsockUdsPath;
+}
+
+function missingVsockError(method: string): ExecError {
+  return new ExecError(
+    "EXEC_VSOCK_UNAVAILABLE",
+    `vm.${method}: no vsock UDS available — MACHINEN_VSOCK was set to an ` +
+      "unrecognized spec. Expected `in:<port>:<uds-path>`.",
+  );
+}
+
+function makeWriteFile(getHandle: () => VmHandle): VmHandle["writeFile"] {
+  return async (guestPath, contents, writeOpts) => {
+    for (const cmd of buildWriteFileCmds(guestPath, contents, writeOpts)) {
+      await getHandle().exec(cmd);
+    }
+  };
+}
+
+function makeMemoryStats(
+  childPid: number,
+  statsFilePath: string | undefined,
+  memoryCeilingMib: number | undefined,
+): VmHandle["memoryStats"] {
+  return async () => {
+    const balloon = statsFilePath ? readBalloonStats(statsFilePath) : null;
+    const lazyTotal = findEntry({ pid: childPid })?.lazyPagesTotal ?? 0;
+    return {
+      ceilingMib: memoryCeilingMib ?? null,
+      hostRssBytes: readHostRssBytes(childPid, statsFilePath),
+      balloonInflatedBytes: balloon?.bytesReported ?? 0,
+      lazyPagesPending: lazyTotal,
+    };
+  };
+}
+
+function makeSnapshot(
+  args: BootHandleArgs,
+  snapshotContext: () => SnapshotContext,
+): VmHandle["snapshot"] {
+  return async (snapshotOpts) => {
+    ensureSnapshotBacking(args.diskAbs, args.vmstateStatePath, "snapshot");
+    return performSnapshot(snapshotContext(), snapshotOpts);
+  };
+}
+
+function makeFork(args: BootHandleArgs, snapshotContext: () => SnapshotContext): VmHandle["fork"] {
+  return async (forkOpts) => {
+    ensureSnapshotBacking(args.diskAbs, args.vmstateStatePath, "fork");
+    return performForkWithRestore(snapshotContext(), forkOpts ?? {}, restoreForFork);
+  };
+}
+
+async function restoreForFork(
+  restoreOpts: Parameters<typeof performForkWithRestore>[2] extends (
+    opts: infer T,
+  ) => Promise<VmHandle>
+    ? T
+    : never,
+): Promise<VmHandle> {
+  const runtimeEntryPath = runtimeEntryImportPath();
+  const { restore } = await import(runtimeEntryPath);
+  return restore(restoreOpts);
+}
+
+function ensureSnapshotBacking(
+  diskAbs: string | undefined,
+  vmstateStatePath: string | undefined,
+  action: "snapshot" | "fork",
+): void {
+  const engine = resolveSnapshotEngine();
+  if (engine === "criu" && !diskAbs) {
+    throw noSnapshotBackingError(action);
+  }
+  if (engine === "vmstate" && !vmstateStatePath) {
+    throw noSnapshotBackingError(action);
+  }
+}
+
+function noSnapshotBackingError(action: "snapshot" | "fork"): SnapshotError {
+  return new SnapshotError("SNAPSHOT_NO_DISK", NO_SNAPSHOT_BACKING_MESSAGES[action]);
+}
+
+const NO_SNAPSHOT_BACKING_MESSAGES = {
+  snapshot:
+    "vm.snapshot: this VM was booted with `snapshot: false` (no scratch " +
+    "disk attached). Re-boot without that flag — the runtime will " +
+    "auto-allocate a sparse scratch — or pass `snapshot: '<path>'`.",
+  fork:
+    "vm.fork: source VM has no scratch disk (booted with `snapshot: false`). " +
+    "Re-boot the source without that flag so it can be snapshotted.",
+} as const;
+
+function buildBootSnapshotContext(
+  args: BootSnapshotContextArgs,
+  handle: VmHandle,
+): SnapshotContext {
+  return {
+    pid: args.childPid,
+    sourceName: args.vmName,
+    sourceImage: args.sourceImageAbs,
+    rootDiskPath: args.rootDiskPath,
+    rootDiskMode: args.rootDiskMode,
+    memoryCeilingMib: args.memoryCeilingMib,
+    kernelPath: args.env.MACHINEN_KERNEL,
+    dtbPath: args.env.MACHINEN_DTB,
+    diskPath: args.diskAbs!,
+    mountDisk: snapshotMountDisk(args.mountDiskPaths),
+    liveMounts: snapshotLiveMounts(args.liveMountsResolved),
+    vmstatePath: args.vmstate.statePath,
+    vmstateChain: snapshotVmstateChain(args.vmstate),
+    updateVmstateChain: snapshotVmstateUpdater(args.vmstate, args.childPid),
+    nested: args.nested,
+    execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
+    wait: () => handle.wait(),
+    kill: () => handle.kill(),
+    teeGuestConsole: (onChunk) => {
+      args.child.stderr.on("data", onChunk);
+    },
+    errorOutput: () => handle.errorOutput(),
+  };
+}
+
+function snapshotMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
+  if (!mountDiskPaths) {
+    return undefined;
+  }
+  return {
+    guest: mountDiskPaths.guest,
+    lowerPath: mountDiskPaths.lowerPath,
+    upperPath: mountDiskPaths.upperPath,
+  };
+}
+
+function snapshotLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
+  return nonEmptyList(
+    liveMountsResolved.map((lm) => ({
+      host: lm.host,
+      guest: lm.guest,
+      mode: lm.mode,
+    })),
+  );
+}
+
+function snapshotVmstateChain(vmstate: BootVmstateRuntime): SnapshotContext["vmstateChain"] {
+  if (!vmstate.statePath) {
+    return undefined;
+  }
+  return {
+    chainId: vmstate.chainId,
+    parentDir: vmstate.checkpointParent,
+    sequence: vmstate.checkpointSequence,
+  };
+}
+
+function snapshotVmstateUpdater(
+  vmstate: BootVmstateRuntime,
+  childPid: number,
+): SnapshotContext["updateVmstateChain"] {
+  if (!vmstate.statePath) {
+    return undefined;
+  }
+  return ({ parentDir, sequence }) =>
+    updateVmstateChainState(vmstate, childPid, parentDir, sequence);
+}
+
+function updateVmstateChainState(
+  vmstate: BootVmstateRuntime,
+  childPid: number,
+  parentDir: string | undefined,
+  sequence: number,
+): void {
+  vmstate.checkpointParent = parentDir;
+  vmstate.checkpointSequence = sequence;
+  const cur = findEntry({ pid: childPid });
+  if (cur) {
+    writeEntry({
+      ...cur,
+      vmstateChainId: vmstate.chainId,
+      vmstateCheckpointParent: vmstate.checkpointParent,
+      vmstateCheckpointSequence: vmstate.checkpointSequence,
+    });
+  }
 }
 
 // #150 phase 2: detached mode blocks until the guest produces its

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -185,290 +185,309 @@ export function resolveRestoreLiveMounts(
   });
 }
 
+type BundleMountDisk = {
+  lowerPath: string;
+  upperPath: string;
+  guest: string;
+  upperSizeBytes: number;
+};
+
+interface BundlePackerOptions {
+  useTiny: boolean;
+  env: Record<string, string>;
+  mountDiskUpperSizeBytes?: number;
+  onPhase?: (name: string, ms: number) => void;
+}
+
+interface SynthesizedBundle {
+  tempDir: string;
+  cpioPath: string;
+  mountDisk?: BundleMountDisk;
+}
+
+interface BundleWorkspace {
+  tempDir: string;
+  cpioPath: string;
+  synthBundleDir: string;
+  cleanup: () => void;
+}
+
+interface BundleImageConfig {
+  cmd?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+interface BundleImageInput {
+  baseAbs: string | undefined;
+  imageConfig: BundleImageConfig | undefined;
+}
+
+interface ResolvedMountInput {
+  host: string;
+  guest: string;
+}
+
 export function synthesizeAndPackBundle(
   opts: BootOptions,
   mergedGuestEnv: Record<string, string>,
   liveMounts: ResolvedLiveMount[],
-  packerOpts: {
-    useTiny: boolean;
-    env: Record<string, string>;
-    mountDiskUpperSizeBytes?: number;
-    onPhase?: (name: string, ms: number) => void;
-  },
-): {
-  tempDir: string;
-  cpioPath: string;
-  mountDisk?: {
-    lowerPath: string;
-    upperPath: string;
-    guest: string;
-    upperSizeBytes: number;
-  };
-} {
+  packerOpts: BundlePackerOptions,
+): SynthesizedBundle {
+  const workspace = createBundleWorkspace();
+  try {
+    validateOptionalGuestCwd(opts);
+    const image = resolveBundleImage(opts, packerOpts);
+    const cmd = wrapBundleCommand(resolveBundleCommand(opts, image.imageConfig), opts);
+    const effectiveEnv = { ...image.imageConfig?.env, ...mergedGuestEnv };
+    writeBundleConfig(workspace, {
+      cmd,
+      env: effectiveEnv,
+      guestCwd: opts.guestCwd,
+      imageCwd: image.imageConfig?.cwd,
+      liveMounts,
+    });
+    const mount = resolveBundleMount(opts);
+    packSynthesizedInitramfs(workspace, image.baseAbs, mount, opts, effectiveEnv, packerOpts);
+    return {
+      tempDir: workspace.tempDir,
+      cpioPath: workspace.cpioPath,
+      mountDisk: materializeBundleMountDisk(opts, mount, packerOpts),
+    };
+  } catch (err) {
+    workspace.cleanup();
+    throw err;
+  }
+}
+
+function createBundleWorkspace(): BundleWorkspace {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
-  const cpioPath = join(tempDir, "initramfs.cpio");
-  const synthBundleDir = join(tempDir, "bundle");
-  const cleanup = () => {
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-    } catch {}
+  return {
+    tempDir,
+    cpioPath: join(tempDir, "initramfs.cpio"),
+    synthBundleDir: join(tempDir, "bundle"),
+    cleanup: () => {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {}
+    },
   };
+}
 
+function validateOptionalGuestCwd(opts: BootOptions): void {
   if (opts.guestCwd !== undefined) {
-    try {
-      validateGuestCwd(opts.guestCwd);
-    } catch (err) {
-      cleanup();
-      throw err;
-    }
+    validateGuestCwd(opts.guestCwd);
   }
+}
 
-  let baseAbs: string | undefined;
-  let imageConfig: { cmd?: string[]; env?: Record<string, string>; cwd?: string } | undefined;
-  if (opts.image) {
-    baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
-    if (!existsSync(baseAbs)) {
-      cleanup();
-      throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
-    }
-    const cfgT0 = Date.now();
-    imageConfig = readImageConfig(baseAbs);
-    packerOpts.onPhase?.("image-config-read", Date.now() - cfgT0);
+function resolveBundleImage(opts: BootOptions, packerOpts: BundlePackerOptions): BundleImageInput {
+  if (!opts.image) {
+    return { baseAbs: undefined, imageConfig: undefined };
   }
+  const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image);
+  if (!existsSync(baseAbs)) {
+    throw new BootError("BOOT_IMAGE_NOT_FOUND", `image tarball not found: ${baseAbs}`);
+  }
+  const cfgT0 = Date.now();
+  const imageConfig = readImageConfig(baseAbs);
+  packerOpts.onPhase?.("image-config-read", Date.now() - cfgT0);
+  return { baseAbs, imageConfig };
+}
 
-  // cmd resolution:
-  //   - Snapshot-only restore (`boot({ snapshot })` with no cmd):
-  //     synthesize `["/sbin/machinen-restore"]`. The helper mounts
-  //     /dev/vda, spawns a fresh exec-agent, and runs `criu restore`
-  //     inside `unshare --pid --fork --mount-proc` so the dumped
-  //     workload's PIDs don't collide with the restore-side helpers
-  //     on chained restores (#215). This MUST take precedence over
-  //     the rootfs's baked `imageConfig.cmd` — that field is the
-  //     fresh-boot default; replaying it on restore would launch a
-  //     brand-new workload instead of resuming the dumped one,
-  //     silently dropping all in-memory state.
-  //   - Normal boot: user's cmd wins; fall back to image's baked
-  //     default. Then wrap in /sbin/machinen-supervisor so the
-  //     workload runs as a CRIU-dumpable child of /init and the
-  //     exec-agent stays alive alongside it for vm.exec / vm.snapshot.
-  //     Exception: if the cmd is already `/exec-agent`, skip the
-  //     wrapper — the workload IS the agent (provision() flow).
-  //   - Neither snapshot nor cmd and no image default: error.
-  let effectiveCmd: string[] | undefined;
+function resolveBundleCommand(
+  opts: BootOptions,
+  imageConfig: BundleImageConfig | undefined,
+): string[] {
+  const cmd = explicitOrSyntheticCommand(opts, imageConfig);
+  if (cmd) {
+    return cmd;
+  }
+  throw new BootError(
+    "BOOT_CMD_MISSING",
+    "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
+      "image via `provision({ cmd })`.",
+  );
+}
+
+function explicitOrSyntheticCommand(
+  opts: BootOptions,
+  imageConfig: BundleImageConfig | undefined,
+): string[] | undefined {
   if (opts.cmd) {
-    effectiveCmd = opts.cmd;
-  } else if (typeof opts.snapshot === "string") {
+    return opts.cmd;
+  }
+  if (typeof opts.snapshot === "string") {
     // Only synthesize the restore helper when the caller explicitly
     // passed a snapshot path. The auto-allocated scratch (default
     // `snapshot: undefined`) is empty, so synthesizing here would feed
     // CRIU a bundle-less file and fail.
-    effectiveCmd = ["/sbin/machinen-restore"];
-  } else if (opts._vmstateRestorePath) {
-    // Vmstate restore: the VMM overwrites guest RAM with the bundle's
-    // whole-VM `.vmstate` state before the first vCPU run, so /init
-    // never executes and the cmd is moot — but the VMM still needs a
-    // valid initramfs (MACHINEN_INITRD is required). Give it a
-    // harmless placeholder that's guaranteed present in the rootfs
-    // and, like the criu restore helper, takes precedence over the
-    // image's baked-in cmd (which would otherwise launch a fresh
-    // workload instead of resuming the snapshotted one).
-    effectiveCmd = ["/sbin/machinen-poweroff"];
-  } else if (imageConfig?.cmd) {
-    effectiveCmd = imageConfig.cmd;
+    return ["/sbin/machinen-restore"];
   }
-  if (!effectiveCmd) {
-    cleanup();
+  if (opts._vmstateRestorePath) {
+    // Vmstate restore: the VMM overwrites guest RAM before /init runs,
+    // but the VMM still needs a valid initramfs path.
+    return ["/sbin/machinen-poweroff"];
+  }
+  return imageConfig?.cmd;
+}
+
+function wrapBundleCommand(cmd: string[], opts: BootOptions): string[] {
+  const cmdHead = cmd[0];
+  if (cmdHead === "/exec-agent" || cmdHead === "/sbin/machinen-restore") {
+    return cmd;
+  }
+  const supervisorArgs = typeof opts.snapshot === "string" ? ["--session"] : [];
+  return ["/sbin/machinen-supervisor", ...supervisorArgs, ...cmd];
+}
+
+function writeBundleConfig(
+  workspace: BundleWorkspace,
+  input: {
+    cmd: string[];
+    env: Record<string, string>;
+    guestCwd?: string;
+    imageCwd?: string;
+    liveMounts: ResolvedLiveMount[];
+  },
+): void {
+  mkdirSync(join(workspace.synthBundleDir, "rootfs"), { recursive: true });
+  const configJson = buildMachinenConfig(input);
+  writeFileSync(join(workspace.synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
+}
+
+function resolveBundleMount(opts: BootOptions): ResolvedMountInput | undefined {
+  if (!opts.mount) {
+    return undefined;
+  }
+  validateMountGuest(opts.mount.guest);
+  const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
+  if (!existsSync(hostAbs)) {
     throw new BootError(
-      "BOOT_CMD_MISSING",
-      "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
-        "image via `provision({ cmd })`.",
+      "BOOT_MOUNT_HOST_NOT_FOUND",
+      `mount host path not found: ${opts.mount.host}`,
     );
   }
-
-  // Wrap the cmd in the supervisor unless the caller is booting the
-  // vsock agent directly (provision flow) or the runtime-synthesized
-  // restore helper (which already manages the agent itself).
-  //
-  // `--session` is the legacy "run under setsid" toggle from when CRIU
-  // dumps required it but interactive boots didn't. Both modes now go
-  // through the same `setsid -c -w` path in the supervisor, so the flag
-  // is just consumed for back-compat. Pass it whenever a caller-managed
-  // snapshot path is present — purely cosmetic, mirrors how older
-  // releases logged the boot.
-  const cmdHead = effectiveCmd[0];
-  const isAgentDirect = cmdHead === "/exec-agent";
-  const isRestoreHelper = cmdHead === "/sbin/machinen-restore";
-  const supervisorArgs = typeof opts.snapshot === "string" ? ["--session"] : [];
-  const wrappedCmd =
-    isAgentDirect || isRestoreHelper
-      ? effectiveCmd
-      : ["/sbin/machinen-supervisor", ...supervisorArgs, ...effectiveCmd];
-
-  // env: image defaults overlaid by user + runtime-injected (gvproxy
-  // cache mirror, etc.). User + runtime wins on key collision. Shared
-  // between the synthesized config.json (read by /init) and the
-  // packer's runtime env injection (written into the cpio's
-  // env-overlay file).
-  const effectiveEnv = { ...imageConfig?.env, ...mergedGuestEnv };
-
-  // Synthesize the bundle directory from the effective cmd + env. No
-  // user-authored machinen-config.json; we generate it here and the
-  // caller never sees it.
-  mkdirSync(join(synthBundleDir, "rootfs"), { recursive: true });
-  const configJson = buildMachinenConfig({
-    cmd: wrappedCmd,
-    env: effectiveEnv,
-    guestCwd: opts.guestCwd,
-    imageCwd: imageConfig?.cwd,
-    liveMounts,
-  });
-  writeFileSync(join(synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
-
-  let mount: { host: string; guest: string } | undefined;
-  if (opts.mount) {
-    try {
-      validateMountGuest(opts.mount.guest);
-    } catch (err) {
-      cleanup();
-      throw err;
-    }
-    const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
-    if (!existsSync(hostAbs)) {
-      cleanup();
-      throw new BootError(
-        "BOOT_MOUNT_HOST_NOT_FOUND",
-        `mount host path not found: ${opts.mount.host}`,
-      );
-    }
-    if (!statSync(hostAbs).isDirectory()) {
-      cleanup();
-      throw new BootError(
-        "BOOT_MOUNT_INVALID",
-        `mount host path must be a directory (got a file): ${opts.mount.host}`,
-      );
-    }
-    mount = { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
+  if (!statSync(hostAbs).isDirectory()) {
+    throw new BootError(
+      "BOOT_MOUNT_INVALID",
+      `mount host path must be a directory (got a file): ${opts.mount.host}`,
+    );
   }
+  return { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
+}
 
+function packSynthesizedInitramfs(
+  workspace: BundleWorkspace,
+  baseAbs: string | undefined,
+  mount: ResolvedMountInput | undefined,
+  opts: BootOptions,
+  effectiveEnv: Record<string, string>,
+  packerOpts: BundlePackerOptions,
+): void {
+  const packT0 = Date.now();
   try {
-    const packT0 = Date.now();
     if (packerOpts.useTiny) {
-      // #119: rootDisk path. The on-disk rootfs is mounted from /dev/vda
-      // by /init; the cpio only ships /init + machinen-config.json +
-      // boot-epoch + /dev/console (~500 KB). The custom kernel
-      // (scripts/build-kernel-arm64.sh) has virtio_*, ext4, vsock,
-      // squashfs, and overlayfs built in, so no /modules/*.ko or
-      // finit_module pass is needed.
-      //
-      // #272: the `--mount` payload no longer rides in the cpio. We
-      // pass `mountGuest` so /init learns the target path; the actual
-      // bytes ride on virtio-blk slots 5+6 (set up further down in
-      // boot()).
-      mkinitramfsPackTinyBundle({
-        bundle: synthBundleDir,
-        out: cpioPath,
-        // The cpio just carries the guest mountpoint string for /init
-        // to read. The actual payload (whether materialized fresh or
-        // sourced from a snapshot bundle) rides on virtio-blk slots
-        // 5+6, attached further down in boot().
-        mountGuest: mount?.guest ?? opts._restoreMountDisk?.guest,
-        env: effectiveEnv,
-      });
+      packTinyInitramfs(workspace, mount, opts, effectiveEnv);
     } else {
-      // Legacy fat cpio: explicit `rootDisk: false` opt-out. Drags the
-      // entire base tarball into RAM, by design — callers that need a
-      // Debian userland in the cpio (no virtio-blk root) land here.
-      // The legacy cpio overlay path is preserved here: this branch
-      // does not get the virtio-blk mount overlay, since the kernel
-      // would have to wait for the rootdisk pivot anyway.
-      mkinitramfsPackBundle({
-        bundle: synthBundleDir,
-        out: cpioPath,
-        base: baseAbs,
-        mount,
-        env: effectiveEnv,
-      });
+      packFatInitramfs(workspace, baseAbs, mount, effectiveEnv);
     }
     packerOpts.onPhase?.("cpio-write", Date.now() - packT0);
   } catch (err) {
-    cleanup();
     const msg = err instanceof Error ? err.message : String(err);
     throw new BootError("BOOT_PACK_FAILED", `mkinitramfs pack failed: ${msg}`, { cause: err });
   }
-  // #272: the rootDisk path also needs the squashfs+ext4 payload
-  // built and fd-passed to the VMM. Two paths:
-  //   - fresh boot with `mount`: materialize a content-addressed
-  //     squashfs lower from the host source dir + a per-VM ext4 upper.
-  //   - restore from a snapshot bundle (`_restoreMountDisk`): reuse
-  //     the bundle's lower as-is (it's already content-addressed and
-  //     immutable), but reflink the bundle's upper into a per-VM
-  //     path so guest writes don't mutate the bundle in-place.
-  //
-  // Materialize here so a missing mksquashfs fails fast at boot rather
-  // than mid-spawn.
-  let mountDisk:
-    | { lowerPath: string; upperPath: string; guest: string; upperSizeBytes: number }
-    | undefined;
-  if (packerOpts.useTiny) {
-    if (opts._restoreMountDisk) {
-      try {
-        const r = opts._restoreMountDisk;
-        if (!existsSync(r.lowerPath)) {
-          throw new BootError(
-            "BOOT_SNAPSHOT_NOT_FOUND",
-            `restore: bundle is missing mount-lower at ${r.lowerPath}`,
-          );
-        }
-        if (!existsSync(r.upperPath)) {
-          throw new BootError(
-            "BOOT_SNAPSHOT_NOT_FOUND",
-            `restore: bundle is missing mount-upper at ${r.upperPath}`,
-          );
-        }
-        // Reflink the upper so writes accumulate per-fork instead of
-        // mutating the bundle. APFS clonefile / Linux FICLONE on
-        // capable fs (free, shared blocks until guest writes); falls
-        // back to a regular copy elsewhere.
-        const perVMUpper = join(
-          tmpdir(),
-          `machinen-mountdisk-upper-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-        );
-        reflinkCopy(r.upperPath, perVMUpper);
-        const upperSize = statSync(perVMUpper).size;
-        mountDisk = {
-          lowerPath: r.lowerPath,
-          upperPath: perVMUpper,
-          guest: r.guest,
-          upperSizeBytes: upperSize,
-        };
-      } catch (err) {
-        cleanup();
-        throw err;
-      }
-    } else if (mount) {
-      try {
-        const lower = ensureMountDiskImage(mount.host, {
-          onPhase: (name, ms) => packerOpts.onPhase?.(`mountdisk.${name}`, ms),
-        });
-        // markMountDiskImageClean is idempotent and safe to call here —
-        // we only READ the cached file; the per-boot boot() flow takes
-        // ownership of the .ok marker via the same lifecycle the
-        // rootdisk uses.
-        const upper = ensureMountDiskUpper({
-          sizeBytes: packerOpts.mountDiskUpperSizeBytes,
-        });
-        mountDisk = {
-          lowerPath: lower.lowerPath,
-          upperPath: upper.upperPath,
-          guest: mount.guest,
-          upperSizeBytes: upper.sizeBytes,
-        };
-        markMountDiskImageClean(lower.lowerPath);
-      } catch (err) {
-        cleanup();
-        throw err;
-      }
-    }
+}
+
+function packTinyInitramfs(
+  workspace: BundleWorkspace,
+  mount: ResolvedMountInput | undefined,
+  opts: BootOptions,
+  effectiveEnv: Record<string, string>,
+): void {
+  mkinitramfsPackTinyBundle({
+    bundle: workspace.synthBundleDir,
+    out: workspace.cpioPath,
+    // The cpio just carries the guest mountpoint string for /init to
+    // read. The actual payload rides on virtio-blk slots 5+6.
+    mountGuest: mount?.guest ?? opts._restoreMountDisk?.guest,
+    env: effectiveEnv,
+  });
+}
+
+function packFatInitramfs(
+  workspace: BundleWorkspace,
+  baseAbs: string | undefined,
+  mount: ResolvedMountInput | undefined,
+  effectiveEnv: Record<string, string>,
+): void {
+  mkinitramfsPackBundle({
+    bundle: workspace.synthBundleDir,
+    out: workspace.cpioPath,
+    base: baseAbs,
+    mount,
+    env: effectiveEnv,
+  });
+}
+
+function materializeBundleMountDisk(
+  opts: BootOptions,
+  mount: ResolvedMountInput | undefined,
+  packerOpts: BundlePackerOptions,
+): BundleMountDisk | undefined {
+  if (!packerOpts.useTiny) {
+    return undefined;
   }
-  return { tempDir, cpioPath, mountDisk };
+  if (opts._restoreMountDisk) {
+    return materializeRestoredMountDisk(opts._restoreMountDisk);
+  }
+  return mount ? materializeFreshMountDisk(mount, packerOpts) : undefined;
+}
+
+function materializeRestoredMountDisk(
+  restoreMount: NonNullable<BootOptions["_restoreMountDisk"]>,
+): BundleMountDisk {
+  if (!existsSync(restoreMount.lowerPath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle is missing mount-lower at ${restoreMount.lowerPath}`,
+    );
+  }
+  if (!existsSync(restoreMount.upperPath)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle is missing mount-upper at ${restoreMount.upperPath}`,
+    );
+  }
+  const perVMUpper = join(
+    tmpdir(),
+    `machinen-mountdisk-upper-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  reflinkCopy(restoreMount.upperPath, perVMUpper);
+  return {
+    lowerPath: restoreMount.lowerPath,
+    upperPath: perVMUpper,
+    guest: restoreMount.guest,
+    upperSizeBytes: statSync(perVMUpper).size,
+  };
+}
+
+function materializeFreshMountDisk(
+  mount: ResolvedMountInput,
+  packerOpts: BundlePackerOptions,
+): BundleMountDisk {
+  const lower = ensureMountDiskImage(mount.host, {
+    onPhase: (name, ms) => packerOpts.onPhase?.(`mountdisk.${name}`, ms),
+  });
+  // markMountDiskImageClean is idempotent and safe to call here — we
+  // only READ the cached file; the per-boot boot() flow owns lifecycle.
+  const upper = ensureMountDiskUpper({
+    sizeBytes: packerOpts.mountDiskUpperSizeBytes,
+  });
+  markMountDiskImageClean(lower.lowerPath);
+  return {
+    lowerPath: lower.lowerPath,
+    upperPath: upper.upperPath,
+    guest: mount.guest,
+    upperSizeBytes: upper.sizeBytes,
+  };
 }

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -127,245 +127,258 @@ export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" |
  *   bundle's `meta.liveMounts`.
  */
 export async function restore(opts: RestoreOptions): Promise<VmHandle> {
-  // #221: per-phase timeline for restore. Boot's own phases get logged
-  // separately under DEBUG=machinen:boot — restore tracks the parts
-  // that are restore-specific (meta-read, the boot rollup, and the
-  // wall-clock until the restored guest is responsive over vsock).
-  const phases = new PhaseTimer();
   const snapDir = resolve(opts.snapDir);
-
-  // Auto-detect the engine from the bundle's contents: a
-  // `state.vmstate` file means the vmstate (whole-VM) engine produced
-  // it. A bundle always restores under the engine that wrote it,
-  // regardless of the MACHINEN_SNAPSHOT_ENGINE env var.
   if (existsSync(join(snapDir, VMSTATE_FILE))) {
     return restoreVmstate(opts, snapDir);
   }
+  return restoreCriu(opts, snapDir);
+}
 
+async function restoreCriu(opts: RestoreOptions, snapDir: string): Promise<VmHandle> {
+  const phases = new PhaseTimer();
+  const imgDir = validateCriuSnapshotBundle(snapDir);
+  const meta = readSnapshotMetaWithPhase(join(snapDir, "meta.json"), phases);
+  const resolvedImage = resolveRestoreImage(opts, meta);
+  const lazy = prepareLazyPages(opts, imgDir, phases);
+  const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
+  const delivery = prepareCriuBundleDelivery(lazy.enabled, imgDir, effectiveLiveMounts, phases);
+  const vm = await bootCriuRestore({
+    opts,
+    snapDir,
+    resolvedImage,
+    delivery,
+    restoreMountDisk: resolveRestoreMountDisk(snapDir, meta),
+    phases,
+  });
+  finalizeCriuRestore(vm, opts, meta, phases, lazy.pagesTotal);
+  return vm;
+}
+
+function validateCriuSnapshotBundle(snapDir: string): string {
   const imgDir = join(snapDir, "img");
-  const metaPath = join(snapDir, "meta.json");
   if (!existsSync(imgDir) || !statSync(imgDir).isDirectory()) {
     throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${imgDir} not found`);
   }
-  const imgEntries = readdirSync(imgDir);
-  if (!imgEntries.some((name) => /^core-\d+\.img$/.test(name))) {
+  if (!readdirSync(imgDir).some(isCoreImageName)) {
     throw new BootError(
       "BOOT_SNAPSHOT_NOT_FOUND",
       `restore: ${imgDir} has no core-*.img — is this a snapshot bundle?`,
     );
   }
+  return imgDir;
+}
+
+function isCoreImageName(name: string): boolean {
+  return /^core-\d+\.img$/.test(name);
+}
+
+function readSnapshotMetaWithPhase(metaPath: string, phases: PhaseTimer): SnapshotMeta {
   phases.start("snapshot-meta-read");
-  let meta: SnapshotMeta = { snappedAt: 0 };
-  if (existsSync(metaPath)) {
-    try {
-      meta = JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
-    } catch {
-      // Bundle predates metadata or got corrupted; fall through with
-      // an anonymous source name. The fork still boots; it just won't
-      // have a memorable auto-name.
-    }
-  }
+  const meta = readSnapshotMeta(metaPath);
   phases.end("snapshot-meta-read");
+  return meta;
+}
 
-  // Resolve the rootfs image: caller's `opts.image` wins; otherwise
-  // fall back to the path the source booted from (recorded in
-  // meta.json). Without a usable image, criu's file-backed VMA
-  // restore has nothing to reopen and PID 1 panics — so we throw
-  // here with a message the user can act on instead.
-  const resolvedImage = resolveRestoreImage(opts, meta);
-
-  // Lazy-pages mode (#266, opt-in via `lazy: true`): mark every
-  // PE_PRESENT pagemap entry that lives in an anon-private VMA with
-  // PE_LAZY in place on the host before boot, so
-  // `criu restore --lazy-pages` actually registers UFFD on those
-  // entries instead of loading them eagerly. Dumps are taken without
-  // `--lazy-pages` (machinen-dump.sh keeps the dump path simple);
-  // without this rewrite the lazy-pages daemon would see no lazy
-  // entries and load the whole image up front. Idempotent. See
-  // packages/runtime/src/lazy-pagemap.ts.
-  const lazyPages = opts.lazy === true;
-  let lazyPagesTotal: number | undefined;
-  if (lazyPages) {
-    phases.start("snapshot-mark-lazy");
-    const marked = markPagemapsLazy(imgDir);
-    lazyPagesTotal = marked.entriesFlagged + marked.entriesAlreadyLazy;
-    debug(
-      "lazy-pages mark: files=%d entriesFlagged=%d alreadyLazy=%d",
-      marked.filesRewritten,
-      marked.entriesFlagged,
-      marked.entriesAlreadyLazy,
-    );
-    phases.end("snapshot-mark-lazy");
+function readSnapshotMeta(metaPath: string): SnapshotMeta {
+  if (!existsSync(metaPath)) {
+    return { snappedAt: 0 };
   }
+  try {
+    return JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
+  } catch {
+    // Bundle predates metadata or got corrupted; fall through with an
+    // anonymous source name. The fork still boots.
+    return { snappedAt: 0 };
+  }
+}
 
-  // #273: live-share FUSE mounts the source had at snapshot time.
-  // Re-establish them on the restored VM so the workload's view of
-  // /mnt/<guest>/ comes back intact. opts.liveMounts is an override
-  // map keyed by `guest` (see resolveRestoreLiveMounts).
-  const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
+function prepareLazyPages(
+  opts: RestoreOptions,
+  imgDir: string,
+  phases: PhaseTimer,
+): { enabled: boolean; pagesTotal: number | undefined } {
+  if (opts.lazy !== true) {
+    return { enabled: false, pagesTotal: undefined };
+  }
+  phases.start("snapshot-mark-lazy");
+  const marked = markPagemapsLazy(imgDir);
+  debug(
+    "lazy-pages mark: files=%d entriesFlagged=%d alreadyLazy=%d",
+    marked.filesRewritten,
+    marked.entriesFlagged,
+    marked.entriesAlreadyLazy,
+  );
+  phases.end("snapshot-mark-lazy");
+  return { enabled: true, pagesTotal: marked.entriesFlagged + marked.entriesAlreadyLazy };
+}
 
-  // Bundle delivery split by mode:
-  //   - eager (default): pack `imgDir/` into a tar archive attached
-  //     as /dev/vdb. The guest's machinen-restore.sh untars into
-  //     tmpfs and CRIU does an eager load. Simple, robust — and on the
-  //     workloads we actually ship for (small JS heaps, short-lived
-  //     MicroVMs) the workload faults every page within the first
-  //     second anyway, so the lazy save is moot.
-  //   - lazy (opt-in via `lazy: true`): live-mount `imgDir/` read-only
-  //     at /mnt/snap-src/img via an in-VMM virtio-fs device (#332). CRIU
-  //     restore reads pagemap-*.img + pages-*.img directly through it;
-  //     bytes stream from the host on demand and never materialize in
-  //     guest tmpfs. This is the #266 path — it keeps host RSS
-  //     proportional to the touched set. The historical virtio-balloon
-  //     interaction is fixed in #290 (in-tree kernel patch).
+interface CriuDeliveryPlan {
+  scratchPath: string;
+  restoreEnv: Record<string, string>;
+  liveMounts: BootOptions["liveMounts"];
+}
+
+function prepareCriuBundleDelivery(
+  lazyPages: boolean,
+  imgDir: string,
+  effectiveLiveMounts: BootOptions["liveMounts"],
+  phases: PhaseTimer,
+): CriuDeliveryPlan {
   phases.start("snapshot-pack");
-  const restoreEnv: Record<string, string> = {};
-  let scratchPath: string;
-  let liveMounts: Array<{ host: string; guest: string; mode?: "ro" | "rw" }> | undefined;
-  if (lazyPages) {
-    scratchPath = join(
-      tmpdir(),
-      `machinen-restore-scratch-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-    );
-    allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
-    restoreEnv.MACHINEN_RESTORE_BUNDLE_LIVE = "1";
-    restoreEnv.MACHINEN_RESTORE_LAZY_PAGES = "1";
-    // #290: lazy-restore + virtio-balloon free-page-reporting used to
-    // get into a runaway re-report cycle — the workload's PE_LAZY anon
-    // range stays as huge contiguous free runs in the buddy allocator,
-    // and `__free_one_page`'s buddy merge clears the Reported flag on
-    // every neighbour it merges with, so the next reporting cycle sees
-    // the merged block as unreported and reports the same physical
-    // region again. Fixed in the guest kernel by
-    // `packages/microvm/patches/kernel/0001-mm-page-reporting-skip-merge-with-reported-buddy.patch`,
-    // which refuses to merge a freshly-freed page with a Reported buddy
-    // so the cycle terminates after a single warm-up sweep.
-    liveMounts = [
+  try {
+    return lazyPages
+      ? prepareLazyCriuDelivery(imgDir, effectiveLiveMounts)
+      : prepareEagerCriuDelivery(imgDir, effectiveLiveMounts);
+  } finally {
+    phases.end("snapshot-pack");
+  }
+}
+
+function prepareLazyCriuDelivery(
+  imgDir: string,
+  effectiveLiveMounts: BootOptions["liveMounts"],
+): CriuDeliveryPlan {
+  const scratchPath = join(
+    tmpdir(),
+    `machinen-restore-scratch-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
+  return {
+    scratchPath,
+    restoreEnv: {
+      MACHINEN_RESTORE_BUNDLE_LIVE: "1",
+      MACHINEN_RESTORE_LAZY_PAGES: "1",
+    },
+    liveMounts: [
       ...(effectiveLiveMounts ?? []),
       { host: imgDir, guest: "/mnt/snap-src/img", mode: "ro" as const },
-    ];
-  } else {
-    // Pack the bundle into a tar so machinen-restore.sh can untar it
-    // off /dev/vdb. tar is `bsdtar` on darwin and `gnu tar` on linux;
-    // both produce archives the guest's `tar -xmf` reads. The trailing
-    // sparse extension keeps /dev/vdb at SNAP_SCRATCH_BYTES so chained
-    // `vm.snapshot()` against this VM has scratch room (its mkfs.ext4
-    // happily ignores tar bytes at the front).
-    //
-    // --no-xattrs: on darwin, Gatekeeper auto-tags files extracted by
-    // `machinen snapshot` with `com.apple.provenance`, and bsdtar then
-    // embeds them as `LIBARCHIVE.xattr.*` extended headers — which
-    // GNU tar in the guest warns about once per file ("Ignoring
-    // unknown extended header keyword"). CRIU images don't need
-    // xattrs, so drop them at pack time.
-    scratchPath = join(
-      tmpdir(),
-      `machinen-restore-bundle-${process.pid}-${randomBytes(6).toString("hex")}.tar`,
-    );
-    try {
-      execFileSync("tar", ["--no-xattrs", "-cf", scratchPath, "-C", imgDir, "."]);
-      const fd = openSync(scratchPath, "r+");
-      try {
-        const buf = Buffer.alloc(1);
-        writeSync(fd, buf, 0, 1, SNAP_SCRATCH_BYTES - 1);
-      } finally {
-        closeSync(fd);
-      }
-    } catch (err) {
-      try {
-        unlinkSync(scratchPath);
-      } catch {}
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: failed to pack bundle from ${imgDir}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
-    liveMounts = effectiveLiveMounts;
-  }
-  phases.end("snapshot-pack");
+    ],
+  };
+}
 
-  // #272: when the snapshot bundle includes a `--mount` overlay,
-  // hand the lower/upper paths through to boot() so it can fd-pass
-  // them to the VMM without re-running mksquashfs on the host source
-  // dir. Each fork reflinks the upper into a per-VM file so guest
-  // writes accumulate per-fork, not in the bundle.
-  let restoreMountDisk: BootOptions["_restoreMountDisk"];
-  if (meta.mountDisk) {
-    const lowerAbs = join(snapDir, meta.mountDisk.lower);
-    const upperAbs = join(snapDir, meta.mountDisk.upper);
-    if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
-      );
-    }
-    restoreMountDisk = {
-      guest: meta.mountDisk.guest,
-      lowerPath: lowerAbs,
-      upperPath: upperAbs,
-    };
-  }
+function prepareEagerCriuDelivery(
+  imgDir: string,
+  effectiveLiveMounts: BootOptions["liveMounts"],
+): CriuDeliveryPlan {
+  return {
+    scratchPath: packEagerRestoreBundle(imgDir),
+    restoreEnv: {},
+    liveMounts: effectiveLiveMounts,
+  };
+}
 
-  // boot() doesn't know the pid until after the VMM is spawned, so
-  // we can't pass `<sourceName>/<pid>` up front. Boot anonymous,
-  // then claim the auto-name and patch the registry entry below.
-  phases.start("boot");
-  let vm: VmHandle;
+function packEagerRestoreBundle(imgDir: string): string {
+  const scratchPath = join(
+    tmpdir(),
+    `machinen-restore-bundle-${process.pid}-${randomBytes(6).toString("hex")}.tar`,
+  );
   try {
-    vm = await boot({
-      ...opts,
-      image: resolvedImage,
-      snapshot: scratchPath,
-      forkedFrom: snapDir,
-      name: opts.name,
-      liveMounts,
-      env: { ...opts.env, ...restoreEnv },
-      _restoreMountDisk: restoreMountDisk,
-    });
-  } finally {
-    // boot() reflink-clones the source into a per-boot path before
-    // attaching, so the source scratch/tar isn't needed after boot
-    // returns. Clean up regardless of success.
+    execFileSync("tar", ["--no-xattrs", "-cf", scratchPath, "-C", imgDir, "."]);
+    extendRestoreBundleTar(scratchPath);
+    return scratchPath;
+  } catch (err) {
     try {
       unlinkSync(scratchPath);
     } catch {}
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: failed to pack bundle from ${imgDir}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
-  phases.end("boot");
+}
 
+function extendRestoreBundleTar(scratchPath: string): void {
+  const fd = openSync(scratchPath, "r+");
+  try {
+    const buf = Buffer.alloc(1);
+    writeSync(fd, buf, 0, 1, SNAP_SCRATCH_BYTES - 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function resolveRestoreMountDisk(
+  snapDir: string,
+  meta: SnapshotMeta,
+): BootOptions["_restoreMountDisk"] {
+  if (!meta.mountDisk) {
+    return undefined;
+  }
+  const lowerAbs = join(snapDir, meta.mountDisk.lower);
+  const upperAbs = join(snapDir, meta.mountDisk.upper);
+  if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
+    );
+  }
+  return {
+    guest: meta.mountDisk.guest,
+    lowerPath: lowerAbs,
+    upperPath: upperAbs,
+  };
+}
+
+async function bootCriuRestore(args: {
+  opts: RestoreOptions;
+  snapDir: string;
+  resolvedImage: string;
+  delivery: CriuDeliveryPlan;
+  restoreMountDisk: BootOptions["_restoreMountDisk"];
+  phases: PhaseTimer;
+}): Promise<VmHandle> {
+  args.phases.start("boot");
+  try {
+    const vm = await boot({
+      ...args.opts,
+      image: args.resolvedImage,
+      snapshot: args.delivery.scratchPath,
+      forkedFrom: args.snapDir,
+      name: args.opts.name,
+      liveMounts: args.delivery.liveMounts,
+      env: { ...args.opts.env, ...args.delivery.restoreEnv },
+      _restoreMountDisk: args.restoreMountDisk,
+    });
+    args.phases.end("boot");
+    return vm;
+  } finally {
+    try {
+      unlinkSync(args.delivery.scratchPath);
+    } catch {}
+  }
+}
+
+function finalizeCriuRestore(
+  vm: VmHandle,
+  opts: RestoreOptions,
+  meta: SnapshotMeta,
+  phases: PhaseTimer,
+  lazyPagesTotal: number | undefined,
+): void {
   autoNameRestoredFork(vm, opts, meta);
+  persistLazyPagesTotal(vm, lazyPagesTotal);
+  probeRestoredGuestHostname(vm, phases);
+}
 
-  // #274: persist lazy-restore bookkeeping so `vm.memoryStats()` can
-  // report `lazyPagesTotal` without re-reading the bundle. Boot-owned
-  // and attach handles both read this back through the registry.
-  if (lazyPagesTotal !== undefined) {
-    const cur = findEntry({ pid: vm.pid });
-    if (cur) {
-      writeEntry({
-        ...cur,
-        lazyPagesTotal,
-      });
-    }
+function persistLazyPagesTotal(vm: VmHandle, lazyPagesTotal: number | undefined): void {
+  if (lazyPagesTotal === undefined) {
+    return;
   }
+  const cur = findEntry({ pid: vm.pid });
+  if (cur) {
+    writeEntry({
+      ...cur,
+      lazyPagesTotal,
+    });
+  }
+}
 
-  // CRIU restores the dumped UTS namespace, which means the hostname
-  // is whatever the source VM had — not the new VM's identity. Fire
-  // `hostname <label>` over vsock (fire-and-forget) so the guest's
-  // kernel hostname uniquely identifies this VM, with the host VMM
-  // pid as the disambiguator. See buildGuestHostname for the format.
-  //
-  // #221: piggy-back on the same vsock round-trip to time how long
-  // CRIU restore + supervisor takes to become responsive. Anything
-  // that lets the hostname call return is a usable proxy for "guest
-  // ready". We don't await it — boot() already happened, this just
-  // closes the timing line in the background.
+function probeRestoredGuestHostname(vm: VmHandle, phases: PhaseTimer): void {
   phases.start("criu-restore-probe");
   void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).finally(() => {
     phases.end("criu-restore-probe");
     phases.flush(debugRestore, "restore");
   });
-  return vm;
 }
 
 // Resolve the rootfs image for a restore: caller's `opts.image` wins,
@@ -513,23 +526,70 @@ function validateVmstateGuestArch(vmstate: VmstateSnapshotMeta, facts: VmstateFa
 function validateVmstateBackendAndPauth(vmstate: VmstateSnapshotMeta, facts: VmstateFacts): void {
   const source = vmstate.sourceBackend ?? "unknown";
   const target = currentVmstateBackend();
-  const crossVmm = source !== "unknown" && target !== "unknown" && source !== target;
-  if (!crossVmm) {
+  if (!isCrossVmmRestore(source, target)) {
     return;
   }
 
-  const pauthActive = facts.guestPauthActive ?? vmstate.guestPauth?.active;
-  if (pauthActive !== false) {
-    throw new BootError(
-      "BOOT_VMSTATE_UNSUPPORTED",
-      `restore: unsupported cross-VMM vmstate restore (${source} → ${target}).\n` +
-        `  The snapshot has guest pointer authentication ${
-          pauthActive === true ? "enabled" : "in an unknown state"
-        } (SCTLR_EL1=${facts.sctlrEl1 ?? vmstate.guestPauth?.sctlrEl1 ?? "unknown"}).\n` +
-        "  Recreate the source guest with PAuth disabled (the default machinen\n" +
-        "  DTB includes `arm64.nopauth`) before moving vmstate across HVF/KVM.",
-    );
+  const pauthActive = vmstatePauthActive(vmstate, facts);
+  if (pauthActive === false) {
+    return;
   }
+  throw unsupportedCrossVmmPauthError(source, target, pauthActive, vmstate, facts);
+}
+
+function isCrossVmmRestore(source: string, target: string): boolean {
+  if (source === "unknown") {
+    return false;
+  }
+  if (target === "unknown") {
+    return false;
+  }
+  return source !== target;
+}
+
+function vmstatePauthActive(
+  vmstate: VmstateSnapshotMeta,
+  facts: VmstateFacts,
+): boolean | undefined {
+  if (facts.guestPauthActive !== undefined) {
+    return facts.guestPauthActive;
+  }
+  return vmstate.guestPauth?.active;
+}
+
+function unsupportedCrossVmmPauthError(
+  source: string,
+  target: string,
+  pauthActive: boolean | undefined,
+  vmstate: VmstateSnapshotMeta,
+  facts: VmstateFacts,
+): BootError {
+  return new BootError(
+    "BOOT_VMSTATE_UNSUPPORTED",
+    `restore: unsupported cross-VMM vmstate restore (${source} → ${target}).\n` +
+      `  The snapshot has guest pointer authentication ${pauthStateLabel(
+        pauthActive,
+      )} (SCTLR_EL1=${pauthSctlrLabel(vmstate, facts)}).\n` +
+      "  Recreate the source guest with PAuth disabled (the default machinen\n" +
+      "  DTB includes `arm64.nopauth`) before moving vmstate across HVF/KVM.",
+  );
+}
+
+function pauthStateLabel(pauthActive: boolean | undefined): string {
+  if (pauthActive === true) {
+    return "enabled";
+  }
+  return "in an unknown state";
+}
+
+function pauthSctlrLabel(vmstate: VmstateSnapshotMeta, facts: VmstateFacts): string {
+  if (facts.sctlrEl1 !== undefined) {
+    return facts.sctlrEl1;
+  }
+  if (vmstate.guestPauth?.sctlrEl1 !== undefined) {
+    return vmstate.guestPauth.sctlrEl1;
+  }
+  return "unknown";
 }
 
 function validateVmstateArtifacts(opts: RestoreOptions, vmstate: VmstateSnapshotMeta): void {
@@ -549,20 +609,69 @@ function resolveVmstateMemoryCeiling(
   if (expected === undefined) {
     return undefined;
   }
-  const envMemory = opts.vmmEnv?.MACHINEN_MEMORY ?? process.env.MACHINEN_MEMORY;
-  const envMib = envMemory !== undefined ? Number(envMemory) : undefined;
-  const requested = opts.memory ?? envMib;
-  if (requested !== undefined && requested !== expected) {
-    throw new BootError(
-      "BOOT_VMSTATE_UNSUPPORTED",
-      `restore: vmstate guest RAM layout mismatch.\n` +
-        `  snapshot ceiling: ${expected} MiB\n` +
-        `  restore ceiling:  ${requested} MiB\n` +
-        "  This is the VM's address layout, not current host memory use.\n" +
-        "  Whole-VM restore requires the same RAM topology.",
-    );
+  const envMib = restoreEnvMemoryMib(opts);
+  const requested = requestedRestoreMemory(opts, envMib);
+  validateVmstateMemoryCeiling(expected, requested);
+  if (shouldApplySnapshotMemoryCeiling(opts, envMib)) {
+    return expected;
   }
-  return opts.memory === undefined && envMib === undefined ? expected : undefined;
+  return undefined;
+}
+
+function restoreEnvMemoryMib(opts: RestoreOptions): number | undefined {
+  const envMemory = restoreEnvMemory(opts);
+  if (envMemory === undefined) {
+    return undefined;
+  }
+  return Number(envMemory);
+}
+
+function restoreEnvMemory(opts: RestoreOptions): string | undefined {
+  const fromOpts = opts.vmmEnv?.MACHINEN_MEMORY;
+  if (fromOpts !== undefined) {
+    return fromOpts;
+  }
+  return process.env.MACHINEN_MEMORY;
+}
+
+function requestedRestoreMemory(
+  opts: RestoreOptions,
+  envMib: number | undefined,
+): number | undefined {
+  if (opts.memory !== undefined) {
+    return opts.memory;
+  }
+  return envMib;
+}
+
+function validateVmstateMemoryCeiling(expected: number, requested: number | undefined): void {
+  if (requested === undefined) {
+    return;
+  }
+  if (requested === expected) {
+    return;
+  }
+  throw new BootError(
+    "BOOT_VMSTATE_UNSUPPORTED",
+    `restore: vmstate guest RAM layout mismatch.\n` +
+      `  snapshot ceiling: ${expected} MiB\n` +
+      `  restore ceiling:  ${requested} MiB\n` +
+      "  This is the VM's address layout, not current host memory use.\n" +
+      "  Whole-VM restore requires the same RAM topology.",
+  );
+}
+
+function shouldApplySnapshotMemoryCeiling(
+  opts: RestoreOptions,
+  envMib: number | undefined,
+): boolean {
+  if (opts.memory !== undefined) {
+    return false;
+  }
+  if (envMib !== undefined) {
+    return false;
+  }
+  return true;
 }
 
 function resolveVmstateRootDisk(
@@ -572,17 +681,7 @@ function resolveVmstateRootDisk(
 ): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
   const recorded = vmstate.rootDisk;
   if (!recorded) {
-    if (opts.rootDisk !== undefined) {
-      return { rootDisk: opts.rootDisk };
-    }
-    throw new BootError(
-      "BOOT_VMSTATE_UNSUPPORTED",
-      "restore: vmstate bundle has no rootdisk invariant.\n" +
-        "  A whole-VM snapshot resumes with file-backed VMAs and block-device\n" +
-        "  queues that depend on the exact /dev/vda bytes. Recreate the\n" +
-        "  snapshot so the bundle includes rootdisk.img, or pass an explicit\n" +
-        "  restore({ rootDisk: <exact-image> }) to opt into caller-managed bytes.",
-    );
+    return resolveMissingVmstateRootDisk(opts);
   }
   if (recorded.mode === "delta") {
     throw new BootError(
@@ -591,15 +690,49 @@ function resolveVmstateRootDisk(
     );
   }
   if (recorded.mode === "none") {
-    if (typeof opts.rootDisk === "string") {
-      throw new BootError(
-        "BOOT_VMSTATE_UNSUPPORTED",
-        "restore: snapshot was taken without a root block device, but restore passed rootDisk.",
-      );
-    }
-    return { rootDisk: false };
+    return resolveNoneVmstateRootDisk(opts);
   }
+  return resolveFileVmstateRootDisk(opts, snapDir, recorded);
+}
 
+function resolveMissingVmstateRootDisk(
+  opts: RestoreOptions,
+): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
+  if (opts.rootDisk !== undefined) {
+    return { rootDisk: opts.rootDisk };
+  }
+  throw new BootError(
+    "BOOT_VMSTATE_UNSUPPORTED",
+    "restore: vmstate bundle has no rootdisk invariant.\n" +
+      "  A whole-VM snapshot resumes with file-backed VMAs and block-device\n" +
+      "  queues that depend on the exact /dev/vda bytes. Recreate the\n" +
+      "  snapshot so the bundle includes rootdisk.img, or pass an explicit\n" +
+      "  restore({ rootDisk: <exact-image> }) to opt into caller-managed bytes.",
+  );
+}
+
+function resolveNoneVmstateRootDisk(
+  opts: RestoreOptions,
+): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
+  if (typeof opts.rootDisk === "string") {
+    throw new BootError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "restore: snapshot was taken without a root block device, but restore passed rootDisk.",
+    );
+  }
+  return { rootDisk: false };
+}
+
+type VmstateRootDiskBlock = Extract<
+  NonNullable<VmstateSnapshotMeta["rootDisk"]>,
+  { mode: "block" }
+>;
+
+function resolveFileVmstateRootDisk(
+  opts: RestoreOptions,
+  snapDir: string,
+  recorded: VmstateRootDiskBlock,
+): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
   if (opts.rootDisk === false) {
     throw new BootError(
       "BOOT_VMSTATE_UNSUPPORTED",
@@ -695,77 +828,93 @@ function shellQuote(s: string): string {
  * rematerializing a tarball into a fresh ext4 image is not safe.
  */
 async function restoreVmstate(opts: RestoreOptions, snapDir: string): Promise<VmHandle> {
-  let statePath = join(snapDir, VMSTATE_FILE);
-  let effectiveSnapDir = snapDir;
-  let materializedTempDir: string | undefined;
-  const metaPath = join(snapDir, "meta.json");
-
-  let meta: SnapshotMeta = { snappedAt: 0 };
-  if (existsSync(metaPath)) {
-    try {
-      meta = JSON.parse(readFileSync(metaPath, "utf8")) as SnapshotMeta;
-    } catch {
-      // Corrupt / partial meta.json — fall through with an anonymous
-      // source name. The restore still boots; it just won't get a
-      // memorable auto-name.
-    }
-  }
-
+  let prepared = initialVmstateRestoreBundle(snapDir);
   let vm: VmHandle;
   try {
-    if (meta.vmstate?.checkpoint?.parent) {
-      const materialized = materializeVmstateChain(snapDir, meta);
-      materializedTempDir = materialized.tempDir;
-      effectiveSnapDir = materialized.snapDir;
-      statePath = materialized.statePath;
-      meta = materialized.meta;
-    }
-
-    const resolvedImage = resolveRestoreImage(opts, meta);
-    const vmstatePlan = planVmstateRestore(opts, meta, effectiveSnapDir, statePath);
-    const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
-
-    // Re-attach a `--mount` overlay recorded in the bundle (same shape
-    // and per-fork reflink semantics as the CRIU path).
-    let restoreMountDisk: BootOptions["_restoreMountDisk"];
-    if (meta.mountDisk) {
-      const lowerAbs = join(snapDir, meta.mountDisk.lower);
-      const upperAbs = join(snapDir, meta.mountDisk.upper);
-      if (!existsSync(lowerAbs) || !existsSync(upperAbs)) {
-        throw new BootError(
-          "BOOT_SNAPSHOT_NOT_FOUND",
-          `restore: bundle's mount overlay is missing one of:\n  ${lowerAbs}\n  ${upperAbs}`,
-        );
-      }
-      restoreMountDisk = { guest: meta.mountDisk.guest, lowerPath: lowerAbs, upperPath: upperAbs };
-    }
-
-    debugRestore("vmstate restore snapDir=%s state=%s image=%s", snapDir, statePath, resolvedImage);
-
-    vm = await boot({
-      ...opts,
-      image: resolvedImage,
-      forkedFrom: snapDir,
-      name: opts.name,
-      liveMounts: effectiveLiveMounts,
-      memory: vmstatePlan.memoryCeiling ?? opts.memory,
-      rootDisk: vmstatePlan.rootDisk ?? opts.rootDisk,
-      _restoreMountDisk: restoreMountDisk,
-      _vmstateRestorePath: statePath,
-      _rootDiskRestorePath: vmstatePlan.rootDiskRestorePath,
-    });
+    prepared = materializeVmstateRestoreChainIfNeeded(snapDir, prepared);
+    vm = await bootVmstateRestore(opts, snapDir, prepared);
     await reseedVmstateGuestEntropy(vm);
   } finally {
-    if (materializedTempDir) {
-      try {
-        rmSync(materializedTempDir, { recursive: true, force: true });
-      } catch {}
-    }
+    cleanupMaterializedVmstate(prepared.materializedTempDir);
   }
 
-  autoNameRestoredFork(vm, opts, meta);
-  // The restored guest's kernel hostname is whatever the source had;
-  // re-stamp it with this VM's identity. Fire-and-forget over vsock.
-  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).catch(() => {});
+  autoNameRestoredFork(vm, opts, prepared.meta);
+  restampRestoredHostname(vm);
   return vm;
+}
+
+interface PreparedVmstateRestoreBundle {
+  statePath: string;
+  effectiveSnapDir: string;
+  materializedTempDir: string | undefined;
+  meta: SnapshotMeta;
+}
+
+function initialVmstateRestoreBundle(snapDir: string): PreparedVmstateRestoreBundle {
+  return {
+    statePath: join(snapDir, VMSTATE_FILE),
+    effectiveSnapDir: snapDir,
+    materializedTempDir: undefined,
+    meta: readSnapshotMeta(join(snapDir, "meta.json")),
+  };
+}
+
+function materializeVmstateRestoreChainIfNeeded(
+  snapDir: string,
+  prepared: PreparedVmstateRestoreBundle,
+): PreparedVmstateRestoreBundle {
+  if (!prepared.meta.vmstate?.checkpoint?.parent) {
+    return prepared;
+  }
+  const materialized = materializeVmstateChain(snapDir, prepared.meta);
+  return {
+    statePath: materialized.statePath,
+    effectiveSnapDir: materialized.snapDir,
+    materializedTempDir: materialized.tempDir,
+    meta: materialized.meta,
+  };
+}
+
+async function bootVmstateRestore(
+  opts: RestoreOptions,
+  snapDir: string,
+  prepared: PreparedVmstateRestoreBundle,
+): Promise<VmHandle> {
+  const resolvedImage = resolveRestoreImage(opts, prepared.meta);
+  const vmstatePlan = planVmstateRestore(
+    opts,
+    prepared.meta,
+    prepared.effectiveSnapDir,
+    prepared.statePath,
+  );
+  debugRestore(
+    "vmstate restore snapDir=%s state=%s image=%s",
+    snapDir,
+    prepared.statePath,
+    resolvedImage,
+  );
+  return boot({
+    ...opts,
+    image: resolvedImage,
+    forkedFrom: snapDir,
+    name: opts.name,
+    liveMounts: resolveRestoreLiveMounts(prepared.meta.liveMounts, opts.liveMounts),
+    memory: vmstatePlan.memoryCeiling ?? opts.memory,
+    rootDisk: vmstatePlan.rootDisk ?? opts.rootDisk,
+    _restoreMountDisk: resolveRestoreMountDisk(snapDir, prepared.meta),
+    _vmstateRestorePath: prepared.statePath,
+    _rootDiskRestorePath: vmstatePlan.rootDiskRestorePath,
+  });
+}
+
+function cleanupMaterializedVmstate(materializedTempDir: string | undefined): void {
+  if (materializedTempDir) {
+    try {
+      rmSync(materializedTempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+function restampRestoredHostname(vm: VmHandle): void {
+  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).catch(() => {});
 }

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -410,58 +410,111 @@ async function runDumpAndExtractTar(
 // failure mode, leaving the happy path to fall through. `imgEntries`
 // is read once by the parent so the same listing can be reused for
 // the post-success log line.
+interface DumpValidationContext {
+  res: DumpExtractResult;
+  imgEntries: string[];
+  dumpHint: string;
+  tail: string;
+  deadlineMs: number;
+}
+
 function validateDumpResult(
   res: DumpExtractResult,
   imgEntries: string[],
   consoleLog: string,
   deadlineMs: number,
 ): void {
-  const dumpHint = formatDumpOutcomeHint(res.dumpOutcome);
-  const tail = consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : "";
+  const ctx = createDumpValidationContext(res, imgEntries, consoleLog, deadlineMs);
+  assertDumpNotTimedOut(ctx);
+  assertDumpOutcomePresent(ctx);
+  assertDumpSucceeded(ctx);
+  assertTarExtracted(ctx);
+  assertBundleHasCoreImage(ctx);
+}
 
-  if (res.timedOut) {
-    // Source VM is still up (--leave-running). Don't kill it — caller
-    // can retry or kill manually. We just report the failure.
-    throw new SnapshotError(
-      "SNAPSHOT_TIMEOUT",
-      `vm.snapshot: dump exec did not return within ${deadlineMs}ms — dump likely failed.` +
-        dumpHint +
-        tail,
-    );
+function createDumpValidationContext(
+  res: DumpExtractResult,
+  imgEntries: string[],
+  consoleLog: string,
+  deadlineMs: number,
+): DumpValidationContext {
+  return {
+    res,
+    imgEntries,
+    deadlineMs,
+    dumpHint: formatDumpOutcomeHint(res.dumpOutcome),
+    tail: consoleLog ? `\nConsole tail:\n${consoleLog.slice(-2000)}` : "",
+  };
+}
+
+function assertDumpNotTimedOut(ctx: DumpValidationContext): void {
+  if (!ctx.res.timedOut) {
+    return;
   }
-  if (!res.dumpOutcome) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      "vm.snapshot: dump exec produced no outcome — dispatch raced the timeout.",
-    );
+  // Source VM is still up (--leave-running). Don't kill it — caller
+  // can retry or kill manually. We just report the failure.
+  throw new SnapshotError(
+    "SNAPSHOT_TIMEOUT",
+    `vm.snapshot: dump exec did not return within ${ctx.deadlineMs}ms — dump likely failed.` +
+      ctx.dumpHint +
+      ctx.tail,
+  );
+}
+
+function assertDumpOutcomePresent(ctx: DumpValidationContext): void {
+  if (ctx.res.dumpOutcome) {
+    return;
   }
-  if (res.dumpOutcome.kind === "rejected" || res.dumpOutcome.exitCode !== 0) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      "vm.snapshot: dump exec failed." + dumpHint + tail,
-    );
+  throw new SnapshotError(
+    "SNAPSHOT_DUMP_FAILED",
+    "vm.snapshot: dump exec produced no outcome — dispatch raced the timeout.",
+  );
+}
+
+function assertDumpSucceeded(ctx: DumpValidationContext): void {
+  if (ctx.res.dumpOutcome?.kind !== "rejected" && ctx.res.dumpOutcome?.exitCode === 0) {
+    return;
   }
-  if (res.tarSpawnError || res.tarResult.code !== 0) {
-    const tarErr = res.tarSpawnError
-      ? `\nHost tar spawn failed: ${res.tarSpawnError.message}`
-      : `\nHost tar exited code=${res.tarResult.code} signal=${res.tarResult.signal}.${
-          res.tarStderr ? ` stderr:\n${res.tarStderr.slice(-1000)}` : ""
-        }`;
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      "vm.snapshot: failed to extract bundle on the host." + tarErr + tail,
-    );
+  throw new SnapshotError(
+    "SNAPSHOT_DUMP_FAILED",
+    "vm.snapshot: dump exec failed." + ctx.dumpHint + ctx.tail,
+  );
+}
+
+function assertTarExtracted(ctx: DumpValidationContext): void {
+  if (!ctx.res.tarSpawnError && ctx.res.tarResult.code === 0) {
+    return;
   }
+  throw new SnapshotError(
+    "SNAPSHOT_DUMP_FAILED",
+    "vm.snapshot: failed to extract bundle on the host." + formatTarError(ctx.res) + ctx.tail,
+  );
+}
+
+function formatTarError(res: DumpExtractResult): string {
+  return res.tarSpawnError
+    ? `\nHost tar spawn failed: ${res.tarSpawnError.message}`
+    : `\nHost tar exited code=${res.tarResult.code} signal=${res.tarResult.signal}.${tarStderrSuffix(res)}`;
+}
+
+function tarStderrSuffix(res: DumpExtractResult): string {
+  return res.tarStderr ? ` stderr:\n${res.tarStderr.slice(-1000)}` : "";
+}
+
+function assertBundleHasCoreImage(ctx: DumpValidationContext): void {
   // Sanity-check the materialized bundle: we expect at least one
   // core-*.img (CRIU produces one per task). An empty img/ means the
   // dump script ran but didn't actually dump anything (e.g. caller
   // pointed dumpCmd at /usr/bin/true).
-  if (!imgEntries.some((name) => /^core-\d+\.img$/.test(name))) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      `vm.snapshot: bundle has no core-*.img — the dump script likely never ran.` + dumpHint + tail,
-    );
+  if (ctx.imgEntries.some((name) => /^core-\d+\.img$/.test(name))) {
+    return;
   }
+  throw new SnapshotError(
+    "SNAPSHOT_DUMP_FAILED",
+    `vm.snapshot: bundle has no core-*.img — the dump script likely never ran.` +
+      ctx.dumpHint +
+      ctx.tail,
+  );
 }
 
 // #272: reflink the `--mount` overlay's lower + upper into the
@@ -635,12 +688,15 @@ async function performSnapshotVmstate(
 ): Promise<SnapshotResult> {
   const t0 = Date.now();
   const deadlineMs = opts.timeoutMs ?? 90_000;
-  // Vmstate snapshots are now incremental checkpoints. A checkpoint is
-  // non-destructive by definition: the source VM resumes after the VMM
-  // captures the paused state, and future checkpoints in the same VM
-  // chain delta against this bundle.
-  const leaveRunning = true;
+  assertVmstateSnapshotEnabled(ctx);
+  const snapDir = prepareBundleRootDir(opts.outDir);
+  logVmstateSnapshotStart(ctx, snapDir);
+  clearVmstateStateFile(ctx.vmstatePath!);
+  await syncGuestForVmstateSnapshot(ctx, deadlineMs);
+  return captureVmstateSnapshotBundle(ctx, snapDir, deadlineMs, t0);
+}
 
+function assertVmstateSnapshotEnabled(ctx: SnapshotContext): void {
   if (!ctx.vmstatePath) {
     throw new SnapshotError(
       "SNAPSHOT_NO_DISK",
@@ -649,119 +705,133 @@ async function performSnapshotVmstate(
         "  VMM installs the SIGUSR1 whole-VM dump handler.",
     );
   }
-  const snapDir = prepareBundleRootDir(opts.outDir);
+}
+
+function logVmstateSnapshotStart(ctx: SnapshotContext, snapDir: string): void {
   debugVmstate(
     "vmstate snapshot start pid=%d snapDir=%s vmstatePath=%s leaveRunning=%s",
     ctx.pid,
     snapDir,
     ctx.vmstatePath,
-    leaveRunning,
+    true,
   );
+}
 
-  // The VMM writes its state file atomically (tmp + rename). Clear any
-  // stale file first so "the file exists again" is an unambiguous
-  // done signal.
+function clearVmstateStateFile(vmstatePath: string): void {
   try {
-    unlinkSync(ctx.vmstatePath);
+    unlinkSync(vmstatePath);
   } catch {
     // ENOENT — nothing to clear, which is the common case.
   }
+}
 
-  // Best-effort guest sync so a `--mount` overlay reflinked below
-  // reflects the guest's recent writes (mirrors the CRIU path). Drop
-  // clean page cache before incremental vmstate capture: virtio-blk
-  // DMA fills cache pages without tripping the CPU-write dirty tracker,
-  // so keeping those clean pages in RAM can make a later RAM delta
-  // restore stale cache over an otherwise-correct rootdisk delta.
+async function syncGuestForVmstateSnapshot(
+  ctx: SnapshotContext,
+  deadlineMs: number,
+): Promise<void> {
   try {
-    await ctx.execRaw(
-      "sync; sync /mnt 2>/dev/null; " +
-        "if [ -w /proc/sys/vm/drop_caches ]; then echo 3 > /proc/sys/vm/drop_caches; fi; true",
-      {
-        connectTimeoutMs: Math.min(deadlineMs, 5_000),
-        execTimeoutMs: 10_000,
-      },
-    );
+    await ctx.execRaw(VMSTATE_PRE_SNAPSHOT_SYNC, {
+      connectTimeoutMs: Math.min(deadlineMs, 5_000),
+      execTimeoutMs: 10_000,
+    });
   } catch (err) {
     debugVmstate(
       "pre-snapshot sync failed (continuing): %s",
       err instanceof Error ? err.message : String(err),
     );
   }
+}
 
-  // Trigger the dump. SIGUSR1 → the VMM captures whole-VM state,
-  // queues ctx.vmstatePath from a background writer, and then waits
-  // paused until this runtime sends SIGUSR2. Keeping the vCPU stopped
-  // while we copy sidecars makes the rootdisk and mount overlay match
-  // the captured CPU/RAM point even though vmstate checkpoints are
-  // non-destructive.
+const VMSTATE_PRE_SNAPSHOT_SYNC =
+  "sync; sync /mnt 2>/dev/null; " +
+  "if [ -w /proc/sys/vm/drop_caches ]; then echo 3 > /proc/sys/vm/drop_caches; fi; true";
+
+async function captureVmstateSnapshotBundle(
+  ctx: SnapshotContext,
+  snapDir: string,
+  deadlineMs: number,
+  t0: number,
+): Promise<SnapshotResult> {
+  return withPausedVmstateSource(ctx, async () => {
+    await waitForVmstateFile(ctx.vmstatePath!, deadlineMs);
+    const bundleStatePath = copyVmstateStateIntoBundle(ctx.vmstatePath!, snapDir);
+    const nextSequence = (ctx.vmstateChain?.sequence ?? 0) + 1;
+    const vmstateMeta = buildVmstateMeta(
+      ctx,
+      bundleStatePath,
+      snapDir,
+      ctx.vmstateChain?.parentDir,
+      nextSequence,
+    );
+    const mountDiskMeta = await reflinkMountOverlay(ctx, snapDir, deadlineMs);
+    writeSnapshotMeta(ctx, snapDir, mountDiskMeta, "vmstate", vmstateMeta);
+    ctx.updateVmstateChain?.({ parentDir: snapDir, sequence: nextSequence });
+    return vmstateSnapshotResult(snapDir, bundleStatePath, t0);
+  });
+}
+
+async function withPausedVmstateSource<T>(
+  ctx: SnapshotContext,
+  body: () => Promise<T>,
+): Promise<T> {
   let signaled = false;
   try {
-    try {
-      process.kill(ctx.pid, "SIGUSR1");
-      signaled = true;
-    } catch (err) {
-      throw new SnapshotError(
-        "SNAPSHOT_DUMP_FAILED",
-        `vm.snapshot: failed to signal the VMM (pid ${ctx.pid}): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-        { cause: err },
-      );
-    }
-
-    await waitForVmstateFile(ctx.vmstatePath, deadlineMs);
-
-    // Copy the state file into the bundle — an independent copy so the
-    // source VM can be snapshotted again (overwriting ctx.vmstatePath)
-    // without disturbing this bundle.
-    const bundleStatePath = join(snapDir, VMSTATE_FILE);
-    try {
-      copyFileSync(ctx.vmstatePath, bundleStatePath);
-    } catch (err) {
-      throw new SnapshotError(
-        "SNAPSHOT_DUMP_FAILED",
-        `vm.snapshot: failed to copy the .vmstate into the bundle: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-        { cause: err },
-      );
-    }
-
-    const parentDir = ctx.vmstateChain?.parentDir;
-    const nextSequence = (ctx.vmstateChain?.sequence ?? 0) + 1;
-    const vmstateMeta = buildVmstateMeta(ctx, bundleStatePath, snapDir, parentDir, nextSequence);
-
-    // Reflink a `--mount` overlay into the bundle, same as the CRIU path.
-    const mountDiskMeta = await reflinkMountOverlay(ctx, snapDir, deadlineMs);
-
-    writeSnapshotMeta(ctx, snapDir, mountDiskMeta, "vmstate", vmstateMeta);
-
-    ctx.updateVmstateChain?.({ parentDir: snapDir, sequence: nextSequence });
-
-    const elapsedMs = Date.now() - t0;
-    const stateBytes = statSync(bundleStatePath).size;
-    debugVmstate(
-      "vmstate snapshot done snapDir=%s stateBytes=%d elapsedMs=%d",
-      snapDir,
-      stateBytes,
-      elapsedMs,
-    );
-    return {
-      engine: "vmstate",
-      snapDir,
-      vmstatePath: bundleStatePath,
-      elapsedMs,
-      // Vmstate checkpoints are non-destructive, so a boot-owned VMM's
-      // stderr stream stays open. Do not await ctx.errorOutput() here;
-      // attach-owned snapshots couldn't see it anyway.
-      consoleLog: "",
-    };
+    signalVmstateSnapshot(ctx.pid);
+    signaled = true;
+    return await body();
   } finally {
     if (signaled) {
       resumeVmstateSource(ctx.pid);
     }
   }
+}
+
+function signalVmstateSnapshot(pid: number): void {
+  try {
+    process.kill(pid, "SIGUSR1");
+  } catch (err) {
+    throw new SnapshotError(
+      "SNAPSHOT_DUMP_FAILED",
+      `vm.snapshot: failed to signal the VMM (pid ${pid}): ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+function copyVmstateStateIntoBundle(vmstatePath: string, snapDir: string): string {
+  const bundleStatePath = join(snapDir, VMSTATE_FILE);
+  try {
+    copyFileSync(vmstatePath, bundleStatePath);
+    return bundleStatePath;
+  } catch (err) {
+    throw new SnapshotError(
+      "SNAPSHOT_DUMP_FAILED",
+      `vm.snapshot: failed to copy the .vmstate into the bundle: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+}
+
+function vmstateSnapshotResult(
+  snapDir: string,
+  bundleStatePath: string,
+  t0: number,
+): SnapshotResult {
+  const elapsedMs = Date.now() - t0;
+  const stateBytes = statSync(bundleStatePath).size;
+  debugVmstate(
+    "vmstate snapshot done snapDir=%s stateBytes=%d elapsedMs=%d",
+    snapDir,
+    stateBytes,
+    elapsedMs,
+  );
+  return {
+    engine: "vmstate",
+    snapDir,
+    vmstatePath: bundleStatePath,
+    elapsedMs,
+    consoleLog: "",
+  };
 }
 
 function resumeVmstateSource(pid: number): void {
@@ -776,6 +846,13 @@ function resumeVmstateSource(pid: number): void {
   }
 }
 
+interface VmstateSectionFlags {
+  hasRamDelta: boolean;
+  hasRootdiskDelta: boolean;
+}
+
+type VmstateFactsForSnapshot = ReturnType<typeof readVmstateFacts>;
+
 function buildVmstateMeta(
   ctx: SnapshotContext,
   statePath: string,
@@ -784,30 +861,80 @@ function buildVmstateMeta(
   sequence: number,
 ): VmstateSnapshotMeta {
   const facts = readVmstateFacts(statePath);
-  const tags = vmstateSectionTags(statePath);
-  const hasRamDelta = tags.includes(VMSTATE_SECTION.ramDelta);
-  const hasRootdiskDelta = tags.includes(VMSTATE_SECTION.rootdiskDelta);
-  const rootDisk = copyVmstateRootDisk(ctx, snapDir, parentDir !== undefined && hasRootdiskDelta);
+  const flags = readVmstateSectionFlags(statePath);
   return {
     sourceBackend: currentVmstateBackend(),
-    guestArch: facts.arch ?? currentVmstateGuestArch(),
+    guestArch: vmstateGuestArch(facts),
     topologyHash: facts.topologyHash,
     memoryCeilingMib: ctx.memoryCeilingMib,
-    guestPauth: {
-      active: facts.guestPauthActive,
-      sctlrEl1: facts.sctlrEl1,
-    },
-    rootDisk,
-    kernel: ctx.kernelPath ? fileIdentity(ctx.kernelPath) : undefined,
-    dtb: ctx.dtbPath ? fileIdentity(ctx.dtbPath) : undefined,
-    checkpoint: {
-      chainId: ctx.vmstateChain?.chainId ?? `pid-${ctx.pid}`,
-      sequence,
-      parent: relativeCheckpointParent(snapDir, parentDir),
-      ram: hasRamDelta ? "delta" : "full",
-      rootDisk: ctx.rootDiskMode === "none" ? "none" : hasRootdiskDelta ? "delta" : "full",
-    },
+    guestPauth: vmstateGuestPauth(facts),
+    rootDisk: copyVmstateRootDisk(ctx, snapDir, shouldCopyRootdiskDeltaOnly(parentDir, flags)),
+    kernel: optionalFileIdentity(ctx.kernelPath),
+    dtb: optionalFileIdentity(ctx.dtbPath),
+    checkpoint: buildVmstateCheckpoint(ctx, snapDir, parentDir, sequence, flags),
   };
+}
+
+function readVmstateSectionFlags(statePath: string): VmstateSectionFlags {
+  const tags = vmstateSectionTags(statePath);
+  return {
+    hasRamDelta: tags.includes(VMSTATE_SECTION.ramDelta),
+    hasRootdiskDelta: tags.includes(VMSTATE_SECTION.rootdiskDelta),
+  };
+}
+
+function vmstateGuestArch(facts: VmstateFactsForSnapshot): VmstateSnapshotMeta["guestArch"] {
+  return facts.arch ?? currentVmstateGuestArch();
+}
+
+function vmstateGuestPauth(facts: VmstateFactsForSnapshot): VmstateSnapshotMeta["guestPauth"] {
+  return {
+    active: facts.guestPauthActive,
+    sctlrEl1: facts.sctlrEl1,
+  };
+}
+
+function optionalFileIdentity(
+  path: string | undefined,
+): ReturnType<typeof fileIdentity> | undefined {
+  return path ? fileIdentity(path) : undefined;
+}
+
+function shouldCopyRootdiskDeltaOnly(
+  parentDir: string | undefined,
+  flags: VmstateSectionFlags,
+): boolean {
+  return parentDir !== undefined && flags.hasRootdiskDelta;
+}
+
+function buildVmstateCheckpoint(
+  ctx: SnapshotContext,
+  snapDir: string,
+  parentDir: string | undefined,
+  sequence: number,
+  flags: VmstateSectionFlags,
+): VmstateSnapshotMeta["checkpoint"] {
+  return {
+    chainId: vmstateChainId(ctx),
+    sequence,
+    parent: relativeCheckpointParent(snapDir, parentDir),
+    ram: flags.hasRamDelta ? "delta" : "full",
+    rootDisk: checkpointRootDiskMode(ctx, flags),
+  };
+}
+
+function vmstateChainId(ctx: SnapshotContext): string {
+  return ctx.vmstateChain?.chainId ?? `pid-${ctx.pid}`;
+}
+
+function checkpointRootDiskMode(
+  ctx: SnapshotContext,
+  flags: VmstateSectionFlags,
+): VmstateSnapshotMeta["checkpoint"]["rootDisk"] {
+  if (ctx.rootDiskMode === "none") {
+    return "none";
+  }
+  return flags.hasRootdiskDelta ? "delta" : "full";
 }
 
 function copyVmstateRootDisk(

--- a/packages/runtime/src/vm/vmstate-chain.ts
+++ b/packages/runtime/src/vm/vmstate-chain.ts
@@ -352,21 +352,56 @@ function findLatestRootdiskBaseIndex(chain: Array<{ meta: SnapshotMeta }>): numb
   return -1;
 }
 
+interface RootdiskDeltaPayload {
+  diskSize: number;
+  body: Buffer;
+}
+
+interface RootdiskDeltaExtent {
+  extentOff: number;
+  len: number;
+  dataOff: number;
+}
+
 function applyRootdiskDelta(fd: number, destPath: string, payload: Buffer): void {
+  const delta = parseRootdiskDeltaPayload(destPath, payload);
+  applyRootdiskDeltaExtents(fd, delta);
+}
+
+function parseRootdiskDeltaPayload(destPath: string, payload: Buffer): RootdiskDeltaPayload {
+  assertRootdiskDeltaHeader(payload);
+  const diskSize = readRootdiskDeltaDiskSize(payload);
+  assertRootdiskDeltaBlockSize(payload.readUInt32LE(8));
+  assertRootdiskDeltaSizeMatches(destPath, diskSize);
+  const body = payload.subarray(ROOTDISK_DELTA_HEADER_SIZE);
+  assertRootdiskDeltaHash(payload, body);
+  return { diskSize, body };
+}
+
+function assertRootdiskDeltaHeader(payload: Buffer): void {
   if (payload.length < ROOTDISK_DELTA_HEADER_SIZE) {
     throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: truncated rootdisk delta header");
   }
+}
+
+function readRootdiskDeltaDiskSize(payload: Buffer): number {
   const diskSize = Number(payload.readBigUInt64LE(0));
-  const blockSize = payload.readUInt32LE(8);
   if (!Number.isSafeInteger(diskSize) || diskSize < 0) {
     throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: invalid rootdisk delta size");
   }
+  return diskSize;
+}
+
+function assertRootdiskDeltaBlockSize(blockSize: number): void {
   if (blockSize !== ROOTDISK_DELTA_BLOCK_SIZE) {
     throw new BootError(
       "BOOT_VMSTATE_UNSUPPORTED",
       `restore: unsupported rootdisk delta block size ${blockSize}`,
     );
   }
+}
+
+function assertRootdiskDeltaSizeMatches(destPath: string, diskSize: number): void {
   const actualSize = statSync(destPath).size;
   if (actualSize !== diskSize) {
     throw new BootError(
@@ -374,34 +409,65 @@ function applyRootdiskDelta(fd: number, destPath: string, payload: Buffer): void
       `restore: rootdisk delta size mismatch (base=${actualSize}, delta=${diskSize})`,
     );
   }
-  const body = payload.subarray(ROOTDISK_DELTA_HEADER_SIZE);
+}
+
+function assertRootdiskDeltaHash(payload: Buffer, body: Buffer): void {
   const expected = payload.subarray(16, 48).toString("hex");
   const actual = createHash("sha256").update(body).digest("hex");
   if (actual !== expected) {
     throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: rootdisk delta hash mismatch");
   }
+}
 
+function applyRootdiskDeltaExtents(fd: number, delta: RootdiskDeltaPayload): void {
   let off = 0;
-  while (off < body.length) {
-    if (body.length - off < 16) {
-      throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: truncated rootdisk delta extent");
-    }
-    const extentOff = Number(body.readBigUInt64LE(off));
-    const len = Number(body.readBigUInt64LE(off + 8));
-    off += 16;
-    if (
-      !Number.isSafeInteger(extentOff) ||
-      !Number.isSafeInteger(len) ||
-      extentOff < 0 ||
-      len < 0 ||
-      len > diskSize - extentOff ||
-      len > body.length - off
-    ) {
-      throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: invalid rootdisk delta extent");
-    }
-    writeAllAt(fd, body.subarray(off, off + len), extentOff);
-    off += len;
+  while (off < delta.body.length) {
+    const extent = readRootdiskDeltaExtent(delta, off);
+    writeAllAt(
+      fd,
+      delta.body.subarray(extent.dataOff, extent.dataOff + extent.len),
+      extent.extentOff,
+    );
+    off = extent.dataOff + extent.len;
   }
+}
+
+function readRootdiskDeltaExtent(delta: RootdiskDeltaPayload, off: number): RootdiskDeltaExtent {
+  assertRootdiskDeltaExtentHeader(delta.body, off);
+  const extentOff = Number(delta.body.readBigUInt64LE(off));
+  const len = Number(delta.body.readBigUInt64LE(off + 8));
+  const dataOff = off + 16;
+  assertRootdiskDeltaExtentValid(delta, { extentOff, len, dataOff });
+  return { extentOff, len, dataOff };
+}
+
+function assertRootdiskDeltaExtentHeader(body: Buffer, off: number): void {
+  if (body.length - off < 16) {
+    throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: truncated rootdisk delta extent");
+  }
+}
+
+function assertRootdiskDeltaExtentValid(
+  delta: RootdiskDeltaPayload,
+  extent: RootdiskDeltaExtent,
+): void {
+  if (!rootdiskDeltaExtentIsValid(delta, extent)) {
+    throw new BootError("BOOT_VMSTATE_UNSUPPORTED", "restore: invalid rootdisk delta extent");
+  }
+}
+
+function rootdiskDeltaExtentIsValid(
+  delta: RootdiskDeltaPayload,
+  extent: RootdiskDeltaExtent,
+): boolean {
+  return (
+    Number.isSafeInteger(extent.extentOff) &&
+    Number.isSafeInteger(extent.len) &&
+    extent.extentOff >= 0 &&
+    extent.len >= 0 &&
+    extent.len <= delta.diskSize - extent.extentOff &&
+    extent.len <= delta.body.length - extent.dataOff
+  );
 }
 
 function writeAllAt(fd: number, bytes: Buffer, position: number): void {

--- a/packages/runtime/src/vm/vmstate-metadata.ts
+++ b/packages/runtime/src/vm/vmstate-metadata.ts
@@ -3,8 +3,7 @@ import { openSync, readFileSync, readSync, statSync, closeSync } from "node:fs";
 import { gunzipSync } from "node:zlib";
 import type { SnapshotFileIdentity as FileIdentity, VmstateBackend } from "../vm-handle.ts";
 
-export type { VmstateBackend } from "../vm-handle.ts";
-export type VmstateGuestArch = "arm64" | "amd64" | "unknown";
+type VmstateGuestArch = "arm64" | "amd64" | "unknown";
 
 export interface VmstateFacts {
   arch: VmstateGuestArch;

--- a/provision.ts
+++ b/provision.ts
@@ -96,27 +96,69 @@ async function bench<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
 }
 
 function renderPhaseBlock(evt: import("@machinen/runtime").PhaseLogEvent): void {
-  const total = evt.totalMs;
-  const names = [...evt.phases.keys()];
-  const labelW = Math.max(22, ...names.map((n) => n.length + (n.includes(".") ? 2 : 0)));
-  console.log(`\nprovision: === runtime phases (${evt.kind}, total ${fmtMs(total)}) ===`);
-  let topSum = 0;
+  const labelW = runtimePhaseLabelWidth(evt, 22);
+  console.log(`\nprovision: === runtime phases (${evt.kind}, total ${fmtMs(evt.totalMs)}) ===`);
+  renderRuntimePhaseRows(evt, labelW);
+  renderRuntimeUnattributedPhase(evt, labelW);
+}
+
+function runtimePhaseLabelWidth(
+  evt: import("@machinen/runtime").PhaseLogEvent,
+  min: number,
+): number {
+  const widths = [...evt.phases.keys()].map(
+    (name) => name.length + runtimeSubPhaseIndent(name).length,
+  );
+  return Math.max(min, ...widths);
+}
+
+function renderRuntimePhaseRows(
+  evt: import("@machinen/runtime").PhaseLogEvent,
+  labelW: number,
+): void {
   for (const [name, ms] of evt.phases) {
-    const isSub = name.includes(".");
-    if (!isSub) {
-      topSum += ms;
-    }
-    const display = isSub ? `  ${name}` : name;
-    const pct = total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
-    console.log(`provision:   ${display.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${pct}%`);
+    logRuntimePhaseRow(runtimePhaseDisplayName(name), ms, evt.totalMs, labelW);
   }
-  const other = Math.max(0, total - topSum);
-  if (other > 0 && total > 0) {
-    const pct = ((other / total) * 100).toFixed(0).padStart(3);
-    console.log(
-      `provision:   ${"(unattributed)".padEnd(labelW)} ${fmtMs(other).padStart(8)}  ${pct}%`,
-    );
+}
+
+function renderRuntimeUnattributedPhase(
+  evt: import("@machinen/runtime").PhaseLogEvent,
+  labelW: number,
+): void {
+  const other = Math.max(0, evt.totalMs - runtimeTopLevelPhaseSum(evt));
+  if (other > 0 && evt.totalMs > 0) {
+    logRuntimePhaseRow("(unattributed)", other, evt.totalMs, labelW);
   }
+}
+
+function runtimeTopLevelPhaseSum(evt: import("@machinen/runtime").PhaseLogEvent): number {
+  let sum = 0;
+  for (const [name, ms] of evt.phases) {
+    sum += isRuntimeSubPhase(name) ? 0 : ms;
+  }
+  return sum;
+}
+
+function logRuntimePhaseRow(label: string, ms: number, total: number, labelW: number): void {
+  console.log(
+    `provision:   ${label.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${runtimePhasePercent(ms, total)}%`,
+  );
+}
+
+function runtimePhaseDisplayName(name: string): string {
+  return `${runtimeSubPhaseIndent(name)}${name}`;
+}
+
+function runtimeSubPhaseIndent(name: string): string {
+  return isRuntimeSubPhase(name) ? "  " : "";
+}
+
+function isRuntimeSubPhase(name: string): boolean {
+  return name.includes(".");
+}
+
+function runtimePhasePercent(ms: number, total: number): string {
+  return total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
 }
 
 const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");
@@ -321,6 +363,20 @@ console.log(`provision: base=${base === OUT ? "./app.tar.gz (incremental)" : bas
 
 // --- run ------------------------------------------------------------------
 
+const PROVISION_LOG_STREAMS = {
+  "exec-stdout": process.stdout,
+  "guest-console": process.stdout,
+  "exec-stderr": process.stderr,
+} as const;
+
+function handleProvisionLog(evt: import("@machinen/runtime").LogEvent): void {
+  if (evt.source === "phase") {
+    runtimePhases.push(evt);
+    return;
+  }
+  PROVISION_LOG_STREAMS[evt.source].write(evt.chunk);
+}
+
 const provisionStart = performance.now();
 const result = await provision({
   base,
@@ -343,15 +399,7 @@ const result = await provision({
     PS1: "(machinen) # ",
   },
 
-  onLog: (evt) => {
-    if (evt.source === "exec-stdout" || evt.source === "guest-console") {
-      process.stdout.write(evt.chunk);
-    } else if (evt.source === "exec-stderr") {
-      process.stderr.write(evt.chunk);
-    } else if (evt.source === "phase") {
-      runtimePhases.push(evt);
-    }
-  },
+  onLog: handleProvisionLog,
 
   timeoutMs: 30 * 60_000,
   install: installSteps,

--- a/scripts/bench-boot.ts
+++ b/scripts/bench-boot.ts
@@ -84,43 +84,129 @@ interface Args {
   warmOnly: boolean;
 }
 
+type BenchOption = "n" | "mode" | "coldOnly" | "warmOnly" | "help";
+
+type BenchOptionHandler = (out: Args, value: string | undefined) => void;
+
+const BENCH_VALUE_OPTIONS = new Map<string, BenchOption>([
+  ["--n", "n"],
+  ["-n", "n"],
+  ["--mode", "mode"],
+]);
+const BENCH_BARE_OPTIONS = new Map<string, BenchOption>([
+  ["--cold-only", "coldOnly"],
+  ["--warm-only", "warmOnly"],
+  ["-h", "help"],
+  ["--help", "help"],
+]);
+const BENCH_OPTION_HANDLERS: Record<BenchOption, BenchOptionHandler> = {
+  n: (out, value) => (out.n = Number.parseInt(value ?? "", 10)),
+  mode: (out, value) => (out.mode = value as Mode),
+  coldOnly: (out) => (out.coldOnly = true),
+  warmOnly: (out) => (out.warmOnly = true),
+  help: () => printUsageAndExit(0),
+};
+
 function parseArgs(): Args {
-  const argv = process.argv.slice(2);
   const out: Args = { n: 5, mode: "boot", coldOnly: false, warmOnly: false };
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
-    if (a === "--n" || a === "-n") {
-      out.n = Number.parseInt(argv[++i] ?? "", 10);
-    } else if (a.startsWith("--n=")) {
-      out.n = Number.parseInt(a.slice(4), 10);
-    } else if (a === "--mode") {
-      out.mode = argv[++i] as Mode;
-    } else if (a.startsWith("--mode=")) {
-      out.mode = a.slice(7) as Mode;
-    } else if (a === "--cold-only") {
-      out.coldOnly = true;
-    } else if (a === "--warm-only") {
-      out.warmOnly = true;
-    } else if (a === "-h" || a === "--help") {
-      printUsageAndExit(0);
-    } else {
-      console.error(`bench-boot: unknown arg ${a}`);
-      printUsageAndExit(2);
-    }
-  }
-  if (!Number.isInteger(out.n) || out.n < 1) {
-    console.error(`bench-boot: --n must be a positive integer (got ${out.n})`);
-    process.exit(2);
-  }
-  if (out.mode !== "boot" && out.mode !== "restore") {
-    console.error(`bench-boot: --mode must be 'boot' or 'restore' (got ${out.mode})`);
-    process.exit(2);
-  }
-  if (out.coldOnly && out.warmOnly) {
-    console.error("bench-boot: --cold-only and --warm-only are mutually exclusive");
-    process.exit(2);
-  }
+  parseBenchOptions(process.argv.slice(2), out);
+  validateBenchArgs(out);
   return out;
+}
+
+function parseBenchOptions(argv: string[], out: Args): void {
+  for (let i = 0; i < argv.length; i++) {
+    const parsed = splitBenchOption(argv[i]!);
+    const valueOption = BENCH_VALUE_OPTIONS.get(parsed.key);
+    if (valueOption) {
+      const { value, nextIndex } = benchOptionValue(argv, i, parsed);
+      BENCH_OPTION_HANDLERS[valueOption](out, value);
+      i = nextIndex;
+      continue;
+    }
+    if (runBareBenchOption(out, parsed)) {
+      continue;
+    }
+    rejectBenchArg(argv[i]!);
+  }
+}
+
+function splitBenchOption(arg: string): { key: string; hasInlineValue: boolean; value?: string } {
+  const eq = arg.indexOf("=");
+  if (eq === -1) {
+    return { key: arg, hasInlineValue: false };
+  }
+  return { key: arg.slice(0, eq), hasInlineValue: true, value: arg.slice(eq + 1) };
+}
+
+function benchOptionValue(
+  argv: string[],
+  index: number,
+  parsed: { hasInlineValue: boolean; value?: string },
+): { value: string | undefined; nextIndex: number } {
+  if (parsed.hasInlineValue) {
+    return { value: parsed.value, nextIndex: index };
+  }
+  return { value: argv[index + 1], nextIndex: index + 1 };
+}
+
+function runBareBenchOption(out: Args, parsed: { key: string; hasInlineValue: boolean }): boolean {
+  if (parsed.hasInlineValue) {
+    return false;
+  }
+  const option = BENCH_BARE_OPTIONS.get(parsed.key);
+  if (!option) {
+    return false;
+  }
+  BENCH_OPTION_HANDLERS[option](out, undefined);
+  return true;
+}
+
+function rejectBenchArg(arg: string): never {
+  console.error(`bench-boot: unknown arg ${arg}`);
+  printUsageAndExit(2);
+}
+
+function validateBenchArgs(out: Args): void {
+  validateBenchN(out.n);
+  validateBenchMode(out.mode);
+  validateBenchTemperatureFlags(out);
+}
+
+function validateBenchN(n: number): void {
+  if (!Number.isInteger(n)) {
+    rejectBenchN(n);
+  }
+  if (n < 1) {
+    rejectBenchN(n);
+  }
+}
+
+function rejectBenchN(n: number): never {
+  console.error(`bench-boot: --n must be a positive integer (got ${n})`);
+  process.exit(2);
+}
+
+function validateBenchMode(mode: Mode): void {
+  if (mode === "boot") {
+    return;
+  }
+  if (mode === "restore") {
+    return;
+  }
+  console.error(`bench-boot: --mode must be 'boot' or 'restore' (got ${mode})`);
+  process.exit(2);
+}
+
+function validateBenchTemperatureFlags(out: Args): void {
+  if (!out.coldOnly) {
+    return;
+  }
+  if (!out.warmOnly) {
+    return;
+  }
+  console.error("bench-boot: --cold-only and --warm-only are mutually exclusive");
+  process.exit(2);
 }
 
 function printUsageAndExit(code: number): never {
@@ -157,37 +243,71 @@ interface PhaseLine {
  * shape mismatches (e.g. partial line caught mid-flush).
  */
 function parsePhaseLine(line: string): PhaseLine | null {
+  const tail = phaseLineTail(line);
+  if (tail === undefined) {
+    return null;
+  }
+  return parsePhaseTokens(tail.split(/\s+/));
+}
+
+function phaseLineTail(line: string): string | undefined {
   const idx = line.indexOf("phases ");
   if (idx < 0) {
-    return null;
+    return undefined;
   }
-  const tail = line.slice(idx + "phases ".length).trim();
-  const tokens = tail.split(/\s+/);
-  let kind = "";
-  let total = -1;
-  const phases = new Map<string, number>();
-  for (const t of tokens) {
-    const eq = t.indexOf("=");
-    if (eq < 0) {
+  return line.slice(idx + "phases ".length).trim();
+}
+
+function parsePhaseTokens(tokens: string[]): PhaseLine | null {
+  const state: PhaseLine = { kind: "", total: -1, phases: new Map<string, number>() };
+  for (const token of tokens) {
+    const pair = splitPhaseToken(token);
+    if (!pair) {
       return null;
     }
-    const k = t.slice(0, eq);
-    const v = t.slice(eq + 1);
-    if (k === "kind") {
-      kind = v;
-    } else if (k === "total") {
-      total = Number.parseInt(v, 10);
-    } else {
-      const n = Number.parseInt(v, 10);
-      if (Number.isFinite(n)) {
-        phases.set(k, n);
-      }
-    }
+    applyPhaseToken(state, pair.key, pair.value);
   }
-  if (!kind || total < 0) {
+  if (!phaseLineComplete(state)) {
     return null;
   }
-  return { kind, total, phases };
+  return state;
+}
+
+function splitPhaseToken(token: string): { key: string; value: string } | undefined {
+  const eq = token.indexOf("=");
+  if (eq < 0) {
+    return undefined;
+  }
+  return { key: token.slice(0, eq), value: token.slice(eq + 1) };
+}
+
+function applyPhaseToken(state: PhaseLine, key: string, value: string): void {
+  if (key === "kind") {
+    state.kind = value;
+    return;
+  }
+  if (key === "total") {
+    state.total = Number.parseInt(value, 10);
+    return;
+  }
+  setNumericPhase(state, key, value);
+}
+
+function setNumericPhase(state: PhaseLine, key: string, value: string): void {
+  const n = Number.parseInt(value, 10);
+  if (Number.isFinite(n)) {
+    state.phases.set(key, n);
+  }
+}
+
+function phaseLineComplete(state: PhaseLine): boolean {
+  if (!state.kind) {
+    return false;
+  }
+  if (state.total < 0) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -281,15 +401,28 @@ async function runOneRestore(snapDir: string, label: string): Promise<PhaseLine[
   } finally {
     (process.stderr as { write: typeof orig }).write = orig;
   }
-  const captured = lines.join("");
+  return bootOrRestorePhaseLines(lines.join(""));
+}
+
+function bootOrRestorePhaseLines(captured: string): PhaseLine[] {
   const found: PhaseLine[] = [];
-  for (const ln of captured.split("\n")) {
-    const parsed = parsePhaseLine(ln);
-    if (parsed && (parsed.kind === "boot" || parsed.kind === "restore")) {
-      found.push(parsed);
-    }
+  for (const line of captured.split("\n")) {
+    appendBootOrRestorePhase(found, parsePhaseLine(line));
   }
   return found;
+}
+
+function appendBootOrRestorePhase(found: PhaseLine[], parsed: PhaseLine | null): void {
+  if (!parsed) {
+    return;
+  }
+  if (parsed.kind === "boot") {
+    found.push(parsed);
+    return;
+  }
+  if (parsed.kind === "restore") {
+    found.push(parsed);
+  }
 }
 
 async function takeSnapshot(): Promise<string> {
@@ -341,10 +474,18 @@ interface Stats {
 function stats(samples: number[]): Stats {
   const sorted = [...samples].sort((a, b) => a - b);
   const n = sorted.length;
-  const med = sorted[Math.floor(n / 2)] ?? 0;
-  const p95 = sorted[Math.min(n - 1, Math.floor(n * 0.95))] ?? 0;
+  const med = sampleAt(sorted, Math.floor(n / 2));
+  const p95 = sampleAt(sorted, Math.min(n - 1, Math.floor(n * 0.95)));
   const sum = sorted.reduce((s, x) => s + x, 0);
-  return { n, min: sorted[0] ?? 0, med, p95, max: sorted[n - 1] ?? 0, sum };
+  return { n, min: sampleAt(sorted, 0), med, p95, max: sampleAt(sorted, n - 1), sum };
+}
+
+function sampleAt(samples: number[], index: number): number {
+  const value = samples[index];
+  if (value === undefined) {
+    return 0;
+  }
+  return value;
 }
 
 function aggregate(label: string, runs: PhaseLine[]): void {
@@ -352,114 +493,202 @@ function aggregate(label: string, runs: PhaseLine[]): void {
     console.log(`\n=== ${label} (no runs) ===`);
     return;
   }
+  printAggregateHeader(label, runs.length);
+  printAggregateRows(phaseKeys(runs), runs);
+}
+
+function phaseKeys(runs: PhaseLine[]): string[] {
   // Union of phase keys, in first-run order so the table reads as a timeline.
   const keys: string[] = ["total"];
   const seen = new Set<string>(["total"]);
-  for (const r of runs) {
-    for (const k of r.phases.keys()) {
-      if (!seen.has(k)) {
-        seen.add(k);
-        keys.push(k);
-      }
+  for (const run of runs) {
+    appendNewPhaseKeys(keys, seen, run);
+  }
+  return keys;
+}
+
+function appendNewPhaseKeys(keys: string[], seen: Set<string>, run: PhaseLine): void {
+  for (const key of run.phases.keys()) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      keys.push(key);
     }
   }
-  console.log(`\n=== ${label} (n=${runs.length}) ===`);
+}
+
+function printAggregateHeader(label: string, count: number): void {
+  console.log(`\n=== ${label} (n=${count}) ===`);
   console.log(`  ${"phase".padEnd(28)}  min   med   p95   max  (ms)`);
-  for (const k of keys) {
-    const samples: number[] = [];
-    for (const r of runs) {
-      const v = k === "total" ? r.total : r.phases.get(k);
-      if (typeof v === "number") {
-        samples.push(v);
-      }
-    }
+}
+
+function printAggregateRows(keys: string[], runs: PhaseLine[]): void {
+  for (const key of keys) {
+    const samples = samplesForPhase(key, runs);
     if (samples.length === 0) {
       continue;
     }
-    const s = stats(samples);
-    console.log(
-      `  ${k.padEnd(28)}  ${String(s.min).padStart(4)}  ${String(s.med).padStart(4)}  ${String(s.p95).padStart(4)}  ${String(s.max).padStart(4)}`,
-    );
+    printAggregateRow(key, stats(samples));
   }
+}
+
+function samplesForPhase(key: string, runs: PhaseLine[]): number[] {
+  const samples: number[] = [];
+  for (const run of runs) {
+    const value = phaseValue(run, key);
+    if (typeof value === "number") {
+      samples.push(value);
+    }
+  }
+  return samples;
+}
+
+function phaseValue(run: PhaseLine, key: string): number | undefined {
+  if (key === "total") {
+    return run.total;
+  }
+  return run.phases.get(key);
+}
+
+function printAggregateRow(key: string, row: Stats): void {
+  console.log(
+    `  ${key.padEnd(28)}  ${String(row.min).padStart(4)}  ${String(row.med).padStart(4)}  ${String(row.p95).padStart(4)}  ${String(row.max).padStart(4)}`,
+  );
 }
 
 async function main(): Promise<void> {
   const args = parseArgs();
   requireAssets();
-
   if (args.mode === "boot") {
-    const cold: PhaseLine[] = [];
-    const warm: PhaseLine[] = [];
-    if (!args.warmOnly) {
-      for (let i = 0; i < args.n; i++) {
-        clearRootfsImgCache();
-        cold.push(await runOneBoot(`cold-${i + 1}`));
-      }
-    }
-    if (!args.coldOnly) {
-      // Warm = cache populated. Run one priming boot first if we just
-      // wiped it (cold pass), then N measured warm runs.
-      if (!args.warmOnly) {
-        // The last cold pass already populated the cache; that's our prime.
-      } else {
-        // Prime explicitly so the first warm run isn't accidentally cold.
-        await runOneBoot("warm-prime");
-      }
-      for (let i = 0; i < args.n; i++) {
-        warm.push(await runOneBoot(`warm-${i + 1}`));
-      }
-    }
-    if (cold.length) {
-      aggregate("BOOT (cold)", cold);
-    }
-    if (warm.length) {
-      aggregate("BOOT (warm)", warm);
-    }
+    await runBootBench(args);
     return;
   }
+  await runRestoreBench(args);
+}
 
-  // Restore mode.
+async function runBootBench(args: Args): Promise<void> {
+  const cold = await collectColdBootRuns(args);
+  const warm = await collectWarmBootRuns(args);
+  aggregateIfAny("BOOT (cold)", cold);
+  aggregateIfAny("BOOT (warm)", warm);
+}
+
+async function collectColdBootRuns(args: Args): Promise<PhaseLine[]> {
+  const cold: PhaseLine[] = [];
+  if (!shouldRunCold(args)) {
+    return cold;
+  }
+  for (let i = 0; i < args.n; i++) {
+    clearRootfsImgCache();
+    cold.push(await runOneBoot(`cold-${i + 1}`));
+  }
+  return cold;
+}
+
+async function collectWarmBootRuns(args: Args): Promise<PhaseLine[]> {
+  const warm: PhaseLine[] = [];
+  if (!shouldRunWarm(args)) {
+    return warm;
+  }
+  await primeWarmBootIfNeeded(args);
+  for (let i = 0; i < args.n; i++) {
+    warm.push(await runOneBoot(`warm-${i + 1}`));
+  }
+  return warm;
+}
+
+async function primeWarmBootIfNeeded(args: Args): Promise<void> {
+  // Warm = cache populated. If the cold pass ran, its last boot is our
+  // prime. In --warm-only mode, prime explicitly so the first measured
+  // warm run isn't accidentally cold.
+  if (!args.warmOnly) {
+    return;
+  }
+  await runOneBoot("warm-prime");
+}
+
+async function runRestoreBench(args: Args): Promise<void> {
   let snapDir: string | undefined;
   try {
-    snapDir = await takeSnapshot();
-    if (!existsSync(join(snapDir, "disk.img"))) {
-      throw new Error(`takeSnapshot did not produce ${snapDir}/disk.img`);
-    }
-    const cold: PhaseLine[] = [];
-    const warm: PhaseLine[] = [];
-    const collect = (out: PhaseLine[], lines: PhaseLine[]) => {
-      const r = lines.find((l) => l.kind === "restore");
-      if (r) {
-        out.push(r);
-      }
-    };
-    if (!args.warmOnly) {
-      for (let i = 0; i < args.n; i++) {
-        clearRootfsImgCache();
-        collect(cold, await runOneRestore(snapDir, `cold-${i + 1}`));
-      }
-    }
-    if (!args.coldOnly) {
-      if (args.warmOnly) {
-        await runOneRestore(snapDir, "warm-prime");
-      }
-      for (let i = 0; i < args.n; i++) {
-        collect(warm, await runOneRestore(snapDir, `warm-${i + 1}`));
-      }
-    }
-    if (cold.length) {
-      aggregate("RESTORE (cold)", cold);
-    }
-    if (warm.length) {
-      aggregate("RESTORE (warm)", warm);
-    }
+    snapDir = await prepareRestoreSnapshot();
+    const cold = await collectColdRestoreRuns(args, snapDir);
+    const warm = await collectWarmRestoreRuns(args, snapDir);
+    aggregateIfAny("RESTORE (cold)", cold);
+    aggregateIfAny("RESTORE (warm)", warm);
   } finally {
-    if (snapDir && existsSync(snapDir)) {
-      try {
-        rmSync(snapDir, { recursive: true, force: true });
-      } catch {}
-    }
+    cleanupSnapshotDir(snapDir);
   }
+}
+
+async function prepareRestoreSnapshot(): Promise<string> {
+  const snapDir = await takeSnapshot();
+  if (!existsSync(join(snapDir, "disk.img"))) {
+    throw new Error(`takeSnapshot did not produce ${snapDir}/disk.img`);
+  }
+  return snapDir;
+}
+
+async function collectColdRestoreRuns(args: Args, snapDir: string): Promise<PhaseLine[]> {
+  const cold: PhaseLine[] = [];
+  if (!shouldRunCold(args)) {
+    return cold;
+  }
+  for (let i = 0; i < args.n; i++) {
+    clearRootfsImgCache();
+    collectRestorePhase(cold, await runOneRestore(snapDir, `cold-${i + 1}`));
+  }
+  return cold;
+}
+
+async function collectWarmRestoreRuns(args: Args, snapDir: string): Promise<PhaseLine[]> {
+  const warm: PhaseLine[] = [];
+  if (!shouldRunWarm(args)) {
+    return warm;
+  }
+  await primeWarmRestoreIfNeeded(args, snapDir);
+  for (let i = 0; i < args.n; i++) {
+    collectRestorePhase(warm, await runOneRestore(snapDir, `warm-${i + 1}`));
+  }
+  return warm;
+}
+
+async function primeWarmRestoreIfNeeded(args: Args, snapDir: string): Promise<void> {
+  if (!args.warmOnly) {
+    return;
+  }
+  await runOneRestore(snapDir, "warm-prime");
+}
+
+function shouldRunCold(args: Args): boolean {
+  return !args.warmOnly;
+}
+
+function shouldRunWarm(args: Args): boolean {
+  return !args.coldOnly;
+}
+
+function collectRestorePhase(out: PhaseLine[], lines: PhaseLine[]): void {
+  const restore = lines.find((line) => line.kind === "restore");
+  if (restore) {
+    out.push(restore);
+  }
+}
+
+function aggregateIfAny(label: string, runs: PhaseLine[]): void {
+  if (runs.length) {
+    aggregate(label, runs);
+  }
+}
+
+function cleanupSnapshotDir(snapDir: string | undefined): void {
+  if (!snapDir) {
+    return;
+  }
+  if (!existsSync(snapDir)) {
+    return;
+  }
+  try {
+    rmSync(snapDir, { recursive: true, force: true });
+  } catch {}
 }
 
 main().then(

--- a/scripts/bench/mount.ts
+++ b/scripts/bench/mount.ts
@@ -59,26 +59,64 @@ interface CliArgs {
   fixtureKey: string;
 }
 
+interface ParseContext {
+  args: CliArgs;
+  index: number;
+}
+
+type BenchArgHandler = (ctx: ParseContext) => void;
+
+const BENCH_ARG_HANDLERS: Record<string, BenchArgHandler> = {
+  "--no-docker": (ctx) => {
+    ctx.args.noDocker = true;
+  },
+  "--fixture": (ctx) => {
+    ctx.args.fixtureKey = takeBenchArgValue(ctx, "--fixture");
+  },
+  "-h": () => printBenchUsageAndExit(),
+  "--help": () => printBenchUsageAndExit(),
+};
+
 function parseArgs(): CliArgs {
-  const out: CliArgs = {
+  const ctx: ParseContext = { args: defaultCliArgs(), index: 2 };
+  for (; ctx.index < process.argv.length; ctx.index++) {
+    applyBenchArg(ctx);
+  }
+  return ctx.args;
+}
+
+function defaultCliArgs(): CliArgs {
+  return {
     noDocker: false,
     fixtureKey: "node-24-linux-arm64",
   };
-  for (let i = 2; i < process.argv.length; i++) {
-    const a = process.argv[i]!;
-    if (a === "--no-docker") {
-      out.noDocker = true;
-    } else if (a === "--fixture") {
-      out.fixtureKey = process.argv[++i] ?? "";
-    } else if (a === "-h" || a === "--help") {
-      console.log("usage: tsx scripts/bench/mount.ts [--no-docker] [--fixture <key>]");
-      process.exit(0);
-    } else {
-      console.error(`bench-mount: unknown arg ${a}`);
-      process.exit(2);
-    }
+}
+
+function applyBenchArg(ctx: ParseContext): void {
+  const arg = process.argv[ctx.index]!;
+  const handler = BENCH_ARG_HANDLERS[arg];
+  if (!handler) {
+    exitBenchArgError(`bench-mount: unknown arg ${arg}`);
   }
-  return out;
+  handler(ctx);
+}
+
+function takeBenchArgValue(ctx: ParseContext, name: string): string {
+  const value = process.argv[++ctx.index];
+  if (!value) {
+    exitBenchArgError(`bench-mount: ${name} requires a value`);
+  }
+  return value;
+}
+
+function printBenchUsageAndExit(): never {
+  console.log("usage: tsx scripts/bench/mount.ts [--no-docker] [--fixture <key>]");
+  process.exit(0);
+}
+
+function exitBenchArgError(message: string): never {
+  console.error(message);
+  process.exit(2);
 }
 
 interface FixtureEntry {
@@ -109,30 +147,53 @@ function loadFixture(key: string): FixtureEntry {
 async function downloadAndVerify(entry: FixtureEntry): Promise<string> {
   mkdirSync(TARBALL_CACHE, { recursive: true });
   const tarballPath = join(TARBALL_CACHE, basename(entry.url));
-  if (existsSync(tarballPath)) {
-    const got = sha256File(tarballPath);
-    if (got === entry.sha256) {
-      return tarballPath;
-    }
-    console.error(
-      `bench-mount: cached tarball has wrong sha256 (got ${got}, want ${entry.sha256}). Re-downloading.`,
-    );
-    rmSync(tarballPath);
+  if (useValidCachedTarball(tarballPath, entry)) {
+    return tarballPath;
   }
+  await downloadTarball(entry, tarballPath);
+  return tarballPath;
+}
+
+function useValidCachedTarball(tarballPath: string, entry: FixtureEntry): boolean {
+  if (!existsSync(tarballPath)) {
+    return false;
+  }
+  const got = sha256File(tarballPath);
+  if (got === entry.sha256) {
+    return true;
+  }
+  console.error(
+    `bench-mount: cached tarball has wrong sha256 (got ${got}, want ${entry.sha256}). Re-downloading.`,
+  );
+  rmSync(tarballPath);
+  return false;
+}
+
+async function downloadTarball(entry: FixtureEntry, tarballPath: string): Promise<void> {
   console.error(`bench-mount: downloading ${entry.url} → ${tarballPath}`);
   const res = await fetch(entry.url);
+  assertDownloadResponse(res);
+  const tmp = `${tarballPath}.tmp.${process.pid}`;
+  await pipeline(Readable.fromWeb(res.body as never), createWriteStream(tmp));
+  verifyDownloadedTarball(tmp, entry);
+  renameSync(tmp, tarballPath);
+}
+
+function assertDownloadResponse(
+  res: Response,
+): asserts res is Response & { body: NonNullable<Response["body"]> } {
   if (!res.ok || !res.body) {
     throw new Error(`download failed: ${res.status} ${res.statusText}`);
   }
-  const tmp = `${tarballPath}.tmp.${process.pid}`;
-  await pipeline(Readable.fromWeb(res.body as never), createWriteStream(tmp));
+}
+
+function verifyDownloadedTarball(tmp: string, entry: FixtureEntry): void {
   const got = sha256File(tmp);
-  if (got !== entry.sha256) {
-    rmSync(tmp);
-    throw new Error(`sha256 mismatch for ${entry.url}: got ${got}, want ${entry.sha256}`);
+  if (got === entry.sha256) {
+    return;
   }
-  renameSync(tmp, tarballPath);
-  return tarballPath;
+  rmSync(tmp);
+  throw new Error(`sha256 mismatch for ${entry.url}: got ${got}, want ${entry.sha256}`);
 }
 
 function sha256File(path: string): string {
@@ -194,49 +255,103 @@ interface RunResult {
   docker: { wallMs: number } | null;
 }
 
+type RuntimeBoot = (typeof import("@machinen/runtime"))["boot"];
+type BenchVmHandle = Awaited<ReturnType<RuntimeBoot>>;
+
+interface BenchVmInputs {
+  kernel: string;
+  dtb: string;
+  image: string;
+}
+
+interface MountBenchWorkload {
+  tarballName: string;
+  tarballBytes: number;
+  tarballHostDir: string;
+  tarCmd: string;
+}
+
 async function runMountBench(tarballPath: string, fixtureKey: string): Promise<RunResult> {
   const { boot } = await import("@machinen/runtime");
+  const inputs = resolveBenchVmInputs();
+  const scratch = createScratchDir();
+  const workload = buildMountBenchWorkload(tarballPath);
+  const runId = createRunId();
+  logRunStart(runId, scratch);
 
-  const kernel = pickFirstExisting([join(ASSETS, "Image-arm64"), join(FALLBACK_BASE, "Image")]);
-  const dtb = pickFirstExisting([join(ASSETS, "virt-arm64.dtb"), join(FALLBACK_BASE, "virt.dtb")]);
-  const image = pickFirstExisting([
-    join(ASSETS, "rootfs-debian-arm64.tar.gz"),
-    join(FALLBACK_BASE, "rootfs.tar.gz"),
-  ]);
-  for (const p of [kernel, dtb, image]) {
-    if (!existsSync(p)) {
-      console.error(
-        `bench-mount: missing fixture ${p}. Run scripts/build-base-assets.sh + pnpm provision.`,
-      );
-      process.exit(2);
-    }
+  const vm = await bootMountBenchVm(boot, inputs, scratch, workload.tarballHostDir);
+  try {
+    const wallMs = await runTarWorkload(vm, workload.tarCmd);
+    return buildRunResult(runId, fixtureKey, workload, wallMs);
+  } finally {
+    await cleanupMountBenchRun(vm, scratch);
   }
+}
 
-  // Per-run host scratch — the guest writes through to this directory
-  // over the live-mount channel. Removed after the bench so repeated
-  // runs don't accumulate.
+function resolveBenchVmInputs(): BenchVmInputs {
+  const inputs = {
+    kernel: pickFirstExisting([join(ASSETS, "Image-arm64"), join(FALLBACK_BASE, "Image")]),
+    dtb: pickFirstExisting([join(ASSETS, "virt-arm64.dtb"), join(FALLBACK_BASE, "virt.dtb")]),
+    image: pickFirstExisting([
+      join(ASSETS, "rootfs-debian-arm64.tar.gz"),
+      join(FALLBACK_BASE, "rootfs.tar.gz"),
+    ]),
+  };
+  ensureBenchFixtures([inputs.kernel, inputs.dtb, inputs.image]);
+  return inputs;
+}
+
+function ensureBenchFixtures(paths: string[]): void {
+  for (const path of paths) {
+    ensureBenchFixture(path);
+  }
+}
+
+function ensureBenchFixture(path: string): void {
+  if (!existsSync(path)) {
+    console.error(
+      `bench-mount: missing fixture ${path}. Run scripts/build-base-assets.sh + pnpm provision.`,
+    );
+    process.exit(2);
+  }
+}
+
+function createScratchDir(): string {
   const scratch = join(tmpdir(), `machinen-bench-mount-${process.pid}-${Date.now()}`);
   mkdirSync(scratch, { recursive: true });
+  return scratch;
+}
 
+function buildMountBenchWorkload(tarballPath: string): MountBenchWorkload {
   const tarballName = basename(tarballPath);
-  const tarballBytes = readFileSync(tarballPath).length;
+  return {
+    tarballName,
+    tarballBytes: readFileSync(tarballPath).length,
+    tarballHostDir: dirname(tarballPath),
+    tarCmd: `cd /mnt/out && tar -xzf /mnt/in/${tarballName}`,
+  };
+}
 
-  // The exec-agent reads the tarball from a path inside the guest. Two
-  // ways to get it there: copy via writeFile (we'd pay the same channel
-  // cost we're benching), or mount the host directory holding the
-  // tarball as a separate read-only live-mount. The latter is cleaner —
-  // the write-side mount is the one being measured.
-  const tarballHostDir = dirname(tarballPath);
+function createRunId(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
 
-  const runId = new Date().toISOString().replace(/[:.]/g, "-");
+function logRunStart(runId: string, scratch: string): void {
   console.error(`bench-mount: runId=${runId}`);
   console.error(`bench-mount: scratch=${scratch}`);
+}
 
+async function bootMountBenchVm(
+  boot: RuntimeBoot,
+  inputs: BenchVmInputs,
+  scratch: string,
+  tarballHostDir: string,
+): Promise<BenchVmHandle> {
   const t0 = Date.now();
   const vm = await boot({
-    image,
-    kernel,
-    dtb,
+    image: inputs.image,
+    kernel: inputs.kernel,
+    dtb: inputs.dtb,
     cmd: ["/bin/sh", "-c", "while :; do sleep 1; done"],
     // `/mnt/out` is the measured write side; `/mnt/in` is a read-only
     // convenience mount carrying the tarball source. Both ride in-VMM
@@ -248,40 +363,47 @@ async function runMountBench(tarballPath: string, fixtureKey: string): Promise<R
     timeoutMs: 120_000,
   });
   console.error(`bench-mount: VM booted (${Date.now() - t0}ms)`);
+  return vm;
+}
 
-  let result: RunResult;
-  try {
-    // Time the actual workload: shell out to tar inside the guest. The
-    // `time` line goes to stderr; we read wall via host hrtime because
-    // it's the user-visible number we promised in the README.
-    const tarCmd = `cd /mnt/out && tar -xzf /mnt/in/${tarballName}`;
-    const ts = Date.now();
-    const tarRes = await vm.execRaw(tarCmd, { execTimeoutMs: 300_000 });
-    const wallMs = Date.now() - ts;
-    if (tarRes.exitCode !== 0) {
-      throw new Error(
-        `tar exited ${tarRes.exitCode}\nstdout: ${tarRes.stdout}\nstderr: ${tarRes.stderr}`,
-      );
-    }
-    console.error(`bench-mount: tar finished in ${wallMs}ms`);
-
-    result = {
-      runId,
-      host: hostInfo(),
-      fixtures: { tarball: fixtureKey, tarballBytes },
-      workload: tarCmd,
-      wallMs,
-      docker: null,
-    };
-  } finally {
-    await vm.kill().catch(() => {});
-    await vm.wait().catch(() => undefined);
-    try {
-      rmSync(scratch, { recursive: true, force: true });
-    } catch {}
+async function runTarWorkload(vm: BenchVmHandle, tarCmd: string): Promise<number> {
+  // Time the actual workload: shell out to tar inside the guest. The
+  // `time` line goes to stderr; we read wall via host hrtime because
+  // it's the user-visible number we promised in the README.
+  const ts = Date.now();
+  const tarRes = await vm.execRaw(tarCmd, { execTimeoutMs: 300_000 });
+  const wallMs = Date.now() - ts;
+  if (tarRes.exitCode !== 0) {
+    throw new Error(
+      `tar exited ${tarRes.exitCode}\nstdout: ${tarRes.stdout}\nstderr: ${tarRes.stderr}`,
+    );
   }
+  console.error(`bench-mount: tar finished in ${wallMs}ms`);
+  return wallMs;
+}
 
-  return result;
+function buildRunResult(
+  runId: string,
+  fixtureKey: string,
+  workload: MountBenchWorkload,
+  wallMs: number,
+): RunResult {
+  return {
+    runId,
+    host: hostInfo(),
+    fixtures: { tarball: fixtureKey, tarballBytes: workload.tarballBytes },
+    workload: workload.tarCmd,
+    wallMs,
+    docker: null,
+  };
+}
+
+async function cleanupMountBenchRun(vm: BenchVmHandle, scratch: string): Promise<void> {
+  await vm.kill().catch(() => {});
+  await vm.wait().catch(() => undefined);
+  try {
+    rmSync(scratch, { recursive: true, force: true });
+  } catch {}
 }
 
 function writeResult(result: RunResult): string {

--- a/scripts/release-base-assets.mjs
+++ b/scripts/release-base-assets.mjs
@@ -67,83 +67,159 @@ Environment mirrors the options for manual use:
   process.exit(exitCode);
 }
 
+const RELEASE_COMMANDS = new Set(["publish", "verify", "checksums"]);
+const RELEASE_VALUE_OPTIONS = new Map([
+  ["--tag", (opts, value) => (opts.tag = value)],
+  ["--repo", (opts, value) => (opts.repo = value)],
+  ["--assets-dir", setAssetsDirOption],
+  ["--base-url", (opts, value) => (opts.baseUrl = value)],
+  ["--asset", (opts, value) => opts.assets.push(value)],
+  ["--tries", (opts, value) => (opts.tries = Number(value))],
+  ["--sleep", (opts, value) => (opts.sleepSeconds = Number(value))],
+]);
+const RELEASE_BARE_OPTIONS = new Map([["--dry-run", (opts) => (opts.dryRun = true)]]);
+
 function parseArgs(argv) {
-  const command = argv.shift();
-  if (!command || command === "-h" || command === "--help") {
-    usage(command ? 0 : 2);
+  const command = argv[0];
+  const helpExitCode = releaseHelpExitCode(command);
+  if (helpExitCode !== undefined) {
+    usage(helpExitCode);
   }
-  if (!["publish", "verify", "checksums"].includes(command)) {
+  if (!RELEASE_COMMANDS.has(command)) {
     usage(2);
   }
 
+  const opts = defaultReleaseOptions(command);
+  parseReleaseOptions(argv.slice(1), opts);
+  finalizeReleaseOptions(opts);
+  return opts;
+}
+
+function releaseHelpExitCode(command) {
+  if (!command) {
+    return 2;
+  }
+  if (command === "-h") {
+    return 0;
+  }
+  if (command === "--help") {
+    return 0;
+  }
+  return undefined;
+}
+
+function defaultReleaseOptions(command) {
   const envAssetsDir = process.env.MACHINEN_RELEASE_ASSETS_DIR;
-  const opts = {
+  return {
     command,
     repo: DEFAULT_REPO,
-    assetsDir: envAssetsDir ?? DEFAULT_ASSETS_DIR,
-    compareLocal: command !== "verify" || Boolean(envAssetsDir),
+    assetsDir: releaseAssetsDir(envAssetsDir),
+    compareLocal: shouldCompareLocalAssets(command, envAssetsDir),
     baseUrl: process.env.MACHINEN_RELEASE_ASSETS_BASE_URL,
     assets: [],
     tries: Number(process.env.MACHINEN_RELEASE_VERIFY_TRIES ?? 6),
     sleepSeconds: Number(process.env.MACHINEN_RELEASE_VERIFY_SLEEP ?? 10),
     dryRun: false,
   };
+}
 
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    const next = () => {
-      const value = argv[++i];
-      if (!value) {
-        usage(2);
-      }
-      return value;
-    };
-    if (arg === "--tag") {
-      opts.tag = next();
-    } else if (arg?.startsWith("--tag=")) {
-      opts.tag = arg.slice("--tag=".length);
-    } else if (arg === "--repo") {
-      opts.repo = next();
-    } else if (arg?.startsWith("--repo=")) {
-      opts.repo = arg.slice("--repo=".length);
-    } else if (arg === "--assets-dir") {
-      opts.assetsDir = next();
-      opts.compareLocal = true;
-    } else if (arg?.startsWith("--assets-dir=")) {
-      opts.assetsDir = arg.slice("--assets-dir=".length);
-      opts.compareLocal = true;
-    } else if (arg === "--base-url") {
-      opts.baseUrl = next();
-    } else if (arg?.startsWith("--base-url=")) {
-      opts.baseUrl = arg.slice("--base-url=".length);
-    } else if (arg === "--asset") {
-      opts.assets.push(next());
-    } else if (arg?.startsWith("--asset=")) {
-      opts.assets.push(arg.slice("--asset=".length));
-    } else if (arg === "--tries") {
-      opts.tries = Number(next());
-    } else if (arg?.startsWith("--tries=")) {
-      opts.tries = Number(arg.slice("--tries=".length));
-    } else if (arg === "--sleep") {
-      opts.sleepSeconds = Number(next());
-    } else if (arg?.startsWith("--sleep=")) {
-      opts.sleepSeconds = Number(arg.slice("--sleep=".length));
-    } else if (arg === "--dry-run") {
-      opts.dryRun = true;
-    } else {
-      usage(2);
+function releaseAssetsDir(envAssetsDir) {
+  if (envAssetsDir) {
+    return envAssetsDir;
+  }
+  return DEFAULT_ASSETS_DIR;
+}
+
+function shouldCompareLocalAssets(command, envAssetsDir) {
+  if (command !== "verify") {
+    return true;
+  }
+  return Boolean(envAssetsDir);
+}
+
+function parseReleaseOptions(args, opts) {
+  for (let i = 0; i < args.length; i++) {
+    const parsed = splitReleaseOption(args[i]);
+    const valueHandler = RELEASE_VALUE_OPTIONS.get(parsed.key);
+    if (valueHandler) {
+      const { value, nextIndex } = releaseOptionValue(args, i, parsed);
+      valueHandler(opts, value);
+      i = nextIndex;
+      continue;
     }
+    if (runBareReleaseOption(opts, parsed)) {
+      continue;
+    }
+    usage(2);
   }
+}
 
+function runBareReleaseOption(opts, parsed) {
+  if (parsed.hasInlineValue) {
+    return false;
+  }
+  const handler = RELEASE_BARE_OPTIONS.get(parsed.key);
+  if (!handler) {
+    return false;
+  }
+  handler(opts);
+  return true;
+}
+
+function splitReleaseOption(arg) {
+  const eq = arg?.indexOf("=") ?? -1;
+  if (eq === -1) {
+    return { key: arg, hasInlineValue: false, value: undefined };
+  }
+  return { key: arg.slice(0, eq), hasInlineValue: true, value: arg.slice(eq + 1) };
+}
+
+function releaseOptionValue(args, index, parsed) {
+  if (parsed.hasInlineValue) {
+    return { value: parsed.value, nextIndex: index };
+  }
+  const value = args[index + 1];
+  if (!value) {
+    usage(2);
+  }
+  return { value, nextIndex: index + 1 };
+}
+
+function setAssetsDirOption(opts, value) {
+  opts.assetsDir = value;
+  opts.compareLocal = true;
+}
+
+function finalizeReleaseOptions(opts) {
   opts.assetsDir = resolve(opts.assetsDir);
-  opts.assets = opts.assets.length > 0 ? opts.assets : [...PAYLOAD_ASSETS];
-  if (!Number.isInteger(opts.tries) || opts.tries < 1) {
-    throw new Error("--tries must be a positive integer");
+  opts.assets = releaseAssetsList(opts.assets);
+  assertPositiveInteger(opts.tries, "--tries must be a positive integer");
+  assertNonNegativeNumber(opts.sleepSeconds, "--sleep must be a non-negative number");
+}
+
+function releaseAssetsList(assets) {
+  if (assets.length > 0) {
+    return assets;
   }
-  if (!Number.isFinite(opts.sleepSeconds) || opts.sleepSeconds < 0) {
-    throw new Error("--sleep must be a non-negative number");
+  return [...PAYLOAD_ASSETS];
+}
+
+function assertPositiveInteger(value, message) {
+  if (!Number.isInteger(value)) {
+    throw new Error(message);
   }
-  return opts;
+  if (value < 1) {
+    throw new Error(message);
+  }
+}
+
+function assertNonNegativeNumber(value, message) {
+  if (!Number.isFinite(value)) {
+    throw new Error(message);
+  }
+  if (value < 0) {
+    throw new Error(message);
+  }
 }
 
 async function defaultTag() {
@@ -254,76 +330,127 @@ async function verifyPublishedOnce({ baseUrl, assets, assetsDir, compareLocal })
   const tmp = await mkdtemp(join(tmpdir(), "machinen-release-assets-"));
   try {
     for (const asset of assets) {
-      console.log(`verify ${asset}`);
-      const sidecarUrl = assetUrl(baseUrl, `${asset}.sha256`);
-      const payloadUrl = assetUrl(baseUrl, asset);
-      const remoteExpected = parseSidecar(await fetchText(sidecarUrl), sidecarUrl);
-
-      let expected = remoteExpected;
-      if (compareLocal) {
-        const localSidecar = join(assetsDir, `${asset}.sha256`);
-        const localExpected = parseSidecar(await readFile(localSidecar, "utf8"), localSidecar);
-        const localGot = await localPayloadSha(assetsDir, asset);
-        if (localGot !== localExpected) {
-          throw new Error(
-            `local checksum sidecar mismatch for ${asset}: expected ${localExpected}, got ${localGot}`,
-          );
-        }
-        if (remoteExpected !== localExpected) {
-          throw new Error(
-            `published checksum sidecar mismatch for ${asset}: expected ${localExpected}, got ${remoteExpected}`,
-          );
-        }
-        expected = localExpected;
-      }
-
-      const downloaded = join(tmp, asset.replace(/[/:]/g, "_"));
-      await downloadToFile(payloadUrl, downloaded);
-      const got = await sha256File(downloaded);
-      if (got !== expected) {
-        throw new Error(`checksum mismatch for ${asset}: expected ${expected}, got ${got}`);
-      }
-      console.log(`  ok ${asset} ${got}`);
+      await verifyPublishedAsset({ baseUrl, assetsDir, compareLocal, tmp, asset });
     }
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
 }
 
+async function verifyPublishedAsset({ baseUrl, assetsDir, compareLocal, tmp, asset }) {
+  console.log(`verify ${asset}`);
+  const sidecarUrl = assetUrl(baseUrl, `${asset}.sha256`);
+  const payloadUrl = assetUrl(baseUrl, asset);
+  const remoteExpected = parseSidecar(await fetchText(sidecarUrl), sidecarUrl);
+  const expected = await expectedPublishedChecksum({
+    assetsDir,
+    asset,
+    compareLocal,
+    remoteExpected,
+  });
+  const downloaded = join(tmp, asset.replace(/[/:]/g, "_"));
+
+  await downloadToFile(payloadUrl, downloaded);
+  const got = await sha256File(downloaded);
+  assertChecksumMatch(got, expected, `checksum mismatch for ${asset}`);
+  console.log(`  ok ${asset} ${got}`);
+}
+
+async function expectedPublishedChecksum({ assetsDir, asset, compareLocal, remoteExpected }) {
+  if (!compareLocal) {
+    return remoteExpected;
+  }
+  const localExpected = await verifiedLocalChecksum(assetsDir, asset);
+  assertChecksumMatch(
+    remoteExpected,
+    localExpected,
+    `published checksum sidecar mismatch for ${asset}`,
+  );
+  return localExpected;
+}
+
+async function verifiedLocalChecksum(assetsDir, asset) {
+  const localSidecar = join(assetsDir, `${asset}.sha256`);
+  const localExpected = parseSidecar(await readFile(localSidecar, "utf8"), localSidecar);
+  const localGot = await localPayloadSha(assetsDir, asset);
+  assertChecksumMatch(localGot, localExpected, `local checksum sidecar mismatch for ${asset}`);
+  return localExpected;
+}
+
+function assertChecksumMatch(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
+  }
+}
+
 async function verifyPublished(opts) {
   let lastError;
   for (let attempt = 1; attempt <= opts.tries; attempt++) {
-    try {
-      await verifyPublishedOnce(opts);
-      console.log(`release-assets: verified ${opts.assets.length} asset(s) for ${opts.tag}`);
+    const result = await verifyPublishedAttempt(opts, attempt);
+    if (result.ok) {
       return;
-    } catch (err) {
-      lastError = err;
-      if (attempt < opts.tries) {
-        console.error(
-          `release-assets: verification attempt ${attempt}/${opts.tries} failed: ${err.message}`,
-        );
-        await new Promise((resolveSleep) =>
-          setTimeout(resolveSleep, Math.round(opts.sleepSeconds * 1000)),
-        );
-      }
     }
+    lastError = result.error;
   }
   throw new Error(
     `release-assets: verification failed after ${opts.tries} attempt(s): ${lastError?.message}`,
   );
 }
 
+async function verifyPublishedAttempt(opts, attempt) {
+  try {
+    await verifyPublishedOnce(opts);
+    console.log(`release-assets: verified ${opts.assets.length} asset(s) for ${opts.tag}`);
+    return { ok: true };
+  } catch (err) {
+    await delayVerificationRetry(opts, attempt, err);
+    return { ok: false, error: err };
+  }
+}
+
+async function delayVerificationRetry(opts, attempt, err) {
+  if (attempt >= opts.tries) {
+    return;
+  }
+  console.error(
+    `release-assets: verification attempt ${attempt}/${opts.tries} failed: ${err.message}`,
+  );
+  await new Promise((resolveSleep) =>
+    setTimeout(resolveSleep, Math.round(opts.sleepSeconds * 1000)),
+  );
+}
+
 function runGh(args, { allowFailure = false } = {}) {
   const result = spawnSync("gh", args, {
     cwd: REPO_ROOT,
-    stdio: allowFailure ? "ignore" : "inherit",
+    stdio: ghStdio(allowFailure),
     env: process.env,
   });
-  if (!allowFailure && result.status !== 0) {
-    throw new Error(`gh ${args.join(" ")} failed with exit code ${result.status}`);
+  assertGhSuccess(args, allowFailure, result.status);
+  return exitStatus(result.status);
+}
+
+function ghStdio(allowFailure) {
+  if (allowFailure) {
+    return "ignore";
   }
-  return result.status ?? 1;
+  return "inherit";
+}
+
+function assertGhSuccess(args, allowFailure, status) {
+  if (allowFailure) {
+    return;
+  }
+  if (status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed with exit code ${status}`);
+  }
+}
+
+function exitStatus(status) {
+  if (status === null) {
+    return 1;
+  }
+  return status;
 }
 
 async function uploadList(assetsDir, assets) {
@@ -371,18 +498,29 @@ async function publish(opts) {
   await verifyPublished(opts);
 }
 
+const RELEASE_COMMAND_RUNNERS = new Map([
+  ["checksums", runChecksumsCommand],
+  ["verify", verifyPublished],
+  ["publish", publish],
+]);
+
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
-  opts.tag ??= await defaultTag();
-  opts.baseUrl ??= releaseBaseUrl(opts.repo, opts.tag);
+  await fillReleaseDefaults(opts);
+  await RELEASE_COMMAND_RUNNERS.get(opts.command)(opts);
+}
 
-  if (opts.command === "checksums") {
-    await rewriteChecksums(opts.assetsDir, opts.assets);
-  } else if (opts.command === "verify") {
-    await verifyPublished(opts);
-  } else {
-    await publish(opts);
+async function fillReleaseDefaults(opts) {
+  if (opts.tag === undefined) {
+    opts.tag = await defaultTag();
   }
+  if (opts.baseUrl === undefined) {
+    opts.baseUrl = releaseBaseUrl(opts.repo, opts.tag);
+  }
+}
+
+async function runChecksumsCommand(opts) {
+  await rewriteChecksums(opts.assetsDir, opts.assets);
 }
 
 main().catch((err) => {

--- a/scripts/repro-issue-192-child.ts
+++ b/scripts/repro-issue-192-child.ts
@@ -10,6 +10,7 @@
 //   REPRO_FUSE   "0" to skip the live mount             (default on)
 
 import { boot } from "@machinen/runtime";
+import type { LogEvent } from "@machinen/runtime";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -42,6 +43,48 @@ const inner = fuse
     ].join("\n")
   : `echo "[guest${idx}] booted"\nsleep ${watchSec}\necho done`;
 
+interface ParsedHit {
+  descId: number;
+  uptime?: number;
+}
+
+function handleBootLog(evt: LogEvent): void {
+  if (evt.source !== "guest-console") {
+    return;
+  }
+  appendConsoleTail(evt.chunk);
+  recordHitIfNeeded();
+}
+
+function appendConsoleTail(chunk: Buffer): void {
+  tail = (tail + chunk.toString("utf8")).slice(-65536);
+}
+
+function recordHitIfNeeded(): void {
+  if (hit) {
+    return;
+  }
+  const parsed = parseHit(tail);
+  if (!parsed) {
+    return;
+  }
+  hit = true;
+  descId = parsed.descId;
+  uptime = parsed.uptime;
+}
+
+function parseHit(text: string): ParsedHit | undefined {
+  const match = HIT_RE.exec(text);
+  if (!match) {
+    return undefined;
+  }
+  const uptimeMatch = UPTIME_RE.exec(text);
+  return {
+    descId: Number(match[1]),
+    uptime: uptimeMatch ? Number(uptimeMatch[1]) : undefined,
+  };
+}
+
 const t0 = Date.now();
 const vm = await boot({
   image,
@@ -50,23 +93,7 @@ const vm = await boot({
   liveMounts: fuse ? [{ host: REPO_ROOT, guest: "/mnt/workspace", mode: "ro" }] : undefined,
   cmd: ["/bin/bash", "-lc", inner],
   timeoutMs: null,
-  onLog: (evt) => {
-    if (evt.source !== "guest-console") {
-      return;
-    }
-    tail = (tail + evt.chunk.toString("utf8")).slice(-65536);
-    if (!hit) {
-      const m = HIT_RE.exec(tail);
-      if (m) {
-        hit = true;
-        descId = Number(m[1]);
-        const um = UPTIME_RE.exec(tail);
-        if (um) {
-          uptime = Number(um[1]);
-        }
-      }
-    }
-  },
+  onLog: handleBootLog,
 });
 
 const bootMs = Date.now() - t0;

--- a/scripts/repro-issue-192.ts
+++ b/scripts/repro-issue-192.ts
@@ -34,6 +34,7 @@
 // Exit codes: 0 ran cleanly (regardless of hit/no-hit). 2 script error.
 
 import { boot } from "@machinen/runtime";
+import type { BootOptions, OnLog, VmHandle } from "@machinen/runtime";
 import { existsSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -53,46 +54,92 @@ interface Args {
   fuse: boolean;
 }
 
+const USAGE =
+  "Usage: node scripts/repro-issue-192.ts [--n N] [--serial] [--watch S] [--image PATH] [--no-fuse]";
+
+interface ParseContext {
+  argv: string[];
+  args: Args;
+  index: number;
+}
+
+type ArgHandler = (ctx: ParseContext) => void;
+
+const ARG_HANDLERS: Record<string, ArgHandler> = {
+  "--n": (ctx) => {
+    ctx.args.n = Number(takeOptionValue(ctx, "--n"));
+  },
+  "--serial": (ctx) => {
+    ctx.args.serial = true;
+  },
+  "--watch": (ctx) => {
+    ctx.args.watchSec = Number(takeOptionValue(ctx, "--watch"));
+  },
+  "--image": (ctx) => {
+    ctx.args.image = takeOptionValue(ctx, "--image");
+  },
+  "--no-fuse": (ctx) => {
+    ctx.args.fuse = false;
+  },
+  "-h": () => printUsageAndExit(),
+  "--help": () => printUsageAndExit(),
+};
+
 function parseArgs(): Args {
-  const argv = process.argv.slice(2);
-  const out: Args = {
+  const ctx: ParseContext = { argv: process.argv.slice(2), args: defaultArgs(), index: 0 };
+  for (; ctx.index < ctx.argv.length; ctx.index++) {
+    applyArg(ctx);
+  }
+  validateArgs(ctx.args);
+  return ctx.args;
+}
+
+function defaultArgs(): Args {
+  return {
     n: 8,
     serial: false,
     watchSec: 90,
     image: DEFAULT_IMAGE,
     fuse: true,
   };
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === "--n") {
-      out.n = Number(argv[++i]);
-    } else if (a === "--serial") {
-      out.serial = true;
-    } else if (a === "--watch") {
-      out.watchSec = Number(argv[++i]);
-    } else if (a === "--image") {
-      out.image = argv[++i];
-    } else if (a === "--no-fuse") {
-      out.fuse = false;
-    } else if (a === "-h" || a === "--help") {
-      console.log(
-        "Usage: node scripts/repro-issue-192.ts [--n N] [--serial] [--watch S] [--image PATH] [--no-fuse]",
-      );
-      process.exit(0);
-    } else {
-      console.error(`repro-192: unknown arg: ${a}`);
-      process.exit(2);
-    }
+}
+
+function applyArg(ctx: ParseContext): void {
+  const arg = ctx.argv[ctx.index];
+  const handler = ARG_HANDLERS[arg];
+  if (!handler) {
+    exitArgError(`repro-192: unknown arg: ${arg}`);
   }
-  if (!Number.isFinite(out.n) || out.n < 1) {
-    console.error(`repro-192: --n must be >= 1 (got ${out.n})`);
-    process.exit(2);
+  handler(ctx);
+}
+
+function takeOptionValue(ctx: ParseContext, name: string): string {
+  const value = ctx.argv[++ctx.index];
+  if (value === undefined) {
+    exitArgError(`repro-192: ${name} requires a value`);
   }
-  if (!Number.isFinite(out.watchSec) || out.watchSec < 5) {
-    console.error(`repro-192: --watch must be >= 5 (got ${out.watchSec})`);
-    process.exit(2);
+  return value;
+}
+
+function printUsageAndExit(): never {
+  console.log(USAGE);
+  process.exit(0);
+}
+
+function validateArgs(out: Args): void {
+  assertNumericArg("--n", out.n, 1);
+  assertNumericArg("--watch", out.watchSec, 5);
+}
+
+function assertNumericArg(name: string, value: number, min: number): void {
+  if (!Number.isFinite(value) || value < min) {
+    exitArgError(`repro-192: ${name} must be >= ${min} (got ${value})`);
   }
-  return out;
+}
+
+function exitArgError(message: string): never {
+  console.error(message);
+  process.exit(2);
 }
 
 const args = parseArgs();
@@ -137,148 +184,280 @@ interface Result {
   consoleTail?: string;
 }
 
+interface ConsoleTailBuffer {
+  text: string;
+}
+
+interface ParsedHit {
+  descId: number;
+  guestUptimeAtHit?: number;
+}
+
 async function runOne(index: number): Promise<Result> {
   const result: Result = { index, hit: false };
-  const t0 = Date.now();
-
-  // Inside-guest cmd. With FUSE: poll the live mount to keep vsock
-  // traffic flowing, since the warning correlates with vsock load.
-  // Without FUSE: just sleep — the agent (winsize, exec) on vsock
-  // still does its periodic chatter.
-  const tickSec = 5;
-  const ticks = Math.max(1, Math.ceil(args.watchSec / tickSec));
-  const inner = args.fuse
-    ? [
-        `echo "[guest${index}] booted uptime=$(awk '{print $1}' /proc/uptime)"`,
-        `for i in $(seq 1 ${ticks}); do`,
-        `  find /mnt/workspace -maxdepth 3 -type f >/dev/null 2>&1 || true`,
-        `  sleep ${tickSec}`,
-        `done`,
-        `echo "[guest${index}] done uptime=$(awk '{print $1}' /proc/uptime)"`,
-      ].join("\n")
-    : `echo "[guest${index}] booted"\nsleep ${args.watchSec}\necho "[guest${index}] done"`;
-
-  let tail = "";
-
-  let vm;
-  try {
-    vm = await boot({
-      image: args.image,
-      kernel: KERNEL,
-      dtb: DTB,
-      liveMounts: args.fuse
-        ? [{ host: REPO_ROOT, guest: "/mnt/workspace", mode: "ro" }]
-        : undefined,
-      cmd: ["/bin/bash", "-lc", inner],
-      timeoutMs: null,
-      vmmEnv: { MACHINEN_RAM_BYTES: String(RAM) },
-      onLog: (evt) => {
-        if (evt.source !== "guest-console") {
-          return;
-        }
-        tail = (tail + evt.chunk.toString("utf8")).slice(-65536);
-        if (!result.hit) {
-          const m = HIT_RE.exec(tail);
-          if (m) {
-            result.hit = true;
-            result.descId = Number(m[1]);
-            result.hitAtMs = Date.now() - t0;
-            const um = UPTIME_RE.exec(tail);
-            if (um) {
-              result.guestUptimeAtHit = Number(um[1]);
-            }
-            console.error(
-              `[vm${index}] HIT  desc=${result.descId} uptime=${result.guestUptimeAtHit ?? "?"}s wall=${(result.hitAtMs / 1000).toFixed(1)}s`,
-            );
-          }
-        }
-      },
-    });
-  } catch (err) {
-    result.error = err instanceof Error ? err.message : String(err);
-    console.error(`[vm${index}] BOOT FAILED: ${result.error}`);
+  const startedAt = Date.now();
+  const tail: ConsoleTailBuffer = { text: "" };
+  const vm = await bootReproVm(index, result, startedAt, tail);
+  if (!vm) {
     return result;
   }
+  recordBootSuccess(result, vm, startedAt);
+  await waitForVmWithDeadline(vm, index, result);
+  attachDiagnosticTail(result, tail);
+  return result;
+}
+
+async function bootReproVm(
+  index: number,
+  result: Result,
+  startedAt: number,
+  tail: ConsoleTailBuffer,
+): Promise<VmHandle | undefined> {
+  try {
+    return await boot(buildBootOptions(index, result, startedAt, tail));
+  } catch (err) {
+    result.error = errorMessage(err);
+    console.error(`[vm${index}] BOOT FAILED: ${result.error}`);
+    return undefined;
+  }
+}
+
+function buildBootOptions(
+  index: number,
+  result: Result,
+  startedAt: number,
+  tail: ConsoleTailBuffer,
+): BootOptions {
+  return {
+    image: args.image,
+    kernel: KERNEL,
+    dtb: DTB,
+    liveMounts: liveMountsForRun(),
+    cmd: ["/bin/bash", "-lc", buildInnerCommand(index)],
+    timeoutMs: null,
+    vmmEnv: { MACHINEN_RAM_BYTES: String(RAM) },
+    onLog: createReproLogHandler(index, result, startedAt, tail),
+  };
+}
+
+function liveMountsForRun(): BootOptions["liveMounts"] {
+  return args.fuse ? [{ host: REPO_ROOT, guest: "/mnt/workspace", mode: "ro" }] : undefined;
+}
+
+function buildInnerCommand(index: number): string {
+  return args.fuse ? buildFuseTrafficCommand(index) : buildSleepOnlyCommand(index);
+}
+
+function buildFuseTrafficCommand(index: number): string {
+  const tickSec = 5;
+  const ticks = Math.max(1, Math.ceil(args.watchSec / tickSec));
+  return [
+    `echo "[guest${index}] booted uptime=$(awk '{print $1}' /proc/uptime)"`,
+    `for i in $(seq 1 ${ticks}); do`,
+    `  find /mnt/workspace -maxdepth 3 -type f >/dev/null 2>&1 || true`,
+    `  sleep ${tickSec}`,
+    `done`,
+    `echo "[guest${index}] done uptime=$(awk '{print $1}' /proc/uptime)"`,
+  ].join("\n");
+}
+
+function buildSleepOnlyCommand(index: number): string {
+  return `echo "[guest${index}] booted"\nsleep ${args.watchSec}\necho "[guest${index}] done"`;
+}
+
+function createReproLogHandler(
+  index: number,
+  result: Result,
+  startedAt: number,
+  tail: ConsoleTailBuffer,
+): OnLog {
+  return (evt) => {
+    if (evt.source !== "guest-console") {
+      return;
+    }
+    appendConsoleTail(tail, evt.chunk);
+    recordFirstHit(index, result, startedAt, tail.text);
+  };
+}
+
+function appendConsoleTail(tail: ConsoleTailBuffer, chunk: Buffer): void {
+  tail.text = (tail.text + chunk.toString("utf8")).slice(-65536);
+}
+
+function recordFirstHit(index: number, result: Result, startedAt: number, tail: string): void {
+  if (result.hit) {
+    return;
+  }
+  const hit = parseHit(tail);
+  if (!hit) {
+    return;
+  }
+  result.hit = true;
+  result.descId = hit.descId;
+  result.guestUptimeAtHit = hit.guestUptimeAtHit;
+  result.hitAtMs = Date.now() - startedAt;
+  console.error(
+    `[vm${index}] HIT  desc=${result.descId} uptime=${result.guestUptimeAtHit ?? "?"}s wall=${(result.hitAtMs / 1000).toFixed(1)}s`,
+  );
+}
+
+function parseHit(tail: string): ParsedHit | undefined {
+  const match = HIT_RE.exec(tail);
+  if (!match) {
+    return undefined;
+  }
+  const uptime = UPTIME_RE.exec(tail)?.[1];
+  return {
+    descId: Number(match[1]),
+    guestUptimeAtHit: uptime === undefined ? undefined : Number(uptime),
+  };
+}
+
+function recordBootSuccess(result: Result, vm: VmHandle, startedAt: number): void {
   result.pid = vm.pid;
-  result.bootMs = Date.now() - t0;
-  console.error(`[vm${index}] booted pid=${vm.pid} in ${result.bootMs}ms`);
+  result.bootMs = Date.now() - startedAt;
+  console.error(`[vm${result.index}] booted pid=${vm.pid} in ${result.bootMs}ms`);
+}
 
-  // Hard deadline: cmd should self-terminate after watchSec, and
-  // /init poweroffs after that. Wedged vsock can leave the cmd
-  // hanging even though the warning fired, so kill if it overruns.
-  const deadlineMs = (args.watchSec + 60) * 1000;
-  const killTimer = setTimeout(() => {
-    result.killed = true;
-    console.error(`[vm${index}] deadline exceeded — killing`);
-    vm.kill().catch(() => {});
-  }, deadlineMs);
-
+async function waitForVmWithDeadline(vm: VmHandle, index: number, result: Result): Promise<void> {
+  const killTimer = armDeadline(vm, index, result);
   try {
     const exit = await vm.wait();
     result.exitCode = exit.code;
   } catch (err) {
-    result.error = err instanceof Error ? err.message : String(err);
+    result.error = errorMessage(err);
   } finally {
     clearTimeout(killTimer);
   }
-  // Snapshot the console tail for diagnosis: only useful when something
-  // weird happened (hit, wedge, or boot error). Skip for clean exits to
-  // keep the report compact.
-  if (result.hit || result.killed || result.error) {
-    result.consoleTail = tail;
+}
+
+function armDeadline(vm: VmHandle, index: number, result: Result): ReturnType<typeof setTimeout> {
+  return setTimeout(() => {
+    result.killed = true;
+    console.error(`[vm${index}] deadline exceeded — killing`);
+    vm.kill().catch(() => {});
+  }, deadlineMs());
+}
+
+function deadlineMs(): number {
+  return (args.watchSec + 60) * 1000;
+}
+
+function attachDiagnosticTail(result: Result, tail: ConsoleTailBuffer): void {
+  if (shouldIncludeConsoleTail(result)) {
+    result.consoleTail = tail.text;
   }
-  return result;
+}
+
+function shouldIncludeConsoleTail(result: Result): boolean {
+  return result.hit || Boolean(result.killed) || Boolean(result.error);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 async function main(): Promise<void> {
+  printRunHeader();
+  const startedAt = Date.now();
+  const results = await runBatch();
+  printSummary(results, elapsedSeconds(startedAt));
+}
+
+function printRunHeader(): void {
   console.error(
-    `repro-192: n=${args.n} mode=${args.serial ? "serial" : "concurrent"} ` +
+    `repro-192: n=${args.n} mode=${modeLabel()} ` +
       `watch=${args.watchSec}s fuse=${args.fuse} image=${args.image}`,
   );
   console.error(`repro-192: per-vm ram=${(RAM / 1024 ** 3).toFixed(1)} GiB`);
+}
 
-  const t0 = Date.now();
+async function runBatch(): Promise<Result[]> {
+  return args.serial ? runSerialBatch() : runConcurrentBatch();
+}
+
+async function runSerialBatch(): Promise<Result[]> {
   const results: Result[] = [];
-  if (args.serial) {
-    for (let i = 0; i < args.n; i++) {
-      results.push(await runOne(i));
-    }
-  } else {
-    const settled = await Promise.all(Array.from({ length: args.n }, (_, i) => runOne(i)));
-    results.push(...settled);
+  for (let i = 0; i < args.n; i++) {
+    results.push(await runOne(i));
   }
-  const elapsedSec = (Date.now() - t0) / 1000;
+  return results;
+}
 
-  const hits = results.filter((r) => r.hit);
-  const bootFailed = results.filter((r) => r.error && !r.pid);
-  const killed = results.filter((r) => r.killed);
+async function runConcurrentBatch(): Promise<Result[]> {
+  return Promise.all(Array.from({ length: args.n }, (_, i) => runOne(i)));
+}
 
+function elapsedSeconds(startedAt: number): number {
+  return (Date.now() - startedAt) / 1000;
+}
+
+function printSummary(results: Result[], elapsedSec: number): void {
+  const counts = countOutcomes(results);
   console.log("");
   console.log("=== repro-192 summary ===");
+  console.log(`n=${args.n} mode=${modeLabel()} elapsed=${elapsedSec.toFixed(1)}s`);
   console.log(
-    `n=${args.n} mode=${args.serial ? "serial" : "concurrent"} elapsed=${elapsedSec.toFixed(1)}s`,
+    `hits=${counts.hits}/${args.n} (${hitPercent(counts.hits)}%) ` +
+      `wedged=${counts.killed} bootFailed=${counts.bootFailed}`,
   );
-  console.log(
-    `hits=${hits.length}/${args.n} (${((hits.length / args.n) * 100).toFixed(0)}%) ` +
-      `wedged=${killed.length} bootFailed=${bootFailed.length}`,
-  );
-  for (const r of results) {
-    const tag = r.error
-      ? `ERR ${r.error}`
-      : r.hit
-        ? `HIT  desc=${r.descId} uptime=${r.guestUptimeAtHit ?? "?"}s` +
-          (r.killed ? " (wedged past deadline)" : "")
-        : `ok   exit=${r.exitCode}` + (r.killed ? " (wedged past deadline)" : "");
-    console.log(`  vm${r.index}: ${tag}` + (r.bootMs ? `  bootMs=${r.bootMs}` : ""));
-  }
+  printResultLines(results);
+  printConsoleTails(results);
+}
 
-  for (const r of results) {
-    if (r.consoleTail) {
-      console.log("");
-      console.log(`--- vm${r.index} console tail (last ${r.consoleTail.length} bytes) ---`);
-      console.log(r.consoleTail.trimEnd());
-    }
+function countOutcomes(results: Result[]): { hits: number; bootFailed: number; killed: number } {
+  return {
+    hits: results.filter((r) => r.hit).length,
+    bootFailed: results.filter((r) => r.error && !r.pid).length,
+    killed: results.filter((r) => r.killed).length,
+  };
+}
+
+function hitPercent(hits: number): string {
+  return ((hits / args.n) * 100).toFixed(0);
+}
+
+function printResultLines(results: Result[]): void {
+  for (const result of results) {
+    console.log(`  vm${result.index}: ${resultTag(result)}${bootMsSuffix(result)}`);
   }
+}
+
+function resultTag(result: Result): string {
+  if (result.error) {
+    return `ERR ${result.error}`;
+  }
+  if (result.hit) {
+    return `HIT  desc=${result.descId} uptime=${result.guestUptimeAtHit ?? "?"}s${wedgeSuffix(result)}`;
+  }
+  return `ok   exit=${result.exitCode}${wedgeSuffix(result)}`;
+}
+
+function bootMsSuffix(result: Result): string {
+  return result.bootMs ? `  bootMs=${result.bootMs}` : "";
+}
+
+function wedgeSuffix(result: Result): string {
+  return result.killed ? " (wedged past deadline)" : "";
+}
+
+function printConsoleTails(results: Result[]): void {
+  for (const result of results) {
+    printConsoleTail(result);
+  }
+}
+
+function printConsoleTail(result: Result): void {
+  if (!result.consoleTail) {
+    return;
+  }
+  console.log("");
+  console.log(`--- vm${result.index} console tail (last ${result.consoleTail.length} bytes) ---`);
+  console.log(result.consoleTail.trimEnd());
+}
+
+function modeLabel(): string {
+  return args.serial ? "serial" : "concurrent";
 }
 
 main().catch((err) => {

--- a/scripts/stream-demo.ts
+++ b/scripts/stream-demo.ts
@@ -84,24 +84,38 @@ const savedSnapDir = join(workDir, "saved");
  */
 function printer(api: string) {
   const buffers = new Map<string, string>();
-  return (evt: LogEvent) => {
-    if (evt.source === "phase") {
-      process.stderr.write(`[${api}][phase ${evt.kind}] total=${evt.totalMs}ms\n`);
-      return;
+  return (evt: LogEvent) => printLogEvent(api, buffers, evt);
+}
+
+function printLogEvent(api: string, buffers: Map<string, string>, evt: LogEvent): void {
+  if (evt.source === "phase") {
+    process.stderr.write(`[${api}][phase ${evt.kind}] total=${evt.totalMs}ms\n`);
+    return;
+  }
+  printChunkLogEvent(api, buffers, evt);
+}
+
+function printChunkLogEvent(
+  api: string,
+  buffers: Map<string, string>,
+  evt: Extract<LogEvent, { source: "guest-console" | "exec-stdout" | "exec-stderr" }>,
+): void {
+  const prefix = evt.cmd ? `[${api}][${evt.source} ${evt.cmd}]` : `[${api}][${evt.source}]`;
+  const key = `${evt.source}|${evt.cmd ?? ""}`;
+  const pending = (buffers.get(key) ?? "") + evt.chunk.toString("utf8");
+  buffers.set(key, flushCompleteLines(prefix, pending));
+}
+
+function flushCompleteLines(prefix: string, pendingInput: string): string {
+  let pending = pendingInput;
+  for (;;) {
+    const nl = pending.indexOf("\n");
+    if (nl === -1) {
+      return pending;
     }
-    const prefix = evt.cmd ? `[${api}][${evt.source} ${evt.cmd}]` : `[${api}][${evt.source}]`;
-    const key = `${evt.source}|${evt.cmd ?? ""}`;
-    let pending = (buffers.get(key) ?? "") + evt.chunk.toString("utf8");
-    for (;;) {
-      const nl = pending.indexOf("\n");
-      if (nl === -1) {
-        break;
-      }
-      process.stdout.write(`${prefix} ${pending.slice(0, nl)}\n`);
-      pending = pending.slice(nl + 1);
-    }
-    buffers.set(key, pending);
-  };
+    process.stdout.write(`${prefix} ${pending.slice(0, nl)}\n`);
+    pending = pending.slice(nl + 1);
+  }
 }
 
 // The Zig test binary gates actual boot behavior on MACHINEN_BOOT_TEST.

--- a/scripts/test-claude-bootstrap.mjs
+++ b/scripts/test-claude-bootstrap.mjs
@@ -84,134 +84,284 @@ const BOOTSTRAP = [
 ].join("\n");
 
 // --- Run a bootstrap scenario in an isolated $HOME --------------------
-function run({ name, preexisting, useLoginShell, accountEnv }) {
+function run(scenario) {
+  const { name, preexisting } = scenario;
   const home = mkdtempSync(join(tmpdir(), "claude-bootstrap-test-"));
   try {
-    if (preexisting !== undefined) {
-      writeFileSync(join(home, ".claude.json"), preexisting);
-    }
+    writePreexistingAccount(home, preexisting);
     const slice = readHostSlice();
-    const args = useLoginShell ? ["-lc", BOOTSTRAP] : ["-c", BOOTSTRAP];
-    const env = {
-      ...process.env,
-      HOME: home,
-      MACHINEN_CLAUDE_CREDENTIALS: '{"fake":"creds"}',
-    };
-    // accountEnv: undefined → use real slice; null → leave var unset; "" → empty string
-    if (accountEnv === undefined) {
-      env.MACHINEN_CLAUDE_ACCOUNT_JSON = slice;
-    } else if (accountEnv !== null) {
-      env.MACHINEN_CLAUDE_ACCOUNT_JSON = accountEnv;
-    }
-    const result = spawnSync("bash", args, { env, encoding: "utf8" });
-    const credsPath = join(home, ".claude", ".credentials.json");
-    const acctPath = join(home, ".claude.json");
+    const result = runBootstrapScenario(home, scenario, slice);
+    const paths = scenarioPaths(home);
+    const fail = makeFailReporter(name, result, paths.acctPath);
 
-    const fail = (msg) => {
-      console.error(`  FAIL [${name}]: ${msg}`);
-      console.error(`    exit=${result.status}`);
-      console.error(`    stdout=${JSON.stringify(result.stdout)}`);
-      console.error(`    stderr=${JSON.stringify(result.stderr)}`);
-      if (existsSync(acctPath)) {
-        console.error(`    .claude.json=${readFileSync(acctPath, "utf8").slice(0, 200)}`);
-      }
-      process.exitCode = 1;
-    };
-
-    if (result.status !== 0) {
-      return fail(`bash exit ${result.status}`);
-    }
-    if (result.stderr.trim()) {
-      return fail(`unexpected stderr: ${result.stderr}`);
-    }
-    if (!existsSync(credsPath)) {
-      return fail("credentials file not written");
-    }
-    if (readFileSync(credsPath, "utf8") !== '{"fake":"creds"}') {
-      return fail("credentials content wrong");
-    }
-    // Alias: ~/.bashrc.machinen written; ~/.bashrc sources it; calling
-    // `claude` from `bash -i` injects IS_SANDBOX=1 +
-    // --dangerously-skip-permissions and forwards user args. Verified
-    // for every scenario, regardless of account-env state.
-    const bashrcMachinen = join(home, ".bashrc.machinen");
-    if (!existsSync(bashrcMachinen)) {
-      return fail("~/.bashrc.machinen not written");
-    }
-    const bashrc = join(home, ".bashrc");
-    if (!existsSync(bashrc) || !readFileSync(bashrc, "utf8").includes(".bashrc.machinen")) {
-      return fail("~/.bashrc not sourcing ~/.bashrc.machinen");
-    }
-    const fakeBin = join(home, "fakebin");
-    const fakeClaude = join(fakeBin, "claude");
-    mkdirSync(fakeBin, { recursive: true });
-    writeFileSync(
-      fakeClaude,
-      '#!/bin/sh\nprintf \'IS_SANDBOX=%s\\n\' "$IS_SANDBOX"\nfor a in "$@"; do printf \'arg=%s\\n\' "$a"; done\n',
-    );
-    chmodSync(fakeClaude, 0o755);
-    const aliasCheck = spawnSync("bash", ["-ic", "claude one two"], {
-      env: { ...process.env, HOME: home, PATH: `${fakeBin}:${process.env.PATH}` },
-      encoding: "utf8",
-    });
-    const aliasOut = aliasCheck.stdout;
-    if (!aliasOut.includes("IS_SANDBOX=1")) {
-      return fail(`alias didn't set IS_SANDBOX=1; stdout=${aliasOut}`);
-    }
-    if (!aliasOut.includes("arg=--dangerously-skip-permissions")) {
-      return fail(`alias didn't pass --dangerously-skip-permissions; stdout=${aliasOut}`);
-    }
-    if (!aliasOut.includes("arg=one") || !aliasOut.includes("arg=two")) {
-      return fail(`alias didn't forward user args; stdout=${aliasOut}`);
-    }
-    const haveAccountEnv = accountEnv !== null && accountEnv !== "";
-    if (!haveAccountEnv && preexisting === undefined) {
-      // No account env, no prior file. Bootstrap should have left
-      // .claude.json absent — credentials still go through.
-      if (existsSync(acctPath)) {
-        return fail(".claude.json should not exist when account env is missing");
-      }
-      console.log(`  PASS [${name}]`);
+    if (!assertBootstrapBasics(result, paths, fail)) {
       return;
     }
-    if (!existsSync(acctPath)) {
-      return fail(".claude.json not written");
+    if (!assertClaudeAlias(home, fail)) {
+      return;
     }
-    let parsed;
-    try {
-      parsed = JSON.parse(readFileSync(acctPath, "utf8"));
-    } catch (e) {
-      return fail(`.claude.json invalid JSON: ${e.message}`);
-    }
-    const expected = haveAccountEnv ? JSON.parse(slice) : {};
-    if (haveAccountEnv) {
-      for (const k of Object.keys(expected)) {
-        if (JSON.stringify(parsed[k]) !== JSON.stringify(expected[k])) {
-          return fail(`key ${k} not present/equal in merged .claude.json`);
-        }
-      }
-    }
-    if (preexisting) {
-      let pre;
-      try {
-        pre = JSON.parse(preexisting);
-      } catch {
-        pre = null;
-      }
-      if (pre && typeof pre === "object") {
-        for (const k of Object.keys(pre)) {
-          if (k in expected) {
-            continue;
-          }
-          if (JSON.stringify(parsed[k]) !== JSON.stringify(pre[k])) {
-            return fail(`pre-existing key ${k} clobbered`);
-          }
-        }
-      }
+    if (!assertAccountJson(scenario, paths.acctPath, slice, fail)) {
+      return;
     }
     console.log(`  PASS [${name}]`);
   } finally {
     rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function writePreexistingAccount(home, preexisting) {
+  if (preexisting !== undefined) {
+    writeFileSync(join(home, ".claude.json"), preexisting);
+  }
+}
+
+function runBootstrapScenario(home, scenario, slice) {
+  const args = scenario.useLoginShell ? ["-lc", BOOTSTRAP] : ["-c", BOOTSTRAP];
+  const env = bootstrapEnv(home, scenario.accountEnv, slice);
+  return spawnSync("bash", args, { env, encoding: "utf8" });
+}
+
+function bootstrapEnv(home, accountEnv, slice) {
+  const env = {
+    ...process.env,
+    HOME: home,
+    MACHINEN_CLAUDE_CREDENTIALS: '{"fake":"creds"}',
+  };
+  // accountEnv: undefined → use real slice; null → leave var unset; "" → empty string
+  if (accountEnv === undefined) {
+    env.MACHINEN_CLAUDE_ACCOUNT_JSON = slice;
+  } else if (accountEnv !== null) {
+    env.MACHINEN_CLAUDE_ACCOUNT_JSON = accountEnv;
+  }
+  return env;
+}
+
+function scenarioPaths(home) {
+  return {
+    credsPath: join(home, ".claude", ".credentials.json"),
+    acctPath: join(home, ".claude.json"),
+    bashrcMachinen: join(home, ".bashrc.machinen"),
+    bashrc: join(home, ".bashrc"),
+  };
+}
+
+function makeFailReporter(name, result, acctPath) {
+  return (msg) => {
+    console.error(`  FAIL [${name}]: ${msg}`);
+    console.error(`    exit=${result.status}`);
+    console.error(`    stdout=${JSON.stringify(result.stdout)}`);
+    console.error(`    stderr=${JSON.stringify(result.stderr)}`);
+    if (existsSync(acctPath)) {
+      console.error(`    .claude.json=${readFileSync(acctPath, "utf8").slice(0, 200)}`);
+    }
+    process.exitCode = 1;
+    return false;
+  };
+}
+
+function assertBootstrapBasics(result, paths, fail) {
+  for (const check of basicBootstrapChecks(result, paths)) {
+    const message = check();
+    if (message) {
+      return fail(message);
+    }
+  }
+  return true;
+}
+
+function basicBootstrapChecks(result, paths) {
+  return [
+    () => nonzeroExitMessage(result),
+    () => unexpectedStderrMessage(result),
+    () => missingFileMessage(paths.credsPath, "credentials file not written"),
+    () => wrongCredentialsMessage(paths.credsPath),
+    () => missingFileMessage(paths.bashrcMachinen, "~/.bashrc.machinen not written"),
+    () =>
+      bashrcSourcesMachinen(paths.bashrc) ? null : "~/.bashrc not sourcing ~/.bashrc.machinen",
+  ];
+}
+
+function nonzeroExitMessage(result) {
+  return result.status === 0 ? null : `bash exit ${result.status}`;
+}
+
+function unexpectedStderrMessage(result) {
+  return result.stderr.trim() ? `unexpected stderr: ${result.stderr}` : null;
+}
+
+function missingFileMessage(path, message) {
+  return existsSync(path) ? null : message;
+}
+
+function wrongCredentialsMessage(credsPath) {
+  return readFileSync(credsPath, "utf8") === '{"fake":"creds"}'
+    ? null
+    : "credentials content wrong";
+}
+
+function bashrcSourcesMachinen(bashrc) {
+  return existsSync(bashrc) && readFileSync(bashrc, "utf8").includes(".bashrc.machinen");
+}
+
+function assertClaudeAlias(home, fail) {
+  const fakeBin = join(home, "fakebin");
+  const fakeClaude = join(fakeBin, "claude");
+  mkdirSync(fakeBin, { recursive: true });
+  writeFakeClaude(fakeClaude);
+  const aliasOut = runAliasCheck(home, fakeBin).stdout;
+  const message = aliasFailureMessage(aliasOut);
+  return message ? fail(message) : true;
+}
+
+function aliasFailureMessage(aliasOut) {
+  for (const check of aliasChecks(aliasOut)) {
+    const message = check();
+    if (message) {
+      return message;
+    }
+  }
+  return null;
+}
+
+function aliasChecks(aliasOut) {
+  return [
+    () =>
+      aliasOut.includes("IS_SANDBOX=1")
+        ? null
+        : `alias didn't set IS_SANDBOX=1; stdout=${aliasOut}`,
+    () =>
+      aliasOut.includes("arg=--dangerously-skip-permissions")
+        ? null
+        : `alias didn't pass --dangerously-skip-permissions; stdout=${aliasOut}`,
+    () =>
+      aliasOut.includes("arg=one") && aliasOut.includes("arg=two")
+        ? null
+        : `alias didn't forward user args; stdout=${aliasOut}`,
+  ];
+}
+
+function writeFakeClaude(fakeClaude) {
+  writeFileSync(
+    fakeClaude,
+    '#!/bin/sh\nprintf \'IS_SANDBOX=%s\\n\' "$IS_SANDBOX"\nfor a in "$@"; do printf \'arg=%s\\n\' "$a"; done\n',
+  );
+  chmodSync(fakeClaude, 0o755);
+}
+
+function runAliasCheck(home, fakeBin) {
+  return spawnSync("bash", ["-ic", "claude one two"], {
+    env: { ...process.env, HOME: home, PATH: `${fakeBin}:${process.env.PATH}` },
+    encoding: "utf8",
+  });
+}
+
+function assertAccountJson(scenario, acctPath, slice, fail) {
+  const haveAccountEnv = hasAccountEnv(scenario.accountEnv);
+  if (shouldLeaveAccountAbsent(scenario, haveAccountEnv)) {
+    return assertNoAccountFile(acctPath, fail);
+  }
+  const parsed = readRequiredAccountFile(acctPath, fail);
+  if (!parsed) {
+    return false;
+  }
+  return assertParsedAccountJson(
+    parsed,
+    expectedAccountSlice(haveAccountEnv, slice),
+    scenario,
+    fail,
+  );
+}
+
+function hasAccountEnv(accountEnv) {
+  return accountEnv !== null && accountEnv !== "";
+}
+
+function shouldLeaveAccountAbsent(scenario, haveAccountEnv) {
+  return !haveAccountEnv && scenario.preexisting === undefined;
+}
+
+function readRequiredAccountFile(acctPath, fail) {
+  if (!existsSync(acctPath)) {
+    return fail(".claude.json not written") && null;
+  }
+  return parseAccountFile(acctPath, fail);
+}
+
+function expectedAccountSlice(haveAccountEnv, slice) {
+  return haveAccountEnv ? JSON.parse(slice) : {};
+}
+
+function assertParsedAccountJson(parsed, expected, scenario, fail) {
+  if (!assertExpectedAccountKeys(parsed, expected, hasAccountEnv(scenario.accountEnv), fail)) {
+    return false;
+  }
+  return assertPreexistingKeysPreserved(parsed, expected, scenario.preexisting, fail);
+}
+
+function assertNoAccountFile(acctPath, fail) {
+  if (existsSync(acctPath)) {
+    return fail(".claude.json should not exist when account env is missing");
+  }
+  return true;
+}
+
+function parseAccountFile(acctPath, fail) {
+  try {
+    return JSON.parse(readFileSync(acctPath, "utf8"));
+  } catch (e) {
+    return fail(`.claude.json invalid JSON: ${e.message}`) && null;
+  }
+}
+
+function assertExpectedAccountKeys(parsed, expected, haveAccountEnv, fail) {
+  if (!haveAccountEnv) {
+    return true;
+  }
+  for (const k of Object.keys(expected)) {
+    if (JSON.stringify(parsed[k]) !== JSON.stringify(expected[k])) {
+      return fail(`key ${k} not present/equal in merged .claude.json`);
+    }
+  }
+  return true;
+}
+
+function assertPreexistingKeysPreserved(parsed, expected, preexisting, fail) {
+  const pre = parsePreexistingAccount(preexisting);
+  if (!isObjectRecord(pre)) {
+    return true;
+  }
+  return assertPreservedKeys(parsed, expected, pre, fail);
+}
+
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === "object";
+}
+
+function assertPreservedKeys(parsed, expected, pre, fail) {
+  for (const k of Object.keys(pre)) {
+    if (shouldCheckPreexistingKey(k, expected) && !sameJson(parsed[k], pre[k])) {
+      return fail(`pre-existing key ${k} clobbered`);
+    }
+  }
+  return true;
+}
+
+function shouldCheckPreexistingKey(key, expected) {
+  return !(key in expected);
+}
+
+function sameJson(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function parsePreexistingAccount(preexisting) {
+  if (!preexisting) {
+    return null;
+  }
+  try {
+    return JSON.parse(preexisting);
+  } catch {
+    return null;
   }
 }
 

--- a/vm.ts
+++ b/vm.ts
@@ -94,29 +94,61 @@ async function bench<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
 }
 
 function renderPhaseBlock(evt: import("@machinen/runtime").PhaseLogEvent): void {
-  const total = evt.totalMs;
-  const names = [...evt.phases.keys()];
-  const labelW = Math.max(20, ...names.map((n) => n.length + (n.includes(".") ? 2 : 0)));
-  process.stderr.write(`[machinen] === ${evt.kind} phases (total ${fmtMs(total)}) ===\n`);
-  let topSum = 0;
+  const labelW = phaseLabelWidth(evt, 20);
+  process.stderr.write(`[machinen] === ${evt.kind} phases (total ${fmtMs(evt.totalMs)}) ===\n`);
+  renderPhaseRows(evt, labelW);
+  renderUnattributedPhase(evt, labelW);
+}
+
+function phaseLabelWidth(evt: import("@machinen/runtime").PhaseLogEvent, min: number): number {
+  const widths = [...evt.phases.keys()].map((name) => name.length + subPhaseIndent(name).length);
+  return Math.max(min, ...widths);
+}
+
+function renderPhaseRows(evt: import("@machinen/runtime").PhaseLogEvent, labelW: number): void {
   for (const [name, ms] of evt.phases) {
-    const isSub = name.includes(".");
-    if (!isSub) {
-      topSum += ms;
-    }
-    const display = isSub ? `  ${name}` : name;
-    const pct = total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
-    process.stderr.write(
-      `[machinen]   ${display.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${pct}%\n`,
-    );
+    writePhaseRow(phaseDisplayName(name), ms, evt.totalMs, labelW);
   }
-  const other = Math.max(0, total - topSum);
-  if (other > 0 && total > 0) {
-    const pct = ((other / total) * 100).toFixed(0).padStart(3);
-    process.stderr.write(
-      `[machinen]   ${"(unattributed)".padEnd(labelW)} ${fmtMs(other).padStart(8)}  ${pct}%\n`,
-    );
+}
+
+function renderUnattributedPhase(
+  evt: import("@machinen/runtime").PhaseLogEvent,
+  labelW: number,
+): void {
+  const other = Math.max(0, evt.totalMs - topLevelPhaseSum(evt));
+  if (other > 0 && evt.totalMs > 0) {
+    writePhaseRow("(unattributed)", other, evt.totalMs, labelW);
   }
+}
+
+function topLevelPhaseSum(evt: import("@machinen/runtime").PhaseLogEvent): number {
+  let sum = 0;
+  for (const [name, ms] of evt.phases) {
+    sum += isSubPhase(name) ? 0 : ms;
+  }
+  return sum;
+}
+
+function writePhaseRow(label: string, ms: number, total: number, labelW: number): void {
+  process.stderr.write(
+    `[machinen]   ${label.padEnd(labelW)} ${fmtMs(ms).padStart(8)}  ${phasePercent(ms, total)}%\n`,
+  );
+}
+
+function phaseDisplayName(name: string): string {
+  return `${subPhaseIndent(name)}${name}`;
+}
+
+function subPhaseIndent(name: string): string {
+  return isSubPhase(name) ? "  " : "";
+}
+
+function isSubPhase(name: string): boolean {
+  return name.includes(".");
+}
+
+function phasePercent(ms: number, total: number): string {
+  return total > 0 ? ((ms / total) * 100).toFixed(0).padStart(3) : "  -";
 }
 
 const ASSETS = process.env.MACHINEN_ASSETS_DIR ?? resolve(MAIN_REPO, "release-assets");


### PR DESCRIPTION
## Problem

Fallow was noisy. It counted test files in health and duplicate-code checks, so the report mixed real code problems with test helper noise. The main report also had many large functions that were hard to scan and easy to break by accident.

## Solution

This PR makes fallow ignore test files for health and duplicate-code checks. It also breaks the largest CLI, runtime, and script functions into smaller helper functions. The fallow health report now has 0 functions above the limit, and the duplicate-code report is smaller too.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `NPM_CONFIG_USERCONFIG=$PWD/.npmrc npx vitest run`
- `pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=$PWD/.npmrc npx agent-ci run --all -q -p`
- `pnpm exec fallow --quiet --summary`
- `pnpm exec fallow audit --quiet`
