### PR TITLE
Rename Zig functions to snake case

### DIFF
--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -108,17 +108,17 @@ const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const PORT: u32 = 1978;
 const CHUNK = 32 * 1024;
 
-fn logErr(s: []const u8) void {
+fn log_err(s: []const u8) void {
     _ = write(2, s.ptr, s.len);
     _ = write(2, "\n", 1);
 }
 
-fn logLine(msg: []const u8) void {
+fn log_line(msg: []const u8) void {
     _ = write(1, msg.ptr, msg.len);
     _ = write(1, "\n", 1);
 }
 
-fn waitExitStatus(pid: pid_t) c_int {
+fn wait_exit_status(pid: pid_t) c_int {
     var status: c_int = 0;
     _ = waitpid(pid, &status, 0);
     // WIFEXITED / WEXITSTATUS.
@@ -129,7 +129,7 @@ fn waitExitStatus(pid: pid_t) c_int {
     return 128 + (status & 0x7f);
 }
 
-fn writeAll(fd: c_int, buf: []const u8) bool {
+fn write_all(fd: c_int, buf: []const u8) bool {
     var off: usize = 0;
     while (off < buf.len) {
         const n = write(fd, buf.ptr + off, buf.len - off);
@@ -139,25 +139,25 @@ fn writeAll(fd: c_int, buf: []const u8) bool {
     return true;
 }
 
-fn sendFrame(fd: c_int, tag: u8, payload: []const u8) bool {
+fn send_frame(fd: c_int, tag: u8, payload: []const u8) bool {
     var hdr_buf: [32]u8 = undefined;
     const hdr = std.fmt.bufPrint(&hdr_buf, "{c} {d}\n", .{ tag, payload.len }) catch return false;
-    if (!writeAll(fd, hdr)) return false;
-    if (payload.len > 0 and !writeAll(fd, payload)) return false;
+    if (!write_all(fd, hdr)) return false;
+    if (payload.len > 0 and !write_all(fd, payload)) return false;
     return true;
 }
 
-fn pumpToFrame(client_fd: c_int, src_fd: c_int, tag: u8) void {
+fn pump_to_frame(client_fd: c_int, src_fd: c_int, tag: u8) void {
     var buf: [CHUNK]u8 = undefined;
     while (true) {
         const n = read(src_fd, &buf, buf.len);
         if (n <= 0) return;
         const chunk: []const u8 = buf[0..@intCast(n)];
-        if (!sendFrame(client_fd, tag, chunk)) return;
+        if (!send_frame(client_fd, tag, chunk)) return;
     }
 }
 
-fn readLine(fd: c_int, out: []u8) ?usize {
+fn read_line(fd: c_int, out: []u8) ?usize {
     var i: usize = 0;
     while (i < out.len) {
         const n = read(fd, out.ptr + i, 1);
@@ -168,7 +168,7 @@ fn readLine(fd: c_int, out: []u8) ?usize {
     return null;
 }
 
-fn readExact(fd: c_int, out: []u8) bool {
+fn read_exact(fd: c_int, out: []u8) bool {
     var off: usize = 0;
     while (off < out.len) {
         const n = read(fd, out.ptr + off, out.len - off);
@@ -188,7 +188,7 @@ const MAX_EXEC2_CMD: usize = 1 * 1024 * 1024;
 // client can't make us alloc unbounded.
 const MAX_PTY_INPUT: usize = 64 * 1024;
 
-fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void {
+fn run_command(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void {
     // Make a NUL-terminated copy for the shell.
     const cmd_z = try alloc.dupeZ(u8, cmd);
     defer alloc.free(cmd_z);
@@ -236,15 +236,15 @@ fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void
     // A more faithful implementation would use poll(2) across both
     // fds; this is fine for install commands where interleaving
     // cadence doesn't matter much.
-    pumpToFrame(client_fd, out_pipe[0], 'O');
-    pumpToFrame(client_fd, err_pipe[0], 'E');
+    pump_to_frame(client_fd, out_pipe[0], 'O');
+    pump_to_frame(client_fd, err_pipe[0], 'E');
     _ = close(out_pipe[0]);
     _ = close(err_pipe[0]);
 
-    const code = waitExitStatus(pid);
+    const code = wait_exit_status(pid);
     var tail_buf: [32]u8 = undefined;
     const tail = std.fmt.bufPrint(&tail_buf, "X {d}\n", .{code}) catch "X 1\n";
-    _ = writeAll(client_fd, tail);
+    _ = write_all(client_fd, tail);
     _ = shutdown(client_fd, SHUT_WR);
 }
 
@@ -259,7 +259,7 @@ fn runCommand(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void
 // Closing the master fd at the end sends SIGHUP to the workload's
 // session leader, so the child terminates cleanly even when the host
 // disconnects mid-session.
-fn runPtyCommand(
+fn run_pty_command(
     client_fd: c_int,
     cmd: []const u8,
     cols: u16,
@@ -324,7 +324,7 @@ fn runPtyCommand(
             var out_buf: [CHUNK]u8 = undefined;
             const r = read(master_fd, &out_buf, out_buf.len);
             if (r > 0) {
-                if (!sendFrame(client_fd, 'O', out_buf[0..@intCast(r)])) break :pump;
+                if (!send_frame(client_fd, 'O', out_buf[0..@intCast(r)])) break :pump;
             } else {
                 // EOF on master = the slave was fully closed by the
                 // child (and any descendants that inherited it).
@@ -338,18 +338,18 @@ fn runPtyCommand(
 
         if ((fds[1].revents & POLLIN) != 0) {
             var header: [256]u8 = undefined;
-            const hlen = readLine(client_fd, &header) orelse break :pump;
+            const hlen = read_line(client_fd, &header) orelse break :pump;
             const line = header[0..hlen];
             if (line.len >= 2 and std.mem.startsWith(u8, line, "I ")) {
                 const ilen = std.fmt.parseInt(usize, line[2..], 10) catch break :pump;
                 if (ilen > MAX_PTY_INPUT) {
-                    logErr("exec-agent: PTY I frame too large");
+                    log_err("exec-agent: PTY I frame too large");
                     break :pump;
                 }
                 if (ilen > 0) {
                     var ibuf: [MAX_PTY_INPUT]u8 = undefined;
-                    if (!readExact(client_fd, ibuf[0..ilen])) break :pump;
-                    if (!writeAll(master_fd, ibuf[0..ilen])) break :pump;
+                    if (!read_exact(client_fd, ibuf[0..ilen])) break :pump;
+                    if (!write_all(master_fd, ibuf[0..ilen])) break :pump;
                 }
             } else if (line.len >= 2 and std.mem.startsWith(u8, line, "R ")) {
                 var it = std.mem.tokenizeScalar(u8, line[2..], ' ');
@@ -367,7 +367,7 @@ fn runPtyCommand(
             } else {
                 // Unknown frame on a PTY connection — bail rather than
                 // get out of sync.
-                logErr("exec-agent: PTY unknown frame");
+                log_err("exec-agent: PTY unknown frame");
                 break :pump;
             }
         }
@@ -379,18 +379,18 @@ fn runPtyCommand(
     }
 
     _ = close(master_fd);
-    const code = waitExitStatus(pid);
+    const code = wait_exit_status(pid);
     var tail_buf: [32]u8 = undefined;
     const tail = std.fmt.bufPrint(&tail_buf, "X {d}\n", .{code}) catch "X 1\n";
-    _ = writeAll(client_fd, tail);
+    _ = write_all(client_fd, tail);
     _ = shutdown(client_fd, SHUT_WR);
 }
 
-fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
+fn handle_connection(client_fd: c_int, alloc: std.mem.Allocator) void {
     defer _ = close(client_fd);
     var line_buf: [4096]u8 = undefined;
-    const len = readLine(client_fd, &line_buf) orelse {
-        logErr("exec-agent: bad header");
+    const len = read_line(client_fd, &line_buf) orelse {
+        log_err("exec-agent: bad header");
         return;
     };
     const line = line_buf[0..len];
@@ -402,46 +402,46 @@ fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
     if (std.mem.startsWith(u8, line, "PTY ")) {
         var it = std.mem.tokenizeScalar(u8, line[4..], ' ');
         const cols_str = it.next() orelse {
-            logErr("exec-agent: PTY missing cols");
+            log_err("exec-agent: PTY missing cols");
             return;
         };
         const rows_str = it.next() orelse {
-            logErr("exec-agent: PTY missing rows");
+            log_err("exec-agent: PTY missing rows");
             return;
         };
         const len_str = it.next() orelse {
-            logErr("exec-agent: PTY missing cmd-bytes");
+            log_err("exec-agent: PTY missing cmd-bytes");
             return;
         };
         const cols = std.fmt.parseInt(u16, cols_str, 10) catch {
-            logErr("exec-agent: PTY bad cols");
+            log_err("exec-agent: PTY bad cols");
             return;
         };
         const rows = std.fmt.parseInt(u16, rows_str, 10) catch {
-            logErr("exec-agent: PTY bad rows");
+            log_err("exec-agent: PTY bad rows");
             return;
         };
         const cmd_len = std.fmt.parseInt(usize, len_str, 10) catch {
-            logErr("exec-agent: PTY bad length");
+            log_err("exec-agent: PTY bad length");
             return;
         };
         if (cmd_len > MAX_EXEC2_CMD) {
-            logErr("exec-agent: PTY cmd too large");
+            log_err("exec-agent: PTY cmd too large");
             return;
         }
         const cmd_buf = alloc.alloc(u8, cmd_len) catch {
-            logErr("exec-agent: PTY alloc failed");
+            log_err("exec-agent: PTY alloc failed");
             return;
         };
         defer alloc.free(cmd_buf);
-        if (cmd_len > 0 and !readExact(client_fd, cmd_buf)) {
-            logErr("exec-agent: PTY short read");
+        if (cmd_len > 0 and !read_exact(client_fd, cmd_buf)) {
+            log_err("exec-agent: PTY short read");
             return;
         }
-        runPtyCommand(client_fd, cmd_buf, cols, rows, alloc) catch |err| {
+        run_pty_command(client_fd, cmd_buf, cols, rows, alloc) catch |err| {
             var msg_buf: [128]u8 = undefined;
             const msg = std.fmt.bufPrint(&msg_buf, "exec-agent: pty error: {s}", .{@errorName(err)}) catch "exec-agent: pty error";
-            logErr(msg);
+            log_err(msg);
         };
         return;
     }
@@ -450,40 +450,40 @@ fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
     if (std.mem.startsWith(u8, line, "EXEC2 ")) {
         const len_str = line[6..];
         const cmd_len = std.fmt.parseInt(usize, len_str, 10) catch {
-            logErr("exec-agent: EXEC2 bad length");
+            log_err("exec-agent: EXEC2 bad length");
             return;
         };
         if (cmd_len > MAX_EXEC2_CMD) {
-            logErr("exec-agent: EXEC2 cmd too large");
+            log_err("exec-agent: EXEC2 cmd too large");
             return;
         }
         const cmd_buf = alloc.alloc(u8, cmd_len) catch {
-            logErr("exec-agent: EXEC2 alloc failed");
+            log_err("exec-agent: EXEC2 alloc failed");
             return;
         };
         defer alloc.free(cmd_buf);
-        if (cmd_len > 0 and !readExact(client_fd, cmd_buf)) {
-            logErr("exec-agent: EXEC2 short read");
+        if (cmd_len > 0 and !read_exact(client_fd, cmd_buf)) {
+            log_err("exec-agent: EXEC2 short read");
             return;
         }
-        runCommand(client_fd, cmd_buf, alloc) catch |err| {
+        run_command(client_fd, cmd_buf, alloc) catch |err| {
             var msg_buf: [128]u8 = undefined;
             const msg = std.fmt.bufPrint(&msg_buf, "exec-agent: run error: {s}", .{@errorName(err)}) catch "exec-agent: run error";
-            logErr(msg);
+            log_err(msg);
         };
         return;
     }
 
     // EXEC <cmd>\n — legacy single-line opcode.
     if (line.len < 5 or !std.mem.startsWith(u8, line, "EXEC ")) {
-        logErr("exec-agent: unknown op");
+        log_err("exec-agent: unknown op");
         return;
     }
     const cmd = line[5..];
-    runCommand(client_fd, cmd, alloc) catch |err| {
+    run_command(client_fd, cmd, alloc) catch |err| {
         var msg_buf: [128]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, "exec-agent: run error: {s}", .{@errorName(err)}) catch "exec-agent: run error";
-        logErr(msg);
+        log_err(msg);
     };
 }
 
@@ -497,7 +497,7 @@ pub fn main() !void {
 
     const srv = socket(AF_VSOCK, SOCK_STREAM, 0);
     if (srv < 0) {
-        logErr("exec-agent: socket() failed");
+        log_err("exec-agent: socket() failed");
         return error.SocketFailed;
     }
     var addr: SockaddrVm = .{
@@ -508,21 +508,21 @@ pub fn main() !void {
         .svm_zero = .{ 0, 0, 0, 0 },
     };
     if (bind(srv, @ptrCast(&addr), @sizeOf(SockaddrVm)) < 0) {
-        logErr("exec-agent: bind() failed");
+        log_err("exec-agent: bind() failed");
         return error.BindFailed;
     }
     if (listen(srv, 4) < 0) {
-        logErr("exec-agent: listen() failed");
+        log_err("exec-agent: listen() failed");
         return error.ListenFailed;
     }
-    logLine("exec-agent: listening on vsock port 1978");
+    log_line("exec-agent: listening on vsock port 1978");
 
     while (true) {
         const client = accept(srv, null, null);
         if (client < 0) {
-            logErr("exec-agent: accept() failed; continuing");
+            log_err("exec-agent: accept() failed; continuing");
             continue;
         }
-        handleConnection(client, alloc);
+        handle_connection(client, alloc);
     }
 }

--- a/packages/microvm/assets/file-agent.zig
+++ b/packages/microvm/assets/file-agent.zig
@@ -65,19 +65,19 @@ const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const PORT: u32 = 1976;
 const CHUNK = 64 * 1024;
 
-fn logLine(msg: []const u8) void {
+fn log_line(msg: []const u8) void {
     _ = write(1, msg.ptr, msg.len);
     _ = write(1, "\n", 1);
 }
 
-fn waitExitStatus(pid: pid_t) c_int {
+fn wait_exit_status(pid: pid_t) c_int {
     var status: c_int = 0;
     _ = waitpid(pid, &status, 0);
     if ((status & 0x7f) == 0) return (status >> 8) & 0xff;
     return 128 + (status & 0x7f);
 }
 
-fn readLine(fd: c_int, out: []u8) ?usize {
+fn read_line(fd: c_int, out: []u8) ?usize {
     var i: usize = 0;
     while (i < out.len) {
         const n = read(fd, out.ptr + i, 1);
@@ -91,7 +91,7 @@ fn readLine(fd: c_int, out: []u8) ?usize {
 // Recursive mkdir — mimics Python's os.makedirs(..., exist_ok=True). Caller
 // passes a mutable path buffer that we scribble over; original bytes are
 // restored after each intermediate mkdir.
-fn mkdirP(path: []u8) void {
+fn mkdir_p(path: []u8) void {
     if (path.len == 0) return;
     var i: usize = 1;
     while (i <= path.len) : (i += 1) {
@@ -107,7 +107,7 @@ fn mkdirP(path: []u8) void {
 // Fork+exec with pipe for either stdin (is_writer=true) or stdout
 // (is_writer=false). Returns (pid, pipe_fd) where pipe_fd is the
 // parent's end of the pipe.
-fn spawnTar(
+fn spawn_tar(
     is_writer: bool,
     path_z: [*:0]const u8,
 ) struct { pid: pid_t, fd: c_int } {
@@ -150,8 +150,8 @@ fn spawnTar(
     return .{ .pid = pid, .fd = parent_fd };
 }
 
-fn doPush(client_fd: c_int, path_z: [*:0]const u8) void {
-    const spawned = spawnTar(true, path_z);
+fn do_push(client_fd: c_int, path_z: [*:0]const u8) void {
+    const spawned = spawn_tar(true, path_z);
     var total: usize = 0;
     var buf: [CHUNK]u8 = undefined;
     while (true) {
@@ -167,21 +167,21 @@ fn doPush(client_fd: c_int, path_z: [*:0]const u8) void {
         total += slice.len;
     }
     _ = close(spawned.fd);
-    const rc = waitExitStatus(spawned.pid);
+    const rc = wait_exit_status(spawned.pid);
     var msg_buf: [256]u8 = undefined;
     if (rc == 0) {
         const msg = std.fmt.bufPrint(&msg_buf, "file-agent: PUSH -> {s} OK ({d} bytes)", .{ path_z, total }) catch "file-agent: PUSH OK";
-        logLine(msg);
+        log_line(msg);
     } else {
         const msg = std.fmt.bufPrint(&msg_buf, "file-agent: PUSH -> {s} tar failed rc={d}", .{ path_z, rc }) catch "file-agent: PUSH failed";
-        logLine(msg);
+        log_line(msg);
     }
 }
 
-fn doPull(client_fd: c_int, path_z: [*:0]const u8) void {
+fn do_pull(client_fd: c_int, path_z: [*:0]const u8) void {
     // Python does `os.path.exists` first; we skip that and let tar fail with
     // its own stderr — same observable outcome.
-    const spawned = spawnTar(false, path_z);
+    const spawned = spawn_tar(false, path_z);
     var buf: [CHUNK]u8 = undefined;
     while (true) {
         const n = read(spawned.fd, &buf, buf.len);
@@ -195,29 +195,29 @@ fn doPull(client_fd: c_int, path_z: [*:0]const u8) void {
         }
     }
     _ = close(spawned.fd);
-    const rc = waitExitStatus(spawned.pid);
+    const rc = wait_exit_status(spawned.pid);
     _ = shutdown(client_fd, SHUT_WR);
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(&msg_buf, "file-agent: PULL <- {s} rc={d}", .{ path_z, rc }) catch "file-agent: PULL done";
-    logLine(msg);
+    log_line(msg);
 }
 
-fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
+fn handle_connection(client_fd: c_int, alloc: std.mem.Allocator) void {
     defer _ = close(client_fd);
     var line_buf: [4096]u8 = undefined;
-    const len = readLine(client_fd, &line_buf) orelse {
-        logLine("file-agent: bad header, dropping");
+    const len = read_line(client_fd, &line_buf) orelse {
+        log_line("file-agent: bad header, dropping");
         return;
     };
     const line = line_buf[0..len];
     const sp = std.mem.indexOfScalar(u8, line, ' ') orelse {
-        logLine("file-agent: malformed command");
+        log_line("file-agent: malformed command");
         return;
     };
     const op = line[0..sp];
     const path = line[sp + 1 ..];
     const path_z = alloc.dupeZ(u8, path) catch {
-        logLine("file-agent: alloc failed");
+        log_line("file-agent: alloc failed");
         return;
     };
     defer alloc.free(path_z);
@@ -225,18 +225,18 @@ fn handleConnection(client_fd: c_int, alloc: std.mem.Allocator) void {
     if (std.mem.eql(u8, op, "PUSH")) {
         // Ensure dest dir exists.
         const path_mut = alloc.dupe(u8, path) catch {
-            logLine("file-agent: alloc failed");
+            log_line("file-agent: alloc failed");
             return;
         };
         defer alloc.free(path_mut);
-        mkdirP(path_mut);
-        doPush(client_fd, path_z.ptr);
+        mkdir_p(path_mut);
+        do_push(client_fd, path_z.ptr);
     } else if (std.mem.eql(u8, op, "PULL")) {
-        doPull(client_fd, path_z.ptr);
+        do_pull(client_fd, path_z.ptr);
     } else {
         var msg_buf: [128]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, "file-agent: unknown op {s}", .{op}) catch "file-agent: unknown op";
-        logLine(msg);
+        log_line(msg);
     }
 }
 
@@ -246,7 +246,7 @@ pub fn main() !void {
 
     const srv = socket(AF_VSOCK, SOCK_STREAM, 0);
     if (srv < 0) {
-        logLine("file-agent: socket() failed");
+        log_line("file-agent: socket() failed");
         return error.SocketFailed;
     }
     var addr: SockaddrVm = .{
@@ -257,22 +257,22 @@ pub fn main() !void {
         .svm_zero = .{ 0, 0, 0, 0 },
     };
     if (bind(srv, @ptrCast(&addr), @sizeOf(SockaddrVm)) < 0) {
-        logLine("file-agent: bind() failed");
+        log_line("file-agent: bind() failed");
         return error.BindFailed;
     }
     if (listen(srv, 4) < 0) {
-        logLine("file-agent: listen() failed");
+        log_line("file-agent: listen() failed");
         return error.ListenFailed;
     }
-    logLine("file-agent: listening on vsock port 1976");
+    log_line("file-agent: listening on vsock port 1976");
 
     while (true) {
         const client = accept(srv, null, null);
         if (client < 0) {
-            logLine("file-agent: accept error");
+            log_line("file-agent: accept error");
             continue;
         }
-        logLine("file-agent: accepted");
-        handleConnection(client, alloc);
+        log_line("file-agent: accepted");
+        handle_connection(client, alloc);
     }
 }

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -121,7 +121,7 @@ const OVERLAY_UPPER_MNT = "/run/.mountdisk-upper";
 const OVERLAY_UPPER_DIR = "/run/.mountdisk-upper/upper";
 const OVERLAY_WORK_DIR = "/run/.mountdisk-upper/work";
 
-fn writeStr(fd: c_int, s: []const u8) void {
+fn write_str(fd: c_int, s: []const u8) void {
     _ = write(fd, s.ptr, s.len);
 }
 
@@ -153,13 +153,13 @@ fn klog(s: []const u8) void {
     _ = write(kmsg_fd, out.ptr, out.len);
 }
 
-fn logLine(s: []const u8) void {
+fn log_line(s: []const u8) void {
     klog(s);
-    writeStr(2, s);
-    writeStr(2, "\n");
+    write_str(2, s);
+    write_str(2, "\n");
 }
 
-fn sleepMs(ms: i64) void {
+fn sleep_ms(ms: i64) void {
     var ts: timespec = .{
         .tv_sec = @divTrunc(ms, 1000),
         .tv_nsec = @mod(ms, 1000) * 1_000_000,
@@ -176,7 +176,7 @@ fn sleepMs(ms: i64) void {
 // nanosleep would keep the VMM running indefinitely — Ctrl-C from the
 // host's stdin is forwarded through to the guest where nothing reads
 // it, so the user has to pgrep+kill the VMM by hand. See issue #135.
-fn psciSystemOff() noreturn {
+fn psci_system_off() noreturn {
     if (comptime builtin.cpu.arch != .aarch64) unreachable;
     while (true) {
         asm volatile ("hvc #0"
@@ -186,45 +186,45 @@ fn psciSystemOff() noreturn {
         // PSCI SYSTEM_OFF is supposed to never return. If it does
         // (older kernel without PSCI? hypervisor refused?), fall
         // through and try again rather than spinning the CPU at 100%.
-        sleepMs(60_000);
+        sleep_ms(60_000);
     }
 }
 
-fn linuxPowerOff() noreturn {
+fn linux_power_off() noreturn {
     sync();
     _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);
-    while (true) sleepMs(60_000);
+    while (true) sleep_ms(60_000);
 }
 
-fn machinenPowerOff() noreturn {
+fn machinen_power_off() noreturn {
     if (comptime builtin.cpu.arch == .aarch64) {
-        psciSystemOff();
+        psci_system_off();
     } else {
-        linuxPowerOff();
+        linux_power_off();
     }
 }
 
 fn die(msg: []const u8) noreturn {
-    logLine(msg);
+    log_line(msg);
     // Give the kernel printk + UART TX path a beat to drain so the
     // failure message reaches the host before poweroff tears the VM
     // down. 100ms is overkill for a virtual UART but cheap.
-    sleepMs(100);
-    machinenPowerOff();
+    sleep_ms(100);
+    machinen_power_off();
 }
 
-fn mountIgnore(src: [*:0]const u8, dst: [*:0]const u8, fstype: [*:0]const u8) void {
+fn mount_ignore(src: [*:0]const u8, dst: [*:0]const u8, fstype: [*:0]const u8) void {
     _ = mount(src, dst, fstype, 0, null);
 }
 
-fn mkdirIgnore(path: [*:0]const u8) void {
+fn mkdir_ignore(path: [*:0]const u8) void {
     _ = mkdir(path, 0o755);
 }
 
 // Set the realtime clock from /etc/machinen-boot-epoch. mkinitramfs.ts
 // bakes the host's wall-clock epoch into the cpio at pack time; without
 // this the guest boots at 1970 and TLS / apt date checks fail.
-fn setBootClock() void {
+fn set_boot_clock() void {
     const fd = open("/etc/machinen-boot-epoch", O_RDONLY);
     if (fd < 0) return;
     defer _ = close(fd);
@@ -245,10 +245,10 @@ fn setBootClock() void {
 // (a static helper shipped in the base rootfs). Best-effort: if the
 // helper is missing or fails, log and continue — the user cmd still
 // runs, just without networking.
-fn bringUpNetwork() void {
+fn bring_up_network() void {
     const pid = fork();
     if (pid < 0) {
-        logLine("init: fork failed — skipping network bring-up");
+        log_line("init: fork failed — skipping network bring-up");
         return;
     }
     if (pid == 0) {
@@ -260,10 +260,10 @@ fn bringUpNetwork() void {
     }
     var status: c_int = 0;
     _ = waitpid(pid, &status, 0);
-    if (status != 0) logLine("init: machinen-netup exited non-zero — network may not be up");
+    if (status != 0) log_line("init: machinen-netup exited non-zero — network may not be up");
 }
 
-fn waitForConsole() c_int {
+fn wait_for_console() c_int {
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
         const fd_ttyS0 = open("/dev/ttyS0", O_RDWR);
@@ -272,12 +272,12 @@ fn waitForConsole() c_int {
         if (fd >= 0) return fd;
         const fd2 = open("/dev/console", O_RDWR);
         if (fd2 >= 0) return fd2;
-        sleepMs(50);
+        sleep_ms(50);
     }
     return -1;
 }
 
-fn readConfigFile(arena: std.mem.Allocator) ![]u8 {
+fn read_config_file(arena: std.mem.Allocator) ![]u8 {
     const fd = open(CONFIG_PATH, O_RDONLY);
     if (fd < 0) return error.ConfigOpenFailed;
     defer _ = close(fd);
@@ -297,7 +297,7 @@ fn readConfigFile(arena: std.mem.Allocator) ![]u8 {
     return buf;
 }
 
-fn dupZ(arena: std.mem.Allocator, s: []const u8) ![*:0]const u8 {
+fn dup_z(arena: std.mem.Allocator, s: []const u8) ![*:0]const u8 {
     const buf = try arena.alloc(u8, s.len + 1);
     @memcpy(buf[0..s.len], s);
     buf[s.len] = 0;
@@ -328,8 +328,8 @@ const Config = struct {
     live_mounts: []LiveMount,
 };
 
-fn loadConfig(arena: std.mem.Allocator) !Config {
-    const data = try readConfigFile(arena);
+fn load_config(arena: std.mem.Allocator) !Config {
+    const data = try read_config_file(arena);
     const parsed = try std.json.parseFromSlice(std.json.Value, arena, data, .{});
     const root = parsed.value;
     if (root != .object) return error.ConfigNotObject;
@@ -344,7 +344,7 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
     const argv_buf = try arena.alloc(?[*:0]const u8, cmd_arr.items.len + 1);
     for (cmd_arr.items, 0..) |item, i| {
         if (item != .string) return error.CmdItemNotString;
-        argv_buf[i] = try dupZ(arena, item.string);
+        argv_buf[i] = try dup_z(arena, item.string);
     }
     argv_buf[cmd_arr.items.len] = null;
     const argv: [*:null]const ?[*:0]const u8 = @ptrCast(argv_buf.ptr);
@@ -364,13 +364,13 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
         while (it.next()) |e| {
             if (e.value_ptr.* != .string) return error.EnvValueNotString;
             const kv = try std.fmt.allocPrint(arena, "{s}={s}", .{ e.key_ptr.*, e.value_ptr.string });
-            envp_buf[env_idx] = try dupZ(arena, kv);
+            envp_buf[env_idx] = try dup_z(arena, kv);
             env_idx += 1;
             if (std.mem.eql(u8, e.key_ptr.*, "TERM")) saw_term = true;
         }
     }
     if (!saw_term) {
-        envp_buf[env_idx] = try dupZ(arena, "TERM=linux");
+        envp_buf[env_idx] = try dup_z(arena, "TERM=linux");
         env_idx += 1;
     }
     envp_buf[env_idx] = null;
@@ -380,7 +380,7 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
     var cwd_z: ?[*:0]const u8 = null;
     if (obj.get("cwd")) |cwd_val| {
         if (cwd_val != .string) return error.CwdNotString;
-        cwd_z = try dupZ(arena, cwd_val.string);
+        cwd_z = try dup_z(arena, cwd_val.string);
     }
 
     // liveMounts — optional array. Each entry is `{guest: string, tag:
@@ -396,7 +396,7 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
             const eobj = entry.object;
             const guest_val = eobj.get("guest") orelse return error.LiveMountMissingGuest;
             if (guest_val != .string) return error.LiveMountGuestNotString;
-            const guest_z = try dupZ(arena, guest_val.string);
+            const guest_z = try dup_z(arena, guest_val.string);
 
             const tag_val = eobj.get("tag") orelse return error.LiveMountMissingTag;
             if (tag_val != .string) return error.LiveMountTagNotString;
@@ -405,7 +405,7 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
                 .guest = guest_val.string,
                 .guest_z = guest_z,
                 .tag = tag_val.string,
-                .tag_z = try dupZ(arena, tag_val.string),
+                .tag_z = try dup_z(arena, tag_val.string),
             };
         }
         live_mounts = buf;
@@ -429,12 +429,12 @@ fn loadConfig(arena: std.mem.Allocator) !Config {
 /// before returning so the user cmd sees it already populated. The
 /// virtio-fs driver is built into the kernel (CONFIG_VIRTIO_FS=y) so no
 /// module load is needed first.
-fn bringUpLiveMounts(mounts: []LiveMount) void {
+fn bring_up_live_mounts(mounts: []LiveMount) void {
     if (mounts.len == 0) return;
     for (mounts) |lm| {
         // mkdir the guest path first — a lean on-disk rootfs may not
         // carry it.
-        mkdirParents(lm.guest);
+        mkdir_parents(lm.guest);
         if (mount(lm.tag_z, lm.guest_z, "virtiofs", 0, null) != 0) {
             var buf: [256]u8 = undefined;
             const msg = std.fmt.bufPrint(
@@ -442,19 +442,19 @@ fn bringUpLiveMounts(mounts: []LiveMount) void {
                 "init: virtiofs mount {s} (tag {s}) failed",
                 .{ lm.guest, lm.tag },
             ) catch "init: virtiofs mount failed";
-            logLine(msg);
+            log_line(msg);
             continue;
         }
     }
     for (mounts) |lm| {
-        if (!waitForLiveMount(lm.guest, 5_000)) {
+        if (!wait_for_live_mount(lm.guest, 5_000)) {
             var buf: [256]u8 = undefined;
             const msg = std.fmt.bufPrint(
                 &buf,
                 "init: live mount {s} never appeared in /proc/self/mounts",
                 .{lm.guest},
             ) catch "init: live mount never appeared";
-            logLine(msg);
+            log_line(msg);
         }
     }
 }
@@ -463,16 +463,16 @@ fn bringUpLiveMounts(mounts: []LiveMount) void {
 /// mount. We parse /proc rather than statfs() because statfs() on
 /// AArch64 musl needs a struct we'd have to redeclare, while /proc
 /// parsing needs no extra bindings.
-fn waitForLiveMount(guest: []const u8, timeout_ms: i64) bool {
-    const deadline_ms = nowMs() + timeout_ms;
-    while (nowMs() < deadline_ms) {
-        if (liveMountPresent(guest)) return true;
-        sleepMs(25);
+fn wait_for_live_mount(guest: []const u8, timeout_ms: i64) bool {
+    const deadline_ms = now_ms() + timeout_ms;
+    while (now_ms() < deadline_ms) {
+        if (live_mount_present(guest)) return true;
+        sleep_ms(25);
     }
     return false;
 }
 
-fn liveMountPresent(guest: []const u8) bool {
+fn live_mount_present(guest: []const u8) bool {
     // /proc/self/mounts is fstab-like: `<src> <target> <fstype> ...`.
     // /init issues mount(src=<tag>, target=guest, fstype="virtiofs"),
     // so we check the 2nd field (target) and 3rd field (fstype). The
@@ -507,7 +507,7 @@ fn liveMountPresent(guest: []const u8) bool {
     return false;
 }
 
-fn nowMs() i64 {
+fn now_ms() i64 {
     // Simple, portable-enough elapsed source. Only used for mount wait
     // timeout; jitter is fine.
     var ts: timespec = .{ .tv_sec = 0, .tv_nsec = 0 };
@@ -528,17 +528,17 @@ fn nowMs() i64 {
 // with the existing capacity than refuse to come up. The current size
 // check via statfs(2) skips the ioctl when the fs already fills the
 // device, which is the steady-state cache-hit case.
-fn growRootdiskFs(mount_point: [*:0]const u8) void {
+fn grow_rootdisk_fs(mount_point: [*:0]const u8) void {
     const dev_fd = open(ROOTDISK_DEV, O_RDONLY);
     if (dev_fd < 0) {
-        logLine("init: rootdisk grow skip: cannot open /dev/vda");
+        log_line("init: rootdisk grow skip: cannot open /dev/vda");
         return;
     }
     defer _ = close(dev_fd);
 
     var dev_bytes: u64 = 0;
     if (ioctl(dev_fd, BLKGETSIZE64, &dev_bytes) != 0) {
-        logLine("init: rootdisk grow skip: BLKGETSIZE64 failed");
+        log_line("init: rootdisk grow skip: BLKGETSIZE64 failed");
         return;
     }
     // 4 KiB blocks — matches the materializer's `mke2fs -b 4096`.
@@ -549,7 +549,7 @@ fn growRootdiskFs(mount_point: [*:0]const u8) void {
     // an fd that points at the filesystem, not write access.
     const mount_fd = open(mount_point, O_RDONLY);
     if (mount_fd < 0) {
-        logLine("init: rootdisk grow skip: cannot open mount point");
+        log_line("init: rootdisk grow skip: cannot open mount point");
         return;
     }
     defer _ = close(mount_fd);
@@ -567,7 +567,7 @@ fn growRootdiskFs(mount_point: [*:0]const u8) void {
             "init: rootdisk grow ioctl rc={d} blocks={d} bytes={d}",
             .{ r, blocks, dev_bytes },
         ) catch "init: rootdisk grow ioctl failed";
-        logLine(msg);
+        log_line(msg);
         return;
     }
     var ok_buf: [96]u8 = undefined;
@@ -576,7 +576,7 @@ fn growRootdiskFs(mount_point: [*:0]const u8) void {
         "init: rootdisk grew to {d} 4K blocks ({d} bytes)",
         .{ blocks, dev_bytes },
     ) catch "init: rootdisk grew";
-    logLine(ok_msg);
+    log_line(ok_msg);
 }
 
 // Try to mount /dev/vda as ext4 and chroot into it. Returns true if the
@@ -600,7 +600,7 @@ fn growRootdiskFs(mount_point: [*:0]const u8) void {
 // freshly-mounted rootfs, moves /proc, /sys, /dev across, then calls
 // chroot(NEWROOT) + chdir("/"). Subsequent code runs against the
 // on-disk rootfs.
-fn tryRootDiskPivot() bool {
+fn try_root_disk_pivot() bool {
     // Wait for the device node. The kernel finishes binding /dev/vda
     // within a few tens of ms after devtmpfs mounts. Cap the wait at
     // 2s in case the device is genuinely missing (no rootDisk attached).
@@ -608,9 +608,9 @@ fn tryRootDiskPivot() bool {
     // vCPU, nanosleep parks the whole guest and the kernel's
     // deferred-probe workqueue can't progress.
     {
-        const deadline_ms = nowMs() + 2_000;
+        const deadline_ms = now_ms() + 2_000;
         var found = false;
-        while (nowMs() < deadline_ms) {
+        while (now_ms() < deadline_ms) {
             if (access(ROOTDISK_DEV, F_OK) == 0) {
                 found = true;
                 break;
@@ -618,33 +618,33 @@ fn tryRootDiskPivot() bool {
             _ = sched_yield();
         }
         if (!found) {
-            logLine("init: rootdisk skip: /dev/vda did not appear");
+            log_line("init: rootdisk skip: /dev/vda did not appear");
             return false;
         }
     }
 
-    mkdirIgnore(NEWROOT);
+    mkdir_ignore(NEWROOT);
     if (mount(ROOTDISK_DEV, NEWROOT, "ext4", 0, null) != 0) {
         // /dev/vda isn't ext4 — assume legacy CRIU scratch mode.
-        logLine("init: rootdisk skip: mount /dev/vda failed");
+        log_line("init: rootdisk skip: mount /dev/vda failed");
         return false;
     }
     if (access(ROOTFS_MARKER, F_OK) != 0) {
         // Mounted, but no machinen rootfs inside — assume CRIU scratch.
-        logLine("init: rootdisk skip: marker /sbin/machinen-supervisor missing");
+        log_line("init: rootdisk skip: marker /sbin/machinen-supervisor missing");
         _ = umount2(NEWROOT, MNT_DETACH);
         return false;
     }
 
     // Online-grow the ext4 fs to fill /dev/vda. See growRootdiskFs.
-    growRootdiskFs(NEWROOT);
+    grow_rootdisk_fs(NEWROOT);
 
     // Hand off /proc, /sys, /dev to the new root via MS_MOVE so the
     // already-mounted filesystems stay live across the chroot. mkdir
     // first in case the on-disk rootfs is too lean to ship them.
-    mkdirIgnore("/newroot/proc");
-    mkdirIgnore("/newroot/sys");
-    mkdirIgnore("/newroot/dev");
+    mkdir_ignore("/newroot/proc");
+    mkdir_ignore("/newroot/sys");
+    mkdir_ignore("/newroot/dev");
     _ = mount("/proc", "/newroot/proc", "", MS_MOVE, null);
     _ = mount("/sys", "/newroot/sys", "", MS_MOVE, null);
     _ = mount("/dev", "/newroot/dev", "", MS_MOVE, null);
@@ -652,12 +652,12 @@ fn tryRootDiskPivot() bool {
     // Carry the per-boot ephemera the cpio packed at root level. The
     // on-disk rootfs is shared across boots and intentionally doesn't
     // bake these in.
-    copyFileBest("/machinen-config.json", "/newroot/machinen-config.json");
-    copyFileBest("/etc/machinen-boot-epoch", "/newroot/etc/machinen-boot-epoch");
+    copy_file_best("/machinen-config.json", "/newroot/machinen-config.json");
+    copy_file_best("/etc/machinen-boot-epoch", "/newroot/etc/machinen-boot-epoch");
     // #272: bringUpMountDisk reads this file from /etc/ post-pivot to
     // learn which guest path the squashfs+ext4 overlay should land at.
     // Without the carry it would stay on the discarded initramfs tmpfs.
-    copyFileBest("/etc/machinen-mountdisk-guest", "/newroot/etc/machinen-mountdisk-guest");
+    copy_file_best("/etc/machinen-mountdisk-guest", "/newroot/etc/machinen-mountdisk-guest");
 
     // #272: the `--mount` payload no longer rides in the cpio. It now
     // lives on /dev/vdc (squashfs RO lower) + /dev/vdd (ext4 RW upper),
@@ -672,17 +672,17 @@ fn tryRootDiskPivot() bool {
     if (chdir("/") != 0) {
         // Same: shouldn't happen post-chroot.
     }
-    writeStr(1, "init: pivoted into /dev/vda rootfs\n");
+    write_str(1, "init: pivoted into /dev/vda rootfs\n");
     return true;
 }
 
 /// Wait up to `timeout_ms` for `path` to exist. Used to bridge the gap
 /// between modprobe and devtmpfs creating the matching device node.
-fn waitForPath(path: [*:0]const u8, timeout_ms: i64) bool {
-    const deadline_ms = nowMs() + timeout_ms;
-    while (nowMs() < deadline_ms) {
+fn wait_for_path(path: [*:0]const u8, timeout_ms: i64) bool {
+    const deadline_ms = now_ms() + timeout_ms;
+    while (now_ms() < deadline_ms) {
         if (access(path, F_OK) == 0) return true;
-        sleepMs(25);
+        sleep_ms(25);
     }
     return false;
 }
@@ -709,21 +709,21 @@ fn waitForPath(path: [*:0]const u8, timeout_ms: i64) bool {
 // fail with a clear ENOENT against /mnt/<guest>/ anyway. The
 // happy-path flow assumes the kernel ships SQUASHFS + OVERLAY_FS
 // (scripts/build-kernel-arm64.sh enforces this).
-fn bringUpMountDisk() void {
+fn bring_up_mount_disk() void {
     // 1. Guest path. Absent → no mount was requested by the runtime.
-    const guest = readGuestMountpoint() orelse return;
+    const guest = read_guest_mountpoint() orelse return;
     klog("checkpoint: mountdisk: guest path read");
 
     // 2. Identify the two virtio-blk devices. squashfs lower first,
     //    ext4 upper second.
     var lower_dev_buf: [64]u8 = undefined;
     var upper_dev_buf: [64]u8 = undefined;
-    const found = identifyMountDiskDevices(&lower_dev_buf, &upper_dev_buf, 5_000) catch {
-        logLine("init: mountdisk: device probe failed");
+    const found = identify_mount_disk_devices(&lower_dev_buf, &upper_dev_buf, 5_000) catch {
+        log_line("init: mountdisk: device probe failed");
         return;
     };
     if (!found) {
-        logLine("init: mountdisk: lower or upper device not found within 5s — skipping");
+        log_line("init: mountdisk: lower or upper device not found within 5s — skipping");
         return;
     }
     const lower_dev_z: [*:0]const u8 = @ptrCast(&lower_dev_buf[0]);
@@ -731,11 +731,11 @@ fn bringUpMountDisk() void {
     klog("checkpoint: mountdisk: devices identified");
 
     // 3. Mount squashfs RO. MS_RDONLY = 1 on Linux/musl.
-    mkdirIgnore(OVERLAY_LOWER_MNT);
+    mkdir_ignore(OVERLAY_LOWER_MNT);
     if (mount(lower_dev_z, OVERLAY_LOWER_MNT, "squashfs", 1, null) != 0) {
         var buf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "init: mountdisk: squashfs mount failed dev={s}", .{std.mem.span(lower_dev_z)}) catch "init: mountdisk: squashfs mount failed";
-        logLine(msg);
+        log_line(msg);
         return;
     }
     klog("checkpoint: mountdisk: lower mounted");
@@ -744,29 +744,29 @@ fn bringUpMountDisk() void {
     //    options string; "discard" tells ext4 to issue VIRTIO_BLK_T_DISCARD
     //    on file deletes so the host backing file releases bytes via
     //    fallocate(PUNCH_HOLE).
-    mkdirIgnore(OVERLAY_UPPER_MNT);
+    mkdir_ignore(OVERLAY_UPPER_MNT);
     const ext4_opts: [*:0]const u8 = "discard";
     if (mount(upper_dev_z, OVERLAY_UPPER_MNT, "ext4", 0, @ptrCast(ext4_opts)) != 0) {
         // First ext4 mount on a freshly-mke2fs'd image sometimes needs
         // a no-options retry on older kernels — try once without
         // `discard` before giving up. Logged either way.
         if (mount(upper_dev_z, OVERLAY_UPPER_MNT, "ext4", 0, null) != 0) {
-            logLine("init: mountdisk: ext4 mount failed");
+            log_line("init: mountdisk: ext4 mount failed");
             _ = umount2(OVERLAY_LOWER_MNT, MNT_DETACH);
             return;
         }
-        logLine("init: mountdisk: ext4 mount succeeded only without `discard`");
+        log_line("init: mountdisk: ext4 mount succeeded only without `discard`");
     }
-    growMountDiskUpperFs(OVERLAY_UPPER_MNT, upper_dev_z);
-    mkdirIgnore(OVERLAY_UPPER_DIR);
-    mkdirIgnore(OVERLAY_WORK_DIR);
+    grow_mount_disk_upper_fs(OVERLAY_UPPER_MNT, upper_dev_z);
+    mkdir_ignore(OVERLAY_UPPER_DIR);
+    mkdir_ignore(OVERLAY_WORK_DIR);
     klog("checkpoint: mountdisk: upper mounted");
 
     // 5. mkdir -p the user's guest path, then layer the overlay on top.
     //    We walk and mkdir each segment by hand because the on-disk
     //    rootfs may not have any of these directories yet (typical:
     //    /mnt exists, /mnt/<sub> doesn't).
-    mkdirParents(guest);
+    mkdir_parents(guest);
 
     // overlayfs options string. lowerdir is the squashfs mount,
     // upperdir lives inside the ext4 mount (so writes survive
@@ -778,7 +778,7 @@ fn bringUpMountDisk() void {
         "lowerdir={s},upperdir={s},workdir={s}",
         .{ OVERLAY_LOWER_MNT, OVERLAY_UPPER_DIR, OVERLAY_WORK_DIR },
     ) catch {
-        logLine("init: mountdisk: overlay opts buffer overrun");
+        log_line("init: mountdisk: overlay opts buffer overrun");
         return;
     };
     var guest_buf: [512]u8 = undefined;
@@ -788,20 +788,20 @@ fn bringUpMountDisk() void {
     if (mount("overlay", guest_z, "overlay", 0, opts.ptr) != 0) {
         var buf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "init: mountdisk: overlay mount failed at {s}", .{guest}) catch "init: mountdisk: overlay mount failed";
-        logLine(msg);
+        log_line(msg);
         return;
     }
     klog("checkpoint: mountdisk: overlay mounted");
 
     var ok_buf: [256]u8 = undefined;
     const ok_msg = std.fmt.bufPrint(&ok_buf, "init: mountdisk overlay live at {s}", .{guest}) catch "init: mountdisk overlay live";
-    logLine(ok_msg);
+    log_line(ok_msg);
 }
 
 /// Read /etc/machinen-mountdisk-guest into a static buffer.
 /// Returns the guest path slice (without trailing whitespace) or
 /// null when the file is absent / empty.
-fn readGuestMountpoint() ?[]const u8 {
+fn read_guest_mountpoint() ?[]const u8 {
     const Static = struct {
         var buf: [512]u8 = undefined;
     };
@@ -835,7 +835,7 @@ fn readGuestMountpoint() ?[]const u8 {
 /// scratch volume; identifying them via the negative list is simpler
 /// than holding a list of "candidate" letters that shifts with which
 /// slots happen to be populated.
-fn identifyMountDiskDevices(
+fn identify_mount_disk_devices(
     lower_buf: *[64]u8,
     upper_buf: *[64]u8,
     timeout_ms: i64,
@@ -846,8 +846,8 @@ fn identifyMountDiskDevices(
     // included as headroom in case future slots shift letters again.
     const candidates = [_][]const u8{ "/dev/vdc", "/dev/vdd", "/dev/vde", "/dev/vdf" };
 
-    const deadline_ms = nowMs() + timeout_ms;
-    while (nowMs() < deadline_ms) {
+    const deadline_ms = now_ms() + timeout_ms;
+    while (now_ms() < deadline_ms) {
         var lower_idx: ?usize = null;
         var upper_idx: ?usize = null;
         for (candidates, 0..) |c, i| {
@@ -894,7 +894,7 @@ fn identifyMountDiskDevices(
             }
         }
 
-        sleepMs(25);
+        sleep_ms(25);
     }
     return false;
 }
@@ -904,7 +904,7 @@ fn identifyMountDiskDevices(
 /// have been extended past the fs size since the last boot.
 /// Failures are logged and ignored: the caller falls back to
 /// whatever capacity the on-disk fs already has.
-fn growMountDiskUpperFs(mount_point: [*:0]const u8, dev: [*:0]const u8) void {
+fn grow_mount_disk_upper_fs(mount_point: [*:0]const u8, dev: [*:0]const u8) void {
     const dev_fd = open(dev, O_RDONLY);
     if (dev_fd < 0) return;
     defer _ = close(dev_fd);
@@ -925,7 +925,7 @@ fn growMountDiskUpperFs(mount_point: [*:0]const u8, dev: [*:0]const u8) void {
 /// mkdir -p for an absolute path. Walks from the root, mkdir-ing
 /// each segment with mode 0755. Existing dirs are tolerated. Used to
 /// stage the user's guest mountpoint before the overlay mount.
-fn mkdirParents(path: []const u8) void {
+fn mkdir_parents(path: []const u8) void {
     if (path.len == 0 or path[0] != '/') return;
     var i: usize = 1;
     while (i <= path.len) : (i += 1) {
@@ -936,7 +936,7 @@ fn mkdirParents(path: []const u8) void {
             @memcpy(seg_buf[0..i], path[0..i]);
             seg_buf[i] = 0;
             const seg_z: [*:0]const u8 = @ptrCast(&seg_buf[0]);
-            mkdirIgnore(seg_z);
+            mkdir_ignore(seg_z);
         }
     }
 }
@@ -944,11 +944,11 @@ fn mkdirParents(path: []const u8) void {
 /// Best-effort `cp src dst`. Used to bring the per-boot config + epoch
 /// files across the pivot. Failures are silent — the boot continues
 /// without them and the caller deals with the consequences.
-fn copyFileBest(src: [*:0]const u8, dst: [*:0]const u8) void {
-    copyFileWithMode(src, dst, 0o644);
+fn copy_file_best(src: [*:0]const u8, dst: [*:0]const u8) void {
+    copy_file_with_mode(src, dst, 0o644);
 }
 
-fn copyFileWithMode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) void {
+fn copy_file_with_mode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) void {
     const in_fd = open(src, O_RDONLY);
     if (in_fd < 0) return;
     defer _ = close(in_fd);
@@ -981,9 +981,9 @@ fn copyFileWithMode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) void {
 // failure does not abort the walk. The caller takes the resulting
 // "best-effort partial" mount as-is, mirroring copyFileBest's policy
 // for the per-boot ephemera the pivot also carries across.
-fn copyTreeBest(src: [*:0]const u8, dst: [*:0]const u8) void {
+fn copy_tree_best(src: [*:0]const u8, dst: [*:0]const u8) void {
     if (access(src, F_OK) != 0) return;
-    mkdirIgnore(dst);
+    mkdir_ignore(dst);
     const dir = opendir(src) orelse return;
     defer _ = closedir(dir);
 
@@ -1005,8 +1005,8 @@ fn copyTreeBest(src: [*:0]const u8, dst: [*:0]const u8) void {
         const dst_path = std.fmt.bufPrintZ(&dst_buf, "{s}/{s}", .{ dst_str, name }) catch continue;
 
         switch (ent.d_type) {
-            DT_DIR => copyTreeBest(src_path.ptr, dst_path.ptr),
-            DT_REG => copyFileBest(src_path.ptr, dst_path.ptr),
+            DT_DIR => copy_tree_best(src_path.ptr, dst_path.ptr),
+            DT_REG => copy_file_best(src_path.ptr, dst_path.ptr),
             DT_LNK => {
                 var tgt_buf: [4096]u8 = undefined;
                 const n = readlink(src_path.ptr, &tgt_buf, tgt_buf.len - 1);
@@ -1023,11 +1023,11 @@ fn copyTreeBest(src: [*:0]const u8, dst: [*:0]const u8) void {
 pub fn main() noreturn {
     // Basic FS mounts. Ignore failures — the kernel might have mounted
     // some already, or we might be in a stripped rootfs.
-    mkdirIgnore("/proc");
-    mkdirIgnore("/sys");
-    mountIgnore("devtmpfs", "/dev", "devtmpfs");
-    mountIgnore("proc", "/proc", "proc");
-    mountIgnore("sysfs", "/sys", "sysfs");
+    mkdir_ignore("/proc");
+    mkdir_ignore("/sys");
+    mount_ignore("devtmpfs", "/dev", "devtmpfs");
+    mount_ignore("proc", "/proc", "proc");
+    mount_ignore("sysfs", "/sys", "sysfs");
     // /dev/pts is the slave-side namespace for pseudoterminals.
     // Without it, anything that allocates a PTY pair via /dev/ptmx
     // (e.g. forkpty(3) in the exec-agent's PTY path — #133, or
@@ -1035,8 +1035,8 @@ pub fn main() noreturn {
     // open the slave node, because the slave name /dev/pts/<n> only
     // resolves once devpts is mounted there. /dev/ptmx itself is
     // already in /dev (devtmpfs creates it).
-    mkdirIgnore("/dev/pts");
-    mountIgnore("devpts", "/dev/pts", "devpts");
+    mkdir_ignore("/dev/pts");
+    mount_ignore("devpts", "/dev/pts", "devpts");
     // Fresh tmpfs on /run, matching the systemd / Debian default.
     // Many maintainer scripts assume /run is a writable tmpfs:
     // adduser/addgroup take a flock on /run/adduser, apt parks lock
@@ -1047,11 +1047,11 @@ pub fn main() noreturn {
     // previous provision, an unexpected symlink, root-not-owning the
     // dir) breaks postinst flows mid-install. tmpfs gives every boot
     // a clean, root-owned, writable /run regardless of what's on disk.
-    mkdirIgnore("/run");
-    mountIgnore("tmpfs", "/run", "tmpfs");
+    mkdir_ignore("/run");
+    mount_ignore("tmpfs", "/run", "tmpfs");
 
     // Wire up the serial console.
-    const console = waitForConsole();
+    const console = wait_for_console();
     if (console >= 0) {
         _ = dup2(console, 0);
         _ = dup2(console, 1);
@@ -1059,7 +1059,7 @@ pub fn main() noreturn {
         if (console > 2) _ = close(console);
     }
 
-    writeStr(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
+    write_str(1, "\n=== machinen /init: reading /machinen-config.json ===\n");
     // Mirror the boot banner to /dev/kmsg so post-pivot debug shows
     // both channels in dmesg / the host stderr echo. See klog() above.
     klog("=== machinen /init: reading /machinen-config.json ===");
@@ -1069,12 +1069,12 @@ pub fn main() noreturn {
     // chroot into it; subsequent setup runs against the on-disk rootfs
     // rather than the cpio-extracted tmpfs. Falls through silently to
     // the legacy path if /dev/vda isn't a rootdisk.
-    const pivoted = tryRootDiskPivot();
+    const pivoted = try_root_disk_pivot();
     klog(if (pivoted) "checkpoint: post-tryRootDiskPivot pivoted=true" else "checkpoint: post-tryRootDiskPivot pivoted=false");
 
-    setBootClock();
+    set_boot_clock();
     klog("checkpoint: post-setBootClock");
-    bringUpNetwork();
+    bring_up_network();
     klog("checkpoint: post-bringUpNetwork");
 
     // Page allocator works on musl via mmap.
@@ -1082,7 +1082,7 @@ pub fn main() noreturn {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const cfg = loadConfig(arena) catch |err| {
+    const cfg = load_config(arena) catch |err| {
         var buf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "init: config error: {s}", .{@errorName(err)}) catch "init: config error";
         die(msg);
@@ -1093,17 +1093,17 @@ pub fn main() noreturn {
     // Goes up before live mounts and the user cmd so the user's guest
     // path is populated when their code touches it. No-op when the
     // runtime didn't pass mountdisk fds.
-    bringUpMountDisk();
+    bring_up_mount_disk();
     klog("checkpoint: post-bringUpMountDisk");
 
     // Live-share mounts go up before the user cmd so the mount points
     // are populated when user code touches them. The in-VMM virtio-fs
     // devices serve them — nothing guest-side to keep alive.
-    bringUpLiveMounts(cfg.live_mounts);
+    bring_up_live_mounts(cfg.live_mounts);
     klog("checkpoint: post-bringUpLiveMounts");
 
     if (cfg.cwd_z) |p| {
-        if (chdir(p) < 0) logLine("init: chdir failed; staying in /");
+        if (chdir(p) < 0) log_line("init: chdir failed; staying in /");
     }
 
     {
@@ -1115,7 +1115,7 @@ pub fn main() noreturn {
     // execve only returns on failure. errno is set; report it on the
     // diag channel because the tty path may have eaten the message.
     {
-        const e = errnoValue();
+        const e = errno_value();
         var buf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "init: execve failed errno={d} path={s}", .{ e, std.mem.span(cfg.path) }) catch "init: execve failed";
         die(msg);
@@ -1128,6 +1128,6 @@ pub fn main() noreturn {
 // is missing (rootfs pivot incomplete?), EACCES (13) flags a perms
 // issue, ENOEXEC (8) means the binary is malformed, etc.
 extern "c" fn __errno_location() *c_int;
-fn errnoValue() c_int {
+fn errno_value() c_int {
     return __errno_location().*;
 }

--- a/packages/microvm/assets/memdirty.zig
+++ b/packages/microvm/assets/memdirty.zig
@@ -32,7 +32,7 @@ extern "c" fn mmap(addr: ?*anyopaque, len: usize, prot: c_int, flags: c_int, fd:
 extern "c" fn pause() c_int;
 extern "c" fn write(fd: c_int, buf: [*]const u8, n: usize) isize;
 
-fn writeAll(fd: c_int, buf: []const u8) void {
+fn write_all(fd: c_int, buf: []const u8) void {
     var off: usize = 0;
     while (off < buf.len) {
         const n = write(fd, buf.ptr + off, buf.len - off);
@@ -42,8 +42,8 @@ fn writeAll(fd: c_int, buf: []const u8) void {
 }
 
 fn die(msg: []const u8) noreturn {
-    writeAll(2, msg);
-    writeAll(2, "\n");
+    write_all(2, msg);
+    write_all(2, "\n");
     std.process.exit(1);
 }
 
@@ -78,7 +78,7 @@ pub fn main(init: std.process.Init) !void {
     // Stdout marker for the host-side smoke test to wait on.
     var buf: [64]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, "READY mib={d}\n", .{mib}) catch unreachable;
-    writeAll(1, line);
+    write_all(1, line);
 
     // Park forever — caller signals exit via SIGTERM (machinen
     // snapshot/restore tear-down). Loop guards against EINTR.

--- a/packages/microvm/assets/net-bench-probe.zig
+++ b/packages/microvm/assets/net-bench-probe.zig
@@ -64,7 +64,7 @@ extern "c" fn inet_pton(af: c_int, src: [*:0]const u8, dst: *anyopaque) c_int;
 extern "c" fn clock_gettime(clk_id: c_int, tp: *timespec) c_int;
 extern "c" fn htons(host: u16) u16;
 
-fn printErr(comptime tag: []const u8, rc: c_int) void {
+fn print_err(comptime tag: []const u8, rc: c_int) void {
     std.debug.print("net-bench: error={s} rc={d}\n", .{ tag, rc });
 }
 
@@ -97,7 +97,7 @@ pub fn main(init: std.process.Init.Minimal) u8 {
 
     const fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
-        printErr("socket", fd);
+        print_err("socket", fd);
         return 0;
     }
     defer _ = close(fd);
@@ -106,12 +106,12 @@ pub fn main(init: std.process.Init.Minimal) u8 {
     // so any Nagle batching would inflate the numbers.
     const one: c_int = 1;
     if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, @sizeOf(c_int)) < 0) {
-        printErr("setsockopt_nodelay", -1);
+        print_err("setsockopt_nodelay", -1);
         return 0;
     }
 
     if (connect(fd, &addr, @sizeOf(sockaddr_in)) < 0) {
-        printErr("connect", -1);
+        print_err("connect", -1);
         return 0;
     }
 
@@ -122,7 +122,7 @@ pub fn main(init: std.process.Init.Minimal) u8 {
     while (i < pings) : (i += 1) {
         const snt = write(fd, "x", 1);
         if (snt != 1) {
-            printErr("write", @intCast(snt));
+            print_err("write", @intCast(snt));
             return 0;
         }
         var buf: [1]u8 = undefined;

--- a/packages/microvm/assets/no-iou.zig
+++ b/packages/microvm/assets/no-iou.zig
@@ -60,7 +60,7 @@ extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_
 extern "c" fn perror(s: [*:0]const u8) void;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
 
-fn writeStr(fd: c_int, s: []const u8) void {
+fn write_str(fd: c_int, s: []const u8) void {
     _ = write(fd, s.ptr, s.len);
 }
 
@@ -70,7 +70,7 @@ pub fn main(init: std.process.Init.Minimal) u8 {
     // lifetime, which is all execvp needs.
     const argv = init.args.vector;
     if (argv.len < 2) {
-        writeStr(2, "usage: machinen-no-iou CMD [ARGS...]\n");
+        write_str(2, "usage: machinen-no-iou CMD [ARGS...]\n");
         return 2;
     }
 
@@ -106,7 +106,7 @@ pub fn main(init: std.process.Init.Minimal) u8 {
     // guarantees argv[argc] == NULL), so a small stack array is enough.
     var child_argv: [256]?[*:0]const u8 = undefined;
     if (argv.len > child_argv.len) {
-        writeStr(2, "machinen-no-iou: argv too long\n");
+        write_str(2, "machinen-no-iou: argv too long\n");
         return 6;
     }
     for (argv[1..], 0..) |a, i| child_argv[i] = a;

--- a/packages/microvm/assets/poweroff.zig
+++ b/packages/microvm/assets/poweroff.zig
@@ -31,7 +31,7 @@ extern "c" fn open(path: [*:0]const u8, flags: c_int, ...) c_int;
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
 
-fn writeConsole(bytes: []const u8) void {
+fn write_console(bytes: []const u8) void {
     const fd = open("/dev/console", O_WRONLY, @as(c_int, 0));
     if (fd >= 0) {
         _ = write(fd, bytes.ptr, bytes.len);
@@ -49,7 +49,7 @@ pub fn main() u8 {
     sync();
 
     if (access("/dev/kvm", F_OK) == 0) {
-        writeConsole(nested_poweroff_marker);
+        write_console(nested_poweroff_marker);
         while (true) {}
     }
 

--- a/packages/microvm/assets/secrets-agent.zig
+++ b/packages/microvm/assets/secrets-agent.zig
@@ -44,12 +44,12 @@ const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const PORT: u32 = 1975;
 const ENV_PATH = "/etc/machinen.env";
 
-fn logLine(s: []const u8) void {
+fn log_line(s: []const u8) void {
     _ = write(1, s.ptr, s.len);
     _ = write(1, "\n", 1);
 }
 
-fn writeAll(fd: c_int, buf: []const u8) bool {
+fn write_all(fd: c_int, buf: []const u8) bool {
     var off: usize = 0;
     while (off < buf.len) {
         const n = write(fd, buf.ptr + off, buf.len - off);
@@ -59,7 +59,7 @@ fn writeAll(fd: c_int, buf: []const u8) bool {
     return true;
 }
 
-fn isIdentifier(s: []const u8) bool {
+fn is_identifier(s: []const u8) bool {
     if (s.len == 0) return false;
     const first = s[0];
     if (!(std.ascii.isAlphabetic(first) or first == '_')) return false;
@@ -76,7 +76,7 @@ fn trim(s: []const u8) []const u8 {
 pub fn main() !void {
     const srv = socket(AF_VSOCK, SOCK_STREAM, 0);
     if (srv < 0) {
-        logLine("secrets-agent: socket() failed");
+        log_line("secrets-agent: socket() failed");
         return error.SocketFailed;
     }
     var addr: SockaddrVm = .{
@@ -87,21 +87,21 @@ pub fn main() !void {
         .svm_zero = .{ 0, 0, 0, 0 },
     };
     if (bind(srv, @ptrCast(&addr), @sizeOf(SockaddrVm)) < 0) {
-        logLine("secrets-agent: bind() failed");
+        log_line("secrets-agent: bind() failed");
         return error.BindFailed;
     }
     if (listen(srv, 1) < 0) {
-        logLine("secrets-agent: listen() failed");
+        log_line("secrets-agent: listen() failed");
         return error.ListenFailed;
     }
-    logLine("secrets-agent: listening on vsock port 1975");
+    log_line("secrets-agent: listening on vsock port 1975");
 
     const conn = accept(srv, null, null);
     if (conn < 0) {
-        logLine("secrets-agent: accept() failed");
+        log_line("secrets-agent: accept() failed");
         return error.AcceptFailed;
     }
-    logLine("secrets-agent: accepted");
+    log_line("secrets-agent: accepted");
 
     const alloc = std.heap.c_allocator;
     var raw: std.ArrayList(u8) = .empty;
@@ -129,10 +129,10 @@ pub fn main() !void {
         const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
         const key = trim(line[0..eq]);
         const val = trim(line[eq + 1 ..]);
-        if (!isIdentifier(key)) {
+        if (!is_identifier(key)) {
             var msg_buf: [256]u8 = undefined;
             const msg = std.fmt.bufPrint(&msg_buf, "secrets-agent: skip non-identifier key {s}", .{key}) catch "secrets-agent: skip non-identifier key";
-            logLine(msg);
+            log_line(msg);
             continue;
         }
         const kv = try std.fmt.allocPrint(alloc, "{s}={s}", .{ key, val });
@@ -144,14 +144,14 @@ pub fn main() !void {
 
     const fd = open(ENV_PATH, O_WRONLY | O_CREAT | O_TRUNC, @as(c_uint, 0o600));
     if (fd < 0) {
-        logLine("secrets-agent: open /etc/machinen.env failed");
+        log_line("secrets-agent: open /etc/machinen.env failed");
         return error.OpenFailed;
     }
     defer _ = close(fd);
 
     for (entries.items) |e| {
-        if (!writeAll(fd, e) or !writeAll(fd, "\n")) {
-            logLine("secrets-agent: write failed");
+        if (!write_all(fd, e) or !write_all(fd, "\n")) {
+            log_line("secrets-agent: write failed");
             return error.WriteFailed;
         }
     }
@@ -159,5 +159,5 @@ pub fn main() !void {
 
     var msg_buf: [128]u8 = undefined;
     const msg = std.fmt.bufPrint(&msg_buf, "secrets-agent: wrote {d} entries to {s}", .{ entries.items.len, ENV_PATH }) catch "secrets-agent: wrote entries";
-    logLine(msg);
+    log_line(msg);
 }

--- a/packages/microvm/assets/snapshot-harness.zig
+++ b/packages/microvm/assets/snapshot-harness.zig
@@ -33,7 +33,7 @@ const LINUX_REBOOT_CMD_POWER_OFF: c_int = @bitCast(@as(u32, 0x4321fedc));
 extern "c" fn write(fd: c_int, buf: *const anyopaque, count: usize) isize;
 extern "c" fn reboot(cmd: c_int) c_int;
 
-fn writeAll(fd: c_int, bytes: []const u8) void {
+fn write_all(fd: c_int, bytes: []const u8) void {
     var off: usize = 0;
     while (off < bytes.len) {
         const rc = write(fd, bytes.ptr + off, bytes.len - off);
@@ -42,7 +42,7 @@ fn writeAll(fd: c_int, bytes: []const u8) void {
     }
 }
 
-fn printCheckpoint(iter: u64, hash: *const [32]u8) void {
+fn print_checkpoint(iter: u64, hash: *const [32]u8) void {
     // Format: "snapshot-harness: iter=<n> hash=<64 hex>\n"
     var buf: [128]u8 = undefined;
     var len: usize = 0;
@@ -68,7 +68,7 @@ fn printCheckpoint(iter: u64, hash: *const [32]u8) void {
     }
     buf[len] = '\n';
     len += 1;
-    writeAll(1, buf[0..len]);
+    write_all(1, buf[0..len]);
 }
 
 pub fn main() u8 {
@@ -82,7 +82,7 @@ pub fn main() u8 {
         if (next == EARLY_CHECKPOINT or
             (next >= CHECKPOINT_INTERVAL and next % CHECKPOINT_INTERVAL == 0))
         {
-            printCheckpoint(next, &state);
+            print_checkpoint(next, &state);
         }
     }
     _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);

--- a/packages/microvm/assets/winsize-agent.zig
+++ b/packages/microvm/assets/winsize-agent.zig
@@ -68,12 +68,12 @@ const SockaddrVm = extern struct {
 const VMADDR_CID_ANY: u32 = 0xFFFF_FFFF;
 const PORT: u32 = 1974;
 
-fn logLine(msg: []const u8) void {
+fn log_line(msg: []const u8) void {
     _ = write(1, msg.ptr, msg.len);
     _ = write(1, "\n", 1);
 }
 
-fn sleepMs(ms: i64) void {
+fn sleep_ms(ms: i64) void {
     var ts: timespec = .{
         .tv_sec = @divTrunc(ms, 1000),
         .tv_nsec = @mod(ms, 1000) * 1_000_000,
@@ -81,7 +81,7 @@ fn sleepMs(ms: i64) void {
     _ = nanosleep(&ts, null);
 }
 
-fn writeAll(fd: c_int, buf: []const u8) bool {
+fn write_all(fd: c_int, buf: []const u8) bool {
     var off: usize = 0;
     while (off < buf.len) {
         const n = write(fd, buf.ptr + off, buf.len - off);
@@ -91,7 +91,7 @@ fn writeAll(fd: c_int, buf: []const u8) bool {
     return true;
 }
 
-fn setWinsize(fd: c_int, cols: u16, rows: u16) bool {
+fn set_winsize(fd: c_int, cols: u16, rows: u16) bool {
     const ws: Winsize = .{
         .ws_row = rows,
         .ws_col = cols,
@@ -101,20 +101,20 @@ fn setWinsize(fd: c_int, cols: u16, rows: u16) bool {
     return ioctl(fd, TIOCSWINSZ, &ws) == 0;
 }
 
-fn applyTo(path_z: [*:0]const u8, cols: u16, rows: u16) bool {
+fn apply_to(path_z: [*:0]const u8, cols: u16, rows: u16) bool {
     const fd = open(path_z, O_RDWR | O_NOCTTY);
     if (fd < 0) return false;
     defer _ = close(fd);
-    return setWinsize(fd, cols, rows);
+    return set_winsize(fd, cols, rows);
 }
 
 fn apply(cols: u16, rows: u16) void {
     var applied_any = false;
     for ([_][*:0]const u8{ "/dev/console", "/dev/ttyAMA0", "/dev/tty0" }) |path| {
-        if (applyTo(path, cols, rows)) {
+        if (apply_to(path, cols, rows)) {
             var msg_buf: [128]u8 = undefined;
             const msg = std.fmt.bufPrint(&msg_buf, "applied: {d} {d} -> {s}", .{ cols, rows, path }) catch continue;
-            logLine(msg);
+            log_line(msg);
             applied_any = true;
         }
     }
@@ -124,7 +124,7 @@ fn apply(cols: u16, rows: u16) void {
         if (!applied_any) {
             var msg_buf: [64]u8 = undefined;
             const msg = std.fmt.bufPrint(&msg_buf, "applied: {d} {d} -> (no ttys)", .{ cols, rows }) catch "applied: (no ttys)";
-            logLine(msg);
+            log_line(msg);
         }
         return;
     };
@@ -158,12 +158,12 @@ fn apply(cols: u16, rows: u16) void {
 
             const fd = open(link.ptr, O_RDWR | O_NOCTTY);
             if (fd < 0) continue;
-            const ok = setWinsize(fd, cols, rows);
+            const ok = set_winsize(fd, cols, rows);
             _ = close(fd);
             if (ok) {
                 var msg_buf: [512]u8 = undefined;
                 const msg = std.fmt.bufPrint(&msg_buf, "applied: {d} {d} -> {s}->{s}", .{ cols, rows, link, target }) catch continue;
-                logLine(msg);
+                log_line(msg);
                 applied_any = true;
             }
         }
@@ -172,16 +172,16 @@ fn apply(cols: u16, rows: u16) void {
     if (!applied_any) {
         var msg_buf: [64]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, "applied: {d} {d} -> (no ttys)", .{ cols, rows }) catch "applied: (no ttys)";
-        logLine(msg);
+        log_line(msg);
     }
 }
 
-fn bindWithRetry() c_int {
+fn bind_with_retry() c_int {
     var attempt: u32 = 0;
     while (attempt < 10) : (attempt += 1) {
         const srv = socket(AF_VSOCK, SOCK_STREAM, 0);
         if (srv < 0) {
-            sleepMs(500);
+            sleep_ms(500);
             continue;
         }
         var addr: SockaddrVm = .{
@@ -197,33 +197,33 @@ fn bindWithRetry() c_int {
         _ = close(srv);
         var msg_buf: [64]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, "winsize-agent: bind retry ({d})", .{attempt + 1}) catch "winsize-agent: bind retry";
-        logLine(msg);
-        sleepMs(500);
+        log_line(msg);
+        sleep_ms(500);
     }
     return -1;
 }
 
 pub fn main() !void {
-    const srv = bindWithRetry();
+    const srv = bind_with_retry();
     if (srv < 0) {
-        logLine("winsize-agent: could not bind AF_VSOCK, giving up");
+        log_line("winsize-agent: could not bind AF_VSOCK, giving up");
         return error.BindFailed;
     }
     if (listen(srv, 1) < 0) {
-        logLine("winsize-agent: listen() failed");
+        log_line("winsize-agent: listen() failed");
         return error.ListenFailed;
     }
-    logLine("winsize-agent: listening on vsock port 1974");
+    log_line("winsize-agent: listening on vsock port 1974");
 
     var buf: [4096]u8 = undefined;
     while (true) {
         const conn = accept(srv, null, null);
         if (conn < 0) {
-            logLine("winsize-agent: accept failed");
-            sleepMs(200);
+            log_line("winsize-agent: accept failed");
+            sleep_ms(200);
             continue;
         }
-        logLine("winsize-agent: accepted");
+        log_line("winsize-agent: accepted");
 
         var line_buf: [256]u8 = undefined;
         var line_len: usize = 0;
@@ -239,21 +239,21 @@ pub fn main() !void {
                     const sp = std.mem.indexOfScalar(u8, line, ' ') orelse {
                         var msg_buf: [128]u8 = undefined;
                         const msg = std.fmt.bufPrint(&msg_buf, "winsize-agent: bad line {s}", .{line}) catch "winsize-agent: bad line";
-                        logLine(msg);
+                        log_line(msg);
                         continue;
                     };
                     const cols = std.fmt.parseInt(u16, line[0..sp], 10) catch {
-                        logLine("winsize-agent: bad cols");
+                        log_line("winsize-agent: bad cols");
                         continue;
                     };
                     const rows = std.fmt.parseInt(u16, line[sp + 1 ..], 10) catch {
-                        logLine("winsize-agent: bad rows");
+                        log_line("winsize-agent: bad rows");
                         continue;
                     };
                     apply(cols, rows);
                     var ack_buf: [64]u8 = undefined;
                     const ack = std.fmt.bufPrint(&ack_buf, "ok {d} {d}\n", .{ cols, rows }) catch "ok\n";
-                    _ = writeAll(conn, ack);
+                    _ = write_all(conn, ack);
                 } else if (line_len < line_buf.len) {
                     line_buf[line_len] = c;
                     line_len += 1;
@@ -261,6 +261,6 @@ pub fn main() !void {
             }
         }
         _ = close(conn);
-        logLine("winsize-agent: conn closed");
+        log_line("winsize-agent: conn closed");
     }
 }

--- a/packages/microvm/build.zig
+++ b/packages/microvm/build.zig
@@ -196,24 +196,24 @@ pub fn build(b: *std.Build) void {
     // can actually succeed (otherwise HV_DENIED). See
     // .docs/learnings/microvm/hvf.md.
     if (target.result.os.tag == .macos) {
-        const sign_mod_tests = signWithHvfEntitlement(b, mod_tests);
+        const sign_mod_tests = sign_with_hvf_entitlement(b, mod_tests);
         run_mod_tests.step.dependOn(&sign_mod_tests.step);
 
-        const sign_exe_tests = signWithHvfEntitlement(b, exe_tests);
+        const sign_exe_tests = sign_with_hvf_entitlement(b, exe_tests);
         run_exe_tests.step.dependOn(&sign_exe_tests.step);
 
-        const sign_exe = signWithHvfEntitlement(b, exe);
+        const sign_exe = sign_with_hvf_entitlement(b, exe);
         run_cmd.step.dependOn(&sign_exe.step);
 
         // snapshot-test will eventually need the HVF entitlement (when
         // dump/load wire up — tasks #19/#22+); sign now for forward-compat.
         // Wire the sign step into the install step so `zig build` actually
         // runs it (returning the step without dependOn would orphan it).
-        const sign_snap = signWithHvfEntitlement(b, snap_exe);
+        const sign_snap = sign_with_hvf_entitlement(b, snap_exe);
         b.getInstallStep().dependOn(&sign_snap.step);
 
         // sysreg-probe creates an HVF vCPU — needs the entitlement.
-        const sign_sysreg = signWithHvfEntitlement(b, sysreg_exe);
+        const sign_sysreg = sign_with_hvf_entitlement(b, sysreg_exe);
         b.getInstallStep().dependOn(&sign_sysreg.step);
     }
 
@@ -240,7 +240,7 @@ pub fn build(b: *std.Build) void {
 /// Ad-hoc codesigns the compiled artifact with com.apple.security.hypervisor.
 /// macOS-only. Returns a Run step that consumers should depend on before
 /// executing the artifact.
-fn signWithHvfEntitlement(
+fn sign_with_hvf_entitlement(
     b: *std.Build,
     artifact: *std.Build.Step.Compile,
 ) *std.Build.Step.Run {

--- a/packages/microvm/src/balloon.zig
+++ b/packages/microvm/src/balloon.zig
@@ -138,13 +138,13 @@ pub const Backend = struct {
     /// Default constructor — uses the process-static stub. Convenient
     /// for unit tests and dev runs that don't need host-side stats.
     pub fn init() Backend {
-        return .{ .counters = stats_mod.stubCounters() };
+        return .{ .counters = stats_mod.stub_counters() };
     }
 
     /// Construct a backend whose counters live at the caller-supplied
     /// pointer. Used by the boot wiring to redirect updates into the
     /// mmap'd stats region.
-    pub fn initWithCounters(counters: *stats_mod.Counters) Backend {
+    pub fn init_with_counters(counters: *stats_mod.Counters) Backend {
         return .{ .counters = counters };
     }
 
@@ -174,24 +174,24 @@ pub const Backend = struct {
 
     /// Wire-format config bytes for `virtio.Device.config`. Stable
     /// pointer for the lifetime of `*Backend`.
-    pub fn configBytes(self: *const Backend) []const u8 {
+    pub fn config_bytes(self: *const Backend) []const u8 {
         return std.mem.asBytes(&self.config);
     }
 
     /// Dispatch entry point. Plug into `virtio.Device.request_handler`.
     /// Switches on `q_idx` and hands off to the per-queue handler.
-    pub fn handleRequest(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
+    pub fn handle_request(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
         assert(ctx != null);
         const self: *Backend = @ptrCast(@alignCast(ctx.?));
         switch (q_idx) {
-            QUEUE_INFLATE => self.handleInflate(dev, head),
-            QUEUE_DEFLATE => self.handleDeflate(dev, head),
-            QUEUE_REPORTING => self.handleReporting(dev, head),
+            QUEUE_INFLATE => self.handle_inflate(dev, head),
+            QUEUE_DEFLATE => self.handle_deflate(dev, head),
+            QUEUE_REPORTING => self.handle_reporting(dev, head),
             else => {
                 // Unknown queue — fold into "ack the chain so the
                 // driver doesn't stall." Treats stats/free-page-hint
                 // as no-ops since we didn't negotiate them.
-                ackChain(dev, q_idx, head);
+                ack_chain(dev, q_idx, head);
             },
         }
     }
@@ -202,12 +202,12 @@ pub const Backend = struct {
     /// guest never sends anything here. Account for completeness and
     /// ack so a buggy driver doesn't wedge on a ring that never
     /// drains.
-    fn handleInflate(self: *Backend, dev: *virtio.Device, head: u16) void {
+    fn handle_inflate(self: *Backend, dev: *virtio.Device, head: u16) void {
         var bytes_seen: u64 = 0;
         var idx: u16 = head;
         var steps: u32 = 0;
         while (steps < virtio.max_chain_descriptors) : (steps += 1) {
-            const d = dev.queueDescriptor(QUEUE_INFLATE, idx) orelse break;
+            const d = dev.queue_descriptor(QUEUE_INFLATE, idx) orelse break;
             // Each descriptor is a u32 array; len is bytes; one page
             // == one u32. We don't actually act on these.
             bytes_seen += @as(u64, d.len) / 4 * 4096;
@@ -216,15 +216,15 @@ pub const Backend = struct {
         }
         assert(steps <= virtio.max_chain_descriptors);
         _ = @atomicRmw(u64, &self.counters.bytes_inflated, .Add, bytes_seen, .monotonic);
-        dev.queuePushUsed(QUEUE_INFLATE, head, 0);
+        dev.queue_push_used(QUEUE_INFLATE, head, 0);
     }
 
     /// Deflate-queue chain. Same story as inflate but in reverse:
     /// driver giving pages back. We don't track "balloon contents"
     /// so this is a pure ack.
-    fn handleDeflate(self: *Backend, dev: *virtio.Device, head: u16) void {
+    fn handle_deflate(self: *Backend, dev: *virtio.Device, head: u16) void {
         _ = self;
-        ackChain(dev, QUEUE_DEFLATE, head);
+        ack_chain(dev, QUEUE_DEFLATE, head);
     }
 
     /// Reporting-queue chain. Each descriptor describes a contiguous
@@ -248,9 +248,9 @@ pub const Backend = struct {
     /// kernel's reporting framework only reports each page once, so
     /// "drop the chain to skip a cycle" loses reclaim opportunities
     /// permanently). Deferred to a follow-up. See #263 phase E.
-    fn handleReporting(self: *Backend, dev: *virtio.Device, head: u16) void {
+    fn handle_reporting(self: *Backend, dev: *virtio.Device, head: u16) void {
         const ram_slice = dev.ram orelse {
-            ackChain(dev, QUEUE_REPORTING, head);
+            ack_chain(dev, QUEUE_REPORTING, head);
             return;
         };
         const ram_base = dev.ram_base;
@@ -271,7 +271,7 @@ pub const Backend = struct {
         var idx: u16 = head;
         var steps: u32 = 0;
         while (steps < virtio.max_chain_descriptors) : (steps += 1) {
-            const d = dev.queueDescriptor(QUEUE_REPORTING, idx) orelse break;
+            const d = dev.queue_descriptor(QUEUE_REPORTING, idx) orelse break;
             descs += 1;
             bytes_seen += d.len;
             // Overflow-safe in-RAM check. The naive `d.addr + d.len <=
@@ -287,7 +287,7 @@ pub const Backend = struct {
                 assert(n_ranges < ranges.len);
                 ranges[n_ranges] = .{ .addr = d.addr, .len = d.len };
                 n_ranges += 1;
-            } else if (debugEnabled()) {
+            } else if (debug_enabled()) {
                 std.debug.print(
                     "balloon: report out of RAM range addr=0x{x} len={d} ram=[0x{x},0x{x})\n",
                     .{ d.addr, d.len, ram_base, ram_end },
@@ -304,7 +304,7 @@ pub const Backend = struct {
         // n_ranges ≤ 32, so insertion sort is fine. The framework
         // walks a sorted free list so chains usually arrive ordered;
         // sortByAddr short-circuits in that case.
-        sortByAddr(ranges[0..n_ranges]);
+        sort_by_addr(ranges[0..n_ranges]);
 
         // Coalesce adjacent ranges in place, then issue mmaps.
         var n_merged: usize = 0;
@@ -344,7 +344,7 @@ pub const Backend = struct {
             const rc = madvise(host_va_ptr, len, MADVISE_RECLAIM);
             if (rc == 0) {
                 bytes_freed += r.len;
-            } else if (debugEnabled()) {
+            } else if (debug_enabled()) {
                 std.debug.print(
                     "balloon: madvise reclaim failed addr=0x{x} len={d} rc={d}\n",
                     .{ r.addr, r.len, rc },
@@ -352,14 +352,14 @@ pub const Backend = struct {
             }
         }
 
-        if (debugEnabled() and descs > 0) {
+        if (debug_enabled() and descs > 0) {
             std.debug.print(
                 "balloon: reporting chain head={d} descs={d}->merged={d} seen={d} freed={d}\n",
                 .{ head, descs, n_merged, bytes_seen, bytes_freed },
             );
         }
         _ = @atomicRmw(u64, &self.counters.bytes_reported, .Add, bytes_freed, .monotonic);
-        dev.queuePushUsed(QUEUE_REPORTING, head, 0);
+        dev.queue_push_used(QUEUE_REPORTING, head, 0);
     }
 };
 
@@ -372,7 +372,7 @@ const Range = struct { addr: u64, len: u64 };
 /// chain limit (32 today), so the O(n²) worst case is trivial.
 /// Short-circuits if the slice is already sorted — the common case
 /// for free-page-reporting since the kernel walks a sorted free list.
-fn sortByAddr(rs: []Range) void {
+fn sort_by_addr(rs: []Range) void {
     // Bounded by the reporting handler's collection cap; stays at
     // O(n²) worst case which is trivial for n ≤ 32.
     assert(rs.len <= virtio.max_chain_descriptors);
@@ -389,21 +389,21 @@ fn sortByAddr(rs: []Range) void {
 
 /// Walk a chain to the end, then push it back on the used ring with
 /// zero bytes written. Used for queues whose state we don't track.
-fn ackChain(dev: *virtio.Device, q_idx: u32, head: u16) void {
+fn ack_chain(dev: *virtio.Device, q_idx: u32, head: u16) void {
     var idx: u16 = head;
     var steps: u32 = 0;
     while (steps < virtio.max_chain_descriptors) : (steps += 1) {
-        const d = dev.queueDescriptor(q_idx, idx) orelse break;
+        const d = dev.queue_descriptor(q_idx, idx) orelse break;
         if ((d.flags & virtio.VringDesc.F_NEXT) == 0) break;
         idx = d.next;
     }
     assert(steps <= virtio.max_chain_descriptors);
-    dev.queuePushUsed(q_idx, head, 0);
+    dev.queue_push_used(q_idx, head, 0);
 }
 
 /// Gate noisy diagnostics on `MACHINEN_DEBUG=1` so production runs
 /// stay quiet. Mirrors `boot_hvf.zig`'s `debugEnabled` helper.
-fn debugEnabled() bool {
+fn debug_enabled() bool {
     return getenv("MACHINEN_DEBUG") != null;
 }
 
@@ -454,7 +454,7 @@ test "BalloonConfig has the v1.1 layout the driver expects" {
 
 test "Backend.init starts with zero accounting" {
     var counters: stats_mod.Counters = .{};
-    const b: Backend = .initWithCounters(&counters);
+    const b: Backend = .init_with_counters(&counters);
     try std.testing.expectEqual(
         @as(u64, 0),
         @atomicLoad(u64, &b.counters.bytes_reported, .monotonic),
@@ -472,7 +472,7 @@ test "sortByAddr orders ranges and short-circuits sorted input" {
         .{ .addr = 0x200, .len = 0x10 },
         .{ .addr = 0x040, .len = 0x10 },
     };
-    sortByAddr(&rs);
+    sort_by_addr(&rs);
     try std.testing.expectEqual(@as(u64, 0x040), rs[0].addr);
     try std.testing.expectEqual(@as(u64, 0x080), rs[1].addr);
     try std.testing.expectEqual(@as(u64, 0x100), rs[2].addr);
@@ -488,7 +488,7 @@ test "coalescing merges adjacent ranges" {
         .{ .addr = 0x40800000, .len = 0x400000 },
         .{ .addr = 0x41000000, .len = 0x400000 }, // 4 MiB gap
     };
-    sortByAddr(&ranges);
+    sort_by_addr(&ranges);
     var n_merged: usize = 1;
     for (ranges[1..]) |r| {
         const tail = &ranges[n_merged - 1];

--- a/packages/microvm/src/blk.zig
+++ b/packages/microvm/src/blk.zig
@@ -155,15 +155,15 @@ pub const Backend = struct {
     /// can hand out a stable slice reference.
     config: BlkConfig,
 
-    pub fn initFromFd(fd: c_int, size_bytes: u64) Backend {
-        return initFromFdWithMode(fd, size_bytes, false);
+    pub fn init_from_fd(fd: c_int, size_bytes: u64) Backend {
+        return init_from_fd_with_mode(fd, size_bytes, false);
     }
 
     /// Same as `initFromFd` but lets callers pin the backend as
     /// read-only — used for the squashfs lower in #272 where the
     /// host opens the cache file `O_RDONLY` and must reject any
     /// guest write rather than letting `pwrite` ENOSPC the host.
-    pub fn initFromFdWithMode(fd: c_int, size_bytes: u64, read_only: bool) Backend {
+    pub fn init_from_fd_with_mode(fd: c_int, size_bytes: u64, read_only: bool) Backend {
         assert(fd >= 0);
         assert(size_bytes > 0);
         // virtio-blk capacity is in 512-byte sectors; a non-multiple
@@ -189,28 +189,28 @@ pub const Backend = struct {
         _ = close(self.fd);
     }
 
-    pub fn enableDirtyTracking(self: *Backend, allocator: std.mem.Allocator) !void {
+    pub fn enable_dirty_tracking(self: *Backend, allocator: std.mem.Allocator) !void {
         if (self.dirty != null) return;
         self.dirty = try DirtyTracker.init(allocator, self.capacity_sectors * 512);
     }
 
-    pub fn clearDirty(self: *Backend) void {
+    pub fn clear_dirty(self: *Backend) void {
         if (self.dirty) |*d| d.clear();
     }
 
-    pub fn encodeDirtyDelta(self: *Backend, allocator: std.mem.Allocator) ![]u8 {
+    pub fn encode_dirty_delta(self: *Backend, allocator: std.mem.Allocator) ![]u8 {
         if (self.dirty) |*d| {
-            return rootdisk_delta.encodeFromFd(allocator, self.fd, d.disk_size, d.bits);
+            return rootdisk_delta.encode_from_fd(allocator, self.fd, d.disk_size, d.bits);
         }
-        return rootdisk_delta.encodeFromFd(allocator, self.fd, self.capacity_sectors * 512, &.{});
+        return rootdisk_delta.encode_from_fd(allocator, self.fd, self.capacity_sectors * 512, &.{});
     }
 
-    fn markDirtyBytes(self: *Backend, offset: u64, len: u64) void {
+    fn mark_dirty_bytes(self: *Backend, offset: u64, len: u64) void {
         if (self.dirty) |*d| d.mark(offset, len);
     }
 
     /// The request-handler callback to feed `virtio.Device.request_handler`.
-    pub fn handleRequest(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
+    pub fn handle_request(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
         assert(ctx != null);
         _ = q_idx; // virtio-blk has just one queue (0)
         const self: *Backend = @ptrCast(@alignCast(ctx.?));
@@ -228,7 +228,7 @@ pub const Backend = struct {
         // 32 is a guest-input bound, not a programmer invariant; an evil/buggy guest can ring
         // a longer chain and we silently break, which is the right policy here.
         while (steps < 32) : (steps += 1) {
-            const d = dev.queueDescriptor(0, idx) orelse break;
+            const d = dev.queue_descriptor(0, idx) orelse break;
             if (hdr == null) {
                 hdr = d;
             } else if ((d.flags & virtio.VringDesc.F_NEXT) == 0 and d.len == 1) {
@@ -253,11 +253,11 @@ pub const Backend = struct {
 
         if (hdr == null or status_desc == null) {
             // Malformed; nothing to write back. Still ack the chain.
-            dev.queuePushUsed(0, head, 0);
+            dev.queue_push_used(0, head, 0);
             return;
         }
-        const hdr_bytes = dev.guestBytes(hdr.?.addr, @sizeOf(BlkOutHdr)) orelse {
-            dev.queuePushUsed(0, head, 0);
+        const hdr_bytes = dev.guest_bytes(hdr.?.addr, @sizeOf(BlkOutHdr)) orelse {
+            dev.queue_push_used(0, head, 0);
             return;
         };
         // Pair with the comptime layout assertion: every byte we copy lines up with a field.
@@ -269,7 +269,7 @@ pub const Backend = struct {
             .in => {
                 var sector = out_hdr.sector;
                 for (data[0..data_count]) |d| {
-                    const dst = dev.guestBytes(d.addr, d.len) orelse {
+                    const dst = dev.guest_bytes(d.addr, d.len) orelse {
                         status = VIRTIO_BLK_S_IOERR;
                         break;
                     };
@@ -281,7 +281,7 @@ pub const Backend = struct {
                     bytes_written += @intCast(n_bytes);
                     sector += dst.len / 512;
                 }
-                traceBlk("read", out_hdr.sector, data_count, bytes_written);
+                trace_blk("read", out_hdr.sector, data_count, bytes_written);
             },
             .out => {
                 if (self.read_only) {
@@ -290,12 +290,12 @@ pub const Backend = struct {
                     // a misbehaving one would silently get its bytes
                     // discarded by us — surface the error instead.
                     status = VIRTIO_BLK_S_IOERR;
-                    traceBlk("write-rejected-ro", out_hdr.sector, data_count, 0);
+                    trace_blk("write-rejected-ro", out_hdr.sector, data_count, 0);
                 } else {
                     var total_bytes: u32 = 0;
                     var sector = out_hdr.sector;
                     for (data[0..data_count]) |d| {
-                        const src = dev.guestBytes(d.addr, d.len) orelse {
+                        const src = dev.guest_bytes(d.addr, d.len) orelse {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         };
@@ -305,11 +305,11 @@ pub const Backend = struct {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         }
-                        self.markDirtyBytes(byte_off, @intCast(n_bytes));
+                        self.mark_dirty_bytes(byte_off, @intCast(n_bytes));
                         total_bytes += @intCast(n_bytes);
                         sector += src.len / 512;
                     }
-                    traceBlk("write", out_hdr.sector, data_count, total_bytes);
+                    trace_blk("write", out_hdr.sector, data_count, total_bytes);
                 }
             },
             .flush => {
@@ -329,7 +329,7 @@ pub const Backend = struct {
                     for (data[0..data_count]) |d| {
                         const seg_count: usize = d.len / @sizeOf(BlkDiscardSeg);
                         if (seg_count == 0) continue;
-                        const bytes = dev.guestBytes(d.addr, seg_count * @sizeOf(BlkDiscardSeg)) orelse {
+                        const bytes = dev.guest_bytes(d.addr, seg_count * @sizeOf(BlkDiscardSeg)) orelse {
                             status = VIRTIO_BLK_S_IOERR;
                             break;
                         };
@@ -340,17 +340,17 @@ pub const Backend = struct {
                             const offset_bytes: i64 = @as(i64, @intCast(seg.sector)) * 512;
                             const len_bytes: i64 = @as(i64, @intCast(seg.num_sectors)) * 512;
                             if (len_bytes <= 0) continue;
-                            self.markDirtyBytes(@intCast(offset_bytes), @intCast(len_bytes));
-                            const rc = punchHole(self.fd, offset_bytes, len_bytes);
+                            self.mark_dirty_bytes(@intCast(offset_bytes), @intCast(len_bytes));
+                            const rc = punch_hole(self.fd, offset_bytes, len_bytes);
                             if (rc != 0) {
                                 // EOPNOTSUPP / EINVAL on hosts that
                                 // don't support hole-punching — log
                                 // once at debug level so it's diagnosable.
-                                traceBlk("discard-fallback", seg.sector, seg.num_sectors, 0);
+                                trace_blk("discard-fallback", seg.sector, seg.num_sectors, 0);
                             }
                         }
                     }
-                    traceBlk("discard", out_hdr.sector, data_count, 0);
+                    trace_blk("discard", out_hdr.sector, data_count, 0);
                 }
             },
             .get_id => {
@@ -358,7 +358,7 @@ pub const Backend = struct {
                 if (data_count >= 1) {
                     const id_str: []const u8 = "machinen-vda" ++ ("\x00" ** 8);
                     assert(id_str.len == 20);
-                    const dst = dev.guestBytes(data[0].addr, @min(data[0].len, 20)) orelse {
+                    const dst = dev.guest_bytes(data[0].addr, @min(data[0].len, 20)) orelse {
                         status = VIRTIO_BLK_S_IOERR;
                         return;
                     };
@@ -376,18 +376,18 @@ pub const Backend = struct {
             status == VIRTIO_BLK_S_UNSUPP);
 
         // Write the status byte the device owes the guest.
-        if (dev.guestBytes(status_desc.?.addr, 1)) |st| {
+        if (dev.guest_bytes(status_desc.?.addr, 1)) |st| {
             assert(st.len == 1);
             st[0] = status;
         }
 
         // virtio-blk reports used `len` as the number of bytes the
         // DEVICE wrote into the chain (read data + the status byte).
-        dev.queuePushUsed(0, head, bytes_written + 1);
+        dev.queue_push_used(0, head, bytes_written + 1);
     }
 };
 
-fn traceBlk(kind: []const u8, sector: u64, segs: usize, bytes: u32) void {
+fn trace_blk(kind: []const u8, sector: u64, segs: usize, bytes: u32) void {
     assert(kind.len > 0);
     assert(kind.len < 16);
     // Per-request tracing is great for bring-up but useless at volume
@@ -421,7 +421,7 @@ extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
 // correctness, and HVF is dev-only anyway.
 const has_fallocate = builtin.os.tag == .linux;
 extern "c" fn fallocate(fd: c_int, mode: c_int, offset: i64, len: i64) c_int;
-fn punchHole(fd: c_int, offset: i64, len: i64) c_int {
+fn punch_hole(fd: c_int, offset: i64, len: i64) c_int {
     if (!has_fallocate) return -1;
     return fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset, len);
 }
@@ -438,15 +438,15 @@ pub const FALLOC_FL_PUNCH_HOLE: c_int = 0x02;
 
 /// Convenience: open a host file read-write and wrap it as a Backend.
 /// Returns `FileNotFound` / `IoError` on obvious failures.
-pub fn openFile(path: []const u8) !Backend {
-    return openFileWithMode(path, false);
+pub fn open_file(path: []const u8) !Backend {
+    return open_file_with_mode(path, false);
 }
 
 /// Same as `openFile` but lets callers pin the host fd (and the
 /// resulting Backend) to read-only — used for paths backing the
 /// squashfs lower in #272 where guest writes would corrupt the
 /// content-addressed cache file.
-pub fn openFileWithMode(path: []const u8, read_only: bool) !Backend {
+pub fn open_file_with_mode(path: []const u8, read_only: bool) !Backend {
     assert(path.len > 0);
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return error.NameTooLong;
@@ -463,5 +463,5 @@ pub fn openFileWithMode(path: []const u8, read_only: bool) !Backend {
         return error.IoError;
     }
     assert(size > 0);
-    return Backend.initFromFdWithMode(fd, @intCast(size), read_only);
+    return Backend.init_from_fd_with_mode(fd, @intCast(size), read_only);
 }

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -182,7 +182,7 @@ pub const Result = struct {
 /// are gated behind this so interactive boots (`try.sh shell` /
 /// `try.sh repl`) don't bury the user's shell output under VMM logs.
 /// Smokes that assert on `[tx]` lines set it before they run.
-fn debugEnabled() bool {
+fn debug_enabled() bool {
     return getenv("MACHINEN_DEBUG") != null;
 }
 
@@ -192,7 +192,7 @@ fn debugEnabled() bool {
 /// Caller-supplied layout must satisfy the basic geometry the boot
 /// protocol depends on. These are programmer errors at the call site,
 /// not anything the guest can influence — assert hard.
-fn validateConfig(cfg: Config) void {
+fn validate_config(cfg: Config) void {
     assert(cfg.kernel_path.len > 0);
     assert(cfg.dtb_path.len > 0);
     assert(cfg.ram_size >= 16 * 1024 * 1024);
@@ -210,24 +210,24 @@ fn validateConfig(cfg: Config) void {
 /// 0x080A_0000 per a QEMU `virt,gic-version=3` DTB dump). Without
 /// this the kernel has nowhere to register interrupts and the virtual
 /// timer has nothing to deliver to.
-fn enableGic() !void {
+fn enable_gic() !void {
     try hvf.Gic.enable(.{});
-    if (debugEnabled()) {
+    if (debug_enabled()) {
         std.debug.print(
             "GIC dist align=0x{x} size=0x{x}; rdist align=0x{x} size=0x{x} region=0x{x}\n",
             .{
-                try hvf.Gic.distributorAlignment(),
-                try hvf.Gic.distributorSize(),
-                try hvf.Gic.redistributorAlignment(),
-                try hvf.Gic.redistributorSize(),
-                try hvf.Gic.redistributorRegionSize(),
+                try hvf.Gic.distributor_alignment(),
+                try hvf.Gic.distributor_size(),
+                try hvf.Gic.redistributor_alignment(),
+                try hvf.Gic.redistributor_size(),
+                try hvf.Gic.redistributor_region_size(),
             },
         );
     }
 }
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
-    validateConfig(cfg);
+    validate_config(cfg);
 
     // Install the SIGUSR1 snapshot handler FIRST — before the
     // multi-second fixture load + device bring-up. Until the handler
@@ -237,7 +237,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // The watcher thread still starts later (it needs the vCPU
     // handle); a SIGUSR1 in the gap just sets the atomic flag, which
     // the watcher picks up the moment it comes up.
-    if (cfg.snapshot_path != null) installSnapshotSignal();
+    if (cfg.snapshot_path != null) install_snapshot_signal();
 
     // Topology fingerprint — matches the KVM side (task #25). GIC
     // addresses on HVF are baked into hvf.Gic defaults (no Config
@@ -248,24 +248,24 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .gic_dist_base = 0x0800_0000,
         .gic_redist_base = 0x1000_0000,
     };
-    const topo_hex = topo.hashHex();
+    const topo_hex = topo.hash_hex();
     std.debug.print("topology: {s}\n", .{topo_hex});
 
-    var fx = try loadFixtures(gpa, cfg);
+    var fx = try load_fixtures(gpa, cfg);
     defer fx.deinit(gpa);
 
-    const ram = try allocateAndPopulateRam(gpa, cfg, fx);
+    const ram = try allocate_and_populate_ram(gpa, cfg, fx);
     defer std.posix.munmap(ram);
 
     const vm = if (cfg.nested) nested_vm: {
-        break :nested_vm hvf.Vm.createNested() catch |err| {
+        break :nested_vm hvf.Vm.create_nested() catch |err| {
             std.debug.print("hvf boot: nested virtualization requested but EL2 is unavailable: {s}\n", .{@errorName(err)});
             return error.NestedVirtUnsupported;
         };
     } else try hvf.Vm.create();
     defer vm.destroy();
 
-    try enableGic();
+    try enable_gic();
 
     // Give the guest full read/write/execute on this region. Stage-2
     // permissions; the guest's own MMU still decides what it does at
@@ -273,7 +273,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     try vm.map(ram, cfg.ram_base, hvf.MapFlags.rwx);
     defer vm.unmap(cfg.ram_base, cfg.ram_size) catch {};
 
-    const vcpu = try initVcpu(fx.img, cfg);
+    const vcpu = try init_vcpu(fx.img, cfg);
     defer vcpu.destroy();
 
     // --- run loop -------------------------------------------------
@@ -290,7 +290,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // protocol QEMU uses with `-netdev socket,fd=…`.
     const virtio_mac = [_]u8{ 0x02, 0xDE, 0xAD, 0xBE, 0xEF, 0x01 };
     var tx_stats = TxStats{};
-    var netdev = makeNetDevice(ram, cfg, &virtio_mac, &onTxFrame, @ptrCast(&tx_stats));
+    var netdev = make_net_device(ram, cfg, &virtio_mac, &on_tx_frame, @ptrCast(&tx_stats));
 
     // virtio-blk (#47, #114). Two slots:
     //   slot 1 (virtio_blk_base)  — rootdisk preferred; falls back to
@@ -305,23 +305,23 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
     const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
 
-    var blk_backend_opt: ?blk_mod.Backend = openBlkBackend(slot1_path, "slot 1");
+    var blk_backend_opt: ?blk_mod.Backend = open_blk_backend(slot1_path, "slot 1");
     defer if (blk_backend_opt) |*b| b.deinit();
     if (cfg.rootdisk_path != null and cfg.snapshot_path != null) {
-        if (blk_backend_opt) |*b| b.enableDirtyTracking(gpa) catch |err| {
+        if (blk_backend_opt) |*b| b.enable_dirty_tracking(gpa) catch |err| {
             std.debug.print("blk: rootdisk dirty tracking disabled: {s}\n", .{@errorName(err)});
         };
     }
     var blkdev_opt: ?virtio.Device = if (blk_backend_opt) |*b|
-        makeBlkDevice(virtio_blk_base, virtio_blk_size, ram, cfg, b)
+        make_blk_device(virtio_blk_base, virtio_blk_size, ram, cfg, b)
     else
         null;
     const blkdev_ptr: ?*virtio.Device = if (blkdev_opt) |_| &blkdev_opt.? else null;
 
-    var blk2_backend_opt: ?blk_mod.Backend = openBlkBackend(slot3_path, "slot 3");
+    var blk2_backend_opt: ?blk_mod.Backend = open_blk_backend(slot3_path, "slot 3");
     defer if (blk2_backend_opt) |*b| b.deinit();
     var blk2dev_opt: ?virtio.Device = if (blk2_backend_opt) |*b|
-        makeBlkDevice(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
+        make_blk_device(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
     else
         null;
     const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
@@ -336,26 +336,26 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // `vm.memoryStats()` can read the live counters. Falls back to
     // a process-static stub on env-missing or open failure —
     // observability is best-effort, the device must boot regardless.
-    var stats_inst = stats_mod.Stats.openOrStub();
+    var stats_inst = stats_mod.Stats.open_or_stub();
     defer stats_inst.deinit();
     // Darwin-only background thread that polls `phys_footprint`
     // into the stats file every ~500 ms, so the host runtime's
     // `vm.memoryStats().hostRssBytes` reflects balloon reclaim
     // (`MADV_FREE_REUSABLE` doesn't drop `task_basic_info.resident_size`).
     // No-op on Linux. See `stats.zig` for details.
-    stats_mod.startPhysFootprintSampler(stats_inst.counters);
-    var balloon_backend = balloon_mod.Backend.initWithCounters(stats_inst.counters);
-    var balloon_dev = makeBalloonDevice(ram, cfg, &balloon_backend);
+    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
+    var balloon_dev = make_balloon_device(ram, cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;
 
     // virtio-blk slot 5 — squashfs RO lower for the `--mount` overlay
     // (#272). The runtime fd-passes the content-addressed cache file
     // O_RDONLY; we wrap it in a read-only Backend so any guest write
     // is rejected with VIRTIO_BLK_S_IOERR before the host pwrite.
-    var blk3_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
+    var blk3_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
     defer if (blk3_backend_opt) |*b| b.deinit();
     var blk3dev_opt: ?virtio.Device = if (blk3_backend_opt) |*b|
-        makeBlkDevice(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
+        make_blk_device(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
     else
         null;
     const blk3dev_ptr: ?*virtio.Device = if (blk3dev_opt) |_| &blk3dev_opt.? else null;
@@ -364,10 +364,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // (#272). Per-VM sparse file, opened O_RDWR; we negotiate
     // VIRTIO_BLK_F_DISCARD so ext4's `discard` mount option auto-
     // PUNCH_HOLEs the upper as the guest deletes.
-    var blk4_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
+    var blk4_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
     defer if (blk4_backend_opt) |*b| b.deinit();
     var blk4dev_opt: ?virtio.Device = if (blk4_backend_opt) |*b|
-        makeBlkDeviceWithDiscard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
+        make_blk_device_with_discard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
     else
         null;
     const blk4dev_ptr: ?*virtio.Device = if (blk4dev_opt) |_| &blk4dev_opt.? else null;
@@ -380,9 +380,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     //
     // Parsed paths are allocated from gpa and leak for the VMM's life.
     const vsock_cid_storage: u64 = vsock_mod.default_guest_cid;
-    const vsock_ports = parseVsockEnv(gpa);
+    const vsock_ports = parse_vsock_env(gpa);
     var vsock_dev_opt: ?virtio.Device = if (vsock_ports.len > 0)
-        makeVsockDevice(ram, cfg, &vsock_cid_storage)
+        make_vsock_device(ram, cfg, &vsock_cid_storage)
     else
         null;
     const vsock_dev_ptr: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
@@ -394,14 +394,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // no guest fuse-agent. Request handling is synchronous on the vCPU
     // thread (the device's `request_handler` drains on each guest
     // kick), so unlike vsock no host poll thread is needed.
-    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parseVirtiofsEnv();
+    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parse_virtiofs_env();
     defer for (&virtiofs_backends) |*b| {
         if (b.*) |*d| d.deinit();
     };
     var virtiofs_devs: [MAX_VIRTIOFS_SLOTS]?virtio.Device = undefined;
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         virtiofs_devs[i] = if (virtiofs_backends[i]) |*b|
-            makeVirtioFsDevice(virtio_virtiofs_bases[i], ram, cfg, b)
+            make_virtio_fs_device(virtio_virtiofs_bases[i], ram, cfg, b)
         else
             null;
     }
@@ -411,7 +411,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     }
 
     // Connect to gvproxy if a socket path was provided.
-    const net_inst: ?*net_mod.NetSocket = connectGvproxy(gpa, &netdev);
+    const net_inst: ?*net_mod.NetSocket = connect_gvproxy(gpa, &netdev);
     defer if (net_inst) |n| n.destroy();
     // Bridge context passed into TX/RX callbacks.
     var net_ctx = NetBridge{
@@ -419,18 +419,18 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .net = net_inst,
     };
     if (net_inst != null) {
-        netdev.tx_handler = &onTxFrameBridge;
+        netdev.tx_handler = &on_tx_frame_bridge;
         netdev.tx_ctx = @ptrCast(&net_ctx);
     }
 
-    const irqs = try assignIrqs();
+    const irqs = try assign_irqs();
 
     // Feed the virtio IRQ id into the network bridge, and arm the
     // RX callback so the net backend can raise the SPI after each
     // frame it injects.
     net_ctx.virtio_irq = irqs.net;
     if (net_inst) |n| {
-        n.on_rx = &onNetRx;
+        n.on_rx = &on_net_rx;
         n.on_rx_ctx = @ptrCast(&net_ctx);
     }
 
@@ -439,7 +439,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var vsock_irq_ctx = VsockIrqCtx{ .irq = irqs.vsock };
     var vsock_bridge_opt: ?*vsock_mod.Bridge = null;
     if (vsock_dev_ptr) |d| {
-        vsock_bridge_opt = startVsockBridge(gpa, d, vsock_ports, &vsock_irq_ctx);
+        vsock_bridge_opt = start_vsock_bridge(gpa, d, vsock_ports, &vsock_irq_ctx);
         if (vsock_bridge_opt == null) vsock_dev_opt = null;
     }
     defer if (vsock_bridge_opt) |b| b.destroy();
@@ -458,7 +458,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .uart = &uart,
         .irq = irqs.pl011,
     };
-    const stdin_thread = try std.Thread.spawn(.{}, stdinThreadMain, .{&stdin_ctx});
+    const stdin_thread = try std.Thread.spawn(.{}, stdin_thread_main, .{&stdin_ctx});
     defer {
         stdin_ctx.stop.store(true, .release);
         stdin_thread.detach();
@@ -483,7 +483,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // Apply restore-from-vmstate before the first vcpu.run() if the
     // host orchestrator gave us one.
     if (cfg.restore_path) |path| {
-        applyRestoreFile(gpa, path, vcpu, ram, cfg, &devs) catch |err| {
+        apply_restore_file(gpa, path, vcpu, ram, cfg, &devs) catch |err| {
             std.debug.print("hvf boot: restore from {s} failed: {s}\n", .{ path, @errorName(err) });
             return err;
         };
@@ -491,10 +491,10 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     }
     if (cfg.snapshot_path != null) {
         std.debug.print("hvf boot: starting snapshot watcher (vcpu={d})\n", .{vcpu.handle});
-        startSnapshotWatcher(vcpu.handle);
+        start_snapshot_watcher(vcpu.handle);
     }
 
-    return try runLoop(gpa, cfg, vm, vcpu, &devs, irqs, ram);
+    return try run_loop(gpa, cfg, vm, vcpu, &devs, irqs, ram);
 }
 
 // SIGUSR1 atomic + watcher-thread plumbing. macOS HVF doesn't return
@@ -512,7 +512,7 @@ var snapshot_watcher_vcpu: u64 = 0;
 
 extern "c" fn hv_vcpus_exit(vcpus: *const u64, count: u32) c_int;
 
-fn sigusr1HandlerHvf(sig: c_int) callconv(.c) void {
+fn sigusr1_handler_hvf(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_requested_hvf.store(true, .seq_cst);
     // async-signal-safe diagnostic: write() is on the safe list.
@@ -523,22 +523,22 @@ fn sigusr1HandlerHvf(sig: c_int) callconv(.c) void {
     _ = c.write(2, msg.ptr, msg.len);
 }
 
-fn sigusr2HandlerHvf(sig: c_int) callconv(.c) void {
+fn sigusr2_handler_hvf(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_resume_requested_hvf.store(true, .seq_cst);
 }
 
-fn installSnapshotSignal() void {
+fn install_snapshot_signal() void {
     const c = struct {
         extern "c" fn signal(sig: c_int, handler: usize) usize;
     };
     const SIGUSR1: c_int = 30; // macOS SIGUSR1; differs from Linux (10)
     const SIGUSR2: c_int = 31; // macOS SIGUSR2; differs from Linux (12)
-    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1HandlerHvf));
-    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2HandlerHvf));
+    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1_handler_hvf));
+    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2_handler_hvf));
 }
 
-fn waitForSnapshotResumeHvf() void {
+fn wait_for_snapshot_resume_hvf() void {
     const c = struct {
         extern "c" fn usleep(usec: u32) c_int;
     };
@@ -557,7 +557,7 @@ fn waitForSnapshotResumeHvf() void {
     }
 }
 
-fn snapshotWatcherThread(arg: ?*anyopaque) callconv(.c) ?*anyopaque {
+fn snapshot_watcher_thread(arg: ?*anyopaque) callconv(.c) ?*anyopaque {
     _ = arg;
     std.debug.print("hvf watcher: thread started, vcpu={d}\n", .{snapshot_watcher_vcpu});
     const c = struct {
@@ -579,7 +579,7 @@ fn snapshotWatcherThread(arg: ?*anyopaque) callconv(.c) ?*anyopaque {
     return null;
 }
 
-fn startSnapshotWatcher(vcpu_handle: u64) void {
+fn start_snapshot_watcher(vcpu_handle: u64) void {
     snapshot_watcher_vcpu = vcpu_handle;
     snapshot_watcher_running.store(true, .seq_cst);
     const c = struct {
@@ -594,7 +594,7 @@ fn startSnapshotWatcher(vcpu_handle: u64) void {
         extern "c" fn pthread_detach(thread: ?*anyopaque) c_int;
     };
     var tid: ?*anyopaque = null;
-    const rc = c.pthread_create(&tid, null, &snapshotWatcherThread, null);
+    const rc = c.pthread_create(&tid, null, &snapshot_watcher_thread, null);
     if (rc != 0) {
         std.debug.print("hvf boot: pthread_create failed: {d}\n", .{rc});
         return;
@@ -613,7 +613,7 @@ const SNAP_O_RDONLY: c_int = 0;
 const SNAP_SEEK_END: c_int = 2;
 const SNAP_SEEK_SET: c_int = 0;
 
-fn captureSnapshotJob(
+fn capture_snapshot_job(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: hvf.Vcpu,
@@ -638,25 +638,25 @@ fn captureSnapshotJob(
 
     const job = try vmstate_writer.Job.create(gpa, "hvf", path, topo.hash());
     errdefer job.destroy();
-    const a = job.arenaAllocator();
+    const a = job.arena_allocator();
 
-    const vcpu_payload = try vcpu_dump.dumpHvf(a, vcpu.handle);
+    const vcpu_payload = try vcpu_dump.dump_hvf(a, vcpu.handle);
     const ram_payload = if (full_ram)
         try ram_dump.encode(a, cfg.ram_base, ram)
     else
-        try ram_dump.encodeDelta(a, cfg.ram_base, ram, dirty_bits.?);
+        try ram_dump.encode_delta(a, cfg.ram_base, ram, dirty_bits.?);
     // GICv3 distributor + per-vCPU redistributor state. Without these
     // a cross-VMM restore lands the guest on a fresh GIC: interrupts
     // the kernel thinks are enabled (the vtimer PPI especially) are
     // silently disabled, and the resumed guest never makes progress.
-    const gic_dist_payload = try gic_state.dumpHvfDist(a);
-    const gic_redist_payload = try gic_state.dumpHvfRedist(a, vcpu.handle);
+    const gic_dist_payload = try gic_state.dump_hvf_dist(a);
+    const gic_redist_payload = try gic_state.dump_hvf_redist(a, vcpu.handle);
     // CPU interface (ICC_*) — captured via hv_gic_get_icc_reg. This
     // gates whether interrupts the distributor marks pending actually
     // reach the resumed vCPU; without a real capture the restored
     // interface sits at reset (IGRPEN1=0, PMR=0) and the guest never
     // wakes from its idle WFI.
-    const gic_cpuif_payload = try gic_state.dumpHvfCpuIf(a, vcpu.handle);
+    const gic_cpuif_payload = try gic_state.dump_hvf_cpu_if(a, vcpu.handle);
 
     // One `.virtio` section per present device — the section `id` is
     // the device's MMIO base so restore can match it back. Without
@@ -664,7 +664,7 @@ fn captureSnapshotJob(
     // freshly-reset device (queues unconfigured) and every notify is
     // dropped — the exec-agent's vsock goes silent.
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
 
     var sections = std.ArrayList(snapshot.Section).empty;
     try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
@@ -673,7 +673,7 @@ fn captureSnapshotJob(
     try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
     try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
     for (vdevs) |d| {
-        const vp = try virtio_dump.dumpDevice(a, d);
+        const vp = try virtio_dump.dump_device(a, d);
         try sections.append(a, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
     }
     // virtio-fs FUSE backend state — the nodeid→path map and the open
@@ -686,12 +686,12 @@ fn captureSnapshotJob(
     for (vdevs) |d| {
         if (d.id != .virtio_fs) continue;
         const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-        const fp = try backend.state.dumpState(a);
+        const fp = try backend.state.dump_state(a);
         try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
     if (!full_ram) {
         if (devs.root_blk) |b| {
-            const dp = try b.encodeDirtyDelta(a);
+            const dp = try b.encode_dirty_delta(a);
             try sections.append(a, .{ .tag = .rootdisk_delta, .id = 0, .payload = dp });
         }
     }
@@ -699,7 +699,7 @@ fn captureSnapshotJob(
     return job;
 }
 
-fn applyRestoreFile(
+fn apply_restore_file(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: hvf.Vcpu,
@@ -737,7 +737,7 @@ fn applyRestoreFile(
     timing.mark("read-file");
 
     // gunzip if the file is compressed; a plain .vmstate borrows `raw`.
-    const decoded = try @import("vmstate_zip.zig").decompressMaybeOwned(gpa, raw);
+    const decoded = try @import("vmstate_zip.zig").decompress_maybe_owned(gpa, raw);
     defer decoded.deinit(gpa);
     timing.mark("decompress");
 
@@ -765,31 +765,31 @@ fn applyRestoreFile(
     // the end — re-enabling the GIC without fixing the counter jump
     // just trades a quiescent guest for a tick-catch-up storm.
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
     var gic_cpuif_applied = false;
     for (snap.sections) |s| {
-        const section_t0 = timing.sectionStart();
+        const section_t0 = timing.section_start();
         switch (s.tag) {
-            .vcpu => try vcpu_dump.loadHvf(gpa, vcpu.handle, s.payload),
+            .vcpu => try vcpu_dump.load_hvf(gpa, vcpu.handle, s.payload),
             .ram => {
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
-                _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
+                _ = try ram_dump.decode_into_zeroed(s.payload, ram);
             },
             .ram_delta => {
                 // Overlay a checkpoint delta onto the RAM reconstructed
                 // from its parent section(s).
-                _ = try ram_dump.decodeDeltaInto(s.payload, ram);
+                _ = try ram_dump.decode_delta_into(s.payload, ram);
             },
-            .gic_dist => gic_state.loadHvfDist(gpa, s.payload) catch |err| {
+            .gic_dist => gic_state.load_hvf_dist(gpa, s.payload) catch |err| {
                 std.debug.print("hvf boot: gic_dist restore failed: {s}\n", .{@errorName(err)});
             },
-            .gic_redist => gic_state.loadHvfRedist(gpa, vcpu.handle, s.payload) catch |err| {
+            .gic_redist => gic_state.load_hvf_redist(gpa, vcpu.handle, s.payload) catch |err| {
                 std.debug.print("hvf boot: gic_redist restore failed: {s}\n", .{@errorName(err)});
             },
             .gic_cpuif => {
                 if (s.payload.len > 4) {
-                    gic_state.loadHvfCpuIf(gpa, vcpu.handle, s.payload) catch |err| {
+                    gic_state.load_hvf_cpu_if(gpa, vcpu.handle, s.payload) catch |err| {
                         std.debug.print("hvf boot: gic_cpuif restore failed: {s}\n", .{@errorName(err)});
                     };
                     gic_cpuif_applied = true;
@@ -803,7 +803,7 @@ fn applyRestoreFile(
             .virtio => {
                 for (vdevs) |d| {
                     if (@as(u32, @truncate(d.base)) == s.id) {
-                        virtio_dump.applyDevice(gpa, d, s.payload) catch |err| {
+                        virtio_dump.apply_device(gpa, d, s.payload) catch |err| {
                             std.debug.print(
                                 "hvf boot: virtio restore for base 0x{x} failed: {s}\n",
                                 .{ d.base, @errorName(err) },
@@ -822,7 +822,7 @@ fn applyRestoreFile(
                     if (d.id != .virtio_fs) continue;
                     if (@as(u32, @truncate(d.base)) != s.id) continue;
                     const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-                    backend.state.applyState(s.payload) catch |err| {
+                    backend.state.apply_state(s.payload) catch |err| {
                         std.debug.print(
                             "hvf boot: virtio-fs state restore for base 0x{x} failed: {s}\n",
                             .{ d.base, @errorName(err) },
@@ -843,7 +843,7 @@ fn applyRestoreFile(
     // written before `dumpHvfCpuIf` could capture the CPU interface —
     // without *some* programming the interface stays at reset and the
     // resumed guest never wakes from its idle WFI.
-    if (!gic_cpuif_applied) gic_state.applyHvfCpuIfDefaults(vcpu.handle);
+    if (!gic_cpuif_applied) gic_state.apply_hvf_cpu_if_defaults(vcpu.handle);
     timing.mark("gic-cpuif-fallback");
 
     // Virtual-timer fixup. loadHvf restored CNTV_CVAL_EL0 — an absolute
@@ -919,13 +919,13 @@ const RamDirtyTracker = struct {
         self.bits = &.{};
     }
 
-    fn activateClean(self: *RamDirtyTracker) !void {
+    fn activate_clean(self: *RamDirtyTracker) !void {
         @memset(self.bits, 0);
         try self.vm.protect(self.ram_base, self.ram_size, hvf.MapFlags.rx);
         self.active = true;
     }
 
-    fn handleWriteFault(self: *RamDirtyTracker, info: hvf.DataAbort) !bool {
+    fn handle_write_fault(self: *RamDirtyTracker, info: hvf.DataAbort) !bool {
         if (!self.active or !info.is_write) return false;
         if (info.ipa < self.ram_base) return false;
         const rel = info.ipa - self.ram_base;
@@ -950,7 +950,7 @@ const RamDirtyTracker = struct {
 /// configured serial-capture threshold, or `max_exits`. Each exit is
 /// classified and dispatched to the appropriate handler; the loop
 /// owns the `saw_off` / `exits` accounting and emits the final Result.
-fn runLoop(
+fn run_loop(
     gpa: std.mem.Allocator,
     cfg: Config,
     vm: hvf.Vm,
@@ -966,7 +966,7 @@ fn runLoop(
     var ram_dirty = try RamDirtyTracker.init(gpa, vm, cfg);
     defer ram_dirty.deinit();
     if (checkpoint_delta_mode and cfg.snapshot_path != null) {
-        try ram_dirty.activateClean();
+        try ram_dirty.activate_clean();
     }
     var snapshot_writer_state: vmstate_writer.Writer = .{};
     defer snapshot_writer_state.wait();
@@ -983,11 +983,11 @@ fn runLoop(
                     snapshot_resume_requested_hvf.store(false, .seq_cst);
                     const full_ram = !checkpoint_delta_mode;
                     const dirty_bits: ?[]const u64 = if (full_ram) null else ram_dirty.bits;
-                    if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
+                    if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
                         snapshotted = true;
                         checkpoint_delta_mode = true;
-                        try ram_dirty.activateClean();
-                        if (devs.root_blk) |b| b.clearDirty();
+                        try ram_dirty.activate_clean();
+                        if (devs.root_blk) |b| b.clear_dirty();
                         // Clear the flag and wait for the runtime's
                         // SIGUSR2 before RESUME so sidecar files are
                         // point-in-time consistent with CPU/RAM. Keep
@@ -995,7 +995,7 @@ fn runLoop(
                         // (chained snapshot / fork-the-fork) triggers
                         // another capture.
                         snapshot_requested_hvf.store(false, .seq_cst);
-                        waitForSnapshotResumeHvf();
+                        wait_for_snapshot_resume_hvf();
                     } else {
                         snapshot_requested_hvf.store(false, .seq_cst);
                     }
@@ -1008,23 +1008,23 @@ fn runLoop(
         // we don't immediately re-fire on the next run; the kernel
         // handles the timer interrupt the GIC delivers.
         if (vcpu.exit.reason == .vtimer_activated) {
-            try vcpu.setVtimerMask(true);
-            try vcpu.setVtimerMask(false);
+            try vcpu.set_vtimer_mask(true);
+            try vcpu.set_vtimer_mask(false);
             continue;
         }
 
         if (vcpu.exit.reason != .exception) {
-            logUnhandledExit(vcpu, "non-exception exit");
+            log_unhandled_exit(vcpu, "non-exception exit");
             return error.GuestCrashed;
         }
-        const ec = hvf.ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome);
+        const ec = hvf.ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
 
         switch (ec) {
             .trapped_wfx => {
-                try handleWaitTrap(vcpu);
+                try handle_wait_trap(vcpu);
             },
             .hvc_aarch64, .smc_aarch64 => {
-                switch (try handlePsci(vcpu)) {
+                switch (try handle_psci(vcpu)) {
                     .shutdown => {
                         saw_off = true;
                         break;
@@ -1033,19 +1033,19 @@ fn runLoop(
                 }
             },
             .system_register => {
-                if (!try handleSystemRegisterTrap(vcpu)) {
-                    logUnhandledException(vcpu, ec, "unsupported system-register trap");
+                if (!try handle_system_register_trap(vcpu)) {
+                    log_unhandled_exception(vcpu, ec, "unsupported system-register trap");
                     break;
                 }
             },
             .data_abort_lower_el => {
                 const info = hvf.DataAbort.decode(vcpu.exit.exception);
-                if (!try ram_dirty.handleWriteFault(info)) {
-                    try routeDataAbort(vcpu, devs, irqs, info);
+                if (!try ram_dirty.handle_write_fault(info)) {
+                    try route_data_abort(vcpu, devs, irqs, info);
                 }
             },
             else => {
-                logUnhandledException(vcpu, ec, "unhandled exception class");
+                log_unhandled_exception(vcpu, ec, "unhandled exception class");
                 break;
             },
         }
@@ -1070,13 +1070,13 @@ fn runLoop(
                 snapshot_resume_requested_hvf.store(false, .seq_cst);
                 const full_ram = !checkpoint_delta_mode;
                 const dirty_bits: ?[]const u64 = if (full_ram) null else ram_dirty.bits;
-                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
+                if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits)) {
                     snapshotted = true;
                     checkpoint_delta_mode = true;
-                    try ram_dirty.activateClean();
-                    if (devs.root_blk) |b| b.clearDirty();
+                    try ram_dirty.activate_clean();
+                    if (devs.root_blk) |b| b.clear_dirty();
                     snapshot_requested_hvf.store(false, .seq_cst);
-                    waitForSnapshotResumeHvf();
+                    wait_for_snapshot_resume_hvf();
                 } else {
                     snapshot_requested_hvf.store(false, .seq_cst);
                 }
@@ -1086,7 +1086,7 @@ fn runLoop(
 
     if (exits >= cfg.max_exits) return error.RanTooLong;
 
-    const serial = try gpa.dupe(u8, devs.uart.capturedBytes());
+    const serial = try gpa.dupe(u8, devs.uart.captured_bytes());
     return .{
         .serial = serial,
         .saw_psci_shutdown = saw_off,
@@ -1099,18 +1099,18 @@ fn runLoop(
 /// instead of blocking inside hv_vcpu_run(). Emulate the architected
 /// wait instruction by stepping over it and yielding briefly; pending
 /// GIC/timer state is then observed on the next vCPU entry.
-fn handleWaitTrap(vcpu: hvf.Vcpu) !void {
+fn handle_wait_trap(vcpu: hvf.Vcpu) !void {
     const trap = hvf.WaitTrap.decode(vcpu.exit.exception);
-    const pc = try vcpu.getReg(.pc);
-    try vcpu.setReg(.pc, pc + 4);
+    const pc = try vcpu.get_reg(.pc);
+    try vcpu.set_reg(.pc, pc + 4);
 
     // WFI should park until an interrupt, while WFE is only a hint.
     // HVF does not expose a portable "pending interrupt" poll here,
     // so use a tiny sleep to avoid a hot idle spin while keeping exec /
     // network wakeups responsive.
     switch (trap.instruction) {
-        .wfi => sleepMicros(250),
-        .wfe => sleepMicros(10),
+        .wfi => sleep_micros(250),
+        .wfe => sleep_micros(10),
     }
 }
 
@@ -1118,63 +1118,63 @@ fn handleWaitTrap(vcpu: hvf.Vcpu) !void {
 /// choose to expose system-register traps that older macOS releases
 /// handled internally; if HVF recognizes the register, emulating it
 /// here keeps the Linux boot moving without hard-coding guest values.
-fn handleSystemRegisterTrap(vcpu: hvf.Vcpu) !bool {
+fn handle_system_register_trap(vcpu: hvf.Vcpu) !bool {
     const trap = hvf.SysRegTrap.decode(vcpu.exit.exception);
     if (trap.is_read) {
-        const value = readTrappedSysReg(vcpu, trap.encoding) catch |err| switch (err) {
+        const value = read_trapped_sys_reg(vcpu, trap.encoding) catch |err| switch (err) {
             error.BadArgument, error.Denied, error.Unsupported => return false,
             else => return err,
         };
-        try trap.writeTarget(vcpu, value);
+        try trap.write_target(vcpu, value);
     } else {
-        const value = try trap.readSource(vcpu);
-        writeTrappedSysReg(vcpu, trap.encoding, value) catch |err| switch (err) {
+        const value = try trap.read_source(vcpu);
+        write_trapped_sys_reg(vcpu, trap.encoding, value) catch |err| switch (err) {
             error.BadArgument, error.Denied, error.Unsupported => return false,
             else => return err,
         };
     }
 
-    const pc = try vcpu.getReg(.pc);
-    try vcpu.setReg(.pc, pc + 4);
+    const pc = try vcpu.get_reg(.pc);
+    try vcpu.set_reg(.pc, pc + 4);
     return true;
 }
 
-fn readTrappedSysReg(vcpu: hvf.Vcpu, encoding: u16) hvf.Error!u64 {
-    if (hvf.Gic.isIccReg(encoding)) {
-        return hvf.Gic.readIcc(vcpu, encoding) catch |err| switch (err) {
-            error.BadArgument, error.Unsupported => return vcpu.getRawSysReg(encoding),
+fn read_trapped_sys_reg(vcpu: hvf.Vcpu, encoding: u16) hvf.Error!u64 {
+    if (hvf.Gic.is_icc_reg(encoding)) {
+        return hvf.Gic.read_icc(vcpu, encoding) catch |err| switch (err) {
+            error.BadArgument, error.Unsupported => return vcpu.get_raw_sys_reg(encoding),
             else => return err,
         };
     }
-    return vcpu.getRawSysReg(encoding) catch |err| switch (err) {
+    return vcpu.get_raw_sys_reg(encoding) catch |err| switch (err) {
         // Guest hardware-debug state is not virtualized. Linux only
         // clears/probes these while booting; read-as-zero keeps that
         // init path moving on M4/Tahoe slots missing from Apple's SDK.
-        error.BadArgument, error.Denied, error.Unsupported => if (hvf.isDebugSysReg(encoding)) 0 else return err,
+        error.BadArgument, error.Denied, error.Unsupported => if (hvf.is_debug_sys_reg(encoding)) 0 else return err,
         else => return err,
     };
 }
 
-fn writeTrappedSysReg(vcpu: hvf.Vcpu, encoding: u16, value: u64) hvf.Error!void {
-    if (hvf.Gic.isIccReg(encoding)) {
-        hvf.Gic.writeIcc(vcpu, encoding, value) catch |err| switch (err) {
-            error.BadArgument, error.Unsupported => return vcpu.setRawSysReg(encoding, value),
+fn write_trapped_sys_reg(vcpu: hvf.Vcpu, encoding: u16, value: u64) hvf.Error!void {
+    if (hvf.Gic.is_icc_reg(encoding)) {
+        hvf.Gic.write_icc(vcpu, encoding, value) catch |err| switch (err) {
+            error.BadArgument, error.Unsupported => return vcpu.set_raw_sys_reg(encoding, value),
             else => return err,
         };
         return;
     }
-    vcpu.setRawSysReg(encoding, value) catch |err| switch (err) {
+    vcpu.set_raw_sys_reg(encoding, value) catch |err| switch (err) {
         // Same debug-register policy as reads, plus a broader early-boot
         // hardening rule: unsupported zero-writes are clears of optional
         // state, so drop them instead of killing the VM. The Tahoe report
         // that drove this was `msr DBGBVR19_EL1, xzr` (encoding 0x809c).
-        error.BadArgument, error.Denied, error.Unsupported => if (hvf.shouldIgnoreUnsupportedSysRegWrite(encoding, value)) return else return err,
+        error.BadArgument, error.Denied, error.Unsupported => if (hvf.should_ignore_unsupported_sys_reg_write(encoding, value)) return else return err,
         else => return err,
     };
 }
 
-fn logUnhandledExit(vcpu: hvf.Vcpu, why: []const u8) void {
-    const pc = vcpu.getReg(.pc) catch 0;
+fn log_unhandled_exit(vcpu: hvf.Vcpu, why: []const u8) void {
+    const pc = vcpu.get_reg(.pc) catch 0;
     std.debug.print(
         "hvf boot: {s}: reason={d} syndrome=0x{x} far=0x{x} ipa=0x{x} pc=0x{x}\n",
         .{
@@ -1186,11 +1186,11 @@ fn logUnhandledExit(vcpu: hvf.Vcpu, why: []const u8) void {
             pc,
         },
     );
-    logReportHint();
+    log_report_hint();
 }
 
-fn logUnhandledException(vcpu: hvf.Vcpu, ec: hvf.ExceptionClass, why: []const u8) void {
-    const pc = vcpu.getReg(.pc) catch 0;
+fn log_unhandled_exception(vcpu: hvf.Vcpu, ec: hvf.ExceptionClass, why: []const u8) void {
+    const pc = vcpu.get_reg(.pc) catch 0;
     const trap = if (ec == .system_register) hvf.SysRegTrap.decode(vcpu.exit.exception) else null;
     if (trap) |t| {
         std.debug.print(
@@ -1205,7 +1205,7 @@ fn logUnhandledException(vcpu: hvf.Vcpu, ec: hvf.ExceptionClass, why: []const u8
                 pc,
             },
         );
-        logReportHint();
+        log_report_hint();
         return;
     }
     std.debug.print(
@@ -1219,17 +1219,17 @@ fn logUnhandledException(vcpu: hvf.Vcpu, ec: hvf.ExceptionClass, why: []const u8
             pc,
         },
     );
-    logReportHint();
+    log_report_hint();
 }
 
-fn logReportHint() void {
+fn log_report_hint() void {
     std.debug.print(
         "hvf boot: please report this diagnostic at https://github.com/redwoodjs/machinen.dev/issues/new\n",
         .{},
     );
 }
 
-fn queueSnapshotWrite(
+fn queue_snapshot_write(
     writer: *vmstate_writer.Writer,
     gpa: std.mem.Allocator,
     path: []const u8,
@@ -1246,7 +1246,7 @@ fn queueSnapshotWrite(
     }
 
     std.debug.print("hvf: writing snapshot to {s}\n", .{path});
-    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits) catch |err| {
+    const job = capture_snapshot_job(gpa, path, vcpu, ram, cfg, devs, full_ram, dirty_bits) catch |err| {
         std.debug.print("hvf boot: snapshot capture failed: {s}\n", .{@errorName(err)});
         return false;
     };
@@ -1255,7 +1255,7 @@ fn queueSnapshotWrite(
             "hvf: snapshot async writer spawn failed: {s}; writing synchronously\n",
             .{@errorName(err)},
         );
-        vmstate_writer.writeAndDestroy(job) catch |write_err| {
+        vmstate_writer.write_and_destroy(job) catch |write_err| {
             std.debug.print("hvf boot: snapshot write failed: {s}\n", .{@errorName(write_err)});
             return false;
         };
@@ -1291,22 +1291,22 @@ pub const NetBridge = struct {
     virtio_irq: u32 = 0,
 };
 
-fn onTxFrameBridge(ctx: ?*anyopaque, frame: []const u8) void {
+fn on_tx_frame_bridge(ctx: ?*anyopaque, frame: []const u8) void {
     assert(ctx != null);
     assert(frame.len > 0);
     const bridge: *NetBridge = @ptrCast(@alignCast(ctx.?));
     // Still log for smoke tests and diagnostics.
-    onTxFrame(@ptrCast(bridge.stats), frame);
+    on_tx_frame(@ptrCast(bridge.stats), frame);
     if (bridge.net) |n| n.input(frame);
 }
 
-fn onNetRx(ctx: ?*anyopaque) void {
+fn on_net_rx(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const bridge: *NetBridge = @ptrCast(@alignCast(ctx.?));
     assert(bridge.virtio_irq >= 32);
     // Device's interrupt_status was set inside injectRx. Sync the GIC
     // line so the guest sees a pending interrupt.
-    hvf.Gic.setSpi(bridge.virtio_irq, true) catch {};
+    hvf.Gic.set_spi(bridge.virtio_irq, true) catch {};
 }
 
 /// Opaque box holding the vsock virtio IRQ id. The Bridge thread calls
@@ -1314,14 +1314,14 @@ fn onNetRx(ctx: ?*anyopaque) void {
 /// capture a stack slot that may have moved.
 pub const VsockIrqCtx = struct { irq: u32 };
 
-fn onVsockIrq(ctx: ?*anyopaque) void {
+fn on_vsock_irq(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
     assert(c.irq >= 32);
-    hvf.Gic.setSpi(c.irq, true) catch {};
+    hvf.Gic.set_spi(c.irq, true) catch {};
 }
 
-fn onTxFrame(ctx: ?*anyopaque, frame: []const u8) void {
+fn on_tx_frame(ctx: ?*anyopaque, frame: []const u8) void {
     assert(ctx != null);
     const stats: *TxStats = @ptrCast(@alignCast(ctx.?));
     stats.frames += 1;
@@ -1361,7 +1361,7 @@ fn onTxFrame(ctx: ?*anyopaque, frame: []const u8) void {
     // One line per frame so smoke tests can grep. Off by default
     // because interactive boots drown under it the moment the guest
     // does any network.
-    if (!debugEnabled()) return;
+    if (!debug_enabled()) return;
     var buf: [96]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &buf,
@@ -1388,15 +1388,15 @@ const LoadedFixtures = struct {
 /// Read kernel + DTB off disk, parse the kernel header, and validate
 /// they fit in the configured guest RAM. `error.FixtureMissing` is
 /// surfaced so the boot tests can `expectError` it cleanly.
-fn loadFixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
-    const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
+fn load_fixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
+    const kernel = read_all(gpa, cfg.kernel_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     errdefer gpa.free(kernel);
     assert(kernel.len > 0);
 
-    const dtb = readAll(gpa, cfg.dtb_path) catch |err| {
+    const dtb = read_all(gpa, cfg.dtb_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
@@ -1413,7 +1413,7 @@ fn loadFixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
 /// Allocate the host-backed slab the guest sees as its RAM, then copy
 /// kernel + DTB + (optional) initramfs into it. Returns the mapped
 /// slice; caller owns the munmap.
-fn allocateAndPopulateRam(
+fn allocate_and_populate_ram(
     gpa: std.mem.Allocator,
     cfg: Config,
     fx: LoadedFixtures,
@@ -1445,7 +1445,7 @@ fn allocateAndPopulateRam(
     // from virt.dts); without this patch any other ceiling silently
     // becomes 4 GiB to the kernel. Failures here would silently cap
     // the guest, so log loudly even outside debug mode.
-    dtb_patch.patchMemorySize(ram[cfg.dtb_offset..][0..fx.dtb.len], cfg.ram_size) catch |err| {
+    dtb_patch.patch_memory_size(ram[cfg.dtb_offset..][0..fx.dtb.len], cfg.ram_size) catch |err| {
         std.debug.print(
             "warn: patchMemorySize failed ({s}); guest will see the DTB-declared ceiling, not cfg.ram_size={d}\n",
             .{ @errorName(err), cfg.ram_size },
@@ -1453,7 +1453,7 @@ fn allocateAndPopulateRam(
     };
 
     if (cfg.initrd_path) |initrd_path| {
-        const initrd = readAll(gpa, initrd_path) catch |err| {
+        const initrd = read_all(gpa, initrd_path) catch |err| {
             if (err == error.OpenFailed) return error.FixtureMissing;
             return err;
         };
@@ -1466,8 +1466,8 @@ fn allocateAndPopulateRam(
         // compressed archives — at ~1 GB/s of wall clock. Leaving 1 GB
         // of dead tail in that window costs ~1 s of early boot.
         const initrd_end_abs: u32 = @intCast(cfg.ram_base + cfg.initrd_offset + initrd.len);
-        dtb_patch.patchInitrdEnd(ram[cfg.dtb_offset..][0..fx.dtb.len], initrd_end_abs) catch |err| {
-            if (debugEnabled()) std.debug.print(
+        dtb_patch.patch_initrd_end(ram[cfg.dtb_offset..][0..fx.dtb.len], initrd_end_abs) catch |err| {
+            if (debug_enabled()) std.debug.print(
                 "warn: patchInitrdEnd failed ({s}); kernel will scan the full DTB-declared initrd window\n",
                 .{@errorName(err)},
             );
@@ -1479,7 +1479,7 @@ fn allocateAndPopulateRam(
 /// Bring up the vCPU: register MPIDR/timer/EL1 state, then point
 /// X0 at the DTB and PC at the kernel entry per the arm64 Linux boot
 /// protocol. Caller owns the destroy.
-fn initVcpu(img: hvf.KernelImage, cfg: Config) !hvf.Vcpu {
+fn init_vcpu(img: hvf.KernelImage, cfg: Config) !hvf.Vcpu {
     const vcpu = try hvf.Vcpu.create();
     errdefer vcpu.destroy();
 
@@ -1488,16 +1488,16 @@ fn initVcpu(img: hvf.KernelImage, cfg: Config) !hvf.Vcpu {
     // any `hv_gic_*_redistributor_reg` call returns HV_DENIED. Value
     // layout: bit 31 reserved-as-1, bits 23:16/15:8/7:0 = Aff2/Aff1/Aff0.
     // For our single-CPU guest, all affinity fields = 0.
-    try vcpu.setSysReg(.mpidr_el1, 1 << 31);
+    try vcpu.set_sys_reg(.mpidr_el1, 1 << 31);
 
     // Let the virtual timer wake the vCPU so we can deliver ticks.
-    try vcpu.setVtimerMask(false);
+    try vcpu.set_vtimer_mask(false);
 
     // Diagnostic: query where HVF actually placed this vCPU's
     // redistributor. If this differs from what we told the kernel via
     // the DTB, the kernel will report "No redistributor present."
-    if (debugEnabled()) {
-        if (hvf.Gic.redistributorBase(vcpu)) |rdist| {
+    if (debug_enabled()) {
+        if (hvf.Gic.redistributor_base(vcpu)) |rdist| {
             std.debug.print("GIC redistributor for vcpu 0: 0x{x}\n", .{rdist});
         } else |err| {
             std.debug.print("GIC redistributor query failed: {s}\n", .{@errorName(err)});
@@ -1508,18 +1508,18 @@ fn initVcpu(img: hvf.KernelImage, cfg: Config) !hvf.Vcpu {
         // EL2h, all interrupts masked. When EL2 is exposed, Linux must
         // enter at EL2 so it can own the guest hypervisor state and
         // later provide /dev/kvm to workloads inside the VM.
-        try vcpu.setReg(.cpsr, 0x3C9);
+        try vcpu.set_reg(.cpsr, 0x3C9);
         // HCR_EL2.RW=1 selects AArch64 for EL1. CNTHCTL bits allow EL1
         // to read the physical counter/timer as required by the arm64
         // boot protocol. Keep the virtual offset at zero.
-        try vcpu.setSysReg(.hcr_el2, @as(u64, 1) << 31);
-        try vcpu.setSysReg(.cnthctl_el2, 0x3);
-        try vcpu.setSysReg(.cntvoff_el2, 0);
+        try vcpu.set_sys_reg(.hcr_el2, @as(u64, 1) << 31);
+        try vcpu.set_sys_reg(.cnthctl_el2, 0x3);
+        try vcpu.set_sys_reg(.cntvoff_el2, 0);
     } else {
         // EL1h, all interrupts masked.
-        try vcpu.setReg(.cpsr, 0x3C5);
+        try vcpu.set_reg(.cpsr, 0x3C5);
         // MMU off (kernel turns it on itself); I-bit for executable fetches.
-        try vcpu.setSysReg(.sctlr_el1, 1 << 12);
+        try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
     }
 
     // arm64 Linux boot protocol: X0 = physical address of DTB.
@@ -1528,11 +1528,11 @@ fn initVcpu(img: hvf.KernelImage, cfg: Config) !hvf.Vcpu {
     assert(dtb_phys >= cfg.ram_base);
     assert(entry_phys >= cfg.ram_base);
     assert(entry_phys < cfg.ram_base + cfg.ram_size);
-    try vcpu.setReg(.x0, dtb_phys);
-    try vcpu.setReg(.x1, 0);
-    try vcpu.setReg(.x2, 0);
-    try vcpu.setReg(.x3, 0);
-    try vcpu.setReg(.pc, entry_phys);
+    try vcpu.set_reg(.x0, dtb_phys);
+    try vcpu.set_reg(.x1, 0);
+    try vcpu.set_reg(.x2, 0);
+    try vcpu.set_reg(.x3, 0);
+    try vcpu.set_reg(.pc, entry_phys);
 
     return vcpu;
 }
@@ -1554,8 +1554,8 @@ const IrqMap = struct {
     virtiofs: [MAX_VIRTIOFS_SLOTS]u32,
 };
 
-fn assignIrqs() !IrqMap {
-    const spi = try hvf.Gic.spiRange();
+fn assign_irqs() !IrqMap {
+    const spi = try hvf.Gic.spi_range();
     // SPIs start at 32 on ARM GIC; HVF must report at least the device
     // IDs we wire up (1, 16..23+MAX_VIRTIOFS_SLOTS-1) past spi.base.
     assert(spi.base >= 32);
@@ -1579,7 +1579,7 @@ fn assignIrqs() !IrqMap {
 
 /// Build the virtio-net device. virtio-net sits in slot 0 with a
 /// stable MAC the runtime hands the gvproxy DHCP server.
-fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8, tx_handler: *const fn (?*anyopaque, []const u8) void, tx_ctx: ?*anyopaque) virtio.Device {
+fn make_net_device(ram: []u8, cfg: Config, mac: *const [6]u8, tx_handler: *const fn (?*anyopaque, []const u8) void, tx_ctx: ?*anyopaque) virtio.Device {
     return .{
         .base = virtio_net_base,
         .size = virtio_net_size,
@@ -1599,9 +1599,9 @@ fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8, tx_handler: *const f
 /// caller didn't ask for this slot, or when the file open failed —
 /// matches the original "warn and continue" policy so a missing scratch
 /// disk doesn't prevent the rest of the VMM from booting.
-fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
     const p = path orelse return null;
-    return blk_mod.openFile(p) catch |err| {
+    return blk_mod.open_file(p) catch |err| {
         std.debug.print("virtio-blk {s} disabled: {s} ({s})\n", .{ label, @errorName(err), p });
         return null;
     };
@@ -1614,7 +1614,7 @@ fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
 /// when the caller didn't pass an fd — matches the warn-and-continue
 /// policy so the rest of the VMM keeps booting if the runtime
 /// neglected to wire the slot up.
-fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend_from_fd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
     const f = fd orelse return null;
     if (f < 0) return null;
     // SEEK_END to discover size — same trick `openFile` uses. The
@@ -1632,13 +1632,13 @@ fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod
         );
         return null;
     }
-    return blk_mod.Backend.initFromFdWithMode(f, @intCast(size_bytes), read_only);
+    return blk_mod.Backend.init_from_fd_with_mode(f, @intCast(size_bytes), read_only);
 }
 
 /// Wrap a `blk_mod.Backend` as a virtio-mmio device. `backend` must
 /// outlive the returned device — the device's `config` and
 /// `request_ctx` are pointers into it.
-fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -1647,7 +1647,7 @@ fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1657,7 +1657,7 @@ fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod
 /// guest's ext4 driver can issue discard requests when mounted with
 /// `discard` and the host punches the corresponding holes via
 /// fallocate(PUNCH_HOLE).
-fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device_with_discard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -1666,7 +1666,7 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1675,11 +1675,11 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
 /// an empty slice; parse errors log and return empty so a typo in the
 /// env doesn't prevent boot. The returned slice and its path strings
 /// are allocated from `gpa`.
-fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
+fn parse_vsock_env(gpa: std.mem.Allocator) []vsock_mod.PortMap {
     const raw = getenv("MACHINEN_VSOCK") orelse return &.{};
     const s = std.mem.span(raw);
     if (s.len == 0) return &.{};
-    return vsock_mod.parseEnv(gpa, s) catch |err| {
+    return vsock_mod.parse_env(gpa, s) catch |err| {
         std.debug.print("vsock: MACHINEN_VSOCK parse failed ({s}); ignoring\n", .{@errorName(err)});
         return &.{};
     };
@@ -1688,23 +1688,23 @@ fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
 /// Build the virtio-balloon device. `backend` must outlive the
 /// returned Device — the config + request_ctx are pointers into it.
 /// #263 phase B: continuous free-page reporting (no inflate driving).
-fn makeBalloonDevice(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
+fn make_balloon_device(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
     return .{
         .base = virtio_balloon_base,
         .size = virtio_balloon_size,
         .id = .balloon,
         .features = balloon_mod.Backend.features(),
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &balloon_mod.Backend.handleRequest,
+        .request_handler = &balloon_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
 
 /// Build the virtio-vsock device. `cid_ptr` must outlive the device —
 /// the config field is a pointer into it.
-fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
+fn make_vsock_device(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
     return .{
         .base = virtio_vsock_base,
         .size = virtio_vsock_size,
@@ -1713,7 +1713,7 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
         .config = std.mem.asBytes(cid_ptr),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &vsock_mod.Bridge.handleTxChain,
+        .request_handler = &vsock_mod.Bridge.handle_tx_chain,
         .request_ctx = null,
         // Queues 0 (RX) and 2 (event) are driver-posts-empty-buffers
         // queues — we fill them on demand, not on every kick.
@@ -1738,19 +1738,19 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
 /// of tiny replies per bench and the page allocator's per-alloc
 /// mmap/munmap dominated wall-clock during that bring-up. The backends
 /// outlive boot() in the caller's frame; `deinit` frees the state.
-fn parseVirtiofsEnv() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
+fn parse_virtiofs_env() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
     var out: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = @splat(null);
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         var name_buf: [32]u8 = undefined;
         const name = std.fmt.bufPrintZ(&name_buf, "MACHINEN_VIRTIOFS_{d}", .{i}) catch continue;
-        out[i] = parseOneVirtiofsEnv(name);
+        out[i] = parse_one_virtiofs_env(name);
     }
     return out;
 }
 
 /// Parse a single `MACHINEN_VIRTIOFS_<i>` env var into a backend, or
 /// null if unset / malformed. See `parseVirtiofsEnv`.
-fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
+fn parse_one_virtiofs_env(name: [*:0]const u8) ?virtiofs_mod.Device {
     const raw = getenv(name) orelse return null;
     const s = std.mem.span(raw);
     if (s.len == 0) return null;
@@ -1799,16 +1799,16 @@ fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
 /// Wrap a `virtiofs.Device` backend as a virtio-mmio device on the
 /// given slot `base`. `backend` must outlive the returned device —
 /// `config` and `request_ctx` are pointers into it.
-fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
+fn make_virtio_fs_device(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
     return .{
         .base = base,
         .size = virtio_virtiofs_size,
         .id = .virtio_fs,
         .features = (1 << 32), // VIRTIO_F_VERSION_1
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &virtiofs_mod.Device.handleRequest,
+        .request_handler = &virtiofs_mod.Device.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1816,7 +1816,7 @@ fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.
 /// Dial gvproxy if `MACHINEN_NET_SOCKET` is set; null on missing env
 /// or any connect failure (the rest of the VMM still runs without
 /// network).
-fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
+fn connect_gvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
     const env = getenv("MACHINEN_NET_SOCKET") orelse return null;
     const path = std.mem.span(env);
     if (path.len == 0) return null;
@@ -1830,7 +1830,7 @@ fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetS
 /// device, start the poll thread, and log the active port mappings.
 /// Returns null on any failure (and clears `dev` so callers know the
 /// device is no longer live).
-fn startVsockBridge(
+fn start_vsock_bridge(
     gpa: std.mem.Allocator,
     dev: *virtio.Device,
     ports: []const vsock_mod.PortMap,
@@ -1838,7 +1838,7 @@ fn startVsockBridge(
 ) ?*vsock_mod.Bridge {
     const bridge = vsock_mod.Bridge.create(gpa, dev, .{
         .ports = ports,
-        .raise_irq = &onVsockIrq,
+        .raise_irq = &on_vsock_irq,
         .raise_irq_ctx = @ptrCast(irq_ctx),
     }) catch |err| {
         std.debug.print("vsock: bridge create failed: {s}\n", .{@errorName(err)});
@@ -1866,30 +1866,30 @@ const PsciOutcome = enum { handled, shutdown };
 
 /// Decode and respond to a PSCI HVC/SMC. Returns `.shutdown` only on
 /// SYSTEM_OFF / SYSTEM_RESET; all other cases are answered in-place.
-fn handlePsci(vcpu: hvf.Vcpu) !PsciOutcome {
+fn handle_psci(vcpu: hvf.Vcpu) !PsciOutcome {
     const f = try hvf.Psci.decode(vcpu) orelse return .handled;
     switch (f) {
         .system_off, .system_reset => return .shutdown,
         .version => {
             // PSCI 1.0 = major 1, minor 0.
-            try vcpu.setReg(.x0, 0x0001_0000);
+            try vcpu.set_reg(.x0, 0x0001_0000);
         },
         .migrate_info_type => {
             // "Not present" — no migratable trusted OS.
-            try vcpu.setReg(.x0, 2);
+            try vcpu.set_reg(.x0, 2);
         },
         .affinity_info_64 => {
             // CPU 0 is "ON." The kernel queries this as part of setup;
             // anything else gets NOT_SUPPORTED.
-            const x1 = try vcpu.getReg(.x1);
-            try vcpu.setReg(.x0, if (x1 == 0) 0 else @bitCast(@as(i64, -1)));
+            const x1 = try vcpu.get_reg(.x1);
+            try vcpu.set_reg(.x0, if (x1 == 0) 0 else @bitCast(@as(i64, -1)));
         },
         .cpu_off, .cpu_on_64, .features => {
             // We only support one CPU and no optional features.
-            try vcpu.setReg(.x0, @bitCast(@as(i64, -1)));
+            try vcpu.set_reg(.x0, @bitCast(@as(i64, -1)));
         },
         _ => {
-            try vcpu.setReg(.x0, @bitCast(@as(i64, -1)));
+            try vcpu.set_reg(.x0, @bitCast(@as(i64, -1)));
         },
     }
     return .handled;
@@ -1924,7 +1924,7 @@ const Devices = struct {
     /// populated prefix. Used by snapshot/restore to dump/apply each
     /// device's transport state — virtio-fs slots included, so a
     /// `--mount-live` VM's queue state round-trips through vmstate.
-    pub fn virtioDevices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
+    pub fn virtio_devices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
         var n: usize = 0;
         buf[n] = self.netdev;
         n += 1;
@@ -1952,7 +1952,7 @@ const Devices = struct {
 const VirtiofsMatch = struct { dev: *virtio.Device, irq: u32 };
 
 /// Find the virtio-fs slot (if any) whose MMIO window owns `ipa`.
-fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, ipa: u64) ?VirtiofsMatch {
+fn virtiofs_match(devs: *const Devices, irqs: IrqMap, ipa: u64) ?VirtiofsMatch {
     for (devs.virtiofs_devs, irqs.virtiofs) |dev_opt, irq| {
         if (dev_opt) |d| {
             if (d.handles(ipa)) return .{ .dev = d, .irq = irq };
@@ -1964,26 +1964,26 @@ fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, ipa: u64) ?VirtiofsMatch {
 /// Route a data-abort MMIO fault to the device that owns the IPA, then
 /// advance PC past the faulting load/store. This is the dispatch table
 /// — the per-device helpers do the actual read/write.
-fn routeDataAbort(
+fn route_data_abort(
     vcpu: hvf.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
     info: hvf.DataAbort,
 ) !void {
     if (devs.uart.handles(info.ipa)) {
-        try handlePl011Mmio(devs.uart, vcpu, info, irqs.pl011, devs.nested, devs.nested_poweroff);
+        try handle_pl011_mmio(devs.uart, vcpu, info, irqs.pl011, devs.nested, devs.nested_poweroff);
     } else if (info.ipa >= 0x0800_0000 and info.ipa < 0x0801_0000) {
-        try handleGicDistMmio(vcpu, info);
+        try handle_gic_dist_mmio(vcpu, info);
     } else if (devs.netdev.handles(info.ipa)) {
-        try handleVirtioMmio(devs.netdev, irqs.net, vcpu, info);
+        try handle_virtio_mmio(devs.netdev, irqs.net, vcpu, info);
     } else if (devs.blk_dev != null and devs.blk_dev.?.handles(info.ipa)) {
-        try handleVirtioMmio(devs.blk_dev.?, irqs.blk, vcpu, info);
+        try handle_virtio_mmio(devs.blk_dev.?, irqs.blk, vcpu, info);
     } else if (devs.blk2_dev != null and devs.blk2_dev.?.handles(info.ipa)) {
-        try handleVirtioMmio(devs.blk2_dev.?, irqs.blk2, vcpu, info);
+        try handle_virtio_mmio(devs.blk2_dev.?, irqs.blk2, vcpu, info);
     } else if (devs.blk3_dev != null and devs.blk3_dev.?.handles(info.ipa)) {
-        try handleVirtioMmio(devs.blk3_dev.?, irqs.blk3, vcpu, info);
+        try handle_virtio_mmio(devs.blk3_dev.?, irqs.blk3, vcpu, info);
     } else if (devs.blk4_dev != null and devs.blk4_dev.?.handles(info.ipa)) {
-        try handleVirtioMmio(devs.blk4_dev.?, irqs.blk4, vcpu, info);
+        try handle_virtio_mmio(devs.blk4_dev.?, irqs.blk4, vcpu, info);
     } else if (devs.vsock_dev != null and devs.vsock_dev.?.handles(info.ipa)) {
         // The vCPU side of (RMW interrupt_status + setSpi) must
         // serialise against the bridge poll thread's same pair.
@@ -1995,36 +1995,36 @@ fn routeDataAbort(
         // bridge.mu; see its docstring.
         if (devs.vsock_bridge) |b| b.mu.lock();
         defer if (devs.vsock_bridge) |b| b.mu.unlock();
-        try handleVirtioMmio(devs.vsock_dev.?, irqs.vsock, vcpu, info);
+        try handle_virtio_mmio(devs.vsock_dev.?, irqs.vsock, vcpu, info);
     } else if (devs.balloon_dev != null and devs.balloon_dev.?.handles(info.ipa)) {
-        try handleVirtioMmio(devs.balloon_dev.?, irqs.balloon, vcpu, info);
-    } else if (virtiofsMatch(devs, irqs, info.ipa)) |m| {
+        try handle_virtio_mmio(devs.balloon_dev.?, irqs.balloon, vcpu, info);
+    } else if (virtiofs_match(devs, irqs, info.ipa)) |m| {
         // virtio-fs request handling is synchronous on this thread —
         // `handleVirtioMmio` → `dev.write` → `notify` drains the chain
         // through `virtiofs.Device.handleRequest` inline. No bridge
         // lock to take (unlike vsock): there's no host poll thread.
-        try handleVirtioMmio(m.dev, m.irq, vcpu, info);
+        try handle_virtio_mmio(m.dev, m.irq, vcpu, info);
     } else if (info.ipa >= 0x1000_0000 and info.ipa < 0x1200_0000) {
-        try handleGicRdistMmio(vcpu, info);
+        try handle_gic_rdist_mmio(vcpu, info);
     } else {
-        try handleUnknownMmio(vcpu, info);
+        try handle_unknown_mmio(vcpu, info);
     }
-    const pc = try vcpu.getReg(.pc);
-    try vcpu.setReg(.pc, pc + 4);
+    const pc = try vcpu.get_reg(.pc);
+    try vcpu.set_reg(.pc, pc + 4);
 }
 
 /// Sync the PL011 IRQ line to the UART's current state. Called from
 /// the vCPU thread after any PL011 MMIO that can change imsc/ris (the
 /// kernel masking interrupts in its ISR is the common case). The
 /// stdin thread does its own update after pushing bytes.
-fn syncPl011Irq(uart: *hvf.Pl011, irq: u32) void {
+fn sync_pl011_irq(uart: *hvf.Pl011, irq: u32) void {
     assert(irq >= 32);
-    hvf.Gic.setSpi(irq, uart.irqAsserted()) catch {};
+    hvf.Gic.set_spi(irq, uart.irq_asserted()) catch {};
 }
 
 /// PL011 MMIO. DR-write echoes to host stderr so the user sees guest
 /// console output live; every access resyncs the IRQ line.
-fn handlePl011Mmio(
+fn handle_pl011_mmio(
     uart: *hvf.Pl011,
     vcpu: hvf.Vcpu,
     info: hvf.DataAbort,
@@ -2034,7 +2034,7 @@ fn handlePl011Mmio(
 ) !void {
     assert(uart.handles(info.ipa));
     if (info.is_write) {
-        const value = try info.readSource(vcpu);
+        const value = try info.read_source(vcpu);
         uart.write(info.ipa, value);
         if ((info.ipa - uart.base) == 0) {
             const byte: [1]u8 = .{@truncate(value)};
@@ -2045,17 +2045,17 @@ fn handlePl011Mmio(
         const v = uart.read(info.ipa);
         if (info.srt != 31) {
             const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
-            try vcpu.setReg(reg, v);
+            try vcpu.set_reg(reg, v);
         }
     }
-    syncPl011Irq(uart, irq);
+    sync_pl011_irq(uart, irq);
 }
 
 /// virtio-MMIO read/write + raise/lower the SPI based on the device's
 /// post-access interrupt_status. Shared shape across net / blk / blk2;
 /// vsock callers wrap this in `bridge.mu` per the locking note in
 /// `vsock.Bridge.handleTxChain`.
-fn handleVirtioMmio(
+fn handle_virtio_mmio(
     dev: *virtio.Device,
     irq: u32,
     vcpu: hvf.Vcpu,
@@ -2064,53 +2064,53 @@ fn handleVirtioMmio(
     assert(dev.handles(info.ipa));
     assert(irq >= 32);
     if (info.is_write) {
-        const value = try info.readSource(vcpu);
+        const value = try info.read_source(vcpu);
         dev.write(info.ipa, value);
     } else if (info.srt != 31) {
         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
-        try vcpu.setReg(reg, dev.read(info.ipa));
+        try vcpu.set_reg(reg, dev.read(info.ipa));
     }
-    hvf.Gic.setSpi(irq, @atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) catch {};
+    hvf.Gic.set_spi(irq, @atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) catch {};
 }
 
 /// GIC distributor MMIO ([0x0800_0000, 0x0801_0000)). Routes the
 /// access to HVF; reads land in the target register.
-fn handleGicDistMmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
+fn handle_gic_dist_mmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
     const offset: u32 = @truncate(info.ipa - 0x0800_0000);
     if (info.is_write) {
-        const value = try info.readSource(vcpu);
-        hvf.Gic.writeDistributor(offset, value);
+        const value = try info.read_source(vcpu);
+        hvf.Gic.write_distributor(offset, value);
     } else if (info.srt != 31) {
         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
-        try vcpu.setReg(reg, hvf.Gic.readDistributor(offset));
+        try vcpu.set_reg(reg, hvf.Gic.read_distributor(offset));
     }
 }
 
 /// GIC redistributor MMIO ([0x1000_0000, 0x1200_0000)). Each vCPU's
 /// frame is 128 KB; for our single-vCPU setup, frame 0 is the only
 /// one and the offset within it is the HVF register.
-fn handleGicRdistMmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
+fn handle_gic_rdist_mmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
     const offset: u32 = @truncate((info.ipa - 0x1000_0000) % 0x0002_0000);
     if (info.is_write) {
-        const value = try info.readSource(vcpu);
-        hvf.Gic.writeRedistributor(vcpu, offset, value);
+        const value = try info.read_source(vcpu);
+        hvf.Gic.write_redistributor(vcpu, offset, value);
     } else if (info.srt != 31) {
         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
-        try vcpu.setReg(reg, hvf.Gic.readRedistributor(vcpu, offset));
+        try vcpu.set_reg(reg, hvf.Gic.read_redistributor(vcpu, offset));
     }
 }
 
 /// MMIO outside any registered window. Reads return 0; writes are
 /// dropped. Keeps the boot moving instead of crashing the run loop on
 /// stray DTB-described regions we haven't hooked up yet.
-fn handleUnknownMmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
+fn handle_unknown_mmio(vcpu: hvf.Vcpu, info: hvf.DataAbort) !void {
     if (!info.is_write and info.srt != 31) {
         const reg: hvf.Reg = @enumFromInt(@as(u32, info.srt));
-        try vcpu.setReg(reg, 0);
+        try vcpu.set_reg(reg, 0);
     }
 }
 
-fn stdinThreadMain(ctx: *StdinThread) void {
+fn stdin_thread_main(ctx: *StdinThread) void {
     assert(ctx.irq >= 32);
     var buf: [256]u8 = undefined;
     while (!ctx.stop.load(.acquire)) {
@@ -2121,9 +2121,9 @@ fn stdinThreadMain(ctx: *StdinThread) void {
             return;
         }
         assert(@as(usize, @intCast(n)) <= buf.len);
-        ctx.uart.pushRx(buf[0..@intCast(n)]);
+        ctx.uart.push_rx(buf[0..@intCast(n)]);
         // Assert the IRQ so the vCPU wakes from WFI and services it.
-        hvf.Gic.setSpi(ctx.irq, ctx.uart.irqAsserted()) catch {};
+        hvf.Gic.set_spi(ctx.irq, ctx.uart.irq_asserted()) catch {};
     }
 }
 
@@ -2143,11 +2143,11 @@ extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
 extern "c" fn usleep(useconds: c_uint) c_int;
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
-fn sleepMicros(useconds: c_uint) void {
+fn sleep_micros(useconds: c_uint) void {
     _ = usleep(useconds);
 }
 
-fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+fn read_all(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     assert(path.len > 0);
     var path_buf: [4096]u8 = undefined;
     if (path.len >= path_buf.len) return error.NameTooLong;
@@ -2190,7 +2190,7 @@ const kernel_fixture = "test-fixtures/Image";
 const dtb_fixture = "test-fixtures/virt.dtb";
 const initrd_fixture = "test-fixtures/initramfs.cpio";
 
-fn fixturesPresent() bool {
+fn fixtures_present() bool {
     inline for (.{ kernel_fixture, dtb_fixture, initrd_fixture }) |p| {
         var buf: [4096]u8 = undefined;
         if (p.len >= buf.len) return false;
@@ -2214,7 +2214,7 @@ test "boot a real arm64 Linux kernel" {
         std.debug.print("skip: set MACHINEN_BOOT_TEST=1 to enable\n", .{});
         return;
     }
-    if (!fixturesPresent()) {
+    if (!fixtures_present()) {
         std.debug.print(
             "skip: missing {s} or {s} (run scripts/build-base-assets.sh)\n",
             .{ kernel_fixture, dtb_fixture },

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -172,7 +172,7 @@ pub const Result = struct {
 /// Caller-supplied layout must satisfy the basic geometry the boot
 /// protocol depends on. These are programmer errors at the call site,
 /// not anything the guest can influence — assert hard.
-fn validateConfig(cfg: Config) void {
+fn validate_config(cfg: Config) void {
     assert(cfg.kernel_path.len > 0);
     assert(cfg.dtb_path.len > 0);
     assert(cfg.ram_size >= 16 * 1024 * 1024);
@@ -187,7 +187,7 @@ fn validateConfig(cfg: Config) void {
 }
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
-    validateConfig(cfg);
+    validate_config(cfg);
 
     // Topology fingerprint — printed on stderr so snapshot tooling can
     // capture the live guest's IPA layout. Tests assert this matches
@@ -198,39 +198,39 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         .gic_dist_base = cfg.gic_dist_addr,
         .gic_redist_base = cfg.gic_redist_addr,
     };
-    const topo_hex = topo.hashHex();
+    const topo_hex = topo.hash_hex();
     std.debug.print("topology: {s}\n", .{topo_hex});
 
     // Install SIGUSR1 handler so the host can request a mid-flight
     // snapshot. Idempotent (signal() is fine to call before boot).
-    if (cfg.snapshot_path != null) installSnapshotSignal();
+    if (cfg.snapshot_path != null) install_snapshot_signal();
 
-    var fx = try loadFixtures(gpa, cfg);
+    var fx = try load_fixtures(gpa, cfg);
     defer fx.deinit(gpa);
 
-    const ram = try allocateAndPopulateRam(gpa, cfg, fx);
+    const ram = try allocate_and_populate_ram(gpa, cfg, fx);
     defer std.posix.munmap(ram);
 
     // --- KVM bring-up --------------------------------------------
     var k = try kvm.Kvm.open_();
     defer k.close_();
 
-    if (cfg.nested and !k.armEl2Supported()) {
+    if (cfg.nested and !k.arm_el2_supported()) {
         std.debug.print("kvm boot: nested virtualization requested but KVM_CAP_ARM_EL2 is unavailable\n", .{});
         return error.NestedVirtUnsupported;
     }
 
-    var vm = try k.createVm();
+    var vm = try k.create_vm();
     defer vm.destroy();
 
     const ram_flags: u32 = if (cfg.snapshot_path != null) kvm.KVM_MEM_LOG_DIRTY_PAGES else 0;
-    try vm.mapMemoryWithFlags(0, cfg.ram_base, ram, ram_flags);
+    try vm.map_memory_with_flags(0, cfg.ram_base, ram, ram_flags);
 
     // vGIC BEFORE vCPU creation (KVM requires it).
-    var gic = try vm.createGicV3(cfg.gic_dist_addr, cfg.gic_redist_addr);
+    var gic = try vm.create_gic_v3(cfg.gic_dist_addr, cfg.gic_redist_addr);
     defer gic.destroy();
 
-    var vcpu = try initVcpu(&vm, fx.img, cfg);
+    var vcpu = try init_vcpu(&vm, fx.img, cfg);
     defer vcpu.destroy();
 
     // vGIC finalize happens AFTER vcpus exist.
@@ -254,41 +254,41 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
     const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
 
-    var blk_backend_opt: ?blk_mod.Backend = openBlkBackend(slot1_path, "slot 1");
+    var blk_backend_opt: ?blk_mod.Backend = open_blk_backend(slot1_path, "slot 1");
     defer if (blk_backend_opt) |*b| b.deinit();
     if (cfg.rootdisk_path != null and cfg.snapshot_path != null) {
-        if (blk_backend_opt) |*b| b.enableDirtyTracking(gpa) catch |err| {
+        if (blk_backend_opt) |*b| b.enable_dirty_tracking(gpa) catch |err| {
             std.debug.print("blk: rootdisk dirty tracking disabled: {s}\n", .{@errorName(err)});
         };
     }
     var blkdev_opt: ?virtio.Device = if (blk_backend_opt) |*b|
-        makeBlkDevice(virtio_blk_base, virtio_blk_size, ram, cfg, b)
+        make_blk_device(virtio_blk_base, virtio_blk_size, ram, cfg, b)
     else
         null;
     const blkdev_ptr: ?*virtio.Device = if (blkdev_opt) |_| &blkdev_opt.? else null;
 
-    var blk2_backend_opt: ?blk_mod.Backend = openBlkBackend(slot3_path, "slot 3");
+    var blk2_backend_opt: ?blk_mod.Backend = open_blk_backend(slot3_path, "slot 3");
     defer if (blk2_backend_opt) |*b| b.deinit();
     var blk2dev_opt: ?virtio.Device = if (blk2_backend_opt) |*b|
-        makeBlkDevice(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
+        make_blk_device(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
     else
         null;
     const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
 
     // virtio-blk slot 5 — squashfs RO lower for `--mount` (#272).
-    var blk3_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
+    var blk3_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
     defer if (blk3_backend_opt) |*b| b.deinit();
     var blk3dev_opt: ?virtio.Device = if (blk3_backend_opt) |*b|
-        makeBlkDevice(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
+        make_blk_device(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
     else
         null;
     const blk3dev_ptr: ?*virtio.Device = if (blk3dev_opt) |_| &blk3dev_opt.? else null;
 
     // virtio-blk slot 6 — ext4 RW upper for `--mount` overlay (#272).
-    var blk4_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
+    var blk4_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
     defer if (blk4_backend_opt) |*b| b.deinit();
     var blk4dev_opt: ?virtio.Device = if (blk4_backend_opt) |*b|
-        makeBlkDeviceWithDiscard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
+        make_blk_device_with_discard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
     else
         null;
     const blk4dev_ptr: ?*virtio.Device = if (blk4dev_opt) |_| &blk4dev_opt.? else null;
@@ -300,8 +300,8 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // RX/TX go nowhere, so eth0 stays link-down. That matches the
     // pre-#197 behaviour where the slot returned zeros.
     const virtio_mac = [_]u8{ 0x02, 0xDE, 0xAD, 0xBE, 0xEF, 0x01 };
-    var netdev = makeNetDevice(ram, cfg, &virtio_mac);
-    const net_inst: ?*net_mod.NetSocket = connectGvproxy(gpa, &netdev);
+    var netdev = make_net_device(ram, cfg, &virtio_mac);
+    const net_inst: ?*net_mod.NetSocket = connect_gvproxy(gpa, &netdev);
     defer if (net_inst) |n| n.destroy();
     var net_irq_ctx = NetIrqCtx{ .vm = &vm, .irq = irqs.net };
     if (net_inst) |n| {
@@ -309,14 +309,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         // → gvproxy. The kernel's notify() drains the TX avail queue
         // and calls tx_handler per frame (with the 12-byte virtio-net
         // header already stripped by virtio.zig::walkAndEmit).
-        netdev.tx_handler = &onNetTx;
+        netdev.tx_handler = &on_net_tx;
         netdev.tx_ctx = @ptrCast(n);
         // RX: NetSocket's rxLoop calls on_rx after each injectRx,
         // both under `n.irq_mu`. routeMmio takes the same mutex
         // around the net arm, so the (RMW + setIrq) pairs serialise
         // across the two threads — without this, the RX thread's
         // setIrq(1) can be overridden by a stale vCPU setIrq(0).
-        n.on_rx = &onNetIrq;
+        n.on_rx = &on_net_irq;
         n.on_rx_ctx = @ptrCast(&net_irq_ctx);
     }
 
@@ -325,9 +325,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // env grammar as HVF (see boot_hvf.zig for the syntax doc) — parsed
     // ports are gpa-allocated and leak for the VMM's life.
     const vsock_cid_storage: u64 = vsock_mod.default_guest_cid;
-    const vsock_ports = parseVsockEnv(gpa);
+    const vsock_ports = parse_vsock_env(gpa);
     var vsock_dev_opt: ?virtio.Device = if (vsock_ports.len > 0)
-        makeVsockDevice(ram, cfg, &vsock_cid_storage)
+        make_vsock_device(ram, cfg, &vsock_cid_storage)
     else
         null;
     const vsock_dev_ptr: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
@@ -335,7 +335,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var vsock_irq_ctx = VsockIrqCtx{ .vm = &vm, .irq = irqs.vsock };
     var vsock_bridge_opt: ?*vsock_mod.Bridge = null;
     if (vsock_dev_ptr) |d| {
-        vsock_bridge_opt = startVsockBridge(gpa, d, vsock_ports, &vsock_irq_ctx);
+        vsock_bridge_opt = start_vsock_bridge(gpa, d, vsock_ports, &vsock_irq_ctx);
         if (vsock_bridge_opt == null) vsock_dev_opt = null;
     }
     defer if (vsock_bridge_opt) |b| b.destroy();
@@ -351,14 +351,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // #274: redirect accounting into the shared stats file pointed
     // at by MACHINEN_STATS_FILE; falls back to a process-static stub
     // when missing.
-    var stats_inst = stats_mod.Stats.openOrStub();
+    var stats_inst = stats_mod.Stats.open_or_stub();
     defer stats_inst.deinit();
     // No-op on Linux — runtime reads `/proc/<pid>/status:VmRSS`,
     // which is exact and reflects `MADV_DONTNEED` reclaim. See
     // `stats.zig` for the Darwin rationale.
-    stats_mod.startPhysFootprintSampler(stats_inst.counters);
-    var balloon_backend = balloon_mod.Backend.initWithCounters(stats_inst.counters);
-    var balloon_dev = makeBalloonDevice(ram, cfg, &balloon_backend);
+    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
+    var balloon_dev = make_balloon_device(ram, cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;
 
     // virtio-fs slots 7..10 (#332, #338). Off by default; set
@@ -368,14 +368,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // the vCPU thread (the device drains on each guest kick), so unlike
     // vsock no host poll thread is needed. Same env grammar as HVF (see
     // boot_hvf.zig's parser).
-    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parseVirtiofsEnv();
+    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parse_virtiofs_env();
     defer for (&virtiofs_backends) |*b| {
         if (b.*) |*d| d.deinit();
     };
     var virtiofs_devs: [MAX_VIRTIOFS_SLOTS]?virtio.Device = undefined;
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         virtiofs_devs[i] = if (virtiofs_backends[i]) |*b|
-            makeVirtioFsDevice(virtio_virtiofs_bases[i], ram, cfg, b)
+            make_virtio_fs_device(virtio_virtiofs_bases[i], ram, cfg, b)
         else
             null;
     }
@@ -405,13 +405,13 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // first vcpu.run(). Topology hash mismatch is a hard error: the
     // wrong layout would scramble guest memory.
     if (cfg.restore_path) |path| {
-        applyRestoreFile(gpa, path, &vcpu, ram, cfg, gic.fd, &devs) catch |err| {
+        apply_restore_file(gpa, path, &vcpu, ram, cfg, gic.fd, &devs) catch |err| {
             std.debug.print("kvm boot: restore from {s} failed: {s}\n", .{ path, @errorName(err) });
             return err;
         };
         std.debug.print("kvm boot: restored from {s}\n", .{path});
     }
-    return try runLoop(gpa, cfg, &vm, &vcpu, &devs, irqs, ram, gic.fd);
+    return try run_loop(gpa, cfg, &vm, &vcpu, &devs, irqs, ram, gic.fd);
 }
 
 /// Kernel + DTB bytes loaded off disk plus the parsed kernel header.
@@ -431,15 +431,15 @@ const LoadedFixtures = struct {
 /// Read kernel + DTB off disk, parse the kernel header, and validate
 /// they fit in the configured guest RAM. `error.FixtureMissing` is
 /// surfaced so callers can `expectError` it cleanly.
-fn loadFixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
-    const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
+fn load_fixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
+    const kernel = read_all(gpa, cfg.kernel_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
     errdefer gpa.free(kernel);
     assert(kernel.len > 0);
 
-    const dtb = readAll(gpa, cfg.dtb_path) catch |err| {
+    const dtb = read_all(gpa, cfg.dtb_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
@@ -456,7 +456,7 @@ fn loadFixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
 /// Allocate the host-backed slab the guest sees as its RAM, then copy
 /// kernel + DTB + (optional) initramfs into it. Returns the mapped
 /// slice; caller owns the munmap.
-fn allocateAndPopulateRam(
+fn allocate_and_populate_ram(
     gpa: std.mem.Allocator,
     cfg: Config,
     fx: LoadedFixtures,
@@ -486,7 +486,7 @@ fn allocateAndPopulateRam(
     // #263 phase A: rewrite the DTB's `memory@<base>` reg-size cells
     // to match cfg.ram_size. Without this the shipped DTB caps the
     // guest at the DTS-declared 4 GiB regardless of cfg.ram_size.
-    dtb_patch.patchMemorySize(ram[cfg.dtb_offset..][0..fx.dtb.len], cfg.ram_size) catch |err| {
+    dtb_patch.patch_memory_size(ram[cfg.dtb_offset..][0..fx.dtb.len], cfg.ram_size) catch |err| {
         std.debug.print(
             "warn: patchMemorySize failed ({s}); guest will see the DTB-declared ceiling, not cfg.ram_size={d}\n",
             .{ @errorName(err), cfg.ram_size },
@@ -494,7 +494,7 @@ fn allocateAndPopulateRam(
     };
 
     if (cfg.initrd_path) |initrd_path| {
-        const initrd = readAll(gpa, initrd_path) catch |err| {
+        const initrd = read_all(gpa, initrd_path) catch |err| {
             if (err == error.OpenFailed) return error.FixtureMissing;
             return err;
         };
@@ -506,7 +506,7 @@ fn allocateAndPopulateRam(
         // walking dead tail. Failures here only cost startup latency,
         // so log only with MACHINEN_DEBUG set (the kernel still boots).
         const initrd_end_abs: u32 = @intCast(cfg.ram_base + cfg.initrd_offset + initrd.len);
-        dtb_patch.patchInitrdEnd(ram[cfg.dtb_offset..][0..fx.dtb.len], initrd_end_abs) catch {};
+        dtb_patch.patch_initrd_end(ram[cfg.dtb_offset..][0..fx.dtb.len], initrd_end_abs) catch {};
     }
     return ram;
 }
@@ -520,15 +520,15 @@ const SYS_HCR_EL2: u16 = 0xe088;
 const SYS_CNTHCTL_EL2: u16 = 0xe708;
 const SYS_CNTVOFF_EL2: u16 = 0xe703;
 
-fn initNestedEl2State(vcpu: *kvm.Vcpu) !void {
+fn init_nested_el2_state(vcpu: *kvm.Vcpu) !void {
     // Linux should enter at EL2 when we expose nested virtualization.
     // Give it the standard arm64 boot state: EL2h with interrupts
     // masked, AArch64 EL1 selected, and EL1 access to the physical
     // counter/timer enabled. KVM owns the rest of the EL2 reset state.
-    try vcpu.setReg(kvm.REG_PSTATE, PSTATE_DAIF_MASKED | PSTATE_EL2H);
-    try vcpu.setReg(kvmSysregId(SYS_HCR_EL2), HCR_EL2_RW);
-    try vcpu.setReg(kvmSysregId(SYS_CNTHCTL_EL2), CNTHCTL_EL2_EL1PCTEN | CNTHCTL_EL2_EL1PCEN);
-    try vcpu.setReg(kvmSysregId(SYS_CNTVOFF_EL2), 0);
+    try vcpu.set_reg(kvm.REG_PSTATE, PSTATE_DAIF_MASKED | PSTATE_EL2H);
+    try vcpu.set_reg(kvm_sysreg_id(SYS_HCR_EL2), HCR_EL2_RW);
+    try vcpu.set_reg(kvm_sysreg_id(SYS_CNTHCTL_EL2), CNTHCTL_EL2_EL1PCTEN | CNTHCTL_EL2_EL1PCEN);
+    try vcpu.set_reg(kvm_sysreg_id(SYS_CNTVOFF_EL2), 0);
 }
 
 /// Bring up the vCPU: enable PSCI 0.2 in the init features (so KVM
@@ -536,11 +536,11 @@ fn initNestedEl2State(vcpu: *kvm.Vcpu) !void {
 /// KVM_EXIT_SYSTEM_EVENT), then point X0 at the DTB and PC at the
 /// kernel entry per the arm64 Linux boot protocol. Caller owns the
 /// destroy.
-fn initVcpu(vm: *kvm.Vm, img: KernelImage, cfg: Config) !kvm.Vcpu {
-    var vcpu = try vm.createVcpu(0);
+fn init_vcpu(vm: *kvm.Vm, img: KernelImage, cfg: Config) !kvm.Vcpu {
+    var vcpu = try vm.create_vcpu(0);
     errdefer vcpu.destroy();
 
-    var init = try vm.preferredTarget();
+    var init = try vm.preferred_target();
     init.features[0] |= (@as(u32, 1) << @as(u5, @intCast(kvm.KVM_ARM_VCPU_PSCI_0_2)));
     if (cfg.nested) {
         init.features[0] |= (@as(u32, 1) << @as(u5, @intCast(kvm.KVM_ARM_VCPU_HAS_EL2)));
@@ -594,7 +594,7 @@ fn initVcpu(vm: *kvm.Vm, img: KernelImage, cfg: Config) !kvm.Vcpu {
     }
 
     if (cfg.nested) {
-        try initNestedEl2State(&vcpu);
+        try init_nested_el2_state(&vcpu);
     }
 
     const dtb_phys = cfg.ram_base + cfg.dtb_offset;
@@ -602,11 +602,11 @@ fn initVcpu(vm: *kvm.Vm, img: KernelImage, cfg: Config) !kvm.Vcpu {
     assert(dtb_phys >= cfg.ram_base);
     assert(entry_phys >= cfg.ram_base);
     assert(entry_phys < cfg.ram_base + cfg.ram_size);
-    try vcpu.setReg(kvm.REG_X0, dtb_phys);
-    try vcpu.setReg(kvm.REG_X1, 0);
-    try vcpu.setReg(kvm.REG_X2, 0);
-    try vcpu.setReg(kvm.REG_X3, 0);
-    try vcpu.setReg(kvm.REG_PC, entry_phys);
+    try vcpu.set_reg(kvm.REG_X0, dtb_phys);
+    try vcpu.set_reg(kvm.REG_X1, 0);
+    try vcpu.set_reg(kvm.REG_X2, 0);
+    try vcpu.set_reg(kvm.REG_X3, 0);
+    try vcpu.set_reg(kvm.REG_PC, entry_phys);
 
     return vcpu;
 }
@@ -614,7 +614,7 @@ fn initVcpu(vm: *kvm.Vm, img: KernelImage, cfg: Config) !kvm.Vcpu {
 /// Build the virtio-net device. virtio-net sits in slot 0 with a
 /// stable MAC the runtime hands the gvproxy DHCP server. tx_handler /
 /// tx_ctx are wired later, after the gvproxy connect.
-fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
+fn make_net_device(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
     return .{
         .base = virtio_net_base,
         .size = virtio_net_size,
@@ -629,9 +629,9 @@ fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
 
 /// Open a host file as a virtio-blk backend. Returns null when the
 /// caller didn't ask for this slot, or when the file open failed.
-fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
     const p = path orelse return null;
-    return blk_mod.openFile(p) catch |err| {
+    return blk_mod.open_file(p) catch |err| {
         std.debug.print("virtio-blk {s} disabled: {s} ({s})\n", .{ label, @errorName(err), p });
         return null;
     };
@@ -639,7 +639,7 @@ fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
 
 /// Wrap a runtime-passed fd as a virtio-blk backend (#272). Mirror
 /// of boot_hvf.zig's matching helper — see that file for the design.
-fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend_from_fd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
     const f = fd orelse return null;
     if (f < 0) return null;
     const size_bytes = lseek(f, 0, 2);
@@ -654,13 +654,13 @@ fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod
         );
         return null;
     }
-    return blk_mod.Backend.initFromFdWithMode(f, @intCast(size_bytes), read_only);
+    return blk_mod.Backend.init_from_fd_with_mode(f, @intCast(size_bytes), read_only);
 }
 
 /// Wrap a `blk_mod.Backend` as a virtio-mmio device. `backend` must
 /// outlive the returned device — the device's `config` and
 /// `request_ctx` are pointers into it.
-fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -669,14 +669,14 @@ fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
 
 /// Variant of `makeBlkDevice` that advertises VIRTIO_BLK_F_DISCARD
 /// in the feature bits (#272). Mirror of boot_hvf.zig's helper.
-fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device_with_discard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -685,7 +685,7 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -694,11 +694,11 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
 /// an empty slice; parse errors log and return empty so a typo in the
 /// env doesn't prevent boot. Returned slice + path strings allocated
 /// from `gpa`.
-fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
+fn parse_vsock_env(gpa: std.mem.Allocator) []vsock_mod.PortMap {
     const raw = getenv("MACHINEN_VSOCK") orelse return &.{};
     const s = std.mem.span(raw);
     if (s.len == 0) return &.{};
-    return vsock_mod.parseEnv(gpa, s) catch |err| {
+    return vsock_mod.parse_env(gpa, s) catch |err| {
         std.debug.print("vsock: MACHINEN_VSOCK parse failed ({s}); ignoring\n", .{@errorName(err)});
         return &.{};
     };
@@ -706,7 +706,7 @@ fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
 
 /// Build the virtio-vsock device. `cid_ptr` must outlive the device —
 /// the config field is a pointer into it.
-fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
+fn make_vsock_device(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
     return .{
         .base = virtio_vsock_base,
         .size = virtio_vsock_size,
@@ -715,7 +715,7 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
         .config = std.mem.asBytes(cid_ptr),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &vsock_mod.Bridge.handleTxChain,
+        .request_handler = &vsock_mod.Bridge.handle_tx_chain,
         .request_ctx = null,
         // Queues 0 (RX) and 2 (event) are driver-posts-empty-buffers
         // queues — host fills them on demand, not on every kick.
@@ -728,19 +728,19 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
 /// `<tag>:<mode>:<host_path>` grammar, the numbered-env rationale, and
 /// the c_allocator rationale. A missing slot is null; a malformed value
 /// is left null (warn-and-continue).
-fn parseVirtiofsEnv() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
+fn parse_virtiofs_env() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
     var out: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = @splat(null);
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         var name_buf: [32]u8 = undefined;
         const name = std.fmt.bufPrintZ(&name_buf, "MACHINEN_VIRTIOFS_{d}", .{i}) catch continue;
-        out[i] = parseOneVirtiofsEnv(name);
+        out[i] = parse_one_virtiofs_env(name);
     }
     return out;
 }
 
 /// Parse a single `MACHINEN_VIRTIOFS_<i>` env var into a backend, or
 /// null if unset / malformed. See `parseVirtiofsEnv`.
-fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
+fn parse_one_virtiofs_env(name: [*:0]const u8) ?virtiofs_mod.Device {
     const raw = getenv(name) orelse return null;
     const s = std.mem.span(raw);
     if (s.len == 0) return null;
@@ -788,16 +788,16 @@ fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
 
 /// Wrap a `virtiofs.Device` backend as a virtio-mmio device on the
 /// given slot `base`. `backend` must outlive the returned device.
-fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
+fn make_virtio_fs_device(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
     return .{
         .base = base,
         .size = virtio_virtiofs_size,
         .id = .virtio_fs,
         .features = (1 << 32), // VIRTIO_F_VERSION_1
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &virtiofs_mod.Device.handleRequest,
+        .request_handler = &virtiofs_mod.Device.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -805,16 +805,16 @@ fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.
 /// Build the virtio-balloon device. `backend` must outlive the
 /// returned Device — config + request_ctx are pointers into it.
 /// #263 phase B: continuous free-page reporting.
-fn makeBalloonDevice(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
+fn make_balloon_device(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
     return .{
         .base = virtio_balloon_base,
         .size = virtio_balloon_size,
         .id = .balloon,
         .features = balloon_mod.Backend.features(),
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &balloon_mod.Backend.handleRequest,
+        .request_handler = &balloon_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -822,7 +822,7 @@ fn makeBalloonDevice(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virt
 /// Dial gvproxy if `MACHINEN_NET_SOCKET` is set; null on missing env
 /// or any connect failure (the rest of the VMM still runs without
 /// network).
-fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
+fn connect_gvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
     const env = getenv("MACHINEN_NET_SOCKET") orelse return null;
     const path = std.mem.span(env);
     if (path.len == 0) return null;
@@ -836,7 +836,7 @@ fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetS
 /// device, start the poll thread, and log the active port mappings.
 /// Returns null on any failure (and clears `dev` so callers know the
 /// device is no longer live).
-fn startVsockBridge(
+fn start_vsock_bridge(
     gpa: std.mem.Allocator,
     dev: *virtio.Device,
     ports: []const vsock_mod.PortMap,
@@ -844,7 +844,7 @@ fn startVsockBridge(
 ) ?*vsock_mod.Bridge {
     const bridge = vsock_mod.Bridge.create(gpa, dev, .{
         .ports = ports,
-        .raise_irq = &onVsockIrq,
+        .raise_irq = &on_vsock_irq,
         .raise_irq_ctx = @ptrCast(irq_ctx),
     }) catch |err| {
         std.debug.print("vsock: bridge create failed: {s}\n", .{@errorName(err)});
@@ -874,27 +874,27 @@ fn startVsockBridge(
 var snapshot_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var snapshot_resume_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
-fn sigusr1Handler(sig: c_int) callconv(.c) void {
+fn sigusr1_handler(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_requested.store(true, .seq_cst);
 }
 
-fn sigusr2Handler(sig: c_int) callconv(.c) void {
+fn sigusr2_handler(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_resume_requested.store(true, .seq_cst);
 }
 
-fn installSnapshotSignal() void {
+fn install_snapshot_signal() void {
     const c = struct {
         extern "c" fn signal(sig: c_int, handler: usize) usize;
     };
     const SIGUSR1: c_int = 10;
     const SIGUSR2: c_int = 12;
-    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1Handler));
-    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2Handler));
+    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1_handler));
+    _ = c.signal(SIGUSR2, @intFromPtr(&sigusr2_handler));
 }
 
-fn waitForSnapshotResume() void {
+fn wait_for_snapshot_resume() void {
     const c = struct {
         extern "c" fn usleep(usec: u32) c_int;
     };
@@ -916,7 +916,7 @@ fn waitForSnapshotResume() void {
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exit, the
 /// configured serial-capture threshold, `max_exits`, or a
 /// SIGUSR1-triggered snapshot.
-fn runLoop(
+fn run_loop(
     gpa: std.mem.Allocator,
     cfg: Config,
     vm: *kvm.Vm,
@@ -936,11 +936,11 @@ fn runLoop(
         const reason = try vcpu.run();
         switch (reason) {
             .mmio => {
-                const ev = vcpu.mmioExit();
-                try routeMmio(vm, vcpu, devs, irqs, ev);
+                const ev = vcpu.mmio_exit();
+                try route_mmio(vm, vcpu, devs, irqs, ev);
             },
             .system_event => {
-                const ev = vcpu.systemEventExit();
+                const ev = vcpu.system_event_exit();
                 const typ: kvm.SystemEventType = @enumFromInt(ev.type);
                 if (typ == .shutdown or typ == .reset) {
                     saw_off = true;
@@ -974,20 +974,20 @@ fn runLoop(
                 var dirty_bits: ?[]u64 = null;
                 const page_count = ram.len / ram_dump.PAGE;
                 if (cfg.snapshot_path != null) {
-                    dirty_bits = vm.getDirtyLog(gpa, 0, page_count) catch |err| blk: {
+                    dirty_bits = vm.get_dirty_log(gpa, 0, page_count) catch |err| blk: {
                         std.debug.print("kvm: dirty-log read failed: {s}; writing a full RAM section\n", .{@errorName(err)});
                         break :blk null;
                     };
                 }
                 defer if (dirty_bits) |bits| gpa.free(bits);
                 const full_ram = !checkpoint_delta_mode or dirty_bits == null;
-                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits)) {
+                if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits)) {
                     snapshotted = true;
                     checkpoint_delta_mode = true;
-                    if (dirty_bits) |bits| vm.clearDirtyLog(0, bits, page_count);
-                    if (devs.root_blk) |b| b.clearDirty();
+                    if (dirty_bits) |bits| vm.clear_dirty_log(0, bits, page_count);
+                    if (devs.root_blk) |b| b.clear_dirty();
                     snapshot_requested.store(false, .seq_cst);
-                    waitForSnapshotResume();
+                    wait_for_snapshot_resume();
                 } else {
                     snapshot_requested.store(false, .seq_cst);
                 }
@@ -998,12 +998,12 @@ fn runLoop(
     if (exits >= cfg.max_exits) {
         std.debug.print(
             "kvm boot: RanTooLong after {d} exits. Captured serial ({d} bytes):\n{s}\n",
-            .{ exits, devs.uart.captured_len, devs.uart.capturedBytes() },
+            .{ exits, devs.uart.captured_len, devs.uart.captured_bytes() },
         );
         return error.RanTooLong;
     }
 
-    const serial = try gpa.dupe(u8, devs.uart.capturedBytes());
+    const serial = try gpa.dupe(u8, devs.uart.captured_bytes());
     return .{
         .serial = serial,
         .saw_psci_shutdown = saw_off,
@@ -1012,7 +1012,7 @@ fn runLoop(
     };
 }
 
-fn queueSnapshotWrite(
+fn queue_snapshot_write(
     writer: *vmstate_writer.Writer,
     gpa: std.mem.Allocator,
     path: []const u8,
@@ -1030,7 +1030,7 @@ fn queueSnapshotWrite(
     }
 
     std.debug.print("kvm: writing snapshot to {s}\n", .{path});
-    const job = captureSnapshotJob(gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits) catch |err| {
+    const job = capture_snapshot_job(gpa, path, vcpu, ram, cfg, gic_fd, devs, full_ram, dirty_bits) catch |err| {
         std.debug.print("kvm boot: snapshot capture failed: {s}\n", .{@errorName(err)});
         return false;
     };
@@ -1039,7 +1039,7 @@ fn queueSnapshotWrite(
             "kvm: snapshot async writer spawn failed: {s}; writing synchronously\n",
             .{@errorName(err)},
         );
-        vmstate_writer.writeAndDestroy(job) catch |write_err| {
+        vmstate_writer.write_and_destroy(job) catch |write_err| {
             std.debug.print("kvm boot: snapshot write failed: {s}\n", .{@errorName(write_err)});
             return false;
         };
@@ -1063,18 +1063,18 @@ const SEEK_SET: c_int = 0;
 /// KVM register ID for a 64-bit AArch64 system register, given its
 /// 16-bit op0/op1/CRn/CRm/op2 encoding.
 /// REG_ARM64 | SIZE_U64 | ARM64_SYSREG(0x0013_0000) | encoding.
-fn kvmSysregId(enc: u16) u64 {
+fn kvm_sysreg_id(enc: u16) u64 {
     return 0x6030_0000_0013_0000 | @as(u64, enc);
 }
 
 /// KVM register ID for MPIDR_EL1 (op0=3,op1=0,CRn=0,CRm=0,op2=5).
 const KVM_REG_MPIDR_EL1: u64 = 0x6030_0000_0013_C005;
 
-fn kvmVcpuMpidr(vcpu: *kvm.Vcpu) u64 {
-    return vcpu.getReg(KVM_REG_MPIDR_EL1) catch 0;
+fn kvm_vcpu_mpidr(vcpu: *kvm.Vcpu) u64 {
+    return vcpu.get_reg(KVM_REG_MPIDR_EL1) catch 0;
 }
 
-fn captureSnapshotJob(
+fn capture_snapshot_job(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: *kvm.Vcpu,
@@ -1100,26 +1100,26 @@ fn captureSnapshotJob(
 
     const job = try vmstate_writer.Job.create(gpa, "kvm", path, topo.hash());
     errdefer job.destroy();
-    const a = job.arenaAllocator();
+    const a = job.arena_allocator();
 
-    const vcpu_payload = try vcpu_dump.dumpKvm(a, vcpu.fd);
+    const vcpu_payload = try vcpu_dump.dump_kvm(a, vcpu.fd);
     const ram_payload = if (full_ram)
         try ram_dump.encode(a, cfg.ram_base, ram)
     else
-        try ram_dump.encodeDelta(a, cfg.ram_base, ram, dirty_bits.?);
+        try ram_dump.encode_delta(a, cfg.ram_base, ram, dirty_bits.?);
     // GICv3 distributor + per-vCPU redistributor + CPU interface —
     // see the matching block in boot_hvf.zig for why a cross-VMM
     // restore can't resume without it.
-    const mpidr = kvmVcpuMpidr(vcpu);
-    const gic_dist_payload = try gic_state.dumpKvmDist(a, gic_fd);
-    const gic_redist_payload = try gic_state.dumpKvmRedist(a, gic_fd, mpidr);
-    const gic_cpuif_payload = try gic_state.dumpKvmCpuIf(a, gic_fd, mpidr);
+    const mpidr = kvm_vcpu_mpidr(vcpu);
+    const gic_dist_payload = try gic_state.dump_kvm_dist(a, gic_fd);
+    const gic_redist_payload = try gic_state.dump_kvm_redist(a, gic_fd, mpidr);
+    const gic_cpuif_payload = try gic_state.dump_kvm_cpu_if(a, gic_fd, mpidr);
 
     // One `.virtio` section per present device (section `id` = the
     // device's MMIO base). See boot_hvf.zig's matching block for why
     // a restored guest's virtio drivers need this.
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
 
     var sections = std.ArrayList(snapshot.Section).empty;
     try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = vcpu_payload });
@@ -1128,7 +1128,7 @@ fn captureSnapshotJob(
     try sections.append(a, .{ .tag = .gic_redist, .id = 0, .payload = gic_redist_payload });
     try sections.append(a, .{ .tag = .gic_cpuif, .id = 0, .payload = gic_cpuif_payload });
     for (vdevs) |d| {
-        const vp = try virtio_dump.dumpDevice(a, d);
+        const vp = try virtio_dump.dump_device(a, d);
         try sections.append(a, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
     }
     // virtio-fs FUSE backend state — the nodeid→path map and the open
@@ -1141,12 +1141,12 @@ fn captureSnapshotJob(
     for (vdevs) |d| {
         if (d.id != .virtio_fs) continue;
         const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-        const fp = try backend.state.dumpState(a);
+        const fp = try backend.state.dump_state(a);
         try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
     if (!full_ram) {
         if (devs.root_blk) |b| {
-            const dp = try b.encodeDirtyDelta(a);
+            const dp = try b.encode_dirty_delta(a);
             try sections.append(a, .{ .tag = .rootdisk_delta, .id = 0, .payload = dp });
         }
     }
@@ -1154,7 +1154,7 @@ fn captureSnapshotJob(
     return job;
 }
 
-fn applyRestoreFile(
+fn apply_restore_file(
     gpa: std.mem.Allocator,
     path: []const u8,
     vcpu: *kvm.Vcpu,
@@ -1193,7 +1193,7 @@ fn applyRestoreFile(
     timing.mark("read-file");
 
     // gunzip if the file is compressed; a plain .vmstate borrows `raw`.
-    const decoded = try @import("vmstate_zip.zig").decompressMaybeOwned(gpa, raw);
+    const decoded = try @import("vmstate_zip.zig").decompress_maybe_owned(gpa, raw);
     defer decoded.deinit(gpa);
     timing.mark("decompress");
 
@@ -1212,7 +1212,7 @@ fn applyRestoreFile(
     }
     timing.mark("topology-check");
 
-    const mpidr = kvmVcpuMpidr(vcpu);
+    const mpidr = kvm_vcpu_mpidr(vcpu);
 
     // GIC state is only applied when the snapshot carries a *complete*
     // picture: distributor + redistributor + a populated CPU-interface
@@ -1237,26 +1237,26 @@ fn applyRestoreFile(
     timing.mark("gic-scan");
 
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
     var cpuif_applied: usize = 0;
     for (snap.sections) |s| {
-        const section_t0 = timing.sectionStart();
+        const section_t0 = timing.section_start();
         switch (s.tag) {
-            .vcpu => try vcpu_dump.loadKvm(gpa, vcpu.fd, s.payload),
+            .vcpu => try vcpu_dump.load_kvm(gpa, vcpu.fd, s.payload),
             .ram => {
                 // Reconstructs straight into the live guest RAM: zero
                 // pages are implicit, stored extents land on top.
-                _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
+                _ = try ram_dump.decode_into_zeroed(s.payload, ram);
             },
             .ram_delta => {
                 // Overlay a checkpoint delta onto the RAM reconstructed
                 // from its parent section(s).
-                _ = try ram_dump.decodeDeltaInto(s.payload, ram);
+                _ = try ram_dump.decode_delta_into(s.payload, ram);
             },
-            .gic_dist => if (apply_gic) try gic_state.loadKvmDist(gpa, gic_fd, s.payload),
-            .gic_redist => if (apply_gic) try gic_state.loadKvmRedist(gpa, gic_fd, mpidr, s.payload),
+            .gic_dist => if (apply_gic) try gic_state.load_kvm_dist(gpa, gic_fd, s.payload),
+            .gic_redist => if (apply_gic) try gic_state.load_kvm_redist(gpa, gic_fd, mpidr, s.payload),
             .gic_cpuif => if (apply_gic) {
-                cpuif_applied = gic_state.loadKvmCpuIf(gpa, gic_fd, mpidr, s.payload) catch 0;
+                cpuif_applied = gic_state.load_kvm_cpu_if(gpa, gic_fd, mpidr, s.payload) catch 0;
             },
             // Restore each virtio device's transport state onto the
             // matching freshly-created device (matched by MMIO base,
@@ -1264,7 +1264,7 @@ fn applyRestoreFile(
             .virtio => {
                 for (vdevs) |d| {
                     if (@as(u32, @truncate(d.base)) == s.id) {
-                        virtio_dump.applyDevice(gpa, d, s.payload) catch |err| {
+                        virtio_dump.apply_device(gpa, d, s.payload) catch |err| {
                             std.debug.print(
                                 "kvm boot: virtio restore for base 0x{x} failed: {s}\n",
                                 .{ d.base, @errorName(err) },
@@ -1283,7 +1283,7 @@ fn applyRestoreFile(
                     if (d.id != .virtio_fs) continue;
                     if (@as(u32, @truncate(d.base)) != s.id) continue;
                     const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-                    backend.state.applyState(s.payload) catch |err| {
+                    backend.state.apply_state(s.payload) catch |err| {
                         std.debug.print(
                             "kvm boot: virtio-fs state restore for base 0x{x} failed: {s}\n",
                             .{ d.base, @errorName(err) },
@@ -1315,11 +1315,11 @@ fn applyRestoreFile(
     // 100% with zero forward progress. Mirror what loadKvm parked in
     // the counter into the comparator so CNTVCT and CNTV_CVAL line up:
     // one clean tick on resume, then normal cadence.
-    const KVM_REG_ARM_TIMER_CNT = kvmSysregId(0xDF1A);
-    const KVM_REG_ARM_TIMER_CVAL = kvmSysregId(0xDF02);
-    const guest_cval = vcpu.getReg(KVM_REG_ARM_TIMER_CNT) catch 0;
+    const KVM_REG_ARM_TIMER_CNT = kvm_sysreg_id(0xDF1A);
+    const KVM_REG_ARM_TIMER_CVAL = kvm_sysreg_id(0xDF02);
+    const guest_cval = vcpu.get_reg(KVM_REG_ARM_TIMER_CNT) catch 0;
     if (guest_cval != 0) {
-        vcpu.setReg(KVM_REG_ARM_TIMER_CVAL, guest_cval) catch |err| {
+        vcpu.set_reg(KVM_REG_ARM_TIMER_CVAL, guest_cval) catch |err| {
             std.debug.print("kvm boot: timer comparator fixup failed: {s}\n", .{@errorName(err)});
         };
     }
@@ -1329,11 +1329,11 @@ fn applyRestoreFile(
     // won't resume. PC/PSTATE should match the snapshot's EL/PC; a
     // zeroed TTBR or cleared SCTLR.M means the MMU sysregs didn't
     // stick and EL0 will instruction-abort on the first fetch.
-    const pc = vcpu.getReg(kvm.REG_PC) catch 0;
-    const pstate = vcpu.getReg(kvm.REG_PSTATE) catch 0;
-    const sctlr = vcpu.getReg(kvmSysregId(0xC080)) catch 0;
-    const ttbr0 = vcpu.getReg(kvmSysregId(0xC100)) catch 0;
-    const ttbr1 = vcpu.getReg(kvmSysregId(0xC101)) catch 0;
+    const pc = vcpu.get_reg(kvm.REG_PC) catch 0;
+    const pstate = vcpu.get_reg(kvm.REG_PSTATE) catch 0;
+    const sctlr = vcpu.get_reg(kvm_sysreg_id(0xC080)) catch 0;
+    const ttbr0 = vcpu.get_reg(kvm_sysreg_id(0xC100)) catch 0;
+    const ttbr1 = vcpu.get_reg(kvm_sysreg_id(0xC101)) catch 0;
     std.debug.print(
         "kvm boot: restore readback PC=0x{x} PSTATE=0x{x} SCTLR_EL1=0x{x} TTBR0=0x{x} TTBR1=0x{x} cpuif_regs={d} timer_cval=0x{x}\n",
         .{ pc, pstate, sctlr, ttbr0, ttbr1, cpuif_applied, guest_cval },
@@ -1360,17 +1360,17 @@ const IrqMap = struct {
     fn init() IrqMap {
         var virtiofs_irqs: [MAX_VIRTIOFS_SLOTS]u32 = undefined;
         for (0..MAX_VIRTIOFS_SLOTS) |i| {
-            virtiofs_irqs[i] = kvm.irqSpi(23 + @as(u32, @intCast(i)));
+            virtiofs_irqs[i] = kvm.irq_spi(23 + @as(u32, @intCast(i)));
         }
         return .{
-            .pl011 = kvm.irqSpi(1),
-            .net = kvm.irqSpi(16),
-            .blk = kvm.irqSpi(17),
-            .vsock = kvm.irqSpi(18),
-            .blk2 = kvm.irqSpi(19),
-            .balloon = kvm.irqSpi(20),
-            .blk3 = kvm.irqSpi(21),
-            .blk4 = kvm.irqSpi(22),
+            .pl011 = kvm.irq_spi(1),
+            .net = kvm.irq_spi(16),
+            .blk = kvm.irq_spi(17),
+            .vsock = kvm.irq_spi(18),
+            .blk2 = kvm.irq_spi(19),
+            .balloon = kvm.irq_spi(20),
+            .blk3 = kvm.irq_spi(21),
+            .blk4 = kvm.irq_spi(22),
             .virtiofs = virtiofs_irqs,
         };
     }
@@ -1407,7 +1407,7 @@ const Devices = struct {
     /// populated prefix. Used by snapshot/restore to dump/apply each
     /// device's transport state — virtio-fs slots included, so a
     /// `--mount-live` VM's queue state round-trips through vmstate.
-    pub fn virtioDevices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
+    pub fn virtio_devices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
         var n: usize = 0;
         buf[n] = self.netdev;
         n += 1;
@@ -1435,7 +1435,7 @@ const Devices = struct {
 const VirtiofsMatch = struct { dev: *virtio.Device, irq: u32 };
 
 /// Find the virtio-fs slot (if any) whose MMIO window owns `phys_addr`.
-fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMatch {
+fn virtiofs_match(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMatch {
     for (devs.virtiofs_devs, irqs.virtiofs) |dev_opt, irq| {
         if (dev_opt) |d| {
             if (d.handles(phys_addr)) return .{ .dev = d, .irq = irq };
@@ -1446,7 +1446,7 @@ fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMa
 
 /// PL011 MMIO. Console-byte writes echo to host stderr; every access
 /// resyncs the SPI line based on `irqAsserted()`.
-fn handlePl011Mmio(
+fn handle_pl011_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     uart: *pl011_mod.Pl011,
@@ -1457,24 +1457,24 @@ fn handlePl011Mmio(
 ) !void {
     assert(uart.handles(ev.phys_addr));
     if (ev.is_write != 0) {
-        const val = mmioReadValue(ev);
+        const val = mmio_read_value(ev);
         uart.write(ev.phys_addr, val);
         if ((ev.phys_addr - uart.base) == 0 and ev.len > 0) {
             const byte: [1]u8 = .{ev.data[0]};
-            _ = hostWrite(2, &byte, 1);
+            _ = host_write(2, &byte, 1);
             if (nested) poweroff.observe(byte[0]);
         }
     } else {
-        vcpu.writeMmioReadData(uart.read(ev.phys_addr), ev.len);
+        vcpu.write_mmio_read_data(uart.read(ev.phys_addr), ev.len);
     }
-    vm.setIrq(irq, if (uart.irqAsserted()) 1 else 0) catch {};
+    vm.set_irq(irq, if (uart.irq_asserted()) 1 else 0) catch {};
 }
 
 /// virtio-MMIO read/write + raise/lower the SPI based on the device's
 /// post-access interrupt_status. Shared shape across net / blk / blk2 /
 /// vsock; the callers that need cross-thread serialisation take the
 /// appropriate mutex around this call.
-fn handleVirtioMmio(
+fn handle_virtio_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     dev: *virtio.Device,
@@ -1484,16 +1484,16 @@ fn handleVirtioMmio(
     assert(dev.handles(ev.phys_addr));
     assert(irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
     if (ev.is_write != 0) {
-        dev.write(ev.phys_addr, mmioReadValue(ev));
+        dev.write(ev.phys_addr, mmio_read_value(ev));
     } else {
-        vcpu.writeMmioReadData(dev.read(ev.phys_addr), ev.len);
+        vcpu.write_mmio_read_data(dev.read(ev.phys_addr), ev.len);
     }
-    vm.setIrq(irq, if (@atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) 1 else 0) catch {};
+    vm.set_irq(irq, if (@atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) 1 else 0) catch {};
 }
 
 /// Route an MMIO exit to the device that owns the IPA. Each cross-
 /// thread arm wraps `handleVirtioMmio` in the appropriate mutex.
-fn routeMmio(
+fn route_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
@@ -1506,50 +1506,50 @@ fn routeMmio(
     assert(ev.is_write <= 1);
 
     if (devs.uart.handles(ev.phys_addr)) {
-        try handlePl011Mmio(vm, vcpu, devs.uart, ev, irqs.pl011, devs.nested, devs.nested_poweroff);
+        try handle_pl011_mmio(vm, vcpu, devs.uart, ev, irqs.pl011, devs.nested, devs.nested_poweroff);
         return;
     }
     if (devs.netdev.handles(ev.phys_addr)) {
-        try dispatchNetMmio(vm, vcpu, devs, irqs, ev);
+        try dispatch_net_mmio(vm, vcpu, devs, irqs, ev);
         return;
     }
     if (devs.blk_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk, ev);
         return;
     };
     if (devs.blk2_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk2, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk2, ev);
         return;
     };
     if (devs.blk3_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk3, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk3, ev);
         return;
     };
     if (devs.blk4_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk4, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk4, ev);
         return;
     };
     if (devs.vsock_dev) |d| if (d.handles(ev.phys_addr)) {
-        try dispatchVsockMmio(vm, vcpu, devs, d, irqs.vsock, ev);
+        try dispatch_vsock_mmio(vm, vcpu, devs, d, irqs.vsock, ev);
         return;
     };
     if (devs.balloon_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.balloon, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.balloon, ev);
         return;
     };
-    if (virtiofsMatch(devs, irqs, ev.phys_addr)) |m| {
+    if (virtiofs_match(devs, irqs, ev.phys_addr)) |m| {
         // virtio-fs request handling is synchronous on the vCPU thread
         // (`handleVirtioMmio` → `dev.write` → `notify` drains the chain
         // inline through `virtiofs.Device.handleRequest`). No second
         // thread, so no mutex to take — unlike net / vsock.
-        try handleVirtioMmio(vm, vcpu, m.dev, m.irq, ev);
+        try handle_virtio_mmio(vm, vcpu, m.dev, m.irq, ev);
         return;
     }
     // Other MMIO (DTB-described regions we haven't hooked up) — for
     // reads, hand back zeros (the writeMmioReadData default on
     // untouched kvm_run bytes is already zero, but be explicit so a
     // future non-zero lingerer doesn't bite).
-    if (ev.is_write == 0) vcpu.writeMmioReadData(0, ev.len);
+    if (ev.is_write == 0) vcpu.write_mmio_read_data(0, ev.len);
 }
 
 /// Run a virtio-net MMIO event under `net_inst.irq_mu`. The RX thread
@@ -1558,16 +1558,16 @@ fn routeMmio(
 /// can't override the bridge's. No-op when `net_inst` is null (no
 /// gvproxy backend) — there is no second thread to race against, and
 /// the kernel still sees a valid virtio-net device with link-down.
-fn dispatchNetMmio(
+fn dispatch_net_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
     ev: kvm.MmioExit,
 ) !void {
-    if (devs.net_inst) |n| n.lockIrq();
-    defer if (devs.net_inst) |n| n.unlockIrq();
-    try handleVirtioMmio(vm, vcpu, devs.netdev, irqs.net, ev);
+    if (devs.net_inst) |n| n.lock_irq();
+    defer if (devs.net_inst) |n| n.unlock_irq();
+    try handle_virtio_mmio(vm, vcpu, devs.netdev, irqs.net, ev);
 }
 
 /// Run a virtio-vsock MMIO event under `vsock_bridge.mu`. The vCPU
@@ -1582,7 +1582,7 @@ fn dispatchNetMmio(
 /// HVF passes smoke and KVM doesn't until this lock lands.
 /// `handleTxChain` assumes the caller holds `bridge.mu` — see its
 /// docstring.
-fn dispatchVsockMmio(
+fn dispatch_vsock_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
@@ -1592,12 +1592,12 @@ fn dispatchVsockMmio(
 ) !void {
     if (devs.vsock_bridge) |b| b.mu.lock();
     defer if (devs.vsock_bridge) |b| b.mu.unlock();
-    try handleVirtioMmio(vm, vcpu, dev, irq, ev);
+    try handle_virtio_mmio(vm, vcpu, dev, irq, ev);
 }
 
 /// Pack the up-to-8 little-endian bytes KVM hands us in `mmio.data`
 /// into a u64 the device handlers expect.
-fn mmioReadValue(ev: kvm.MmioExit) u64 {
+fn mmio_read_value(ev: kvm.MmioExit) u64 {
     assert(ev.len >= 1 and ev.len <= 8);
     var val: u64 = 0;
     const n = @min(@as(usize, ev.len), 8);
@@ -1608,7 +1608,7 @@ fn mmioReadValue(ev: kvm.MmioExit) u64 {
     return val;
 }
 
-fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+fn read_all(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     assert(path.len > 0);
     var path_buf: [4096]u8 = undefined;
     if (path.len >= path_buf.len) return error.NameTooLong;
@@ -1616,14 +1616,14 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     path_buf[path.len] = 0;
     const path_z: [*:0]const u8 = @ptrCast(&path_buf);
 
-    const fd = hostOpen(path_z, 0, 0);
+    const fd = host_open(path_z, 0, 0);
     if (fd < 0) return error.OpenFailed;
     assert(fd >= 0);
-    defer _ = hostClose(fd);
+    defer _ = host_close(fd);
 
-    const size_signed = hostLseek(fd, 0, 2);
+    const size_signed = host_lseek(fd, 0, 2);
     if (size_signed < 0) return error.SeekFailed;
-    _ = hostLseek(fd, 0, 0);
+    _ = host_lseek(fd, 0, 0);
     const size_bytes: usize = @intCast(size_signed);
     assert(size_bytes > 0);
 
@@ -1631,7 +1631,7 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     errdefer gpa.free(buf);
     var total_bytes: usize = 0;
     while (total_bytes < size_bytes) {
-        const n_bytes = hostRead(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
+        const n_bytes = host_read(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
         if (n_bytes <= 0) return error.ShortRead;
         total_bytes += @intCast(n_bytes);
     }
@@ -1649,19 +1649,19 @@ extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 // Rename'd because `read`/`write` collide with std method names in
 // some generic contexts; kept the extern shims unchanged.
-fn hostOpen(path: [*:0]const u8, flags: c_int, mode: c_int) c_int {
+fn host_open(path: [*:0]const u8, flags: c_int, mode: c_int) c_int {
     return open(path, flags, mode);
 }
-fn hostClose(fd: c_int) c_int {
+fn host_close(fd: c_int) c_int {
     return close(fd);
 }
-fn hostRead(fd: c_int, buf: [*]u8, count: usize) isize {
+fn host_read(fd: c_int, buf: [*]u8, count: usize) isize {
     return read(fd, buf, count);
 }
-fn hostWrite(fd: c_int, buf: [*]const u8, count: usize) isize {
+fn host_write(fd: c_int, buf: [*]const u8, count: usize) isize {
     return write(fd, buf, count);
 }
-fn hostLseek(fd: c_int, offset: i64, whence: c_int) i64 {
+fn host_lseek(fd: c_int, offset: i64, whence: c_int) i64 {
     return lseek(fd, offset, whence);
 }
 
@@ -1674,11 +1674,11 @@ pub const VsockIrqCtx = struct {
     irq: u32,
 };
 
-fn onVsockIrq(ctx: ?*anyopaque) void {
+fn on_vsock_irq(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
     assert(c.irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
-    c.vm.setIrq(c.irq, 1) catch {};
+    c.vm.set_irq(c.irq, 1) catch {};
 }
 
 /// Same shape as VsockIrqCtx, but for the virtio-net SPI. NetSocket's
@@ -1689,11 +1689,11 @@ pub const NetIrqCtx = struct {
     irq: u32,
 };
 
-fn onNetIrq(ctx: ?*anyopaque) void {
+fn on_net_irq(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const c: *NetIrqCtx = @ptrCast(@alignCast(ctx.?));
     assert(c.irq >> kvm.KVM_ARM_IRQ_TYPE_SHIFT == kvm.KVM_ARM_IRQ_TYPE_SPI);
-    c.vm.setIrq(c.irq, 1) catch {};
+    c.vm.set_irq(c.irq, 1) catch {};
 }
 
 /// Pump a guest-emitted ethernet frame through to gvproxy. Called
@@ -1702,7 +1702,7 @@ fn onNetIrq(ctx: ?*anyopaque) void {
 /// been stripped by `walkAndEmit`, so we just hand the bare ethernet
 /// frame to NetSocket.input which prepends the 4-byte length prefix
 /// and writes to the gvproxy UDS.
-fn onNetTx(ctx: ?*anyopaque, frame: []const u8) void {
+fn on_net_tx(ctx: ?*anyopaque, frame: []const u8) void {
     assert(ctx != null);
     assert(frame.len > 0);
     const n: *net_mod.NetSocket = @ptrCast(@alignCast(ctx.?));
@@ -1746,7 +1746,7 @@ const kernel_fixture = "test-fixtures/Image";
 const dtb_fixture = "test-fixtures/virt.dtb";
 const initrd_fixture = "test-fixtures/initramfs.cpio";
 
-fn fixturesPresent() bool {
+fn fixtures_present() bool {
     inline for (.{ kernel_fixture, dtb_fixture, initrd_fixture }) |p| {
         var buf: [4096]u8 = undefined;
         if (p.len >= buf.len) return false;
@@ -1772,7 +1772,7 @@ test "KVM: boot a real arm64 Linux kernel" {
         std.debug.print("skip: /dev/kvm not readable\n", .{});
         return;
     }
-    if (!fixturesPresent()) {
+    if (!fixtures_present()) {
         std.debug.print(
             "skip: missing {s} or {s} (run scripts/build-base-assets.sh)\n",
             .{ kernel_fixture, dtb_fixture },

--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -116,7 +116,7 @@ pub const Result = struct {
     snapshotted: bool = false,
 };
 
-fn validateConfig(cfg: Config) void {
+fn validate_config(cfg: Config) void {
     assert(cfg.kernel_path.len > 0);
     assert(cfg.ram_base == 0);
     assert(cfg.ram_size >= 512 * 1024 * 1024);
@@ -127,30 +127,30 @@ fn validateConfig(cfg: Config) void {
 }
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
-    validateConfig(cfg);
-    if (cfg.snapshot_path != null) installSnapshotSignal();
+    validate_config(cfg);
+    if (cfg.snapshot_path != null) install_snapshot_signal();
 
-    var fx = try loadFixtures(gpa, cfg);
+    var fx = try load_fixtures(gpa, cfg);
     defer fx.deinit(gpa);
 
-    const ram = try allocateAndPopulateRam(gpa, cfg, fx);
+    const ram = try allocate_and_populate_ram(gpa, cfg, fx);
     defer std.posix.munmap(ram);
 
     var k = try kvm.Kvm.open_();
     defer k.close_();
 
-    var vm = try k.createVm();
+    var vm = try k.create_vm();
     defer vm.destroy();
 
-    try vm.setTssAddr(0xFFFBD000);
-    try vm.createIrqchip();
-    try vm.createPit2();
-    try mapGuestRam(&vm, cfg, ram);
+    try vm.set_tss_addr(0xFFFBD000);
+    try vm.create_irqchip();
+    try vm.create_pit2();
+    try map_guest_ram(&vm, cfg, ram);
 
-    var vcpu = try initVcpu(&vm, ram, cfg);
+    var vcpu = try init_vcpu(&vm, ram, cfg);
     defer vcpu.destroy();
 
-    var uart = uart8250_mod.Uart8250.withBase(uart_base);
+    var uart = uart8250_mod.Uart8250.with_base(uart_base);
     uart.capture_enabled = !cfg.unbounded_serial;
 
     const irqs = IrqMap.init();
@@ -158,54 +158,54 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
     const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
 
-    var blk_backend_opt: ?blk_mod.Backend = openBlkBackend(slot1_path, "slot 1");
+    var blk_backend_opt: ?blk_mod.Backend = open_blk_backend(slot1_path, "slot 1");
     defer if (blk_backend_opt) |*b| b.deinit();
     var blkdev_opt: ?virtio.Device = if (blk_backend_opt) |*b|
-        makeBlkDevice(virtio_blk_base, virtio_blk_size, ram, cfg, b)
+        make_blk_device(virtio_blk_base, virtio_blk_size, ram, cfg, b)
     else
         null;
     const blkdev_ptr: ?*virtio.Device = if (blkdev_opt) |_| &blkdev_opt.? else null;
 
-    var blk2_backend_opt: ?blk_mod.Backend = openBlkBackend(slot3_path, "slot 3");
+    var blk2_backend_opt: ?blk_mod.Backend = open_blk_backend(slot3_path, "slot 3");
     defer if (blk2_backend_opt) |*b| b.deinit();
     var blk2dev_opt: ?virtio.Device = if (blk2_backend_opt) |*b|
-        makeBlkDevice(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
+        make_blk_device(virtio_blk2_base, virtio_blk2_size, ram, cfg, b)
     else
         null;
     const blk2dev_ptr: ?*virtio.Device = if (blk2dev_opt) |_| &blk2dev_opt.? else null;
 
-    var blk3_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
+    var blk3_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_lower_fd, true, "slot 5 (mount lower)");
     defer if (blk3_backend_opt) |*b| b.deinit();
     var blk3dev_opt: ?virtio.Device = if (blk3_backend_opt) |*b|
-        makeBlkDevice(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
+        make_blk_device(virtio_blk3_base, virtio_blk3_size, ram, cfg, b)
     else
         null;
     const blk3dev_ptr: ?*virtio.Device = if (blk3dev_opt) |_| &blk3dev_opt.? else null;
 
-    var blk4_backend_opt: ?blk_mod.Backend = openBlkBackendFromFd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
+    var blk4_backend_opt: ?blk_mod.Backend = open_blk_backend_from_fd(cfg.mountdisk_upper_fd, false, "slot 6 (mount upper)");
     defer if (blk4_backend_opt) |*b| b.deinit();
     var blk4dev_opt: ?virtio.Device = if (blk4_backend_opt) |*b|
-        makeBlkDeviceWithDiscard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
+        make_blk_device_with_discard(virtio_blk4_base, virtio_blk4_size, ram, cfg, b)
     else
         null;
     const blk4dev_ptr: ?*virtio.Device = if (blk4dev_opt) |_| &blk4dev_opt.? else null;
 
     const virtio_mac = [_]u8{ 0x02, 0xDE, 0xAD, 0xBE, 0xEF, 0x01 };
-    var netdev = makeNetDevice(ram, cfg, &virtio_mac);
-    const net_inst: ?*net_mod.NetSocket = connectGvproxy(gpa, &netdev);
+    var netdev = make_net_device(ram, cfg, &virtio_mac);
+    const net_inst: ?*net_mod.NetSocket = connect_gvproxy(gpa, &netdev);
     defer if (net_inst) |n| n.destroy();
     var net_irq_ctx = NetIrqCtx{ .vm = &vm, .irq = irqs.net };
     if (net_inst) |n| {
-        netdev.tx_handler = &onNetTx;
+        netdev.tx_handler = &on_net_tx;
         netdev.tx_ctx = @ptrCast(n);
-        n.on_rx = &onNetIrq;
+        n.on_rx = &on_net_irq;
         n.on_rx_ctx = @ptrCast(&net_irq_ctx);
     }
 
     const vsock_cid_storage: u64 = vsock_mod.default_guest_cid;
-    const vsock_ports = parseVsockEnv(gpa);
+    const vsock_ports = parse_vsock_env(gpa);
     var vsock_dev_opt: ?virtio.Device = if (vsock_ports.len > 0)
-        makeVsockDevice(ram, cfg, &vsock_cid_storage)
+        make_vsock_device(ram, cfg, &vsock_cid_storage)
     else
         null;
     const vsock_dev_ptr: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
@@ -213,27 +213,27 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     var vsock_irq_ctx = VsockIrqCtx{ .vm = &vm, .irq = irqs.vsock };
     var vsock_bridge_opt: ?*vsock_mod.Bridge = null;
     if (vsock_dev_ptr) |d| {
-        vsock_bridge_opt = startVsockBridge(gpa, d, vsock_ports, &vsock_irq_ctx);
+        vsock_bridge_opt = start_vsock_bridge(gpa, d, vsock_ports, &vsock_irq_ctx);
         if (vsock_bridge_opt == null) vsock_dev_opt = null;
     }
     defer if (vsock_bridge_opt) |b| b.destroy();
     const vsock_dev_ptr_run: ?*virtio.Device = if (vsock_dev_opt) |_| &vsock_dev_opt.? else null;
 
-    var stats_inst = stats_mod.Stats.openOrStub();
+    var stats_inst = stats_mod.Stats.open_or_stub();
     defer stats_inst.deinit();
-    stats_mod.startPhysFootprintSampler(stats_inst.counters);
-    var balloon_backend = balloon_mod.Backend.initWithCounters(stats_inst.counters);
-    var balloon_dev = makeBalloonDevice(ram, cfg, &balloon_backend);
+    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
+    var balloon_dev = make_balloon_device(ram, cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;
 
-    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parseVirtiofsEnv();
+    var virtiofs_backends: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = parse_virtiofs_env();
     defer for (&virtiofs_backends) |*b| {
         if (b.*) |*d| d.deinit();
     };
     var virtiofs_devs: [MAX_VIRTIOFS_SLOTS]?virtio.Device = undefined;
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         virtiofs_devs[i] = if (virtiofs_backends[i]) |*b|
-            makeVirtioFsDevice(virtio_virtiofs_bases[i], ram, cfg, b)
+            make_virtio_fs_device(virtio_virtiofs_bases[i], ram, cfg, b)
         else
             null;
     }
@@ -257,14 +257,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     };
 
     if (cfg.restore_path) |path| {
-        applyRestoreFile(gpa, path, &vm, &vcpu, ram, cfg, &devs) catch |err| {
+        apply_restore_file(gpa, path, &vm, &vcpu, ram, cfg, &devs) catch |err| {
             std.debug.print("kvm-x86_64 boot: restore from {s} failed: {s}\n", .{ path, @errorName(err) });
             return err;
         };
         std.debug.print("kvm-x86_64 boot: restored from {s}\n", .{path});
     }
 
-    return try runLoop(gpa, cfg, &vm, &vcpu, &devs, irqs, ram);
+    return try run_loop(gpa, cfg, &vm, &vcpu, &devs, irqs, ram);
 }
 
 const LoadedFixtures = struct {
@@ -276,8 +276,8 @@ const LoadedFixtures = struct {
     }
 };
 
-fn loadFixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
-    const kernel = readAll(gpa, cfg.kernel_path) catch |err| {
+fn load_fixtures(gpa: std.mem.Allocator, cfg: Config) !LoadedFixtures {
+    const kernel = read_all(gpa, cfg.kernel_path) catch |err| {
         if (err == error.FileNotFound) return error.FixtureMissing;
         return err;
     };
@@ -309,7 +309,7 @@ const BzImage = struct {
     }
 };
 
-fn allocateAndPopulateRam(
+fn allocate_and_populate_ram(
     gpa: std.mem.Allocator,
     cfg: Config,
     fx: LoadedFixtures,
@@ -332,89 +332,89 @@ fn allocateAndPopulateRam(
         return ram;
     }
 
-    @memcpy(guestSlice(ram, kernel_load_addr, fx.img.protected.len), fx.img.protected);
+    @memcpy(guest_slice(ram, kernel_load_addr, fx.img.protected.len), fx.img.protected);
 
-    const bp = guestSlice(ram, boot_params_addr, 4096);
+    const bp = guest_slice(ram, boot_params_addr, 4096);
     @memset(bp, 0);
     const setup_copy = @min(fx.img.setup_size, bp.len);
     @memcpy(bp[0..setup_copy], fx.kernel[0..setup_copy]);
-    populateBootParams(bp, cfg, fx.img);
+    populate_boot_params(bp, cfg, fx.img);
 
-    const cmdline = cfg.cmdline orelse defaultCmdline();
+    const cmdline = cfg.cmdline orelse default_cmdline();
     if (cmdline.len + 1 > 4096) return error.BootParamsTooLarge;
-    const cmd = guestSlice(ram, cmdline_addr, cmdline.len + 1);
+    const cmd = guest_slice(ram, cmdline_addr, cmdline.len + 1);
     @memcpy(cmd[0..cmdline.len], cmdline);
     cmd[cmdline.len] = 0;
 
     if (cfg.initrd_path) |initrd_path| {
-        const initrd = readAll(gpa, initrd_path) catch |err| {
+        const initrd = read_all(gpa, initrd_path) catch |err| {
             if (err == error.OpenFailed or err == error.FileNotFound) return error.FixtureMissing;
             return err;
         };
         defer gpa.free(initrd);
         if (cfg.initrd_offset + initrd.len > cfg.ram_size) return error.InitrdTooLarge;
-        @memcpy(guestSlice(ram, cfg.initrd_offset, initrd.len), initrd);
-        writeInt(bp, 0x218, u32, @intCast(cfg.initrd_offset));
-        writeInt(bp, 0x21C, u32, @intCast(initrd.len));
+        @memcpy(guest_slice(ram, cfg.initrd_offset, initrd.len), initrd);
+        write_int(bp, 0x218, u32, @intCast(cfg.initrd_offset));
+        write_int(bp, 0x21C, u32, @intCast(initrd.len));
     }
 
-    writeGdt(ram);
-    writeAcpiTables(ram);
+    write_gdt(ram);
+    write_acpi_tables(ram);
     return ram;
 }
 
-fn guestSlice(ram: []u8, phys: u64, len: usize) []u8 {
+fn guest_slice(ram: []u8, phys: u64, len: usize) []u8 {
     assert(phys <= std.math.maxInt(usize));
     const off: usize = @intCast(phys);
     assert(off + len <= ram.len);
     return ram[off..][0..len];
 }
 
-fn mapGuestRam(vm: *kvm.Vm, cfg: Config, ram: []u8) !void {
+fn map_guest_ram(vm: *kvm.Vm, cfg: Config, ram: []u8) !void {
     assert(cfg.ram_base == 0);
     assert(cfg.ram_size == ram.len);
     assert(cfg.ram_size > virtio_mmio_hole_end);
     const low_len: usize = @intCast(virtio_mmio_hole_base);
     const high_off: usize = @intCast(virtio_mmio_hole_end);
-    try vm.mapMemory(0, 0, ram[0..low_len]);
-    try vm.mapMemory(1, virtio_mmio_hole_end, ram[high_off..]);
+    try vm.map_memory(0, 0, ram[0..low_len]);
+    try vm.map_memory(1, virtio_mmio_hole_end, ram[high_off..]);
 }
 
-fn writeInt(buf: []u8, off: usize, comptime T: type, value: T) void {
+fn write_int(buf: []u8, off: usize, comptime T: type, value: T) void {
     std.mem.writeInt(T, buf[off..][0..@sizeOf(T)], value, .little);
 }
 
-fn populateBootParams(bp: []u8, cfg: Config, img: BzImage) void {
+fn populate_boot_params(bp: []u8, cfg: Config, img: BzImage) void {
     assert(bp.len >= 4096);
     _ = img;
     bp[0x210] = 0xFF; // type_of_loader: unknown bootloader
     bp[0x211] |= 0x81; // LOADED_HIGH | CAN_USE_HEAP
-    writeInt(bp, 0x214, u32, @intCast(kernel_load_addr));
-    writeInt(bp, 0x224, u16, 0xFE00); // heap_end_ptr
-    writeInt(bp, 0x228, u32, @intCast(cmdline_addr));
-    writeInt(bp, 0x238, u32, 4096); // cmdline_size
-    writeInt(bp, 0x1E8, u8, 6); // e820_entries
+    write_int(bp, 0x214, u32, @intCast(kernel_load_addr));
+    write_int(bp, 0x224, u16, 0xFE00); // heap_end_ptr
+    write_int(bp, 0x228, u32, @intCast(cmdline_addr));
+    write_int(bp, 0x238, u32, 4096); // cmdline_size
+    write_int(bp, 0x1E8, u8, 6); // e820_entries
 
     // Keep the arm64 virtio-mmio layout (0x0a00_0000...), but on x86
     // guest RAM starts at GPA 0. Carve a page-aligned hole out of both
     // KVM's RAM slots (see mapGuestRam) and Linux's e820 map so the
     // virtio-mmio resources are neither System RAM nor backed by RAM.
-    writeE820(bp, 0, 0x0000_0000, 0x0009_FC00, 1);
-    writeE820(bp, 1, 0x0009_FC00, 0x0005_0400, 2);
-    writeE820(bp, 2, acpi_base, 0x0001_0000, 3);
-    writeE820(bp, 3, 0x0010_0000, virtio_mmio_hole_base - 0x0010_0000, 1);
-    writeE820(bp, 4, virtio_mmio_hole_base, virtio_mmio_hole_size, 2);
-    writeE820(bp, 5, virtio_mmio_hole_end, cfg.ram_size - virtio_mmio_hole_end, 1);
+    write_e820(bp, 0, 0x0000_0000, 0x0009_FC00, 1);
+    write_e820(bp, 1, 0x0009_FC00, 0x0005_0400, 2);
+    write_e820(bp, 2, acpi_base, 0x0001_0000, 3);
+    write_e820(bp, 3, 0x0010_0000, virtio_mmio_hole_base - 0x0010_0000, 1);
+    write_e820(bp, 4, virtio_mmio_hole_base, virtio_mmio_hole_size, 2);
+    write_e820(bp, 5, virtio_mmio_hole_end, cfg.ram_size - virtio_mmio_hole_end, 1);
 }
 
-fn writeE820(bp: []u8, idx: usize, addr: u64, size: u64, typ: u32) void {
+fn write_e820(bp: []u8, idx: usize, addr: u64, size: u64, typ: u32) void {
     const off = 0x2D0 + idx * 20;
-    writeInt(bp, off + 0, u64, addr);
-    writeInt(bp, off + 8, u64, size);
-    writeInt(bp, off + 16, u32, typ);
+    write_int(bp, off + 0, u64, addr);
+    write_int(bp, off + 8, u64, size);
+    write_int(bp, off + 16, u32, typ);
 }
 
-fn defaultCmdline() []const u8 {
+fn default_cmdline() []const u8 {
     return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 panic=1 loglevel=3 quiet reboot=k acpi=force pci=off " ++
         "virtio_mmio.device=512@0x0a000000:5 " ++
         "virtio_mmio.device=512@0x0a000200:6 " ++
@@ -430,46 +430,46 @@ fn defaultCmdline() []const u8 {
         "virtio_mmio.device=512@0x0a001600:16";
 }
 
-fn writeGdt(ram: []u8) void {
-    const gdt = guestSlice(ram, gdt_addr, 32);
-    writeInt(gdt, 0, u64, 0);
-    writeInt(gdt, 8, u64, 0);
-    writeInt(gdt, 16, u64, 0x00CF_9B00_0000_FFFF);
-    writeInt(gdt, 24, u64, 0x00CF_9300_0000_FFFF);
+fn write_gdt(ram: []u8) void {
+    const gdt = guest_slice(ram, gdt_addr, 32);
+    write_int(gdt, 0, u64, 0);
+    write_int(gdt, 8, u64, 0);
+    write_int(gdt, 16, u64, 0x00CF_9B00_0000_FFFF);
+    write_int(gdt, 24, u64, 0x00CF_9300_0000_FFFF);
 }
 
-fn initVcpu(vm: *kvm.Vm, ram: []u8, cfg: Config) !kvm.Vcpu {
+fn init_vcpu(vm: *kvm.Vm, ram: []u8, cfg: Config) !kvm.Vcpu {
     _ = ram;
     _ = cfg;
-    var vcpu = try vm.createVcpu(0);
+    var vcpu = try vm.create_vcpu(0);
     errdefer vcpu.destroy();
 
-    const cpuid = try vm.parent.supportedCpuid();
-    try vcpu.setCpuid2(&cpuid);
+    const cpuid = try vm.parent.supported_cpuid();
+    try vcpu.set_cpuid2(&cpuid);
 
-    var sregs = try vcpu.getSregsX86();
+    var sregs = try vcpu.get_sregs_x86();
     sregs.gdt.base = gdt_addr;
     sregs.gdt.limit = 32 - 1;
-    sregs.cs = flatSegment(2, true);
-    sregs.ds = flatSegment(3, false);
-    sregs.es = flatSegment(3, false);
-    sregs.fs = flatSegment(3, false);
-    sregs.gs = flatSegment(3, false);
-    sregs.ss = flatSegment(3, false);
+    sregs.cs = flat_segment(2, true);
+    sregs.ds = flat_segment(3, false);
+    sregs.es = flat_segment(3, false);
+    sregs.fs = flat_segment(3, false);
+    sregs.gs = flat_segment(3, false);
+    sregs.ss = flat_segment(3, false);
     sregs.cr0 |= 1; // protected mode
-    try vcpu.setSregsX86(sregs);
+    try vcpu.set_sregs_x86(sregs);
 
-    var regs = try vcpu.getRegsX86();
+    var regs = try vcpu.get_regs_x86();
     regs.rip = kernel_load_addr;
     regs.rsi = boot_params_addr;
     regs.rsp = boot_stack_addr;
     regs.rbp = boot_stack_addr;
     regs.rflags = 0x2;
-    try vcpu.setRegsX86(regs);
+    try vcpu.set_regs_x86(regs);
     return vcpu;
 }
 
-fn flatSegment(index: u16, code: bool) kvm.X86Segment {
+fn flat_segment(index: u16, code: bool) kvm.X86Segment {
     return .{
         .base = 0,
         .limit = 0xFFFF_FFFF,
@@ -487,7 +487,7 @@ fn flatSegment(index: u16, code: bool) kvm.X86Segment {
     };
 }
 
-fn writeAcpiTables(ram: []u8) void {
+fn write_acpi_tables(ram: []u8) void {
     const rsdp_addr = acpi_base;
     const rsdt_addr = acpi_base + 0x0100;
     const xsdt_addr = acpi_base + 0x0180;
@@ -495,116 +495,116 @@ fn writeAcpiTables(ram: []u8) void {
     const fadt_addr = acpi_base + 0x0300;
     const dsdt_addr = acpi_base + 0x0500;
 
-    writeMadt(guestSlice(ram, madt_addr, 74));
-    writeDsdt(guestSlice(ram, dsdt_addr, 128));
-    writeFadt(guestSlice(ram, fadt_addr, 244), dsdt_addr);
-    writeRsdt(guestSlice(ram, rsdt_addr, 44), madt_addr, fadt_addr);
-    writeXsdt(guestSlice(ram, xsdt_addr, 52), madt_addr, fadt_addr);
-    writeRsdp(guestSlice(ram, rsdp_addr, 36), rsdt_addr, xsdt_addr);
+    write_madt(guest_slice(ram, madt_addr, 74));
+    write_dsdt(guest_slice(ram, dsdt_addr, 128));
+    write_fadt(guest_slice(ram, fadt_addr, 244), dsdt_addr);
+    write_rsdt(guest_slice(ram, rsdt_addr, 44), madt_addr, fadt_addr);
+    write_xsdt(guest_slice(ram, xsdt_addr, 52), madt_addr, fadt_addr);
+    write_rsdp(guest_slice(ram, rsdp_addr, 36), rsdt_addr, xsdt_addr);
 }
 
-fn writeAcpiHeader(table: []u8, sig: *const [4]u8, revision: u8, table_id: *const [8]u8) void {
+fn write_acpi_header(table: []u8, sig: *const [4]u8, revision: u8, table_id: *const [8]u8) void {
     @memcpy(table[0..4], sig);
-    writeInt(table, 4, u32, @intCast(table.len));
+    write_int(table, 4, u32, @intCast(table.len));
     table[8] = revision;
     table[9] = 0;
     @memcpy(table[10..16], "MCHNEN");
     @memcpy(table[16..24], table_id);
-    writeInt(table, 24, u32, 1);
+    write_int(table, 24, u32, 1);
     @memcpy(table[28..32], "MCHN");
-    writeInt(table, 32, u32, 1);
+    write_int(table, 32, u32, 1);
 }
 
-fn finishChecksum(table: []u8, off: usize) void {
+fn finish_checksum(table: []u8, off: usize) void {
     table[off] = 0;
     var sum: u8 = 0;
     for (table) |b| sum +%= b;
     table[off] = 0 -% sum;
 }
 
-fn writeRsdp(rsdp: []u8, rsdt_addr: u64, xsdt_addr: u64) void {
+fn write_rsdp(rsdp: []u8, rsdt_addr: u64, xsdt_addr: u64) void {
     @memset(rsdp, 0);
     @memcpy(rsdp[0..8], "RSD PTR ");
     @memcpy(rsdp[9..15], "MCHNEN");
     rsdp[15] = 2;
-    writeInt(rsdp, 16, u32, @intCast(rsdt_addr));
-    writeInt(rsdp, 20, u32, 36);
-    writeInt(rsdp, 24, u64, xsdt_addr);
-    finishChecksum(rsdp[0..20], 8);
-    finishChecksum(rsdp, 32);
+    write_int(rsdp, 16, u32, @intCast(rsdt_addr));
+    write_int(rsdp, 20, u32, 36);
+    write_int(rsdp, 24, u64, xsdt_addr);
+    finish_checksum(rsdp[0..20], 8);
+    finish_checksum(rsdp, 32);
 }
 
-fn writeRsdt(rsdt: []u8, madt_addr: u64, fadt_addr: u64) void {
+fn write_rsdt(rsdt: []u8, madt_addr: u64, fadt_addr: u64) void {
     @memset(rsdt, 0);
-    writeAcpiHeader(rsdt, "RSDT", 1, "MACHRSDT");
-    writeInt(rsdt, 36, u32, @intCast(madt_addr));
-    writeInt(rsdt, 40, u32, @intCast(fadt_addr));
-    finishChecksum(rsdt, 9);
+    write_acpi_header(rsdt, "RSDT", 1, "MACHRSDT");
+    write_int(rsdt, 36, u32, @intCast(madt_addr));
+    write_int(rsdt, 40, u32, @intCast(fadt_addr));
+    finish_checksum(rsdt, 9);
 }
 
-fn writeXsdt(xsdt: []u8, madt_addr: u64, fadt_addr: u64) void {
+fn write_xsdt(xsdt: []u8, madt_addr: u64, fadt_addr: u64) void {
     @memset(xsdt, 0);
-    writeAcpiHeader(xsdt, "XSDT", 1, "MACHXSDT");
-    writeInt(xsdt, 36, u64, madt_addr);
-    writeInt(xsdt, 44, u64, fadt_addr);
-    finishChecksum(xsdt, 9);
+    write_acpi_header(xsdt, "XSDT", 1, "MACHXSDT");
+    write_int(xsdt, 36, u64, madt_addr);
+    write_int(xsdt, 44, u64, fadt_addr);
+    finish_checksum(xsdt, 9);
 }
 
-fn writeMadt(madt: []u8) void {
+fn write_madt(madt: []u8) void {
     @memset(madt, 0);
-    writeAcpiHeader(madt, "APIC", 1, "MACHAPIC");
-    writeInt(madt, 36, u32, 0xFEE0_0000);
-    writeInt(madt, 40, u32, 1); // PC/AT dual-8259 present
+    write_acpi_header(madt, "APIC", 1, "MACHAPIC");
+    write_int(madt, 36, u32, 0xFEE0_0000);
+    write_int(madt, 40, u32, 1); // PC/AT dual-8259 present
     var off: usize = 44;
     madt[off + 0] = 0; // processor local APIC
     madt[off + 1] = 8;
     madt[off + 2] = 0;
     madt[off + 3] = 0;
-    writeInt(madt, off + 4, u32, 1);
+    write_int(madt, off + 4, u32, 1);
     off += 8;
     madt[off + 0] = 1; // IOAPIC
     madt[off + 1] = 12;
     madt[off + 2] = 0;
     madt[off + 3] = 0;
-    writeInt(madt, off + 4, u32, 0xFEC0_0000);
-    writeInt(madt, off + 8, u32, 0);
+    write_int(madt, off + 4, u32, 0xFEC0_0000);
+    write_int(madt, off + 8, u32, 0);
     off += 12;
     madt[off + 0] = 2; // IRQ0 -> GSI2 override, standard PC routing
     madt[off + 1] = 10;
     madt[off + 2] = 0;
     madt[off + 3] = 0;
-    writeInt(madt, off + 4, u32, 2);
-    writeInt(madt, off + 8, u16, 0);
-    finishChecksum(madt, 9);
+    write_int(madt, off + 4, u32, 2);
+    write_int(madt, off + 8, u16, 0);
+    finish_checksum(madt, 9);
 }
 
-fn writeGas(buf: []u8, off: usize, space: u8, width: u8, access_size: u8, addr: u64) void {
+fn write_gas(buf: []u8, off: usize, space: u8, width: u8, access_size: u8, addr: u64) void {
     buf[off + 0] = space;
     buf[off + 1] = width;
     buf[off + 2] = 0;
     buf[off + 3] = access_size;
-    writeInt(buf, off + 4, u64, addr);
+    write_int(buf, off + 4, u64, addr);
 }
 
-fn writeFadt(fadt: []u8, dsdt_addr: u64) void {
+fn write_fadt(fadt: []u8, dsdt_addr: u64) void {
     @memset(fadt, 0);
-    writeAcpiHeader(fadt, "FACP", 3, "MACHFADT");
-    writeInt(fadt, 40, u32, @intCast(dsdt_addr));
-    writeInt(fadt, 46, u16, 9); // SCI IRQ
-    writeInt(fadt, 56, u32, pm1a_evt_port);
-    writeInt(fadt, 64, u32, pm1a_cnt_port);
+    write_acpi_header(fadt, "FACP", 3, "MACHFADT");
+    write_int(fadt, 40, u32, @intCast(dsdt_addr));
+    write_int(fadt, 46, u16, 9); // SCI IRQ
+    write_int(fadt, 56, u32, pm1a_evt_port);
+    write_int(fadt, 64, u32, pm1a_cnt_port);
     fadt[88] = 4;
     fadt[89] = 2;
-    writeInt(fadt, 113, u32, @as(u32, 1) << 10); // RESET_REG_SUP
-    writeGas(fadt, 117, 1, 8, 1, reset_port);
+    write_int(fadt, 113, u32, @as(u32, 1) << 10); // RESET_REG_SUP
+    write_gas(fadt, 117, 1, 8, 1, reset_port);
     fadt[129] = 0x06;
-    writeInt(fadt, 140, u64, dsdt_addr);
-    writeGas(fadt, 148, 1, 32, 3, pm1a_evt_port);
-    writeGas(fadt, 172, 1, 16, 2, pm1a_cnt_port);
-    finishChecksum(fadt, 9);
+    write_int(fadt, 140, u64, dsdt_addr);
+    write_gas(fadt, 148, 1, 32, 3, pm1a_evt_port);
+    write_gas(fadt, 172, 1, 16, 2, pm1a_cnt_port);
+    finish_checksum(fadt, 9);
 }
 
-fn writeDsdt(dsdt_buf: []u8) void {
+fn write_dsdt(dsdt_buf: []u8) void {
     // iasl-compiled from:
     //   Name (_S5, Package (4) { 5, 5, 0, 0 })
     //   Device (COM1) { _HID PNP0501; _UID 1; _CRS IO 0x3f8 len 8, IRQ 4 }
@@ -624,7 +624,7 @@ fn writeDsdt(dsdt_buf: []u8) void {
     @memcpy(dsdt_buf[0..dsdt.len], &dsdt);
 }
 
-fn runLoop(
+fn run_loop(
     gpa: std.mem.Allocator,
     cfg: Config,
     vm: *kvm.Vm,
@@ -642,12 +642,12 @@ fn runLoop(
         const reason = try vcpu.run();
         switch (reason) {
             .mmio => {
-                const ev = vcpu.mmioExit();
-                try routeMmio(vm, vcpu, devs, irqs, ev);
+                const ev = vcpu.mmio_exit();
+                try route_mmio(vm, vcpu, devs, irqs, ev);
             },
             .io => {
-                const ev = vcpu.ioExit();
-                if (routeIo(vcpu, devs, ev)) {
+                const ev = vcpu.io_exit();
+                if (route_io(vcpu, devs, ev)) {
                     saw_off = true;
                     break;
                 }
@@ -669,7 +669,7 @@ fn runLoop(
         if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
         if (snapshot_requested.load(.seq_cst)) {
             if (cfg.snapshot_path) |path| {
-                if (queueSnapshotWrite(&snapshot_writer_state, gpa, path, vm, vcpu, ram, cfg, devs)) {
+                if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vm, vcpu, ram, cfg, devs)) {
                     snapshotted = true;
                 }
                 snapshot_requested.store(false, .seq_cst);
@@ -680,16 +680,16 @@ fn runLoop(
     if (exits >= cfg.max_exits) {
         std.debug.print(
             "kvm-x86_64 boot: RanTooLong after {d} exits. Captured serial ({d} bytes):\n{s}\n",
-            .{ exits, devs.uart.captured_len, devs.uart.capturedBytes() },
+            .{ exits, devs.uart.captured_len, devs.uart.captured_bytes() },
         );
         return error.RanTooLong;
     }
 
-    const serial = try gpa.dupe(u8, devs.uart.capturedBytes());
+    const serial = try gpa.dupe(u8, devs.uart.captured_bytes());
     return .{ .serial = serial, .saw_psci_shutdown = saw_off, .exits = exits, .snapshotted = snapshotted };
 }
 
-fn queueSnapshotWrite(
+fn queue_snapshot_write(
     writer: *vmstate_writer.Writer,
     gpa: std.mem.Allocator,
     path: []const u8,
@@ -705,7 +705,7 @@ fn queueSnapshotWrite(
     }
 
     std.debug.print("kvm-x86_64: writing snapshot to {s}\n", .{path});
-    const job = captureSnapshotJob(gpa, path, vm, vcpu, ram, cfg, devs) catch |err| {
+    const job = capture_snapshot_job(gpa, path, vm, vcpu, ram, cfg, devs) catch |err| {
         std.debug.print("kvm-x86_64 boot: snapshot capture failed: {s}\n", .{@errorName(err)});
         return false;
     };
@@ -714,7 +714,7 @@ fn queueSnapshotWrite(
             "kvm-x86_64: snapshot async writer spawn failed: {s}; writing synchronously\n",
             .{@errorName(err)},
         );
-        vmstate_writer.writeAndDestroy(job) catch |write_err| {
+        vmstate_writer.write_and_destroy(job) catch |write_err| {
             std.debug.print("kvm-x86_64 boot: snapshot write failed: {s}\n", .{@errorName(write_err)});
             return false;
         };
@@ -735,7 +735,7 @@ const O_RDONLY: c_int = 0;
 const SEEK_END: c_int = 2;
 const SEEK_SET: c_int = 0;
 
-fn x86Topology(cfg: Config) @import("topology.zig").Topology {
+fn x86_topology(cfg: Config) @import("topology.zig").Topology {
     const topology = @import("topology.zig");
     return .{
         .arch = topology.ARCH_X86_64,
@@ -747,7 +747,7 @@ fn x86Topology(cfg: Config) @import("topology.zig").Topology {
     };
 }
 
-fn appendBytesSection(
+fn append_bytes_section(
     a: std.mem.Allocator,
     sections: *std.ArrayList(@import("snapshot.zig").Section),
     tag: @import("snapshot.zig").SectionTag,
@@ -758,7 +758,7 @@ fn appendBytesSection(
     try sections.append(a, .{ .tag = tag, .id = id, .payload = payload });
 }
 
-fn captureSnapshotJob(
+fn capture_snapshot_job(
     gpa: std.mem.Allocator,
     path: []const u8,
     vm: *kvm.Vm,
@@ -772,12 +772,12 @@ fn captureSnapshotJob(
     const ram_dump = @import("ram_dump.zig");
     const virtio_dump = @import("virtio_dump.zig");
 
-    const topo = x86Topology(cfg);
-    const job = try vmstate_writer.Job.createWithArch(gpa, "kvm-x86_64", path, snapshot.ARCH_X86_64, topo.hash());
+    const topo = x86_topology(cfg);
+    const job = try vmstate_writer.Job.create_with_arch(gpa, "kvm-x86_64", path, snapshot.ARCH_X86_64, topo.hash());
     errdefer job.destroy();
-    const a = job.arenaAllocator();
+    const a = job.arena_allocator();
 
-    const vcpu_payload = try vcpu_dump.dumpKvmX86(a, vcpu.fd);
+    const vcpu_payload = try vcpu_dump.dump_kvm_x86(a, vcpu.fd);
     const ram_payload = try ram_dump.encode(a, cfg.ram_base, ram);
 
     var sections = std.ArrayList(snapshot.Section).empty;
@@ -786,22 +786,22 @@ fn captureSnapshotJob(
 
     const irqchip_ids = [_]u32{ kvm.KVM_IRQCHIP_PIC_MASTER, kvm.KVM_IRQCHIP_PIC_SLAVE, kvm.KVM_IRQCHIP_IOAPIC };
     for (irqchip_ids) |chip_id| {
-        var chip = try vm.getIrqchip(chip_id);
-        try appendBytesSection(a, &sections, .x86_irqchip, chip_id, std.mem.asBytes(&chip));
+        var chip = try vm.get_irqchip(chip_id);
+        try append_bytes_section(a, &sections, .x86_irqchip, chip_id, std.mem.asBytes(&chip));
     }
-    var pit = try vm.getPit2();
-    try appendBytesSection(a, &sections, .x86_pit, 0, std.mem.asBytes(&pit));
+    var pit = try vm.get_pit2();
+    try append_bytes_section(a, &sections, .x86_pit, 0, std.mem.asBytes(&pit));
 
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
     for (vdevs) |d| {
-        const vp = try virtio_dump.dumpDevice(a, d);
+        const vp = try virtio_dump.dump_device(a, d);
         try sections.append(a, .{ .tag = .virtio, .id = @truncate(d.base), .payload = vp });
     }
     for (vdevs) |d| {
         if (d.id != .virtio_fs) continue;
         const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-        const fp = try backend.state.dumpState(a);
+        const fp = try backend.state.dump_state(a);
         try sections.append(a, .{ .tag = .virtiofs_state, .id = @truncate(d.base), .payload = fp });
     }
 
@@ -809,14 +809,14 @@ fn captureSnapshotJob(
     return job;
 }
 
-fn bytesToStruct(comptime T: type, bytes: []const u8) !T {
+fn bytes_to_struct(comptime T: type, bytes: []const u8) !T {
     if (bytes.len != @sizeOf(T)) return error.BadSnapshotSection;
     var out: T = undefined;
     @memcpy(std.mem.asBytes(&out), bytes);
     return out;
 }
 
-fn applyRestoreFile(
+fn apply_restore_file(
     gpa: std.mem.Allocator,
     path: []const u8,
     vm: *kvm.Vm,
@@ -853,7 +853,7 @@ fn applyRestoreFile(
     }
     timing.mark("read-file");
 
-    const decoded = try @import("vmstate_zip.zig").decompressMaybeOwned(gpa, raw);
+    const decoded = try @import("vmstate_zip.zig").decompress_maybe_owned(gpa, raw);
     defer decoded.deinit(gpa);
     timing.mark("decompress");
 
@@ -861,33 +861,33 @@ fn applyRestoreFile(
     defer snap.deinit();
     timing.mark("container-decode");
 
-    const topo = x86Topology(cfg);
+    const topo = x86_topology(cfg);
     if (!std.mem.eql(u8, &topo.hash(), &snap.header.topology_hash)) {
         return error.TopologyMismatch;
     }
     timing.mark("topology-check");
 
     var vbufs: [Devices.virtio_max]*virtio.Device = undefined;
-    const vdevs = devs.virtioDevices(&vbufs);
+    const vdevs = devs.virtio_devices(&vbufs);
     for (snap.sections) |s| {
-        const section_t0 = timing.sectionStart();
+        const section_t0 = timing.section_start();
         switch (s.tag) {
-            .vcpu => try vcpu_dump.loadKvmX86(gpa, vcpu.fd, s.payload),
+            .vcpu => try vcpu_dump.load_kvm_x86(gpa, vcpu.fd, s.payload),
             .ram => {
-                _ = try ram_dump.decodeIntoZeroed(s.payload, ram);
+                _ = try ram_dump.decode_into_zeroed(s.payload, ram);
             },
             .x86_irqchip => {
-                const chip = try bytesToStruct(kvm.Irqchip, s.payload);
-                try vm.setIrqchip(chip);
+                const chip = try bytes_to_struct(kvm.Irqchip, s.payload);
+                try vm.set_irqchip(chip);
             },
             .x86_pit => {
-                const pit = try bytesToStruct(kvm.PitState2, s.payload);
-                try vm.setPit2(pit);
+                const pit = try bytes_to_struct(kvm.PitState2, s.payload);
+                try vm.set_pit2(pit);
             },
             .virtio => {
                 for (vdevs) |d| {
                     if (@as(u32, @truncate(d.base)) == s.id) {
-                        virtio_dump.applyDevice(gpa, d, s.payload) catch |err| {
+                        virtio_dump.apply_device(gpa, d, s.payload) catch |err| {
                             std.debug.print(
                                 "kvm-x86_64 boot: virtio restore for base 0x{x} failed: {s}\n",
                                 .{ d.base, @errorName(err) },
@@ -902,7 +902,7 @@ fn applyRestoreFile(
                     if (d.id != .virtio_fs) continue;
                     if (@as(u32, @truncate(d.base)) != s.id) continue;
                     const backend: *virtiofs_mod.Device = @ptrCast(@alignCast(d.request_ctx.?));
-                    backend.state.applyState(s.payload) catch |err| {
+                    backend.state.apply_state(s.payload) catch |err| {
                         std.debug.print(
                             "kvm-x86_64 boot: virtio-fs state restore for base 0x{x} failed: {s}\n",
                             .{ d.base, @errorName(err) },
@@ -919,34 +919,34 @@ fn applyRestoreFile(
     timing.done();
 }
 
-fn routeIo(vcpu: *kvm.Vcpu, devs: *const Devices, ev: kvm.IoExit) bool {
+fn route_io(vcpu: *kvm.Vcpu, devs: *const Devices, ev: kvm.IoExit) bool {
     const dir: kvm.IoDirection = @enumFromInt(ev.direction);
     if (ev.port >= uart_io_base and ev.port < uart_io_base + 8) {
         const addr = devs.uart.base + (ev.port - uart_io_base);
         if (dir == .out) {
-            const value = vcpu.ioDataValue(ev);
+            const value = vcpu.io_data_value(ev);
             devs.uart.write(addr, value);
             if (ev.port == uart_io_base and ev.size > 0) {
                 const byte: [1]u8 = .{@truncate(value)};
-                _ = hostWrite(2, &byte, 1);
+                _ = host_write(2, &byte, 1);
             }
         } else {
-            vcpu.writeIoReadData(ev, @truncate(devs.uart.read(addr)));
+            vcpu.write_io_read_data(ev, @truncate(devs.uart.read(addr)));
         }
         return false;
     }
     if (dir == .out) {
-        const value = vcpu.ioDataValue(ev);
+        const value = vcpu.io_data_value(ev);
         if (ev.port == pm1a_cnt_port and (value & (1 << 13)) != 0) return true;
         if (ev.port == reset_port and (value & 0x06) != 0) return true;
         if (ev.port == 0x64 and value == 0xFE) return true;
         return false;
     }
-    vcpu.writeIoReadData(ev, 0);
+    vcpu.write_io_read_data(ev, 0);
     return false;
 }
 
-fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
+fn make_net_device(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
     return .{
         .base = virtio_net_base,
         .size = virtio_net_size,
@@ -961,9 +961,9 @@ fn makeNetDevice(ram: []u8, cfg: Config, mac: *const [6]u8) virtio.Device {
 
 /// Open a host file as a virtio-blk backend. Returns null when the
 /// caller didn't ask for this slot, or when the file open failed.
-fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
     const p = path orelse return null;
-    return blk_mod.openFile(p) catch |err| {
+    return blk_mod.open_file(p) catch |err| {
         std.debug.print("virtio-blk {s} disabled: {s} ({s})\n", .{ label, @errorName(err), p });
         return null;
     };
@@ -971,7 +971,7 @@ fn openBlkBackend(path: ?[]const u8, label: []const u8) ?blk_mod.Backend {
 
 /// Wrap a runtime-passed fd as a virtio-blk backend (#272). Mirror
 /// of boot_hvf.zig's matching helper — see that file for the design.
-fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
+fn open_blk_backend_from_fd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod.Backend {
     const f = fd orelse return null;
     if (f < 0) return null;
     const size_bytes = lseek(f, 0, 2);
@@ -986,13 +986,13 @@ fn openBlkBackendFromFd(fd: ?c_int, read_only: bool, label: []const u8) ?blk_mod
         );
         return null;
     }
-    return blk_mod.Backend.initFromFdWithMode(f, @intCast(size_bytes), read_only);
+    return blk_mod.Backend.init_from_fd_with_mode(f, @intCast(size_bytes), read_only);
 }
 
 /// Wrap a `blk_mod.Backend` as a virtio-mmio device. `backend` must
 /// outlive the returned device — the device's `config` and
 /// `request_ctx` are pointers into it.
-fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -1001,14 +1001,14 @@ fn makeBlkDevice(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
 
 /// Variant of `makeBlkDevice` that advertises VIRTIO_BLK_F_DISCARD
 /// in the feature bits (#272). Mirror of boot_hvf.zig's helper.
-fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
+fn make_blk_device_with_discard(base: u64, size: u64, ram: []u8, cfg: Config, backend: *blk_mod.Backend) virtio.Device {
     return .{
         .base = base,
         .size = size,
@@ -1017,7 +1017,7 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
         .config = std.mem.asBytes(&backend.config),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &blk_mod.Backend.handleRequest,
+        .request_handler = &blk_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1026,11 +1026,11 @@ fn makeBlkDeviceWithDiscard(base: u64, size: u64, ram: []u8, cfg: Config, backen
 /// an empty slice; parse errors log and return empty so a typo in the
 /// env doesn't prevent boot. Returned slice + path strings allocated
 /// from `gpa`.
-fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
+fn parse_vsock_env(gpa: std.mem.Allocator) []vsock_mod.PortMap {
     const raw = getenv("MACHINEN_VSOCK") orelse return &.{};
     const s = std.mem.span(raw);
     if (s.len == 0) return &.{};
-    return vsock_mod.parseEnv(gpa, s) catch |err| {
+    return vsock_mod.parse_env(gpa, s) catch |err| {
         std.debug.print("vsock: MACHINEN_VSOCK parse failed ({s}); ignoring\n", .{@errorName(err)});
         return &.{};
     };
@@ -1038,7 +1038,7 @@ fn parseVsockEnv(gpa: std.mem.Allocator) []vsock_mod.PortMap {
 
 /// Build the virtio-vsock device. `cid_ptr` must outlive the device —
 /// the config field is a pointer into it.
-fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
+fn make_vsock_device(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
     return .{
         .base = virtio_vsock_base,
         .size = virtio_vsock_size,
@@ -1047,7 +1047,7 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
         .config = std.mem.asBytes(cid_ptr),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &vsock_mod.Bridge.handleTxChain,
+        .request_handler = &vsock_mod.Bridge.handle_tx_chain,
         .request_ctx = null,
         // Queues 0 (RX) and 2 (event) are driver-posts-empty-buffers
         // queues — host fills them on demand, not on every kick.
@@ -1060,19 +1060,19 @@ fn makeVsockDevice(ram: []u8, cfg: Config, cid_ptr: *const u64) virtio.Device {
 /// `<tag>:<mode>:<host_path>` grammar, the numbered-env rationale, and
 /// the c_allocator rationale. A missing slot is null; a malformed value
 /// is left null (warn-and-continue).
-fn parseVirtiofsEnv() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
+fn parse_virtiofs_env() [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device {
     var out: [MAX_VIRTIOFS_SLOTS]?virtiofs_mod.Device = @splat(null);
     for (0..MAX_VIRTIOFS_SLOTS) |i| {
         var name_buf: [32]u8 = undefined;
         const name = std.fmt.bufPrintZ(&name_buf, "MACHINEN_VIRTIOFS_{d}", .{i}) catch continue;
-        out[i] = parseOneVirtiofsEnv(name);
+        out[i] = parse_one_virtiofs_env(name);
     }
     return out;
 }
 
 /// Parse a single `MACHINEN_VIRTIOFS_<i>` env var into a backend, or
 /// null if unset / malformed. See `parseVirtiofsEnv`.
-fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
+fn parse_one_virtiofs_env(name: [*:0]const u8) ?virtiofs_mod.Device {
     const raw = getenv(name) orelse return null;
     const s = std.mem.span(raw);
     if (s.len == 0) return null;
@@ -1120,16 +1120,16 @@ fn parseOneVirtiofsEnv(name: [*:0]const u8) ?virtiofs_mod.Device {
 
 /// Wrap a `virtiofs.Device` backend as a virtio-mmio device on the
 /// given slot `base`. `backend` must outlive the returned device.
-fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
+fn make_virtio_fs_device(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.Device) virtio.Device {
     return .{
         .base = base,
         .size = virtio_virtiofs_size,
         .id = .virtio_fs,
         .features = (1 << 32), // VIRTIO_F_VERSION_1
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &virtiofs_mod.Device.handleRequest,
+        .request_handler = &virtiofs_mod.Device.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1137,16 +1137,16 @@ fn makeVirtioFsDevice(base: u64, ram: []u8, cfg: Config, backend: *virtiofs_mod.
 /// Build the virtio-balloon device. `backend` must outlive the
 /// returned Device — config + request_ctx are pointers into it.
 /// #263 phase B: continuous free-page reporting.
-fn makeBalloonDevice(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
+fn make_balloon_device(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virtio.Device {
     return .{
         .base = virtio_balloon_base,
         .size = virtio_balloon_size,
         .id = .balloon,
         .features = balloon_mod.Backend.features(),
-        .config = backend.configBytes(),
+        .config = backend.config_bytes(),
         .ram = ram,
         .ram_base = cfg.ram_base,
-        .request_handler = &balloon_mod.Backend.handleRequest,
+        .request_handler = &balloon_mod.Backend.handle_request,
         .request_ctx = @ptrCast(backend),
     };
 }
@@ -1154,7 +1154,7 @@ fn makeBalloonDevice(ram: []u8, cfg: Config, backend: *balloon_mod.Backend) virt
 /// Dial gvproxy if `MACHINEN_NET_SOCKET` is set; null on missing env
 /// or any connect failure (the rest of the VMM still runs without
 /// network).
-fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
+fn connect_gvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetSocket {
     const env = getenv("MACHINEN_NET_SOCKET") orelse return null;
     const path = std.mem.span(env);
     if (path.len == 0) return null;
@@ -1168,7 +1168,7 @@ fn connectGvproxy(gpa: std.mem.Allocator, netdev: *virtio.Device) ?*net_mod.NetS
 /// device, start the poll thread, and log the active port mappings.
 /// Returns null on any failure (and clears `dev` so callers know the
 /// device is no longer live).
-fn startVsockBridge(
+fn start_vsock_bridge(
     gpa: std.mem.Allocator,
     dev: *virtio.Device,
     ports: []const vsock_mod.PortMap,
@@ -1176,7 +1176,7 @@ fn startVsockBridge(
 ) ?*vsock_mod.Bridge {
     const bridge = vsock_mod.Bridge.create(gpa, dev, .{
         .ports = ports,
-        .raise_irq = &onVsockIrq,
+        .raise_irq = &on_vsock_irq,
         .raise_irq_ctx = @ptrCast(irq_ctx),
     }) catch |err| {
         std.debug.print("vsock: bridge create failed: {s}\n", .{@errorName(err)});
@@ -1204,17 +1204,17 @@ fn startVsockBridge(
 /// one boot loop reading this.
 var snapshot_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
-fn sigusr1Handler(sig: c_int) callconv(.c) void {
+fn sigusr1_handler(sig: c_int) callconv(.c) void {
     _ = sig;
     snapshot_requested.store(true, .seq_cst);
 }
 
-fn installSnapshotSignal() void {
+fn install_snapshot_signal() void {
     const c = struct {
         extern "c" fn signal(sig: c_int, handler: usize) usize;
     };
     const SIGUSR1: c_int = 10;
-    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1Handler));
+    _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1_handler));
 }
 
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exit, the
@@ -1275,7 +1275,7 @@ const Devices = struct {
     /// populated prefix. Used by snapshot/restore to dump/apply each
     /// device's transport state — virtio-fs slots included, so a
     /// `--mount-live` VM's queue state round-trips through vmstate.
-    pub fn virtioDevices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
+    pub fn virtio_devices(self: *const Devices, buf: *[virtio_max]*virtio.Device) []*virtio.Device {
         var n: usize = 0;
         buf[n] = self.netdev;
         n += 1;
@@ -1303,7 +1303,7 @@ const Devices = struct {
 const VirtiofsMatch = struct { dev: *virtio.Device, irq: u32 };
 
 /// Find the virtio-fs slot (if any) whose MMIO window owns `phys_addr`.
-fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMatch {
+fn virtiofs_match(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMatch {
     for (devs.virtiofs_devs, irqs.virtiofs) |dev_opt, irq| {
         if (dev_opt) |d| {
             if (d.handles(phys_addr)) return .{ .dev = d, .irq = irq };
@@ -1314,7 +1314,7 @@ fn virtiofsMatch(devs: *const Devices, irqs: IrqMap, phys_addr: u64) ?VirtiofsMa
 
 /// 8250 MMIO. Console-byte writes echo to host stderr; every access
 /// resyncs the SPI line based on `irqAsserted()`.
-fn handlePl011Mmio(
+fn handle_pl011_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     uart: *uart8250_mod.Uart8250,
@@ -1323,23 +1323,23 @@ fn handlePl011Mmio(
 ) !void {
     assert(uart.handles(ev.phys_addr));
     if (ev.is_write != 0) {
-        const val = mmioReadValue(ev);
+        const val = mmio_read_value(ev);
         uart.write(ev.phys_addr, val);
         if ((ev.phys_addr - uart.base) == 0 and ev.len > 0) {
             const byte: [1]u8 = .{ev.data[0]};
-            _ = hostWrite(2, &byte, 1);
+            _ = host_write(2, &byte, 1);
         }
     } else {
-        vcpu.writeMmioReadData(uart.read(ev.phys_addr), ev.len);
+        vcpu.write_mmio_read_data(uart.read(ev.phys_addr), ev.len);
     }
-    vm.setIrq(irq, if (uart.irqAsserted()) 1 else 0) catch {};
+    vm.set_irq(irq, if (uart.irq_asserted()) 1 else 0) catch {};
 }
 
 /// virtio-MMIO read/write + raise/lower the SPI based on the device's
 /// post-access interrupt_status. Shared shape across net / blk / blk2 /
 /// vsock; the callers that need cross-thread serialisation take the
 /// appropriate mutex around this call.
-fn handleVirtioMmio(
+fn handle_virtio_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     dev: *virtio.Device,
@@ -1348,16 +1348,16 @@ fn handleVirtioMmio(
 ) !void {
     assert(dev.handles(ev.phys_addr));
     if (ev.is_write != 0) {
-        dev.write(ev.phys_addr, mmioReadValue(ev));
+        dev.write(ev.phys_addr, mmio_read_value(ev));
     } else {
-        vcpu.writeMmioReadData(dev.read(ev.phys_addr), ev.len);
+        vcpu.write_mmio_read_data(dev.read(ev.phys_addr), ev.len);
     }
-    vm.setIrq(irq, if (@atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) 1 else 0) catch {};
+    vm.set_irq(irq, if (@atomicLoad(u32, &dev.interrupt_status, .acquire) != 0) 1 else 0) catch {};
 }
 
 /// Route an MMIO exit to the device that owns the IPA. Each cross-
 /// thread arm wraps `handleVirtioMmio` in the appropriate mutex.
-fn routeMmio(
+fn route_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
@@ -1370,50 +1370,50 @@ fn routeMmio(
     assert(ev.is_write <= 1);
 
     if (devs.uart.handles(ev.phys_addr)) {
-        try handlePl011Mmio(vm, vcpu, devs.uart, ev, irqs.uart);
+        try handle_pl011_mmio(vm, vcpu, devs.uart, ev, irqs.uart);
         return;
     }
     if (devs.netdev.handles(ev.phys_addr)) {
-        try dispatchNetMmio(vm, vcpu, devs, irqs, ev);
+        try dispatch_net_mmio(vm, vcpu, devs, irqs, ev);
         return;
     }
     if (devs.blk_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk, ev);
         return;
     };
     if (devs.blk2_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk2, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk2, ev);
         return;
     };
     if (devs.blk3_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk3, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk3, ev);
         return;
     };
     if (devs.blk4_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.blk4, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.blk4, ev);
         return;
     };
     if (devs.vsock_dev) |d| if (d.handles(ev.phys_addr)) {
-        try dispatchVsockMmio(vm, vcpu, devs, d, irqs.vsock, ev);
+        try dispatch_vsock_mmio(vm, vcpu, devs, d, irqs.vsock, ev);
         return;
     };
     if (devs.balloon_dev) |d| if (d.handles(ev.phys_addr)) {
-        try handleVirtioMmio(vm, vcpu, d, irqs.balloon, ev);
+        try handle_virtio_mmio(vm, vcpu, d, irqs.balloon, ev);
         return;
     };
-    if (virtiofsMatch(devs, irqs, ev.phys_addr)) |m| {
+    if (virtiofs_match(devs, irqs, ev.phys_addr)) |m| {
         // virtio-fs request handling is synchronous on the vCPU thread
         // (`handleVirtioMmio` → `dev.write` → `notify` drains the chain
         // inline through `virtiofs.Device.handleRequest`). No second
         // thread, so no mutex to take — unlike net / vsock.
-        try handleVirtioMmio(vm, vcpu, m.dev, m.irq, ev);
+        try handle_virtio_mmio(vm, vcpu, m.dev, m.irq, ev);
         return;
     }
     // Other MMIO (DTB-described regions we haven't hooked up) — for
     // reads, hand back zeros (the writeMmioReadData default on
     // untouched kvm_run bytes is already zero, but be explicit so a
     // future non-zero lingerer doesn't bite).
-    if (ev.is_write == 0) vcpu.writeMmioReadData(0, ev.len);
+    if (ev.is_write == 0) vcpu.write_mmio_read_data(0, ev.len);
 }
 
 /// Run a virtio-net MMIO event under `net_inst.irq_mu`. The RX thread
@@ -1422,16 +1422,16 @@ fn routeMmio(
 /// can't override the bridge's. No-op when `net_inst` is null (no
 /// gvproxy backend) — there is no second thread to race against, and
 /// the kernel still sees a valid virtio-net device with link-down.
-fn dispatchNetMmio(
+fn dispatch_net_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
     ev: kvm.MmioExit,
 ) !void {
-    if (devs.net_inst) |n| n.lockIrq();
-    defer if (devs.net_inst) |n| n.unlockIrq();
-    try handleVirtioMmio(vm, vcpu, devs.netdev, irqs.net, ev);
+    if (devs.net_inst) |n| n.lock_irq();
+    defer if (devs.net_inst) |n| n.unlock_irq();
+    try handle_virtio_mmio(vm, vcpu, devs.netdev, irqs.net, ev);
 }
 
 /// Run a virtio-vsock MMIO event under `vsock_bridge.mu`. The vCPU
@@ -1446,7 +1446,7 @@ fn dispatchNetMmio(
 /// HVF passes smoke and KVM doesn't until this lock lands.
 /// `handleTxChain` assumes the caller holds `bridge.mu` — see its
 /// docstring.
-fn dispatchVsockMmio(
+fn dispatch_vsock_mmio(
     vm: *kvm.Vm,
     vcpu: *kvm.Vcpu,
     devs: *const Devices,
@@ -1456,12 +1456,12 @@ fn dispatchVsockMmio(
 ) !void {
     if (devs.vsock_bridge) |b| b.mu.lock();
     defer if (devs.vsock_bridge) |b| b.mu.unlock();
-    try handleVirtioMmio(vm, vcpu, dev, irq, ev);
+    try handle_virtio_mmio(vm, vcpu, dev, irq, ev);
 }
 
 /// Pack the up-to-8 little-endian bytes KVM hands us in `mmio.data`
 /// into a u64 the device handlers expect.
-fn mmioReadValue(ev: kvm.MmioExit) u64 {
+fn mmio_read_value(ev: kvm.MmioExit) u64 {
     assert(ev.len >= 1 and ev.len <= 8);
     var val: u64 = 0;
     const n = @min(@as(usize, ev.len), 8);
@@ -1472,7 +1472,7 @@ fn mmioReadValue(ev: kvm.MmioExit) u64 {
     return val;
 }
 
-fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
+fn read_all(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     assert(path.len > 0);
     var path_buf: [4096]u8 = undefined;
     if (path.len >= path_buf.len) return error.NameTooLong;
@@ -1480,14 +1480,14 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     path_buf[path.len] = 0;
     const path_z: [*:0]const u8 = @ptrCast(&path_buf);
 
-    const fd = hostOpen(path_z, 0, 0);
+    const fd = host_open(path_z, 0, 0);
     if (fd < 0) return error.OpenFailed;
     assert(fd >= 0);
-    defer _ = hostClose(fd);
+    defer _ = host_close(fd);
 
-    const size_signed = hostLseek(fd, 0, 2);
+    const size_signed = host_lseek(fd, 0, 2);
     if (size_signed < 0) return error.SeekFailed;
-    _ = hostLseek(fd, 0, 0);
+    _ = host_lseek(fd, 0, 0);
     const size_bytes: usize = @intCast(size_signed);
     assert(size_bytes > 0);
 
@@ -1495,7 +1495,7 @@ fn readAll(gpa: std.mem.Allocator, path: []const u8) ![]u8 {
     errdefer gpa.free(buf);
     var total_bytes: usize = 0;
     while (total_bytes < size_bytes) {
-        const n_bytes = hostRead(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
+        const n_bytes = host_read(fd, buf[total_bytes..].ptr, size_bytes - total_bytes);
         if (n_bytes <= 0) return error.ShortRead;
         total_bytes += @intCast(n_bytes);
     }
@@ -1513,19 +1513,19 @@ extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 // Rename'd because `read`/`write` collide with std method names in
 // some generic contexts; kept the extern shims unchanged.
-fn hostOpen(path: [*:0]const u8, flags: c_int, mode: c_int) c_int {
+fn host_open(path: [*:0]const u8, flags: c_int, mode: c_int) c_int {
     return open(path, flags, mode);
 }
-fn hostClose(fd: c_int) c_int {
+fn host_close(fd: c_int) c_int {
     return close(fd);
 }
-fn hostRead(fd: c_int, buf: [*]u8, count: usize) isize {
+fn host_read(fd: c_int, buf: [*]u8, count: usize) isize {
     return read(fd, buf, count);
 }
-fn hostWrite(fd: c_int, buf: [*]const u8, count: usize) isize {
+fn host_write(fd: c_int, buf: [*]const u8, count: usize) isize {
     return write(fd, buf, count);
 }
-fn hostLseek(fd: c_int, offset: i64, whence: c_int) i64 {
+fn host_lseek(fd: c_int, offset: i64, whence: c_int) i64 {
     return lseek(fd, offset, whence);
 }
 
@@ -1538,10 +1538,10 @@ pub const VsockIrqCtx = struct {
     irq: u32,
 };
 
-fn onVsockIrq(ctx: ?*anyopaque) void {
+fn on_vsock_irq(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const c: *VsockIrqCtx = @ptrCast(@alignCast(ctx.?));
-    c.vm.setIrq(c.irq, 1) catch {};
+    c.vm.set_irq(c.irq, 1) catch {};
 }
 
 /// Same shape as VsockIrqCtx, but for the virtio-net SPI. NetSocket's
@@ -1552,10 +1552,10 @@ pub const NetIrqCtx = struct {
     irq: u32,
 };
 
-fn onNetIrq(ctx: ?*anyopaque) void {
+fn on_net_irq(ctx: ?*anyopaque) void {
     assert(ctx != null);
     const c: *NetIrqCtx = @ptrCast(@alignCast(ctx.?));
-    c.vm.setIrq(c.irq, 1) catch {};
+    c.vm.set_irq(c.irq, 1) catch {};
 }
 
 /// Pump a guest-emitted ethernet frame through to gvproxy. Called
@@ -1564,7 +1564,7 @@ fn onNetIrq(ctx: ?*anyopaque) void {
 /// been stripped by `walkAndEmit`, so we just hand the bare ethernet
 /// frame to NetSocket.input which prepends the 4-byte length prefix
 /// and writes to the gvproxy UDS.
-fn onNetTx(ctx: ?*anyopaque, frame: []const u8) void {
+fn on_net_tx(ctx: ?*anyopaque, frame: []const u8) void {
     assert(ctx != null);
     assert(frame.len > 0);
     const n: *net_mod.NetSocket = @ptrCast(@alignCast(ctx.?));
@@ -1584,7 +1584,7 @@ test "x86 bzImage parser rejects non-bzImage" {
 }
 
 test "x86 cmdline advertises ttyS0 and virtio-mmio" {
-    const cmd = defaultCmdline();
+    const cmd = default_cmdline();
     try std.testing.expect(std.mem.indexOf(u8, cmd, "console=ttyS0") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a000200:6") != null);
 }

--- a/packages/microvm/src/dtb_patch.zig
+++ b/packages/microvm/src/dtb_patch.zig
@@ -89,7 +89,7 @@ const Header = struct {
         return h;
     }
 
-    fn stringOffset(self: Header, dtb: []const u8, needle: []const u8) ?u32 {
+    fn string_offset(self: Header, dtb: []const u8, needle: []const u8) ?u32 {
         assert(needle.len > 0);
         assert(@as(usize, self.off_strings) + @as(usize, self.size_strings) <= dtb.len);
         const strings = dtb[self.off_strings..][0..self.size_strings];
@@ -106,11 +106,11 @@ const Header = struct {
 /// scans the whole window for cpio / compressed archives. Patching the
 /// end pointer to match the actual cpio length stops the kernel from
 /// burning wall-clock walking dead tail.
-pub fn patchInitrdEnd(dtb: []u8, new_end: u32) !void {
+pub fn patch_initrd_end(dtb: []u8, new_end: u32) !void {
     assert(dtb.len > 0);
     const h = try Header.read(dtb);
     const needle = "linux,initrd-end\x00";
-    const name_offset = h.stringOffset(dtb, needle) orelse return error.InitrdEndNotFound;
+    const name_offset = h.string_offset(dtb, needle) orelse return error.InitrdEndNotFound;
 
     // Each loop iteration consumes at least 4 bytes (one token), so
     // dtb.len/4 is a hard upper bound on iterations. +1 covers the
@@ -124,7 +124,7 @@ pub fn patchInitrdEnd(dtb: []u8, new_end: u32) !void {
         const tok = std.mem.readInt(u32, dtb[i..][0..4], .big);
         i += 4;
         switch (tok) {
-            FDT_BEGIN_NODE => i = try skipName(dtb, i),
+            FDT_BEGIN_NODE => i = try skip_name(dtb, i),
             FDT_END_NODE, FDT_NOP => {},
             FDT_PROP => {
                 if (i + 8 > dtb.len) return error.DtbTruncated;
@@ -163,11 +163,11 @@ pub fn patchInitrdEnd(dtb: []u8, new_end: u32) !void {
 /// "child of root" means depth == 2 in the BEGIN_NODE/END_NODE
 /// counter. `reserved-memory`'s inner `memory@...` entries live at
 /// depth 3 and are correctly skipped.
-pub fn patchMemorySize(dtb: []u8, size_bytes: u64) !void {
+pub fn patch_memory_size(dtb: []u8, size_bytes: u64) !void {
     assert(dtb.len > 0);
     if (size_bytes == 0) return error.MemorySizeZero;
     const h = try Header.read(dtb);
-    const reg_offset = h.stringOffset(dtb, "reg\x00") orelse return error.RegPropNotFound;
+    const reg_offset = h.string_offset(dtb, "reg\x00") orelse return error.RegPropNotFound;
 
     // Walk the struct block. `depth` counts open BEGIN_NODE tokens;
     // root sits at depth 1, its children at depth 2.
@@ -188,13 +188,13 @@ pub fn patchMemorySize(dtb: []u8, size_bytes: u64) !void {
             FDT_BEGIN_NODE => {
                 if (depth >= MAX_FDT_DEPTH) return error.DtbTooDeep;
                 const name_start = i;
-                i = try skipName(dtb, i);
+                i = try skip_name(dtb, i);
                 depth += 1;
                 assert(depth > 0);
                 assert(depth <= MAX_FDT_DEPTH);
                 if (depth == ROOT_CHILD_DEPTH) {
-                    const name = nameSlice(dtb, name_start);
-                    in_memory_node = isMemoryNodeName(name);
+                    const name = name_slice(dtb, name_start);
+                    in_memory_node = is_memory_node_name(name);
                 }
             },
             FDT_END_NODE => {
@@ -235,7 +235,7 @@ pub fn patchMemorySize(dtb: []u8, size_bytes: u64) !void {
     return error.DtbTruncated;
 }
 
-fn skipName(dtb: []const u8, start: usize) !usize {
+fn skip_name(dtb: []const u8, start: usize) !usize {
     assert(start <= dtb.len);
     var i = start;
     while (i < dtb.len and dtb[i] != 0) : (i += 1) {
@@ -252,7 +252,7 @@ fn skipName(dtb: []const u8, start: usize) !usize {
     return aligned;
 }
 
-fn nameSlice(dtb: []const u8, start: usize) []const u8 {
+fn name_slice(dtb: []const u8, start: usize) []const u8 {
     assert(start <= dtb.len);
     var end = start;
     // Always reached after skipName succeeded, so the name is bounded
@@ -265,7 +265,7 @@ fn nameSlice(dtb: []const u8, start: usize) []const u8 {
 
 /// True for both bare `memory` and `memory@<unit-address>` (the
 /// canonical name for a real DTS-compiled node).
-fn isMemoryNodeName(name: []const u8) bool {
+fn is_memory_node_name(name: []const u8) bool {
     assert(name.len <= MAX_NAME_BYTES);
     if (std.mem.eql(u8, name, "memory")) return true;
     if (std.mem.startsWith(u8, name, "memory@")) return true;
@@ -275,8 +275,8 @@ fn isMemoryNodeName(name: []const u8) bool {
 // --- tests ---
 
 test "patchInitrdEnd round-trips a minimal hand-built DTB" {
-    var buf = minimalSinglePropDtb("linux,initrd-end\x00", 4, &[_]u8{ 0xaa, 0xbb, 0xcc, 0xdd });
-    try patchInitrdEnd(buf.bytes(), 0x12345678);
+    var buf = minimal_single_prop_dtb("linux,initrd-end\x00", 4, &[_]u8{ 0xaa, 0xbb, 0xcc, 0xdd });
+    try patch_initrd_end(buf.bytes(), 0x12345678);
     // Layout from `minimalSinglePropDtb` (offset relative to struct_off):
     //   0..4   BEGIN_NODE
     //   4..8   empty name + pad
@@ -291,7 +291,7 @@ test "patchInitrdEnd round-trips a minimal hand-built DTB" {
 
 test "patchInitrdEnd rejects bad magic" {
     var bytes = [_]u8{0} ** 40;
-    try std.testing.expectError(error.DtbBadMagic, patchInitrdEnd(&bytes, 0));
+    try std.testing.expectError(error.DtbBadMagic, patch_initrd_end(&bytes, 0));
 }
 
 test "patchInitrdEnd rejects header with off_struct inside header" {
@@ -304,17 +304,17 @@ test "patchInitrdEnd rejects header with off_struct inside header" {
     std.mem.writeInt(u32, bytes[8..12], 8, .big); // off_struct (BAD)
     std.mem.writeInt(u32, bytes[12..16], 40, .big); // off_strings
     std.mem.writeInt(u32, bytes[32..36], 1, .big); // size_strings
-    try std.testing.expectError(error.DtbBadStruct, patchInitrdEnd(&bytes, 0));
+    try std.testing.expectError(error.DtbBadStruct, patch_initrd_end(&bytes, 0));
 }
 
 test "patchInitrdEnd reports a missing property" {
-    var buf = minimalSinglePropDtb("some,other\x00", 4, &[_]u8{ 0, 0, 0, 0 });
-    try std.testing.expectError(error.InitrdEndNotFound, patchInitrdEnd(buf.bytes(), 0x1));
+    var buf = minimal_single_prop_dtb("some,other\x00", 4, &[_]u8{ 0, 0, 0, 0 });
+    try std.testing.expectError(error.InitrdEndNotFound, patch_initrd_end(buf.bytes(), 0x1));
 }
 
 test "patchMemorySize rewrites the reg size cells of memory@..." {
-    var buf = minimalMemoryNodeDtb(0x4000_0000, 0x1_0000_0000);
-    try patchMemorySize(buf.bytes(), 0x4_0000_0000);
+    var buf = minimal_memory_node_dtb(0x4000_0000, 0x1_0000_0000);
+    try patch_memory_size(buf.bytes(), 0x4_0000_0000);
     // reg property data sits 4 bytes (PROP-len) + 4 bytes (PROP-nameoff)
     // past the FDT_PROP token. minimalMemoryNodeDtb places the PROP at
     // a known offset inside the struct block; the helper exposes it.
@@ -326,16 +326,16 @@ test "patchMemorySize rewrites the reg size cells of memory@..." {
 }
 
 test "patchMemorySize refuses size_bytes == 0" {
-    var buf = minimalMemoryNodeDtb(0x4000_0000, 0x1_0000_0000);
-    try std.testing.expectError(error.MemorySizeZero, patchMemorySize(buf.bytes(), 0));
+    var buf = minimal_memory_node_dtb(0x4000_0000, 0x1_0000_0000);
+    try std.testing.expectError(error.MemorySizeZero, patch_memory_size(buf.bytes(), 0));
 }
 
 test "patchMemorySize ignores a depth>1 memory node (e.g. reserved-memory)" {
     // Build a DTB where the only node named "memory" lives at depth 2;
     // depth-1 walk should never enter it, so the patch reports
     // MemoryRegNotFound rather than corrupting an unrelated node.
-    var buf = nestedMemoryNodeDtb();
-    try std.testing.expectError(error.MemoryRegNotFound, patchMemorySize(buf.bytes(), 0x1000));
+    var buf = nested_memory_node_dtb();
+    try std.testing.expectError(error.MemoryRegNotFound, patch_memory_size(buf.bytes(), 0x1000));
 }
 
 // Real-fixture coverage (DTB shape match against `assets/virt.dtb`)
@@ -361,7 +361,7 @@ const FixtureBuf = struct {
 /// strings block (via `name_with_nul`), value is `value` (length
 /// `plen`). Layout is the same minimal shape as the boot_hvf test
 /// fixture, just generalized.
-fn minimalSinglePropDtb(name_with_nul: []const u8, plen: u32, value: []const u8) FixtureBuf {
+fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const u8) FixtureBuf {
     var fb: FixtureBuf = undefined;
     fb.storage = [_]u8{0} ** 256;
 
@@ -423,7 +423,7 @@ fn minimalSinglePropDtb(name_with_nul: []const u8, plen: u32, value: []const u8)
 /// `memory@40000000` child with one `reg` property (16 bytes;
 /// address+size, 2 cells each). Matches the shape patchMemorySize
 /// expects to walk in `assets/virt.dtb`.
-fn minimalMemoryNodeDtb(addr: u64, size: u64) FixtureBuf {
+fn minimal_memory_node_dtb(addr: u64, size: u64) FixtureBuf {
     var fb: FixtureBuf = undefined;
     fb.storage = [_]u8{0} ** 256;
 
@@ -495,7 +495,7 @@ fn minimalMemoryNodeDtb(addr: u64, size: u64) FixtureBuf {
 /// — i.e. the memory-named node lives at depth 3 (grandchild of root).
 /// patchMemorySize should not touch it; only direct children of root
 /// (depth 2) are valid candidates.
-fn nestedMemoryNodeDtb() FixtureBuf {
+fn nested_memory_node_dtb() FixtureBuf {
     var fb: FixtureBuf = undefined;
     fb.storage = [_]u8{0} ** 256;
 

--- a/packages/microvm/src/gic_dump.zig
+++ b/packages/microvm/src/gic_dump.zig
@@ -33,7 +33,7 @@ pub const Header = extern struct {
     _reserved: u32 = 0,
 };
 
-pub const DecodeError = error{Truncated, BadKind, BadLength};
+pub const DecodeError = error{ Truncated, BadKind, BadLength };
 
 pub fn encode(allocator: std.mem.Allocator, kind: u32, id: u32, payload: []const u8) ![]u8 {
     // Tiger-style preconditions.

--- a/packages/microvm/src/gic_state.zig
+++ b/packages/microvm/src/gic_state.zig
@@ -134,7 +134,7 @@ pub const max_payload_bytes: usize = 4 + (dist_regs.len + redist_regs.len) * ENT
 // -- portable payload codec ---------------------------------------
 
 /// Encode an entry list into a section payload. Caller owns the bytes.
-pub fn encodePayload(allocator: std.mem.Allocator, entries: []const Entry) ![]u8 {
+pub fn encode_payload(allocator: std.mem.Allocator, entries: []const Entry) ![]u8 {
     assert(entries.len <= std.math.maxInt(u32));
 
     const total = 4 + entries.len * ENTRY_SIZE;
@@ -156,7 +156,7 @@ pub fn encodePayload(allocator: std.mem.Allocator, entries: []const Entry) ![]u8
 
 /// Decode a section payload back into an entry list. Caller owns the
 /// returned slice.
-pub fn decodePayload(allocator: std.mem.Allocator, payload: []const u8) ![]Entry {
+pub fn decode_payload(allocator: std.mem.Allocator, payload: []const u8) ![]Entry {
     if (payload.len < 4) return error.Truncated;
     const n = std.mem.readInt(u32, payload[0..4], .little);
     if (4 + @as(usize, n) * ENTRY_SIZE != payload.len) return error.Truncated;
@@ -187,7 +187,7 @@ const hvf_gic = struct {
 };
 
 /// Dump the HVF distributor register window into a portable payload.
-pub fn dumpHvfDist(allocator: std.mem.Allocator) ![]u8 {
+pub fn dump_hvf_dist(allocator: std.mem.Allocator) ![]u8 {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
     var list = std.ArrayList(Entry).empty;
@@ -198,15 +198,15 @@ pub fn dumpHvfDist(allocator: std.mem.Allocator) ![]u8 {
         if (hvf_gic.hv_gic_get_distributor_reg(r.offset, &v) != 0) continue;
         try list.append(allocator, .{ .offset = r.offset, .width = r.width, .value = v });
     }
-    return encodePayload(allocator, list.items);
+    return encode_payload(allocator, list.items);
 }
 
 /// Replay a distributor payload onto the HVF GIC. Best-effort: a reg
 /// HVF rejects is skipped rather than aborting the whole restore.
-pub fn loadHvfDist(allocator: std.mem.Allocator, payload: []const u8) !void {
+pub fn load_hvf_dist(allocator: std.mem.Allocator, payload: []const u8) !void {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
-    const entries = try decodePayload(allocator, payload);
+    const entries = try decode_payload(allocator, payload);
     defer allocator.free(entries);
     for (entries) |e| {
         _ = hvf_gic.hv_gic_set_distributor_reg(e.offset, e.value);
@@ -214,7 +214,7 @@ pub fn loadHvfDist(allocator: std.mem.Allocator, payload: []const u8) !void {
 }
 
 /// Dump the HVF redistributor SGI-frame registers for one vCPU.
-pub fn dumpHvfRedist(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
+pub fn dump_hvf_redist(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
     var list = std.ArrayList(Entry).empty;
@@ -225,14 +225,14 @@ pub fn dumpHvfRedist(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
         if (hvf_gic.hv_gic_get_redistributor_reg(vcpu_handle, r.offset, &v) != 0) continue;
         try list.append(allocator, .{ .offset = r.offset, .width = r.width, .value = v });
     }
-    return encodePayload(allocator, list.items);
+    return encode_payload(allocator, list.items);
 }
 
 /// Replay a redistributor payload onto one HVF vCPU's redistributor.
-pub fn loadHvfRedist(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
+pub fn load_hvf_redist(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
-    const entries = try decodePayload(allocator, payload);
+    const entries = try decode_payload(allocator, payload);
     defer allocator.free(entries);
     for (entries) |e| {
         _ = hvf_gic.hv_gic_set_redistributor_reg(vcpu_handle, e.offset, e.value);
@@ -279,7 +279,7 @@ const KVM_GET_DEVICE_ATTR: c_ulong = (1 << 30) | (@as(c_ulong, @sizeOf(KvmDevice
 const KVM_DEV_ARM_VGIC_GRP_DIST_REGS: u32 = 1;
 const KVM_DEV_ARM_VGIC_GRP_REDIST_REGS: u32 = 5;
 
-fn kvmGetReg(gic_fd: c_int, group: u32, attr: u64) Error!u32 {
+fn kvm_get_reg(gic_fd: c_int, group: u32, attr: u64) Error!u32 {
     assert(gic_fd >= 0);
     var val: u32 = 0;
     var da = KvmDeviceAttr{ .flags = 0, .group = group, .attr = attr, .addr = @intFromPtr(&val) };
@@ -287,7 +287,7 @@ fn kvmGetReg(gic_fd: c_int, group: u32, attr: u64) Error!u32 {
     return val;
 }
 
-fn kvmSetReg(gic_fd: c_int, group: u32, attr: u64, val: u32) Error!void {
+fn kvm_set_reg(gic_fd: c_int, group: u32, attr: u64, val: u32) Error!void {
     assert(gic_fd >= 0);
     var v = val;
     var da = KvmDeviceAttr{ .flags = 0, .group = group, .attr = attr, .addr = @intFromPtr(&v) };
@@ -297,13 +297,13 @@ fn kvmSetReg(gic_fd: c_int, group: u32, attr: u64, val: u32) Error!void {
 /// KVM REDIST_REGS keys the redistributor by MPIDR affinity in attr
 /// bits 63:32. Aff0..2 are all our single-vCPU guest ever uses; Aff3
 /// (MPIDR bits 39:32) has no room in the 32-bit field and is dropped.
-fn redistAttr(mpidr: u64, offset: u32) u64 {
+fn redist_attr(mpidr: u64, offset: u32) u64 {
     const aff: u64 = mpidr & 0x00ff_ffff;
     return (aff << 32) | offset;
 }
 
 /// Dump the KVM distributor registers into a portable payload.
-pub fn dumpKvmDist(allocator: std.mem.Allocator, gic_fd: c_int) ![]u8 {
+pub fn dump_kvm_dist(allocator: std.mem.Allocator, gic_fd: c_int) ![]u8 {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
@@ -314,7 +314,7 @@ pub fn dumpKvmDist(allocator: std.mem.Allocator, gic_fd: c_int) ![]u8 {
     var first_errno: c_int = 0;
     var nonzero: usize = 0;
     for (dist_regs) |r| {
-        const v = kvmGetReg(gic_fd, KVM_DEV_ARM_VGIC_GRP_DIST_REGS, r.offset) catch {
+        const v = kvm_get_reg(gic_fd, KVM_DEV_ARM_VGIC_GRP_DIST_REGS, r.offset) catch {
             failed += 1;
             if (first_errno == 0) first_errno = errno();
             continue;
@@ -326,24 +326,24 @@ pub fn dumpKvmDist(allocator: std.mem.Allocator, gic_fd: c_int) ![]u8 {
         "gic_state.dumpKvmDist: {d}/{d} read ({d} non-zero), {d} failed (errno={d})\n",
         .{ list.items.len, dist_regs.len, nonzero, failed, first_errno },
     );
-    return encodePayload(allocator, list.items);
+    return encode_payload(allocator, list.items);
 }
 
 /// Replay a distributor payload onto the KVM GIC. Best-effort per reg.
-pub fn loadKvmDist(allocator: std.mem.Allocator, gic_fd: c_int, payload: []const u8) !void {
+pub fn load_kvm_dist(allocator: std.mem.Allocator, gic_fd: c_int, payload: []const u8) !void {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
-    const entries = try decodePayload(allocator, payload);
+    const entries = try decode_payload(allocator, payload);
     defer allocator.free(entries);
     for (entries) |e| {
-        kvmSetReg(gic_fd, KVM_DEV_ARM_VGIC_GRP_DIST_REGS, e.offset, @truncate(e.value)) catch {};
+        kvm_set_reg(gic_fd, KVM_DEV_ARM_VGIC_GRP_DIST_REGS, e.offset, @truncate(e.value)) catch {};
     }
 }
 
 /// Dump the KVM redistributor SGI-frame registers for one vCPU,
 /// selected by `mpidr` (the vCPU's MPIDR_EL1).
-pub fn dumpKvmRedist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]u8 {
+pub fn dump_kvm_redist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]u8 {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
@@ -353,7 +353,7 @@ pub fn dumpKvmRedist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![
     var failed: usize = 0;
     var first_errno: c_int = 0;
     for (redist_regs) |r| {
-        const v = kvmGetReg(gic_fd, KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, redistAttr(mpidr, r.offset)) catch {
+        const v = kvm_get_reg(gic_fd, KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, redist_attr(mpidr, r.offset)) catch {
             failed += 1;
             if (first_errno == 0) first_errno = errno();
             continue;
@@ -364,18 +364,18 @@ pub fn dumpKvmRedist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![
         "gic_state.dumpKvmRedist: {d}/{d} read, {d} failed (mpidr=0x{x} errno={d})\n",
         .{ list.items.len, redist_regs.len, failed, mpidr, first_errno },
     );
-    return encodePayload(allocator, list.items);
+    return encode_payload(allocator, list.items);
 }
 
 /// Replay a redistributor payload onto one KVM vCPU's redistributor.
-pub fn loadKvmRedist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64, payload: []const u8) !void {
+pub fn load_kvm_redist(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64, payload: []const u8) !void {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
-    const entries = try decodePayload(allocator, payload);
+    const entries = try decode_payload(allocator, payload);
     defer allocator.free(entries);
     for (entries) |e| {
-        kvmSetReg(gic_fd, KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, redistAttr(mpidr, e.offset), @truncate(e.value)) catch {};
+        kvm_set_reg(gic_fd, KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, redist_attr(mpidr, e.offset), @truncate(e.value)) catch {};
     }
 }
 
@@ -412,7 +412,7 @@ const cpuif_regs = [_]CpuIfReg{
     .{ .name = "ICC_AP0R0_EL1", .enc = 0xC644 },
 };
 
-fn cpuIfRegByName(name: []const u8) ?CpuIfReg {
+fn cpu_if_reg_by_name(name: []const u8) ?CpuIfReg {
     for (cpuif_regs) |r| {
         if (std.mem.eql(u8, r.name, name)) return r;
     }
@@ -438,7 +438,7 @@ const hvf_gic_icc = struct {
 /// Dump the HVF CPU interface into a name-tagged payload via
 /// hv_gic_get_icc_reg. A reg HVF rejects is dropped rather than
 /// aborting the whole dump.
-pub fn dumpHvfCpuIf(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
+pub fn dump_hvf_cpu_if(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
     var entries = std.ArrayList(snapshot.VcpuEntry).empty;
@@ -454,18 +454,18 @@ pub fn dumpHvfCpuIf(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
         std.mem.writeInt(u64, buf[0..8], v, .little);
         try entries.append(allocator, .{ .name = r.name, .value = buf });
     }
-    return snapshot.encodeVcpuPayload(allocator, entries.items);
+    return snapshot.encode_vcpu_payload(allocator, entries.items);
 }
 
 /// Replay a CPU-interface payload onto an HVF vCPU via
 /// hv_gic_set_icc_reg. Best-effort: a rejected reg is skipped.
-pub fn loadHvfCpuIf(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
+pub fn load_hvf_cpu_if(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
-    const entries = try snapshot.decodeVcpuPayload(allocator, payload);
+    const entries = try snapshot.decode_vcpu_payload(allocator, payload);
     defer allocator.free(entries);
     for (entries) |e| {
-        const r = cpuIfRegByName(e.name) orelse continue;
+        const r = cpu_if_reg_by_name(e.name) orelse continue;
         if (e.value.len != 8) continue;
         _ = hvf_gic_icc.hv_gic_set_icc_reg(vcpu_handle, r.enc, std.mem.readInt(u64, e.value[0..8], .little));
     }
@@ -494,14 +494,14 @@ const cpuif_defaults = [_]struct { enc: u16, value: u64 }{
 /// state — a current snapshot carries a real `gic_cpuif` section and
 /// `loadHvfCpuIf` replays that instead, so this only runs when no
 /// section is present.
-pub fn applyHvfCpuIfDefaults(vcpu_handle: u64) void {
+pub fn apply_hvf_cpu_if_defaults(vcpu_handle: u64) void {
     if (builtin.os.tag != .macos) return;
     for (cpuif_defaults) |r| {
         _ = hvf_gic_icc.hv_gic_set_icc_reg(vcpu_handle, r.enc, r.value);
     }
 }
 
-fn kvmGetSysreg(gic_fd: c_int, mpidr: u64, enc: u16) Error!u64 {
+fn kvm_get_sysreg(gic_fd: c_int, mpidr: u64, enc: u16) Error!u64 {
     assert(gic_fd >= 0);
     var val: u64 = 0;
     var da = KvmDeviceAttr{
@@ -514,7 +514,7 @@ fn kvmGetSysreg(gic_fd: c_int, mpidr: u64, enc: u16) Error!u64 {
     return val;
 }
 
-fn kvmSetSysreg(gic_fd: c_int, mpidr: u64, enc: u16, val: u64) Error!void {
+fn kvm_set_sysreg(gic_fd: c_int, mpidr: u64, enc: u16, val: u64) Error!void {
     assert(gic_fd >= 0);
     var v = val;
     var da = KvmDeviceAttr{
@@ -527,7 +527,7 @@ fn kvmSetSysreg(gic_fd: c_int, mpidr: u64, enc: u16, val: u64) Error!void {
 }
 
 /// Dump the KVM CPU interface for one vCPU into a name-tagged payload.
-pub fn dumpKvmCpuIf(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]u8 {
+pub fn dump_kvm_cpu_if(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]u8 {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
@@ -540,7 +540,7 @@ pub fn dumpKvmCpuIf(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]
     var failed: usize = 0;
     var first_errno: c_int = 0;
     for (cpuif_regs) |r| {
-        const v = kvmGetSysreg(gic_fd, mpidr, r.enc) catch {
+        const v = kvm_get_sysreg(gic_fd, mpidr, r.enc) catch {
             failed += 1;
             if (first_errno == 0) first_errno = errno();
             continue;
@@ -553,23 +553,23 @@ pub fn dumpKvmCpuIf(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64) ![]
         "gic_state.dumpKvmCpuIf: {d}/{d} read, {d} failed (mpidr=0x{x} errno={d})\n",
         .{ entries.items.len, cpuif_regs.len, failed, mpidr, first_errno },
     );
-    return snapshot.encodeVcpuPayload(allocator, entries.items);
+    return snapshot.encode_vcpu_payload(allocator, entries.items);
 }
 
 /// Replay a CPU-interface payload onto one KVM vCPU. Best-effort per
 /// register. Returns the count actually applied so the caller can
 /// tell a real capture from an empty (HVF-sourced) one.
-pub fn loadKvmCpuIf(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64, payload: []const u8) !usize {
+pub fn load_kvm_cpu_if(allocator: std.mem.Allocator, gic_fd: c_int, mpidr: u64, payload: []const u8) !usize {
     if (builtin.os.tag != .linux) return error.WrongHost;
     assert(gic_fd >= 0);
 
-    const entries = try snapshot.decodeVcpuPayload(allocator, payload);
+    const entries = try snapshot.decode_vcpu_payload(allocator, payload);
     defer allocator.free(entries);
     var applied: usize = 0;
     for (entries) |e| {
-        const r = cpuIfRegByName(e.name) orelse continue;
+        const r = cpu_if_reg_by_name(e.name) orelse continue;
         if (e.value.len != 8) continue;
-        kvmSetSysreg(gic_fd, mpidr, r.enc, std.mem.readInt(u64, e.value[0..8], .little)) catch continue;
+        kvm_set_sysreg(gic_fd, mpidr, r.enc, std.mem.readInt(u64, e.value[0..8], .little)) catch continue;
         applied += 1;
     }
     return applied;
@@ -584,10 +584,10 @@ test "payload round-trips an entry list" {
         .{ .offset = 0x0104, .width = 4, .value = 0xdead_beef },
         .{ .offset = 0x6000, .width = 8, .value = 0x1122_3344_5566_7788 },
     };
-    const payload = try encodePayload(a, &entries);
+    const payload = try encode_payload(a, &entries);
     defer a.free(payload);
 
-    const decoded = try decodePayload(a, payload);
+    const decoded = try decode_payload(a, payload);
     defer a.free(decoded);
 
     try std.testing.expectEqual(@as(usize, 3), decoded.len);
@@ -600,22 +600,22 @@ test "payload round-trips an entry list" {
 
 test "payload round-trips an empty list" {
     const a = std.testing.allocator;
-    const payload = try encodePayload(a, &.{});
+    const payload = try encode_payload(a, &.{});
     defer a.free(payload);
     try std.testing.expectEqual(@as(usize, 4), payload.len);
 
-    const decoded = try decodePayload(a, payload);
+    const decoded = try decode_payload(a, payload);
     defer a.free(decoded);
     try std.testing.expectEqual(@as(usize, 0), decoded.len);
 }
 
 test "decode rejects a truncated payload" {
     const a = std.testing.allocator;
-    try std.testing.expectError(error.Truncated, decodePayload(a, &[_]u8{ 1, 0, 0 }));
+    try std.testing.expectError(error.Truncated, decode_payload(a, &[_]u8{ 1, 0, 0 }));
     // count says 2 entries but only one entry's worth of bytes follow.
     var buf: [4 + ENTRY_SIZE]u8 = @splat(0);
     std.mem.writeInt(u32, buf[0..4], 2, .little);
-    try std.testing.expectError(error.Truncated, decodePayload(a, &buf));
+    try std.testing.expectError(error.Truncated, decode_payload(a, &buf));
 }
 
 test "register tables are non-empty and bounded" {
@@ -633,17 +633,17 @@ test "register tables are non-empty and bounded" {
 }
 
 test "redistAttr packs mpidr affinity into bits 63:32" {
-    try std.testing.expectEqual(@as(u64, 0x10100), redistAttr(0, 0x10100));
+    try std.testing.expectEqual(@as(u64, 0x10100), redist_attr(0, 0x10100));
     // Aff3 (MPIDR bits 39:32) is dropped; Aff0..2 survive.
-    try std.testing.expectEqual(@as(u64, 0x0012_3499_0001_0080), redistAttr(0xff00_0012_3499, 0x10080));
+    try std.testing.expectEqual(@as(u64, 0x0012_3499_0001_0080), redist_attr(0xff00_0012_3499, 0x10080));
 }
 
 test "cpuif register table resolves names to ICC encodings" {
-    const grpen1 = cpuIfRegByName("ICC_IGRPEN1_EL1") orelse return error.TestExpectedEqual;
+    const grpen1 = cpu_if_reg_by_name("ICC_IGRPEN1_EL1") orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(@as(u16, 0xC667), grpen1.enc);
-    const pmr = cpuIfRegByName("ICC_PMR_EL1") orelse return error.TestExpectedEqual;
+    const pmr = cpu_if_reg_by_name("ICC_PMR_EL1") orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(@as(u16, 0xC230), pmr.enc);
-    try std.testing.expectEqual(@as(?CpuIfReg, null), cpuIfRegByName("NOT_A_REG"));
+    try std.testing.expectEqual(@as(?CpuIfReg, null), cpu_if_reg_by_name("NOT_A_REG"));
 }
 
 test "cpuif encodings match the hv_gic_icc_reg_t enum values" {
@@ -665,7 +665,7 @@ test "cpuif encodings match the hv_gic_icc_reg_t enum values" {
         .{ .name = "ICC_IGRPEN1_EL1", .enc = 0xc667 },
     };
     for (want) |w| {
-        const r = cpuIfRegByName(w.name) orelse return error.TestExpectedEqual;
+        const r = cpu_if_reg_by_name(w.name) orelse return error.TestExpectedEqual;
         try std.testing.expectEqual(w.enc, r.enc);
     }
 }

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -64,28 +64,28 @@ const HvVmConfigCreateFn = *const fn () callconv(.c) c.hv_vm_config_t;
 const HvVmConfigGetEl2SupportedFn = *const fn (*bool) callconv(.c) c.hv_return_t;
 const HvVmConfigSetEl2EnabledFn = *const fn (c.hv_vm_config_t, bool) callconv(.c) c.hv_return_t;
 
-fn hvfSym(comptime T: type, comptime name: [:0]const u8) ?T {
+fn hvf_sym(comptime T: type, comptime name: [:0]const u8) ?T {
     const ptr = dlsym(RTLD_DEFAULT, name.ptr) orelse return null;
     return @ptrCast(@alignCast(ptr));
 }
 
-fn vmConfigCreate() ?HvVmConfigCreateFn {
-    return hvfSym(HvVmConfigCreateFn, "hv_vm_config_create");
+fn vm_config_create() ?HvVmConfigCreateFn {
+    return hvf_sym(HvVmConfigCreateFn, "hv_vm_config_create");
 }
 
-fn vmConfigGetEl2Supported() ?HvVmConfigGetEl2SupportedFn {
-    return hvfSym(HvVmConfigGetEl2SupportedFn, "hv_vm_config_get_el2_supported");
+fn vm_config_get_el2_supported() ?HvVmConfigGetEl2SupportedFn {
+    return hvf_sym(HvVmConfigGetEl2SupportedFn, "hv_vm_config_get_el2_supported");
 }
 
-fn vmConfigSetEl2Enabled() ?HvVmConfigSetEl2EnabledFn {
-    return hvfSym(HvVmConfigSetEl2EnabledFn, "hv_vm_config_set_el2_enabled");
+fn vm_config_set_el2_enabled() ?HvVmConfigSetEl2EnabledFn {
+    return hvf_sym(HvVmConfigSetEl2EnabledFn, "hv_vm_config_set_el2_enabled");
 }
 
 /// Authoritative HVF probe for nested EL2 support. Uses dlsym so this
 /// binary still launches on macOS releases whose Hypervisor.framework
 /// lacks the macOS 15 hv_vm_config_* entry points.
-pub fn nestedSupported() bool {
-    const get_el2 = vmConfigGetEl2Supported() orelse return false;
+pub fn nested_supported() bool {
+    const get_el2 = vm_config_get_el2_supported() orelse return false;
     var supported = false;
     check(get_el2(&supported)) catch return false;
     return supported;
@@ -98,10 +98,10 @@ pub const Vm = struct {
         return .{};
     }
 
-    pub fn createNested() Error!Vm {
-        const create_config = vmConfigCreate() orelse return error.Unsupported;
-        const get_el2 = vmConfigGetEl2Supported() orelse return error.Unsupported;
-        const set_el2 = vmConfigSetEl2Enabled() orelse return error.Unsupported;
+    pub fn create_nested() Error!Vm {
+        const create_config = vm_config_create() orelse return error.Unsupported;
+        const get_el2 = vm_config_get_el2_supported() orelse return error.Unsupported;
+        const set_el2 = vm_config_set_el2_enabled() orelse return error.Unsupported;
         const config = create_config() orelse return error.NoResources;
         defer os_release(config);
         var supported = false;
@@ -328,38 +328,38 @@ pub const Gic = struct {
         try check(hv_gic_create(config));
     }
 
-    pub fn distributorAlignment() Error!usize {
+    pub fn distributor_alignment() Error!usize {
         var a: usize = 0;
         try check(hv_gic_get_distributor_base_alignment(&a));
         return a;
     }
 
-    pub fn redistributorAlignment() Error!usize {
+    pub fn redistributor_alignment() Error!usize {
         var a: usize = 0;
         try check(hv_gic_get_redistributor_base_alignment(&a));
         return a;
     }
 
-    pub fn redistributorBase(vcpu: Vcpu) Error!u64 {
+    pub fn redistributor_base(vcpu: Vcpu) Error!u64 {
         var b: u64 = 0;
         try check(hv_gic_get_redistributor_base(vcpu.handle, &b));
         assert(b != 0);
         return b;
     }
 
-    pub fn distributorSize() Error!usize {
+    pub fn distributor_size() Error!usize {
         var s: usize = 0;
         try check(hv_gic_get_distributor_size(&s));
         return s;
     }
 
-    pub fn redistributorSize() Error!usize {
+    pub fn redistributor_size() Error!usize {
         var s: usize = 0;
         try check(hv_gic_get_redistributor_size(&s));
         return s;
     }
 
-    pub fn redistributorRegionSize() Error!usize {
+    pub fn redistributor_region_size() Error!usize {
         var s: usize = 0;
         try check(hv_gic_get_redistributor_region_size(&s));
         return s;
@@ -369,30 +369,30 @@ pub const Gic = struct {
     /// Returns 0 if HVF doesn't recognize the offset — common for
     /// reserved or vendor-specific areas; matches GIC "read as zero"
     /// semantics.
-    pub fn readDistributor(offset: u32) u64 {
+    pub fn read_distributor(offset: u32) u64 {
         var v: u64 = 0;
         _ = hv_gic_get_distributor_reg(offset, &v);
         return v;
     }
 
-    pub fn writeDistributor(offset: u32, value: u64) void {
+    pub fn write_distributor(offset: u32, value: u64) void {
         _ = hv_gic_set_distributor_reg(offset, value);
     }
 
-    pub fn readRedistributor(vcpu: Vcpu, offset: u32) u64 {
+    pub fn read_redistributor(vcpu: Vcpu, offset: u32) u64 {
         var v: u64 = 0;
         _ = hv_gic_get_redistributor_reg(vcpu.handle, offset, &v);
         return v;
     }
 
-    pub fn writeRedistributor(vcpu: Vcpu, offset: u32, value: u64) void {
+    pub fn write_redistributor(vcpu: Vcpu, offset: u32, value: u64) void {
         _ = hv_gic_set_redistributor_reg(vcpu.handle, offset, value);
     }
 
     /// True when `encoding` is one of the ICC CPU-interface registers
     /// Apple exposes through hv_gic_{get,set}_icc_reg. Values are the
     /// standard arm64 op0/op1/CRn/CRm/op2 packing used by hv_sys_reg_t.
-    pub fn isIccReg(encoding: u16) bool {
+    pub fn is_icc_reg(encoding: u16) bool {
         return switch (encoding) {
             0xC230, // ICC_PMR_EL1
             0xC643, // ICC_BPR0_EL1
@@ -410,15 +410,15 @@ pub const Gic = struct {
         };
     }
 
-    pub fn readIcc(vcpu: Vcpu, encoding: u16) Error!u64 {
-        assert(isIccReg(encoding));
+    pub fn read_icc(vcpu: Vcpu, encoding: u16) Error!u64 {
+        assert(is_icc_reg(encoding));
         var v: u64 = 0;
         try check(hv_gic_get_icc_reg(vcpu.handle, encoding, &v));
         return v;
     }
 
-    pub fn writeIcc(vcpu: Vcpu, encoding: u16, value: u64) Error!void {
-        assert(isIccReg(encoding));
+    pub fn write_icc(vcpu: Vcpu, encoding: u16, value: u64) Error!void {
+        assert(is_icc_reg(encoding));
         try check(hv_gic_set_icc_reg(vcpu.handle, encoding, value));
     }
 
@@ -426,7 +426,7 @@ pub const Gic = struct {
     /// interrupt. `intid` is the GIC-absolute id (SPIs start at 32
     /// on ARM GIC; the DTS number is 0-based within SPIs, so for a
     /// device that says `interrupts = <0 1 4>` call with intid = 33).
-    pub fn setSpi(intid: u32, level: bool) Error!void {
+    pub fn set_spi(intid: u32, level: bool) Error!void {
         // SPIs start at 32 on ARM GIC; values below that hit SGI/PPI
         // ranges and silently drop on hv_gic_set_spi.
         assert(intid >= 32);
@@ -436,7 +436,7 @@ pub const Gic = struct {
     }
 
     /// Returns (base_intid, count) — the absolute GIC ID range of SPIs.
-    pub fn spiRange() Error!struct { base: u32, count: u32 } {
+    pub fn spi_range() Error!struct { base: u32, count: u32 } {
         var base: u32 = 0;
         var count: u32 = 0;
         try check(hv_gic_get_spi_interrupt_range(&base, &count));
@@ -475,31 +475,31 @@ pub const Vcpu = struct {
         _ = hv_vcpu_destroy(self.handle);
     }
 
-    pub fn setReg(self: Vcpu, reg: Reg, value: u64) Error!void {
+    pub fn set_reg(self: Vcpu, reg: Reg, value: u64) Error!void {
         try check(hv_vcpu_set_reg(self.handle, @intFromEnum(reg), value));
     }
 
-    pub fn getReg(self: Vcpu, reg: Reg) Error!u64 {
+    pub fn get_reg(self: Vcpu, reg: Reg) Error!u64 {
         var value: u64 = 0;
         try check(hv_vcpu_get_reg(self.handle, @intFromEnum(reg), &value));
         return value;
     }
 
-    pub fn setSysReg(self: Vcpu, reg: SysReg, value: u64) Error!void {
+    pub fn set_sys_reg(self: Vcpu, reg: SysReg, value: u64) Error!void {
         try check(hv_vcpu_set_sys_reg(self.handle, @intFromEnum(reg), value));
     }
 
-    pub fn getSysReg(self: Vcpu, reg: SysReg) Error!u64 {
+    pub fn get_sys_reg(self: Vcpu, reg: SysReg) Error!u64 {
         var value: u64 = 0;
         try check(hv_vcpu_get_sys_reg(self.handle, @intFromEnum(reg), &value));
         return value;
     }
 
-    pub fn setRawSysReg(self: Vcpu, encoding: u16, value: u64) Error!void {
+    pub fn set_raw_sys_reg(self: Vcpu, encoding: u16, value: u64) Error!void {
         try check(hv_vcpu_set_sys_reg(self.handle, encoding, value));
     }
 
-    pub fn getRawSysReg(self: Vcpu, encoding: u16) Error!u64 {
+    pub fn get_raw_sys_reg(self: Vcpu, encoding: u16) Error!u64 {
         var value: u64 = 0;
         try check(hv_vcpu_get_sys_reg(self.handle, encoding, &value));
         return value;
@@ -513,7 +513,7 @@ pub const Vcpu = struct {
     /// it (true) to let the guest run with the timer disabled; unmask
     /// (false) before running so an expired timer triggers a
     /// vtimer_activated exit.
-    pub fn setVtimerMask(self: Vcpu, masked: bool) Error!void {
+    pub fn set_vtimer_mask(self: Vcpu, masked: bool) Error!void {
         try check(hv_vcpu_set_vtimer_mask(self.handle, masked));
     }
 };
@@ -531,7 +531,7 @@ pub const ExceptionClass = enum(u6) {
     brk_aarch64 = 0x3C,
     _,
 
-    pub fn fromSyndrome(syndrome: u64) ExceptionClass {
+    pub fn from_syndrome(syndrome: u64) ExceptionClass {
         return @enumFromInt(@as(u6, @truncate(syndrome >> 26)));
     }
 };
@@ -549,7 +549,7 @@ pub const WaitTrap = struct {
 /// Decoded AArch64 system-register trap. Valid when ExceptionClass ==
 /// .system_register for MRS/MSR traps. `encoding` is the same 16-bit
 /// op0/op1/CRn/CRm/op2 packing HVF and KVM use everywhere else.
-pub fn isDebugSysReg(encoding: u16) bool {
+pub fn is_debug_sys_reg(encoding: u16) bool {
     // AArch64 debug register bank (DBGBVR/DBGBCR/DBGWVR/DBGWCR,
     // MDSCR/MDCCINT, and future breakpoint/watchpoint slots). Apple
     // SDKs currently name only slots 0..15, but M4/Tahoe can expose
@@ -560,13 +560,13 @@ pub fn isDebugSysReg(encoding: u16) bool {
     return encoding >= 0x8000 and encoding <= 0x80ff;
 }
 
-pub fn shouldIgnoreUnsupportedSysRegWrite(encoding: u16, value: u64) bool {
+pub fn should_ignore_unsupported_sys_reg_write(encoding: u16, value: u64) bool {
     // Linux commonly clears optional CPU state by writing xzr / 0.
     // If a future Apple CPU exposes a new optional register before
     // HVF exposes it, dropping that zero-write is safer than killing
     // the VM during early boot. Non-zero writes still fail unless the
     // register class is explicitly RAZ/WI-safe (debug regs above).
-    return value == 0 or isDebugSysReg(encoding);
+    return value == 0 or is_debug_sys_reg(encoding);
 }
 
 pub const SysRegTrap = struct {
@@ -588,20 +588,20 @@ pub const SysRegTrap = struct {
         };
     }
 
-    pub fn readSource(self: SysRegTrap, vcpu: Vcpu) Error!u64 {
+    pub fn read_source(self: SysRegTrap, vcpu: Vcpu) Error!u64 {
         assert(!self.is_read);
         assert(self.rt <= 31);
         if (self.rt == 31) return 0; // XZR
         const reg: Reg = @enumFromInt(@as(u32, self.rt));
-        return vcpu.getReg(reg);
+        return vcpu.get_reg(reg);
     }
 
-    pub fn writeTarget(self: SysRegTrap, vcpu: Vcpu, value: u64) Error!void {
+    pub fn write_target(self: SysRegTrap, vcpu: Vcpu, value: u64) Error!void {
         assert(self.is_read);
         assert(self.rt <= 31);
         if (self.rt == 31) return; // XZR
         const reg: Reg = @enumFromInt(@as(u32, self.rt));
-        try vcpu.setReg(reg, value);
+        try vcpu.set_reg(reg, value);
     }
 };
 
@@ -629,14 +629,14 @@ pub const DataAbort = struct {
 
     /// Read the guest register holding the value the guest was storing.
     /// XZR reads as 0. Out-of-range is a bug.
-    pub fn readSource(self: DataAbort, vcpu: Vcpu) Error!u64 {
+    pub fn read_source(self: DataAbort, vcpu: Vcpu) Error!u64 {
         // Only meaningful when the syndrome decoded a load/store
         // operand; otherwise srt is whatever bits happened to land.
         assert(self.isv);
         assert(self.srt <= 31);
         if (self.srt == 31) return 0; // XZR
         const reg: Reg = @enumFromInt(@as(u32, self.srt));
-        return vcpu.getReg(reg);
+        return vcpu.get_reg(reg);
     }
 };
 
@@ -699,7 +699,7 @@ pub const Psci = struct {
     /// When the vCPU exits with EC=HVC, the requested function ID
     /// is in X0. Returns null if it isn't a PSCI-shaped HVC.
     pub fn decode(vcpu: Vcpu) Error!?Function {
-        const x0 = try vcpu.getReg(.x0);
+        const x0 = try vcpu.get_reg(.x0);
         const f: Function = @enumFromInt(@as(u32, @truncate(x0)));
         return switch (f) {
             .version,
@@ -752,15 +752,15 @@ test "decode system register traps to HVF encoding" {
 }
 
 test "debug sysreg classifier includes Tahoe/M4 high breakpoint slots" {
-    try std.testing.expect(isDebugSysReg(0x8004)); // DBGBVR0_EL1
-    try std.testing.expect(isDebugSysReg(0x809c)); // DBGBVR19_EL1 on M4/Tahoe
-    try std.testing.expect(!isDebugSysReg(0xC665)); // ICC_SRE_EL1
+    try std.testing.expect(is_debug_sys_reg(0x8004)); // DBGBVR0_EL1
+    try std.testing.expect(is_debug_sys_reg(0x809c)); // DBGBVR19_EL1 on M4/Tahoe
+    try std.testing.expect(!is_debug_sys_reg(0xC665)); // ICC_SRE_EL1
 }
 
 test "unsupported sysreg write policy ignores zero writes" {
-    try std.testing.expect(shouldIgnoreUnsupportedSysRegWrite(0x809c, 0x1234)); // debug reg
-    try std.testing.expect(shouldIgnoreUnsupportedSysRegWrite(0xD123, 0)); // clear unknown optional state
-    try std.testing.expect(!shouldIgnoreUnsupportedSysRegWrite(0xD123, 1)); // non-zero unknown state
+    try std.testing.expect(should_ignore_unsupported_sys_reg_write(0x809c, 0x1234)); // debug reg
+    try std.testing.expect(should_ignore_unsupported_sys_reg_write(0xD123, 0)); // clear unknown optional state
+    try std.testing.expect(!should_ignore_unsupported_sys_reg_write(0xD123, 1)); // non-zero unknown state
 }
 
 test "hv_vm_create and destroy" {
@@ -821,7 +821,7 @@ test "map a page, run hvc #0, observe exception exit" {
     // HVF's default CPSR on arm64 starts the vCPU at EL0, so an
     // instruction fetch at guest_base would fault (IA from lower EL,
     // EC=0x20) before reaching our BRK.
-    try vcpu.setReg(.cpsr, 0x3C5);
+    try vcpu.set_reg(.cpsr, 0x3C5);
 
     // Configure SCTLR_EL1:
     //   M (bit 0)  = 0 — MMU disabled, VA = PA
@@ -829,23 +829,23 @@ test "map a page, run hvc #0, observe exception exit" {
     //                    memory type for instruction fetches when the
     //                    MMU is off; otherwise fetches are Device and
     //                    non-executable).
-    try vcpu.setSysReg(.sctlr_el1, 1 << 12);
+    try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
 
     // Point the vCPU at our instruction.
-    try vcpu.setReg(.pc, guest_base);
+    try vcpu.set_reg(.pc, guest_base);
 
     // Run. The vCPU exits immediately after executing HVC.
     try vcpu.run();
 
     // Expected exit: exception reason, EC=0x16 (HVC), PC advanced by 4.
     try std.testing.expectEqual(ExitReason.exception, vcpu.exit.reason);
-    const ec = ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome);
+    const ec = ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
     try std.testing.expectEqual(ExceptionClass.hvc_aarch64, ec);
-    try std.testing.expectEqual(@as(u64, guest_base + 4), try vcpu.getReg(.pc));
+    try std.testing.expectEqual(@as(u64, guest_base + 4), try vcpu.get_reg(.pc));
 
     std.debug.print(
         "hvc #0 exit: EC=0x{x:0>2} (HVC), pc=0x{x} (advanced past instr)\n",
-        .{ @intFromEnum(ec), try vcpu.getReg(.pc) },
+        .{ @intFromEnum(ec), try vcpu.get_reg(.pc) },
     );
 }
 
@@ -888,9 +888,9 @@ test "run a small program and read register state" {
     const vcpu = try Vcpu.create();
     defer vcpu.destroy();
 
-    try vcpu.setReg(.cpsr, 0x3C5);
-    try vcpu.setSysReg(.sctlr_el1, 1 << 12);
-    try vcpu.setReg(.pc, guest_base);
+    try vcpu.set_reg(.cpsr, 0x3C5);
+    try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
+    try vcpu.set_reg(.pc, guest_base);
 
     try vcpu.run();
 
@@ -901,15 +901,15 @@ test "run a small program and read register state" {
     try std.testing.expectEqual(ExitReason.exception, vcpu.exit.reason);
     try std.testing.expectEqual(
         ExceptionClass.hvc_aarch64,
-        ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome),
+        ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome),
     );
-    try std.testing.expectEqual(@as(u64, guest_base + 12), try vcpu.getReg(.pc));
-    try std.testing.expectEqual(@as(u64, 42), try vcpu.getReg(.x0));
-    try std.testing.expectEqual(@as(u64, 99), try vcpu.getReg(.x1));
+    try std.testing.expectEqual(@as(u64, guest_base + 12), try vcpu.get_reg(.pc));
+    try std.testing.expectEqual(@as(u64, 42), try vcpu.get_reg(.x0));
+    try std.testing.expectEqual(@as(u64, 99), try vcpu.get_reg(.x1));
 
     std.debug.print(
         "3-instr program: x0=42 x1=99 pc=0x{x}\n",
-        .{try vcpu.getReg(.pc)},
+        .{try vcpu.get_reg(.pc)},
     );
 }
 
@@ -957,9 +957,9 @@ test "catch guest store to unmapped MMIO address" {
     const vcpu = try Vcpu.create();
     defer vcpu.destroy();
 
-    try vcpu.setReg(.cpsr, 0x3C5);
-    try vcpu.setSysReg(.sctlr_el1, 1 << 12);
-    try vcpu.setReg(.pc, guest_base);
+    try vcpu.set_reg(.cpsr, 0x3C5);
+    try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
+    try vcpu.set_reg(.pc, guest_base);
 
     // Host run loop: keep running the vCPU; on data aborts, record the
     // write and step past the instruction; on HVC, we're done.
@@ -972,7 +972,7 @@ test "catch guest store to unmapped MMIO address" {
         try vcpu.run();
 
         if (vcpu.exit.reason != .exception) return error.UnexpectedExitReason;
-        const ec = ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome);
+        const ec = ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
 
         switch (ec) {
             .hvc_aarch64 => break, // clean exit
@@ -981,13 +981,13 @@ test "catch guest store to unmapped MMIO address" {
                 try std.testing.expect(info.isv); // syndrome was actually helpful
                 if (info.is_write) {
                     mmio_addr = info.ipa;
-                    mmio_value = try info.readSource(vcpu);
+                    mmio_value = try info.read_source(vcpu);
                     mmio_writes += 1;
                 }
                 // Advance PC past the faulting instruction (all arm64
                 // instructions are 4 bytes) and resume.
-                const faulting_pc = try vcpu.getReg(.pc);
-                try vcpu.setReg(.pc, faulting_pc + 4);
+                const faulting_pc = try vcpu.get_reg(.pc);
+                try vcpu.set_reg(.pc, faulting_pc + 4);
             },
             else => return error.UnexpectedExceptionClass,
         }
@@ -1052,9 +1052,9 @@ test "guest writes bytes to PL011 UART, host captures them" {
     const vcpu = try Vcpu.create();
     defer vcpu.destroy();
 
-    try vcpu.setReg(.cpsr, 0x3C5);
-    try vcpu.setSysReg(.sctlr_el1, 1 << 12);
-    try vcpu.setReg(.pc, guest_base);
+    try vcpu.set_reg(.cpsr, 0x3C5);
+    try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
+    try vcpu.set_reg(.pc, guest_base);
 
     var uart: Pl011 = .init;
 
@@ -1063,7 +1063,7 @@ test "guest writes bytes to PL011 UART, host captures them" {
     while (iters < max_iters) : (iters += 1) {
         try vcpu.run();
         if (vcpu.exit.reason != .exception) return error.UnexpectedExitReason;
-        const ec = ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome);
+        const ec = ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
 
         switch (ec) {
             .hvc_aarch64 => break,
@@ -1071,24 +1071,24 @@ test "guest writes bytes to PL011 UART, host captures them" {
                 const info = DataAbort.decode(vcpu.exit.exception);
                 if (uart.handles(info.ipa)) {
                     if (info.is_write) {
-                        const value = try info.readSource(vcpu);
+                        const value = try info.read_source(vcpu);
                         uart.write(info.ipa, value);
                     }
                     // (reads not exercised in this test)
                 }
                 // advance past faulting instruction
-                const pc = try vcpu.getReg(.pc);
-                try vcpu.setReg(.pc, pc + 4);
+                const pc = try vcpu.get_reg(.pc);
+                try vcpu.set_reg(.pc, pc + 4);
             },
             else => return error.UnexpectedExceptionClass,
         }
     }
     try std.testing.expect(iters < max_iters);
 
-    try std.testing.expectEqualStrings("Hi\n", uart.capturedBytes());
+    try std.testing.expectEqualStrings("Hi\n", uart.captured_bytes());
     std.debug.print(
         "PL011 captured {d} bytes: \"{s}\"",
-        .{ uart.captured_len, uart.capturedBytes() },
+        .{ uart.captured_len, uart.captured_bytes() },
     );
 }
 
@@ -1105,7 +1105,7 @@ test "guest writes bytes to PL011 UART, host captures them" {
 test "Pl011: pushRx buffers bytes and sets RX_INT in RIS" {
     var uart: Pl011 = .init;
 
-    uart.pushRx("abc");
+    uart.push_rx("abc");
     try std.testing.expectEqual(@as(usize, 3), uart.rx_len);
     try std.testing.expect((uart.ris & Pl011.RX_INT) != 0);
 }
@@ -1113,23 +1113,23 @@ test "Pl011: pushRx buffers bytes and sets RX_INT in RIS" {
 test "Pl011: irqAsserted is gated on IMSC" {
     var uart: Pl011 = .init;
 
-    uart.pushRx("x");
+    uart.push_rx("x");
     // RIS has RX_INT set, but the kernel hasn't enabled the mask yet.
-    try std.testing.expect(!uart.irqAsserted());
+    try std.testing.expect(!uart.irq_asserted());
 
     // Kernel enables RX interrupt (IMSC bit 4 = 0x10).
     uart.write(uart.base + 0x038, 0x10);
-    try std.testing.expect(uart.irqAsserted());
+    try std.testing.expect(uart.irq_asserted());
 
     // Kernel masks everything — IRQ line should drop even though bytes remain.
     uart.write(uart.base + 0x038, 0x00);
-    try std.testing.expect(!uart.irqAsserted());
+    try std.testing.expect(!uart.irq_asserted());
 }
 
 test "Pl011: ICR clears selected RIS bits, preserves RX_INT while FIFO has bytes" {
     var uart: Pl011 = .init;
 
-    uart.pushRx("y");
+    uart.push_rx("y");
     // Enable + assert: the RT (receive-timeout) bit too, so we can see
     // ICR clear it without clearing RX_INT.
     uart.ris |= (1 << 6); // RT
@@ -1145,7 +1145,7 @@ test "Pl011: ICR clears selected RIS bits, preserves RX_INT while FIFO has bytes
 test "Pl011: DR read pops a byte; RX_INT clears when FIFO drains" {
     var uart: Pl011 = .init;
 
-    uart.pushRx("hi");
+    uart.push_rx("hi");
     const a = uart.read(uart.base + 0x000); // DR
     try std.testing.expectEqual(@as(u64, 'h'), a);
     try std.testing.expect((uart.ris & Pl011.RX_INT) != 0); // still one byte left
@@ -1162,7 +1162,7 @@ test "Pl011: FR.RXFE flips with FIFO occupancy" {
     // Empty: bit 4 (RXFE) set.
     try std.testing.expect((uart.read(uart.base + 0x018) & (1 << 4)) != 0);
 
-    uart.pushRx("z");
+    uart.push_rx("z");
     // Not empty: RXFE clear.
     try std.testing.expect((uart.read(uart.base + 0x018) & (1 << 4)) == 0);
 
@@ -1245,16 +1245,16 @@ test "guest makes a PSCI SYSTEM_OFF call, host stops the run loop" {
     const vcpu = try Vcpu.create();
     defer vcpu.destroy();
 
-    try vcpu.setReg(.cpsr, 0x3C5);
-    try vcpu.setSysReg(.sctlr_el1, 1 << 12);
-    try vcpu.setReg(.pc, guest_base);
+    try vcpu.set_reg(.cpsr, 0x3C5);
+    try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
+    try vcpu.set_reg(.pc, guest_base);
 
     // Run loop: exit on PSCI SYSTEM_OFF.
     var saw_system_off = false;
     while (true) {
         try vcpu.run();
         if (vcpu.exit.reason != .exception) return error.UnexpectedExitReason;
-        const ec = ExceptionClass.fromSyndrome(vcpu.exit.exception.syndrome);
+        const ec = ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
         if (ec != .hvc_aarch64) return error.UnexpectedExceptionClass;
 
         if (try Psci.decode(vcpu)) |f| switch (f) {

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -202,7 +202,7 @@ pub const KVM_DEV_TYPE_ARM_VGIC_V3: u32 = 7;
 // VM type helper for arm64 IPA sizing. Passing 0 to KVM_CREATE_VM keeps
 // the kernel default; KVM_VM_TYPE_ARM_IPA_SIZE(n) requests n IPA bits.
 pub const KVM_VM_TYPE_ARM_IPA_SIZE_MASK: u64 = 0xff;
-pub fn KVM_VM_TYPE_ARM_IPA_SIZE(bits: u64) u64 {
+pub fn kvm_vm_type_arm_ipa_size(bits: u64) u64 {
     return bits & KVM_VM_TYPE_ARM_IPA_SIZE_MASK;
 }
 
@@ -242,7 +242,7 @@ pub const KVM_ARM_IRQ_TYPE_PPI: u32 = 2;
 /// virtio-blk slot 1 = 17). Without the type bits, KVM treats the
 /// call as a legacy CPU-line IRQ (type 0) and silently drops virtio
 /// doorbells, which manifests as guest hangs after QueueNotify.
-pub fn irqSpi(spi_id: u32) u32 {
+pub fn irq_spi(spi_id: u32) u32 {
     // INTID lives in bits 15:0 of the encoded value; anything wider
     // would either collide with the type field or wrap silently.
     assert(spi_id < (1 << 16) - 32);
@@ -443,19 +443,19 @@ pub const REG_SIZE_U64: u64 = 0x0030_0000_0000_0000;
 pub const REG_ARM_CORE: u64 = 0x00_0010_0000;
 
 /// Build an ID for a core register at the given struct offset.
-fn armCoreReg(comptime offset: u64) u64 {
+fn arm_core_reg(comptime offset: u64) u64 {
     // struct user_pt_regs fields on arm64 are u64; offsets are in
     // bytes. Encoding: ARM64 | U64 | REG_ARM_CORE | (offset / 4).
     return REG_ARM64 | REG_SIZE_U64 | REG_ARM_CORE | (offset / 4);
 }
 
-pub const REG_X0 = armCoreReg(0x00);
-pub const REG_X1 = armCoreReg(0x08);
-pub const REG_X2 = armCoreReg(0x10);
-pub const REG_X3 = armCoreReg(0x18);
-pub const REG_SP = armCoreReg(0xF8);
-pub const REG_PC = armCoreReg(0x100);
-pub const REG_PSTATE = armCoreReg(0x108);
+pub const REG_X0 = arm_core_reg(0x00);
+pub const REG_X1 = arm_core_reg(0x08);
+pub const REG_X2 = arm_core_reg(0x10);
+pub const REG_X3 = arm_core_reg(0x18);
+pub const REG_SP = arm_core_reg(0xF8);
+pub const REG_PC = arm_core_reg(0x100);
+pub const REG_PSTATE = arm_core_reg(0x108);
 
 // ---------------------------------------------------------------
 // Layout asserts — KVM ABI is stable; if any of these trip, our
@@ -632,18 +632,18 @@ pub const Kvm = struct {
         _ = close(self.kvm_fd);
     }
 
-    pub fn checkExtension(self: *Kvm, cap: c_ulong) !c_int {
+    pub fn check_extension(self: *Kvm, cap: c_ulong) !c_int {
         assert(self.kvm_fd >= 0);
         const r = ioctl(self.kvm_fd, KVM_CHECK_EXTENSION, cap);
         if (r < 0) return error.KvmCheckExtensionFailed;
         return r;
     }
 
-    pub fn armEl2Supported(self: *Kvm) bool {
-        return (self.checkExtension(KVM_CAP_ARM_EL2) catch 0) > 0;
+    pub fn arm_el2_supported(self: *Kvm) bool {
+        return (self.check_extension(KVM_CAP_ARM_EL2) catch 0) > 0;
     }
 
-    pub fn supportedCpuid(self: *Kvm) !Cpuid2 {
+    pub fn supported_cpuid(self: *Kvm) !Cpuid2 {
         assert(self.kvm_fd >= 0);
         var out = Cpuid2{ .nent = max_cpuid_entries };
         if (ioctl(self.kvm_fd, KVM_GET_SUPPORTED_CPUID, &out) != 0) {
@@ -653,11 +653,11 @@ pub const Kvm = struct {
         return out;
     }
 
-    pub fn createVm(self: *Kvm) !Vm {
-        return self.createVmWithType(0);
+    pub fn create_vm(self: *Kvm) !Vm {
+        return self.create_vm_with_type(0);
     }
 
-    pub fn createVmWithType(self: *Kvm, vm_type: c_ulong) !Vm {
+    pub fn create_vm_with_type(self: *Kvm, vm_type: c_ulong) !Vm {
         assert(self.kvm_fd >= 0);
         assert(self.vcpu_mmap_size >= 4096);
         const fd = ioctl(self.kvm_fd, KVM_CREATE_VM, vm_type);
@@ -677,16 +677,16 @@ pub const Vm = struct {
     }
 
     /// Map `host_buf` into the guest at `guest_phys_addr`.
-    pub fn mapMemory(
+    pub fn map_memory(
         self: *Vm,
         slot: u32,
         guest_phys_addr: u64,
         host_buf: []u8,
     ) !void {
-        return self.mapMemoryWithFlags(slot, guest_phys_addr, host_buf, 0);
+        return self.map_memory_with_flags(slot, guest_phys_addr, host_buf, 0);
     }
 
-    pub fn mapMemoryWithFlags(
+    pub fn map_memory_with_flags(
         self: *Vm,
         slot: u32,
         guest_phys_addr: u64,
@@ -715,7 +715,7 @@ pub const Vm = struct {
         }
     }
 
-    pub fn getDirtyLog(self: *Vm, allocator: std.mem.Allocator, slot: u32, page_count: usize) ![]u64 {
+    pub fn get_dirty_log(self: *Vm, allocator: std.mem.Allocator, slot: u32, page_count: usize) ![]u64 {
         assert(page_count > 0);
         const word_count = (page_count + 63) / 64;
         const bits = try allocator.alloc(u64, word_count);
@@ -726,7 +726,7 @@ pub const Vm = struct {
         return bits;
     }
 
-    pub fn clearDirtyLog(self: *Vm, slot: u32, bits: []const u64, page_count: usize) void {
+    pub fn clear_dirty_log(self: *Vm, slot: u32, bits: []const u64, page_count: usize) void {
         if (bits.len == 0 or page_count == 0) return;
         var clear = ClearDirtyLog{
             .slot = slot,
@@ -741,7 +741,7 @@ pub const Vm = struct {
 
     /// x86 only: set the per-VM TSS address KVM uses for ring transitions.
     /// Must happen before createIrqchip() on Intel hosts.
-    pub fn setTssAddr(self: *Vm, addr: u64) !void {
+    pub fn set_tss_addr(self: *Vm, addr: u64) !void {
         assert(self.fd >= 0);
         assert(addr % 4096 == 0);
         if (ioctl(self.fd, KVM_SET_TSS_ADDR, @as(c_ulong, @intCast(addr))) != 0) {
@@ -750,7 +750,7 @@ pub const Vm = struct {
     }
 
     /// x86 only: create the in-kernel PIC + IOAPIC irqchip.
-    pub fn createIrqchip(self: *Vm) !void {
+    pub fn create_irqchip(self: *Vm) !void {
         assert(self.fd >= 0);
         if (ioctl(self.fd, KVM_CREATE_IRQCHIP, @as(c_ulong, 0)) != 0) {
             return error.KvmCreateIrqchipFailed;
@@ -758,7 +758,7 @@ pub const Vm = struct {
     }
 
     /// x86 only: create an in-kernel PIT so early Linux timer calibration works.
-    pub fn createPit2(self: *Vm) !void {
+    pub fn create_pit2(self: *Vm) !void {
         assert(self.fd >= 0);
         var cfg = PitConfig{ .flags = KVM_PIT_SPEAKER_DUMMY };
         if (ioctl(self.fd, KVM_CREATE_PIT2, &cfg) != 0) {
@@ -770,7 +770,7 @@ pub const Vm = struct {
     /// redistributor MMIO windows at the given guest-physical
     /// addresses. Call BEFORE `createVcpu` — KVM requires it.
     /// Returns a Gic with the device fd owned; destroy() closes it.
-    pub fn createGicV3(
+    pub fn create_gic_v3(
         self: *Vm,
         dist_addr: u64,
         redist_addr: u64,
@@ -833,7 +833,7 @@ pub const Vm = struct {
     /// Use `irqSpi(spi_id)` to encode the type+id correctly. Without
     /// the type bits, KVM treats the call as a CPU-line legacy IRQ
     /// (type 0) which silently drops virtio doorbells.
-    pub fn setIrq(self: *Vm, irq: u32, level: u32) !void {
+    pub fn set_irq(self: *Vm, irq: u32, level: u32) !void {
         assert(self.fd >= 0);
         // KVM_IRQ_LINE level is a boolean (0 = deassert, 1 = assert).
         // Anything else is a programmer bug — the kernel ignores high
@@ -843,33 +843,33 @@ pub const Vm = struct {
         if (ioctl(self.fd, KVM_IRQ_LINE, &lvl) != 0) return error.KvmIrqLineFailed;
     }
 
-    pub fn getIrqchip(self: *Vm, chip_id: u32) !Irqchip {
+    pub fn get_irqchip(self: *Vm, chip_id: u32) !Irqchip {
         assert(self.fd >= 0);
         var chip = Irqchip{ .chip_id = chip_id, .pad = 0, .chip = @splat(0) };
         if (ioctl(self.fd, KVM_GET_IRQCHIP, &chip) != 0) return error.KvmGetRegFailed;
         return chip;
     }
 
-    pub fn setIrqchip(self: *Vm, chip: Irqchip) !void {
+    pub fn set_irqchip(self: *Vm, chip: Irqchip) !void {
         assert(self.fd >= 0);
         var v = chip;
         if (ioctl(self.fd, KVM_SET_IRQCHIP, &v) != 0) return error.KvmSetRegFailed;
     }
 
-    pub fn getPit2(self: *Vm) !PitState2 {
+    pub fn get_pit2(self: *Vm) !PitState2 {
         assert(self.fd >= 0);
         var pit: PitState2 = undefined;
         if (ioctl(self.fd, KVM_GET_PIT2, &pit) != 0) return error.KvmGetRegFailed;
         return pit;
     }
 
-    pub fn setPit2(self: *Vm, pit: PitState2) !void {
+    pub fn set_pit2(self: *Vm, pit: PitState2) !void {
         assert(self.fd >= 0);
         var v = pit;
         if (ioctl(self.fd, KVM_SET_PIT2, &v) != 0) return error.KvmSetRegFailed;
     }
 
-    pub fn createVcpu(self: *Vm, id: u32) !Vcpu {
+    pub fn create_vcpu(self: *Vm, id: u32) !Vcpu {
         assert(self.fd >= 0);
         assert(self.parent.vcpu_mmap_size >= 4096);
         const fd = ioctl(self.fd, KVM_CREATE_VCPU, @as(c_ulong, id));
@@ -883,7 +883,7 @@ pub const Vm = struct {
 
     /// Fill in `out` with the host's preferred CPU target for this
     /// VM's arm64 vCPUs. Caller passes that to Vcpu.init.
-    pub fn preferredTarget(self: *Vm) !VcpuInit {
+    pub fn preferred_target(self: *Vm) !VcpuInit {
         assert(self.fd >= 0);
         var out: VcpuInit = .{ .target = 0, .features = @splat(0) };
         if (ioctl(self.fd, KVM_ARM_PREFERRED_TARGET, &out) != 0) {
@@ -942,7 +942,7 @@ pub const Vcpu = struct {
         }
     }
 
-    pub fn setReg(self: *Vcpu, id: u64, value: u64) !void {
+    pub fn set_reg(self: *Vcpu, id: u64, value: u64) !void {
         assert(self.fd >= 0);
         // Reg id 0 is reserved; KVM rejects with -ENOENT.
         assert(id != 0);
@@ -953,7 +953,7 @@ pub const Vcpu = struct {
         }
     }
 
-    pub fn getReg(self: *Vcpu, id: u64) !u64 {
+    pub fn get_reg(self: *Vcpu, id: u64) !u64 {
         assert(self.fd >= 0);
         assert(id != 0);
         var v: u64 = 0;
@@ -989,7 +989,7 @@ pub const Vcpu = struct {
     }
 
     /// Read the I/O-port exit payload. Call only when run() returned .io.
-    pub fn ioExit(self: *Vcpu) IoExit {
+    pub fn io_exit(self: *Vcpu) IoExit {
         assert(self.run_size >= 0x20 + @sizeOf(IoExit));
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: IoExit = undefined;
@@ -1001,7 +1001,7 @@ pub const Vcpu = struct {
     }
 
     /// Read the first scalar attached to a KVM_EXIT_IO OUT payload.
-    pub fn ioDataValue(self: *Vcpu, ev: IoExit) u32 {
+    pub fn io_data_value(self: *Vcpu, ev: IoExit) u32 {
         assert(ev.size == 1 or ev.size == 2 or ev.size == 4);
         assert(ev.count > 0);
         assert(ev.data_offset + ev.size <= self.run_size);
@@ -1016,7 +1016,7 @@ pub const Vcpu = struct {
     }
 
     /// Fill the first scalar attached to a KVM_EXIT_IO IN payload.
-    pub fn writeIoReadData(self: *Vcpu, ev: IoExit, value: u32) void {
+    pub fn write_io_read_data(self: *Vcpu, ev: IoExit, value: u32) void {
         assert(ev.size == 1 or ev.size == 2 or ev.size == 4);
         assert(ev.count > 0);
         assert(ev.data_offset + ev.size <= self.run_size);
@@ -1034,7 +1034,7 @@ pub const Vcpu = struct {
     /// .mmio. The union starts at offset 0x20 inside kvm_run (right
     /// after `apic_base` at 0x18), on builds without the S390
     /// extension — which matches x86_64 and arm64.
-    pub fn mmioExit(self: *Vcpu) MmioExit {
+    pub fn mmio_exit(self: *Vcpu) MmioExit {
         assert(self.run_size >= 0x20 + @sizeOf(MmioExit));
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: MmioExit = undefined;
@@ -1048,7 +1048,7 @@ pub const Vcpu = struct {
 
     /// Read the SYSTEM_EVENT exit payload. Used for PSCI SHUTDOWN /
     /// RESET. Same struct union as MMIO; offset 0x20 inside kvm_run.
-    pub fn systemEventExit(self: *Vcpu) SystemEventExit {
+    pub fn system_event_exit(self: *Vcpu) SystemEventExit {
         assert(self.run_size >= 0x20 + @sizeOf(SystemEventExit));
         const base: [*]u8 = @ptrCast(self.run_page);
         var out: SystemEventExit = undefined;
@@ -1062,7 +1062,7 @@ pub const Vcpu = struct {
     /// fill `kvm_run.mmio.data[0..len]` with the register contents
     /// before the next `KVM_RUN`. `mmio.data` lives at 0x20 + 8 =
     /// 0x28 in the kvm_run page.
-    pub fn writeMmioReadData(self: *Vcpu, value: u64, len: u32) void {
+    pub fn write_mmio_read_data(self: *Vcpu, value: u64, len: u32) void {
         assert(self.run_size >= 0x28 + 8);
         // mmio.data is 8 bytes; len > 8 would corrupt the next field.
         assert(len <= 8);
@@ -1074,33 +1074,33 @@ pub const Vcpu = struct {
 
     // x86-specific register access. arm64 uses setReg/getReg above.
 
-    pub fn setCpuid2(self: *Vcpu, cpuid: *const Cpuid2) !void {
+    pub fn set_cpuid2(self: *Vcpu, cpuid: *const Cpuid2) !void {
         assert(self.fd >= 0);
         assert(cpuid.nent <= max_cpuid_entries);
         if (ioctl(self.fd, KVM_SET_CPUID2, cpuid) != 0) return error.Unsupported;
     }
 
-    pub fn getRegsX86(self: *Vcpu) !X86Regs {
+    pub fn get_regs_x86(self: *Vcpu) !X86Regs {
         assert(self.fd >= 0);
         var r: X86Regs = undefined;
         if (ioctl(self.fd, KVM_GET_REGS, &r) != 0) return error.KvmGetRegFailed;
         return r;
     }
 
-    pub fn setRegsX86(self: *Vcpu, r: X86Regs) !void {
+    pub fn set_regs_x86(self: *Vcpu, r: X86Regs) !void {
         assert(self.fd >= 0);
         var v = r;
         if (ioctl(self.fd, KVM_SET_REGS, &v) != 0) return error.KvmSetRegFailed;
     }
 
-    pub fn getSregsX86(self: *Vcpu) !X86Sregs {
+    pub fn get_sregs_x86(self: *Vcpu) !X86Sregs {
         assert(self.fd >= 0);
         var s: X86Sregs = undefined;
         if (ioctl(self.fd, KVM_GET_SREGS, &s) != 0) return error.KvmGetRegFailed;
         return s;
     }
 
-    pub fn setSregsX86(self: *Vcpu, s: X86Sregs) !void {
+    pub fn set_sregs_x86(self: *Vcpu, s: X86Sregs) !void {
         assert(self.fd >= 0);
         var v = s;
         if (ioctl(self.fd, KVM_SET_SREGS, &v) != 0) return error.KvmSetRegFailed;
@@ -1115,9 +1115,9 @@ test "KVM arm64 nested constants match uapi" {
     try std.testing.expectEqual(@as(c_ulong, 165), KVM_CAP_ARM_VM_IPA_SIZE);
     try std.testing.expectEqual(@as(c_ulong, 240), KVM_CAP_ARM_EL2);
     try std.testing.expectEqual(@as(u32, 7), KVM_ARM_VCPU_HAS_EL2);
-    try std.testing.expectEqual(@as(u64, 0), KVM_VM_TYPE_ARM_IPA_SIZE(0));
-    try std.testing.expectEqual(@as(u64, 40), KVM_VM_TYPE_ARM_IPA_SIZE(40));
-    try std.testing.expectEqual(@as(u64, 0xff), KVM_VM_TYPE_ARM_IPA_SIZE(0x1ff));
+    try std.testing.expectEqual(@as(u64, 0), kvm_vm_type_arm_ipa_size(0));
+    try std.testing.expectEqual(@as(u64, 40), kvm_vm_type_arm_ipa_size(40));
+    try std.testing.expectEqual(@as(u64, 0xff), kvm_vm_type_arm_ipa_size(0x1ff));
 }
 
 test "KVMIO ioctl numbers match their documented kernel values" {
@@ -1199,13 +1199,13 @@ test "KVM arch-agnostic: open, API v12, create VM, check capability" {
     // vcpu_mmap_size should be at least one page (typical: 4096 or 12288).
     try std.testing.expect(kvm.vcpu_mmap_size >= 4096);
 
-    var vm = try kvm.createVm();
+    var vm = try kvm.create_vm();
     defer vm.destroy();
 
     // KVM_CAP_USER_MEMORY = 3 — present on every modern kernel; makes
     // sure CHECK_EXTENSION is wired through the wrapper.
     const cap_user_memory: c_ulong = 3;
-    const has_user_memory = try kvm.checkExtension(cap_user_memory);
+    const has_user_memory = try kvm.check_extension(cap_user_memory);
     try std.testing.expect(has_user_memory >= 1);
 }
 
@@ -1219,7 +1219,7 @@ test "KVM x86_64 proof-of-life: create VM, map `hlt`, run, expect KVM_EXIT_HLT" 
     };
     defer kvm.close_();
 
-    var vm = try kvm.createVm();
+    var vm = try kvm.create_vm();
     defer vm.destroy();
 
     // One 4 KiB page of anonymous guest RAM.
@@ -1232,25 +1232,25 @@ test "KVM x86_64 proof-of-life: create VM, map `hlt`, run, expect KVM_EXIT_HLT" 
     // Guest instruction: hlt (0xF4). vCPU halts → KVM_EXIT_HLT.
     const guest_phys: u64 = 0x1000;
     page[0] = 0xF4;
-    try vm.mapMemory(0, guest_phys, page[0..page_size]);
+    try vm.map_memory(0, guest_phys, page[0..page_size]);
 
-    var vcpu = try vm.createVcpu(0);
+    var vcpu = try vm.create_vcpu(0);
     defer vcpu.destroy();
 
     // Zero-out CS.base + CS.selector so real-mode execution starts
     // at physical RIP instead of CS*16 + IP. The rest of the default
     // SREGS (GDT/IDT/LDT, other segments) is fine — we never
     // dereference anything but the instruction byte.
-    var sregs = try vcpu.getSregsX86();
+    var sregs = try vcpu.get_sregs_x86();
     sregs.cs.base = 0;
     sregs.cs.selector = 0;
-    try vcpu.setSregsX86(sregs);
+    try vcpu.set_sregs_x86(sregs);
 
     // RIP = guest_phys, RFLAGS = 0x2 (the single mandatory bit).
-    var regs = try vcpu.getRegsX86();
+    var regs = try vcpu.get_regs_x86();
     regs.rip = guest_phys;
     regs.rflags = 0x2;
-    try vcpu.setRegsX86(regs);
+    try vcpu.set_regs_x86(regs);
 
     const reason = try vcpu.run();
     try std.testing.expectEqual(ExitReason.hlt, reason);
@@ -1269,7 +1269,7 @@ test "KVM proof-of-life: create VM, create vCPU, map + run one instr" {
     };
     defer kvm.close_();
 
-    var vm = try kvm.createVm();
+    var vm = try kvm.create_vm();
     defer vm.destroy();
 
     // One 4 KiB page of host memory, anonymous, mmap'd so the kernel
@@ -1292,17 +1292,17 @@ test "KVM proof-of-life: create VM, create vCPU, map + run one instr" {
     page[3] = 0xB9;
 
     const guest_phys: u64 = 0x4000_0000;
-    try vm.mapMemory(0, guest_phys, page[0..page_size]);
+    try vm.map_memory(0, guest_phys, page[0..page_size]);
 
-    const target = try vm.preferredTarget();
+    const target = try vm.preferred_target();
 
-    var vcpu = try vm.createVcpu(0);
+    var vcpu = try vm.create_vcpu(0);
     defer vcpu.destroy();
 
     try vcpu.init(target);
-    try vcpu.setReg(REG_PC, guest_phys);
+    try vcpu.set_reg(REG_PC, guest_phys);
     // Unmapped address — the load will fault and exit with MMIO.
-    try vcpu.setReg(REG_X0, 0xA000_0000);
+    try vcpu.set_reg(REG_X0, 0xA000_0000);
 
     const reason = try vcpu.run();
     std.debug.print("kvm proof-of-life: exit reason = {d}\n", .{@intFromEnum(reason)});

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -40,19 +40,19 @@ pub fn main(init: std.process.Init) !void {
 
     const gpa = std.heap.page_allocator;
 
-    if (envBool("MACHINEN_NESTED_PROBE")) {
-        probeNestedSupport();
+    if (env_bool("MACHINEN_NESTED_PROBE")) {
+        probe_nested_support();
     }
 
-    const kernel_path = envRequired("MACHINEN_KERNEL");
-    const dtb_path = envOptional("MACHINEN_DTB");
-    const initrd_path = envRequired("MACHINEN_INITRD");
+    const kernel_path = env_required("MACHINEN_KERNEL");
+    const dtb_path = env_optional("MACHINEN_DTB");
+    const initrd_path = env_required("MACHINEN_INITRD");
     // #263 phase A: optional ceiling override. Runtime auto-sizes and
     // forwards a value; direct invocations get the boot_*.zig default.
-    const ram_size_override = envMemoryMib();
+    const ram_size_override = env_memory_mib();
     // #271: explicit opt-in to expose EL2 / nested virtualization to
     // the guest. The runtime sets this from boot({ nested: true }).
-    const nested = envBool("MACHINEN_NESTED");
+    const nested = env_bool("MACHINEN_NESTED");
 
     // Guest console is live-echoed to stderr from inside the boot loop
     // (boot_hvf.zig's PL011 DR-write handler). The result.serial buffer is
@@ -68,19 +68,19 @@ pub fn main(init: std.process.Init) !void {
     // and passes the inherited fd numbers in the env. The VMM then
     // wraps them as virtio-blk backends without ever consulting the
     // host source dir.
-    const mountdisk_lower_fd = envInt("MACHINEN_MOUNTDISK_LOWER_FD");
-    const mountdisk_upper_fd = envInt("MACHINEN_MOUNTDISK_UPPER_FD");
+    const mountdisk_lower_fd = env_int("MACHINEN_MOUNTDISK_LOWER_FD");
+    const mountdisk_upper_fd = env_int("MACHINEN_MOUNTDISK_UPPER_FD");
 
     // Snapshot/restore plumbing — host orchestrator drives via env.
     // MACHINEN_RESTORE_PATH: load .vmstate at boot before vcpu.run().
     // MACHINEN_SNAPSHOT_PATH: capture on SIGUSR1, write .vmstate, then resume after SIGUSR2.
-    const restore_path = envOptional("MACHINEN_RESTORE_PATH");
-    const snapshot_path = envOptional("MACHINEN_SNAPSHOT_PATH");
+    const restore_path = env_optional("MACHINEN_RESTORE_PATH");
+    const snapshot_path = env_optional("MACHINEN_SNAPSHOT_PATH");
 
     if (builtin.os.tag == .macos) {
-        const disk_path = envOptional("MACHINEN_DISK");
-        const rootdisk_path = envOptional("MACHINEN_ROOTDISK");
-        const hvf_dtb_path = dtb_path orelse envRequired("MACHINEN_DTB");
+        const disk_path = env_optional("MACHINEN_DISK");
+        const rootdisk_path = env_optional("MACHINEN_ROOTDISK");
+        const hvf_dtb_path = dtb_path orelse env_required("MACHINEN_DTB");
         var cfg: microvm.boot_hvf.Config = .{
             .kernel_path = kernel_path,
             .dtb_path = hvf_dtb_path,
@@ -102,8 +102,8 @@ pub fn main(init: std.process.Init) !void {
         // .vmstate file's existence.
         std.process.exit(if (result.saw_psci_shutdown or result.snapshotted) 0 else 1);
     } else {
-        const disk_path = envOptional("MACHINEN_DISK");
-        const rootdisk_path = envOptional("MACHINEN_ROOTDISK");
+        const disk_path = env_optional("MACHINEN_DISK");
+        const rootdisk_path = env_optional("MACHINEN_ROOTDISK");
         if (builtin.cpu.arch == .x86_64) {
             if (nested) {
                 std.debug.print("machinen-microvm: nested virtualization unsupported on x86_64 hosts\n", .{});
@@ -126,7 +126,7 @@ pub fn main(init: std.process.Init) !void {
             gpa.free(result.serial);
             std.process.exit(if (result.saw_psci_shutdown or result.snapshotted) 0 else 1);
         } else {
-            const arm_dtb_path = dtb_path orelse envRequired("MACHINEN_DTB");
+            const arm_dtb_path = dtb_path orelse env_required("MACHINEN_DTB");
             var cfg: microvm.boot_kvm.Config = .{
                 .kernel_path = kernel_path,
                 .dtb_path = arm_dtb_path,
@@ -149,9 +149,9 @@ pub fn main(init: std.process.Init) !void {
     }
 }
 
-fn probeNestedSupport() noreturn {
+fn probe_nested_support() noreturn {
     if (builtin.os.tag == .macos) {
-        if (microvm.hvf.nestedSupported()) {
+        if (microvm.hvf.nested_supported()) {
             std.debug.print("machinen-microvm: nested virtualization supported\n", .{});
             std.process.exit(0);
         }
@@ -167,7 +167,7 @@ fn probeNestedSupport() noreturn {
             std.process.exit(2);
         };
         defer k.close_();
-        if (k.armEl2Supported()) {
+        if (k.arm_el2_supported()) {
             std.debug.print("machinen-microvm: nested virtualization supported\n", .{});
             std.process.exit(0);
         }
@@ -176,7 +176,7 @@ fn probeNestedSupport() noreturn {
     }
 }
 
-fn envBool(comptime name: [:0]const u8) bool {
+fn env_bool(comptime name: [:0]const u8) bool {
     comptime assert(name.len > 0);
     const raw = getenv(name.ptr) orelse return false;
     const s = std.mem.span(raw);
@@ -200,7 +200,7 @@ fn envBool(comptime name: [:0]const u8) bool {
 /// or empty; rejects non-numeric values with a die() rather than
 /// silently treating them as 0 (a fd of 0 is stdin and would mask a
 /// configuration mistake).
-fn envInt(comptime name: [:0]const u8) ?c_int {
+fn env_int(comptime name: [:0]const u8) ?c_int {
     comptime assert(name.len > 0);
     const raw = getenv(name.ptr) orelse return null;
     const s = std.mem.span(raw);
@@ -227,22 +227,22 @@ fn envInt(comptime name: [:0]const u8) ?c_int {
 /// value in bytes, or null if the var is unset / empty. Refuses
 /// anything we can't safely turn into a `usize` byte count: bad
 /// digits, zero, or values that would overflow.
-fn envMemoryMib() ?usize {
+fn env_memory_mib() ?usize {
     const raw = getenv("MACHINEN_MEMORY") orelse return null;
     const s = std.mem.span(raw);
     if (s.len == 0) return null;
     assert(s.len > 0);
-    const mib = std.fmt.parseInt(u64, s, 10) catch dieMemory(s, "must be a decimal integer");
-    if (mib == 0) dieMemory(s, "must be > 0");
+    const mib = std.fmt.parseInt(u64, s, 10) catch die_memory(s, "must be a decimal integer");
+    if (mib == 0) die_memory(s, "must be > 0");
     assert(mib > 0);
-    const bytes = std.math.mul(u64, mib, 1024 * 1024) catch dieMemory(s, "value overflows usize");
-    if (bytes > std.math.maxInt(usize)) dieMemory(s, "value overflows usize");
+    const bytes = std.math.mul(u64, mib, 1024 * 1024) catch die_memory(s, "value overflows usize");
+    if (bytes > std.math.maxInt(usize)) die_memory(s, "value overflows usize");
     assert(bytes > 0);
     assert(bytes <= std.math.maxInt(usize));
     return @intCast(bytes);
 }
 
-fn dieMemory(value: []const u8, why: []const u8) noreturn {
+fn die_memory(value: []const u8, why: []const u8) noreturn {
     assert(value.len > 0);
     assert(why.len > 0);
     std.debug.print(
@@ -252,23 +252,23 @@ fn dieMemory(value: []const u8, why: []const u8) noreturn {
     std.process.exit(2);
 }
 
-fn envRequired(comptime name: [:0]const u8) []const u8 {
+fn env_required(comptime name: [:0]const u8) []const u8 {
     comptime assert(name.len > 0);
-    const raw = getenv(name.ptr) orelse dieUsage(name);
+    const raw = getenv(name.ptr) orelse die_usage(name);
     const s = std.mem.span(raw);
-    if (s.len == 0) dieUsage(name);
+    if (s.len == 0) die_usage(name);
     assert(s.len > 0);
     return s;
 }
 
-fn envOptional(comptime name: [:0]const u8) ?[]const u8 {
+fn env_optional(comptime name: [:0]const u8) ?[]const u8 {
     comptime assert(name.len > 0);
     const raw = getenv(name.ptr) orelse return null;
     const s = std.mem.span(raw);
     return if (s.len == 0) null else s;
 }
 
-fn dieUsage(missing: []const u8) noreturn {
+fn die_usage(missing: []const u8) noreturn {
     assert(missing.len > 0);
     std.debug.print(
         "machinen-microvm: {s} is unset.\n" ++
@@ -280,6 +280,6 @@ fn dieUsage(missing: []const u8) noreturn {
 }
 
 test "backend detection is non-null" {
-    const backend = microvm.detectBackend();
+    const backend = microvm.detect_backend();
     try std.testing.expect(backend != .none);
 }

--- a/packages/microvm/src/net_socket.zig
+++ b/packages/microvm/src/net_socket.zig
@@ -171,7 +171,7 @@ pub const NetSocket = struct {
 
         const self = try gpa.create(NetSocket);
         self.* = .{ .fd = fd, .netdev = netdev, .gpa = gpa };
-        self.rx_thread = try std.Thread.spawn(.{}, rxLoop, .{self});
+        self.rx_thread = try std.Thread.spawn(.{}, rx_loop, .{self});
         return self;
     }
 
@@ -201,11 +201,11 @@ pub const NetSocket = struct {
         // the prefix fails, skip the payload; the stream is now broken
         // but serialized senders won't interleave mid-frame.
 
-        if (writeAll(self.fd, &prefix) != 0) return;
-        _ = writeAll(self.fd, frame);
+        if (write_all(self.fd, &prefix) != 0) return;
+        _ = write_all(self.fd, frame);
     }
 
-    fn rxLoop(self: *NetSocket) void {
+    fn rx_loop(self: *NetSocket) void {
         assert(self.fd >= 0);
         // One buffer for the whole thread. MTU is 1500 on the gvproxy
         // tap; 16 KiB is plenty of headroom for a future jumbo config.
@@ -220,15 +220,15 @@ pub const NetSocket = struct {
         // and the kernel buffer keeps them ordered while we drain.
         while (!self.stop.load(.acquire)) {
             var prefix: [4]u8 = undefined;
-            if (readAll(self.fd, &prefix) != 0) return;
+            if (read_all(self.fd, &prefix) != 0) return;
             const frame_len_bytes = std.mem.readInt(u32, &prefix, .big);
             if (frame_len_bytes == 0 or frame_len_bytes > buf.len) return;
             assert(frame_len_bytes > 0 and frame_len_bytes <= buf.len);
 
-            if (readAll(self.fd, buf[0..frame_len_bytes]) != 0) return;
+            if (read_all(self.fd, buf[0..frame_len_bytes]) != 0) return;
 
             self.irq_mu.lock();
-            _ = self.netdev.injectRx(buf[0..frame_len_bytes]);
+            _ = self.netdev.inject_rx(buf[0..frame_len_bytes]);
             if (self.on_rx) |cb| cb(self.on_rx_ctx);
             self.irq_mu.unlock();
         }
@@ -236,17 +236,17 @@ pub const NetSocket = struct {
 
     /// Take/release `irq_mu` for the vCPU's net-MMIO handler. See
     /// the field doc above for why.
-    pub fn lockIrq(self: *NetSocket) void {
+    pub fn lock_irq(self: *NetSocket) void {
         self.irq_mu.lock();
     }
-    pub fn unlockIrq(self: *NetSocket) void {
+    pub fn unlock_irq(self: *NetSocket) void {
         self.irq_mu.unlock();
     }
 };
 
 // ---- helpers -------------------------------------------------------
 
-fn writeAll(fd: c_int, data: []const u8) c_int {
+fn write_all(fd: c_int, data: []const u8) c_int {
     assert(fd >= 0);
     assert(data.len > 0);
     var remaining = data;
@@ -271,7 +271,7 @@ fn writeAll(fd: c_int, data: []const u8) c_int {
     return 0;
 }
 
-fn readAll(fd: c_int, into: []u8) c_int {
+fn read_all(fd: c_int, into: []u8) c_int {
     assert(fd >= 0);
     assert(into.len > 0);
     var remaining = into;

--- a/packages/microvm/src/pl011.zig
+++ b/packages/microvm/src/pl011.zig
@@ -29,9 +29,9 @@ pub const PthreadMutex = extern struct {
     // zero-init the whole thing and let pthread handle it. macOS
     // has a sentinel magic it requires, which we write into the
     // first 8 bytes.
-    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macosInit() else @splat(0),
+    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macos_init() else @splat(0),
 
-    fn macosInit() [64]u8 {
+    fn macos_init() [64]u8 {
         var out: [64]u8 = @splat(0);
         // sig = 0x32AAABA7 (PTHREAD_MUTEX_INITIALIZER's magic).
         const sig: u64 = 0x32AAABA7;
@@ -118,7 +118,7 @@ pub const Pl011 = struct {
         .base = 0x0900_0000,
     };
 
-    pub fn withBase(base: u64) Pl011 {
+    pub fn with_base(base: u64) Pl011 {
         // base 0 collides with the GIC distributor on the arm-virt
         // machine; non-zero is a programmer invariant for every caller.
         assert(base != 0);
@@ -133,7 +133,7 @@ pub const Pl011 = struct {
     }
 
     /// IRQ line should be asserted iff there's any masked interrupt pending.
-    pub fn irqAsserted(self: *Pl011) bool {
+    pub fn irq_asserted(self: *Pl011) bool {
         assert(self.size > 0);
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -143,7 +143,7 @@ pub const Pl011 = struct {
     /// Slice over the captured DR-write bytes. The returned slice
     /// aliases the inline buffer — copy it (e.g. via `gpa.dupe`) if
     /// you need it to outlive the Pl011.
-    pub fn capturedBytes(self: *const Pl011) []const u8 {
+    pub fn captured_bytes(self: *const Pl011) []const u8 {
         assert(self.captured_len <= captured_capacity);
         return self.captured[0..self.captured_len];
     }
@@ -151,7 +151,7 @@ pub const Pl011 = struct {
     /// Drop bytes that don't fit. Real PL011 hardware does the same
     /// when its 32-byte RX FIFO is full; the kernel's driver expects
     /// to lose data on overrun rather than block the producer.
-    pub fn pushRx(self: *Pl011, bytes: []const u8) void {
+    pub fn push_rx(self: *Pl011, bytes: []const u8) void {
         assert(self.size > 0);
         self.mutex.lock();
         defer self.mutex.unlock();

--- a/packages/microvm/src/ram_dump.zig
+++ b/packages/microvm/src/ram_dump.zig
@@ -83,7 +83,7 @@ pub const RamDeltaHeader = extern struct {
 
 /// True if every byte of `buf` is zero. Word-wise so the multi-GiB
 /// scan stays a fraction of a second instead of a per-byte crawl.
-fn isZero(buf: []const u8) bool {
+fn is_zero(buf: []const u8) bool {
     var i: usize = 0;
     while (i + 8 <= buf.len) : (i += 8) {
         if (std.mem.readInt(u64, buf[i..][0..8], .little) != 0) return false;
@@ -97,19 +97,19 @@ fn isZero(buf: []const u8) bool {
 /// The next run of non-zero 4 KiB pages at or after `from`, or null
 /// when the rest of `ram` is all zero. `end` is clamped to `ram.len`
 /// so a non-page-aligned tail still encodes.
-fn nextExtent(ram: []const u8, from: usize) ?struct { start: usize, end: usize } {
+fn next_extent(ram: []const u8, from: usize) ?struct { start: usize, end: usize } {
     std.debug.assert(from <= ram.len);
     var i = from;
     while (i < ram.len) {
         const pe = @min(i + PAGE, ram.len);
-        if (!isZero(ram[i..pe])) break;
+        if (!is_zero(ram[i..pe])) break;
         i = pe;
     }
     if (i >= ram.len) return null;
     const start = i;
     while (i < ram.len) {
         const pe = @min(i + PAGE, ram.len);
-        if (isZero(ram[i..pe])) break;
+        if (is_zero(ram[i..pe])) break;
         i = pe;
     }
     // A returned extent is non-empty, stays within bounds, and never
@@ -130,7 +130,7 @@ pub fn encode(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8) ![]u
     var body_len: usize = 0;
     {
         var cursor: usize = 0;
-        while (nextExtent(ram, cursor)) |e| {
+        while (next_extent(ram, cursor)) |e| {
             body_len += EXTENT_HEADER_SIZE + (e.end - e.start);
             cursor = e.end;
         }
@@ -143,7 +143,7 @@ pub fn encode(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8) ![]u
     var w: usize = HEADER_SIZE;
     {
         var cursor: usize = 0;
-        while (nextExtent(ram, cursor)) |e| {
+        while (next_extent(ram, cursor)) |e| {
             const ext_len = e.end - e.start;
             std.mem.writeInt(u64, out[w..][0..8], e.start, .little);
             w += 8;
@@ -170,21 +170,21 @@ pub fn encode(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8) ![]u
     return out;
 }
 
-fn dirtyBitSet(bits: []const u64, page_idx: usize) bool {
+fn dirty_bit_set(bits: []const u64, page_idx: usize) bool {
     const word = page_idx / 64;
     if (word >= bits.len) return false;
     const bit: u6 = @intCast(page_idx % 64);
     return (bits[word] & (@as(u64, 1) << bit)) != 0;
 }
 
-fn nextDirtyExtent(ram_len: usize, dirty_bits: []const u64, from: usize) ?struct { start: usize, end: usize } {
+fn next_dirty_extent(ram_len: usize, dirty_bits: []const u64, from: usize) ?struct { start: usize, end: usize } {
     std.debug.assert(from <= ram_len);
     var page = from / PAGE;
     const page_count = if (ram_len == 0) 0 else 1 + ((ram_len - 1) / PAGE);
-    while (page < page_count and !dirtyBitSet(dirty_bits, page)) : (page += 1) {}
+    while (page < page_count and !dirty_bit_set(dirty_bits, page)) : (page += 1) {}
     if (page >= page_count) return null;
     const start_page = page;
-    while (page < page_count and dirtyBitSet(dirty_bits, page)) : (page += 1) {}
+    while (page < page_count and dirty_bit_set(dirty_bits, page)) : (page += 1) {}
     const start = start_page * PAGE;
     const end = @min(page * PAGE, ram_len);
     std.debug.assert(start < end and end <= ram_len);
@@ -195,14 +195,14 @@ fn nextDirtyExtent(ram_len: usize, dirty_bits: []const u64, from: usize) ?struct
 /// destination restore buffer is expected to already contain the
 /// parent checkpoint's RAM; decodeDeltaInto overlays these extents.
 /// Unlike the full sparse encoder, dirty zero pages are stored too.
-pub fn encodeDelta(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8, dirty_bits: []const u64) ![]u8 {
+pub fn encode_delta(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8, dirty_bits: []const u64) ![]u8 {
     std.debug.assert(ram.len > 0);
     std.debug.assert(ram_base % PAGE == 0);
 
     var body_len: usize = 0;
     {
         var cursor: usize = 0;
-        while (nextDirtyExtent(ram.len, dirty_bits, cursor)) |e| {
+        while (next_dirty_extent(ram.len, dirty_bits, cursor)) |e| {
             body_len += EXTENT_HEADER_SIZE + (e.end - e.start);
             cursor = e.end;
         }
@@ -214,7 +214,7 @@ pub fn encodeDelta(allocator: std.mem.Allocator, ram_base: u64, ram: []const u8,
     var w: usize = DELTA_HEADER_SIZE;
     {
         var cursor: usize = 0;
-        while (nextDirtyExtent(ram.len, dirty_bits, cursor)) |e| {
+        while (next_dirty_extent(ram.len, dirty_bits, cursor)) |e| {
             const ext_len = e.end - e.start;
             std.mem.writeInt(u64, out[w..][0..8], e.start, .little);
             w += 8;
@@ -254,8 +254,8 @@ pub const DecodedMeta = struct {
 /// bytes are zero-filled and then the stored extents are laid down on
 /// top. The SHA256 over the extent stream is checked first — a flipped
 /// bit fails loudly here instead of scrambling the restored guest.
-pub fn decodeInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
-    return decodeIntoMode(payload, dest, .zero_dest_first);
+pub fn decode_into(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+    return decode_into_mode(payload, dest, .zero_dest_first);
 }
 
 /// Same sparse-RAM decoder, but assumes the leading `ram_size` bytes of
@@ -263,13 +263,13 @@ pub fn decodeInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
 /// is a fresh anonymous mmap, so the kernel provides zero pages lazily.
 /// Avoiding an eager `@memset` keeps restore proportional to the saved
 /// extents instead of the configured guest RAM ceiling.
-pub fn decodeIntoZeroed(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
-    return decodeIntoMode(payload, dest, .dest_already_zero);
+pub fn decode_into_zeroed(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+    return decode_into_mode(payload, dest, .dest_already_zero);
 }
 
 const DecodeMode = enum { zero_dest_first, dest_already_zero };
 
-fn decodeIntoMode(payload: []const u8, dest: []u8, mode: DecodeMode) DecodeError!DecodedMeta {
+fn decode_into_mode(payload: []const u8, dest: []u8, mode: DecodeMode) DecodeError!DecodedMeta {
     if (payload.len < HEADER_SIZE) return error.Truncated;
     var hdr: RamHeader = undefined;
     @memcpy(std.mem.asBytes(&hdr), payload[0..HEADER_SIZE]);
@@ -320,7 +320,7 @@ fn decodeIntoMode(payload: []const u8, dest: []u8, mode: DecodeMode) DecodeError
 /// Apply a RAM-delta payload onto an existing destination buffer.
 /// Unlike decodeInto(), this does not zero-fill first: the caller must
 /// have already reconstructed the parent checkpoint's RAM.
-pub fn decodeDeltaInto(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
+pub fn decode_delta_into(payload: []const u8, dest: []u8) DecodeError!DecodedMeta {
     if (payload.len < DELTA_HEADER_SIZE) return error.Truncated;
     var hdr: RamDeltaHeader = undefined;
     @memcpy(std.mem.asBytes(&hdr), payload[0..DELTA_HEADER_SIZE]);
@@ -377,7 +377,7 @@ test "encode/decode round-trip reconstructs a sparse buffer" {
     defer a.free(dest);
     @memset(dest, 0xFF); // poison — decodeInto must zero-fill first.
 
-    const meta = try decodeInto(payload, dest);
+    const meta = try decode_into(payload, dest);
     try std.testing.expectEqual(@as(u64, 0x4000_0000), meta.ram_base);
     try std.testing.expectEqual(@as(u64, 4 * PAGE), meta.ram_size);
     try std.testing.expectEqualSlices(u8, ram, dest);
@@ -397,7 +397,7 @@ test "encode/decode round-trip on an all-zero buffer" {
     const dest = try a.alloc(u8, 8 * PAGE);
     defer a.free(dest);
     @memset(dest, 0xFF);
-    _ = try decodeInto(payload, dest);
+    _ = try decode_into(payload, dest);
     try std.testing.expectEqualSlices(u8, ram, dest);
 }
 
@@ -414,12 +414,12 @@ test "RAM delta overlays dirty pages including zeroed pages" {
 
     var bits = [_]u64{0};
     bits[0] |= (@as(u64, 1) << 1) | (@as(u64, 1) << 3);
-    const payload = try encodeDelta(a, 0x4000_0000, child, &bits);
+    const payload = try encode_delta(a, 0x4000_0000, child, &bits);
     defer a.free(payload);
 
     const dest = try a.dupe(u8, parent);
     defer a.free(dest);
-    const meta = try decodeDeltaInto(payload, dest);
+    const meta = try decode_delta_into(payload, dest);
     try std.testing.expectEqual(@as(u64, 0x4000_0000), meta.ram_base);
     try std.testing.expectEqual(@as(u64, 4 * PAGE), meta.ram_size);
     try std.testing.expectEqualSlices(u8, child, dest);
@@ -438,13 +438,13 @@ test "decodeIntoZeroed reconstructs without clearing implicit zero pages" {
     const zeroed = try a.alloc(u8, 4 * PAGE);
     defer a.free(zeroed);
     @memset(zeroed, 0);
-    _ = try decodeIntoZeroed(payload, zeroed);
+    _ = try decode_into_zeroed(payload, zeroed);
     try std.testing.expectEqualSlices(u8, ram, zeroed);
 
     const poisoned = try a.alloc(u8, 4 * PAGE);
     defer a.free(poisoned);
     @memset(poisoned, 0xA5);
-    _ = try decodeIntoZeroed(payload, poisoned);
+    _ = try decode_into_zeroed(payload, poisoned);
     try std.testing.expectEqualSlices(u8, ram[PAGE..][0..PAGE], poisoned[PAGE..][0..PAGE]);
     // Precondition is real: omitted pages are not cleared by this fast path.
     try std.testing.expectEqual(@as(u8, 0xA5), poisoned[0]);
@@ -462,13 +462,13 @@ test "encode/decode handles a non-page-aligned tail" {
 
     const dest = try a.alloc(u8, PAGE + 100);
     defer a.free(dest);
-    _ = try decodeInto(payload, dest);
+    _ = try decode_into(payload, dest);
     try std.testing.expectEqualSlices(u8, ram, dest);
 }
 
 test "decodeInto rejects a truncated header" {
     var dest: [PAGE]u8 = undefined;
-    try std.testing.expectError(error.Truncated, decodeInto("short", &dest));
+    try std.testing.expectError(error.Truncated, decode_into("short", &dest));
 }
 
 test "decodeInto rejects a dest smaller than ram_size" {
@@ -482,7 +482,7 @@ test "decodeInto rejects a dest smaller than ram_size" {
     defer a.free(payload);
 
     var dest: [2 * PAGE]u8 = undefined;
-    try std.testing.expectError(error.SizeMismatch, decodeInto(payload, &dest));
+    try std.testing.expectError(error.SizeMismatch, decode_into(payload, &dest));
 }
 
 test "decodeInto rejects a flipped bit in an extent" {
@@ -500,5 +500,5 @@ test "decodeInto rejects a flipped bit in an extent" {
     mut[HEADER_SIZE + EXTENT_HEADER_SIZE + 3] ^= 0x01;
 
     var dest: [2 * PAGE]u8 = undefined;
-    try std.testing.expectError(error.HashMismatch, decodeInto(mut, &dest));
+    try std.testing.expectError(error.HashMismatch, decode_into(mut, &dest));
 }

--- a/packages/microvm/src/root.zig
+++ b/packages/microvm/src/root.zig
@@ -56,7 +56,7 @@ pub const Backend = enum { hvf, kvm, none };
 
 /// Pick the host's available backend. HVF on macOS, KVM on Linux,
 /// none on anything else.
-pub fn detectBackend() Backend {
+pub fn detect_backend() Backend {
     return switch (builtin.os.tag) {
         .macos => .hvf,
         .linux => .kvm,
@@ -69,7 +69,7 @@ pub fn detectBackend() Backend {
 /// real resource (HVF framework presence, /dev/kvm readability).
 /// Returns false if the backend exists in principle but can't be
 /// opened — e.g. /dev/kvm permissions, or no virtualization enabled.
-pub fn backendAvailable() bool {
+pub fn backend_available() bool {
     return switch (comptime builtin.os.tag) {
         .macos => true, // HVF availability is checked when hv_vm_create runs
         .linux => blk: {
@@ -86,7 +86,7 @@ pub fn backendAvailable() bool {
 }
 
 test "detectBackend matches build target" {
-    const b = detectBackend();
+    const b = detect_backend();
     switch (builtin.os.tag) {
         .macos => try std.testing.expectEqual(Backend.hvf, b),
         .linux => try std.testing.expectEqual(Backend.kvm, b),
@@ -98,7 +98,7 @@ test "backendAvailable is a bool that corresponds to the OS" {
     // On macOS we always return true; on Linux it depends on
     // /dev/kvm; on other hosts it's false. We can only assert the
     // type round-trip; the runtime value depends on the runner.
-    try std.testing.expect(@TypeOf(backendAvailable()) == bool);
+    try std.testing.expect(@TypeOf(backend_available()) == bool);
 }
 
 // Pull in backend-specific test blocks so `zig build test` discovers them.

--- a/packages/microvm/src/rootdisk_delta.zig
+++ b/packages/microvm/src/rootdisk_delta.zig
@@ -27,28 +27,28 @@ pub const Header = extern struct {
     }
 };
 
-fn bitSet(bits: []const u64, block_idx: usize) bool {
+fn bit_set(bits: []const u64, block_idx: usize) bool {
     const word = block_idx / 64;
     if (word >= bits.len) return false;
     const bit: u6 = @intCast(block_idx % 64);
     return (bits[word] & (@as(u64, 1) << bit)) != 0;
 }
 
-fn nextDirtyExtent(disk_size: u64, bits: []const u64, from: u64) ?struct { start: u64, end: u64 } {
+fn next_dirty_extent(disk_size: u64, bits: []const u64, from: u64) ?struct { start: u64, end: u64 } {
     std.debug.assert(from <= disk_size);
     const block_count = if (disk_size == 0) 0 else 1 + ((disk_size - 1) / BLOCK);
     var block = from / BLOCK;
-    while (block < block_count and !bitSet(bits, @intCast(block))) : (block += 1) {}
+    while (block < block_count and !bit_set(bits, @intCast(block))) : (block += 1) {}
     if (block >= block_count) return null;
     const start_block = block;
-    while (block < block_count and bitSet(bits, @intCast(block))) : (block += 1) {}
+    while (block < block_count and bit_set(bits, @intCast(block))) : (block += 1) {}
     const start = start_block * BLOCK;
     const end = @min(block * BLOCK, disk_size);
     std.debug.assert(start < end and end <= disk_size);
     return .{ .start = start, .end = end };
 }
 
-pub fn encodeFromFd(
+pub fn encode_from_fd(
     allocator: std.mem.Allocator,
     fd: c_int,
     disk_size: u64,
@@ -60,7 +60,7 @@ pub fn encodeFromFd(
     var body_len: usize = 0;
     {
         var cursor: u64 = 0;
-        while (nextDirtyExtent(disk_size, dirty_bits, cursor)) |e| {
+        while (next_dirty_extent(disk_size, dirty_bits, cursor)) |e| {
             body_len += EXTENT_HEADER_SIZE + @as(usize, @intCast(e.end - e.start));
             cursor = e.end;
         }
@@ -72,13 +72,13 @@ pub fn encodeFromFd(
     var w: usize = HEADER_SIZE;
     {
         var cursor: u64 = 0;
-        while (nextDirtyExtent(disk_size, dirty_bits, cursor)) |e| {
+        while (next_dirty_extent(disk_size, dirty_bits, cursor)) |e| {
             const len: usize = @intCast(e.end - e.start);
             std.mem.writeInt(u64, out[w..][0..8], e.start, .little);
             w += 8;
             std.mem.writeInt(u64, out[w..][0..8], len, .little);
             w += 8;
-            try preadAll(fd, out[w..][0..len], e.start);
+            try pread_all(fd, out[w..][0..len], e.start);
             w += len;
             cursor = e.end;
         }
@@ -95,7 +95,7 @@ pub fn encodeFromFd(
     return out;
 }
 
-fn preadAll(fd: c_int, dst: []u8, offset: u64) !void {
+fn pread_all(fd: c_int, dst: []u8, offset: u64) !void {
     var done: usize = 0;
     while (done < dst.len) {
         const rc = pread(fd, dst[done..].ptr, dst.len - done, @as(i64, @intCast(offset + done)));
@@ -121,7 +121,7 @@ test "encodeFromFd stores contiguous dirty block extents" {
 
     var bits = [_]u64{0};
     bits[0] |= (@as(u64, 1) << 1) | (@as(u64, 1) << 2);
-    const payload = try encodeFromFd(a, file.handle, 4 * BLOCK, &bits);
+    const payload = try encode_from_fd(a, file.handle, 4 * BLOCK, &bits);
     defer a.free(payload);
 
     try std.testing.expectEqual(HEADER_SIZE + EXTENT_HEADER_SIZE + 2 * BLOCK, payload.len);

--- a/packages/microvm/src/snapshot.zig
+++ b/packages/microvm/src/snapshot.zig
@@ -123,10 +123,10 @@ pub fn encode(
     topology_hash: [32]u8,
     sections: []const Section,
 ) ![]u8 {
-    return encodeWithArch(allocator, ARCH_AARCH64, topology_hash, sections);
+    return encode_with_arch(allocator, ARCH_AARCH64, topology_hash, sections);
 }
 
-pub fn encodeWithArch(
+pub fn encode_with_arch(
     allocator: std.mem.Allocator,
     arch: u32,
     topology_hash: [32]u8,
@@ -217,7 +217,7 @@ pub const VcpuParseError = error{Truncated} || std.mem.Allocator.Error;
 ///
 /// Bounds: entries.len fits in u32; each name fits in u8 (255 chars);
 /// each value fits in u32 (4 GiB).
-pub fn encodeVcpuPayload(allocator: std.mem.Allocator, entries: []const VcpuEntry) ![]u8 {
+pub fn encode_vcpu_payload(allocator: std.mem.Allocator, entries: []const VcpuEntry) ![]u8 {
     std.debug.assert(entries.len <= std.math.maxInt(u32));
 
     var total: usize = 4; // entry_count
@@ -248,7 +248,7 @@ pub fn encodeVcpuPayload(allocator: std.mem.Allocator, entries: []const VcpuEntr
 
 /// Decode a VCPU payload. Slices point into the input buffer (caller
 /// keeps it alive). No copies.
-pub fn decodeVcpuPayload(allocator: std.mem.Allocator, payload: []const u8) VcpuParseError![]VcpuEntry {
+pub fn decode_vcpu_payload(allocator: std.mem.Allocator, payload: []const u8) VcpuParseError![]VcpuEntry {
     if (payload.len < 4) return error.Truncated;
     const n = std.mem.readInt(u32, payload[0..4], .little);
     const entries = try allocator.alloc(VcpuEntry, n);
@@ -304,7 +304,7 @@ test "encode/decode round-trip with x86_64 arch" {
     const allocator = std.testing.allocator;
     const topo: [32]u8 = @splat(0xcd);
 
-    const bytes = try encodeWithArch(allocator, ARCH_X86_64, topo, &.{});
+    const bytes = try encode_with_arch(allocator, ARCH_X86_64, topo, &.{});
     defer allocator.free(bytes);
 
     var snap = try decode(allocator, bytes);
@@ -398,10 +398,10 @@ test "vcpu payload round-trip" {
         .{ .name = "CNTVOFF_EL2", .value = &[_]u8{ 0x10, 0x20, 0, 0, 0, 0, 0, 0 } },
     };
 
-    const payload = try encodeVcpuPayload(allocator, &entries);
+    const payload = try encode_vcpu_payload(allocator, &entries);
     defer allocator.free(payload);
 
-    const decoded = try decodeVcpuPayload(allocator, payload);
+    const decoded = try decode_vcpu_payload(allocator, payload);
     defer allocator.free(decoded);
 
     try std.testing.expectEqual(@as(usize, 3), decoded.len);
@@ -415,5 +415,5 @@ test "vcpu payload round-trip" {
 
 test "vcpu payload rejects truncated" {
     const allocator = std.testing.allocator;
-    try std.testing.expectError(error.Truncated, decodeVcpuPayload(allocator, &[_]u8{ 1, 0, 0 }));
+    try std.testing.expectError(error.Truncated, decode_vcpu_payload(allocator, &[_]u8{ 1, 0, 0 }));
 }

--- a/packages/microvm/src/snapshot_cli.zig
+++ b/packages/microvm/src/snapshot_cli.zig
@@ -28,7 +28,7 @@ const vmstate_zip = microvm.vmstate_zip;
 /// Centralises the read + transparent-gunzip + decode the three
 /// file-consuming subcommands share. Caller owns the returned
 /// `Vmstate` and must `deinit()` it.
-fn loadVmstateFile(allocator: std.mem.Allocator, path: []const u8) !snapshot.Vmstate {
+fn load_vmstate_file(allocator: std.mem.Allocator, path: []const u8) !snapshot.Vmstate {
     const raw = try std.Io.Dir.cwd().readFileAlloc(g_io, path, allocator, .limited(1 << 30));
     defer allocator.free(raw);
     const bytes = try vmstate_zip.decompress(allocator, raw);
@@ -49,30 +49,30 @@ pub fn main(init: std.process.Init) !u8 {
     _ = it.next(); // argv[0]
 
     const sub = it.next() orelse {
-        try printUsage();
+        try print_usage();
         return @intFromEnum(Exit.usage);
     };
 
     const allocator = init.gpa;
 
     if (eq(sub, "--help") or eq(sub, "-h") or eq(sub, "help")) {
-        try printUsage();
+        try print_usage();
         return @intFromEnum(Exit.ok);
     } else if (eq(sub, "dump")) {
-        return @intFromEnum(try runDump(allocator, &it));
+        return @intFromEnum(try run_dump(allocator, &it));
     } else if (eq(sub, "load")) {
-        return @intFromEnum(try runLoad(allocator, &it));
+        return @intFromEnum(try run_load(allocator, &it));
     } else if (eq(sub, "translate")) {
-        return @intFromEnum(try runTranslate(allocator, &it));
+        return @intFromEnum(try run_translate(allocator, &it));
     } else if (eq(sub, "diff")) {
-        return @intFromEnum(try runDiff(allocator, &it));
+        return @intFromEnum(try run_diff(allocator, &it));
     } else if (eq(sub, "xload")) {
-        return @intFromEnum(try runXload(allocator, &it));
+        return @intFromEnum(try run_xload(allocator, &it));
     } else {
         try stderr("unknown subcommand: ");
         try stderr(sub);
         try stderr("\n");
-        try printUsage();
+        try print_usage();
         return @intFromEnum(Exit.usage);
     }
 }
@@ -89,7 +89,7 @@ fn stdout(s: []const u8) !void {
     try std.Io.File.stdout().writeStreamingAll(g_io, s);
 }
 
-fn printUsage() !void {
+fn print_usage() !void {
     const u =
         \\snapshot-test — .vmstate snapshot tool
         \\
@@ -108,7 +108,7 @@ fn printUsage() !void {
     try stderr(u);
 }
 
-fn runDump(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
+fn run_dump(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
     var vmm: []const u8 = "";
     var section: []const u8 = "";
     while (it.next()) |arg| {
@@ -128,14 +128,14 @@ fn runDump(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
             try stderr("dump --vmm=kvm only runs on Linux\n");
             return .fail;
         }
-        return try dumpVcpuKvmCmd(allocator);
+        return try dump_vcpu_kvm_cmd(allocator);
     }
     if (eq(section, "vcpu") and eq(vmm, "hvf")) {
         if (builtin.os.tag != .macos) {
             try stderr("dump --vmm=hvf only runs on macOS\n");
             return .fail;
         }
-        return try dumpVcpuHvfCmd(allocator);
+        return try dump_vcpu_hvf_cmd(allocator);
     }
 
     try stderr("dump: --vmm=");
@@ -148,7 +148,7 @@ fn runDump(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
 
 const builtin = @import("builtin");
 
-fn dumpVcpuKvmCmd(allocator: std.mem.Allocator) !Exit {
+fn dump_vcpu_kvm_cmd(allocator: std.mem.Allocator) !Exit {
     if (builtin.os.tag != .linux) return .fail;
     const kvm = microvm.kvm;
     const vcpu_dump = microvm.vcpu_dump;
@@ -159,7 +159,7 @@ fn dumpVcpuKvmCmd(allocator: std.mem.Allocator) !Exit {
     };
     defer k.close_();
 
-    var vm = k.createVm() catch {
+    var vm = k.create_vm() catch {
         try stderr("dump: KVM_CREATE_VM failed\n");
         return .fail;
     };
@@ -176,7 +176,7 @@ fn dumpVcpuKvmCmd(allocator: std.mem.Allocator) !Exit {
         return .fail;
     }
 
-    var vcpu = vm.createVcpu(0) catch {
+    var vcpu = vm.create_vcpu(0) catch {
         try stderr("dump: KVM_CREATE_VCPU failed\n");
         return .fail;
     };
@@ -186,7 +186,7 @@ fn dumpVcpuKvmCmd(allocator: std.mem.Allocator) !Exit {
         return .fail;
     };
 
-    const payload = vcpu_dump.dumpKvm(allocator, vcpu.fd) catch |err| {
+    const payload = vcpu_dump.dump_kvm(allocator, vcpu.fd) catch |err| {
         try stderr("dump: dumpKvm failed: ");
         try stderr(@errorName(err));
         try stderr("\n");
@@ -211,7 +211,7 @@ fn dumpVcpuKvmCmd(allocator: std.mem.Allocator) !Exit {
     return .ok;
 }
 
-fn runXload(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
+fn run_xload(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
     // xload --vmm=<hvf|kvm> <in.vmstate>
     // Load the VCPU section into a fresh vCPU of the named backend,
     // then dump back to stdout. Used for task #20 cross-load.
@@ -233,7 +233,7 @@ fn runXload(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit 
         return .usage;
     }
 
-    var snap = loadVmstateFile(allocator, path) catch |err| {
+    var snap = load_vmstate_file(allocator, path) catch |err| {
         try stderr("xload: cannot load ");
         try stderr(path);
         try stderr(": ");
@@ -260,19 +260,19 @@ fn runXload(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit 
             try stderr("xload --vmm=kvm only runs on Linux\n");
             return .fail;
         }
-        return try xloadKvm(allocator, payload);
+        return try xload_kvm(allocator, payload);
     } else if (eq(vmm, "hvf")) {
         if (builtin.os.tag != .macos) {
             try stderr("xload --vmm=hvf only runs on macOS\n");
             return .fail;
         }
-        return try xloadHvf(allocator, payload);
+        return try xload_hvf(allocator, payload);
     }
     try stderr("xload: --vmm must be hvf or kvm\n");
     return .usage;
 }
 
-fn xloadHvf(allocator: std.mem.Allocator, payload: []const u8) !Exit {
+fn xload_hvf(allocator: std.mem.Allocator, payload: []const u8) !Exit {
     if (builtin.os.tag != .macos) return .fail;
     const hvf = microvm.hvf;
     const vcpu_dump = microvm.vcpu_dump;
@@ -288,13 +288,13 @@ fn xloadHvf(allocator: std.mem.Allocator, payload: []const u8) !Exit {
     };
     defer vcpu.destroy();
 
-    vcpu_dump.loadHvf(allocator, vcpu.handle, payload) catch |err| {
+    vcpu_dump.load_hvf(allocator, vcpu.handle, payload) catch |err| {
         try stderr("xload: loadHvf: ");
         try stderr(@errorName(err));
         try stderr("\n");
         return .fail;
     };
-    const out = vcpu_dump.dumpHvf(allocator, vcpu.handle) catch |err| {
+    const out = vcpu_dump.dump_hvf(allocator, vcpu.handle) catch |err| {
         try stderr("xload: dumpHvf: ");
         try stderr(@errorName(err));
         try stderr("\n");
@@ -318,7 +318,7 @@ fn xloadHvf(allocator: std.mem.Allocator, payload: []const u8) !Exit {
     return .ok;
 }
 
-fn xloadKvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
+fn xload_kvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
     if (builtin.os.tag != .linux) return .fail;
     const kvm = microvm.kvm;
     const vcpu_dump = microvm.vcpu_dump;
@@ -328,7 +328,7 @@ fn xloadKvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
         return .fail;
     };
     defer k.close_();
-    var vm = k.createVm() catch {
+    var vm = k.create_vm() catch {
         try stderr("xload: KVM_CREATE_VM failed\n");
         return .fail;
     };
@@ -343,7 +343,7 @@ fn xloadKvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
         try stderr("xload: KVM_ARM_PREFERRED_TARGET failed\n");
         return .fail;
     }
-    var vcpu = vm.createVcpu(0) catch {
+    var vcpu = vm.create_vcpu(0) catch {
         try stderr("xload: KVM_CREATE_VCPU failed\n");
         return .fail;
     };
@@ -353,13 +353,13 @@ fn xloadKvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
         return .fail;
     };
 
-    vcpu_dump.loadKvm(allocator, vcpu.fd, payload) catch |err| {
+    vcpu_dump.load_kvm(allocator, vcpu.fd, payload) catch |err| {
         try stderr("xload: loadKvm: ");
         try stderr(@errorName(err));
         try stderr("\n");
         return .fail;
     };
-    const out = vcpu_dump.dumpKvm(allocator, vcpu.fd) catch |err| {
+    const out = vcpu_dump.dump_kvm(allocator, vcpu.fd) catch |err| {
         try stderr("xload: dumpKvm: ");
         try stderr(@errorName(err));
         try stderr("\n");
@@ -383,7 +383,7 @@ fn xloadKvm(allocator: std.mem.Allocator, payload: []const u8) !Exit {
     return .ok;
 }
 
-fn dumpVcpuHvfCmd(allocator: std.mem.Allocator) !Exit {
+fn dump_vcpu_hvf_cmd(allocator: std.mem.Allocator) !Exit {
     if (builtin.os.tag != .macos) return .fail;
     const hvf = microvm.hvf;
     const vcpu_dump = microvm.vcpu_dump;
@@ -399,7 +399,7 @@ fn dumpVcpuHvfCmd(allocator: std.mem.Allocator) !Exit {
     };
     defer vcpu.destroy();
 
-    const payload = vcpu_dump.dumpHvf(allocator, vcpu.handle) catch |err| {
+    const payload = vcpu_dump.dump_hvf(allocator, vcpu.handle) catch |err| {
         try stderr("dump: dumpHvf failed: ");
         try stderr(@errorName(err));
         try stderr("\n");
@@ -423,20 +423,20 @@ fn dumpVcpuHvfCmd(allocator: std.mem.Allocator) !Exit {
     return .ok;
 }
 
-fn runTranslate(allocator: std.mem.Allocator, _: *std.process.Args.Iterator) !Exit {
+fn run_translate(allocator: std.mem.Allocator, _: *std.process.Args.Iterator) !Exit {
     _ = allocator;
     try stderr("translate: not yet wired (lands with #10/#14/#20)\n");
     return .fail;
 }
 
-fn runLoad(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
+fn run_load(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
     var path_opt: ?[]const u8 = null;
     var expected_topo: ?[32]u8 = null;
 
     while (it.next()) |arg| {
         if (std.mem.startsWith(u8, arg, "--expected-topology=")) {
             const hex = arg["--expected-topology=".len..];
-            expected_topo = parseHex32(hex) catch {
+            expected_topo = parse_hex32(hex) catch {
                 try stderr("load: --expected-topology requires 64 hex chars\n");
                 return .usage;
             };
@@ -453,7 +453,7 @@ fn runLoad(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
         return .usage;
     };
 
-    var snap = loadVmstateFile(allocator, path) catch |err| {
+    var snap = load_vmstate_file(allocator, path) catch |err| {
         try stderr("load: cannot load ");
         try stderr(path);
         try stderr(": ");
@@ -467,9 +467,9 @@ fn runLoad(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
         if (!std.mem.eql(u8, &exp, &snap.header.topology_hash)) {
             try stderr("load: topology mismatch\n");
             try stderr("  expected: ");
-            try writeHex(&exp);
+            try write_hex(&exp);
             try stderr("\n  actual:   ");
-            try writeHex(&snap.header.topology_hash);
+            try write_hex(&snap.header.topology_hash);
             try stderr("\n");
             return .fail;
         }
@@ -489,14 +489,14 @@ const Mask = struct {
     names: [][]const u8 = &.{},
 };
 
-fn runDiff(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
+fn run_diff(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
     var a_path: ?[]const u8 = null;
     var b_path: ?[]const u8 = null;
     var mask: Mask = .{};
 
     while (it.next()) |arg| {
         if (std.mem.startsWith(u8, arg, "--mask=")) {
-            mask = parseMask(allocator, arg["--mask=".len..]) catch {
+            mask = parse_mask(allocator, arg["--mask=".len..]) catch {
                 try stderr("diff: malformed --mask (expected <kind>=<n1,n2,...>)\n");
                 return .usage;
             };
@@ -520,16 +520,16 @@ fn runDiff(allocator: std.mem.Allocator, it: *std.process.Args.Iterator) !Exit {
         return .usage;
     };
 
-    var snap_a = readVmstate(allocator, ap) catch return .fail;
+    var snap_a = read_vmstate(allocator, ap) catch return .fail;
     defer snap_a.deinit();
-    var snap_b = readVmstate(allocator, bp) catch return .fail;
+    var snap_b = read_vmstate(allocator, bp) catch return .fail;
     defer snap_b.deinit();
 
-    return diffVmstates(allocator, &snap_a, &snap_b, mask);
+    return diff_vmstates(allocator, &snap_a, &snap_b, mask);
 }
 
-fn readVmstate(allocator: std.mem.Allocator, path: []const u8) !snapshot.Vmstate {
-    return loadVmstateFile(allocator, path) catch |err| {
+fn read_vmstate(allocator: std.mem.Allocator, path: []const u8) !snapshot.Vmstate {
+    return load_vmstate_file(allocator, path) catch |err| {
         try stderr("diff: cannot load ");
         try stderr(path);
         try stderr(": ");
@@ -539,7 +539,7 @@ fn readVmstate(allocator: std.mem.Allocator, path: []const u8) !snapshot.Vmstate
     };
 }
 
-fn diffVmstates(
+fn diff_vmstates(
     allocator: std.mem.Allocator,
     a: *snapshot.Vmstate,
     b: *snapshot.Vmstate,
@@ -548,11 +548,11 @@ fn diffVmstates(
     var differs = false;
 
     if (a.header.version != b.header.version) {
-        try diffMsg("header.version", a.header.version, b.header.version);
+        try diff_msg("header.version", a.header.version, b.header.version);
         differs = true;
     }
     if (a.header.arch != b.header.arch) {
-        try diffMsg("header.arch", a.header.arch, b.header.arch);
+        try diff_msg("header.arch", a.header.arch, b.header.arch);
         differs = true;
     }
     if (!std.mem.eql(u8, &a.header.topology_hash, &b.header.topology_hash)) {
@@ -560,7 +560,7 @@ fn diffVmstates(
         differs = true;
     }
     if (a.sections.len != b.sections.len) {
-        try diffMsg("section_count", a.sections.len, b.sections.len);
+        try diff_msg("section_count", a.sections.len, b.sections.len);
         differs = true;
     }
 
@@ -586,7 +586,7 @@ fn diffVmstates(
             // sysreg mask suppresses named entries; with no mask, every
             // diverging entry is reported by name.
             const names: []const []const u8 = if (eq(mask.kind, "sysreg")) mask.names else &.{};
-            if (try diffVcpuMasked(allocator, idx, sa.payload, sb.payload, names)) {
+            if (try diff_vcpu_masked(allocator, idx, sa.payload, sb.payload, names)) {
                 differs = true;
             }
         } else {
@@ -602,16 +602,16 @@ fn diffVmstates(
     return if (differs) .fail else .ok;
 }
 
-fn diffVcpuMasked(
+fn diff_vcpu_masked(
     allocator: std.mem.Allocator,
     section_idx: usize,
     a_payload: []const u8,
     b_payload: []const u8,
     masked_names: []const []const u8,
 ) !bool {
-    const entries_a = try snapshot.decodeVcpuPayload(allocator, a_payload);
+    const entries_a = try snapshot.decode_vcpu_payload(allocator, a_payload);
     defer allocator.free(entries_a);
-    const entries_b = try snapshot.decodeVcpuPayload(allocator, b_payload);
+    const entries_b = try snapshot.decode_vcpu_payload(allocator, b_payload);
     defer allocator.free(entries_b);
 
     // Auto-mask any reg the classifier flags as .mask or .translate.
@@ -633,7 +633,7 @@ fn diffVcpuMasked(
     @memset(seen_in_b, false);
 
     for (entries_a) |ea| {
-        if (isMasked(ea.name, masked_names)) continue;
+        if (is_masked(ea.name, masked_names)) continue;
         const cls_a = classify(ea.name);
         if (cls_a == .mask or cls_a == .translate) continue;
         const bi = b_index.get(ea.name) orelse {
@@ -653,7 +653,7 @@ fn diffVcpuMasked(
     }
     for (entries_b, 0..) |eb, i| {
         if (seen_in_b[i]) continue;
-        if (isMasked(eb.name, masked_names)) continue;
+        if (is_masked(eb.name, masked_names)) continue;
         const cls_b = classify(eb.name);
         if (cls_b == .mask or cls_b == .translate) continue;
         var buf: [256]u8 = undefined;
@@ -664,12 +664,12 @@ fn diffVcpuMasked(
     return differs;
 }
 
-fn isMasked(name: []const u8, masked_names: []const []const u8) bool {
+fn is_masked(name: []const u8, masked_names: []const []const u8) bool {
     for (masked_names) |m| if (eq(name, m)) return true;
     return false;
 }
 
-fn parseMask(allocator: std.mem.Allocator, s: []const u8) !Mask {
+fn parse_mask(allocator: std.mem.Allocator, s: []const u8) !Mask {
     const eq_idx = std.mem.indexOfScalar(u8, s, '=') orelse return error.MissingEquals;
     const kind = s[0..eq_idx];
     const rest = s[eq_idx + 1 ..];
@@ -692,13 +692,13 @@ fn parseMask(allocator: std.mem.Allocator, s: []const u8) !Mask {
     return .{ .kind = kind, .names = names };
 }
 
-fn diffMsg(label: []const u8, a: anytype, b: anytype) !void {
+fn diff_msg(label: []const u8, a: anytype, b: anytype) !void {
     var buf: [128]u8 = undefined;
     const msg = try std.fmt.bufPrint(&buf, "{s} differs ({any} vs {any})\n", .{ label, a, b });
     try stderr(msg);
 }
 
-fn parseHex32(s: []const u8) ![32]u8 {
+fn parse_hex32(s: []const u8) ![32]u8 {
     if (s.len != 64) return error.InvalidLength;
     var out: [32]u8 = undefined;
     for (0..32) |i| {
@@ -709,7 +709,7 @@ fn parseHex32(s: []const u8) ![32]u8 {
     return out;
 }
 
-fn writeHex(bytes: []const u8) !void {
+fn write_hex(bytes: []const u8) !void {
     const hex = "0123456789abcdef";
     var buf: [128]u8 = undefined;
     var i: usize = 0;

--- a/packages/microvm/src/stats.zig
+++ b/packages/microvm/src/stats.zig
@@ -71,7 +71,7 @@ var stub_storage: Counters = .{};
 
 /// Pointer to the process-static stub. Useful for tests that want a
 /// deterministic, isolated counter to read after a fake balloon op.
-pub fn stubCounters() *Counters {
+pub fn stub_counters() *Counters {
     return &stub_storage;
 }
 
@@ -119,20 +119,20 @@ pub const Stats = struct {
     /// Stats backed by the file pointed at by `MACHINEN_STATS_FILE`,
     /// or by the process-static stub when the env var is missing or
     /// the open fails. Never throws — the VMM must boot regardless.
-    pub fn openOrStub() Stats {
-        const env_ptr = libc.getenv("MACHINEN_STATS_FILE") orelse return stubInstance();
+    pub fn open_or_stub() Stats {
+        const env_ptr = libc.getenv("MACHINEN_STATS_FILE") orelse return stub_instance();
         return open(env_ptr) catch |err| {
-            if (debugEnabled()) {
+            if (debug_enabled()) {
                 std.debug.print("stats: open '{s}' failed ({s}); using stub\n", .{
                     std.mem.span(env_ptr),
                     @errorName(err),
                 });
             }
-            return stubInstance();
+            return stub_instance();
         };
     }
 
-    fn stubInstance() Stats {
+    fn stub_instance() Stats {
         return .{ .counters = &stub_storage };
     }
 
@@ -151,7 +151,7 @@ pub const Stats = struct {
     }
 };
 
-fn debugEnabled() bool {
+fn debug_enabled() bool {
     return libc.getenv("MACHINEN_DEBUG") != null;
 }
 
@@ -225,14 +225,14 @@ const RUSAGE_PHYS_FOOTPRINT_OFFSET: usize = 72;
 /// joinable — the VMM exits via `std.process.exit` once boot
 /// returns, so there's no cleanup window where the sampler could
 /// race with `Stats.deinit()`.
-pub fn startPhysFootprintSampler(counters: *Counters) void {
+pub fn start_phys_footprint_sampler(counters: *Counters) void {
     if (builtin.os.tag != .macos) return;
     const handle = std.Thread.spawn(
         .{},
-        samplerLoop,
+        sampler_loop,
         .{counters},
     ) catch |err| {
-        if (debugEnabled()) {
+        if (debug_enabled()) {
             std.debug.print("stats: sampler spawn failed: {s}\n", .{@errorName(err)});
         }
         return;
@@ -240,10 +240,10 @@ pub fn startPhysFootprintSampler(counters: *Counters) void {
     handle.detach();
 }
 
-fn samplerLoop(counters: *Counters) void {
+fn sampler_loop(counters: *Counters) void {
     const half_second = libc.timespec{ .tv_sec = 0, .tv_nsec = 500 * 1_000_000 };
     while (true) {
-        if (samplePhysFootprint()) |bytes| {
+        if (sample_phys_footprint()) |bytes| {
             @atomicStore(u64, &counters.host_phys_footprint, bytes, .monotonic);
         }
         // libc nanosleep — std.Thread.sleep was removed in Zig 0.16
@@ -257,7 +257,7 @@ fn samplerLoop(counters: *Counters) void {
 /// One synchronous sample. Returns null on non-Darwin or on syscall
 /// failure (pid gone, kernel out of memory, etc.). Exposed for
 /// tests; the production caller is `samplerLoop` above.
-pub fn samplePhysFootprint() ?u64 {
+pub fn sample_phys_footprint() ?u64 {
     if (builtin.os.tag != .macos) return null;
     // Comptime guard so a future struct-version bump that moved
     // phys_footprint out of the v4 layout fails to build instead of
@@ -294,13 +294,13 @@ test "Counters layout matches the host wire format" {
 
 test "samplePhysFootprint returns a positive value on Darwin" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
-    const v = samplePhysFootprint() orelse return error.UnexpectedNull;
+    const v = sample_phys_footprint() orelse return error.UnexpectedNull;
     try std.testing.expect(v > 0);
 }
 
 test "stubCounters returns the same address every call" {
-    const a = stubCounters();
-    const b = stubCounters();
+    const a = stub_counters();
+    const b = stub_counters();
     try std.testing.expectEqual(a, b);
 }
 

--- a/packages/microvm/src/sysreg_classify.zig
+++ b/packages/microvm/src/sysreg_classify.zig
@@ -25,9 +25,9 @@ pub const Class = enum {
 pub fn classify(name: []const u8) Class {
     // --- skip: invariant / host-determined ---
     // Identity / discovery
-    if (startsWith(name, "ID_AA64") or startsWith(name, "ID_DFR") or
-        startsWith(name, "ID_ISAR") or startsWith(name, "ID_MMFR") or
-        startsWith(name, "ID_PFR") or startsWith(name, "ID_AFR"))
+    if (starts_with(name, "ID_AA64") or starts_with(name, "ID_DFR") or
+        starts_with(name, "ID_ISAR") or starts_with(name, "ID_MMFR") or
+        starts_with(name, "ID_PFR") or starts_with(name, "ID_AFR"))
         return .skip;
     if (eq(name, "MIDR_EL1") or eq(name, "REVIDR_EL1") or
         eq(name, "MPIDR_EL1") or eq(name, "AIDR_EL1") or
@@ -37,14 +37,14 @@ pub fn classify(name: []const u8) Class {
     if (eq(name, "ACTLR_EL1") or eq(name, "ACTLR_EL2"))
         return .skip;
     // Apple proprietary
-    if (startsWith(name, "S3_1_C15_")) return .skip;
+    if (starts_with(name, "S3_1_C15_")) return .skip;
     // Cache topology — host-determined
     if (eq(name, "CCSIDR_EL1") or eq(name, "CCSIDR2_EL1") or
         eq(name, "CSSELR_EL1") or eq(name, "CLIDR_EL1") or
         eq(name, "CTR_EL0") or eq(name, "DCZID_EL0"))
         return .skip;
     // FP feature ID — host caps
-    if (startsWith(name, "MVFR")) return .skip;
+    if (starts_with(name, "MVFR")) return .skip;
     // RNG — host RNG, no state
     if (eq(name, "RNDR") or eq(name, "RNDRRS")) return .skip;
     // SME ID — host feature; mismatch must refuse snapshot
@@ -69,12 +69,12 @@ pub fn classify(name: []const u8) Class {
     // PMU counters
     if (eq(name, "PMCCNTR_EL0") or eq(name, "PMCCFILTR_EL0"))
         return .mask;
-    if (startsWith(name, "PMEVCNTR") or startsWith(name, "PMEVTYPER"))
+    if (starts_with(name, "PMEVCNTR") or starts_with(name, "PMEVTYPER"))
         return .mask;
     if (eq(name, "PMCR_EL0")) return .mask; // E bit + counter clears
     // Debug — mask until task #29 forces portable
-    if (startsWith(name, "DBGBVR") or startsWith(name, "DBGBCR") or
-        startsWith(name, "DBGWVR") or startsWith(name, "DBGWCR"))
+    if (starts_with(name, "DBGBVR") or starts_with(name, "DBGBCR") or
+        starts_with(name, "DBGWVR") or starts_with(name, "DBGWCR"))
         return .mask;
     if (eq(name, "MDSCR_EL1") or eq(name, "OSDTRRX_EL1") or
         eq(name, "OSDTRTX_EL1") or eq(name, "OSLAR_EL1") or
@@ -96,7 +96,7 @@ fn eq(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, a, b);
 }
 
-fn startsWith(s: []const u8, prefix: []const u8) bool {
+fn starts_with(s: []const u8, prefix: []const u8) bool {
     return std.mem.startsWith(u8, s, prefix);
 }
 

--- a/packages/microvm/src/sysreg_probe.zig
+++ b/packages/microvm/src/sysreg_probe.zig
@@ -28,8 +28,8 @@ pub fn main(init: std.process.Init) !u8 {
     const allocator = init.gpa;
 
     return switch (builtin.os.tag) {
-        .macos => try probeHvf(allocator),
-        .linux => try probeKvm(allocator),
+        .macos => try probe_hvf(allocator),
+        .linux => try probe_kvm(allocator),
         else => {
             try stderr("sysreg-probe: unsupported host\n");
             return 2;
@@ -47,7 +47,7 @@ fn stderr(s: []const u8) !void {
 // -----------------------------------------------------------------
 // HVF probe (macOS)
 
-fn probeHvf(_: std.mem.Allocator) !u8 {
+fn probe_hvf(_: std.mem.Allocator) !u8 {
     if (builtin.os.tag != .macos) unreachable;
     const hvf = microvm.hvf;
     var vm = try hvf.Vm.create();
@@ -69,11 +69,11 @@ fn probeHvf(_: std.mem.Allocator) !u8 {
         var value: u64 = 0;
         const rc = c.hv_vcpu_get_sys_reg(vcpu.handle, entry.encoding, &value);
         var line_buf: [256]u8 = undefined;
-        const line = try formatProbeLine(&line_buf, entry.encoding, entry.name, rc, value);
+        const line = try format_probe_line(&line_buf, entry.encoding, entry.name, rc, value);
         try lines.append(std.heap.page_allocator, try std.heap.page_allocator.dupe(u8, line));
     }
 
-    std.mem.sort([]u8, lines.items, {}, lessThanLine);
+    std.mem.sort([]u8, lines.items, {}, less_than_line);
     for (lines.items) |l| {
         try stdout(l);
         try stdout("\n");
@@ -82,7 +82,7 @@ fn probeHvf(_: std.mem.Allocator) !u8 {
     return 0;
 }
 
-fn formatProbeLine(buf: []u8, encoding: u16, name: []const u8, rc: i32, value: u64) ![]u8 {
+fn format_probe_line(buf: []u8, encoding: u16, name: []const u8, rc: i32, value: u64) ![]u8 {
     // HVF return codes (hv_return_t in hv_error.h):
     //   HV_SUCCESS      = 0
     //   HV_ERROR        = 0xfae94001
@@ -107,7 +107,7 @@ fn formatProbeLine(buf: []u8, encoding: u16, name: []const u8, rc: i32, value: u
     return std.fmt.bufPrint(buf, "0x{x:04}\t{s}\t{s}", .{ encoding, name, status });
 }
 
-fn lessThanLine(_: void, a: []const u8, b: []const u8) bool {
+fn less_than_line(_: void, a: []const u8, b: []const u8) bool {
     return std.mem.lessThan(u8, a, b);
 }
 
@@ -173,7 +173,7 @@ const KVM_REG_SIZE_U64: u64 = 0x0030_0000_0000_0000;
 const KVM_REG_ARM64_SYSREG: u64 = 0x0013_0000;
 const KVM_REG_ARM64_SYSREG_ENC_MASK: u64 = 0xffff;
 
-fn probeKvm(allocator: std.mem.Allocator) !u8 {
+fn probe_kvm(allocator: std.mem.Allocator) !u8 {
     if (builtin.os.tag != .linux) unreachable;
 
     const c = struct {
@@ -274,7 +274,7 @@ fn probeKvm(allocator: std.mem.Allocator) !u8 {
         try lines.append(std.heap.page_allocator, try std.heap.page_allocator.dupe(u8, line));
     }
 
-    std.mem.sort([]u8, lines.items, {}, lessThanLine);
+    std.mem.sort([]u8, lines.items, {}, less_than_line);
     for (lines.items) |l| {
         try stdout(l);
         try stdout("\n");

--- a/packages/microvm/src/topology.zig
+++ b/packages/microvm/src/topology.zig
@@ -81,7 +81,7 @@ pub const Topology = struct {
         return out;
     }
 
-    pub fn hashHex(self: Topology) [64]u8 {
+    pub fn hash_hex(self: Topology) [64]u8 {
         const bytes = self.hash();
         var hex: [64]u8 = undefined;
         const digits = "0123456789abcdef";
@@ -150,7 +150,7 @@ test "hashHex round-trips through parseHex32" {
         .gic_dist_base = 0x0800_0000,
         .gic_redist_base = 0x1000_0000,
     };
-    const hex = t.hashHex();
+    const hex = t.hash_hex();
     const bytes = t.hash();
     var parsed: [32]u8 = undefined;
     for (0..32) |i| {

--- a/packages/microvm/src/uart8250.zig
+++ b/packages/microvm/src/uart8250.zig
@@ -35,7 +35,7 @@ pub const Uart8250 = struct {
 
     pub const init: Uart8250 = .{ .base = 0x0900_0000 };
 
-    pub fn withBase(base: u64) Uart8250 {
+    pub fn with_base(base: u64) Uart8250 {
         assert(base != 0);
         return .{ .base = base };
     }
@@ -45,17 +45,17 @@ pub const Uart8250 = struct {
         return addr >= self.base and addr < self.base + self.size;
     }
 
-    pub fn irqAsserted(self: *Uart8250) bool {
+    pub fn irq_asserted(self: *Uart8250) bool {
         _ = self;
         return false;
     }
 
-    pub fn capturedBytes(self: *const Uart8250) []const u8 {
+    pub fn captured_bytes(self: *const Uart8250) []const u8 {
         assert(self.captured_len <= captured_capacity);
         return self.captured[0..self.captured_len];
     }
 
-    pub fn pushRx(self: *Uart8250, bytes: []const u8) void {
+    pub fn push_rx(self: *Uart8250, bytes: []const u8) void {
         self.mutex.lock();
         defer self.mutex.unlock();
         const room = rx_capacity - self.rx_len;
@@ -126,6 +126,6 @@ test "uart8250 captures THR writes" {
     var uart = Uart8250.init;
     uart.write(uart.base, 'O');
     uart.write(uart.base, 'K');
-    try std.testing.expectEqualStrings("OK", uart.capturedBytes());
+    try std.testing.expectEqualStrings("OK", uart.captured_bytes());
     try std.testing.expectEqual(@as(u64, 0x60), uart.read(uart.base + 5) & 0x60);
 }

--- a/packages/microvm/src/vcpu_dump.zig
+++ b/packages/microvm/src/vcpu_dump.zig
@@ -39,7 +39,7 @@ const CoreReg = struct {
     size: enum { u32_, u64_, u128_ },
 };
 
-pub const core_regs: []const CoreReg = &generateCoreRegs();
+pub const core_regs: []const CoreReg = &generate_core_regs();
 
 // X0..X30 + PC + PSTATE + SP_EL0 + SP_EL1 + ELR_EL1 + SPSR_EL1 +
 // V0..V31 + FPSR + FPCR.
@@ -52,7 +52,7 @@ pub const core_regs: []const CoreReg = &generateCoreRegs();
 // this core-reg offset. Routing them through the sysreg path on KVM
 // (the pre-#37 bug) returned ENOENT, leaving SP_EL0 garbage and the
 // resumed guest fault-looping on its first stack access.
-fn generateCoreRegs() [71]CoreReg {
+fn generate_core_regs() [71]CoreReg {
     @setEvalBranchQuota(20000);
     var out: [71]CoreReg = undefined;
     var idx: usize = 0;
@@ -100,7 +100,7 @@ const KVM_REG_SIZE_U128: u64 = 0x0040_0000_0000_0000;
 const KVM_REG_ARM_CORE: u64 = 0x0010_0000;
 const KVM_REG_ARM64_SYSREG: u64 = 0x0013_0000;
 
-fn kvmIdForCore(reg: CoreReg) u64 {
+fn kvm_id_for_core(reg: CoreReg) u64 {
     // The register ID packs `offset / 4`; a non-4-aligned offset
     // would silently truncate and address the wrong register.
     std.debug.assert(reg.offset % 4 == 0);
@@ -112,7 +112,7 @@ fn kvmIdForCore(reg: CoreReg) u64 {
     return KVM_REG_ARM64 | KVM_REG_ARM_CORE | size_bits | (reg.offset / 4);
 }
 
-fn kvmIdForSysreg(encoding: u16) u64 {
+fn kvm_id_for_sysreg(encoding: u16) u64 {
     return KVM_REG_ARM64 | KVM_REG_SIZE_U64 | KVM_REG_ARM64_SYSREG | encoding;
 }
 
@@ -121,18 +121,18 @@ fn kvmIdForSysreg(encoding: u16) u64 {
 /// Look up the 16-bit op0/op1/CRn/CRm/op2 encoding for a sysreg name.
 /// Recognizes both the named table (from hv_sys_reg_t) and the
 /// generic `S<op0>_<op1>_C<CRn>_C<CRm>_<op2>` form.
-pub fn encodingForName(name: []const u8) ?u16 {
+pub fn encoding_for_name(name: []const u8) ?u16 {
     std.debug.assert(name.len > 0);
     for (sysreg_names.table) |e| {
         if (std.mem.eql(u8, e.name, name)) return e.encoding;
     }
     if (std.mem.startsWith(u8, name, "S")) {
-        return parseSynthName(name);
+        return parse_synth_name(name);
     }
     return null;
 }
 
-fn parseSynthName(name: []const u8) ?u16 {
+fn parse_synth_name(name: []const u8) ?u16 {
     // Format: S<op0>_<op1>_C<CRn>_C<CRm>_<op2>
     var it = std.mem.tokenizeScalar(u8, name, '_');
     const s_tok = it.next() orelse return null;
@@ -154,7 +154,7 @@ fn parseSynthName(name: []const u8) ?u16 {
 /// Inverse: encoding → name. Returns the table name if present, else
 /// the synthetic generic form. The returned slice for synth names
 /// points into `buf` (caller-owned).
-pub fn nameForEncoding(encoding: u16, buf: []u8) []const u8 {
+pub fn name_for_encoding(encoding: u16, buf: []u8) []const u8 {
     // Longest synthetic form is "S3_7_C15_C15_7" (14 bytes); the
     // bufPrint below relies on `buf` having room for it, which is
     // why its failure path can be `unreachable`.
@@ -187,7 +187,7 @@ const kvm_one_reg = extern struct {
     addr: u64,
 };
 
-fn kvmGet(vcpu_fd: c_int, id: u64, buf: []u8) !void {
+fn kvm_get(vcpu_fd: c_int, id: u64, buf: []u8) !void {
     // KVM writes the register width into `buf`; a zero-length target
     // is always a caller bug.
     std.debug.assert(buf.len > 0);
@@ -195,7 +195,7 @@ fn kvmGet(vcpu_fd: c_int, id: u64, buf: []u8) !void {
     if (C.ioctl(vcpu_fd, KVM_GET_ONE_REG, &r) < 0) return error.KvmGetOneRegFailed;
 }
 
-fn kvmSet(vcpu_fd: c_int, id: u64, buf: []const u8) !void {
+fn kvm_set(vcpu_fd: c_int, id: u64, buf: []const u8) !void {
     // KVM reads the register width from `buf`; a zero-length source
     // is always a caller bug.
     std.debug.assert(buf.len > 0);
@@ -228,7 +228,7 @@ const HV_REG_CPSR: u32 = 34; // canonical name "PSTATE"
 /// Dump every dumpable register from `vcpu_fd` into a fresh
 /// name-tagged VCPU payload. Skip-classified regs are omitted.
 /// Caller owns the returned bytes.
-pub fn dumpKvm(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
+pub fn dump_kvm(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
     if (builtin.os.tag != .linux) return error.WrongHost;
 
     var entries = std.ArrayList(snapshot.VcpuEntry).empty;
@@ -249,7 +249,7 @@ pub fn dumpKvm(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
         // Some core slots (e.g. SPSR_ABT/UND/IRQ/FIQ) aren't exposed
         // by every KVM version; treat ENOENT as "drop the entry"
         // rather than abort the whole dump.
-        kvmGet(vcpu_fd, kvmIdForCore(reg), buf) catch |err| {
+        kvm_get(vcpu_fd, kvm_id_for_core(reg), buf) catch |err| {
             if (err == error.KvmGetOneRegFailed) continue;
             return err;
         };
@@ -259,7 +259,7 @@ pub fn dumpKvm(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
     for (sysreg_names.table) |e| {
         if (sysreg_classify.classify(e.name) == .skip) continue;
         const buf = try a.alloc(u8, 8);
-        kvmGet(vcpu_fd, kvmIdForSysreg(e.encoding), buf) catch |err| {
+        kvm_get(vcpu_fd, kvm_id_for_sysreg(e.encoding), buf) catch |err| {
             // KVM may not expose every reg Apple's enum lists (e.g.
             // SME on hosts without it). That's fine; drop the entry.
             if (err == error.KvmGetOneRegFailed) continue;
@@ -268,7 +268,7 @@ pub fn dumpKvm(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
         try entries.append(allocator, .{ .name = e.name, .value = buf });
     }
 
-    const out = try snapshot.encodeVcpuPayload(allocator, entries.items);
+    const out = try snapshot.encode_vcpu_payload(allocator, entries.items);
     // The codec always emits at least the entry_count header word.
     std.debug.assert(out.len >= 4);
     return out;
@@ -422,7 +422,7 @@ comptime {
     std.debug.assert(@sizeOf(X86Msrs) == 8 + x86_msr_capacity * 16);
 }
 
-fn appendOwnedBytes(
+fn append_owned_bytes(
     outer: std.mem.Allocator,
     arena: std.mem.Allocator,
     entries: *std.ArrayList(snapshot.VcpuEntry),
@@ -433,7 +433,7 @@ fn appendOwnedBytes(
     try entries.append(outer, .{ .name = name, .value = dup });
 }
 
-fn appendX86Struct(
+fn append_x86_struct(
     comptime T: type,
     outer: std.mem.Allocator,
     arena: std.mem.Allocator,
@@ -444,10 +444,10 @@ fn appendX86Struct(
 ) !void {
     var value: T = undefined;
     if (C.ioctl(vcpu_fd, request, &value) != 0) return error.KvmGetX86StateFailed;
-    try appendOwnedBytes(outer, arena, entries, name, std.mem.asBytes(&value));
+    try append_owned_bytes(outer, arena, entries, name, std.mem.asBytes(&value));
 }
 
-fn appendX86StructOptional(
+fn append_x86_struct_optional(
     comptime T: type,
     outer: std.mem.Allocator,
     arena: std.mem.Allocator,
@@ -456,13 +456,13 @@ fn appendX86StructOptional(
     request: c_ulong,
     name: []const u8,
 ) !void {
-    appendX86Struct(T, outer, arena, entries, vcpu_fd, request, name) catch |err| {
+    append_x86_struct(T, outer, arena, entries, vcpu_fd, request, name) catch |err| {
         if (err == error.KvmGetX86StateFailed) return;
         return err;
     };
 }
 
-fn appendX86Msrs(
+fn append_x86_msrs(
     outer: std.mem.Allocator,
     arena: std.mem.Allocator,
     entries: *std.ArrayList(snapshot.VcpuEntry),
@@ -474,14 +474,14 @@ fn appendX86Msrs(
     if (rc < 0) return;
     msrs.nmsrs = @intCast(rc);
     const byte_len: usize = 8 + @as(usize, @intCast(rc)) * @sizeOf(X86MsrEntry);
-    try appendOwnedBytes(outer, arena, entries, "X86_MSRS", std.mem.asBytes(&msrs)[0..byte_len]);
+    try append_owned_bytes(outer, arena, entries, "X86_MSRS", std.mem.asBytes(&msrs)[0..byte_len]);
 }
 
 /// Dump an x86_64 KVM vCPU into the same name-tagged VCPU payload
 /// container used by arm64. Values whose KVM capabilities are optional
 /// (debug regs, XSAVE/XCRS, some MSRs) are omitted if the host rejects
 /// the ioctl; core execution state is required.
-pub fn dumpKvmX86(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
+pub fn dump_kvm_x86(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
     if (builtin.os.tag != .linux) return error.WrongHost;
 
     var entries = std.ArrayList(snapshot.VcpuEntry).empty;
@@ -491,35 +491,35 @@ pub fn dumpKvmX86(allocator: std.mem.Allocator, vcpu_fd: c_int) ![]u8 {
     defer arena.deinit();
     const a = arena.allocator();
 
-    try appendX86Struct(X86Sregs, allocator, a, &entries, vcpu_fd, KVM_GET_SREGS_X86, "X86_SREGS");
-    try appendX86Struct(X86Regs, allocator, a, &entries, vcpu_fd, KVM_GET_REGS_X86, "X86_REGS");
-    try appendX86Struct(X86Fpu, allocator, a, &entries, vcpu_fd, KVM_GET_FPU_X86, "X86_FPU");
-    try appendX86Struct(X86LapicState, allocator, a, &entries, vcpu_fd, KVM_GET_LAPIC_X86, "X86_LAPIC");
-    try appendX86Struct(X86MpState, allocator, a, &entries, vcpu_fd, KVM_GET_MP_STATE_X86, "X86_MP_STATE");
-    try appendX86Struct(X86VcpuEvents, allocator, a, &entries, vcpu_fd, KVM_GET_VCPU_EVENTS_X86, "X86_VCPU_EVENTS");
-    try appendX86Msrs(allocator, a, &entries, vcpu_fd);
-    try appendX86StructOptional(X86DebugRegs, allocator, a, &entries, vcpu_fd, KVM_GET_DEBUGREGS_X86, "X86_DEBUGREGS");
-    try appendX86StructOptional(X86Xcrs, allocator, a, &entries, vcpu_fd, KVM_GET_XCRS_X86, "X86_XCRS");
-    try appendX86StructOptional(X86Xsave, allocator, a, &entries, vcpu_fd, KVM_GET_XSAVE_X86, "X86_XSAVE");
+    try append_x86_struct(X86Sregs, allocator, a, &entries, vcpu_fd, KVM_GET_SREGS_X86, "X86_SREGS");
+    try append_x86_struct(X86Regs, allocator, a, &entries, vcpu_fd, KVM_GET_REGS_X86, "X86_REGS");
+    try append_x86_struct(X86Fpu, allocator, a, &entries, vcpu_fd, KVM_GET_FPU_X86, "X86_FPU");
+    try append_x86_struct(X86LapicState, allocator, a, &entries, vcpu_fd, KVM_GET_LAPIC_X86, "X86_LAPIC");
+    try append_x86_struct(X86MpState, allocator, a, &entries, vcpu_fd, KVM_GET_MP_STATE_X86, "X86_MP_STATE");
+    try append_x86_struct(X86VcpuEvents, allocator, a, &entries, vcpu_fd, KVM_GET_VCPU_EVENTS_X86, "X86_VCPU_EVENTS");
+    try append_x86_msrs(allocator, a, &entries, vcpu_fd);
+    try append_x86_struct_optional(X86DebugRegs, allocator, a, &entries, vcpu_fd, KVM_GET_DEBUGREGS_X86, "X86_DEBUGREGS");
+    try append_x86_struct_optional(X86Xcrs, allocator, a, &entries, vcpu_fd, KVM_GET_XCRS_X86, "X86_XCRS");
+    try append_x86_struct_optional(X86Xsave, allocator, a, &entries, vcpu_fd, KVM_GET_XSAVE_X86, "X86_XSAVE");
 
-    return try snapshot.encodeVcpuPayload(allocator, entries.items);
+    return try snapshot.encode_vcpu_payload(allocator, entries.items);
 }
 
-fn findEntry(entries: []const snapshot.VcpuEntry, name: []const u8) ?[]const u8 {
+fn find_entry(entries: []const snapshot.VcpuEntry, name: []const u8) ?[]const u8 {
     for (entries) |e| {
         if (std.mem.eql(u8, e.name, name)) return e.value;
     }
     return null;
 }
 
-fn setX86Bytes(vcpu_fd: c_int, request: c_ulong, value: []const u8, comptime T: type) !void {
+fn set_x86_bytes(vcpu_fd: c_int, request: c_ulong, value: []const u8, comptime T: type) !void {
     if (value.len != @sizeOf(T)) return error.BadX86State;
     var tmp: T = undefined;
     @memcpy(std.mem.asBytes(&tmp), value);
     if (C.ioctl(vcpu_fd, request, &tmp) != 0) return error.KvmSetX86StateFailed;
 }
 
-fn setX86Msrs(vcpu_fd: c_int, value: []const u8) !void {
+fn set_x86_msrs(vcpu_fd: c_int, value: []const u8) !void {
     if (value.len < 8) return error.BadX86State;
     const n = std.mem.readInt(u32, value[0..4], .little);
     if (n > x86_msr_capacity) return error.BadX86State;
@@ -531,7 +531,7 @@ fn setX86Msrs(vcpu_fd: c_int, value: []const u8) !void {
     if (rc < 0 or @as(u32, @intCast(rc)) != n) return error.KvmSetX86StateFailed;
 }
 
-fn setIfPresent(
+fn set_if_present(
     entries: []const snapshot.VcpuEntry,
     vcpu_fd: c_int,
     name: []const u8,
@@ -540,8 +540,8 @@ fn setIfPresent(
     applied: *usize,
     failed: *usize,
 ) void {
-    if (findEntry(entries, name)) |value| {
-        setX86Bytes(vcpu_fd, request, value, T) catch {
+    if (find_entry(entries, name)) |value| {
+        set_x86_bytes(vcpu_fd, request, value, T) catch {
             failed.* += 1;
             return;
         };
@@ -551,32 +551,32 @@ fn setIfPresent(
 
 /// Load an x86_64 KVM vCPU payload produced by dumpKvmX86. Unknown
 /// entries are ignored so future snapshots can carry more state.
-pub fn loadKvmX86(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8) !void {
+pub fn load_kvm_x86(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8) !void {
     if (builtin.os.tag != .linux) return error.WrongHost;
-    const entries = try snapshot.decodeVcpuPayload(allocator, payload);
+    const entries = try snapshot.decode_vcpu_payload(allocator, payload);
     defer allocator.free(entries);
 
     var applied: usize = 0;
     var failed: usize = 0;
-    setIfPresent(entries, vcpu_fd, "X86_SREGS", KVM_SET_SREGS_X86, X86Sregs, &applied, &failed);
-    if (findEntry(entries, "X86_MSRS")) |value| {
-        setX86Msrs(vcpu_fd, value) catch {
+    set_if_present(entries, vcpu_fd, "X86_SREGS", KVM_SET_SREGS_X86, X86Sregs, &applied, &failed);
+    if (find_entry(entries, "X86_MSRS")) |value| {
+        set_x86_msrs(vcpu_fd, value) catch {
             failed += 1;
             return error.KvmSetX86StateFailed;
         };
         applied += 1;
     }
-    setIfPresent(entries, vcpu_fd, "X86_FPU", KVM_SET_FPU_X86, X86Fpu, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_XCRS", KVM_SET_XCRS_X86, X86Xcrs, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_XSAVE", KVM_SET_XSAVE_X86, X86Xsave, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_LAPIC", KVM_SET_LAPIC_X86, X86LapicState, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_MP_STATE", KVM_SET_MP_STATE_X86, X86MpState, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_VCPU_EVENTS", KVM_SET_VCPU_EVENTS_X86, X86VcpuEvents, &applied, &failed);
-    setIfPresent(entries, vcpu_fd, "X86_DEBUGREGS", KVM_SET_DEBUGREGS_X86, X86DebugRegs, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_FPU", KVM_SET_FPU_X86, X86Fpu, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_XCRS", KVM_SET_XCRS_X86, X86Xcrs, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_XSAVE", KVM_SET_XSAVE_X86, X86Xsave, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_LAPIC", KVM_SET_LAPIC_X86, X86LapicState, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_MP_STATE", KVM_SET_MP_STATE_X86, X86MpState, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_VCPU_EVENTS", KVM_SET_VCPU_EVENTS_X86, X86VcpuEvents, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_DEBUGREGS", KVM_SET_DEBUGREGS_X86, X86DebugRegs, &applied, &failed);
     // General-purpose regs last: if RIP/RSP resume immediately after
     // KVM_RUN, the descriptor tables, MSRs, xstate, LAPIC, and pending
     // event window have already been installed.
-    setIfPresent(entries, vcpu_fd, "X86_REGS", KVM_SET_REGS_X86, X86Regs, &applied, &failed);
+    set_if_present(entries, vcpu_fd, "X86_REGS", KVM_SET_REGS_X86, X86Regs, &applied, &failed);
 
     std.debug.print(
         "vcpu_dump.loadKvmX86: {d} applied, {d} failed ({d} entries)\n",
@@ -587,7 +587,7 @@ pub fn loadKvmX86(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const
 
 // -- HVF dump / load ----------------------------------------------
 
-pub fn dumpHvf(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
+pub fn dump_hvf(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
     if (builtin.os.tag != .macos) return error.WrongHost;
 
     var entries = std.ArrayList(snapshot.VcpuEntry).empty;
@@ -640,22 +640,22 @@ pub fn dumpHvf(allocator: std.mem.Allocator, vcpu_handle: u64) ![]u8 {
         try entries.append(allocator, .{ .name = e.name, .value = buf });
     }
 
-    const out = try snapshot.encodeVcpuPayload(allocator, entries.items);
+    const out = try snapshot.encode_vcpu_payload(allocator, entries.items);
     // The codec always emits at least the entry_count header word.
     std.debug.assert(out.len >= 4);
     return out;
 }
 
-pub fn loadHvf(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
+pub fn load_hvf(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const u8) !void {
     if (builtin.os.tag != .macos) return error.WrongHost;
-    const entries = try snapshot.decodeVcpuPayload(allocator, payload);
+    const entries = try snapshot.decode_vcpu_payload(allocator, payload);
     defer allocator.free(entries);
 
     for (entries) |e| {
         // X<n>?
         if (e.name.len >= 2 and e.name[0] == 'X') {
             const idx = std.fmt.parseInt(u32, e.name[1..], 10) catch {
-                applyHvfNamed(vcpu_handle, e) catch {};
+                apply_hvf_named(vcpu_handle, e) catch {};
                 continue;
             };
             if (idx > 30) continue;
@@ -667,7 +667,7 @@ pub fn loadHvf(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const 
         // V<n>?
         if (e.name.len >= 2 and e.name[0] == 'V') {
             const idx = std.fmt.parseInt(u32, e.name[1..], 10) catch {
-                applyHvfNamed(vcpu_handle, e) catch {};
+                apply_hvf_named(vcpu_handle, e) catch {};
                 continue;
             };
             if (idx > 31) continue;
@@ -676,11 +676,11 @@ pub fn loadHvf(allocator: std.mem.Allocator, vcpu_handle: u64, payload: []const 
             _ = hvf_extern.hv_vcpu_set_simd_fp_reg(vcpu_handle, idx, v);
             continue;
         }
-        applyHvfNamed(vcpu_handle, e) catch {};
+        apply_hvf_named(vcpu_handle, e) catch {};
     }
 }
 
-fn applyHvfNamed(vcpu_handle: u64, e: snapshot.VcpuEntry) !void {
+fn apply_hvf_named(vcpu_handle: u64, e: snapshot.VcpuEntry) !void {
     if (std.mem.eql(u8, e.name, "PC")) {
         if (e.value.len != 8) return;
         const v = std.mem.readInt(u64, e.value[0..8], .little);
@@ -697,7 +697,7 @@ fn applyHvfNamed(vcpu_handle: u64, e: snapshot.VcpuEntry) !void {
         if (e.value.len != 4) return;
         const v = @as(u64, std.mem.readInt(u32, e.value[0..4], .little));
         _ = hvf_extern.hv_vcpu_set_reg(vcpu_handle, HV_REG_FPSR, v);
-    } else if (encodingForName(e.name)) |enc| {
+    } else if (encoding_for_name(e.name)) |enc| {
         if (e.value.len != 8) return;
         const v = std.mem.readInt(u64, e.value[0..8], .little);
         _ = hvf_extern.hv_vcpu_set_sys_reg(vcpu_handle, enc, v);
@@ -707,9 +707,9 @@ fn applyHvfNamed(vcpu_handle: u64, e: snapshot.VcpuEntry) !void {
 /// Load every reg in `payload` into `vcpu_fd`. Unknown names are
 /// silently dropped (a future dump format may carry more regs than
 /// the current load path understands; that's not an error).
-pub fn loadKvm(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8) !void {
+pub fn load_kvm(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8) !void {
     if (builtin.os.tag != .linux) return error.WrongHost;
-    const entries = try snapshot.decodeVcpuPayload(allocator, payload);
+    const entries = try snapshot.decode_vcpu_payload(allocator, payload);
     defer allocator.free(entries);
 
     // Restore diagnostics — a high `failed` count, and especially
@@ -731,15 +731,15 @@ pub fn loadKvm(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8
         for (core_regs) |c| {
             if (std.mem.eql(u8, c.name, e.name)) {
                 handled = true;
-                ok = if (kvmSet(vcpu_fd, kvmIdForCore(c), e.value)) true else |_| false;
+                ok = if (kvm_set(vcpu_fd, kvm_id_for_core(c), e.value)) true else |_| false;
                 break;
             }
         }
         if (!handled) {
             // Else sysreg by name.
-            if (encodingForName(e.name)) |enc| {
+            if (encoding_for_name(e.name)) |enc| {
                 handled = true;
-                ok = if (kvmSet(vcpu_fd, kvmIdForSysreg(enc), e.value)) true else |_| false;
+                ok = if (kvm_set(vcpu_fd, kvm_id_for_sysreg(enc), e.value)) true else |_| false;
             }
         }
         if (!handled) {
@@ -766,28 +766,28 @@ pub fn loadKvm(allocator: std.mem.Allocator, vcpu_fd: c_int, payload: []const u8
 // -- tests --------------------------------------------------------
 
 test "encodingForName resolves known names" {
-    try std.testing.expectEqual(@as(?u16, 0x8012), encodingForName("MDSCR_EL1"));
-    try std.testing.expectEqual(@as(?u16, 0xc080), encodingForName("SCTLR_EL1"));
+    try std.testing.expectEqual(@as(?u16, 0x8012), encoding_for_name("MDSCR_EL1"));
+    try std.testing.expectEqual(@as(?u16, 0xc080), encoding_for_name("SCTLR_EL1"));
 }
 
 test "encodingForName parses synthetic names" {
     // S3_0_C0_C0_6 = (3<<14)|(0<<11)|(0<<7)|(0<<3)|6 = 0xC006
-    try std.testing.expectEqual(@as(?u16, 0xC006), encodingForName("S3_0_C0_C0_6"));
+    try std.testing.expectEqual(@as(?u16, 0xC006), encoding_for_name("S3_0_C0_C0_6"));
     // S2_4_C0_C7_0 = (2<<14)|(4<<11)|(0<<7)|(7<<3)|0 = 0xA038
-    try std.testing.expectEqual(@as(?u16, 0xA038), encodingForName("S2_4_C0_C7_0"));
+    try std.testing.expectEqual(@as(?u16, 0xA038), encoding_for_name("S2_4_C0_C7_0"));
 }
 
 test "encodingForName rejects malformed synthetic names" {
-    try std.testing.expectEqual(@as(?u16, null), encodingForName("S5_0_C0_C0_0")); // op0 > 3
-    try std.testing.expectEqual(@as(?u16, null), encodingForName("S3_X_C0_C0_0")); // bad int
-    try std.testing.expectEqual(@as(?u16, null), encodingForName("noprefix"));
+    try std.testing.expectEqual(@as(?u16, null), encoding_for_name("S5_0_C0_C0_0")); // op0 > 3
+    try std.testing.expectEqual(@as(?u16, null), encoding_for_name("S3_X_C0_C0_0")); // bad int
+    try std.testing.expectEqual(@as(?u16, null), encoding_for_name("noprefix"));
 }
 
 test "nameForEncoding round-trips" {
     var buf: [32]u8 = undefined;
-    try std.testing.expectEqualStrings("MDSCR_EL1", nameForEncoding(0x8012, &buf));
-    try std.testing.expectEqualStrings("SCTLR_EL1", nameForEncoding(0xc080, &buf));
-    try std.testing.expectEqualStrings("S3_0_C0_C0_6", nameForEncoding(0xc006, &buf));
+    try std.testing.expectEqualStrings("MDSCR_EL1", name_for_encoding(0x8012, &buf));
+    try std.testing.expectEqualStrings("SCTLR_EL1", name_for_encoding(0xc080, &buf));
+    try std.testing.expectEqualStrings("S3_0_C0_C0_6", name_for_encoding(0xc006, &buf));
 }
 
 test "core reg generation produces the right set" {
@@ -811,17 +811,17 @@ test "core reg generation produces the right set" {
 
 test "kvmIdForCore matches known constants" {
     // X0: KVM_REG_ARM64 | ARM_CORE | SIZE_U64 | (0/4) = 0x6030_0000_0010_0000
-    const x0 = kvmIdForCore(core_regs[0]);
+    const x0 = kvm_id_for_core(core_regs[0]);
     try std.testing.expectEqual(@as(u64, 0x6030_0000_0010_0000), x0);
     // PC is index 31 (31 X regs, then PC).
     try std.testing.expectEqualStrings("PC", core_regs[31].name);
-    const pc = kvmIdForCore(core_regs[31]);
+    const pc = kvm_id_for_core(core_regs[31]);
     try std.testing.expectEqual(@as(u64, 0x6030_0000_0010_0040), pc);
 }
 
 test "kvmIdForSysreg matches expected layout" {
     // PMCR_EL0 encoding 0xdce0: id = 0x6030_0000_0013_dce0
-    const id = kvmIdForSysreg(0xdce0);
+    const id = kvm_id_for_sysreg(0xdce0);
     try std.testing.expectEqual(@as(u64, 0x6030_0000_0013_dce0), id);
 }
 
@@ -841,7 +841,7 @@ test "dump/load round-trip on HVF" {
     _ = hvf_extern.hv_vcpu_set_reg(vcpu_a.handle, HV_REG_X0, 0xDEAD_BEEF_CAFE_BABE);
     _ = hvf_extern.hv_vcpu_set_reg(vcpu_a.handle, HV_REG_PC, 0x4000_0000);
     _ = hvf_extern.hv_vcpu_set_reg(vcpu_a.handle, HV_REG_CPSR, 0x3C5);
-    const dump_a = try dumpHvf(a, vcpu_a.handle);
+    const dump_a = try dump_hvf(a, vcpu_a.handle);
     defer a.free(dump_a);
     vcpu_a.destroy();
     vm_a.destroy();
@@ -851,14 +851,14 @@ test "dump/load round-trip on HVF" {
     defer vm_b.destroy();
     var vcpu_b = try hvf.Vcpu.create();
     defer vcpu_b.destroy();
-    try loadHvf(a, vcpu_b.handle, dump_a);
-    const dump_b = try dumpHvf(a, vcpu_b.handle);
+    try load_hvf(a, vcpu_b.handle, dump_a);
+    const dump_b = try dump_hvf(a, vcpu_b.handle);
     defer a.free(dump_b);
 
     // Compare under classification.
-    const entries_a = try snapshot.decodeVcpuPayload(a, dump_a);
+    const entries_a = try snapshot.decode_vcpu_payload(a, dump_a);
     defer a.free(entries_a);
-    const entries_b = try snapshot.decodeVcpuPayload(a, dump_b);
+    const entries_b = try snapshot.decode_vcpu_payload(a, dump_b);
     defer a.free(entries_b);
 
     var b_index = std.StringHashMap([]const u8).init(a);
@@ -900,7 +900,7 @@ test "dump/load round-trip on KVM" {
     // target. Returns vcpu_fd via the kvm.Vcpu wrapper.
     const makeVcpu = struct {
         fn run(k_: *kvm.Kvm) !struct { vm: kvm.Vm, vcpu: kvm.Vcpu } {
-            var vm = try k_.createVm();
+            var vm = try k_.create_vm();
             errdefer vm.destroy();
             var pref: kvm.VcpuInit = std.mem.zeroes(kvm.VcpuInit);
             const c = struct {
@@ -909,7 +909,7 @@ test "dump/load round-trip on KVM" {
             const PREF_TARGET: c_ulong = (2 << 30) | (@sizeOf(kvm.VcpuInit) << 16) |
                 (@as(c_ulong, 0xae) << 8) | 0xaf;
             if (c.ioctl(vm.fd, PREF_TARGET, &pref) < 0) return error.PreferredTargetFailed;
-            var vcpu = try vm.createVcpu(0);
+            var vcpu = try vm.create_vcpu(0);
             errdefer vcpu.destroy();
             try vcpu.init(pref);
             return .{ .vm = vm, .vcpu = vcpu };
@@ -922,26 +922,26 @@ test "dump/load round-trip on KVM" {
     var pair_a = try makeVcpu(&k);
     defer pair_a.vcpu.destroy();
     defer pair_a.vm.destroy();
-    try pair_a.vcpu.setReg(kvmIdForCore(core_regs[0]), 0xDEAD_BEEF_CAFE_BABE); // X0
-    try pair_a.vcpu.setReg(kvmIdForCore(core_regs[31]), 0x4000_0000); // PC
-    try pair_a.vcpu.setReg(kvmIdForCore(core_regs[32]), 0x3C5); // PSTATE
-    const dump_a = try dumpKvm(a, pair_a.vcpu.fd);
+    try pair_a.vcpu.set_reg(kvm_id_for_core(core_regs[0]), 0xDEAD_BEEF_CAFE_BABE); // X0
+    try pair_a.vcpu.set_reg(kvm_id_for_core(core_regs[31]), 0x4000_0000); // PC
+    try pair_a.vcpu.set_reg(kvm_id_for_core(core_regs[32]), 0x3C5); // PSTATE
+    const dump_a = try dump_kvm(a, pair_a.vcpu.fd);
     defer a.free(dump_a);
 
     // Second vCPU: fresh init, load dump_a, then dump again.
     var pair_b = try makeVcpu(&k);
     defer pair_b.vcpu.destroy();
     defer pair_b.vm.destroy();
-    try loadKvm(a, pair_b.vcpu.fd, dump_a);
-    const dump_b = try dumpKvm(a, pair_b.vcpu.fd);
+    try load_kvm(a, pair_b.vcpu.fd, dump_a);
+    const dump_b = try dump_kvm(a, pair_b.vcpu.fd);
     defer a.free(dump_b);
 
     // Compare under the classification: entries that classify as
     // .mask may differ (PMU counters, debug regs); .skip never
     // appears in either dump; .portable / .translate must match.
-    const entries_a = try snapshot.decodeVcpuPayload(a, dump_a);
+    const entries_a = try snapshot.decode_vcpu_payload(a, dump_a);
     defer a.free(entries_a);
-    const entries_b = try snapshot.decodeVcpuPayload(a, dump_b);
+    const entries_b = try snapshot.decode_vcpu_payload(a, dump_b);
     defer a.free(entries_b);
 
     // Build a name -> value lookup for b.
@@ -1007,7 +1007,7 @@ test "single-host HVF RT (vCPU + RAM, no execution)" {
     _ = hvf_extern.hv_vcpu_set_reg(vcpu_a.handle, HV_REG_X0, 0xCAFE_F00D_1234_5678);
     _ = hvf_extern.hv_vcpu_set_reg(vcpu_a.handle, HV_REG_X0 + 1, 0x0001_0002_0003_0004);
 
-    const cpu_payload = try dumpHvf(a, vcpu_a.handle);
+    const cpu_payload = try dump_hvf(a, vcpu_a.handle);
     defer a.free(cpu_payload);
     const ram_payload = try ram_dump.encode(a, RAM_BASE, ram_a);
     defer a.free(ram_payload);
@@ -1034,8 +1034,8 @@ test "single-host HVF RT (vCPU + RAM, no execution)" {
     const ram_b: []align(hvf.page_size) u8 = @alignCast(ram_b_raw);
     @memset(ram_b, 0);
 
-    try loadHvf(a, vcpu_b.handle, cpu_payload);
-    _ = try ram_dump.decodeInto(ram_payload, ram_b);
+    try load_hvf(a, vcpu_b.handle, cpu_payload);
+    _ = try ram_dump.decode_into(ram_payload, ram_b);
     try vm_b.map(ram_b, RAM_BASE, hvf.MapFlags.rwx);
     defer vm_b.unmap(RAM_BASE, RAM_LEN) catch {};
 
@@ -1068,7 +1068,7 @@ test "single-host KVM RT (vCPU + RAM, no execution)" {
 
     // Side A: VM + vCPU with known register values; RAM filled with a
     // pattern.
-    var vm_a = try k.createVm();
+    var vm_a = try k.create_vm();
     defer vm_a.destroy();
     var pref: kvm.VcpuInit = std.mem.zeroes(kvm.VcpuInit);
     const c = struct {
@@ -1077,27 +1077,27 @@ test "single-host KVM RT (vCPU + RAM, no execution)" {
     const PREF_TARGET: c_ulong = (2 << 30) | (@sizeOf(kvm.VcpuInit) << 16) |
         (@as(c_ulong, 0xae) << 8) | 0xaf;
     if (c.ioctl(vm_a.fd, PREF_TARGET, &pref) < 0) return error.PrefTargetFailed;
-    var vcpu_a = try vm_a.createVcpu(0);
+    var vcpu_a = try vm_a.create_vcpu(0);
     defer vcpu_a.destroy();
     try vcpu_a.init(pref);
 
-    try vcpu_a.setReg(kvmIdForCore(core_regs[0]), 0xCAFE_F00D_1234_5678);
-    try vcpu_a.setReg(kvmIdForCore(core_regs[1]), 0x0001_0002_0003_0004);
+    try vcpu_a.set_reg(kvm_id_for_core(core_regs[0]), 0xCAFE_F00D_1234_5678);
+    try vcpu_a.set_reg(kvm_id_for_core(core_regs[1]), 0x0001_0002_0003_0004);
 
     const ram_a = try a.alloc(u8, RAM_LEN);
     defer a.free(ram_a);
     for (ram_a, 0..) |*b, i| b.* = @intCast(i & 0xff);
 
-    const cpu_payload = try dumpKvm(a, vcpu_a.fd);
+    const cpu_payload = try dump_kvm(a, vcpu_a.fd);
     defer a.free(cpu_payload);
     const ram_payload = try ram_dump.encode(a, RAM_BASE, ram_a);
     defer a.free(ram_payload);
 
     // Side B: fresh VM + vCPU, fresh RAM (zeroed).
-    var vm_b = try k.createVm();
+    var vm_b = try k.create_vm();
     defer vm_b.destroy();
     if (c.ioctl(vm_b.fd, PREF_TARGET, &pref) < 0) return error.PrefTargetFailed;
-    var vcpu_b = try vm_b.createVcpu(0);
+    var vcpu_b = try vm_b.create_vcpu(0);
     defer vcpu_b.destroy();
     try vcpu_b.init(pref);
 
@@ -1105,15 +1105,15 @@ test "single-host KVM RT (vCPU + RAM, no execution)" {
     defer a.free(ram_b);
     @memset(ram_b, 0);
 
-    try loadKvm(a, vcpu_b.fd, cpu_payload);
-    const decoded = try ram_dump.decodeInto(ram_payload, ram_b);
+    try load_kvm(a, vcpu_b.fd, cpu_payload);
+    const decoded = try ram_dump.decode_into(ram_payload, ram_b);
     try std.testing.expectEqual(@as(u64, RAM_BASE), decoded.ram_base);
     try std.testing.expectEqual(@as(u64, RAM_LEN), decoded.ram_size);
 
     // Verify side B matches side A.
     try std.testing.expectEqualSlices(u8, ram_a, ram_b);
-    const x0 = try vcpu_b.getReg(kvmIdForCore(core_regs[0]));
+    const x0 = try vcpu_b.get_reg(kvm_id_for_core(core_regs[0]));
     try std.testing.expectEqual(@as(u64, 0xCAFE_F00D_1234_5678), x0);
-    const x1 = try vcpu_b.getReg(kvmIdForCore(core_regs[1]));
+    const x1 = try vcpu_b.get_reg(kvm_id_for_core(core_regs[1]));
     try std.testing.expectEqual(@as(u64, 0x0001_0002_0003_0004), x1);
 }

--- a/packages/microvm/src/virtio.zig
+++ b/packages/microvm/src/virtio.zig
@@ -235,7 +235,7 @@ pub const Device = struct {
             0x060 => @atomicLoad(u32, &self.interrupt_status, .acquire),
             0x070 => @as(u32, @bitCast(self.status)),
             0x0FC => self.config_generation,
-            0x100...0x1FF => self.readConfig(@intCast(off - 0x100)),
+            0x100...0x1FF => self.read_config(@intCast(off - 0x100)),
             else => 0,
         };
     }
@@ -295,7 +295,7 @@ pub const Device = struct {
         }
     }
 
-    fn readConfig(self: *const Device, off: usize) u64 {
+    fn read_config(self: *const Device, off: usize) u64 {
         // Caller in `read` masks 0x100..0x1FF and subtracts 0x100, so
         // off is bounded by the MMIO window — programmer error if not.
         assert(off < 0x100);
@@ -341,7 +341,7 @@ pub const Device = struct {
             // cadence (e.g. vsock RX: filled lazily by the host when
             // there's something to send to the guest).
             if ((self.skip_notify_queues >> @as(u5, @intCast(q_idx))) & 1 != 0) return;
-            const avail = self.readAvailHeader(q) orelse return;
+            const avail = self.read_avail_header(q) orelse return;
             // A well-formed driver can post at most q.num avail entries
             // before it must wait for used. A buggy driver that bumps
             // avail.idx past that bound would otherwise spin us; cap at
@@ -349,7 +349,7 @@ pub const Device = struct {
             // the boot run loop) catch up.
             var chains: u32 = 0;
             while (chains < q.num and q.last_avail_idx != avail.idx) : (chains += 1) {
-                const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return;
+                const head = self.read_avail_ring_entry(q, q.last_avail_idx) orelse return;
                 handler(self.request_ctx, self, q_idx, head);
                 q.last_avail_idx +%= 1;
             }
@@ -361,18 +361,18 @@ pub const Device = struct {
         // Net default: RX is driver-posts-empty-buffers (nothing to
         // drain); TX chains get emitted via tx_handler.
         if (q_idx == 0) return;
-        self.drainAvail(q);
+        self.drain_avail(q);
     }
 
     // --- Public helpers for external request handlers -------------
 
     /// Read one descriptor from `q_idx` at index `idx`. Returns null
     /// on out-of-range or missing ram.
-    pub fn queueDescriptor(self: *Device, q_idx: u32, idx: u16) ?VringDesc {
+    pub fn queue_descriptor(self: *Device, q_idx: u32, idx: u16) ?VringDesc {
         assert(self.size > 0);
         assert(self.queue_num_max > 0);
         if (q_idx >= max_queues) return null;
-        return self.readDescriptor(&self.queues[q_idx], idx);
+        return self.read_descriptor(&self.queues[q_idx], idx);
     }
 
     /// Mark a descriptor chain as processed. `head` is the head index
@@ -380,17 +380,17 @@ pub const Device = struct {
     /// device wrote into the chain (0 for read requests where we
     /// provided data, since the guest cares about the byte count of
     /// data written BY the device).
-    pub fn queuePushUsed(self: *Device, q_idx: u32, head: u16, len: u32) void {
+    pub fn queue_push_used(self: *Device, q_idx: u32, head: u16, len: u32) void {
         assert(self.size > 0);
         assert(self.queue_num_max > 0);
         if (q_idx >= max_queues) return;
-        self.pushUsed(&self.queues[q_idx], head, len);
+        self.push_used(&self.queues[q_idx], head, len);
     }
 
     /// Return a mutable slice of guest RAM starting at `addr`. Null
     /// if out of range or if the device wasn't wired with ram.
-    pub fn guestBytes(self: *Device, addr: u64, len: usize) ?[]u8 {
-        return self.guestSlice(addr, len);
+    pub fn guest_bytes(self: *Device, addr: u64, len: usize) ?[]u8 {
+        return self.guest_slice(addr, len);
     }
 
     /// Deliver `frame` (a complete ethernet frame — no virtio-net
@@ -402,7 +402,7 @@ pub const Device = struct {
     /// Returns true if the frame was delivered, false if the guest
     /// hasn't posted any receive buffers (drop). Call setSpi after
     /// this to match `interrupt_status`.
-    pub fn injectRx(self: *Device, frame: []const u8) bool {
+    pub fn inject_rx(self: *Device, frame: []const u8) bool {
         assert(self.size > 0);
         // Programmer error to inject an empty frame; jumbo > 16K is
         // larger than the TX scratch can ever produce, so the same
@@ -412,9 +412,9 @@ pub const Device = struct {
         const q = &self.queues[0]; // virtio-net: queue 0 is RX
         if (q.ready == 0 or q.num == 0) return false;
 
-        const avail = self.readAvailHeader(q) orelse return false;
+        const avail = self.read_avail_header(q) orelse return false;
         if (q.last_avail_idx == avail.idx) return false; // no buffers posted
-        const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return false;
+        const head = self.read_avail_ring_entry(q, q.last_avail_idx) orelse return false;
 
         // Build the payload: 12-byte header + frame bytes.
         const net_hdr = [_]u8{0} ** 12;
@@ -432,7 +432,7 @@ pub const Device = struct {
         // Truncating an over-long chain is fail-soft (we drop the frame
         // and the next inject will pick up a fresh head).
         while (steps < max_chain_descriptors) : (steps += 1) {
-            const desc = self.readDescriptor(q, idx) orelse return false;
+            const desc = self.read_descriptor(q, idx) orelse return false;
             // RX descriptors must be writable by the device.
             if ((desc.flags & VringDesc.F_WRITE) == 0) return false;
 
@@ -450,7 +450,7 @@ pub const Device = struct {
                 }
                 const chunk_bytes: u32 = @intCast(@min(@as(u64, budget), remaining.len));
                 assert(chunk_bytes > 0);
-                const dst = self.guestSlice(desc.addr + (desc.len - budget), chunk_bytes) orelse return false;
+                const dst = self.guest_slice(desc.addr + (desc.len - budget), chunk_bytes) orelse return false;
                 @memcpy(dst, remaining[0..chunk_bytes]);
                 remaining = remaining[chunk_bytes..];
                 budget -= chunk_bytes;
@@ -462,26 +462,26 @@ pub const Device = struct {
         }
         assert(steps <= max_chain_descriptors);
 
-        self.pushUsed(q, head, written);
+        self.push_used(q, head, written);
         q.last_avail_idx +%= 1;
         _ = @atomicRmw(u32, &self.interrupt_status, .Or, IRQ_USED_BUFFER, .release);
         _ = total_len;
         return true;
     }
 
-    fn drainAvail(self: *Device, q: *Queue) void {
+    fn drain_avail(self: *Device, q: *Queue) void {
         // Caller (notify) gates on these; assert them so a bad caller
         // doesn't quietly enter the loop body.
         assert(q.ready != 0);
         assert(q.num > 0);
-        const avail = self.readAvailHeader(q) orelse return;
+        const avail = self.read_avail_header(q) orelse return;
         // Bound matches the request_handler path in notify(): no driver
         // can post more than q.num avail entries before consuming used.
         var chains: u32 = 0;
         while (chains < q.num and q.last_avail_idx != avail.idx) : (chains += 1) {
-            const head = self.readAvailRingEntry(q, q.last_avail_idx) orelse return;
-            const total_len = self.walkAndEmit(q, head);
-            self.pushUsed(q, head, total_len);
+            const head = self.read_avail_ring_entry(q, q.last_avail_idx) orelse return;
+            const total_len = self.walk_and_emit(q, head);
+            self.push_used(q, head, total_len);
             q.last_avail_idx +%= 1;
         }
         assert(chains <= q.num);
@@ -497,7 +497,7 @@ pub const Device = struct {
     /// every packet when VIRTIO_F_VERSION_1 is negotiated. We strip
     /// it before calling the handler — the handler gets a bare
     /// ethernet frame, which is what any backend wants to forward.
-    fn walkAndEmit(self: *Device, q: *Queue, head: u16) u32 {
+    fn walk_and_emit(self: *Device, q: *Queue, head: u16) u32 {
         // Caller drains under notify, which has gated on q.num > 0.
         assert(q.num > 0);
         // Worst case: MTU 9000 + headers. 16 KiB is a comfortable cap.
@@ -511,10 +511,10 @@ pub const Device = struct {
         // `next` in a cycle truncates the frame instead of pinning the
         // VMM thread. Same fail-soft policy as injectRx / blk.zig.
         while (steps < max_chain_descriptors) : (steps += 1) {
-            const desc = self.readDescriptor(q, idx) orelse break;
+            const desc = self.read_descriptor(q, idx) orelse break;
             if (desc.len > 0 and written < scratch.len) {
                 const take_bytes: usize = @min(desc.len, scratch.len - written);
-                if (self.guestSlice(desc.addr, take_bytes)) |bytes| {
+                if (self.guest_slice(desc.addr, take_bytes)) |bytes| {
                     @memcpy(scratch[written..][0..take_bytes], bytes);
                     written += take_bytes;
                 }
@@ -535,7 +535,7 @@ pub const Device = struct {
     }
 
     /// Reads raw bytes from guest memory. `null` on out-of-range.
-    fn guestSlice(self: *Device, addr: u64, len: usize) ?[]u8 {
+    fn guest_slice(self: *Device, addr: u64, len: usize) ?[]u8 {
         const ram = self.ram orelse return null;
         if (addr < self.ram_base) return null;
         const off: u64 = addr - self.ram_base;
@@ -543,22 +543,22 @@ pub const Device = struct {
         return ram[@intCast(off)..][0..len];
     }
 
-    fn readDescriptor(self: *Device, q: *const Queue, idx: u16) ?VringDesc {
+    fn read_descriptor(self: *Device, q: *const Queue, idx: u16) ?VringDesc {
         if (idx >= q.num) return null;
         // Past the gate above: q.num > 0 (idx is a u16; idx >= 0 is
         // tautological, so reaching here implies q.num >= 1).
         assert(q.num > 0);
         const offset: u64 = q.desc_addr + @as(u64, idx) * @sizeOf(VringDesc);
-        const bytes = self.guestSlice(offset, @sizeOf(VringDesc)) orelse return null;
+        const bytes = self.guest_slice(offset, @sizeOf(VringDesc)) orelse return null;
         assert(bytes.len == @sizeOf(VringDesc));
         var d: VringDesc = undefined;
         @memcpy(std.mem.asBytes(&d), bytes);
         return d;
     }
 
-    pub fn readAvailHeader(self: *Device, q: *const Queue) ?VringAvail {
+    pub fn read_avail_header(self: *Device, q: *const Queue) ?VringAvail {
         assert(self.size > 0);
-        const bytes = self.guestSlice(q.driver_addr, @sizeOf(VringAvail)) orelse return null;
+        const bytes = self.guest_slice(q.driver_addr, @sizeOf(VringAvail)) orelse return null;
         assert(bytes.len == @sizeOf(VringAvail));
         // The driver's smp_wmb() pairs `ring[idx] = head` (release)
         // with the `avail.idx` bump. We must acquire-load `avail.idx`
@@ -576,22 +576,22 @@ pub const Device = struct {
         return .{ .flags = flags, .idx = idx };
     }
 
-    fn readAvailRingEntry(self: *Device, q: *const Queue, idx: u16) ?u16 {
+    fn read_avail_ring_entry(self: *Device, q: *const Queue, idx: u16) ?u16 {
         // mod by q.num below — caller (notify / injectRx) has gated.
         assert(q.num > 0);
         // avail.ring follows the 4-byte avail header.
         const slot: u32 = @as(u32, idx) % q.num;
         assert(slot < q.num);
         const offset: u64 = q.driver_addr + @sizeOf(VringAvail) + @as(u64, slot) * @sizeOf(u16);
-        const bytes = self.guestSlice(offset, @sizeOf(u16)) orelse return null;
+        const bytes = self.guest_slice(offset, @sizeOf(u16)) orelse return null;
         return std.mem.readInt(u16, bytes[0..2], .little);
     }
 
-    fn pushUsed(self: *Device, q: *Queue, id: u16, len: u32) void {
+    fn push_used(self: *Device, q: *Queue, id: u16, len: u32) void {
         // mod by q.num below — caller has already gated on this.
         assert(q.num > 0);
         // used header (4 bytes) + used.ring[num] of VringUsedElem (8 bytes each)
-        const used_bytes = self.guestSlice(q.device_addr, @sizeOf(VringUsed)) orelse return;
+        const used_bytes = self.guest_slice(q.device_addr, @sizeOf(VringUsed)) orelse return;
         assert(used_bytes.len == @sizeOf(VringUsed));
         var header: VringUsed = undefined;
         @memcpy(std.mem.asBytes(&header), used_bytes);
@@ -599,7 +599,7 @@ pub const Device = struct {
         assert(slot < q.num);
 
         const elem_off: u64 = q.device_addr + @sizeOf(VringUsed) + @as(u64, slot) * @sizeOf(VringUsedElem);
-        const elem_bytes = self.guestSlice(elem_off, @sizeOf(VringUsedElem)) orelse return;
+        const elem_bytes = self.guest_slice(elem_off, @sizeOf(VringUsedElem)) orelse return;
         assert(elem_bytes.len == @sizeOf(VringUsedElem));
         const elem = VringUsedElem{ .id = id, .len = len };
         @memcpy(elem_bytes, std.mem.asBytes(&elem));
@@ -713,7 +713,7 @@ test "virtio: DriverFeatures are written into the right half based on sel" {
 // it, kick the doorbell, and check that the used ring + interrupt
 // status reflect the work. No HVF, no real kernel.
 
-fn setupRing(ram: []u8, comptime num: u32) struct { q: Queue } {
+fn setup_ring(ram: []u8, comptime num: u32) struct { q: Queue } {
     _ = ram;
     // Lay out descriptor table, avail, used back-to-back starting at 0.
     const q = Queue{
@@ -735,7 +735,7 @@ test "virtio: notify acks a single-descriptor TX chain + raises IRQ" {
         .ram = &ram,
         .ram_base = 0, // our ram[0] is guest-phys 0 for this test
     };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[1] = r.q;
 
     // Descriptor 0: points at a 64-byte "packet" at offset 0x200 in ram.
@@ -770,7 +770,7 @@ test "virtio: notify follows F_NEXT chains and sums lengths" {
     const num = 8;
     var ram: [4096]u8 = @splat(0);
     var dev = Device{ .base = 0x0A00_0000, .id = .net, .ram = &ram, .ram_base = 0 };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[1] = r.q;
 
     // desc0 -> desc1 -> desc2 (end). Lengths 10 + 20 + 30 = 60.
@@ -799,7 +799,7 @@ test "virtio: notify on RX queue is a no-op (null backend)" {
     const num = 8;
     var ram: [4096]u8 = @splat(0);
     var dev = Device{ .base = 0x0A00_0000, .id = .net, .ram = &ram, .ram_base = 0 };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[0] = r.q;
 
     // Pretend there's an avail waiting.
@@ -826,7 +826,7 @@ test "virtio: InterruptACK clears the bits the driver wrote" {
 // static buffer we can inspect after notify().
 var tx_capture_buf: [256]u8 = @splat(0);
 var tx_capture_len: usize = 0;
-fn txCapture(_: ?*anyopaque, frame: []const u8) void {
+fn tx_capture(_: ?*anyopaque, frame: []const u8) void {
     const n = @min(frame.len, tx_capture_buf.len);
     @memcpy(tx_capture_buf[0..n], frame[0..n]);
     tx_capture_len = n;
@@ -841,7 +841,7 @@ test "virtio: injectRx copies the frame into a posted RX descriptor + raises IRQ
         .ram = &ram,
         .ram_base = 0,
     };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[0] = r.q; // RX queue
 
     // RX descriptor 0 points at a 128-byte guest buffer at 0x400 and
@@ -855,7 +855,7 @@ test "virtio: injectRx copies the frame into a posted RX descriptor + raises IRQ
     std.mem.writeInt(u16, ram[r.q.driver_addr + @sizeOf(VringAvail) ..][0..2], 0, .little);
 
     const frame = [_]u8{ 0x02, 0x00, 0x00, 0x00, 0x00, 0x42, 0x02, 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x08, 0x00, 0xAB, 0xCD };
-    try std.testing.expect(dev.injectRx(&frame));
+    try std.testing.expect(dev.inject_rx(&frame));
 
     // Guest buffer should now contain: 12 zero bytes (virtio-net header),
     // followed by our frame.
@@ -873,11 +873,11 @@ test "virtio: injectRx returns false when no RX buffers are posted" {
     const num = 4;
     var ram: [4096]u8 = @splat(0);
     var dev = Device{ .base = 0x0A00_0000, .id = .net, .ram = &ram, .ram_base = 0 };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[0] = r.q;
 
     // avail.idx stays at 0 -> no buffers posted yet.
-    try std.testing.expect(!dev.injectRx(&[_]u8{ 1, 2, 3, 4 }));
+    try std.testing.expect(!dev.inject_rx(&[_]u8{ 1, 2, 3, 4 }));
     try std.testing.expectEqual(@as(u32, 0), dev.interrupt_status);
 }
 
@@ -891,9 +891,9 @@ test "virtio: TX handler receives the ethernet frame with virtio-net header stri
         .id = .net,
         .ram = &ram,
         .ram_base = 0,
-        .tx_handler = &txCapture,
+        .tx_handler = &tx_capture,
     };
-    const r = setupRing(&ram, num);
+    const r = setup_ring(&ram, num);
     dev.queues[1] = r.q;
 
     // Plant a 12-byte virtio-net header + a tiny ethernet frame at 0x200.

--- a/packages/microvm/src/virtio_dump.zig
+++ b/packages/microvm/src/virtio_dump.zig
@@ -82,7 +82,7 @@ pub const Snapshot = struct {
     queues: []QueueState,
 };
 
-fn knownDevice(device: u32) bool {
+fn known_device(device: u32) bool {
     return device == DEVICE_NET or device == DEVICE_BLK or
         device == DEVICE_CONSOLE or device == DEVICE_BALLOON or
         device == DEVICE_VSOCK or device == DEVICE_VIRTIO_FS;
@@ -99,7 +99,7 @@ pub fn encode(
 ) ![]u8 {
     // Tiger-style: bounded queue count + recognized device id.
     std.debug.assert(queues.len <= std.math.maxInt(u32));
-    std.debug.assert(knownDevice(device));
+    std.debug.assert(known_device(device));
 
     const total = HEADER_SIZE + queues.len * QUEUE_ENTRY_SIZE;
     const out = try allocator.alloc(u8, total);
@@ -126,7 +126,7 @@ pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Snaps
     if (bytes.len < HEADER_SIZE) return error.Truncated;
     var hdr: Header = undefined;
     @memcpy(std.mem.asBytes(&hdr), bytes[0..HEADER_SIZE]);
-    if (!knownDevice(hdr.device)) return error.BadDevice;
+    if (!known_device(hdr.device)) return error.BadDevice;
 
     const needed = HEADER_SIZE + @as(usize, hdr.queue_count) * QUEUE_ENTRY_SIZE;
     if (needed != bytes.len) return error.Truncated;
@@ -153,7 +153,7 @@ pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) DecodeError!Snaps
 /// `virtio.max_queues` queues are captured (unused ones are zero —
 /// cheap, and keeps restore a straight index-for-index copy). Caller
 /// owns the returned bytes.
-pub fn dumpDevice(allocator: std.mem.Allocator, dev: *const virtio.Device) ![]u8 {
+pub fn dump_device(allocator: std.mem.Allocator, dev: *const virtio.Device) ![]u8 {
     var queues: [virtio.max_queues]QueueState = undefined;
     for (&queues, dev.queues) |*qs, q| {
         qs.* = .{
@@ -182,7 +182,7 @@ pub const ApplyError = DecodeError || error{DeviceMismatch};
 /// `virtio.Device`. The device must already exist with the same
 /// `id`, MMIO base, and `ram`/`ram_base` wiring — this only restores
 /// the driver-programmed transport state on top.
-pub fn applyDevice(allocator: std.mem.Allocator, dev: *virtio.Device, payload: []const u8) ApplyError!void {
+pub fn apply_device(allocator: std.mem.Allocator, dev: *virtio.Device, payload: []const u8) ApplyError!void {
     const snap = try decode(allocator, payload);
     defer allocator.free(snap.queues);
     if (snap.device != @intFromEnum(dev.id)) return error.DeviceMismatch;
@@ -243,11 +243,11 @@ test "dumpDevice/applyDevice round-trip a live device's transport state" {
     src.queues[0] = .{ .num = 256, .ready = 1, .desc_addr = 0x4010_0000, .driver_addr = 0x4010_1000, .device_addr = 0x4010_2000, .last_avail_idx = 42 };
     src.queues[1] = .{ .num = 256, .ready = 1, .desc_addr = 0x4011_0000, .driver_addr = 0x4011_1000, .device_addr = 0x4011_2000, .last_avail_idx = 9 };
 
-    const payload = try dumpDevice(a, &src);
+    const payload = try dump_device(a, &src);
     defer a.free(payload);
 
     var dst: virtio.Device = .{ .base = 0x0a00_0200, .id = .vsock };
-    try applyDevice(a, &dst, payload);
+    try apply_device(a, &dst, payload);
 
     try std.testing.expectEqual(src.driver_features, dst.driver_features);
     try std.testing.expectEqual(@as(u32, @bitCast(src.status)), @as(u32, @bitCast(dst.status)));
@@ -270,12 +270,12 @@ test "dumpDevice/applyDevice round-trip a virtio-fs device's transport state" {
     src.queues[0] = .{ .num = 256, .ready = 1, .desc_addr = 0x5000_0000, .driver_addr = 0x5000_1000, .device_addr = 0x5000_2000, .last_avail_idx = 3 };
     src.queues[1] = .{ .num = 256, .ready = 1, .desc_addr = 0x5001_0000, .driver_addr = 0x5001_1000, .device_addr = 0x5001_2000, .last_avail_idx = 71 };
 
-    const payload = try dumpDevice(a, &src);
+    const payload = try dump_device(a, &src);
     defer a.free(payload);
     try std.testing.expectEqual(DEVICE_VIRTIO_FS, std.mem.readInt(u32, payload[0..4], .little));
 
     var dst: virtio.Device = .{ .base = 0x0a00_0e00, .id = .virtio_fs };
-    try applyDevice(a, &dst, payload);
+    try apply_device(a, &dst, payload);
     try std.testing.expectEqual(src.driver_features, dst.driver_features);
     try std.testing.expectEqual(src.queue_sel, dst.queue_sel);
     try std.testing.expectEqual(src.queues[1].desc_addr, dst.queues[1].desc_addr);
@@ -285,8 +285,8 @@ test "dumpDevice/applyDevice round-trip a virtio-fs device's transport state" {
 test "applyDevice rejects a payload from a different device type" {
     const a = std.testing.allocator;
     var blk: virtio.Device = .{ .base = 0x0a00_0200, .id = .block };
-    const payload = try dumpDevice(a, &blk);
+    const payload = try dump_device(a, &blk);
     defer a.free(payload);
     var net: virtio.Device = .{ .base = 0x0a00_0000, .id = .net };
-    try std.testing.expectError(error.DeviceMismatch, applyDevice(a, &net, payload));
+    try std.testing.expectError(error.DeviceMismatch, apply_device(a, &net, payload));
 }

--- a/packages/microvm/src/virtiofs.zig
+++ b/packages/microvm/src/virtiofs.zig
@@ -132,7 +132,7 @@ pub const Device = struct {
 
     /// The config-space slice for `virtio.Device.config`. Stable for
     /// the backend's lifetime.
-    pub fn configBytes(self: *const Device) []const u8 {
+    pub fn config_bytes(self: *const Device) []const u8 {
         return std.mem.asBytes(&self.config);
     }
 
@@ -144,7 +144,7 @@ pub const Device = struct {
     /// address, or an allocator failure all end in a zero-length used
     /// entry rather than a wedged VMM. This matches `blk.zig`'s policy
     /// — guest-driven input is never trusted to be well-formed.
-    pub fn handleRequest(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
+    pub fn handle_request(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
         assert(ctx != null);
         const self: *Device = @ptrCast(@alignCast(ctx.?));
         assert(self.state.root_abs.len > 0);
@@ -166,14 +166,14 @@ pub const Device = struct {
         // is `MAX_CHAIN_DESCRIPTORS`, sized for virtio-fs's page-per-
         // descriptor large I/O (see the constant's doc comment).
         while (steps < MAX_CHAIN_DESCRIPTORS) : (steps += 1) {
-            const d = dev.queueDescriptor(q_idx, idx) orelse break;
+            const d = dev.queue_descriptor(q_idx, idx) orelse break;
             if ((d.flags & virtio.VringDesc.F_WRITE) != 0) {
                 if (writable_count < writable.len) {
                     writable[writable_count] = d;
                     writable_count += 1;
                 }
             } else if (d.len > 0) {
-                const src = dev.guestBytes(d.addr, d.len) orelse break;
+                const src = dev.guest_bytes(d.addr, d.len) orelse break;
                 const take: usize = @min(src.len, self.req_buf.len - req_len);
                 @memcpy(self.req_buf[req_len..][0..take], src[0..take]);
                 req_len += take;
@@ -189,7 +189,7 @@ pub const Device = struct {
         // `fuse.dispatch` asserts the precondition. Ack it and move on;
         // a well-formed guest never produces this.
         if (req_len < fuse.FUSE_IN_HEADER_SIZE) {
-            dev.queuePushUsed(q_idx, head, 0);
+            dev.queue_push_used(q_idx, head, 0);
             return;
         }
 
@@ -199,11 +199,11 @@ pub const Device = struct {
         // failure inside a handler — fail-soft ack, same as a malformed
         // chain.
         const reply_opt = fuse.dispatch(&self.state, self.req_buf[0..req_len]) catch {
-            dev.queuePushUsed(q_idx, head, 0);
+            dev.queue_push_used(q_idx, head, 0);
             return;
         };
         const reply = reply_opt orelse {
-            dev.queuePushUsed(q_idx, head, 0);
+            dev.queue_push_used(q_idx, head, 0);
             return;
         };
         defer self.state.gpa.free(reply);
@@ -216,14 +216,14 @@ pub const Device = struct {
         var off: usize = 0;
         for (writable[0..writable_count]) |wd| {
             if (off >= reply.len) break;
-            const dst = dev.guestBytes(wd.addr, wd.len) orelse break;
+            const dst = dev.guest_bytes(wd.addr, wd.len) orelse break;
             const n: usize = @min(dst.len, reply.len - off);
             @memcpy(dst[0..n], reply[off..][0..n]);
             off += n;
             written += @intCast(n);
         }
         assert(off <= reply.len);
-        dev.queuePushUsed(q_idx, head, written);
+        dev.queue_push_used(q_idx, head, written);
     }
 };
 
@@ -236,7 +236,7 @@ const testing = std.testing;
 
 /// Lay out a split-ring (descriptor table, avail, used) back-to-back
 /// at offset 0 of `ram`, returning the configured Queue.
-fn testSetupRing(comptime num: u32) virtio.Queue {
+fn test_setup_ring(comptime num: u32) virtio.Queue {
     return .{
         .num = num,
         .ready = 1,
@@ -247,19 +247,19 @@ fn testSetupRing(comptime num: u32) virtio.Queue {
 }
 
 /// Write descriptor `i` of the table at ram[0].
-fn testPutDesc(ram: []u8, i: usize, d: virtio.VringDesc) void {
+fn test_put_desc(ram: []u8, i: usize, d: virtio.VringDesc) void {
     @memcpy(ram[i * @sizeOf(virtio.VringDesc) ..][0..@sizeOf(virtio.VringDesc)], std.mem.asBytes(&d));
 }
 
 /// Post descriptor `head` on the avail ring (single chain, idx 0).
-fn testPostAvail(ram: []u8, q: virtio.Queue, head: u16) void {
+fn test_post_avail(ram: []u8, q: virtio.Queue, head: u16) void {
     const avail = virtio.VringAvail{ .flags = 0, .idx = 1 };
     @memcpy(ram[q.driver_addr..][0..@sizeOf(virtio.VringAvail)], std.mem.asBytes(&avail));
     std.mem.writeInt(u16, ram[q.driver_addr + @sizeOf(virtio.VringAvail) ..][0..2], head, .little);
 }
 
 /// Read the single used-ring entry the device posted.
-fn testReadUsed(ram: []u8, q: virtio.Queue) virtio.VringUsedElem {
+fn test_read_used(ram: []u8, q: virtio.Queue) virtio.VringUsedElem {
     var elem: virtio.VringUsedElem = undefined;
     const elem_off = q.device_addr + @sizeOf(virtio.VringUsed);
     @memcpy(std.mem.asBytes(&elem), ram[elem_off..][0..@sizeOf(virtio.VringUsedElem)]);
@@ -271,7 +271,7 @@ test "FsConfig carries the mount tag and one request queue" {
     var dev = try Device.init(gpa, "machinen0", try gpa.dupe(u8, "/test-root"), true);
     defer dev.deinit();
 
-    const bytes = dev.configBytes();
+    const bytes = dev.config_bytes();
     try testing.expectEqual(@as(usize, 40), bytes.len);
     try testing.expectEqualStrings("machinen0", bytes[0..9]);
     try testing.expectEqual(@as(u8, 0), bytes[9]); // NUL-padded past the tag
@@ -290,10 +290,10 @@ test "handleRequest: FUSE_INIT round-trips through the virtqueue" {
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(&fsdev),
     };
-    const q = testSetupRing(num);
+    const q = test_setup_ring(num);
     dev.queues[1] = q;
 
     // Build a FUSE_INIT request: 40-byte in-header + 16-byte init body.
@@ -310,15 +310,15 @@ test "handleRequest: FUSE_INIT round-trips through the virtqueue" {
 
     // Descriptor 0: readable request. Descriptor 1: writable reply
     // window (chained off 0).
-    testPutDesc(&ram, 0, .{ .addr = req_off, .len = req.len, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
-    testPutDesc(&ram, 1, .{ .addr = reply_off, .len = 256, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
-    testPostAvail(&ram, q, 0);
+    test_put_desc(&ram, 0, .{ .addr = req_off, .len = req.len, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
+    test_put_desc(&ram, 1, .{ .addr = reply_off, .len = 256, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
     // The used entry records how many bytes the device wrote: a FUSE
     // out-header (16) + the fuse_init_out payload (64) = 80.
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     try testing.expectEqual(@as(u32, 0), elem.id);
     try testing.expectEqual(@as(u32, fuse.FUSE_OUT_HEADER_SIZE + 64), elem.len);
 
@@ -344,10 +344,10 @@ test "handleRequest: unknown opcode replies ENOSYS without wedging" {
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(&fsdev),
     };
-    const q = testSetupRing(num);
+    const q = test_setup_ring(num);
     dev.queues[1] = q;
 
     const req_off: u64 = 0x800;
@@ -358,13 +358,13 @@ test "handleRequest: unknown opcode replies ENOSYS without wedging" {
     std.mem.writeInt(u64, req[8..16], 7, .little); // unique
     @memcpy(ram[req_off..][0..req.len], &req);
 
-    testPutDesc(&ram, 0, .{ .addr = req_off, .len = req.len, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
-    testPutDesc(&ram, 1, .{ .addr = reply_off, .len = 256, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
-    testPostAvail(&ram, q, 0);
+    test_put_desc(&ram, 0, .{ .addr = req_off, .len = req.len, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
+    test_put_desc(&ram, 1, .{ .addr = reply_off, .len = 256, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     try testing.expectEqual(@as(u32, fuse.FUSE_OUT_HEADER_SIZE), elem.len);
     const reply = ram[reply_off..][0..@as(usize, elem.len)];
     // -ENOSYS == -38 in the out-header's error field.
@@ -383,19 +383,19 @@ test "handleRequest: a short frame is acked, not dispatched" {
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(&fsdev),
     };
-    const q = testSetupRing(num);
+    const q = test_setup_ring(num);
     dev.queues[1] = q;
 
     // 8-byte readable descriptor — well under the 40-byte in-header.
-    testPutDesc(&ram, 0, .{ .addr = 0x800, .len = 8, .flags = 0, .next = 0 });
-    testPostAvail(&ram, q, 0);
+    test_put_desc(&ram, 0, .{ .addr = 0x800, .len = 8, .flags = 0, .next = 0 });
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     try testing.expectEqual(@as(u32, 0), elem.id);
     try testing.expectEqual(@as(u32, 0), elem.len);
 }
@@ -424,17 +424,17 @@ const TestReply = struct {
 /// Drive one FUSE request through `fsdev`'s virtqueue path and read the
 /// reply back. Builds a 2-descriptor chain (readable request → writable
 /// 4 KiB reply window), kicks the queue, and copies out the used entry.
-fn testRunOp(fsdev: *Device, opcode: u32, unique: u64, nodeid: u64, body: []const u8) TestReply {
+fn test_run_op(fsdev: *Device, opcode: u32, unique: u64, nodeid: u64, body: []const u8) TestReply {
     var ram: [16384]u8 = @splat(0);
     var dev = virtio.Device{
         .base = 0x0A00_0000,
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(fsdev),
     };
-    const q = testSetupRing(8);
+    const q = test_setup_ring(8);
     dev.queues[1] = q;
 
     const req_off: u64 = 0x1000;
@@ -446,13 +446,13 @@ fn testRunOp(fsdev: *Device, opcode: u32, unique: u64, nodeid: u64, body: []cons
     std.mem.writeInt(u64, ram[req_off + 16 ..][0..8], nodeid, .little);
     @memcpy(ram[req_off + fuse.FUSE_IN_HEADER_SIZE ..][0..body.len], body);
 
-    testPutDesc(&ram, 0, .{ .addr = req_off, .len = req_total, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
-    testPutDesc(&ram, 1, .{ .addr = reply_off, .len = 4096, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
-    testPostAvail(&ram, q, 0);
+    test_put_desc(&ram, 0, .{ .addr = req_off, .len = req_total, .flags = virtio.VringDesc.F_NEXT, .next = 1 });
+    test_put_desc(&ram, 1, .{ .addr = reply_off, .len = 4096, .flags = virtio.VringDesc.F_WRITE, .next = 0 });
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     var r = TestReply{ .used_len = elem.len };
     const n: usize = @min(elem.len, r.buf.len);
     @memcpy(r.buf[0..n], ram[reply_off..][0..n]);
@@ -463,7 +463,7 @@ fn testRunOp(fsdev: *Device, opcode: u32, unique: u64, nodeid: u64, body: []cons
 /// The #329 FUSE handlers need a real path to stat/open against.
 /// Heap-allocated with `gpa`; the caller hands it to `Device.init`,
 /// which takes ownership and frees it in `deinit`.
-fn testTmpRootAbs(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+fn test_tmp_root_abs(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
     const cwd = try std.process.currentPathAlloc(std.testing.io, gpa);
     defer gpa.free(cwd);
     return std.fs.path.join(gpa, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
@@ -473,7 +473,7 @@ test "handleRequest: CREATE materializes a file on the host fs" {
     const gpa = testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
     // fuse_create_in: flags(4) mode(4) umask(4) open_flags(4) + name.
@@ -482,7 +482,7 @@ test "handleRequest: CREATE materializes a file on the host fs" {
     std.mem.writeInt(u32, body[4..8], 0o644, .little); // mode
     @memcpy(body[16..][0.."created.txt".len], "created.txt");
 
-    const r = testRunOp(&fsdev, 35, 1, 1, &body); // CREATE, parent = root
+    const r = test_run_op(&fsdev, 35, 1, 1, &body); // CREATE, parent = root
     try testing.expectEqual(@as(i32, 0), r.err());
     // The handler ran against the real host fs — the file is there.
     try tmp.dir.access(std.testing.io, "created.txt", .{});
@@ -492,10 +492,10 @@ test "handleRequest: GETATTR on the root inode stats the host directory" {
     const gpa = testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const r = testRunOp(&fsdev, 3, 7, 1, &.{}); // GETATTR, nodeid = root
+    const r = test_run_op(&fsdev, 3, 7, 1, &.{}); // GETATTR, nodeid = root
     try testing.expectEqual(@as(i32, 0), r.err());
     // fuse_attr_out = attr_valid(8) + nsec(4) + dummy(4) + fuse_attr(88);
     // fuse_attr.mode sits 60 bytes into fuse_attr. Root is a directory.
@@ -508,30 +508,30 @@ test "handleRequest: O_WRONLY open of an existing file supports READ fill and WR
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "existing.txt", .data = "old-data" });
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const lookup = testRunOp(&fsdev, 1, 1, 1, "existing.txt\x00");
+    const lookup = test_run_op(&fsdev, 1, 1, 1, "existing.txt\x00");
     try testing.expectEqual(@as(i32, 0), lookup.err());
     const nodeid = std.mem.readInt(u64, lookup.payload()[0..8], .little);
 
     var open_body: [8]u8 = @splat(0);
     std.mem.writeInt(u32, open_body[0..4], 1 | 0o1000, .little); // O_WRONLY | O_TRUNC
-    const open = testRunOp(&fsdev, 14, 2, nodeid, &open_body);
+    const open = test_run_op(&fsdev, 14, 2, nodeid, &open_body);
     try testing.expectEqual(@as(i32, 0), open.err());
     const fh = std.mem.readInt(u64, open.payload()[0..8], .little);
 
     var read_body: [32]u8 = @splat(0);
     std.mem.writeInt(u64, read_body[0..8], fh, .little);
     std.mem.writeInt(u32, read_body[16..20], 16, .little);
-    const read = testRunOp(&fsdev, 15, 3, nodeid, &read_body);
+    const read = test_run_op(&fsdev, 15, 3, nodeid, &read_body);
     try testing.expectEqual(@as(i32, 0), read.err());
 
     var write_body: [40 + 3]u8 = @splat(0);
     std.mem.writeInt(u64, write_body[0..8], fh, .little);
     std.mem.writeInt(u32, write_body[16..20], 3, .little);
     @memcpy(write_body[40..], "new");
-    const write_reply = testRunOp(&fsdev, 16, 4, nodeid, &write_body);
+    const write_reply = test_run_op(&fsdev, 16, 4, nodeid, &write_body);
     try testing.expectEqual(@as(i32, 0), write_reply.err());
     try testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, write_reply.payload()[0..4], .little));
 
@@ -546,24 +546,24 @@ test "handleRequest: READLINK returns symlink targets and errors through virtio-
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "target.txt", .data = "target-data" });
     try tmp.dir.symLink(std.testing.io, "target.txt", "link.txt", .{});
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const lookup = testRunOp(&fsdev, 1, 1, 1, "link.txt\x00");
+    const lookup = test_run_op(&fsdev, 1, 1, 1, "link.txt\x00");
     try testing.expectEqual(@as(i32, 0), lookup.err());
     const link_nodeid = std.mem.readInt(u64, lookup.payload()[0..8], .little);
 
-    const readlink = testRunOp(&fsdev, 5, 2, link_nodeid, &.{});
+    const readlink = test_run_op(&fsdev, 5, 2, link_nodeid, &.{});
     try testing.expectEqual(@as(i32, 0), readlink.err());
     try testing.expectEqualStrings("target.txt", readlink.payload());
 
-    const regular_lookup = testRunOp(&fsdev, 1, 3, 1, "target.txt\x00");
+    const regular_lookup = test_run_op(&fsdev, 1, 3, 1, "target.txt\x00");
     try testing.expectEqual(@as(i32, 0), regular_lookup.err());
     const regular_nodeid = std.mem.readInt(u64, regular_lookup.payload()[0..8], .little);
-    const nonlink = testRunOp(&fsdev, 5, 4, regular_nodeid, &.{});
+    const nonlink = test_run_op(&fsdev, 5, 4, regular_nodeid, &.{});
     try testing.expectEqual(@as(i32, -22), nonlink.err()); // -EINVAL
 
-    const stale = testRunOp(&fsdev, 5, 5, 9999, &.{});
+    const stale = test_run_op(&fsdev, 5, 5, 9999, &.{});
     try testing.expectEqual(@as(i32, -116), stale.err()); // -ESTALE
 }
 
@@ -572,17 +572,17 @@ test "handleRequest: LINK creates hardlinks and maps :ro/malformed failures" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a.txt", .data = "hard" });
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const lookup = testRunOp(&fsdev, 1, 1, 1, "a.txt\x00");
+    const lookup = test_run_op(&fsdev, 1, 1, 1, "a.txt\x00");
     try testing.expectEqual(@as(i32, 0), lookup.err());
     const oldnodeid = std.mem.readInt(u64, lookup.payload()[0..8], .little);
 
     var body: [8 + 6]u8 = @splat(0);
     std.mem.writeInt(u64, body[0..8], oldnodeid, .little);
     @memcpy(body[8..][0.."b.txt".len], "b.txt");
-    const linked = testRunOp(&fsdev, 13, 2, 1, body[0 .. 8 + "b.txt".len + 1]);
+    const linked = test_run_op(&fsdev, 13, 2, 1, body[0 .. 8 + "b.txt".len + 1]);
     try testing.expectEqual(@as(i32, 0), linked.err());
     try testing.expectEqual(oldnodeid, std.mem.readInt(u64, linked.payload()[0..8], .little));
 
@@ -598,24 +598,24 @@ test "handleRequest: LINK creates hardlinks and maps :ro/malformed failures" {
     try testing.expectEqualStrings("updated", after_unlink);
 
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a.txt", .data = "again" });
-    const rel_lookup = testRunOp(&fsdev, 1, 3, 1, "a.txt\x00");
+    const rel_lookup = test_run_op(&fsdev, 1, 3, 1, "a.txt\x00");
     try testing.expectEqual(@as(i32, 0), rel_lookup.err());
     std.mem.writeInt(u64, body[0..8], std.mem.readInt(u64, rel_lookup.payload()[0..8], .little), .little);
-    const exists = testRunOp(&fsdev, 13, 4, 1, body[0 .. 8 + "b.txt".len + 1]);
+    const exists = test_run_op(&fsdev, 13, 4, 1, body[0 .. 8 + "b.txt".len + 1]);
     try testing.expectEqual(@as(i32, -17), exists.err()); // -EEXIST
 
-    var ro = try Device.init(gpa, "machinen1", try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try Device.init(gpa, "machinen1", try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const ro_lookup = testRunOp(&ro, 1, 5, 1, "a.txt\x00");
+    const ro_lookup = test_run_op(&ro, 1, 5, 1, "a.txt\x00");
     try testing.expectEqual(@as(i32, 0), ro_lookup.err());
     var ro_body: [8 + 9]u8 = @splat(0);
     std.mem.writeInt(u64, ro_body[0..8], std.mem.readInt(u64, ro_lookup.payload()[0..8], .little), .little);
     @memcpy(ro_body[8..][0.."ro-b.txt".len], "ro-b.txt");
-    const blocked = testRunOp(&ro, 13, 6, 1, ro_body[0 .. 8 + "ro-b.txt".len + 1]);
+    const blocked = test_run_op(&ro, 13, 6, 1, ro_body[0 .. 8 + "ro-b.txt".len + 1]);
     try testing.expectEqual(@as(i32, -30), blocked.err()); // -EROFS
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "ro-b.txt", .{}));
 
-    const malformed = testRunOp(&fsdev, 13, 7, 1, "short");
+    const malformed = test_run_op(&fsdev, 13, 7, 1, "short");
     try testing.expectEqual(@as(i32, -22), malformed.err()); // -EINVAL, not a wedge
 }
 
@@ -624,17 +624,17 @@ test "handleRequest: SETATTR FATTR_MODE makes chmod executable on the host" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "script.sh", .data = "#!/bin/sh\necho hi\n" });
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const lookup = testRunOp(&fsdev, 1, 1, 1, "script.sh\x00");
+    const lookup = test_run_op(&fsdev, 1, 1, 1, "script.sh\x00");
     try testing.expectEqual(@as(i32, 0), lookup.err());
     const nodeid = std.mem.readInt(u64, lookup.payload()[0..8], .little);
 
     var body: [88]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], 1, .little); // FATTR_MODE
     std.mem.writeInt(u32, body[68..72], 0o755, .little);
-    const chmodded = testRunOp(&fsdev, 4, 2, nodeid, &body);
+    const chmodded = test_run_op(&fsdev, 4, 2, nodeid, &body);
     try testing.expectEqual(@as(i32, 0), chmodded.err());
     const mode = std.mem.readInt(u32, chmodded.payload()[16 + 60 ..][0..4], .little);
     try testing.expectEqual(@as(u32, 0o755), mode & 0o777);
@@ -642,13 +642,13 @@ test "handleRequest: SETATTR FATTR_MODE makes chmod executable on the host" {
     const st = try tmp.dir.statFile(std.testing.io, "script.sh", .{});
     try testing.expectEqual(@as(u32, 0o755), @as(u32, @intCast(st.permissions.toMode())) & 0o777);
 
-    var ro = try Device.init(gpa, "machinen1", try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try Device.init(gpa, "machinen1", try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const ro_lookup = testRunOp(&ro, 1, 3, 1, "script.sh\x00");
+    const ro_lookup = test_run_op(&ro, 1, 3, 1, "script.sh\x00");
     try testing.expectEqual(@as(i32, 0), ro_lookup.err());
     const ro_nodeid = std.mem.readInt(u64, ro_lookup.payload()[0..8], .little);
     std.mem.writeInt(u32, body[68..72], 0o600, .little);
-    const blocked = testRunOp(&ro, 4, 4, ro_nodeid, &body);
+    const blocked = test_run_op(&ro, 4, 4, ro_nodeid, &body);
     try testing.expectEqual(@as(i32, -30), blocked.err()); // -EROFS
 }
 
@@ -660,27 +660,27 @@ test "handleRequest: RMDIR removes empty dirs and maps ENOTEMPTY/:ro/malformed f
     try tmp.dir.createDir(std.testing.io, "nonempty", .default_dir);
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "nonempty/child.txt", .data = "x" });
     try tmp.dir.createDir(std.testing.io, "blocked", .default_dir);
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const removed = testRunOp(&fsdev, 11, 1, 1, "empty\x00");
+    const removed = test_run_op(&fsdev, 11, 1, 1, "empty\x00");
     try testing.expectEqual(@as(i32, 0), removed.err());
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "empty", .{}));
 
-    const nonempty = testRunOp(&fsdev, 11, 2, 1, "nonempty\x00");
+    const nonempty = test_run_op(&fsdev, 11, 2, 1, "nonempty\x00");
     try testing.expectEqual(@as(i32, -39), nonempty.err()); // -ENOTEMPTY, not -EIO
     try tmp.dir.access(std.testing.io, "nonempty/child.txt", .{});
 
-    const missing = testRunOp(&fsdev, 11, 3, 1, "missing\x00");
+    const missing = test_run_op(&fsdev, 11, 3, 1, "missing\x00");
     try testing.expectEqual(@as(i32, -2), missing.err()); // -ENOENT
 
-    var ro = try Device.init(gpa, "machinen1", try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try Device.init(gpa, "machinen1", try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const blocked = testRunOp(&ro, 11, 4, 1, "blocked\x00");
+    const blocked = test_run_op(&ro, 11, 4, 1, "blocked\x00");
     try testing.expectEqual(@as(i32, -30), blocked.err()); // -EROFS
     try tmp.dir.access(std.testing.io, "blocked", .{});
 
-    const malformed = testRunOp(&fsdev, 11, 5, 1, "bad/name\x00");
+    const malformed = test_run_op(&fsdev, 11, 5, 1, "bad/name\x00");
     try testing.expectEqual(@as(i32, -22), malformed.err()); // -EINVAL, not a wedge
 }
 
@@ -690,7 +690,7 @@ test "handleRequest: RENAME replaces an existing file and :ro/malformed paths fa
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src.txt", .data = "source" });
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "dst.txt", .data = "dest" });
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
     var rename_body: [8 + 16]u8 = @splat(0);
@@ -698,7 +698,7 @@ test "handleRequest: RENAME replaces an existing file and :ro/malformed paths fa
     @memcpy(rename_body[8..][0.."src.txt".len], "src.txt");
     @memcpy(rename_body[8 + "src.txt".len + 1 ..][0.."dst.txt".len], "dst.txt");
     const rename_len = 8 + "src.txt".len + 1 + "dst.txt".len + 1;
-    const renamed = testRunOp(&fsdev, 12, 1, 1, rename_body[0..rename_len]);
+    const renamed = test_run_op(&fsdev, 12, 1, 1, rename_body[0..rename_len]);
     try testing.expectEqual(@as(i32, 0), renamed.err());
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "src.txt", .{}));
     const got = try tmp.dir.readFileAlloc(std.testing.io, "dst.txt", gpa, .limited(1024));
@@ -710,15 +710,15 @@ test "handleRequest: RENAME replaces an existing file and :ro/malformed paths fa
     @memcpy(missing_body[8..][0.."missing".len], "missing");
     @memcpy(missing_body[8 + "missing".len + 1 ..][0.."other".len], "other");
     const missing_len = 8 + "missing".len + 1 + "other".len + 1;
-    const missing = testRunOp(&fsdev, 12, 2, 1, missing_body[0..missing_len]);
+    const missing = test_run_op(&fsdev, 12, 2, 1, missing_body[0..missing_len]);
     try testing.expectEqual(@as(i32, -2), missing.err()); // -ENOENT
 
-    var ro = try Device.init(gpa, "machinen1", try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try Device.init(gpa, "machinen1", try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const blocked = testRunOp(&ro, 12, 3, 1, rename_body[0..rename_len]);
+    const blocked = test_run_op(&ro, 12, 3, 1, rename_body[0..rename_len]);
     try testing.expectEqual(@as(i32, -30), blocked.err()); // -EROFS
 
-    const malformed = testRunOp(&fsdev, 12, 4, 1, "short");
+    const malformed = test_run_op(&fsdev, 12, 4, 1, "short");
     try testing.expectEqual(@as(i32, -22), malformed.err()); // -EINVAL, not a wedge
 }
 
@@ -726,10 +726,10 @@ test "handleRequest: LOOKUP of a missing name returns ENOENT" {
     const gpa = testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
-    const r = testRunOp(&fsdev, 1, 9, 1, "nonexistent\x00"); // LOOKUP under root
+    const r = test_run_op(&fsdev, 1, 9, 1, "nonexistent\x00"); // LOOKUP under root
     try testing.expectEqual(@as(i32, -2), r.err()); // -ENOENT
 }
 
@@ -737,7 +737,7 @@ test "handleRequest: CREATE on a :ro mount returns EROFS and never touches the h
     const gpa = testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), false); // :ro
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), false); // :ro
     defer fsdev.deinit();
 
     var body: [16 + 12]u8 = @splat(0);
@@ -745,7 +745,7 @@ test "handleRequest: CREATE on a :ro mount returns EROFS and never touches the h
     std.mem.writeInt(u32, body[4..8], 0o644, .little);
     @memcpy(body[16..][0.."blocked.txt".len], "blocked.txt");
 
-    const r = testRunOp(&fsdev, 35, 1, 1, &body); // CREATE
+    const r = test_run_op(&fsdev, 35, 1, 1, &body); // CREATE
     try testing.expectEqual(@as(i32, -30), r.err()); // -EROFS
     // The `:ro` gate fires before any host syscall — nothing was created.
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "blocked.txt", .{}));
@@ -762,22 +762,22 @@ test "handleRequest: a self-cycling descriptor chain is capped, not hung" {
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(&fsdev),
     };
-    const q = testSetupRing(8);
+    const q = test_setup_ring(8);
     dev.queues[1] = q;
 
     // desc 0 points `next` at itself with F_NEXT set — an infinite
     // cycle without the max_chain_descriptors cap. len 0 keeps the
     // gather empty so the capped walk ends in a short-frame ack. The
     // assertion that matters is simply that `notify` *returns*.
-    testPutDesc(&ram, 0, .{ .addr = 0x800, .len = 0, .flags = virtio.VringDesc.F_NEXT, .next = 0 });
-    testPostAvail(&ram, q, 0);
+    test_put_desc(&ram, 0, .{ .addr = 0x800, .len = 0, .flags = virtio.VringDesc.F_NEXT, .next = 0 });
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     try testing.expectEqual(@as(u32, 0), elem.id);
     try testing.expectEqual(@as(u32, 0), elem.len);
 }
@@ -792,7 +792,7 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
     const gpa = testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    var fsdev = try Device.init(gpa, "machinen0", try testTmpRootAbs(gpa, &tmp), true);
+    var fsdev = try Device.init(gpa, "machinen0", try test_tmp_root_abs(gpa, &tmp), true);
     defer fsdev.deinit();
 
     // CREATE the target file and capture its handle. fuse_create_in
@@ -802,7 +802,7 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
     std.mem.writeInt(u32, create_body[0..4], 2, .little); // Linux O_RDWR
     std.mem.writeInt(u32, create_body[4..8], 0o644, .little);
     @memcpy(create_body[16..][0.."big.bin".len], "big.bin");
-    const create = testRunOp(&fsdev, 35, 1, 1, &create_body);
+    const create = test_run_op(&fsdev, 35, 1, 1, &create_body);
     try testing.expectEqual(@as(i32, 0), create.err());
     const fh = std.mem.readInt(u64, create.payload()[128..136], .little);
 
@@ -818,10 +818,10 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
         .id = .virtio_fs,
         .ram = &ram,
         .ram_base = 0,
-        .request_handler = &Device.handleRequest,
+        .request_handler = &Device.handle_request,
         .request_ctx = @ptrCast(&fsdev),
     };
-    const q = testSetupRing(64);
+    const q = test_setup_ring(64);
     dev.queues[1] = q;
 
     const hdr_off: u64 = 0x4000;
@@ -840,7 +840,7 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
     for (0..payload_len) |i| ram[data_off + i] = @intCast(i & 0xff);
 
     // desc 0: the 80-byte header (in-header + fuse_write_in).
-    testPutDesc(&ram, 0, .{
+    test_put_desc(&ram, 0, .{
         .addr = hdr_off,
         .len = @intCast(fuse.FUSE_IN_HEADER_SIZE + 40),
         .flags = virtio.VringDesc.F_NEXT,
@@ -849,7 +849,7 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
     // descs 1..pages: one 4 KiB data page each.
     var i: usize = 0;
     while (i < pages) : (i += 1) {
-        testPutDesc(&ram, 1 + i, .{
+        test_put_desc(&ram, 1 + i, .{
             .addr = data_off + i * page,
             .len = page,
             .flags = virtio.VringDesc.F_NEXT,
@@ -857,19 +857,19 @@ test "handleRequest: a large WRITE spanning >32 descriptors is fully gathered" {
         });
     }
     // final desc: the writable reply window.
-    testPutDesc(&ram, 1 + pages, .{
+    test_put_desc(&ram, 1 + pages, .{
         .addr = reply_off,
         .len = 256,
         .flags = virtio.VringDesc.F_WRITE,
         .next = 0,
     });
-    testPostAvail(&ram, q, 0);
+    test_post_avail(&ram, q, 0);
 
     dev.notify(1);
 
     // The reply is fuse_write_out, and its `size` must equal the full
     // payload — proof the gather walked every descriptor, not just 32.
-    const elem = testReadUsed(&ram, q);
+    const elem = test_read_used(&ram, q);
     try testing.expectEqual(@as(u32, fuse.FUSE_OUT_HEADER_SIZE + 8), elem.len);
     const reply = ram[reply_off..][0..@as(usize, elem.len)];
     try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, reply[4..8], .little));

--- a/packages/microvm/src/vmstate_timing.zig
+++ b/packages/microvm/src/vmstate_timing.zig
@@ -26,7 +26,7 @@ pub const RestoreTimer = struct {
 
     pub fn start(backend: []const u8, file_bytes: usize, ram_bytes: usize) RestoreTimer {
         const e = enabled();
-        const now = if (e) nowUs() else 0;
+        const now = if (e) now_us() else 0;
         if (e) {
             std.debug.print(
                 "vmstate restore timing backend={s} event=start file_bytes={d} ram_bytes={d}\n",
@@ -38,7 +38,7 @@ pub const RestoreTimer = struct {
 
     pub fn mark(self: *RestoreTimer, phase: []const u8) void {
         if (!self.enabled) return;
-        const now = nowUs();
+        const now = now_us();
         std.debug.print(
             "vmstate restore timing backend={s} phase={s} delta_ms={d} total_ms={d}\n",
             .{ self.backend, phase, ms(now - self.last_us), ms(now - self.start_us) },
@@ -46,9 +46,9 @@ pub const RestoreTimer = struct {
         self.last_us = now;
     }
 
-    pub fn sectionStart(self: *const RestoreTimer) i128 {
+    pub fn section_start(self: *const RestoreTimer) i128 {
         if (!self.enabled) return 0;
-        return nowUs();
+        return now_us();
     }
 
     pub fn section(
@@ -59,16 +59,16 @@ pub const RestoreTimer = struct {
         section_start_us: i128,
     ) void {
         if (!self.enabled) return;
-        const now = nowUs();
+        const now = now_us();
         std.debug.print(
             "vmstate restore timing backend={s} section={s} id={d} bytes={d} ms={d} total_ms={d}\n",
-            .{ self.backend, tagName(tag), id, payload_bytes, ms(now - section_start_us), ms(now - self.start_us) },
+            .{ self.backend, tag_name(tag), id, payload_bytes, ms(now - section_start_us), ms(now - self.start_us) },
         );
     }
 
     pub fn done(self: *RestoreTimer) void {
         if (!self.enabled) return;
-        const now = nowUs();
+        const now = now_us();
         std.debug.print(
             "vmstate restore timing backend={s} event=done total_ms={d}\n",
             .{ self.backend, ms(now - self.start_us) },
@@ -81,10 +81,10 @@ fn enabled() bool {
     if (libc.getenv("MACHINEN_VMSTATE_TIMING") != null) return true;
     if (libc.getenv("MACHINEN_DEBUG") != null) return true;
     const debug_raw = libc.getenv("DEBUG") orelse return false;
-    return debugSpecEnablesTiming(std.mem.span(debug_raw));
+    return debug_spec_enables_timing(std.mem.span(debug_raw));
 }
 
-pub fn debugSpecEnablesTiming(spec: []const u8) bool {
+pub fn debug_spec_enables_timing(spec: []const u8) bool {
     var vmstate = false;
     var restore = false;
 
@@ -95,14 +95,14 @@ pub fn debugSpecEnablesTiming(spec: []const u8) bool {
         const token = if (negated) raw_token[1..] else raw_token;
         if (token.len == 0) continue;
 
-        if (debugTokenMatches(token, "machinen:vmstate")) vmstate = !negated;
-        if (debugTokenMatches(token, "machinen:restore")) restore = !negated;
+        if (debug_token_matches(token, "machinen:vmstate")) vmstate = !negated;
+        if (debug_token_matches(token, "machinen:restore")) restore = !negated;
     }
 
     return vmstate or restore;
 }
 
-fn debugTokenMatches(token: []const u8, namespace: []const u8) bool {
+fn debug_token_matches(token: []const u8, namespace: []const u8) bool {
     if (std.mem.eql(u8, token, "*")) return true;
     if (std.mem.endsWith(u8, token, "*")) {
         return std.mem.startsWith(u8, namespace, token[0 .. token.len - 1]);
@@ -110,7 +110,7 @@ fn debugTokenMatches(token: []const u8, namespace: []const u8) bool {
     return std.mem.eql(u8, token, namespace);
 }
 
-fn tagName(tag: snapshot.SectionTag) []const u8 {
+fn tag_name(tag: snapshot.SectionTag) []const u8 {
     return switch (tag) {
         .ram => "ram",
         .vcpu => "vcpu",
@@ -123,7 +123,7 @@ fn tagName(tag: snapshot.SectionTag) []const u8 {
     };
 }
 
-fn nowUs() i128 {
+fn now_us() i128 {
     var tv: std.c.timeval = undefined;
     _ = std.c.gettimeofday(&tv, null);
     return @as(i128, tv.sec) * 1_000_000 + @as(i128, tv.usec);
@@ -136,10 +136,10 @@ fn ms(us: i128) i128 {
 // -- tests --------------------------------------------------------
 
 test "DEBUG spec enables vmstate restore timing" {
-    try std.testing.expect(debugSpecEnablesTiming("machinen:vmstate"));
-    try std.testing.expect(debugSpecEnablesTiming("machinen:restore"));
-    try std.testing.expect(debugSpecEnablesTiming("machinen:*"));
-    try std.testing.expect(debugSpecEnablesTiming("*,other"));
-    try std.testing.expect(!debugSpecEnablesTiming("machinen:boot"));
-    try std.testing.expect(!debugSpecEnablesTiming("machinen:*,-machinen:vmstate,-machinen:restore"));
+    try std.testing.expect(debug_spec_enables_timing("machinen:vmstate"));
+    try std.testing.expect(debug_spec_enables_timing("machinen:restore"));
+    try std.testing.expect(debug_spec_enables_timing("machinen:*"));
+    try std.testing.expect(debug_spec_enables_timing("*,other"));
+    try std.testing.expect(!debug_spec_enables_timing("machinen:boot"));
+    try std.testing.expect(!debug_spec_enables_timing("machinen:*,-machinen:vmstate,-machinen:restore"));
 }

--- a/packages/microvm/src/vmstate_writer.zig
+++ b/packages/microvm/src/vmstate_writer.zig
@@ -32,10 +32,10 @@ pub const Job = struct {
         path: []const u8,
         topology_hash: [32]u8,
     ) !*Job {
-        return createWithArch(allocator, label, path, snapshot.ARCH_AARCH64, topology_hash);
+        return create_with_arch(allocator, label, path, snapshot.ARCH_AARCH64, topology_hash);
     }
 
-    pub fn createWithArch(
+    pub fn create_with_arch(
         allocator: std.mem.Allocator,
         label: []const u8,
         path: []const u8,
@@ -60,7 +60,7 @@ pub const Job = struct {
         return job;
     }
 
-    pub fn arenaAllocator(self: *Job) std.mem.Allocator {
+    pub fn arena_allocator(self: *Job) std.mem.Allocator {
         return self.arena.allocator();
     }
 
@@ -80,11 +80,11 @@ pub const Writer = struct {
     /// `job` on success; on error, the caller still owns it and can
     /// fall back to `writeAndDestroy(job)`.
     pub fn start(self: *Writer, job: *Job) StartError!void {
-        self.reapFinished();
+        self.reap_finished();
         if (self.handle != null) return error.SnapshotInFlight;
 
         self.done.store(false, .release);
-        const handle = std.Thread.spawn(.{}, workerMain, .{ job, &self.done }) catch |err| {
+        const handle = std.Thread.spawn(.{}, worker_main, .{ job, &self.done }) catch |err| {
             self.done.store(true, .release);
             return err;
         };
@@ -93,7 +93,7 @@ pub const Writer = struct {
 
     /// Join a completed worker without blocking the vCPU thread. Call
     /// this opportunistically before accepting a new snapshot request.
-    pub fn reapFinished(self: *Writer) void {
+    pub fn reap_finished(self: *Writer) void {
         if (self.handle) |handle| {
             if (self.done.load(.acquire)) {
                 handle.join();
@@ -103,7 +103,7 @@ pub const Writer = struct {
     }
 
     pub fn busy(self: *Writer) bool {
-        self.reapFinished();
+        self.reap_finished();
         return self.handle != null;
     }
 
@@ -118,7 +118,7 @@ pub const Writer = struct {
     }
 };
 
-fn workerMain(job: *Job, done: *std.atomic.Value(bool)) void {
+fn worker_main(job: *Job, done: *std.atomic.Value(bool)) void {
     const label = job.label;
     write(job) catch |err| {
         std.debug.print("{s}: snapshot async write failed: {s}\n", .{ label, @errorName(err) });
@@ -129,21 +129,21 @@ fn workerMain(job: *Job, done: *std.atomic.Value(bool)) void {
 
 /// Synchronous fallback used if the background thread cannot be
 /// spawned. Consumes `job` either way.
-pub fn writeAndDestroy(job: *Job) !void {
+pub fn write_and_destroy(job: *Job) !void {
     defer job.destroy();
     try write(job);
 }
 
 fn write(job: *Job) !void {
     const allocator = job.arena.allocator();
-    const bytes = try snapshot.encodeWithArch(allocator, job.arch, job.topology_hash, job.sections);
-    const compression = vmstate_zip.writeCompression();
+    const bytes = try snapshot.encode_with_arch(allocator, job.arch, job.topology_hash, job.sections);
+    const compression = vmstate_zip.write_compression();
     const out: []const u8 = switch (compression) {
         .none => bytes,
         .gzip => try vmstate_zip.compress(allocator, bytes),
     };
     std.debug.print("{s}: snapshot {d} bytes -> {d} {s}\n", .{ job.label, bytes.len, out.len, @tagName(compression) });
-    try writeAtomic(allocator, job.path, out);
+    try write_atomic(allocator, job.path, out);
     std.debug.print("{s}: snapshot write done\n", .{job.label});
 }
 
@@ -159,7 +159,7 @@ const O_WRONLY: c_int = 1;
 const O_CREAT: c_int = if (builtin.os.tag == .macos) 0x200 else 64;
 const O_TRUNC: c_int = if (builtin.os.tag == .macos) 0x400 else 512;
 
-fn writeAtomic(allocator: std.mem.Allocator, path: []const u8, data: []const u8) !void {
+fn write_atomic(allocator: std.mem.Allocator, path: []const u8, data: []const u8) !void {
     // Write atomically: dump into `<path>.tmp`, then rename() onto the
     // final path. The runtime polls for the final path's existence as
     // the "dump complete" signal, so a partial file must never be
@@ -184,7 +184,7 @@ fn writeAtomic(allocator: std.mem.Allocator, path: []const u8, data: []const u8)
     if (c.rename(tmp_z, path_z) != 0) return error.WriteFailed;
 }
 
-fn testTmpPath(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir, name: []const u8) ![]u8 {
+fn test_tmp_path(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir, name: []const u8) ![]u8 {
     const cwd = try std.process.currentPathAlloc(std.testing.io, gpa);
     defer gpa.free(cwd);
     return std.fs.path.join(gpa, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path, name });
@@ -195,12 +195,12 @@ test "Writer writes a complete vmstate asynchronously" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const path = try testTmpPath(gpa, &tmp, "state.vmstate");
+    const path = try test_tmp_path(gpa, &tmp, "state.vmstate");
     defer gpa.free(path);
 
     const topo: [32]u8 = @splat(0xAB);
     const job = try Job.create(gpa, "test", path, topo);
-    const a = job.arenaAllocator();
+    const a = job.arena_allocator();
     const payload = try a.dupe(u8, "payload");
     var sections = std.ArrayList(snapshot.Section).empty;
     try sections.append(a, .{ .tag = .vcpu, .id = 0, .payload = payload });

--- a/packages/microvm/src/vmstate_zip.zig
+++ b/packages/microvm/src/vmstate_zip.zig
@@ -27,12 +27,12 @@ pub const gzip_magic = [2]u8{ 0x1f, 0x8b };
 /// On-disk transport used for newly-written snapshots.
 pub const Compression = enum { none, gzip };
 
-pub fn writeCompression() Compression {
+pub fn write_compression() Compression {
     const raw = libc.getenv("MACHINEN_VMSTATE_COMPRESSION") orelse return .none;
-    return parseCompression(std.mem.span(raw)) orelse .none;
+    return parse_compression(std.mem.span(raw)) orelse .none;
 }
 
-pub fn parseCompression(raw: []const u8) ?Compression {
+pub fn parse_compression(raw: []const u8) ?Compression {
     const v = std.mem.trim(u8, raw, " \t\r\n");
     if (std.ascii.eqlIgnoreCase(v, "gzip") or
         std.ascii.eqlIgnoreCase(v, "gz") or
@@ -88,7 +88,7 @@ pub const Decompressed = struct {
 /// Inverse of `compress`, optimized for restore: gzip input is inflated
 /// into an owned buffer; plain input is returned as a borrowed slice so
 /// restore avoids an extra full-container copy.
-pub fn decompressMaybeOwned(gpa: std.mem.Allocator, input: []const u8) !Decompressed {
+pub fn decompress_maybe_owned(gpa: std.mem.Allocator, input: []const u8) !Decompressed {
     if (input.len < 2 or !std.mem.eql(u8, input[0..2], &gzip_magic)) {
         return .{ .bytes = input, .owned = false };
     }
@@ -105,7 +105,7 @@ pub fn decompressMaybeOwned(gpa: std.mem.Allocator, input: []const u8) !Decompre
 /// magic is assumed to be a plain .vmstate and returned as an owned
 /// copy unchanged. Caller owns the returned bytes either way.
 pub fn decompress(gpa: std.mem.Allocator, input: []const u8) ![]u8 {
-    const decoded = try decompressMaybeOwned(gpa, input);
+    const decoded = try decompress_maybe_owned(gpa, input);
     if (decoded.owned) return @constCast(decoded.bytes);
     return gpa.dupe(u8, decoded.bytes);
 }
@@ -154,27 +154,27 @@ test "decompress passes a non-gzip buffer through unchanged" {
 test "decompressMaybeOwned borrows plain buffers and owns gzip buffers" {
     const a = std.testing.allocator;
     var plain = [_]u8{ 'V', 'M', 'S', 'T', 'A', 'T', 'E', 0 };
-    const plain_back = try decompressMaybeOwned(a, &plain);
+    const plain_back = try decompress_maybe_owned(a, &plain);
     defer plain_back.deinit(a);
     try std.testing.expect(!plain_back.owned);
     try std.testing.expectEqual(@intFromPtr(plain[0..].ptr), @intFromPtr(plain_back.bytes.ptr));
 
     const zipped = try compress(a, &plain);
     defer a.free(zipped);
-    const zipped_back = try decompressMaybeOwned(a, zipped);
+    const zipped_back = try decompress_maybe_owned(a, zipped);
     defer zipped_back.deinit(a);
     try std.testing.expect(zipped_back.owned);
     try std.testing.expectEqualSlices(u8, &plain, zipped_back.bytes);
 }
 
 test "parseCompression accepts documented values" {
-    try std.testing.expectEqual(Compression.none, parseCompression("none").?);
-    try std.testing.expectEqual(Compression.none, parseCompression("plain").?);
-    try std.testing.expectEqual(Compression.none, parseCompression("0").?);
-    try std.testing.expectEqual(Compression.gzip, parseCompression("gzip").?);
-    try std.testing.expectEqual(Compression.gzip, parseCompression("GZ").?);
-    try std.testing.expectEqual(Compression.gzip, parseCompression("1").?);
-    try std.testing.expect(parseCompression("surprise") == null);
+    try std.testing.expectEqual(Compression.none, parse_compression("none").?);
+    try std.testing.expectEqual(Compression.none, parse_compression("plain").?);
+    try std.testing.expectEqual(Compression.none, parse_compression("0").?);
+    try std.testing.expectEqual(Compression.gzip, parse_compression("gzip").?);
+    try std.testing.expectEqual(Compression.gzip, parse_compression("GZ").?);
+    try std.testing.expectEqual(Compression.gzip, parse_compression("1").?);
+    try std.testing.expect(parse_compression("surprise") == null);
 }
 
 test "decompress handles an empty/short buffer as plain" {

--- a/packages/microvm/src/vsock.zig
+++ b/packages/microvm/src/vsock.zig
@@ -55,9 +55,9 @@ const assert = std.debug.assert;
 /// place the vCPU thread tries to acquire it, which is what surfaced
 /// the bug as a kernel hang at earlycon.
 const PthreadMutex = extern struct {
-    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macosInit() else @splat(0),
+    _bytes: [64]u8 align(8) = if (builtin.os.tag == .macos) macos_init() else @splat(0),
 
-    fn macosInit() [64]u8 {
+    fn macos_init() [64]u8 {
         var out: [64]u8 = @splat(0);
         // sig = 0x32AAABA7 (macOS PTHREAD_MUTEX_INITIALIZER magic).
         const sig: u64 = 0x32AAABA7;
@@ -276,7 +276,7 @@ comptime {
 ///
 /// The returned slice and the path strings inside it are allocated
 /// with `gpa` and must be freed by the caller (via `freeParsed`).
-pub fn parseEnv(gpa: std.mem.Allocator, raw: []const u8) ![]PortMap {
+pub fn parse_env(gpa: std.mem.Allocator, raw: []const u8) ![]PortMap {
     var list: std.ArrayList(PortMap) = .empty;
     errdefer {
         for (list.items) |pm| gpa.free(pm.uds_path);
@@ -314,7 +314,7 @@ pub fn parseEnv(gpa: std.mem.Allocator, raw: []const u8) ![]PortMap {
     return list.toOwnedSlice(gpa);
 }
 
-pub fn freeParsed(gpa: std.mem.Allocator, parsed: []PortMap) void {
+pub fn free_parsed(gpa: std.mem.Allocator, parsed: []PortMap) void {
     for (parsed) |pm| gpa.free(pm.uds_path);
     gpa.free(parsed);
 }
@@ -394,7 +394,7 @@ test "Op and Type enums survive unknown values via catch-all" {
 ///
 /// Returns `null` if the chain is malformed (too short, header read
 /// went out of guest RAM, etc.).
-pub fn readPacket(
+pub fn read_packet(
     dev: *virtio.Device,
     q_idx: u32,
     head: u16,
@@ -414,11 +414,11 @@ pub fn readPacket(
     // (the same 32-entry policy as blk.zig and virtio's own walks)
     // and silently truncate longer chains.
     while (steps < virtio.max_chain_descriptors) : (steps += 1) {
-        const d = dev.queueDescriptor(q_idx, idx) orelse return null;
+        const d = dev.queue_descriptor(q_idx, idx) orelse return null;
         if (d.len > 0) {
             const take: usize = @min(@as(usize, d.len), scratch.len - written);
             if (take > 0) {
-                const src = dev.guestBytes(d.addr, take) orelse return null;
+                const src = dev.guest_bytes(d.addr, take) orelse return null;
                 @memcpy(scratch[written..][0..take], src);
                 written += take;
             }
@@ -445,7 +445,7 @@ pub fn readPacket(
 /// Lays down hdr.encode() followed by `body`. Returns the number of
 /// bytes written (= header_size + body.len on success), or `null` if
 /// the chain was too short to hold everything.
-pub fn writePacket(
+pub fn write_packet(
     dev: *virtio.Device,
     q_idx: u32,
     head: u16,
@@ -469,7 +469,7 @@ pub fn writePacket(
     // and treat a longer chain as "too short" to fit our packet (return
     // null) — same fail-soft as the chain-too-short branch below.
     while (steps < virtio.max_chain_descriptors) : (steps += 1) {
-        const d = dev.queueDescriptor(q_idx, idx) orelse return null;
+        const d = dev.queue_descriptor(q_idx, idx) orelse return null;
         // RX descriptors must be writable.
         if ((d.flags & virtio.VringDesc.F_WRITE) == 0) return null;
 
@@ -482,7 +482,7 @@ pub fn writePacket(
             const source: []const u8 = if (remaining_hdr.len > 0) remaining_hdr else remaining_body;
             const chunk: u32 = @intCast(@min(@as(u64, budget), source.len));
             assert(chunk > 0);
-            const dst = dev.guestBytes(d.addr + desc_off, chunk) orelse return null;
+            const dst = dev.guest_bytes(d.addr + desc_off, chunk) orelse return null;
             @memcpy(dst, source[0..chunk]);
             if (remaining_hdr.len > 0) {
                 remaining_hdr = remaining_hdr[chunk..];
@@ -551,7 +551,7 @@ test "readPacket reads a single-descriptor TX chain" {
     @memcpy(ram[0..@sizeOf(virtio.VringDesc)], std.mem.asBytes(&desc0));
 
     var scratch: [256]u8 = undefined;
-    const pkt = readPacket(&dev, Q_TX, 0, &scratch) orelse return error.TestFailed;
+    const pkt = read_packet(&dev, Q_TX, 0, &scratch) orelse return error.TestFailed;
     try std.testing.expectEqual(hdr.src_cid, pkt.hdr.src_cid);
     try std.testing.expectEqual(hdr.dst_port, pkt.hdr.dst_port);
     try std.testing.expectEqual(@as(u32, 5), pkt.hdr.len);
@@ -597,7 +597,7 @@ test "writePacket lays down hdr + body into an RX chain" {
         .fwd_cnt = 0,
     };
     const body = [_]u8{ 0xAA, 0xBB, 0xCC };
-    const n = writePacket(&dev, Q_RX, 0, hdr, &body) orelse return error.TestFailed;
+    const n = write_packet(&dev, Q_RX, 0, hdr, &body) orelse return error.TestFailed;
     try std.testing.expectEqual(@as(u32, header_size + 3), n);
 
     // Verify what the guest would see.
@@ -678,7 +678,7 @@ const SockaddrUn = extern struct {
     bytes: [110]u8 align(4) = @splat(0),
 };
 
-fn makeSockaddrUn(path: []const u8) struct { sa: SockaddrUn, len: u32 } {
+fn make_sockaddr_un(path: []const u8) struct { sa: SockaddrUn, len: u32 } {
     assert(path.len > 0);
     // Leave room for sun_len/sun_family + NUL.
     assert(path.len < 100);
@@ -703,19 +703,19 @@ fn makeSockaddrUn(path: []const u8) struct { sa: SockaddrUn, len: u32 } {
     }
 }
 
-fn setNonblocking(fd: c_int) void {
+fn set_nonblocking(fd: c_int) void {
     assert(fd >= 0);
     _ = fcntl(fd, F_SETFL, O_NONBLOCK);
 }
 
 /// Connect (blocking) to a UDS at `path`. Returns the fd on success,
 /// -1 on any failure. Caller sets nonblocking and tracks the fd.
-fn connectUds(path: [:0]const u8) c_int {
+fn connect_uds(path: [:0]const u8) c_int {
     assert(path.len > 0);
     assert(path.len < 100);
     const fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) return -1;
-    const made = makeSockaddrUn(path);
+    const made = make_sockaddr_un(path);
     if (connect(fd, &made.sa, made.len) != 0) {
         _ = close(fd);
         return -1;
@@ -848,7 +848,7 @@ pub const Bridge = struct {
     /// Callers handle full by closing the new fd and either sending
     /// RST (guest-initiated dial) or logging and dropping it. Must
     /// be called with `self.mu` held.
-    fn connsPush(self: *Bridge, c: Connection) ?usize {
+    fn conns_push(self: *Bridge, c: Connection) ?usize {
         assert(self.conns_len <= bridge_conns_max);
         if (self.conns_len >= bridge_conns_max) return null;
         const idx = self.conns_len;
@@ -861,7 +861,7 @@ pub const Bridge = struct {
     /// O(1); does not preserve order, which is fine since callers
     /// scan the table by `(guest_port, host_port)` not by index.
     /// Must be called with `self.mu` held.
-    fn connsSwapRemove(self: *Bridge, idx: usize) Connection {
+    fn conns_swap_remove(self: *Bridge, idx: usize) Connection {
         assert(idx < self.conns_len);
         const removed = self.conns[idx];
         self.conns_len -= 1;
@@ -887,21 +887,21 @@ pub const Bridge = struct {
             errdefer _ = close(fd);
             const yes: c_int = 1;
             _ = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, @sizeOf(c_int));
-            const made = makeSockaddrUn(pm.uds_path);
+            const made = make_sockaddr_un(pm.uds_path);
             if (bind(fd, &made.sa, made.len) != 0) return error.UdsBindFailed;
             if (listen(fd, 8) != 0) return error.UdsListenFailed;
-            setNonblocking(fd);
+            set_nonblocking(fd);
             try self.listeners.append(self.gpa, fd);
             try self.listener_port_idx.append(self.gpa, i);
         }
 
         var pipe_fds: [2]c_int = .{ -1, -1 };
         if (pipe(&pipe_fds) != 0) return error.PipeFailed;
-        setNonblocking(pipe_fds[0]);
-        setNonblocking(pipe_fds[1]);
+        set_nonblocking(pipe_fds[0]);
+        set_nonblocking(pipe_fds[1]);
         self.wake = pipe_fds;
 
-        self.thread = try std.Thread.spawn(.{}, runThread, .{self});
+        self.thread = try std.Thread.spawn(.{}, run_thread, .{self});
     }
 
     pub fn stop(self: *Bridge) !void {
@@ -920,7 +920,7 @@ pub const Bridge = struct {
         }
     }
 
-    fn runThread(self: *Bridge) void {
+    fn run_thread(self: *Bridge) void {
         // Self-pipe must be wired up by start() before this thread spawns.
         assert(self.wake[0] >= 0);
         assert(self.wake[1] >= 0);
@@ -983,8 +983,8 @@ pub const Bridge = struct {
                     const port = self.cfg.ports[port_idx].guest_port;
                     const c = accept(lfd, null, null);
                     if (c >= 0) {
-                        setNonblocking(c);
-                        self.startConnection(c, port) catch |err| {
+                        set_nonblocking(c);
+                        self.start_connection(c, port) catch |err| {
                             std.debug.print("vsock: startConnection failed: {s}\n", .{@errorName(err)});
                             _ = close(c);
                         };
@@ -1008,12 +1008,12 @@ pub const Bridge = struct {
                 };
                 if (match) |k| {
                     if ((events & POLLIN) != 0) {
-                        self.drainConnection(k) catch |err| {
+                        self.drain_connection(k) catch |err| {
                             std.debug.print("vsock: drainConnection err {s}\n", .{@errorName(err)});
-                            self.closeConnection(k);
+                            self.close_connection(k);
                         };
                     } else if ((events & (POLLERR | POLLHUP)) != 0) {
-                        self.closeConnection(k);
+                        self.close_connection(k);
                     }
                 }
                 self.mu.unlock();
@@ -1029,16 +1029,16 @@ pub const Bridge = struct {
             var k: usize = 0;
             while (k < self.conns_len) : (k += 1) {
                 if (self.conns[k].pending_rx_len == 0) continue;
-                self.drainConnection(k) catch |err| {
+                self.drain_connection(k) catch |err| {
                     std.debug.print("vsock: pending drainConnection err {s}\n", .{@errorName(err)});
-                    self.closeConnection(k);
+                    self.close_connection(k);
                 };
             }
             self.mu.unlock();
         }
     }
 
-    fn findOutbound(self: *Bridge, host_port: u32) ?[:0]const u8 {
+    fn find_outbound(self: *Bridge, host_port: u32) ?[:0]const u8 {
         for (self.cfg.ports) |pm| {
             if (pm.direction == .outbound and pm.guest_port == host_port) {
                 return pm.uds_path;
@@ -1047,7 +1047,7 @@ pub const Bridge = struct {
         return null;
     }
 
-    fn sendRst(self: *Bridge, in: VsockHdr) void {
+    fn send_rst(self: *Bridge, in: VsockHdr) void {
         const rst = VsockHdr{
             .src_cid = host_cid,
             .dst_cid = self.cfg.guest_cid,
@@ -1060,17 +1060,17 @@ pub const Bridge = struct {
             .buf_alloc = advertised_buf_alloc,
             .fwd_cnt = 0,
         };
-        _ = self.injectRx(rst, &[_]u8{});
+        _ = self.inject_rx(rst, &[_]u8{});
     }
 
     // Must be called with self.mu held.
-    fn startConnection(self: *Bridge, uds_fd: c_int, guest_port: u32) !void {
+    fn start_connection(self: *Bridge, uds_fd: c_int, guest_port: u32) !void {
         assert(uds_fd >= 0);
         assert(guest_port != 0);
         const host_port = self.next_host_port;
         self.next_host_port += 1;
         assert(host_port != 0);
-        const idx = self.connsPush(.{
+        const idx = self.conns_push(.{
             .guest_port = guest_port,
             .host_port = host_port,
             .uds_fd = uds_fd,
@@ -1090,17 +1090,17 @@ pub const Bridge = struct {
             .buf_alloc = advertised_buf_alloc,
             .fwd_cnt = 0,
         };
-        const ok = self.injectRx(hdr, &[_]u8{});
+        const ok = self.inject_rx(hdr, &[_]u8{});
         if (!ok) {
             std.debug.print("vsock: REQUEST inject failed (guest not ready?) — closing\n", .{});
-            self.closeConnection(idx);
+            self.close_connection(idx);
         }
     }
 
     /// How many more bytes the peer will accept right now. A fresh
     /// stream starts with no window info; treat zero as "send one
     /// and see" so we don't deadlock before the first packet.
-    fn peerRoom(c: *const Connection) u32 {
+    fn peer_room(c: *const Connection) u32 {
         if (c.peer_buf_alloc == 0) return 64 * 1024;
         const inflight = c.bytes_to_peer -% c.peer_fwd_cnt;
         if (inflight >= c.peer_buf_alloc) return 0;
@@ -1108,7 +1108,7 @@ pub const Bridge = struct {
     }
 
     // Must be called with self.mu held.
-    fn drainConnection(self: *Bridge, idx: usize) !void {
+    fn drain_connection(self: *Bridge, idx: usize) !void {
         assert(idx < self.conns_len);
         const c = &self.conns[idx];
         assert(c.uds_fd >= 0);
@@ -1119,7 +1119,7 @@ pub const Bridge = struct {
         // poll loop re-fires often enough that the guest will have
         // refilled the ring by some later iteration.
         if (c.pending_rx_len > 0) {
-            const room = peerRoom(c);
+            const room = peer_room(c);
             if (room == 0) {
                 c.paused = true;
                 return;
@@ -1136,7 +1136,7 @@ pub const Bridge = struct {
                 .buf_alloc = advertised_buf_alloc,
                 .fwd_cnt = c.fwd_cnt,
             };
-            if (!self.injectRx(hdr, c.pending_rx_buf[0..c.pending_rx_len])) {
+            if (!self.inject_rx(hdr, c.pending_rx_buf[0..c.pending_rx_len])) {
                 // Ring is still empty; keep the bytes parked, return,
                 // try again next poll cycle.
                 return;
@@ -1145,7 +1145,7 @@ pub const Bridge = struct {
             c.pending_rx_len = 0;
         }
 
-        const room = peerRoom(c);
+        const room = peer_room(c);
         if (room == 0) {
             c.paused = true;
             return;
@@ -1172,7 +1172,7 @@ pub const Bridge = struct {
                 .buf_alloc = advertised_buf_alloc,
                 .fwd_cnt = c.fwd_cnt,
             };
-            _ = self.injectRx(hdr, &[_]u8{});
+            _ = self.inject_rx(hdr, &[_]u8{});
             c.state = .closing;
             return;
         }
@@ -1190,7 +1190,7 @@ pub const Bridge = struct {
             .buf_alloc = advertised_buf_alloc,
             .fwd_cnt = c.fwd_cnt,
         };
-        if (self.injectRx(hdr, payload)) {
+        if (self.inject_rx(hdr, payload)) {
             c.bytes_to_peer +%= @intCast(payload.len);
             return;
         }
@@ -1203,9 +1203,9 @@ pub const Bridge = struct {
     }
 
     // Must be called with self.mu held.
-    fn closeConnection(self: *Bridge, idx: usize) void {
+    fn close_connection(self: *Bridge, idx: usize) void {
         assert(idx < self.conns_len);
-        const c = self.connsSwapRemove(idx);
+        const c = self.conns_swap_remove(idx);
         assert(c.uds_fd >= 0);
         _ = close(c.uds_fd);
     }
@@ -1214,7 +1214,7 @@ pub const Bridge = struct {
     //
     // Claim the next posted RX descriptor chain, lay down hdr+body,
     // push used, and raise the virtio IRQ.
-    fn injectRx(self: *Bridge, hdr: VsockHdr, body: []const u8) bool {
+    fn inject_rx(self: *Bridge, hdr: VsockHdr, body: []const u8) bool {
         assert(self.dev.size > 0);
         // Body is constructed on the host side; oversized means a
         // bridge-internal bug, not a guest one.
@@ -1228,17 +1228,17 @@ pub const Bridge = struct {
         // Inlining @memcpy here used to skip the barrier and let
         // weakly-ordered cores hoist the ring[idx] read above the
         // avail.idx load. See #192.
-        const avail = self.dev.readAvailHeader(q) orelse return false;
+        const avail = self.dev.read_avail_header(q) orelse return false;
         if (q.last_avail_idx == avail.idx) return false; // no buffer posted
 
         // avail.ring[slot]
         const slot: u32 = @as(u32, q.last_avail_idx) % q.num;
         const ring_off: u64 = q.driver_addr + @sizeOf(virtio.VringAvail) + @as(u64, slot) * @sizeOf(u16);
-        const ring_bytes = self.dev.guestBytes(ring_off, @sizeOf(u16)) orelse return false;
+        const ring_bytes = self.dev.guest_bytes(ring_off, @sizeOf(u16)) orelse return false;
         const head: u16 = std.mem.readInt(u16, ring_bytes[0..2], .little);
 
-        const written = writePacket(self.dev, Q_RX, head, hdr, body) orelse return false;
-        self.dev.queuePushUsed(Q_RX, head, written);
+        const written = write_packet(self.dev, Q_RX, head, hdr, body) orelse return false;
+        self.dev.queue_push_used(Q_RX, head, written);
         q.last_avail_idx +%= 1;
         _ = @atomicRmw(u32, &self.dev.interrupt_status, .Or, virtio.IRQ_USED_BUFFER, .release);
 
@@ -1256,30 +1256,30 @@ pub const Bridge = struct {
     /// mutex around vsock MMIO` doc on `Bridge`. We rely on that
     /// outer lock instead of taking it again here (PthreadMutex isn't
     /// reentrant).
-    pub fn handleTxChain(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
+    pub fn handle_tx_chain(ctx: ?*anyopaque, dev: *virtio.Device, q_idx: u32, head: u16) void {
         assert(ctx != null);
         assert(q_idx < virtio.max_queues);
         const self: *Bridge = @ptrCast(@alignCast(ctx.?));
         assert(self.dev == dev);
         if (q_idx != Q_TX) {
             // Event queue or unexpected: ack and move on.
-            dev.queuePushUsed(q_idx, head, 0);
+            dev.queue_push_used(q_idx, head, 0);
             return;
         }
 
         var scratch: [max_payload + header_size]u8 = undefined;
-        const pkt = readPacket(dev, q_idx, head, &scratch) orelse {
-            dev.queuePushUsed(q_idx, head, 0);
+        const pkt = read_packet(dev, q_idx, head, &scratch) orelse {
+            dev.queue_push_used(q_idx, head, 0);
             return;
         };
         const total_len: u32 = @as(u32, @intCast(header_size)) + @as(u32, @intCast(pkt.body.len));
-        dev.queuePushUsed(q_idx, head, total_len);
+        dev.queue_push_used(q_idx, head, total_len);
 
-        self.dispatchGuestPacket(pkt.hdr, pkt.body);
+        self.dispatch_guest_packet(pkt.hdr, pkt.body);
     }
 
     // Must be called with self.mu held.
-    fn dispatchGuestPacket(self: *Bridge, hdr: VsockHdr, body: []const u8) void {
+    fn dispatch_guest_packet(self: *Bridge, hdr: VsockHdr, body: []const u8) void {
         // body is the slice readPacket carved out of its scratch; the
         // caller bounded it to scratch.len = max_payload + header_size.
         assert(body.len <= max_payload);
@@ -1297,11 +1297,11 @@ pub const Bridge = struct {
             // No existing connection. If it's a REQUEST targeting an
             // outbound-mapped host port, dial the UDS and accept.
             if (op == .request) {
-                if (self.findOutbound(hdr.dst_port)) |uds_path| {
-                    const fd = connectUds(uds_path);
+                if (self.find_outbound(hdr.dst_port)) |uds_path| {
+                    const fd = connect_uds(uds_path);
                     if (fd >= 0) {
-                        setNonblocking(fd);
-                        const pushed = self.connsPush(.{
+                        set_nonblocking(fd);
+                        const pushed = self.conns_push(.{
                             .guest_port = hdr.src_port,
                             .host_port = hdr.dst_port,
                             .uds_fd = fd,
@@ -1311,7 +1311,7 @@ pub const Bridge = struct {
                         });
                         if (pushed == null) {
                             _ = close(fd);
-                            self.sendRst(hdr);
+                            self.send_rst(hdr);
                             return;
                         }
                         const resp = VsockHdr{
@@ -1326,13 +1326,13 @@ pub const Bridge = struct {
                             .buf_alloc = advertised_buf_alloc,
                             .fwd_cnt = 0,
                         };
-                        _ = self.injectRx(resp, &[_]u8{});
+                        _ = self.inject_rx(resp, &[_]u8{});
                         return;
                     }
                 }
             }
             // Unknown / unmapped stream → reject with RST.
-            self.sendRst(hdr);
+            self.send_rst(hdr);
             return;
         }
         const idx = match.?;
@@ -1340,10 +1340,10 @@ pub const Bridge = struct {
 
         // Every inbound packet carries peer window + fwd_cnt — pick them
         // up before dispatch so peerRoom() reflects the latest view.
-        const had_room = peerRoom(c) > 0;
+        const had_room = peer_room(c) > 0;
         c.peer_buf_alloc = hdr.buf_alloc;
         c.peer_fwd_cnt = hdr.fwd_cnt;
-        const has_room = peerRoom(c) > 0;
+        const has_room = peer_room(c) > 0;
         // If credit opened up, unpause so the next poll wakes the fd.
         if (c.paused and !had_room and has_room) {
             c.paused = false;
@@ -1391,14 +1391,14 @@ pub const Bridge = struct {
                 // trickles.
                 const threshold: u32 = advertised_buf_alloc / 2;
                 if ((c.fwd_cnt -% c.last_credit_fwd_cnt) >= threshold) {
-                    self.sendCreditUpdate(c);
+                    self.send_credit_update(c);
                 }
             },
             .shutdown, .rst => {
-                self.closeConnection(idx);
+                self.close_connection(idx);
             },
             .credit_request => {
-                self.sendCreditUpdate(c);
+                self.send_credit_update(c);
             },
             .credit_update => {
                 // peer_fwd_cnt already absorbed above.
@@ -1407,7 +1407,7 @@ pub const Bridge = struct {
         }
     }
 
-    fn sendCreditUpdate(self: *Bridge, c: *Connection) void {
+    fn send_credit_update(self: *Bridge, c: *Connection) void {
         assert(c.uds_fd >= 0);
         assert(c.host_port != 0);
         const credit = VsockHdr{
@@ -1422,7 +1422,7 @@ pub const Bridge = struct {
             .buf_alloc = advertised_buf_alloc,
             .fwd_cnt = c.fwd_cnt,
         };
-        if (self.injectRx(credit, &[_]u8{})) {
+        if (self.inject_rx(credit, &[_]u8{})) {
             c.last_credit_fwd_cnt = c.fwd_cnt;
         }
     }
@@ -1430,8 +1430,8 @@ pub const Bridge = struct {
 
 test "parseEnv: legacy single-entry defaults to inbound" {
     const gpa = std.testing.allocator;
-    const parsed = try parseEnv(gpa, "1234:/tmp/a.sock");
-    defer freeParsed(gpa, parsed);
+    const parsed = try parse_env(gpa, "1234:/tmp/a.sock");
+    defer free_parsed(gpa, parsed);
     try std.testing.expectEqual(@as(usize, 1), parsed.len);
     try std.testing.expectEqual(@as(u32, 1234), parsed[0].guest_port);
     try std.testing.expectEqual(Direction.inbound, parsed[0].direction);
@@ -1440,8 +1440,8 @@ test "parseEnv: legacy single-entry defaults to inbound" {
 
 test "parseEnv: in: and out: prefixes" {
     const gpa = std.testing.allocator;
-    const parsed = try parseEnv(gpa, "in:10:/tmp/i.sock,out:20:/tmp/o.sock");
-    defer freeParsed(gpa, parsed);
+    const parsed = try parse_env(gpa, "in:10:/tmp/i.sock,out:20:/tmp/o.sock");
+    defer free_parsed(gpa, parsed);
     try std.testing.expectEqual(@as(usize, 2), parsed.len);
     try std.testing.expectEqual(Direction.inbound, parsed[0].direction);
     try std.testing.expectEqual(@as(u32, 10), parsed[0].guest_port);
@@ -1451,15 +1451,15 @@ test "parseEnv: in: and out: prefixes" {
 
 test "parseEnv: rejects malformed input" {
     const gpa = std.testing.allocator;
-    try std.testing.expectError(error.MissingColon, parseEnv(gpa, "nope"));
-    try std.testing.expectError(error.BadPort, parseEnv(gpa, "abc:/tmp/x.sock"));
-    try std.testing.expectError(error.EmptyPath, parseEnv(gpa, "10:"));
+    try std.testing.expectError(error.MissingColon, parse_env(gpa, "nope"));
+    try std.testing.expectError(error.BadPort, parse_env(gpa, "abc:/tmp/x.sock"));
+    try std.testing.expectError(error.EmptyPath, parse_env(gpa, "10:"));
 }
 
 test "parseEnv: skips empty segments (trailing comma)" {
     const gpa = std.testing.allocator;
-    const parsed = try parseEnv(gpa, "1:/a.sock,,2:/b.sock,");
-    defer freeParsed(gpa, parsed);
+    const parsed = try parse_env(gpa, "1:/a.sock,,2:/b.sock,");
+    defer free_parsed(gpa, parsed);
     try std.testing.expectEqual(@as(usize, 2), parsed.len);
 }
 
@@ -1494,5 +1494,5 @@ test "writePacket fails cleanly when the chain is too short" {
         .buf_alloc = advertised_buf_alloc,
         .fwd_cnt = 0,
     };
-    try std.testing.expectEqual(@as(?u32, null), writePacket(&dev, Q_RX, 0, hdr, &[_]u8{}));
+    try std.testing.expectEqual(@as(?u32, null), write_packet(&dev, Q_RX, 0, hdr, &[_]u8{}));
 }

--- a/packages/mount-server/src/fuse.zig
+++ b/packages/mount-server/src/fuse.zig
@@ -204,13 +204,13 @@ const O_CREAT: c_int = if (builtin.os.tag == .macos) 0x0200 else 0o100;
 const O_TRUNC: c_int = if (builtin.os.tag == .macos) 0x0400 else 0o1000;
 const O_APPEND: c_int = if (builtin.os.tag == .macos) 0x0008 else 0o2000;
 
-fn nowNs() u64 {
+fn now_ns() u64 {
     var ts: timespec_c = .{ .tv_sec = 0, .tv_nsec = 0 };
     _ = clock_gettime(CLOCK_MONOTONIC, &ts);
     return @as(u64, @intCast(ts.tv_sec)) * 1_000_000_000 + @as(u64, @intCast(ts.tv_nsec));
 }
 
-fn nowMs() i64 {
+fn now_ms() i64 {
     var ts: timespec_c = .{ .tv_sec = 0, .tv_nsec = 0 };
     _ = clock_gettime(CLOCK_REALTIME, &ts);
     return @as(i64, ts.tv_sec) * 1000 + @divFloor(@as(i64, ts.tv_nsec), 1_000_000);
@@ -369,7 +369,7 @@ const InHeader = struct {
     pid: u32,
 };
 
-fn readInHeader(buf: []const u8) InHeader {
+fn read_in_header(buf: []const u8) InHeader {
     assert(buf.len >= FUSE_IN_HEADER_SIZE);
     return .{
         .len = std.mem.readInt(u32, buf[0..4], .little),
@@ -383,7 +383,7 @@ fn readInHeader(buf: []const u8) InHeader {
     };
 }
 
-fn writeOutHeader(dst: []u8, payload_len: usize, err: i32, unique: u64) void {
+fn write_out_header(dst: []u8, payload_len: usize, err: i32, unique: u64) void {
     assert(dst.len >= FUSE_OUT_HEADER_SIZE);
     const total: u32 = @intCast(FUSE_OUT_HEADER_SIZE + payload_len);
     std.mem.writeInt(u32, dst[0..4], total, .little);
@@ -410,7 +410,7 @@ const Attr = struct {
     flags: u32,
 };
 
-fn writeAttr(dst: []u8, a: Attr) void {
+fn write_attr(dst: []u8, a: Attr) void {
     assert(dst.len >= FUSE_ATTR_SIZE);
     std.mem.writeInt(u64, dst[0..8], a.ino, .little);
     std.mem.writeInt(u64, dst[8..16], a.size, .little);
@@ -518,7 +518,7 @@ pub const State = struct {
         self.inodes.deinit();
 
         var hit = self.handles.iterator();
-        while (hit.next()) |e| freeHandle(self, e.value_ptr);
+        while (hit.next()) |e| free_handle(self, e.value_ptr);
         self.handles.deinit();
 
         self.op_stats.deinit();
@@ -533,20 +533,20 @@ pub const State = struct {
     /// (reopened by path on restore — READ/WRITE are stateless
     /// pread/pwrite, so the fd offset doesn't matter), and the
     /// profiling/stats fields (re-initialised at boot).
-    pub fn dumpState(self: *State, gpa: std.mem.Allocator) ![]u8 {
+    pub fn dump_state(self: *State, gpa: std.mem.Allocator) ![]u8 {
         var b = fuse_state.Builder.init(gpa, self.mode_rw, self.next_inode, self.next_handle);
         errdefer b.deinit();
 
         var it = self.inodes.iterator();
         while (it.next()) |e| {
-            try b.addInode(e.key_ptr.*, e.value_ptr.nlookup, e.value_ptr.rel_path);
+            try b.add_inode(e.key_ptr.*, e.value_ptr.nlookup, e.value_ptr.rel_path);
         }
         var hit = self.handles.iterator();
         while (hit.next()) |e| {
             const h = e.value_ptr;
             switch (h.kind) {
-                .file => try b.addFileHandle(e.key_ptr.*, h.nodeid, h.open_flags),
-                .dir => try b.addDirHandle(e.key_ptr.*, h.nodeid, h.dir_entries orelse &.{}),
+                .file => try b.add_file_handle(e.key_ptr.*, h.nodeid, h.open_flags),
+                .dir => try b.add_dir_handle(e.key_ptr.*, h.nodeid, h.dir_entries orelse &.{}),
             }
         }
         assert(b.inode_count == self.inodes.count());
@@ -564,7 +564,7 @@ pub const State = struct {
     /// current mount root; a reopen that fails (file removed on the
     /// host since the snapshot) degrades to fd = -1, so the next op on
     /// that handle returns EBADF — fail-soft, never a wedge.
-    pub fn applyState(self: *State, payload: []const u8) !void {
+    pub fn apply_state(self: *State, payload: []const u8) !void {
         var d = try fuse_state.decode(self.gpa, payload);
         defer d.deinit();
 
@@ -576,7 +576,7 @@ pub const State = struct {
         self.inodes.clearRetainingCapacity();
 
         var hit = self.handles.iterator();
-        while (hit.next()) |e| freeHandle(self, e.value_ptr);
+        while (hit.next()) |e| free_handle(self, e.value_ptr);
         self.handles.clearRetainingCapacity();
 
         self.mode_rw = d.mode_rw;
@@ -591,7 +591,7 @@ pub const State = struct {
             switch (rec.kind) {
                 .file => try self.handles.put(rec.handle_id, .{
                     .kind = .file,
-                    .fd = self.reopenHandle(rec.nodeid, rec.open_flags),
+                    .fd = self.reopen_handle(rec.nodeid, rec.open_flags),
                     .nodeid = rec.nodeid,
                     .open_flags = rec.open_flags,
                 }),
@@ -614,13 +614,13 @@ pub const State = struct {
     /// O_TRUNC is masked off (it would wipe the file we're restoring),
     /// and a `:ro` mount is forced down to O_RDONLY. A missing nodeid,
     /// an unresolvable path, or a failed open all yield -1.
-    fn reopenHandle(self: *State, nodeid: u64, open_flags: u32) c_int {
+    fn reopen_handle(self: *State, nodeid: u64, open_flags: u32) c_int {
         const entry = self.inodes.getPtr(nodeid) orelse return -1;
         var path_buf: [4096]u8 = undefined;
-        const abs = buildAbsPath(self, entry.rel_path, &path_buf) catch return -1;
+        const abs = build_abs_path(self, entry.rel_path, &path_buf) catch return -1;
         var flags = open_flags & ~LINUX_O_TRUNC;
         if (!self.mode_rw) flags &= ~@as(u32, 0o3); // force O_RDONLY
-        return openHost(abs, linuxOpenToHost(flags), 0) catch -1;
+        return open_host(abs, linux_open_to_host(flags), 0) catch -1;
     }
 };
 
@@ -628,7 +628,7 @@ pub const State = struct {
 /// free the packed-dirent slices for a `dir`. Idempotent enough: a
 /// double-free can't happen because callers `remove()` from the map
 /// right after.
-fn freeHandle(state: *State, e: *OpenEntry) void {
+fn free_handle(state: *State, e: *OpenEntry) void {
     switch (e.kind) {
         .file => {
             // A `.file` handle never carries dir entries — the two
@@ -652,7 +652,7 @@ fn freeHandle(state: *State, e: *OpenEntry) void {
 /// Write exactly `data.len` bytes to `fd`. Used only by
 /// `writeStatsAtomic` for the small stats JSON — the request/reply
 /// frame I/O lives in the owning transport, not here.
-fn writeFileAll(fd: c_int, data: []const u8) bool {
+fn write_file_all(fd: c_int, data: []const u8) bool {
     var total: usize = 0;
     while (total < data.len) {
         const n = write(fd, data[total..].ptr, data.len - total);
@@ -668,11 +668,11 @@ fn writeFileAll(fd: c_int, data: []const u8) bool {
 
 // --- inode bookkeeping --------------------------------------------------
 
-fn requireInode(state: *State, ino: u64) ?*const InodeEntry {
+fn require_inode(state: *State, ino: u64) ?*const InodeEntry {
     return state.inodes.getPtr(ino);
 }
 
-fn bindInode(state: *State, rel_path: []const u8) !u64 {
+fn bind_inode(state: *State, rel_path: []const u8) !u64 {
     // Reuse an existing entry so nlookup accumulates correctly.
     var it = state.inodes.iterator();
     while (it.next()) |e| {
@@ -690,7 +690,7 @@ fn bindInode(state: *State, rel_path: []const u8) !u64 {
     return ino;
 }
 
-fn decrefInode(state: *State, ino: u64, n: u64) void {
+fn decref_inode(state: *State, ino: u64, n: u64) void {
     const e = state.inodes.getPtr(ino) orelse return;
     if (e.nlookup == NLOOKUP_PINNED) return; // root pinned
     if (n >= e.nlookup) {
@@ -711,7 +711,7 @@ fn decrefInode(state: *State, ino: u64, n: u64) void {
 /// POSIX path with no `..`, `.`, leading `/`, or NUL bytes — every
 /// site that puts a path into the inode table goes through
 /// `validateName` first.
-fn buildAbsPath(state: *State, rel_path: []const u8, out: []u8) ![]u8 {
+fn build_abs_path(state: *State, rel_path: []const u8, out: []u8) ![]u8 {
     if (rel_path.len == 0) {
         if (state.root_abs.len > out.len) return error.PathTooLong;
         @memcpy(out[0..state.root_abs.len], state.root_abs);
@@ -725,7 +725,7 @@ fn buildAbsPath(state: *State, rel_path: []const u8, out: []u8) ![]u8 {
     return out[0..need];
 }
 
-fn validateName(name: []const u8) !void {
+fn validate_name(name: []const u8) !void {
     if (name.len == 0) return error.InvalidName;
     if (std.mem.eql(u8, name, ".")) return error.InvalidName;
     if (std.mem.eql(u8, name, "..")) return error.InvalidName;
@@ -734,7 +734,7 @@ fn validateName(name: []const u8) !void {
     }
 }
 
-fn joinRel(gpa: std.mem.Allocator, parent_rel: []const u8, name: []const u8) ![]u8 {
+fn join_rel(gpa: std.mem.Allocator, parent_rel: []const u8, name: []const u8) ![]u8 {
     if (parent_rel.len == 0) return try gpa.dupe(u8, name);
     var buf = try gpa.alloc(u8, parent_rel.len + 1 + name.len);
     @memcpy(buf[0..parent_rel.len], parent_rel);
@@ -759,53 +759,53 @@ fn joinRel(gpa: std.mem.Allocator, parent_rel: []const u8, name: []const u8) ![]
 pub fn dispatch(state: *State, msg: []const u8) !?[]const u8 {
     assert(msg.len >= FUSE_IN_HEADER_SIZE);
 
-    const hdr = readInHeader(msg);
-    const start_ns: u64 = if (state.profile_enabled) nowNs() else 0;
+    const hdr = read_in_header(msg);
+    const start_ns: u64 = if (state.profile_enabled) now_ns() else 0;
 
     const op_e: Op = @enumFromInt(hdr.opcode);
     const reply_opt: ?[]const u8 = blk: {
         switch (op_e) {
-            .INIT => break :blk try onInit(state, hdr, msg),
-            .DESTROY => break :blk try buildErrorReply(state, hdr.unique, 0),
+            .INIT => break :blk try on_init(state, hdr, msg),
+            .DESTROY => break :blk try build_error_reply(state, hdr.unique, 0),
             .INTERRUPT => break :blk null, // no reply ever
             .FORGET => {
-                onForget(state, hdr, msg);
+                on_forget(state, hdr, msg);
                 break :blk null;
             },
             .BATCH_FORGET => {
-                onBatchForget(state, msg);
+                on_batch_forget(state, msg);
                 break :blk null;
             },
-            .LOOKUP => break :blk try onLookup(state, hdr, msg),
-            .GETATTR => break :blk try onGetattr(state, hdr),
-            .READLINK => break :blk try onReadlink(state, hdr),
-            .CREATE => break :blk try onCreate(state, hdr, msg),
-            .WRITE => break :blk try onWrite(state, hdr, msg),
-            .RELEASE => break :blk try onRelease(state, hdr, msg),
-            .OPEN => break :blk try onOpen(state, hdr, msg),
-            .READ => break :blk try onRead(state, hdr, msg),
-            .OPENDIR => break :blk try onOpendir(state, hdr),
-            .READDIR => break :blk try onReaddir(state, hdr, msg),
-            .RELEASEDIR => break :blk try onReleasedir(state, hdr, msg),
-            .MKDIR => break :blk try onMkdir(state, hdr, msg),
-            .UNLINK => break :blk try onUnlink(state, hdr, msg),
-            .RMDIR => break :blk try onRmdir(state, hdr, msg),
-            .RENAME => break :blk try onRename(state, hdr, msg),
-            .LINK => break :blk try onLink(state, hdr, msg),
-            .SYMLINK => break :blk try onSymlink(state, hdr, msg),
-            .SETATTR => break :blk try onSetattr(state, hdr, msg),
-            .STATFS => break :blk try onStatfs(state, hdr),
+            .LOOKUP => break :blk try on_lookup(state, hdr, msg),
+            .GETATTR => break :blk try on_getattr(state, hdr),
+            .READLINK => break :blk try on_readlink(state, hdr),
+            .CREATE => break :blk try on_create(state, hdr, msg),
+            .WRITE => break :blk try on_write(state, hdr, msg),
+            .RELEASE => break :blk try on_release(state, hdr, msg),
+            .OPEN => break :blk try on_open(state, hdr, msg),
+            .READ => break :blk try on_read(state, hdr, msg),
+            .OPENDIR => break :blk try on_opendir(state, hdr),
+            .READDIR => break :blk try on_readdir(state, hdr, msg),
+            .RELEASEDIR => break :blk try on_releasedir(state, hdr, msg),
+            .MKDIR => break :blk try on_mkdir(state, hdr, msg),
+            .UNLINK => break :blk try on_unlink(state, hdr, msg),
+            .RMDIR => break :blk try on_rmdir(state, hdr, msg),
+            .RENAME => break :blk try on_rename(state, hdr, msg),
+            .LINK => break :blk try on_link(state, hdr, msg),
+            .SYMLINK => break :blk try on_symlink(state, hdr, msg),
+            .SETATTR => break :blk try on_setattr(state, hdr, msg),
+            .STATFS => break :blk try on_statfs(state, hdr),
             // Soft-success: the guest can ask, we just say "ok". tar
             // calls FSYNC after writing each file; the host fs already
             // ack'd the write so this is durable enough for the bench.
             // FLUSH/ACCESS/FSYNCDIR are likewise userspace-OK-to-ignore.
-            .FSYNC, .FSYNCDIR, .FLUSH, .ACCESS => break :blk try buildErrorReply(state, hdr.unique, 0),
-            else => break :blk try buildErrorReply(state, hdr.unique, -E.NOSYS),
+            .FSYNC, .FSYNCDIR, .FLUSH, .ACCESS => break :blk try build_error_reply(state, hdr.unique, 0),
+            else => break :blk try build_error_reply(state, hdr.unique, -E.NOSYS),
         }
     };
 
     if (state.profile_enabled) {
-        const end_ns = nowNs();
+        const end_ns = now_ns();
         const gop = try state.op_stats.getOrPut(hdr.opcode);
         if (!gop.found_existing) gop.value_ptr.* = .{};
         gop.value_ptr.count += 1;
@@ -819,7 +819,7 @@ pub fn dispatch(state: *State, msg: []const u8) !?[]const u8 {
         if (state.ops_since_last_publish >= 256 and
             end_ns -% state.last_stats_publish_ns > 250 * std.time.ns_per_ms)
         {
-            writeStatsAtomic(state);
+            write_stats_atomic(state);
             state.last_stats_publish_ns = end_ns;
             state.ops_since_last_publish = 0;
         }
@@ -830,32 +830,32 @@ pub fn dispatch(state: *State, msg: []const u8) !?[]const u8 {
 
 // --- response builders --------------------------------------------------
 
-fn buildErrorReply(state: *State, unique: u64, err: i32) ![]u8 {
+fn build_error_reply(state: *State, unique: u64, err: i32) ![]u8 {
     // FUSE convention: a negative errno, or 0 for a success-with-no-
     // payload ack. A positive errno would corrupt the kernel's view.
     assert(err <= 0);
     const buf = try state.gpa.alloc(u8, FUSE_OUT_HEADER_SIZE);
-    writeOutHeader(buf, 0, err, unique);
+    write_out_header(buf, 0, err, unique);
     return buf;
 }
 
-fn buildReply(state: *State, unique: u64, payload: []const u8) ![]u8 {
+fn build_reply(state: *State, unique: u64, payload: []const u8) ![]u8 {
     // The whole reply (header + payload) rides one FUSE frame whose
     // length is a u32; in practice nothing we build approaches that,
     // but assert it so a future op that returns a huge payload trips
     // here instead of silently truncating in writeOutHeader's @intCast.
     assert(FUSE_OUT_HEADER_SIZE + payload.len <= std.math.maxInt(u32));
     const buf = try state.gpa.alloc(u8, FUSE_OUT_HEADER_SIZE + payload.len);
-    writeOutHeader(buf, payload.len, 0, unique);
+    write_out_header(buf, payload.len, 0, unique);
     @memcpy(buf[FUSE_OUT_HEADER_SIZE..], payload);
     return buf;
 }
 
 // --- INIT ---------------------------------------------------------------
 
-fn onInit(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_init(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     const major = std.mem.readInt(u32, body[0..4], .little);
     const minor = std.mem.readInt(u32, body[4..8], .little);
@@ -885,19 +885,19 @@ fn onInit(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u16, payload[30..32], 0, .little); // map_alignment
     std.mem.writeInt(u32, payload[32..36], 0, .little); // flags2
     // unused[7] already zero
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- FORGET / BATCH_FORGET ----------------------------------------------
 
-fn onForget(state: *State, hdr: InHeader, msg: []const u8) void {
+fn on_forget(state: *State, hdr: InHeader, msg: []const u8) void {
     const body = msg[FUSE_IN_HEADER_SIZE..];
     if (body.len < 8) return;
     const nlookup = std.mem.readInt(u64, body[0..8], .little);
-    decrefInode(state, hdr.nodeid, nlookup);
+    decref_inode(state, hdr.nodeid, nlookup);
 }
 
-fn onBatchForget(state: *State, msg: []const u8) void {
+fn on_batch_forget(state: *State, msg: []const u8) void {
     const body = msg[FUSE_IN_HEADER_SIZE..];
     if (body.len < 8) return;
     const count = std.mem.readInt(u32, body[0..4], .little);
@@ -907,33 +907,33 @@ fn onBatchForget(state: *State, msg: []const u8) void {
         if (off + 16 > body.len) return;
         const nodeid = std.mem.readInt(u64, body[off..][0..8], .little);
         const nlookup = std.mem.readInt(u64, body[off + 8 ..][0..8], .little);
-        decrefInode(state, nodeid, nlookup);
+        decref_inode(state, nodeid, nlookup);
     }
 }
 
 // --- LOOKUP -------------------------------------------------------------
 
-fn onLookup(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_lookup(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    const name = decodeName(body);
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const name = decode_name(body);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     // Compose the child's rel path off the parent's rel path. Parent
     // rel path was validated when its inode was bound.
-    const child_rel = try joinRel(state.gpa, parent.rel_path, name);
+    const child_rel = try join_rel(state.gpa, parent.rel_path, name);
     defer state.gpa.free(child_rel);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, child_rel, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, child_rel, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
-    const ino = try bindInode(state, child_rel);
+    const ino = try bind_inode(state, child_rel);
 
     var payload: [FUSE_ENTRY_OUT_SIZE]u8 = @splat(0);
     std.mem.writeInt(u64, payload[0..8], ino, .little);
@@ -942,59 +942,59 @@ fn onLookup(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[24..32], 0, .little); // attr_valid — force fresh GETATTR after mutations
     std.mem.writeInt(u32, payload[32..36], 0, .little); // entry_valid_nsec
     std.mem.writeInt(u32, payload[36..40], 0, .little); // attr_valid_nsec
-    writeAttr(payload[40..128], statToAttr(st, ino));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[40..128], stat_to_attr(st, ino));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- GETATTR / READLINK -------------------------------------------------
 
-fn onGetattr(state: *State, hdr: InHeader) ![]u8 {
-    const entry = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+fn on_getattr(state: *State, hdr: InHeader) ![]u8 {
+    const entry = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, entry.rel_path, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, entry.rel_path, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     var payload: [FUSE_ATTR_OUT_SIZE]u8 = @splat(0);
     std.mem.writeInt(u64, payload[0..8], 0, .little); // attr_valid — host attrs may change through aliases
     std.mem.writeInt(u32, payload[8..12], 0, .little); // attr_valid_nsec
     // dummy at offset 12
-    writeAttr(payload[16..104], statToAttr(st, hdr.nodeid));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[16..104], stat_to_attr(st, hdr.nodeid));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
-fn onReadlink(state: *State, hdr: InHeader) ![]u8 {
-    const entry = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+fn on_readlink(state: *State, hdr: InHeader) ![]u8 {
+    const entry = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, entry.rel_path, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, entry.rel_path, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var path_z: [4097]u8 = undefined;
-    if (abs.len >= path_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (abs.len >= path_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(path_z[0..abs.len], abs);
     path_z[abs.len] = 0;
 
     var target: [4096]u8 = undefined;
     const n = readlink(@ptrCast(&path_z), target[0..].ptr, target.len);
     if (n < 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
-    return try buildReply(state, hdr.unique, target[0..@intCast(n)]);
+    return try build_reply(state, hdr.unique, target[0..@intCast(n)]);
 }
 
 // --- CREATE -------------------------------------------------------------
 
-fn onCreate(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_create(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < FUSE_CREATE_IN_SIZE) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < FUSE_CREATE_IN_SIZE) return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     const flags = std.mem.readInt(u32, body[0..4], .little);
     const mode = std.mem.readInt(u32, body[4..8], .little);
@@ -1002,30 +1002,30 @@ fn onCreate(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     // currently (the kernel pre-applies umask before sending us
     // CREATE since we don't advertise FUSE_DONT_MASK).
 
-    const name = decodeName(body[FUSE_CREATE_IN_SIZE..]);
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const name = decode_name(body[FUSE_CREATE_IN_SIZE..]);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const child_rel = try joinRel(state.gpa, parent.rel_path, name);
+    const child_rel = try join_rel(state.gpa, parent.rel_path, name);
     errdefer state.gpa.free(child_rel);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, child_rel, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, child_rel, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const host_flags = linuxOpenToHost(flags) | O_CREAT;
-    const fd = openHost(abs, host_flags, @intCast(mode & 0o7777)) catch |e|
-        return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    const host_flags = linux_open_to_host(flags) | O_CREAT;
+    const fd = open_host(abs, host_flags, @intCast(mode & 0o7777)) catch |e|
+        return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     var st = std.mem.zeroes(Stat);
-    hostFstat(fd, &st) catch |e| {
+    host_fstat(fd, &st) catch |e| {
         _ = close(fd);
-        return try buildErrorReply(state, hdr.unique, mapFsError(e));
+        return try build_error_reply(state, hdr.unique, map_fs_error(e));
     };
 
-    const ino = try bindInode(state, child_rel);
+    const ino = try bind_inode(state, child_rel);
     state.gpa.free(child_rel); // bindInode took its own copy
 
     const id = state.next_handle;
@@ -1040,20 +1040,20 @@ fn onCreate(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[24..32], 0, .little); // attr_valid — force fresh GETATTR after mutations
     std.mem.writeInt(u32, payload[32..36], 0, .little); // entry_valid_nsec
     std.mem.writeInt(u32, payload[36..40], 0, .little); // attr_valid_nsec
-    writeAttr(payload[40..128], statToAttr(st, ino));
+    write_attr(payload[40..128], stat_to_attr(st, ino));
     std.mem.writeInt(u64, payload[128..136], id, .little); // fh
     std.mem.writeInt(u32, payload[136..140], 0, .little); // open_flags
     // padding at 140
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- WRITE --------------------------------------------------------------
 
-fn onWrite(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_write(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < FUSE_WRITE_IN_SIZE) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < FUSE_WRITE_IN_SIZE) return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     const fh = std.mem.readInt(u64, body[0..8], .little);
     const offset = std.mem.readInt(u64, body[8..16], .little);
@@ -1061,47 +1061,47 @@ fn onWrite(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     // write_flags at 20, lock_owner at 24, flags at 32
 
     const data_start = FUSE_WRITE_IN_SIZE;
-    if (data_start + size > body.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (data_start + size > body.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const data = body[data_start..][0..size];
 
     const handle = state.handles.get(fh) orelse
-        return try buildErrorReply(state, hdr.unique, -E.BADF);
-    if (handle.kind != .file) return try buildErrorReply(state, hdr.unique, -E.BADF);
+        return try build_error_reply(state, hdr.unique, -E.BADF);
+    if (handle.kind != .file) return try build_error_reply(state, hdr.unique, -E.BADF);
     // fd < 0 means a snapshot restore couldn't reopen this handle's
     // backing file (it was removed on the host since the snapshot).
     // An invalid descriptor is EBADF — fail-soft, never a wedge.
-    if (handle.fd < 0) return try buildErrorReply(state, hdr.unique, -E.BADF);
+    if (handle.fd < 0) return try build_error_reply(state, hdr.unique, -E.BADF);
 
-    const written = pwriteAll(handle.fd, data, offset) catch |e|
-        return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    const written = pwrite_all(handle.fd, data, offset) catch |e|
+        return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     var payload: [8]u8 = @splat(0);
     std.mem.writeInt(u32, payload[0..4], @intCast(written), .little);
     // padding at 4
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- OPEN ---------------------------------------------------------------
 
-fn onOpen(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_open(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const flags = std.mem.readInt(u32, body[0..4], .little);
 
     const access = flags & 0o3;
     if ((access == LINUX_O_WRONLY or access == LINUX_O_RDWR) and !state.mode_rw) {
-        return try buildErrorReply(state, hdr.unique, -E.ROFS);
+        return try build_error_reply(state, hdr.unique, -E.ROFS);
     }
 
-    const entry = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const entry = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, entry.rel_path, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, entry.rel_path, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const fd = openHost(abs, linuxOpenToHost(flags), 0) catch |e|
-        return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    const fd = open_host(abs, linux_open_to_host(flags), 0) catch |e|
+        return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     const id = state.next_handle;
     state.next_handle += 1;
@@ -1111,35 +1111,35 @@ fn onOpen(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[0..8], id, .little); // fh
     std.mem.writeInt(u32, payload[8..12], 0, .little); // open_flags
     // padding at 12
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- READ ---------------------------------------------------------------
 
-fn onRead(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_read(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 32) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 32) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const fh = std.mem.readInt(u64, body[0..8], .little);
     const offset = std.mem.readInt(u64, body[8..16], .little);
     const size = std.mem.readInt(u32, body[16..20], .little);
 
     const handle = state.handles.get(fh) orelse
-        return try buildErrorReply(state, hdr.unique, -E.BADF);
-    if (handle.kind != .file) return try buildErrorReply(state, hdr.unique, -E.BADF);
+        return try build_error_reply(state, hdr.unique, -E.BADF);
+    if (handle.kind != .file) return try build_error_reply(state, hdr.unique, -E.BADF);
     // fd < 0 means a snapshot restore couldn't reopen this handle's
     // backing file (it was removed on the host since the snapshot).
     // An invalid descriptor is EBADF — fail-soft, never a wedge.
-    if (handle.fd < 0) return try buildErrorReply(state, hdr.unique, -E.BADF);
+    if (handle.fd < 0) return try build_error_reply(state, hdr.unique, -E.BADF);
 
     const buf = try state.gpa.alloc(u8, FUSE_OUT_HEADER_SIZE + size);
     errdefer state.gpa.free(buf);
     const n = pread(handle.fd, buf[FUSE_OUT_HEADER_SIZE..].ptr, size, @intCast(offset));
     if (n < 0) {
         state.gpa.free(buf);
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
     const got: usize = @intCast(n);
-    writeOutHeader(buf[0..FUSE_OUT_HEADER_SIZE], got, 0, hdr.unique);
+    write_out_header(buf[0..FUSE_OUT_HEADER_SIZE], got, 0, hdr.unique);
     // Resize the over-allocated buffer down to (header + got). Use a
     // shrinkAndFree so a partial read doesn't ship trailing garbage.
     return state.gpa.realloc(buf, FUSE_OUT_HEADER_SIZE + got) catch {
@@ -1152,39 +1152,39 @@ fn onRead(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 
 // --- MKDIR --------------------------------------------------------------
 
-fn onMkdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_mkdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const mode = std.mem.readInt(u32, body[0..4], .little);
     // umask at offset 4
 
-    const name = decodeName(body[8..]);
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const name = decode_name(body[8..]);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const child_rel = try joinRel(state.gpa, parent.rel_path, name);
+    const child_rel = try join_rel(state.gpa, parent.rel_path, name);
     errdefer state.gpa.free(child_rel);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, child_rel, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, child_rel, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var path_z: [4097]u8 = undefined;
-    if (abs.len >= path_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (abs.len >= path_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(path_z[0..abs.len], abs);
     path_z[abs.len] = 0;
     if (mkdir(@ptrCast(&path_z), @intCast(mode & 0o7777)) != 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
-    const ino = try bindInode(state, child_rel);
+    const ino = try bind_inode(state, child_rel);
     state.gpa.free(child_rel);
 
     var payload: [FUSE_ENTRY_OUT_SIZE]u8 = @splat(0);
@@ -1194,92 +1194,92 @@ fn onMkdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[24..32], 0, .little);
     std.mem.writeInt(u32, payload[32..36], 0, .little);
     std.mem.writeInt(u32, payload[36..40], 0, .little);
-    writeAttr(payload[40..128], statToAttr(st, ino));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[40..128], stat_to_attr(st, ino));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- UNLINK / RMDIR / LINK / RENAME / SYMLINK ---------------------------
 
-fn unlinkOrRmdir(
+fn unlink_or_rmdir(
     state: *State,
     hdr: InHeader,
     msg: []const u8,
     is_rmdir: bool,
 ) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    const name = decodeName(body);
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const name = decode_name(body);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const child_rel = try joinRel(state.gpa, parent.rel_path, name);
+    const child_rel = try join_rel(state.gpa, parent.rel_path, name);
     defer state.gpa.free(child_rel);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, child_rel, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, child_rel, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var path_z: [4097]u8 = undefined;
-    if (abs.len >= path_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (abs.len >= path_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(path_z[0..abs.len], abs);
     path_z[abs.len] = 0;
 
     const rc = if (is_rmdir) rmdir(@ptrCast(&path_z)) else unlink(@ptrCast(&path_z));
     if (rc != 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
-    return try buildErrorReply(state, hdr.unique, 0);
+    return try build_error_reply(state, hdr.unique, 0);
 }
 
-fn onUnlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    return unlinkOrRmdir(state, hdr, msg, false);
+fn on_unlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    return unlink_or_rmdir(state, hdr, msg, false);
 }
 
-fn onRmdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    return unlinkOrRmdir(state, hdr, msg, true);
+fn on_rmdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    return unlink_or_rmdir(state, hdr, msg, true);
 }
 
-fn onLink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_link(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const oldnodeid = std.mem.readInt(u64, body[0..8], .little);
-    const name = decodeName(body[8..]);
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const name = decode_name(body[8..]);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const old_entry = requireInode(state, oldnodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
-    const new_parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const old_entry = require_inode(state, oldnodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
+    const new_parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const new_rel = try joinRel(state.gpa, new_parent.rel_path, name);
+    const new_rel = try join_rel(state.gpa, new_parent.rel_path, name);
     defer state.gpa.free(new_rel);
 
     var old_path_buf: [4096]u8 = undefined;
-    const old_abs = buildAbsPath(state, old_entry.rel_path, &old_path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const old_abs = build_abs_path(state, old_entry.rel_path, &old_path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
     var new_path_buf: [4096]u8 = undefined;
-    const new_abs = buildAbsPath(state, new_rel, &new_path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const new_abs = build_abs_path(state, new_rel, &new_path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var old_z: [4097]u8 = undefined;
-    if (old_abs.len >= old_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (old_abs.len >= old_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(old_z[0..old_abs.len], old_abs);
     old_z[old_abs.len] = 0;
     var new_z: [4097]u8 = undefined;
-    if (new_abs.len >= new_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (new_abs.len >= new_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(new_z[0..new_abs.len], new_abs);
     new_z[new_abs.len] = 0;
 
     if (link(@ptrCast(&old_z), @ptrCast(&new_z)) != 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(new_abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(new_abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     // FUSE hardlinks must point at the same nodeid so the guest sees
     // shared size/nlink updates through either path. Our inode table is
@@ -1294,7 +1294,7 @@ fn onLink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
         if (entry.nlookup != NLOOKUP_PINNED) entry.nlookup += 1;
     } else {
         state.gpa.free(replacement);
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+        return try build_error_reply(state, hdr.unique, -E.STALE);
     }
     const ino = oldnodeid;
 
@@ -1305,109 +1305,109 @@ fn onLink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[24..32], 0, .little);
     std.mem.writeInt(u32, payload[32..36], 0, .little);
     std.mem.writeInt(u32, payload[36..40], 0, .little);
-    writeAttr(payload[40..128], statToAttr(st, ino));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[40..128], stat_to_attr(st, ino));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
-fn onRename(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_rename(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const newdir = std.mem.readInt(u64, body[0..8], .little);
     const names = body[8..];
     const old_nul = std.mem.indexOfScalar(u8, names, 0) orelse
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
     const old_name = names[0..old_nul];
-    validateName(old_name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    validate_name(old_name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     const rest = names[old_nul + 1 ..];
     const new_nul = std.mem.indexOfScalar(u8, rest, 0) orelse rest.len;
     const new_name = rest[0..new_nul];
-    validateName(new_name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    validate_name(new_name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const old_parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
-    const new_parent = requireInode(state, newdir) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const old_parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
+    const new_parent = require_inode(state, newdir) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const old_rel = try joinRel(state.gpa, old_parent.rel_path, old_name);
+    const old_rel = try join_rel(state.gpa, old_parent.rel_path, old_name);
     defer state.gpa.free(old_rel);
-    const new_rel = try joinRel(state.gpa, new_parent.rel_path, new_name);
+    const new_rel = try join_rel(state.gpa, new_parent.rel_path, new_name);
     defer state.gpa.free(new_rel);
 
     var old_path_buf: [4096]u8 = undefined;
-    const old_abs = buildAbsPath(state, old_rel, &old_path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const old_abs = build_abs_path(state, old_rel, &old_path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
     var new_path_buf: [4096]u8 = undefined;
-    const new_abs = buildAbsPath(state, new_rel, &new_path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const new_abs = build_abs_path(state, new_rel, &new_path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var old_z: [4097]u8 = undefined;
-    if (old_abs.len >= old_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (old_abs.len >= old_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(old_z[0..old_abs.len], old_abs);
     old_z[old_abs.len] = 0;
     var new_z: [4097]u8 = undefined;
-    if (new_abs.len >= new_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (new_abs.len >= new_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(new_z[0..new_abs.len], new_abs);
     new_z[new_abs.len] = 0;
 
     if (rename(@ptrCast(&old_z), @ptrCast(&new_z)) != 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
 
     // Keep any already-bound source inode usable after a successful
     // rename. Destination dentries are left path-bound; if the guest
     // had looked one up before replacement, that nodeid still resolves
     // the destination path, which now contains the renamed bytes.
-    updateBoundInodesAfterRename(state, old_rel, new_rel) catch return try buildErrorReply(state, hdr.unique, -E.IO);
-    return try buildErrorReply(state, hdr.unique, 0);
+    update_bound_inodes_after_rename(state, old_rel, new_rel) catch return try build_error_reply(state, hdr.unique, -E.IO);
+    return try build_error_reply(state, hdr.unique, 0);
 }
 
-fn onSymlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
-    if (!state.mode_rw) return try buildErrorReply(state, hdr.unique, -E.ROFS);
+fn on_symlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     // Wire format: two NUL-terminated strings, name then target. No
     // fixed-size struct prefix.
     const body = msg[FUSE_IN_HEADER_SIZE..];
     const first_nul = std.mem.indexOfScalar(u8, body, 0) orelse
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
     const name = body[0..first_nul];
-    validateName(name) catch return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    validate_name(name) catch return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     const rest = body[first_nul + 1 ..];
     const target_end = std.mem.indexOfScalar(u8, rest, 0) orelse rest.len;
     const target = rest[0..target_end];
-    if (target.len == 0) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (target.len == 0) return try build_error_reply(state, hdr.unique, -E.INVAL);
 
-    const parent = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const parent = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
-    const child_rel = try joinRel(state.gpa, parent.rel_path, name);
+    const child_rel = try join_rel(state.gpa, parent.rel_path, name);
     errdefer state.gpa.free(child_rel);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, child_rel, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, child_rel, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var link_z: [4097]u8 = undefined;
-    if (abs.len >= link_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (abs.len >= link_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(link_z[0..abs.len], abs);
     link_z[abs.len] = 0;
 
     var tgt_z: [4097]u8 = undefined;
-    if (target.len >= tgt_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (target.len >= tgt_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(tgt_z[0..target.len], target);
     tgt_z[target.len] = 0;
 
     if (symlink(@ptrCast(&tgt_z), @ptrCast(&link_z)) != 0) {
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
-    const ino = try bindInode(state, child_rel);
+    const ino = try bind_inode(state, child_rel);
     state.gpa.free(child_rel);
 
     var payload: [FUSE_ENTRY_OUT_SIZE]u8 = @splat(0);
@@ -1417,8 +1417,8 @@ fn onSymlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     std.mem.writeInt(u64, payload[24..32], 0, .little);
     std.mem.writeInt(u32, payload[32..36], 0, .little);
     std.mem.writeInt(u32, payload[36..40], 0, .little);
-    writeAttr(payload[40..128], statToAttr(st, ino));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[40..128], stat_to_attr(st, ino));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- SETATTR ------------------------------------------------------------
@@ -1430,9 +1430,9 @@ fn onSymlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 // still acknowledged without a host syscall; the guest kernel caches
 // them well enough for today's workloads, and we can harden them when
 // a real caller needs host-visible persistence.
-fn onSetattr(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_setattr(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const valid = std.mem.readInt(u32, body[0..4], .little);
 
     // FATTR bits 0..8 (MODE / UID / GID / SIZE / ATIME / MTIME / FH /
@@ -1442,43 +1442,43 @@ fn onSetattr(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const mutating_mask: u32 = FATTR_MODE | FATTR_UID | FATTR_GID | FATTR_SIZE |
         FATTR_ATIME | FATTR_MTIME | FATTR_ATIME_NOW | FATTR_MTIME_NOW;
     if (!state.mode_rw and (valid & mutating_mask) != 0) {
-        return try buildErrorReply(state, hdr.unique, -E.ROFS);
+        return try build_error_reply(state, hdr.unique, -E.ROFS);
     }
 
-    const entry = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+    const entry = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, entry.rel_path, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, entry.rel_path, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     if ((valid & FATTR_SIZE) != 0) {
-        if (body.len < 24) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+        if (body.len < 24) return try build_error_reply(state, hdr.unique, -E.INVAL);
         const size = std.mem.readInt(u64, body[16..24], .little);
         if (size > @as(u64, @intCast(std.math.maxInt(i64)))) {
-            return try buildErrorReply(state, hdr.unique, -E.INVAL);
+            return try build_error_reply(state, hdr.unique, -E.INVAL);
         }
 
         var truncated = false;
         if ((valid & FATTR_FH) != 0) {
             const fh = std.mem.readInt(u64, body[8..16], .little);
             if (state.handles.get(fh)) |handle| {
-                if (handle.kind != .file or handle.fd < 0) return try buildErrorReply(state, hdr.unique, -E.BADF);
+                if (handle.kind != .file or handle.fd < 0) return try build_error_reply(state, hdr.unique, -E.BADF);
                 if (ftruncate(handle.fd, @intCast(size)) != 0) {
-                    return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+                    return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
                 }
                 truncated = true;
             } else {
-                return try buildErrorReply(state, hdr.unique, -E.BADF);
+                return try build_error_reply(state, hdr.unique, -E.BADF);
             }
         }
         if (!truncated) {
             var path_z: [4097]u8 = undefined;
-            if (abs.len >= path_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+            if (abs.len >= path_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
             @memcpy(path_z[0..abs.len], abs);
             path_z[abs.len] = 0;
             if (truncate(@ptrCast(&path_z), @intCast(size)) != 0) {
-                return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+                return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
             }
         }
     }
@@ -1487,46 +1487,46 @@ fn onSetattr(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
         // fuse_setattr_in.mode sits at byte 68. Only permission/sticky
         // bits are accepted by chmod/fchmod; the file-type bits come
         // back from the host lstat below.
-        if (body.len < 72) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+        if (body.len < 72) return try build_error_reply(state, hdr.unique, -E.INVAL);
         const mode = std.mem.readInt(u32, body[68..72], .little) & 0o7777;
 
         var chmodded = false;
         if ((valid & FATTR_FH) != 0) {
             const fh = std.mem.readInt(u64, body[8..16], .little);
             if (state.handles.get(fh)) |handle| {
-                if (handle.kind != .file or handle.fd < 0) return try buildErrorReply(state, hdr.unique, -E.BADF);
+                if (handle.kind != .file or handle.fd < 0) return try build_error_reply(state, hdr.unique, -E.BADF);
                 if (fchmod(handle.fd, @intCast(mode)) != 0) {
-                    return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+                    return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
                 }
                 chmodded = true;
             } else {
-                return try buildErrorReply(state, hdr.unique, -E.BADF);
+                return try build_error_reply(state, hdr.unique, -E.BADF);
             }
         }
         if (!chmodded) {
             var path_z: [4097]u8 = undefined;
-            if (abs.len >= path_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+            if (abs.len >= path_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
             @memcpy(path_z[0..abs.len], abs);
             path_z[abs.len] = 0;
             if (chmod(@ptrCast(&path_z), @intCast(mode)) != 0) {
-                return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+                return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
             }
         }
     }
 
     var st = std.mem.zeroes(Stat);
-    hostLstat(abs, &st) catch |e| return try buildErrorReply(state, hdr.unique, mapFsError(e));
+    host_lstat(abs, &st) catch |e| return try build_error_reply(state, hdr.unique, map_fs_error(e));
 
     var payload: [FUSE_ATTR_OUT_SIZE]u8 = @splat(0);
     std.mem.writeInt(u64, payload[0..8], 1, .little);
     std.mem.writeInt(u32, payload[8..12], 0, .little);
-    writeAttr(payload[16..104], statToAttr(st, hdr.nodeid));
-    return try buildReply(state, hdr.unique, &payload);
+    write_attr(payload[16..104], stat_to_attr(st, hdr.nodeid));
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- STATFS -------------------------------------------------------------
 
-fn onStatfs(state: *State, hdr: InHeader) ![]u8 {
+fn on_statfs(state: *State, hdr: InHeader) ![]u8 {
     // Plausible defaults — exactness isn't required for correctness;
     // tar / df / etc. just want non-zero free space.
     var payload: [80]u8 = @splat(0);
@@ -1538,33 +1538,33 @@ fn onStatfs(state: *State, hdr: InHeader) ![]u8 {
     std.mem.writeInt(u32, payload[40..44], 4096, .little); // bsize
     std.mem.writeInt(u32, payload[44..48], 255, .little); // namelen
     std.mem.writeInt(u32, payload[48..52], 4096, .little); // frsize
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
 // --- RELEASE / RELEASEDIR -----------------------------------------------
 
-fn onRelease(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_release(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < FUSE_RELEASE_IN_SIZE) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < FUSE_RELEASE_IN_SIZE) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const fh = std.mem.readInt(u64, body[0..8], .little);
     if (state.handles.getPtr(fh)) |handle| {
-        freeHandle(state, handle);
+        free_handle(state, handle);
         _ = state.handles.remove(fh);
     }
-    return try buildErrorReply(state, hdr.unique, 0);
+    return try build_error_reply(state, hdr.unique, 0);
 }
 
 // fuse_release_in is the same wire shape RELEASEDIR uses — fh is the
 // first u64. Free the snapshotted dirent buffers.
-fn onReleasedir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_releasedir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 8) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const fh = std.mem.readInt(u64, body[0..8], .little);
     if (state.handles.getPtr(fh)) |handle| {
-        freeHandle(state, handle);
+        free_handle(state, handle);
         _ = state.handles.remove(fh);
     }
-    return try buildErrorReply(state, hdr.unique, 0);
+    return try build_error_reply(state, hdr.unique, 0);
 }
 
 // --- OPENDIR / READDIR --------------------------------------------------
@@ -1581,7 +1581,7 @@ const DT_LNK: u32 = 10;
 const DT_SOCK: u32 = 12;
 
 // S_IFMT type bits → DT_* dirent type.
-fn modeToDT(mode: u32) u32 {
+fn mode_to_dt(mode: u32) u32 {
     return switch (mode & 0o170000) {
         0o040000 => DT_DIR,
         0o100000 => DT_REG,
@@ -1596,7 +1596,7 @@ fn modeToDT(mode: u32) u32 {
 
 // Pack one `fuse_dirent`: 24-byte header (ino, off, namelen, type) +
 // the name, zero-padded to an 8-byte boundary. Caller owns the result.
-fn buildDirent(gpa: std.mem.Allocator, ino: u64, off: u64, dtype: u32, name: []const u8) ![]u8 {
+fn build_dirent(gpa: std.mem.Allocator, ino: u64, off: u64, dtype: u32, name: []const u8) ![]u8 {
     const padded_name = (name.len + 7) & ~@as(usize, 7);
     const buf = try gpa.alloc(u8, 24 + padded_name);
     @memset(buf, 0);
@@ -1608,21 +1608,21 @@ fn buildDirent(gpa: std.mem.Allocator, ino: u64, off: u64, dtype: u32, name: []c
     return buf;
 }
 
-fn onOpendir(state: *State, hdr: InHeader) ![]u8 {
-    const entry = requireInode(state, hdr.nodeid) orelse
-        return try buildErrorReply(state, hdr.unique, -E.STALE);
+fn on_opendir(state: *State, hdr: InHeader) ![]u8 {
+    const entry = require_inode(state, hdr.nodeid) orelse
+        return try build_error_reply(state, hdr.unique, -E.STALE);
 
     var path_buf: [4096]u8 = undefined;
-    const abs = buildAbsPath(state, entry.rel_path, &path_buf) catch
-        return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    const abs = build_abs_path(state, entry.rel_path, &path_buf) catch
+        return try build_error_reply(state, hdr.unique, -E.INVAL);
 
     var abs_z: [4097]u8 = undefined;
-    if (abs.len >= abs_z.len) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (abs.len >= abs_z.len) return try build_error_reply(state, hdr.unique, -E.INVAL);
     @memcpy(abs_z[0..abs.len], abs);
     abs_z[abs.len] = 0;
 
     const dir = opendir(@ptrCast(&abs_z)) orelse
-        return try buildErrorReply(state, hdr.unique, mapFsError(errnoToZigError(errno())));
+        return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     defer _ = closedir(dir);
 
     // Pack every child into its own fuse_dirent buffer. An ArrayList
@@ -1656,15 +1656,15 @@ fn onOpendir(state: *State, hdr: InHeader) ![]u8 {
         var dtype: u32 = de.d_type;
         if (dtype == DT_UNKNOWN) {
             var child_buf: [4096]u8 = undefined;
-            const child_rel = joinRel(state.gpa, entry.rel_path, name) catch continue;
+            const child_rel = join_rel(state.gpa, entry.rel_path, name) catch continue;
             defer state.gpa.free(child_rel);
-            const child_abs = buildAbsPath(state, child_rel, &child_buf) catch continue;
+            const child_abs = build_abs_path(state, child_rel, &child_buf) catch continue;
             var st = std.mem.zeroes(Stat);
-            if (hostLstat(child_abs, &st)) |_| {
-                dtype = modeToDT(st.mode);
+            if (host_lstat(child_abs, &st)) |_| {
+                dtype = mode_to_dt(st.mode);
             } else |_| {}
         }
-        const packed_de = try buildDirent(state.gpa, off, off, dtype, name);
+        const packed_de = try build_dirent(state.gpa, off, off, dtype, name);
         try entries.append(state.gpa, packed_de);
     }
 
@@ -1676,21 +1676,21 @@ fn onOpendir(state: *State, hdr: InHeader) ![]u8 {
     var payload: [16]u8 = @splat(0);
     std.mem.writeInt(u64, payload[0..8], id, .little); // fh
     std.mem.writeInt(u32, payload[8..12], 0, .little); // open_flags
-    return try buildReply(state, hdr.unique, &payload);
+    return try build_reply(state, hdr.unique, &payload);
 }
 
-fn onReaddir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+fn on_readdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
     const body = msg[FUSE_IN_HEADER_SIZE..];
-    if (body.len < 32) return try buildErrorReply(state, hdr.unique, -E.INVAL);
+    if (body.len < 32) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const fh = std.mem.readInt(u64, body[0..8], .little);
     const offset = std.mem.readInt(u64, body[8..16], .little);
     const size = std.mem.readInt(u32, body[16..20], .little);
 
     const handle = state.handles.get(fh) orelse
-        return try buildErrorReply(state, hdr.unique, -E.BADF);
-    if (handle.kind != .dir) return try buildErrorReply(state, hdr.unique, -E.BADF);
+        return try build_error_reply(state, hdr.unique, -E.BADF);
+    if (handle.kind != .dir) return try build_error_reply(state, hdr.unique, -E.BADF);
     const entries = handle.dir_entries orelse
-        return try buildErrorReply(state, hdr.unique, -E.BADF);
+        return try build_error_reply(state, hdr.unique, -E.BADF);
 
     // Fill the reply with as many whole dirents as fit in `size`,
     // starting at `offset` (1-based "off" the kernel echoed back from
@@ -1703,7 +1703,7 @@ fn onReaddir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
         total += entries[i].len;
     }
     const reply = try state.gpa.alloc(u8, FUSE_OUT_HEADER_SIZE + total);
-    writeOutHeader(reply[0..FUSE_OUT_HEADER_SIZE], total, 0, hdr.unique);
+    write_out_header(reply[0..FUSE_OUT_HEADER_SIZE], total, 0, hdr.unique);
     var cursor: usize = FUSE_OUT_HEADER_SIZE;
     var j: usize = start;
     while (j < i) : (j += 1) {
@@ -1720,31 +1720,31 @@ fn onReaddir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 
 // --- host fs ops --------------------------------------------------------
 
-fn hostLstat(path: []const u8, out: *Stat) !void {
+fn host_lstat(path: []const u8, out: *Stat) !void {
     var path_z: [4097]u8 = undefined;
     if (path.len >= path_z.len) return error.PathTooLong;
     @memcpy(path_z[0..path.len], path);
     path_z[path.len] = 0;
     if (fstatat(AT_FDCWD, @ptrCast(&path_z), out, AT_SYMLINK_NOFOLLOW) != 0) {
-        return errnoToZigError(errno());
+        return errno_to_zig_error(errno());
     }
 }
 
-fn hostFstat(fd: c_int, out: *Stat) !void {
-    if (fstat(fd, out) != 0) return errnoToZigError(errno());
+fn host_fstat(fd: c_int, out: *Stat) !void {
+    if (fstat(fd, out) != 0) return errno_to_zig_error(errno());
 }
 
-fn openHost(path: []const u8, flags: c_int, mode: c_int) !c_int {
+fn open_host(path: []const u8, flags: c_int, mode: c_int) !c_int {
     var path_z: [4097]u8 = undefined;
     if (path.len >= path_z.len) return error.PathTooLong;
     @memcpy(path_z[0..path.len], path);
     path_z[path.len] = 0;
     const fd = open(@ptrCast(&path_z), flags, mode);
-    if (fd < 0) return errnoToZigError(errno());
+    if (fd < 0) return errno_to_zig_error(errno());
     return fd;
 }
 
-fn pwriteAll(fd: c_int, data: []const u8, offset: u64) !usize {
+fn pwrite_all(fd: c_int, data: []const u8, offset: u64) !usize {
     var total: usize = 0;
     while (total < data.len) {
         const n = pwrite(fd, data[total..].ptr, data.len - total, @intCast(offset + total));
@@ -1754,12 +1754,12 @@ fn pwriteAll(fd: c_int, data: []const u8, offset: u64) !usize {
         }
         if (n == 0) break;
         if (errno() == EINTR) continue;
-        return errnoToZigError(errno());
+        return errno_to_zig_error(errno());
     }
     return total;
 }
 
-fn errnoToZigError(e: c_int) anyerror {
+fn errno_to_zig_error(e: c_int) anyerror {
     return switch (e) {
         2 => error.FileNotFound,
         13 => error.AccessDenied,
@@ -1775,7 +1775,7 @@ fn errnoToZigError(e: c_int) anyerror {
     };
 }
 
-fn mapFsError(e: anyerror) i32 {
+fn map_fs_error(e: anyerror) i32 {
     return switch (e) {
         error.FileNotFound => -E.NOENT,
         error.AccessDenied => -E.ACCES,
@@ -1792,7 +1792,7 @@ fn mapFsError(e: anyerror) i32 {
     };
 }
 
-fn linuxOpenToHost(linux_flags: u32) c_int {
+fn linux_open_to_host(linux_flags: u32) c_int {
     const access = linux_flags & 0o3;
     // With FUSE_CAP_WRITEBACK_CACHE the guest kernel may issue READs on
     // a handle the process opened O_WRONLY, to fill a page before a
@@ -1811,7 +1811,7 @@ fn linuxOpenToHost(linux_flags: u32) c_int {
     return host;
 }
 
-fn updateBoundInodesAfterRename(state: *State, old_rel: []const u8, new_rel: []const u8) !void {
+fn update_bound_inodes_after_rename(state: *State, old_rel: []const u8, new_rel: []const u8) !void {
     var it = state.inodes.iterator();
     while (it.next()) |e| {
         const rel = e.value_ptr.rel_path;
@@ -1831,7 +1831,7 @@ fn updateBoundInodesAfterRename(state: *State, old_rel: []const u8, new_rel: []c
     }
 }
 
-fn statToAttr(st: Stat, ino: u64) Attr {
+fn stat_to_attr(st: Stat, ino: u64) Attr {
     const atime_ts = if (builtin.os.tag == .macos) st.atimespec else st.atim;
     const mtime_ts = if (builtin.os.tag == .macos) st.mtimespec else st.mtim;
     const ctime_ts = if (builtin.os.tag == .macos) st.ctimespec else st.ctim;
@@ -1857,14 +1857,14 @@ fn statToAttr(st: Stat, ino: u64) Attr {
 
 // --- name decoding ------------------------------------------------------
 
-fn decodeName(body: []const u8) []const u8 {
+fn decode_name(body: []const u8) []const u8 {
     const nul = std.mem.indexOfScalar(u8, body, 0) orelse body.len;
     return body[0..nul];
 }
 
 // --- stats file ---------------------------------------------------------
 
-pub fn writeStatsAtomic(state: *State) void {
+pub fn write_stats_atomic(state: *State) void {
     const stats_path = state.stats_path orelse return;
 
     // Build the JSON in one heap buffer. Stats files are small (<10 KiB
@@ -1876,7 +1876,7 @@ pub fn writeStatsAtomic(state: *State) void {
 
     var slice = std.fmt.bufPrint(body_buf[cur..], "{{\"bytesServedOnPagesImg\":{d},\"updatedAtMs\":{d}", .{
         state.bytes_served_on_pages_img,
-        nowMs(),
+        now_ms(),
     }) catch return;
     cur += slice.len;
 
@@ -1892,7 +1892,7 @@ pub fn writeStatsAtomic(state: *State) void {
             }
             first = false;
             slice = std.fmt.bufPrint(body_buf[cur..], "\"{s}\":{{\"count\":{d},\"sumNs\":{d},\"p50Ns\":0,\"p99Ns\":0}}", .{
-                opName(e.key_ptr.*),
+                op_name(e.key_ptr.*),
                 e.value_ptr.count,
                 e.value_ptr.sum_ns,
             }) catch return;
@@ -1917,7 +1917,7 @@ pub fn writeStatsAtomic(state: *State) void {
 
     const fd = open(@ptrCast(&tmp_z), O_WRONLY | O_CREAT | O_TRUNC, @as(c_int, 0o644));
     if (fd < 0) return;
-    _ = writeFileAll(fd, body_items);
+    _ = write_file_all(fd, body_items);
     _ = close(fd);
 
     var dst_z: [4097]u8 = undefined;
@@ -1927,7 +1927,7 @@ pub fn writeStatsAtomic(state: *State) void {
     _ = rename(@ptrCast(&tmp_z), @ptrCast(&dst_z));
 }
 
-fn opName(code: u32) []const u8 {
+fn op_name(code: u32) []const u8 {
     return switch (@as(Op, @enumFromInt(code))) {
         .LOOKUP => "LOOKUP",
         .FORGET => "FORGET",
@@ -1980,7 +1980,7 @@ const testing = std.testing;
 /// Build a contiguous FUSE request frame — 40-byte in-header + body —
 /// exactly as a transport would hand it to `dispatch`. Caller owns the
 /// returned slice.
-fn testBuildFrame(
+fn test_build_frame(
     gpa: std.mem.Allocator,
     opcode: u32,
     unique: u64,
@@ -2000,19 +2000,19 @@ fn testBuildFrame(
 /// A `State` over a root path that never gets touched — every test
 /// here exercises a control-flow branch (negotiation, ENOSYS, the
 /// `:ro` gate, no-reply ops) that returns before any host fs syscall.
-fn testState(gpa: std.mem.Allocator, mode_rw: bool) !State {
+fn test_state(gpa: std.mem.Allocator, mode_rw: bool) !State {
     return State.init(gpa, try gpa.dupe(u8, "/nonexistent-machinen-test-root"), mode_rw);
 }
 
 test "dispatch: INIT negotiates protocol 7.31" {
     const gpa = testing.allocator;
-    var state = try testState(gpa, true);
+    var state = try test_state(gpa, true);
     defer state.deinit();
 
     var body: [16]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], 7, .little); // major
     std.mem.writeInt(u32, body[4..8], 36, .little); // minor — guest offers newer
-    const frame = try testBuildFrame(gpa, @intFromEnum(Op.INIT), 42, 0, &body);
+    const frame = try test_build_frame(gpa, @intFromEnum(Op.INIT), 42, 0, &body);
     defer gpa.free(frame);
 
     const reply = (try dispatch(&state, frame)) orelse return error.ExpectedReply;
@@ -2029,10 +2029,10 @@ test "dispatch: INIT negotiates protocol 7.31" {
 
 test "dispatch: unknown opcode returns ENOSYS" {
     const gpa = testing.allocator;
-    var state = try testState(gpa, true);
+    var state = try test_state(gpa, true);
     defer state.deinit();
 
-    const frame = try testBuildFrame(gpa, 9999, 7, 1, &.{});
+    const frame = try test_build_frame(gpa, 9999, 7, 1, &.{});
     defer gpa.free(frame);
 
     const reply = (try dispatch(&state, frame)) orelse return error.ExpectedReply;
@@ -2044,10 +2044,10 @@ test "dispatch: unknown opcode returns ENOSYS" {
 
 test "dispatch: CREATE on a :ro mount returns EROFS" {
     const gpa = testing.allocator;
-    var state = try testState(gpa, false); // read-only
+    var state = try test_state(gpa, false); // read-only
     defer state.deinit();
 
-    const frame = try testBuildFrame(gpa, @intFromEnum(Op.CREATE), 9, 1, &.{});
+    const frame = try test_build_frame(gpa, @intFromEnum(Op.CREATE), 9, 1, &.{});
     defer gpa.free(frame);
 
     const reply = (try dispatch(&state, frame)) orelse return error.ExpectedReply;
@@ -2058,26 +2058,26 @@ test "dispatch: CREATE on a :ro mount returns EROFS" {
 
 test "dispatch: FORGET and INTERRUPT produce no reply" {
     const gpa = testing.allocator;
-    var state = try testState(gpa, true);
+    var state = try test_state(gpa, true);
     defer state.deinit();
 
     const forget_body: [8]u8 = @splat(0);
-    const forget = try testBuildFrame(gpa, @intFromEnum(Op.FORGET), 1, 1, &forget_body);
+    const forget = try test_build_frame(gpa, @intFromEnum(Op.FORGET), 1, 1, &forget_body);
     defer gpa.free(forget);
     try testing.expect((try dispatch(&state, forget)) == null);
 
-    const interrupt = try testBuildFrame(gpa, @intFromEnum(Op.INTERRUPT), 2, 0, &.{});
+    const interrupt = try test_build_frame(gpa, @intFromEnum(Op.INTERRUPT), 2, 0, &.{});
     defer gpa.free(interrupt);
     try testing.expect((try dispatch(&state, interrupt)) == null);
 }
 
 test "validateName rejects path-escape and empty names" {
-    try testing.expectError(error.InvalidName, validateName(""));
-    try testing.expectError(error.InvalidName, validateName("."));
-    try testing.expectError(error.InvalidName, validateName(".."));
-    try testing.expectError(error.InvalidName, validateName("a/b"));
-    try testing.expectError(error.InvalidName, validateName("a\x00b"));
-    try validateName("normal-file.txt");
+    try testing.expectError(error.InvalidName, validate_name(""));
+    try testing.expectError(error.InvalidName, validate_name("."));
+    try testing.expectError(error.InvalidName, validate_name(".."));
+    try testing.expectError(error.InvalidName, validate_name("a/b"));
+    try testing.expectError(error.InvalidName, validate_name("a\x00b"));
+    try validate_name("normal-file.txt");
 }
 
 // --- snapshot (dumpState / applyState) tests ---------------------------
@@ -2092,7 +2092,7 @@ test "validateName rejects path-escape and empty names" {
 /// Absolute path of a `std.testing.tmpDir` — the dumpState/applyState
 /// tests need a real root the reopened fds can resolve against. Heap-
 /// allocated; the caller hands it to `State.init`, which takes ownership.
-fn testTmpRootAbs(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+fn test_tmp_root_abs(gpa: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
     const cwd = try std.process.currentPathAlloc(std.testing.io, gpa);
     defer gpa.free(cwd);
     return std.fs.path.join(gpa, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
@@ -2103,10 +2103,10 @@ test "dispatch: GETATTR returns sane attrs for the host stat layout" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
 
-    const frame = try testBuildFrame(gpa, @intFromEnum(Op.GETATTR), 9, 1, &.{});
+    const frame = try test_build_frame(gpa, @intFromEnum(Op.GETATTR), 9, 1, &.{});
     defer gpa.free(frame);
     const r = (try dispatch(&state, frame)) orelse return error.ExpectedReply;
     defer gpa.free(r);
@@ -2124,12 +2124,12 @@ test "dispatch: GETATTR returns sane attrs for the host stat layout" {
 }
 
 /// CREATE `name` under the root inode; returns its (nodeid, fh).
-fn testCreate(state: *State, name: []const u8) !struct { nodeid: u64, fh: u64 } {
+fn test_create(state: *State, name: []const u8) !struct { nodeid: u64, fh: u64 } {
     var body: [16 + 96]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], LINUX_O_RDWR, .little);
     std.mem.writeInt(u32, body[4..8], 0o644, .little);
     @memcpy(body[16..][0..name.len], name);
-    const frame = try testBuildFrame(state.gpa, @intFromEnum(Op.CREATE), 1, 1, body[0 .. 16 + name.len]);
+    const frame = try test_build_frame(state.gpa, @intFromEnum(Op.CREATE), 1, 1, body[0 .. 16 + name.len]);
     defer state.gpa.free(frame);
     const r = (try dispatch(state, frame)) orelse return error.ExpectedReply;
     defer state.gpa.free(r);
@@ -2140,10 +2140,10 @@ fn testCreate(state: *State, name: []const u8) !struct { nodeid: u64, fh: u64 } 
     };
 }
 
-fn testLookup(state: *State, name: []const u8) !u64 {
+fn test_lookup(state: *State, name: []const u8) !u64 {
     var body: [128]u8 = @splat(0);
     @memcpy(body[0..name.len], name);
-    const frame = try testBuildFrame(state.gpa, @intFromEnum(Op.LOOKUP), 1, 1, body[0 .. name.len + 1]);
+    const frame = try test_build_frame(state.gpa, @intFromEnum(Op.LOOKUP), 1, 1, body[0 .. name.len + 1]);
     defer state.gpa.free(frame);
     const r = (try dispatch(state, frame)) orelse return error.ExpectedReply;
     defer state.gpa.free(r);
@@ -2151,10 +2151,10 @@ fn testLookup(state: *State, name: []const u8) !u64 {
     return std.mem.readInt(u64, r[FUSE_OUT_HEADER_SIZE..][0..8], .little);
 }
 
-fn testOpen(state: *State, nodeid: u64, flags: u32) !u64 {
+fn test_open(state: *State, nodeid: u64, flags: u32) !u64 {
     var body: [8]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], flags, .little);
-    const frame = try testBuildFrame(state.gpa, @intFromEnum(Op.OPEN), 1, nodeid, &body);
+    const frame = try test_build_frame(state.gpa, @intFromEnum(Op.OPEN), 1, nodeid, &body);
     defer state.gpa.free(frame);
     const r = (try dispatch(state, frame)) orelse return error.ExpectedReply;
     defer state.gpa.free(r);
@@ -2168,17 +2168,17 @@ test "dispatch: OPEN O_WRONLY handles writeback-cache read fill then WRITE exist
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "existing.txt", .data = "old-data" });
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
-    const nodeid = try testLookup(&state, "existing.txt");
-    const fh = try testOpen(&state, nodeid, LINUX_O_WRONLY | LINUX_O_TRUNC);
+    const nodeid = try test_lookup(&state, "existing.txt");
+    const fh = try test_open(&state, nodeid, LINUX_O_WRONLY | LINUX_O_TRUNC);
 
     // The guest kernel may issue this READ on an O_WRONLY handle when
     // WRITEBACK_CACHE is negotiated. It must not turn into EBADF/EIO.
     var rbody: [32]u8 = @splat(0);
     std.mem.writeInt(u64, rbody[0..8], fh, .little);
     std.mem.writeInt(u32, rbody[16..20], 16, .little);
-    const rf = try testBuildFrame(gpa, @intFromEnum(Op.READ), 2, nodeid, &rbody);
+    const rf = try test_build_frame(gpa, @intFromEnum(Op.READ), 2, nodeid, &rbody);
     defer gpa.free(rf);
     const rr = (try dispatch(&state, rf)) orelse return error.ExpectedReply;
     defer gpa.free(rr);
@@ -2188,7 +2188,7 @@ test "dispatch: OPEN O_WRONLY handles writeback-cache read fill then WRITE exist
     std.mem.writeInt(u64, wbody[0..8], fh, .little);
     std.mem.writeInt(u32, wbody[16..20], 3, .little);
     @memcpy(wbody[FUSE_WRITE_IN_SIZE..], "new");
-    const wf = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 3, nodeid, &wbody);
+    const wf = try test_build_frame(gpa, @intFromEnum(Op.WRITE), 3, nodeid, &wbody);
     defer gpa.free(wf);
     const wr = (try dispatch(&state, wf)) orelse return error.ExpectedReply;
     defer gpa.free(wr);
@@ -2205,10 +2205,10 @@ test "dispatch: O_APPEND writes honor guest offsets, not host append mode" {
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "append.txt", .data = "append-base\n" });
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
-    const nodeid = try testLookup(&state, "append.txt");
-    const fh = try testOpen(&state, nodeid, LINUX_O_WRONLY | LINUX_O_APPEND);
+    const nodeid = try test_lookup(&state, "append.txt");
+    const fh = try test_open(&state, nodeid, LINUX_O_WRONLY | LINUX_O_APPEND);
 
     // With WRITEBACK_CACHE, the guest can satisfy `echo x >> file` by
     // sending the rewritten page at offset 0. If the host fd also has
@@ -2220,7 +2220,7 @@ test "dispatch: O_APPEND writes honor guest offsets, not host append mode" {
     std.mem.writeInt(u64, wbody[8..16], 0, .little);
     std.mem.writeInt(u32, wbody[16..20], data.len, .little);
     @memcpy(wbody[FUSE_WRITE_IN_SIZE..], data);
-    const wf = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 3, nodeid, &wbody);
+    const wf = try test_build_frame(gpa, @intFromEnum(Op.WRITE), 3, nodeid, &wbody);
     defer gpa.free(wf);
     const wr = (try dispatch(&state, wf)) orelse return error.ExpectedReply;
     defer gpa.free(wr);
@@ -2237,13 +2237,13 @@ test "dispatch: SETATTR FATTR_SIZE truncates an existing file and honors :ro" {
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "truncate.txt", .data = "abcdef" });
 
-    var rw = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var rw = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer rw.deinit();
-    const nodeid = try testLookup(&rw, "truncate.txt");
+    const nodeid = try test_lookup(&rw, "truncate.txt");
     var body: [24]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], FATTR_SIZE, .little);
     std.mem.writeInt(u64, body[16..24], 2, .little);
-    const sf = try testBuildFrame(gpa, @intFromEnum(Op.SETATTR), 1, nodeid, &body);
+    const sf = try test_build_frame(gpa, @intFromEnum(Op.SETATTR), 1, nodeid, &body);
     defer gpa.free(sf);
     const sr = (try dispatch(&rw, sf)) orelse return error.ExpectedReply;
     defer gpa.free(sr);
@@ -2253,11 +2253,11 @@ test "dispatch: SETATTR FATTR_SIZE truncates an existing file and honors :ro" {
     defer gpa.free(got);
     try testing.expectEqualStrings("ab", got);
 
-    var ro = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const ro_nodeid = try testLookup(&ro, "truncate.txt");
+    const ro_nodeid = try test_lookup(&ro, "truncate.txt");
     std.mem.writeInt(u64, body[16..24], 1, .little);
-    const rof = try testBuildFrame(gpa, @intFromEnum(Op.SETATTR), 2, ro_nodeid, &body);
+    const rof = try test_build_frame(gpa, @intFromEnum(Op.SETATTR), 2, ro_nodeid, &body);
     defer gpa.free(rof);
     const ror = (try dispatch(&ro, rof)) orelse return error.ExpectedReply;
     defer gpa.free(ror);
@@ -2275,25 +2275,25 @@ test "dispatch: READLINK returns symlink targets and reports errors" {
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "target.txt", .data = "target-data" });
     try tmp.dir.symLink(std.testing.io, "target.txt", "link.txt", .{});
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
 
-    const link_nodeid = try testLookup(&state, "link.txt");
-    const rf = try testBuildFrame(gpa, @intFromEnum(Op.READLINK), 1, link_nodeid, &.{});
+    const link_nodeid = try test_lookup(&state, "link.txt");
+    const rf = try test_build_frame(gpa, @intFromEnum(Op.READLINK), 1, link_nodeid, &.{});
     defer gpa.free(rf);
     const rr = (try dispatch(&state, rf)) orelse return error.ExpectedReply;
     defer gpa.free(rr);
     try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, rr[4..8], .little));
     try testing.expectEqualStrings("target.txt", rr[FUSE_OUT_HEADER_SIZE..]);
 
-    const regular_nodeid = try testLookup(&state, "target.txt");
-    const nonlink = try testBuildFrame(gpa, @intFromEnum(Op.READLINK), 2, regular_nodeid, &.{});
+    const regular_nodeid = try test_lookup(&state, "target.txt");
+    const nonlink = try test_build_frame(gpa, @intFromEnum(Op.READLINK), 2, regular_nodeid, &.{});
     defer gpa.free(nonlink);
     const nr = (try dispatch(&state, nonlink)) orelse return error.ExpectedReply;
     defer gpa.free(nr);
     try testing.expectEqual(@as(i32, -E.INVAL), std.mem.readInt(i32, nr[4..8], .little));
 
-    const stale = try testBuildFrame(gpa, @intFromEnum(Op.READLINK), 3, 9999, &.{});
+    const stale = try test_build_frame(gpa, @intFromEnum(Op.READLINK), 3, 9999, &.{});
     defer gpa.free(stale);
     const sr = (try dispatch(&state, stale)) orelse return error.ExpectedReply;
     defer gpa.free(sr);
@@ -2306,14 +2306,14 @@ test "dispatch: LINK creates hardlinks, reports errors, and respects :ro" {
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a.txt", .data = "hard" });
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
-    const oldnodeid = try testLookup(&state, "a.txt");
+    const oldnodeid = try test_lookup(&state, "a.txt");
 
     var body: [8 + 6]u8 = @splat(0);
     std.mem.writeInt(u64, body[0..8], oldnodeid, .little);
     @memcpy(body[8..][0.."b.txt".len], "b.txt");
-    const lf = try testBuildFrame(gpa, @intFromEnum(Op.LINK), 1, 1, body[0 .. 8 + "b.txt".len + 1]);
+    const lf = try test_build_frame(gpa, @intFromEnum(Op.LINK), 1, 1, body[0 .. 8 + "b.txt".len + 1]);
     defer gpa.free(lf);
     const lr = (try dispatch(&state, lf)) orelse return error.ExpectedReply;
     defer gpa.free(lr);
@@ -2322,7 +2322,7 @@ test "dispatch: LINK creates hardlinks, reports errors, and respects :ro" {
 
     var st = std.mem.zeroes(Stat);
     var a_path_buf: [4096]u8 = undefined;
-    try hostLstat(try buildAbsPath(&state, "a.txt", &a_path_buf), &st);
+    try host_lstat(try build_abs_path(&state, "a.txt", &a_path_buf), &st);
     try testing.expect(st.nlink >= 2);
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a.txt", .data = "updated" });
     const got = try tmp.dir.readFileAlloc(std.testing.io, "b.txt", gpa, .limited(1024));
@@ -2335,28 +2335,28 @@ test "dispatch: LINK creates hardlinks, reports errors, and respects :ro" {
 
     // Reusing the same destination name reports EEXIST and leaves it alone.
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a.txt", .data = "again" });
-    const new_oldnodeid = try testLookup(&state, "a.txt");
+    const new_oldnodeid = try test_lookup(&state, "a.txt");
     std.mem.writeInt(u64, body[0..8], new_oldnodeid, .little);
-    const exists = try testBuildFrame(gpa, @intFromEnum(Op.LINK), 2, 1, body[0 .. 8 + "b.txt".len + 1]);
+    const exists = try test_build_frame(gpa, @intFromEnum(Op.LINK), 2, 1, body[0 .. 8 + "b.txt".len + 1]);
     defer gpa.free(exists);
     const er = (try dispatch(&state, exists)) orelse return error.ExpectedReply;
     defer gpa.free(er);
     try testing.expectEqual(@as(i32, -E.EXIST), std.mem.readInt(i32, er[4..8], .little));
 
-    var ro = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const ro_oldnodeid = try testLookup(&ro, "a.txt");
+    const ro_oldnodeid = try test_lookup(&ro, "a.txt");
     var ro_body: [8 + 9]u8 = @splat(0);
     std.mem.writeInt(u64, ro_body[0..8], ro_oldnodeid, .little);
     @memcpy(ro_body[8..][0.."ro-b.txt".len], "ro-b.txt");
-    const rof = try testBuildFrame(gpa, @intFromEnum(Op.LINK), 3, 1, ro_body[0 .. 8 + "ro-b.txt".len + 1]);
+    const rof = try test_build_frame(gpa, @intFromEnum(Op.LINK), 3, 1, ro_body[0 .. 8 + "ro-b.txt".len + 1]);
     defer gpa.free(rof);
     const ror = (try dispatch(&ro, rof)) orelse return error.ExpectedReply;
     defer gpa.free(ror);
     try testing.expectEqual(@as(i32, -E.ROFS), std.mem.readInt(i32, ror[4..8], .little));
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "ro-b.txt", .{}));
 
-    const bad = try testBuildFrame(gpa, @intFromEnum(Op.LINK), 4, 1, "short");
+    const bad = try test_build_frame(gpa, @intFromEnum(Op.LINK), 4, 1, "short");
     defer gpa.free(bad);
     const br = (try dispatch(&state, bad)) orelse return error.ExpectedReply;
     defer gpa.free(br);
@@ -2369,13 +2369,13 @@ test "dispatch: SETATTR FATTR_MODE applies chmod and honors :ro" {
     defer tmp.cleanup();
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "script.sh", .data = "#!/bin/sh\necho hi\n" });
 
-    var rw = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var rw = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer rw.deinit();
-    const nodeid = try testLookup(&rw, "script.sh");
+    const nodeid = try test_lookup(&rw, "script.sh");
     var body: [88]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], FATTR_MODE, .little);
     std.mem.writeInt(u32, body[68..72], 0o755, .little);
-    const sf = try testBuildFrame(gpa, @intFromEnum(Op.SETATTR), 1, nodeid, &body);
+    const sf = try test_build_frame(gpa, @intFromEnum(Op.SETATTR), 1, nodeid, &body);
     defer gpa.free(sf);
     const sr = (try dispatch(&rw, sf)) orelse return error.ExpectedReply;
     defer gpa.free(sr);
@@ -2384,14 +2384,14 @@ test "dispatch: SETATTR FATTR_MODE applies chmod and honors :ro" {
 
     var st = std.mem.zeroes(Stat);
     var script_path_buf: [4096]u8 = undefined;
-    try hostLstat(try buildAbsPath(&rw, "script.sh", &script_path_buf), &st);
+    try host_lstat(try build_abs_path(&rw, "script.sh", &script_path_buf), &st);
     try testing.expectEqual(@as(u32, 0o755), st.mode & 0o777);
 
-    var ro = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const ro_nodeid = try testLookup(&ro, "script.sh");
+    const ro_nodeid = try test_lookup(&ro, "script.sh");
     std.mem.writeInt(u32, body[68..72], 0o600, .little);
-    const rof = try testBuildFrame(gpa, @intFromEnum(Op.SETATTR), 2, ro_nodeid, &body);
+    const rof = try test_build_frame(gpa, @intFromEnum(Op.SETATTR), 2, ro_nodeid, &body);
     defer gpa.free(rof);
     const ror = (try dispatch(&ro, rof)) orelse return error.ExpectedReply;
     defer gpa.free(ror);
@@ -2399,12 +2399,12 @@ test "dispatch: SETATTR FATTR_MODE applies chmod and honors :ro" {
 
     var still = std.mem.zeroes(Stat);
     var still_path_buf: [4096]u8 = undefined;
-    try hostLstat(try buildAbsPath(&rw, "script.sh", &still_path_buf), &still);
+    try host_lstat(try build_abs_path(&rw, "script.sh", &still_path_buf), &still);
     try testing.expectEqual(@as(u32, 0o755), still.mode & 0o777);
 
     var short_body: [8]u8 = @splat(0);
     std.mem.writeInt(u32, short_body[0..4], FATTR_MODE, .little);
-    const bad = try testBuildFrame(gpa, @intFromEnum(Op.SETATTR), 3, nodeid, &short_body);
+    const bad = try test_build_frame(gpa, @intFromEnum(Op.SETATTR), 3, nodeid, &short_body);
     defer gpa.free(bad);
     const br = (try dispatch(&rw, bad)) orelse return error.ExpectedReply;
     defer gpa.free(br);
@@ -2420,39 +2420,39 @@ test "dispatch: RMDIR removes empty dirs, maps ENOTEMPTY, and respects :ro" {
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "nonempty/child.txt", .data = "x" });
     try tmp.dir.createDir(std.testing.io, "blocked", .default_dir);
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
 
-    const ok = try testBuildFrame(gpa, @intFromEnum(Op.RMDIR), 1, 1, "empty\x00");
+    const ok = try test_build_frame(gpa, @intFromEnum(Op.RMDIR), 1, 1, "empty\x00");
     defer gpa.free(ok);
     const okr = (try dispatch(&state, ok)) orelse return error.ExpectedReply;
     defer gpa.free(okr);
     try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, okr[4..8], .little));
     try testing.expectError(error.FileNotFound, tmp.dir.access(std.testing.io, "empty", .{}));
 
-    const nonempty = try testBuildFrame(gpa, @intFromEnum(Op.RMDIR), 2, 1, "nonempty\x00");
+    const nonempty = try test_build_frame(gpa, @intFromEnum(Op.RMDIR), 2, 1, "nonempty\x00");
     defer gpa.free(nonempty);
     const ner = (try dispatch(&state, nonempty)) orelse return error.ExpectedReply;
     defer gpa.free(ner);
     try testing.expectEqual(@as(i32, -E.NOTEMPTY), std.mem.readInt(i32, ner[4..8], .little));
     try tmp.dir.access(std.testing.io, "nonempty/child.txt", .{});
 
-    const missing = try testBuildFrame(gpa, @intFromEnum(Op.RMDIR), 3, 1, "missing\x00");
+    const missing = try test_build_frame(gpa, @intFromEnum(Op.RMDIR), 3, 1, "missing\x00");
     defer gpa.free(missing);
     const mr = (try dispatch(&state, missing)) orelse return error.ExpectedReply;
     defer gpa.free(mr);
     try testing.expectEqual(@as(i32, -E.NOENT), std.mem.readInt(i32, mr[4..8], .little));
 
-    var ro = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const rof = try testBuildFrame(gpa, @intFromEnum(Op.RMDIR), 4, 1, "blocked\x00");
+    const rof = try test_build_frame(gpa, @intFromEnum(Op.RMDIR), 4, 1, "blocked\x00");
     defer gpa.free(rof);
     const ror = (try dispatch(&ro, rof)) orelse return error.ExpectedReply;
     defer gpa.free(ror);
     try testing.expectEqual(@as(i32, -E.ROFS), std.mem.readInt(i32, ror[4..8], .little));
     try tmp.dir.access(std.testing.io, "blocked", .{});
 
-    const bad = try testBuildFrame(gpa, @intFromEnum(Op.RMDIR), 5, 1, "bad/name\x00");
+    const bad = try test_build_frame(gpa, @intFromEnum(Op.RMDIR), 5, 1, "bad/name\x00");
     defer gpa.free(bad);
     const br = (try dispatch(&state, bad)) orelse return error.ExpectedReply;
     defer gpa.free(br);
@@ -2466,13 +2466,13 @@ test "dispatch: RENAME replaces an existing file, reports errors, and respects :
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "src.txt", .data = "source" });
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "dst.txt", .data = "dest" });
 
-    var state = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer state.deinit();
     var body: [8 + 8 + 8]u8 = @splat(0);
     std.mem.writeInt(u64, body[0..8], 1, .little); // newdir = root
     @memcpy(body[8..][0.."src.txt".len], "src.txt");
     @memcpy(body[8 + "src.txt".len + 1 ..][0.."dst.txt".len], "dst.txt");
-    const rf = try testBuildFrame(gpa, @intFromEnum(Op.RENAME), 1, 1, body[0 .. 8 + "src.txt".len + 1 + "dst.txt".len + 1]);
+    const rf = try test_build_frame(gpa, @intFromEnum(Op.RENAME), 1, 1, body[0 .. 8 + "src.txt".len + 1 + "dst.txt".len + 1]);
     defer gpa.free(rf);
     const rr = (try dispatch(&state, rf)) orelse return error.ExpectedReply;
     defer gpa.free(rr);
@@ -2486,21 +2486,21 @@ test "dispatch: RENAME replaces an existing file, reports errors, and respects :
     std.mem.writeInt(u64, missing_body[0..8], 1, .little);
     @memcpy(missing_body[8..][0.."missing".len], "missing");
     @memcpy(missing_body[8 + "missing".len + 1 ..][0.."other".len], "other");
-    const mf = try testBuildFrame(gpa, @intFromEnum(Op.RENAME), 2, 1, missing_body[0 .. 8 + "missing".len + 1 + "other".len + 1]);
+    const mf = try test_build_frame(gpa, @intFromEnum(Op.RENAME), 2, 1, missing_body[0 .. 8 + "missing".len + 1 + "other".len + 1]);
     defer gpa.free(mf);
     const mr = (try dispatch(&state, mf)) orelse return error.ExpectedReply;
     defer gpa.free(mr);
     try testing.expectEqual(@as(i32, -E.NOENT), std.mem.readInt(i32, mr[4..8], .little));
 
-    var ro = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var ro = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer ro.deinit();
-    const rof = try testBuildFrame(gpa, @intFromEnum(Op.RENAME), 3, 1, body[0 .. 8 + "src.txt".len + 1 + "dst.txt".len + 1]);
+    const rof = try test_build_frame(gpa, @intFromEnum(Op.RENAME), 3, 1, body[0 .. 8 + "src.txt".len + 1 + "dst.txt".len + 1]);
     defer gpa.free(rof);
     const ror = (try dispatch(&ro, rof)) orelse return error.ExpectedReply;
     defer gpa.free(ror);
     try testing.expectEqual(@as(i32, -E.ROFS), std.mem.readInt(i32, ror[4..8], .little));
 
-    const bad = try testBuildFrame(gpa, @intFromEnum(Op.RENAME), 4, 1, "short");
+    const bad = try test_build_frame(gpa, @intFromEnum(Op.RENAME), 4, 1, "short");
     defer gpa.free(bad);
     const br = (try dispatch(&state, bad)) orelse return error.ExpectedReply;
     defer gpa.free(br);
@@ -2512,9 +2512,9 @@ test "dumpState/applyState: a file handle survives a snapshot round-trip" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var src = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var src = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer src.deinit();
-    const h = try testCreate(&src, "doc.txt");
+    const h = try test_create(&src, "doc.txt");
 
     // WRITE "snapshot-me" through the handle, onto the real host file.
     {
@@ -2522,20 +2522,20 @@ test "dumpState/applyState: a file handle survives a snapshot round-trip" {
         std.mem.writeInt(u64, body[0..8], h.fh, .little);
         std.mem.writeInt(u32, body[16..20], 11, .little);
         @memcpy(body[FUSE_WRITE_IN_SIZE..], "snapshot-me");
-        const frame = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 2, h.nodeid, &body);
+        const frame = try test_build_frame(gpa, @intFromEnum(Op.WRITE), 2, h.nodeid, &body);
         defer gpa.free(frame);
         const r = (try dispatch(&src, frame)) orelse return error.ExpectedReply;
         defer gpa.free(r);
         try testing.expectEqual(@as(i32, 0), std.mem.readInt(i32, r[4..8], .little));
     }
 
-    const payload = try src.dumpState(gpa);
+    const payload = try src.dump_state(gpa);
     defer gpa.free(payload);
 
     // A fresh State over the SAME root — a vmstate restore.
-    var dst = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var dst = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer dst.deinit();
-    try dst.applyState(payload);
+    try dst.apply_state(payload);
     try testing.expectEqual(src.next_inode, dst.next_inode);
     try testing.expectEqual(src.next_handle, dst.next_handle);
 
@@ -2545,7 +2545,7 @@ test "dumpState/applyState: a file handle survives a snapshot round-trip" {
     var rbody: [32]u8 = @splat(0);
     std.mem.writeInt(u64, rbody[0..8], h.fh, .little);
     std.mem.writeInt(u32, rbody[16..20], 64, .little);
-    const frame = try testBuildFrame(gpa, @intFromEnum(Op.READ), 3, h.nodeid, &rbody);
+    const frame = try test_build_frame(gpa, @intFromEnum(Op.READ), 3, h.nodeid, &rbody);
     defer gpa.free(frame);
     const r = (try dispatch(&dst, frame)) orelse return error.ExpectedReply;
     defer gpa.free(r);
@@ -2558,25 +2558,25 @@ test "applyState: a file removed since the snapshot restores fail-soft to EBADF"
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var src = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var src = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer src.deinit();
-    const h = try testCreate(&src, "gone.txt");
-    const payload = try src.dumpState(gpa);
+    const h = try test_create(&src, "gone.txt");
+    const payload = try src.dump_state(gpa);
     defer gpa.free(payload);
 
     // The file vanishes on the host before the restore.
     try tmp.dir.deleteFile(std.testing.io, "gone.txt");
 
-    var dst = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var dst = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer dst.deinit();
-    try dst.applyState(payload); // must not error — the reopen fails soft
+    try dst.apply_state(payload); // must not error — the reopen fails soft
 
     // The handle still exists, but its fd is -1; READ returns EBADF
     // instead of wedging.
     var rbody: [32]u8 = @splat(0);
     std.mem.writeInt(u64, rbody[0..8], h.fh, .little);
     std.mem.writeInt(u32, rbody[16..20], 16, .little);
-    const frame = try testBuildFrame(gpa, @intFromEnum(Op.READ), 1, h.nodeid, &rbody);
+    const frame = try test_build_frame(gpa, @intFromEnum(Op.READ), 1, h.nodeid, &rbody);
     defer gpa.free(frame);
     const r = (try dispatch(&dst, frame)) orelse return error.ExpectedReply;
     defer gpa.free(r);
@@ -2590,42 +2590,42 @@ test "dumpState/applyState: a :ro mount round-trips and stays read-only" {
 
     // Seed "data.txt" on the host via a throwaway rw state.
     {
-        var rw = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+        var rw = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
         defer rw.deinit();
-        const h = try testCreate(&rw, "data.txt");
+        const h = try test_create(&rw, "data.txt");
         var wbody: [FUSE_WRITE_IN_SIZE + 4]u8 = @splat(0);
         std.mem.writeInt(u64, wbody[0..8], h.fh, .little);
         std.mem.writeInt(u32, wbody[16..20], 4, .little);
         @memcpy(wbody[FUSE_WRITE_IN_SIZE..], "ABCD");
-        const wf = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 1, h.nodeid, &wbody);
+        const wf = try test_build_frame(gpa, @intFromEnum(Op.WRITE), 1, h.nodeid, &wbody);
         defer gpa.free(wf);
         gpa.free((try dispatch(&rw, wf)).?);
     }
 
     // A :ro mount LOOKUPs + OPENs it read-only.
-    var src = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), false);
+    var src = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), false);
     defer src.deinit();
     {
-        const lf = try testBuildFrame(gpa, @intFromEnum(Op.LOOKUP), 1, 1, "data.txt\x00");
+        const lf = try test_build_frame(gpa, @intFromEnum(Op.LOOKUP), 1, 1, "data.txt\x00");
         defer gpa.free(lf);
         gpa.free((try dispatch(&src, lf)).?);
     }
     var obody: [8]u8 = @splat(0);
     std.mem.writeInt(u32, obody[0..4], LINUX_O_RDONLY, .little);
-    const of = try testBuildFrame(gpa, @intFromEnum(Op.OPEN), 2, 2, &obody); // nodeid 2 = data.txt
+    const of = try test_build_frame(gpa, @intFromEnum(Op.OPEN), 2, 2, &obody); // nodeid 2 = data.txt
     defer gpa.free(of);
     const orep = (try dispatch(&src, of)) orelse return error.ExpectedReply;
     const fh = std.mem.readInt(u64, orep[FUSE_OUT_HEADER_SIZE..][0..8], .little);
     gpa.free(orep);
 
-    const payload = try src.dumpState(gpa);
+    const payload = try src.dump_state(gpa);
     defer gpa.free(payload);
 
     // Restore onto a State the boot path created as rw — `applyState`
     // must override `mode_rw` with the snapshot's `:ro`.
-    var dst = try State.init(gpa, try testTmpRootAbs(gpa, &tmp), true);
+    var dst = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
     defer dst.deinit();
-    try dst.applyState(payload);
+    try dst.apply_state(payload);
     try testing.expectEqual(false, dst.mode_rw);
 
     // READ through the restored handle works — the fd was reopened
@@ -2633,7 +2633,7 @@ test "dumpState/applyState: a :ro mount round-trips and stays read-only" {
     var rbody: [32]u8 = @splat(0);
     std.mem.writeInt(u64, rbody[0..8], fh, .little);
     std.mem.writeInt(u32, rbody[16..20], 8, .little);
-    const rf = try testBuildFrame(gpa, @intFromEnum(Op.READ), 3, 2, &rbody);
+    const rf = try test_build_frame(gpa, @intFromEnum(Op.READ), 3, 2, &rbody);
     defer gpa.free(rf);
     const rr = (try dispatch(&dst, rf)) orelse return error.ExpectedReply;
     defer gpa.free(rr);
@@ -2644,7 +2644,7 @@ test "dumpState/applyState: a :ro mount round-trips and stays read-only" {
     var wbody: [FUSE_WRITE_IN_SIZE + 1]u8 = @splat(0);
     std.mem.writeInt(u64, wbody[0..8], fh, .little);
     std.mem.writeInt(u32, wbody[16..20], 1, .little);
-    const wf = try testBuildFrame(gpa, @intFromEnum(Op.WRITE), 4, 2, &wbody);
+    const wf = try test_build_frame(gpa, @intFromEnum(Op.WRITE), 4, 2, &wbody);
     defer gpa.free(wf);
     const wr = (try dispatch(&dst, wf)) orelse return error.ExpectedReply;
     defer gpa.free(wr);
@@ -2653,19 +2653,19 @@ test "dumpState/applyState: a :ro mount round-trips and stays read-only" {
 
 test "applyState: a malformed payload is rejected, leaving the State usable" {
     const gpa = testing.allocator;
-    var state = try testState(gpa, true);
+    var state = try test_state(gpa, true);
     defer state.deinit();
 
     // Truncated and bad-magic payloads must come back as errors — and
     // `applyState` returns before touching the live maps, so a wedged
     // VMM thread is impossible.
-    try testing.expectError(error.Truncated, state.applyState("xx"));
+    try testing.expectError(error.Truncated, state.apply_state("xx"));
     var bad: [fuse_state.HEADER_SIZE]u8 = @splat(0);
-    try testing.expectError(error.BadMagic, state.applyState(&bad));
+    try testing.expectError(error.BadMagic, state.apply_state(&bad));
 
     // The State is still intact afterwards: dumpState still succeeds
     // and the root inode is still seeded.
-    const ok = try state.dumpState(gpa);
+    const ok = try state.dump_state(gpa);
     defer gpa.free(ok);
     var d = try fuse_state.decode(gpa, ok);
     defer d.deinit();

--- a/packages/mount-server/src/fuse_state.zig
+++ b/packages/mount-server/src/fuse_state.zig
@@ -125,7 +125,7 @@ pub const Builder = struct {
         self.handle_body.deinit(self.gpa);
     }
 
-    pub fn addInode(self: *Builder, nodeid: u64, nlookup: u64, rel_path: []const u8) !void {
+    pub fn add_inode(self: *Builder, nodeid: u64, nlookup: u64, rel_path: []const u8) !void {
         assert(rel_path.len <= std.math.maxInt(u32));
         const hdr: InodeRecHeader = .{
             .nodeid = nodeid,
@@ -137,7 +137,7 @@ pub const Builder = struct {
         self.inode_count += 1;
     }
 
-    pub fn addFileHandle(self: *Builder, handle_id: u64, nodeid: u64, open_flags: u32) !void {
+    pub fn add_file_handle(self: *Builder, handle_id: u64, nodeid: u64, open_flags: u32) !void {
         const hdr: HandleRecHeader = .{
             .handle_id = handle_id,
             .nodeid = nodeid,
@@ -149,7 +149,7 @@ pub const Builder = struct {
         self.handle_count += 1;
     }
 
-    pub fn addDirHandle(
+    pub fn add_dir_handle(
         self: *Builder,
         handle_id: u64,
         nodeid: u64,
@@ -316,11 +316,11 @@ test "encode/decode round-trip preserves inodes, handles, dir entries" {
     const gpa = testing.allocator;
     var b = Builder.init(gpa, true, 17, 5);
     defer b.deinit();
-    try b.addInode(1, std.math.maxInt(u64), ""); // root, pinned
-    try b.addInode(2, 3, "src");
-    try b.addInode(7, 1, "src/main.zig");
-    try b.addFileHandle(1, 7, 2); // O_RDWR
-    try b.addDirHandle(2, 2, &.{ "dirent-a", "dirent-bb" });
+    try b.add_inode(1, std.math.maxInt(u64), ""); // root, pinned
+    try b.add_inode(2, 3, "src");
+    try b.add_inode(7, 1, "src/main.zig");
+    try b.add_file_handle(1, 7, 2); // O_RDWR
+    try b.add_dir_handle(2, 2, &.{ "dirent-a", "dirent-bb" });
 
     const payload = try b.finish();
     defer gpa.free(payload);
@@ -362,7 +362,7 @@ test "decode rejects truncated payload" {
 
     var b = Builder.init(gpa, true, 9, 4);
     defer b.deinit();
-    try b.addInode(2, 1, "a-long-enough-path");
+    try b.add_inode(2, 1, "a-long-enough-path");
     const payload = try b.finish();
     defer gpa.free(payload);
     // Lop the tail off the path — the inode header still claims it.
@@ -385,7 +385,7 @@ test "decode rejects an unknown handle kind" {
     const gpa = testing.allocator;
     var b = Builder.init(gpa, true, 2, 2);
     defer b.deinit();
-    try b.addFileHandle(1, 1, 0);
+    try b.add_file_handle(1, 1, 0);
     const payload = try b.finish();
     defer gpa.free(payload);
     // The handle record's `kind` byte sits right after its 16-byte

--- a/scripts/clonefile.zig
+++ b/scripts/clonefile.zig
@@ -14,7 +14,7 @@ extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: u32) c_in
 extern "c" fn write(fd: c_int, buf: [*]const u8, n: usize) isize;
 extern "c" fn __error() *c_int;
 
-fn errOut(msg: []const u8, rc: u8) u8 {
+fn err_out(msg: []const u8, rc: u8) u8 {
     _ = write(2, msg.ptr, msg.len);
     return rc;
 }
@@ -22,9 +22,9 @@ fn errOut(msg: []const u8, rc: u8) u8 {
 pub fn main(init: std.process.Init.Minimal) u8 {
     var it = init.args.iterate();
     _ = it.next(); // argv[0]
-    const src = it.next() orelse return errOut("usage: clonefile <src> <dst>\n", 2);
-    const dst = it.next() orelse return errOut("usage: clonefile <src> <dst>\n", 2);
-    if (it.next() != null) return errOut("usage: clonefile <src> <dst>\n", 2);
+    const src = it.next() orelse return err_out("usage: clonefile <src> <dst>\n", 2);
+    const dst = it.next() orelse return err_out("usage: clonefile <src> <dst>\n", 2);
+    if (it.next() != null) return err_out("usage: clonefile <src> <dst>\n", 2);
 
     if (clonefile(src.ptr, dst.ptr, 0) != 0) {
         const e = __error().*;


### PR DESCRIPTION
## Problem

Our TigerStyle audit found that the Zig code mostly used camelCase function names. That made the code drift away from the style we want to move toward. It also made future naming cleanup harder, because old and new styles would be mixed together.

## Solution

This PR renames Zig function and method identifiers to `snake_case`. It keeps behavior the same and leaves strings/protocol text alone. This is one step toward the naming checklist in #369; variable names and file names can follow in smaller PRs.

## Tests

- `pnpm -F @machinen/mount-server test`
- `pnpm -F @machinen/microvm test`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 MACHINEN_GUEST_ARCH=arm64 bash scripts/build-base-assets.sh`
- `pnpm smoke-tests`
