### PR TITLE
Add Zig TigerStyle guardrails

### DIFF
--- a/packages/cli/src/__tests__/zig-tigerstyle.test.ts
+++ b/packages/cli/src/__tests__/zig-tigerstyle.test.ts
@@ -1,0 +1,253 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const ZIG_STYLE_BUDGET = {
+  lineLengthViolations: 233,
+  longFunctions: 33,
+  minAssertions: 505,
+  zeroAssertionFunctions: 506,
+};
+
+const zigFiles = spawnSync("git", ["ls-files", "*.zig"], {
+  encoding: "utf8",
+  maxBuffer: 1024 * 1024,
+})
+  .stdout.trim()
+  .split("\n")
+  .filter(Boolean)
+  .filter((path) => !path.includes("/.zig-cache/"));
+
+type FunctionMetric = {
+  file: string;
+  name: string;
+  startLine: number;
+  endLine: number;
+  lineCount: number;
+  assertionCount: number;
+};
+
+function sanitizeZigSource(source: string): string {
+  const out: string[] = [];
+  let index = 0;
+  let lineStart = true;
+  let whitespaceOnly = true;
+
+  while (index < source.length) {
+    const byte = source[index];
+
+    if (lineStart && whitespaceOnly) {
+      let probe = index;
+      while (probe < source.length && (source[probe] === " " || source[probe] === "\t")) {
+        probe += 1;
+      }
+      if (source[probe] === "\\" && source[probe + 1] === "\\") {
+        while (index < source.length && source[index] !== "\n") {
+          out.push(" ");
+          index += 1;
+        }
+        continue;
+      }
+    }
+
+    if (byte === "/" && source[index + 1] === "/") {
+      while (index < source.length && source[index] !== "\n") {
+        out.push(" ");
+        index += 1;
+      }
+      continue;
+    }
+
+    if (byte === '"') {
+      out.push(" ");
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === "\\" && index + 1 < source.length) {
+          out.push(" ");
+          out.push(" ");
+          index += 2;
+          continue;
+        }
+        if (source[index] === '"') {
+          out.push(" ");
+          index += 1;
+          break;
+        }
+        if (source[index] === "\n") {
+          out.push("\n");
+          lineStart = true;
+          whitespaceOnly = true;
+        } else {
+          out.push(" ");
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (byte === "'") {
+      out.push(" ");
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === "\\" && index + 1 < source.length) {
+          out.push(" ");
+          out.push(" ");
+          index += 2;
+          continue;
+        }
+        if (source[index] === "'") {
+          out.push(" ");
+          index += 1;
+          break;
+        }
+        out.push(source[index] === "\n" ? "\n" : " ");
+        index += 1;
+      }
+      continue;
+    }
+
+    out.push(byte);
+    if (byte === "\n") {
+      lineStart = true;
+      whitespaceOnly = true;
+    } else {
+      if (byte !== " " && byte !== "\t") {
+        whitespaceOnly = false;
+      }
+      if (!whitespaceOnly) {
+        lineStart = false;
+      }
+    }
+    index += 1;
+  }
+
+  return out.join("");
+}
+
+function lineNumberAt(source: string, offset: number): number {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (source[index] === "\n") {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+function collectFunctionMetrics(): FunctionMetric[] {
+  const metrics: FunctionMetric[] = [];
+  const fnPattern = /\b(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+
+  for (const file of zigFiles) {
+    const source = sanitizeZigSource(readFileSync(file, "utf8"));
+    for (const match of source.matchAll(fnPattern)) {
+      const name = match[1];
+      let cursor = match.index + match[0].length;
+      let bodyStart = -1;
+      while (cursor < source.length) {
+        if (source[cursor] === ";") {
+          break;
+        }
+        if (source[cursor] === "{") {
+          bodyStart = cursor;
+          break;
+        }
+        cursor += 1;
+      }
+      if (bodyStart === -1) {
+        continue;
+      }
+
+      let depth = 0;
+      let bodyEnd = -1;
+      for (cursor = bodyStart; cursor < source.length; cursor += 1) {
+        if (source[cursor] === "{") {
+          depth += 1;
+        }
+        if (source[cursor] === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            bodyEnd = cursor;
+            break;
+          }
+        }
+      }
+      if (bodyEnd === -1) {
+        continue;
+      }
+
+      const startLine = lineNumberAt(source, match.index);
+      const endLine = lineNumberAt(source, bodyEnd);
+      const body = source.slice(bodyStart, bodyEnd + 1);
+      metrics.push({
+        file,
+        name,
+        startLine,
+        endLine,
+        lineCount: endLine - startLine + 1,
+        assertionCount: Array.from(body.matchAll(/(?<![A-Za-z0-9_])(?:std\.debug\.)?assert\s*\(/g))
+          .length,
+      });
+    }
+  }
+
+  return metrics;
+}
+
+function formatExamples(items: string[]): string {
+  return items.slice(0, 10).join("\n");
+}
+
+describe("Zig TigerStyle guardrails", () => {
+  it("passes zig fmt", () => {
+    const result = spawnSync("zig", ["fmt", "--check", ...zigFiles], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+  });
+
+  it("does not grow the >100-column line budget", () => {
+    const violations: string[] = [];
+    for (const file of zigFiles) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, index) => {
+        if (line.length > 100) {
+          violations.push(`${file}:${index + 1}:${line.length}`);
+        }
+      });
+    }
+
+    expect(
+      violations.length,
+      `First overlong lines:\n${formatExamples(violations)}`,
+    ).toBeLessThanOrEqual(ZIG_STYLE_BUDGET.lineLengthViolations);
+  });
+
+  it("does not grow the >70-line function budget", () => {
+    const longFunctions = collectFunctionMetrics()
+      .filter((metric) => metric.lineCount > 70)
+      .map(
+        (metric) =>
+          `${metric.file}:${metric.startLine}-${metric.endLine} ${metric.name} (${metric.lineCount})`,
+      );
+
+    expect(
+      longFunctions.length,
+      `First long functions:\n${formatExamples(longFunctions)}`,
+    ).toBeLessThanOrEqual(ZIG_STYLE_BUDGET.longFunctions);
+  });
+
+  it("does not lose assertion coverage", () => {
+    const functionMetrics = collectFunctionMetrics();
+    const assertionCount = functionMetrics.reduce((sum, metric) => sum + metric.assertionCount, 0);
+    const zeroAssertionFunctions = functionMetrics.filter(
+      (metric) => metric.assertionCount === 0,
+    ).length;
+
+    expect(assertionCount).toBeGreaterThanOrEqual(ZIG_STYLE_BUDGET.minAssertions);
+    expect(zeroAssertionFunctions).toBeLessThanOrEqual(ZIG_STYLE_BUDGET.zeroAssertionFunctions);
+  });
+});

--- a/packages/cli/src/__tests__/zig-tigerstyle.test.ts
+++ b/packages/cli/src/__tests__/zig-tigerstyle.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from "vitest";
 const ZIG_STYLE_BUDGET = {
   lineLengthViolations: 233,
   longFunctions: 33,
-  minAssertions: 505,
-  zeroAssertionFunctions: 506,
+  minAssertions: 583,
+  zeroAssertionFunctions: 473,
 };
 
 const zigFiles = spawnSync("git", ["ls-files", "*.zig"], {

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -189,6 +189,9 @@ const MAX_EXEC2_CMD: usize = 1 * 1024 * 1024;
 const MAX_PTY_INPUT: usize = 64 * 1024;
 
 fn run_command(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void {
+    std.debug.assert(client_fd >= 0);
+    std.debug.assert(cmd.len <= MAX_EXEC2_CMD);
+
     // Make a NUL-terminated copy for the shell.
     const cmd_z = try alloc.dupeZ(u8, cmd);
     defer alloc.free(cmd_z);
@@ -266,6 +269,9 @@ fn run_pty_command(
     rows: u16,
     alloc: std.mem.Allocator,
 ) !void {
+    std.debug.assert(client_fd >= 0);
+    std.debug.assert(cmd.len <= MAX_EXEC2_CMD);
+
     const cmd_z = try alloc.dupeZ(u8, cmd);
     defer alloc.free(cmd_z);
 
@@ -387,6 +393,8 @@ fn run_pty_command(
 }
 
 fn handle_connection(client_fd: c_int, alloc: std.mem.Allocator) void {
+    std.debug.assert(client_fd >= 0);
+
     defer _ = close(client_fd);
     var line_buf: [4096]u8 = undefined;
     const len = read_line(client_fd, &line_buf) orelse {

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -411,6 +411,9 @@ fn load_config(arena: std.mem.Allocator) !Config {
         live_mounts = buf;
     }
 
+    std.debug.assert(argv_buf[0] != null);
+    std.debug.assert(envp_buf[env_idx] == null);
+
     return Config{
         .argv = argv,
         .envp = envp,
@@ -601,6 +604,10 @@ fn grow_rootdisk_fs(mount_point: [*:0]const u8) void {
 // chroot(NEWROOT) + chdir("/"). Subsequent code runs against the
 // on-disk rootfs.
 fn try_root_disk_pivot() bool {
+    std.debug.assert(ROOTDISK_DEV.len > 0);
+    std.debug.assert(NEWROOT.len > 0);
+    std.debug.assert(ROOTFS_MARKER.len > 0);
+
     // Wait for the device node. The kernel finishes binding /dev/vda
     // within a few tens of ms after devtmpfs mounts. Cap the wait at
     // 2s in case the device is genuinely missing (no rootDisk attached).
@@ -712,6 +719,8 @@ fn wait_for_path(path: [*:0]const u8, timeout_ms: i64) bool {
 fn bring_up_mount_disk() void {
     // 1. Guest path. Absent → no mount was requested by the runtime.
     const guest = read_guest_mountpoint() orelse return;
+    std.debug.assert(guest.len > 0);
+    std.debug.assert(guest.len < 512);
     klog("checkpoint: mountdisk: guest path read");
 
     // 2. Identify the two virtio-blk devices. squashfs lower first,
@@ -1021,6 +1030,8 @@ fn copy_tree_best(src: [*:0]const u8, dst: [*:0]const u8) void {
 }
 
 pub fn main() noreturn {
+    std.debug.assert(@sizeOf(timespec) >= 16);
+
     // Basic FS mounts. Ignore failures — the kernel might have mounted
     // some already, or we might be in a stripped rootfs.
     mkdir_ignore("/proc");
@@ -1087,6 +1098,8 @@ pub fn main() noreturn {
         const msg = std.fmt.bufPrint(&buf, "init: config error: {s}", .{@errorName(err)}) catch "init: config error";
         die(msg);
     };
+    std.debug.assert(cfg.argv[0] != null);
+    std.debug.assert(std.mem.len(cfg.path) > 0);
     klog("checkpoint: post-loadConfig");
 
     // #272: bring up the `--mount` overlay (squashfs RO + ext4 RW).

--- a/packages/microvm/assets/net-bench-probe.zig
+++ b/packages/microvm/assets/net-bench-probe.zig
@@ -69,6 +69,10 @@ fn print_err(comptime tag: []const u8, rc: c_int) void {
 }
 
 pub fn main(init: std.process.Init.Minimal) u8 {
+    std.debug.assert(@sizeOf(sockaddr_in) == 16);
+    std.debug.assert(default_port > 0);
+    std.debug.assert(default_pings > 0);
+
     var it = init.args.iterate();
     _ = it.next(); // argv[0]
 
@@ -82,6 +86,8 @@ pub fn main(init: std.process.Init.Minimal) u8 {
         (std.fmt.parseInt(u32, s, 10) catch default_pings)
     else
         default_pings;
+
+    if (pings == 0) return 0;
 
     std.debug.print("=== net-bench: tcp://{s}:{d} ({d} pings) ===\n", .{ host_slice, port, pings });
 

--- a/packages/microvm/assets/secrets-agent.zig
+++ b/packages/microvm/assets/secrets-agent.zig
@@ -74,6 +74,10 @@ fn trim(s: []const u8) []const u8 {
 }
 
 pub fn main() !void {
+    std.debug.assert(@sizeOf(SockaddrVm) == 16);
+    std.debug.assert(PORT > 0);
+    std.debug.assert(ENV_PATH.len > 0);
+
     const srv = socket(AF_VSOCK, SOCK_STREAM, 0);
     if (srv < 0) {
         log_line("secrets-agent: socket() failed");
@@ -101,6 +105,7 @@ pub fn main() !void {
         log_line("secrets-agent: accept() failed");
         return error.AcceptFailed;
     }
+    std.debug.assert(conn >= 0);
     log_line("secrets-agent: accepted");
 
     const alloc = std.heap.c_allocator;
@@ -147,6 +152,7 @@ pub fn main() !void {
         log_line("secrets-agent: open /etc/machinen.env failed");
         return error.OpenFailed;
     }
+    std.debug.assert(fd >= 0);
     defer _ = close(fd);
 
     for (entries.items) |e| {

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -255,6 +255,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     defer fx.deinit(gpa);
 
     const ram = try allocate_and_populate_ram(gpa, cfg, fx);
+    assert(ram.len == cfg.ram_size);
     defer std.posix.munmap(ram);
 
     const vm = if (cfg.nested) nested_vm: {
@@ -623,6 +624,10 @@ fn capture_snapshot_job(
     full_ram: bool,
     dirty_bits: ?[]const u64,
 ) !*vmstate_writer.Job {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+    if (full_ram) assert(dirty_bits == null) else assert(dirty_bits != null);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const gic_state = @import("gic_state.zig");
@@ -707,6 +712,9 @@ fn apply_restore_file(
     cfg: Config,
     devs: *const Devices,
 ) !void {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const gic_state = @import("gic_state.zig");
@@ -959,6 +967,9 @@ fn run_loop(
     irqs: IrqMap,
     ram: []u8,
 ) !Result {
+    assert(cfg.max_exits > 0);
+    assert(ram.len == cfg.ram_size);
+
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -209,6 +209,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     defer fx.deinit(gpa);
 
     const ram = try allocate_and_populate_ram(gpa, cfg, fx);
+    assert(ram.len == cfg.ram_size);
     defer std.posix.munmap(ram);
 
     // --- KVM bring-up --------------------------------------------
@@ -926,6 +927,10 @@ fn run_loop(
     ram: []u8,
     gic_fd: c_int,
 ) !Result {
+    assert(cfg.max_exits > 0);
+    assert(ram.len == cfg.ram_size);
+    assert(gic_fd >= 0);
+
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
@@ -1085,6 +1090,11 @@ fn capture_snapshot_job(
     full_ram: bool,
     dirty_bits: ?[]const u64,
 ) !*vmstate_writer.Job {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+    assert(gic_fd >= 0);
+    if (full_ram) assert(dirty_bits == null) else assert(dirty_bits != null);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const gic_state = @import("gic_state.zig");
@@ -1163,6 +1173,10 @@ fn apply_restore_file(
     gic_fd: c_int,
     devs: *const Devices,
 ) !void {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+    assert(gic_fd >= 0);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const gic_state = @import("gic_state.zig");

--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -134,6 +134,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     defer fx.deinit(gpa);
 
     const ram = try allocate_and_populate_ram(gpa, cfg, fx);
+    assert(ram.len == cfg.ram_size);
     defer std.posix.munmap(ram);
 
     var k = try kvm.Kvm.open_();
@@ -633,6 +634,9 @@ fn run_loop(
     irqs: IrqMap,
     ram: []u8,
 ) !Result {
+    assert(cfg.max_exits > 0);
+    assert(ram.len == cfg.ram_size);
+
     var exits: usize = 0;
     var saw_off = false;
     var snapshotted = false;
@@ -767,6 +771,9 @@ fn capture_snapshot_job(
     cfg: Config,
     devs: *const Devices,
 ) !*vmstate_writer.Job {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const ram_dump = @import("ram_dump.zig");
@@ -825,6 +832,9 @@ fn apply_restore_file(
     cfg: Config,
     devs: *const Devices,
 ) !void {
+    assert(path.len > 0);
+    assert(ram.len == cfg.ram_size);
+
     const snapshot = @import("snapshot.zig");
     const vcpu_dump = @import("vcpu_dump.zig");
     const ram_dump = @import("ram_dump.zig");

--- a/packages/microvm/src/dtb_patch.zig
+++ b/packages/microvm/src/dtb_patch.zig
@@ -362,6 +362,9 @@ const FixtureBuf = struct {
 /// `plen`). Layout is the same minimal shape as the boot_hvf test
 /// fixture, just generalized.
 fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const u8) FixtureBuf {
+    assert(plen <= value.len);
+    assert(name_with_nul.len > 0);
+
     var fb: FixtureBuf = undefined;
     fb.storage = [_]u8{0} ** 256;
 
@@ -377,6 +380,7 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
     const strings_off: u32 = struct_off + struct_size;
     const strings_size: u32 = @intCast(name_with_nul.len);
     const total: u32 = strings_off + strings_size;
+    assert(total <= fb.storage.len);
 
     // header
     std.mem.writeInt(u32, fb.storage[0..4], FDT_MAGIC, .big);
@@ -424,6 +428,7 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
 /// address+size, 2 cells each). Matches the shape patchMemorySize
 /// expects to walk in `assets/virt.dtb`.
 fn minimal_memory_node_dtb(addr: u64, size: u64) FixtureBuf {
+    assert(size > 0);
     var fb: FixtureBuf = undefined;
     fb.storage = [_]u8{0} ** 256;
 
@@ -441,6 +446,8 @@ fn minimal_memory_node_dtb(addr: u64, size: u64) FixtureBuf {
     const strings_off: u32 = struct_off + struct_size;
     const strings_size: u32 = @intCast(reg_str.len);
     const total: u32 = strings_off + strings_size;
+    assert(total <= fb.storage.len);
+    assert(node_name.len == 16);
 
     std.mem.writeInt(u32, fb.storage[0..4], FDT_MAGIC, .big);
     std.mem.writeInt(u32, fb.storage[4..8], total, .big);
@@ -515,6 +522,9 @@ fn nested_memory_node_dtb() FixtureBuf {
     const strings_off: u32 = struct_off + struct_size;
     const strings_size: u32 = @intCast(reg_str.len);
     const total: u32 = strings_off + strings_size;
+    assert(total <= fb.storage.len);
+    assert(wrap_name.len == 8);
+    assert(inner_name.len == 16);
 
     std.mem.writeInt(u32, fb.storage[0..4], FDT_MAGIC, .big);
     std.mem.writeInt(u32, fb.storage[4..8], total, .big);

--- a/packages/microvm/src/gic_dump.zig
+++ b/packages/microvm/src/gic_dump.zig
@@ -37,12 +37,14 @@ pub const DecodeError = error{ Truncated, BadKind, BadLength };
 
 pub fn encode(allocator: std.mem.Allocator, kind: u32, id: u32, payload: []const u8) ![]u8 {
     // Tiger-style preconditions.
-    std.debug.assert(kind == KIND_DIST or kind == KIND_REDIST or kind == KIND_CPU_SYSREGS);
+    std.debug.assert(kind >= KIND_DIST);
+    std.debug.assert(kind <= KIND_CPU_SYSREGS);
     std.debug.assert(payload.len <= std.math.maxInt(u32));
-    // distributor section uses id = 0; redist/cpu use vcpu index.
-    std.debug.assert(kind != KIND_DIST or id == 0);
+    // Distributor section uses id = 0; redist/cpu use vcpu index.
+    if (kind == KIND_DIST) std.debug.assert(id == 0);
 
     const out = try allocator.alloc(u8, HEADER_SIZE + payload.len);
+    std.debug.assert(out.len == HEADER_SIZE + payload.len);
     const hdr: Header = .{ .kind = kind, .id = id, .length = @intCast(payload.len) };
     @memcpy(out[0..HEADER_SIZE], std.mem.asBytes(&hdr));
     @memcpy(out[HEADER_SIZE..], payload);
@@ -59,9 +61,8 @@ pub fn decode(bytes: []const u8) DecodeError!Decoded {
     if (bytes.len < HEADER_SIZE) return error.Truncated;
     var hdr: Header = undefined;
     @memcpy(std.mem.asBytes(&hdr), bytes[0..HEADER_SIZE]);
-    if (hdr.kind != KIND_DIST and hdr.kind != KIND_REDIST and hdr.kind != KIND_CPU_SYSREGS) {
-        return error.BadKind;
-    }
+    if (hdr.kind < KIND_DIST) return error.BadKind;
+    if (hdr.kind > KIND_CPU_SYSREGS) return error.BadKind;
     if (hdr.length != bytes.len - HEADER_SIZE) return error.BadLength;
     return .{
         .kind = hdr.kind,

--- a/packages/microvm/src/sysreg_probe.zig
+++ b/packages/microvm/src/sysreg_probe.zig
@@ -188,6 +188,7 @@ fn probe_kvm(allocator: std.mem.Allocator) !u8 {
         try stderr("sysreg-probe: open /dev/kvm failed\n");
         return 1;
     }
+    std.debug.assert(kvm_fd >= 0);
     defer _ = c.close(kvm_fd);
 
     const vm_fd = c.ioctl(kvm_fd, KVM.KVM_CREATE_VM, @as(c_long, 0));
@@ -195,6 +196,7 @@ fn probe_kvm(allocator: std.mem.Allocator) !u8 {
         try stderr("sysreg-probe: KVM_CREATE_VM failed\n");
         return 1;
     }
+    std.debug.assert(vm_fd >= 0);
     defer _ = c.close(vm_fd);
 
     const vcpu_fd = c.ioctl(vm_fd, KVM.KVM_CREATE_VCPU, @as(c_long, 0));
@@ -202,6 +204,7 @@ fn probe_kvm(allocator: std.mem.Allocator) !u8 {
         try stderr("sysreg-probe: KVM_CREATE_VCPU failed\n");
         return 1;
     }
+    std.debug.assert(vcpu_fd >= 0);
     defer _ = c.close(vcpu_fd);
 
     var init: KVM.kvm_vcpu_init = .{ .target = 0, .features = @splat(0) };

--- a/packages/mount-server/src/fuse.zig
+++ b/packages/mount-server/src/fuse.zig
@@ -565,6 +565,8 @@ pub const State = struct {
     /// host since the snapshot) degrades to fd = -1, so the next op on
     /// that handle returns EBADF — fail-soft, never a wedge.
     pub fn apply_state(self: *State, payload: []const u8) !void {
+        assert(self.root_abs.len > 0);
+
         var d = try fuse_state.decode(self.gpa, payload);
         defer d.deinit();
 
@@ -991,6 +993,9 @@ fn on_readlink(state: *State, hdr: InHeader) ![]u8 {
 // --- CREATE -------------------------------------------------------------
 
 fn on_create(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.CREATE));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
@@ -1153,6 +1158,9 @@ fn on_read(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 // --- MKDIR --------------------------------------------------------------
 
 fn on_mkdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.MKDIR));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
@@ -1242,6 +1250,9 @@ fn on_rmdir(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 }
 
 fn on_link(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.LINK));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
@@ -1310,6 +1321,9 @@ fn on_link(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 }
 
 fn on_rename(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.RENAME));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     const body = msg[FUSE_IN_HEADER_SIZE..];
@@ -1365,6 +1379,9 @@ fn on_rename(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 }
 
 fn on_symlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.SYMLINK));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     if (!state.mode_rw) return try build_error_reply(state, hdr.unique, -E.ROFS);
 
     // Wire format: two NUL-terminated strings, name then target. No
@@ -1431,6 +1448,9 @@ fn on_symlink(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
 // them well enough for today's workloads, and we can harden them when
 // a real caller needs host-visible persistence.
 fn on_setattr(state: *State, hdr: InHeader, msg: []const u8) ![]u8 {
+    assert(hdr.opcode == @intFromEnum(Op.SETATTR));
+    assert(msg.len >= FUSE_IN_HEADER_SIZE);
+
     const body = msg[FUSE_IN_HEADER_SIZE..];
     if (body.len < 8) return try build_error_reply(state, hdr.unique, -E.INVAL);
     const valid = std.mem.readInt(u32, body[0..4], .little);
@@ -1866,6 +1886,8 @@ fn decode_name(body: []const u8) []const u8 {
 
 pub fn write_stats_atomic(state: *State) void {
     const stats_path = state.stats_path orelse return;
+    assert(stats_path.len > 0);
+    assert(state.root_abs.len > 0);
 
     // Build the JSON in one heap buffer. Stats files are small (<10 KiB
     // even with all ~30 opcodes), and a single allocPrint per write


### PR DESCRIPTION
## Problem

The TigerStyle audit found two kinds of debt in our Zig code: formatting debt and weak assertion coverage. We had no automatic guardrail for either one. That meant a new PR could make the numbers worse without anyone noticing.

## Solution

This PR adds a Vitest guardrail for Zig style debt. It now checks `zig fmt --check`, makes sure the overlong-line and long-function counts do not grow, and makes sure assertion coverage does not go backwards. It also tightens one `gic_dump.zig` assertion site by splitting a compound assertion and adding an allocation postcondition.

Refs #369.

## Tests

- `pnpm -F @machinen/mount-server test`
- `pnpm -F @machinen/microvm test`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 MACHINEN_GUEST_ARCH=arm64 bash scripts/build-base-assets.sh`
- `pnpm smoke-tests`
