### PR TITLE
Bound Zig recursion and daemon loops

### DIFF
--- a/packages/cli/src/__tests__/zig-tigerstyle.test.ts
+++ b/packages/cli/src/__tests__/zig-tigerstyle.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from "vitest";
 const ZIG_STYLE_BUDGET = {
   lineLengthViolations: 233,
   longFunctions: 33,
-  minAssertions: 583,
-  zeroAssertionFunctions: 473,
+  minAssertions: 599,
+  zeroAssertionFunctions: 472,
 };
 
 const zigFiles = spawnSync("git", ["ls-files", "*.zig"], {
@@ -26,6 +26,7 @@ type FunctionMetric = {
   endLine: number;
   lineCount: number;
   assertionCount: number;
+  recursiveCallCount: number;
 };
 
 function sanitizeZigSource(source: string): string {
@@ -125,6 +126,10 @@ function sanitizeZigSource(source: string): string {
   return out.join("");
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function lineNumberAt(source: string, offset: number): number {
   let line = 1;
   for (let index = 0; index < offset; index += 1) {
@@ -180,6 +185,10 @@ function collectFunctionMetrics(): FunctionMetric[] {
       const startLine = lineNumberAt(source, match.index);
       const endLine = lineNumberAt(source, bodyEnd);
       const body = source.slice(bodyStart, bodyEnd + 1);
+      const recursiveCallPattern = new RegExp(
+        `(?<![A-Za-z0-9_.])${escapeRegExp(name)}\\s*\\(`,
+        "g",
+      );
       metrics.push({
         file,
         name,
@@ -188,6 +197,7 @@ function collectFunctionMetrics(): FunctionMetric[] {
         lineCount: endLine - startLine + 1,
         assertionCount: Array.from(body.matchAll(/(?<![A-Za-z0-9_])(?:std\.debug\.)?assert\s*\(/g))
           .length,
+        recursiveCallCount: Array.from(body.matchAll(recursiveCallPattern)).length,
       });
     }
   }
@@ -238,6 +248,17 @@ describe("Zig TigerStyle guardrails", () => {
       longFunctions.length,
       `First long functions:\n${formatExamples(longFunctions)}`,
     ).toBeLessThanOrEqual(ZIG_STYLE_BUDGET.longFunctions);
+  });
+
+  it("does not allow direct recursive Zig functions", () => {
+    const recursiveFunctions = collectFunctionMetrics()
+      .filter((metric) => metric.recursiveCallCount > 0)
+      .map((metric) => `${metric.file}:${metric.startLine} ${metric.name}`);
+
+    expect(
+      recursiveFunctions,
+      `Recursive functions:\n${formatExamples(recursiveFunctions)}`,
+    ).toEqual([]);
   });
 
   it("does not lose assertion coverage", () => {

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -149,6 +149,8 @@ fn send_frame(fd: c_int, tag: u8, payload: []const u8) bool {
 
 fn pump_to_frame(client_fd: c_int, src_fd: c_int, tag: u8) void {
     var buf: [CHUNK]u8 = undefined;
+    // EOF-bounded pump: the child pipe closes when the command exits;
+    // read errors also stop the best-effort frame stream.
     while (true) {
         const n = read(src_fd, &buf, buf.len);
         if (n <= 0) return;
@@ -525,6 +527,8 @@ pub fn main() !void {
     }
     log_line("exec-agent: listening on vsock port 1978");
 
+    // Intentional daemon loop. `accept` blocks between connections;
+    // the VMM tears the agent down with the guest.
     while (true) {
         const client = accept(srv, null, null);
         if (client < 0) {

--- a/packages/microvm/assets/file-agent.zig
+++ b/packages/microvm/assets/file-agent.zig
@@ -154,6 +154,8 @@ fn do_push(client_fd: c_int, path_z: [*:0]const u8) void {
     const spawned = spawn_tar(true, path_z);
     var total: usize = 0;
     var buf: [CHUNK]u8 = undefined;
+    // EOF-bounded upload: the host closes the request stream when the
+    // tar payload is complete; read errors stop this best-effort copy.
     while (true) {
         const n = read(client_fd, &buf, buf.len);
         if (n <= 0) break;
@@ -183,6 +185,8 @@ fn do_pull(client_fd: c_int, path_z: [*:0]const u8) void {
     // its own stderr — same observable outcome.
     const spawned = spawn_tar(false, path_z);
     var buf: [CHUNK]u8 = undefined;
+    // EOF-bounded download: tar closes stdout at archive end; write
+    // errors stop forwarding to the host.
     while (true) {
         const n = read(spawned.fd, &buf, buf.len);
         if (n <= 0) break;
@@ -266,6 +270,8 @@ pub fn main() !void {
     }
     log_line("file-agent: listening on vsock port 1976");
 
+    // Intentional daemon loop. `accept` blocks between file-transfer
+    // sessions; the guest lifetime bounds the process.
     while (true) {
         const client = accept(srv, null, null);
         if (client < 0) {

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -178,6 +178,9 @@ fn sleep_ms(ms: i64) void {
 // it, so the user has to pgrep+kill the VMM by hand. See issue #135.
 fn psci_system_off() noreturn {
     if (comptime builtin.cpu.arch != .aarch64) unreachable;
+    // Intentional unbounded retry: PSCI SYSTEM_OFF should not return,
+    // but if the hypervisor refuses it we sleep between attempts so PID
+    // 1 neither exits nor spins.
     while (true) {
         asm volatile ("hvc #0"
             :
@@ -193,7 +196,11 @@ fn psci_system_off() noreturn {
 fn linux_power_off() noreturn {
     sync();
     _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);
-    while (true) sleep_ms(60_000);
+    // Intentional unbounded park after a failed reboot syscall: /init
+    // must not return from PID 1 and panic the guest.
+    while (true) {
+        sleep_ms(60_000);
+    }
 }
 
 fn machinen_power_off() noreturn {
@@ -966,6 +973,8 @@ fn copy_file_with_mode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) voi
     if (out_fd < 0) return;
     defer _ = close(out_fd);
     var buf: [8192]u8 = undefined;
+    // EOF-bounded stream copy. `read` decides the bound; errors and
+    // EOF both stop this best-effort helper.
     while (true) {
         const n = read(in_fd, &buf, buf.len);
         if (n <= 0) return;
@@ -979,51 +988,132 @@ fn copy_file_with_mode(src: [*:0]const u8, dst: [*:0]const u8, mode: c_uint) voi
     }
 }
 
-// Best-effort recursive `cp -a` of the `src` directory into `dst`.
+const COPY_TREE_PATH_MAX: usize = 4096;
+// Explicit stack bound for the best-effort pivot copy below. Real
+// mount payloads are shallow project trees; if a hostile/odd tree is
+// deeper than this we skip the excess subtree instead of recursing or
+// growing unbounded state in PID 1.
+const COPY_TREE_MAX_DEPTH: usize = 32;
+
+const CopyTreeFrame = struct {
+    dir: *anyopaque,
+    src: [COPY_TREE_PATH_MAX]u8,
+    src_len: usize,
+    dst: [COPY_TREE_PATH_MAX]u8,
+    dst_len: usize,
+};
+
+fn copy_tree_path(
+    buf: *[COPY_TREE_PATH_MAX]u8,
+    parent: []const u8,
+    name: []const u8,
+) ?[:0]u8 {
+    std.debug.assert(buf.len == COPY_TREE_PATH_MAX);
+    std.debug.assert(parent.len > 0);
+    std.debug.assert(name.len > 0);
+    return std.fmt.bufPrintZ(buf, "{s}/{s}", .{ parent, name }) catch null;
+}
+
+fn copy_tree_regular(frame: *const CopyTreeFrame, name: []const u8) void {
+    std.debug.assert(frame.src_len > 0);
+    std.debug.assert(frame.dst_len > 0);
+    std.debug.assert(name.len > 0);
+
+    var src_buf: [COPY_TREE_PATH_MAX]u8 = undefined;
+    var dst_buf: [COPY_TREE_PATH_MAX]u8 = undefined;
+    const src_path = copy_tree_path(&src_buf, frame.src[0..frame.src_len], name) orelse return;
+    const dst_path = copy_tree_path(&dst_buf, frame.dst[0..frame.dst_len], name) orelse return;
+    copy_file_best(src_path.ptr, dst_path.ptr);
+}
+
+fn copy_tree_symlink(frame: *const CopyTreeFrame, name: []const u8) void {
+    std.debug.assert(frame.src_len > 0);
+    std.debug.assert(frame.dst_len > 0);
+    std.debug.assert(name.len > 0);
+
+    var src_buf: [COPY_TREE_PATH_MAX]u8 = undefined;
+    var dst_buf: [COPY_TREE_PATH_MAX]u8 = undefined;
+    const src_path = copy_tree_path(&src_buf, frame.src[0..frame.src_len], name) orelse return;
+    const dst_path = copy_tree_path(&dst_buf, frame.dst[0..frame.dst_len], name) orelse return;
+
+    var tgt_buf: [COPY_TREE_PATH_MAX]u8 = undefined;
+    const n = readlink(src_path.ptr, &tgt_buf, tgt_buf.len - 1);
+    if (n <= 0) return;
+    tgt_buf[@intCast(n)] = 0;
+    const tgt_ptr: [*:0]const u8 = @ptrCast(&tgt_buf[0]);
+    _ = symlink(tgt_ptr, dst_path.ptr);
+}
+
+fn copy_tree_push_dir(
+    stack: *[COPY_TREE_MAX_DEPTH]CopyTreeFrame,
+    depth: *usize,
+    frame: *const CopyTreeFrame,
+    name: []const u8,
+) void {
+    std.debug.assert(frame.src_len > 0);
+    std.debug.assert(frame.dst_len > 0);
+    std.debug.assert(name.len > 0);
+    std.debug.assert(depth.* <= COPY_TREE_MAX_DEPTH);
+
+    if (depth.* >= COPY_TREE_MAX_DEPTH) return;
+    const child = &stack[depth.*];
+    const src_path = copy_tree_path(&child.src, frame.src[0..frame.src_len], name) orelse return;
+    const dst_path = copy_tree_path(&child.dst, frame.dst[0..frame.dst_len], name) orelse return;
+    mkdir_ignore(dst_path.ptr);
+    const child_dir = opendir(src_path.ptr) orelse return;
+    child.dir = child_dir;
+    child.src_len = src_path.len;
+    child.dst_len = dst_path.len;
+    depth.* += 1;
+    std.debug.assert(depth.* <= COPY_TREE_MAX_DEPTH);
+}
+
+// Best-effort iterative `cp -a` of the `src` directory into `dst`.
 // Used to bring the `mount: { host, guest }` payload (overlaid into
 // the initramfs at /mnt/<guest>/ by mkinitramfs.ts) across the
 // rootdisk pivot — the chroot to /newroot would otherwise strand it
 // on the discarded initramfs tmpfs. See #125.
 //
 // Failures are silent on a per-entry basis: a missing source dir, a
-// symlink whose target overruns PATH_MAX, or a single-file copy
-// failure does not abort the walk. The caller takes the resulting
-// "best-effort partial" mount as-is, mirroring copyFileBest's policy
-// for the per-boot ephemera the pivot also carries across.
+// symlink whose target overruns PATH_MAX, a tree deeper than
+// COPY_TREE_MAX_DEPTH, or a single-file copy failure does not abort the
+// walk. The caller takes the resulting "best-effort partial" mount
+// as-is, mirroring copyFileBest's policy for the per-boot ephemera the
+// pivot also carries across.
 fn copy_tree_best(src: [*:0]const u8, dst: [*:0]const u8) void {
+    std.debug.assert(COPY_TREE_PATH_MAX == 4096);
+    std.debug.assert(COPY_TREE_MAX_DEPTH > 0);
+
     if (access(src, F_OK) != 0) return;
     mkdir_ignore(dst);
-    const dir = opendir(src) orelse return;
-    defer _ = closedir(dir);
 
-    const src_str = std.mem.span(src);
-    const dst_str = std.mem.span(dst);
+    var stack: [COPY_TREE_MAX_DEPTH]CopyTreeFrame = undefined;
+    var depth: usize = 0;
+    const root = &stack[0];
+    const root_src = std.fmt.bufPrintZ(&root.src, "{s}", .{std.mem.span(src)}) catch return;
+    const root_dst = std.fmt.bufPrintZ(&root.dst, "{s}", .{std.mem.span(dst)}) catch return;
+    const root_dir = opendir(root_src.ptr) orelse return;
+    root.dir = root_dir;
+    root.src_len = root_src.len;
+    root.dst_len = root_dst.len;
+    depth = 1;
 
-    while (readdir(dir)) |ent| {
+    while (depth > 0) {
+        const frame = &stack[depth - 1];
+        const ent = readdir(frame.dir) orelse {
+            _ = closedir(frame.dir);
+            depth -= 1;
+            continue;
+        };
         const name_ptr: [*:0]const u8 = @ptrCast(&ent.d_name);
         const name = std.mem.span(name_ptr);
         if (name.len == 0) continue;
         if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) continue;
 
-        // PATH_MAX on Linux is 4096; cap each path here regardless of
-        // the initial src/dst length. bufPrintZ failure means the
-        // path overruns, which we silently skip.
-        var src_buf: [4096]u8 = undefined;
-        var dst_buf: [4096]u8 = undefined;
-        const src_path = std.fmt.bufPrintZ(&src_buf, "{s}/{s}", .{ src_str, name }) catch continue;
-        const dst_path = std.fmt.bufPrintZ(&dst_buf, "{s}/{s}", .{ dst_str, name }) catch continue;
-
         switch (ent.d_type) {
-            DT_DIR => copy_tree_best(src_path.ptr, dst_path.ptr),
-            DT_REG => copy_file_best(src_path.ptr, dst_path.ptr),
-            DT_LNK => {
-                var tgt_buf: [4096]u8 = undefined;
-                const n = readlink(src_path.ptr, &tgt_buf, tgt_buf.len - 1);
-                if (n <= 0) continue;
-                tgt_buf[@intCast(n)] = 0;
-                const tgt_ptr: [*:0]const u8 = @ptrCast(&tgt_buf[0]);
-                _ = symlink(tgt_ptr, dst_path.ptr);
-            },
+            DT_DIR => copy_tree_push_dir(&stack, &depth, frame, name),
+            DT_REG => copy_tree_regular(frame, name),
+            DT_LNK => copy_tree_symlink(frame, name),
             else => {},
         }
     }

--- a/packages/microvm/assets/memdirty.zig
+++ b/packages/microvm/assets/memdirty.zig
@@ -80,8 +80,9 @@ pub fn main(init: std.process.Init) !void {
     const line = std.fmt.bufPrint(&buf, "READY mib={d}\n", .{mib}) catch unreachable;
     write_all(1, line);
 
-    // Park forever — caller signals exit via SIGTERM (machinen
-    // snapshot/restore tear-down). Loop guards against EINTR.
+    // Intentional unbounded park — caller signals exit via SIGTERM
+    // (machinen snapshot/restore tear-down). pause() blocks each
+    // iteration; the loop only guards against EINTR.
     while (true) {
         _ = pause();
     }

--- a/packages/microvm/assets/poweroff.zig
+++ b/packages/microvm/assets/poweroff.zig
@@ -30,6 +30,7 @@ extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
 extern "c" fn open(path: [*:0]const u8, flags: c_int, ...) c_int;
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
+extern "c" fn pause() c_int;
 
 fn write_console(bytes: []const u8) void {
     const fd = open("/dev/console", O_WRONLY, @as(c_int, 0));
@@ -50,7 +51,12 @@ pub fn main() u8 {
 
     if (access("/dev/kvm", F_OK) == 0) {
         write_console(nested_poweroff_marker);
-        while (true) {}
+        // Intentional park: the L0 VMM exits after seeing the marker.
+        // If that handoff fails, pause() keeps PID 1 from returning
+        // without burning CPU.
+        while (true) {
+            _ = pause();
+        }
     }
 
     // glibc's reboot(3) wrapper uses only the cmd; musl forwards it to
@@ -59,6 +65,8 @@ pub fn main() u8 {
     _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);
 
     // Shouldn't return on success. If it does, the kernel refused;
-    // loop so /init doesn't exit and panic the machine.
-    while (true) {}
+    // park so /init doesn't exit and panic the machine.
+    while (true) {
+        _ = pause();
+    }
 }

--- a/packages/microvm/assets/secrets-agent.zig
+++ b/packages/microvm/assets/secrets-agent.zig
@@ -113,6 +113,8 @@ pub fn main() !void {
     defer raw.deinit(alloc);
 
     var buf: [4096]u8 = undefined;
+    // EOF-bounded read: the host closes the one-shot secrets stream
+    // after sending all KEY=VALUE lines.
     while (true) {
         const n = read(conn, &buf, buf.len);
         if (n <= 0) break;

--- a/packages/microvm/assets/snapshot-harness.zig
+++ b/packages/microvm/assets/snapshot-harness.zig
@@ -6,8 +6,9 @@
 //!
 //!   snapshot-harness: iter=<n> hash=<64 hex chars>
 //!
-//! No syscalls beyond write(2) and reboot(2). No clock reads, no
-//! rng, no file I/O. SHA256 runs entirely in registers + stack.
+//! No syscalls beyond write(2), reboot(2), and pause(2) if reboot
+//! unexpectedly returns. No clock reads, no rng, no file I/O. SHA256
+//! runs entirely in registers + stack.
 //! That makes the (iter, hash) stream a pure function of the binary,
 //! so any HVF<->KVM divergence here is a foundational determinism
 //! problem, not a snapshot bug.
@@ -32,6 +33,7 @@ const LINUX_REBOOT_CMD_POWER_OFF: c_int = @bitCast(@as(u32, 0x4321fedc));
 
 extern "c" fn write(fd: c_int, buf: *const anyopaque, count: usize) isize;
 extern "c" fn reboot(cmd: c_int) c_int;
+extern "c" fn pause() c_int;
 
 fn write_all(fd: c_int, bytes: []const u8) void {
     var off: usize = 0;
@@ -86,7 +88,9 @@ pub fn main() u8 {
         }
     }
     _ = reboot(LINUX_REBOOT_CMD_POWER_OFF);
-    // reboot shouldn't return on success. If it does, spin so /init
+    // reboot shouldn't return on success. If it does, park so /init
     // doesn't exit (which would panic the guest, not exit the VMM).
-    while (true) {}
+    while (true) {
+        _ = pause();
+    }
 }

--- a/packages/microvm/assets/winsize-agent.zig
+++ b/packages/microvm/assets/winsize-agent.zig
@@ -216,6 +216,8 @@ pub fn main() !void {
     log_line("winsize-agent: listening on vsock port 1974");
 
     var buf: [4096]u8 = undefined;
+    // Intentional daemon loop. `accept` blocks between resize streams;
+    // the process exits only when the guest exits.
     while (true) {
         const conn = accept(srv, null, null);
         if (conn < 0) {
@@ -227,6 +229,8 @@ pub fn main() !void {
 
         var line_buf: [256]u8 = undefined;
         var line_len: usize = 0;
+        // EOF-bounded stream parse: the host closes the vsock when the
+        // watched PTY is gone.
         while (true) {
             const n = read(conn, &buf, buf.len);
             if (n <= 0) break;

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -1249,9 +1249,11 @@ test "guest makes a PSCI SYSTEM_OFF call, host stops the run loop" {
     try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
     try vcpu.set_reg(.pc, guest_base);
 
-    // Run loop: exit on PSCI SYSTEM_OFF.
+    // Run loop: this fixture should take exactly one HVC exit. Keep a
+    // small explicit bound so a bad PSCI decode cannot loop forever.
     var saw_system_off = false;
-    while (true) {
+    var exits: usize = 0;
+    while (exits < 4) : (exits += 1) {
         try vcpu.run();
         if (vcpu.exit.reason != .exception) return error.UnexpectedExitReason;
         const ec = ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);

--- a/packages/microvm/src/stats.zig
+++ b/packages/microvm/src/stats.zig
@@ -242,6 +242,8 @@ pub fn start_phys_footprint_sampler(counters: *Counters) void {
 
 fn sampler_loop(counters: *Counters) void {
     const half_second = libc.timespec{ .tv_sec = 0, .tv_nsec = 500 * 1_000_000 };
+    // Intentional daemon loop for the VMM lifetime. Each iteration is
+    // bounded by one synchronous sample plus the sleep below.
     while (true) {
         if (sample_phys_footprint()) |bytes| {
             @atomicStore(u64, &counters.host_phys_footprint, bytes, .monotonic);


### PR DESCRIPTION
## Problem

The TigerStyle audit still had one clear recursion issue. `/init` copied mount trees with a recursive helper, so a very deep tree could grow the call stack in PID 1. Several `while (true)` loops also did not say why they were safe or what bounded them.

## Solution

`copy_tree_best` now walks directories with a fixed-size stack instead of recursion. Deep trees are skipped after an explicit depth limit, matching the existing best-effort behavior. Intentional daemon, stream, and poweroff loops now have clear comments, and busy post-reboot spins now park with `pause()`. The Zig style test also rejects direct recursive functions and tightens the assertion budget.

## Tests

- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 MACHINEN_GUEST_ARCH=arm64 bash scripts/build-base-assets.sh`
- `pnpm -F @machinen/mount-server test`
- `pnpm -F @machinen/microvm test`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `pnpm smoke-tests`
