### PR TITLE
Document vmstate and native package updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thanks for hacking on machinen. This doc gets you to the point of running
 
 ## Prerequisites
 
-Today's dev targets are **arm64 macOS** (HVF) and **arm64 Linux** (KVM). x86_64
-dev isn't wired up yet.
+Today's dev targets are **arm64 macOS** (HVF), **arm64 Linux** (KVM), and
+**x86_64 Linux** (KVM). Intel macOS/HVF is not a supported target.
 
 | Tool   | Version                                           | Install                                                           |
 | ------ | ------------------------------------------------- | ----------------------------------------------------------------- |
@@ -40,10 +40,16 @@ zig build -Doptimize=ReleaseSafe
 # 3. (darwin only) codesign with the hypervisor entitlement
 codesign -s - --force --entitlements entitlements.plist zig-out/bin/microvm
 
-# 4. Stage the binary where @machinen/vmm-arm64-<os> expects it
+# 4. Stage the binary where the matching native package expects it
 cd ../..
-mkdir -p packages/vmm-arm64-darwin/bin        # or vmm-arm64-linux/bin
-cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-darwin/bin/microvm
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64) pkg=packages/native-arm64-darwin ;;
+  Linux:aarch64|Linux:arm64) pkg=packages/native-arm64-linux ;;
+  Linux:x86_64|Linux:amd64) pkg=packages/native-x64-linux ;;
+  *) echo "unsupported dev host" >&2; exit 1 ;;
+esac
+mkdir -p "$pkg/vmm/bin"
+cp packages/microvm/zig-out/bin/microvm "$pkg/vmm/bin/machinen-vm"
 ```
 
 ## Run the CLI locally
@@ -51,15 +57,20 @@ cp packages/microvm/zig-out/bin/microvm packages/vmm-arm64-darwin/bin/microvm
 One loose end normally handled by the release pipeline you need to cover by
 hand in dev:
 
-- **Base assets.** The CLI wants a kernel, device tree, and rootfs tarball.
-  Ordinarily `machinen boot` fetches them from the GitHub Release that matches
-  the CLI's own version. For an unreleased dev checkout, build them yourself
-  and point the CLI at them with `MACHINEN_ASSETS_DIR`:
+- **Base assets.** The CLI wants a kernel, rootfs tarball, and (for arm64
+  guests) a device tree. Ordinarily `machinen boot` fetches the right guest
+  architecture from the GitHub Release that matches the CLI's own version. For
+  an unreleased dev checkout, build them yourself and point the CLI at them
+  with `MACHINEN_ASSETS_DIR`:
 
   ```bash
   ./scripts/build-base-assets.sh                  # outputs ./release-assets/
   export MACHINEN_ASSETS_DIR=$PWD/release-assets
   ```
+
+  Host architecture picks the guest architecture by default (`arm64` on Apple
+  Silicon/arm64 Linux, `amd64` on x86_64 Linux). Override with
+  `MACHINEN_GUEST_ARCH=arm64` or `MACHINEN_GUEST_ARCH=amd64` when needed.
 
 Then boot a shell in a throwaway VM:
 
@@ -68,16 +79,10 @@ alias machinen="node $PWD/packages/cli/dist/cli.js"
 machinen boot -- /bin/sh
 ```
 
-**Heads up on the current state:** the released VMM binary (`zig build`, i.e.
-`packages/microvm/src/main.zig`) is a scaffold — it prints a banner, detects
-HVF/KVM, and exits. The boot-Linux code path exists but is only reachable via
-`zig build test` + `packages/microvm/test-fixtures/assets/handoff.sh`. Wiring
-`main.zig` up to the real boot code is tracked separately.
-
 ## Tests, lint, format
 
 ```bash
-npx vitest run                      # unit tests (26, run from repo root)
+npx vitest run                      # unit tests (run from repo root)
 pnpm run lint                       # oxlint
 pnpm run format:check               # oxfmt
 npx agent-ci run --all -q -p        # full local CI (mirrors GH Actions)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Hand off a running Linux VM between hosts. Freeze it on your laptop, thaw it
 on a server, resume it next week. The program picks up exactly where it left
 off — like waking a laptop from sleep, except on a different computer.
 
-A native arm64 microVM runtime under the hood. Node.js is the first-class
-target; Python, bash, and anything else that boots in a Linux VM works too.
+A native microVM runtime under the hood: arm64 on Apple Silicon/Linux and
+x86_64 on Linux/KVM. Node.js is the first-class target; Python, bash, and
+anything else that boots in a Linux VM works too.
 
 > **Note:** the source code isn't published yet — it'll be available here soon.
 
@@ -23,11 +24,12 @@ Then run the CLI with `npx machinen …` (or the shorter `npx mn …` — both
 names install). Prefer it on your PATH? `npm i -g @machinen/cli` is fine
 too.
 
-The right VMM binary is pulled automatically via optional dependencies
-(`@machinen/vmm-arm64-darwin` on Apple Silicon Macs, `@machinen/vmm-arm64-linux`
-on arm64 Linux). No system dependencies.
+The right native package is pulled automatically via optional dependencies:
+`@machinen/native-arm64-darwin` on Apple Silicon Macs,
+`@machinen/native-arm64-linux` on arm64 Linux, and
+`@machinen/native-x64-linux` on x86_64 Linux. No system dependencies.
 
-First run fetches the kernel + rootfs from a Github release on the
+First run fetches the matching kernel + rootfs from a GitHub release on the
 companion repo over plain HTTPS — no auth required.
 
 ## Quickstart
@@ -90,8 +92,9 @@ ssh host-b npx machinen restore ./counter.snap -p 3000:3000 &
 curl host-b:3000                           # { count: 3 }  ← same process
 ```
 
-Same arch only (arm64 ↔ arm64). Memory, file descriptors, and timers come
-back exactly as they were.
+Same guest architecture only (arm64 ↔ arm64, amd64 ↔ amd64). Cross-ISA
+restore is not supported. Memory, file descriptors, and timers come back
+exactly as they were.
 
 The bundle remembers the absolute path of the rootfs tarball you booted
 from. On the same host that's all you need — `restore` reuses the same

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,8 @@ Then dive deeper:
 - [Networking](./guides/networking.md) — port forwards and outbound traffic via gvproxy
 - [Nested virtualization](./guides/nested-virtualization.md) — opt-in `/dev/kvm` inside a VM
 - [Run Firecracker inside machinen](./guides/firecracker.md) — boot an aarch64 L2 microVM with nested KVM
+
+Snapshot internals:
+
+- [vmstate specification](./snapshot/vmstate-specification.md) — whole-VM snapshot file format and saved state
+- [vmstate portability policy](./snapshot/vmstate-portability.md) — restore invariants and cross-HVF/KVM policy

--- a/docs/guides/handoff.md
+++ b/docs/guides/handoff.md
@@ -27,8 +27,8 @@ These host-local pieces must be supplied again on the target:
 - **Live mounts:** restore keeps the same guest mount paths. If a target
   host path differs, remap only the host side with
   `--mount-live <new-host>:<recorded-guest-path>[:mode]`.
-- **Architecture:** source and target must match, for example arm64 to
-  arm64.
+- **Architecture:** source and target guest architectures must match, for
+  example arm64 to arm64 or amd64 to amd64. Cross-ISA restore is unsupported.
 
 ## Minimal SSH handoff
 
@@ -43,8 +43,10 @@ Move it to `host-b`:
 ```bash
 REMOTE=.machinen/handoffs/counter
 
-# Snapshot stops the source by default. That makes this a true handoff.
+# The default vmstate snapshot is non-destructive, so stop the source after
+# the snapshot succeeds if this should be a true one-active-copy handoff.
 npx machinen snapshot counter ./counter.snap
+npx machinen stop counter
 
 ssh host-b "mkdir -p $REMOTE"
 rsync -aS ./counter.snap/ host-b:$REMOTE/counter.snap/
@@ -60,8 +62,9 @@ ssh host-b \
 Use `rsync -aS` for snapshots so sparse files stay sparse. `scp` is fine
 for small demos, but can make sparse files much larger.
 
-Pass `--keep-alive` to `snapshot` only when the source should keep
-running. That is a copy/fork workflow, not a strict handoff.
+Leaving the source running after `snapshot` is a copy/fork workflow, not a
+strict handoff. Stop it once the bundle is safely written if only one copy
+should be active.
 
 ## Build your own handoff
 

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -107,23 +107,21 @@ attach` is the right tool — same vsock channel, but with a PTY.
 
 ## Detached boots with mounts and port forwards
 
-`--detached` composes with `--mount`, `--mount-live`, and `-p`. The
-helpers that need to outlive the parent — gvproxy and the live-mount
-FUSE servers — spawn as standalone daemons wrapped through
-`pdeathsig --watch-pid <vmm>`, so they track the VMM's lifetime and
-exit when it does. `--mount` (copy-once squashfs + ext4 overlay) needs
-no runtime relay at all: both files are fd-passed to the VMM at spawn,
-so the supervisor holds no live state afterwards.
+`--detached` composes with `--mount`, `--mount-live`, and `-p`. gvproxy is
+kept alive with the VM and recorded in the registry. Live mounts are served by
+in-VMM virtio-fs devices, so there is no separate live-mount server process to
+keep alive after the CLI exits. `--mount` (copy-once squashfs + ext4 overlay)
+needs no runtime relay either: both files are fd-passed to the VMM at spawn, so
+the supervisor holds no live state afterwards.
 
-Helper pids live in the registry alongside the VMM's, so
-`machinen stop` reaps them on shutdown and `machinen ls` surfaces the
-full set under a single name. `boot --detached -p ...`,
+`machinen stop` reaps the VMM and gvproxy on shutdown, and `machinen ls`
+surfaces the full set under a single name. `boot --detached -p ...`,
 `boot --detached --mount-live ...`, and `fork --detach ...` with any
 combination of these flags all work today.
 
 ## Custom gvproxy
 
-The pinned gvproxy release that ships in `@machinen/vmm-*` is the right
+The pinned gvproxy release that ships in `@machinen/native-*` is the right
 choice for almost everyone. If you need to override it — local
 development of gvproxy itself, an airgapped install where the Github
 fetch isn't an option, a custom build with extra logging — point at

--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -13,10 +13,10 @@ Two patterns get a lot of mileage out of that:
   immediately restore the bundle into a sibling VM. Now you have two
   copies of the same process running side by side.
 
-This guide covers both. There's a constraint worth getting out of the
-way first: same arch only. arm64 to arm64 works (laptop to Graviton).
-arm64 to x86 does not — the snapshot includes machine-code register
-state, and that doesn't translate.
+This guide covers both. There's a constraint worth getting out of the way
+first: same guest architecture only. arm64 to arm64 works, and amd64 to amd64
+works on x86_64 Linux/KVM. arm64 to x86 does not — the snapshot includes
+machine-code register state, and that doesn't translate.
 
 ## Vmstate restore contract
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,10 +68,10 @@ its heap. That's the state we're about to move.
 
 ## 3. Hand it off to another machine
 
-`machinen snapshot` freezes the running VM into a directory on disk. The
-directory is the whole snapshot: `disk.img` is the workload's memory and
-file descriptors as a CRIU dump on an ext4 volume; `meta.json` is a small
-manifest.
+`machinen snapshot` freezes the running VM into a directory on disk. With the
+default vmstate engine, the directory is the whole snapshot: `state.vmstate`
+holds CPU, RAM, and device state; `rootdisk.img` holds the exact root block
+image bytes; `meta.json` is a small manifest.
 
 ```bash
 npx machinen snapshot counter ./counter.snap
@@ -84,10 +84,10 @@ The third `curl` returns `{ count: 3 }` because it's the same process —
 it just resumed on a different host. Same heap, same TCP listener, same
 counter. The Node runtime never noticed the move.
 
-A constraint to know about: the host architectures have to match. arm64
-to arm64 works (your laptop to a Graviton instance, say). arm64 to x86
-does not — CRIU is replaying actual machine-code register state, and that
-doesn't translate.
+A constraint to know about: the guest architecture has to match. arm64 to
+arm64 works, and amd64 to amd64 works on x86_64 Linux/KVM. arm64 to x86 does
+not — vmstate restores actual machine-code register state, and that doesn't
+translate.
 
 ## Where to go next
 

--- a/docs/snapshot/vmstate-portability.md
+++ b/docs/snapshot/vmstate-portability.md
@@ -1,5 +1,8 @@
 # `.vmstate` portability policy
 
+See also: [`vmstate-specification.md`](./vmstate-specification.md) for the
+binary format and section-level saved state.
+
 `.vmstate` is a whole-VM snapshot: RAM, vCPU state, interrupt/device
 state, and virtio transport state. It is **not** just a process image.
 Restoring it safely requires the restore side to recreate the same VM

--- a/docs/snapshot/vmstate-specification.md
+++ b/docs/snapshot/vmstate-specification.md
@@ -1,0 +1,410 @@
+# `.vmstate` specification
+
+Status: current implementation, format version 1.
+
+This document describes machinen's VMM-level snapshot format: what is
+serialized, how it is bundled, and which parts are architecture-specific.
+It intentionally separates two concepts that are easy to blur:
+
+- **Cross-backend restore**: moving the same guest architecture between
+  HVF and KVM. This is the portability target of `.vmstate`.
+- **Cross-ISA restore**: moving a live `arm64` guest into an `amd64`
+  guest, or the reverse. Whole-VM `.vmstate` snapshots are **same guest
+  architecture only**. Guest RAM contains ISA-specific kernel code,
+  userspace code, stacks, page tables, register ABI state, and device
+  assumptions that cannot be reinterpreted as another ISA.
+
+## Bundle layout
+
+A vmstate snapshot bundle is a directory containing at least:
+
+```text
+<snapshot>/
+  state.vmstate       # VMM-level VM state container
+  meta.json           # restore invariants and sidecar identities
+  rootdisk.img        # base checkpoint root block image, when present
+```
+
+Later incremental checkpoints may omit `rootdisk.img` and instead carry
+RAM/rootdisk delta sections plus parent pointers in `meta.json`. Restore
+materializes a flat temporary state/rootdisk pair before booting.
+
+The `state.vmstate` file is normally plain bytes. If
+`MACHINEN_VMSTATE_COMPRESSION=gzip` was set while writing, the whole
+container is gzip-compressed. Readers sniff the gzip magic and accept
+both forms.
+
+## Snapshot/restore protocol
+
+Snapshot:
+
+1. The runtime boots the VMM with `MACHINEN_SNAPSHOT_PATH`.
+2. `vm.snapshot()` sends `SIGUSR1` to the VMM.
+3. The VMM stops the vCPU, captures vCPU/RAM/device state into immutable
+   section payloads, then starts an atomic writer (`<path>.tmp` + rename).
+4. The runtime waits for the final state file, copies it into the bundle,
+   copies/reflinks sidecars, writes `meta.json`, then sends `SIGUSR2` so
+   the source VM resumes.
+
+Restore:
+
+1. The runtime validates `meta.json`, materializes checkpoint chains if
+   needed, and boots a fresh VMM with `MACHINEN_RESTORE_PATH`.
+2. Before the first vCPU run, the VMM reads `state.vmstate`, validates the
+   topology hash, and applies sections onto the freshly-created VM.
+3. Backend-specific fixups are applied for timers/interrupt delivery.
+4. The restored VM starts running from the captured vCPU state.
+
+## Container format
+
+All integers are little-endian.
+
+### Header: 64 bytes
+
+| Offset | Field           | Type     | Meaning                               |
+| -----: | --------------- | -------- | ------------------------------------- |
+|      0 | `magic`         | `u8[8]`  | `"VMSTATE\0"`                         |
+|      8 | `version`       | `u32`    | currently `1`                         |
+|     12 | `arch`          | `u32`    | `1 = aarch64`, `2 = x86_64`           |
+|     16 | `section_count` | `u32`    | number of following sections          |
+|     20 | `reserved`      | `u32`    | zero                                  |
+|     24 | `topology_hash` | `u8[32]` | SHA-256 over the guest machine layout |
+|     56 | `reserved2`     | `u8[8]`  | zero                                  |
+
+### Section header: 16 bytes
+
+Each section is:
+
+| Field     | Type         | Meaning                      |
+| --------- | ------------ | ---------------------------- |
+| `tag`     | `u32`        | `SectionTag`                 |
+| `id`      | `u32`        | subtype key; `0` when unused |
+| `length`  | `u64`        | payload byte length          |
+| `payload` | `u8[length]` | section-specific bytes       |
+
+Unknown tags are ignored by current restore paths. New payloads should
+use new tags; do not reuse existing tag numbers.
+
+## Topology hash
+
+The topology hash is a SHA-256 over these fields, in order:
+
+1. guest architecture
+2. RAM base
+3. RAM size
+4. GIC distributor base
+5. GIC redistributor base
+6. UART base
+7. virtio-MMIO base
+8. virtio-MMIO stride
+9. virtio-MMIO count
+
+Restore recomputes this for the fresh VM and refuses to apply state if it
+mismatches.
+
+## Section tags
+
+| Tag | Name             | Used for                                                 |
+| --: | ---------------- | -------------------------------------------------------- |
+|   1 | `ram`            | full sparse guest RAM payload                            |
+|   2 | `vcpu`           | architecture-specific vCPU state                         |
+|   3 | `gic_dist`       | arm64 GICv3 distributor state                            |
+|   4 | `gic_redist`     | arm64 GICv3 redistributor state                          |
+|   5 | `virtio`         | virtio-MMIO transport state for one device               |
+|   6 | `gic_cpuif`      | arm64 GIC CPU interface `ICC_*` state                    |
+|   7 | `virtiofs_state` | host-side FUSE session state for one virtio-fs device    |
+|   8 | `ram_delta`      | incremental RAM overlay against a parent checkpoint      |
+|   9 | `rootdisk_delta` | incremental rootdisk overlay against a parent checkpoint |
+|  10 | `x86_irqchip`    | x86 KVM PIC/IOAPIC state; `id` is KVM irqchip id         |
+|  11 | `x86_pit`        | x86 KVM PIT state                                        |
+
+## Payloads
+
+### `ram`
+
+Full RAM is sparse. Zero pages are implicit.
+
+Payload layout:
+
+```text
+RamHeader (48 bytes)
+  ram_base u64
+  ram_size u64
+  sha256[32]       # hash of the extent stream only
+
+extent stream:
+  offset u64       # byte offset into guest RAM
+  length u64
+  bytes[length]    # non-zero extent bytes
+```
+
+The encoder scans in 4 KiB pages and stores contiguous non-zero extents.
+The loader starts from zeroed RAM and overlays extents.
+
+### `ram_delta`
+
+A RAM delta overlays a parent checkpoint's reconstructed RAM.
+
+```text
+RamDeltaHeader (64 bytes)
+  ram_base u64
+  ram_size u64
+  page_size u32    # currently 4096
+  reserved u32
+  sha256[32]       # hash of extent stream
+  reserved2[8]
+
+extent stream:
+  offset u64
+  length u64
+  bytes[length]    # dirty bytes; dirty zero pages are stored explicitly
+```
+
+### `vcpu`
+
+The vCPU section uses a name-tagged entry list:
+
+```text
+entry_count u32
+entry_count × {
+  name_len u8
+  name[name_len]       # ASCII register/bank name
+  value_len u32
+  value[value_len]
+}
+```
+
+The names are the portability boundary. Backend-private register ids are
+not serialized for arm64.
+
+#### `aarch64` vCPU contents
+
+The arm64 payload contains architectural names such as:
+
+- GPRs: `X0`..`X30`
+- control flow: `PC`, `PSTATE`
+- stack/exception state: `SP_EL0`, `SP_EL1`, `ELR_EL1`, `SPSR_EL1`
+- SIMD/FP: `V0`..`V31`, `FPSR`, `FPCR`
+- system registers such as MMU, exception, timer, and kernel-control
+  state (`SCTLR_EL1`, `TTBR0_EL1`, `TTBR1_EL1`, `TCR_EL1`, `VBAR_EL1`,
+  timer registers, PAuth key registers, etc.)
+
+Registers are classified before dump:
+
+- **portable**: copied and expected to represent guest state
+- **mask**: copied but known to legitimately diverge, such as PMU/debug
+  counters or timer state
+- **translate**: host-relative timer offset state
+- **skip**: host-determined identity/discovery/cache-topology/RNG state
+
+Important skipped examples: `MIDR_EL1`, `MPIDR_EL1`, `ID_AA64*`, cache
+identity registers, and host RNG registers.
+
+#### `x86_64` vCPU contents
+
+The x86_64 payload stores KVM's x86 state banks under named entries:
+
+- `X86_SREGS`: segments, descriptor tables, control regs, `EFER`, APIC base
+- `X86_REGS`: GPRs, `RIP`, `RFLAGS`
+- `X86_FPU`: x87/XMM state
+- `X86_LAPIC`: local APIC state
+- `X86_MP_STATE`: vCPU multiprocessing state
+- `X86_VCPU_EVENTS`: pending exception/interrupt event state
+- `X86_MSRS`: selected MSRs (`TSC`, SYSENTER, PAT, syscall MSRs,
+  FS/GS bases, kernel GS base, `TSC_AUX` when available)
+- optional `X86_DEBUGREGS`, `X86_XCRS`, `X86_XSAVE`
+
+These are x86_64-specific and are not translatable to arm64 vCPU state.
+
+### `gic_dist`, `gic_redist`, `gic_cpuif`
+
+arm64 interrupt state is split into:
+
+- GICv3 distributor MMIO registers
+- per-vCPU redistributor SGI/PPI registers
+- per-vCPU CPU interface `ICC_*` registers
+
+Distributor/redistributor payloads are lists of:
+
+```text
+count u32
+count × {
+  offset u32       # GICv3 register offset
+  width u32        # 4 or 8; current tables emit 4-byte regs
+  value u64
+}
+```
+
+The CPU interface payload reuses the vCPU name-tagged format for
+registers like `ICC_SRE_EL1`, `ICC_PMR_EL1`, and `ICC_IGRPEN1_EL1`.
+
+Without this state, Linux may believe timer and virtio interrupts are
+enabled while the fresh interrupt controller drops them, leaving the
+restored guest stuck.
+
+### `x86_irqchip`, `x86_pit`
+
+x86_64 uses KVM's in-kernel legacy platform state instead of a GIC:
+
+- `x86_irqchip`: raw `struct kvm_irqchip`; `id` is:
+  - `0`: master PIC
+  - `1`: slave PIC
+  - `2`: IOAPIC
+- `x86_pit`: raw `struct kvm_pit_state2`
+
+These sections are x86/KVM platform state and have no arm64 equivalent.
+
+### `virtio`
+
+One section is written per present virtio-MMIO device. The section `id`
+is the device's MMIO base so restore can match it to the fresh device.
+
+The payload captures VMM-side transport state, not the in-RAM virtqueue
+rings themselves:
+
+```text
+Header (32 bytes)
+  device u32             # virtio device id
+  queue_count u32
+  driver_features u64
+  status u32
+  queue_sel u32
+  interrupt_status u32
+  reserved u32
+
+queue_count × QueueState (40 bytes)
+  num u32
+  ready u32
+  last_avail_idx u32
+  pad u32
+  desc_addr u64
+  driver_addr u64
+  device_addr u64
+```
+
+The guest-owned ring descriptors and buffers are restored by the RAM
+section. This section restores the device-side queue pointers, negotiated
+features, status, and consumed-ring cursor.
+
+### `virtiofs_state`
+
+A virtio-fs device has two pieces of state:
+
+1. virtio transport state (`virtio` section)
+2. host-side FUSE session state (`virtiofs_state` section)
+
+The FUSE state payload contains:
+
+- mount mode (`rw`/`ro`)
+- next node id and next handle id
+- `nodeid -> relative path` map with lookup counts
+- open file/dir handle table
+- packed directory-entry buffers for open directory handles
+
+It deliberately does **not** capture:
+
+- the host mount root path (`root_abs`), supplied fresh at boot
+- host file descriptors, reopened by path on restore
+- profiling/statistics fields
+
+If a file handle cannot be reopened because the host file changed or was
+removed, restore keeps the handle as `fd = -1`; later guest operations
+fail soft with `EBADF` instead of wedging the VMM.
+
+### `rootdisk_delta`
+
+Rootdisk deltas are dirty 4 KiB block overlays against a parent
+checkpoint's rootdisk image.
+
+```text
+Header (56 bytes)
+  disk_size u64
+  block_size u32       # currently 4096
+  reserved u32
+  sha256[32]
+  reserved2[8]
+
+extent stream:
+  offset u64
+  length u64
+  bytes[length]
+```
+
+A base checkpoint normally carries `rootdisk.img` outside the `.vmstate`
+container. Later checkpoints can carry `rootdisk_delta` sections and
+record `rootDisk: "delta"` in `meta.json`.
+
+## `meta.json` restore invariants
+
+`meta.json` is not part of the binary `.vmstate` container, but restore
+requires it for safety. New bundles record:
+
+- source backend: `hvf`, `kvm`, or `unknown`
+- guest architecture: `arm64`, `amd64`, or `unknown`
+- topology hash copied from the `.vmstate` header
+- guest RAM ceiling/layout in MiB
+- arm64 PAuth status inferred from `SCTLR_EL1`
+- rootdisk mode and identity/hash
+- kernel and DTB identity/hash when explicit files were used
+- checkpoint chain id, sequence, parent pointer, and delta/full markers
+
+Restore refuses bundles that predate these invariants.
+
+## Architecture and backend portability policy
+
+### Same-architecture only
+
+The `.vmstate` header and `meta.json` both record guest architecture.
+Restore refuses an `arm64` snapshot into an `amd64` guest or the reverse.
+
+This is by design. Whole-VM snapshots include raw guest RAM and raw vCPU
+state. Those bytes encode the guest ISA's page tables, exception model,
+thread state, code, stack frames, syscall ABI, TLS layout, and kernel
+assumptions.
+
+### Cross-HVF/KVM arm64
+
+arm64 HVF/KVM portability is achieved by serializing architectural names
+and GIC register offsets instead of HVF/KVM private handles. Restore then
+maps those names/offsets back onto the destination backend.
+
+Cross-HVF/KVM restore is refused when guest pointer authentication is
+active or unknown. PAuth keys and signed pointers can make RAM meaningful
+only under a compatible PAuth execution environment. The default machinen
+DTB disables guest PAuth with `arm64.nopauth` for portable snapshots.
+
+Timer state is host-relative. Restore applies backend-specific timer
+fixups so the guest resumes near the captured virtual timer point instead
+of seeing a large host-counter discontinuity.
+
+### x86_64
+
+The current x86_64 path is KVM-based and stores KVM x86 state banks plus
+KVM PIC/IOAPIC/PIT state. These sections are not meaningful to arm64 and
+are not a cross-ISA bridge.
+
+## State intentionally outside `.vmstate`
+
+The binary container does not capture every host resource:
+
+- port-forward configuration and host networking sidecars are recreated
+  by the runtime; established host-side TCP streams are not portable
+- live-mount host root paths are supplied at restore and FUSE fds are
+  reopened by path
+- rootdisk base bytes live as `rootdisk.img` sidecars or are materialized
+  from checkpoint chains
+- entropy is present in RAM, so restore injects fresh entropy into the
+  guest after boot
+- provider-level snapshots of nested-enabled VMs are refused until nested
+  KVM/HVF state is explicitly captured
+
+## Versioning rules
+
+- Keep existing header fields and section tag numbers stable.
+- Add new header fields only by using reserved space or bumping the
+  format version.
+- Add new section kinds with new tag numbers.
+- Payloads should be little-endian and self-bounded.
+- Restore paths should ignore unknown sections unless the new state is
+  required for correctness, in which case `meta.json` should advertise a
+  restore invariant and old restore paths should refuse the bundle.

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -61,17 +61,17 @@ cache (populated by `machinen install`, or auto-fetched on first use).
   baked-in default cmd (set via `provision({ cmd })`), `-- <cmd>` is
   optional; pass it to override.
 
-| Flag                                            | What it does                                                                                                                                                                                                                                                              |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`)                                                                                                                                                                                                |
-| `--mount <host-dir>:<guest-path>`               | Copy-once host directory into the guest (`/mnt/...`)                                                                                                                                                                                                                      |
-| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Live-share via FUSE — guest reads stream in on demand. `rw` (default) or `ro`                                                                                                                                                                                             |
-| `--env KEY=VALUE`                               | Set an env var inside the guest (repeatable)                                                                                                                                                                                                                              |
-| `--cwd <abs-path>`                              | Start the guest cmd in this directory (must be absolute)                                                                                                                                                                                                                  |
-| `-p <hostPort>:<guestPort>`                     | Forward a host TCP port to the guest (repeatable)                                                                                                                                                                                                                         |
-| `--detached`                                    | Detach the VMM from the CLI on first-guest-byte readiness; reattach with `attach`. Composes with `--mount`, `--mount-live`, and `-p`: gvproxy and the live-mount FUSE servers spawn as standalone daemons under `pdeathsig --watch-pid <vmm>` so they outlive the parent. |
-| `--memory <mib>`                                | Guest RAM ceiling, decimal MiB. Debug knob — defaults to `min(host_ram_mib/2, 16384)`, floor 512. See #263                                                                                                                                                                |
-| `--snapshot <path>`                             | Attach `<path>` as `/dev/vda` — scratch disk for a future `vm.snapshot()`                                                                                                                                                                                                 |
+| Flag                                            | What it does                                                                                                                                                                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`)                                                                                                                                          |
+| `--mount <host-dir>:<guest-path>`               | Copy-once host directory into the guest (`/mnt/...`)                                                                                                                                                                |
+| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Live-share via in-VMM virtio-fs — guest reads stream in on demand. `rw` (default) or `ro`                                                                                                                           |
+| `--env KEY=VALUE`                               | Set an env var inside the guest (repeatable)                                                                                                                                                                        |
+| `--cwd <abs-path>`                              | Start the guest cmd in this directory (must be absolute)                                                                                                                                                            |
+| `-p <hostPort>:<guestPort>`                     | Forward a host TCP port to the guest (repeatable)                                                                                                                                                                   |
+| `--detached`                                    | Detach the VMM from the CLI on first-guest-byte readiness; reattach with `attach`. Composes with `--mount`, `--mount-live`, and `-p`; gvproxy is kept alive with the VM, and live mounts are served inside the VMM. |
+| `--memory <mib>`                                | Guest RAM ceiling, decimal MiB. Debug knob — defaults to `min(host_ram_mib/2, 16384)`, floor 512. See #263                                                                                                          |
+| `--snapshot <path>`                             | Attach `<path>` as `/dev/vda` — scratch disk for a future `vm.snapshot()`                                                                                                                                           |
 
 ## `machinen restore`
 
@@ -79,10 +79,10 @@ cache (populated by `machinen install`, or auto-fetched on first use).
 machinen restore <snap-dir> [--name <name>]
 ```
 
-Restores a VM from a snapshot bundle (a directory holding `disk.img` +
-`meta.json` produced by `machinen snapshot`). Anonymous restores
-auto-name as `<source-name>/<pid>` so lineage shows up in `machinen ls`.
-Resolves base assets the same way `boot` does.
+Restores a VM from a snapshot bundle. Vmstate bundles hold `state.vmstate`,
+`rootdisk.img`, and `meta.json`; legacy CRIU bundles hold `img/` plus
+`meta.json`. Anonymous restores auto-name as `<source-name>/<pid>` so lineage
+shows up in `machinen ls`. Resolves base assets the same way `boot` does.
 
 ## `machinen ls` / `ps`
 
@@ -149,7 +149,7 @@ source's rootdisk at dump time.
 | `--detach`                                      | Don't attach the caller's stdio to the fork — return as soon as it's up                                                   |
 | `-p <hostPort>:<guestPort>`                     | Forward a host TCP port into the fork. NOT inherited from the source (host ports are global) — pick a non-conflicting one |
 | `--mount <host-dir>:<guest-path>`               | Overlay an additional copy-once host directory on the fork                                                                |
-| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Establish a fresh FUSE live-share on the fork. Source must NOT have its own live mount active (vsock FUSE ≠ CRIU)         |
+| `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Establish a fresh in-VMM virtio-fs live-share on the fork. Host path can differ from the source                           |
 | `--env KEY=VALUE`                               | Set an env var inside the forked guest (repeatable)                                                                       |
 | `--cwd <abs-path>`                              | Working directory for the guest cmd in the fork (must be absolute)                                                        |
 | `--memory <mib>`                                | Guest RAM ceiling for the fork, decimal MiB. Debug knob                                                                   |
@@ -204,9 +204,9 @@ the parent is gone.
 
 ## `machinen install [--version <tag>]`
 
-Pre-downloads the kernel, device tree, and Debian base rootfs for the
-given release tag (defaults to this CLI's own version) into
-`~/.machinen/<tag>/bases/debian-arm64/`.
+Pre-downloads the matching kernel, optional device tree, and Debian base
+rootfs for the given release tag (defaults to this CLI's own version) into
+`~/.machinen/<tag>/bases/debian-arm64/` or `debian-amd64/`.
 
 ## `machinen completion <shell>`
 
@@ -220,9 +220,10 @@ tab-complete VM names against the live `machinen ls` output.
 | ----------------------- | ----------------------------------------------------------------------- |
 | `MACHINEN_VMM`          | Override the VMM binary path (development)                              |
 | `MACHINEN_ASSETS_DIR`   | Use base assets from this directory instead of the on-disk cache.       |
-|                         | Expected filenames: `Image-arm64`, `virt-arm64.dtb`,                    |
-|                         | `rootfs-debian-arm64.tar.gz` — what `./scripts/build-base-assets.sh`    |
-|                         | produces.                                                               |
+|                         | Expected filenames for arm64: `Image-arm64`, `virt-arm64.dtb`,          |
+|                         | `rootfs-debian-arm64.tar.gz`; for amd64: `bzImage-x86_64`,              |
+|                         | `rootfs-debian-amd64.tar.gz`.                                           |
+| `MACHINEN_GUEST_ARCH`   | Override guest asset arch: `arm64` or `amd64`.                          |
 | `MACHINEN_REGISTRY_DIR` | Override the running-VM registry location (default `~/.machinen/vms/`). |
 
 ## Cache layout
@@ -233,8 +234,11 @@ tab-complete VM names against the live `machinen ls` output.
     bases/
       debian-arm64/
         Image           # arm64 Linux kernel
-        virt.dtb        # device tree
-        rootfs.tar.gz   # Debian base rootfs
+        virt.dtb        # arm64 device tree
+        rootfs.tar.gz   # Debian arm64 base rootfs
+      debian-amd64/
+        Image           # x86_64 bzImage
+        rootfs.tar.gz   # Debian amd64 base rootfs
   current -> <release-tag>   # symlink to the most recent install
   vms/<id>/meta.json         # one entry per running VM (name, pid, socket)
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,19 +43,13 @@ npm i -g @machinen/cli        # or globally if you prefer it on PATH
 
 Both `machinen` and the shorter alias `mn` are installed.
 
-The matching VMM binary (`@machinen/vmm-arm64-darwin` or
-`@machinen/vmm-arm64-linux`) is pulled in via optional dependencies.
-Each VMM package also ships a sibling `gvproxy` binary that the
-runtime auto-spawns to provide guest networking — no system packages
-required.
+The matching native package (`@machinen/native-arm64-darwin`,
+`@machinen/native-arm64-linux`, or `@machinen/native-x64-linux`) is pulled in
+via optional dependencies. It ships the VMM plus sibling host tools such as
+`gvproxy`, `mke2fs`, and `mksquashfs`, so no system packages are required.
 
-First boot fetches the kernel + base rootfs from a private GitHub
-release, so make sure you've authenticated [GitHub
-CLI](https://cli.github.com/):
-
-```bash
-gh auth login
-```
+First boot fetches the matching kernel + base rootfs from the public
+companion GitHub release over HTTPS; no GitHub authentication is needed.
 
 ## At a glance
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -309,10 +309,10 @@ describe("parseRunArgs --detached", () => {
   });
 
   // The parser doesn't gate flag combinations — it captures whatever
-  // it sees and lets the runtime apply semantic checks. #150 phase 3
+  // it sees and lets the runtime apply semantic checks. In-VMM virtio-fs
   // removed the last detach compat gate (mount, liveMounts, and
-  // portForward all coexist with --detached), so there is nothing
-  // for the parser to mirror here.
+  // portForward all coexist with --detached), so there is nothing for
+  // the parser to mirror here.
 });
 
 describe("parseRunArgs --memory (#263 phase A)", () => {

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -135,7 +135,7 @@ export const COMMANDS: CommandSpec[] = [
         name: "--lazy",
         type: "boolean",
         description:
-          "Opt into lazy-pages restore (#266) — vsock-FUSE mount the bundle and fault pages on demand. Default is eager.",
+          "Opt into CRIU lazy-pages restore (#266) — virtio-fs mount the bundle and fault pages on demand. Default is eager.",
       },
       {
         name: "-p",
@@ -232,7 +232,7 @@ export const COMMANDS: CommandSpec[] = [
         name: "--lazy",
         type: "boolean",
         description:
-          "Opt into lazy-pages restore (#266); ignored when --detach is set since the FUSE server can't survive supervisor exit.",
+          "Opt into CRIU lazy-pages restore (#266); the CLI currently ignores this when --detach is set.",
       },
       {
         name: "-p",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -930,7 +930,7 @@ type ParsedRestoreCommandArgs = ReturnType<typeof parseRestoreArgs>;
 async function cmdRestore(args: string[]): Promise<number> {
   // `machinen restore <snap-dir> [--image <tarball>] [--name <name>]
   // [--lazy] [-p <hostPort>:<guestPort>]`. Restore is eager by
-  // default; `--lazy` opts into the #266 vsock-FUSE lazy-pages path.
+  // default; `--lazy` opts into the #266 CRIU lazy-pages path.
   const parsed = parseRestoreCommandArgs(args);
   validateRestoreCommandArgs(parsed);
   const snapDir = resolve(parsed.positional[0]!);

--- a/packages/cli/src/parse-fork-args.ts
+++ b/packages/cli/src/parse-fork-args.ts
@@ -30,13 +30,9 @@ interface ParsedForkArgs {
   /** Hand the fork off and return immediately (`--detach`). */
   detach: boolean;
   /**
-   * `--lazy` — opt into lazy-pages restore for this fork (#266).
-   * Forced off whenever `--detach` is set: the lazy path relies on
-   * a host-side FUSE server that lives in the runtime supervisor
-   * process, and `--detach` exits that process, which would leave
-   * the in-guest `criu lazy-pages` daemon blocked on the now-dead
-   * FUSE channel. Lifting this constraint is #150 phase 3 — until
-   * then, detach implies eager.
+   * `--lazy` — opt into CRIU lazy-pages restore for this fork (#266).
+   * The CLI still forces this off whenever `--detach` is set until
+   * lazy+detach is revalidated end-to-end on the in-VMM virtio-fs path.
    */
   lazy: boolean;
   /**
@@ -188,11 +184,9 @@ function forkFlagFor(arg: string): ForkFlag | undefined {
 }
 
 function finishForkArgs(state: ForkParseState): ParsedForkArgs {
-  // Detach exits the runtime supervisor, taking the host-side FUSE
-  // server with it — the in-guest lazy-pages daemon would then block
-  // on a dead FUSE channel. Force eager (lazy=false) to keep --detach
-  // usable until the FUSE server gains its own detach handoff
-  // (#150 phase 3).
+  // Keep the existing CLI contract: detach implies eager restore.
+  // Lazy now uses in-VMM virtio-fs, but lazy+detach still needs a fresh
+  // end-to-end validation pass before the CLI exposes that combination.
   return {
     newName: state.newName,
     outDir: state.outDir,

--- a/packages/microvm/README.md
+++ b/packages/microvm/README.md
@@ -1,13 +1,16 @@
 # @machinen/microvm
 
-Zig source for the native arm64 microVM that powers
+Zig source for the native microVM that powers
 [machinen](https://github.com/redwoodjs/machinen).
 
-- **darwin** (Apple Silicon) — uses HVF (`Hypervisor.framework`)
-- **linux** (arm64) — uses KVM
+- **darwin arm64** (Apple Silicon) — uses HVF (`Hypervisor.framework`)
+- **linux arm64** — uses KVM
+- **linux x86_64** — uses KVM
 
-The pre-built binaries ship as [`@machinen/vmm-arm64-darwin`](../vmm-arm64-darwin)
-and [`@machinen/vmm-arm64-linux`](../vmm-arm64-linux). This package is the
+The pre-built binaries ship inside the consolidated native packages:
+[`@machinen/native-arm64-darwin`](../native-arm64-darwin),
+[`@machinen/native-arm64-linux`](../native-arm64-linux), and
+[`@machinen/native-x64-linux`](../native-x64-linux). This package is the
 source if you want to build the VMM yourself.
 
 ## Build
@@ -46,16 +49,16 @@ rootfs.
 
 ## Run
 
-The VMM expects a kernel, device tree, and initramfs — see
-[`docs/rootfs.md`](./docs/rootfs.md) for the contract and
-[`docs/architecture.md`](./docs/architecture.md) for the bigger
-picture. In practice you drive it through `@machinen/runtime`:
+The VMM expects a kernel, an initramfs, and (for arm64 guests) a device tree —
+see [`docs/rootfs.md`](./docs/rootfs.md) for the contract and
+[`docs/architecture.md`](./docs/architecture.md) for the bigger picture. In
+practice you drive it through `@machinen/runtime`:
 
 ```ts
 import { boot } from "@machinen/runtime";
 const vm = await boot({
   binary: "./zig-out/bin/microvm",
-  image: "./rootfs-debian-arm64.tar.gz",
+  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on x64 Linux
   cmd: ["/bin/sh"],
 });
 ```

--- a/packages/microvm/assets/machinen-restore.sh
+++ b/packages/microvm/assets/machinen-restore.sh
@@ -53,11 +53,11 @@ if [ -x /sbin/machinen-winsize-agent ]; then
     WINSIZE_PID=$!
 fi
 
-# Bundle delivery (#266 final): the host vsock-FUSE-mounts its bundle
-# `img/` directory at /mnt/snap-src/img read-only and signals us with
-# MACHINEN_RESTORE_BUNDLE_LIVE=1. Reads stream from the host's bundle
-# on demand — no tmpfs duplicate copy. Legacy mode (no env) falls back
-# to untarring /dev/vdb into tmpfs.
+# Bundle delivery (#266 final): the host exposes its bundle `img/`
+# directory at /mnt/snap-src/img read-only via the VMM's virtio-fs live
+# mount and signals us with MACHINEN_RESTORE_BUNDLE_LIVE=1. Reads stream
+# from the host's bundle on demand — no tmpfs duplicate copy. Legacy mode
+# (no env) falls back to untarring /dev/vdb into tmpfs.
 mkdir -p /mnt/snap-src/img
 if [ "${MACHINEN_RESTORE_BUNDLE_LIVE:-0}" = "1" ]; then
     if [ -z "$(ls -A /mnt/snap-src/img 2>/dev/null)" ]; then
@@ -85,7 +85,7 @@ fi
 # Lazy-pages mode (#266): when MACHINEN_RESTORE_LAZY_PAGES=1, run a
 # `criu lazy-pages` daemon alongside `criu restore --lazy-pages`. The
 # daemon reads pagemap-*.img + pages-*.img from /mnt/snap-src/img,
-# which (with MACHINEN_RESTORE_BUNDLE_LIVE=1) is a vsock-FUSE mount of
+# which (with MACHINEN_RESTORE_BUNDLE_LIVE=1) is a virtio-fs mount of
 # the host bundle dir — bytes stream from the host on demand.
 LAZY_FLAGS=""
 LAZY_PAGES_PID=""
@@ -128,7 +128,7 @@ if [ -n "$LAZY_FLAGS" ]; then
     # Spawn the lazy-pages daemon BEFORE criu restore. It opens
     # /tmp/lazy-pages.socket and serves UFFD page faults from
     # pages-*.img in /mnt/snap-src/img — which is the host's bundle
-    # over vsock-FUSE in live-mount mode. The daemon must outlive
+    # over virtio-fs in live-mount mode. The daemon must outlive
     # `criu restore` because UFFD events keep flowing as the workload
     # runs.
     criu lazy-pages \

--- a/packages/native-arm64-darwin/README.md
+++ b/packages/native-arm64-darwin/README.md
@@ -9,10 +9,8 @@ package:
 | `e2fsprogs/` | bundled `mke2fs` + its dylibs                      |
 | `squashfs/`  | bundled `mksquashfs` + its dylibs                  |
 
-This replaces the former per-tool packages
-(`@machinen/vmm-arm64-darwin`, `@machinen/e2fsprogs-arm64-darwin`,
-`@machinen/squashfs-tools-arm64-darwin`) — one install, one
-`optionalDependency`, one `os`/`cpu` gate per host.
+This is the consolidated native optional dependency for this host — one
+install, one `optionalDependency`, one `os`/`cpu` gate.
 
 `index.mjs` exports an absolute path per binary: `binary` (the VMM),
 `gvproxy`, `initPath`, `execAgentPath`, `mke2fs`, `mksquashfs`.

--- a/packages/native-arm64-linux/README.md
+++ b/packages/native-arm64-linux/README.md
@@ -9,10 +9,8 @@ package:
 | `e2fsprogs/` | bundled `mke2fs`                                   |
 | `squashfs/`  | bundled `mksquashfs`                               |
 
-This replaces the former per-tool packages
-(`@machinen/vmm-arm64-linux`, `@machinen/e2fsprogs-arm64-linux`,
-`@machinen/squashfs-tools-arm64-linux`) — one install, one
-`optionalDependency`, one `os`/`cpu` gate per host.
+This is the consolidated native optional dependency for this host — one
+install, one `optionalDependency`, one `os`/`cpu` gate.
 
 `index.mjs` exports an absolute path per binary: `binary` (the VMM),
 `gvproxy`, `initPath`, `execAgentPath`, `mke2fs`, `mksquashfs`.

--- a/packages/native-x64-linux/README.md
+++ b/packages/native-x64-linux/README.md
@@ -9,10 +9,8 @@ package:
 | `e2fsprogs/` | bundled `mke2fs`                                   |
 | `squashfs/`  | bundled `mksquashfs`                               |
 
-This replaces the former per-tool packages
-(`@machinen/vmm-x86_64-linux`, `@machinen/e2fsprogs-x86_64-linux`,
-`@machinen/squashfs-tools-x86_64-linux`) — one install, one
-`optionalDependency`, one `os`/`cpu` gate per host.
+This is the consolidated native optional dependency for this host — one
+install, one `optionalDependency`, one `os`/`cpu` gate.
 
 `index.mjs` exports an absolute path per binary: `binary` (the VMM),
 `gvproxy`, `initPath`, `execAgentPath`, `mke2fs`, `mksquashfs`.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -1742,7 +1742,8 @@ Path to the initramfs cpio to write.
 
 > `optional` **base?**: `string`
 
-Optional base rootfs tarball (rootfs-debian-arm64.tar.gz).
+Optional arch-specific base rootfs tarball
+(`rootfs-debian-arm64.tar.gz` or `rootfs-debian-amd64.tar.gz`).
 
 ##### mount?
 
@@ -3552,17 +3553,16 @@ Streaming log callback for the snapshot half. Same shape as
 
 > `optional` **lazy?**: `boolean`
 
-Opt into lazy-pages restore for the fork — vsock-FUSE-mounted
-bundle + `criu restore --lazy-pages`. Default false: the runtime
-packs the CRIU image into a tar on `/dev/vdb` and the guest does
-an eager load.
+Opt into CRIU lazy-pages restore for the fork — the CRIU image directory
+is mounted into the guest read-only via in-VMM virtio-fs and `criu restore
+--lazy-pages` faults pages on demand. Default false: the runtime packs the
+CRIU image into a tar on `/dev/vdb` and the guest does an eager load.
 
-Lazy keeps fork RSS proportional to the pages the sibling
-actually touches, not the full snapshot size. Worth setting when
-the source dumped a large heap that the fork will only sample.
-Cannot combine with `--detach` (the lazy path needs the host's
-FUSE server alive as long as the guest may fault, see #150
-phase 3); the runtime falls back to eager in that case.
+Lazy keeps fork RSS proportional to the pages the sibling actually
+touches, not the full snapshot size. Worth setting when the source dumped
+a large heap that the fork will only sample. The CLI currently forces
+eager restore for `fork --detach --lazy`; use the runtime API directly if
+you need to experiment with that combination.
 
 ###### Overrides
 
@@ -3700,10 +3700,10 @@ without touching the source dir.
 
 Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
 runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is a live
-vsock-FUSE pass-through (writes land on the host, doesn't survive
-snapshot/restore). Pick `mount` for inputs the guest may modify
-but the host shouldn't see; `liveMount` for shared scratch.
+but writes don't propagate to the host); `liveMount` is an in-VMM
+virtio-fs pass-through (writes land on the host and restore/fork
+re-establish the same guest mount topology). Pick `mount` for inputs the
+guest may modify but the host shouldn't see; `liveMount` for shared scratch.
 
 See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
 relocation; same shape), #272 (this overlay relocation).
@@ -3748,8 +3748,8 @@ the host (#151, #156). Set `"ro"` for a one-way share (host
 caches, untrusted guests).
 
 Each guest path must live under `/mnt/` (same rule as `mount`).
-Repeatable up to 4 entries per VM — each is served by its own
-in-VMM virtio-fs device (the VMM wires 4 virtio-fs slots). The
+Repeatable up to 5 entries per VM — each is served by its own
+in-VMM virtio-fs device (the VMM wires 5 virtio-fs slots). The
 FUSE opcode handlers run inside the VMM and the guest mounts each
 share directly with `mount -t virtiofs` — no agent process, no
 vsock hop. Requires a guest kernel with `CONFIG_VIRTIO_FS` — every
@@ -3928,16 +3928,15 @@ the child and is free to exit.
 
 Forces `pdeathsig: false` (otherwise the parent's exit kills the
 VMM, defeating the purpose). Compatible with every other boot
-option: gvproxy + live-mount FUSE servers spawn as detached
-daemons wrapped through `pdeathsig --watch-pid <vmm>`, and `mount`
-(squashfs+ext4 overlay) is fd-passed to the VMM at spawn so the
-supervisor holds no live state afterwards.
+option: gvproxy is tracked in the registry, live mounts are served
+by in-VMM virtio-fs devices, and `mount` (squashfs+ext4 overlay)
+is fd-passed to the VMM at spawn so the supervisor holds no live
+state afterwards.
 
 Cleanup of per-boot reflink disks, bundle dirs, and vsock UDS
 directories normally happens in the parent's `child.once("exit")`
-hook. After detach the parent is gone, so those leak until the
-follow-up `machinen gc` / `machinen stop` commands (PR2 of #150)
-land. Use `--detached` only when you understand that trade-off.
+hook. After detach the parent is gone, so those leak until
+`machinen gc` / `machinen stop` reaps them.
 
 Reattach with `attach({ name | pid })` from another process —
 the registry entry stays live, the vsock UDS is still listening.
@@ -4000,7 +3999,8 @@ called `boot()`), so only `exec-stdout` / `exec-stderr` sources fire.
 > `optional` **image?**: `string`
 
 Path to a rootfs tarball to boot from (e.g. the output of
-`provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
+`provision()`, or an arch-specific base rootfs tarball shipped in
+releases: `rootfs-debian-arm64.tar.gz` / `rootfs-debian-amd64.tar.gz`).
 Paired with `cmd` — both required, or neither (test-mode binary
 boots and snapshot-only restores both skip initramfs packing).
 
@@ -4140,10 +4140,10 @@ without touching the source dir.
 
 Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
 runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is a live
-vsock-FUSE pass-through (writes land on the host, doesn't survive
-snapshot/restore). Pick `mount` for inputs the guest may modify
-but the host shouldn't see; `liveMount` for shared scratch.
+but writes don't propagate to the host); `liveMount` is an in-VMM
+virtio-fs pass-through (writes land on the host and restore/fork
+re-establish the same guest mount topology). Pick `mount` for inputs the
+guest may modify but the host shouldn't see; `liveMount` for shared scratch.
 
 See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
 relocation; same shape), #272 (this overlay relocation).
@@ -4180,8 +4180,8 @@ the host (#151, #156). Set `"ro"` for a one-way share (host
 caches, untrusted guests).
 
 Each guest path must live under `/mnt/` (same rule as `mount`).
-Repeatable up to 4 entries per VM — each is served by its own
-in-VMM virtio-fs device (the VMM wires 4 virtio-fs slots). The
+Repeatable up to 5 entries per VM — each is served by its own
+in-VMM virtio-fs device (the VMM wires 5 virtio-fs slots). The
 FUSE opcode handlers run inside the VMM and the guest mounts each
 share directly with `mount -t virtiofs` — no agent process, no
 vsock hop. Requires a guest kernel with `CONFIG_VIRTIO_FS` — every
@@ -4357,16 +4357,15 @@ the child and is free to exit.
 
 Forces `pdeathsig: false` (otherwise the parent's exit kills the
 VMM, defeating the purpose). Compatible with every other boot
-option: gvproxy + live-mount FUSE servers spawn as detached
-daemons wrapped through `pdeathsig --watch-pid <vmm>`, and `mount`
-(squashfs+ext4 overlay) is fd-passed to the VMM at spawn so the
-supervisor holds no live state afterwards.
+option: gvproxy is tracked in the registry, live mounts are served
+by in-VMM virtio-fs devices, and `mount` (squashfs+ext4 overlay)
+is fd-passed to the VMM at spawn so the supervisor holds no live
+state afterwards.
 
 Cleanup of per-boot reflink disks, bundle dirs, and vsock UDS
 directories normally happens in the parent's `child.once("exit")`
-hook. After detach the parent is gone, so those leak until the
-follow-up `machinen gc` / `machinen stop` commands (PR2 of #150)
-land. Use `--detached` only when you understand that trade-off.
+hook. After detach the parent is gone, so those leak until
+`machinen gc` / `machinen stop` reaps them.
 
 Reattach with `attach({ name | pid })` from another process —
 the registry entry stays live, the vsock UDS is still listening.
@@ -4495,10 +4494,10 @@ without touching the source dir.
 
 Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
 runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is a live
-vsock-FUSE pass-through (writes land on the host, doesn't survive
-snapshot/restore). Pick `mount` for inputs the guest may modify
-but the host shouldn't see; `liveMount` for shared scratch.
+but writes don't propagate to the host); `liveMount` is an in-VMM
+virtio-fs pass-through (writes land on the host and restore/fork
+re-establish the same guest mount topology). Pick `mount` for inputs the
+guest may modify but the host shouldn't see; `liveMount` for shared scratch.
 
 See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
 relocation; same shape), #272 (this overlay relocation).
@@ -4543,8 +4542,8 @@ the host (#151, #156). Set `"ro"` for a one-way share (host
 caches, untrusted guests).
 
 Each guest path must live under `/mnt/` (same rule as `mount`).
-Repeatable up to 4 entries per VM — each is served by its own
-in-VMM virtio-fs device (the VMM wires 4 virtio-fs slots). The
+Repeatable up to 5 entries per VM — each is served by its own
+in-VMM virtio-fs device (the VMM wires 5 virtio-fs slots). The
 FUSE opcode handlers run inside the VMM and the guest mounts each
 share directly with `mount -t virtiofs` — no agent process, no
 vsock hop. Requires a guest kernel with `CONFIG_VIRTIO_FS` — every
@@ -4772,16 +4771,15 @@ the child and is free to exit.
 
 Forces `pdeathsig: false` (otherwise the parent's exit kills the
 VMM, defeating the purpose). Compatible with every other boot
-option: gvproxy + live-mount FUSE servers spawn as detached
-daemons wrapped through `pdeathsig --watch-pid <vmm>`, and `mount`
-(squashfs+ext4 overlay) is fd-passed to the VMM at spawn so the
-supervisor holds no live state afterwards.
+option: gvproxy is tracked in the registry, live mounts are served
+by in-VMM virtio-fs devices, and `mount` (squashfs+ext4 overlay)
+is fd-passed to the VMM at spawn so the supervisor holds no live
+state afterwards.
 
 Cleanup of per-boot reflink disks, bundle dirs, and vsock UDS
 directories normally happens in the parent's `child.once("exit")`
-hook. After detach the parent is gone, so those leak until the
-follow-up `machinen gc` / `machinen stop` commands (PR2 of #150)
-land. Use `--detached` only when you understand that trade-off.
+hook. After detach the parent is gone, so those leak until
+`machinen gc` / `machinen stop` reaps them.
 
 Reattach with `attach({ name | pid })` from another process —
 the registry entry stays live, the vsock UDS is still listening.
@@ -4794,8 +4792,9 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > **snapDir**: `string`
 
-Snapshot bundle directory produced by `vm.snapshot()`.
-Must contain `img/<crius>` and `meta.json`.
+Snapshot bundle directory produced by `vm.snapshot()`. Vmstate bundles
+contain `state.vmstate`, `rootdisk.img`, and `meta.json`; legacy CRIU
+bundles contain `img/<crius>` and `meta.json`.
 
 ##### image?
 
@@ -4819,19 +4818,17 @@ unique under the source's namespace.
 
 > `optional` **lazy?**: `boolean`
 
-Opt into lazy-pages restore — bundle is vsock-FUSE-mounted into
-the guest read-only and `criu restore --lazy-pages` faults pages
-on demand (#266). Default false: the runtime packs the CRIU
-image into a tar on `/dev/vdb`, the guest's
-`/sbin/machinen-restore` untars it into tmpfs, and CRIU does an
-eager load.
+Opt into CRIU lazy-pages restore — the CRIU image directory is mounted
+into the guest read-only via in-VMM virtio-fs and `criu restore
+--lazy-pages` faults pages on demand (#266). Default false: the runtime
+packs the CRIU image into a tar on `/dev/vdb`, the guest's
+`/sbin/machinen-restore` untars it into tmpfs, and CRIU does an eager
+load.
 
-Eager is still the default because lazy bundles a host-side FUSE
-server that doesn't compose with `--detach` (#150 phase 3). The
-historical second blocker — runaway free-page-reporting under
-lazy — is fixed in #290 by the in-tree kernel patch that stops
-the buddy allocator from clearing the Reported flag during a
-merge.
+Eager is still the CRIU default because lazy restore is a specialized
+UFFD path. The historical runaway free-page-reporting blocker under
+lazy is fixed in #290 by the in-tree kernel patch that stops the buddy
+allocator from clearing the Reported flag during a merge.
 
 ***
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -28,19 +28,17 @@ If you want a CLI rather than a library, see
 npm i @machinen/runtime
 ```
 
-You also need a VMM binary. The matching one for your host
-(`@machinen/vmm-arm64-darwin` for Apple Silicon Macs,
-`@machinen/vmm-arm64-linux` for arm64 Linux) is pulled in
-automatically as an optional dependency. If you'd rather install it
-explicitly:
+You also need a native package with the VMM and host tools. The matching one
+for your host (`@machinen/native-arm64-darwin`,
+`@machinen/native-arm64-linux`, or `@machinen/native-x64-linux`) is pulled in
+automatically as an optional dependency. If you'd rather install it explicitly:
 
 ```bash
-npm i @machinen/vmm-arm64-darwin    # or @machinen/vmm-arm64-linux
+npm i @machinen/native-arm64-darwin    # or native-arm64-linux / native-x64-linux
 ```
 
-First boot fetches the kernel + base rootfs from a private GitHub
-release, so make sure you've authenticated [GitHub
-CLI](https://cli.github.com/) (`gh auth login`).
+First boot fetches the matching kernel + base rootfs from the public
+companion GitHub release over HTTPS; no `gh auth login` is needed.
 
 ## A taste
 
@@ -48,7 +46,7 @@ CLI](https://cli.github.com/) (`gh auth login`).
 import { boot } from "@machinen/runtime";
 
 const vm = await boot({
-  image: "./rootfs-debian-arm64.tar.gz",
+  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on x64 Linux
   cmd: ["/bin/sh"],
 });
 

--- a/packages/runtime/src/__tests__/detached.test.ts
+++ b/packages/runtime/src/__tests__/detached.test.ts
@@ -1,11 +1,10 @@
 // Detached-boot v1 (issue #150 phase 2). Covers:
 //   - boot-console snapshot writer (writeBootSnapshot + path layout)
 //   - regression guard against re-introducing the helper-compat gate.
-//     Phase 2 PR3 lifted portForward, phase 3 lifted liveMounts (each
-//     spawns as a detached helper under pdeathsig --watch-pid), and
-//     `mount` (squashfs+ext4) was lifted once we verified it holds no
-//     live supervisor state after fd-pass. Every boot option is now
-//     detach-compatible — assert boot() doesn't refuse them.
+//     portForward, liveMounts (in-VMM virtio-fs), and `mount`
+//     (squashfs+ext4) all hold no live supervisor state after readiness.
+//     Every boot option is now detach-compatible — assert boot() doesn't
+//     refuse them.
 //
 // The end-to-end "boot --detached, parent exits, VMM keeps running"
 // flow needs the real VMM binary and lives in the smoke suite —
@@ -78,7 +77,7 @@ describe("boot({ detached }) accepts every option", () => {
     expect((err as { code: string }).code).not.toMatch(/INCOMPATIBLE/);
   });
 
-  it("does NOT reject liveMounts (#150 phase 3 — detached helper)", async () => {
+  it("does NOT reject liveMounts (in-VMM virtio-fs)", async () => {
     const err = await boot({
       detached: true,
       image: "/tmp/does-not-exist.tar.gz",

--- a/packages/runtime/src/__tests__/pdeathsig.test.ts
+++ b/packages/runtime/src/__tests__/pdeathsig.test.ts
@@ -181,9 +181,9 @@ describe("pdeathsig kill -9 survival", () => {
   }, 15000);
 
   // --watch-pid <pid> mode: the wrapped target dies when the *named*
-  // process dies, even if it's not the wrapper's parent. Used by the
-  // detached live-mount helper (#150 phase 3): the helper is spawned
-  // by the supervisor but must die when the VMM dies.
+  // process dies, even if it's not the wrapper's parent. Kept for any
+  // future helper whose immediate parent can exit before the process it
+  // should track.
   it("--watch-pid <n>: target dies when the watched (non-parent) pid is killed", async () => {
     if (process.platform !== "linux" && process.platform !== "darwin") {
       return;

--- a/packages/runtime/src/detached-log.ts
+++ b/packages/runtime/src/detached-log.ts
@@ -11,8 +11,8 @@
 // Phase 1 `collect()` cap, ~1 MiB) to a one-shot file at detach time
 // so a post-mortem on a detached VM's boot still has the kernel
 // console + early-userspace output. Live tailing of a detached VM is
-// out of scope for v1 — Phase 3 either folds logging into Zig with
-// SIGHUP-reopen or routes through a forwarder daemon.
+// separate future logging work (for example, folding log rotation into
+// Zig with SIGHUP-reopen or routing through a forwarder daemon).
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -23,7 +23,8 @@
 //     env: {
 //       MACHINEN_VSOCK: "in:1978:/tmp/machinen-exec.sock",
 //     },
-//     image: "./rootfs-debian-arm64.tar.gz", cmd: ["/sbin/machinen-exec-agent"],
+//     image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz
+//     cmd: ["/sbin/machinen-exec-agent"],
 //   });
 //   const res = await VsockExec.run("/tmp/machinen-exec.sock", "apt-get --version");
 //   // res.exitCode, res.stdout, res.stderr

--- a/packages/runtime/src/gvproxy.ts
+++ b/packages/runtime/src/gvproxy.ts
@@ -483,7 +483,7 @@ function isGvproxyDisabledSentinel(value: string): boolean {
 /**
  * Pick the upstream release asset for this host. Mirrors the mapping
  * in `scripts/install-gvproxy.sh` so the release path (bundled in
- * `@machinen/vmm-*` via CI) and the dev auto-install path stay lockstep.
+ * `@machinen/native-*` via CI) and the dev auto-install path stay lockstep.
  */
 function gvproxyAssetName(): string {
   const platform = osPlatform();

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -477,7 +477,10 @@ export interface PackBundleOptions {
   bundle: string;
   /** Path to the initramfs cpio to write. */
   out: string;
-  /** Optional base rootfs tarball (rootfs-debian-arm64.tar.gz). */
+  /**
+   * Optional arch-specific base rootfs tarball
+   * (`rootfs-debian-arm64.tar.gz` or `rootfs-debian-amd64.tar.gz`).
+   */
   base?: string;
   /**
    * A single host directory copied into the guest between the base

--- a/packages/runtime/src/pdeathsig.ts
+++ b/packages/runtime/src/pdeathsig.ts
@@ -11,10 +11,9 @@
 //
 //   1. Default — watch the immediate parent (the process that exec'd
 //      the shim). Used by gvproxy and the VMM today.
-//   2. `--watch-pid <pid>` — watch an explicit, non-parent PID. Used
-//      by the detached live-mount helper (#150 phase 3): the helper
-//      is spawned by the supervisor, but it should die when the *VMM*
-//      dies, not when the supervisor exits.
+//   2. `--watch-pid <pid>` — watch an explicit, non-parent PID. Kept
+//      for helpers whose immediate parent may exit before the process
+//      they should track.
 //
 // Cross-platform via a tiny C shim, ~200 lines, three branches:
 //
@@ -531,10 +530,9 @@ function compilePdeathsig(outPath: string): string {
  * `pdeathsigBin` is `null` the argv is returned unchanged — caller
  * gets the unwrapped behavior (orphan-on-kill -9).
  *
- * `opts.watchPid` is for the detached live-mount helper case (#150
- * phase 3): the helper's immediate parent (the supervisor) exits on
- * purpose post-detach, but the helper must die when the *VMM* dies.
- * Pass the VMM's pid here.
+ * `opts.watchPid` is for helpers whose immediate parent exits on purpose
+ * while the helper should live only as long as another process (for example,
+ * the VMM). Pass that watched process pid here.
  */
 export function wrapWithPdeathsig(
   pdeathsigBin: string | null,

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -8,7 +8,7 @@
 // Minimum correct round-trip:
 //
 //   const snap = await provision({
-//     base: "./rootfs-debian-arm64.tar.gz",
+//     base: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz
 //     install: async vm => {
 //       await vm.exec("apt-get update");
 //       await vm.exec("apt-get install -y --no-install-recommends tree");

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -477,17 +477,16 @@ export interface ForkOptions extends Omit<RestoreOptions, "snapDir"> {
    */
   onLog?: OnLog;
   /**
-   * Opt into lazy-pages restore for the fork — vsock-FUSE-mounted
-   * bundle + `criu restore --lazy-pages`. Default false: the runtime
-   * packs the CRIU image into a tar on `/dev/vdb` and the guest does
-   * an eager load.
+   * Opt into CRIU lazy-pages restore for the fork — the CRIU image directory
+   * is mounted into the guest read-only via in-VMM virtio-fs and `criu restore
+   * --lazy-pages` faults pages on demand. Default false: the runtime packs the
+   * CRIU image into a tar on `/dev/vdb` and the guest does an eager load.
    *
-   * Lazy keeps fork RSS proportional to the pages the sibling
-   * actually touches, not the full snapshot size. Worth setting when
-   * the source dumped a large heap that the fork will only sample.
-   * Cannot combine with `--detach` (the lazy path needs the host's
-   * FUSE server alive as long as the guest may fault, see #150
-   * phase 3); the runtime falls back to eager in that case.
+   * Lazy keeps fork RSS proportional to the pages the sibling actually
+   * touches, not the full snapshot size. Worth setting when the source dumped
+   * a large heap that the fork will only sample. The CLI currently forces
+   * eager restore for `fork --detach --lazy`; use the runtime API directly if
+   * you need to experiment with that combination.
    */
   lazy?: boolean;
   /**

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -74,7 +74,8 @@ const restoreDebug = debugLib("machinen:restore");
 export interface BootOptions {
   /**
    * Path to a rootfs tarball to boot from (e.g. the output of
-   * `provision()`, or `rootfs-debian-arm64.tar.gz` shipped in releases).
+   * `provision()`, or an arch-specific base rootfs tarball shipped in
+   * releases: `rootfs-debian-arm64.tar.gz` / `rootfs-debian-amd64.tar.gz`).
    * Paired with `cmd` — both required, or neither (test-mode binary
    * boots and snapshot-only restores both skip initramfs packing).
    */
@@ -196,10 +197,10 @@ export interface BootOptions {
    *
    * Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
    * runtime channel back to the host source dir, snapshots cleanly,
-   * but writes don't propagate to the host); `liveMount` is a live
-   * vsock-FUSE pass-through (writes land on the host, doesn't survive
-   * snapshot/restore). Pick `mount` for inputs the guest may modify
-   * but the host shouldn't see; `liveMount` for shared scratch.
+   * but writes don't propagate to the host); `liveMount` is an in-VMM
+   * virtio-fs pass-through (writes land on the host and restore/fork
+   * re-establish the same guest mount topology). Pick `mount` for inputs the
+   * guest may modify but the host shouldn't see; `liveMount` for shared scratch.
    *
    * See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
    * relocation; same shape), #272 (this overlay relocation).
@@ -259,8 +260,8 @@ export interface BootOptions {
    * caches, untrusted guests).
    *
    * Each guest path must live under `/mnt/` (same rule as `mount`).
-   * Repeatable up to 4 entries per VM — each is served by its own
-   * in-VMM virtio-fs device (the VMM wires 4 virtio-fs slots). The
+   * Repeatable up to 5 entries per VM — each is served by its own
+   * in-VMM virtio-fs device (the VMM wires 5 virtio-fs slots). The
    * FUSE opcode handlers run inside the VMM and the guest mounts each
    * share directly with `mount -t virtiofs` — no agent process, no
    * vsock hop. Requires a guest kernel with `CONFIG_VIRTIO_FS` — every
@@ -385,16 +386,15 @@ export interface BootOptions {
    *
    * Forces `pdeathsig: false` (otherwise the parent's exit kills the
    * VMM, defeating the purpose). Compatible with every other boot
-   * option: gvproxy + live-mount FUSE servers spawn as detached
-   * daemons wrapped through `pdeathsig --watch-pid <vmm>`, and `mount`
-   * (squashfs+ext4 overlay) is fd-passed to the VMM at spawn so the
-   * supervisor holds no live state afterwards.
+   * option: gvproxy is tracked in the registry, live mounts are served
+   * by in-VMM virtio-fs devices, and `mount` (squashfs+ext4 overlay)
+   * is fd-passed to the VMM at spawn so the supervisor holds no live
+   * state afterwards.
    *
    * Cleanup of per-boot reflink disks, bundle dirs, and vsock UDS
    * directories normally happens in the parent's `child.once("exit")`
-   * hook. After detach the parent is gone, so those leak until the
-   * follow-up `machinen gc` / `machinen stop` commands (PR2 of #150)
-   * land. Use `--detached` only when you understand that trade-off.
+   * hook. After detach the parent is gone, so those leak until
+   * `machinen gc` / `machinen stop` reaps them.
    *
    * Reattach with `attach({ name | pid })` from another process —
    * the registry entry stays live, the vsock UDS is still listening.
@@ -1486,8 +1486,8 @@ function materializeRootdisk(
 }
 
 // Roll back gvproxy + per-boot disks/dirs after a pre-spawn failure.
-// No live-mount helpers exist yet at this point (they spawn post-VMM
-// in #150 phase 3) — only the gv + per-boot disks need rolling back.
+// Live mounts are in-VMM virtio-fs devices configured through env, so
+// there are no separate live-mount helper processes to roll back.
 function rollbackPreSpawn(state: {
   gvStop: (() => void) | undefined;
   bundleTempDir: string | undefined;

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -1,6 +1,6 @@
 // Restore a microVM from a snapshot bundle produced by `vm.snapshot()`.
 // Handles bundle validation, image resolution, lazy-pagemap rewriting,
-// CRIU image delivery (eager tar on /dev/vdb vs. lazy FUSE mount),
+// CRIU image delivery (eager tar on /dev/vdb vs. lazy virtio-fs mount),
 // mount-overlay re-attach, and the post-boot auto-name + hostname
 // patch-up.
 
@@ -56,8 +56,9 @@ const VMSTATE_RESEED_MARKER = "/run/machinen-vmstate-reseed";
 
 export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" | "cmd" | "name"> {
   /**
-   * Snapshot bundle directory produced by `vm.snapshot()`.
-   * Must contain `img/<crius>` and `meta.json`.
+   * Snapshot bundle directory produced by `vm.snapshot()`. Vmstate bundles
+   * contain `state.vmstate`, `rootdisk.img`, and `meta.json`; legacy CRIU
+   * bundles contain `img/<crius>` and `meta.json`.
    */
   snapDir: string;
   /**
@@ -75,19 +76,17 @@ export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" |
    */
   name?: string;
   /**
-   * Opt into lazy-pages restore — bundle is vsock-FUSE-mounted into
-   * the guest read-only and `criu restore --lazy-pages` faults pages
-   * on demand (#266). Default false: the runtime packs the CRIU
-   * image into a tar on `/dev/vdb`, the guest's
-   * `/sbin/machinen-restore` untars it into tmpfs, and CRIU does an
-   * eager load.
+   * Opt into CRIU lazy-pages restore — the CRIU image directory is mounted
+   * into the guest read-only via in-VMM virtio-fs and `criu restore
+   * --lazy-pages` faults pages on demand (#266). Default false: the runtime
+   * packs the CRIU image into a tar on `/dev/vdb`, the guest's
+   * `/sbin/machinen-restore` untars it into tmpfs, and CRIU does an eager
+   * load.
    *
-   * Eager is still the default because lazy bundles a host-side FUSE
-   * server that doesn't compose with `--detach` (#150 phase 3). The
-   * historical second blocker — runaway free-page-reporting under
-   * lazy — is fixed in #290 by the in-tree kernel patch that stops
-   * the buddy allocator from clearing the Reported flag during a
-   * merge.
+   * Eager is still the CRIU default because lazy restore is a specialized
+   * UFFD path. The historical runaway free-page-reporting blocker under
+   * lazy is fixed in #290 by the in-tree kernel patch that stops the buddy
+   * allocator from clearing the Reported flag during a merge.
    */
   lazy?: boolean;
 }


### PR DESCRIPTION
## Problem

The docs still talked about older parts of machinen in a few places. They said live mounts used vsock-FUSE, restore bundles were mostly CRIU-shaped, and native binaries came from the old `@machinen/vmm-*` packages. That can send readers down the wrong path when they are trying to use vmstate snapshots, amd64 guests, or the new native packages.

## Solution

This updates the docs and code comments to match the current shape of the project. It adds a new `.vmstate` format spec, links it from the docs index, and refreshes the restore, live-mount, detach, native package, and guest-architecture wording across the READMEs and generated API docs.

## Tests

- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `pnpm smoke-tests`
