### PR TITLE
Add cooperative checkpoint ABI

### DIFF
--- a/docs/snapshot/portable-snapshot-format.md
+++ b/docs/snapshot/portable-snapshot-format.md
@@ -29,11 +29,21 @@ The TypeScript source of truth for the JSON schemas and validator is
 - program identity (`program.name`, `program.executable`, optional `identity`)
 - source build identity (`sourceBuild.buildId`, optional `version`)
 - required target build (`targetBuild.buildId` or `targetBuild.version`)
+- cooperative checkpoint ABI (`checkpointAbi.version`, `machinen_checkpoint`,
+  `machinen_checkpoint_roots`, and safe-point requirements)
 - checkpoint continuation symbol (`checkpointContinuation.name`)
-- restore entrypoint symbol (`restoreEntrypoint.name`)
+- restore entrypoint symbol (`restoreEntrypoint.name`, currently
+  `machinen_restore_main`)
 - process argv/env/cwd (`process`)
 - feature flags (`features`)
 - diagnostics vocabulary (`unsupported.refusals`)
+
+The proof ABI requires checkpoint requests to happen at a named cooperative
+safe point, outside signal handlers and outside in-flight syscalls. The bundle
+records the continuation name instead of raw source registers or stack frames.
+Checkpoint refusals use stable diagnostic codes such as
+`checkpoint-inside-syscall`, `checkpoint-inside-signal-handler`, and
+`checkpoint-invalid-roots`.
 
 The engine selector is opt-in via `MACHINEN_SNAPSHOT_ENGINE=portable`.
 Until the checkpoint implementation lands, snapshot/restore fail with an

--- a/packages/microvm/assets/portable-checkpoint-abi.h
+++ b/packages/microvm/assets/portable-checkpoint-abi.h
@@ -1,0 +1,77 @@
+#ifndef MACHINEN_PORTABLE_CHECKPOINT_ABI_H
+#define MACHINEN_PORTABLE_CHECKPOINT_ABI_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MACHINEN_CHECKPOINT_ABI_VERSION 1u
+#define MACHINEN_CHECKPOINT_MAX_ROOTS 64u
+
+#define MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SIGNAL_HANDLER (1u << 0)
+#define MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SYSCALL (1u << 1)
+#define MACHINEN_CHECKPOINT_FLAG_KNOWN_SAFE_POINT \
+  (MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SIGNAL_HANDLER | MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SYSCALL)
+
+enum machinen_checkpoint_root_kind {
+  MACHINEN_CHECKPOINT_ROOT_GLOBAL = 1,
+  MACHINEN_CHECKPOINT_ROOT_HEAP = 2,
+  MACHINEN_CHECKPOINT_ROOT_STACK = 3,
+  MACHINEN_CHECKPOINT_ROOT_THREAD_LOCAL = 4,
+  MACHINEN_CHECKPOINT_ROOT_OPAQUE = 5,
+};
+
+enum machinen_checkpoint_result {
+  MACHINEN_CHECKPOINT_OK = 0,
+  MACHINEN_CHECKPOINT_REFUSED_INVALID_ABI = 1,
+  MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS = 2,
+  MACHINEN_CHECKPOINT_REFUSED_INSIDE_SIGNAL_HANDLER = 3,
+  MACHINEN_CHECKPOINT_REFUSED_INSIDE_SYSCALL = 4,
+  MACHINEN_CHECKPOINT_REFUSED_UNSUPPORTED_ROOT = 5,
+};
+
+struct machinen_checkpoint_root {
+  const char *name;
+  const void *address;
+  uint64_t size_bytes;
+  uint32_t kind;
+  uint32_t flags;
+  const char *type_name;
+};
+
+struct machinen_checkpoint_roots {
+  uint32_t abi_version;
+  uint32_t flags;
+  const char *continuation_name;
+  const struct machinen_checkpoint_root *roots;
+  uint32_t root_count;
+  uint32_t reserved;
+};
+
+struct machinen_restore_object {
+  const char *name;
+  void *target_address;
+  uint64_t size_bytes;
+  uint32_t kind;
+  uint32_t flags;
+};
+
+struct machinen_restore_bundle {
+  uint32_t abi_version;
+  uint32_t flags;
+  const char *continuation_name;
+  const struct machinen_restore_object *objects;
+  uint32_t object_count;
+  uint32_t reserved;
+};
+
+int machinen_checkpoint(const struct machinen_checkpoint_roots *roots);
+int machinen_restore_main(const struct machinen_restore_bundle *bundle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/packages/microvm/assets/portable-proof-workload.c
+++ b/packages/microvm/assets/portable-proof-workload.c
@@ -1,13 +1,20 @@
 // Tiny deterministic workload for the experimental portable snapshot engine.
 //
-// It keeps a simple pointer graph in global storage and exposes stable
-// checkpoint/restore symbols that future portable-checkpoint tooling can
-// locate by name in both arm64 and amd64 guest binaries.
+// It keeps a simple pointer graph in global storage and uses the cooperative
+// checkpoint ABI from portable-checkpoint-abi.h. The checkpoint request happens
+// from a named safe-point function, and restore enters through machinen_restore_main
+// instead of reconstructing a raw machine stack.
+
+#include "portable-checkpoint-abi.h"
 
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#define PORTABLE_PROOF_ROOT_COUNT 2u
+#define PORTABLE_PROOF_CONTINUATION "machinen_portable_checkpoint"
+#define PORTABLE_PROOF_RESTORE_CONTINUATION "machinen_portable_restore_entry"
 
 struct Node {
   uint64_t value;
@@ -29,24 +36,125 @@ struct AppState {
 
 __attribute__((used, visibility("default"))) struct Node machinen_portable_nodes[3];
 __attribute__((used, visibility("default"))) struct AppState machinen_portable_app_state;
+__attribute__((used, visibility("default"))) int machinen_portable_last_checkpoint_result;
+
+static const struct machinen_checkpoint_root machinen_portable_roots[PORTABLE_PROOF_ROOT_COUNT] = {
+    {
+        .name = "machinen_portable_app_state",
+        .address = &machinen_portable_app_state,
+        .size_bytes = sizeof(machinen_portable_app_state),
+        .kind = MACHINEN_CHECKPOINT_ROOT_GLOBAL,
+        .flags = 0,
+        .type_name = "struct AppState",
+    },
+    {
+        .name = "machinen_portable_nodes",
+        .address = &machinen_portable_nodes,
+        .size_bytes = sizeof(machinen_portable_nodes),
+        .kind = MACHINEN_CHECKPOINT_ROOT_GLOBAL,
+        .flags = 0,
+        .type_name = "struct Node[3]",
+    },
+};
 
 __attribute__((used, visibility("default"))) const char machinen_portable_metadata[] =
     "{\"schema_version\":1,"
     "\"workload\":\"machinen-portable-proof\","
-    "\"checkpoint_symbol\":\"machinen_portable_checkpoint\","
-    "\"restore_symbol\":\"machinen_portable_restore_entry\","
+    "\"checkpoint_abi_version\":1,"
+    "\"checkpoint_symbol\":\"machinen_checkpoint\","
+    "\"checkpoint_roots_type\":\"machinen_checkpoint_roots\","
+    "\"checkpoint_continuation\":\"machinen_portable_checkpoint\","
+    "\"restore_symbol\":\"machinen_restore_main\","
+    "\"restore_bundle_type\":\"machinen_restore_bundle\","
+    "\"restore_continuation\":\"machinen_portable_restore_entry\","
     "\"state_symbol\":\"machinen_portable_app_state\"}";
 
-__attribute__((noinline, used, visibility("default"))) void machinen_portable_checkpoint(
-    struct AppState *state) {
-  (void)state;
-  __asm__ __volatile__("" ::: "memory");
+static bool root_kind_supported(uint32_t kind) {
+  switch (kind) {
+    case MACHINEN_CHECKPOINT_ROOT_GLOBAL:
+    case MACHINEN_CHECKPOINT_ROOT_HEAP:
+    case MACHINEN_CHECKPOINT_ROOT_STACK:
+    case MACHINEN_CHECKPOINT_ROOT_THREAD_LOCAL:
+    case MACHINEN_CHECKPOINT_ROOT_OPAQUE:
+      return true;
+  }
+  return false;
 }
 
-__attribute__((noinline, used, visibility("default"))) void machinen_portable_restore_entry(
+__attribute__((noinline, used, visibility("default"))) int machinen_checkpoint(
+    const struct machinen_checkpoint_roots *roots) {
+  if (!roots) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  if (roots->abi_version != MACHINEN_CHECKPOINT_ABI_VERSION) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ABI;
+  }
+  if (!(roots->flags & MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SIGNAL_HANDLER)) {
+    return MACHINEN_CHECKPOINT_REFUSED_INSIDE_SIGNAL_HANDLER;
+  }
+  if (!(roots->flags & MACHINEN_CHECKPOINT_FLAG_OUTSIDE_SYSCALL)) {
+    return MACHINEN_CHECKPOINT_REFUSED_INSIDE_SYSCALL;
+  }
+  if (!roots->continuation_name || !roots->roots) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  if (roots->root_count == 0 || roots->root_count > MACHINEN_CHECKPOINT_MAX_ROOTS) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  for (uint32_t i = 0; i < roots->root_count; i++) {
+    const struct machinen_checkpoint_root *root = &roots->roots[i];
+    if (!root->name || !root->address || root->size_bytes == 0) {
+      return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+    }
+    if (!root_kind_supported(root->kind)) {
+      return MACHINEN_CHECKPOINT_REFUSED_UNSUPPORTED_ROOT;
+    }
+  }
+  return MACHINEN_CHECKPOINT_OK;
+}
+
+__attribute__((noinline, used, visibility("default"))) int machinen_portable_checkpoint(
     struct AppState *state) {
-  (void)state;
+  if (state != &machinen_portable_app_state) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  const struct machinen_checkpoint_roots roots = {
+      .abi_version = MACHINEN_CHECKPOINT_ABI_VERSION,
+      .flags = MACHINEN_CHECKPOINT_FLAG_KNOWN_SAFE_POINT,
+      .continuation_name = PORTABLE_PROOF_CONTINUATION,
+      .roots = machinen_portable_roots,
+      .root_count = PORTABLE_PROOF_ROOT_COUNT,
+      .reserved = 0,
+  };
+  machinen_portable_last_checkpoint_result = machinen_checkpoint(&roots);
   __asm__ __volatile__("" ::: "memory");
+  return machinen_portable_last_checkpoint_result;
+}
+
+__attribute__((noinline, used, visibility("default"))) int machinen_portable_restore_entry(
+    struct AppState *state) {
+  if (state != &machinen_portable_app_state) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  __asm__ __volatile__("" ::: "memory");
+  return MACHINEN_CHECKPOINT_OK;
+}
+
+__attribute__((noinline, used, visibility("default"))) int machinen_restore_main(
+    const struct machinen_restore_bundle *bundle) {
+  if (!bundle) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  if (bundle->abi_version != MACHINEN_CHECKPOINT_ABI_VERSION) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ABI;
+  }
+  if (!bundle->continuation_name) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  if (strcmp(bundle->continuation_name, PORTABLE_PROOF_RESTORE_CONTINUATION) != 0) {
+    return MACHINEN_CHECKPOINT_REFUSED_INVALID_ROOTS;
+  }
+  return machinen_portable_restore_entry(&machinen_portable_app_state);
 }
 
 static void reset_state(void) {
@@ -58,6 +166,7 @@ static void reset_state(void) {
   machinen_portable_nodes[2].next = 0;
   machinen_portable_app_state.counter = 1000;
   machinen_portable_app_state.list = &machinen_portable_nodes[0];
+  machinen_portable_last_checkpoint_result = MACHINEN_CHECKPOINT_OK;
 }
 
 static bool list_matches_1_2_3(const struct AppState *state) {
@@ -72,15 +181,25 @@ static void print_marker(const char *phase) {
       "MACHINEN_PORTABLE_PROOF "
       "{\"schema_version\":1,\"phase\":\"%s\",\"arch\":\"%s\","
       "\"counter\":%llu,\"list\":[%llu,%llu,%llu],"
-      "\"checkpoint_symbol\":\"machinen_portable_checkpoint\","
-      "\"restore_symbol\":\"machinen_portable_restore_entry\","
-      "\"state_symbol\":\"machinen_portable_app_state\"}\n",
+      "\"checkpoint_abi_version\":%u,"
+      "\"checkpoint_symbol\":\"machinen_checkpoint\","
+      "\"checkpoint_continuation\":\"machinen_portable_checkpoint\","
+      "\"restore_symbol\":\"machinen_restore_main\","
+      "\"restore_continuation\":\"machinen_portable_restore_entry\","
+      "\"state_symbol\":\"machinen_portable_app_state\","
+      "\"root_count\":%u,"
+      "\"root_names\":[\"machinen_portable_app_state\",\"machinen_portable_nodes\"],"
+      "\"checkpoint_result\":%d,"
+      "\"safe_point\":{\"outside_signal_handler\":true,\"outside_syscall\":true}}\n",
       phase,
       PORTABLE_PROOF_ARCH,
       (unsigned long long)machinen_portable_app_state.counter,
       (unsigned long long)machinen_portable_nodes[0].value,
       (unsigned long long)machinen_portable_nodes[1].value,
-      (unsigned long long)machinen_portable_nodes[2].value);
+      (unsigned long long)machinen_portable_nodes[2].value,
+      MACHINEN_CHECKPOINT_ABI_VERSION,
+      PORTABLE_PROOF_ROOT_COUNT,
+      machinen_portable_last_checkpoint_result);
   fflush(stdout);
 }
 
@@ -100,11 +219,27 @@ int main(int argc, char **argv) {
     return 2;
   }
 
+  int result = machinen_portable_checkpoint(&machinen_portable_app_state);
+  if (result != MACHINEN_CHECKPOINT_OK) {
+    fprintf(stderr, "portable proof: checkpoint refused: %d\n", result);
+    return 4;
+  }
   print_marker("checkpoint");
-  machinen_portable_checkpoint(&machinen_portable_app_state);
 
   if (has_arg(argc, argv, "--restore-proof")) {
-    machinen_portable_restore_entry(&machinen_portable_app_state);
+    const struct machinen_restore_bundle bundle = {
+        .abi_version = MACHINEN_CHECKPOINT_ABI_VERSION,
+        .flags = 0,
+        .continuation_name = PORTABLE_PROOF_RESTORE_CONTINUATION,
+        .objects = 0,
+        .object_count = 0,
+        .reserved = 0,
+    };
+    result = machinen_restore_main(&bundle);
+    if (result != MACHINEN_CHECKPOINT_OK) {
+      fprintf(stderr, "portable proof: restore refused: %d\n", result);
+      return 5;
+    }
     if (machinen_portable_app_state.counter != 1000 ||
         !list_matches_1_2_3(&machinen_portable_app_state)) {
       fprintf(stderr, "portable proof: restore state mismatch\n");

--- a/packages/runtime/src/__tests__/portable-proof-helper.test.ts
+++ b/packages/runtime/src/__tests__/portable-proof-helper.test.ts
@@ -23,9 +23,19 @@ function marker(phase: string, counter: number, arch = "amd64"): string {
       arch,
       counter,
       list: [1, 2, 3],
-      checkpoint_symbol: "machinen_portable_checkpoint",
-      restore_symbol: "machinen_portable_restore_entry",
+      checkpoint_abi_version: 1,
+      checkpoint_symbol: "machinen_checkpoint",
+      checkpoint_continuation: "machinen_portable_checkpoint",
+      restore_symbol: "machinen_restore_main",
+      restore_continuation: "machinen_portable_restore_entry",
       state_symbol: "machinen_portable_app_state",
+      root_count: 2,
+      root_names: ["machinen_portable_app_state", "machinen_portable_nodes"],
+      checkpoint_result: 0,
+      safe_point: {
+        outside_signal_handler: true,
+        outside_syscall: true,
+      },
     }) +
     "\n"
   );
@@ -39,8 +49,8 @@ function writeLog(contents: string): string {
   return path;
 }
 
-function runHelper(args: string[]) {
-  return spawnSync(process.execPath, [HELPER, ...args], { encoding: "utf8" });
+function runHelper(args: string[], input?: string) {
+  return spawnSync(process.execPath, [HELPER, ...args], { encoding: "utf8", input });
 }
 
 describe("portable proof workload helper", () => {
@@ -59,6 +69,15 @@ describe("portable proof workload helper", () => {
     expect(JSON.parse(res.stdout)).toMatchObject({ ok: true, events: 3 });
   });
 
+  it("accepts stdin when the path is '-'", () => {
+    const res = runHelper(
+      ["--expect-arch", "amd64", "--require-restore", "--require-continue", "-"],
+      marker("checkpoint", 1000) + marker("restore", 1000) + marker("continue", 1001),
+    );
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout)).toMatchObject({ ok: true, events: 3 });
+  });
+
   it("rejects a restore marker whose state differs from the checkpoint", () => {
     const badRestore =
       "MACHINEN_PORTABLE_PROOF " +
@@ -68,9 +87,19 @@ describe("portable proof workload helper", () => {
         arch: "amd64",
         counter: 999,
         list: [1, 2, 3],
-        checkpoint_symbol: "machinen_portable_checkpoint",
-        restore_symbol: "machinen_portable_restore_entry",
+        checkpoint_abi_version: 1,
+        checkpoint_symbol: "machinen_checkpoint",
+        checkpoint_continuation: "machinen_portable_checkpoint",
+        restore_symbol: "machinen_restore_main",
+        restore_continuation: "machinen_portable_restore_entry",
         state_symbol: "machinen_portable_app_state",
+        root_count: 2,
+        root_names: ["machinen_portable_app_state", "machinen_portable_nodes"],
+        checkpoint_result: 0,
+        safe_point: {
+          outside_signal_handler: true,
+          outside_syscall: true,
+        },
       }) +
       "\n";
     const log = writeLog(marker("checkpoint", 1000) + badRestore);

--- a/packages/runtime/src/__tests__/portable-snapshot.test.ts
+++ b/packages/runtime/src/__tests__/portable-snapshot.test.ts
@@ -44,8 +44,18 @@ function tinyManifest(overrides: Record<string, unknown> = {}) {
     },
     sourceBuild: { buildId: "0123456789abcdef", version: "0.1.0" },
     targetBuild: { version: "0.1.x" },
+    checkpointAbi: {
+      version: 1,
+      checkpointFunction: { name: "machinen_checkpoint" },
+      rootsType: "machinen_checkpoint_roots",
+      restoreBundleType: "machinen_restore_bundle",
+      safePoint: {
+        outsideSignalHandlers: true,
+        outsideSyscalls: true,
+      },
+    },
     checkpointContinuation: { name: "machinen_portable_checkpoint" },
-    restoreEntrypoint: { name: "machinen_portable_restore_entry" },
+    restoreEntrypoint: { name: "machinen_restore_main" },
     process: {
       argv: ["/usr/local/bin/machinen-portable-proof", "--restore-proof"],
       env: { MACHINEN_PORTABLE_PROOF: "1" },
@@ -157,6 +167,39 @@ describe("portable snapshot schemas", () => {
     expect(() => validatePortableSnapshotBundle(dir)).toThrow(
       /manifest\.restoreEntrypoint\.name must be a valid symbol name/,
     );
+  });
+
+  it("requires the cooperative checkpoint ABI to name the safe point contract", () => {
+    const docs = tinyDocs({
+      checkpointAbi: {
+        version: 1,
+        checkpointFunction: { name: "machinen_checkpoint" },
+        rootsType: "machinen_checkpoint_roots",
+        restoreBundleType: "machinen_restore_bundle",
+        safePoint: {
+          outsideSignalHandlers: true,
+          outsideSyscalls: false,
+        },
+      },
+    });
+    expect(validatePortableSnapshotDocuments(docs)).toContain(
+      "manifest.checkpointAbi.safePoint.outsideSyscalls must be true",
+    );
+  });
+
+  it("accepts checkpoint refusal codes in the portable diagnostics vocabulary", () => {
+    const docs = tinyDocs({
+      unsupported: {
+        vocabularyVersion: 1,
+        refusals: [
+          {
+            code: "checkpoint-inside-syscall",
+            message: "checkpoint must happen from a cooperative safe point",
+          },
+        ],
+      },
+    });
+    expect(validatePortableSnapshotDocuments(docs)).toEqual([]);
   });
 
   it("reports missing target build metadata without reading from disk", () => {

--- a/packages/runtime/src/vm/portable-snapshot.ts
+++ b/packages/runtime/src/vm/portable-snapshot.ts
@@ -1,9 +1,20 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-export const PORTABLE_SNAPSHOT_FORMAT_VERSION = 1;
+const PORTABLE_SNAPSHOT_FORMAT_VERSION = 1;
+const PORTABLE_CHECKPOINT_ABI_VERSION = 1;
 
-export const PORTABLE_SNAPSHOT_FILES = {
+const PORTABLE_CHECKPOINT_ABI = {
+  checkpointFunction: "machinen_checkpoint",
+  rootsType: "machinen_checkpoint_roots",
+  restoreBundleType: "machinen_restore_bundle",
+  safePoint: {
+    outsideSignalHandlers: true,
+    outsideSyscalls: true,
+  },
+} as const;
+
+const PORTABLE_SNAPSHOT_FILES = {
   manifest: "manifest.json",
   memory: "memory.bin",
   objects: "objects.json",
@@ -12,10 +23,16 @@ export const PORTABLE_SNAPSHOT_FILES = {
   logs: "logs",
 } as const;
 
-export const PORTABLE_GUEST_ARCHES = ["arm64", "amd64"] as const;
-export type PortableGuestArch = (typeof PORTABLE_GUEST_ARCHES)[number];
+const PORTABLE_GUEST_ARCHES = ["arm64", "amd64"] as const;
+type PortableGuestArch = (typeof PORTABLE_GUEST_ARCHES)[number];
 
-export const PORTABLE_REFUSAL_CODES = [
+const PORTABLE_REFUSAL_CODES = [
+  "checkpoint-refused",
+  "checkpoint-invalid-abi",
+  "checkpoint-invalid-roots",
+  "checkpoint-inside-signal-handler",
+  "checkpoint-inside-syscall",
+  "checkpoint-unsupported-root",
   "architecture-unsupported",
   "build-id-mismatch",
   "entrypoint-missing",
@@ -26,20 +43,33 @@ export const PORTABLE_REFUSAL_CODES = [
   "resource-unsupported",
   "syscall-unsupported",
 ] as const;
-export type PortableRefusalCode = (typeof PORTABLE_REFUSAL_CODES)[number];
+type PortableRefusalCode = (typeof PORTABLE_REFUSAL_CODES)[number];
 
-export interface PortableRefusal {
+interface PortableRefusal {
   code: PortableRefusalCode;
   message: string;
   detail?: Record<string, unknown>;
 }
 
-export interface PortableUnsupportedVocabulary {
+interface PortableUnsupportedVocabulary {
   vocabularyVersion: number;
   refusals: PortableRefusal[];
 }
 
-export interface PortableSnapshotManifest {
+interface PortableCheckpointAbi {
+  version: number;
+  checkpointFunction: {
+    name: string;
+  };
+  rootsType: "machinen_checkpoint_roots";
+  restoreBundleType: "machinen_restore_bundle";
+  safePoint: {
+    outsideSignalHandlers: true;
+    outsideSyscalls: true;
+  };
+}
+
+interface PortableSnapshotManifest {
   formatVersion: number;
   sourceGuestArch: PortableGuestArch;
   allowedTargetGuestArchs: PortableGuestArch[];
@@ -56,6 +86,7 @@ export interface PortableSnapshotManifest {
     buildId?: string;
     version?: string;
   };
+  checkpointAbi: PortableCheckpointAbi;
   checkpointContinuation: {
     name: string;
   };
@@ -71,7 +102,7 @@ export interface PortableSnapshotManifest {
   unsupported: PortableUnsupportedVocabulary;
 }
 
-export interface PortableSnapshotObjects {
+interface PortableSnapshotObjects {
   formatVersion: number;
   objects: Array<{
     id: string;
@@ -87,7 +118,7 @@ export interface PortableSnapshotObjects {
   unsupported: PortableUnsupportedVocabulary;
 }
 
-export interface PortableSnapshotRelocations {
+interface PortableSnapshotRelocations {
   formatVersion: number;
   relocations: Array<{
     fromObject: string;
@@ -99,7 +130,7 @@ export interface PortableSnapshotRelocations {
   unsupported: PortableUnsupportedVocabulary;
 }
 
-export interface PortableSnapshotResources {
+interface PortableSnapshotResources {
   formatVersion: number;
   resources: Array<{
     id: string;
@@ -111,7 +142,7 @@ export interface PortableSnapshotResources {
   unsupported: PortableUnsupportedVocabulary;
 }
 
-export interface PortableSnapshotDocuments {
+interface PortableSnapshotDocuments {
   rootDir?: string;
   manifest: PortableSnapshotManifest;
   objects: PortableSnapshotObjects;
@@ -119,7 +150,7 @@ export interface PortableSnapshotDocuments {
   resources: PortableSnapshotResources;
 }
 
-export interface PortableSnapshotDocumentInput {
+interface PortableSnapshotDocumentInput {
   rootDir?: string;
   manifest: unknown;
   objects: unknown;
@@ -178,6 +209,7 @@ export const portableSnapshotSchemas = {
       "program",
       "sourceBuild",
       "targetBuild",
+      "checkpointAbi",
       "checkpointContinuation",
       "restoreEntrypoint",
       "process",
@@ -219,6 +251,26 @@ export const portableSnapshotSchemas = {
         properties: {
           buildId: BUILD_ID_SCHEMA,
           version: { type: "string", minLength: 1 },
+        },
+      },
+      checkpointAbi: {
+        type: "object",
+        additionalProperties: false,
+        required: ["version", "checkpointFunction", "rootsType", "restoreBundleType", "safePoint"],
+        properties: {
+          version: { const: PORTABLE_CHECKPOINT_ABI_VERSION },
+          checkpointFunction: SYMBOL_SCHEMA,
+          rootsType: { const: PORTABLE_CHECKPOINT_ABI.rootsType },
+          restoreBundleType: { const: PORTABLE_CHECKPOINT_ABI.restoreBundleType },
+          safePoint: {
+            type: "object",
+            additionalProperties: false,
+            required: ["outsideSignalHandlers", "outsideSyscalls"],
+            properties: {
+              outsideSignalHandlers: { const: true },
+              outsideSyscalls: { const: true },
+            },
+          },
         },
       },
       checkpointContinuation: SYMBOL_SCHEMA,
@@ -419,6 +471,7 @@ function validateManifest(ctx: ValidationContext, manifest: unknown): void {
   validateProgram(ctx, m.program);
   validateSourceBuild(ctx, m.sourceBuild);
   validateTargetBuild(ctx, m.targetBuild);
+  validateCheckpointAbi(ctx, m.checkpointAbi);
   validateSymbolObject(ctx, "manifest.checkpointContinuation", m.checkpointContinuation);
   validateSymbolObject(ctx, "manifest.restoreEntrypoint", m.restoreEntrypoint);
   validateProcess(ctx, m.process);
@@ -434,43 +487,78 @@ function validateObjects(ctx: ValidationContext, objectsDoc: unknown): void {
   validateFormatVersion(ctx, "objects.formatVersion", doc.formatVersion);
   const objects = expectArray(ctx, "objects.objects", doc.objects);
   if (objects) {
-    const ids = new Set<string>();
-    for (let i = 0; i < objects.length; i++) {
-      const path = `objects.objects[${i}]`;
-      const obj = expectRecord(ctx, path, objects[i]);
-      if (!obj) {
-        continue;
-      }
-      validateNonEmptyString(ctx, `${path}.id`, obj.id);
-      if (typeof obj.id === "string") {
-        if (ids.has(obj.id)) {
-          ctx.errors.push(`${path}.id duplicates object id ${JSON.stringify(obj.id)}`);
-        }
-        ids.add(obj.id);
-      }
-      validateEnum(ctx, `${path}.kind`, obj.kind, [
-        "global",
-        "heap",
-        "stack",
-        "thread",
-        "tls",
-        "opaque",
-      ]);
-      if (obj.type !== undefined) {
-        validateNonEmptyString(ctx, `${path}.type`, obj.type);
-      }
-      if (obj.sizeBytes !== undefined) {
-        validateNonNegativeInteger(ctx, `${path}.sizeBytes`, obj.sizeBytes);
-      }
-      if (obj.memory !== undefined) {
-        validateMemoryRange(ctx, `${path}.memory`, obj.memory);
-      }
-      if (obj.unsupported !== undefined) {
-        validateUnsupported(ctx, `${path}.unsupported`, obj.unsupported);
-      }
-    }
+    validateObjectEntries(ctx, objects);
   }
   validateUnsupported(ctx, "objects.unsupported", doc.unsupported);
+}
+
+function validateObjectEntries(ctx: ValidationContext, objects: unknown[]): void {
+  const ids = new Set<string>();
+  for (let i = 0; i < objects.length; i++) {
+    validateObjectEntry(ctx, `objects.objects[${i}]`, objects[i], ids);
+  }
+}
+
+function validateObjectEntry(
+  ctx: ValidationContext,
+  path: string,
+  value: unknown,
+  ids: Set<string>,
+): void {
+  const obj = expectRecord(ctx, path, value);
+  if (!obj) {
+    return;
+  }
+  validateObjectId(ctx, path, obj.id, ids);
+  validateEnum(ctx, `${path}.kind`, obj.kind, OBJECT_KINDS);
+  validateOptionalObjectType(ctx, path, obj.type);
+  validateOptionalObjectSize(ctx, path, obj.sizeBytes);
+  validateOptionalObjectMemory(ctx, path, obj.memory);
+  validateOptionalObjectUnsupported(ctx, path, obj.unsupported);
+}
+
+function validateObjectId(
+  ctx: ValidationContext,
+  path: string,
+  value: unknown,
+  ids: Set<string>,
+): void {
+  validateNonEmptyString(ctx, `${path}.id`, value);
+  if (typeof value !== "string") {
+    return;
+  }
+  if (ids.has(value)) {
+    ctx.errors.push(`${path}.id duplicates object id ${JSON.stringify(value)}`);
+  }
+  ids.add(value);
+}
+
+function validateOptionalObjectType(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateNonEmptyString(ctx, `${path}.type`, value);
+  }
+}
+
+function validateOptionalObjectSize(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateNonNegativeInteger(ctx, `${path}.sizeBytes`, value);
+  }
+}
+
+function validateOptionalObjectMemory(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateMemoryRange(ctx, `${path}.memory`, value);
+  }
+}
+
+function validateOptionalObjectUnsupported(
+  ctx: ValidationContext,
+  path: string,
+  value: unknown,
+): void {
+  if (value !== undefined) {
+    validateUnsupported(ctx, `${path}.unsupported`, value);
+  }
 }
 
 function validateRelocations(
@@ -552,24 +640,27 @@ function validatePortableBundleFiles(ctx: ValidationContext): void {
 }
 
 function validateExistingFile(ctx: ValidationContext, name: string): void {
-  const path = join(ctx.rootDir!, name);
-  if (!existsSync(path)) {
-    ctx.errors.push(`${name} is missing`);
-    return;
-  }
-  if (!statSync(path).isFile()) {
-    ctx.errors.push(`${name} must be a file`);
-  }
+  validateExistingPath(ctx, name, name, "file", (stat) => stat.isFile());
 }
 
 function validateExistingDirectory(ctx: ValidationContext, name: string): void {
+  validateExistingPath(ctx, name, `${name}/`, "directory", (stat) => stat.isDirectory());
+}
+
+function validateExistingPath(
+  ctx: ValidationContext,
+  name: string,
+  label: string,
+  kind: string,
+  matchesKind: (stat: ReturnType<typeof statSync>) => boolean,
+): void {
   const path = join(ctx.rootDir!, name);
   if (!existsSync(path)) {
-    ctx.errors.push(`${name}/ is missing`);
+    ctx.errors.push(`${label} is missing`);
     return;
   }
-  if (!statSync(path).isDirectory()) {
-    ctx.errors.push(`${name}/ must be a directory`);
+  if (!matchesKind(statSync(path))) {
+    ctx.errors.push(`${label} must be a ${kind}`);
   }
 }
 
@@ -643,6 +734,49 @@ function validateTargetBuild(ctx: ValidationContext, value: unknown): void {
   }
 }
 
+function validateCheckpointAbi(ctx: ValidationContext, value: unknown): void {
+  const abi = expectRecord(ctx, "manifest.checkpointAbi", value);
+  if (!abi) {
+    return;
+  }
+  if (abi.version !== PORTABLE_CHECKPOINT_ABI_VERSION) {
+    ctx.errors.push(`manifest.checkpointAbi.version must be ${PORTABLE_CHECKPOINT_ABI_VERSION}`);
+  }
+  validateSymbolObject(ctx, "manifest.checkpointAbi.checkpointFunction", abi.checkpointFunction);
+  const checkpointFunction = isRecord(abi.checkpointFunction)
+    ? abi.checkpointFunction.name
+    : undefined;
+  if (checkpointFunction !== PORTABLE_CHECKPOINT_ABI.checkpointFunction) {
+    ctx.errors.push(
+      `manifest.checkpointAbi.checkpointFunction.name must be ${PORTABLE_CHECKPOINT_ABI.checkpointFunction}`,
+    );
+  }
+  if (abi.rootsType !== PORTABLE_CHECKPOINT_ABI.rootsType) {
+    ctx.errors.push(
+      `manifest.checkpointAbi.rootsType must be ${PORTABLE_CHECKPOINT_ABI.rootsType}`,
+    );
+  }
+  if (abi.restoreBundleType !== PORTABLE_CHECKPOINT_ABI.restoreBundleType) {
+    ctx.errors.push(
+      `manifest.checkpointAbi.restoreBundleType must be ${PORTABLE_CHECKPOINT_ABI.restoreBundleType}`,
+    );
+  }
+  validateCheckpointSafePoint(ctx, abi.safePoint);
+}
+
+function validateCheckpointSafePoint(ctx: ValidationContext, value: unknown): void {
+  const safePoint = expectRecord(ctx, "manifest.checkpointAbi.safePoint", value);
+  if (!safePoint) {
+    return;
+  }
+  if (safePoint.outsideSignalHandlers !== true) {
+    ctx.errors.push("manifest.checkpointAbi.safePoint.outsideSignalHandlers must be true");
+  }
+  if (safePoint.outsideSyscalls !== true) {
+    ctx.errors.push("manifest.checkpointAbi.safePoint.outsideSyscalls must be true");
+  }
+}
+
 function validateBuildId(ctx: ValidationContext, path: string, value: unknown): void {
   if (typeof value !== "string" || !BUILD_ID_RE.test(value)) {
     ctx.errors.push(`${path} must be 8-128 hex characters`);
@@ -686,28 +820,76 @@ function validateStringArray(
   if (!arr) {
     return undefined;
   }
-  if (opts.minItems !== undefined && arr.length < opts.minItems) {
-    ctx.errors.push(`${path} must contain at least ${opts.minItems} item(s)`);
+  validateArrayMinItems(ctx, path, arr, opts.minItems);
+  validateStringArrayItems(ctx, path, arr, opts);
+  return arr.filter((v): v is string => typeof v === "string");
+}
+
+function validateArrayMinItems(
+  ctx: ValidationContext,
+  path: string,
+  arr: unknown[],
+  minItems: number | undefined,
+): void {
+  if (minItems !== undefined && arr.length < minItems) {
+    ctx.errors.push(`${path} must contain at least ${minItems} item(s)`);
   }
+}
+
+function validateStringArrayItems(
+  ctx: ValidationContext,
+  path: string,
+  arr: unknown[],
+  opts: { unique?: boolean; pattern?: RegExp },
+): void {
   const seen = new Set<string>();
   for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-    const itemPath = `${path}[${i}]`;
-    if (typeof item !== "string") {
-      ctx.errors.push(`${itemPath} must be a string`);
-      continue;
-    }
-    if (opts.pattern && !opts.pattern.test(item)) {
-      ctx.errors.push(`${itemPath} has invalid shape`);
-    }
-    if (opts.unique) {
-      if (seen.has(item)) {
-        ctx.errors.push(`${path} duplicates ${JSON.stringify(item)}`);
-      }
-      seen.add(item);
-    }
+    validateStringArrayItem(ctx, path, i, arr[i], opts, seen);
   }
-  return arr.filter((v): v is string => typeof v === "string");
+}
+
+function validateStringArrayItem(
+  ctx: ValidationContext,
+  path: string,
+  index: number,
+  value: unknown,
+  opts: { unique?: boolean; pattern?: RegExp },
+  seen: Set<string>,
+): void {
+  const itemPath = `${path}[${index}]`;
+  if (typeof value !== "string") {
+    ctx.errors.push(`${itemPath} must be a string`);
+    return;
+  }
+  validateStringArrayPattern(ctx, itemPath, value, opts.pattern);
+  validateStringArrayUnique(ctx, path, value, opts.unique, seen);
+}
+
+function validateStringArrayPattern(
+  ctx: ValidationContext,
+  path: string,
+  value: string,
+  pattern: RegExp | undefined,
+): void {
+  if (pattern && !pattern.test(value)) {
+    ctx.errors.push(`${path} has invalid shape`);
+  }
+}
+
+function validateStringArrayUnique(
+  ctx: ValidationContext,
+  path: string,
+  value: string,
+  unique: boolean | undefined,
+  seen: Set<string>,
+): void {
+  if (!unique) {
+    return;
+  }
+  if (seen.has(value)) {
+    ctx.errors.push(`${path} duplicates ${JSON.stringify(value)}`);
+  }
+  seen.add(value);
 }
 
 function validateStringRecord(ctx: ValidationContext, path: string, value: unknown): void {
@@ -850,6 +1032,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const OBJECT_KINDS = ["global", "heap", "stack", "thread", "tls", "opaque"] as const;
 const BUILD_ID_RE = /^[0-9A-Fa-f]{8,128}$/;
 const SYMBOL_RE = /^[A-Za-z_][A-Za-z0-9_.$@-]*$/;
 const FEATURE_RE = /^[a-z0-9][a-z0-9._-]*$/;

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -96,6 +96,7 @@ rootfs_input_files() {
     "${ASSETS}/net-bench-probe.zig" \
     "${ASSETS}/no-iou.zig" \
     "${ASSETS}/poweroff.zig" \
+    "${ASSETS}/portable-checkpoint-abi.h" \
     "${ASSETS}/portable-proof-workload.c" \
     "${ASSETS}/vmstate-reseed.c" \
     "${ASSETS}/winsize-agent.zig" \

--- a/scripts/portable-proof-compare.mjs
+++ b/scripts/portable-proof-compare.mjs
@@ -4,11 +4,90 @@ import { pathToFileURL } from "node:url";
 
 const MARKER = "MACHINEN_PORTABLE_PROOF ";
 const EXPECTED_LIST = [1, 2, 3];
+const EXPECTED_ROOT_NAMES = ["machinen_portable_app_state", "machinen_portable_nodes"];
+const VALID_PHASES = ["checkpoint", "restore", "continue"];
+const VALID_ARCHES = ["arm64", "amd64"];
 const EXPECTED_SYMBOLS = {
-  checkpoint_symbol: "machinen_portable_checkpoint",
-  restore_symbol: "machinen_portable_restore_entry",
+  checkpoint_symbol: "machinen_checkpoint",
+  checkpoint_continuation: "machinen_portable_checkpoint",
+  restore_symbol: "machinen_restore_main",
+  restore_continuation: "machinen_portable_restore_entry",
   state_symbol: "machinen_portable_app_state",
 };
+
+const ARG_PARSERS = [
+  {
+    match: (arg) => arg === "-",
+    consume: (state, index, arg) => {
+      state.positional.push(arg);
+      return index;
+    },
+  },
+  {
+    match: (arg) => arg.startsWith("--expect-arch="),
+    consume: (state, index, arg) => {
+      state.opts.expectArch = arg.slice("--expect-arch=".length);
+      return index;
+    },
+  },
+  {
+    match: (arg) => FLAG_HANDLERS.has(arg),
+    consume: (state, index, arg) => FLAG_HANDLERS.get(arg)(state, index),
+  },
+  {
+    match: (arg) => arg.startsWith("-"),
+    consume: (_state, _index, arg) => usage(`unknown flag: ${arg}`),
+  },
+  {
+    match: () => true,
+    consume: (state, index, arg) => {
+      state.positional.push(arg);
+      return index;
+    },
+  },
+];
+
+const FLAG_HANDLERS = new Map([
+  [
+    "--require-restore",
+    (state, index) => {
+      state.opts.requireRestore = true;
+      return index;
+    },
+  ],
+  [
+    "--require-continue",
+    (state, index) => {
+      state.opts.requireContinue = true;
+      return index;
+    },
+  ],
+  [
+    "--expect-arch",
+    (state, index) => {
+      const value = state.argv[index + 1];
+      if (!value) {
+        usage("--expect-arch requires arm64 or amd64");
+      }
+      state.opts.expectArch = value;
+      return index + 1;
+    },
+  ],
+  [
+    "--help",
+    () => {
+      printUsage();
+      process.exit(0);
+    },
+  ],
+  [
+    "-h",
+    () => {
+      printUsage();
+      process.exit(0);
+    },
+  ],
+]);
 
 export function parsePortableProofEvents(text) {
   const events = [];
@@ -31,38 +110,62 @@ export function parsePortableProofEvents(text) {
 
 export function validatePortableProofEvents(events, opts = {}) {
   const errors = [];
-  const checkpoint = firstPhase(events, "checkpoint");
-  const restore = firstPhase(events, "restore");
-  const continues = events.filter((event) => event.phase === "continue");
+  const phases = collectPhases(events);
 
-  if (!checkpoint) {
-    errors.push("missing checkpoint marker");
-  }
-  if (opts.requireRestore && !restore) {
-    errors.push("missing restore marker");
-  }
-  if (opts.requireContinue && continues.length === 0) {
-    errors.push("missing continue marker");
-  }
-
-  for (const [i, event] of events.entries()) {
-    validateEventShape(errors, event, i, opts.expectArch);
-  }
-
-  if (checkpoint) {
-    validateSnapshotState(errors, "checkpoint", checkpoint, 1000);
-  }
-  if (restore) {
-    validateSnapshotState(errors, "restore", restore, 1000);
-  }
-  if (checkpoint && restore && !sameList(checkpoint.list, restore.list)) {
-    errors.push("restore list does not match checkpoint list");
-  }
-  if (continues.length > 0 && !continues.some((event) => Number(event.counter) > 1000)) {
-    errors.push("continue markers never increment counter beyond 1000");
-  }
+  validateRequiredPhases(errors, phases, opts);
+  validateEventList(errors, events, opts.expectArch);
+  validateCrossPhaseState(errors, phases);
 
   return errors;
+}
+
+function collectPhases(events) {
+  return {
+    checkpoint: firstPhase(events, "checkpoint"),
+    restore: firstPhase(events, "restore"),
+    continues: events.filter((event) => event.phase === "continue"),
+  };
+}
+
+function validateRequiredPhases(errors, phases, opts) {
+  pushIf(errors, !phases.checkpoint, "missing checkpoint marker");
+  pushIf(errors, opts.requireRestore && !phases.restore, "missing restore marker");
+  pushIf(errors, opts.requireContinue && phases.continues.length === 0, "missing continue marker");
+}
+
+function validateEventList(errors, events, expectArch) {
+  for (const [i, event] of events.entries()) {
+    validateEventShape(errors, event, i, expectArch);
+  }
+}
+
+function validateCrossPhaseState(errors, phases) {
+  validateExpectedPhaseState(errors, "checkpoint", phases.checkpoint);
+  validateExpectedPhaseState(errors, "restore", phases.restore);
+  validateRestoreMatchesCheckpoint(errors, phases.checkpoint, phases.restore);
+  validateForwardProgress(errors, phases.continues);
+}
+
+function validateExpectedPhaseState(errors, phase, event) {
+  if (event) {
+    validateSnapshotState(errors, phase, event, 1000);
+  }
+}
+
+function validateRestoreMatchesCheckpoint(errors, checkpoint, restore) {
+  pushIf(
+    errors,
+    Boolean(checkpoint) && Boolean(restore) && !sameList(checkpoint.list, restore.list),
+    "restore list does not match checkpoint list",
+  );
+}
+
+function validateForwardProgress(errors, continues) {
+  pushIf(
+    errors,
+    continues.length > 0 && !continues.some((event) => Number(event.counter) > 1000),
+    "continue markers never increment counter beyond 1000",
+  );
 }
 
 function firstPhase(events, phase) {
@@ -71,38 +174,86 @@ function firstPhase(events, phase) {
 
 function validateEventShape(errors, event, i, expectArch) {
   const prefix = `event[${i}]`;
-  if (event.schema_version !== 1) {
-    errors.push(`${prefix}.schema_version must be 1`);
-  }
-  if (!["checkpoint", "restore", "continue"].includes(event.phase)) {
-    errors.push(`${prefix}.phase is unknown: ${JSON.stringify(event.phase)}`);
-  }
-  if (!["arm64", "amd64"].includes(event.arch)) {
-    errors.push(`${prefix}.arch must be arm64 or amd64`);
-  }
-  if (expectArch && event.arch !== expectArch) {
-    errors.push(`${prefix}.arch expected ${expectArch}, got ${event.arch}`);
-  }
-  if (!Number.isInteger(event.counter)) {
-    errors.push(`${prefix}.counter must be an integer`);
-  }
-  if (!sameList(event.list, EXPECTED_LIST)) {
-    errors.push(`${prefix}.list expected [1,2,3], got ${JSON.stringify(event.list)}`);
-  }
+  validateBasicEventFields(errors, prefix, event, expectArch);
+  validateCheckpointAbiFields(errors, prefix, event);
+  validateProofSymbols(errors, prefix, event);
+}
+
+function validateBasicEventFields(errors, prefix, event, expectArch) {
+  pushIf(errors, event.schema_version !== 1, `${prefix}.schema_version must be 1`);
+  pushIf(
+    errors,
+    !VALID_PHASES.includes(event.phase),
+    `${prefix}.phase is unknown: ${JSON.stringify(event.phase)}`,
+  );
+  pushIf(errors, !VALID_ARCHES.includes(event.arch), `${prefix}.arch must be arm64 or amd64`);
+  pushIf(
+    errors,
+    Boolean(expectArch) && event.arch !== expectArch,
+    `${prefix}.arch expected ${expectArch}, got ${event.arch}`,
+  );
+  pushIf(errors, !Number.isInteger(event.counter), `${prefix}.counter must be an integer`);
+  pushIf(
+    errors,
+    !sameList(event.list, EXPECTED_LIST),
+    `${prefix}.list expected [1,2,3], got ${JSON.stringify(event.list)}`,
+  );
+}
+
+function validateCheckpointAbiFields(errors, prefix, event) {
+  pushIf(errors, event.checkpoint_abi_version !== 1, `${prefix}.checkpoint_abi_version must be 1`);
+  pushIf(
+    errors,
+    event.checkpoint_result !== 0,
+    `${prefix}.checkpoint_result expected 0, got ${JSON.stringify(event.checkpoint_result)}`,
+  );
+  pushIf(
+    errors,
+    event.root_count !== EXPECTED_ROOT_NAMES.length,
+    `${prefix}.root_count expected ${EXPECTED_ROOT_NAMES.length}, got ${JSON.stringify(event.root_count)}`,
+  );
+  pushIf(
+    errors,
+    !sameList(event.root_names, EXPECTED_ROOT_NAMES),
+    `${prefix}.root_names expected ${JSON.stringify(EXPECTED_ROOT_NAMES)}, got ${JSON.stringify(event.root_names)}`,
+  );
+  validateSafePoint(errors, prefix, event.safe_point);
+}
+
+function validateSafePoint(errors, prefix, safePoint) {
+  pushIf(
+    errors,
+    !safePoint || safePoint.outside_signal_handler !== true,
+    `${prefix}.safe_point.outside_signal_handler must be true`,
+  );
+  pushIf(
+    errors,
+    !safePoint || safePoint.outside_syscall !== true,
+    `${prefix}.safe_point.outside_syscall must be true`,
+  );
+}
+
+function validateProofSymbols(errors, prefix, event) {
   for (const [field, expected] of Object.entries(EXPECTED_SYMBOLS)) {
-    if (event[field] !== expected) {
-      errors.push(`${prefix}.${field} expected ${expected}, got ${JSON.stringify(event[field])}`);
-    }
+    pushIf(
+      errors,
+      event[field] !== expected,
+      `${prefix}.${field} expected ${expected}, got ${JSON.stringify(event[field])}`,
+    );
   }
 }
 
 function validateSnapshotState(errors, phase, event, expectedCounter) {
-  if (event.counter !== expectedCounter) {
-    errors.push(`${phase}.counter expected ${expectedCounter}, got ${event.counter}`);
-  }
-  if (!sameList(event.list, EXPECTED_LIST)) {
-    errors.push(`${phase}.list expected [1,2,3], got ${JSON.stringify(event.list)}`);
-  }
+  pushIf(
+    errors,
+    event.counter !== expectedCounter,
+    `${phase}.counter expected ${expectedCounter}, got ${event.counter}`,
+  );
+  pushIf(
+    errors,
+    !sameList(event.list, EXPECTED_LIST),
+    `${phase}.list expected [1,2,3], got ${JSON.stringify(event.list)}`,
+  );
 }
 
 function sameList(a, b) {
@@ -114,38 +265,38 @@ function sameList(a, b) {
   );
 }
 
+function pushIf(errors, condition, message) {
+  if (condition) {
+    errors.push(message);
+  }
+}
+
 function parseArgs(argv) {
-  const opts = { requireRestore: false, requireContinue: false, expectArch: undefined };
-  const positional = [];
+  const state = {
+    argv,
+    opts: { requireRestore: false, requireContinue: false, expectArch: undefined },
+    positional: [],
+  };
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === "--require-restore") {
-      opts.requireRestore = true;
-    } else if (arg === "--require-continue") {
-      opts.requireContinue = true;
-    } else if (arg === "--expect-arch") {
-      opts.expectArch = argv[++i];
-      if (!opts.expectArch) {
-        usage("--expect-arch requires arm64 or amd64");
-      }
-    } else if (arg.startsWith("--expect-arch=")) {
-      opts.expectArch = arg.slice("--expect-arch=".length);
-    } else if (arg === "--help" || arg === "-h") {
-      printUsage();
-      process.exit(0);
-    } else if (arg.startsWith("-")) {
-      usage(`unknown flag: ${arg}`);
-    } else {
-      positional.push(arg);
-    }
+    i = consumeArg(state, i);
   }
-  if (opts.expectArch && !["arm64", "amd64"].includes(opts.expectArch)) {
-    usage(`--expect-arch must be arm64 or amd64 (got ${opts.expectArch})`);
+  validateArgs(state);
+  return { ...state.opts, path: state.positional[0] };
+}
+
+function consumeArg(state, index) {
+  const arg = state.argv[index];
+  const parser = ARG_PARSERS.find((candidate) => candidate.match(arg));
+  return parser.consume(state, index, arg);
+}
+
+function validateArgs(state) {
+  if (state.opts.expectArch && !VALID_ARCHES.includes(state.opts.expectArch)) {
+    usage(`--expect-arch must be arm64 or amd64 (got ${state.opts.expectArch})`);
   }
-  if (positional.length !== 1) {
+  if (state.positional.length !== 1) {
     usage("expected one log file path or '-'");
   }
-  return { ...opts, path: positional[0] };
 }
 
 function usage(message) {


### PR DESCRIPTION
## Problem

Portable snapshots should not try to copy a raw CPU stack from one architecture to another. The first proof needs the program to stop at a known safe point and tell Machinen which pieces of state matter. Without that contract, future restore code would have to guess too much.

## Solution

This PR adds a small cooperative checkpoint ABI for the proof workload. The workload now calls `machinen_checkpoint()` with named roots, records a continuation name, and enters restore through `machinen_restore_main()`. The portable bundle schema also records the ABI and safe-point rules, including that checkpoints must happen outside signal handlers and syscalls.

Stacked on #390. Refs #380.

## Testing

- `cc -fsyntax-only -Wall -Wextra -I packages/microvm/assets packages/microvm/assets/portable-proof-workload.c`
- Local arm64 proof run through `scripts/portable-proof-compare.mjs`
- Proxmox amd64 Docker proof run through `scripts/portable-proof-compare.mjs`
- `pnpm exec fallow audit --changed-since origin/pp-implement-377-portable-snapshot-format`
- `pnpm run lint`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
