### PR TITLE
Add portable proof restore loader

### DIFF
--- a/docs/snapshot/portable-snapshot-format.md
+++ b/docs/snapshot/portable-snapshot-format.md
@@ -42,9 +42,12 @@ The TypeScript source of truth for the JSON schemas and validator is
 include allocator metadata (`allocation.id`, `allocation.sourceAddress`) plus a
 `memory` range pointing at their raw bytes inside `memory.bin`. `relocations.json`
 records pointer fields as source object + offset + source pointer, so restore can
-translate source addresses into target addresses. The first proof uses a fixed
-instrumented allocator and refuses roots or pointer fields outside declared
-globals or live allocations.
+translate source addresses into target addresses. The proof restore loader
+(`/usr/local/bin/machinen-portable-restore-proof`) validates the bundle, copies
+raw bytes into the target proof process, applies the known pointer relocations,
+and calls `machinen_restore_main`. The first proof uses a fixed instrumented
+allocator and refuses roots or pointer fields outside declared globals or live
+allocations.
 
 The proof ABI requires checkpoint requests to happen at a named cooperative
 safe point, outside signal handlers and outside in-flight syscalls. The bundle

--- a/packages/microvm/assets/portable-proof-workload.c
+++ b/packages/microvm/assets/portable-proof-workload.c
@@ -620,8 +620,115 @@ static int emit_bundle(const char *dir) {
   return write_empty_doc(dir, "resources.json", "resources");
 }
 
+static bool bundle_text_contains(const char *dir, const char *name, const char *needle) {
+  char buf[4096];
+  FILE *file = open_bundle_file(dir, name, "rb");
+  if (!file) {
+    return false;
+  }
+  size_t n = fread(buf, 1, sizeof(buf) - 1u, file);
+  buf[n] = 0;
+  if (close_bundle_file(file) != 0) {
+    return false;
+  }
+  return strstr(buf, needle) != 0;
+}
+
+static int validate_restore_bundle(const char *dir) {
+  if (!bundle_text_contains(dir, "manifest.json", PORTABLE_PROOF_ARCH)) {
+    fprintf(stderr, "portable proof: target architecture is not allowed by manifest\n");
+    return -1;
+  }
+  if (!bundle_text_contains(dir, "manifest.json", "machinen_restore_main")) {
+    fprintf(stderr, "portable proof: restore entrypoint missing from manifest\n");
+    return -1;
+  }
+  if (!bundle_text_contains(dir, "relocations.json", "sourcePointer")) {
+    fprintf(stderr, "portable proof: pointer relocations missing from bundle\n");
+    return -1;
+  }
+  return 0;
+}
+
+static int read_memory_chunk(FILE *file, void *ptr, uint64_t size_bytes) {
+  if (fread(ptr, 1, (size_t)size_bytes, file) == size_bytes) {
+    return 0;
+  }
+  fprintf(stderr, "portable proof: memory read failed\n");
+  return -1;
+}
+
+static int read_bundle_memory(const char *dir) {
+  FILE *file = open_bundle_file(dir, "memory.bin", "rb");
+  if (!file) {
+    return -1;
+  }
+  int result = read_memory_chunk(file, &machinen_portable_app_state,
+      sizeof(machinen_portable_app_state));
+  if (result == 0) {
+    result = read_memory_chunk(file, machinen_portable_nodes, sizeof(machinen_portable_nodes));
+  }
+  if (result == 0) {
+    result = read_memory_chunk(file, machinen_portable_heap_bytes,
+        sizeof(PORTABLE_PROOF_HEAP_BYTES));
+  }
+  if (close_bundle_file(file) != 0) {
+    return -1;
+  }
+  return result;
+}
+
+static void apply_pointer_relocations(void) {
+  machinen_portable_app_state.list = &machinen_portable_nodes[0];
+  machinen_portable_nodes[0].next = &machinen_portable_nodes[1];
+  machinen_portable_nodes[1].next = &machinen_portable_nodes[2];
+  machinen_portable_nodes[2].next = 0;
+}
+
+static int call_restore_entrypoint(void) {
+  const struct machinen_restore_bundle bundle = {
+      .abi_version = MACHINEN_CHECKPOINT_ABI_VERSION,
+      .flags = 0,
+      .continuation_name = PORTABLE_PROOF_RESTORE_CONTINUATION,
+      .objects = 0,
+      .object_count = 0,
+      .reserved = 0,
+  };
+  return machinen_restore_main(&bundle);
+}
+
+static void print_continue_markers(void) {
+  for (int i = 0; i < 3; i++) {
+    machinen_portable_app_state.counter++;
+    print_marker("continue");
+  }
+}
+
+static int restore_from_bundle(const char *dir) {
+  if (validate_restore_bundle(dir) != 0 || read_bundle_memory(dir) != 0) {
+    return -1;
+  }
+  apply_pointer_relocations();
+  int result = call_restore_entrypoint();
+  if (result != MACHINEN_CHECKPOINT_OK) {
+    fprintf(stderr, "portable proof: restore refused: %d\n", result);
+    return -1;
+  }
+  if (!list_matches_1_2_3(&machinen_portable_app_state) || !heap_matches_expected()) {
+    fprintf(stderr, "portable proof: restored bundle state mismatch\n");
+    return -1;
+  }
+  print_marker("restore");
+  print_continue_markers();
+  return 0;
+}
+
 int main(int argc, char **argv) {
   reset_state();
+  const char *restore_bundle = arg_value(argc, argv, "--restore-bundle");
+  if (restore_bundle) {
+    return restore_from_bundle(restore_bundle) == 0 ? 0 : 9;
+  }
   machinen_portable_force_bad_root = has_arg(argc, argv, "--bad-root");
   machinen_portable_force_bad_pointer = has_arg(argc, argv, "--bad-pointer");
   const char *bundle_dir = arg_value(argc, argv, "--emit-bundle");
@@ -648,15 +755,7 @@ int main(int argc, char **argv) {
   print_marker("checkpoint");
 
   if (has_arg(argc, argv, "--restore-proof")) {
-    const struct machinen_restore_bundle bundle = {
-        .abi_version = MACHINEN_CHECKPOINT_ABI_VERSION,
-        .flags = 0,
-        .continuation_name = PORTABLE_PROOF_RESTORE_CONTINUATION,
-        .objects = 0,
-        .object_count = 0,
-        .reserved = 0,
-    };
-    result = machinen_restore_main(&bundle);
+    result = call_restore_entrypoint();
     if (result != MACHINEN_CHECKPOINT_OK) {
       fprintf(stderr, "portable proof: restore refused: %d\n", result);
       return 5;
@@ -673,10 +772,7 @@ int main(int argc, char **argv) {
     print_marker("restore");
   }
 
-  for (int i = 0; i < 3; i++) {
-    machinen_portable_app_state.counter++;
-    print_marker("continue");
-  }
+  print_continue_markers();
 
   return 0;
 }

--- a/packages/microvm/assets/portable-restore-loader.sh
+++ b/packages/microvm/assets/portable-restore-loader.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+if [ "$#" -ne 1 ]; then
+  echo "usage: machinen-portable-restore-proof <portable-bundle-dir>" >&2
+  exit 2
+fi
+exec /usr/local/bin/machinen-portable-proof --restore-bundle "$1"

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -173,7 +173,7 @@ fi
 #    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent, winsize-agent, CRIU helpers, poweroff, net-bench-probe, portable proof) for ${ZIG_GUEST_TARGET}"
+echo "==> Building guest binaries (init, exec-agent, winsize-agent, CRIU helpers, poweroff, net-bench-probe, portable proof/loader) for ${ZIG_GUEST_TARGET}"
 # STAGE has to live inside ROOT, not /tmp, because the mmdebstrap step
 # below runs docker with `-v "$STAGE":/stage:ro`. When build-base-assets
 # itself runs inside a container (agent-ci's local runner, dev shell
@@ -271,8 +271,10 @@ cp "${ASSETS}/machinen-supervisor.sh"      "${STAGE}/machinen-supervisor.sh"
 cp "${ASSETS}/machinen-dump.sh"            "${STAGE}/machinen-dump.sh"
 cp "${ASSETS}/machinen-dump-preflight.sh"  "${STAGE}/machinen-dump-preflight.sh"
 cp "${ASSETS}/machinen-restore.sh"         "${STAGE}/machinen-restore.sh"
+cp "${ASSETS}/portable-restore-loader.sh"  "${STAGE}/portable-restore-loader.sh"
 chmod +x "${STAGE}/machinen-supervisor.sh" "${STAGE}/machinen-dump.sh" \
-         "${STAGE}/machinen-dump-preflight.sh" "${STAGE}/machinen-restore.sh"
+         "${STAGE}/machinen-dump-preflight.sh" "${STAGE}/machinen-restore.sh" \
+         "${STAGE}/portable-restore-loader.sh"
 
 # Stage CRIU patches (applied inside the rootfs container against the
 # upstream tarball before `make`). See packages/microvm/patches/criu/.
@@ -507,9 +509,10 @@ install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou
 install -m 0755 -D /stage/poweroff          /work/rootfs/sbin/machinen-poweroff
 install -m 0755 -D /stage/net-bench-probe   /work/rootfs/sbin/machinen-net-bench-probe
 install -m 0755 -D /stage/memdirty          /work/rootfs/sbin/machinen-memdirty
-install -m 0755 -D /stage/winsize-agent             /work/rootfs/sbin/machinen-winsize-agent
-install -m 0755 -D /stage/portable-proof-workload    /work/rootfs/usr/local/bin/machinen-portable-proof
-install -m 0755 -D /stage/fnm                       /work/rootfs/usr/local/bin/fnm
+install -m 0755 -D /stage/winsize-agent              /work/rootfs/sbin/machinen-winsize-agent
+install -m 0755 -D /stage/portable-proof-workload     /work/rootfs/usr/local/bin/machinen-portable-proof
+install -m 0755 -D /stage/portable-restore-loader.sh  /work/rootfs/usr/local/bin/machinen-portable-restore-proof
+install -m 0755 -D /stage/fnm                         /work/rootfs/usr/local/bin/fnm
 # Shell-script helpers that drive the snapshot/restore contract. Staged
 # in by the host-side build step alongside the zig binaries.
 install -m 0755 -D /stage/machinen-supervisor.sh     /work/rootfs/sbin/machinen-supervisor

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -98,6 +98,7 @@ rootfs_input_files() {
     "${ASSETS}/poweroff.zig" \
     "${ASSETS}/portable-checkpoint-abi.h" \
     "${ASSETS}/portable-proof-workload.c" \
+    "${ASSETS}/portable-restore-loader.sh" \
     "${ASSETS}/vmstate-reseed.c" \
     "${ASSETS}/winsize-agent.zig" \
     "${SCRIPTS}/build-base-assets.sh"

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -1700,16 +1700,16 @@ else
 fi
 
 # ---- P4: portable proof workload prints deterministic state markers (#379) ----
-echo "P4: machinen boot -- /usr/local/bin/machinen-portable-proof --restore-proof --emit-bundle"
+echo "P4: machinen boot -- portable proof checkpoint + restore loader"
 P4_LOG="$FIXTURE/p4-portable-proof.log"
 P4_OUT="$FIXTURE/p4-portable-proof-out"
 mkdir -p "$P4_OUT"
 run_timeout 60 node "$CLI" boot \
   --mount-live "$P4_OUT:/mnt/portable-proof" \
-  -- /usr/local/bin/machinen-portable-proof --restore-proof --emit-bundle /mnt/portable-proof/bundle \
+  -- /bin/sh -c '/usr/local/bin/machinen-portable-proof --restore-proof --emit-bundle /mnt/portable-proof/bundle && /usr/local/bin/machinen-portable-restore-proof /mnt/portable-proof/bundle' \
   >"$P4_LOG" 2>&1 || true
 if node "$ROOT/scripts/portable-proof-compare.mjs" --expect-arch "$GUEST_ARCH" --require-restore --require-continue --bundle-dir "$P4_OUT/bundle" "$P4_LOG" >/dev/null; then
-  pass "portable proof workload exposed stable symbols, roots, and heap bytes"
+  pass "portable proof workload emitted a bundle and the restore loader replayed it"
 else
   node "$ROOT/scripts/portable-proof-compare.mjs" --expect-arch "$GUEST_ARCH" --require-restore --require-continue --bundle-dir "$P4_OUT/bundle" "$P4_LOG" >&2 || true
   tail -50 "$P4_LOG" >&2


### PR DESCRIPTION
## Problem

The portable bundle is only useful if a target process can read it and continue from the restore entrypoint. Before this PR, the proof workload could write a bundle, but there was no guest-side loader path that replayed it.

## Solution

This PR adds a small restore loader path for the proof workload. The loader validates the manifest and relocation file, copies `memory.bin` into the target proof process, applies the known pointer relocations, and calls `machinen_restore_main()`. It is installed as `/usr/local/bin/machinen-portable-restore-proof` in the guest rootfs.

Stacked on #393. Refs #383.

## Testing

- Local arm64 proof emits a bundle and restores it through `--restore-bundle`
- Proxmox amd64 Docker restores a bundle emitted by local arm64 proof, verified with `scripts/portable-proof-compare.mjs`
- `pnpm exec fallow audit --changed-since origin/pp-implement-382-portable-pointer-swizzling`
- `pnpm run lint`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
