### PR TITLE
Record portable process resources

### DIFF
--- a/docs/snapshot/portable-snapshot-format.md
+++ b/docs/snapshot/portable-snapshot-format.md
@@ -45,9 +45,11 @@ records pointer fields as source object + offset + source pointer, so restore ca
 translate source addresses into target addresses. The proof restore loader
 (`/usr/local/bin/machinen-portable-restore-proof`) validates the bundle, copies
 raw bytes into the target proof process, applies the known pointer relocations,
-and calls `machinen_restore_main`. The first proof uses a fixed instrumented
-allocator and refuses roots or pointer fields outside declared globals or live
-allocations.
+and calls `machinen_restore_main`. `resources.json` records process argv, env,
+cwd, and a basic regular-file resource as path + fd + flags + offset; the loader
+reopens the file and seeks back to the saved offset. The first proof uses a fixed
+instrumented allocator and refuses roots or pointer fields outside declared
+globals or live allocations.
 
 The proof ABI requires checkpoint requests to happen at a named cooperative
 safe point, outside signal handlers and outside in-flight syscalls. The bundle

--- a/packages/microvm/assets/portable-proof-workload.c
+++ b/packages/microvm/assets/portable-proof-workload.c
@@ -13,9 +13,11 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #define PORTABLE_PROOF_ROOT_COUNT 3u
 #define PORTABLE_PROOF_MAX_ALLOCATIONS 4u
@@ -70,6 +72,7 @@ static uint8_t *machinen_portable_heap_bytes;
 static uint64_t machinen_portable_unknown_root;
 static bool machinen_portable_force_bad_root;
 static bool machinen_portable_force_bad_pointer;
+static const char *machinen_portable_resource_file_path;
 
 __attribute__((used, visibility("default"))) const char machinen_portable_metadata[] =
     "{\"schema_version\":1,"
@@ -589,15 +592,51 @@ static int write_relocations(const char *dir) {
   return close_bundle_file(file);
 }
 
-static int write_empty_doc(const char *dir, const char *name, const char *key) {
-  FILE *file = open_bundle_file(dir, name, "wb");
+static long capture_resource_offset(const char *path) {
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    fprintf(stderr, "portable proof: resource open failed for %s: %s\n", path, strerror(errno));
+    return -1;
+  }
+  if (fseek(file, 4, SEEK_SET) != 0) {
+    fclose(file);
+    return -1;
+  }
+  long offset = ftell(file);
+  fclose(file);
+  return offset;
+}
+
+static int write_resources(const char *dir) {
+  char cwd[PORTABLE_PROOF_PATH_CAPACITY];
+  if (!getcwd(cwd, sizeof(cwd))) {
+    snprintf(cwd, sizeof(cwd), "/");
+  }
+  long resource_offset = -1;
+  if (machinen_portable_resource_file_path) {
+    resource_offset = capture_resource_offset(machinen_portable_resource_file_path);
+    if (resource_offset < 0) {
+      return -1;
+    }
+  }
+  FILE *file = open_bundle_file(dir, "resources.json", "wb");
   if (!file) {
     return -1;
   }
   fprintf(file,
-      "{\"formatVersion\":1,\"%s\":[],"
-      "\"unsupported\":{\"vocabularyVersion\":1,\"refusals\":[]}}",
-      key);
+      "{\"formatVersion\":1,\"resources\":["
+      "{\"id\":\"argv\",\"kind\":\"argv\",\"state\":\"captured\","
+      "\"argv\":[\"/usr/local/bin/machinen-portable-proof\"]},"
+      "{\"id\":\"env\",\"kind\":\"env\",\"state\":\"captured\",\"env\":{}},"
+      "{\"id\":\"cwd\",\"kind\":\"cwd\",\"state\":\"captured\",\"path\":\"%s\"}",
+      cwd);
+  if (machinen_portable_resource_file_path) {
+    fprintf(file,
+        ",{\"id\":\"file-1\",\"kind\":\"file\",\"state\":\"captured\","
+        "\"path\":\"%s\",\"fd\":3,\"flags\":[\"read\"],\"offset\":%ld}",
+        machinen_portable_resource_file_path, resource_offset);
+  }
+  fprintf(file, "],\"unsupported\":{\"vocabularyVersion\":1,\"refusals\":[]}}");
   return close_bundle_file(file);
 }
 
@@ -617,7 +656,7 @@ static int emit_bundle(const char *dir) {
   if (write_relocations(dir) != 0) {
     return -1;
   }
-  return write_empty_doc(dir, "resources.json", "resources");
+  return write_resources(dir);
 }
 
 static bool bundle_text_contains(const char *dir, const char *name, const char *needle) {
@@ -634,6 +673,54 @@ static bool bundle_text_contains(const char *dir, const char *name, const char *
   return strstr(buf, needle) != 0;
 }
 
+static int copy_json_string(char *out, uint32_t out_len, const char *start) {
+  uint32_t i = 0;
+  while (start[i] && start[i] != '"') {
+    if (i + 1u >= out_len) {
+      return -1;
+    }
+    out[i] = start[i];
+    i++;
+  }
+  out[i] = 0;
+  return start[i] == '"' ? 0 : -1;
+}
+
+static int validate_resource_reopen(const char *dir) {
+  char buf[4096];
+  FILE *file = open_bundle_file(dir, "resources.json", "rb");
+  if (!file) {
+    return -1;
+  }
+  size_t n = fread(buf, 1, sizeof(buf) - 1u, file);
+  buf[n] = 0;
+  if (close_bundle_file(file) != 0) {
+    return -1;
+  }
+  char *resource = strstr(buf, "\"id\":\"file-1\"");
+  if (!resource) {
+    return 0;
+  }
+  char *path_field = strstr(resource, "\"path\":\"");
+  char *offset_field = strstr(resource, "\"offset\":");
+  if (!path_field || !offset_field) {
+    return -1;
+  }
+  char path[PORTABLE_PROOF_PATH_CAPACITY];
+  if (copy_json_string(path, sizeof(path), path_field + strlen("\"path\":\"")) != 0) {
+    return -1;
+  }
+  long offset = strtol(offset_field + strlen("\"offset\":"), 0, 10);
+  FILE *resource_file = fopen(path, "rb");
+  if (!resource_file) {
+    fprintf(stderr, "portable proof: resource reopen failed for %s: %s\n", path, strerror(errno));
+    return -1;
+  }
+  int result = fseek(resource_file, offset, SEEK_SET);
+  fclose(resource_file);
+  return result == 0 ? 0 : -1;
+}
+
 static int validate_restore_bundle(const char *dir) {
   if (!bundle_text_contains(dir, "manifest.json", PORTABLE_PROOF_ARCH)) {
     fprintf(stderr, "portable proof: target architecture is not allowed by manifest\n");
@@ -647,7 +734,7 @@ static int validate_restore_bundle(const char *dir) {
     fprintf(stderr, "portable proof: pointer relocations missing from bundle\n");
     return -1;
   }
-  return 0;
+  return validate_resource_reopen(dir);
 }
 
 static int read_memory_chunk(FILE *file, void *ptr, uint64_t size_bytes) {
@@ -732,6 +819,7 @@ int main(int argc, char **argv) {
   machinen_portable_force_bad_root = has_arg(argc, argv, "--bad-root");
   machinen_portable_force_bad_pointer = has_arg(argc, argv, "--bad-pointer");
   const char *bundle_dir = arg_value(argc, argv, "--emit-bundle");
+  machinen_portable_resource_file_path = arg_value(argc, argv, "--resource-file");
   if (!list_matches_1_2_3(&machinen_portable_app_state)) {
     fprintf(stderr, "portable proof: initial state mismatch\n");
     return 2;

--- a/packages/runtime/src/__tests__/portable-proof-helper.test.ts
+++ b/packages/runtime/src/__tests__/portable-proof-helper.test.ts
@@ -65,6 +65,7 @@ function writeBundle(heapBytes = EXPECTED_HEAP_BYTES): string {
   const memory = Buffer.concat([Buffer.from([0, 1, 2, 3]), Buffer.from(heapBytes)]);
   writeFileSync(join(dir, "memory.bin"), memory);
   writeFileSync(join(dir, "relocations.json"), JSON.stringify(tinyRelocations()));
+  writeFileSync(join(dir, "resources.json"), JSON.stringify(tinyResources()));
   writeFileSync(
     join(dir, "objects.json"),
     JSON.stringify({
@@ -83,6 +84,27 @@ function writeBundle(heapBytes = EXPECTED_HEAP_BYTES): string {
     }),
   );
   return dir;
+}
+
+function tinyResources() {
+  return {
+    formatVersion: 1,
+    resources: [
+      { id: "argv", kind: "argv", state: "captured", argv: ["portable-proof"] },
+      { id: "env", kind: "env", state: "captured", env: {} },
+      { id: "cwd", kind: "cwd", state: "captured", path: "/" },
+      {
+        id: "file-1",
+        kind: "file",
+        state: "captured",
+        path: "/tmp/proof-resource.txt",
+        fd: 3,
+        flags: ["read"],
+        offset: 4,
+      },
+    ],
+    unsupported: { vocabularyVersion: 1, refusals: [] },
+  };
 }
 
 function tinyRelocations() {

--- a/packages/runtime/src/__tests__/portable-snapshot.test.ts
+++ b/packages/runtime/src/__tests__/portable-snapshot.test.ts
@@ -109,7 +109,20 @@ function tinyDocs(manifestOverrides: Record<string, unknown> = {}) {
     },
     resources: {
       formatVersion: 1,
-      resources: [],
+      resources: [
+        { id: "argv", kind: "argv", state: "captured", argv: ["portable-proof"] },
+        { id: "env", kind: "env", state: "captured", env: { PORTABLE_PROOF: "1" } },
+        { id: "cwd", kind: "cwd", state: "captured", path: "/" },
+        {
+          id: "file-1",
+          kind: "file",
+          state: "captured",
+          path: "/tmp/proof-resource.txt",
+          fd: 3,
+          flags: ["read"],
+          offset: 4,
+        },
+      ],
       unsupported: unsupported(),
     },
   };
@@ -224,6 +237,14 @@ describe("portable snapshot schemas", () => {
     docs.relocations.relocations[0]!.sourcePointer = "not-hex";
     expect(validatePortableSnapshotDocuments(docs)).toContain(
       "relocations.relocations[0].sourcePointer must be a hex address",
+    );
+  });
+
+  it("validates semantic resource metadata", () => {
+    const docs = tinyDocs();
+    docs.resources.resources[3]!.offset = -1;
+    expect(validatePortableSnapshotDocuments(docs)).toContain(
+      "resources.resources[3].offset must be a non-negative integer",
     );
   });
 

--- a/packages/runtime/src/vm/portable-snapshot.ts
+++ b/packages/runtime/src/vm/portable-snapshot.ts
@@ -142,9 +142,14 @@ interface PortableSnapshotResources {
   formatVersion: number;
   resources: Array<{
     id: string;
-    kind: "fd" | "file" | "socket" | "timer" | "signal" | "cwd" | "env" | "unknown";
+    kind: "argv" | "fd" | "file" | "socket" | "timer" | "signal" | "cwd" | "env" | "unknown";
     state: "captured" | "refused" | "unsupported";
     path?: string;
+    fd?: number;
+    flags?: string[];
+    offset?: number;
+    argv?: string[];
+    env?: Record<string, string>;
     refusal?: PortableRefusal;
   }>;
   unsupported: PortableUnsupportedVocabulary;
@@ -392,9 +397,16 @@ export const portableSnapshotSchemas = {
           required: ["id", "kind", "state"],
           properties: {
             id: { type: "string", minLength: 1 },
-            kind: { enum: ["fd", "file", "socket", "timer", "signal", "cwd", "env", "unknown"] },
+            kind: {
+              enum: ["argv", "fd", "file", "socket", "timer", "signal", "cwd", "env", "unknown"],
+            },
             state: { enum: ["captured", "refused", "unsupported"] },
             path: { type: "string" },
+            fd: { type: "integer", minimum: 0 },
+            flags: { type: "array", items: { type: "string", minLength: 1 }, uniqueItems: true },
+            offset: { type: "integer", minimum: 0 },
+            argv: { type: "array", items: { type: "string" } },
+            env: { type: "object", additionalProperties: { type: "string" } },
             refusal: REFUSAL_SCHEMA,
           },
         },
@@ -699,26 +711,60 @@ function validateResources(ctx: ValidationContext, resourcesDoc: unknown): void 
         continue;
       }
       validateNonEmptyString(ctx, `${path}.id`, resource.id);
-      validateEnum(ctx, `${path}.kind`, resource.kind, [
-        "fd",
-        "file",
-        "socket",
-        "timer",
-        "signal",
-        "cwd",
-        "env",
-        "unknown",
-      ]);
+      validateEnum(ctx, `${path}.kind`, resource.kind, RESOURCE_KINDS);
       validateEnum(ctx, `${path}.state`, resource.state, ["captured", "refused", "unsupported"]);
-      if (resource.path !== undefined) {
-        validateString(ctx, `${path}.path`, resource.path);
-      }
+      validateOptionalResourcePath(ctx, path, resource.path);
+      validateOptionalResourceFd(ctx, path, resource.fd);
+      validateOptionalResourceFlags(ctx, path, resource.flags);
+      validateOptionalResourceOffset(ctx, path, resource.offset);
+      validateOptionalResourceArgv(ctx, path, resource.argv);
+      validateOptionalResourceEnv(ctx, path, resource.env);
       if (resource.refusal !== undefined) {
         validateRefusal(ctx, `${path}.refusal`, resource.refusal);
       }
     }
   }
   validateUnsupported(ctx, "resources.unsupported", doc.unsupported);
+}
+
+function validateOptionalResourcePath(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateString(ctx, `${path}.path`, value);
+  }
+}
+
+function validateOptionalResourceFd(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateNonNegativeInteger(ctx, `${path}.fd`, value);
+  }
+}
+
+function validateOptionalResourceFlags(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateStringArray(ctx, `${path}.flags`, value, { unique: true });
+  }
+}
+
+function validateOptionalResourceOffset(
+  ctx: ValidationContext,
+  path: string,
+  value: unknown,
+): void {
+  if (value !== undefined) {
+    validateNonNegativeInteger(ctx, `${path}.offset`, value);
+  }
+}
+
+function validateOptionalResourceArgv(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateStringArray(ctx, `${path}.argv`, value);
+  }
+}
+
+function validateOptionalResourceEnv(ctx: ValidationContext, path: string, value: unknown): void {
+  if (value !== undefined) {
+    validateStringRecord(ctx, `${path}.env`, value);
+  }
 }
 
 function validatePortableBundleFiles(ctx: ValidationContext): void {
@@ -1135,6 +1181,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 const OBJECT_KINDS = ["global", "heap", "stack", "thread", "tls", "opaque"] as const;
+const RESOURCE_KINDS = [
+  "argv",
+  "fd",
+  "file",
+  "socket",
+  "timer",
+  "signal",
+  "cwd",
+  "env",
+  "unknown",
+] as const;
 const ADDRESS_RE = /^0x[0-9A-Fa-f]+$/;
 const BUILD_ID_RE = /^[0-9A-Fa-f]{8,128}$/;
 const SYMBOL_RE = /^[A-Za-z_][A-Za-z0-9_.$@-]*$/;

--- a/scripts/portable-proof-compare.mjs
+++ b/scripts/portable-proof-compare.mjs
@@ -283,16 +283,38 @@ function validateSnapshotState(errors, phase, event, expectedCounter) {
 
 function validatePortableProofBundle(dir) {
   const errors = [];
-  const objects = readBundleJson(errors, dir, "objects.json");
-  const relocations = readBundleJson(errors, dir, "relocations.json");
-  const memory = readBundleFile(errors, dir, "memory.bin");
+  const bundle = readPortableBundleDocuments(errors, dir);
+  validateOptionalBundleObjects(errors, bundle.objects, bundle.memory);
+  validateOptionalBundleRelocations(errors, bundle.relocations);
+  validateOptionalBundleResources(errors, bundle.resources);
+  return errors;
+}
+
+function readPortableBundleDocuments(errors, dir) {
+  return {
+    objects: readBundleJson(errors, dir, "objects.json"),
+    relocations: readBundleJson(errors, dir, "relocations.json"),
+    resources: readBundleJson(errors, dir, "resources.json"),
+    memory: readBundleFile(errors, dir, "memory.bin"),
+  };
+}
+
+function validateOptionalBundleObjects(errors, objects, memory) {
   if (objects && memory) {
     validateBundleObjects(errors, objects, memory);
   }
+}
+
+function validateOptionalBundleRelocations(errors, relocations) {
   if (relocations) {
     validateBundleRelocations(errors, relocations);
   }
-  return errors;
+}
+
+function validateOptionalBundleResources(errors, resources) {
+  if (resources) {
+    validateBundleResources(errors, resources);
+  }
 }
 
 function readBundleJson(errors, dir, name) {
@@ -319,6 +341,37 @@ function validateBundleObjects(errors, objectsDoc, memory) {
   const heap = objects.find((object) => object.id === "heap-1");
   pushIf(errors, globals.length < 2, "objects.json must capture global roots separately");
   validateHeapBundleObject(errors, heap, memory);
+}
+
+function validateBundleResources(errors, resourcesDoc) {
+  const resources = Array.isArray(resourcesDoc.resources) ? resourcesDoc.resources : [];
+  pushIf(
+    errors,
+    !resources.some((resource) => resource.kind === "argv"),
+    "resources.json missing argv",
+  );
+  pushIf(
+    errors,
+    !resources.some((resource) => resource.kind === "env"),
+    "resources.json missing env",
+  );
+  pushIf(
+    errors,
+    !resources.some((resource) => resource.kind === "cwd"),
+    "resources.json missing cwd",
+  );
+  const file = resources.find((resource) => resource.id === "file-1");
+  if (file) {
+    validateFileResource(errors, file);
+  }
+}
+
+function validateFileResource(errors, file) {
+  pushIf(errors, file.kind !== "file", "file-1 must be a file resource");
+  pushIf(errors, typeof file.path !== "string" || file.path.length === 0, "file-1 path invalid");
+  pushIf(errors, file.fd !== 3, "file-1 fd must be 3");
+  pushIf(errors, !sameList(file.flags, ["read"]), "file-1 flags must be [read]");
+  pushIf(errors, file.offset !== 4, "file-1 offset must be 4");
 }
 
 function validateBundleRelocations(errors, relocationsDoc) {

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -1704,9 +1704,10 @@ echo "P4: machinen boot -- portable proof checkpoint + restore loader"
 P4_LOG="$FIXTURE/p4-portable-proof.log"
 P4_OUT="$FIXTURE/p4-portable-proof-out"
 mkdir -p "$P4_OUT"
+echo "portable-resource-marker" >"$P4_OUT/resource.txt"
 run_timeout 60 node "$CLI" boot \
   --mount-live "$P4_OUT:/mnt/portable-proof" \
-  -- /bin/sh -c '/usr/local/bin/machinen-portable-proof --restore-proof --emit-bundle /mnt/portable-proof/bundle && /usr/local/bin/machinen-portable-restore-proof /mnt/portable-proof/bundle' \
+  -- /bin/sh -c '/usr/local/bin/machinen-portable-proof --restore-proof --resource-file /mnt/portable-proof/resource.txt --emit-bundle /mnt/portable-proof/bundle && /usr/local/bin/machinen-portable-restore-proof /mnt/portable-proof/bundle' \
   >"$P4_LOG" 2>&1 || true
 if node "$ROOT/scripts/portable-proof-compare.mjs" --expect-arch "$GUEST_ARCH" --require-restore --require-continue --bundle-dir "$P4_OUT/bundle" "$P4_LOG" >/dev/null; then
   pass "portable proof workload emitted a bundle and the restore loader replayed it"


### PR DESCRIPTION
## Problem

A process is more than memory bytes. It also has simple resources like its arguments, environment, current directory, and open files. The portable proof needed a place to record those resources in a clear way.

## Solution

This PR extends `resources.json` for argv, env, cwd, and a basic regular file resource. The proof workload records a file path, fd, flags, and offset, and the restore loader reopens the file and seeks back to that offset. The smoke proof now writes a bundle with a regular file resource and replays it through the guest loader.

Stacked on #394. Refs #384.

## Testing

- Local proof emits/restores a bundle with a regular file resource
- Proxmox amd64 Docker emits/restores a bundle with a regular file resource
- `pnpm exec fallow audit --changed-since origin/pp-implement-383-portable-restore-loader`
- `pnpm run lint`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
