### PR TITLE
Add portable cross-ISA smoke proof

### DIFF
--- a/docs/snapshot/portable-snapshot-format.md
+++ b/docs/snapshot/portable-snapshot-format.md
@@ -62,6 +62,10 @@ Checkpoint refusals use stable diagnostic codes such as
 `checkpoint-inside-signal-handler`, `checkpoint-invalid-roots`, and
 `checkpoint-unknown-root`.
 
+`pnpm smoke-portable-cross-isa` runs the proof as an arm64 source process,
+ships the bundle to an amd64 Proxmox/Docker target, and verifies restore markers
+plus bundle bytes. It skips if the amd64 target is unavailable.
+
 The engine selector is opt-in via `MACHINEN_SNAPSHOT_ENGINE=portable`.
 Until the checkpoint implementation lands, snapshot/restore fail with an
 explicit experimental/unsupported-workload error.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",
     "smoke-vmstate-entropy": "bash scripts/smoke/vmstate/entropy.sh",
     "smoke-vmstate-sockets": "bash scripts/smoke/vmstate/sockets.sh",
+    "smoke-portable-cross-isa": "bash scripts/smoke/portable-cross-isa.sh",
     "bench-net": "bash scripts/bench-net.sh",
     "bench-boot": "tsx scripts/bench-boot.ts"
   },

--- a/scripts/smoke/portable-cross-isa.sh
+++ b/scripts/smoke/portable-cross-isa.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PROXMOX_SSH=${PORTABLE_AMD64_SSH:-root@192.168.0.8}
+PROXMOX_CT=${PORTABLE_AMD64_PROXMOX_CT:-111}
+DOCKER_IMAGE=${PORTABLE_AMD64_DOCKER_IMAGE:-node:22-bookworm}
+
+if ! command -v cc >/dev/null 2>&1; then
+  echo "portable-cross-isa: skip — host cc not found"
+  exit 0
+fi
+
+if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "$PROXMOX_SSH" 'true' >/dev/null 2>&1; then
+  echo "portable-cross-isa: skip — cannot reach $PROXMOX_SSH"
+  exit 0
+fi
+
+if ! ssh "$PROXMOX_SSH" "pct exec '$PROXMOX_CT' -- docker version >/dev/null 2>&1"; then
+  echo "portable-cross-isa: skip — Proxmox CT $PROXMOX_CT has no Docker"
+  exit 0
+fi
+
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+mkdir -p "$WORK/work/packages/microvm/assets" "$WORK/work/scripts"
+cc -Wall -Wextra -I "$ROOT/packages/microvm/assets" \
+  "$ROOT/packages/microvm/assets/portable-proof-workload.c" \
+  -o "$WORK/portable-proof-arm64"
+
+echo "portable-resource-marker" >"$WORK/resource.txt"
+"$WORK/portable-proof-arm64" \
+  --restore-proof \
+  --resource-file "$WORK/resource.txt" \
+  --emit-bundle "$WORK/work/bundle" \
+  >"$WORK/work/source.log"
+
+cp "$ROOT/packages/microvm/assets/portable-checkpoint-abi.h" \
+   "$ROOT/packages/microvm/assets/portable-proof-workload.c" \
+   "$WORK/work/packages/microvm/assets/"
+cp "$ROOT/scripts/portable-proof-compare.mjs" "$WORK/work/scripts/"
+cp "$WORK/resource.txt" "$WORK/work/resource.txt"
+
+tar --no-xattrs -czf - -C "$WORK/work" . |
+  ssh "$PROXMOX_SSH" \
+    "pct exec '$PROXMOX_CT' -- bash -lc 'rm -rf /tmp/machinen-portable-cross && mkdir -p /tmp/machinen-portable-cross && tar -xzf - -C /tmp/machinen-portable-cross'"
+
+ssh "$PROXMOX_SSH" "pct exec '$PROXMOX_CT' -- docker run --rm -i -v /tmp/machinen-portable-cross:/work -w /work '$DOCKER_IMAGE' bash -s" <<'REMOTE'
+set -euo pipefail
+gcc -Wall -Wextra -I packages/microvm/assets \
+  packages/microvm/assets/portable-proof-workload.c \
+  -o /tmp/machinen-portable-proof-amd64
+# The arm64 source bundle records the host temp path for the regular-file
+# resource. Rewrite it to the path available inside this amd64 target container.
+python3 - <<'PY'
+from pathlib import Path
+p = Path('/work/bundle/resources.json')
+s = p.read_text()
+start = s.index('"id":"file-1"')
+path_key = '"path":"'
+path_start = s.index(path_key, start) + len(path_key)
+path_end = s.index('"', path_start)
+s = s[:path_start] + '/work/resource.txt' + s[path_end:]
+p.write_text(s)
+PY
+/tmp/machinen-portable-proof-amd64 --restore-bundle /work/bundle >/tmp/target.log
+cat /work/source.log /tmp/target.log >/tmp/combined.log
+node scripts/portable-proof-compare.mjs \
+  --require-restore \
+  --require-continue \
+  --bundle-dir /work/bundle \
+  /tmp/combined.log
+REMOTE
+
+echo "portable-cross-isa: pass — arm64 bundle restored in amd64 proof process"


### PR DESCRIPTION
## Problem

The portable proof can emit and restore a bundle, but we also need a repeatable cross-ISA check so we know the format is not quietly depending on the source CPU.

## Solution

This PR adds `pnpm smoke-portable-cross-isa`. It emits a proof bundle from the local arm64 process, ships it to the amd64 Proxmox/Docker target, rewrites the test resource path for that target container, restores the bundle, and verifies the combined proof log plus bundle contents.

The script skips cleanly if the amd64 target is unavailable.

Stacked on #396. Refs #386.

## Testing

- `pnpm smoke-portable-cross-isa` against Proxmox amd64 Docker
- `pnpm exec fallow audit --changed-since origin/pp-implement-385-portable-refusal-diagnostics`
- `pnpm run lint`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
