### PR TITLE
Add controlled binary corpus

### DIFF
--- a/docs/snapshot/controlled-binary-corpus.md
+++ b/docs/snapshot/controlled-binary-corpus.md
@@ -1,0 +1,32 @@
+# Controlled binary corpus
+
+Issue #415 starts the next portable snapshot step: binaries we control, built for more than one CPU architecture.
+
+The fixture source is `packages/microvm/assets/controlled-binary-corpus.c`. It is a normal C program. It does not call `machinen_checkpoint` and does not write a portable bundle. Instead, it exposes stable symbols and prints deterministic observation markers so later work can practice external capture and semantic extraction.
+
+## Fixtures
+
+The corpus has five fixtures:
+
+1. `global` — scalar global state.
+2. `heap` — a small heap graph with pointer edges.
+3. `stack` — a nested function with a live local value at an observation point.
+4. `resource` — argv/env plus a regular file and saved offset.
+5. `threads` — two pthread workers stopped at known semantic points.
+
+Each fixture prints one `MACHINEN_CONTROLLED_BINARY` JSON marker. Passing `--pause-at-observation` makes the process raise `SIGSTOP` after a marker, leaving the state live for an external capturer.
+
+## Build and verify
+
+Run:
+
+```sh
+pnpm controlled-binary-corpus
+```
+
+The verifier compiles the source natively, runs all fixtures, and cross-builds Linux binaries for:
+
+- `aarch64-linux-musl`
+- `x86_64-linux-musl`
+
+The cross builds prove that the same source can produce arm64 and amd64 controlled binaries. The native run proves the fixtures produce deterministic state before the later raw-capture work begins.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "repro-192": "node scripts/repro-issue-192.ts",
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
+    "controlled-binary-corpus": "node scripts/controlled-binary-corpus.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/controlled-binary-corpus.c
+++ b/packages/microvm/assets/controlled-binary-corpus.c
@@ -1,0 +1,458 @@
+// Controlled cross-ISA fixture corpus for portable state translation research.
+//
+// This binary is intentionally ordinary C. It does not call the Machinen
+// checkpoint ABI and it does not write a portable bundle. Future extraction
+// work can launch or attach to it, stop it at an observation point, and recover
+// semantic state from normal process memory, symbols, DWARF, or sidecar data.
+
+#include <errno.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+#define CONTROLLED_MARKER "MACHINEN_CONTROLLED_BINARY "
+#define CONTROLLED_SCHEMA_VERSION 1u
+#define CONTROLLED_LABEL_CAPACITY 32u
+#define CONTROLLED_THREAD_COUNT 2u
+#define CONTROLLED_RESOURCE_PAYLOAD "machinen-controlled-resource\n"
+#define CONTROLLED_RESOURCE_OFFSET 9u
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define CONTROLLED_ARCH "arm64"
+#elif defined(__x86_64__) || defined(_M_X64)
+#define CONTROLLED_ARCH "amd64"
+#else
+#define CONTROLLED_ARCH "unknown"
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define CONTROLLED_EXPORT __attribute__((used, visibility("default")))
+#else
+#define CONTROLLED_EXPORT
+#endif
+
+struct ControlledGlobalState {
+  uint64_t counter;
+  uint32_t flags;
+  char label[CONTROLLED_LABEL_CAPACITY];
+};
+
+struct ControlledNode {
+  uint64_t value;
+  struct ControlledNode *next;
+};
+
+struct ControlledHeapState {
+  struct ControlledNode *head;
+  uint64_t node_count;
+  uint64_t checksum;
+};
+
+struct ControlledStackObservation {
+  uint64_t live_local;
+  uint64_t caller_counter;
+  char continuation[CONTROLLED_LABEL_CAPACITY];
+};
+
+struct ControlledResourceState {
+  uint32_t argc;
+  uint32_t env_seen;
+  uint64_t file_bytes;
+  uint64_t file_offset;
+  uint64_t checksum;
+};
+
+struct ControlledThreadState {
+  uint32_t id;
+  uint32_t at_observation;
+  uint64_t local_counter;
+  char continuation[CONTROLLED_LABEL_CAPACITY];
+};
+
+struct ThreadArgs {
+  uint32_t id;
+  uint64_t base_counter;
+};
+
+CONTROLLED_EXPORT struct ControlledGlobalState machinen_controlled_global_state;
+CONTROLLED_EXPORT struct ControlledHeapState machinen_controlled_heap_state;
+CONTROLLED_EXPORT struct ControlledStackObservation machinen_controlled_stack_observation;
+CONTROLLED_EXPORT struct ControlledResourceState machinen_controlled_resource_state;
+CONTROLLED_EXPORT struct ControlledThreadState machinen_controlled_thread_states[CONTROLLED_THREAD_COUNT];
+
+CONTROLLED_EXPORT const char machinen_controlled_corpus_metadata[] =
+    "{\"schema_version\":1,"
+    "\"workload\":\"machinen-controlled-binary-corpus\","
+    "\"fixtures\":[\"global\",\"heap\",\"stack\",\"resource\",\"threads\"],"
+    "\"global_symbol\":\"machinen_controlled_global_state\","
+    "\"heap_symbol\":\"machinen_controlled_heap_state\","
+    "\"stack_symbol\":\"machinen_controlled_stack_observation\","
+    "\"resource_symbol\":\"machinen_controlled_resource_state\","
+    "\"threads_symbol\":\"machinen_controlled_thread_states\"}";
+
+static bool g_pause_at_observation;
+static pthread_mutex_t g_thread_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_thread_cond = PTHREAD_COND_INITIALIZER;
+static uint32_t g_threads_arrived;
+static bool g_threads_release;
+
+static void copy_label(char destination[CONTROLLED_LABEL_CAPACITY], const char *source) {
+  uint32_t i = 0;
+  while (i + 1u < CONTROLLED_LABEL_CAPACITY && source[i] != '\0') {
+    destination[i] = source[i];
+    i++;
+  }
+  destination[i] = '\0';
+  while (i + 1u < CONTROLLED_LABEL_CAPACITY) {
+    i++;
+    destination[i] = '\0';
+  }
+}
+
+static uint64_t fnv1a_bytes(const uint8_t *bytes, uint64_t len) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  for (uint64_t i = 0; i < len; i++) {
+    hash ^= bytes[i];
+    hash *= UINT64_C(1099511628211);
+  }
+  return hash;
+}
+
+static uint64_t checksum_string(const char *value) {
+  return fnv1a_bytes((const uint8_t *)value, (uint64_t)strlen(value));
+}
+
+static uint64_t checksum_nodes(const struct ControlledNode *head) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  const struct ControlledNode *node = head;
+  while (node) {
+    hash ^= node->value;
+    hash *= UINT64_C(1099511628211);
+    node = node->next;
+  }
+  return hash;
+}
+
+static void maybe_pause_at_observation(const char *fixture) {
+  if (!g_pause_at_observation) {
+    return;
+  }
+  fprintf(stderr, "machinen-controlled-corpus: paused fixture=%s pid=%ld\n", fixture, (long)getpid());
+  fflush(stderr);
+  raise(SIGSTOP);
+}
+
+static void print_global_marker(void) {
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"global\",\"arch\":\"%s\","
+         "\"counter\":%" PRIu64 ",\"flags\":%u,\"label\":\"%s\",\"checksum\":%" PRIu64 "}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_global_state.counter,
+      machinen_controlled_global_state.flags, machinen_controlled_global_state.label,
+      checksum_string(machinen_controlled_global_state.label));
+  fflush(stdout);
+}
+
+static int run_global_fixture(void) {
+  machinen_controlled_global_state.counter = 1000;
+  machinen_controlled_global_state.flags = 0xa5a5u;
+  copy_label(machinen_controlled_global_state.label, "global-scalar-v1");
+  print_global_marker();
+  maybe_pause_at_observation("global");
+  return 0;
+}
+
+static void print_heap_marker(void) {
+  const struct ControlledNode *head = machinen_controlled_heap_state.head;
+  const uint64_t first = head ? head->value : 0;
+  const uint64_t second = head && head->next ? head->next->value : 0;
+  const uint64_t third = head && head->next && head->next->next ? head->next->next->value : 0;
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"heap\",\"arch\":\"%s\","
+         "\"node_count\":%" PRIu64 ",\"values\":[%" PRIu64 ",%" PRIu64 ",%" PRIu64 "],"
+         "\"checksum\":%" PRIu64 "}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_heap_state.node_count, first,
+      second, third, machinen_controlled_heap_state.checksum);
+  fflush(stdout);
+}
+
+static int run_heap_fixture(void) {
+  struct ControlledNode *nodes = calloc(3u, sizeof(struct ControlledNode));
+  if (!nodes) {
+    fprintf(stderr, "machinen-controlled-corpus: heap allocation failed\n");
+    return 1;
+  }
+
+  nodes[0].value = 11;
+  nodes[0].next = &nodes[1];
+  nodes[1].value = 22;
+  nodes[1].next = &nodes[2];
+  nodes[2].value = 33;
+  nodes[2].next = NULL;
+
+  machinen_controlled_heap_state.head = &nodes[0];
+  machinen_controlled_heap_state.node_count = 3;
+  machinen_controlled_heap_state.checksum = checksum_nodes(machinen_controlled_heap_state.head);
+
+  print_heap_marker();
+  maybe_pause_at_observation("heap");
+
+  free(nodes);
+  machinen_controlled_heap_state.head = NULL;
+  machinen_controlled_heap_state.node_count = 0;
+  machinen_controlled_heap_state.checksum = 0;
+  return 0;
+}
+
+static void print_stack_marker(void) {
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"stack\",\"arch\":\"%s\","
+         "\"continuation\":\"%s\",\"live_local\":%" PRIu64 ",\"caller_counter\":%" PRIu64 "}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_stack_observation.continuation,
+      machinen_controlled_stack_observation.live_local,
+      machinen_controlled_stack_observation.caller_counter);
+  fflush(stdout);
+}
+
+static uint64_t controlled_nested_stack_point(uint64_t seed) {
+  volatile uint64_t live_local = seed + UINT64_C(4242);
+  machinen_controlled_stack_observation.live_local = live_local;
+  machinen_controlled_stack_observation.caller_counter = seed;
+  copy_label(machinen_controlled_stack_observation.continuation, "controlled_nested_stack_point");
+
+  print_stack_marker();
+  maybe_pause_at_observation("stack");
+  return live_local + 1u;
+}
+
+static int run_stack_fixture(void) {
+  uint64_t after_observation = controlled_nested_stack_point(1000);
+  if (after_observation != 5243u) {
+    fprintf(stderr, "machinen-controlled-corpus: stack continuation invariant failed\n");
+    return 1;
+  }
+  return 0;
+}
+
+static void print_resource_marker(void) {
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"resource\",\"arch\":\"%s\","
+         "\"argc\":%u,\"env_seen\":%s,\"file_bytes\":%" PRIu64 ","
+         "\"file_offset\":%" PRIu64 ",\"checksum\":%" PRIu64 "}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_resource_state.argc,
+      machinen_controlled_resource_state.env_seen ? "true" : "false",
+      machinen_controlled_resource_state.file_bytes, machinen_controlled_resource_state.file_offset,
+      machinen_controlled_resource_state.checksum);
+  fflush(stdout);
+}
+
+static int write_resource_file(const char *path) {
+  FILE *file = fopen(path, "wb+");
+  if (!file) {
+    fprintf(stderr, "machinen-controlled-corpus: fopen(%s) failed: %s\n", path, strerror(errno));
+    return 1;
+  }
+
+  const char payload[] = CONTROLLED_RESOURCE_PAYLOAD;
+  const size_t payload_len = sizeof(payload) - 1u;
+  if (fwrite(payload, 1u, payload_len, file) != payload_len) {
+    fprintf(stderr, "machinen-controlled-corpus: fwrite(%s) failed\n", path);
+    fclose(file);
+    return 1;
+  }
+  if (fflush(file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fflush(%s) failed\n", path);
+    fclose(file);
+    return 1;
+  }
+  if (fseek(file, (long)CONTROLLED_RESOURCE_OFFSET, SEEK_SET) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fseek(%s) failed\n", path);
+    fclose(file);
+    return 1;
+  }
+
+  machinen_controlled_resource_state.file_bytes = (uint64_t)payload_len;
+  machinen_controlled_resource_state.file_offset = CONTROLLED_RESOURCE_OFFSET;
+  machinen_controlled_resource_state.checksum = checksum_string(payload);
+
+  if (fclose(file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", path);
+    return 1;
+  }
+  return 0;
+}
+
+static int run_resource_fixture(const char *resource_path, int argc) {
+  machinen_controlled_resource_state.argc = (uint32_t)argc;
+  machinen_controlled_resource_state.env_seen = getenv("MACHINEN_CONTROLLED_ENV") ? 1u : 0u;
+  machinen_controlled_resource_state.file_bytes = 0;
+  machinen_controlled_resource_state.file_offset = 0;
+  machinen_controlled_resource_state.checksum = 0;
+
+  if (write_resource_file(resource_path) != 0) {
+    return 1;
+  }
+
+  print_resource_marker();
+  maybe_pause_at_observation("resource");
+  return 0;
+}
+
+static void print_threads_marker(void) {
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"threads\",\"arch\":\"%s\","
+         "\"thread_count\":%u,\"threads\":["
+         "{\"id\":%u,\"at_observation\":%s,\"local_counter\":%" PRIu64 ",\"continuation\":\"%s\"},"
+         "{\"id\":%u,\"at_observation\":%s,\"local_counter\":%" PRIu64 ",\"continuation\":\"%s\"}]}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, CONTROLLED_THREAD_COUNT,
+      machinen_controlled_thread_states[0].id,
+      machinen_controlled_thread_states[0].at_observation ? "true" : "false",
+      machinen_controlled_thread_states[0].local_counter,
+      machinen_controlled_thread_states[0].continuation, machinen_controlled_thread_states[1].id,
+      machinen_controlled_thread_states[1].at_observation ? "true" : "false",
+      machinen_controlled_thread_states[1].local_counter,
+      machinen_controlled_thread_states[1].continuation);
+  fflush(stdout);
+}
+
+static void *controlled_thread_main(void *opaque) {
+  const struct ThreadArgs *args = (const struct ThreadArgs *)opaque;
+  const uint32_t id = args->id;
+  struct ControlledThreadState *state = &machinen_controlled_thread_states[id];
+
+  pthread_mutex_lock(&g_thread_mutex);
+  state->id = id;
+  state->at_observation = 1;
+  state->local_counter = args->base_counter + (uint64_t)id + 1u;
+  copy_label(state->continuation, id == 0 ? "controlled_thread_main_0" : "controlled_thread_main_1");
+  g_threads_arrived++;
+  pthread_cond_broadcast(&g_thread_cond);
+  while (!g_threads_release) {
+    pthread_cond_wait(&g_thread_cond, &g_thread_mutex);
+  }
+  pthread_mutex_unlock(&g_thread_mutex);
+  return NULL;
+}
+
+static int run_threads_fixture(void) {
+  pthread_t threads[CONTROLLED_THREAD_COUNT];
+  struct ThreadArgs args[CONTROLLED_THREAD_COUNT];
+
+  memset(machinen_controlled_thread_states, 0, sizeof(machinen_controlled_thread_states));
+  g_threads_arrived = 0;
+  g_threads_release = false;
+
+  for (uint32_t i = 0; i < CONTROLLED_THREAD_COUNT; i++) {
+    args[i].id = i;
+    args[i].base_counter = 2000;
+    const int err = pthread_create(&threads[i], NULL, controlled_thread_main, &args[i]);
+    if (err != 0) {
+      fprintf(stderr, "machinen-controlled-corpus: pthread_create failed: %s\n", strerror(err));
+      return 1;
+    }
+  }
+
+  pthread_mutex_lock(&g_thread_mutex);
+  while (g_threads_arrived != CONTROLLED_THREAD_COUNT) {
+    pthread_cond_wait(&g_thread_cond, &g_thread_mutex);
+  }
+  pthread_mutex_unlock(&g_thread_mutex);
+
+  print_threads_marker();
+  maybe_pause_at_observation("threads");
+
+  pthread_mutex_lock(&g_thread_mutex);
+  g_threads_release = true;
+  pthread_cond_broadcast(&g_thread_cond);
+  pthread_mutex_unlock(&g_thread_mutex);
+
+  for (uint32_t i = 0; i < CONTROLLED_THREAD_COUNT; i++) {
+    const int err = pthread_join(threads[i], NULL);
+    if (err != 0) {
+      fprintf(stderr, "machinen-controlled-corpus: pthread_join failed: %s\n", strerror(err));
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static void print_usage(const char *argv0) {
+  fprintf(stderr,
+      "usage: %s [--fixture all|global|heap|stack|resource|threads] "
+      "[--resource-file path] [--pause-at-observation]\n",
+      argv0);
+}
+
+static bool streq(const char *a, const char *b) {
+  return strcmp(a, b) == 0;
+}
+
+static int run_selected_fixture(const char *fixture, const char *resource_path, int argc) {
+  if (streq(fixture, "global")) {
+    return run_global_fixture();
+  }
+  if (streq(fixture, "heap")) {
+    return run_heap_fixture();
+  }
+  if (streq(fixture, "stack")) {
+    return run_stack_fixture();
+  }
+  if (streq(fixture, "resource")) {
+    return run_resource_fixture(resource_path, argc);
+  }
+  if (streq(fixture, "threads")) {
+    return run_threads_fixture();
+  }
+  fprintf(stderr, "machinen-controlled-corpus: unknown fixture: %s\n", fixture);
+  return 1;
+}
+
+static int run_all_fixtures(const char *resource_path, int argc) {
+  const char *fixtures[] = {"global", "heap", "stack", "resource", "threads"};
+  for (uint32_t i = 0; i < sizeof(fixtures) / sizeof(fixtures[0]); i++) {
+    if (run_selected_fixture(fixtures[i], resource_path, argc) != 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  const char *fixture = "all";
+  const char *resource_path = "machinen-controlled-resource.txt";
+
+  for (int i = 1; i < argc; i++) {
+    if (streq(argv[i], "--fixture")) {
+      if (i + 1 >= argc) {
+        print_usage(argv[0]);
+        return 2;
+      }
+      fixture = argv[++i];
+    } else if (streq(argv[i], "--resource-file")) {
+      if (i + 1 >= argc) {
+        print_usage(argv[0]);
+        return 2;
+      }
+      resource_path = argv[++i];
+    } else if (streq(argv[i], "--pause-at-observation")) {
+      g_pause_at_observation = true;
+    } else if (streq(argv[i], "--help") || streq(argv[i], "-h")) {
+      print_usage(argv[0]);
+      return 0;
+    } else {
+      fprintf(stderr, "machinen-controlled-corpus: unknown argument: %s\n", argv[i]);
+      print_usage(argv[0]);
+      return 2;
+    }
+  }
+
+  if (streq(fixture, "all")) {
+    return run_all_fixtures(resource_path, argc);
+  }
+  return run_selected_fixture(fixture, resource_path, argc);
+}

--- a/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
+++ b/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/controlled-binary-corpus.mjs");
+const TMP: string[] = [];
+
+interface ControlledSummary {
+  native: {
+    arch: string;
+    events: Array<Record<string, unknown>>;
+  };
+  crossBuilds: Array<{ arch: string; triple: string; bytes: number }>;
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("controlled binary corpus", () => {
+  it("builds deterministic fixtures natively and for both Linux ISAs", { timeout: 120_000 }, () => {
+    const outDir = mkdtempSync(join(tmpdir(), "controlled-binary-corpus-test-"));
+    TMP.push(outDir);
+
+    const result = spawnSync(
+      process.execPath,
+      [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+      { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout) as ControlledSummary;
+
+    expect(summary.native.arch).toMatch(/^(arm64|amd64)$/);
+    expect(summary.native.events.map((event) => event.fixture)).toEqual([
+      "global",
+      "heap",
+      "stack",
+      "resource",
+      "threads",
+    ]);
+    expect(summary.native.events.find((event) => event.fixture === "stack")).toMatchObject({
+      continuation: "controlled_nested_stack_point",
+      live_local: 5242,
+    });
+    expect(summary.crossBuilds.map((build) => build.arch)).toEqual(["arm64", "amd64"]);
+    expect(summary.crossBuilds.every((build) => build.bytes > 0)).toBe(true);
+  });
+});

--- a/scripts/controlled-binary-corpus.mjs
+++ b/scripts/controlled-binary-corpus.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MARKER = "MACHINEN_CONTROLLED_BINARY ";
+const FIXTURES = ["global", "heap", "stack", "resource", "threads"];
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SOURCE = join(REPO_ROOT, "packages/microvm/assets/controlled-binary-corpus.c");
+const CROSS_TARGETS = [
+  { arch: "arm64", triple: "aarch64-linux-musl", output: "machinen-controlled-corpus-linux-arm64" },
+  { arch: "amd64", triple: "x86_64-linux-musl", output: "machinen-controlled-corpus-linux-amd64" },
+];
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workspace = createWorkspace(args);
+
+  try {
+    emitResult(verifyCorpus(workspace.outDir), args, workspace);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+const ARG_HANDLERS = [
+  { match: (arg) => arg === "verify", consume: keepIndex },
+  { match: (arg) => arg === "--out-dir", consume: consumeOutDir },
+  { match: (arg) => arg.startsWith("--out-dir="), consume: consumeInlineOutDir },
+  { match: (arg) => arg === "--json", consume: consumeJson },
+  { match: (arg) => arg === "--keep", consume: consumeKeep },
+  { match: (arg) => arg === "--help" || arg === "-h", consume: consumeHelp },
+];
+
+function parseArgs(argv) {
+  const state = { outDir: "", json: false, keep: false };
+  for (let i = 0; i < argv.length; i++) {
+    const handler = ARG_HANDLERS.find((candidate) => candidate.match(argv[i]));
+    if (!handler) {
+      usage(`unknown argument: ${argv[i]}`);
+    }
+    i = handler.consume(state, argv, i);
+  }
+  return state;
+}
+
+function keepIndex(_state, _argv, index) {
+  return index;
+}
+
+function consumeOutDir(state, argv, index) {
+  state.outDir = resolve(requireValue(argv[index + 1], "--out-dir"));
+  return index + 1;
+}
+
+function consumeInlineOutDir(state, argv, index) {
+  state.outDir = resolve(argv[index].slice("--out-dir=".length));
+  return index;
+}
+
+function consumeJson(state, _argv, index) {
+  state.json = true;
+  return index;
+}
+
+function consumeKeep(state, _argv, index) {
+  state.keep = true;
+  return index;
+}
+
+function consumeHelp(_state, _argv, _index) {
+  printUsage();
+  process.exit(0);
+}
+
+function requireValue(value, flag) {
+  if (!value) {
+    usage(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function createWorkspace(args) {
+  if (args.outDir) {
+    return { outDir: args.outDir, temporary: false };
+  }
+  return { outDir: mkdtempSync(join(tmpdir(), "machinen-controlled-corpus-")), temporary: true };
+}
+
+function emitResult(summary, args, workspace) {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return;
+  }
+  printSummary(summary, workspace.temporary && !args.keep);
+}
+
+function cleanupWorkspace(workspace, args) {
+  if (workspace.temporary && !args.keep) {
+    rmSync(workspace.outDir, { recursive: true, force: true });
+  }
+}
+
+function verifyCorpus(outDir) {
+  if (!existsSync(SOURCE)) {
+    throw new Error(`missing controlled binary corpus source: ${SOURCE}`);
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  const native = compileNative(outDir);
+  const nativeRun = runNativeFixtures(native.executable, outDir);
+  const crossBuilds = compileCrossTargets(outDir);
+  const summary = { source: SOURCE, native: { ...native, ...nativeRun }, crossBuilds };
+  validateSummary(summary);
+  return summary;
+}
+
+function compileNative(outDir) {
+  const nativeDir = join(outDir, "native");
+  mkdirSync(nativeDir, { recursive: true });
+  const executable = join(nativeDir, "machinen-controlled-corpus");
+  const compiler = process.env.CC || "cc";
+  runCommand(compiler, commonCompileArgs(executable), { label: "native controlled corpus build" });
+  return { compiler, executable };
+}
+
+function compileCrossTargets(outDir) {
+  ensureCommand("zig");
+  const crossDir = join(outDir, "cross");
+  mkdirSync(crossDir, { recursive: true });
+
+  return CROSS_TARGETS.map((target) => {
+    const executable = join(crossDir, target.output);
+    runCommand("zig", ["cc", "-target", target.triple, ...commonCompileArgs(executable)], {
+      label: `${target.arch} controlled corpus build`,
+    });
+    return { ...target, executable, bytes: statSync(executable).size };
+  });
+}
+
+function commonCompileArgs(executable) {
+  return [
+    "-std=c11",
+    "-O0",
+    "-g",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-pthread",
+    SOURCE,
+    "-o",
+    executable,
+  ];
+}
+
+function runNativeFixtures(executable, outDir) {
+  const resourceFile = join(outDir, "controlled-resource.txt");
+  const result = runCommand(executable, ["--fixture", "all", "--resource-file", resourceFile], {
+    label: "native controlled corpus run",
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+  const events = parseEvents(result.stdout);
+  return { arch: events[0]?.arch || "unknown", events, resourceFile };
+}
+
+function parseEvents(stdout) {
+  const events = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.startsWith(MARKER)) {
+      continue;
+    }
+    events.push(JSON.parse(line.slice(MARKER.length)));
+  }
+  return events;
+}
+
+function validateSummary(summary) {
+  const events = summary.native.events;
+  const names = events.map((event) => event.fixture);
+  assert(
+    JSON.stringify(names) === JSON.stringify(FIXTURES),
+    `fixtures ran in wrong order: ${names.join(",")}`,
+  );
+  assert(
+    ["arm64", "amd64"].includes(summary.native.arch),
+    `unexpected native arch: ${summary.native.arch}`,
+  );
+
+  const global = requireFixture(events, "global");
+  assert(global.counter === 1000, "global fixture counter changed");
+  assert(global.flags === 0xa5a5, "global fixture flags changed");
+  assert(global.label === "global-scalar-v1", "global fixture label changed");
+
+  const heap = requireFixture(events, "heap");
+  assert(heap.node_count === 3, "heap fixture node count changed");
+  assert(
+    JSON.stringify(heap.values) === JSON.stringify([11, 22, 33]),
+    "heap fixture values changed",
+  );
+  assert(Number.isFinite(heap.checksum) && heap.checksum > 0, "heap fixture checksum missing");
+
+  const stack = requireFixture(events, "stack");
+  assert(
+    stack.continuation === "controlled_nested_stack_point",
+    "stack fixture continuation changed",
+  );
+  assert(stack.caller_counter === 1000, "stack fixture caller counter changed");
+  assert(stack.live_local === 5242, "stack fixture live local changed");
+
+  const resource = requireFixture(events, "resource");
+  assert(resource.argc === 5, "resource fixture argc changed");
+  assert(resource.env_seen === true, "resource fixture did not observe test environment");
+  assert(
+    resource.file_bytes === "machinen-controlled-resource\n".length,
+    "resource fixture byte count changed",
+  );
+  assert(resource.file_offset === 9, "resource fixture file offset changed");
+
+  const threads = requireFixture(events, "threads");
+  assert(threads.thread_count === 2, "thread fixture count changed");
+  assert(
+    JSON.stringify(threads.threads.map((thread) => thread.id)) === JSON.stringify([0, 1]),
+    "thread fixture ids changed",
+  );
+  assert(
+    JSON.stringify(threads.threads.map((thread) => thread.local_counter)) ===
+      JSON.stringify([2001, 2002]),
+    "thread fixture counters changed",
+  );
+  assert(
+    threads.threads.every((thread) => thread.at_observation === true),
+    "thread fixture missed observation point",
+  );
+
+  const crossArches = summary.crossBuilds.map((build) => build.arch);
+  assert(
+    JSON.stringify(crossArches) === JSON.stringify(["arm64", "amd64"]),
+    "cross builds did not cover arm64 and amd64",
+  );
+  assert(
+    summary.crossBuilds.every((build) => build.bytes > 0),
+    "cross build output was empty",
+  );
+}
+
+function requireFixture(events, fixture) {
+  const event = events.find((item) => item.fixture === fixture);
+  if (!event) {
+    throw new Error(`missing fixture marker: ${fixture}`);
+  }
+  return event;
+}
+
+function runCommand(command, args, opts = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: opts.env || process.env,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  assertCommandStarted(result, opts.label || command);
+  assertCommandPassed(result, opts.label || command);
+  return result;
+}
+
+function assertCommandStarted(result, label) {
+  if (result.error) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
+}
+
+function assertCommandPassed(result, label) {
+  if (result.status !== 0) {
+    throw new Error(
+      `${label} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+}
+
+function ensureCommand(command) {
+  const result = spawnSync(command, ["version"], { encoding: "utf8" });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `${command} is required to build the controlled corpus for both guest architectures`,
+    );
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `controlled-binary-corpus: native ${summary.native.arch} ran ${summary.native.events.length} fixtures`,
+  );
+  for (const build of summary.crossBuilds) {
+    console.log(
+      `controlled-binary-corpus: built ${build.arch} (${build.triple}) ${build.bytes} bytes`,
+    );
+  }
+  if (temporary) {
+    console.log(
+      "controlled-binary-corpus: temporary artifacts removed; pass --keep to inspect them",
+    );
+  }
+}
+
+function usage(message) {
+  console.error(`controlled-binary-corpus: ${message}`);
+  printUsage();
+  process.exit(2);
+}
+
+function printUsage() {
+  console.error(
+    "usage: node scripts/controlled-binary-corpus.mjs [verify] [--out-dir path] [--json] [--keep]",
+  );
+}
+
+main();


### PR DESCRIPTION
## Problem

The next portable snapshot work needs binaries we control. We need one stable target before we try raw memory capture, DWARF, sidecars, Node, Bun, or real tools like Claude Code. Without that target, every later proof has to invent its own test program.

## Solution

This adds a normal C fixture corpus with global, heap, stack, resource, and thread workloads. The program exposes stable symbols and prints deterministic observation markers, but it does not call the Machinen checkpoint ABI. A new verifier builds it natively, runs every fixture, and cross-builds Linux arm64 and amd64 outputs.

Closes #415.

## Validation

- `pnpm controlled-binary-corpus`
- `pnpm exec fallow audit --changed-since origin/pp-portable-cross-isa-combined`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`

## Office amd64 validation

Back at the office, the Linux amd64 artifact was executed on an x86_64 Proxmox host/container and emitted all five deterministic `arch:"amd64"` fixture markers. The same source was also compiled with GCC inside an amd64 Docker container and emitted the same five markers.
