### PR TITLE
Add raw process capture proof

### DIFF
--- a/docs/snapshot/raw-process-capture.md
+++ b/docs/snapshot/raw-process-capture.md
@@ -1,0 +1,33 @@
+# Raw process capture proof
+
+Issue #416 adds the first external capture step for the controlled binary corpus.
+
+The target is still a binary we control, but it does **not** call `machinen_checkpoint` and does **not** write a portable bundle. The external capturer launches the target with `--pause-at-observation`, waits for the target to stop itself with `SIGSTOP`, and then captures process state from the outside.
+
+## Captured state
+
+The Linux capturer writes an inspectable directory with:
+
+- `manifest.json` — pid, target argv, stop signal, and host architecture.
+- `threads.json` — thread ids and raw `NT_PRSTATUS` register bytes from `ptrace`.
+- `maps.json` — parsed `/proc/<pid>/maps` entries.
+- `fds.json` — `/proc/<pid>/fd` targets.
+- `symbols.json` — exported symbol addresses passed in by the verifier.
+- `memory.json` and `memory.bin` — raw bytes read from `/proc/<pid>/mem` for those symbols.
+- `target.log` — the controlled fixture's observation marker and pause log.
+
+## Verify
+
+Run on Linux:
+
+```sh
+pnpm raw-process-capture
+```
+
+The verifier builds the controlled corpus as a non-PIE Linux binary, scans its exported symbols with `nm`, and runs three captures:
+
+1. `global` — recovers scalar global state from raw memory.
+2. `resource` — captures a live regular-file descriptor.
+3. `threads` — captures the main thread plus two worker threads and recovers their semantic state from raw memory.
+
+On non-Linux hosts, the verifier skips because it depends on Linux `/proc` and `ptrace`.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
     "controlled-binary-corpus": "node scripts/controlled-binary-corpus.mjs verify",
+    "raw-process-capture": "node scripts/raw-process-capture.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/controlled-binary-corpus.c
+++ b/packages/microvm/assets/controlled-binary-corpus.c
@@ -251,11 +251,11 @@ static void print_resource_marker(void) {
   fflush(stdout);
 }
 
-static int write_resource_file(const char *path) {
+static FILE *open_resource_file_at_observation(const char *path) {
   FILE *file = fopen(path, "wb+");
   if (!file) {
     fprintf(stderr, "machinen-controlled-corpus: fopen(%s) failed: %s\n", path, strerror(errno));
-    return 1;
+    return NULL;
   }
 
   const char payload[] = CONTROLLED_RESOURCE_PAYLOAD;
@@ -263,28 +263,23 @@ static int write_resource_file(const char *path) {
   if (fwrite(payload, 1u, payload_len, file) != payload_len) {
     fprintf(stderr, "machinen-controlled-corpus: fwrite(%s) failed\n", path);
     fclose(file);
-    return 1;
+    return NULL;
   }
   if (fflush(file) != 0) {
     fprintf(stderr, "machinen-controlled-corpus: fflush(%s) failed\n", path);
     fclose(file);
-    return 1;
+    return NULL;
   }
   if (fseek(file, (long)CONTROLLED_RESOURCE_OFFSET, SEEK_SET) != 0) {
     fprintf(stderr, "machinen-controlled-corpus: fseek(%s) failed\n", path);
     fclose(file);
-    return 1;
+    return NULL;
   }
 
   machinen_controlled_resource_state.file_bytes = (uint64_t)payload_len;
   machinen_controlled_resource_state.file_offset = CONTROLLED_RESOURCE_OFFSET;
   machinen_controlled_resource_state.checksum = checksum_string(payload);
-
-  if (fclose(file) != 0) {
-    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", path);
-    return 1;
-  }
-  return 0;
+  return file;
 }
 
 static int run_resource_fixture(const char *resource_path, int argc) {
@@ -294,12 +289,18 @@ static int run_resource_fixture(const char *resource_path, int argc) {
   machinen_controlled_resource_state.file_offset = 0;
   machinen_controlled_resource_state.checksum = 0;
 
-  if (write_resource_file(resource_path) != 0) {
+  FILE *resource_file = open_resource_file_at_observation(resource_path);
+  if (!resource_file) {
     return 1;
   }
 
   print_resource_marker();
   maybe_pause_at_observation("resource");
+
+  if (fclose(resource_file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", resource_path);
+    return 1;
+  }
   return 0;
 }
 

--- a/packages/microvm/assets/raw-process-capture.c
+++ b/packages/microvm/assets/raw-process-capture.c
@@ -1,0 +1,576 @@
+// External raw process capturer for the controlled binary corpus.
+//
+// The target program does not link against Machinen and does not write a
+// portable bundle. This helper launches it, waits for a SIGSTOP observation
+// point, and captures Linux process state through ptrace and /proc.
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <elf.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define RAW_CAPTURE_MAX_SYMBOLS 32u
+#define RAW_CAPTURE_MAX_THREADS 64u
+#define RAW_CAPTURE_MAX_ARGV 128u
+#define RAW_CAPTURE_REG_BYTES 1024u
+
+#if defined(__aarch64__)
+#define RAW_CAPTURE_ARCH "arm64"
+#elif defined(__x86_64__)
+#define RAW_CAPTURE_ARCH "amd64"
+#else
+#define RAW_CAPTURE_ARCH "unknown"
+#endif
+
+struct CaptureSymbol {
+  char name[128];
+  uint64_t address;
+  uint64_t size_bytes;
+};
+
+struct Options {
+  const char *output_dir;
+  struct CaptureSymbol symbols[RAW_CAPTURE_MAX_SYMBOLS];
+  uint32_t symbol_count;
+  int command_index;
+};
+
+static void die(const char *message) {
+  fprintf(stderr, "machinen-raw-capture: %s: %s\n", message, strerror(errno));
+  exit(1);
+}
+
+static void fail(const char *message) {
+  fprintf(stderr, "machinen-raw-capture: %s\n", message);
+  exit(1);
+}
+
+static bool streq(const char *a, const char *b) {
+  return strcmp(a, b) == 0;
+}
+
+static void path_join(char out[PATH_MAX], const char *dir, const char *name) {
+  int written = snprintf(out, PATH_MAX, "%s/%s", dir, name);
+  if (written < 0 || written >= PATH_MAX) {
+    fail("path too long");
+  }
+}
+
+static void proc_path(char out[PATH_MAX], pid_t pid, const char *suffix) {
+  int written = snprintf(out, PATH_MAX, "/proc/%ld/%s", (long)pid, suffix);
+  if (written < 0 || written >= PATH_MAX) {
+    fail("proc path too long");
+  }
+}
+
+static FILE *open_output(const char *dir, const char *name) {
+  char path[PATH_MAX];
+  path_join(path, dir, name);
+  FILE *file = fopen(path, "wb");
+  if (!file) {
+    die("open output");
+  }
+  return file;
+}
+
+static void json_string(FILE *file, const char *value) {
+  fputc('"', file);
+  for (const unsigned char *p = (const unsigned char *)value; *p; p++) {
+    if (*p == '"' || *p == '\\') {
+      fputc('\\', file);
+      fputc(*p, file);
+    } else if (*p == '\n') {
+      fputs("\\n", file);
+    } else if (*p == '\r') {
+      fputs("\\r", file);
+    } else if (*p == '\t') {
+      fputs("\\t", file);
+    } else if (*p < 0x20u) {
+      fprintf(file, "\\u%04x", *p);
+    } else {
+      fputc(*p, file);
+    }
+  }
+  fputc('"', file);
+}
+
+static void hex_bytes(FILE *file, const uint8_t *bytes, uint64_t len) {
+  static const char alphabet[] = "0123456789abcdef";
+  fputc('"', file);
+  for (uint64_t i = 0; i < len; i++) {
+    fputc(alphabet[bytes[i] >> 4], file);
+    fputc(alphabet[bytes[i] & 0x0fu], file);
+  }
+  fputc('"', file);
+}
+
+static uint64_t parse_u64(const char *value, const char *field) {
+  errno = 0;
+  char *end = NULL;
+  uint64_t parsed = strtoull(value, &end, 0);
+  if (errno != 0 || end == value || *end != '\0') {
+    fprintf(stderr, "machinen-raw-capture: invalid %s: %s\n", field, value);
+    exit(2);
+  }
+  return parsed;
+}
+
+static void parse_symbol(struct Options *opts, const char *spec) {
+  if (opts->symbol_count >= RAW_CAPTURE_MAX_SYMBOLS) {
+    fail("too many symbols");
+  }
+
+  char scratch[256];
+  if (snprintf(scratch, sizeof(scratch), "%s", spec) >= (int)sizeof(scratch)) {
+    fail("symbol spec too long");
+  }
+
+  char *first = strchr(scratch, ':');
+  char *second = first ? strchr(first + 1, ':') : NULL;
+  if (!first || !second) {
+    fail("--symbol must be name:address:size");
+  }
+  *first = '\0';
+  *second = '\0';
+
+  struct CaptureSymbol *symbol = &opts->symbols[opts->symbol_count++];
+  if (snprintf(symbol->name, sizeof(symbol->name), "%s", scratch) >= (int)sizeof(symbol->name)) {
+    fail("symbol name too long");
+  }
+  symbol->address = parse_u64(first + 1, "symbol address");
+  symbol->size_bytes = parse_u64(second + 1, "symbol size");
+}
+
+static void usage(const char *argv0) {
+  fprintf(stderr,
+      "usage: %s --output dir [--symbol name:address:size ...] -- program [args...]\n", argv0);
+}
+
+static struct Options parse_args(int argc, char **argv) {
+  struct Options opts = {0};
+  for (int i = 1; i < argc; i++) {
+    if (streq(argv[i], "--output")) {
+      if (i + 1 >= argc) {
+        usage(argv[0]);
+        exit(2);
+      }
+      opts.output_dir = argv[++i];
+    } else if (streq(argv[i], "--symbol")) {
+      if (i + 1 >= argc) {
+        usage(argv[0]);
+        exit(2);
+      }
+      parse_symbol(&opts, argv[++i]);
+    } else if (streq(argv[i], "--")) {
+      opts.command_index = i + 1;
+      break;
+    } else if (streq(argv[i], "--help") || streq(argv[i], "-h")) {
+      usage(argv[0]);
+      exit(0);
+    } else {
+      fprintf(stderr, "machinen-raw-capture: unknown argument: %s\n", argv[i]);
+      usage(argv[0]);
+      exit(2);
+    }
+  }
+
+  if (!opts.output_dir || opts.command_index <= 0 || opts.command_index >= argc) {
+    usage(argv[0]);
+    exit(2);
+  }
+  return opts;
+}
+
+static void ensure_output_dir(const char *path) {
+  if (mkdir(path, 0777) != 0 && errno != EEXIST) {
+    die("mkdir output dir");
+  }
+}
+
+static void redirect_child_logs(const char *output_dir) {
+  char path[PATH_MAX];
+  path_join(path, output_dir, "target.log");
+  int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  if (fd < 0) {
+    _exit(127);
+  }
+  if (dup2(fd, STDOUT_FILENO) < 0 || dup2(fd, STDERR_FILENO) < 0) {
+    _exit(127);
+  }
+  if (fd > STDERR_FILENO) {
+    close(fd);
+  }
+}
+
+static pid_t launch_target(const struct Options *opts, char **argv) {
+  pid_t child = fork();
+  if (child < 0) {
+    die("fork");
+  }
+  if (child == 0) {
+    redirect_child_logs(opts->output_dir);
+    execvp(argv[opts->command_index], &argv[opts->command_index]);
+    _exit(127);
+  }
+  return child;
+}
+
+static void wait_for_observation_stop(pid_t child) {
+  for (;;) {
+    int status = 0;
+    pid_t got = waitpid(child, &status, WUNTRACED);
+    if (got < 0) {
+      die("wait for child stop");
+    }
+    if (WIFSTOPPED(status)) {
+      return;
+    }
+    if (WIFEXITED(status) || WIFSIGNALED(status)) {
+      fail("target exited before observation stop");
+    }
+  }
+}
+
+static void cleanup_child(pid_t child) {
+  kill(child, SIGKILL);
+  for (;;) {
+    int status = 0;
+    pid_t got = waitpid(child, &status, 0);
+    if (got == child) {
+      return;
+    }
+    if (got < 0 && errno == ECHILD) {
+      return;
+    }
+    if (got < 0 && errno != EINTR) {
+      die("wait for child cleanup");
+    }
+  }
+}
+
+static void write_manifest(const struct Options *opts, char **argv, pid_t child) {
+  FILE *file = open_output(opts->output_dir, "manifest.json");
+  fprintf(file,
+      "{\"formatVersion\":1,\"capturer\":\"machinen-raw-process-capture\","
+      "\"hostArch\":\"%s\",\"pid\":%ld,\"stopSignal\":\"SIGSTOP\",\"target\":{",
+      RAW_CAPTURE_ARCH, (long)child);
+  fputs("\"path\":", file);
+  json_string(file, argv[opts->command_index]);
+  fputs(",\"argv\":[", file);
+  for (int i = opts->command_index; argv[i]; i++) {
+    if (i != opts->command_index) {
+      fputc(',', file);
+    }
+    json_string(file, argv[i]);
+  }
+  fputs("]}}\n", file);
+  fclose(file);
+}
+
+static void write_symbols(const struct Options *opts) {
+  FILE *file = open_output(opts->output_dir, "symbols.json");
+  fputs("{\"formatVersion\":1,\"symbols\":[", file);
+  for (uint32_t i = 0; i < opts->symbol_count; i++) {
+    const struct CaptureSymbol *symbol = &opts->symbols[i];
+    if (i != 0) {
+      fputc(',', file);
+    }
+    fputs("{\"name\":", file);
+    json_string(file, symbol->name);
+    fprintf(file, ",\"address\":\"0x%" PRIx64 "\",\"sizeBytes\":%" PRIu64 "}",
+        symbol->address, symbol->size_bytes);
+  }
+  fputs("]}\n", file);
+  fclose(file);
+}
+
+static void trim_newline(char *line) {
+  size_t len = strlen(line);
+  while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+    line[--len] = '\0';
+  }
+}
+
+static void write_maps(const struct Options *opts, pid_t child) {
+  char path[PATH_MAX];
+  proc_path(path, child, "maps");
+  FILE *input = fopen(path, "rb");
+  if (!input) {
+    die("open proc maps");
+  }
+
+  FILE *output = open_output(opts->output_dir, "maps.json");
+  fputs("{\"formatVersion\":1,\"maps\":[", output);
+
+  char line[4096];
+  bool first = true;
+  while (fgets(line, sizeof(line), input)) {
+    trim_newline(line);
+    unsigned long start = 0;
+    unsigned long end = 0;
+    unsigned long offset = 0;
+    unsigned long inode = 0;
+    char perms[8] = {0};
+    char dev[32] = {0};
+    int path_offset = 0;
+    int matched = sscanf(line, "%lx-%lx %7s %lx %31s %lu %n", &start, &end, perms, &offset, dev,
+        &inode, &path_offset);
+    if (matched < 6) {
+      continue;
+    }
+    const char *map_path = line + path_offset;
+    if (!first) {
+      fputc(',', output);
+    }
+    first = false;
+    fprintf(output,
+        "{\"start\":\"0x%lx\",\"end\":\"0x%lx\",\"perms\":\"%s\","
+        "\"offset\":\"0x%lx\",\"dev\":",
+        start, end, perms, offset);
+    json_string(output, dev);
+    fprintf(output, ",\"inode\":%lu,\"path\":", inode);
+    json_string(output, map_path);
+    fprintf(output, ",\"readable\":%s,\"writable\":%s,\"executable\":%s}",
+        perms[0] == 'r' ? "true" : "false", perms[1] == 'w' ? "true" : "false",
+        perms[2] == 'x' ? "true" : "false");
+  }
+
+  fputs("]}\n", output);
+  fclose(output);
+  fclose(input);
+}
+
+static void write_fds(const struct Options *opts, pid_t child) {
+  char path[PATH_MAX];
+  proc_path(path, child, "fd");
+  DIR *dir = opendir(path);
+  if (!dir) {
+    die("open proc fd");
+  }
+
+  FILE *output = open_output(opts->output_dir, "fds.json");
+  fputs("{\"formatVersion\":1,\"fds\":[", output);
+  bool first = true;
+  for (;;) {
+    struct dirent *entry = readdir(dir);
+    if (!entry) {
+      break;
+    }
+    if (entry->d_name[0] == '.') {
+      continue;
+    }
+
+    char link_path[PATH_MAX];
+    char target[PATH_MAX];
+    int written = snprintf(link_path, sizeof(link_path), "%s/%s", path, entry->d_name);
+    if (written < 0 || written >= (int)sizeof(link_path)) {
+      fail("fd path too long");
+    }
+    ssize_t len = readlink(link_path, target, sizeof(target) - 1u);
+    if (len < 0) {
+      continue;
+    }
+    target[len] = '\0';
+
+    if (!first) {
+      fputc(',', output);
+    }
+    first = false;
+    fprintf(output, "{\"fd\":%ld,\"target\":", strtol(entry->d_name, NULL, 10));
+    json_string(output, target);
+    fputc('}', output);
+  }
+  fputs("]}\n", output);
+  fclose(output);
+  closedir(dir);
+}
+
+static int compare_pid(const void *left, const void *right) {
+  pid_t a = *(const pid_t *)left;
+  pid_t b = *(const pid_t *)right;
+  return (a > b) - (a < b);
+}
+
+static uint32_t list_threads(pid_t child, pid_t tids[RAW_CAPTURE_MAX_THREADS]) {
+  char path[PATH_MAX];
+  proc_path(path, child, "task");
+  DIR *dir = opendir(path);
+  if (!dir) {
+    die("open proc task");
+  }
+
+  uint32_t count = 0;
+  for (;;) {
+    struct dirent *entry = readdir(dir);
+    if (!entry) {
+      break;
+    }
+    if (entry->d_name[0] == '.') {
+      continue;
+    }
+    if (count >= RAW_CAPTURE_MAX_THREADS) {
+      fail("too many target threads");
+    }
+    tids[count++] = (pid_t)strtol(entry->d_name, NULL, 10);
+  }
+  closedir(dir);
+  qsort(tids, count, sizeof(tids[0]), compare_pid);
+  return count;
+}
+
+static bool attach_thread(pid_t tid) {
+  if (ptrace(PTRACE_ATTACH, tid, NULL, NULL) != 0) {
+    return false;
+  }
+  for (;;) {
+    int status = 0;
+    pid_t got = waitpid(tid, &status, __WALL);
+    if (got == tid && WIFSTOPPED(status)) {
+      return true;
+    }
+    if (got < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+}
+
+static uint64_t get_register_bytes(pid_t tid, uint8_t registers[RAW_CAPTURE_REG_BYTES]) {
+  struct iovec iov = {.iov_base = registers, .iov_len = RAW_CAPTURE_REG_BYTES};
+  memset(registers, 0, RAW_CAPTURE_REG_BYTES);
+  if (ptrace(PTRACE_GETREGSET, tid, (void *)NT_PRSTATUS, &iov) != 0) {
+    return 0;
+  }
+  return (uint64_t)iov.iov_len;
+}
+
+static void detach_thread(pid_t tid) {
+  if (ptrace(PTRACE_DETACH, tid, NULL, (void *)(uintptr_t)SIGSTOP) != 0) {
+    die("ptrace detach");
+  }
+}
+
+static void write_threads(const struct Options *opts, pid_t child) {
+  pid_t tids[RAW_CAPTURE_MAX_THREADS];
+  uint32_t count = list_threads(child, tids);
+  FILE *output = open_output(opts->output_dir, "threads.json");
+  fputs("{\"formatVersion\":1,\"threads\":[", output);
+
+  for (uint32_t i = 0; i < count; i++) {
+    uint8_t registers[RAW_CAPTURE_REG_BYTES];
+    bool attached = attach_thread(tids[i]);
+    uint64_t register_bytes = attached ? get_register_bytes(tids[i], registers) : 0;
+
+    if (i != 0) {
+      fputc(',', output);
+    }
+    fprintf(output, "{\"tid\":%ld,\"registers\":{\"arch\":\"%s\",", (long)tids[i],
+        RAW_CAPTURE_ARCH);
+    fprintf(output, "\"set\":\"NT_PRSTATUS\",\"sizeBytes\":%" PRIu64 ",\"bytes\":",
+        register_bytes);
+    hex_bytes(output, registers, register_bytes);
+    if (!attached) {
+      fputs(",\"error\":\"ptrace-attach-failed\"", output);
+    } else if (register_bytes == 0) {
+      fputs(",\"error\":\"ptrace-getregset-failed\"", output);
+    }
+    fputs("}}", output);
+
+    if (attached) {
+      detach_thread(tids[i]);
+    }
+  }
+
+  fputs("]}\n", output);
+  fclose(output);
+}
+
+static void write_memory(const struct Options *opts, pid_t child) {
+  char mem_path[PATH_MAX];
+  proc_path(mem_path, child, "mem");
+  int mem_fd = open(mem_path, O_RDONLY);
+  if (mem_fd < 0) {
+    die("open proc mem");
+  }
+
+  char bin_path[PATH_MAX];
+  path_join(bin_path, opts->output_dir, "memory.bin");
+  FILE *bin = fopen(bin_path, "wb");
+  if (!bin) {
+    die("open memory.bin");
+  }
+  FILE *json = open_output(opts->output_dir, "memory.json");
+  fputs("{\"formatVersion\":1,\"chunks\":[", json);
+
+  uint64_t file_offset = 0;
+  for (uint32_t i = 0; i < opts->symbol_count; i++) {
+    const struct CaptureSymbol *symbol = &opts->symbols[i];
+    if (symbol->size_bytes > 1024u * 1024u) {
+      fail("symbol capture too large");
+    }
+    uint8_t *buffer = malloc((size_t)symbol->size_bytes);
+    if (!buffer) {
+      die("malloc memory chunk");
+    }
+    ssize_t got = pread(mem_fd, buffer, (size_t)symbol->size_bytes, (off_t)symbol->address);
+    if (got < 0 || (uint64_t)got != symbol->size_bytes) {
+      free(buffer);
+      fail("failed to read symbol memory");
+    }
+    if (fwrite(buffer, 1u, (size_t)symbol->size_bytes, bin) != symbol->size_bytes) {
+      free(buffer);
+      die("write memory.bin");
+    }
+
+    if (i != 0) {
+      fputc(',', json);
+    }
+    fputs("{\"name\":", json);
+    json_string(json, symbol->name);
+    fprintf(json,
+        ",\"sourceAddress\":\"0x%" PRIx64 "\",\"sizeBytes\":%" PRIu64
+        ",\"fileOffset\":%" PRIu64 "}",
+        symbol->address, symbol->size_bytes, file_offset);
+    file_offset += symbol->size_bytes;
+    free(buffer);
+  }
+
+  fputs("]}\n", json);
+  fclose(json);
+  fclose(bin);
+  close(mem_fd);
+}
+
+int main(int argc, char **argv) {
+  struct Options opts = parse_args(argc, argv);
+  ensure_output_dir(opts.output_dir);
+
+  pid_t child = launch_target(&opts, argv);
+  wait_for_observation_stop(child);
+
+  write_manifest(&opts, argv, child);
+  write_symbols(&opts);
+  write_maps(&opts, child);
+  write_fds(&opts, child);
+  write_threads(&opts, child);
+  write_memory(&opts, child);
+
+  cleanup_child(child);
+  return 0;
+}

--- a/packages/runtime/src/__tests__/raw-process-capture.test.ts
+++ b/packages/runtime/src/__tests__/raw-process-capture.test.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/raw-process-capture.mjs");
+const TMP: string[] = [];
+
+interface RawCaptureSummary {
+  skipped?: boolean;
+  hostArch: string;
+  captures: Array<{
+    name: string;
+    threadCount: number;
+    mapCount: number;
+    fdCount: number;
+    registerBytes: number[];
+    resourceFdCaptured?: boolean;
+    recoveredState: unknown;
+  }>;
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("raw process capture", () => {
+  it.skipIf(process.platform !== "linux")(
+    "captures registers maps memory symbols and fds from an unmodified stopped process",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "raw-process-capture-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as RawCaptureSummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.captures.map((capture) => capture.name)).toEqual([
+        "global",
+        "resource",
+        "threads",
+      ]);
+      expect(summary.captures.every((capture) => capture.mapCount > 0)).toBe(true);
+      expect(summary.captures.every((capture) => capture.fdCount > 0)).toBe(true);
+      expect(
+        summary.captures.every((capture) => capture.registerBytes.every((size) => size > 0)),
+      ).toBe(true);
+      expect(summary.captures.find((capture) => capture.name === "resource")).toMatchObject({
+        resourceFdCaptured: true,
+      });
+      expect(
+        summary.captures.find((capture) => capture.name === "threads")?.threadCount,
+      ).toBeGreaterThanOrEqual(3);
+    },
+  );
+});

--- a/scripts/controlled-binary-corpus.mjs
+++ b/scripts/controlled-binary-corpus.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
 
 const MARKER = "MACHINEN_CONTROLLED_BINARY ";
 const FIXTURES = ["global", "heap", "stack", "resource", "threads"];
@@ -13,93 +19,17 @@ const CROSS_TARGETS = [
   { arch: "arm64", triple: "aarch64-linux-musl", output: "machinen-controlled-corpus-linux-arm64" },
   { arch: "amd64", triple: "x86_64-linux-musl", output: "machinen-controlled-corpus-linux-amd64" },
 ];
+const USAGE =
+  "usage: node scripts/controlled-binary-corpus.mjs [verify] [--out-dir path] [--json] [--keep]";
 
 function main() {
-  const args = parseArgs(process.argv.slice(2));
-  const workspace = createWorkspace(args);
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-controlled-corpus-");
 
   try {
-    emitResult(verifyCorpus(workspace.outDir), args, workspace);
+    emitResult(verifyCorpus(workspace.outDir), args, workspace, printSummary);
   } finally {
     cleanupWorkspace(workspace, args);
-  }
-}
-
-const ARG_HANDLERS = [
-  { match: (arg) => arg === "verify", consume: keepIndex },
-  { match: (arg) => arg === "--out-dir", consume: consumeOutDir },
-  { match: (arg) => arg.startsWith("--out-dir="), consume: consumeInlineOutDir },
-  { match: (arg) => arg === "--json", consume: consumeJson },
-  { match: (arg) => arg === "--keep", consume: consumeKeep },
-  { match: (arg) => arg === "--help" || arg === "-h", consume: consumeHelp },
-];
-
-function parseArgs(argv) {
-  const state = { outDir: "", json: false, keep: false };
-  for (let i = 0; i < argv.length; i++) {
-    const handler = ARG_HANDLERS.find((candidate) => candidate.match(argv[i]));
-    if (!handler) {
-      usage(`unknown argument: ${argv[i]}`);
-    }
-    i = handler.consume(state, argv, i);
-  }
-  return state;
-}
-
-function keepIndex(_state, _argv, index) {
-  return index;
-}
-
-function consumeOutDir(state, argv, index) {
-  state.outDir = resolve(requireValue(argv[index + 1], "--out-dir"));
-  return index + 1;
-}
-
-function consumeInlineOutDir(state, argv, index) {
-  state.outDir = resolve(argv[index].slice("--out-dir=".length));
-  return index;
-}
-
-function consumeJson(state, _argv, index) {
-  state.json = true;
-  return index;
-}
-
-function consumeKeep(state, _argv, index) {
-  state.keep = true;
-  return index;
-}
-
-function consumeHelp(_state, _argv, _index) {
-  printUsage();
-  process.exit(0);
-}
-
-function requireValue(value, flag) {
-  if (!value) {
-    usage(`${flag} requires a value`);
-  }
-  return value;
-}
-
-function createWorkspace(args) {
-  if (args.outDir) {
-    return { outDir: args.outDir, temporary: false };
-  }
-  return { outDir: mkdtempSync(join(tmpdir(), "machinen-controlled-corpus-")), temporary: true };
-}
-
-function emitResult(summary, args, workspace) {
-  if (args.json) {
-    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
-    return;
-  }
-  printSummary(summary, workspace.temporary && !args.keep);
-}
-
-function cleanupWorkspace(workspace, args) {
-  if (workspace.temporary && !args.keep) {
-    rmSync(workspace.outDir, { recursive: true, force: true });
   }
 }
 
@@ -253,44 +183,10 @@ function requireFixture(events, fixture) {
   return event;
 }
 
-function runCommand(command, args, opts = {}) {
-  const result = spawnSync(command, args, {
-    encoding: "utf8",
-    env: opts.env || process.env,
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  assertCommandStarted(result, opts.label || command);
-  assertCommandPassed(result, opts.label || command);
-  return result;
-}
-
-function assertCommandStarted(result, label) {
-  if (result.error) {
-    throw new Error(`${label} failed to start: ${result.error.message}`);
-  }
-}
-
-function assertCommandPassed(result, label) {
-  if (result.status !== 0) {
-    throw new Error(
-      `${label} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-    );
-  }
-}
-
 function ensureCommand(command) {
-  const result = spawnSync(command, ["version"], { encoding: "utf8" });
-  if (result.error || result.status !== 0) {
-    throw new Error(
-      `${command} is required to build the controlled corpus for both guest architectures`,
-    );
-  }
-}
-
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(message);
-  }
+  runCommand(command, ["version"], {
+    label: `${command} is required to build the controlled corpus for both guest architectures`,
+  });
 }
 
 function printSummary(summary, temporary) {
@@ -307,18 +203,6 @@ function printSummary(summary, temporary) {
       "controlled-binary-corpus: temporary artifacts removed; pass --keep to inspect them",
     );
   }
-}
-
-function usage(message) {
-  console.error(`controlled-binary-corpus: ${message}`);
-  printUsage();
-  process.exit(2);
-}
-
-function printUsage() {
-  console.error(
-    "usage: node scripts/controlled-binary-corpus.mjs [verify] [--out-dir path] [--json] [--keep]",
-  );
 }
 
 main();

--- a/scripts/proof-script-utils.mjs
+++ b/scripts/proof-script-utils.mjs
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const ARG_HANDLERS = [
+  { match: (arg) => arg === "verify", consume: keepIndex },
+  { match: (arg) => arg === "--out-dir", consume: consumeOutDir },
+  { match: (arg) => arg.startsWith("--out-dir="), consume: consumeInlineOutDir },
+  { match: (arg) => arg === "--json", consume: consumeJson },
+  { match: (arg) => arg === "--keep", consume: consumeKeep },
+  { match: (arg) => arg === "--help" || arg === "-h", consume: consumeHelp },
+];
+
+export function parseVerifyArgs(argv, usageText) {
+  const state = { outDir: "", json: false, keep: false, usageText };
+  for (let i = 0; i < argv.length; i++) {
+    const handler = ARG_HANDLERS.find((candidate) => candidate.match(argv[i]));
+    assert(handler, `unknown argument: ${argv[i]}`);
+    i = handler.consume(state, argv, i);
+  }
+  return { outDir: state.outDir, json: state.json, keep: state.keep };
+}
+
+function keepIndex(_state, _argv, index) {
+  return index;
+}
+
+function consumeOutDir(state, argv, index) {
+  state.outDir = resolve(requireValue(argv[index + 1], "--out-dir", state.usageText));
+  return index + 1;
+}
+
+function consumeInlineOutDir(state, argv, index) {
+  state.outDir = resolve(argv[index].slice("--out-dir=".length));
+  return index;
+}
+
+function consumeJson(state, _argv, index) {
+  state.json = true;
+  return index;
+}
+
+function consumeKeep(state, _argv, index) {
+  state.keep = true;
+  return index;
+}
+
+function consumeHelp(state, _argv, _index) {
+  printUsage(state.usageText);
+  process.exit(0);
+}
+
+function requireValue(value, flag, usageText) {
+  if (!value) {
+    usage(`${flag} requires a value`, usageText);
+  }
+  return value;
+}
+
+export function createWorkspace(args, prefix) {
+  if (args.outDir) {
+    return { outDir: args.outDir, temporary: false };
+  }
+  return { outDir: mkdtempSync(join(tmpdir(), prefix)), temporary: true };
+}
+
+export function emitResult(summary, args, workspace, printSummary) {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return;
+  }
+  printSummary(summary, workspace.temporary && !args.keep);
+}
+
+export function cleanupWorkspace(workspace, args) {
+  if (workspace.temporary && !args.keep) {
+    rmSync(workspace.outDir, { recursive: true, force: true });
+  }
+}
+
+export function runCommand(command, args, opts = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: opts.env || process.env,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const label = opts.label || command;
+  assertCommandStarted(result, label);
+  assertCommandPassed(result, label);
+  return result;
+}
+
+function assertCommandStarted(result, label) {
+  if (result.error) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
+}
+
+function assertCommandPassed(result, label) {
+  if (result.status !== 0) {
+    throw new Error(
+      `${label} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+}
+
+export function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function usage(message, usageText) {
+  console.error(message);
+  printUsage(usageText);
+  process.exit(2);
+}
+
+function printUsage(usageText) {
+  console.error(usageText);
+}

--- a/scripts/raw-process-capture.mjs
+++ b/scripts/raw-process-capture.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CONTROLLED_SOURCE = join(REPO_ROOT, "packages/microvm/assets/controlled-binary-corpus.c");
+const CAPTURE_SOURCE = join(REPO_ROOT, "packages/microvm/assets/raw-process-capture.c");
+const WANTED_SYMBOLS = [
+  "machinen_controlled_global_state",
+  "machinen_controlled_resource_state",
+  "machinen_controlled_thread_states",
+];
+const CAPTURE_PLANS = [
+  { name: "global", fixture: "global", symbols: ["machinen_controlled_global_state"] },
+  { name: "resource", fixture: "resource", symbols: ["machinen_controlled_resource_state"] },
+  { name: "threads", fixture: "threads", symbols: ["machinen_controlled_thread_states"] },
+];
+const USAGE =
+  "usage: node scripts/raw-process-capture.mjs [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(args, "raw process capture uses Linux /proc and ptrace");
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-raw-capture-");
+  try {
+    emitResult(verifyRawCapture(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyRawCapture(outDir) {
+  ensureSourcesExist();
+  mkdirSync(outDir, { recursive: true });
+  const binDir = join(outDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  const target = compileControlledTarget(binDir);
+  const capturer = compileRawCapturer(binDir);
+  const symbols = readSymbols(target);
+  const captures = CAPTURE_PLANS.map((plan) =>
+    runCapturePlan(plan, { capturer, target, symbols, outDir }),
+  );
+  const summary = { formatVersion: 1, hostArch: hostArch(), target, capturer, captures };
+  validateSummary(summary);
+  return summary;
+}
+
+function ensureSourcesExist() {
+  for (const source of [CONTROLLED_SOURCE, CAPTURE_SOURCE]) {
+    if (!existsSync(source)) {
+      throw new Error(`missing source: ${source}`);
+    }
+  }
+}
+
+function compileControlledTarget(binDir) {
+  const executable = join(binDir, "machinen-controlled-corpus");
+  runCommand(
+    "cc",
+    [
+      "-std=c11",
+      "-O0",
+      "-g",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-pie",
+      "-no-pie",
+      "-pthread",
+      CONTROLLED_SOURCE,
+      "-o",
+      executable,
+    ],
+    { label: "controlled corpus build" },
+  );
+  return executable;
+}
+
+function compileRawCapturer(binDir) {
+  const executable = join(binDir, "machinen-raw-process-capture");
+  runCommand(
+    "cc",
+    ["-std=c11", "-O0", "-g", "-Wall", "-Wextra", "-Werror", CAPTURE_SOURCE, "-o", executable],
+    { label: "raw capturer build" },
+  );
+  return executable;
+}
+
+function readSymbols(target) {
+  const result = runCommand("nm", ["-S", "--defined-only", target], { label: "symbol scan" });
+  const symbols = parseNm(result.stdout);
+  for (const name of WANTED_SYMBOLS) {
+    if (!symbols.has(name)) {
+      throw new Error(`missing target symbol: ${name}`);
+    }
+  }
+  return symbols;
+}
+
+function parseNm(stdout) {
+  const symbols = new Map();
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+\S\s+(\S+)$/.exec(line.trim());
+    if (match) {
+      symbols.set(match[3], { address: `0x${match[1]}`, sizeBytes: Number.parseInt(match[2], 16) });
+    }
+  }
+  return symbols;
+}
+
+function runCapturePlan(plan, context) {
+  const captureDir = join(context.outDir, `capture-${plan.name}`);
+  const resourceFile = join(captureDir, "resource-file.txt");
+  const args = ["--output", captureDir, ...symbolArgs(plan.symbols, context.symbols)];
+  args.push("--", context.target, "--fixture", plan.fixture, "--pause-at-observation");
+  args.push("--resource-file", resourceFile);
+
+  runCommand(context.capturer, args, {
+    label: `${plan.name} raw capture`,
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+
+  const capture = loadCapture(captureDir);
+  return summarizeCapture(plan, capture, captureDir, resourceFile);
+}
+
+function symbolArgs(names, symbols) {
+  return names.flatMap((name) => {
+    const symbol = symbols.get(name);
+    return ["--symbol", `${name}:${symbol.address}:${symbol.sizeBytes}`];
+  });
+}
+
+function loadCapture(captureDir) {
+  return {
+    manifest: readJson(join(captureDir, "manifest.json")),
+    symbols: readJson(join(captureDir, "symbols.json")),
+    maps: readJson(join(captureDir, "maps.json")),
+    fds: readJson(join(captureDir, "fds.json")),
+    threads: readJson(join(captureDir, "threads.json")),
+    memory: readJson(join(captureDir, "memory.json")),
+    memoryBin: readFileSync(join(captureDir, "memory.bin")),
+    targetLogBytes: statSync(join(captureDir, "target.log")).size,
+  };
+}
+
+function summarizeCapture(plan, capture, captureDir, resourceFile) {
+  const recoveredState = recoverState(plan.name, capture);
+  return {
+    name: plan.name,
+    captureDir,
+    pid: capture.manifest.pid,
+    threadCount: capture.threads.threads.length,
+    mapCount: capture.maps.maps.length,
+    fdCount: capture.fds.fds.length,
+    symbols: capture.symbols.symbols.map((symbol) => symbol.name),
+    targetLogBytes: capture.targetLogBytes,
+    recoveredState,
+    resourceFdCaptured: capture.fds.fds.some((fd) => fd.target === resourceFile),
+    registerBytes: capture.threads.threads.map((thread) => thread.registers.sizeBytes),
+  };
+}
+
+function recoverState(name, capture) {
+  if (name === "global") {
+    return recoverGlobalState(chunkBytes(capture, "machinen_controlled_global_state"));
+  }
+  if (name === "resource") {
+    return recoverResourceState(chunkBytes(capture, "machinen_controlled_resource_state"));
+  }
+  if (name === "threads") {
+    return recoverThreadState(chunkBytes(capture, "machinen_controlled_thread_states"));
+  }
+  throw new Error(`unknown capture plan: ${name}`);
+}
+
+function recoverGlobalState(bytes) {
+  return {
+    counter: Number(bytes.readBigUInt64LE(0)),
+    flags: bytes.readUInt32LE(8),
+    label: readCString(bytes, 12),
+  };
+}
+
+function recoverResourceState(bytes) {
+  return {
+    argc: bytes.readUInt32LE(0),
+    envSeen: bytes.readUInt32LE(4) === 1,
+    fileBytes: Number(bytes.readBigUInt64LE(8)),
+    fileOffset: Number(bytes.readBigUInt64LE(16)),
+  };
+}
+
+function recoverThreadState(bytes) {
+  const entrySize = bytes.length / 2;
+  return [0, 1].map((index) => {
+    const base = index * entrySize;
+    return {
+      id: bytes.readUInt32LE(base),
+      atObservation: bytes.readUInt32LE(base + 4) === 1,
+      localCounter: Number(bytes.readBigUInt64LE(base + 8)),
+      continuation: readCString(bytes, base + 16),
+    };
+  });
+}
+
+function chunkBytes(capture, name) {
+  const chunk = capture.memory.chunks.find((candidate) => candidate.name === name);
+  if (!chunk) {
+    throw new Error(`missing memory chunk: ${name}`);
+  }
+  return capture.memoryBin.subarray(chunk.fileOffset, chunk.fileOffset + chunk.sizeBytes);
+}
+
+function readCString(bytes, offset) {
+  let end = offset;
+  while (end < bytes.length && bytes[end] !== 0) {
+    end++;
+  }
+  return bytes.subarray(offset, end).toString("utf8");
+}
+
+function validateSummary(summary) {
+  validateGlobal(summary.captures.find((capture) => capture.name === "global"));
+  validateResource(summary.captures.find((capture) => capture.name === "resource"));
+  validateThreads(summary.captures.find((capture) => capture.name === "threads"));
+  for (const capture of summary.captures) {
+    assert(capture.pid > 0, `${capture.name}: missing pid`);
+    assert(capture.mapCount > 0, `${capture.name}: missing memory maps`);
+    assert(capture.fdCount > 0, `${capture.name}: missing file descriptors`);
+    assert(capture.targetLogBytes > 0, `${capture.name}: missing target log`);
+    assert(
+      capture.registerBytes.every((size) => size > 0),
+      `${capture.name}: missing registers`,
+    );
+  }
+}
+
+function validateGlobal(capture) {
+  assert(capture?.recoveredState.counter === 1000, "global counter not recovered from memory");
+  assert(capture.recoveredState.flags === 0xa5a5, "global flags not recovered from memory");
+  assert(
+    capture.recoveredState.label === "global-scalar-v1",
+    "global label not recovered from memory",
+  );
+}
+
+function validateResource(capture) {
+  assert(capture?.recoveredState.envSeen === true, "resource env flag not recovered from memory");
+  assert(
+    capture.recoveredState.fileBytes === "machinen-controlled-resource\n".length,
+    "resource byte count changed",
+  );
+  assert(capture.recoveredState.fileOffset === 9, "resource file offset changed");
+  assert(capture.resourceFdCaptured === true, "resource file descriptor was not captured");
+}
+
+function validateThreads(capture) {
+  assert(capture?.threadCount >= 3, "thread fixture should expose main plus two workers");
+  assert(
+    JSON.stringify(capture.recoveredState.map((thread) => thread.id)) === JSON.stringify([0, 1]),
+    "thread ids changed",
+  );
+  assert(
+    JSON.stringify(capture.recoveredState.map((thread) => thread.localCounter)) ===
+      JSON.stringify([2001, 2002]),
+    "thread counters changed",
+  );
+  assert(
+    capture.recoveredState.every((thread) => thread.atObservation),
+    "thread observation flags missing",
+  );
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function emitSkip(args, reason) {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ skipped: true, reason }, null, 2)}\n`);
+    return;
+  }
+  console.log(`raw-process-capture: skip — ${reason}`);
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `raw-process-capture: ${summary.hostArch} captured ${summary.captures.length} stopped processes`,
+  );
+  for (const capture of summary.captures) {
+    console.log(
+      `raw-process-capture: ${capture.name} pid=${capture.pid} threads=${capture.threadCount} maps=${capture.mapCount} fds=${capture.fdCount}`,
+    );
+  }
+  if (temporary) {
+    console.log("raw-process-capture: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+function hostArch() {
+  if (process.arch === "arm64") {
+    return "arm64";
+  }
+  if (process.arch === "x64") {
+    return "amd64";
+  }
+  return process.arch;
+}
+
+main();


### PR DESCRIPTION
## Problem

The controlled binary corpus gave us test programs, but we still needed to prove Machinen can inspect them from the outside. The next step is raw capture. That means the target process must not call the checkpoint ABI or write its own bundle.

## Solution

This adds a Linux raw-capture helper that launches a controlled binary, waits for its `SIGSTOP` observation point, and captures process state through `/proc` and `ptrace`. It writes inspectable JSON for pids, threads, registers, maps, fds, symbols, and memory bytes. The verifier proves we can recover known global, resource, and thread state from raw memory.

Closes #416.

## Validation

- `pnpm controlled-binary-corpus`
- `pnpm raw-process-capture` on macOS arm64 skips as expected because raw capture is Linux-only
- `pnpm raw-process-capture` on Linux amd64 via the office Proxmox/Docker host
- external C helper validation on Linux arm64 via `friend@100.126.46.90`
- `pnpm exec fallow audit --changed-since origin/pp-415-controlled-binary-corpus`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
