### PR TITLE
Add known-symbol extraction proof

### DIFF
--- a/docs/snapshot/known-symbol-extraction.md
+++ b/docs/snapshot/known-symbol-extraction.md
@@ -1,0 +1,32 @@
+# Known-symbol semantic extraction proof
+
+Issue #417 is the first step from raw capture toward portable state translation.
+
+The source process still does not call `machinen_checkpoint` and does not write a bundle. Instead, the verifier uses a normal exported symbol, `machinen_controlled_heap_state`, plus the known C layout of `struct ControlledHeapState` and `struct ControlledNode`.
+
+## Flow
+
+1. Build the controlled corpus and raw capturer on Linux.
+2. Launch the controlled corpus heap fixture with `--pause-at-observation`.
+3. Capture `machinen_controlled_heap_state` from `/proc/<pid>/mem`.
+4. Read the `head` pointer from that captured struct.
+5. Follow each `struct ControlledNode.next` pointer in the stopped process.
+6. Emit a portable bundle with:
+   - `manifest.json`
+   - `objects.json`
+   - `relocations.json`
+   - `resources.json`
+   - `memory.bin`
+7. Start a matching target-architecture controlled binary and restore the extracted semantic heap graph.
+
+The target restore path reads `controlled-state.txt`, an intentionally small sidecar inside the proof bundle. The standard portable files are still emitted and validated by tests. Later issues can replace the proof sidecar with a real restore loader that consumes only the portable bundle documents.
+
+## Verify
+
+Run on Linux:
+
+```sh
+pnpm known-symbol-extract
+```
+
+On non-Linux hosts the verifier skips, because the capture path depends on Linux `/proc` and `ptrace`.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "smoke-tests": "bash scripts/smoke-tests.sh",
     "controlled-binary-corpus": "node scripts/controlled-binary-corpus.mjs verify",
     "raw-process-capture": "node scripts/raw-process-capture.mjs verify",
+    "known-symbol-extract": "node scripts/known-symbol-extract.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/controlled-binary-corpus.c
+++ b/packages/microvm/assets/controlled-binary-corpus.c
@@ -20,6 +20,7 @@
 #define CONTROLLED_SCHEMA_VERSION 1u
 #define CONTROLLED_LABEL_CAPACITY 32u
 #define CONTROLLED_THREAD_COUNT 2u
+#define CONTROLLED_PATH_CAPACITY 512u
 #define CONTROLLED_RESOURCE_PAYLOAD "machinen-controlled-resource\n"
 #define CONTROLLED_RESOURCE_OFFSET 9u
 
@@ -382,10 +383,113 @@ static int run_threads_fixture(void) {
   return 0;
 }
 
+struct ControlledKnownSymbolRestoreState {
+  uint64_t node_count;
+  uint64_t values[3];
+  uint64_t checksum;
+};
+
+static bool parse_u64_line(const char *line, const char *prefix, uint64_t *out) {
+  size_t prefix_len = strlen(prefix);
+  if (strncmp(line, prefix, prefix_len) != 0) {
+    return false;
+  }
+  errno = 0;
+  char *end = NULL;
+  unsigned long long parsed = strtoull(line + prefix_len, &end, 0);
+  if (errno != 0 || end == line + prefix_len || (*end != '\0' && *end != '\n' && *end != '\r')) {
+    return false;
+  }
+  *out = (uint64_t)parsed;
+  return true;
+}
+
+static int load_known_symbol_restore_state(
+    const char *bundle_dir, struct ControlledKnownSymbolRestoreState *state) {
+  char path[CONTROLLED_PATH_CAPACITY];
+  int written = snprintf(path, sizeof(path), "%s/controlled-state.txt", bundle_dir);
+  if (written < 0 || written >= (int)sizeof(path)) {
+    fprintf(stderr, "machinen-controlled-corpus: restore bundle path too long\n");
+    return 1;
+  }
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    fprintf(stderr, "machinen-controlled-corpus: fopen(%s) failed: %s\n", path, strerror(errno));
+    return 1;
+  }
+
+  char line[128];
+  while (fgets(line, sizeof(line), file)) {
+    if (parse_u64_line(line, "node_count=", &state->node_count) ||
+        parse_u64_line(line, "value0=", &state->values[0]) ||
+        parse_u64_line(line, "value1=", &state->values[1]) ||
+        parse_u64_line(line, "value2=", &state->values[2]) ||
+        parse_u64_line(line, "checksum=", &state->checksum)) {
+      continue;
+    }
+  }
+
+  if (fclose(file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", path);
+    return 1;
+  }
+  if (state->node_count != 3) {
+    fprintf(stderr, "machinen-controlled-corpus: expected three restore nodes\n");
+    return 1;
+  }
+  return 0;
+}
+
+static void print_known_symbol_restore_marker(void) {
+  const struct ControlledNode *head = machinen_controlled_heap_state.head;
+  const uint64_t first = head ? head->value : 0;
+  const uint64_t second = head && head->next ? head->next->value : 0;
+  const uint64_t third = head && head->next && head->next->next ? head->next->next->value : 0;
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"known-symbol-restore\",\"arch\":\"%s\","
+         "\"node_count\":%" PRIu64 ",\"values\":[%" PRIu64 ",%" PRIu64 ",%" PRIu64 "],"
+         "\"checksum\":%" PRIu64 ",\"checksum_hex\":\"0x%" PRIx64 "\"}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_heap_state.node_count, first,
+      second, third, machinen_controlled_heap_state.checksum,
+      machinen_controlled_heap_state.checksum);
+  fflush(stdout);
+}
+
+static int run_known_symbol_restore(const char *bundle_dir) {
+  struct ControlledKnownSymbolRestoreState state = {0};
+  if (load_known_symbol_restore_state(bundle_dir, &state) != 0) {
+    return 1;
+  }
+
+  struct ControlledNode *nodes = calloc((size_t)state.node_count, sizeof(struct ControlledNode));
+  if (!nodes) {
+    fprintf(stderr, "machinen-controlled-corpus: restore heap allocation failed\n");
+    return 1;
+  }
+  for (uint64_t i = 0; i < state.node_count; i++) {
+    nodes[i].value = state.values[i];
+    nodes[i].next = i + 1u < state.node_count ? &nodes[i + 1u] : NULL;
+  }
+  machinen_controlled_heap_state.head = &nodes[0];
+  machinen_controlled_heap_state.node_count = state.node_count;
+  machinen_controlled_heap_state.checksum = checksum_nodes(machinen_controlled_heap_state.head);
+
+  if (machinen_controlled_heap_state.checksum != state.checksum) {
+    fprintf(stderr, "machinen-controlled-corpus: restore checksum mismatch\n");
+    free(nodes);
+    return 1;
+  }
+  print_known_symbol_restore_marker();
+  free(nodes);
+  return 0;
+}
+
 static void print_usage(const char *argv0) {
   fprintf(stderr,
       "usage: %s [--fixture all|global|heap|stack|resource|threads] "
-      "[--resource-file path] [--pause-at-observation]\n",
+      "[--resource-file path] [--pause-at-observation] "
+      "[--restore-known-symbol-bundle path]\n",
       argv0);
 }
 
@@ -426,6 +530,7 @@ static int run_all_fixtures(const char *resource_path, int argc) {
 int main(int argc, char **argv) {
   const char *fixture = "all";
   const char *resource_path = "machinen-controlled-resource.txt";
+  const char *restore_bundle_dir = NULL;
 
   for (int i = 1; i < argc; i++) {
     if (streq(argv[i], "--fixture")) {
@@ -442,6 +547,12 @@ int main(int argc, char **argv) {
       resource_path = argv[++i];
     } else if (streq(argv[i], "--pause-at-observation")) {
       g_pause_at_observation = true;
+    } else if (streq(argv[i], "--restore-known-symbol-bundle")) {
+      if (i + 1 >= argc) {
+        print_usage(argv[0]);
+        return 2;
+      }
+      restore_bundle_dir = argv[++i];
     } else if (streq(argv[i], "--help") || streq(argv[i], "-h")) {
       print_usage(argv[0]);
       return 0;
@@ -452,6 +563,9 @@ int main(int argc, char **argv) {
     }
   }
 
+  if (restore_bundle_dir) {
+    return run_known_symbol_restore(restore_bundle_dir);
+  }
   if (streq(fixture, "all")) {
     return run_all_fixtures(resource_path, argc);
   }

--- a/packages/microvm/assets/raw-process-capture.c
+++ b/packages/microvm/assets/raw-process-capture.c
@@ -29,6 +29,9 @@
 #define RAW_CAPTURE_MAX_THREADS 64u
 #define RAW_CAPTURE_MAX_ARGV 128u
 #define RAW_CAPTURE_REG_BYTES 1024u
+#define RAW_CAPTURE_CONTROLLED_NODE_SIZE 16u
+#define RAW_CAPTURE_CONTROLLED_HEAP_STATE_SIZE 24u
+#define RAW_CAPTURE_CONTROLLED_MAX_NODES 64u
 
 #if defined(__aarch64__)
 #define RAW_CAPTURE_ARCH "arm64"
@@ -501,6 +504,80 @@ static void write_threads(const struct Options *opts, pid_t child) {
   fclose(output);
 }
 
+static uint64_t read_u64_native(const uint8_t *bytes) {
+  uint64_t value = 0;
+  memcpy(&value, bytes, sizeof(value));
+  return value;
+}
+
+static void read_process_memory(int mem_fd, uint64_t address, uint8_t *buffer, uint64_t size_bytes) {
+  ssize_t got = pread(mem_fd, buffer, (size_t)size_bytes, (off_t)address);
+  if (got < 0 || (uint64_t)got != size_bytes) {
+    fail("failed to read process memory");
+  }
+}
+
+static void append_memory_chunk(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
+    const char *name, uint64_t source_address, const uint8_t *buffer, uint64_t size_bytes) {
+  if (fwrite(buffer, 1u, (size_t)size_bytes, bin) != size_bytes) {
+    die("write memory.bin");
+  }
+  if (!*first) {
+    fputc(',', json);
+  }
+  *first = false;
+  fputs("{\"name\":", json);
+  json_string(json, name);
+  fprintf(json,
+      ",\"sourceAddress\":\"0x%" PRIx64 "\",\"sizeBytes\":%" PRIu64
+      ",\"fileOffset\":%" PRIu64 "}",
+      source_address, size_bytes, *file_offset);
+  *file_offset += size_bytes;
+}
+
+static void append_controlled_heap_nodes(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
+    int mem_fd, const uint8_t *heap_state, uint64_t heap_state_size) {
+  if (heap_state_size < RAW_CAPTURE_CONTROLLED_HEAP_STATE_SIZE) {
+    fail("controlled heap state chunk is too small");
+  }
+
+  uint64_t node_address = read_u64_native(heap_state);
+  uint64_t node_count = read_u64_native(heap_state + 8u);
+  if (node_count > RAW_CAPTURE_CONTROLLED_MAX_NODES) {
+    fail("controlled heap node count too large");
+  }
+
+  for (uint64_t i = 0; i < node_count && node_address != 0; i++) {
+    uint8_t node[RAW_CAPTURE_CONTROLLED_NODE_SIZE];
+    char name[64];
+    read_process_memory(mem_fd, node_address, node, sizeof(node));
+    int written = snprintf(name, sizeof(name), "machinen_controlled_node_%" PRIu64, i);
+    if (written < 0 || written >= (int)sizeof(name)) {
+      fail("controlled node name too long");
+    }
+    append_memory_chunk(json, bin, first, file_offset, name, node_address, node, sizeof(node));
+    node_address = read_u64_native(node + 8u);
+  }
+}
+
+static void append_symbol_memory(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
+    int mem_fd, const struct CaptureSymbol *symbol) {
+  if (symbol->size_bytes > 1024u * 1024u) {
+    fail("symbol capture too large");
+  }
+  uint8_t *buffer = malloc((size_t)symbol->size_bytes);
+  if (!buffer) {
+    die("malloc memory chunk");
+  }
+  read_process_memory(mem_fd, symbol->address, buffer, symbol->size_bytes);
+  append_memory_chunk(json, bin, first, file_offset, symbol->name, symbol->address, buffer,
+      symbol->size_bytes);
+  if (streq(symbol->name, "machinen_controlled_heap_state")) {
+    append_controlled_heap_nodes(json, bin, first, file_offset, mem_fd, buffer, symbol->size_bytes);
+  }
+  free(buffer);
+}
+
 static void write_memory(const struct Options *opts, pid_t child) {
   char mem_path[PATH_MAX];
   proc_path(mem_path, child, "mem");
@@ -518,37 +595,10 @@ static void write_memory(const struct Options *opts, pid_t child) {
   FILE *json = open_output(opts->output_dir, "memory.json");
   fputs("{\"formatVersion\":1,\"chunks\":[", json);
 
+  bool first = true;
   uint64_t file_offset = 0;
   for (uint32_t i = 0; i < opts->symbol_count; i++) {
-    const struct CaptureSymbol *symbol = &opts->symbols[i];
-    if (symbol->size_bytes > 1024u * 1024u) {
-      fail("symbol capture too large");
-    }
-    uint8_t *buffer = malloc((size_t)symbol->size_bytes);
-    if (!buffer) {
-      die("malloc memory chunk");
-    }
-    ssize_t got = pread(mem_fd, buffer, (size_t)symbol->size_bytes, (off_t)symbol->address);
-    if (got < 0 || (uint64_t)got != symbol->size_bytes) {
-      free(buffer);
-      fail("failed to read symbol memory");
-    }
-    if (fwrite(buffer, 1u, (size_t)symbol->size_bytes, bin) != symbol->size_bytes) {
-      free(buffer);
-      die("write memory.bin");
-    }
-
-    if (i != 0) {
-      fputc(',', json);
-    }
-    fputs("{\"name\":", json);
-    json_string(json, symbol->name);
-    fprintf(json,
-        ",\"sourceAddress\":\"0x%" PRIx64 "\",\"sizeBytes\":%" PRIu64
-        ",\"fileOffset\":%" PRIu64 "}",
-        symbol->address, symbol->size_bytes, file_offset);
-    file_offset += symbol->size_bytes;
-    free(buffer);
+    append_symbol_memory(json, bin, &first, &file_offset, mem_fd, &opts->symbols[i]);
   }
 
   fputs("]}\n", json);

--- a/packages/runtime/src/__tests__/known-symbol-extract.test.ts
+++ b/packages/runtime/src/__tests__/known-symbol-extract.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePortableSnapshotBundle } from "../vm/portable-snapshot.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/known-symbol-extract.mjs");
+const TMP: string[] = [];
+
+interface KnownSymbolSummary {
+  skipped?: boolean;
+  hostArch: string;
+  bundleDir: string;
+  semanticState: {
+    nodeCount: number;
+    values: number[];
+    nodes: Array<{ id: string; value: number; sourceAddress: string }>;
+  };
+  restoreEvent: {
+    fixture: string;
+    arch: string;
+    node_count: number;
+    values: number[];
+  };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("known-symbol extraction", () => {
+  it.skipIf(process.platform !== "linux")(
+    "extracts a heap graph from raw memory and emits a portable bundle",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "known-symbol-extract-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as KnownSymbolSummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.semanticState).toMatchObject({ nodeCount: 3, values: [11, 22, 33] });
+      expect(summary.semanticState.nodes.map((node) => node.id)).toEqual([
+        "controlled-node-0",
+        "controlled-node-1",
+        "controlled-node-2",
+      ]);
+      expect(summary.restoreEvent).toMatchObject({
+        fixture: "known-symbol-restore",
+        values: [11, 22, 33],
+      });
+
+      const bundle = validatePortableSnapshotBundle(summary.bundleDir);
+      expect(bundle.manifest.features).toContain("known-symbol-extraction");
+      expect(bundle.objects.objects.map((object) => object.id)).toEqual([
+        "controlled-heap-state",
+        "controlled-node-0",
+        "controlled-node-1",
+        "controlled-node-2",
+      ]);
+      expect(bundle.relocations.relocations).toHaveLength(3);
+    },
+  );
+});

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCommand } from "./proof-script-utils.mjs";
+
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+export const CONTROLLED_SOURCE = join(
+  REPO_ROOT,
+  "packages/microvm/assets/controlled-binary-corpus.c",
+);
+export const CAPTURE_SOURCE = join(REPO_ROOT, "packages/microvm/assets/raw-process-capture.c");
+
+export function ensureSourcesExist(sources) {
+  for (const source of sources) {
+    if (!existsSync(source)) {
+      throw new Error(`missing source: ${source}`);
+    }
+  }
+}
+
+export function compileControlledTarget(binDir) {
+  const executable = join(binDir, "machinen-controlled-corpus");
+  runCommand("cc", controlledCompileArgs(executable), { label: "controlled corpus build" });
+  return executable;
+}
+
+export function controlledCompileArgs(executable) {
+  return [
+    "-std=c11",
+    "-O0",
+    "-g",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-fno-pie",
+    "-no-pie",
+    "-pthread",
+    CONTROLLED_SOURCE,
+    "-o",
+    executable,
+  ];
+}
+
+export function compileRawCapturer(binDir) {
+  const executable = join(binDir, "machinen-raw-process-capture");
+  runCommand(
+    "cc",
+    ["-std=c11", "-O0", "-g", "-Wall", "-Wextra", "-Werror", CAPTURE_SOURCE, "-o", executable],
+    { label: "raw capturer build" },
+  );
+  return executable;
+}
+
+export function readSymbols(target, wantedSymbols) {
+  const result = runCommand("nm", ["-S", "--defined-only", target], { label: "symbol scan" });
+  const symbols = parseNm(result.stdout);
+  for (const name of wantedSymbols) {
+    if (!symbols.has(name)) {
+      throw new Error(`missing target symbol: ${name}`);
+    }
+  }
+  return symbols;
+}
+
+function parseNm(stdout) {
+  const symbols = new Map();
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+\S\s+(\S+)$/.exec(line.trim());
+    if (match) {
+      symbols.set(match[3], { address: `0x${match[1]}`, sizeBytes: Number.parseInt(match[2], 16) });
+    }
+  }
+  return symbols;
+}
+
+export function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function hostArch() {
+  if (process.arch === "arm64") {
+    return "arm64";
+  }
+  if (process.arch === "x64") {
+    return "amd64";
+  }
+  return process.arch;
+}

--- a/scripts/known-symbol-extract.mjs
+++ b/scripts/known-symbol-extract.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+import { copyFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPTURE_SOURCE,
+  CONTROLLED_SOURCE,
+  compileControlledTarget,
+  compileRawCapturer,
+  ensureSourcesExist,
+  hostArch,
+  readJson,
+  readSymbols,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/known-symbol-extract.mjs [verify] [--out-dir path] [--json] [--keep]";
+const HEAP_STATE_SYMBOL = "machinen_controlled_heap_state";
+const BUILD_ID = "4174174174174170";
+const MARKER = "MACHINEN_CONTROLLED_BINARY ";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(
+      args,
+      "known-symbol-extract",
+      "known-symbol extraction proof uses Linux /proc and ptrace",
+    );
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-known-symbol-extract-");
+  try {
+    emitResult(verifyKnownSymbolExtraction(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyKnownSymbolExtraction(outDir) {
+  ensureSourcesExist([CONTROLLED_SOURCE, CAPTURE_SOURCE]);
+  const binDir = join(outDir, "bin");
+  const captureDir = join(outDir, "capture-heap");
+  const bundleDir = join(outDir, "bundle");
+  mkdirSync(binDir, { recursive: true });
+
+  const target = compileControlledTarget(binDir);
+  const capturer = compileRawCapturer(binDir);
+  const symbols = readSymbols(target, [HEAP_STATE_SYMBOL]);
+  runHeapCapture({ capturer, target, symbols, captureDir });
+
+  const capture = loadCapture(captureDir);
+  const semanticState = recoverHeapGraph(capture);
+  writePortableBundle({ bundleDir, captureDir, capture, semanticState, target });
+  const restoreEvent = runTargetRestore(target, bundleDir);
+  validateRestore(semanticState, restoreEvent);
+
+  return {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    captureDir,
+    bundleDir,
+    target,
+    semanticState,
+    restoreEvent,
+    bundleFiles: bundleFileStats(bundleDir),
+  };
+}
+
+function runHeapCapture(context) {
+  const symbol = context.symbols.get(HEAP_STATE_SYMBOL);
+  const resourceFile = join(context.captureDir, "resource-file.txt");
+  runCommand(
+    context.capturer,
+    [
+      "--output",
+      context.captureDir,
+      "--symbol",
+      `${HEAP_STATE_SYMBOL}:${symbol.address}:${symbol.sizeBytes}`,
+      "--",
+      context.target,
+      "--fixture",
+      "heap",
+      "--pause-at-observation",
+      "--resource-file",
+      resourceFile,
+    ],
+    {
+      label: "known-symbol heap raw capture",
+      env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+    },
+  );
+}
+
+function loadCapture(captureDir) {
+  return {
+    manifest: readJson(join(captureDir, "manifest.json")),
+    symbols: readJson(join(captureDir, "symbols.json")),
+    memory: readJson(join(captureDir, "memory.json")),
+    memoryBin: readFileSync(join(captureDir, "memory.bin")),
+    targetLog: readFileSync(join(captureDir, "target.log"), "utf8"),
+  };
+}
+
+function recoverHeapGraph(capture) {
+  const heapState = chunkBytes(capture, HEAP_STATE_SYMBOL);
+  const nodeCount = Number(heapState.readBigUInt64LE(8));
+  const checksum = heapState.readBigUInt64LE(16);
+  const headPointer = heapState.readBigUInt64LE(0);
+  const nodes = [];
+
+  for (let i = 0; i < nodeCount; i++) {
+    const chunk = chunkByName(capture, `machinen_controlled_node_${i}`);
+    const bytes = chunkBytesByDescriptor(capture, chunk);
+    nodes.push({
+      id: `controlled-node-${i}`,
+      sourceAddress: chunk.sourceAddress,
+      value: Number(bytes.readBigUInt64LE(0)),
+      nextPointer: hexAddress(bytes.readBigUInt64LE(8)),
+      sizeBytes: chunk.sizeBytes,
+      memory: { offset: chunk.fileOffset, sizeBytes: chunk.sizeBytes },
+    });
+  }
+
+  return {
+    nodeCount,
+    checksum: checksum.toString(10),
+    checksumHex: hexAddress(checksum),
+    headPointer: hexAddress(headPointer),
+    values: nodes.map((node) => node.value),
+    nodes,
+    heapState: {
+      sourceAddress: chunkByName(capture, HEAP_STATE_SYMBOL).sourceAddress,
+      sizeBytes: heapState.length,
+      memory: chunkByName(capture, HEAP_STATE_SYMBOL),
+    },
+  };
+}
+
+function chunkByName(capture, name) {
+  const chunk = capture.memory.chunks.find((candidate) => candidate.name === name);
+  if (!chunk) {
+    throw new Error(`missing memory chunk: ${name}`);
+  }
+  return chunk;
+}
+
+function chunkBytes(capture, name) {
+  return chunkBytesByDescriptor(capture, chunkByName(capture, name));
+}
+
+function chunkBytesByDescriptor(capture, chunk) {
+  return capture.memoryBin.subarray(chunk.fileOffset, chunk.fileOffset + chunk.sizeBytes);
+}
+
+function hexAddress(value) {
+  return `0x${value.toString(16)}`;
+}
+
+function writePortableBundle(context) {
+  mkdirSync(context.bundleDir, { recursive: true });
+  mkdirSync(join(context.bundleDir, "logs"), { recursive: true });
+
+  const memory = buildBundleMemory(context.capture);
+  const objects = buildObjects(memory.chunks, context.semanticState);
+  writeFileSync(join(context.bundleDir, "memory.bin"), memory.bytes);
+  writeFileSync(join(context.bundleDir, "manifest.json"), json(manifest(context)));
+  writeFileSync(join(context.bundleDir, "objects.json"), json(objects));
+  writeFileSync(
+    join(context.bundleDir, "relocations.json"),
+    json(relocations(context.semanticState)),
+  );
+  writeFileSync(join(context.bundleDir, "resources.json"), json(resources(context.capture)));
+  writeFileSync(
+    join(context.bundleDir, "controlled-state.txt"),
+    controlledStateText(context.semanticState),
+  );
+  copyFileSync(
+    join(context.captureDir, "target.log"),
+    join(context.bundleDir, "logs/source-target.log"),
+  );
+}
+
+function buildBundleMemory(capture) {
+  const chunks = capture.memory.chunks.map((source) => ({ ...source }));
+  const buffers = [];
+  let offset = 0;
+  for (const chunk of chunks) {
+    const bytes = chunkBytesByDescriptor(capture, chunk);
+    chunk.bundleOffset = offset;
+    buffers.push(bytes);
+    offset += bytes.length;
+  }
+  return { chunks, bytes: Buffer.concat(buffers) };
+}
+
+function buildObjects(chunks, semanticState) {
+  const byName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+  const heapState = byName.get(HEAP_STATE_SYMBOL);
+  return {
+    formatVersion: 1,
+    objects: [
+      heapStateObject(heapState),
+      ...semanticState.nodes.map((node, index) => nodeObject(byName, node, index)),
+    ],
+    unsupported: unsupported(),
+  };
+}
+
+function heapStateObject(chunk) {
+  return {
+    id: "controlled-heap-state",
+    kind: "global",
+    type: "struct ControlledHeapState",
+    sizeBytes: chunk.sizeBytes,
+    sourceAddress: chunk.sourceAddress,
+    memory: { offset: chunk.bundleOffset, sizeBytes: chunk.sizeBytes },
+  };
+}
+
+function nodeObject(byName, node, index) {
+  const chunk = byName.get(`machinen_controlled_node_${index}`);
+  return {
+    id: node.id,
+    kind: "heap",
+    type: "struct ControlledNode",
+    sizeBytes: chunk.sizeBytes,
+    sourceAddress: chunk.sourceAddress,
+    allocation: { id: index + 1, sourceAddress: chunk.sourceAddress },
+    memory: { offset: chunk.bundleOffset, sizeBytes: chunk.sizeBytes },
+  };
+}
+
+function manifest(context) {
+  return {
+    formatVersion: 1,
+    sourceGuestArch: hostArch(),
+    allowedTargetGuestArchs: ["arm64", "amd64"],
+    program: {
+      name: "controlled-binary-corpus",
+      executable: context.target,
+      identity: "com.redwoodjs.machinen.controlled-binary-corpus",
+    },
+    sourceBuild: { buildId: BUILD_ID, version: "known-symbol-proof" },
+    targetBuild: { version: "known-symbol-proof" },
+    checkpointAbi: {
+      version: 1,
+      checkpointFunction: { name: "machinen_checkpoint" },
+      rootsType: "machinen_checkpoint_roots",
+      restoreBundleType: "machinen_restore_bundle",
+      safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
+    },
+    checkpointContinuation: { name: "machinen_controlled_heap_observation" },
+    restoreEntrypoint: { name: "machinen_controlled_known_symbol_restore" },
+    process: {
+      argv: context.capture.manifest.target.argv,
+      env: { MACHINEN_CONTROLLED_ENV: "1" },
+      cwd: process.cwd(),
+    },
+    features: ["controlled-binary-corpus", "external-raw-capture", "known-symbol-extraction"],
+    unsupported: unsupported(),
+  };
+}
+
+function relocations(semanticState) {
+  return {
+    formatVersion: 1,
+    relocations: [heapHeadRelocation(semanticState), ...nodeRelocations(semanticState)],
+    unsupported: unsupported(),
+  };
+}
+
+function heapHeadRelocation(semanticState) {
+  return {
+    fromObject: "controlled-heap-state",
+    fromOffset: 0,
+    toObject: "controlled-node-0",
+    addend: 0,
+    kind: "pointer",
+    sourcePointer: semanticState.headPointer,
+  };
+}
+
+function nodeRelocations(semanticState) {
+  const relocations = [];
+  for (let i = 0; i + 1 < semanticState.nodes.length; i++) {
+    relocations.push({
+      fromObject: `controlled-node-${i}`,
+      fromOffset: 8,
+      toObject: `controlled-node-${i + 1}`,
+      addend: 0,
+      kind: "pointer",
+      sourcePointer: semanticState.nodes[i].nextPointer,
+    });
+  }
+  return relocations;
+}
+
+function resources(capture) {
+  return {
+    formatVersion: 1,
+    resources: [
+      { id: "argv", kind: "argv", state: "captured", argv: capture.manifest.target.argv },
+      { id: "env", kind: "env", state: "captured", env: { MACHINEN_CONTROLLED_ENV: "1" } },
+      { id: "cwd", kind: "cwd", state: "captured", path: process.cwd() },
+    ],
+    unsupported: unsupported(),
+  };
+}
+
+function controlledStateText(semanticState) {
+  return [
+    `node_count=${semanticState.nodeCount}`,
+    `value0=${semanticState.values[0]}`,
+    `value1=${semanticState.values[1]}`,
+    `value2=${semanticState.values[2]}`,
+    `checksum=${semanticState.checksumHex}`,
+    "",
+  ].join("\n");
+}
+
+function unsupported() {
+  return { vocabularyVersion: 1, refusals: [] };
+}
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function runTargetRestore(target, bundleDir) {
+  const result = runCommand(target, ["--restore-known-symbol-bundle", bundleDir], {
+    label: "known-symbol target restore",
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+  const event = parseMarker(result.stdout);
+  assert(event.fixture === "known-symbol-restore", "target did not emit restore marker");
+  return event;
+}
+
+function parseMarker(stdout) {
+  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(MARKER));
+  if (!line) {
+    throw new Error("missing controlled binary restore marker");
+  }
+  return JSON.parse(line.slice(MARKER.length));
+}
+
+function validateRestore(semanticState, restoreEvent) {
+  assert(restoreEvent.arch === hostArch(), "restore ran on unexpected host architecture");
+  assert(restoreEvent.node_count === semanticState.nodeCount, "restored node count changed");
+  assert(
+    JSON.stringify(restoreEvent.values) === JSON.stringify(semanticState.values),
+    "restored node values changed",
+  );
+  assert(restoreEvent.checksum_hex === semanticState.checksumHex, "restored checksum changed");
+}
+
+function bundleFileStats(bundleDir) {
+  return ["manifest.json", "objects.json", "relocations.json", "resources.json", "memory.bin"].map(
+    (name) => ({ name, bytes: statSync(join(bundleDir, name)).size }),
+  );
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `known-symbol-extract: ${summary.hostArch} extracted ${summary.semanticState.nodeCount} heap nodes`,
+  );
+  console.log(`known-symbol-extract: restored values ${summary.restoreEvent.values.join(",")}`);
+  if (temporary) {
+    console.log("known-symbol-extract: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+main();

--- a/scripts/proof-script-utils.mjs
+++ b/scripts/proof-script-utils.mjs
@@ -73,6 +73,14 @@ export function emitResult(summary, args, workspace, printSummary) {
   printSummary(summary, workspace.temporary && !args.keep);
 }
 
+export function emitSkip(args, label, reason) {
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ skipped: true, reason }, null, 2)}\n`);
+    return;
+  }
+  console.log(`${label}: skip — ${reason}`);
+}
+
 export function cleanupWorkspace(workspace, args) {
   if (workspace.temporary && !args.keep) {
     rmSync(workspace.outDir, { recursive: true, force: true });

--- a/scripts/raw-process-capture.mjs
+++ b/scripts/raw-process-capture.mjs
@@ -1,19 +1,25 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { mkdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPTURE_SOURCE,
+  CONTROLLED_SOURCE,
+  compileControlledTarget,
+  compileRawCapturer,
+  ensureSourcesExist,
+  hostArch,
+  readJson,
+  readSymbols,
+} from "./controlled-corpus-utils.mjs";
 import {
   assert,
   cleanupWorkspace,
   createWorkspace,
   emitResult,
+  emitSkip,
   parseVerifyArgs,
   runCommand,
 } from "./proof-script-utils.mjs";
-
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const CONTROLLED_SOURCE = join(REPO_ROOT, "packages/microvm/assets/controlled-binary-corpus.c");
-const CAPTURE_SOURCE = join(REPO_ROOT, "packages/microvm/assets/raw-process-capture.c");
 const WANTED_SYMBOLS = [
   "machinen_controlled_global_state",
   "machinen_controlled_resource_state",
@@ -30,7 +36,7 @@ const USAGE =
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
   if (process.platform !== "linux") {
-    emitSkip(args, "raw process capture uses Linux /proc and ptrace");
+    emitSkip(args, "raw-process-capture", "raw process capture uses Linux /proc and ptrace");
     return;
   }
 
@@ -43,83 +49,20 @@ function main() {
 }
 
 function verifyRawCapture(outDir) {
-  ensureSourcesExist();
+  ensureSourcesExist([CONTROLLED_SOURCE, CAPTURE_SOURCE]);
   mkdirSync(outDir, { recursive: true });
   const binDir = join(outDir, "bin");
   mkdirSync(binDir, { recursive: true });
 
   const target = compileControlledTarget(binDir);
   const capturer = compileRawCapturer(binDir);
-  const symbols = readSymbols(target);
+  const symbols = readSymbols(target, WANTED_SYMBOLS);
   const captures = CAPTURE_PLANS.map((plan) =>
     runCapturePlan(plan, { capturer, target, symbols, outDir }),
   );
   const summary = { formatVersion: 1, hostArch: hostArch(), target, capturer, captures };
   validateSummary(summary);
   return summary;
-}
-
-function ensureSourcesExist() {
-  for (const source of [CONTROLLED_SOURCE, CAPTURE_SOURCE]) {
-    if (!existsSync(source)) {
-      throw new Error(`missing source: ${source}`);
-    }
-  }
-}
-
-function compileControlledTarget(binDir) {
-  const executable = join(binDir, "machinen-controlled-corpus");
-  runCommand(
-    "cc",
-    [
-      "-std=c11",
-      "-O0",
-      "-g",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-fno-pie",
-      "-no-pie",
-      "-pthread",
-      CONTROLLED_SOURCE,
-      "-o",
-      executable,
-    ],
-    { label: "controlled corpus build" },
-  );
-  return executable;
-}
-
-function compileRawCapturer(binDir) {
-  const executable = join(binDir, "machinen-raw-process-capture");
-  runCommand(
-    "cc",
-    ["-std=c11", "-O0", "-g", "-Wall", "-Wextra", "-Werror", CAPTURE_SOURCE, "-o", executable],
-    { label: "raw capturer build" },
-  );
-  return executable;
-}
-
-function readSymbols(target) {
-  const result = runCommand("nm", ["-S", "--defined-only", target], { label: "symbol scan" });
-  const symbols = parseNm(result.stdout);
-  for (const name of WANTED_SYMBOLS) {
-    if (!symbols.has(name)) {
-      throw new Error(`missing target symbol: ${name}`);
-    }
-  }
-  return symbols;
-}
-
-function parseNm(stdout) {
-  const symbols = new Map();
-  for (const line of stdout.split(/\r?\n/)) {
-    const match = /^([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+\S\s+(\S+)$/.exec(line.trim());
-    if (match) {
-      symbols.set(match[3], { address: `0x${match[1]}`, sizeBytes: Number.parseInt(match[2], 16) });
-    }
-  }
-  return symbols;
 }
 
 function runCapturePlan(plan, context) {
@@ -286,18 +229,6 @@ function validateThreads(capture) {
   );
 }
 
-function readJson(path) {
-  return JSON.parse(readFileSync(path, "utf8"));
-}
-
-function emitSkip(args, reason) {
-  if (args.json) {
-    process.stdout.write(`${JSON.stringify({ skipped: true, reason }, null, 2)}\n`);
-    return;
-  }
-  console.log(`raw-process-capture: skip — ${reason}`);
-}
-
 function printSummary(summary, temporary) {
   console.log(
     `raw-process-capture: ${summary.hostArch} captured ${summary.captures.length} stopped processes`,
@@ -310,16 +241,6 @@ function printSummary(summary, temporary) {
   if (temporary) {
     console.log("raw-process-capture: temporary artifacts removed; pass --keep to inspect them");
   }
-}
-
-function hostArch() {
-  if (process.arch === "arm64") {
-    return "arm64";
-  }
-  if (process.arch === "x64") {
-    return "amd64";
-  }
-  return process.arch;
 }
 
 main();


### PR DESCRIPTION
## Problem

The raw capturer could read bytes from a stopped process, but the bytes were still just bytes. We needed to prove that known symbols and known C layouts are enough to turn those bytes into portable state. Without that step, the next DWARF and sidecar work has nothing concrete to replace.

## Solution

This adds a known-symbol extractor for the controlled heap fixture. It captures `machinen_controlled_heap_state`, follows the linked-list pointers in raw process memory, and emits a portable bundle with objects, relocations, resources, and `memory.bin`. The matching target fixture can then restore the extracted heap graph and prove the values survived.

Closes #417.

## Validation

- `pnpm known-symbol-extract` on macOS arm64 skips as expected because capture is Linux-only
- `pnpm known-symbol-extract` on Linux arm64 via `friend@100.126.46.90`
- `pnpm known-symbol-extract` on Linux amd64 via office Proxmox/Docker
- arm64 source bundle restored into an amd64 controlled target on the office Proxmox host
- `pnpm exec fallow audit --changed-since origin/pp-416-raw-process-capture`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
