### PR TITLE
Add DWARF metadata extraction proof

### DIFF
--- a/docs/snapshot/dwarf-metadata-extraction.md
+++ b/docs/snapshot/dwarf-metadata-extraction.md
@@ -1,0 +1,62 @@
+# DWARF metadata extraction proof
+
+Issue #418 replaces the known-symbol proof's hardcoded C offsets with DWARF/debug metadata.
+
+The source process is still an ordinary controlled C binary. It does not call `machinen_checkpoint`. The verifier reads DWARF from the debug build, finds exported globals, decodes struct members by name, detects pointer-typed fields, and then uses those offsets to capture and translate semantic state.
+
+## Flow
+
+1. Build the controlled corpus with `-g -O0 -fno-pie -no-pie`.
+2. Read DWARF `.debug_info` with `readelf --debug-dump=info`.
+3. Locate these global variables from DWARF, including their `DW_OP_addr` locations:
+   - `machinen_controlled_dwarf_global_state`
+   - `machinen_controlled_dwarf_heap_state`
+4. Read these struct layouts from DWARF instead of from JavaScript constants:
+   - `struct ControlledDwarfGlobalState`
+   - `struct ControlledDwarfHeapState`
+   - `struct ControlledDwarfNode`
+5. Detect pointer fields such as `ControlledDwarfHeapState.head` and `ControlledDwarfNode.next`.
+6. Pass the DWARF-derived list layout to the raw capturer.
+7. Capture global bytes and heap nodes from `/proc/<pid>/mem`.
+8. Decode fields by name and emit a portable bundle plus `dwarf-layout.json`.
+9. Restore the semantic global and heap state into a matching target binary.
+
+The DWARF fixture deliberately uses a layout that differs from the earlier known-symbol heap fixture. The extractor still recovers the state because it asks DWARF for field offsets and pointer fields.
+
+## Cross-architecture mapping
+
+The bundle records a field-name mapping from source layout to target layout:
+
+- source field name
+- source offset
+- target offset
+- source type
+- target type
+- pointer/non-pointer classification
+
+For the same build on another architecture, the semantic values are moved by field name rather than by raw offset. The current proof uses the controlled restore sidecar for the final replay step, but the portable bundle documents and `dwarf-layout.json` contain the information needed to rewrite pointers and fields for a target layout.
+
+## Stack/local-variable probe
+
+The verifier also inspects DWARF for `controlled_nested_stack_point` and reports visible formal parameters and locals, including `live_local` on unoptimized builds. This is exploratory only. Stack continuation translation is handled in the next issue because local-variable DWARF is less stable than global/heap metadata.
+
+## Limits
+
+DWARF is enough for this controlled `-O0` proof, but real optimized binaries need more care:
+
+- Optimized locals may live only in registers or may be optimized away.
+- Inlined functions can split one source frame across several machine frames.
+- Location lists can be PC-range dependent.
+- Tail calls can erase frames that existed in the source language.
+- Stripped binaries need an external debug file, build-id lookup, or a sidecar format.
+- Raw stack bytes are still architecture-specific; DWARF only tells us how to interpret values that are recoverable at a safe point.
+
+## Verify
+
+Run on Linux:
+
+```sh
+pnpm dwarf-symbol-extract
+```
+
+On non-Linux hosts the verifier skips, because capture depends on Linux `/proc`, `ptrace`, and `readelf`.

--- a/docs/snapshot/raw-process-capture.md
+++ b/docs/snapshot/raw-process-capture.md
@@ -14,6 +14,7 @@ The Linux capturer writes an inspectable directory with:
 - `fds.json` — `/proc/<pid>/fd` targets.
 - `symbols.json` — exported symbol addresses passed in by the verifier.
 - `memory.json` and `memory.bin` — raw bytes read from `/proc/<pid>/mem` for those symbols.
+- Optional followed-list chunks — when a verifier supplies a DWARF-derived `--follow-list`, the capturer reads a root pointer/count pair and captures the pointed-to heap nodes by a generic node size and next-pointer offset.
 - `target.log` — the controlled fixture's observation marker and pause log.
 
 ## Verify

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "controlled-binary-corpus": "node scripts/controlled-binary-corpus.mjs verify",
     "raw-process-capture": "node scripts/raw-process-capture.mjs verify",
     "known-symbol-extract": "node scripts/known-symbol-extract.mjs verify",
+    "dwarf-symbol-extract": "node scripts/dwarf-symbol-extract.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/controlled-binary-corpus.c
+++ b/packages/microvm/assets/controlled-binary-corpus.c
@@ -81,21 +81,46 @@ struct ThreadArgs {
   uint64_t base_counter;
 };
 
+struct ControlledDwarfGlobalState {
+  char label[CONTROLLED_LABEL_CAPACITY];
+  uint32_t flags;
+  uint16_t generation;
+  uint64_t counter;
+};
+
+struct ControlledDwarfNode {
+  uint32_t tag;
+  uint8_t color;
+  uint64_t value;
+  struct ControlledDwarfNode *next;
+};
+
+struct ControlledDwarfHeapState {
+  uint16_t version;
+  struct ControlledDwarfNode *head;
+  uint64_t checksum;
+  uint64_t node_count;
+};
+
 CONTROLLED_EXPORT struct ControlledGlobalState machinen_controlled_global_state;
 CONTROLLED_EXPORT struct ControlledHeapState machinen_controlled_heap_state;
 CONTROLLED_EXPORT struct ControlledStackObservation machinen_controlled_stack_observation;
 CONTROLLED_EXPORT struct ControlledResourceState machinen_controlled_resource_state;
 CONTROLLED_EXPORT struct ControlledThreadState machinen_controlled_thread_states[CONTROLLED_THREAD_COUNT];
+CONTROLLED_EXPORT struct ControlledDwarfGlobalState machinen_controlled_dwarf_global_state;
+CONTROLLED_EXPORT struct ControlledDwarfHeapState machinen_controlled_dwarf_heap_state;
 
 CONTROLLED_EXPORT const char machinen_controlled_corpus_metadata[] =
     "{\"schema_version\":1,"
     "\"workload\":\"machinen-controlled-binary-corpus\","
-    "\"fixtures\":[\"global\",\"heap\",\"stack\",\"resource\",\"threads\"],"
+    "\"fixtures\":[\"global\",\"heap\",\"stack\",\"resource\",\"threads\",\"dwarf\"],"
     "\"global_symbol\":\"machinen_controlled_global_state\","
     "\"heap_symbol\":\"machinen_controlled_heap_state\","
     "\"stack_symbol\":\"machinen_controlled_stack_observation\","
     "\"resource_symbol\":\"machinen_controlled_resource_state\","
-    "\"threads_symbol\":\"machinen_controlled_thread_states\"}";
+    "\"threads_symbol\":\"machinen_controlled_thread_states\","
+    "\"dwarf_global_symbol\":\"machinen_controlled_dwarf_global_state\","
+    "\"dwarf_heap_symbol\":\"machinen_controlled_dwarf_heap_state\"}";
 
 static bool g_pause_at_observation;
 static pthread_mutex_t g_thread_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -133,6 +158,21 @@ static uint64_t checksum_nodes(const struct ControlledNode *head) {
   uint64_t hash = UINT64_C(1469598103934665603);
   const struct ControlledNode *node = head;
   while (node) {
+    hash ^= node->value;
+    hash *= UINT64_C(1099511628211);
+    node = node->next;
+  }
+  return hash;
+}
+
+static uint64_t checksum_dwarf_nodes(const struct ControlledDwarfNode *head) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  const struct ControlledDwarfNode *node = head;
+  while (node) {
+    hash ^= node->tag;
+    hash *= UINT64_C(1099511628211);
+    hash ^= node->color;
+    hash *= UINT64_C(1099511628211);
     hash ^= node->value;
     hash *= UINT64_C(1099511628211);
     node = node->next;
@@ -207,6 +247,72 @@ static int run_heap_fixture(void) {
   machinen_controlled_heap_state.head = NULL;
   machinen_controlled_heap_state.node_count = 0;
   machinen_controlled_heap_state.checksum = 0;
+  return 0;
+}
+
+static void print_dwarf_marker(void) {
+  const struct ControlledDwarfNode *head = machinen_controlled_dwarf_heap_state.head;
+  const struct ControlledDwarfNode *second = head ? head->next : NULL;
+  const struct ControlledDwarfNode *third = second ? second->next : NULL;
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"dwarf\",\"arch\":\"%s\","
+         "\"global\":{\"counter\":%" PRIu64 ",\"flags\":%u,"
+         "\"generation\":%u,\"label\":\"%s\"},"
+         "\"heap\":{\"version\":%u,\"node_count\":%" PRIu64 ","
+         "\"values\":[%" PRIu64 ",%" PRIu64 ",%" PRIu64 "],"
+         "\"tags\":[%u,%u,%u],\"colors\":[%u,%u,%u],"
+         "\"checksum\":%" PRIu64 ",\"checksum_hex\":\"0x%" PRIx64 "\"}}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_dwarf_global_state.counter,
+      machinen_controlled_dwarf_global_state.flags,
+      (unsigned)machinen_controlled_dwarf_global_state.generation,
+      machinen_controlled_dwarf_global_state.label,
+      (unsigned)machinen_controlled_dwarf_heap_state.version,
+      machinen_controlled_dwarf_heap_state.node_count, head ? head->value : 0,
+      second ? second->value : 0, third ? third->value : 0, head ? head->tag : 0,
+      second ? second->tag : 0, third ? third->tag : 0, head ? (unsigned)head->color : 0,
+      second ? (unsigned)second->color : 0, third ? (unsigned)third->color : 0,
+      machinen_controlled_dwarf_heap_state.checksum,
+      machinen_controlled_dwarf_heap_state.checksum);
+  fflush(stdout);
+}
+
+static int run_dwarf_fixture(void) {
+  struct ControlledDwarfNode *nodes = calloc(3u, sizeof(struct ControlledDwarfNode));
+  if (!nodes) {
+    fprintf(stderr, "machinen-controlled-corpus: dwarf heap allocation failed\n");
+    return 1;
+  }
+
+  copy_label(machinen_controlled_dwarf_global_state.label, "dwarf-global-layout-v2");
+  machinen_controlled_dwarf_global_state.flags = 0x5a5au;
+  machinen_controlled_dwarf_global_state.generation = 7u;
+  machinen_controlled_dwarf_global_state.counter = 7000u;
+
+  nodes[0].tag = 101u;
+  nodes[0].color = 3u;
+  nodes[0].value = 111u;
+  nodes[0].next = &nodes[1];
+  nodes[1].tag = 102u;
+  nodes[1].color = 5u;
+  nodes[1].value = 222u;
+  nodes[1].next = &nodes[2];
+  nodes[2].tag = 103u;
+  nodes[2].color = 7u;
+  nodes[2].value = 333u;
+  nodes[2].next = NULL;
+
+  machinen_controlled_dwarf_heap_state.version = 2u;
+  machinen_controlled_dwarf_heap_state.head = &nodes[0];
+  machinen_controlled_dwarf_heap_state.node_count = 3u;
+  machinen_controlled_dwarf_heap_state.checksum =
+      checksum_dwarf_nodes(machinen_controlled_dwarf_heap_state.head);
+
+  print_dwarf_marker();
+  maybe_pause_at_observation("dwarf");
+
+  free(nodes);
+  memset(&machinen_controlled_dwarf_global_state, 0, sizeof(machinen_controlled_dwarf_global_state));
+  memset(&machinen_controlled_dwarf_heap_state, 0, sizeof(machinen_controlled_dwarf_heap_state));
   return 0;
 }
 
@@ -389,6 +495,18 @@ struct ControlledKnownSymbolRestoreState {
   uint64_t checksum;
 };
 
+struct ControlledDwarfRestoreState {
+  char label[CONTROLLED_LABEL_CAPACITY];
+  uint64_t counter;
+  uint64_t flags;
+  uint64_t generation;
+  uint64_t node_count;
+  uint64_t values[3];
+  uint64_t tags[3];
+  uint64_t colors[3];
+  uint64_t checksum;
+};
+
 static bool parse_u64_line(const char *line, const char *prefix, uint64_t *out) {
   size_t prefix_len = strlen(prefix);
   if (strncmp(line, prefix, prefix_len) != 0) {
@@ -401,6 +519,20 @@ static bool parse_u64_line(const char *line, const char *prefix, uint64_t *out) 
     return false;
   }
   *out = (uint64_t)parsed;
+  return true;
+}
+
+static bool parse_string_line(const char *line, const char *prefix, char *out, size_t capacity) {
+  size_t prefix_len = strlen(prefix);
+  if (strncmp(line, prefix, prefix_len) != 0) {
+    return false;
+  }
+  size_t len = strcspn(line + prefix_len, "\r\n");
+  if (len >= capacity) {
+    return false;
+  }
+  memcpy(out, line + prefix_len, len);
+  out[len] = '\0';
   return true;
 }
 
@@ -485,11 +617,122 @@ static int run_known_symbol_restore(const char *bundle_dir) {
   return 0;
 }
 
+static int load_dwarf_restore_state(const char *bundle_dir, struct ControlledDwarfRestoreState *state) {
+  char path[CONTROLLED_PATH_CAPACITY];
+  int written = snprintf(path, sizeof(path), "%s/controlled-state.txt", bundle_dir);
+  if (written < 0 || written >= (int)sizeof(path)) {
+    fprintf(stderr, "machinen-controlled-corpus: dwarf restore bundle path too long\n");
+    return 1;
+  }
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    fprintf(stderr, "machinen-controlled-corpus: fopen(%s) failed: %s\n", path, strerror(errno));
+    return 1;
+  }
+
+  char line[128];
+  while (fgets(line, sizeof(line), file)) {
+    if (parse_string_line(line, "global_label=", state->label, sizeof(state->label)) ||
+        parse_u64_line(line, "global_counter=", &state->counter) ||
+        parse_u64_line(line, "global_flags=", &state->flags) ||
+        parse_u64_line(line, "global_generation=", &state->generation) ||
+        parse_u64_line(line, "node_count=", &state->node_count) ||
+        parse_u64_line(line, "value0=", &state->values[0]) ||
+        parse_u64_line(line, "value1=", &state->values[1]) ||
+        parse_u64_line(line, "value2=", &state->values[2]) ||
+        parse_u64_line(line, "tag0=", &state->tags[0]) ||
+        parse_u64_line(line, "tag1=", &state->tags[1]) ||
+        parse_u64_line(line, "tag2=", &state->tags[2]) ||
+        parse_u64_line(line, "color0=", &state->colors[0]) ||
+        parse_u64_line(line, "color1=", &state->colors[1]) ||
+        parse_u64_line(line, "color2=", &state->colors[2]) ||
+        parse_u64_line(line, "checksum=", &state->checksum)) {
+      continue;
+    }
+  }
+
+  if (fclose(file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", path);
+    return 1;
+  }
+  if (state->node_count != 3 || state->label[0] == '\0') {
+    fprintf(stderr, "machinen-controlled-corpus: invalid dwarf restore state\n");
+    return 1;
+  }
+  return 0;
+}
+
+static void print_dwarf_restore_marker(void) {
+  const struct ControlledDwarfNode *head = machinen_controlled_dwarf_heap_state.head;
+  const struct ControlledDwarfNode *second = head ? head->next : NULL;
+  const struct ControlledDwarfNode *third = second ? second->next : NULL;
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"dwarf-restore\",\"arch\":\"%s\","
+         "\"global\":{\"counter\":%" PRIu64 ",\"flags\":%u,"
+         "\"generation\":%u,\"label\":\"%s\"},"
+         "\"heap\":{\"version\":%u,\"node_count\":%" PRIu64 ","
+         "\"values\":[%" PRIu64 ",%" PRIu64 ",%" PRIu64 "],"
+         "\"tags\":[%u,%u,%u],\"colors\":[%u,%u,%u],"
+         "\"checksum\":%" PRIu64 ",\"checksum_hex\":\"0x%" PRIx64 "\"}}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, machinen_controlled_dwarf_global_state.counter,
+      machinen_controlled_dwarf_global_state.flags,
+      (unsigned)machinen_controlled_dwarf_global_state.generation,
+      machinen_controlled_dwarf_global_state.label,
+      (unsigned)machinen_controlled_dwarf_heap_state.version,
+      machinen_controlled_dwarf_heap_state.node_count, head ? head->value : 0,
+      second ? second->value : 0, third ? third->value : 0, head ? head->tag : 0,
+      second ? second->tag : 0, third ? third->tag : 0, head ? (unsigned)head->color : 0,
+      second ? (unsigned)second->color : 0, third ? (unsigned)third->color : 0,
+      machinen_controlled_dwarf_heap_state.checksum,
+      machinen_controlled_dwarf_heap_state.checksum);
+  fflush(stdout);
+}
+
+static int run_dwarf_restore(const char *bundle_dir) {
+  struct ControlledDwarfRestoreState state = {0};
+  if (load_dwarf_restore_state(bundle_dir, &state) != 0) {
+    return 1;
+  }
+
+  copy_label(machinen_controlled_dwarf_global_state.label, state.label);
+  machinen_controlled_dwarf_global_state.counter = state.counter;
+  machinen_controlled_dwarf_global_state.flags = (uint32_t)state.flags;
+  machinen_controlled_dwarf_global_state.generation = (uint16_t)state.generation;
+
+  struct ControlledDwarfNode *nodes = calloc((size_t)state.node_count, sizeof(struct ControlledDwarfNode));
+  if (!nodes) {
+    fprintf(stderr, "machinen-controlled-corpus: dwarf restore heap allocation failed\n");
+    return 1;
+  }
+  for (uint64_t i = 0; i < state.node_count; i++) {
+    nodes[i].tag = (uint32_t)state.tags[i];
+    nodes[i].color = (uint8_t)state.colors[i];
+    nodes[i].value = state.values[i];
+    nodes[i].next = i + 1u < state.node_count ? &nodes[i + 1u] : NULL;
+  }
+
+  machinen_controlled_dwarf_heap_state.version = 2u;
+  machinen_controlled_dwarf_heap_state.head = &nodes[0];
+  machinen_controlled_dwarf_heap_state.node_count = state.node_count;
+  machinen_controlled_dwarf_heap_state.checksum =
+      checksum_dwarf_nodes(machinen_controlled_dwarf_heap_state.head);
+
+  if (machinen_controlled_dwarf_heap_state.checksum != state.checksum) {
+    fprintf(stderr, "machinen-controlled-corpus: dwarf restore checksum mismatch\n");
+    free(nodes);
+    return 1;
+  }
+  print_dwarf_restore_marker();
+  free(nodes);
+  return 0;
+}
+
 static void print_usage(const char *argv0) {
   fprintf(stderr,
-      "usage: %s [--fixture all|global|heap|stack|resource|threads] "
+      "usage: %s [--fixture all|global|heap|stack|resource|threads|dwarf] "
       "[--resource-file path] [--pause-at-observation] "
-      "[--restore-known-symbol-bundle path]\n",
+      "[--restore-known-symbol-bundle path] [--restore-dwarf-bundle path]\n",
       argv0);
 }
 
@@ -507,6 +750,9 @@ static int run_selected_fixture(const char *fixture, const char *resource_path, 
   if (streq(fixture, "stack")) {
     return run_stack_fixture();
   }
+  if (streq(fixture, "dwarf")) {
+    return run_dwarf_fixture();
+  }
   if (streq(fixture, "resource")) {
     return run_resource_fixture(resource_path, argc);
   }
@@ -518,7 +764,7 @@ static int run_selected_fixture(const char *fixture, const char *resource_path, 
 }
 
 static int run_all_fixtures(const char *resource_path, int argc) {
-  const char *fixtures[] = {"global", "heap", "stack", "resource", "threads"};
+  const char *fixtures[] = {"global", "heap", "stack", "resource", "threads", "dwarf"};
   for (uint32_t i = 0; i < sizeof(fixtures) / sizeof(fixtures[0]); i++) {
     if (run_selected_fixture(fixtures[i], resource_path, argc) != 0) {
       return 1;
@@ -531,6 +777,7 @@ int main(int argc, char **argv) {
   const char *fixture = "all";
   const char *resource_path = "machinen-controlled-resource.txt";
   const char *restore_bundle_dir = NULL;
+  const char *dwarf_restore_bundle_dir = NULL;
 
   for (int i = 1; i < argc; i++) {
     if (streq(argv[i], "--fixture")) {
@@ -553,6 +800,12 @@ int main(int argc, char **argv) {
         return 2;
       }
       restore_bundle_dir = argv[++i];
+    } else if (streq(argv[i], "--restore-dwarf-bundle")) {
+      if (i + 1 >= argc) {
+        print_usage(argv[0]);
+        return 2;
+      }
+      dwarf_restore_bundle_dir = argv[++i];
     } else if (streq(argv[i], "--help") || streq(argv[i], "-h")) {
       print_usage(argv[0]);
       return 0;
@@ -565,6 +818,9 @@ int main(int argc, char **argv) {
 
   if (restore_bundle_dir) {
     return run_known_symbol_restore(restore_bundle_dir);
+  }
+  if (dwarf_restore_bundle_dir) {
+    return run_dwarf_restore(dwarf_restore_bundle_dir);
   }
   if (streq(fixture, "all")) {
     return run_all_fixtures(resource_path, argc);

--- a/packages/microvm/assets/raw-process-capture.c
+++ b/packages/microvm/assets/raw-process-capture.c
@@ -26,9 +26,11 @@
 #include <unistd.h>
 
 #define RAW_CAPTURE_MAX_SYMBOLS 32u
+#define RAW_CAPTURE_MAX_FOLLOW_LISTS 8u
 #define RAW_CAPTURE_MAX_THREADS 64u
 #define RAW_CAPTURE_MAX_ARGV 128u
 #define RAW_CAPTURE_REG_BYTES 1024u
+#define RAW_CAPTURE_MAX_FOLLOW_NODE_SIZE (1024u * 1024u)
 #define RAW_CAPTURE_CONTROLLED_NODE_SIZE 16u
 #define RAW_CAPTURE_CONTROLLED_HEAP_STATE_SIZE 24u
 #define RAW_CAPTURE_CONTROLLED_MAX_NODES 64u
@@ -47,10 +49,21 @@ struct CaptureSymbol {
   uint64_t size_bytes;
 };
 
+struct FollowList {
+  char root_symbol[128];
+  uint64_t head_offset;
+  uint64_t count_offset;
+  uint64_t node_size;
+  uint64_t next_offset;
+  char chunk_prefix[128];
+};
+
 struct Options {
   const char *output_dir;
   struct CaptureSymbol symbols[RAW_CAPTURE_MAX_SYMBOLS];
   uint32_t symbol_count;
+  struct FollowList follow_lists[RAW_CAPTURE_MAX_FOLLOW_LISTS];
+  uint32_t follow_list_count;
   int command_index;
 };
 
@@ -160,9 +173,66 @@ static void parse_symbol(struct Options *opts, const char *spec) {
   symbol->size_bytes = parse_u64(second + 1, "symbol size");
 }
 
+static char *next_token(char **cursor) {
+  char *token = *cursor;
+  if (!token) {
+    return NULL;
+  }
+  char *separator = strchr(token, ':');
+  if (separator) {
+    *separator = '\0';
+    *cursor = separator + 1;
+  } else {
+    *cursor = NULL;
+  }
+  return token;
+}
+
+static void parse_follow_list(struct Options *opts, const char *spec) {
+  if (opts->follow_list_count >= RAW_CAPTURE_MAX_FOLLOW_LISTS) {
+    fail("too many follow lists");
+  }
+
+  char scratch[512];
+  if (snprintf(scratch, sizeof(scratch), "%s", spec) >= (int)sizeof(scratch)) {
+    fail("follow-list spec too long");
+  }
+
+  char *cursor = scratch;
+  char *root = next_token(&cursor);
+  char *head_offset = next_token(&cursor);
+  char *count_offset = next_token(&cursor);
+  char *node_size = next_token(&cursor);
+  char *next_offset = next_token(&cursor);
+  char *prefix = next_token(&cursor);
+  if (!root || !head_offset || !count_offset || !node_size || !next_offset || !prefix || cursor) {
+    fail("--follow-list must be root-symbol:head-offset:count-offset:node-size:next-offset:chunk-prefix");
+  }
+
+  struct FollowList *follow = &opts->follow_lists[opts->follow_list_count++];
+  if (snprintf(follow->root_symbol, sizeof(follow->root_symbol), "%s", root) >=
+      (int)sizeof(follow->root_symbol)) {
+    fail("follow-list root symbol too long");
+  }
+  follow->head_offset = parse_u64(head_offset, "follow-list head offset");
+  follow->count_offset = parse_u64(count_offset, "follow-list count offset");
+  follow->node_size = parse_u64(node_size, "follow-list node size");
+  follow->next_offset = parse_u64(next_offset, "follow-list next offset");
+  if (follow->node_size == 0 || follow->node_size > RAW_CAPTURE_MAX_FOLLOW_NODE_SIZE) {
+    fail("follow-list node size is out of range");
+  }
+  if (snprintf(follow->chunk_prefix, sizeof(follow->chunk_prefix), "%s", prefix) >=
+      (int)sizeof(follow->chunk_prefix)) {
+    fail("follow-list chunk prefix too long");
+  }
+}
+
 static void usage(const char *argv0) {
   fprintf(stderr,
-      "usage: %s --output dir [--symbol name:address:size ...] -- program [args...]\n", argv0);
+      "usage: %s --output dir [--symbol name:address:size ...] "
+      "[--follow-list root:head-offset:count-offset:node-size:next-offset:prefix ...] "
+      "-- program [args...]\n",
+      argv0);
 }
 
 static struct Options parse_args(int argc, char **argv) {
@@ -180,6 +250,12 @@ static struct Options parse_args(int argc, char **argv) {
         exit(2);
       }
       parse_symbol(&opts, argv[++i]);
+    } else if (streq(argv[i], "--follow-list")) {
+      if (i + 1 >= argc) {
+        usage(argv[0]);
+        exit(2);
+      }
+      parse_follow_list(&opts, argv[++i]);
     } else if (streq(argv[i], "--")) {
       opts.command_index = i + 1;
       break;
@@ -512,8 +588,17 @@ static uint64_t read_u64_native(const uint8_t *bytes) {
 
 static void read_process_memory(int mem_fd, uint64_t address, uint8_t *buffer, uint64_t size_bytes) {
   ssize_t got = pread(mem_fd, buffer, (size_t)size_bytes, (off_t)address);
-  if (got < 0 || (uint64_t)got != size_bytes) {
-    fail("failed to read process memory");
+  if (got < 0) {
+    fprintf(stderr, "machinen-raw-capture: failed to read process memory at 0x%" PRIx64
+                    " (%" PRIu64 " bytes): %s\n",
+        address, size_bytes, strerror(errno));
+    exit(1);
+  }
+  if ((uint64_t)got != size_bytes) {
+    fprintf(stderr, "machinen-raw-capture: short process memory read at 0x%" PRIx64
+                    " (%zd of %" PRIu64 " bytes)\n",
+        address, got, size_bytes);
+    exit(1);
   }
 }
 
@@ -560,8 +645,58 @@ static void append_controlled_heap_nodes(FILE *json, FILE *bin, bool *first, uin
   }
 }
 
+static void require_u64_window(uint64_t offset, uint64_t size, const char *field) {
+  if (offset > size || size - offset < sizeof(uint64_t)) {
+    fprintf(stderr, "machinen-raw-capture: follow-list %s offset is out of range\n", field);
+    exit(1);
+  }
+}
+
+static void append_follow_list_nodes(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
+    int mem_fd, const struct FollowList *follow, const uint8_t *root, uint64_t root_size) {
+  require_u64_window(follow->head_offset, root_size, "head");
+  require_u64_window(follow->count_offset, root_size, "count");
+  require_u64_window(follow->next_offset, follow->node_size, "next");
+
+  uint64_t node_address = read_u64_native(root + follow->head_offset);
+  uint64_t node_count = read_u64_native(root + follow->count_offset);
+  if (node_count > RAW_CAPTURE_CONTROLLED_MAX_NODES) {
+    fail("follow-list node count too large");
+  }
+
+  uint8_t *node = malloc((size_t)follow->node_size);
+  if (!node) {
+    die("malloc follow-list node");
+  }
+
+  for (uint64_t i = 0; i < node_count && node_address != 0; i++) {
+    char name[192];
+    read_process_memory(mem_fd, node_address, node, follow->node_size);
+    int written = snprintf(name, sizeof(name), "%s_%" PRIu64, follow->chunk_prefix, i);
+    if (written < 0 || written >= (int)sizeof(name)) {
+      fail("follow-list node name too long");
+    }
+    append_memory_chunk(json, bin, first, file_offset, name, node_address, node, follow->node_size);
+    node_address = read_u64_native(node + follow->next_offset);
+  }
+
+  free(node);
+}
+
+static void append_matching_follow_lists(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
+    int mem_fd, const struct Options *opts, const struct CaptureSymbol *symbol,
+    const uint8_t *buffer) {
+  for (uint32_t i = 0; i < opts->follow_list_count; i++) {
+    const struct FollowList *follow = &opts->follow_lists[i];
+    if (streq(follow->root_symbol, symbol->name)) {
+      append_follow_list_nodes(json, bin, first, file_offset, mem_fd, follow, buffer,
+          symbol->size_bytes);
+    }
+  }
+}
+
 static void append_symbol_memory(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
-    int mem_fd, const struct CaptureSymbol *symbol) {
+    int mem_fd, const struct Options *opts, const struct CaptureSymbol *symbol) {
   if (symbol->size_bytes > 1024u * 1024u) {
     fail("symbol capture too large");
   }
@@ -575,6 +710,7 @@ static void append_symbol_memory(FILE *json, FILE *bin, bool *first, uint64_t *f
   if (streq(symbol->name, "machinen_controlled_heap_state")) {
     append_controlled_heap_nodes(json, bin, first, file_offset, mem_fd, buffer, symbol->size_bytes);
   }
+  append_matching_follow_lists(json, bin, first, file_offset, mem_fd, opts, symbol, buffer);
   free(buffer);
 }
 
@@ -598,7 +734,7 @@ static void write_memory(const struct Options *opts, pid_t child) {
   bool first = true;
   uint64_t file_offset = 0;
   for (uint32_t i = 0; i < opts->symbol_count; i++) {
-    append_symbol_memory(json, bin, &first, &file_offset, mem_fd, &opts->symbols[i]);
+    append_symbol_memory(json, bin, &first, &file_offset, mem_fd, opts, &opts->symbols[i]);
   }
 
   fputs("]}\n", json);

--- a/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
+++ b/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
@@ -43,10 +43,15 @@ describe("controlled binary corpus", () => {
       "stack",
       "resource",
       "threads",
+      "dwarf",
     ]);
     expect(summary.native.events.find((event) => event.fixture === "stack")).toMatchObject({
       continuation: "controlled_nested_stack_point",
       live_local: 5242,
+    });
+    expect(summary.native.events.find((event) => event.fixture === "dwarf")).toMatchObject({
+      global: { label: "dwarf-global-layout-v2", counter: 7000 },
+      heap: { values: [111, 222, 333], tags: [101, 102, 103] },
     });
     expect(summary.crossBuilds.map((build) => build.arch)).toEqual(["arm64", "amd64"]);
     expect(summary.crossBuilds.every((build) => build.bytes > 0)).toBe(true);

--- a/packages/runtime/src/__tests__/dwarf-symbol-extract.test.ts
+++ b/packages/runtime/src/__tests__/dwarf-symbol-extract.test.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePortableSnapshotBundle } from "../vm/portable-snapshot.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/dwarf-symbol-extract.mjs");
+const TMP: string[] = [];
+
+interface DwarfSummary {
+  skipped?: boolean;
+  hostArch: string;
+  bundleDir: string;
+  dwarf: {
+    layouts: {
+      global: { fields: Array<{ name: string; offset: number; pointer: boolean }> };
+      heap: { fields: Array<{ name: string; offset: number; pointer: boolean }> };
+      node: { fields: Array<{ name: string; offset: number; pointer: boolean }> };
+    };
+    layoutMapping: {
+      heap: { fields: Array<{ name: string; sourceOffset: number; targetOffset: number }> };
+      node: { fields: Array<{ name: string; sourceOffset: number; targetOffset: number }> };
+    };
+    stackProbe: { variables: Array<{ name: string; location: string }> };
+  };
+  semanticState: {
+    global: { label: string; counter: number; flags: number; generation: number };
+    heap: {
+      nodeCount: number;
+      values: number[];
+      tags: number[];
+      colors: number[];
+      nodes: Array<{ id: string; value: number; sourceAddress: string }>;
+    };
+  };
+  restoreEvent: {
+    fixture: string;
+    arch: string;
+    global: { label: string; counter: number; flags: number; generation: number };
+    heap: { node_count: number; values: number[]; tags: number[]; colors: number[] };
+  };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("DWARF metadata extraction", () => {
+  it.skipIf(process.platform !== "linux")(
+    "uses DWARF layouts to extract global and heap state",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "dwarf-symbol-extract-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as DwarfSummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.semanticState.global).toMatchObject({
+        label: "dwarf-global-layout-v2",
+        counter: 7000,
+        flags: 0x5a5a,
+        generation: 7,
+      });
+      expect(summary.semanticState.heap).toMatchObject({
+        nodeCount: 3,
+        values: [111, 222, 333],
+        tags: [101, 102, 103],
+        colors: [3, 5, 7],
+      });
+      expect(summary.restoreEvent).toMatchObject({
+        fixture: "dwarf-restore",
+        global: {
+          label: summary.semanticState.global.label,
+          counter: summary.semanticState.global.counter,
+          flags: summary.semanticState.global.flags,
+          generation: summary.semanticState.global.generation,
+        },
+      });
+      expect(summary.restoreEvent.heap.values).toEqual([111, 222, 333]);
+
+      expect(
+        summary.dwarf.layouts.heap.fields.find((field) => field.name === "head"),
+      ).toMatchObject({
+        pointer: true,
+      });
+      expect(
+        summary.dwarf.layouts.node.fields.find((field) => field.name === "next"),
+      ).toMatchObject({
+        pointer: true,
+      });
+      expect(summary.dwarf.layoutMapping.node.fields.map((field) => field.name)).toEqual([
+        "tag",
+        "color",
+        "value",
+        "next",
+      ]);
+      expect(
+        summary.dwarf.stackProbe.variables.some((variable) => variable.name === "live_local"),
+      ).toBe(true);
+
+      const bundle = validatePortableSnapshotBundle(summary.bundleDir);
+      expect(bundle.manifest.features).toContain("dwarf-metadata-extraction");
+      expect(bundle.objects.objects.map((object) => object.id)).toEqual([
+        "controlled-dwarf-global-state",
+        "controlled-dwarf-heap-state",
+        "controlled-dwarf-node-0",
+        "controlled-dwarf-node-1",
+        "controlled-dwarf-node-2",
+      ]);
+      expect(bundle.relocations.relocations).toHaveLength(3);
+    },
+  );
+});

--- a/scripts/controlled-binary-corpus.mjs
+++ b/scripts/controlled-binary-corpus.mjs
@@ -12,7 +12,7 @@ import {
 } from "./proof-script-utils.mjs";
 
 const MARKER = "MACHINEN_CONTROLLED_BINARY ";
-const FIXTURES = ["global", "heap", "stack", "resource", "threads"];
+const FIXTURES = ["global", "heap", "stack", "resource", "threads", "dwarf"];
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SOURCE = join(REPO_ROOT, "packages/microvm/assets/controlled-binary-corpus.c");
 const CROSS_TARGETS = [
@@ -162,6 +162,25 @@ function validateSummary(summary) {
   assert(
     threads.threads.every((thread) => thread.at_observation === true),
     "thread fixture missed observation point",
+  );
+
+  const dwarf = requireFixture(events, "dwarf");
+  assert(dwarf.global.label === "dwarf-global-layout-v2", "dwarf global label changed");
+  assert(dwarf.global.counter === 7000, "dwarf global counter changed");
+  assert(dwarf.global.flags === 0x5a5a, "dwarf global flags changed");
+  assert(dwarf.global.generation === 7, "dwarf global generation changed");
+  assert(dwarf.heap.node_count === 3, "dwarf heap node count changed");
+  assert(
+    JSON.stringify(dwarf.heap.values) === JSON.stringify([111, 222, 333]),
+    "dwarf heap values changed",
+  );
+  assert(
+    JSON.stringify(dwarf.heap.tags) === JSON.stringify([101, 102, 103]),
+    "dwarf heap tags changed",
+  );
+  assert(
+    JSON.stringify(dwarf.heap.colors) === JSON.stringify([3, 5, 7]),
+    "dwarf heap colors changed",
   );
 
   const crossArches = summary.crossBuilds.map((build) => build.arch);

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -1,4 +1,11 @@
-import { existsSync, readFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCommand } from "./proof-script-utils.mjs";
@@ -9,6 +16,7 @@ export const CONTROLLED_SOURCE = join(
   "packages/microvm/assets/controlled-binary-corpus.c",
 );
 export const CAPTURE_SOURCE = join(REPO_ROOT, "packages/microvm/assets/raw-process-capture.c");
+export const CONTROLLED_MARKER = "MACHINEN_CONTROLLED_BINARY ";
 
 export function ensureSourcesExist(sources) {
   for (const source of sources) {
@@ -75,6 +83,129 @@ function parseNm(stdout) {
 
 export function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function loadRawCapture(captureDir) {
+  return {
+    manifest: readJson(join(captureDir, "manifest.json")),
+    symbols: readJson(join(captureDir, "symbols.json")),
+    memory: readJson(join(captureDir, "memory.json")),
+    memoryBin: readFileSync(join(captureDir, "memory.bin")),
+    targetLog: readFileSync(join(captureDir, "target.log"), "utf8"),
+  };
+}
+
+export function memoryChunkByName(capture, name) {
+  const chunk = capture.memory.chunks.find((candidate) => candidate.name === name);
+  if (!chunk) {
+    throw new Error(`missing memory chunk: ${name}`);
+  }
+  return chunk;
+}
+
+export function memoryChunkBytes(capture, chunk) {
+  return capture.memoryBin.subarray(chunk.fileOffset, chunk.fileOffset + chunk.sizeBytes);
+}
+
+export function buildPortableBundleMemory(capture) {
+  const chunks = capture.memory.chunks.map((source) => ({ ...source }));
+  const buffers = [];
+  let offset = 0;
+  for (const chunk of chunks) {
+    const bytes = memoryChunkBytes(capture, chunk);
+    chunk.bundleOffset = offset;
+    buffers.push(bytes);
+    offset += bytes.length;
+  }
+  return { chunks, bytes: Buffer.concat(buffers) };
+}
+
+export function controlledPortableManifest(options) {
+  return {
+    formatVersion: 1,
+    sourceGuestArch: hostArch(),
+    allowedTargetGuestArchs: ["arm64", "amd64"],
+    program: {
+      name: "controlled-binary-corpus",
+      executable: options.target,
+      identity: "com.redwoodjs.machinen.controlled-binary-corpus",
+    },
+    sourceBuild: { buildId: options.buildId, version: options.version },
+    targetBuild: { version: options.version },
+    checkpointAbi: {
+      version: 1,
+      checkpointFunction: { name: "machinen_checkpoint" },
+      rootsType: "machinen_checkpoint_roots",
+      restoreBundleType: "machinen_restore_bundle",
+      safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
+    },
+    checkpointContinuation: { name: options.checkpointContinuation },
+    restoreEntrypoint: { name: options.restoreEntrypoint },
+    process: {
+      argv: options.capture.manifest.target.argv,
+      env: { MACHINEN_CONTROLLED_ENV: "1" },
+      cwd: process.cwd(),
+    },
+    features: options.features,
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+export function writePortableBundleFiles(options) {
+  mkdirSync(options.bundleDir, { recursive: true });
+  mkdirSync(join(options.bundleDir, "logs"), { recursive: true });
+  writeFileSync(join(options.bundleDir, "memory.bin"), options.memory.bytes);
+  writeFileSync(join(options.bundleDir, "manifest.json"), jsonDocument(options.manifest));
+  writeFileSync(join(options.bundleDir, "objects.json"), jsonDocument(options.objects));
+  writeFileSync(join(options.bundleDir, "relocations.json"), jsonDocument(options.relocations));
+  writeFileSync(
+    join(options.bundleDir, "resources.json"),
+    jsonDocument(controlledResources(options.capture)),
+  );
+  for (const document of options.extraDocuments || []) {
+    writeFileSync(join(options.bundleDir, document.name), jsonDocument(document.value));
+  }
+  writeFileSync(join(options.bundleDir, "controlled-state.txt"), options.controlledStateText);
+  copyFileSync(
+    join(options.captureDir, "target.log"),
+    join(options.bundleDir, "logs/source-target.log"),
+  );
+}
+
+export function controlledResources(capture) {
+  return {
+    formatVersion: 1,
+    resources: [
+      { id: "argv", kind: "argv", state: "captured", argv: capture.manifest.target.argv },
+      { id: "env", kind: "env", state: "captured", env: { MACHINEN_CONTROLLED_ENV: "1" } },
+      { id: "cwd", kind: "cwd", state: "captured", path: process.cwd() },
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+export function parseControlledMarker(stdout, expectedFixture) {
+  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(CONTROLLED_MARKER));
+  if (!line) {
+    throw new Error("missing controlled binary marker");
+  }
+  const event = JSON.parse(line.slice(CONTROLLED_MARKER.length));
+  if (expectedFixture && event.fixture !== expectedFixture) {
+    throw new Error(`unexpected controlled fixture marker: ${event.fixture}`);
+  }
+  return event;
+}
+
+export function bundleFileStats(bundleDir, names) {
+  return names.map((name) => ({ name, bytes: statSync(join(bundleDir, name)).size }));
+}
+
+export function unsupportedVocabulary() {
+  return { vocabularyVersion: 1, refusals: [] };
+}
+
+export function jsonDocument(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
 }
 
 export function hostArch() {

--- a/scripts/dwarf-symbol-extract.mjs
+++ b/scripts/dwarf-symbol-extract.mjs
@@ -1,0 +1,847 @@
+#!/usr/bin/env node
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPTURE_SOURCE,
+  CONTROLLED_SOURCE,
+  buildPortableBundleMemory,
+  bundleFileStats as sharedBundleFileStats,
+  compileControlledTarget,
+  compileRawCapturer,
+  controlledPortableManifest,
+  ensureSourcesExist,
+  hostArch,
+  loadRawCapture,
+  memoryChunkByName,
+  memoryChunkBytes,
+  parseControlledMarker,
+  unsupportedVocabulary,
+  writePortableBundleFiles,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/dwarf-symbol-extract.mjs [verify] [--out-dir path] [--json] [--keep]";
+const DWARF_GLOBAL_SYMBOL = "machinen_controlled_dwarf_global_state";
+const DWARF_HEAP_SYMBOL = "machinen_controlled_dwarf_heap_state";
+const DWARF_NODE_PREFIX = "machinen_controlled_dwarf_node";
+const BUILD_ID = "4184184184184180";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(
+      args,
+      "dwarf-symbol-extract",
+      "DWARF extraction proof uses Linux /proc, ptrace, and readelf",
+    );
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-dwarf-symbol-extract-");
+  try {
+    emitResult(verifyDwarfExtraction(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyDwarfExtraction(outDir) {
+  ensureSourcesExist([CONTROLLED_SOURCE, CAPTURE_SOURCE]);
+  const binDir = join(outDir, "bin");
+  const captureDir = join(outDir, "capture-dwarf");
+  const bundleDir = join(outDir, "bundle");
+  mkdirSync(binDir, { recursive: true });
+
+  const target = compileControlledTarget(binDir);
+  const capturer = compileRawCapturer(binDir);
+  const dwarf = readDwarfModel(target);
+  const layouts = controlledDwarfLayouts(dwarf);
+  const stackProbe = summarizeStackProbe(dwarf);
+  runDwarfCapture({ capturer, target, layouts, captureDir });
+
+  const capture = loadRawCapture(captureDir);
+  const semanticState = recoverDwarfState(capture, layouts);
+  const layoutMapping = mapLayouts(layouts, layouts);
+  writePortableBundle({
+    bundleDir,
+    captureDir,
+    capture,
+    semanticState,
+    layouts,
+    layoutMapping,
+    target,
+    dwarfProducer: dwarf.producer,
+  });
+  const restoreEvent = runTargetRestore(target, bundleDir);
+  validateRestore(semanticState, restoreEvent);
+
+  return {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    captureDir,
+    bundleDir,
+    target,
+    dwarf: {
+      producer: dwarf.producer,
+      globals: [layouts.global.symbol, layouts.heap.symbol],
+      layouts: summarizeLayouts(layouts),
+      layoutMapping,
+      stackProbe,
+    },
+    semanticState,
+    restoreEvent,
+    bundleFiles: bundleFileStats(bundleDir),
+  };
+}
+
+function readDwarfModel(target) {
+  const result = runCommand("readelf", ["--debug-dump=info", target], { label: "DWARF scan" });
+  const dies = parseDwarfInfo(result.stdout);
+  return buildDwarfModel(dies);
+}
+
+function parseDwarfInfo(text) {
+  const roots = [];
+  const byOffset = new Map();
+  const stack = [];
+  let current = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    current = processDwarfInfoLine(line, current, { roots, byOffset, stack });
+  }
+
+  return { roots, byOffset, all: [...byOffset.values()] };
+}
+
+function processDwarfInfoLine(line, current, state) {
+  const die = parseDieLine(line);
+  if (die) {
+    return appendDieNode({ die, ...state });
+  }
+  const attr = parseAttributeLine(line);
+  if (attr && current) {
+    current.attrs.set(attr.name, attr.value);
+  }
+  return current;
+}
+
+function parseDieLine(line) {
+  const match =
+    /^\s*<(\d+)><([0-9a-fA-F]+)>:\s+Abbrev Number:\s+\d+(?:\s+\((DW_TAG_[^)]+)\))?/.exec(line);
+  return match ? { level: Number(match[1]), offset: match[2], tag: match[3] } : null;
+}
+
+function appendDieNode({ die, roots, byOffset, stack }) {
+  if (!die.tag) {
+    return null;
+  }
+  const node = {
+    level: die.level,
+    offset: normalizeDwarfOffset(die.offset),
+    tag: die.tag,
+    attrs: new Map(),
+    children: [],
+    parent: null,
+  };
+  const parent = die.level > 0 ? stack[die.level - 1] : null;
+  if (parent) {
+    node.parent = parent;
+    parent.children.push(node);
+  } else {
+    roots.push(node);
+  }
+  stack[die.level] = node;
+  stack.length = die.level + 1;
+  byOffset.set(node.offset, node);
+  return node;
+}
+
+function parseAttributeLine(line) {
+  const match = /^\s*<[^>]+>\s+(DW_AT_[^\s:]+)\s*:\s+(.*)$/.exec(line);
+  return match ? { name: match[1], value: match[2].trim() } : null;
+}
+
+function buildDwarfModel(dies) {
+  const producerNode = dies.all.find((node) => node.attrs.has("DW_AT_producer"));
+  return {
+    ...dies,
+    producer: producerNode ? parseDwarfString(producerNode.attrs.get("DW_AT_producer")) : "unknown",
+    findTypeByName(name) {
+      const node = dies.all.find(
+        (candidate) => candidate.tag === "DW_TAG_structure_type" && dwarfName(candidate) === name,
+      );
+      assert(node, `missing DWARF struct type: ${name}`);
+      return node;
+    },
+    findGlobal(name) {
+      const node = dies.all.find(
+        (candidate) =>
+          candidate.tag === "DW_TAG_variable" &&
+          dwarfName(candidate) === name &&
+          !candidate.attrs.has("DW_AT_declaration"),
+      );
+      assert(node, `missing DWARF global variable: ${name}`);
+      return node;
+    },
+    describeType(ref) {
+      return describeType(dies.byOffset, ref);
+    },
+    typeSize(ref) {
+      return typeSize(dies.byOffset, ref);
+    },
+    isPointerType(ref) {
+      return isPointerType(dies.byOffset, ref);
+    },
+  };
+}
+
+function controlledDwarfLayouts(dwarf) {
+  const globalType = dwarf.findTypeByName("ControlledDwarfGlobalState");
+  const heapType = dwarf.findTypeByName("ControlledDwarfHeapState");
+  const nodeType = dwarf.findTypeByName("ControlledDwarfNode");
+  return {
+    global: {
+      symbol: globalVariable(dwarf, DWARF_GLOBAL_SYMBOL),
+      layout: structLayout(dwarf, globalType),
+    },
+    heap: {
+      symbol: globalVariable(dwarf, DWARF_HEAP_SYMBOL),
+      layout: structLayout(dwarf, heapType),
+    },
+    node: { layout: structLayout(dwarf, nodeType) },
+  };
+}
+
+function globalVariable(dwarf, name) {
+  const variable = dwarf.findGlobal(name);
+  const typeRef = parseDwarfRef(requireAttr(variable, "DW_AT_type"));
+  const address = parseDwarfAddress(requireAttr(variable, "DW_AT_location"));
+  const type = dwarf.describeType(typeRef);
+  const sizeBytes = dwarf.typeSize(typeRef);
+  return { name, address, type, sizeBytes, typeRef };
+}
+
+function structLayout(dwarf, typeNode) {
+  const name = parseDwarfName(typeNode);
+  const byteSize = parseDwarfInteger(requireAttr(typeNode, "DW_AT_byte_size"));
+  const members = typeNode.children
+    .filter((child) => child.tag === "DW_TAG_member")
+    .map((member) => {
+      const typeRef = parseDwarfRef(requireAttr(member, "DW_AT_type"));
+      return {
+        name: parseDwarfName(member),
+        offset: member.attrs.has("DW_AT_data_member_location")
+          ? parseMemberOffset(member.attrs.get("DW_AT_data_member_location"))
+          : 0,
+        type: dwarf.describeType(typeRef),
+        typeRef,
+        sizeBytes: dwarf.typeSize(typeRef),
+        pointer: dwarf.isPointerType(typeRef),
+      };
+    })
+    .sort((left, right) => left.offset - right.offset);
+  return { type: `struct ${name}`, name, byteSize, members };
+}
+
+function summarizeLayouts(layouts) {
+  return {
+    global: summarizeLayout(layouts.global.layout),
+    heap: summarizeLayout(layouts.heap.layout),
+    node: summarizeLayout(layouts.node.layout),
+  };
+}
+
+function summarizeLayout(layout) {
+  return {
+    type: layout.type,
+    byteSize: layout.byteSize,
+    fields: layout.members.map((member) => ({
+      name: member.name,
+      offset: member.offset,
+      sizeBytes: member.sizeBytes,
+      type: member.type,
+      pointer: member.pointer,
+    })),
+  };
+}
+
+function summarizeStackProbe(dwarf) {
+  const subprogram = dwarf.all.find(
+    (candidate) =>
+      candidate.tag === "DW_TAG_subprogram" &&
+      dwarfName(candidate) === "controlled_nested_stack_point",
+  );
+  if (!subprogram) {
+    return { function: "controlled_nested_stack_point", variables: [], limitation: "not found" };
+  }
+  return {
+    function: "controlled_nested_stack_point",
+    variables: subprogram.children
+      .filter((child) => child.tag === "DW_TAG_variable" || child.tag === "DW_TAG_formal_parameter")
+      .map((child) => ({
+        name: parseDwarfName(child),
+        tag: child.tag,
+        type: child.attrs.has("DW_AT_type")
+          ? dwarf.describeType(parseDwarfRef(child.attrs.get("DW_AT_type")))
+          : "unknown",
+        location:
+          child.attrs.get("DW_AT_location") || child.attrs.get("DW_AT_location_list") || "missing",
+      })),
+  };
+}
+
+function runDwarfCapture(context) {
+  const global = context.layouts.global.symbol;
+  const heap = context.layouts.heap.symbol;
+  const heapLayout = context.layouts.heap.layout;
+  const nodeLayout = context.layouts.node.layout;
+  const resourceFile = join(context.captureDir, "resource-file.txt");
+  const followList = [
+    heap.name,
+    field(heapLayout, "head").offset,
+    field(heapLayout, "node_count").offset,
+    nodeLayout.byteSize,
+    field(nodeLayout, "next").offset,
+    DWARF_NODE_PREFIX,
+  ].join(":");
+
+  runCommand(
+    context.capturer,
+    [
+      "--output",
+      context.captureDir,
+      "--symbol",
+      `${global.name}:${global.address}:${global.sizeBytes}`,
+      "--symbol",
+      `${heap.name}:${heap.address}:${heap.sizeBytes}`,
+      "--follow-list",
+      followList,
+      "--",
+      context.target,
+      "--fixture",
+      "dwarf",
+      "--pause-at-observation",
+      "--resource-file",
+      resourceFile,
+    ],
+    {
+      label: "DWARF-guided raw capture",
+      env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+    },
+  );
+}
+
+function recoverDwarfState(capture, layouts) {
+  const globalChunk = memoryChunkByName(capture, DWARF_GLOBAL_SYMBOL);
+  const heapChunk = memoryChunkByName(capture, DWARF_HEAP_SYMBOL);
+  const globalBytes = memoryChunkBytes(capture, globalChunk);
+  const heapBytes = memoryChunkBytes(capture, heapChunk);
+  const heapLayout = layouts.heap.layout;
+  const nodeLayout = layouts.node.layout;
+
+  const nodeCount = Number(readUnsigned(heapBytes, field(heapLayout, "node_count")));
+  const checksum = readUnsigned(heapBytes, field(heapLayout, "checksum"));
+  const headPointer = readUnsigned(heapBytes, field(heapLayout, "head"));
+  const nodes = [];
+  for (let i = 0; i < nodeCount; i++) {
+    const chunk = memoryChunkByName(capture, `${DWARF_NODE_PREFIX}_${i}`);
+    const bytes = memoryChunkBytes(capture, chunk);
+    nodes.push({
+      id: `controlled-dwarf-node-${i}`,
+      sourceAddress: chunk.sourceAddress,
+      tag: Number(readUnsigned(bytes, field(nodeLayout, "tag"))),
+      color: Number(readUnsigned(bytes, field(nodeLayout, "color"))),
+      value: Number(readUnsigned(bytes, field(nodeLayout, "value"))),
+      nextPointer: hexAddress(readUnsigned(bytes, field(nodeLayout, "next"))),
+      sizeBytes: chunk.sizeBytes,
+      memory: { offset: chunk.fileOffset, sizeBytes: chunk.sizeBytes },
+    });
+  }
+
+  return {
+    global: {
+      sourceAddress: globalChunk.sourceAddress,
+      sizeBytes: globalChunk.sizeBytes,
+      label: readCString(globalBytes, field(layouts.global.layout, "label")),
+      counter: Number(readUnsigned(globalBytes, field(layouts.global.layout, "counter"))),
+      flags: Number(readUnsigned(globalBytes, field(layouts.global.layout, "flags"))),
+      generation: Number(readUnsigned(globalBytes, field(layouts.global.layout, "generation"))),
+      memory: globalChunk,
+    },
+    heap: {
+      sourceAddress: heapChunk.sourceAddress,
+      sizeBytes: heapChunk.sizeBytes,
+      version: Number(readUnsigned(heapBytes, field(heapLayout, "version"))),
+      nodeCount,
+      checksum: checksum.toString(10),
+      checksumHex: hexAddress(checksum),
+      headPointer: hexAddress(headPointer),
+      values: nodes.map((node) => node.value),
+      tags: nodes.map((node) => node.tag),
+      colors: nodes.map((node) => node.color),
+      nodes,
+      memory: heapChunk,
+    },
+  };
+}
+
+function field(layout, name) {
+  const member = layout.members.find((candidate) => candidate.name === name);
+  if (!member) {
+    throw new Error(`missing DWARF field ${layout.type}.${name}`);
+  }
+  return member;
+}
+
+const UNSIGNED_READERS = new Map([
+  [1, (bytes, offset) => BigInt(bytes.readUInt8(offset))],
+  [2, (bytes, offset) => BigInt(bytes.readUInt16LE(offset))],
+  [4, (bytes, offset) => BigInt(bytes.readUInt32LE(offset))],
+  [8, (bytes, offset) => bytes.readBigUInt64LE(offset)],
+]);
+
+function readUnsigned(bytes, member) {
+  const offset = member.offset;
+  if (offset + member.sizeBytes > bytes.length) {
+    throw new Error(`field ${member.name} is outside captured bytes`);
+  }
+  const reader = UNSIGNED_READERS.get(member.sizeBytes);
+  if (!reader) {
+    throw new Error(`unsupported unsigned field width for ${member.name}: ${member.sizeBytes}`);
+  }
+  return reader(bytes, offset);
+}
+
+function readCString(bytes, member) {
+  const start = member.offset;
+  const limit = Math.min(bytes.length, start + member.sizeBytes);
+  let end = start;
+  while (end < limit && bytes[end] !== 0) {
+    end++;
+  }
+  return bytes.subarray(start, end).toString("utf8");
+}
+
+function writePortableBundle(context) {
+  const memory = buildPortableBundleMemory(context.capture);
+  writePortableBundleFiles({
+    bundleDir: context.bundleDir,
+    captureDir: context.captureDir,
+    capture: context.capture,
+    memory,
+    manifest: manifest(context),
+    objects: objects(memory.chunks, context),
+    relocations: relocations(context),
+    controlledStateText: controlledStateText(context.semanticState),
+    extraDocuments: [{ name: "dwarf-layout.json", value: dwarfLayoutDocument(context) }],
+  });
+}
+
+function manifest(context) {
+  return controlledPortableManifest({
+    target: context.target,
+    capture: context.capture,
+    buildId: BUILD_ID,
+    version: "dwarf-metadata-proof",
+    checkpointContinuation: "machinen_controlled_dwarf_observation",
+    restoreEntrypoint: "machinen_controlled_dwarf_restore",
+    features: ["controlled-binary-corpus", "external-raw-capture", "dwarf-metadata-extraction"],
+  });
+}
+
+function objects(chunks, context) {
+  const byName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+  const global = byName.get(DWARF_GLOBAL_SYMBOL);
+  const heap = byName.get(DWARF_HEAP_SYMBOL);
+  return {
+    formatVersion: 1,
+    objects: [
+      {
+        id: "controlled-dwarf-global-state",
+        kind: "global",
+        type: context.layouts.global.layout.type,
+        sizeBytes: global.sizeBytes,
+        sourceAddress: global.sourceAddress,
+        memory: { offset: global.bundleOffset, sizeBytes: global.sizeBytes },
+      },
+      {
+        id: "controlled-dwarf-heap-state",
+        kind: "global",
+        type: context.layouts.heap.layout.type,
+        sizeBytes: heap.sizeBytes,
+        sourceAddress: heap.sourceAddress,
+        memory: { offset: heap.bundleOffset, sizeBytes: heap.sizeBytes },
+      },
+      ...context.semanticState.heap.nodes.map((node, index) =>
+        nodeObject(byName, node, index, context),
+      ),
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function nodeObject(byName, node, index, context) {
+  const chunk = byName.get(`${DWARF_NODE_PREFIX}_${index}`);
+  return {
+    id: node.id,
+    kind: "heap",
+    type: context.layouts.node.layout.type,
+    sizeBytes: chunk.sizeBytes,
+    sourceAddress: chunk.sourceAddress,
+    allocation: { id: index + 1, sourceAddress: chunk.sourceAddress },
+    memory: { offset: chunk.bundleOffset, sizeBytes: chunk.sizeBytes },
+  };
+}
+
+function relocations(context) {
+  const heapHead = field(context.layouts.heap.layout, "head");
+  const nodeNext = field(context.layouts.node.layout, "next");
+  const relocs = [
+    {
+      fromObject: "controlled-dwarf-heap-state",
+      fromOffset: heapHead.offset,
+      toObject: "controlled-dwarf-node-0",
+      addend: 0,
+      kind: "pointer",
+      sourcePointer: context.semanticState.heap.headPointer,
+    },
+  ];
+  for (let i = 0; i + 1 < context.semanticState.heap.nodes.length; i++) {
+    relocs.push({
+      fromObject: `controlled-dwarf-node-${i}`,
+      fromOffset: nodeNext.offset,
+      toObject: `controlled-dwarf-node-${i + 1}`,
+      addend: 0,
+      kind: "pointer",
+      sourcePointer: context.semanticState.heap.nodes[i].nextPointer,
+    });
+  }
+  return { formatVersion: 1, relocations: relocs, unsupported: unsupportedVocabulary() };
+}
+
+function dwarfLayoutDocument(context) {
+  return {
+    formatVersion: 1,
+    sourceGuestArch: hostArch(),
+    producer: context.dwarfProducer,
+    globals: [context.layouts.global.symbol, context.layouts.heap.symbol].map((symbol) => ({
+      name: symbol.name,
+      address: symbol.address,
+      sizeBytes: symbol.sizeBytes,
+      type: symbol.type,
+    })),
+    layouts: summarizeLayouts(context.layouts),
+    layoutMapping: context.layoutMapping,
+  };
+}
+
+function controlledStateText(semanticState) {
+  const lines = [
+    `global_label=${semanticState.global.label}`,
+    `global_counter=${semanticState.global.counter}`,
+    `global_flags=${semanticState.global.flags}`,
+    `global_generation=${semanticState.global.generation}`,
+    `node_count=${semanticState.heap.nodeCount}`,
+  ];
+  semanticState.heap.values.forEach((value, index) => lines.push(`value${index}=${value}`));
+  semanticState.heap.tags.forEach((value, index) => lines.push(`tag${index}=${value}`));
+  semanticState.heap.colors.forEach((value, index) => lines.push(`color${index}=${value}`));
+  lines.push(`checksum=${semanticState.heap.checksumHex}`, "");
+  return lines.join("\n");
+}
+
+function mapLayouts(source, target) {
+  return {
+    global: mapLayout(source.global.layout, target.global.layout),
+    heap: mapLayout(source.heap.layout, target.heap.layout),
+    node: mapLayout(source.node.layout, target.node.layout),
+  };
+}
+
+function mapLayout(source, target) {
+  return {
+    sourceType: source.type,
+    targetType: target.type,
+    fields: source.members.map((sourceField) => {
+      const targetField = field(target, sourceField.name);
+      return {
+        name: sourceField.name,
+        sourceOffset: sourceField.offset,
+        targetOffset: targetField.offset,
+        sourceType: sourceField.type,
+        targetType: targetField.type,
+        pointer: sourceField.pointer || targetField.pointer,
+      };
+    }),
+  };
+}
+
+function runTargetRestore(target, bundleDir) {
+  const result = runCommand(target, ["--restore-dwarf-bundle", bundleDir], {
+    label: "DWARF target restore",
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+  return parseControlledMarker(result.stdout, "dwarf-restore");
+}
+
+function validateRestore(semanticState, restoreEvent) {
+  assert(restoreEvent.arch === hostArch(), "restore ran on unexpected host architecture");
+  assert(restoreEvent.global.label === semanticState.global.label, "restored global label changed");
+  assert(
+    restoreEvent.global.counter === semanticState.global.counter,
+    "restored global counter changed",
+  );
+  assert(restoreEvent.global.flags === semanticState.global.flags, "restored global flags changed");
+  assert(
+    restoreEvent.global.generation === semanticState.global.generation,
+    "restored global generation changed",
+  );
+  assert(
+    restoreEvent.heap.node_count === semanticState.heap.nodeCount,
+    "restored node count changed",
+  );
+  assert(
+    JSON.stringify(restoreEvent.heap.values) === JSON.stringify(semanticState.heap.values),
+    "restored node values changed",
+  );
+  assert(
+    JSON.stringify(restoreEvent.heap.tags) === JSON.stringify(semanticState.heap.tags),
+    "restored node tags changed",
+  );
+  assert(
+    JSON.stringify(restoreEvent.heap.colors) === JSON.stringify(semanticState.heap.colors),
+    "restored node colors changed",
+  );
+  assert(restoreEvent.heap.checksum_hex === semanticState.heap.checksumHex, "checksum changed");
+}
+
+function bundleFileStats(bundleDir) {
+  return sharedBundleFileStats(bundleDir, [
+    "manifest.json",
+    "objects.json",
+    "relocations.json",
+    "resources.json",
+    "dwarf-layout.json",
+    "memory.bin",
+  ]);
+}
+
+function dwarfName(node) {
+  return node.attrs.has("DW_AT_name") ? parseDwarfString(node.attrs.get("DW_AT_name")) : undefined;
+}
+
+function parseDwarfName(node) {
+  const name = dwarfName(node);
+  assert(name !== undefined, `missing DW_AT_name on ${node.tag} ${node.offset}`);
+  return name;
+}
+
+function parseDwarfString(raw) {
+  const value = String(raw).trim();
+  const indirect = /\):\s*(.*)$/.exec(value);
+  if (indirect) {
+    return indirect[1].trim();
+  }
+  const lineString = /^\([^)]*\)\s*(.*)$/.exec(value);
+  if (lineString && lineString[1]) {
+    return lineString[1].trim();
+  }
+  return value;
+}
+
+function parseDwarfRef(raw) {
+  const match = /<0x([0-9a-fA-F]+)>/.exec(String(raw));
+  assert(match, `missing DWARF reference in ${raw}`);
+  return normalizeDwarfOffset(match[1]);
+}
+
+function parseDwarfAddress(raw) {
+  const match = /DW_OP_addr:\s*(?:0x)?([0-9a-fA-F]+)/.exec(String(raw));
+  assert(match, `missing DW_OP_addr in ${raw}`);
+  return hexAddress(BigInt(`0x${match[1]}`));
+}
+
+function parseDwarfInteger(raw) {
+  const text = String(raw).trim();
+  const plusUconst = /DW_OP_plus_uconst:\s*(0x[0-9a-fA-F]+|\d+)/.exec(text);
+  if (plusUconst) {
+    return Number.parseInt(plusUconst[1], 0);
+  }
+  const match = /(0x[0-9a-fA-F]+|\d+)/.exec(text);
+  assert(match, `missing integer in ${raw}`);
+  return Number.parseInt(match[1], 0);
+}
+
+function parseMemberOffset(raw) {
+  return parseDwarfInteger(raw);
+}
+
+function normalizeDwarfOffset(offset) {
+  return `0x${offset.replace(/^0x/i, "").toLowerCase()}`;
+}
+
+function requireAttr(node, name) {
+  const value = node.attrs.get(name);
+  assert(value !== undefined, `missing ${name} on ${node.tag} ${node.offset}`);
+  return value;
+}
+
+const TYPE_MODIFIER_TAGS = new Set([
+  "DW_TAG_const_type",
+  "DW_TAG_volatile_type",
+  "DW_TAG_restrict_type",
+  "DW_TAG_typedef",
+]);
+
+function describeType(byOffset, ref, seen = new Set()) {
+  const node = requireType(byOffset, ref);
+  if (seen.has(ref)) {
+    return dwarfName(node) || node.tag;
+  }
+  seen.add(ref);
+  return describeUnseenType(byOffset, node, seen);
+}
+
+function describeUnseenType(byOffset, node, seen) {
+  const named = describeSimpleType(node);
+  if (named) {
+    return named;
+  }
+  const compound = describeCompoundType(byOffset, node, seen);
+  if (compound) {
+    return compound;
+  }
+  return describeModifiedOrFallback(byOffset, node, seen);
+}
+
+function describeModifiedOrFallback(byOffset, node, seen) {
+  const modified = describeModifiedType(byOffset, node, seen);
+  if (modified) {
+    return modified;
+  }
+  return dwarfName(node) || node.tag;
+}
+
+function describeCompoundType(byOffset, node, seen) {
+  if (node.tag === "DW_TAG_pointer_type") {
+    return `${describePointerTarget(byOffset, node, seen)} *`;
+  }
+  if (node.tag === "DW_TAG_array_type") {
+    const target = describeType(byOffset, parseDwarfRef(requireAttr(node, "DW_AT_type")), seen);
+    return `${target}[]`;
+  }
+  return null;
+}
+
+function describeModifiedType(byOffset, node, seen) {
+  return isTypeModifier(node)
+    ? describeType(byOffset, parseDwarfRef(requireAttr(node, "DW_AT_type")), seen)
+    : null;
+}
+
+function describeSimpleType(node) {
+  if (node.tag === "DW_TAG_base_type") {
+    return parseDwarfName(node);
+  }
+  if (node.tag === "DW_TAG_structure_type") {
+    return `struct ${dwarfName(node) || "<anonymous>"}`;
+  }
+  return null;
+}
+
+function describePointerTarget(byOffset, node, seen) {
+  return node.attrs.has("DW_AT_type")
+    ? describeType(byOffset, parseDwarfRef(node.attrs.get("DW_AT_type")), seen)
+    : "void";
+}
+
+function typeSize(byOffset, ref, seen = new Set()) {
+  const node = requireType(byOffset, ref);
+  const explicitSize = explicitTypeSize(node);
+  if (explicitSize !== null) {
+    return explicitSize;
+  }
+  if (seen.has(ref)) {
+    throw new Error(`recursive DWARF type size: ${ref}`);
+  }
+  seen.add(ref);
+  return derivedTypeSize(byOffset, node, seen, ref);
+}
+
+function explicitTypeSize(node) {
+  return node.attrs.has("DW_AT_byte_size")
+    ? parseDwarfInteger(node.attrs.get("DW_AT_byte_size"))
+    : null;
+}
+
+function derivedTypeSize(byOffset, node, seen, ref) {
+  if (node.tag === "DW_TAG_array_type") {
+    const elementSize = typeSize(byOffset, parseDwarfRef(requireAttr(node, "DW_AT_type")), seen);
+    return elementSize * arrayElementCount(node);
+  }
+  if (isTypeModifier(node)) {
+    return typeSize(byOffset, parseDwarfRef(requireAttr(node, "DW_AT_type")), seen);
+  }
+  throw new Error(`DWARF type has no size: ${node.tag} ${ref}`);
+}
+
+function arrayElementCount(node) {
+  const subrange = node.children.find((child) => child.tag === "DW_TAG_subrange_type");
+  assert(subrange, `array type ${node.offset} has no subrange`);
+  if (subrange.attrs.has("DW_AT_count")) {
+    return parseDwarfInteger(subrange.attrs.get("DW_AT_count"));
+  }
+  if (subrange.attrs.has("DW_AT_upper_bound")) {
+    return parseDwarfInteger(subrange.attrs.get("DW_AT_upper_bound")) + 1;
+  }
+  throw new Error(`array type ${node.offset} has no count or upper bound`);
+}
+
+function isPointerType(byOffset, ref, seen = new Set()) {
+  const node = requireType(byOffset, ref);
+  if (node.tag === "DW_TAG_pointer_type") {
+    return true;
+  }
+  if (seen.has(ref) || !isTypeModifier(node)) {
+    return false;
+  }
+  seen.add(ref);
+  return isPointerType(byOffset, parseDwarfRef(requireAttr(node, "DW_AT_type")), seen);
+}
+
+function isTypeModifier(node) {
+  return TYPE_MODIFIER_TAGS.has(node.tag);
+}
+
+function requireType(byOffset, ref) {
+  const node = byOffset.get(ref);
+  assert(node, `missing DWARF type ${ref}`);
+  return node;
+}
+
+function hexAddress(value) {
+  return `0x${value.toString(16)}`;
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `dwarf-symbol-extract: ${summary.hostArch} extracted global + ${summary.semanticState.heap.nodeCount} heap nodes`,
+  );
+  console.log(
+    `dwarf-symbol-extract: restored ${summary.semanticState.global.label} values ${summary.restoreEvent.heap.values.join(",")}`,
+  );
+  if (temporary) {
+    console.log("dwarf-symbol-extract: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+main();

--- a/scripts/known-symbol-extract.mjs
+++ b/scripts/known-symbol-extract.mjs
@@ -1,15 +1,23 @@
 #!/usr/bin/env node
-import { copyFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import {
   CAPTURE_SOURCE,
   CONTROLLED_SOURCE,
+  buildPortableBundleMemory,
+  bundleFileStats as sharedBundleFileStats,
   compileControlledTarget,
   compileRawCapturer,
+  controlledPortableManifest,
   ensureSourcesExist,
   hostArch,
-  readJson,
+  loadRawCapture,
+  memoryChunkByName,
+  memoryChunkBytes,
+  parseControlledMarker,
   readSymbols,
+  unsupportedVocabulary,
+  writePortableBundleFiles,
 } from "./controlled-corpus-utils.mjs";
 import {
   assert,
@@ -25,7 +33,6 @@ const USAGE =
   "usage: node scripts/known-symbol-extract.mjs [verify] [--out-dir path] [--json] [--keep]";
 const HEAP_STATE_SYMBOL = "machinen_controlled_heap_state";
 const BUILD_ID = "4174174174174170";
-const MARKER = "MACHINEN_CONTROLLED_BINARY ";
 
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
@@ -58,7 +65,7 @@ function verifyKnownSymbolExtraction(outDir) {
   const symbols = readSymbols(target, [HEAP_STATE_SYMBOL]);
   runHeapCapture({ capturer, target, symbols, captureDir });
 
-  const capture = loadCapture(captureDir);
+  const capture = loadRawCapture(captureDir);
   const semanticState = recoverHeapGraph(capture);
   writePortableBundle({ bundleDir, captureDir, capture, semanticState, target });
   const restoreEvent = runTargetRestore(target, bundleDir);
@@ -101,26 +108,17 @@ function runHeapCapture(context) {
   );
 }
 
-function loadCapture(captureDir) {
-  return {
-    manifest: readJson(join(captureDir, "manifest.json")),
-    symbols: readJson(join(captureDir, "symbols.json")),
-    memory: readJson(join(captureDir, "memory.json")),
-    memoryBin: readFileSync(join(captureDir, "memory.bin")),
-    targetLog: readFileSync(join(captureDir, "target.log"), "utf8"),
-  };
-}
-
 function recoverHeapGraph(capture) {
-  const heapState = chunkBytes(capture, HEAP_STATE_SYMBOL);
+  const heapStateChunk = memoryChunkByName(capture, HEAP_STATE_SYMBOL);
+  const heapState = memoryChunkBytes(capture, heapStateChunk);
   const nodeCount = Number(heapState.readBigUInt64LE(8));
   const checksum = heapState.readBigUInt64LE(16);
   const headPointer = heapState.readBigUInt64LE(0);
   const nodes = [];
 
   for (let i = 0; i < nodeCount; i++) {
-    const chunk = chunkByName(capture, `machinen_controlled_node_${i}`);
-    const bytes = chunkBytesByDescriptor(capture, chunk);
+    const chunk = memoryChunkByName(capture, `machinen_controlled_node_${i}`);
+    const bytes = memoryChunkBytes(capture, chunk);
     nodes.push({
       id: `controlled-node-${i}`,
       sourceAddress: chunk.sourceAddress,
@@ -139,27 +137,11 @@ function recoverHeapGraph(capture) {
     values: nodes.map((node) => node.value),
     nodes,
     heapState: {
-      sourceAddress: chunkByName(capture, HEAP_STATE_SYMBOL).sourceAddress,
+      sourceAddress: heapStateChunk.sourceAddress,
       sizeBytes: heapState.length,
-      memory: chunkByName(capture, HEAP_STATE_SYMBOL),
+      memory: heapStateChunk,
     },
   };
-}
-
-function chunkByName(capture, name) {
-  const chunk = capture.memory.chunks.find((candidate) => candidate.name === name);
-  if (!chunk) {
-    throw new Error(`missing memory chunk: ${name}`);
-  }
-  return chunk;
-}
-
-function chunkBytes(capture, name) {
-  return chunkBytesByDescriptor(capture, chunkByName(capture, name));
-}
-
-function chunkBytesByDescriptor(capture, chunk) {
-  return capture.memoryBin.subarray(chunk.fileOffset, chunk.fileOffset + chunk.sizeBytes);
 }
 
 function hexAddress(value) {
@@ -167,40 +149,17 @@ function hexAddress(value) {
 }
 
 function writePortableBundle(context) {
-  mkdirSync(context.bundleDir, { recursive: true });
-  mkdirSync(join(context.bundleDir, "logs"), { recursive: true });
-
-  const memory = buildBundleMemory(context.capture);
-  const objects = buildObjects(memory.chunks, context.semanticState);
-  writeFileSync(join(context.bundleDir, "memory.bin"), memory.bytes);
-  writeFileSync(join(context.bundleDir, "manifest.json"), json(manifest(context)));
-  writeFileSync(join(context.bundleDir, "objects.json"), json(objects));
-  writeFileSync(
-    join(context.bundleDir, "relocations.json"),
-    json(relocations(context.semanticState)),
-  );
-  writeFileSync(join(context.bundleDir, "resources.json"), json(resources(context.capture)));
-  writeFileSync(
-    join(context.bundleDir, "controlled-state.txt"),
-    controlledStateText(context.semanticState),
-  );
-  copyFileSync(
-    join(context.captureDir, "target.log"),
-    join(context.bundleDir, "logs/source-target.log"),
-  );
-}
-
-function buildBundleMemory(capture) {
-  const chunks = capture.memory.chunks.map((source) => ({ ...source }));
-  const buffers = [];
-  let offset = 0;
-  for (const chunk of chunks) {
-    const bytes = chunkBytesByDescriptor(capture, chunk);
-    chunk.bundleOffset = offset;
-    buffers.push(bytes);
-    offset += bytes.length;
-  }
-  return { chunks, bytes: Buffer.concat(buffers) };
+  const memory = buildPortableBundleMemory(context.capture);
+  writePortableBundleFiles({
+    bundleDir: context.bundleDir,
+    captureDir: context.captureDir,
+    capture: context.capture,
+    memory,
+    manifest: manifest(context),
+    objects: buildObjects(memory.chunks, context.semanticState),
+    relocations: relocations(context.semanticState),
+    controlledStateText: controlledStateText(context.semanticState),
+  });
 }
 
 function buildObjects(chunks, semanticState) {
@@ -212,7 +171,7 @@ function buildObjects(chunks, semanticState) {
       heapStateObject(heapState),
       ...semanticState.nodes.map((node, index) => nodeObject(byName, node, index)),
     ],
-    unsupported: unsupported(),
+    unsupported: unsupportedVocabulary(),
   };
 }
 
@@ -241,41 +200,22 @@ function nodeObject(byName, node, index) {
 }
 
 function manifest(context) {
-  return {
-    formatVersion: 1,
-    sourceGuestArch: hostArch(),
-    allowedTargetGuestArchs: ["arm64", "amd64"],
-    program: {
-      name: "controlled-binary-corpus",
-      executable: context.target,
-      identity: "com.redwoodjs.machinen.controlled-binary-corpus",
-    },
-    sourceBuild: { buildId: BUILD_ID, version: "known-symbol-proof" },
-    targetBuild: { version: "known-symbol-proof" },
-    checkpointAbi: {
-      version: 1,
-      checkpointFunction: { name: "machinen_checkpoint" },
-      rootsType: "machinen_checkpoint_roots",
-      restoreBundleType: "machinen_restore_bundle",
-      safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
-    },
-    checkpointContinuation: { name: "machinen_controlled_heap_observation" },
-    restoreEntrypoint: { name: "machinen_controlled_known_symbol_restore" },
-    process: {
-      argv: context.capture.manifest.target.argv,
-      env: { MACHINEN_CONTROLLED_ENV: "1" },
-      cwd: process.cwd(),
-    },
+  return controlledPortableManifest({
+    target: context.target,
+    capture: context.capture,
+    buildId: BUILD_ID,
+    version: "known-symbol-proof",
+    checkpointContinuation: "machinen_controlled_heap_observation",
+    restoreEntrypoint: "machinen_controlled_known_symbol_restore",
     features: ["controlled-binary-corpus", "external-raw-capture", "known-symbol-extraction"],
-    unsupported: unsupported(),
-  };
+  });
 }
 
 function relocations(semanticState) {
   return {
     formatVersion: 1,
     relocations: [heapHeadRelocation(semanticState), ...nodeRelocations(semanticState)],
-    unsupported: unsupported(),
+    unsupported: unsupportedVocabulary(),
   };
 }
 
@@ -305,18 +245,6 @@ function nodeRelocations(semanticState) {
   return relocations;
 }
 
-function resources(capture) {
-  return {
-    formatVersion: 1,
-    resources: [
-      { id: "argv", kind: "argv", state: "captured", argv: capture.manifest.target.argv },
-      { id: "env", kind: "env", state: "captured", env: { MACHINEN_CONTROLLED_ENV: "1" } },
-      { id: "cwd", kind: "cwd", state: "captured", path: process.cwd() },
-    ],
-    unsupported: unsupported(),
-  };
-}
-
 function controlledStateText(semanticState) {
   return [
     `node_count=${semanticState.nodeCount}`,
@@ -328,30 +256,12 @@ function controlledStateText(semanticState) {
   ].join("\n");
 }
 
-function unsupported() {
-  return { vocabularyVersion: 1, refusals: [] };
-}
-
-function json(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
-}
-
 function runTargetRestore(target, bundleDir) {
   const result = runCommand(target, ["--restore-known-symbol-bundle", bundleDir], {
     label: "known-symbol target restore",
     env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
   });
-  const event = parseMarker(result.stdout);
-  assert(event.fixture === "known-symbol-restore", "target did not emit restore marker");
-  return event;
-}
-
-function parseMarker(stdout) {
-  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(MARKER));
-  if (!line) {
-    throw new Error("missing controlled binary restore marker");
-  }
-  return JSON.parse(line.slice(MARKER.length));
+  return parseControlledMarker(result.stdout, "known-symbol-restore");
 }
 
 function validateRestore(semanticState, restoreEvent) {
@@ -365,9 +275,13 @@ function validateRestore(semanticState, restoreEvent) {
 }
 
 function bundleFileStats(bundleDir) {
-  return ["manifest.json", "objects.json", "relocations.json", "resources.json", "memory.bin"].map(
-    (name) => ({ name, bytes: statSync(join(bundleDir, name)).size }),
-  );
+  return sharedBundleFileStats(bundleDir, [
+    "manifest.json",
+    "objects.json",
+    "relocations.json",
+    "resources.json",
+    "memory.bin",
+  ]);
 }
 
 function printSummary(summary, temporary) {


### PR DESCRIPTION
## Problem

The known-symbol extractor could recover state, but it still knew the C struct offsets itself. That is too fragile. If a controlled fixture changes field order or adds padding, the extraction code should learn the layout from debug metadata instead of needing code changes.

## Solution

This adds a DWARF metadata extraction proof. The verifier reads DWARF from the controlled debug build, finds exported globals, reads struct field offsets, detects pointer fields, follows the heap list with a generic raw-capture follow plan, and emits a portable bundle with `dwarf-layout.json`.

It also adds a DWARF-specific controlled fixture with a different struct layout, restores the extracted global and heap state, and documents the limits around optimized builds, inlining, register-only locals, and stack-frame metadata.

Closes #418.

## Validation

- `pnpm controlled-binary-corpus`
- `pnpm dwarf-symbol-extract` on macOS arm64 skips as expected
- `pnpm dwarf-symbol-extract` on Linux arm64 via `friend@100.126.46.90`
- `pnpm dwarf-symbol-extract` on Linux amd64 via office Proxmox/Docker
- arm64 DWARF-extracted bundle restored into an amd64 controlled target on the office Proxmox host
- `pnpm exec fallow audit --changed-since origin/pp-417-known-symbol-extraction`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
