### PR TITLE
Add sidecar metadata extraction proof

### DIFF
--- a/docs/snapshot/machinen-meta.schema.json
+++ b/docs/snapshot/machinen-meta.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://machinen.dev/schemas/snapshot/machinen-meta.schema.json",
+  "title": "Machinen stripped-build sidecar metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "format", "program", "compatibility", "builds"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "format": { "const": "com.redwoodjs.machinen.sidecar" },
+    "program": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "identity"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "identity": { "type": "string", "minLength": 1 }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowedSourceArchs", "allowedTargetArchs", "buildMatch"],
+      "properties": {
+        "allowedSourceArchs": { "$ref": "#/$defs/archList" },
+        "allowedTargetArchs": { "$ref": "#/$defs/archList" },
+        "buildMatch": { "const": "sha256" }
+      }
+    },
+    "builds": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/build" }
+    }
+  },
+  "$defs": {
+    "arch": { "enum": ["arm64", "amd64"] },
+    "archList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/arch" }
+    },
+    "hexAddress": { "type": "string", "pattern": "^0x[0-9A-Fa-f]+$" },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "arch",
+        "buildIdentity",
+        "binary",
+        "symbols",
+        "types",
+        "pointerFields",
+        "continuations",
+        "resources"
+      ],
+      "properties": {
+        "arch": { "$ref": "#/$defs/arch" },
+        "buildIdentity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "binarySha256", "debugSha256"],
+          "properties": {
+            "kind": { "const": "sha256" },
+            "binarySha256": { "$ref": "#/$defs/sha256" },
+            "debugSha256": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "binary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["stripped"],
+          "properties": { "stripped": { "const": true } }
+        },
+        "symbols": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "address", "sizeBytes", "type"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "address": { "$ref": "#/$defs/hexAddress" },
+              "sizeBytes": { "type": "integer", "minimum": 1 },
+              "type": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "types": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/typeLayout" }
+        },
+        "pointerFields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "field", "offset", "targetType"],
+            "properties": {
+              "type": { "type": "string", "minLength": 1 },
+              "field": { "type": "string", "minLength": 1 },
+              "offset": { "type": "integer", "minimum": 0 },
+              "targetType": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "continuations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "fixture",
+              "checkpointContinuation",
+              "restoreEntrypoint",
+              "safePoint"
+            ],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "fixture": { "type": "string", "minLength": 1 },
+              "checkpointContinuation": { "type": "string", "minLength": 1 },
+              "restoreEntrypoint": { "type": "string", "minLength": 1 },
+              "safePoint": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["outsideSignalHandlers", "outsideSyscalls"],
+                "properties": {
+                  "outsideSignalHandlers": { "const": true },
+                  "outsideSyscalls": { "const": true }
+                }
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["recipes", "refusalRules"],
+          "properties": {
+            "recipes": { "type": "array", "items": { "type": "object" } },
+            "refusalRules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["code", "message"],
+                "properties": {
+                  "code": { "type": "string", "minLength": 1 },
+                  "message": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "typeLayout": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "byteSize", "fields"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "byteSize": { "type": "integer", "minimum": 1 },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "offset", "sizeBytes", "type", "pointer"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "offset": { "type": "integer", "minimum": 0 },
+              "sizeBytes": { "type": "integer", "minimum": 1 },
+              "type": { "type": "string", "minLength": 1 },
+              "pointer": { "type": "boolean" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/snapshot/sidecar-metadata.md
+++ b/docs/snapshot/sidecar-metadata.md
@@ -1,0 +1,59 @@
+# Sidecar metadata for stripped builds
+
+Issue #419 defines the proof-side `.machinen-meta.json` file used when a release binary no longer carries DWARF or a symbol table.
+
+The sidecar is generated from a matching debug build, then the verifier strips the controlled binary with `strip --strip-all`. Capture and restore use only the stripped target plus `.machinen-meta.json`.
+
+## What the sidecar records
+
+The schema lives in [`machinen-meta.schema.json`](./machinen-meta.schema.json). The proof sidecar records:
+
+- program name and stable identity
+- allowed source and target architectures
+- per-architecture build identity using SHA-256 of the stripped target
+- symbol names, addresses, sizes, and types
+- type layouts and field offsets
+- pointer fields (`head`, `next`) for relocation discovery
+- continuation ids and safe observation points
+- resource recipes for argv/env/cwd
+- refusal rules for resources the proof does not replay
+
+The model is architecture-indexed, so the same JSON shape can describe arm64 and amd64 builds. A real release pipeline can ship both build entries in one file or ship one sidecar per artifact using the same schema.
+
+## Flow
+
+1. Build the controlled corpus with debug info.
+2. Read DWARF through the #418 verifier and translate it into `.machinen-meta.json`.
+3. Copy and strip the target binary.
+4. Validate that the stripped binary SHA-256 matches the sidecar.
+5. Capture the stripped process by passing sidecar symbol addresses and list-follow rules to the raw capturer.
+6. Decode global and heap state from sidecar layouts.
+7. Emit a portable bundle that includes `.machinen-meta.json`.
+8. Restore the semantic state into the stripped target.
+
+## Stable mismatch refusal
+
+Before capture, the verifier hashes the target binary and compares it to the sidecar build entry. A mismatch refuses before touching process memory:
+
+```json
+{
+  "code": "target-build-mismatch",
+  "message": "target binary sha256 does not match .machinen-meta.json"
+}
+```
+
+This keeps stale sidecars from silently decoding the wrong layout.
+
+## Limits
+
+The sidecar proof still uses the controlled fixture and a cooperative safe point. It proves that stripped binaries do not need in-binary DWARF at extraction time, not that arbitrary optimized stacks can be translated. The next continuation work handles stack-frame state more directly.
+
+## Verify
+
+Run on Linux:
+
+```sh
+pnpm sidecar-metadata-extract
+```
+
+On non-Linux hosts the verifier skips because capture depends on Linux `/proc` and `ptrace`.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "raw-process-capture": "node scripts/raw-process-capture.mjs verify",
     "known-symbol-extract": "node scripts/known-symbol-extract.mjs verify",
     "dwarf-symbol-extract": "node scripts/dwarf-symbol-extract.mjs verify",
+    "sidecar-metadata-extract": "node scripts/sidecar-metadata-extract.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/src/__tests__/sidecar-metadata-extract.test.ts
+++ b/packages/runtime/src/__tests__/sidecar-metadata-extract.test.ts
@@ -1,0 +1,113 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePortableSnapshotBundle } from "../vm/portable-snapshot.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/sidecar-metadata-extract.mjs");
+const TMP: string[] = [];
+
+interface SidecarSummary {
+  skipped?: boolean;
+  hostArch: string;
+  sidecarPath: string;
+  strippedTargetHasDwarf: boolean;
+  bundleDir: string;
+  sidecar: {
+    builds: Array<{
+      arch: string;
+      binaryStripped: boolean;
+      symbolNames: string[];
+      typeNames: string[];
+      pointerFields: Array<{ field: string; offset: number }>;
+      continuations: string[];
+      resourceRefusals: Array<{ code: string }>;
+    }>;
+  };
+  mismatchRefusal: {
+    accepted: boolean;
+    refusal: { code: string; message: string; detail: Record<string, string> };
+  };
+  semanticState: {
+    global: { label: string; counter: number };
+    heap: { nodeCount: number; values: number[]; tags: number[]; colors: number[] };
+  };
+  restoreEvent: {
+    fixture: string;
+    global: { label: string; counter: number };
+    heap: { values: number[]; tags: number[]; colors: number[] };
+  };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("sidecar metadata extraction", () => {
+  it.skipIf(process.platform !== "linux")(
+    "restores a stripped controlled binary using .machinen-meta.json",
+    { timeout: 180_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "sidecar-metadata-extract-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 30 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as SidecarSummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(existsSync(summary.sidecarPath)).toBe(true);
+      expect(summary.strippedTargetHasDwarf).toBe(false);
+
+      const build = summary.sidecar.builds.find((candidate) => candidate.arch === summary.hostArch);
+      expect(build).toBeDefined();
+      expect(build?.binaryStripped).toBe(true);
+      expect(build?.symbolNames).toContain("machinen_controlled_dwarf_global_state");
+      expect(build?.symbolNames).toContain("machinen_controlled_dwarf_heap_state");
+      expect(build?.typeNames).toContain("struct ControlledDwarfNode");
+      expect(build?.pointerFields.map((field) => field.field)).toEqual(["head", "next"]);
+      expect(build?.continuations).toContain("controlled-dwarf-observation");
+      expect(build?.resourceRefusals.map((rule) => rule.code)).toContain("fd-kind-unsupported");
+
+      expect(summary.mismatchRefusal).toMatchObject({
+        accepted: false,
+        refusal: { code: "target-build-mismatch" },
+      });
+      expect(summary.semanticState.global).toMatchObject({
+        label: "dwarf-global-layout-v2",
+        counter: 7000,
+      });
+      expect(summary.semanticState.heap).toMatchObject({
+        nodeCount: 3,
+        values: [111, 222, 333],
+        tags: [101, 102, 103],
+        colors: [3, 5, 7],
+      });
+      expect(summary.restoreEvent).toMatchObject({
+        fixture: "dwarf-restore",
+        global: { label: "dwarf-global-layout-v2", counter: 7000 },
+      });
+      expect(summary.restoreEvent.heap.values).toEqual([111, 222, 333]);
+
+      const bundle = validatePortableSnapshotBundle(summary.bundleDir);
+      expect(bundle.manifest.features).toContain("sidecar-metadata-extraction");
+      expect(bundle.objects.objects.map((object) => object.id)).toEqual([
+        "controlled-sidecar-global-state",
+        "controlled-sidecar-heap-state",
+        "controlled-sidecar-node-0",
+        "controlled-sidecar-node-1",
+        "controlled-sidecar-node-2",
+      ]);
+      expect(bundle.relocations.relocations).toHaveLength(3);
+    },
+  );
+});

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   copyFileSync,
   existsSync,
@@ -184,6 +185,120 @@ export function controlledResources(capture) {
   };
 }
 
+export function runControlledDwarfCapture(options) {
+  const heapHead = layoutField(options.heapLayout, "head");
+  const heapCount = layoutField(options.heapLayout, "node_count");
+  const nodeNext = layoutField(options.nodeLayout, "next");
+  const args = [
+    "--output",
+    options.captureDir,
+    "--symbol",
+    `${options.globalSymbol.name}:${options.globalSymbol.address}:${options.globalSymbol.sizeBytes}`,
+    "--symbol",
+    `${options.heapSymbol.name}:${options.heapSymbol.address}:${options.heapSymbol.sizeBytes}`,
+    "--follow-list",
+    [
+      options.heapSymbol.name,
+      heapHead.offset,
+      heapCount.offset,
+      options.nodeLayout.byteSize,
+      nodeNext.offset,
+      options.nodePrefix,
+    ].join(":"),
+    "--",
+    options.target,
+    "--fixture",
+    "dwarf",
+    "--pause-at-observation",
+  ];
+  if (options.resourceFile) {
+    args.push("--resource-file", options.resourceFile);
+  }
+  runCommand(options.capturer, args, {
+    label: options.label,
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+}
+
+export function layoutField(layout, name) {
+  const fields = layout.fields || layout.members || [];
+  const found = fields.find((candidate) => candidate.name === name);
+  if (!found) {
+    throw new Error(`layout ${layout.type} has no field ${name}`);
+  }
+  return found;
+}
+
+const UNSIGNED_READERS = new Map([
+  [1, (bytes, offset) => BigInt(bytes.readUInt8(offset))],
+  [2, (bytes, offset) => BigInt(bytes.readUInt16LE(offset))],
+  [4, (bytes, offset) => BigInt(bytes.readUInt32LE(offset))],
+  [8, (bytes, offset) => bytes.readBigUInt64LE(offset)],
+]);
+
+export function readLayoutUnsigned(bytes, fieldSpec) {
+  const offset = fieldSpec.offset;
+  if (offset + fieldSpec.sizeBytes > bytes.length) {
+    throw new Error(`field ${fieldSpec.name} is outside captured bytes`);
+  }
+  const reader = UNSIGNED_READERS.get(fieldSpec.sizeBytes);
+  if (!reader) {
+    throw new Error(
+      `unsupported unsigned field width for ${fieldSpec.name}: ${fieldSpec.sizeBytes}`,
+    );
+  }
+  return reader(bytes, offset);
+}
+
+export function readLayoutCString(bytes, fieldSpec) {
+  const start = fieldSpec.offset;
+  const limit = Math.min(bytes.length, start + fieldSpec.sizeBytes);
+  let end = start;
+  while (end < limit && bytes[end] !== 0) {
+    end++;
+  }
+  return bytes.subarray(start, end).toString("utf8");
+}
+
+export function linkedListPointerRelocations(options) {
+  const relocations = [
+    {
+      fromObject: options.heapObject,
+      fromOffset: options.heapHeadOffset,
+      toObject: `${options.nodePrefix}-0`,
+      addend: 0,
+      kind: "pointer",
+      sourcePointer: options.headPointer,
+    },
+  ];
+  for (let index = 0; index + 1 < options.nodes.length; index++) {
+    relocations.push({
+      fromObject: `${options.nodePrefix}-${index}`,
+      fromOffset: options.nodeNextOffset,
+      toObject: `${options.nodePrefix}-${index + 1}`,
+      addend: 0,
+      kind: "pointer",
+      sourcePointer: options.nodes[index].nextPointer,
+    });
+  }
+  return relocations;
+}
+
+export function controlledDwarfStateText(semanticState) {
+  const lines = [
+    `global_label=${semanticState.global.label}`,
+    `global_counter=${semanticState.global.counter}`,
+    `global_flags=${semanticState.global.flags}`,
+    `global_generation=${semanticState.global.generation}`,
+    `node_count=${semanticState.heap.nodeCount}`,
+  ];
+  semanticState.heap.values.forEach((value, index) => lines.push(`value${index}=${value}`));
+  semanticState.heap.tags.forEach((value, index) => lines.push(`tag${index}=${value}`));
+  semanticState.heap.colors.forEach((value, index) => lines.push(`color${index}=${value}`));
+  lines.push(`checksum=${semanticState.heap.checksumHex}`, "");
+  return lines.join("\n");
+}
+
 export function parseControlledMarker(stdout, expectedFixture) {
   const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(CONTROLLED_MARKER));
   if (!line) {
@@ -206,6 +321,10 @@ export function unsupportedVocabulary() {
 
 export function jsonDocument(value) {
   return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
 export function hostArch() {

--- a/scripts/dwarf-symbol-extract.mjs
+++ b/scripts/dwarf-symbol-extract.mjs
@@ -8,13 +8,19 @@ import {
   bundleFileStats as sharedBundleFileStats,
   compileControlledTarget,
   compileRawCapturer,
+  controlledDwarfStateText,
   controlledPortableManifest,
   ensureSourcesExist,
   hostArch,
+  layoutField,
+  linkedListPointerRelocations,
   loadRawCapture,
   memoryChunkByName,
   memoryChunkBytes,
   parseControlledMarker,
+  readLayoutCString,
+  readLayoutUnsigned,
+  runControlledDwarfCapture,
   unsupportedVocabulary,
   writePortableBundleFiles,
 } from "./controlled-corpus-utils.mjs";
@@ -300,44 +306,18 @@ function summarizeStackProbe(dwarf) {
 }
 
 function runDwarfCapture(context) {
-  const global = context.layouts.global.symbol;
-  const heap = context.layouts.heap.symbol;
-  const heapLayout = context.layouts.heap.layout;
-  const nodeLayout = context.layouts.node.layout;
-  const resourceFile = join(context.captureDir, "resource-file.txt");
-  const followList = [
-    heap.name,
-    field(heapLayout, "head").offset,
-    field(heapLayout, "node_count").offset,
-    nodeLayout.byteSize,
-    field(nodeLayout, "next").offset,
-    DWARF_NODE_PREFIX,
-  ].join(":");
-
-  runCommand(
-    context.capturer,
-    [
-      "--output",
-      context.captureDir,
-      "--symbol",
-      `${global.name}:${global.address}:${global.sizeBytes}`,
-      "--symbol",
-      `${heap.name}:${heap.address}:${heap.sizeBytes}`,
-      "--follow-list",
-      followList,
-      "--",
-      context.target,
-      "--fixture",
-      "dwarf",
-      "--pause-at-observation",
-      "--resource-file",
-      resourceFile,
-    ],
-    {
-      label: "DWARF-guided raw capture",
-      env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
-    },
-  );
+  runControlledDwarfCapture({
+    capturer: context.capturer,
+    target: context.target,
+    captureDir: context.captureDir,
+    globalSymbol: context.layouts.global.symbol,
+    heapSymbol: context.layouts.heap.symbol,
+    heapLayout: context.layouts.heap.layout,
+    nodeLayout: context.layouts.node.layout,
+    nodePrefix: DWARF_NODE_PREFIX,
+    resourceFile: join(context.captureDir, "resource-file.txt"),
+    label: "DWARF-guided raw capture",
+  });
 }
 
 function recoverDwarfState(capture, layouts) {
@@ -348,9 +328,9 @@ function recoverDwarfState(capture, layouts) {
   const heapLayout = layouts.heap.layout;
   const nodeLayout = layouts.node.layout;
 
-  const nodeCount = Number(readUnsigned(heapBytes, field(heapLayout, "node_count")));
-  const checksum = readUnsigned(heapBytes, field(heapLayout, "checksum"));
-  const headPointer = readUnsigned(heapBytes, field(heapLayout, "head"));
+  const nodeCount = Number(readLayoutUnsigned(heapBytes, layoutField(heapLayout, "node_count")));
+  const checksum = readLayoutUnsigned(heapBytes, layoutField(heapLayout, "checksum"));
+  const headPointer = readLayoutUnsigned(heapBytes, layoutField(heapLayout, "head"));
   const nodes = [];
   for (let i = 0; i < nodeCount; i++) {
     const chunk = memoryChunkByName(capture, `${DWARF_NODE_PREFIX}_${i}`);
@@ -358,10 +338,10 @@ function recoverDwarfState(capture, layouts) {
     nodes.push({
       id: `controlled-dwarf-node-${i}`,
       sourceAddress: chunk.sourceAddress,
-      tag: Number(readUnsigned(bytes, field(nodeLayout, "tag"))),
-      color: Number(readUnsigned(bytes, field(nodeLayout, "color"))),
-      value: Number(readUnsigned(bytes, field(nodeLayout, "value"))),
-      nextPointer: hexAddress(readUnsigned(bytes, field(nodeLayout, "next"))),
+      tag: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "tag"))),
+      color: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "color"))),
+      value: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "value"))),
+      nextPointer: hexAddress(readLayoutUnsigned(bytes, layoutField(nodeLayout, "next"))),
       sizeBytes: chunk.sizeBytes,
       memory: { offset: chunk.fileOffset, sizeBytes: chunk.sizeBytes },
     });
@@ -371,16 +351,20 @@ function recoverDwarfState(capture, layouts) {
     global: {
       sourceAddress: globalChunk.sourceAddress,
       sizeBytes: globalChunk.sizeBytes,
-      label: readCString(globalBytes, field(layouts.global.layout, "label")),
-      counter: Number(readUnsigned(globalBytes, field(layouts.global.layout, "counter"))),
-      flags: Number(readUnsigned(globalBytes, field(layouts.global.layout, "flags"))),
-      generation: Number(readUnsigned(globalBytes, field(layouts.global.layout, "generation"))),
+      label: readLayoutCString(globalBytes, layoutField(layouts.global.layout, "label")),
+      counter: Number(
+        readLayoutUnsigned(globalBytes, layoutField(layouts.global.layout, "counter")),
+      ),
+      flags: Number(readLayoutUnsigned(globalBytes, layoutField(layouts.global.layout, "flags"))),
+      generation: Number(
+        readLayoutUnsigned(globalBytes, layoutField(layouts.global.layout, "generation")),
+      ),
       memory: globalChunk,
     },
     heap: {
       sourceAddress: heapChunk.sourceAddress,
       sizeBytes: heapChunk.sizeBytes,
-      version: Number(readUnsigned(heapBytes, field(heapLayout, "version"))),
+      version: Number(readLayoutUnsigned(heapBytes, layoutField(heapLayout, "version"))),
       nodeCount,
       checksum: checksum.toString(10),
       checksumHex: hexAddress(checksum),
@@ -394,43 +378,6 @@ function recoverDwarfState(capture, layouts) {
   };
 }
 
-function field(layout, name) {
-  const member = layout.members.find((candidate) => candidate.name === name);
-  if (!member) {
-    throw new Error(`missing DWARF field ${layout.type}.${name}`);
-  }
-  return member;
-}
-
-const UNSIGNED_READERS = new Map([
-  [1, (bytes, offset) => BigInt(bytes.readUInt8(offset))],
-  [2, (bytes, offset) => BigInt(bytes.readUInt16LE(offset))],
-  [4, (bytes, offset) => BigInt(bytes.readUInt32LE(offset))],
-  [8, (bytes, offset) => bytes.readBigUInt64LE(offset)],
-]);
-
-function readUnsigned(bytes, member) {
-  const offset = member.offset;
-  if (offset + member.sizeBytes > bytes.length) {
-    throw new Error(`field ${member.name} is outside captured bytes`);
-  }
-  const reader = UNSIGNED_READERS.get(member.sizeBytes);
-  if (!reader) {
-    throw new Error(`unsupported unsigned field width for ${member.name}: ${member.sizeBytes}`);
-  }
-  return reader(bytes, offset);
-}
-
-function readCString(bytes, member) {
-  const start = member.offset;
-  const limit = Math.min(bytes.length, start + member.sizeBytes);
-  let end = start;
-  while (end < limit && bytes[end] !== 0) {
-    end++;
-  }
-  return bytes.subarray(start, end).toString("utf8");
-}
-
 function writePortableBundle(context) {
   const memory = buildPortableBundleMemory(context.capture);
   writePortableBundleFiles({
@@ -441,7 +388,7 @@ function writePortableBundle(context) {
     manifest: manifest(context),
     objects: objects(memory.chunks, context),
     relocations: relocations(context),
-    controlledStateText: controlledStateText(context.semanticState),
+    controlledStateText: controlledDwarfStateText(context.semanticState),
     extraDocuments: [{ name: "dwarf-layout.json", value: dwarfLayoutDocument(context) }],
   });
 }
@@ -503,29 +450,18 @@ function nodeObject(byName, node, index, context) {
 }
 
 function relocations(context) {
-  const heapHead = field(context.layouts.heap.layout, "head");
-  const nodeNext = field(context.layouts.node.layout, "next");
-  const relocs = [
-    {
-      fromObject: "controlled-dwarf-heap-state",
-      fromOffset: heapHead.offset,
-      toObject: "controlled-dwarf-node-0",
-      addend: 0,
-      kind: "pointer",
-      sourcePointer: context.semanticState.heap.headPointer,
-    },
-  ];
-  for (let i = 0; i + 1 < context.semanticState.heap.nodes.length; i++) {
-    relocs.push({
-      fromObject: `controlled-dwarf-node-${i}`,
-      fromOffset: nodeNext.offset,
-      toObject: `controlled-dwarf-node-${i + 1}`,
-      addend: 0,
-      kind: "pointer",
-      sourcePointer: context.semanticState.heap.nodes[i].nextPointer,
-    });
-  }
-  return { formatVersion: 1, relocations: relocs, unsupported: unsupportedVocabulary() };
+  return {
+    formatVersion: 1,
+    relocations: linkedListPointerRelocations({
+      heapObject: "controlled-dwarf-heap-state",
+      nodePrefix: "controlled-dwarf-node",
+      heapHeadOffset: layoutField(context.layouts.heap.layout, "head").offset,
+      nodeNextOffset: layoutField(context.layouts.node.layout, "next").offset,
+      nodes: context.semanticState.heap.nodes,
+      headPointer: context.semanticState.heap.headPointer,
+    }),
+    unsupported: unsupportedVocabulary(),
+  };
 }
 
 function dwarfLayoutDocument(context) {
@@ -544,21 +480,6 @@ function dwarfLayoutDocument(context) {
   };
 }
 
-function controlledStateText(semanticState) {
-  const lines = [
-    `global_label=${semanticState.global.label}`,
-    `global_counter=${semanticState.global.counter}`,
-    `global_flags=${semanticState.global.flags}`,
-    `global_generation=${semanticState.global.generation}`,
-    `node_count=${semanticState.heap.nodeCount}`,
-  ];
-  semanticState.heap.values.forEach((value, index) => lines.push(`value${index}=${value}`));
-  semanticState.heap.tags.forEach((value, index) => lines.push(`tag${index}=${value}`));
-  semanticState.heap.colors.forEach((value, index) => lines.push(`color${index}=${value}`));
-  lines.push(`checksum=${semanticState.heap.checksumHex}`, "");
-  return lines.join("\n");
-}
-
 function mapLayouts(source, target) {
   return {
     global: mapLayout(source.global.layout, target.global.layout),
@@ -572,7 +493,7 @@ function mapLayout(source, target) {
     sourceType: source.type,
     targetType: target.type,
     fields: source.members.map((sourceField) => {
-      const targetField = field(target, sourceField.name);
+      const targetField = layoutField(target, sourceField.name);
       return {
         name: sourceField.name,
         sourceOffset: sourceField.offset,

--- a/scripts/sidecar-metadata-extract.mjs
+++ b/scripts/sidecar-metadata-extract.mjs
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPTURE_SOURCE,
+  CONTROLLED_SOURCE,
+  REPO_ROOT,
+  buildPortableBundleMemory,
+  bundleFileStats as sharedBundleFileStats,
+  compileRawCapturer,
+  controlledDwarfStateText,
+  controlledPortableManifest,
+  ensureSourcesExist,
+  hostArch,
+  jsonDocument,
+  layoutField,
+  linkedListPointerRelocations,
+  loadRawCapture,
+  memoryChunkByName,
+  memoryChunkBytes,
+  parseControlledMarker,
+  readJson,
+  readLayoutCString,
+  readLayoutUnsigned,
+  runControlledDwarfCapture,
+  sha256File,
+  unsupportedVocabulary,
+  writePortableBundleFiles,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/sidecar-metadata-extract.mjs [verify] [--out-dir path] [--json] [--keep]";
+const DWARF_SCRIPT = join(REPO_ROOT, "scripts/dwarf-symbol-extract.mjs");
+const META_FILE = ".machinen-meta.json";
+const BUILD_ID = "4194194194194190";
+const DWARF_GLOBAL_SYMBOL = "machinen_controlled_dwarf_global_state";
+const DWARF_HEAP_SYMBOL = "machinen_controlled_dwarf_heap_state";
+const NODE_PREFIX = "machinen_sidecar_dwarf_node";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(args, "sidecar-metadata-extract", "sidecar proof uses Linux /proc and ptrace");
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-sidecar-metadata-");
+  try {
+    emitResult(verifySidecarExtraction(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifySidecarExtraction(outDir) {
+  ensureSourcesExist([CONTROLLED_SOURCE, CAPTURE_SOURCE, DWARF_SCRIPT]);
+  const binDir = join(outDir, "bin");
+  const captureDir = join(outDir, "capture-sidecar");
+  const bundleDir = join(outDir, "bundle");
+  mkdirSync(binDir, { recursive: true });
+
+  const metadata = buildSidecarMetadata(outDir, binDir);
+  const sidecar = metadata.sidecar;
+  validateSidecar(sidecar);
+  const targetCheck = validateTargetBuild(sidecar, metadata.strippedTarget);
+  assert(targetCheck.accepted, "fresh stripped target did not match its sidecar");
+  const mismatchRefusal = validateTargetBuild(
+    sidecar,
+    makeMismatchedTarget(binDir, metadata.strippedTarget),
+  );
+  assert(!mismatchRefusal.accepted, "mismatched target should be refused");
+
+  const capturer = compileRawCapturer(binDir);
+  runSidecarCapture({ capturer, target: metadata.strippedTarget, sidecar, captureDir });
+  const capture = loadRawCapture(captureDir);
+  const semanticState = recoverSidecarState(capture, sidecar);
+  writeSidecarBundle({
+    bundleDir,
+    captureDir,
+    capture,
+    semanticState,
+    sidecar,
+    target: metadata.strippedTarget,
+  });
+  const restoreEvent = runTargetRestore(metadata.strippedTarget, bundleDir);
+  validateRestore(semanticState, restoreEvent);
+
+  return {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    sidecarPath: metadata.sidecarPath,
+    strippedTarget: metadata.strippedTarget,
+    strippedTargetHasDwarf: metadata.strippedTargetHasDwarf,
+    captureDir,
+    bundleDir,
+    sidecar: summarizeSidecar(sidecar),
+    mismatchRefusal,
+    semanticState,
+    restoreEvent,
+    bundleFiles: bundleFileStats(bundleDir),
+  };
+}
+
+function buildSidecarMetadata(outDir, binDir) {
+  const debugProof = runDwarfProof(join(outDir, "debug-proof"));
+  const layoutDocument = readJson(join(debugProof.bundleDir, "dwarf-layout.json"));
+  const debugTarget = debugProof.target;
+  const strippedTarget = join(binDir, "machinen-controlled-corpus.stripped");
+  copyFileSync(debugTarget, strippedTarget);
+  runCommand("strip", ["--strip-all", strippedTarget], { label: "strip controlled target" });
+
+  const sidecar = createSidecar({ layoutDocument, debugTarget, strippedTarget });
+  const sidecarPath = join(binDir, META_FILE);
+  writeFileSync(sidecarPath, jsonDocument(sidecar));
+  return {
+    debugProof,
+    sidecar,
+    sidecarPath,
+    strippedTarget,
+    strippedTargetHasDwarf: binaryHasDwarf(strippedTarget),
+  };
+}
+
+function runDwarfProof(outDir) {
+  const result = runCommand(
+    process.execPath,
+    [DWARF_SCRIPT, "verify", "--out-dir", outDir, "--keep", "--json"],
+    { label: "DWARF metadata source proof" },
+  );
+  return JSON.parse(result.stdout);
+}
+
+function createSidecar({ layoutDocument, debugTarget, strippedTarget }) {
+  const build = {
+    arch: hostArch(),
+    buildIdentity: {
+      kind: "sha256",
+      binarySha256: sha256File(strippedTarget),
+      debugSha256: sha256File(debugTarget),
+    },
+    binary: { stripped: true },
+    symbols: layoutDocument.globals.map((symbol) => ({
+      name: symbol.name,
+      address: symbol.address,
+      sizeBytes: symbol.sizeBytes,
+      type: symbol.type,
+    })),
+    types: Object.values(layoutDocument.layouts),
+    pointerFields: pointerFields(layoutDocument.layouts),
+    continuations: [
+      {
+        id: "controlled-dwarf-observation",
+        fixture: "dwarf",
+        checkpointContinuation: "machinen_controlled_dwarf_observation",
+        restoreEntrypoint: "machinen_controlled_dwarf_restore",
+        safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
+      },
+    ],
+    resources: {
+      recipes: [
+        { id: "argv", kind: "argv", capture: "copy" },
+        { id: "env", kind: "env", capture: "allow-list", names: ["MACHINEN_CONTROLLED_ENV"] },
+        { id: "cwd", kind: "cwd", capture: "copy" },
+      ],
+      refusalRules: [
+        { code: "fd-kind-unsupported", message: "only argv/env/cwd resources are replayed" },
+      ],
+    },
+  };
+  return {
+    schemaVersion: 1,
+    format: "com.redwoodjs.machinen.sidecar",
+    program: {
+      name: "controlled-binary-corpus",
+      identity: "com.redwoodjs.machinen.controlled-binary-corpus",
+    },
+    compatibility: {
+      allowedSourceArchs: ["arm64", "amd64"],
+      allowedTargetArchs: ["arm64", "amd64"],
+      buildMatch: "sha256",
+    },
+    builds: [build],
+  };
+}
+
+function pointerFields(layouts) {
+  const fields = [];
+  for (const layout of Object.values(layouts)) {
+    for (const field of layout.fields) {
+      if (field.pointer) {
+        fields.push({
+          type: layout.type,
+          field: field.name,
+          offset: field.offset,
+          targetType: field.type,
+        });
+      }
+    }
+  }
+  return fields;
+}
+
+function binaryHasDwarf(path) {
+  const result = runCommand("readelf", ["--debug-dump=info", path], {
+    label: "stripped DWARF check",
+  });
+  return result.stdout.includes("DW_TAG_");
+}
+
+function validateSidecar(sidecar) {
+  assert(sidecar.schemaVersion === 1, "sidecar schema version changed");
+  assert(sidecar.format === "com.redwoodjs.machinen.sidecar", "sidecar format changed");
+  assert(Array.isArray(sidecar.builds) && sidecar.builds.length > 0, "sidecar has no builds");
+  const build = sidecarBuild(sidecar, hostArch());
+  validateSidecarBuild(build);
+}
+
+function validateSidecarBuild(build) {
+  assert(build.binary.stripped === true, "sidecar build should describe a stripped binary");
+  assert(symbol(build, DWARF_GLOBAL_SYMBOL), "sidecar missing global symbol");
+  assert(symbol(build, DWARF_HEAP_SYMBOL), "sidecar missing heap symbol");
+  assert(typeLayout(build, "struct ControlledDwarfNode"), "sidecar missing node layout");
+  assertSidecarPolicy(build);
+}
+
+function assertSidecarPolicy(build) {
+  assert(hasPointerFields(build), "sidecar missing pointer fields");
+  assert(build.continuations[0]?.safePoint?.outsideSyscalls === true, "sidecar missing safe point");
+  assert(
+    build.resources.refusalRules[0]?.code === "fd-kind-unsupported",
+    "sidecar missing refusal rule",
+  );
+}
+
+function hasPointerFields(build) {
+  const names = new Set(build.pointerFields.map((field) => field.field));
+  return names.has("head") && names.has("next");
+}
+
+function validateTargetBuild(sidecar, target) {
+  const build = sidecarBuild(sidecar, hostArch());
+  const actual = sha256File(target);
+  const expected = build.buildIdentity.binarySha256;
+  if (actual === expected) {
+    return { accepted: true, arch: build.arch, binarySha256: actual };
+  }
+  return {
+    accepted: false,
+    refusal: {
+      code: "target-build-mismatch",
+      message: "target binary sha256 does not match .machinen-meta.json",
+      detail: { arch: build.arch, expectedSha256: expected, actualSha256: actual },
+    },
+  };
+}
+
+function makeMismatchedTarget(binDir, target) {
+  const mismatched = join(binDir, "machinen-controlled-corpus.mismatched");
+  copyFileSync(target, mismatched);
+  writeFileSync(mismatched, "\n# mismatch\n", { flag: "a" });
+  return mismatched;
+}
+
+function runSidecarCapture(context) {
+  const build = sidecarBuild(context.sidecar, hostArch());
+  runControlledDwarfCapture({
+    capturer: context.capturer,
+    target: context.target,
+    captureDir: context.captureDir,
+    globalSymbol: symbol(build, DWARF_GLOBAL_SYMBOL),
+    heapSymbol: symbol(build, DWARF_HEAP_SYMBOL),
+    heapLayout: typeLayout(build, "struct ControlledDwarfHeapState"),
+    nodeLayout: typeLayout(build, "struct ControlledDwarfNode"),
+    nodePrefix: NODE_PREFIX,
+    label: "sidecar-guided raw capture",
+  });
+}
+
+function recoverSidecarState(capture, sidecar) {
+  const build = sidecarBuild(sidecar, hostArch());
+  const globalLayout = typeLayout(build, "struct ControlledDwarfGlobalState");
+  const heapLayout = typeLayout(build, "struct ControlledDwarfHeapState");
+  const nodeLayout = typeLayout(build, "struct ControlledDwarfNode");
+  const globalChunk = memoryChunkByName(capture, DWARF_GLOBAL_SYMBOL);
+  const heapChunk = memoryChunkByName(capture, DWARF_HEAP_SYMBOL);
+  const globalBytes = memoryChunkBytes(capture, globalChunk);
+  const heapBytes = memoryChunkBytes(capture, heapChunk);
+  const nodeCount = Number(readLayoutUnsigned(heapBytes, layoutField(heapLayout, "node_count")));
+  const nodes = readNodes(capture, nodeLayout, nodeCount);
+  const checksum = readLayoutUnsigned(heapBytes, layoutField(heapLayout, "checksum"));
+  return {
+    global: {
+      label: readLayoutCString(globalBytes, layoutField(globalLayout, "label")),
+      counter: Number(readLayoutUnsigned(globalBytes, layoutField(globalLayout, "counter"))),
+      flags: Number(readLayoutUnsigned(globalBytes, layoutField(globalLayout, "flags"))),
+      generation: Number(readLayoutUnsigned(globalBytes, layoutField(globalLayout, "generation"))),
+      sourceAddress: globalChunk.sourceAddress,
+    },
+    heap: {
+      nodeCount,
+      values: nodes.map((node) => node.value),
+      tags: nodes.map((node) => node.tag),
+      colors: nodes.map((node) => node.color),
+      nodes,
+      checksumHex: hexAddress(checksum),
+      headPointer: hexAddress(readLayoutUnsigned(heapBytes, layoutField(heapLayout, "head"))),
+      sourceAddress: heapChunk.sourceAddress,
+    },
+  };
+}
+
+function readNodes(capture, nodeLayout, nodeCount) {
+  return Array.from({ length: nodeCount }, (_unused, index) => {
+    const chunk = memoryChunkByName(capture, `${NODE_PREFIX}_${index}`);
+    const bytes = memoryChunkBytes(capture, chunk);
+    return {
+      id: `controlled-sidecar-node-${index}`,
+      sourceAddress: chunk.sourceAddress,
+      tag: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "tag"))),
+      color: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "color"))),
+      value: Number(readLayoutUnsigned(bytes, layoutField(nodeLayout, "value"))),
+      nextPointer: hexAddress(readLayoutUnsigned(bytes, layoutField(nodeLayout, "next"))),
+    };
+  });
+}
+
+function writeSidecarBundle(context) {
+  const memory = buildPortableBundleMemory(context.capture);
+  writePortableBundleFiles({
+    bundleDir: context.bundleDir,
+    captureDir: context.captureDir,
+    capture: context.capture,
+    memory,
+    manifest: sidecarManifest(context),
+    objects: sidecarObjects(memory.chunks, context),
+    relocations: sidecarRelocations(context),
+    controlledStateText: controlledDwarfStateText(context.semanticState),
+    extraDocuments: [{ name: META_FILE, value: context.sidecar }],
+  });
+}
+
+function sidecarManifest(context) {
+  return controlledPortableManifest({
+    target: context.target,
+    capture: context.capture,
+    buildId: BUILD_ID,
+    version: "sidecar-metadata-proof",
+    checkpointContinuation: "machinen_controlled_dwarf_observation",
+    restoreEntrypoint: "machinen_controlled_dwarf_restore",
+    features: ["controlled-binary-corpus", "external-raw-capture", "sidecar-metadata-extraction"],
+  });
+}
+
+function sidecarObjects(chunks, context) {
+  const byName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+  const build = sidecarBuild(context.sidecar, hostArch());
+  return {
+    formatVersion: 1,
+    objects: [
+      objectForChunk(
+        byName.get(DWARF_GLOBAL_SYMBOL),
+        "controlled-sidecar-global-state",
+        "global",
+        symbol(build, DWARF_GLOBAL_SYMBOL).type,
+      ),
+      objectForChunk(
+        byName.get(DWARF_HEAP_SYMBOL),
+        "controlled-sidecar-heap-state",
+        "global",
+        symbol(build, DWARF_HEAP_SYMBOL).type,
+      ),
+      ...context.semanticState.heap.nodes.map((node, index) => {
+        const chunk = byName.get(`${NODE_PREFIX}_${index}`);
+        return {
+          ...objectForChunk(chunk, node.id, "heap", "struct ControlledDwarfNode"),
+          allocation: { id: index + 1, sourceAddress: chunk.sourceAddress },
+        };
+      }),
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function objectForChunk(chunk, id, kind, type) {
+  return {
+    id,
+    kind,
+    type,
+    sizeBytes: chunk.sizeBytes,
+    sourceAddress: chunk.sourceAddress,
+    memory: { offset: chunk.bundleOffset, sizeBytes: chunk.sizeBytes },
+  };
+}
+
+function sidecarRelocations(context) {
+  const build = sidecarBuild(context.sidecar, hostArch());
+  const heapLayout = typeLayout(build, "struct ControlledDwarfHeapState");
+  const nodeLayout = typeLayout(build, "struct ControlledDwarfNode");
+  return {
+    formatVersion: 1,
+    relocations: linkedListPointerRelocations({
+      heapObject: "controlled-sidecar-heap-state",
+      nodePrefix: "controlled-sidecar-node",
+      heapHeadOffset: layoutField(heapLayout, "head").offset,
+      nodeNextOffset: layoutField(nodeLayout, "next").offset,
+      nodes: context.semanticState.heap.nodes,
+      headPointer: context.semanticState.heap.headPointer,
+    }),
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function runTargetRestore(target, bundleDir) {
+  const result = runCommand(target, ["--restore-dwarf-bundle", bundleDir], {
+    label: "sidecar target restore",
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+  return parseControlledMarker(result.stdout, "dwarf-restore");
+}
+
+function validateRestore(semanticState, restoreEvent) {
+  assert(restoreEvent.arch === hostArch(), "restore ran on the wrong architecture");
+  assert(restoreEvent.global.label === semanticState.global.label, "global label changed");
+  assert(restoreEvent.global.counter === semanticState.global.counter, "global counter changed");
+  assert(restoreEvent.heap.node_count === semanticState.heap.nodeCount, "node count changed");
+  assert(
+    JSON.stringify(restoreEvent.heap.values) === JSON.stringify(semanticState.heap.values),
+    "node values changed",
+  );
+  assert(restoreEvent.heap.checksum_hex === semanticState.heap.checksumHex, "checksum changed");
+}
+
+function summarizeSidecar(sidecar) {
+  return {
+    schemaVersion: sidecar.schemaVersion,
+    builds: sidecar.builds.map((build) => ({
+      arch: build.arch,
+      binaryStripped: build.binary.stripped,
+      symbolNames: build.symbols.map((item) => item.name),
+      typeNames: build.types.map((item) => item.type),
+      pointerFields: build.pointerFields,
+      continuations: build.continuations.map((item) => item.id),
+      resourceRefusals: build.resources.refusalRules,
+    })),
+  };
+}
+
+function sidecarBuild(sidecar, arch) {
+  const build = sidecar.builds.find((candidate) => candidate.arch === arch);
+  if (!build) {
+    throw new Error(`sidecar has no build for ${arch}`);
+  }
+  return build;
+}
+
+function symbol(build, name) {
+  return build.symbols.find((candidate) => candidate.name === name);
+}
+
+function typeLayout(build, typeName) {
+  return build.types.find((candidate) => candidate.type === typeName);
+}
+
+function hexAddress(value) {
+  return `0x${value.toString(16)}`;
+}
+
+function bundleFileStats(bundleDir) {
+  return sharedBundleFileStats(bundleDir, [
+    "manifest.json",
+    "objects.json",
+    "relocations.json",
+    "resources.json",
+    META_FILE,
+    "memory.bin",
+  ]);
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `sidecar-metadata-extract: ${summary.hostArch} restored stripped target values ${summary.restoreEvent.heap.values.join(",")}`,
+  );
+  console.log(`sidecar-metadata-extract: mismatch refusal ${summary.mismatchRefusal.refusal.code}`);
+  if (temporary) {
+    console.log(
+      "sidecar-metadata-extract: temporary artifacts removed; pass --keep to inspect them",
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem

The DWARF extractor still needed debug metadata in the binary at extraction time. Release binaries are often stripped, so we need a separate metadata file that can carry the needed symbols, layouts, pointer fields, safe points, and build identity.

## Solution

This adds a `.machinen-meta.json` sidecar proof. The verifier builds a debug controlled binary, derives sidecar metadata from the DWARF proof, strips the binary with `strip --strip-all`, then captures and restores using only the stripped binary plus the sidecar.

The sidecar records per-architecture build identity, symbols, type layouts, pointer fields, continuations, resource recipes, and refusal rules. A mismatched target hash now produces a stable `target-build-mismatch` refusal before capture.

Closes #419.

## Validation

- `pnpm controlled-binary-corpus`
- `pnpm sidecar-metadata-extract` on macOS arm64 skips as expected
- `pnpm sidecar-metadata-extract` on Linux arm64 via `friend@100.126.46.90`
- `pnpm sidecar-metadata-extract` on Linux amd64 via office Proxmox/Docker
- arm64 sidecar-extracted bundle restored into an amd64 stripped controlled target on the office Proxmox host
- `pnpm exec fallow audit --changed-since origin/pp-418-dwarf-metadata-extraction`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
