### PR TITLE
Add continuation translation proof

### DIFF
--- a/docs/snapshot/continuation-translation.md
+++ b/docs/snapshot/continuation-translation.md
@@ -1,0 +1,47 @@
+# Nested continuation translation proof
+
+Issue #420 moves from global/heap state to a controlled stack continuation.
+
+The source is still the controlled C corpus, but the verifier now stops it while a nested function owns a live stack-local continuation frame. The capturer reads only that described frame object for decoding. The portable bundle records semantic live values and a logical continuation id; it does not copy the source stack bytes into `memory.bin`.
+
+## Flow
+
+1. Build the controlled corpus and raw capturer on Linux.
+2. Launch the target with `--fixture continuation --pause-at-observation`.
+3. The nested function `controlled_continuation_point` creates a stack-local `ControlledContinuationFrame` with:
+   - `seed`
+   - `live_local`
+   - `resume_delta`
+   - `checksum`
+   - `continuation`
+4. The exported `machinen_controlled_continuation_anchor` points at that live frame while the process is stopped.
+5. The raw capturer follows that pointer and reads only the described frame object, not an arbitrary stack window.
+6. The verifier decodes the required live values, validates the checksum, and emits `continuation.json` plus a portable bundle with an empty `memory.bin`.
+7. Restore calls `--restore-continuation-bundle`, which enters `machinen_controlled_continuation_restore`, rebuilds a target-side frame, and resumes the logical continuation.
+
+## Refusal path
+
+If a required live value is not present in the continuation metadata, the proof refuses with:
+
+```json
+{
+  "code": "continuation-live-value-missing",
+  "message": "required continuation live values could not be found"
+}
+```
+
+The verifier exercises this by removing `live_local` from the frame metadata and asserting the refusal happens before restore.
+
+## Scope
+
+This is still a controlled proof. The anchor makes the safe point explicit so we can prove the translation model before handling arbitrary optimized frames. The important property is the bundle shape: restore uses semantic live values and a logical continuation id, not raw return addresses or copied source stack bytes.
+
+## Verify
+
+Run on Linux:
+
+```sh
+pnpm continuation-translate
+```
+
+On non-Linux hosts the verifier skips because capture depends on Linux `/proc` and `ptrace`.

--- a/docs/snapshot/controlled-binary-corpus.md
+++ b/docs/snapshot/controlled-binary-corpus.md
@@ -6,13 +6,15 @@ The fixture source is `packages/microvm/assets/controlled-binary-corpus.c`. It i
 
 ## Fixtures
 
-The corpus has five fixtures:
+The corpus has seven fixtures:
 
 1. `global` — scalar global state.
 2. `heap` — a small heap graph with pointer edges.
 3. `stack` — a nested function with a live local value at an observation point.
-4. `resource` — argv/env plus a regular file and saved offset.
-5. `threads` — two pthread workers stopped at known semantic points.
+4. `continuation` — a nested function with a stack-local continuation frame and logical continuation id.
+5. `resource` — argv/env plus a regular file and saved offset.
+6. `threads` — two pthread workers stopped at known semantic points.
+7. `dwarf` — globals and heap nodes with layouts recovered from DWARF metadata.
 
 Each fixture prints one `MACHINEN_CONTROLLED_BINARY` JSON marker. Passing `--pause-at-observation` makes the process raise `SIGSTOP` after a marker, leaving the state live for an external capturer.
 

--- a/docs/snapshot/raw-process-capture.md
+++ b/docs/snapshot/raw-process-capture.md
@@ -15,6 +15,7 @@ The Linux capturer writes an inspectable directory with:
 - `symbols.json` — exported symbol addresses passed in by the verifier.
 - `memory.json` and `memory.bin` — raw bytes read from `/proc/<pid>/mem` for those symbols.
 - Optional followed-list chunks — when a verifier supplies a DWARF-derived `--follow-list`, the capturer reads a root pointer/count pair and captures the pointed-to heap nodes by a generic node size and next-pointer offset.
+- Optional followed-pointer chunks — when a verifier supplies `--follow-pointer`, the capturer reads one pointer field from a root symbol and captures only that described object. The continuation proof uses this to decode a live stack-local frame without copying a raw stack window.
 - `target.log` — the controlled fixture's observation marker and pause log.
 
 ## Verify

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "known-symbol-extract": "node scripts/known-symbol-extract.mjs verify",
     "dwarf-symbol-extract": "node scripts/dwarf-symbol-extract.mjs verify",
     "sidecar-metadata-extract": "node scripts/sidecar-metadata-extract.mjs verify",
+    "continuation-translate": "node scripts/continuation-translate.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/controlled-binary-corpus.c
+++ b/packages/microvm/assets/controlled-binary-corpus.c
@@ -61,6 +61,20 @@ struct ControlledStackObservation {
   char continuation[CONTROLLED_LABEL_CAPACITY];
 };
 
+struct ControlledContinuationFrame {
+  uint64_t seed;
+  uint64_t live_local;
+  uint64_t resume_delta;
+  uint64_t checksum;
+  char continuation[CONTROLLED_LABEL_CAPACITY];
+};
+
+struct ControlledContinuationAnchor {
+  struct ControlledContinuationFrame *frame;
+  uint64_t frame_size;
+  char continuation[CONTROLLED_LABEL_CAPACITY];
+};
+
 struct ControlledResourceState {
   uint32_t argc;
   uint32_t env_seen;
@@ -105,6 +119,7 @@ struct ControlledDwarfHeapState {
 CONTROLLED_EXPORT struct ControlledGlobalState machinen_controlled_global_state;
 CONTROLLED_EXPORT struct ControlledHeapState machinen_controlled_heap_state;
 CONTROLLED_EXPORT struct ControlledStackObservation machinen_controlled_stack_observation;
+CONTROLLED_EXPORT struct ControlledContinuationAnchor machinen_controlled_continuation_anchor;
 CONTROLLED_EXPORT struct ControlledResourceState machinen_controlled_resource_state;
 CONTROLLED_EXPORT struct ControlledThreadState machinen_controlled_thread_states[CONTROLLED_THREAD_COUNT];
 CONTROLLED_EXPORT struct ControlledDwarfGlobalState machinen_controlled_dwarf_global_state;
@@ -113,10 +128,11 @@ CONTROLLED_EXPORT struct ControlledDwarfHeapState machinen_controlled_dwarf_heap
 CONTROLLED_EXPORT const char machinen_controlled_corpus_metadata[] =
     "{\"schema_version\":1,"
     "\"workload\":\"machinen-controlled-binary-corpus\","
-    "\"fixtures\":[\"global\",\"heap\",\"stack\",\"resource\",\"threads\",\"dwarf\"],"
+    "\"fixtures\":[\"global\",\"heap\",\"stack\",\"continuation\",\"resource\",\"threads\",\"dwarf\"],"
     "\"global_symbol\":\"machinen_controlled_global_state\","
     "\"heap_symbol\":\"machinen_controlled_heap_state\","
     "\"stack_symbol\":\"machinen_controlled_stack_observation\","
+    "\"continuation_symbol\":\"machinen_controlled_continuation_anchor\","
     "\"resource_symbol\":\"machinen_controlled_resource_state\","
     "\"threads_symbol\":\"machinen_controlled_thread_states\","
     "\"dwarf_global_symbol\":\"machinen_controlled_dwarf_global_state\","
@@ -176,6 +192,22 @@ static uint64_t checksum_dwarf_nodes(const struct ControlledDwarfNode *head) {
     hash ^= node->value;
     hash *= UINT64_C(1099511628211);
     node = node->next;
+  }
+  return hash;
+}
+
+static uint64_t checksum_continuation_values(
+    uint64_t seed, uint64_t live_local, uint64_t resume_delta, const char *continuation) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  hash ^= seed;
+  hash *= UINT64_C(1099511628211);
+  hash ^= live_local;
+  hash *= UINT64_C(1099511628211);
+  hash ^= resume_delta;
+  hash *= UINT64_C(1099511628211);
+  for (const unsigned char *p = (const unsigned char *)continuation; *p; p++) {
+    hash ^= *p;
+    hash *= UINT64_C(1099511628211);
   }
   return hash;
 }
@@ -346,6 +378,68 @@ static int run_stack_fixture(void) {
   return 0;
 }
 
+static void fill_continuation_frame(
+    struct ControlledContinuationFrame *frame, uint64_t seed, uint64_t resume_delta) {
+  memset(frame, 0, sizeof(*frame));
+  frame->seed = seed;
+  frame->live_local = seed + UINT64_C(4242);
+  frame->resume_delta = resume_delta;
+  copy_label(frame->continuation, "controlled_continuation_point");
+  frame->checksum = checksum_continuation_values(
+      frame->seed, frame->live_local, frame->resume_delta, frame->continuation);
+}
+
+static uint64_t finish_continuation_frame(const struct ControlledContinuationFrame *frame) {
+  uint64_t expected = checksum_continuation_values(
+      frame->seed, frame->live_local, frame->resume_delta, frame->continuation);
+  if (frame->checksum != expected) {
+    return UINT64_MAX;
+  }
+  return frame->live_local + frame->resume_delta;
+}
+
+static void print_continuation_marker(const char *fixture, uint64_t result) {
+  const struct ControlledContinuationFrame *frame = machinen_controlled_continuation_anchor.frame;
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"%s\",\"arch\":\"%s\","
+         "\"continuation\":\"%s\",\"frame_size\":%" PRIu64 ","
+         "\"seed\":%" PRIu64 ",\"live_local\":%" PRIu64 ","
+         "\"resume_delta\":%" PRIu64 ",\"checksum\":%" PRIu64 ","
+         "\"checksum_hex\":\"0x%" PRIx64 "\",\"result\":%" PRIu64 "}\n",
+      CONTROLLED_SCHEMA_VERSION, fixture, CONTROLLED_ARCH,
+      machinen_controlled_continuation_anchor.continuation,
+      machinen_controlled_continuation_anchor.frame_size, frame ? frame->seed : 0,
+      frame ? frame->live_local : 0, frame ? frame->resume_delta : 0, frame ? frame->checksum : 0,
+      frame ? frame->checksum : 0, result);
+  fflush(stdout);
+}
+
+static uint64_t controlled_continuation_point(uint64_t seed) {
+  struct ControlledContinuationFrame frame;
+  fill_continuation_frame(&frame, seed, 77u);
+  machinen_controlled_continuation_anchor.frame = &frame;
+  machinen_controlled_continuation_anchor.frame_size = sizeof(frame);
+  copy_label(machinen_controlled_continuation_anchor.continuation, frame.continuation);
+
+  print_continuation_marker("continuation", 0);
+  maybe_pause_at_observation("continuation");
+  return finish_continuation_frame(&frame);
+}
+
+static uint64_t controlled_continuation_outer(uint64_t seed) {
+  return controlled_continuation_point(seed);
+}
+
+static int run_continuation_fixture(void) {
+  uint64_t result = controlled_continuation_outer(1000);
+  if (result != 5319u) {
+    fprintf(stderr, "machinen-controlled-corpus: continuation result invariant failed\n");
+    return 1;
+  }
+  memset(&machinen_controlled_continuation_anchor, 0, sizeof(machinen_controlled_continuation_anchor));
+  return 0;
+}
+
 static void print_resource_marker(void) {
   printf(CONTROLLED_MARKER
          "{\"schema_version\":%u,\"fixture\":\"resource\",\"arch\":\"%s\","
@@ -504,6 +598,14 @@ struct ControlledDwarfRestoreState {
   uint64_t values[3];
   uint64_t tags[3];
   uint64_t colors[3];
+  uint64_t checksum;
+};
+
+struct ControlledContinuationRestoreState {
+  char continuation[CONTROLLED_LABEL_CAPACITY];
+  uint64_t seed;
+  uint64_t live_local;
+  uint64_t resume_delta;
   uint64_t checksum;
 };
 
@@ -728,11 +830,88 @@ static int run_dwarf_restore(const char *bundle_dir) {
   return 0;
 }
 
+static int load_continuation_restore_state(
+    const char *bundle_dir, struct ControlledContinuationRestoreState *state) {
+  char path[CONTROLLED_PATH_CAPACITY];
+  int written = snprintf(path, sizeof(path), "%s/controlled-state.txt", bundle_dir);
+  if (written < 0 || written >= (int)sizeof(path)) {
+    fprintf(stderr, "machinen-controlled-corpus: continuation restore bundle path too long\n");
+    return 1;
+  }
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    fprintf(stderr, "machinen-controlled-corpus: fopen(%s) failed: %s\n", path, strerror(errno));
+    return 1;
+  }
+
+  char line[128];
+  while (fgets(line, sizeof(line), file)) {
+    if (parse_string_line(line, "continuation=", state->continuation, sizeof(state->continuation)) ||
+        parse_u64_line(line, "seed=", &state->seed) ||
+        parse_u64_line(line, "live_local=", &state->live_local) ||
+        parse_u64_line(line, "resume_delta=", &state->resume_delta) ||
+        parse_u64_line(line, "checksum=", &state->checksum)) {
+      continue;
+    }
+  }
+
+  if (fclose(file) != 0) {
+    fprintf(stderr, "machinen-controlled-corpus: fclose(%s) failed\n", path);
+    return 1;
+  }
+  if (state->continuation[0] == '\0' || state->live_local == 0) {
+    fprintf(stderr, "machinen-controlled-corpus: invalid continuation restore state\n");
+    return 1;
+  }
+  return 0;
+}
+
+static uint64_t controlled_continuation_restore_trampoline(
+    const struct ControlledContinuationRestoreState *state) {
+  struct ControlledContinuationFrame frame;
+  memset(&frame, 0, sizeof(frame));
+  frame.seed = state->seed;
+  frame.live_local = state->live_local;
+  frame.resume_delta = state->resume_delta;
+  copy_label(frame.continuation, state->continuation);
+  frame.checksum = state->checksum;
+  return finish_continuation_frame(&frame);
+}
+
+static void print_continuation_restore_marker(
+    const struct ControlledContinuationRestoreState *state, uint64_t result) {
+  printf(CONTROLLED_MARKER
+         "{\"schema_version\":%u,\"fixture\":\"continuation-restore\",\"arch\":\"%s\","
+         "\"continuation\":\"%s\",\"seed\":%" PRIu64 ","
+         "\"live_local\":%" PRIu64 ",\"resume_delta\":%" PRIu64 ","
+         "\"checksum\":%" PRIu64 ",\"checksum_hex\":\"0x%" PRIx64 "\","
+         "\"result\":%" PRIu64 ",\"resumed\":true}\n",
+      CONTROLLED_SCHEMA_VERSION, CONTROLLED_ARCH, state->continuation, state->seed,
+      state->live_local, state->resume_delta, state->checksum, state->checksum, result);
+  fflush(stdout);
+}
+
+static int run_continuation_restore(const char *bundle_dir) {
+  struct ControlledContinuationRestoreState state = {0};
+  if (load_continuation_restore_state(bundle_dir, &state) != 0) {
+    return 1;
+  }
+  uint64_t result = controlled_continuation_restore_trampoline(&state);
+  if (result == UINT64_MAX || result != state.live_local + state.resume_delta) {
+    fprintf(stderr, "machinen-controlled-corpus: continuation restore failed\n");
+    return 1;
+  }
+  print_continuation_restore_marker(&state, result);
+  return 0;
+}
+
 static void print_usage(const char *argv0) {
   fprintf(stderr,
       "usage: %s [--fixture all|global|heap|stack|resource|threads|dwarf] "
       "[--resource-file path] [--pause-at-observation] "
-      "[--restore-known-symbol-bundle path] [--restore-dwarf-bundle path]\n",
+      "[--restore-known-symbol-bundle path] [--restore-dwarf-bundle path] "
+      "[--restore-continuation-bundle path]\n",
       argv0);
 }
 
@@ -753,6 +932,9 @@ static int run_selected_fixture(const char *fixture, const char *resource_path, 
   if (streq(fixture, "dwarf")) {
     return run_dwarf_fixture();
   }
+  if (streq(fixture, "continuation")) {
+    return run_continuation_fixture();
+  }
   if (streq(fixture, "resource")) {
     return run_resource_fixture(resource_path, argc);
   }
@@ -764,7 +946,7 @@ static int run_selected_fixture(const char *fixture, const char *resource_path, 
 }
 
 static int run_all_fixtures(const char *resource_path, int argc) {
-  const char *fixtures[] = {"global", "heap", "stack", "resource", "threads", "dwarf"};
+  const char *fixtures[] = {"global", "heap", "stack", "continuation", "resource", "threads", "dwarf"};
   for (uint32_t i = 0; i < sizeof(fixtures) / sizeof(fixtures[0]); i++) {
     if (run_selected_fixture(fixtures[i], resource_path, argc) != 0) {
       return 1;
@@ -778,6 +960,7 @@ int main(int argc, char **argv) {
   const char *resource_path = "machinen-controlled-resource.txt";
   const char *restore_bundle_dir = NULL;
   const char *dwarf_restore_bundle_dir = NULL;
+  const char *continuation_restore_bundle_dir = NULL;
 
   for (int i = 1; i < argc; i++) {
     if (streq(argv[i], "--fixture")) {
@@ -806,6 +989,12 @@ int main(int argc, char **argv) {
         return 2;
       }
       dwarf_restore_bundle_dir = argv[++i];
+    } else if (streq(argv[i], "--restore-continuation-bundle")) {
+      if (i + 1 >= argc) {
+        print_usage(argv[0]);
+        return 2;
+      }
+      continuation_restore_bundle_dir = argv[++i];
     } else if (streq(argv[i], "--help") || streq(argv[i], "-h")) {
       print_usage(argv[0]);
       return 0;
@@ -821,6 +1010,9 @@ int main(int argc, char **argv) {
   }
   if (dwarf_restore_bundle_dir) {
     return run_dwarf_restore(dwarf_restore_bundle_dir);
+  }
+  if (continuation_restore_bundle_dir) {
+    return run_continuation_restore(continuation_restore_bundle_dir);
   }
   if (streq(fixture, "all")) {
     return run_all_fixtures(resource_path, argc);

--- a/packages/microvm/assets/raw-process-capture.c
+++ b/packages/microvm/assets/raw-process-capture.c
@@ -27,6 +27,7 @@
 
 #define RAW_CAPTURE_MAX_SYMBOLS 32u
 #define RAW_CAPTURE_MAX_FOLLOW_LISTS 8u
+#define RAW_CAPTURE_MAX_FOLLOW_POINTERS 8u
 #define RAW_CAPTURE_MAX_THREADS 64u
 #define RAW_CAPTURE_MAX_ARGV 128u
 #define RAW_CAPTURE_REG_BYTES 1024u
@@ -58,12 +59,21 @@ struct FollowList {
   char chunk_prefix[128];
 };
 
+struct FollowPointer {
+  char root_symbol[128];
+  uint64_t pointer_offset;
+  uint64_t object_size;
+  char chunk_name[128];
+};
+
 struct Options {
   const char *output_dir;
   struct CaptureSymbol symbols[RAW_CAPTURE_MAX_SYMBOLS];
   uint32_t symbol_count;
   struct FollowList follow_lists[RAW_CAPTURE_MAX_FOLLOW_LISTS];
   uint32_t follow_list_count;
+  struct FollowPointer follow_pointers[RAW_CAPTURE_MAX_FOLLOW_POINTERS];
+  uint32_t follow_pointer_count;
   int command_index;
 };
 
@@ -227,10 +237,46 @@ static void parse_follow_list(struct Options *opts, const char *spec) {
   }
 }
 
+static void parse_follow_pointer(struct Options *opts, const char *spec) {
+  if (opts->follow_pointer_count >= RAW_CAPTURE_MAX_FOLLOW_POINTERS) {
+    fail("too many follow pointers");
+  }
+
+  char scratch[512];
+  if (snprintf(scratch, sizeof(scratch), "%s", spec) >= (int)sizeof(scratch)) {
+    fail("follow-pointer spec too long");
+  }
+
+  char *cursor = scratch;
+  char *root = next_token(&cursor);
+  char *pointer_offset = next_token(&cursor);
+  char *object_size = next_token(&cursor);
+  char *chunk_name = next_token(&cursor);
+  if (!root || !pointer_offset || !object_size || !chunk_name || cursor) {
+    fail("--follow-pointer must be root-symbol:pointer-offset:object-size:chunk-name");
+  }
+
+  struct FollowPointer *follow = &opts->follow_pointers[opts->follow_pointer_count++];
+  if (snprintf(follow->root_symbol, sizeof(follow->root_symbol), "%s", root) >=
+      (int)sizeof(follow->root_symbol)) {
+    fail("follow-pointer root symbol too long");
+  }
+  follow->pointer_offset = parse_u64(pointer_offset, "follow-pointer pointer offset");
+  follow->object_size = parse_u64(object_size, "follow-pointer object size");
+  if (follow->object_size == 0 || follow->object_size > RAW_CAPTURE_MAX_FOLLOW_NODE_SIZE) {
+    fail("follow-pointer object size is out of range");
+  }
+  if (snprintf(follow->chunk_name, sizeof(follow->chunk_name), "%s", chunk_name) >=
+      (int)sizeof(follow->chunk_name)) {
+    fail("follow-pointer chunk name too long");
+  }
+}
+
 static void usage(const char *argv0) {
   fprintf(stderr,
       "usage: %s --output dir [--symbol name:address:size ...] "
       "[--follow-list root:head-offset:count-offset:node-size:next-offset:prefix ...] "
+      "[--follow-pointer root:pointer-offset:object-size:chunk-name ...] "
       "-- program [args...]\n",
       argv0);
 }
@@ -256,6 +302,12 @@ static struct Options parse_args(int argc, char **argv) {
         exit(2);
       }
       parse_follow_list(&opts, argv[++i]);
+    } else if (streq(argv[i], "--follow-pointer")) {
+      if (i + 1 >= argc) {
+        usage(argv[0]);
+        exit(2);
+      }
+      parse_follow_pointer(&opts, argv[++i]);
     } else if (streq(argv[i], "--")) {
       opts.command_index = i + 1;
       break;
@@ -695,6 +747,30 @@ static void append_matching_follow_lists(FILE *json, FILE *bin, bool *first, uin
   }
 }
 
+static void append_matching_follow_pointers(FILE *json, FILE *bin, bool *first,
+    uint64_t *file_offset, int mem_fd, const struct Options *opts,
+    const struct CaptureSymbol *symbol, const uint8_t *buffer) {
+  for (uint32_t i = 0; i < opts->follow_pointer_count; i++) {
+    const struct FollowPointer *follow = &opts->follow_pointers[i];
+    if (!streq(follow->root_symbol, symbol->name)) {
+      continue;
+    }
+    require_u64_window(follow->pointer_offset, symbol->size_bytes, "pointer");
+    uint64_t address = read_u64_native(buffer + follow->pointer_offset);
+    if (address == 0) {
+      fail("follow-pointer address is null");
+    }
+    uint8_t *object = malloc((size_t)follow->object_size);
+    if (!object) {
+      die("malloc follow-pointer object");
+    }
+    read_process_memory(mem_fd, address, object, follow->object_size);
+    append_memory_chunk(json, bin, first, file_offset, follow->chunk_name, address, object,
+        follow->object_size);
+    free(object);
+  }
+}
+
 static void append_symbol_memory(FILE *json, FILE *bin, bool *first, uint64_t *file_offset,
     int mem_fd, const struct Options *opts, const struct CaptureSymbol *symbol) {
   if (symbol->size_bytes > 1024u * 1024u) {
@@ -711,6 +787,7 @@ static void append_symbol_memory(FILE *json, FILE *bin, bool *first, uint64_t *f
     append_controlled_heap_nodes(json, bin, first, file_offset, mem_fd, buffer, symbol->size_bytes);
   }
   append_matching_follow_lists(json, bin, first, file_offset, mem_fd, opts, symbol, buffer);
+  append_matching_follow_pointers(json, bin, first, file_offset, mem_fd, opts, symbol, buffer);
   free(buffer);
 }
 

--- a/packages/runtime/src/__tests__/continuation-translate.test.ts
+++ b/packages/runtime/src/__tests__/continuation-translate.test.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePortableSnapshotBundle } from "../vm/portable-snapshot.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/continuation-translate.mjs");
+const TMP: string[] = [];
+
+interface ContinuationSummary {
+  skipped?: boolean;
+  hostArch: string;
+  bundleDir: string;
+  continuation: {
+    id: string;
+    restoreEntrypoint: string;
+    requiredLiveValues: string[];
+    rawStackCopied: boolean;
+    liveValues: Array<{ name: string; value: number | string; source: string }>;
+  };
+  semanticState: {
+    id: string;
+    rawStackCopied: boolean;
+    seed: number;
+    liveLocal: number;
+    resumeDelta: number;
+    checksumHex: string;
+    result: number;
+    liveValues: Array<{ name: string; value: number | string; source: string }>;
+  };
+  missingValueRefusal: { code: string; message: string; detail: { missing: string[] } };
+  restoreEvent: {
+    fixture: string;
+    continuation: string;
+    seed: number;
+    live_local: number;
+    resume_delta: number;
+    checksum_hex: string;
+    result: number;
+    resumed: boolean;
+  };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("continuation translation", () => {
+  it.skipIf(process.platform !== "linux")(
+    "restores a nested controlled continuation without copying the raw source stack",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "continuation-translate-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as ContinuationSummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.continuation).toMatchObject({
+        id: "controlled_continuation_point",
+        restoreEntrypoint: "machinen_controlled_continuation_restore",
+        rawStackCopied: false,
+      });
+      expect(summary.continuation.requiredLiveValues).toEqual([
+        "continuation",
+        "seed",
+        "live_local",
+        "resume_delta",
+        "checksum",
+      ]);
+      expect(summary.semanticState).toMatchObject({
+        id: "controlled_continuation_point",
+        rawStackCopied: false,
+        seed: 1000,
+        liveLocal: 5242,
+        resumeDelta: 77,
+        result: 5319,
+      });
+      expect(summary.semanticState.liveValues.map((value) => value.name)).toEqual([
+        "seed",
+        "live_local",
+        "resume_delta",
+        "checksum",
+      ]);
+      expect(
+        summary.semanticState.liveValues.every((value) => value.source === "stack-frame-field"),
+      ).toBe(true);
+      expect(summary.missingValueRefusal).toMatchObject({
+        code: "continuation-live-value-missing",
+        detail: { missing: ["live_local"] },
+      });
+      expect(summary.restoreEvent).toMatchObject({
+        fixture: "continuation-restore",
+        continuation: summary.semanticState.id,
+        seed: summary.semanticState.seed,
+        live_local: summary.semanticState.liveLocal,
+        resume_delta: summary.semanticState.resumeDelta,
+        result: summary.semanticState.result,
+        resumed: true,
+      });
+      expect(summary.restoreEvent.checksum_hex).toBe(summary.semanticState.checksumHex);
+
+      const bundle = validatePortableSnapshotBundle(summary.bundleDir);
+      expect(bundle.manifest.features).toContain("continuation-translation");
+      expect(bundle.objects.objects.map((object) => object.id)).toEqual([
+        "controlled-continuation-frame",
+        "controlled-continuation-live-values",
+      ]);
+      expect(bundle.objects.objects[0]).not.toHaveProperty("memory");
+      expect(bundle.relocations.relocations).toHaveLength(0);
+    },
+  );
+});

--- a/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
+++ b/packages/runtime/src/__tests__/controlled-binary-corpus.test.ts
@@ -41,6 +41,7 @@ describe("controlled binary corpus", () => {
       "global",
       "heap",
       "stack",
+      "continuation",
       "resource",
       "threads",
       "dwarf",
@@ -48,6 +49,11 @@ describe("controlled binary corpus", () => {
     expect(summary.native.events.find((event) => event.fixture === "stack")).toMatchObject({
       continuation: "controlled_nested_stack_point",
       live_local: 5242,
+    });
+    expect(summary.native.events.find((event) => event.fixture === "continuation")).toMatchObject({
+      continuation: "controlled_continuation_point",
+      live_local: 5242,
+      resume_delta: 77,
     });
     expect(summary.native.events.find((event) => event.fixture === "dwarf")).toMatchObject({
       global: { label: "dwarf-global-layout-v2", counter: 7000 },

--- a/packages/runtime/src/vm/portable-snapshot.ts
+++ b/packages/runtime/src/vm/portable-snapshot.ts
@@ -34,6 +34,7 @@ const PORTABLE_REFUSAL_CODES = [
   "checkpoint-inside-syscall",
   "checkpoint-unsupported-root",
   "checkpoint-unknown-root",
+  "continuation-live-value-missing",
   "pointer-outside-known-object",
   "thread-count-unsupported",
   "thread-not-at-barrier",

--- a/scripts/continuation-translate.mjs
+++ b/scripts/continuation-translate.mjs
@@ -1,0 +1,472 @@
+#!/usr/bin/env node
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CAPTURE_SOURCE,
+  CONTROLLED_SOURCE,
+  bundleFileStats as sharedBundleFileStats,
+  compileControlledTarget,
+  compileRawCapturer,
+  controlledPortableManifest,
+  ensureSourcesExist,
+  hostArch,
+  layoutField,
+  loadRawCapture,
+  memoryChunkByName,
+  memoryChunkBytes,
+  parseControlledMarker,
+  readLayoutCString,
+  readLayoutUnsigned,
+  readSymbols,
+  unsupportedVocabulary,
+  writePortableBundleFiles,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/continuation-translate.mjs [verify] [--out-dir path] [--json] [--keep]";
+const BUILD_ID = "4204204204204200";
+const ANCHOR_SYMBOL = "machinen_controlled_continuation_anchor";
+const FRAME_CHUNK = "machinen_controlled_continuation_frame";
+const CONTINUATION_ID = "controlled_continuation_point";
+const RESTORE_ENTRYPOINT = "machinen_controlled_continuation_restore";
+const REQUIRED_LIVE_VALUES = ["continuation", "seed", "live_local", "resume_delta", "checksum"];
+
+const CONTINUATION_LAYOUTS = {
+  anchor: {
+    type: "struct ControlledContinuationAnchor",
+    byteSize: 48,
+    fields: [
+      {
+        name: "frame",
+        offset: 0,
+        sizeBytes: 8,
+        type: "struct ControlledContinuationFrame *",
+        pointer: true,
+      },
+      { name: "frame_size", offset: 8, sizeBytes: 8, type: "uint64_t", pointer: false },
+      { name: "continuation", offset: 16, sizeBytes: 32, type: "char[]", pointer: false },
+    ],
+  },
+  frame: {
+    type: "struct ControlledContinuationFrame",
+    byteSize: 64,
+    fields: [
+      { name: "seed", offset: 0, sizeBytes: 8, type: "uint64_t", pointer: false },
+      { name: "live_local", offset: 8, sizeBytes: 8, type: "uint64_t", pointer: false },
+      { name: "resume_delta", offset: 16, sizeBytes: 8, type: "uint64_t", pointer: false },
+      { name: "checksum", offset: 24, sizeBytes: 8, type: "uint64_t", pointer: false },
+      { name: "continuation", offset: 32, sizeBytes: 32, type: "char[]", pointer: false },
+    ],
+  },
+};
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(
+      args,
+      "continuation-translate",
+      "continuation translation proof uses Linux /proc and ptrace",
+    );
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-continuation-translate-");
+  try {
+    emitResult(verifyContinuationTranslation(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyContinuationTranslation(outDir) {
+  ensureSourcesExist([CONTROLLED_SOURCE, CAPTURE_SOURCE]);
+  const binDir = join(outDir, "bin");
+  const captureDir = join(outDir, "capture-continuation");
+  const bundleDir = join(outDir, "bundle");
+  mkdirSync(binDir, { recursive: true });
+
+  const target = compileControlledTarget(binDir);
+  const capturer = compileRawCapturer(binDir);
+  const metadata = continuationMetadata(target);
+  runContinuationCapture({ capturer, target, captureDir, metadata });
+
+  const capture = loadRawCapture(captureDir);
+  const sourceEvent = parseControlledMarker(capture.targetLog, "continuation");
+  const recovered = recoverContinuationState(capture, metadata);
+  assert(recovered.accepted, recovered.refusal?.message || "continuation recovery failed");
+  const semanticState = recovered.state;
+  validateSourceEvent(sourceEvent, semanticState);
+
+  const missingValueRefusal = recoverContinuationState(
+    capture,
+    metadataWithoutFrameField(metadata, "live_local"),
+  );
+  assert(!missingValueRefusal.accepted, "missing live value should refuse");
+
+  writeContinuationBundle({ bundleDir, captureDir, capture, semanticState, metadata, target });
+  const restoreEvent = runTargetRestore(target, bundleDir);
+  validateRestore(semanticState, restoreEvent);
+
+  return {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    target,
+    captureDir,
+    bundleDir,
+    continuation: continuationSummary(metadata, semanticState),
+    sourceEvent,
+    semanticState,
+    missingValueRefusal: missingValueRefusal.refusal,
+    restoreEvent,
+    bundleFiles: bundleFileStats(bundleDir),
+  };
+}
+
+function continuationMetadata(target) {
+  const symbols = readSymbols(target, [ANCHOR_SYMBOL]);
+  const anchor = symbols.get(ANCHOR_SYMBOL);
+  return {
+    formatVersion: 1,
+    continuation: {
+      id: CONTINUATION_ID,
+      captureFunction: "controlled_continuation_point",
+      restoreEntrypoint: RESTORE_ENTRYPOINT,
+      requiredLiveValues: REQUIRED_LIVE_VALUES,
+      safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
+    },
+    symbols: [{ name: ANCHOR_SYMBOL, type: CONTINUATION_LAYOUTS.anchor.type, ...anchor }],
+    layouts: CONTINUATION_LAYOUTS,
+  };
+}
+
+function runContinuationCapture(context) {
+  const anchor = symbol(context.metadata, ANCHOR_SYMBOL);
+  const framePointer = layoutField(context.metadata.layouts.anchor, "frame");
+  runCommand(
+    context.capturer,
+    [
+      "--output",
+      context.captureDir,
+      "--symbol",
+      `${anchor.name}:${anchor.address}:${anchor.sizeBytes}`,
+      "--follow-pointer",
+      [
+        ANCHOR_SYMBOL,
+        framePointer.offset,
+        context.metadata.layouts.frame.byteSize,
+        FRAME_CHUNK,
+      ].join(":"),
+      "--",
+      context.target,
+      "--fixture",
+      "continuation",
+      "--pause-at-observation",
+    ],
+    { label: "continuation raw capture", env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" } },
+  );
+}
+
+function recoverContinuationState(capture, metadata) {
+  const missing = missingRequiredLiveValues(metadata);
+  if (missing.length > 0) {
+    return liveValueRefusal(missing);
+  }
+
+  const anchorChunk = memoryChunkByName(capture, ANCHOR_SYMBOL);
+  const frameChunk = memoryChunkByName(capture, FRAME_CHUNK);
+  const anchorBytes = memoryChunkBytes(capture, anchorChunk);
+  const frameBytes = memoryChunkBytes(capture, frameChunk);
+  const anchorContinuation = readLayoutCString(
+    anchorBytes,
+    layoutField(metadata.layouts.anchor, "continuation"),
+  );
+  const frameContinuation = readLayoutCString(
+    frameBytes,
+    layoutField(metadata.layouts.frame, "continuation"),
+  );
+  const seed = readLayoutUnsigned(frameBytes, layoutField(metadata.layouts.frame, "seed"));
+  const liveLocal = readLayoutUnsigned(
+    frameBytes,
+    layoutField(metadata.layouts.frame, "live_local"),
+  );
+  const resumeDelta = readLayoutUnsigned(
+    frameBytes,
+    layoutField(metadata.layouts.frame, "resume_delta"),
+  );
+  const checksum = readLayoutUnsigned(frameBytes, layoutField(metadata.layouts.frame, "checksum"));
+  const expectedChecksum = checksumContinuationValues(
+    seed,
+    liveLocal,
+    resumeDelta,
+    frameContinuation,
+  );
+  if (checksum !== expectedChecksum) {
+    return {
+      accepted: false,
+      refusal: {
+        code: "continuation-live-value-missing",
+        message: "continuation live value checksum did not match captured locals",
+        detail: {
+          expectedChecksum: hexAddress(expectedChecksum),
+          actualChecksum: hexAddress(checksum),
+        },
+      },
+    };
+  }
+
+  return {
+    accepted: true,
+    state: {
+      id: frameContinuation,
+      anchorContinuation,
+      sourceFrameAddress: frameChunk.sourceAddress,
+      sourceAnchorAddress: anchorChunk.sourceAddress,
+      rawStackCopied: false,
+      seed: Number(seed),
+      liveLocal: Number(liveLocal),
+      resumeDelta: Number(resumeDelta),
+      checksumHex: hexAddress(checksum),
+      result: Number(liveLocal + resumeDelta),
+      liveValues: [
+        liveValue("seed", seed, metadata),
+        liveValue("live_local", liveLocal, metadata),
+        liveValue("resume_delta", resumeDelta, metadata),
+        liveValue("checksum", checksum, metadata),
+      ],
+    },
+  };
+}
+
+function missingRequiredLiveValues(metadata) {
+  return metadata.continuation.requiredLiveValues.filter((name) => {
+    if (name === "continuation") {
+      return (
+        !hasLayoutField(metadata.layouts.frame, name) ||
+        !hasLayoutField(metadata.layouts.anchor, name)
+      );
+    }
+    return !hasLayoutField(metadata.layouts.frame, name);
+  });
+}
+
+function hasLayoutField(layout, name) {
+  return layout.fields.some((field) => field.name === name);
+}
+
+function liveValueRefusal(missing) {
+  return {
+    accepted: false,
+    refusal: {
+      code: "continuation-live-value-missing",
+      message: "required continuation live values could not be found",
+      detail: { missing },
+    },
+  };
+}
+
+function liveValue(name, value, metadata) {
+  const field = layoutField(metadata.layouts.frame, name);
+  return {
+    name,
+    value: name === "checksum" ? hexAddress(value) : Number(value),
+    source: "stack-frame-field",
+    offset: field.offset,
+    sizeBytes: field.sizeBytes,
+  };
+}
+
+function metadataWithoutFrameField(metadata, fieldName) {
+  return {
+    ...metadata,
+    layouts: {
+      ...metadata.layouts,
+      frame: {
+        ...metadata.layouts.frame,
+        fields: metadata.layouts.frame.fields.filter((field) => field.name !== fieldName),
+      },
+    },
+  };
+}
+
+function validateSourceEvent(sourceEvent, semanticState) {
+  assert(sourceEvent.continuation === semanticState.id, "source continuation id changed");
+  assert(sourceEvent.seed === semanticState.seed, "source seed changed");
+  assert(sourceEvent.live_local === semanticState.liveLocal, "source live local changed");
+  assert(sourceEvent.resume_delta === semanticState.resumeDelta, "source resume delta changed");
+  assert(sourceEvent.checksum_hex === semanticState.checksumHex, "source checksum changed");
+}
+
+function writeContinuationBundle(context) {
+  writePortableBundleFiles({
+    bundleDir: context.bundleDir,
+    captureDir: context.captureDir,
+    capture: context.capture,
+    memory: { chunks: [], bytes: Buffer.alloc(0) },
+    manifest: manifest(context),
+    objects: objects(context),
+    relocations: relocations(),
+    controlledStateText: controlledStateText(context.semanticState),
+    extraDocuments: [{ name: "continuation.json", value: continuationDocument(context) }],
+  });
+}
+
+function manifest(context) {
+  return controlledPortableManifest({
+    target: context.target,
+    capture: context.capture,
+    buildId: BUILD_ID,
+    version: "continuation-translation-proof",
+    checkpointContinuation: CONTINUATION_ID,
+    restoreEntrypoint: RESTORE_ENTRYPOINT,
+    features: ["controlled-binary-corpus", "external-raw-capture", "continuation-translation"],
+  });
+}
+
+function objects(context) {
+  return {
+    formatVersion: 1,
+    objects: [
+      {
+        id: "controlled-continuation-frame",
+        kind: "stack",
+        type: context.metadata.layouts.frame.type,
+        sizeBytes: context.metadata.layouts.frame.byteSize,
+        sourceAddress: context.semanticState.sourceFrameAddress,
+      },
+      {
+        id: "controlled-continuation-live-values",
+        kind: "opaque",
+        type: "semantic continuation live values",
+        sizeBytes: 0,
+      },
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function relocations() {
+  return { formatVersion: 1, relocations: [], unsupported: unsupportedVocabulary() };
+}
+
+function controlledStateText(semanticState) {
+  return [
+    `continuation=${semanticState.id}`,
+    `seed=${semanticState.seed}`,
+    `live_local=${semanticState.liveLocal}`,
+    `resume_delta=${semanticState.resumeDelta}`,
+    `checksum=${semanticState.checksumHex}`,
+    "",
+  ].join("\n");
+}
+
+function continuationDocument(context) {
+  return {
+    formatVersion: 1,
+    sourceGuestArch: hostArch(),
+    continuation: context.metadata.continuation,
+    layouts: context.metadata.layouts,
+    source: {
+      anchorAddress: context.semanticState.sourceAnchorAddress,
+      frameAddress: context.semanticState.sourceFrameAddress,
+      capturedFrameForDecodingOnly: true,
+      rawStackCopied: false,
+    },
+    liveValues: context.semanticState.liveValues,
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function runTargetRestore(target, bundleDir) {
+  const result = runCommand(target, ["--restore-continuation-bundle", bundleDir], {
+    label: "continuation target restore",
+    env: { ...process.env, MACHINEN_CONTROLLED_ENV: "1" },
+  });
+  return parseControlledMarker(result.stdout, "continuation-restore");
+}
+
+function validateRestore(semanticState, restoreEvent) {
+  assert(restoreEvent.arch === hostArch(), "restore ran on unexpected host architecture");
+  assert(restoreEvent.continuation === semanticState.id, "restored continuation id changed");
+  assert(restoreEvent.seed === semanticState.seed, "restored seed changed");
+  assert(restoreEvent.live_local === semanticState.liveLocal, "restored live local changed");
+  assert(restoreEvent.resume_delta === semanticState.resumeDelta, "restored resume delta changed");
+  assert(restoreEvent.checksum_hex === semanticState.checksumHex, "restored checksum changed");
+  assert(restoreEvent.result === semanticState.result, "restored continuation result changed");
+  assert(restoreEvent.resumed === true, "restore trampoline did not resume");
+}
+
+function continuationSummary(metadata, semanticState) {
+  return {
+    id: metadata.continuation.id,
+    captureFunction: metadata.continuation.captureFunction,
+    restoreEntrypoint: metadata.continuation.restoreEntrypoint,
+    requiredLiveValues: metadata.continuation.requiredLiveValues,
+    rawStackCopied: semanticState.rawStackCopied,
+    liveValues: semanticState.liveValues,
+  };
+}
+
+function bundleFileStats(bundleDir) {
+  return sharedBundleFileStats(bundleDir, [
+    "manifest.json",
+    "objects.json",
+    "relocations.json",
+    "resources.json",
+    "continuation.json",
+    "memory.bin",
+  ]);
+}
+
+function symbol(metadata, name) {
+  const found = metadata.symbols.find((candidate) => candidate.name === name);
+  assert(found, `missing continuation symbol ${name}`);
+  return found;
+}
+
+function checksumContinuationValues(seed, liveLocal, resumeDelta, continuation) {
+  let hash = 0x14650fb0739d0383n;
+  hash = fnv1aWord(hash, seed);
+  hash = fnv1aWord(hash, liveLocal);
+  hash = fnv1aWord(hash, resumeDelta);
+  for (const byte of Buffer.from(continuation, "utf8")) {
+    hash ^= BigInt(byte);
+    hash = fnv1aMul(hash);
+  }
+  return hash;
+}
+
+function fnv1aWord(hash, value) {
+  return fnv1aMul(hash ^ value);
+}
+
+function fnv1aMul(value) {
+  return (value * 0x100000001b3n) & 0xffffffffffffffffn;
+}
+
+function hexAddress(value) {
+  return `0x${value.toString(16)}`;
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `continuation-translate: ${summary.hostArch} captured ${summary.continuation.id} live_local=${summary.semanticState.liveLocal}`,
+  );
+  console.log(
+    `continuation-translate: restored result ${summary.restoreEvent.result} without raw stack copy`,
+  );
+  if (temporary) {
+    console.log("continuation-translate: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+main();

--- a/scripts/controlled-binary-corpus.mjs
+++ b/scripts/controlled-binary-corpus.mjs
@@ -12,7 +12,7 @@ import {
 } from "./proof-script-utils.mjs";
 
 const MARKER = "MACHINEN_CONTROLLED_BINARY ";
-const FIXTURES = ["global", "heap", "stack", "resource", "threads", "dwarf"];
+const FIXTURES = ["global", "heap", "stack", "continuation", "resource", "threads", "dwarf"];
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SOURCE = join(REPO_ROOT, "packages/microvm/assets/controlled-binary-corpus.c");
 const CROSS_TARGETS = [
@@ -138,6 +138,15 @@ function validateSummary(summary) {
   );
   assert(stack.caller_counter === 1000, "stack fixture caller counter changed");
   assert(stack.live_local === 5242, "stack fixture live local changed");
+
+  const continuation = requireFixture(events, "continuation");
+  assert(
+    continuation.continuation === "controlled_continuation_point",
+    "continuation fixture id changed",
+  );
+  assert(continuation.seed === 1000, "continuation fixture seed changed");
+  assert(continuation.live_local === 5242, "continuation fixture live local changed");
+  assert(continuation.resume_delta === 77, "continuation fixture resume delta changed");
 
   const resource = requireFixture(events, "resource");
   assert(resource.argc === 5, "resource fixture argc changed");


### PR DESCRIPTION
## Problem

We could move controlled global and heap state across architectures, but stack state was still only a probe. The next missing piece was a nested continuation: a stopped function with live local values that must continue on the target without copying the source stack bytes.

## Solution

This adds a controlled continuation proof. The source stops inside `controlled_continuation_point`, captures a described stack-local frame, decodes the live values, and writes a portable bundle with semantic continuation data instead of raw stack memory. Restore calls a target-side trampoline with the same live values and proves the continuation result is intact.

Closes #420.

## Validation

- `pnpm controlled-binary-corpus`
- `pnpm raw-process-capture` on Linux arm64 and Linux amd64
- `pnpm continuation-translate` on Linux arm64 and Linux amd64
- arm64 continuation bundle restored into an amd64 controlled target on the office Proxmox host
- `pnpm dwarf-symbol-extract` on Linux arm64
- `pnpm sidecar-metadata-extract` on Linux arm64
- `pnpm exec fallow audit --changed-since origin/pp-419-sidecar-metadata`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
