### PR TITLE
Add runtime state probes

### DIFF
--- a/docs/snapshot/runtime-state-probes.md
+++ b/docs/snapshot/runtime-state-probes.md
@@ -1,0 +1,56 @@
+# Node and Bun runtime state probes
+
+Issue #421 applies the controlled-binary lessons to tiny JavaScript runtimes.
+
+The proof does not try to copy a Node or Bun heap. Instead, it builds a small object graph with shared references, a `Map`, scalar roots, and known native handles. It records the graph as semantic state, restores that graph in the target runtime, and records what each runtime still needs from an adapter or sidecar.
+
+## Workloads
+
+The shared workload is `packages/microvm/assets/runtime-state-workload.mjs`.
+
+It creates deterministic state:
+
+- scalar roots: label, counter, and values
+- object identity: `left.shared === right.shared`
+- container references: `list[2]` and `map.get("shared")` point to the same shared object
+- native handles: stdio and timer/runtime queues are recorded as refusals
+
+The verifier runs Node unconditionally. It runs Bun when `bun` is available. If Bun is missing, the result is a stable refusal:
+
+```json
+{
+  "code": "runtime-adapter-missing",
+  "message": "bun executable is not available; install the runtime or provide a runtime adapter sidecar"
+}
+```
+
+## Serializer evidence
+
+The Node probe checks these APIs:
+
+- `node:v8.serialize` preserves this tiny graph's object identity and `Map` shape, and the verifier writes `node-v8-state.bin` as evidence.
+- `structuredClone` preserves identity inside one process, but it is not a persistent format by itself.
+- JSON preserves values, but it loses object identity and `Map` shape without a sidecar graph encoding.
+- V8 heap snapshots are inspection tools in this proof, not a restore contract.
+
+Bun uses the same semantic graph format when available. The current proof treats Bun native handles and runtime heap internals as adapter work unless a Bun-specific runtime adapter is installed.
+
+## Bundle shape
+
+The portable bundle uses an empty `memory.bin`. The important file is `runtime-state.json`, which contains semantic roots, graph objects, reference edges, identity assertions, serializer evidence, and native-handle refusals.
+
+The restore path rebuilds the graph from `runtime-state.json`. This is the same direction needed for Claude Code and pi-style targets: runtime adapters should expose semantic roots and explicit native-handle refusal rules instead of treating raw JS heap bytes as portable state.
+
+## Verify
+
+Run:
+
+```sh
+pnpm runtime-state-probe
+```
+
+Cross-ISA proof can be done by generating the Node bundle on arm64 and running the workload restore mode on amd64:
+
+```sh
+node packages/microvm/assets/runtime-state-workload.mjs restore --bundle <bundle> --runtime node
+```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dwarf-symbol-extract": "node scripts/dwarf-symbol-extract.mjs verify",
     "sidecar-metadata-extract": "node scripts/sidecar-metadata-extract.mjs verify",
     "continuation-translate": "node scripts/continuation-translate.mjs verify",
+    "runtime-state-probe": "node scripts/runtime-state-probe.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/runtime-state-workload.mjs
+++ b/packages/microvm/assets/runtime-state-workload.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const RUNTIME_STATE_WORKLOAD_MARKER = "MACHINEN_RUNTIME_STATE ";
+const SCHEMA_VERSION = 1;
+const LABEL = "runtime-state-probe-v1";
+const USAGE =
+  "usage: runtime-state-workload.mjs capture --out dir --runtime node|bun | restore --bundle dir --runtime node|bun";
+
+async function runtimeStateWorkloadMain() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.mode === "capture") {
+    await capture(args);
+    return;
+  }
+  if (args.mode === "restore") {
+    await restore(args);
+    return;
+  }
+  throw new Error(USAGE);
+}
+
+const ARG_HANDLERS = new Map([
+  ["--out", (args, argv, index) => setValue(args, "outDir", argv, index, "--out")],
+  ["--bundle", (args, argv, index) => setValue(args, "bundleDir", argv, index, "--bundle")],
+  ["--runtime", (args, argv, index) => setValue(args, "runtime", argv, index, "--runtime")],
+]);
+
+function parseArgs(argv) {
+  const args = { mode: argv[0], outDir: null, bundleDir: null, runtime: detectRuntime() };
+  for (let index = 1; index < argv.length; index++) {
+    index = consumeArg(args, argv, index);
+  }
+  validateArgs(args);
+  return args;
+}
+
+function consumeArg(args, argv, index) {
+  if (argv[index] === "--help" || argv[index] === "-h") {
+    console.log(USAGE);
+    process.exit(0);
+  }
+  const handler = ARG_HANDLERS.get(argv[index]);
+  if (!handler) {
+    throw new Error(`unknown argument: ${argv[index]}`);
+  }
+  return handler(args, argv, index);
+}
+
+function setValue(args, key, argv, index, flag) {
+  args[key] = requireValue(argv, index + 1, flag);
+  return index + 1;
+}
+
+const MODE_VALIDATORS = new Map([
+  ["capture", (args) => Boolean(args.outDir)],
+  ["restore", (args) => Boolean(args.bundleDir)],
+]);
+
+function validateArgs(args) {
+  const isValid = MODE_VALIDATORS.get(args.mode);
+  if (!isValid?.(args)) {
+    throw new Error(USAGE);
+  }
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+async function capture(args) {
+  mkdirSync(args.outDir, { recursive: true });
+  const state = buildRuntimeState();
+  const semanticState = semanticStateFromGraph(state, args.runtime);
+  const serializerEvidence = await inspectSerializers(state, args.outDir, args.runtime);
+  const document = {
+    formatVersion: 1,
+    schema: "com.redwoodjs.machinen.runtime-state-probe",
+    runtime: runtimeDescriptor(args.runtime),
+    sourceGuestArch: hostArch(),
+    semanticState,
+    serializerEvidence,
+    conclusion: runtimeConclusion(args.runtime, serializerEvidence),
+  };
+  writeFileSync(join(args.outDir, "runtime-state.json"), jsonDocument(document));
+  const marker = markerLine({
+    mode: "capture",
+    runtime: args.runtime,
+    arch: hostArch(),
+    counter: semanticState.roots.counter,
+    checksum_hex: semanticState.checksumHex,
+    identity_preserved: semanticState.identityAssertions.every((assertion) => assertion.same),
+    v8_serialize_supported: serializerEvidence.v8Serialize.supported,
+    structured_clone_supported: serializerEvidence.structuredClone.supported,
+  });
+  writeFileSync(join(args.outDir, "target.log"), `${marker}\n`);
+  console.log(marker);
+}
+
+async function restore(args) {
+  const document = JSON.parse(readFileSync(join(args.bundleDir, "runtime-state.json"), "utf8"));
+  const graph = rebuildGraph(document.semanticState);
+  const validation = validateGraph(graph, document.semanticState);
+  const v8Restore = await restoreV8Payload(args.bundleDir, args.runtime);
+  const marker = markerLine({
+    mode: "restore",
+    runtime: args.runtime,
+    arch: hostArch(),
+    counter: graph.counter,
+    checksum_hex: checksumGraph(graph),
+    identity_preserved: validation.identityPreserved,
+    references_restored: validation.referencesRestored,
+    v8_deserialize_ok: v8Restore.ok,
+  });
+  console.log(marker);
+}
+
+function buildRuntimeState() {
+  const shared = { label: "shared-runtime-object", weight: 9001, flags: ["hot", "portable"] };
+  const left = { name: "left", ordinal: 1, shared };
+  const right = { name: "right", ordinal: 2, shared };
+  const state = {
+    label: LABEL,
+    counter: 4210,
+    values: [4, 2, 1, 8, 16],
+    shared,
+    left,
+    right,
+    list: [left, right, shared],
+    map: new Map([
+      ["left", left],
+      ["right", right],
+      ["shared", shared],
+    ]),
+  };
+  return state;
+}
+
+function semanticStateFromGraph(state, runtime) {
+  const roots = {
+    label: state.label,
+    counter: state.counter,
+    values: state.values,
+    left: "object:left",
+    right: "object:right",
+    shared: "object:shared",
+    map: "object:map",
+  };
+  const objects = [
+    {
+      id: "object:shared",
+      kind: "object",
+      properties: {
+        label: state.shared.label,
+        weight: state.shared.weight,
+        flags: state.shared.flags,
+      },
+      references: {},
+    },
+    {
+      id: "object:left",
+      kind: "object",
+      properties: { name: state.left.name, ordinal: state.left.ordinal },
+      references: { shared: "object:shared" },
+    },
+    {
+      id: "object:right",
+      kind: "object",
+      properties: { name: state.right.name, ordinal: state.right.ordinal },
+      references: { shared: "object:shared" },
+    },
+    {
+      id: "object:map",
+      kind: "map",
+      entries: [
+        ["left", "object:left"],
+        ["right", "object:right"],
+        ["shared", "object:shared"],
+      ],
+    },
+  ];
+  return {
+    formatVersion: 1,
+    runtime,
+    roots,
+    objects,
+    identityAssertions: identityAssertions(state),
+    checksumHex: checksumGraph(state),
+    nativeHandles: nativeHandles(runtime),
+  };
+}
+
+function identityAssertions(state) {
+  return [
+    {
+      left: "root.left.shared",
+      right: "root.right.shared",
+      same: state.left.shared === state.right.shared,
+    },
+    { left: "root.list[2]", right: "root.shared", same: state.list[2] === state.shared },
+    {
+      left: "root.map.get('shared')",
+      right: "root.shared",
+      same: state.map.get("shared") === state.shared,
+    },
+  ];
+}
+
+function nativeHandles(runtime) {
+  return [
+    {
+      id: `${runtime}:stdio:1`,
+      kind: "fd",
+      state: "refused",
+      refusal: {
+        code: "fd-kind-unsupported",
+        message: "runtime stdio is a native file descriptor and is not replayed by this proof",
+      },
+    },
+    {
+      id: `${runtime}:timer-queue`,
+      kind: "timer",
+      state: "refused",
+      refusal: {
+        code: "runtime-heap-unsupported",
+        message: "runtime timer queues and native handles need a runtime adapter",
+      },
+    },
+  ];
+}
+
+async function inspectSerializers(state, outDir, runtime) {
+  const structuredCloneEvidence = inspectStructuredClone(state);
+  const jsonEvidence = inspectJson(state);
+  const v8Evidence =
+    runtime === "node"
+      ? await inspectNodeV8Serialize(state, outDir)
+      : {
+          supported: false,
+          reason: "Bun does not expose Node's V8 serialization contract as a portable restore API",
+        };
+  return {
+    v8Serialize: v8Evidence,
+    structuredClone: structuredCloneEvidence,
+    json: jsonEvidence,
+    heapSnapshot: {
+      inspected: runtime === "node",
+      restoreSupported: false,
+      finding:
+        "heap snapshots are useful for inspection, but this proof does not treat them as a stable cross-ISA restore format",
+    },
+  };
+}
+
+async function inspectNodeV8Serialize(state, outDir) {
+  const v8 = await import("node:v8");
+  const payload = v8.serialize(state);
+  const roundTrip = v8.deserialize(payload);
+  writeFileSync(join(outDir, "node-v8-state.bin"), payload);
+  return {
+    supported: true,
+    bytes: payload.length,
+    preservesIdentity: identityAssertions(roundTrip).every((assertion) => assertion.same),
+    preservesMap: roundTrip.map instanceof Map,
+    versionBound: true,
+    api: "node:v8.serialize",
+  };
+}
+
+function inspectStructuredClone(state) {
+  if (typeof structuredClone !== "function") {
+    return { supported: false, reason: "structuredClone is not available" };
+  }
+  const cloned = structuredClone(state);
+  return {
+    supported: true,
+    preservesIdentity: identityAssertions(cloned).every((assertion) => assertion.same),
+    preservesMap: cloned.map instanceof Map,
+    persistentFormat: false,
+  };
+}
+
+function inspectJson(state) {
+  const parsed = JSON.parse(JSON.stringify(state));
+  return {
+    supported: true,
+    preservesIdentity: parsed.left.shared === parsed.right.shared,
+    preservesMap: parsed.map && Object.keys(parsed.map).length > 0,
+    finding:
+      "JSON preserves values but loses object identity and Map shape without a sidecar graph encoding",
+  };
+}
+
+async function restoreV8Payload(bundleDir, runtime) {
+  const payloadPath = join(bundleDir, "node-v8-state.bin");
+  if (runtime !== "node" || !existsSync(payloadPath)) {
+    return { ok: false, reason: "no compatible V8 payload" };
+  }
+  const v8 = await import("node:v8");
+  const restored = v8.deserialize(readFileSync(payloadPath));
+  return {
+    ok: identityAssertions(restored).every((assertion) => assertion.same),
+    preservesMap: restored.map instanceof Map,
+  };
+}
+
+function rebuildGraph(semanticState) {
+  const byId = instantiateObjects(semanticState.objects);
+  connectObjectReferences(semanticState.objects, byId);
+  return rebuildRoots(semanticState.roots, byId);
+}
+
+function instantiateObjects(objects) {
+  return new Map(objects.map((object) => [object.id, emptyRuntimeObject(object)]));
+}
+
+function emptyRuntimeObject(object) {
+  return object.kind === "map" ? new Map() : { ...object.properties };
+}
+
+function connectObjectReferences(objects, byId) {
+  objects.forEach((object) => connectRuntimeObject(object, byId.get(object.id), byId));
+}
+
+function connectRuntimeObject(object, target, byId) {
+  Object.entries(object.references || {}).forEach(([name, ref]) => {
+    target[name] = byId.get(ref);
+  });
+  if (object.kind === "map") {
+    object.entries.forEach(([key, ref]) => target.set(key, byId.get(ref)));
+  }
+}
+
+function rebuildRoots(roots, byId) {
+  return {
+    label: roots.label,
+    counter: roots.counter,
+    values: roots.values,
+    shared: byId.get(roots.shared),
+    left: byId.get(roots.left),
+    right: byId.get(roots.right),
+    list: [byId.get(roots.left), byId.get(roots.right), byId.get(roots.shared)],
+    map: byId.get(roots.map),
+  };
+}
+
+function validateGraph(graph, semanticState) {
+  const checksum = checksumGraph(graph);
+  if (checksum !== semanticState.checksumHex) {
+    throw new Error(`semantic checksum mismatch: ${checksum} !== ${semanticState.checksumHex}`);
+  }
+  return {
+    identityPreserved: identityAssertions(graph).every((assertion) => assertion.same),
+    referencesRestored:
+      graph.left.shared.label === "shared-runtime-object" &&
+      graph.map.get("shared") === graph.shared,
+  };
+}
+
+function checksumGraph(graph) {
+  const hashInput = JSON.stringify({
+    label: graph.label,
+    counter: graph.counter,
+    values: graph.values,
+    shared: graph.shared,
+    left: { name: graph.left.name, ordinal: graph.left.ordinal, shared: graph.left.shared.label },
+    right: {
+      name: graph.right.name,
+      ordinal: graph.right.ordinal,
+      shared: graph.right.shared.label,
+    },
+    mapKeys: [...graph.map.keys()],
+  });
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of Buffer.from(hashInput, "utf8")) {
+    hash ^= BigInt(byte);
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return `0x${hash.toString(16)}`;
+}
+
+function markerLine(payload) {
+  return `${RUNTIME_STATE_WORKLOAD_MARKER}${JSON.stringify({ schema_version: SCHEMA_VERSION, ...payload })}`;
+}
+
+const RUNTIME_DESCRIPTORS = new Map([
+  ["node", () => ({ name: "node", version: process.versions.node, v8: process.versions.v8 })],
+  ["bun", () => ({ name: "bun", version: globalThis.Bun?.version || "unknown" })],
+]);
+
+function runtimeDescriptor(runtime) {
+  const describe =
+    RUNTIME_DESCRIPTORS.get(runtime) || (() => ({ name: runtime, version: "unknown" }));
+  return describe();
+}
+
+function runtimeConclusion(runtime, evidence) {
+  if (runtime === "node" && evidence.v8Serialize.supported) {
+    return "Node can restore this tiny graph from semantic state. v8.serialize is useful evidence, but a runtime-version-aware adapter plus graph sidecar is safer than raw heap bytes.";
+  }
+  return `${runtime} needs a runtime adapter or sidecar graph encoding for portable restore of object identity, Maps, and native handles.`;
+}
+
+function detectRuntime() {
+  if (globalThis.Bun) {
+    return "bun";
+  }
+  if (globalThis.process?.versions?.node) {
+    return "node";
+  }
+  return "unknown";
+}
+
+function hostArch() {
+  if (process.arch === "arm64") {
+    return "arm64";
+  }
+  if (process.arch === "x64") {
+    return "amd64";
+  }
+  return process.arch;
+}
+
+function jsonDocument(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function isDirectRun() {
+  return process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+}
+
+if (isDirectRun()) {
+  runtimeStateWorkloadMain().catch((error) => {
+    console.error(`machinen-runtime-state-workload: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/packages/runtime/src/__tests__/runtime-state-probe.test.ts
+++ b/packages/runtime/src/__tests__/runtime-state-probe.test.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePortableSnapshotBundle } from "../vm/portable-snapshot.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/runtime-state-probe.mjs");
+const TMP: string[] = [];
+
+interface RuntimeResult {
+  runtime: string;
+  available: boolean;
+  bundleDir?: string;
+  refusal?: { code: string; message: string };
+  semanticState: {
+    counter: number;
+    values: number[];
+    checksumHex: string;
+    objectCount: number;
+    identityAssertions: Array<{ same: boolean }>;
+    nativeHandleRefusals: string[];
+  };
+  serializerEvidence: {
+    v8Serialize: { supported: boolean; preservesIdentity?: boolean; preservesMap?: boolean };
+    structuredClone: { supported: boolean; preservesIdentity?: boolean; preservesMap?: boolean };
+    json: { preservesIdentity: boolean; preservesMap: boolean };
+  };
+  restoreEvent: {
+    mode: string;
+    runtime: string;
+    counter: number;
+    checksum_hex: string;
+    identity_preserved: boolean;
+    references_restored: boolean;
+    v8_deserialize_ok: boolean;
+  };
+}
+
+interface RuntimeSummary {
+  hostArch: string;
+  node: RuntimeResult;
+  bun:
+    | RuntimeResult
+    | { runtime: "bun"; available: false; refusal: { code: string; message: string } };
+  plan: { claudeCodeTarget: string; piTarget: string; node: string; bun: string };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("runtime state probes", () => {
+  it(
+    "restores Node semantic JS state and reports Bun evidence or refusal",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "runtime-state-probe-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        {
+          encoding: "utf8",
+          maxBuffer: 20 * 1024 * 1024,
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as RuntimeSummary;
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.node.available).toBe(true);
+      expect(summary.node.semanticState).toMatchObject({
+        counter: 4210,
+        values: [4, 2, 1, 8, 16],
+        objectCount: 4,
+      });
+      expect(
+        summary.node.semanticState.identityAssertions.every((assertion) => assertion.same),
+      ).toBe(true);
+      expect(summary.node.semanticState.nativeHandleRefusals).toEqual([
+        "fd-kind-unsupported",
+        "runtime-heap-unsupported",
+      ]);
+      expect(summary.node.serializerEvidence.v8Serialize).toMatchObject({
+        supported: true,
+        preservesIdentity: true,
+        preservesMap: true,
+      });
+      expect(summary.node.serializerEvidence.structuredClone).toMatchObject({
+        supported: true,
+        preservesIdentity: true,
+        preservesMap: true,
+      });
+      expect(summary.node.serializerEvidence.json).toMatchObject({
+        preservesIdentity: false,
+        preservesMap: false,
+      });
+      expect(summary.node.restoreEvent).toMatchObject({
+        mode: "restore",
+        runtime: "node",
+        counter: 4210,
+        checksum_hex: summary.node.semanticState.checksumHex,
+        identity_preserved: true,
+        references_restored: true,
+        v8_deserialize_ok: true,
+      });
+
+      const bundle = validatePortableSnapshotBundle(summary.node.bundleDir!);
+      expect(bundle.manifest.features).toContain("runtime-state-probe");
+      expect(bundle.objects.objects.map((object) => object.id)).toEqual([
+        "js-root-state",
+        "js-object-graph",
+        "js-runtime-handles",
+      ]);
+      expect(bundle.resources.resources.map((resource) => resource.id)).toContain(
+        "node:timer-queue",
+      );
+
+      if (summary.bun.available) {
+        expect(summary.bun.restoreEvent).toMatchObject({
+          mode: "restore",
+          runtime: "bun",
+          identity_preserved: true,
+          references_restored: true,
+        });
+      } else {
+        expect(summary.bun.refusal).toMatchObject({ code: "runtime-adapter-missing" });
+      }
+      expect(summary.plan.claudeCodeTarget).toContain("runtime adapter");
+      expect(summary.plan.piTarget).toContain("semantic JS roots");
+    },
+  );
+});

--- a/packages/runtime/src/vm/portable-snapshot.ts
+++ b/packages/runtime/src/vm/portable-snapshot.ts
@@ -52,6 +52,8 @@ const PORTABLE_REFUSAL_CODES = [
   "object-unsupported",
   "relocation-unsupported",
   "resource-unsupported",
+  "runtime-adapter-missing",
+  "runtime-heap-unsupported",
   "syscall-unsupported",
 ] as const;
 type PortableRefusalCode = (typeof PORTABLE_REFUSAL_CODES)[number];

--- a/scripts/runtime-state-probe.mjs
+++ b/scripts/runtime-state-probe.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { RUNTIME_STATE_WORKLOAD_MARKER } from "../packages/microvm/assets/runtime-state-workload.mjs";
+import {
+  REPO_ROOT,
+  bundleFileStats as sharedBundleFileStats,
+  hostArch,
+  jsonDocument,
+  readJson,
+  unsupportedVocabulary,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/runtime-state-probe.mjs [verify] [--out-dir path] [--json] [--keep]";
+const WORKLOAD = join(REPO_ROOT, "packages/microvm/assets/runtime-state-workload.mjs");
+const BUILD_ID = "4214214214214210";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-runtime-state-probe-");
+  try {
+    emitResult(verifyRuntimeStateProbe(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyRuntimeStateProbe(outDir) {
+  assert(existsSync(WORKLOAD), `missing runtime workload: ${WORKLOAD}`);
+  mkdirSync(outDir, { recursive: true });
+  const node = runRuntimeProbe({ runtime: "node", command: process.execPath, outDir });
+  const bunCommand = findCommand("bun");
+  const bun = bunCommand
+    ? runRuntimeProbe({ runtime: "bun", command: bunCommand, outDir })
+    : unavailableRuntime("bun");
+  const summary = {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    node,
+    bun,
+    plan: planFromEvidence({ node, bun }),
+  };
+  validateSummary(summary);
+  return summary;
+}
+
+function runRuntimeProbe({ runtime, command, outDir }) {
+  const runtimeDir = join(outDir, runtime);
+  const captureDir = join(runtimeDir, "capture");
+  const bundleDir = join(runtimeDir, "bundle");
+  mkdirSync(captureDir, { recursive: true });
+  const captureResult = runCommand(
+    command,
+    [WORKLOAD, "capture", "--out", captureDir, "--runtime", runtime],
+    { label: `${runtime} runtime capture`, env: { ...process.env, MACHINEN_RUNTIME_PROBE: "1" } },
+  );
+  const captureEvent = parseRuntimeMarker(captureResult.stdout, "capture");
+  const runtimeState = readJson(join(captureDir, "runtime-state.json"));
+  writeBundle({ runtime, command, captureDir, bundleDir, runtimeState });
+  const restoreResult = runCommand(
+    command,
+    [WORKLOAD, "restore", "--bundle", bundleDir, "--runtime", runtime],
+    { label: `${runtime} runtime restore`, env: { ...process.env, MACHINEN_RUNTIME_PROBE: "1" } },
+  );
+  const restoreEvent = parseRuntimeMarker(restoreResult.stdout, "restore");
+  return {
+    runtime,
+    available: true,
+    command,
+    captureDir,
+    bundleDir,
+    captureEvent,
+    restoreEvent,
+    semanticState: summarizeSemanticState(runtimeState.semanticState),
+    serializerEvidence: runtimeState.serializerEvidence,
+    conclusion: runtimeState.conclusion,
+    bundleFiles: bundleFileStats(bundleDir, runtime),
+  };
+}
+
+function writeBundle({ runtime, command, captureDir, bundleDir, runtimeState }) {
+  mkdirSync(bundleDir, { recursive: true });
+  mkdirSync(join(bundleDir, "logs"), { recursive: true });
+  writeFileSync(join(bundleDir, "memory.bin"), Buffer.alloc(0));
+  writeFileSync(
+    join(bundleDir, "manifest.json"),
+    jsonDocument(manifest(runtime, command, runtimeState)),
+  );
+  writeFileSync(join(bundleDir, "objects.json"), jsonDocument(objects(runtimeState)));
+  writeFileSync(join(bundleDir, "relocations.json"), jsonDocument(relocations()));
+  writeFileSync(
+    join(bundleDir, "resources.json"),
+    jsonDocument(resources(runtime, command, runtimeState)),
+  );
+  writeFileSync(join(bundleDir, "runtime-state.json"), jsonDocument(runtimeState));
+  copyFileSync(join(captureDir, "target.log"), join(bundleDir, "logs/source-target.log"));
+  const v8Payload = join(captureDir, "node-v8-state.bin");
+  if (existsSync(v8Payload)) {
+    copyFileSync(v8Payload, join(bundleDir, "node-v8-state.bin"));
+  }
+}
+
+function manifest(runtime, command, runtimeState) {
+  return {
+    formatVersion: 1,
+    sourceGuestArch: runtimeState.sourceGuestArch,
+    allowedTargetGuestArchs: ["arm64", "amd64"],
+    program: {
+      name: `${runtime}-runtime-state-probe`,
+      executable: command,
+      identity: `com.redwoodjs.machinen.${runtime}-runtime-state-probe`,
+    },
+    sourceBuild: { buildId: BUILD_ID, version: runtimeState.runtime.version },
+    targetBuild: { version: runtimeState.runtime.version },
+    checkpointAbi: {
+      version: 1,
+      checkpointFunction: { name: "machinen_checkpoint" },
+      rootsType: "machinen_checkpoint_roots",
+      restoreBundleType: "machinen_restore_bundle",
+      safePoint: { outsideSignalHandlers: true, outsideSyscalls: true },
+    },
+    checkpointContinuation: { name: `${runtime}_runtime_semantic_state` },
+    restoreEntrypoint: { name: `${runtime}_runtime_restore_adapter` },
+    process: {
+      argv: [command, WORKLOAD, "restore", "--bundle", "<bundle>", "--runtime", runtime],
+      env: { MACHINEN_RUNTIME_PROBE: "1" },
+      cwd: process.cwd(),
+    },
+    features: ["runtime-state-probe", `${runtime}-semantic-state`, "js-object-identity"],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function objects(runtimeState) {
+  return {
+    formatVersion: 1,
+    objects: [
+      {
+        id: "js-root-state",
+        kind: "opaque",
+        type: "JavaScript semantic roots",
+        sizeBytes: 0,
+      },
+      {
+        id: "js-object-graph",
+        kind: "opaque",
+        type: "JavaScript object graph sidecar",
+        sizeBytes: runtimeState.semanticState.objects.length,
+      },
+      {
+        id: "js-runtime-handles",
+        kind: "opaque",
+        type: "Runtime native handles refused by probe",
+        sizeBytes: runtimeState.semanticState.nativeHandles.length,
+      },
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function relocations() {
+  return { formatVersion: 1, relocations: [], unsupported: unsupportedVocabulary() };
+}
+
+function resources(runtime, command, runtimeState) {
+  return {
+    formatVersion: 1,
+    resources: [
+      {
+        id: "argv",
+        kind: "argv",
+        state: "captured",
+        argv: [command, WORKLOAD, "restore", "--runtime", runtime],
+      },
+      { id: "env", kind: "env", state: "captured", env: { MACHINEN_RUNTIME_PROBE: "1" } },
+      { id: "cwd", kind: "cwd", state: "captured", path: process.cwd() },
+      ...runtimeState.semanticState.nativeHandles.map((handle) => ({
+        id: handle.id,
+        kind: handle.kind,
+        state: handle.state,
+        fd: handle.kind === "fd" ? 1 : undefined,
+        refusal: handle.refusal,
+      })),
+    ],
+    unsupported: unsupportedVocabulary(),
+  };
+}
+
+function summarizeSemanticState(semanticState) {
+  return {
+    runtime: semanticState.runtime,
+    counter: semanticState.roots.counter,
+    values: semanticState.roots.values,
+    checksumHex: semanticState.checksumHex,
+    objectCount: semanticState.objects.length,
+    identityAssertions: semanticState.identityAssertions,
+    nativeHandleRefusals: semanticState.nativeHandles.map((handle) => handle.refusal.code),
+  };
+}
+
+function unavailableRuntime(runtime) {
+  return {
+    runtime,
+    available: false,
+    refusal: {
+      code: "runtime-adapter-missing",
+      message: `${runtime} executable is not available; install the runtime or provide a runtime adapter sidecar`,
+      detail: {
+        command: runtime,
+        requirement: "semantic object graph capture plus native handle refusal reporting",
+      },
+    },
+    conclusion: `${runtime} still needs a runtime adapter or sidecar before portable restore can be proven here.`,
+  };
+}
+
+function findCommand(command) {
+  try {
+    runCommand(command, ["--version"], { label: `${command} availability` });
+    return command;
+  } catch {
+    return null;
+  }
+}
+
+function validateSummary(summary) {
+  validateRuntime(summary.node);
+  if (summary.bun.available) {
+    validateRuntime(summary.bun);
+  } else {
+    assert(
+      summary.bun.refusal.code === "runtime-adapter-missing",
+      "Bun absence should produce a stable refusal",
+    );
+  }
+}
+
+function validateRuntime(result) {
+  assert(result.available, `${result.runtime} runtime was not available`);
+  assert(
+    result.captureEvent.identity_preserved === true,
+    `${result.runtime}: capture lost identity`,
+  );
+  assert(
+    result.restoreEvent.identity_preserved === true,
+    `${result.runtime}: restore lost identity`,
+  );
+  assert(
+    result.restoreEvent.references_restored === true,
+    `${result.runtime}: restore lost references`,
+  );
+  assert(result.semanticState.counter === 4210, `${result.runtime}: counter changed`);
+  assert(
+    result.semanticState.checksumHex === result.restoreEvent.checksum_hex,
+    `${result.runtime}: checksum changed`,
+  );
+  assert(
+    result.semanticState.nativeHandleRefusals.includes("fd-kind-unsupported"),
+    `${result.runtime}: missing fd refusal`,
+  );
+  assert(
+    result.semanticState.nativeHandleRefusals.includes("runtime-heap-unsupported"),
+    `${result.runtime}: missing runtime handle refusal`,
+  );
+}
+
+function planFromEvidence({ node, bun }) {
+  return {
+    claudeCodeTarget:
+      "needs a runtime adapter plus sidecar graph metadata; raw JS heap bytes are not a portable contract",
+    piTarget:
+      "can start with semantic JS roots and explicit native-handle refusals before attempting full process restore",
+    node: node.available
+      ? "semantic graph restore works; v8.serialize is useful only with runtime-version checks"
+      : node.refusal.message,
+    bun: bun.available
+      ? "semantic graph restore works when Bun is installed; native handles still need an adapter"
+      : bun.refusal.message,
+  };
+}
+
+function parseRuntimeMarker(stdout, expectedMode) {
+  const line = stdout
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith(RUNTIME_STATE_WORKLOAD_MARKER));
+  if (!line) {
+    throw new Error("missing runtime state marker");
+  }
+  const event = JSON.parse(line.slice(RUNTIME_STATE_WORKLOAD_MARKER.length));
+  if (event.mode !== expectedMode) {
+    throw new Error(`unexpected runtime marker mode: ${event.mode}`);
+  }
+  return event;
+}
+
+function bundleFileStats(bundleDir, runtime) {
+  const names = [
+    "manifest.json",
+    "objects.json",
+    "relocations.json",
+    "resources.json",
+    "runtime-state.json",
+    "memory.bin",
+  ];
+  if (runtime === "node" && existsSync(join(bundleDir, "node-v8-state.bin"))) {
+    names.push("node-v8-state.bin");
+  }
+  return sharedBundleFileStats(bundleDir, names);
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `runtime-state-probe: node restored counter=${summary.node.semanticState.counter} identity=${summary.node.restoreEvent.identity_preserved}`,
+  );
+  if (summary.bun.available) {
+    console.log(
+      `runtime-state-probe: bun restored counter=${summary.bun.semanticState.counter} identity=${summary.bun.restoreEvent.identity_preserved}`,
+    );
+  } else {
+    console.log(`runtime-state-probe: bun refused (${summary.bun.refusal.code})`);
+  }
+  if (temporary) {
+    console.log("runtime-state-probe: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem

The previous proofs worked with controlled C state. We still needed evidence for real JavaScript runtimes, where useful state lives in a JS heap with object identity, Maps, and native runtime handles.

## Solution

This adds a tiny Node/Bun runtime probe. Node captures and restores semantic JS state, including shared object references and a Map, without copying raw heap bytes. Bun runs the same proof when `bun` is installed; otherwise it reports a stable `runtime-adapter-missing` refusal. The docs record that Claude Code and pi-style targets need a runtime adapter plus sidecar graph metadata, not raw JS heap snapshots.

Closes #421.

## Validation

- `pnpm runtime-state-probe`
- `pnpm runtime-state-probe` on Linux arm64 via `friend@100.126.46.90`
- `pnpm runtime-state-probe` on Linux amd64 via office Proxmox/Docker
- arm64 Node runtime bundle restored into amd64 Node on the office Proxmox host
- local Bun probe restored semantic state when Bun was installed
- Linux Docker Bun path produced stable `runtime-adapter-missing` refusal when Bun was absent
- `pnpm exec fallow audit --changed-since origin/pp-420-continuation-translation`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
