### PR TITLE
Add native restore loader proof

### DIFF
--- a/docs/snapshot/native-restore-loader.md
+++ b/docs/snapshot/native-restore-loader.md
@@ -1,0 +1,48 @@
+# Native restore loader proof
+
+Issue #444 adds the first target-side materialization proof for the transparent
+native track. It is not the final process zygote yet; it proves the boundary
+between a validated native process image and the code that maps target memory.
+
+## Command
+
+```sh
+pnpm native-restore-loader
+```
+
+To keep the synthetic bundle:
+
+```sh
+pnpm native-restore-loader -- --out-dir /tmp/native-loader --keep --json
+```
+
+## What it proves
+
+The proof builds `packages/microvm/assets/native-restore-loader.c`, writes a
+synthetic native process image bundle, then asks the helper to:
+
+1. open `native-memory.bin`;
+2. map an anonymous target page;
+3. copy the requested mapping bytes from the bundle;
+4. verify the materialized prefix;
+5. apply final page permissions with `mprotect`;
+6. emit a materialization event.
+
+The same run also invokes the loader with a missing memory payload and asserts
+that the failure names the loader phase (`open memory failed`).
+
+## Boundary
+
+The JavaScript driver owns bundle validation and translation policy. The C
+helper owns target address-space materialization. This keeps the later ISA
+translation issues separate:
+
+- #445 decides target register/TLS/syscall state;
+- #446 decides target code addresses;
+- #447 decides target stack layout;
+- #448 decides pointer relocations;
+- #449 decides resource recipes.
+
+The synthetic bundle still records a cross-ISA source/target pair, but the
+translation thread is `pending`. This issue proves mapping materialization, not
+register transfer or live continuation.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "runtime-state-probe": "node scripts/runtime-state-probe.mjs verify",
     "real-target-feasibility": "node scripts/real-target-feasibility.mjs verify",
     "native-process-capture": "node scripts/native-process-capture.mjs verify",
+    "native-restore-loader": "node scripts/native-restore-loader.mjs verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/microvm/assets/native-restore-loader.c
+++ b/packages/microvm/assets/native-restore-loader.c
@@ -1,0 +1,168 @@
+// Minimal target-side materialization helper for native process images.
+//
+// This is not the final process zygote. It proves the loader boundary for #444:
+// given a target-native materialization plan chosen by the JavaScript driver, the
+// helper maps memory, copies bytes from native-memory.bin, applies final page
+// permissions, and reports precise failures.
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+struct Options {
+  const char *memory;
+  uint64_t offset;
+  uint64_t size;
+  const char *expect_prefix;
+  const char *final_prot;
+};
+
+static void usage(void) {
+  fprintf(stderr,
+      "usage: machinen-native-restore-loader --memory path --offset n --size n "
+      "--expect-prefix text --final-prot rw|r|rx\n");
+  exit(2);
+}
+
+static uint64_t parse_u64(const char *value, const char *field) {
+  errno = 0;
+  char *end = NULL;
+  uint64_t parsed = strtoull(value, &end, 0);
+  if (errno != 0 || end == value || *end != '\0') {
+    fprintf(stderr, "native-restore-loader: invalid %s: %s\n", field, value);
+    exit(2);
+  }
+  return parsed;
+}
+
+static bool streq(const char *left, const char *right) {
+  return strcmp(left, right) == 0;
+}
+
+static struct Options parse_args(int argc, char **argv) {
+  struct Options opts = {
+      .memory = NULL, .offset = 0, .size = 0, .expect_prefix = NULL, .final_prot = "rw"};
+  for (int i = 1; i < argc; i++) {
+    if (streq(argv[i], "--memory")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.memory = argv[i];
+    } else if (streq(argv[i], "--offset")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.offset = parse_u64(argv[i], "offset");
+    } else if (streq(argv[i], "--size")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.size = parse_u64(argv[i], "size");
+    } else if (streq(argv[i], "--expect-prefix")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.expect_prefix = argv[i];
+    } else if (streq(argv[i], "--final-prot")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.final_prot = argv[i];
+    } else {
+      usage();
+    }
+  }
+  if (!opts.memory || !opts.expect_prefix || opts.size == 0) {
+    usage();
+  }
+  return opts;
+}
+
+static int prot_flags(const char *spec) {
+  if (streq(spec, "rw")) {
+    return PROT_READ | PROT_WRITE;
+  }
+  if (streq(spec, "r")) {
+    return PROT_READ;
+  }
+  if (streq(spec, "rx")) {
+    return PROT_READ | PROT_EXEC;
+  }
+  fprintf(stderr, "native-restore-loader: unsupported final protection: %s\n", spec);
+  exit(2);
+}
+
+static void read_exact(int fd, void *dst, uint64_t size, uint64_t offset) {
+  uint8_t *bytes = dst;
+  uint64_t cursor = 0;
+  while (cursor < size) {
+    size_t chunk = size - cursor > 1024u * 1024u ? 1024u * 1024u : (size_t)(size - cursor);
+    ssize_t got = pread(fd, bytes + cursor, chunk, (off_t)(offset + cursor));
+    if (got < 0) {
+      fprintf(stderr, "native-restore-loader: memory read failed: %s\n", strerror(errno));
+      exit(1);
+    }
+    if (got == 0) {
+      fprintf(stderr,
+          "native-restore-loader: memory read was short at offset 0x%" PRIx64 "\n",
+          offset + cursor);
+      exit(1);
+    }
+    cursor += (uint64_t)got;
+  }
+}
+
+static void verify_prefix(const struct Options *opts, const void *mapping) {
+  size_t prefix_len = strlen(opts->expect_prefix);
+  if (prefix_len > opts->size) {
+    fprintf(stderr, "native-restore-loader: expected prefix is larger than mapping\n");
+    exit(1);
+  }
+  if (memcmp(mapping, opts->expect_prefix, prefix_len) != 0) {
+    fprintf(stderr, "native-restore-loader: materialized bytes did not match expected prefix\n");
+    exit(1);
+  }
+}
+
+int main(int argc, char **argv) {
+  struct Options opts = parse_args(argc, argv);
+  int fd = open(opts.memory, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "native-restore-loader: open memory failed: %s\n", strerror(errno));
+    return 1;
+  }
+
+  void *mapping = mmap(NULL, (size_t)opts.size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+  if (mapping == MAP_FAILED) {
+    fprintf(stderr, "native-restore-loader: mmap failed: %s\n", strerror(errno));
+    close(fd);
+    return 1;
+  }
+
+  read_exact(fd, mapping, opts.size, opts.offset);
+  close(fd);
+  verify_prefix(&opts, mapping);
+
+  int final_prot = prot_flags(opts.final_prot);
+  if (mprotect(mapping, (size_t)opts.size, final_prot) != 0) {
+    fprintf(stderr, "native-restore-loader: mprotect failed: %s\n", strerror(errno));
+    munmap(mapping, (size_t)opts.size);
+    return 1;
+  }
+
+  printf(
+      "MACHINEN_NATIVE_RESTORE_LOADER {\"status\":\"materialized\",\"sizeBytes\":%" PRIu64
+      ",\"finalProt\":\"%s\"}\n",
+      opts.size, opts.final_prot);
+  munmap(mapping, (size_t)opts.size);
+  return 0;
+}

--- a/packages/runtime/src/__tests__/native-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/native-restore-loader.test.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateNativeProcessImageBundle } from "../native-process-image.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/native-restore-loader.mjs");
+const TMP: string[] = [];
+
+interface NativeRestoreLoaderSummary {
+  hostArch: string;
+  bundleDir: string;
+  materializedMapping: string;
+  restoreEvent: { status: string; sizeBytes: number; finalProt: string };
+  missingMemoryRefusal: { status: number; stderr: string };
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("native restore loader", () => {
+  it(
+    "materializes a target mapping from a synthetic native process image",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "native-restore-loader-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        [VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as NativeRestoreLoaderSummary;
+      expect(summary.hostArch).toMatch(/^(arm64|amd64)$/);
+      expect(summary.materializedMapping).toBe("mapping:synthetic-stack");
+      expect(summary.restoreEvent).toMatchObject({
+        status: "materialized",
+        sizeBytes: 4096,
+        finalProt: "r",
+      });
+      expect(summary.missingMemoryRefusal.status).not.toBe(0);
+      expect(summary.missingMemoryRefusal.stderr).toMatch(/open memory failed/);
+
+      const bundle = validateNativeProcessImageBundle(join(outDir, "bundle"));
+      expect(bundle.mappings.mappings[0]?.target.materialization).toBe("translate");
+      expect(bundle.translation.threads[0]?.state).toBe("pending");
+    },
+  );
+});

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -25,6 +25,10 @@ export const NATIVE_CAPTURE_TARGET_SOURCE = join(
   REPO_ROOT,
   "packages/microvm/assets/native-capture-target.c",
 );
+export const NATIVE_RESTORE_LOADER_SOURCE = join(
+  REPO_ROOT,
+  "packages/microvm/assets/native-restore-loader.c",
+);
 export const CONTROLLED_MARKER = "MACHINEN_CONTROLLED_BINARY ";
 
 export function ensureSourcesExist(sources) {
@@ -104,6 +108,26 @@ export function compileNativeCaptureTarget(binDir) {
       executable,
     ],
     { label: "native capture target build" },
+  );
+  return executable;
+}
+
+export function compileNativeRestoreLoader(binDir) {
+  const executable = join(binDir, "machinen-native-restore-loader");
+  runCommand(
+    "cc",
+    [
+      "-std=c11",
+      "-O0",
+      "-g",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      NATIVE_RESTORE_LOADER_SOURCE,
+      "-o",
+      executable,
+    ],
+    { label: "native restore loader build" },
   );
   return executable;
 }

--- a/scripts/native-restore-loader.mjs
+++ b/scripts/native-restore-loader.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  NATIVE_RESTORE_LOADER_SOURCE,
+  bundleFileStats,
+  compileNativeRestoreLoader,
+  ensureSourcesExist,
+  hostArch,
+  jsonDocument,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+  runCommand,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: node scripts/native-restore-loader.mjs [verify] [--out-dir path] [--json] [--keep]";
+const BUNDLE_FILES = [
+  "native-process.json",
+  "native-mappings.json",
+  "native-threads.json",
+  "native-resources.json",
+  "native-translation.json",
+  "native-memory.bin",
+];
+const PAGE_SIZE = 4096;
+const MARKER = "machinen-native-loader-v1";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-restore-loader-");
+  try {
+    emitResult(verifyNativeRestoreLoader(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeRestoreLoader(outDir) {
+  ensureSourcesExist([NATIVE_RESTORE_LOADER_SOURCE]);
+  const binDir = join(outDir, "bin");
+  const bundleDir = join(outDir, "bundle");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(bundleDir, { recursive: true });
+
+  const loader = compileNativeRestoreLoader(binDir);
+  const image = syntheticImage();
+  writeSyntheticBundle(bundleDir, image);
+  const restoreEvent = runLoader(loader, bundleDir, image.mapping);
+  const missingMemoryRefusal = runMissingMemoryFailure(loader, bundleDir, image.mapping);
+  validateSummary({ image, restoreEvent, missingMemoryRefusal });
+
+  return {
+    formatVersion: 1,
+    hostArch: hostArch(),
+    loader,
+    bundleDir,
+    materializedMapping: image.mapping.id,
+    restoreEvent,
+    missingMemoryRefusal,
+    bundleFiles: bundleFileStats(bundleDir, BUNDLE_FILES),
+  };
+}
+
+function syntheticImage() {
+  const targetArch = hostArch();
+  const sourceArch = oppositeArch(targetArch);
+  const mapping = {
+    id: "mapping:synthetic-stack",
+    kind: "stack",
+    sourceStart: "0x700000000000",
+    sourceEnd: "0x700000001000",
+    sizeBytes: PAGE_SIZE,
+    permissions: { read: true, write: true, execute: false, private: true, shared: false },
+    captured: { file: "native-memory.bin", offset: 0, sizeBytes: PAGE_SIZE },
+    target: { materialization: "translate", targetStart: "0x710000000000" },
+  };
+  return {
+    sourceArch,
+    targetArch,
+    mapping,
+    manifest: manifest(sourceArch, targetArch),
+    mappings: { formatVersion: 1, mappings: [mapping], refusals: emptyRefusals() },
+    threads: threads(sourceArch, mapping.id),
+    resources: resources(),
+    translation: translation(sourceArch, targetArch),
+    memory: memoryPage(),
+  };
+}
+
+function oppositeArch(arch) {
+  if (arch === "arm64") {
+    return "amd64";
+  }
+  if (arch === "amd64") {
+    return "arm64";
+  }
+  throw new Error(`unsupported host architecture for native restore loader: ${arch}`);
+}
+
+function emptyRefusals() {
+  return { vocabularyVersion: 1, refusals: [] };
+}
+
+function manifest(sourceArch, targetArch) {
+  return {
+    formatVersion: 1,
+    kind: "machinen.native-process-image",
+    capture: { method: "external-ptrace-procfs", sourceArch, pid: 1 },
+    target: { mode: "native-cross-isa", arch: targetArch, abi: "linux-user" },
+    process: { exe: "/synthetic/native-loader", argv: ["native-loader"], env: {}, cwd: "/" },
+    refusals: emptyRefusals(),
+  };
+}
+
+function threads(sourceArch, stackMapping) {
+  return {
+    formatVersion: 1,
+    threads: [
+      {
+        id: "thread:synthetic-main",
+        state: "stopped",
+        stopReason: "ptrace-stop",
+        stackMapping,
+        sourceRegisters: sourceRegisters(sourceArch),
+        syscall: { state: "outside-syscall" },
+        signal: { blocked: [], pending: [], activeFrame: false, altStack: { state: "disabled" } },
+        tls: { threadPointer: "0x700000000800", rseq: { state: "absent" } },
+      },
+    ],
+    refusals: emptyRefusals(),
+  };
+}
+
+function sourceRegisters(arch) {
+  if (arch === "arm64") {
+    return {
+      arch,
+      pc: "0x400100",
+      sp: "0x700000000f00",
+      pstate: "0x0",
+      x: Array.from({ length: 31 }, () => "0x0"),
+    };
+  }
+  return {
+    arch,
+    rip: "0x400100",
+    rsp: "0x700000000f00",
+    rflags: "0x202",
+    rax: "0x0",
+    rbx: "0x0",
+    rcx: "0x0",
+    rdx: "0x0",
+    rsi: "0x0",
+    rdi: "0x0",
+    rbp: "0x700000000f80",
+    r8: "0x0",
+    r9: "0x0",
+    r10: "0x0",
+    r11: "0x0",
+    r12: "0x0",
+    r13: "0x0",
+    r14: "0x0",
+    r15: "0x0",
+    fsBase: "0x0",
+    gsBase: "0x0",
+  };
+}
+
+function resources() {
+  return {
+    formatVersion: 1,
+    resources: [
+      { id: "argv", kind: "argv", state: "captured", recipe: { argv: ["native-loader"] } },
+      { id: "cwd", kind: "cwd", state: "recipe", path: "/", recipe: { cwd: "/" } },
+      { id: "auxv", kind: "auxv", state: "captured", recipe: { bytesHex: "" } },
+    ],
+    refusals: emptyRefusals(),
+  };
+}
+
+function translation(sourceArch, targetArch) {
+  return {
+    formatVersion: 1,
+    mode: "native-cross-isa",
+    sourceArch,
+    targetArch,
+    codeLocations: [],
+    threads: [{ sourceThreadId: "thread:synthetic-main", state: "pending" }],
+    memoryRelocations: [],
+    refusals: emptyRefusals(),
+  };
+}
+
+function memoryPage() {
+  const page = Buffer.alloc(PAGE_SIZE);
+  page.write(MARKER, 0, "utf8");
+  return page;
+}
+
+function writeSyntheticBundle(bundleDir, image) {
+  writeFileSync(join(bundleDir, "native-process.json"), jsonDocument(image.manifest));
+  writeFileSync(join(bundleDir, "native-mappings.json"), jsonDocument(image.mappings));
+  writeFileSync(join(bundleDir, "native-threads.json"), jsonDocument(image.threads));
+  writeFileSync(join(bundleDir, "native-resources.json"), jsonDocument(image.resources));
+  writeFileSync(join(bundleDir, "native-translation.json"), jsonDocument(image.translation));
+  writeFileSync(join(bundleDir, "native-memory.bin"), image.memory);
+}
+
+function runLoader(loader, bundleDir, mapping) {
+  const result = runCommand(
+    loader,
+    [
+      "--memory",
+      join(bundleDir, "native-memory.bin"),
+      "--offset",
+      String(mapping.captured.offset),
+      "--size",
+      String(mapping.captured.sizeBytes),
+      "--expect-prefix",
+      MARKER,
+      "--final-prot",
+      "r",
+    ],
+    { label: "native restore loader materialization" },
+  );
+  return parseLoaderEvent(result.stdout);
+}
+
+function parseLoaderEvent(stdout) {
+  const line = stdout
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith("MACHINEN_NATIVE_RESTORE_LOADER "));
+  if (!line) {
+    throw new Error("native restore loader did not emit a materialization event");
+  }
+  return JSON.parse(line.slice("MACHINEN_NATIVE_RESTORE_LOADER ".length));
+}
+
+function runMissingMemoryFailure(loader, bundleDir, mapping) {
+  const result = spawnSync(
+    loader,
+    [
+      "--memory",
+      join(bundleDir, "missing-native-memory.bin"),
+      "--offset",
+      String(mapping.captured.offset),
+      "--size",
+      String(mapping.captured.sizeBytes),
+      "--expect-prefix",
+      MARKER,
+      "--final-prot",
+      "r",
+    ],
+    { encoding: "utf8" },
+  );
+  assert(result.status !== 0, "missing memory payload should fail materialization");
+  return { status: result.status, stderr: result.stderr.trim() };
+}
+
+function validateSummary(summary) {
+  assert(summary.restoreEvent.status === "materialized", "loader did not materialize mapping");
+  assert(summary.restoreEvent.sizeBytes === PAGE_SIZE, "loader materialized the wrong size");
+  assert(summary.restoreEvent.finalProt === "r", "loader did not apply final page protection");
+  assert(
+    /open memory failed/.test(summary.missingMemoryRefusal.stderr),
+    "missing memory failure did not report the failing loader phase",
+  );
+}
+
+function printSummary(summary, temporary) {
+  console.log(
+    `native-restore-loader: ${summary.hostArch} materialized ${summary.materializedMapping} (${summary.restoreEvent.sizeBytes} bytes, prot=${summary.restoreEvent.finalProt})`,
+  );
+  console.log(
+    `native-restore-loader: missing-memory failure surfaced as '${summary.missingMemoryRefusal.stderr}'`,
+  );
+  if (temporary) {
+    console.log("native-restore-loader: temporary artifacts removed; pass --keep to inspect them");
+  }
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #444.

## Problem

A captured native process image still had nowhere to land on the target side. We needed a small loader that can prove target memory can be materialized without pretending that cross-ISA execution is solved.

## Solution

This adds a native restore loader proof. The loader maps bytes from `native-memory.bin`, checks the expected marker, applies the requested protection, and reports a structured event. The docs and tests keep the boundary clear: this materializes target memory, but it does not jump into translated code yet.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
