### PR TITLE
Translate native register safe points

### DIFF
--- a/docs/snapshot/native-register-translation.md
+++ b/docs/snapshot/native-register-translation.md
@@ -1,0 +1,47 @@
+# Native register/TLS/syscall translation
+
+Issue #445 defines the first arm64 -> amd64 register translation rules for the
+transparent native process image path.
+
+## Command
+
+```sh
+pnpm native-register-translate
+```
+
+The proof translates one safe arm64 thread and refuses one unsafe thread stopped
+inside a syscall.
+
+## Safe point contract
+
+A thread can translate only when all of these are true:
+
+- source architecture is `arm64`;
+- target architecture is `amd64`;
+- syscall state is `outside-syscall`;
+- no signal frame is active;
+- alternate signal stack state is disabled;
+- rseq state is absent;
+- a target continuation supplies the translated instruction pointer, stack
+  pointer, and TLS base for the thread's captured source PC.
+
+The translator emits an amd64 `targetRegisters` document. It does not copy raw
+arm64 register bytes into the target.
+
+## Refusals
+
+Unsafe states refuse with stable codes:
+
+- `active-syscall` for syscall/restart-block states;
+- `signal-frame-active` for active signal trampolines;
+- `signal-state-unsupported` for alt-stack state;
+- `rseq-state-unsupported` for rseq metadata;
+- `code-location-unknown` when the captured PC has no target continuation;
+- `architecture-pair-unsupported` for anything other than the initial arm64 ->
+  amd64 proof path.
+
+## Boundary
+
+The register translator consumes target continuation addresses. It does not
+compute those addresses itself; #446 owns source-code to target-code mapping,
+and #447 owns stack layout.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "real-target-feasibility": "node scripts/real-target-feasibility.mjs verify",
     "native-process-capture": "node scripts/native-process-capture.mjs verify",
     "native-restore-loader": "node scripts/native-restore-loader.mjs verify",
+    "native-register-translate": "tsx scripts/native-register-translate.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -78,6 +78,10 @@
 - [`validateNativeProcessImageBundle`](#validatenativeprocessimagebundle)
 - [`validateNativeProcessImageDocuments`](#validatenativeprocessimagedocuments)
 - [`assertNativeProcessImageDocuments`](#assertnativeprocessimagedocuments)
+- [`NativeRegisterTranslationRequest`](#nativeregistertranslationrequest)
+- [`NativeContinuationTarget`](#nativecontinuationtarget)
+- [`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
+- [`translateNativeRegisterState`](#translatenativeregisterstate)
 
 ### Provision base images
 
@@ -2870,6 +2874,72 @@ by default when `output` is a TTY.
 ##### translation
 
 > **translation**: `unknown`
+
+***
+
+### NativeRegisterTranslationRequest
+
+#### Properties
+
+##### sourceArch
+
+> **sourceArch**: `"amd64"` \| `"arm64"`
+
+##### targetArch
+
+> **targetArch**: `"amd64"` \| `"arm64"`
+
+##### threads
+
+> **threads**: [`NativeThreadState`](#nativethreadstate)[]
+
+##### continuations
+
+> **continuations**: `Record`\<`string`, [`NativeContinuationTarget`](#nativecontinuationtarget)\>
+
+***
+
+### NativeContinuationTarget
+
+#### Properties
+
+##### sourcePc
+
+> **sourcePc**: `string`
+
+##### targetIp
+
+> **targetIp**: `string`
+
+##### targetSp
+
+> **targetSp**: `string`
+
+##### targetTls
+
+> **targetTls**: `string`
+
+***
+
+### NativeRegisterTranslationResult
+
+#### Properties
+
+##### sourceArch
+
+> **sourceArch**: `"amd64"` \| `"arm64"`
+
+##### targetArch
+
+> **targetArch**: `"amd64"` \| `"arm64"`
+
+##### threads
+
+> **threads**: [`NativeThreadTranslation`](#nativethreadtranslation)[]
+
+##### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
 
 ***
 
@@ -7352,6 +7422,22 @@ available.
 #### Returns
 
 `asserts docs is NativeProcessImageDocuments`
+
+***
+
+### translateNativeRegisterState()
+
+> **translateNativeRegisterState**(`request`): [`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
+
+#### Parameters
+
+##### request
+
+[`NativeRegisterTranslationRequest`](#nativeregistertranslationrequest)
+
+#### Returns
+
+[`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-register-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-register-translation.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { translateNativeRegisterState } from "../native-register-translation.ts";
+import type { NativeThreadState } from "../native-process-image.ts";
+
+function arm64Thread(id = "thread:1"): NativeThreadState {
+  const x = Array.from({ length: 31 }, (_value, index) => `0x${(index + 1).toString(16)}`);
+  return {
+    id,
+    state: "stopped",
+    stopReason: "ptrace-stop",
+    stackMapping: "mapping:stack",
+    sourceRegisters: { arch: "arm64", pc: "0x400120", sp: "0x7fff0000", pstate: "0x0", x },
+    syscall: { state: "outside-syscall" },
+    signal: { blocked: [], pending: [], activeFrame: false, altStack: { state: "disabled" } },
+    tls: { threadPointer: "0xffff0000", rseq: { state: "absent" } },
+  };
+}
+
+function translate(thread: NativeThreadState) {
+  return translateNativeRegisterState({
+    sourceArch: "arm64",
+    targetArch: "amd64",
+    threads: [thread],
+    continuations: {
+      [thread.id]: {
+        sourcePc: "0x400120",
+        targetIp: "0x14000120",
+        targetSp: "0x7fffffffe000",
+        targetTls: "0x7ffff7d00000",
+      },
+    },
+  });
+}
+
+describe("native register translation", () => {
+  it("translates safe arm64 user-space register state into amd64 target registers", () => {
+    const result = translate(arm64Thread());
+
+    expect(result.refusals).toEqual([]);
+    expect(result.threads[0]).toMatchObject({
+      sourceThreadId: "thread:1",
+      state: "translated",
+      targetRegisters: {
+        arch: "amd64",
+        rip: "0x14000120",
+        rsp: "0x7fffffffe000",
+        fsBase: "0x7ffff7d00000",
+        rdi: "0x1",
+        rsi: "0x2",
+        rdx: "0x3",
+        rcx: "0x4",
+      },
+    });
+  });
+
+  it("refuses active syscall states before register translation", () => {
+    const thread = arm64Thread();
+    thread.syscall = { state: "inside-syscall", number: 64, name: "write" };
+
+    const result = translate(thread);
+
+    expect(result.threads[0]).toMatchObject({
+      state: "refused",
+      refusal: { code: "active-syscall", message: expect.stringContaining("inside-syscall") },
+    });
+  });
+
+  it("refuses signal frames and alt-stack state", () => {
+    const signalFrame = arm64Thread("thread:signal");
+    signalFrame.signal.activeFrame = true;
+    const altStack = arm64Thread("thread:altstack");
+    altStack.signal.altStack = { state: "enabled", sp: "0x7000", sizeBytes: 4096 };
+
+    const result = translateNativeRegisterState({
+      sourceArch: "arm64",
+      targetArch: "amd64",
+      threads: [signalFrame, altStack],
+      continuations: {},
+    });
+
+    expect(result.threads.map((thread) => thread.refusal?.code)).toEqual([
+      "signal-frame-active",
+      "signal-state-unsupported",
+    ]);
+  });
+
+  it("refuses captured rseq state", () => {
+    const thread = arm64Thread();
+    thread.tls.rseq = { state: "captured" };
+
+    expect(translate(thread).threads[0]?.refusal?.code).toBe("rseq-state-unsupported");
+  });
+
+  it("refuses missing or mismatched continuation targets", () => {
+    const missing = translateNativeRegisterState({
+      sourceArch: "arm64",
+      targetArch: "amd64",
+      threads: [arm64Thread()],
+      continuations: {},
+    });
+    const mismatched = translateNativeRegisterState({
+      sourceArch: "arm64",
+      targetArch: "amd64",
+      threads: [arm64Thread()],
+      continuations: {
+        "thread:1": {
+          sourcePc: "0x400124",
+          targetIp: "0x14000124",
+          targetSp: "0x7fffffffe000",
+          targetTls: "0x7ffff7d00000",
+        },
+      },
+    });
+
+    expect(missing.threads[0]?.refusal?.code).toBe("code-location-unknown");
+    expect(mismatched.threads[0]?.refusal?.code).toBe("code-location-unknown");
+  });
+
+  it("refuses unsupported architecture pairs for every thread", () => {
+    const result = translateNativeRegisterState({
+      sourceArch: "amd64",
+      targetArch: "arm64",
+      threads: [arm64Thread("thread:a"), arm64Thread("thread:b")],
+      continuations: {},
+    });
+
+    expect(result.threads).toHaveLength(2);
+    expect(
+      result.threads.every((thread) => thread.refusal?.code === "architecture-pair-unsupported"),
+    ).toBe(true);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -102,6 +102,12 @@ export type {
   WriteFileOptions,
 } from "./vm-handle.ts";
 export type { SnapshotEngine } from "./vm/snapshot-engine.ts";
+export { translateNativeRegisterState } from "./native-register-translation.ts";
+export type {
+  NativeContinuationTarget,
+  NativeRegisterTranslationRequest,
+  NativeRegisterTranslationResult,
+} from "./native-register-translation.ts";
 export {
   NATIVE_PROCESS_IMAGE_FILES,
   NATIVE_PROCESS_IMAGE_FORMAT_VERSION,

--- a/packages/runtime/src/native-register-translation.ts
+++ b/packages/runtime/src/native-register-translation.ts
@@ -1,0 +1,175 @@
+/** Register/TLS/syscall-state translation rules for native process images. */
+
+import type {
+  NativeAmd64Registers,
+  NativeArm64Registers,
+  NativeProcessImageArchitecture,
+  NativeProcessImageRefusal,
+  NativeThreadState,
+  NativeThreadTranslation,
+} from "./native-process-image.ts";
+
+export interface NativeRegisterTranslationRequest {
+  sourceArch: NativeProcessImageArchitecture;
+  targetArch: NativeProcessImageArchitecture;
+  threads: NativeThreadState[];
+  continuations: Record<string, NativeContinuationTarget>;
+}
+
+export interface NativeContinuationTarget {
+  sourcePc: string;
+  targetIp: string;
+  targetSp: string;
+  targetTls: string;
+}
+
+export interface NativeRegisterTranslationResult {
+  sourceArch: NativeProcessImageArchitecture;
+  targetArch: NativeProcessImageArchitecture;
+  threads: NativeThreadTranslation[];
+  refusals: NativeProcessImageRefusal[];
+}
+
+export function translateNativeRegisterState(
+  request: NativeRegisterTranslationRequest,
+): NativeRegisterTranslationResult {
+  const architectureRefusal = validateRegisterArchitecturePair(request);
+  if (architectureRefusal) {
+    return refusedRegisterTranslation(request, architectureRefusal);
+  }
+
+  const threads = request.threads.map((thread) => translateThreadRegisters(thread, request));
+  return {
+    sourceArch: request.sourceArch,
+    targetArch: request.targetArch,
+    threads,
+    refusals: threads.flatMap((thread) => (thread.refusal ? [thread.refusal] : [])),
+  };
+}
+
+function validateRegisterArchitecturePair(
+  request: NativeRegisterTranslationRequest,
+): NativeProcessImageRefusal | undefined {
+  if (request.sourceArch !== "arm64" || request.targetArch !== "amd64") {
+    return refusal(
+      "architecture-pair-unsupported",
+      `native register translation only supports arm64 -> amd64 in this proof (got ${request.sourceArch} -> ${request.targetArch})`,
+    );
+  }
+  return undefined;
+}
+
+function refusedRegisterTranslation(
+  request: NativeRegisterTranslationRequest,
+  reason: NativeProcessImageRefusal,
+): NativeRegisterTranslationResult {
+  return {
+    sourceArch: request.sourceArch,
+    targetArch: request.targetArch,
+    threads: request.threads.map((thread) => ({
+      sourceThreadId: thread.id,
+      state: "refused",
+      refusal: reason,
+    })),
+    refusals: [reason],
+  };
+}
+
+function translateThreadRegisters(
+  thread: NativeThreadState,
+  request: NativeRegisterTranslationRequest,
+): NativeThreadTranslation {
+  const unsafe = unsafeThreadState(thread);
+  if (unsafe) {
+    return { sourceThreadId: thread.id, state: "refused", refusal: unsafe };
+  }
+  if (thread.sourceRegisters.arch !== "arm64") {
+    return {
+      sourceThreadId: thread.id,
+      state: "refused",
+      refusal: refusal(
+        "architecture-unsupported",
+        `thread ${thread.id} has ${thread.sourceRegisters.arch} registers, expected arm64`,
+      ),
+    };
+  }
+  const continuation = request.continuations[thread.id];
+  if (!continuation) {
+    return {
+      sourceThreadId: thread.id,
+      state: "refused",
+      refusal: refusal("code-location-unknown", `thread ${thread.id} has no target continuation`),
+    };
+  }
+  if (normalizeHex(continuation.sourcePc) !== normalizeHex(thread.sourceRegisters.pc)) {
+    return {
+      sourceThreadId: thread.id,
+      state: "refused",
+      refusal: refusal(
+        "code-location-unknown",
+        `thread ${thread.id} source pc ${thread.sourceRegisters.pc} does not match continuation ${continuation.sourcePc}`,
+      ),
+    };
+  }
+  return {
+    sourceThreadId: thread.id,
+    state: "translated",
+    targetRegisters: arm64ToAmd64(thread.sourceRegisters, continuation),
+  };
+}
+
+function unsafeThreadState(thread: NativeThreadState): NativeProcessImageRefusal | undefined {
+  if (thread.syscall.state !== "outside-syscall") {
+    return refusal("active-syscall", `thread ${thread.id} is ${thread.syscall.state}`);
+  }
+  if (thread.signal.activeFrame) {
+    return refusal("signal-frame-active", `thread ${thread.id} is inside a signal frame`);
+  }
+  if (thread.signal.altStack.state !== "disabled") {
+    return refusal("signal-state-unsupported", `thread ${thread.id} has active alt-stack state`);
+  }
+  if (thread.tls.rseq.state !== "absent") {
+    return refusal("rseq-state-unsupported", `thread ${thread.id} has rseq state`);
+  }
+  return undefined;
+}
+
+function arm64ToAmd64(
+  source: NativeArm64Registers,
+  continuation: NativeContinuationTarget,
+): NativeAmd64Registers {
+  return {
+    arch: "amd64",
+    rip: continuation.targetIp,
+    rsp: continuation.targetSp,
+    rflags: "0x202",
+    rax: source.x[0] ?? "0x0",
+    rbx: source.x[19] ?? "0x0",
+    rcx: source.x[3] ?? "0x0",
+    rdx: source.x[2] ?? "0x0",
+    rsi: source.x[1] ?? "0x0",
+    rdi: source.x[0] ?? "0x0",
+    rbp: source.x[29] ?? continuation.targetSp,
+    r8: source.x[4] ?? "0x0",
+    r9: source.x[5] ?? "0x0",
+    r10: source.x[6] ?? "0x0",
+    r11: source.x[7] ?? "0x0",
+    r12: source.x[20] ?? "0x0",
+    r13: source.x[21] ?? "0x0",
+    r14: source.x[22] ?? "0x0",
+    r15: source.x[23] ?? "0x0",
+    fsBase: continuation.targetTls,
+    gsBase: "0x0",
+  };
+}
+
+function refusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeProcessImageRefusal {
+  return { code, message };
+}
+
+function normalizeHex(value: string): string {
+  return `0x${BigInt(value).toString(16)}`;
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -100,6 +100,10 @@ const TOC = {
     "validateNativeProcessImageBundle",
     "validateNativeProcessImageDocuments",
     "assertNativeProcessImageDocuments",
+    "NativeRegisterTranslationRequest",
+    "NativeContinuationTarget",
+    "NativeRegisterTranslationResult",
+    "translateNativeRegisterState",
   ],
   "Provision base images": [
     "provision",

--- a/scripts/native-register-translate.ts
+++ b/scripts/native-register-translate.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env tsx
+import { translateNativeRegisterState } from "../packages/runtime/src/native-register-translation.ts";
+import type { NativeThreadState } from "../packages/runtime/src/native-process-image.ts";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: tsx scripts/native-register-translate.ts [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-register-translate-");
+  try {
+    emitResult(verifyNativeRegisterTranslation(), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeRegisterTranslation() {
+  const safeThread = thread("thread:safe");
+  const unsafeThread = thread("thread:syscall");
+  unsafeThread.syscall = { state: "inside-syscall", number: 64, name: "write" };
+  const result = translateNativeRegisterState({
+    sourceArch: "arm64",
+    targetArch: "amd64",
+    threads: [safeThread, unsafeThread],
+    continuations: {
+      "thread:safe": {
+        sourcePc: "0x400120",
+        targetIp: "0x14000120",
+        targetSp: "0x7fffffffe000",
+        targetTls: "0x7ffff7d00000",
+      },
+    },
+  });
+  const translated = result.threads.filter((entry) => entry.state === "translated").length;
+  const refused = result.threads.filter((entry) => entry.state === "refused").length;
+  if (translated !== 1 || refused !== 1) {
+    throw new Error(
+      "native register translation proof did not produce one translated and one refused thread",
+    );
+  }
+  if (result.threads[1]?.refusal?.code !== "active-syscall") {
+    throw new Error("active syscall did not refuse with active-syscall");
+  }
+  return { formatVersion: 1, result, translated, refused };
+}
+
+function thread(id: string): NativeThreadState {
+  const x = Array.from({ length: 31 }, (_value, index) => `0x${(index + 1).toString(16)}`);
+  return {
+    id,
+    state: "stopped",
+    stopReason: "ptrace-stop",
+    stackMapping: "mapping:stack",
+    sourceRegisters: { arch: "arm64", pc: "0x400120", sp: "0x7fff0000", pstate: "0x0", x },
+    syscall: { state: "outside-syscall" },
+    signal: { blocked: [], pending: [], activeFrame: false, altStack: { state: "disabled" } },
+    tls: { threadPointer: "0xffff0000", rseq: { state: "absent" } },
+  };
+}
+
+function printSummary(summary: ReturnType<typeof verifyNativeRegisterTranslation>) {
+  console.log(
+    `native-register-translate: translated=${summary.translated} refused=${summary.refused} refusal=${summary.result.threads[1]?.refusal?.code}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #445.

## Problem

A native snapshot cannot resume if the thread register state is just copied from the source CPU. Arm64 registers, TLS, and syscall state need an amd64-safe target shape, and unsafe states need exact refusal codes.

## Solution

This adds register translation for controlled arm64-to-amd64 safe points. It maps the program counter, stack pointer, TLS pointer, and callee state from explicit continuation metadata. It also refuses active syscalls, signal frames, missing continuations, and unsupported register layouts with precise codes.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
