### PR TITLE
Map native code locations

### DIFF
--- a/docs/snapshot/native-code-map.md
+++ b/docs/snapshot/native-code-map.md
@@ -1,0 +1,39 @@
+# Native code-location mapping
+
+Issue #446 maps source-ISA code locations to target-native code locations before
+register, stack, or memory pointer translation can use them.
+
+## Command
+
+```sh
+pnpm native-code-map
+```
+
+The proof maps a controlled `native_controlled_resume` symbol and separately
+refuses a target build mismatch.
+
+## Contract
+
+A code map requires:
+
+- target build identity matching the expected build id;
+- a source symbol for the captured address;
+- a target symbol with the same logical name;
+- DWARF or sidecar size metadata when bare symbols are not enough to prove the
+  location boundary.
+
+Mapped locations become `NativeCodeLocationMapping` entries with source mapping,
+source address, and target address. Unknown or ambiguous locations are emitted as
+`code-location-unknown` refusals.
+
+## Refusals
+
+- `target-build-mismatch` stops the whole map before translating addresses.
+- `code-location-unknown` is used when a source symbol, target symbol, or
+  required metadata is missing.
+
+## Boundary
+
+This issue only decides where source code addresses land in the target. It does
+not translate stack frames (#447), pointer-bearing memory (#448), or install
+registers (#445).

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "native-process-capture": "node scripts/native-process-capture.mjs verify",
     "native-restore-loader": "node scripts/native-restore-loader.mjs verify",
     "native-register-translate": "tsx scripts/native-register-translate.ts verify",
+    "native-code-map": "tsx scripts/native-code-map.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -82,6 +82,10 @@
 - [`NativeContinuationTarget`](#nativecontinuationtarget)
 - [`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
 - [`translateNativeRegisterState`](#translatenativeregisterstate)
+- [`NativeCodeSymbol`](#nativecodesymbol)
+- [`NativeCodeMapRequest`](#nativecodemaprequest)
+- [`NativeCodeMapResult`](#nativecodemapresult)
+- [`buildNativeCodeMap`](#buildnativecodemap)
 
 ### Provision base images
 
@@ -2160,6 +2164,88 @@ Set to `false` in tests where `input` is a plain PassThrough.
 Forward SIGWINCH on the parent process (terminal resize) to any
 attached sandbox that implements `.resize(cols, rows)`. Enabled
 by default when `output` is a TTY.
+
+***
+
+### NativeCodeSymbol
+
+#### Properties
+
+##### name
+
+> **name**: `string`
+
+##### mapping
+
+> **mapping**: `string`
+
+##### address
+
+> **address**: `string`
+
+##### sizeBytes?
+
+> `optional` **sizeBytes?**: `number`
+
+##### buildId?
+
+> `optional` **buildId?**: `string`
+
+##### metadata
+
+> **metadata**: `"symbol"` \| `"dwarf"` \| `"sidecar"`
+
+***
+
+### NativeCodeMapRequest
+
+#### Properties
+
+##### expectedTargetBuildId
+
+> **expectedTargetBuildId**: `string`
+
+##### targetBuildId
+
+> **targetBuildId**: `string`
+
+##### sourceSymbols
+
+> **sourceSymbols**: [`NativeCodeSymbol`](#nativecodesymbol)[]
+
+##### targetSymbols
+
+> **targetSymbols**: [`NativeCodeSymbol`](#nativecodesymbol)[]
+
+##### requestedLocations
+
+> **requestedLocations**: `object`[]
+
+###### id
+
+> **id**: `string`
+
+###### symbol
+
+> **symbol**: `string`
+
+###### sourceAddress?
+
+> `optional` **sourceAddress?**: `string`
+
+***
+
+### NativeCodeMapResult
+
+#### Properties
+
+##### codeLocations
+
+> **codeLocations**: [`NativeCodeLocationMapping`](#nativecodelocationmapping)[]
+
+##### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
 
 ***
 
@@ -4356,7 +4442,7 @@ kicks in: `<sourceName>/<fork.pid>`.
 
 ###### Overrides
 
-[`RestoreOptions`](#restoreoptions).[`name`](#name-7)
+[`RestoreOptions`](#restoreoptions).[`name`](#name-8)
 
 ##### portForward?
 
@@ -7346,6 +7432,22 @@ available.
 #### Returns
 
 `string`
+
+***
+
+### buildNativeCodeMap()
+
+> **buildNativeCodeMap**(`request`): [`NativeCodeMapResult`](#nativecodemapresult)
+
+#### Parameters
+
+##### request
+
+[`NativeCodeMapRequest`](#nativecodemaprequest)
+
+#### Returns
+
+[`NativeCodeMapResult`](#nativecodemapresult)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-code-map.test.ts
+++ b/packages/runtime/src/__tests__/native-code-map.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { buildNativeCodeMap, type NativeCodeMapRequest } from "../native-code-map.ts";
+
+function request(): NativeCodeMapRequest {
+  return {
+    expectedTargetBuildId: "b16b00b5",
+    targetBuildId: "b16b00b5",
+    sourceSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:source-text",
+        address: "0x400120",
+        sizeBytes: 64,
+        metadata: "dwarf",
+      },
+      {
+        name: "native_controlled_helper",
+        mapping: "mapping:source-text",
+        address: "0x400180",
+        sizeBytes: 32,
+        metadata: "sidecar",
+      },
+    ],
+    targetSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:target-text",
+        address: "0x14000120",
+        sizeBytes: 72,
+        metadata: "dwarf",
+      },
+      {
+        name: "native_controlled_helper",
+        mapping: "mapping:target-text",
+        address: "0x14000190",
+        sizeBytes: 40,
+        metadata: "sidecar",
+      },
+    ],
+    requestedLocations: [
+      { id: "code:resume", symbol: "native_controlled_resume", sourceAddress: "0x400120" },
+      { id: "code:helper", symbol: "native_controlled_helper", sourceAddress: "0x400180" },
+    ],
+  };
+}
+
+describe("native code map", () => {
+  it("maps source code locations to target code by build identity and symbol metadata", () => {
+    const result = buildNativeCodeMap(request());
+
+    expect(result.refusals).toEqual([]);
+    expect(result.codeLocations).toEqual([
+      {
+        id: "code:resume",
+        sourceMapping: "mapping:source-text",
+        sourceAddress: "0x400120",
+        targetAddress: "0x14000120",
+        state: "mapped",
+      },
+      {
+        id: "code:helper",
+        sourceMapping: "mapping:source-text",
+        sourceAddress: "0x400180",
+        targetAddress: "0x14000190",
+        state: "mapped",
+      },
+    ]);
+  });
+
+  it("refuses target build mismatches before mapping any locations", () => {
+    const input = request();
+    input.targetBuildId = "deadbeef";
+
+    const result = buildNativeCodeMap(input);
+
+    expect(result.refusals).toEqual([expect.objectContaining({ code: "target-build-mismatch" })]);
+    expect(result.codeLocations.every((location) => location.state === "refused")).toBe(true);
+  });
+
+  it("refuses unknown target code locations", () => {
+    const input = request();
+    input.requestedLocations.push({ id: "code:missing", symbol: "native_missing" });
+
+    const result = buildNativeCodeMap(input);
+
+    expect(result.codeLocations.at(-1)).toMatchObject({
+      id: "code:missing",
+      state: "refused",
+      refusal: { code: "code-location-unknown" },
+    });
+  });
+
+  it("requires DWARF or sidecar size metadata for bare symbol-only mappings", () => {
+    const input = request();
+    input.sourceSymbols = [
+      {
+        name: "stripped_resume",
+        mapping: "mapping:source-text",
+        address: "0x401000",
+        metadata: "symbol",
+      },
+    ];
+    input.targetSymbols = [
+      {
+        name: "stripped_resume",
+        mapping: "mapping:target-text",
+        address: "0x14001000",
+        metadata: "symbol",
+      },
+    ];
+    input.requestedLocations = [{ id: "code:stripped", symbol: "stripped_resume" }];
+
+    const result = buildNativeCodeMap(input);
+
+    expect(result.codeLocations[0]).toMatchObject({
+      state: "refused",
+      refusal: {
+        code: "code-location-unknown",
+        message: expect.stringContaining("DWARF or sidecar"),
+      },
+    });
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -102,6 +102,12 @@ export type {
   WriteFileOptions,
 } from "./vm-handle.ts";
 export type { SnapshotEngine } from "./vm/snapshot-engine.ts";
+export { buildNativeCodeMap } from "./native-code-map.ts";
+export type {
+  NativeCodeMapRequest,
+  NativeCodeMapResult,
+  NativeCodeSymbol,
+} from "./native-code-map.ts";
 export { translateNativeRegisterState } from "./native-register-translation.ts";
 export type {
   NativeContinuationTarget,

--- a/packages/runtime/src/native-code-map.ts
+++ b/packages/runtime/src/native-code-map.ts
@@ -1,0 +1,140 @@
+/** Source-code to target-code mapping for native cross-ISA restore. */
+
+import type {
+  NativeCodeLocationMapping,
+  NativeProcessImageRefusal,
+} from "./native-process-image.ts";
+
+export interface NativeCodeSymbol {
+  name: string;
+  mapping: string;
+  address: string;
+  sizeBytes?: number;
+  buildId?: string;
+  metadata: "symbol" | "dwarf" | "sidecar";
+}
+
+export interface NativeCodeMapRequest {
+  expectedTargetBuildId: string;
+  targetBuildId: string;
+  sourceSymbols: NativeCodeSymbol[];
+  targetSymbols: NativeCodeSymbol[];
+  requestedLocations: Array<{ id: string; symbol: string; sourceAddress?: string }>;
+}
+
+export interface NativeCodeMapResult {
+  codeLocations: NativeCodeLocationMapping[];
+  refusals: NativeProcessImageRefusal[];
+}
+
+export function buildNativeCodeMap(request: NativeCodeMapRequest): NativeCodeMapResult {
+  const buildMismatch = validateTargetBuild(request);
+  if (buildMismatch) {
+    return {
+      codeLocations: request.requestedLocations.map((location) =>
+        refusedLocation(location, buildMismatch),
+      ),
+      refusals: [buildMismatch],
+    };
+  }
+
+  const sourceByName = symbolsByName(request.sourceSymbols);
+  const targetByName = symbolsByName(request.targetSymbols);
+  const codeLocations = request.requestedLocations.map((location) =>
+    mapRequestedLocation(location, sourceByName, targetByName),
+  );
+  return {
+    codeLocations,
+    refusals: codeLocations.flatMap((location) => (location.refusal ? [location.refusal] : [])),
+  };
+}
+
+function validateTargetBuild(request: NativeCodeMapRequest): NativeProcessImageRefusal | undefined {
+  if (normalizeBuildId(request.targetBuildId) !== normalizeBuildId(request.expectedTargetBuildId)) {
+    return {
+      code: "target-build-mismatch",
+      message: `target build ${request.targetBuildId} does not match expected ${request.expectedTargetBuildId}`,
+      detail: {
+        targetBuildId: request.targetBuildId,
+        expectedTargetBuildId: request.expectedTargetBuildId,
+      },
+    };
+  }
+  return undefined;
+}
+
+function symbolsByName(symbols: NativeCodeSymbol[]): Map<string, NativeCodeSymbol> {
+  const byName = new Map<string, NativeCodeSymbol>();
+  for (const symbol of symbols) {
+    byName.set(symbol.name, symbol);
+  }
+  return byName;
+}
+
+function mapRequestedLocation(
+  location: NativeCodeMapRequest["requestedLocations"][number],
+  sourceByName: Map<string, NativeCodeSymbol>,
+  targetByName: Map<string, NativeCodeSymbol>,
+): NativeCodeLocationMapping {
+  const source = sourceByName.get(location.symbol);
+  if (!source) {
+    return refusedLocation(
+      location,
+      codeRefusal("code-location-unknown", `source symbol ${location.symbol} is missing`),
+    );
+  }
+  const target = targetByName.get(location.symbol);
+  if (!target) {
+    return refusedLocation(
+      location,
+      codeRefusal("code-location-unknown", `target symbol ${location.symbol} is missing`),
+      source,
+    );
+  }
+  if (
+    source.metadata === "symbol" &&
+    target.metadata === "symbol" &&
+    source.sizeBytes === undefined
+  ) {
+    return refusedLocation(
+      location,
+      codeRefusal(
+        "code-location-unknown",
+        `symbol ${location.symbol} needs DWARF or sidecar size metadata before pointer translation`,
+      ),
+      source,
+    );
+  }
+  return {
+    id: location.id,
+    sourceMapping: source.mapping,
+    sourceAddress: location.sourceAddress ?? source.address,
+    targetAddress: target.address,
+    state: "mapped",
+  };
+}
+
+function refusedLocation(
+  location: NativeCodeMapRequest["requestedLocations"][number],
+  refusal: NativeProcessImageRefusal,
+  source?: NativeCodeSymbol,
+): NativeCodeLocationMapping {
+  return {
+    id: location.id,
+    sourceMapping: source?.mapping ?? "mapping:unknown",
+    sourceAddress: location.sourceAddress ?? source?.address ?? "0x0",
+    state: "refused",
+    refusal,
+  };
+}
+
+function codeRefusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeProcessImageRefusal {
+  return { code, message };
+}
+
+function normalizeBuildId(value: string): string {
+  return value.toLowerCase();
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -104,6 +104,10 @@ const TOC = {
     "NativeContinuationTarget",
     "NativeRegisterTranslationResult",
     "translateNativeRegisterState",
+    "NativeCodeSymbol",
+    "NativeCodeMapRequest",
+    "NativeCodeMapResult",
+    "buildNativeCodeMap",
   ],
   "Provision base images": [
     "provision",

--- a/scripts/native-code-map.ts
+++ b/scripts/native-code-map.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+import { buildNativeCodeMap } from "../packages/runtime/src/native-code-map.ts";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE = "usage: tsx scripts/native-code-map.ts [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-code-map-");
+  try {
+    emitResult(verifyNativeCodeMap(), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeCodeMap() {
+  const mapped = buildNativeCodeMap({
+    expectedTargetBuildId: "b16b00b5",
+    targetBuildId: "b16b00b5",
+    sourceSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:arm64-text",
+        address: "0x400120",
+        sizeBytes: 64,
+        metadata: "dwarf",
+      },
+    ],
+    targetSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:amd64-text",
+        address: "0x14000120",
+        sizeBytes: 72,
+        metadata: "dwarf",
+      },
+    ],
+    requestedLocations: [{ id: "code:resume", symbol: "native_controlled_resume" }],
+  });
+  const mismatch = buildNativeCodeMap({
+    ...mappedInputForMismatch(),
+    targetBuildId: "deadbeef",
+  });
+  if (mapped.codeLocations[0]?.state !== "mapped") {
+    throw new Error("native code map did not map the controlled resume symbol");
+  }
+  if (mismatch.refusals[0]?.code !== "target-build-mismatch") {
+    throw new Error("native code map did not refuse a target build mismatch");
+  }
+  return { formatVersion: 1, mapped, mismatchRefusal: mismatch.refusals[0] };
+}
+
+function mappedInputForMismatch() {
+  return {
+    expectedTargetBuildId: "b16b00b5",
+    targetBuildId: "b16b00b5",
+    sourceSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:arm64-text",
+        address: "0x400120",
+        sizeBytes: 64,
+        metadata: "dwarf" as const,
+      },
+    ],
+    targetSymbols: [
+      {
+        name: "native_controlled_resume",
+        mapping: "mapping:amd64-text",
+        address: "0x14000120",
+        sizeBytes: 72,
+        metadata: "dwarf" as const,
+      },
+    ],
+    requestedLocations: [{ id: "code:resume", symbol: "native_controlled_resume" }],
+  };
+}
+
+function printSummary(summary: ReturnType<typeof verifyNativeCodeMap>) {
+  console.log(
+    `native-code-map: mapped=${summary.mapped.codeLocations.length} mismatch=${summary.mismatchRefusal?.code}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #446.

## Problem

Translated registers and stacks need target code addresses. A raw source program counter is not useful on amd64, and using it by accident would hide a broken restore.

## Solution

This adds a code-location mapper. It matches source symbols to target symbols by metadata, records source-to-target addresses, and refuses missing metadata or target build mismatches with specific codes. The proof keeps target-native execution separate from source-ISA emulation.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
