### PR TITLE
Translate native stack continuations

### DIFF
--- a/docs/snapshot/native-stack-translation.md
+++ b/docs/snapshot/native-stack-translation.md
@@ -1,0 +1,36 @@
+# Native stack translation
+
+Issue #447 translates stack continuations for the native cross-ISA path.
+
+## Command
+
+```sh
+pnpm native-stack-translate
+```
+
+The proof translates a metadata-proven frame, its return address, and a pointer
+slot. It also has tests for missing unwind metadata, unknown return addresses,
+and ambiguous pointer-like slots.
+
+## Contract
+
+A frame can translate only when:
+
+- DWARF or sidecar unwind metadata identifies the frame boundary;
+- the frame's source return address has a mapped target code location from #446;
+- pointer or code-pointer slots have proven target values;
+- integer slots are copied as bytes and are not relocated.
+
+The translator emits `NativeMemoryRelocation` entries for return addresses and
+proven pointer slots. It does not blindly copy raw source stack bytes as target
+continuation state.
+
+## Refusals
+
+- `mapping-ambiguous` when a frame has no metadata;
+- `code-location-unknown` when a return address or code pointer has no target;
+- `pointer-ambiguous` when metadata cannot prove whether a slot is a pointer or
+  integer.
+
+Signal frames remain outside the stack translator; #445 refuses active signal
+frames before stack translation starts.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "native-restore-loader": "node scripts/native-restore-loader.mjs verify",
     "native-register-translate": "tsx scripts/native-register-translate.ts verify",
     "native-code-map": "tsx scripts/native-code-map.ts verify",
+    "native-stack-translate": "tsx scripts/native-stack-translate.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -86,6 +86,11 @@
 - [`NativeCodeMapRequest`](#nativecodemaprequest)
 - [`NativeCodeMapResult`](#nativecodemapresult)
 - [`buildNativeCodeMap`](#buildnativecodemap)
+- [`NativeStackFrame`](#nativestackframe)
+- [`NativeStackSlot`](#nativestackslot)
+- [`NativeStackTranslationRequest`](#nativestacktranslationrequest)
+- [`NativeStackTranslationResult`](#nativestacktranslationresult)
+- [`translateNativeStack`](#translatenativestack)
 
 ### Provision base images
 
@@ -3022,6 +3027,106 @@ by default when `output` is a TTY.
 ##### threads
 
 > **threads**: [`NativeThreadTranslation`](#nativethreadtranslation)[]
+
+##### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+***
+
+### NativeStackFrame
+
+#### Properties
+
+##### id
+
+> **id**: `string`
+
+##### sourceSp
+
+> **sourceSp**: `string`
+
+##### sourceReturnAddress
+
+> **sourceReturnAddress**: `string`
+
+##### sizeBytes
+
+> **sizeBytes**: `number`
+
+##### metadata
+
+> **metadata**: `"unknown"` \| `"dwarf"` \| `"sidecar"`
+
+##### locals
+
+> **locals**: [`NativeStackSlot`](#nativestackslot)[]
+
+***
+
+### NativeStackSlot
+
+#### Properties
+
+##### offset
+
+> **offset**: `number`
+
+##### kind
+
+> **kind**: `"pointer"` \| `"integer"` \| `"code-pointer"` \| `"ambiguous"`
+
+##### sourceValue
+
+> **sourceValue**: `string`
+
+##### targetValue?
+
+> `optional` **targetValue?**: `string`
+
+***
+
+### NativeStackTranslationRequest
+
+#### Properties
+
+##### stackMapping
+
+> **stackMapping**: `string`
+
+##### targetStackBase
+
+> **targetStackBase**: `string`
+
+##### frames
+
+> **frames**: [`NativeStackFrame`](#nativestackframe)[]
+
+##### codeLocations
+
+> **codeLocations**: [`NativeCodeLocationMapping`](#nativecodelocationmapping)[]
+
+***
+
+### NativeStackTranslationResult
+
+#### Properties
+
+##### stackMapping
+
+> **stackMapping**: `string`
+
+##### targetStackBase
+
+> **targetStackBase**: `string`
+
+##### targetStackSizeBytes
+
+> **targetStackSizeBytes**: `number`
+
+##### relocations
+
+> **relocations**: [`NativeMemoryRelocation`](#nativememoryrelocation)[]
 
 ##### refusals
 
@@ -7540,6 +7645,22 @@ available.
 #### Returns
 
 [`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
+
+***
+
+### translateNativeStack()
+
+> **translateNativeStack**(`request`): [`NativeStackTranslationResult`](#nativestacktranslationresult)
+
+#### Parameters
+
+##### request
+
+[`NativeStackTranslationRequest`](#nativestacktranslationrequest)
+
+#### Returns
+
+[`NativeStackTranslationResult`](#nativestacktranslationresult)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-stack-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-stack-translation.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  translateNativeStack,
+  type NativeStackTranslationRequest,
+} from "../native-stack-translation.ts";
+
+function request(): NativeStackTranslationRequest {
+  return {
+    stackMapping: "mapping:stack",
+    targetStackBase: "0x7fffffffe000",
+    codeLocations: [
+      {
+        id: "code:return",
+        sourceMapping: "mapping:text",
+        sourceAddress: "0x400180",
+        targetAddress: "0x14000180",
+        state: "mapped",
+      },
+    ],
+    frames: [
+      {
+        id: "frame:main",
+        sourceSp: "0x7fff0000",
+        sourceReturnAddress: "0x400180",
+        sizeBytes: 64,
+        metadata: "dwarf",
+        locals: [
+          { offset: 16, kind: "integer", sourceValue: "0x2a" },
+          { offset: 24, kind: "pointer", sourceValue: "0x600000", targetValue: "0x700000" },
+          { offset: 32, kind: "code-pointer", sourceValue: "0x400180", targetValue: "0x14000180" },
+        ],
+      },
+    ],
+  };
+}
+
+describe("native stack translation", () => {
+  it("translates return addresses and metadata-proven stack pointer slots", () => {
+    const result = translateNativeStack(request());
+
+    expect(result.refusals).toEqual([]);
+    expect(result.targetStackSizeBytes).toBe(64);
+    expect(result.relocations).toEqual([
+      {
+        mapping: "mapping:stack",
+        offset: 0,
+        kind: "return-address",
+        sourceValue: "0x400180",
+        targetValue: "0x14000180",
+        state: "translated",
+      },
+      {
+        mapping: "mapping:stack",
+        offset: 24,
+        kind: "pointer",
+        sourceValue: "0x600000",
+        targetValue: "0x700000",
+        state: "translated",
+      },
+      {
+        mapping: "mapping:stack",
+        offset: 32,
+        kind: "code-pointer",
+        sourceValue: "0x400180",
+        targetValue: "0x14000180",
+        state: "translated",
+      },
+    ]);
+  });
+
+  it("refuses frames without unwind metadata", () => {
+    const input = request();
+    input.frames[0]!.metadata = "unknown";
+
+    const result = translateNativeStack(input);
+
+    expect(result.relocations).toEqual([]);
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "mapping-ambiguous",
+        message: expect.stringContaining("metadata"),
+      }),
+    ]);
+  });
+
+  it("refuses unknown return addresses", () => {
+    const input = request();
+    input.frames[0]!.sourceReturnAddress = "0x499999";
+
+    const result = translateNativeStack(input);
+
+    expect(result.relocations).toEqual([]);
+    expect(result.refusals[0]).toMatchObject({ code: "code-location-unknown" });
+  });
+
+  it("refuses ambiguous pointer-like stack slots", () => {
+    const input = request();
+    input.frames[0]!.locals.push({ offset: 40, kind: "ambiguous", sourceValue: "0x700000" });
+
+    const result = translateNativeStack(input);
+
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "pointer-ambiguous",
+        message: expect.stringContaining("slot 40"),
+      }),
+    ]);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -109,6 +109,13 @@ export type {
   NativeCodeSymbol,
 } from "./native-code-map.ts";
 export { translateNativeRegisterState } from "./native-register-translation.ts";
+export { translateNativeStack } from "./native-stack-translation.ts";
+export type {
+  NativeStackFrame,
+  NativeStackSlot,
+  NativeStackTranslationRequest,
+  NativeStackTranslationResult,
+} from "./native-stack-translation.ts";
 export type {
   NativeContinuationTarget,
   NativeRegisterTranslationRequest,

--- a/packages/runtime/src/native-stack-translation.ts
+++ b/packages/runtime/src/native-stack-translation.ts
@@ -1,0 +1,173 @@
+/** Stack-frame and continuation translation for native process images. */
+
+import type {
+  NativeCodeLocationMapping,
+  NativeMemoryRelocation,
+  NativeProcessImageRefusal,
+} from "./native-process-image.ts";
+
+export interface NativeStackFrame {
+  id: string;
+  sourceSp: string;
+  sourceReturnAddress: string;
+  sizeBytes: number;
+  metadata: "dwarf" | "sidecar" | "unknown";
+  locals: NativeStackSlot[];
+}
+
+export interface NativeStackSlot {
+  offset: number;
+  kind: "integer" | "pointer" | "code-pointer" | "ambiguous";
+  sourceValue: string;
+  targetValue?: string;
+}
+
+export interface NativeStackTranslationRequest {
+  stackMapping: string;
+  targetStackBase: string;
+  frames: NativeStackFrame[];
+  codeLocations: NativeCodeLocationMapping[];
+}
+
+export interface NativeStackTranslationResult {
+  stackMapping: string;
+  targetStackBase: string;
+  targetStackSizeBytes: number;
+  relocations: NativeMemoryRelocation[];
+  refusals: NativeProcessImageRefusal[];
+}
+
+export function translateNativeStack(
+  request: NativeStackTranslationRequest,
+): NativeStackTranslationResult {
+  const codeLocations = mappedCodeLocations(request.codeLocations);
+  const frameResults = request.frames.map((frame) => translateFrame(request, frame, codeLocations));
+  const refusals = frameResults.flatMap((result) => result.refusals);
+  return {
+    stackMapping: request.stackMapping,
+    targetStackBase: request.targetStackBase,
+    targetStackSizeBytes: request.frames.reduce((total, frame) => total + frame.sizeBytes, 0),
+    relocations: frameResults.flatMap((result) => result.relocations),
+    refusals,
+  };
+}
+
+function mappedCodeLocations(codeLocations: NativeCodeLocationMapping[]): Map<string, string> {
+  const mapped = new Map<string, string>();
+  for (const location of codeLocations) {
+    if (location.state === "mapped" && location.targetAddress) {
+      mapped.set(normalizeHex(location.sourceAddress), location.targetAddress);
+    }
+  }
+  return mapped;
+}
+
+function translateFrame(
+  request: NativeStackTranslationRequest,
+  frame: NativeStackFrame,
+  codeLocations: Map<string, string>,
+): { relocations: NativeMemoryRelocation[]; refusals: NativeProcessImageRefusal[] } {
+  if (frame.metadata === "unknown") {
+    return {
+      relocations: [],
+      refusals: [
+        refusal(
+          "mapping-ambiguous",
+          `stack frame ${frame.id} has no unwind/DWARF/sidecar metadata`,
+        ),
+      ],
+    };
+  }
+  const returnAddress = codeLocations.get(normalizeHex(frame.sourceReturnAddress));
+  if (!returnAddress) {
+    return {
+      relocations: [],
+      refusals: [
+        refusal(
+          "code-location-unknown",
+          `stack frame ${frame.id} return address ${frame.sourceReturnAddress} has no target code location`,
+        ),
+      ],
+    };
+  }
+
+  const localResults = frame.locals.map((slot) => translateSlot(request, frame, slot));
+  return {
+    relocations: [
+      {
+        mapping: request.stackMapping,
+        offset: frameOffset(request.frames, frame),
+        kind: "return-address",
+        sourceValue: frame.sourceReturnAddress,
+        targetValue: returnAddress,
+        state: "translated",
+      },
+      ...localResults.flatMap((result) => result.relocations),
+    ],
+    refusals: localResults.flatMap((result) => result.refusals),
+  };
+}
+
+function translateSlot(
+  request: NativeStackTranslationRequest,
+  frame: NativeStackFrame,
+  slot: NativeStackSlot,
+): { relocations: NativeMemoryRelocation[]; refusals: NativeProcessImageRefusal[] } {
+  if (slot.kind === "integer") {
+    return { relocations: [], refusals: [] };
+  }
+  if (slot.kind === "ambiguous") {
+    return {
+      relocations: [],
+      refusals: [
+        refusal("pointer-ambiguous", `stack frame ${frame.id} slot ${slot.offset} is ambiguous`),
+      ],
+    };
+  }
+  if (!slot.targetValue) {
+    return {
+      relocations: [],
+      refusals: [
+        refusal(
+          slot.kind === "code-pointer" ? "code-location-unknown" : "pointer-ambiguous",
+          `stack frame ${frame.id} slot ${slot.offset} has no target value`,
+        ),
+      ],
+    };
+  }
+  return {
+    relocations: [
+      {
+        mapping: request.stackMapping,
+        offset: frameOffset(request.frames, frame) + slot.offset,
+        kind: slot.kind,
+        sourceValue: slot.sourceValue,
+        targetValue: slot.targetValue,
+        state: "translated",
+      },
+    ],
+    refusals: [],
+  };
+}
+
+function frameOffset(frames: NativeStackFrame[], frame: NativeStackFrame): number {
+  let offset = 0;
+  for (const candidate of frames) {
+    if (candidate === frame) {
+      return offset;
+    }
+    offset += candidate.sizeBytes;
+  }
+  return offset;
+}
+
+function refusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeProcessImageRefusal {
+  return { code, message };
+}
+
+function normalizeHex(value: string): string {
+  return `0x${BigInt(value).toString(16)}`;
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -108,6 +108,11 @@ const TOC = {
     "NativeCodeMapRequest",
     "NativeCodeMapResult",
     "buildNativeCodeMap",
+    "NativeStackFrame",
+    "NativeStackSlot",
+    "NativeStackTranslationRequest",
+    "NativeStackTranslationResult",
+    "translateNativeStack",
   ],
   "Provision base images": [
     "provision",

--- a/scripts/native-stack-translate.ts
+++ b/scripts/native-stack-translate.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env tsx
+import { translateNativeStack } from "../packages/runtime/src/native-stack-translation.ts";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: tsx scripts/native-stack-translate.ts [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-stack-translate-");
+  try {
+    emitResult(verifyNativeStackTranslation(), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeStackTranslation() {
+  const result = translateNativeStack({
+    stackMapping: "mapping:stack",
+    targetStackBase: "0x7fffffffe000",
+    codeLocations: [
+      {
+        id: "code:return",
+        sourceMapping: "mapping:text",
+        sourceAddress: "0x400180",
+        targetAddress: "0x14000180",
+        state: "mapped",
+      },
+    ],
+    frames: [
+      {
+        id: "frame:main",
+        sourceSp: "0x7fff0000",
+        sourceReturnAddress: "0x400180",
+        sizeBytes: 64,
+        metadata: "dwarf",
+        locals: [{ offset: 24, kind: "pointer", sourceValue: "0x600000", targetValue: "0x700000" }],
+      },
+    ],
+  });
+  if (result.refusals.length !== 0 || result.relocations.length !== 2) {
+    throw new Error(
+      "native stack translation proof did not translate return address plus pointer slot",
+    );
+  }
+  return { formatVersion: 1, result };
+}
+
+function printSummary(summary: ReturnType<typeof verifyNativeStackTranslation>) {
+  console.log(
+    `native-stack-translate: relocations=${summary.result.relocations.length} refusals=${summary.result.refusals.length}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #447.

## Problem

A stopped thread also carries return addresses and pointer slots on its stack. If those stay in source addresses, the target process would return into the wrong code or point at the wrong data.

## Solution

This adds stack translation for controlled frames. It rewrites return addresses through the code map and records pointer-slot relocations for the target stack. Ambiguous frames are refused unless enough metadata exists to translate them safely.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
