### PR TITLE
Translate native process memory

### DIFF
--- a/docs/snapshot/native-memory-translation.md
+++ b/docs/snapshot/native-memory-translation.md
@@ -1,0 +1,34 @@
+# Native memory translation
+
+Issue #448 classifies and relocates pointer-bearing process memory for native
+cross-ISA restore.
+
+## Command
+
+```sh
+pnpm native-memory-translate
+```
+
+The proof preserves an integer word, relocates a metadata-proven pointer, and
+refuses an ambiguous pointer-like word.
+
+## Contract
+
+Each word considered for relocation carries a classification and proof source:
+
+- `integer` words are preserved as bytes;
+- `pointer`, `code-pointer`, and `thread-pointer` words require a target value;
+- `ambiguous` words or `proof: none` refuse.
+
+This avoids treating every pointer-shaped integer as a pointer. A word is
+relocated only when DWARF, sidecar metadata, symbols, or an explicit policy has
+proven its meaning.
+
+## Refusals
+
+- `pointer-ambiguous` when a word cannot be proven pointer vs integer, or when a
+  data pointer has no target value;
+- `code-location-unknown` when a code pointer lacks a mapped target address.
+
+The result is a relocation report that later restore stages can apply to
+`native-memory.bin` after target mappings are materialized.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "native-register-translate": "tsx scripts/native-register-translate.ts verify",
     "native-code-map": "tsx scripts/native-code-map.ts verify",
     "native-stack-translate": "tsx scripts/native-stack-translate.ts verify",
+    "native-memory-translate": "tsx scripts/native-memory-translate.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -91,6 +91,10 @@
 - [`NativeStackTranslationRequest`](#nativestacktranslationrequest)
 - [`NativeStackTranslationResult`](#nativestacktranslationresult)
 - [`translateNativeStack`](#translatenativestack)
+- [`NativeMemoryWord`](#nativememoryword)
+- [`NativeMemoryTranslationRequest`](#nativememorytranslationrequest)
+- [`NativeMemoryTranslationResult`](#nativememorytranslationresult)
+- [`translateNativeMemory`](#translatenativememory)
 
 ### Provision base images
 
@@ -2247,6 +2251,64 @@ by default when `output` is a TTY.
 ##### codeLocations
 
 > **codeLocations**: [`NativeCodeLocationMapping`](#nativecodelocationmapping)[]
+
+##### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+***
+
+### NativeMemoryWord
+
+#### Properties
+
+##### mapping
+
+> **mapping**: `string`
+
+##### offset
+
+> **offset**: `number`
+
+##### sourceValue
+
+> **sourceValue**: `string`
+
+##### classification
+
+> **classification**: `"pointer"` \| `"integer"` \| `"code-pointer"` \| `"thread-pointer"` \| `"ambiguous"`
+
+##### targetValue?
+
+> `optional` **targetValue?**: `string`
+
+##### proof
+
+> **proof**: `"symbol"` \| `"none"` \| `"dwarf"` \| `"sidecar"` \| `"policy"`
+
+***
+
+### NativeMemoryTranslationRequest
+
+#### Properties
+
+##### words
+
+> **words**: [`NativeMemoryWord`](#nativememoryword)[]
+
+***
+
+### NativeMemoryTranslationResult
+
+#### Properties
+
+##### relocations
+
+> **relocations**: [`NativeMemoryRelocation`](#nativememoryrelocation)[]
+
+##### preservedWords
+
+> **preservedWords**: `number`
 
 ##### refusals
 
@@ -7553,6 +7615,22 @@ available.
 #### Returns
 
 [`NativeCodeMapResult`](#nativecodemapresult)
+
+***
+
+### translateNativeMemory()
+
+> **translateNativeMemory**(`request`): [`NativeMemoryTranslationResult`](#nativememorytranslationresult)
+
+#### Parameters
+
+##### request
+
+[`NativeMemoryTranslationRequest`](#nativememorytranslationrequest)
+
+#### Returns
+
+[`NativeMemoryTranslationResult`](#nativememorytranslationresult)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-memory-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-memory-translation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { translateNativeMemory } from "../native-memory-translation.ts";
+
+describe("native memory translation", () => {
+  it("preserves integers and relocates metadata-proven pointers", () => {
+    const result = translateNativeMemory({
+      words: [
+        {
+          mapping: "mapping:data",
+          offset: 0,
+          sourceValue: "0x2a",
+          classification: "integer",
+          proof: "dwarf",
+        },
+        {
+          mapping: "mapping:data",
+          offset: 8,
+          sourceValue: "0x600000",
+          targetValue: "0x700000",
+          classification: "pointer",
+          proof: "sidecar",
+        },
+        {
+          mapping: "mapping:data",
+          offset: 16,
+          sourceValue: "0x400180",
+          targetValue: "0x14000180",
+          classification: "code-pointer",
+          proof: "dwarf",
+        },
+      ],
+    });
+
+    expect(result.preservedWords).toBe(1);
+    expect(result.refusals).toEqual([]);
+    expect(result.relocations).toEqual([
+      {
+        mapping: "mapping:data",
+        offset: 8,
+        kind: "pointer",
+        sourceValue: "0x600000",
+        targetValue: "0x700000",
+        state: "translated",
+      },
+      {
+        mapping: "mapping:data",
+        offset: 16,
+        kind: "code-pointer",
+        sourceValue: "0x400180",
+        targetValue: "0x14000180",
+        state: "translated",
+      },
+    ]);
+  });
+
+  it("refuses ambiguous pointer-like words", () => {
+    const result = translateNativeMemory({
+      words: [
+        {
+          mapping: "mapping:heap",
+          offset: 24,
+          sourceValue: "0x700000",
+          classification: "ambiguous",
+          proof: "none",
+        },
+      ],
+    });
+
+    expect(result.relocations).toEqual([]);
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "pointer-ambiguous",
+        message: expect.stringContaining("mapping:heap+24"),
+      }),
+    ]);
+  });
+
+  it("refuses missing target values for code pointers", () => {
+    const result = translateNativeMemory({
+      words: [
+        {
+          mapping: "mapping:data",
+          offset: 32,
+          sourceValue: "0x400180",
+          classification: "code-pointer",
+          proof: "dwarf",
+        },
+      ],
+    });
+
+    expect(result.refusals[0]).toMatchObject({ code: "code-location-unknown" });
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -108,6 +108,12 @@ export type {
   NativeCodeMapResult,
   NativeCodeSymbol,
 } from "./native-code-map.ts";
+export { translateNativeMemory } from "./native-memory-translation.ts";
+export type {
+  NativeMemoryTranslationRequest,
+  NativeMemoryTranslationResult,
+  NativeMemoryWord,
+} from "./native-memory-translation.ts";
 export { translateNativeRegisterState } from "./native-register-translation.ts";
 export { translateNativeStack } from "./native-stack-translation.ts";
 export type {

--- a/packages/runtime/src/native-memory-translation.ts
+++ b/packages/runtime/src/native-memory-translation.ts
@@ -1,0 +1,100 @@
+/** Process memory classification and relocation for native cross-ISA restore. */
+
+import type { NativeMemoryRelocation, NativeProcessImageRefusal } from "./native-process-image.ts";
+
+export interface NativeMemoryWord {
+  mapping: string;
+  offset: number;
+  sourceValue: string;
+  classification: "integer" | "pointer" | "code-pointer" | "thread-pointer" | "ambiguous";
+  targetValue?: string;
+  proof: "dwarf" | "sidecar" | "symbol" | "policy" | "none";
+}
+
+export interface NativeMemoryTranslationRequest {
+  words: NativeMemoryWord[];
+}
+
+export interface NativeMemoryTranslationResult {
+  relocations: NativeMemoryRelocation[];
+  preservedWords: number;
+  refusals: NativeProcessImageRefusal[];
+}
+
+export function translateNativeMemory(
+  request: NativeMemoryTranslationRequest,
+): NativeMemoryTranslationResult {
+  const results = request.words.map(translateWord);
+  return {
+    relocations: results.flatMap((result) => result.relocations),
+    preservedWords: results.filter((result) => result.preserved).length,
+    refusals: results.flatMap((result) => result.refusals),
+  };
+}
+
+function translateWord(word: NativeMemoryWord): {
+  relocations: NativeMemoryRelocation[];
+  preserved: boolean;
+  refusals: NativeProcessImageRefusal[];
+} {
+  if (word.classification === "integer") {
+    return { relocations: [], preserved: true, refusals: [] };
+  }
+  if (word.classification === "ambiguous" || word.proof === "none") {
+    return {
+      relocations: [],
+      preserved: false,
+      refusals: [
+        refusal(
+          "pointer-ambiguous",
+          `memory word ${word.mapping}+${word.offset} cannot be proven pointer or integer`,
+        ),
+      ],
+    };
+  }
+  if (!word.targetValue) {
+    return {
+      relocations: [],
+      preserved: false,
+      refusals: [
+        refusal(
+          word.classification === "code-pointer" ? "code-location-unknown" : "pointer-ambiguous",
+          `memory word ${word.mapping}+${word.offset} has no target value`,
+        ),
+      ],
+    };
+  }
+  return {
+    relocations: [
+      {
+        mapping: word.mapping,
+        offset: word.offset,
+        kind: relocationKind(word.classification),
+        sourceValue: word.sourceValue,
+        targetValue: word.targetValue,
+        state: "translated",
+      },
+    ],
+    preserved: false,
+    refusals: [],
+  };
+}
+
+function relocationKind(
+  classification: NativeMemoryWord["classification"],
+): NativeMemoryRelocation["kind"] {
+  if (classification === "code-pointer") {
+    return "code-pointer";
+  }
+  if (classification === "thread-pointer") {
+    return "thread-pointer";
+  }
+  return "pointer";
+}
+
+function refusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeProcessImageRefusal {
+  return { code, message };
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -113,6 +113,10 @@ const TOC = {
     "NativeStackTranslationRequest",
     "NativeStackTranslationResult",
     "translateNativeStack",
+    "NativeMemoryWord",
+    "NativeMemoryTranslationRequest",
+    "NativeMemoryTranslationResult",
+    "translateNativeMemory",
   ],
   "Provision base images": [
     "provision",

--- a/scripts/native-memory-translate.ts
+++ b/scripts/native-memory-translate.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env tsx
+import { translateNativeMemory } from "../packages/runtime/src/native-memory-translation.ts";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: tsx scripts/native-memory-translate.ts [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-memory-translate-");
+  try {
+    emitResult(verifyNativeMemoryTranslation(), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeMemoryTranslation() {
+  const result = translateNativeMemory({
+    words: [
+      {
+        mapping: "mapping:data",
+        offset: 0,
+        sourceValue: "0x2a",
+        classification: "integer",
+        proof: "dwarf",
+      },
+      {
+        mapping: "mapping:data",
+        offset: 8,
+        sourceValue: "0x600000",
+        targetValue: "0x700000",
+        classification: "pointer",
+        proof: "sidecar",
+      },
+      {
+        mapping: "mapping:data",
+        offset: 16,
+        sourceValue: "0x700000",
+        classification: "ambiguous",
+        proof: "none",
+      },
+    ],
+  });
+  if (result.preservedWords !== 1 || result.relocations.length !== 1) {
+    throw new Error(
+      "native memory translation proof did not preserve one integer and relocate one pointer",
+    );
+  }
+  if (result.refusals[0]?.code !== "pointer-ambiguous") {
+    throw new Error("native memory translation proof did not refuse the ambiguous word");
+  }
+  return { formatVersion: 1, result };
+}
+
+function printSummary(summary: ReturnType<typeof verifyNativeMemoryTranslation>) {
+  console.log(
+    `native-memory-translate: preserved=${summary.result.preservedWords} relocations=${summary.result.relocations.length} refusals=${summary.result.refusals.length}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #448.

## Problem

Native process memory mixes plain bytes with pointers. Copying every word as-is would leave source addresses inside the target process, but guessing every word is a pointer would corrupt normal data.

## Solution

This adds memory classification and relocation rules. Known pointer words are rewritten to target addresses, plain bytes stay preserved, and unknown pointer-like values are refused as ambiguous. The proof records every accepted relocation in the native translation document.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
