### PR TITLE
Translate native kernel resources

### DIFF
--- a/docs/snapshot/native-resource-translation.md
+++ b/docs/snapshot/native-resource-translation.md
@@ -1,0 +1,37 @@
+# Native resource translation
+
+Issue #449 translates or refuses Linux kernel resources for native process
+restore.
+
+## Command
+
+```sh
+pnpm native-resource-translate
+```
+
+The proof creates a regular-file reopen recipe and refuses a brokerless socket.
+
+## Recipes
+
+Currently supported recipes:
+
+- argv/env/cwd/exe/auxv metadata is carried through;
+- regular files are reopened with path, offset, and flags;
+- raw sockets and PTYs can be represented only when the caller declares a host
+  broker capability for that kind.
+
+## Refusals
+
+Unsupported resources are not silently dropped. They are returned with:
+
+- `fd-kind-unsupported` for unknown generic fd entries;
+- `resource-kind-unsupported` for sockets, pipes, timers, epoll, futexes,
+  namespaces, credentials, and other resources without a broker recipe.
+
+Each refusal includes the resource id, kind, fd, and path when available.
+
+## Boundary
+
+This issue defines resource recipes. It does not implement the host broker
+itself. That broker is required before `ping` raw sockets, PTYs, child process
+trees, timers, epoll sets, and futex waiters can resume transparently.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "native-code-map": "tsx scripts/native-code-map.ts verify",
     "native-stack-translate": "tsx scripts/native-stack-translate.ts verify",
     "native-memory-translate": "tsx scripts/native-memory-translate.ts verify",
+    "native-resource-translate": "tsx scripts/native-resource-translate.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -95,6 +95,9 @@
 - [`NativeMemoryTranslationRequest`](#nativememorytranslationrequest)
 - [`NativeMemoryTranslationResult`](#nativememorytranslationresult)
 - [`translateNativeMemory`](#translatenativememory)
+- [`NativeResourceTranslationRequest`](#nativeresourcetranslationrequest)
+- [`NativeResourceTranslationResult`](#nativeresourcetranslationresult)
+- [`translateNativeResources`](#translatenativeresources)
 
 ### Provision base images
 
@@ -3089,6 +3092,34 @@ by default when `output` is a TTY.
 ##### threads
 
 > **threads**: [`NativeThreadTranslation`](#nativethreadtranslation)[]
+
+##### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+***
+
+### NativeResourceTranslationRequest
+
+#### Properties
+
+##### resources
+
+> **resources**: [`NativeProcessResource`](#nativeprocessresource)[]
+
+##### hostCapabilities?
+
+> `optional` **hostCapabilities?**: `string`[]
+
+***
+
+### NativeResourceTranslationResult
+
+#### Properties
+
+##### resources
+
+> **resources**: [`NativeProcessResource`](#nativeprocessresource)[]
 
 ##### refusals
 
@@ -7723,6 +7754,22 @@ available.
 #### Returns
 
 [`NativeRegisterTranslationResult`](#nativeregistertranslationresult)
+
+***
+
+### translateNativeResources()
+
+> **translateNativeResources**(`request`): [`NativeResourceTranslationResult`](#nativeresourcetranslationresult)
+
+#### Parameters
+
+##### request
+
+[`NativeResourceTranslationRequest`](#nativeresourcetranslationrequest)
+
+#### Returns
+
+[`NativeResourceTranslationResult`](#nativeresourcetranslationresult)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-resource-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-resource-translation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { translateNativeResources } from "../native-resource-translation.ts";
+import type { NativeProcessResource } from "../native-process-image.ts";
+
+const resources: NativeProcessResource[] = [
+  { id: "argv", kind: "argv", state: "captured", recipe: { argv: ["ping", "example.com"] } },
+  { id: "cwd", kind: "cwd", state: "captured", path: "/tmp", recipe: { cwd: "/tmp" } },
+  { id: "fd:3", kind: "file", state: "captured", fd: 3, path: "/tmp/data.txt", offset: 9 },
+  { id: "fd:4", kind: "socket", state: "captured", fd: 4, path: "socket:[1]" },
+  { id: "fd:5", kind: "raw-socket", state: "captured", fd: 5, path: "icmp" },
+];
+
+describe("native resource translation", () => {
+  it("creates recipes for regular files and refuses brokerless sockets", () => {
+    const result = translateNativeResources({ resources });
+
+    expect(result.resources.find((resource) => resource.id === "fd:3")).toMatchObject({
+      state: "recipe",
+      recipe: { reopen: "/tmp/data.txt", offset: 9 },
+    });
+    expect(result.resources.find((resource) => resource.id === "fd:4")).toMatchObject({
+      state: "refused",
+      refusal: { code: "resource-kind-unsupported" },
+    });
+    expect(result.resources.find((resource) => resource.id === "fd:5")).toMatchObject({
+      state: "refused",
+      refusal: { code: "resource-kind-unsupported" },
+    });
+  });
+
+  it("uses host capabilities for raw sockets and PTYs", () => {
+    const result = translateNativeResources({
+      hostCapabilities: ["raw-socket", "pty"],
+      resources: [
+        { id: "fd:raw", kind: "raw-socket", state: "captured", fd: 7, path: "icmp" },
+        { id: "fd:pty", kind: "pty", state: "captured", fd: 8, path: "/dev/pts/3" },
+      ],
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.resources.map((resource) => resource.recipe)).toEqual([
+      { broker: "raw-socket", fd: 7, path: "icmp" },
+      { broker: "pty", fd: 8, path: "/dev/pts/3" },
+    ]);
+  });
+
+  it("uses fd-kind-unsupported for generic unknown fd resources", () => {
+    const result = translateNativeResources({
+      resources: [{ id: "fd:9", kind: "fd", state: "captured", fd: 9 }],
+    });
+
+    expect(result.refusals[0]).toMatchObject({ code: "fd-kind-unsupported" });
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -115,6 +115,11 @@ export type {
   NativeMemoryWord,
 } from "./native-memory-translation.ts";
 export { translateNativeRegisterState } from "./native-register-translation.ts";
+export { translateNativeResources } from "./native-resource-translation.ts";
+export type {
+  NativeResourceTranslationRequest,
+  NativeResourceTranslationResult,
+} from "./native-resource-translation.ts";
 export { translateNativeStack } from "./native-stack-translation.ts";
 export type {
   NativeStackFrame,

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -1,0 +1,81 @@
+/** Kernel-resource recipes and refusals for native process restore. */
+
+import type { NativeProcessImageRefusal, NativeProcessResource } from "./native-process-image.ts";
+
+export interface NativeResourceTranslationRequest {
+  resources: NativeProcessResource[];
+  hostCapabilities?: string[];
+}
+
+export interface NativeResourceTranslationResult {
+  resources: NativeProcessResource[];
+  refusals: NativeProcessImageRefusal[];
+}
+
+export function translateNativeResources(
+  request: NativeResourceTranslationRequest,
+): NativeResourceTranslationResult {
+  const capabilities = new Set(request.hostCapabilities ?? []);
+  const resources = request.resources.map((resource) => translateResource(resource, capabilities));
+  return {
+    resources,
+    refusals: resources.flatMap((resource) => (resource.refusal ? [resource.refusal] : [])),
+  };
+}
+
+function translateResource(
+  resource: NativeProcessResource,
+  capabilities: Set<string>,
+): NativeProcessResource {
+  if (
+    resource.kind === "argv" ||
+    resource.kind === "env" ||
+    resource.kind === "cwd" ||
+    resource.kind === "exe" ||
+    resource.kind === "auxv"
+  ) {
+    return { ...resource, state: resource.state === "refused" ? "captured" : resource.state };
+  }
+  if (resource.kind === "file" && resource.path) {
+    return {
+      ...resource,
+      state: "recipe",
+      recipe: {
+        reopen: resource.path,
+        offset: resource.offset ?? 0,
+        flags: resource.flags ?? [],
+      },
+      refusal: undefined,
+    };
+  }
+  if (resource.kind === "raw-socket" && capabilities.has("raw-socket")) {
+    return {
+      ...resource,
+      state: "recipe",
+      recipe: { broker: "raw-socket", fd: resource.fd, path: resource.path },
+      refusal: undefined,
+    };
+  }
+  if (resource.kind === "pty" && capabilities.has("pty")) {
+    return {
+      ...resource,
+      state: "recipe",
+      recipe: { broker: "pty", fd: resource.fd, path: resource.path },
+      refusal: undefined,
+    };
+  }
+  return {
+    ...resource,
+    state: "refused",
+    refusal: resourceRefusal(resource),
+  };
+}
+
+function resourceRefusal(resource: NativeProcessResource): NativeProcessImageRefusal {
+  const code = resource.kind === "fd" ? "fd-kind-unsupported" : "resource-kind-unsupported";
+  return {
+    code,
+    message: `resource ${resource.id} (${resource.kind}) needs a host broker recipe before native restore`,
+    detail: { id: resource.id, kind: resource.kind, fd: resource.fd, path: resource.path },
+  };
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -117,6 +117,9 @@ const TOC = {
     "NativeMemoryTranslationRequest",
     "NativeMemoryTranslationResult",
     "translateNativeMemory",
+    "NativeResourceTranslationRequest",
+    "NativeResourceTranslationResult",
+    "translateNativeResources",
   ],
   "Provision base images": [
     "provision",

--- a/scripts/native-resource-translate.ts
+++ b/scripts/native-resource-translate.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: tsx scripts/native-resource-translate.ts [verify] [--out-dir path] [--json] [--keep]";
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  const workspace = createWorkspace(args, "machinen-native-resource-translate-");
+  try {
+    emitResult(verifyNativeResourceTranslation(), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyNativeResourceTranslation() {
+  const result = translateNativeResources({
+    resources: [
+      { id: "fd:file", kind: "file", state: "captured", fd: 3, path: "/tmp/data.txt", offset: 9 },
+      { id: "fd:socket", kind: "socket", state: "captured", fd: 4, path: "socket:[1]" },
+    ],
+  });
+  if (result.resources[0]?.state !== "recipe") {
+    throw new Error("regular file did not produce a restore recipe");
+  }
+  if (result.refusals[0]?.code !== "resource-kind-unsupported") {
+    throw new Error("brokerless socket did not refuse precisely");
+  }
+  return { formatVersion: 1, result };
+}
+
+function printSummary(summary: ReturnType<typeof verifyNativeResourceTranslation>) {
+  console.log(
+    `native-resource-translate: resources=${summary.result.resources.length} refusals=${summary.result.refusals.length}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #449.

## Problem

A live process is more than memory and registers. It also has kernel resources like files, sockets, pipes, and terminals. Some can be reopened, but others need a broker or must be refused.

## Solution

This adds resource translation recipes and refusals. Regular files get reopen recipes with path and offset. Broker-only resources, like sockets and pipes, are refused with specific codes until a resource broker exists.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
