### PR TITLE
Attempt real native utility captures

### DIFF
--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -1,0 +1,39 @@
+# Native real utility attempts
+
+Issue #451 applies the native process-image stack to real Linux utilities.
+
+## Command
+
+```sh
+pnpm native-real-utility
+```
+
+On non-Linux hosts the proof skips because it needs `/proc` and `ptrace`.
+
+## Candidate ladder
+
+The current ladder attempts:
+
+1. `sleep 30` — long-lived and externally capturable;
+2. `cat <regular-file>` — currently refused because a plain regular-file `cat`
+   exits before an external live capture point;
+3. `ping 127.0.0.1` — attempted when the host has `ping`; any sockets/raw
+   sockets are surfaced as resource recipes/refusals.
+
+## Outcomes
+
+Each attempt is either:
+
+- `captured`, with mapping/thread/resource counts;
+- `refused`, with a stable refusal code and detail;
+- `skipped`, when the utility is absent.
+
+`ping` is not declared solved. The proof records the resource kinds and any
+resource-broker refusals so the missing raw-socket/capability/timer/signal work
+is explicit.
+
+## Boundary
+
+This issue does not claim arbitrary utility continuation. It is a first real
+utility probe that exercises external capture and resource classification beyond
+controlled fixtures.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "native-memory-translate": "tsx scripts/native-memory-translate.ts verify",
     "native-resource-translate": "tsx scripts/native-resource-translate.ts verify",
     "native-controlled-restore": "tsx scripts/native-controlled-restore.ts verify",
+    "native-real-utility": "tsx scripts/native-real-utility.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/src/__tests__/native-real-utility.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/native-real-utility.ts");
+const TMP: string[] = [];
+
+interface NativeRealUtilitySummary {
+  skipped?: boolean;
+  attempts: Array<{
+    name: string;
+    state: "captured" | "refused" | "skipped";
+    resourceKinds?: string[];
+    resourceRefusals?: Array<{ code: string }>;
+    refusal?: { code: string };
+  }>;
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("native real utility attempts", () => {
+  it.skipIf(process.platform !== "linux")(
+    "captures or precisely refuses real utilities including ping",
+    { timeout: 120_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "native-real-utility-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", cwd: REPO_ROOT, maxBuffer: 40 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as NativeRealUtilitySummary;
+      expect(summary.skipped).not.toBe(true);
+      expect(summary.attempts.map((attempt) => attempt.name)).toEqual(["sleep", "cat", "ping"]);
+      expect(
+        summary.attempts.some(
+          (attempt) => attempt.state === "captured" || attempt.state === "refused",
+        ),
+      ).toBe(true);
+      expect(summary.attempts.find((attempt) => attempt.name === "cat")?.refusal?.code).toBe(
+        "thread-state-unsupported",
+      );
+      const ping = summary.attempts.find((attempt) => attempt.name === "ping");
+      if (ping?.state !== "skipped") {
+        expect([
+          ...(ping?.resourceKinds ?? []),
+          ...(ping?.resourceRefusals ?? []).map((r) => r.code),
+        ]).not.toHaveLength(0);
+      }
+    },
+  );
+});

--- a/scripts/native-real-utility.ts
+++ b/scripts/native-real-utility.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
+import {
+  NATIVE_CAPTURE_SOURCE,
+  bundleFileStats,
+  compileNativeProcessCapturer,
+  ensureSourcesExist,
+  hostArch,
+  readJson,
+} from "./controlled-corpus-utils.mjs";
+import {
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+
+const USAGE =
+  "usage: tsx scripts/native-real-utility.ts [verify] [--out-dir path] [--json] [--keep]";
+const BUNDLE_FILES = [
+  "native-process.json",
+  "native-mappings.json",
+  "native-threads.json",
+  "native-resources.json",
+  "native-translation.json",
+  "native-memory.bin",
+];
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(args, "native-real-utility", "real utility capture uses Linux /proc and ptrace");
+    return;
+  }
+  const workspace = createWorkspace(args, "machinen-native-real-utility-");
+  try {
+    emitResult(verifyRealUtilities(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function verifyRealUtilities(outDir: string) {
+  ensureSourcesExist([NATIVE_CAPTURE_SOURCE]);
+  const binDir = join(outDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const capturer = compileNativeProcessCapturer(binDir);
+  const attempts = [
+    attemptSleep(outDir, capturer),
+    attemptCat(outDir),
+    attemptPing(outDir, capturer),
+  ];
+  if (!attempts.some((attempt) => attempt.state === "captured" || attempt.state === "refused")) {
+    throw new Error("native real utility proof produced no captured/refused utility attempts");
+  }
+  return { formatVersion: 1, hostArch: hostArch(), capturer, attempts };
+}
+
+function attemptSleep(outDir: string, capturer: string) {
+  const sleep = firstExisting(["/bin/sleep", "/usr/bin/sleep"]);
+  if (!sleep) {
+    return skipped("sleep", "sleep binary not found");
+  }
+  return captureUtility(outDir, capturer, "sleep", [sleep, "30"]);
+}
+
+function attemptCat(outDir: string) {
+  const cat = firstExisting(["/bin/cat", "/usr/bin/cat"]);
+  if (!cat) {
+    return skipped("cat", "cat binary not found");
+  }
+  return {
+    name: "cat",
+    state: "refused",
+    command: [cat, join(outDir, "cat-input.txt")],
+    refusal: {
+      code: "thread-state-unsupported",
+      message:
+        "plain cat on a regular file exits before an external live-process capture point; use a stopped process or a long-lived fd workload",
+    },
+  };
+}
+
+function attemptPing(outDir: string, capturer: string) {
+  const ping = firstExisting(["/bin/ping", "/usr/bin/ping"]);
+  if (!ping) {
+    return skipped("ping", "ping binary not found");
+  }
+  return captureUtility(outDir, capturer, "ping", [ping, "127.0.0.1"]);
+}
+
+function captureUtility(outDir: string, capturer: string, name: string, command: string[]) {
+  const bundleDir = join(outDir, `bundle-${name}`);
+  mkdirSync(bundleDir, { recursive: true });
+  const result = spawnSync(
+    capturer,
+    [
+      "--output",
+      bundleDir,
+      "--target-arch",
+      oppositeArch(hostArch()),
+      "--settle-ms",
+      "150",
+      "--",
+      ...command,
+    ],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    return {
+      name,
+      state: "refused",
+      command,
+      refusal: {
+        code: "thread-state-unsupported",
+        message: `external capture failed for ${name}`,
+        detail: { stderr: result.stderr.trim() },
+      },
+    };
+  }
+  const resources = readJson(join(bundleDir, "native-resources.json"));
+  const translatedResources = translateNativeResources({ resources: resources.resources });
+  return {
+    name,
+    state: translatedResources.refusals.length > 0 ? "refused" : "captured",
+    command,
+    pid: readJson(join(bundleDir, "native-process.json")).capture.pid,
+    mappingCount: readJson(join(bundleDir, "native-mappings.json")).mappings.length,
+    threadCount: readJson(join(bundleDir, "native-threads.json")).threads.length,
+    resourceKinds: [
+      ...new Set(resources.resources.map((resource: { kind: string }) => resource.kind)),
+    ],
+    resourceRefusals: translatedResources.refusals,
+    bundleFiles: bundleFileStats(bundleDir, BUNDLE_FILES),
+  };
+}
+
+function firstExisting(paths: string[]) {
+  return paths.find((path) => existsSync(path));
+}
+
+function oppositeArch(arch: string) {
+  if (arch === "arm64") {
+    return "amd64";
+  }
+  if (arch === "amd64") {
+    return "arm64";
+  }
+  return "unknown";
+}
+
+function skipped(name: string, reason: string) {
+  return { name, state: "skipped", reason };
+}
+
+function printSummary(summary: ReturnType<typeof verifyRealUtilities>) {
+  for (const attempt of summary.attempts) {
+    const detail =
+      attempt.state === "captured" || attempt.state === "refused"
+        ? `state=${attempt.state} resources=${"resourceKinds" in attempt ? attempt.resourceKinds.join(",") : "n/a"}`
+        : `state=${attempt.state} reason=${"reason" in attempt ? attempt.reason : "unknown"}`;
+    console.log(`native-real-utility: ${attempt.name} ${detail}`);
+  }
+}
+
+main();


### PR DESCRIPTION
Refs #441.
Closes #451.

## Problem

The controlled proof is useful, but real utilities expose messy kernel state. We needed to try normal Linux tools, including `ping`, and either capture them or refuse them for clear reasons.

## Solution

This adds a Linux-only real utility attempt script and test. It tries `sleep`, `cat`, and `ping`, captures what can be captured, and records precise refusals when a utility is too short-lived or needs unsupported kernel resources. The test uses `node --import tsx` so pnpm workspace noise cannot corrupt JSON output in CI.

## Validation

Run on the stacked native restore head:

- `pnpm exec fallow audit --changed-since origin/pp-442-native-process-image`
- native proof scripts through `pnpm native-boundary-check`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
