### PR TITLE
Define native non-file resource boundary

### DIFF
--- a/docs/snapshot/native-nonfile-resource-boundary.md
+++ b/docs/snapshot/native-nonfile-resource-boundary.md
@@ -1,0 +1,55 @@
+# Native non-file resource boundary
+
+Issue #484 defines the fail-closed boundary for native resources that are not regular files.
+
+## Flow
+
+The verifier launches an ordinary arm64 Linux target that opens:
+
+- one regular file;
+- a pipe;
+- a Unix socketpair;
+- an epoll set watching the pipe;
+- an eventfd;
+- a timerfd.
+
+The native procfs/ptrace capturer records all open fds through `/proc/<pid>/fd` and `/proc/<pid>/fdinfo`. Resource translation then proves two things can be true at the same time:
+
+1. the regular file keeps a reopen recipe; and
+2. unrelated non-file resources are refused with exact codes instead of hiding or downgrading the safe file recipe.
+
+A passing run emits:
+
+```text
+captured-regular-file-coexists-with-precise-nonfile-resource-refusals
+```
+
+## Matrix
+
+| Resource kind         | Current action                                           | Refusal code                |
+| --------------------- | -------------------------------------------------------- | --------------------------- |
+| argv/env/cwd/exe/auxv | carry metadata/recipe                                    | n/a                         |
+| regular file          | reopen by path + offset                                  | n/a                         |
+| pipe                  | refuse                                                   | `kernel-state-unsupported`  |
+| socket                | refuse                                                   | `kernel-state-unsupported`  |
+| epoll                 | refuse                                                   | `kernel-state-unsupported`  |
+| eventfd               | refuse                                                   | `kernel-state-unsupported`  |
+| timerfd               | refuse as `timer`                                        | `kernel-state-unsupported`  |
+| signalfd              | refuse as `signal`                                       | `kernel-state-unsupported`  |
+| PTY                   | refuse unless a PTY broker capability is supplied        | `resource-kind-unsupported` |
+| raw socket            | refuse unless a raw-socket broker capability is supplied | `resource-kind-unsupported` |
+| unknown fd            | refuse                                                   | `fd-kind-unsupported`       |
+
+## Next broker candidates
+
+The first broker candidates are PTYs and raw sockets because the existing resource translator already has capability gates for those recipe shapes. Pipes, sockets, epoll, eventfd, timerfd, and signalfd carry kernel state that must be modeled or brokered before transparent restore can safely claim support.
+
+## Verify
+
+Run on Linux/arm64:
+
+```sh
+pnpm native-nonfile-resource-boundary
+```
+
+Other hosts skip honestly because this proof captures the arm64 source side through Linux procfs.

--- a/docs/snapshot/native-nonfile-resource-boundary.md
+++ b/docs/snapshot/native-nonfile-resource-boundary.md
@@ -53,3 +53,5 @@ pnpm native-nonfile-resource-boundary
 ```
 
 Other hosts skip honestly because this proof captures the arm64 source side through Linux procfs.
+
+Next: [Native real utility continuation attempt](./native-real-utilities.md).

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -1,6 +1,6 @@
-# Native real utility attempts
+# Native real utility continuation attempt
 
-Issue #451 applies the native process-image stack to real Linux utilities.
+Issue #485 tries the first native-transparent continuation path against a tiny real Linux utility instead of a controlled fixture.
 
 ## Command
 
@@ -8,32 +8,52 @@ Issue #451 applies the native process-image stack to real Linux utilities.
 pnpm native-real-utility
 ```
 
-On non-Linux hosts the proof skips because it needs `/proc` and `ptrace`.
+On non-Linux hosts the proof skips because it needs `/proc` and `ptrace`. The current proof captures the arm64 source side.
 
-## Candidate ladder
+## Utility chosen
 
-The current ladder attempts:
+The first candidate is the system `sleep` utility:
 
-1. `sleep 30` — long-lived and externally capturable;
-2. `cat <regular-file>` — currently refused because a plain regular-file `cat`
-   exits before an external live capture point;
-3. `ping 127.0.0.1` — attempted when the host has `ping`; any sockets/raw
-   sockets are surfaced as resource recipes/refusals.
+```text
+/bin/sleep 30   or   /usr/bin/sleep 30
+```
 
-## Outcomes
+It is tiny, dynamically linked, long-lived, and has a narrow observable process state. The verifier checks that the selected binary is a dynamically linked ELF by reading its program headers and dynamic section.
 
-Each attempt is either:
+## Pipeline
 
-- `captured`, with mapping/thread/resource counts;
-- `refused`, with a stable refusal code and detail;
-- `skipped`, when the utility is absent.
+The attempt runs the stricter native pipeline from the previous proofs:
 
-`ping` is not declared solved. The proof records the resource kinds and any
-resource-broker refusals so the missing raw-socket/capability/timer/signal work
-is explicit.
+1. external ptrace/procfs process capture;
+2. native process-image validation;
+3. mapping materialization planning;
+4. resource translation/refusal classification;
+5. first target-code boundary check.
 
-## Boundary
+The proof intentionally refuses before any target jump unless a matching amd64 target binary/module/RVA map is available. It reports:
 
-This issue does not claim arbitrary utility continuation. It is a first real
-utility probe that exercises external capture and resource classification beyond
-controlled fixtures.
+```json
+{
+  "sourceTextReusedAsTargetCode": false,
+  "targetBinarySource": "not-provided"
+}
+```
+
+That is the important safety property for this issue: source arm64 text is never treated as target-native amd64 code.
+
+## Current result
+
+The expected current result is a fail-closed refusal at the first exact boundary, usually:
+
+- `code-location-unknown` when capture, resources, and mappings are clean but no matching amd64 target code map is provided; or
+- an earlier exact boundary such as `kernel-state-unsupported`, `mapping-ambiguous`, or `mapping-unreadable` if the host utility exposes that state.
+
+A passing run emits an execution string like:
+
+```text
+real-arm64-sleep-refused-at-target-code-location
+```
+
+## Non-claim
+
+This does **not** claim arbitrary native utility migration yet. It proves the real-utility attempt uses the native process-image validation pipeline and stops at a precise known boundary rather than falling back to source-ISA emulation, sidecars, app hooks, or raw source virtual addresses.

--- a/docs/snapshot/native-resource-translation.md
+++ b/docs/snapshot/native-resource-translation.md
@@ -28,8 +28,10 @@ Currently supported recipes:
 Unsupported resources are not silently dropped. They are returned with:
 
 - `fd-kind-unsupported` for unknown generic fd entries;
-- `resource-kind-unsupported` for sockets, pipes, timers, epoll, futexes,
-  namespaces, credentials, and other resources without a broker recipe.
+- `kernel-state-unsupported` for pipes, sockets, epoll, eventfd, timerfd, and
+  signalfd resources whose kernel state is not yet modeled;
+- `resource-kind-unsupported` for resources that need a broker recipe, such as
+  PTYs and raw sockets without an enabled broker capability.
 
 Each refusal includes the resource id, kind, fd, and path when available.
 
@@ -40,3 +42,5 @@ proof applies only regular-file recipes that can be reopened by path on the
 target host. A host broker is still required before `ping` raw sockets, PTYs,
 child process trees, timers, epoll sets, and futex waiters can resume
 transparently.
+
+See also: [Native non-file resource boundary](./native-nonfile-resource-boundary.md).

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "native-dwarf-pointer-classification": "tsx scripts/native-dwarf-pointer-classification.ts verify",
     "native-heap-graph-final-jump": "tsx scripts/native-heap-graph-final-jump.ts verify",
     "native-file-resource-final-jump": "tsx scripts/native-file-resource-final-jump.ts verify",
+    "native-nonfile-resource-boundary": "tsx scripts/native-nonfile-resource-boundary.ts verify",
     "native-real-utility": "tsx scripts/native-real-utility.ts verify",
     "native-boundary-check": "tsx scripts/native-boundary-check.ts verify",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",

--- a/packages/microvm/assets/native-nonfile-resource-boundary.c
+++ b/packages/microvm/assets/native-nonfile-resource-boundary.c
@@ -1,0 +1,173 @@
+// Native resource-boundary target with one regular file and several non-file fds.
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+#define SOURCE_MARKER UINT64_C(0x534f555243454a50)
+
+struct NativeNonfileResourceState {
+  uint64_t self;
+  uint64_t marker;
+  uint64_t regular_fd;
+  uint64_t pipe_read_fd;
+  uint64_t socket_fd;
+  uint64_t epoll_fd;
+  uint64_t event_fd;
+  uint64_t timer_fd;
+  uint64_t padding[56];
+};
+
+static struct NativeNonfileResourceState native_nonfile_resource_state
+    __attribute__((aligned(4096)));
+
+static void die(const char *message) {
+  fprintf(stderr, "machinen-native-nonfile-resource-boundary: %s: %s\n", message, strerror(errno));
+  exit(1);
+}
+
+static const char *resource_file_arg(int argc, char **argv) {
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--resource-file") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "--resource-file requires a path\n");
+        exit(2);
+      }
+      return argv[i + 1];
+    }
+  }
+  return NULL;
+}
+
+static int open_regular_file(const char *path) {
+  if (!path) {
+    return -1;
+  }
+  int fd = open(path, O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0600);
+  if (fd < 0) {
+    die("open regular file");
+  }
+  const char payload[] = "machinen-native-nonfile-resource-boundary\n";
+  if (write(fd, payload, sizeof(payload) - 1u) != (ssize_t)(sizeof(payload) - 1u)) {
+    die("write regular file");
+  }
+  if (lseek(fd, 9, SEEK_SET) < 0) {
+    die("seek regular file");
+  }
+  return fd;
+}
+
+static int make_pipe(int out[2]) {
+  if (pipe2(out, O_CLOEXEC) != 0) {
+    die("pipe2");
+  }
+  return out[0];
+}
+
+static int make_socketpair(int out[2]) {
+  if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, out) != 0) {
+    die("socketpair");
+  }
+  return out[0];
+}
+
+static int make_epoll(int watched_fd) {
+  int fd = epoll_create1(EPOLL_CLOEXEC);
+  if (fd < 0) {
+    die("epoll_create1");
+  }
+  struct epoll_event event = {.events = EPOLLIN, .data.u64 = 0x484848u};
+  if (epoll_ctl(fd, EPOLL_CTL_ADD, watched_fd, &event) != 0) {
+    die("epoll_ctl");
+  }
+  return fd;
+}
+
+static int make_eventfd(void) {
+  int fd = eventfd(7, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (fd < 0) {
+    die("eventfd");
+  }
+  return fd;
+}
+
+static int make_timerfd(void) {
+  int fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
+  if (fd < 0) {
+    die("timerfd_create");
+  }
+  struct itimerspec spec = {0};
+  spec.it_value.tv_sec = 60;
+  if (timerfd_settime(fd, 0, &spec, NULL) != 0) {
+    die("timerfd_settime");
+  }
+  return fd;
+}
+
+#if defined(__aarch64__)
+void machinen_native_nonfile_resource_active(struct NativeNonfileResourceState *state)
+    __attribute__((noreturn));
+__asm__(
+    ".text\n"
+    ".global machinen_native_nonfile_resource_active\n"
+    ".type machinen_native_nonfile_resource_active, %function\n"
+    "machinen_native_nonfile_resource_active:\n"
+    "1:\n"
+    "  ldr x1, [x0, #16]\n"
+    "  add x1, x1, #1\n"
+    "  str x1, [x0, #16]\n"
+    "  b 1b\n"
+    ".size machinen_native_nonfile_resource_active, .-machinen_native_nonfile_resource_active\n");
+#else
+__attribute__((noinline, noreturn)) void machinen_native_nonfile_resource_active(
+    struct NativeNonfileResourceState *state) {
+  for (;;) {
+    state->regular_fd++;
+  }
+}
+#endif
+
+int main(int argc, char **argv) {
+  int pipe_fds[2] = {-1, -1};
+  int socket_fds[2] = {-1, -1};
+  int regular_fd = open_regular_file(resource_file_arg(argc, argv));
+  int pipe_read_fd = make_pipe(pipe_fds);
+  int socket_fd = make_socketpair(socket_fds);
+  int epoll_fd = make_epoll(pipe_read_fd);
+  int event_fd = make_eventfd();
+  int timer_fd = make_timerfd();
+
+  native_nonfile_resource_state.self = (uint64_t)(uintptr_t)&native_nonfile_resource_state;
+  native_nonfile_resource_state.marker = SOURCE_MARKER;
+  native_nonfile_resource_state.regular_fd = (uint64_t)regular_fd;
+  native_nonfile_resource_state.pipe_read_fd = (uint64_t)pipe_read_fd;
+  native_nonfile_resource_state.socket_fd = (uint64_t)socket_fd;
+  native_nonfile_resource_state.epoll_fd = (uint64_t)epoll_fd;
+  native_nonfile_resource_state.event_fd = (uint64_t)event_fd;
+  native_nonfile_resource_state.timer_fd = (uint64_t)timer_fd;
+
+  printf(
+      "MACHINEN_NATIVE_NONFILE_RESOURCE_BOUNDARY pid=%ld file=%d pipe=%d socket=%d epoll=%d eventfd=%d timerfd=%d\n",
+      (long)getpid(),
+      regular_fd,
+      pipe_read_fd,
+      socket_fd,
+      epoll_fd,
+      event_fd,
+      timer_fd);
+  fflush(stdout);
+  machinen_native_nonfile_resource_active(&native_nonfile_resource_state);
+}

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -1002,10 +1002,30 @@ static const char *fd_kind(const char *target) {
   if (strncmp(target, "anon_inode:[eventpoll]", 22) == 0) {
     return "epoll";
   }
+  if (strncmp(target, "anon_inode:[eventfd]", 20) == 0) {
+    return "eventfd";
+  }
+  if (strncmp(target, "anon_inode:[timerfd]", 20) == 0) {
+    return "timer";
+  }
+  if (strncmp(target, "anon_inode:[signalfd]", 21) == 0) {
+    return "signal";
+  }
   if (target[0] == '/') {
     return "file";
   }
   return "unknown";
+}
+
+static const char *fd_refusal_code(const char *kind) {
+  if (streq(kind, "fd") || streq(kind, "unknown")) {
+    return "fd-kind-unsupported";
+  }
+  if (streq(kind, "pipe") || streq(kind, "socket") || streq(kind, "epoll") ||
+      streq(kind, "eventfd") || streq(kind, "timer") || streq(kind, "signal")) {
+    return "kernel-state-unsupported";
+  }
+  return "resource-kind-unsupported";
 }
 
 static uint64_t fdinfo_value(pid_t pid, const char *fd_name, const char *field) {
@@ -1061,7 +1081,7 @@ static void write_fd_resource(FILE *out, pid_t pid, const char *fd_name, const c
     fputs("}", out);
   } else {
     fputs(",\"refusal\":", out);
-    write_refusal(out, "resource-kind-unsupported", "fd kind needs a resource broker recipe");
+    write_refusal(out, fd_refusal_code(kind), "fd kind needs a resource broker recipe");
   }
   fputc('}', out);
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -6524,7 +6524,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeProcessResourceKind
 
-> **NativeProcessResourceKind** = `"argv"` \| `"env"` \| `"cwd"` \| `"exe"` \| `"auxv"` \| `"fd"` \| `"file"` \| `"pipe"` \| `"socket"` \| `"raw-socket"` \| `"pty"` \| `"timer"` \| `"signal"` \| `"namespace"` \| `"credential"` \| `"futex"` \| `"epoll"` \| `"unknown"`
+> **NativeProcessResourceKind** = `"argv"` \| `"env"` \| `"cwd"` \| `"exe"` \| `"auxv"` \| `"fd"` \| `"file"` \| `"pipe"` \| `"socket"` \| `"raw-socket"` \| `"pty"` \| `"timer"` \| `"eventfd"` \| `"signal"` \| `"namespace"` \| `"credential"` \| `"futex"` \| `"epoll"` \| `"unknown"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-nonfile-resource-boundary.test.ts
+++ b/packages/runtime/src/__tests__/native-nonfile-resource-boundary.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/native-nonfile-resource-boundary.ts");
+const TMP: string[] = [];
+
+interface NativeNonfileResourceBoundarySummary {
+  skipped?: boolean;
+  reason?: string;
+  phase?: string;
+  regularFileRecipe?: { reopen?: string; offset?: number; flags?: string[] };
+  nonFileKinds?: string[];
+  refusalCodes?: string[];
+  execution?: string;
+}
+
+afterEach(() => {
+  for (const dir of TMP.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("native non-file resource boundary", () => {
+  it.skipIf(process.platform !== "linux")(
+    "keeps regular file recipes while refusing non-file kernel resources precisely",
+    { timeout: 180_000 },
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "native-nonfile-resource-boundary-test-"));
+      TMP.push(outDir);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", VERIFY_SCRIPT, "verify", "--out-dir", outDir, "--json"],
+        { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout) as NativeNonfileResourceBoundarySummary;
+      if (summary.skipped) {
+        expect(summary.reason).toMatch(/arm64 source side|unsupported host architecture/);
+        return;
+      }
+
+      expect(summary.phase).toBe("nonfile-resource-boundary");
+      expect(summary.regularFileRecipe?.reopen).toContain("native-nonfile-resource-boundary.txt");
+      expect(summary.nonFileKinds).toEqual(
+        expect.arrayContaining(["eventfd", "epoll", "pipe", "socket", "timer"]),
+      );
+      expect(summary.refusalCodes).toEqual(expect.arrayContaining(["kernel-state-unsupported"]));
+      expect(summary.execution).toBe(
+        "captured-regular-file-coexists-with-precise-nonfile-resource-refusals",
+      );
+    },
+  );
+});

--- a/packages/runtime/src/__tests__/native-real-utility.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility.test.ts
@@ -10,13 +10,19 @@ const TMP: string[] = [];
 
 interface NativeRealUtilitySummary {
   skipped?: boolean;
-  attempts: Array<{
+  reason?: string;
+  utility: {
     name: string;
-    state: "captured" | "refused" | "skipped";
-    resourceKinds?: string[];
-    resourceRefusals?: Array<{ code: string }>;
-    refusal?: { code: string };
-  }>;
+    state: "refused" | "resumed";
+    dynamicallyLinked?: boolean;
+    processImageValidated: boolean;
+    blockingBoundary: string;
+    blockingRefusal: { code: string };
+    attemptedResume: boolean;
+    sourceTextReusedAsTargetCode: boolean;
+    targetBinarySource?: string;
+    execution: string;
+  };
 }
 
 afterEach(() => {
@@ -25,9 +31,9 @@ afterEach(() => {
   }
 });
 
-describe("native real utility attempts", () => {
+describe("native real utility continuation attempt", () => {
   it.skipIf(process.platform !== "linux")(
-    "captures or precisely refuses real utilities including ping",
+    "captures a real dynamically linked utility and stops at an exact boundary",
     { timeout: 120_000 },
     () => {
       const outDir = mkdtempSync(join(tmpdir(), "native-real-utility-test-"));
@@ -41,23 +47,26 @@ describe("native real utility attempts", () => {
 
       expect(result.status, result.stderr).toBe(0);
       const summary = JSON.parse(result.stdout) as NativeRealUtilitySummary;
-      expect(summary.skipped).not.toBe(true);
-      expect(summary.attempts.map((attempt) => attempt.name)).toEqual(["sleep", "cat", "ping"]);
-      expect(
-        summary.attempts.some(
-          (attempt) => attempt.state === "captured" || attempt.state === "refused",
-        ),
-      ).toBe(true);
-      expect(summary.attempts.find((attempt) => attempt.name === "cat")?.refusal?.code).toBe(
-        "thread-state-unsupported",
-      );
-      const ping = summary.attempts.find((attempt) => attempt.name === "ping");
-      if (ping?.state !== "skipped") {
-        expect([
-          ...(ping?.resourceKinds ?? []),
-          ...(ping?.resourceRefusals ?? []).map((r) => r.code),
-        ]).not.toHaveLength(0);
+      if (summary.skipped) {
+        expect(summary.reason).toMatch(/arm64 Linux source utility|Linux procfs/);
+        return;
       }
+
+      expect(summary.utility).toMatchObject({
+        name: "sleep",
+        state: "refused",
+        dynamicallyLinked: true,
+        processImageValidated: true,
+        attemptedResume: false,
+        sourceTextReusedAsTargetCode: false,
+      });
+      expect([
+        "code-location-unknown",
+        "kernel-state-unsupported",
+        "mapping-ambiguous",
+        "mapping-unreadable",
+      ]).toContain(summary.utility.blockingRefusal.code);
+      expect(summary.utility.execution).toContain(`real-arm64-sleep-refused-at-`);
     },
   );
 });

--- a/packages/runtime/src/__tests__/native-resource-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-resource-translation.test.ts
@@ -21,7 +21,7 @@ describe("native resource translation", () => {
     });
     expect(result.resources.find((resource) => resource.id === "fd:4")).toMatchObject({
       state: "refused",
-      refusal: { code: "resource-kind-unsupported" },
+      refusal: { code: "kernel-state-unsupported" },
     });
     expect(result.resources.find((resource) => resource.id === "fd:5")).toMatchObject({
       state: "refused",
@@ -45,11 +45,23 @@ describe("native resource translation", () => {
     ]);
   });
 
-  it("uses fd-kind-unsupported for generic unknown fd resources", () => {
+  it("uses exact refusal codes for generic and stateful kernel fd resources", () => {
     const result = translateNativeResources({
-      resources: [{ id: "fd:9", kind: "fd", state: "captured", fd: 9 }],
+      resources: [
+        { id: "fd:9", kind: "fd", state: "captured", fd: 9 },
+        { id: "fd:10", kind: "pipe", state: "captured", fd: 10, path: "pipe:[1]" },
+        { id: "fd:11", kind: "eventfd", state: "captured", fd: 11, path: "anon_inode:[eventfd]" },
+        { id: "fd:12", kind: "timer", state: "captured", fd: 12, path: "anon_inode:[timerfd]" },
+        { id: "fd:13", kind: "epoll", state: "captured", fd: 13, path: "anon_inode:[eventpoll]" },
+      ],
     });
 
-    expect(result.refusals[0]).toMatchObject({ code: "fd-kind-unsupported" });
+    expect(result.refusals.map((refusal) => refusal.code)).toEqual([
+      "fd-kind-unsupported",
+      "kernel-state-unsupported",
+      "kernel-state-unsupported",
+      "kernel-state-unsupported",
+      "kernel-state-unsupported",
+    ]);
   });
 });

--- a/packages/runtime/src/native-process-image.ts
+++ b/packages/runtime/src/native-process-image.ts
@@ -219,6 +219,7 @@ export type NativeProcessResourceKind =
   | "raw-socket"
   | "pty"
   | "timer"
+  | "eventfd"
   | "signal"
   | "namespace"
   | "credential"
@@ -1366,6 +1367,7 @@ const RESOURCE_KINDS = [
   "raw-socket",
   "pty",
   "timer",
+  "eventfd",
   "signal",
   "namespace",
   "credential",

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -73,10 +73,33 @@ function translateResource(
 }
 
 function resourceRefusal(resource: NativeProcessResource): NativeProcessImageRefusal {
-  const code = resource.kind === "fd" ? "fd-kind-unsupported" : "resource-kind-unsupported";
+  const code = resourceRefusalCode(resource);
   return {
     code,
     message: `resource ${resource.id} (${resource.kind}) needs a host broker recipe before native restore`,
-    detail: { id: resource.id, kind: resource.kind, fd: resource.fd, path: resource.path },
+    detail: {
+      id: resource.id,
+      kind: resource.kind,
+      fd: resource.fd,
+      path: resource.path,
+      boundary: code === "kernel-state-unsupported" ? "kernel-state" : "broker-recipe",
+    },
   };
+}
+
+function resourceRefusalCode(resource: NativeProcessResource): NativeProcessImageRefusal["code"] {
+  if (resource.kind === "fd" || resource.kind === "unknown") {
+    return "fd-kind-unsupported";
+  }
+  if (
+    resource.kind === "pipe" ||
+    resource.kind === "socket" ||
+    resource.kind === "epoll" ||
+    resource.kind === "timer" ||
+    resource.kind === "eventfd" ||
+    resource.kind === "signal"
+  ) {
+    return "kernel-state-unsupported";
+  }
+  return "resource-kind-unsupported";
 }

--- a/packages/runtime/src/native-support-boundary.ts
+++ b/packages/runtime/src/native-support-boundary.ts
@@ -61,11 +61,11 @@ export const nativeAmbiguityClasses: NativeAmbiguityClass[] = [
   {
     id: "kernel-resource",
     description:
-      "fds, sockets, PTYs, timers, epoll, namespaces, credentials, and raw sockets need broker recipes.",
-    requiredMetadata: ["fd table", "resource kind", "host broker capability"],
+      "fds, sockets, PTYs, timers, epoll, namespaces, credentials, and raw sockets need broker recipes or modeled kernel state.",
+    requiredMetadata: ["fd table", "resource kind", "host broker capability", "kernel state"],
     translationRule:
-      "Regular files can reopen/reseek; brokered resources require declared capability.",
-    refusalCode: "resource-kind-unsupported",
+      "Regular files can reopen/reseek; brokered resources require declared capability; kernel-stateful fds fail closed.",
+    refusalCode: "kernel-state-unsupported",
   },
   {
     id: "vdso-vvar-special-mapping",

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -77,6 +77,10 @@ export const NATIVE_FILE_RESOURCE_CONTINUATION_SOURCE = join(
   REPO_ROOT,
   "packages/microvm/assets/native-file-resource-continuation.c",
 );
+export const NATIVE_NONFILE_RESOURCE_BOUNDARY_SOURCE = join(
+  REPO_ROOT,
+  "packages/microvm/assets/native-nonfile-resource-boundary.c",
+);
 export const CONTROLLED_MARKER = "MACHINEN_CONTROLLED_BINARY ";
 export const NATIVE_PROCESS_IMAGE_BUNDLE_FILES = [
   "native-process.json",
@@ -350,6 +354,18 @@ export function compileNativeFileResourceContinuation(binDir) {
     nativeTargetBinaryCompileArgs(executable, NATIVE_FILE_RESOURCE_CONTINUATION_SOURCE),
     {
       label: "native file resource continuation build",
+    },
+  );
+  return executable;
+}
+
+export function compileNativeNonfileResourceBoundary(binDir) {
+  const executable = join(binDir, "machinen-native-nonfile-resource-boundary");
+  runCommand(
+    "cc",
+    nativeTargetBinaryCompileArgs(executable, NATIVE_NONFILE_RESOURCE_BOUNDARY_SOURCE),
+    {
+      label: "native non-file resource boundary build",
     },
   );
   return executable;

--- a/scripts/native-nonfile-resource-boundary.ts
+++ b/scripts/native-nonfile-resource-boundary.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+import { basename } from "node:path";
+import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
+import type {
+  NativeProcessImageDocuments,
+  NativeProcessImageRefusal,
+  NativeProcessResource,
+  NativeProcessResourceKind,
+} from "../packages/runtime/src/native-process-image.ts";
+import {
+  NATIVE_NONFILE_RESOURCE_BOUNDARY_SOURCE,
+  NATIVE_PROCESS_IMAGE_BUNDLE_FILES,
+  bundleFileStats,
+  compileNativeNonfileResourceBoundary,
+} from "./controlled-corpus-utils.mjs";
+import {
+  assert,
+  cleanupWorkspace,
+  createWorkspace,
+  emitResult,
+  emitSkip,
+  parseVerifyArgs,
+} from "./proof-script-utils.mjs";
+import { finalJumpHex } from "./native-final-jump-utils.ts";
+import { captureNativeArm64SourceBundle } from "./native-captured-source-utils.ts";
+
+const USAGE =
+  "usage: tsx scripts/native-nonfile-resource-boundary.ts [verify] [--out-dir path] [--json] [--keep]";
+const RESOURCE_FILE_NAME = "native-nonfile-resource-boundary.txt";
+const NONFILE_KINDS = new Set<NativeProcessResourceKind>([
+  "pipe",
+  "socket",
+  "epoll",
+  "eventfd",
+  "timer",
+  "pty",
+]);
+
+type NativeNonfileResourceBoundarySummary =
+  | ReturnType<typeof verifyBoundary>
+  | ReturnType<typeof unsupportedHostSkip>;
+
+function main() {
+  const args = parseVerifyArgs(process.argv.slice(2), USAGE);
+  if (process.platform !== "linux") {
+    emitSkip(
+      args,
+      "native-nonfile-resource-boundary",
+      "native non-file resource capture uses Linux procfs",
+    );
+    return;
+  }
+  if (process.arch !== "arm64") {
+    emitSkip(
+      args,
+      "native-nonfile-resource-boundary",
+      "native non-file resource boundary currently captures the arm64 source side",
+    );
+    return;
+  }
+
+  const workspace = createWorkspace(args, "machinen-native-nonfile-resource-boundary-");
+  try {
+    emitResult(verifyBoundary(workspace.outDir), args, workspace, printSummary);
+  } finally {
+    cleanupWorkspace(workspace, args);
+  }
+}
+
+function unsupportedHostSkip() {
+  return { skipped: true, reason: `unsupported host architecture: ${process.arch}` };
+}
+
+function verifyBoundary(outDir: string) {
+  const { sourceBundleDir, capturer, target, sourceBundle, facts } = captureNativeArm64SourceBundle(
+    {
+      outDir,
+      targetSource: NATIVE_NONFILE_RESOURCE_BOUNDARY_SOURCE,
+      compileTarget: compileNativeNonfileResourceBoundary,
+      resourceFileName: RESOURCE_FILE_NAME,
+      label: "native non-file resource boundary capture",
+    },
+  );
+  const boundary = inspectResourceBoundary(sourceBundle, RESOURCE_FILE_NAME);
+  return {
+    formatVersion: 1,
+    phase: "nonfile-resource-boundary",
+    hostArch: "arm64",
+    sourceBundleDir,
+    capturer,
+    target,
+    pid: sourceBundle.manifest.capture.pid,
+    threadId: facts.thread.id,
+    capturedSourcePc: finalJumpHex(facts.sourcePc),
+    capturedSourcePointer: finalJumpHex(facts.sourcePointer),
+    regularFile: summarizeResource(boundary.regularFile),
+    regularFileRecipe: boundary.regularFileRecipe,
+    nonFileKinds: boundary.nonFileKinds,
+    refusalCodes: boundary.refusals.map((refusal) => refusal.code),
+    refusedResources: boundary.refusedResources.map(summarizeResource),
+    unrelatedRefusals: boundary.unrelatedRefusals.map((refusal) => refusal.code),
+    execution: "captured-regular-file-coexists-with-precise-nonfile-resource-refusals",
+    bundleFiles: bundleFileStats(sourceBundleDir, NATIVE_PROCESS_IMAGE_BUNDLE_FILES),
+  };
+}
+
+function inspectResourceBoundary(bundle: NativeProcessImageDocuments, resourceFileName: string) {
+  const translated = translateNativeResources({ resources: bundle.resources.resources });
+  const regularFile = findRegularFile(translated.resources, resourceFileName);
+  assert(regularFile.recipe, "regular file resource did not keep a reopen recipe");
+  const refusedResources = translated.resources.filter(
+    (resource) => NONFILE_KINDS.has(resource.kind) && resource.refusal,
+  );
+  const nonFileKinds = [...new Set(refusedResources.map((resource) => resource.kind))].sort();
+  assert(nonFileKinds.includes("pipe"), "captured resources did not include a pipe");
+  assert(nonFileKinds.includes("socket"), "captured resources did not include a socket");
+  assert(nonFileKinds.includes("epoll"), "captured resources did not include epoll");
+  assert(nonFileKinds.includes("eventfd"), "captured resources did not include eventfd");
+  assert(nonFileKinds.includes("timer"), "captured resources did not include timerfd");
+  const refusals = refusedResources.map((resource) => resource.refusal).filter(isRefusal);
+  for (const refusal of refusals) {
+    assert(
+      refusal.code === "kernel-state-unsupported" || refusal.code === "resource-kind-unsupported",
+      `unexpected non-file refusal code ${refusal.code}`,
+    );
+  }
+  const unrelatedRefusals = translated.refusals.filter(
+    (refusal) => !refusals.some((candidate) => candidate === refusal),
+  );
+  return {
+    regularFile,
+    regularFileRecipe: regularFile.recipe,
+    refusedResources,
+    nonFileKinds,
+    refusals,
+    unrelatedRefusals,
+  };
+}
+
+function findRegularFile(resources: NativeProcessResource[], resourceFileName: string) {
+  const regularFile = resources.find(
+    (resource) =>
+      resource.kind === "file" && resource.path && basename(resource.path) === resourceFileName,
+  );
+  assert(regularFile, `captured resources did not include ${resourceFileName}`);
+  assert(regularFile.state === "recipe", "regular file resource was not translated to a recipe");
+  return regularFile;
+}
+
+function summarizeResource(resource: NativeProcessResource) {
+  return {
+    id: resource.id,
+    kind: resource.kind,
+    state: resource.state,
+    fd: resource.fd,
+    path: resource.path,
+    refusalCode: resource.refusal?.code,
+  };
+}
+
+function isRefusal(
+  value: NativeProcessImageRefusal | undefined,
+): value is NativeProcessImageRefusal {
+  return value !== undefined;
+}
+
+function printSummary(summary: NativeNonfileResourceBoundarySummary) {
+  if ("skipped" in summary) {
+    console.log(`native-nonfile-resource-boundary: skip — ${summary.reason}`);
+    return;
+  }
+  console.log(
+    `native-nonfile-resource-boundary: file=${summary.regularFile.fd} nonfile=${summary.nonFileKinds.join(",")}`,
+  );
+  console.log(`native-nonfile-resource-boundary: execution=${summary.execution}`);
+}
+
+main();

--- a/scripts/native-real-utility.ts
+++ b/scripts/native-real-utility.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env tsx
-import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { planNativeMappingMaterialization } from "../packages/runtime/src/native-mapping-materialization.ts";
+import {
+  validateNativeProcessImageBundle,
+  type NativeProcessImageRefusal,
+} from "../packages/runtime/src/native-process-image.ts";
 import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
 import {
   NATIVE_CAPTURE_SOURCE,
@@ -10,154 +15,196 @@ import {
   compileNativeProcessCapturer,
   ensureSourcesExist,
   hostArch,
-  readJson,
 } from "./controlled-corpus-utils.mjs";
 import {
+  assert,
   cleanupWorkspace,
   createWorkspace,
   emitResult,
   emitSkip,
   parseVerifyArgs,
+  runCommand,
 } from "./proof-script-utils.mjs";
 
 const USAGE =
   "usage: tsx scripts/native-real-utility.ts [verify] [--out-dir path] [--json] [--keep]";
+const UTILITY_NAME = "sleep";
+const SETTLE_MS = "150";
+
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
   if (process.platform !== "linux") {
-    emitSkip(args, "native-real-utility", "real utility capture uses Linux /proc and ptrace");
+    emitSkip(args, "native-real-utility", "real utility continuation attempt uses Linux procfs");
+    return;
+  }
+  if (process.arch !== "arm64") {
+    emitSkip(
+      args,
+      "native-real-utility",
+      "real utility continuation attempt currently captures an arm64 Linux source utility",
+    );
     return;
   }
   const workspace = createWorkspace(args, "machinen-native-real-utility-");
   try {
-    emitResult(verifyRealUtilities(workspace.outDir), args, workspace, printSummary);
+    emitResult(verifyRealUtilityContinuation(workspace.outDir), args, workspace, printSummary);
   } finally {
     cleanupWorkspace(workspace, args);
   }
 }
 
-function verifyRealUtilities(outDir: string) {
+function verifyRealUtilityContinuation(outDir: string) {
   ensureSourcesExist([NATIVE_CAPTURE_SOURCE]);
   const binDir = join(outDir, "bin");
   mkdirSync(binDir, { recursive: true });
   const capturer = compileNativeProcessCapturer(binDir);
-  const attempts = [
-    attemptSleep(outDir, capturer),
-    attemptCat(outDir),
-    attemptPing(outDir, capturer),
-  ];
-  if (!attempts.some((attempt) => attempt.state === "captured" || attempt.state === "refused")) {
-    throw new Error("native real utility proof produced no captured/refused utility attempts");
-  }
-  return { formatVersion: 1, hostArch: hostArch(), capturer, attempts };
-}
-
-function attemptSleep(outDir: string, capturer: string) {
-  const sleep = firstExisting(["/bin/sleep", "/usr/bin/sleep"]);
-  if (!sleep) {
-    return skipped("sleep", "sleep binary not found");
-  }
-  return captureUtility(outDir, capturer, "sleep", [sleep, "30"]);
-}
-
-function attemptCat(outDir: string) {
-  const cat = firstExisting(["/bin/cat", "/usr/bin/cat"]);
-  if (!cat) {
-    return skipped("cat", "cat binary not found");
-  }
+  const utility = requireUtility(["/bin/sleep", "/usr/bin/sleep"]);
+  const dynamicLinking = inspectDynamicLinking(utility);
+  const attempt = attemptSleepContinuation(outDir, capturer, utility, dynamicLinking);
   return {
-    name: "cat",
-    state: "refused",
-    command: [cat, join(outDir, "cat-input.txt")],
-    refusal: {
-      code: "thread-state-unsupported",
-      message:
-        "plain cat on a regular file exits before an external live-process capture point; use a stopped process or a long-lived fd workload",
-    },
+    formatVersion: 1,
+    hostArch: hostArch(),
+    targetArch: "amd64",
+    capturer,
+    utility: attempt,
   };
 }
 
-function attemptPing(outDir: string, capturer: string) {
-  const ping = firstExisting(["/bin/ping", "/usr/bin/ping"]);
-  if (!ping) {
-    return skipped("ping", "ping binary not found");
-  }
-  return captureUtility(outDir, capturer, "ping", [ping, "127.0.0.1"]);
-}
-
-function captureUtility(outDir: string, capturer: string, name: string, command: string[]) {
-  const bundleDir = join(outDir, `bundle-${name}`);
+function attemptSleepContinuation(
+  outDir: string,
+  capturer: string,
+  utility: string,
+  dynamicLinking: ReturnType<typeof inspectDynamicLinking>,
+) {
+  const bundleDir = join(outDir, "sleep-source-bundle");
   mkdirSync(bundleDir, { recursive: true });
-  const result = spawnSync(
+  const command = [utility, "30"];
+  const capture = spawnSync(
     capturer,
-    [
-      "--output",
-      bundleDir,
-      "--target-arch",
-      oppositeArch(hostArch()),
-      "--settle-ms",
-      "150",
-      "--",
-      ...command,
-    ],
-    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+    ["--output", bundleDir, "--target-arch", "amd64", "--settle-ms", SETTLE_MS, "--", ...command],
+    {
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
   );
-  if (result.status !== 0) {
-    return {
-      name,
-      state: "refused",
-      command,
-      refusal: {
-        code: "thread-state-unsupported",
-        message: `external capture failed for ${name}`,
-        detail: { stderr: result.stderr.trim() },
-      },
-    };
+  if (capture.status !== 0) {
+    return refusedUtility(command, "thread-state-unsupported", "external live capture failed", {
+      stderr: capture.stderr.trim(),
+    });
   }
-  const resources = readJson(join(bundleDir, "native-resources.json"));
-  const translatedResources = translateNativeResources({ resources: resources.resources });
+
+  const bundle = validateNativeProcessImageBundle(bundleDir);
+  assert(
+    bundle.manifest.capture.sourceArch === "arm64",
+    "real utility source capture was not arm64",
+  );
+  assert(bundle.manifest.target.arch === "amd64", "real utility target arch was not amd64");
+  const resources = translateNativeResources({ resources: bundle.resources.resources });
+  const memoryBytes = statSync(join(bundleDir, "native-memory.bin")).size;
+  const mappings = planNativeMappingMaterialization({
+    mappings: bundle.mappings.mappings,
+    memorySizeBytes: memoryBytes,
+  });
+  const blocking = firstBlockingBoundary(resources.refusals, mappings.refusals);
+  const codeBoundary = blocking ?? codeLocationBoundary(bundle.manifest.process.exe);
   return {
-    name,
-    state: translatedResources.refusals.length > 0 ? "refused" : "captured",
+    name: UTILITY_NAME,
+    state: "refused" as const,
     command,
-    pid: readJson(join(bundleDir, "native-process.json")).capture.pid,
-    mappingCount: readJson(join(bundleDir, "native-mappings.json")).mappings.length,
-    threadCount: readJson(join(bundleDir, "native-threads.json")).threads.length,
-    resourceKinds: [
-      ...new Set(resources.resources.map((resource: { kind: string }) => resource.kind)),
-    ],
-    resourceRefusals: translatedResources.refusals,
+    pid: bundle.manifest.capture.pid,
+    executable: bundle.manifest.process.exe,
+    dynamicallyLinked: dynamicLinking.dynamicallyLinked,
+    interpreter: dynamicLinking.interpreter,
+    processImageValidated: true,
+    mappingSteps: mappings.steps.length,
+    mappingRefusals: mappings.refusals,
+    threadCount: bundle.threads.threads.length,
+    mappingCount: bundle.mappings.mappings.length,
+    resourceKinds: [...new Set(bundle.resources.resources.map((resource) => resource.kind))].sort(),
+    resourceRefusals: resources.refusals,
+    blockingBoundary: codeBoundary.boundary,
+    blockingRefusal: codeBoundary.refusal,
+    attemptedResume: false,
+    sourceTextReusedAsTargetCode: false,
+    targetBinarySource: "not-provided",
+    execution: `real-arm64-${UTILITY_NAME}-refused-at-${codeBoundary.boundary}`,
     bundleFiles: bundleFileStats(bundleDir, NATIVE_PROCESS_IMAGE_BUNDLE_FILES),
   };
 }
 
-function firstExisting(paths: string[]) {
-  return paths.find((path) => existsSync(path));
+function firstBlockingBoundary(
+  resourceRefusals: NativeProcessImageRefusal[],
+  mappingRefusals: NativeProcessImageRefusal[],
+) {
+  const resource = resourceRefusals[0];
+  if (resource) {
+    return { boundary: "resource-boundary" as const, refusal: resource };
+  }
+  const mapping = mappingRefusals[0];
+  if (mapping) {
+    return { boundary: "mapping-materialization" as const, refusal: mapping };
+  }
+  return undefined;
 }
 
-function oppositeArch(arch: string) {
-  if (arch === "arm64") {
-    return "amd64";
-  }
-  if (arch === "amd64") {
-    return "arm64";
-  }
-  return "unknown";
+function codeLocationBoundary(executable: string) {
+  return {
+    boundary: "target-code-location" as const,
+    refusal: {
+      code: "code-location-unknown" as const,
+      message:
+        "real utility continuation has no matching amd64 target module/RVA and will not reuse arm64 source text",
+      detail: {
+        executable,
+        required: ["matching target binary", "module/RVA code map", "unwind-derived landing"],
+      },
+    },
+  };
 }
 
-function skipped(name: string, reason: string) {
-  return { name, state: "skipped", reason };
+function refusedUtility(
+  command: string[],
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+  detail: Record<string, unknown>,
+) {
+  return {
+    name: UTILITY_NAME,
+    state: "refused" as const,
+    command,
+    processImageValidated: false,
+    blockingBoundary: "capture" as const,
+    blockingRefusal: { code, message, detail },
+    attemptedResume: false,
+    sourceTextReusedAsTargetCode: false,
+    execution: `real-arm64-${UTILITY_NAME}-refused-at-capture`,
+  };
 }
 
-// fallow-ignore-next-line complexity
-function printSummary(summary: ReturnType<typeof verifyRealUtilities>) {
-  for (const attempt of summary.attempts) {
-    const detail =
-      attempt.state === "captured" || attempt.state === "refused"
-        ? `state=${attempt.state} resources=${"resourceKinds" in attempt ? attempt.resourceKinds.join(",") : "n/a"}`
-        : `state=${attempt.state} reason=${"reason" in attempt ? attempt.reason : "unknown"}`;
-    console.log(`native-real-utility: ${attempt.name} ${detail}`);
-  }
+function requireUtility(paths: string[]) {
+  const utility = paths.find((path) => existsSync(path));
+  assert(utility, `${UTILITY_NAME} utility not found`);
+  return utility;
+}
+
+function inspectDynamicLinking(path: string) {
+  const programHeaders = runCommand("readelf", ["-l", path], {
+    label: "real utility ELF scan",
+  }).stdout;
+  const dynamic = runCommand("readelf", ["-d", path], { label: "real utility dynamic scan" });
+  const interpreter = /Requesting program interpreter:\s*([^\]]+)/.exec(programHeaders)?.[1];
+  const dynamicallyLinked = programHeaders.includes("INTERP") && dynamic.status === 0;
+  assert(dynamicallyLinked, `${path} is not a dynamically linked ELF utility`);
+  return { dynamicallyLinked, interpreter: interpreter?.trim() ?? "unknown" };
+}
+
+function printSummary(summary: ReturnType<typeof verifyRealUtilityContinuation>) {
+  const attempt = summary.utility;
+  console.log(
+    `native-real-utility: ${attempt.name} state=${attempt.state} boundary=${attempt.blockingBoundary} refusal=${attempt.blockingRefusal.code}`,
+  );
+  console.log(`native-real-utility: execution=${attempt.execution}`);
 }
 
 main();


### PR DESCRIPTION
## Problem

Before trying a less-controlled real utility, native restore needs a clear boundary for non-file kernel resources. Regular files can be reopened, but pipes, sockets, epoll sets, eventfds, and timerfds carry kernel state we do not replay yet.

## Solution

This extends native resource classification and refusal codes. The proof target opens one regular file plus pipe/socket/epoll/eventfd/timerfd resources. Translation keeps the regular-file reopen recipe and refuses the unrelated non-file resources with exact fail-closed codes, mainly `kernel-state-unsupported`.

Closes #484

## Validation

- `pnpm exec fallow audit --changed-since origin/pp-483-native-dwarf-pointer-classification`
- `pnpm native-nonfile-resource-boundary --json` (skips on macOS)
- focused Vitest for resource translation + non-file boundary
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
