### PR TITLE
Attempt real utility native continuation

### DIFF
--- a/docs/snapshot/native-nonfile-resource-boundary.md
+++ b/docs/snapshot/native-nonfile-resource-boundary.md
@@ -53,3 +53,5 @@ pnpm native-nonfile-resource-boundary
 ```
 
 Other hosts skip honestly because this proof captures the arm64 source side through Linux procfs.
+
+Next: [Native real utility continuation attempt](./native-real-utilities.md).

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -1,6 +1,6 @@
-# Native real utility attempts
+# Native real utility continuation attempt
 
-Issue #451 applies the native process-image stack to real Linux utilities.
+Issue #485 tries the first native-transparent continuation path against a tiny real Linux utility instead of a controlled fixture.
 
 ## Command
 
@@ -8,32 +8,52 @@ Issue #451 applies the native process-image stack to real Linux utilities.
 pnpm native-real-utility
 ```
 
-On non-Linux hosts the proof skips because it needs `/proc` and `ptrace`.
+On non-Linux hosts the proof skips because it needs `/proc` and `ptrace`. The current proof captures the arm64 source side.
 
-## Candidate ladder
+## Utility chosen
 
-The current ladder attempts:
+The first candidate is the system `sleep` utility:
 
-1. `sleep 30` — long-lived and externally capturable;
-2. `cat <regular-file>` — currently refused because a plain regular-file `cat`
-   exits before an external live capture point;
-3. `ping 127.0.0.1` — attempted when the host has `ping`; any sockets/raw
-   sockets are surfaced as resource recipes/refusals.
+```text
+/bin/sleep 30   or   /usr/bin/sleep 30
+```
 
-## Outcomes
+It is tiny, dynamically linked, long-lived, and has a narrow observable process state. The verifier checks that the selected binary is a dynamically linked ELF by reading its program headers and dynamic section.
 
-Each attempt is either:
+## Pipeline
 
-- `captured`, with mapping/thread/resource counts;
-- `refused`, with a stable refusal code and detail;
-- `skipped`, when the utility is absent.
+The attempt runs the stricter native pipeline from the previous proofs:
 
-`ping` is not declared solved. The proof records the resource kinds and any
-resource-broker refusals so the missing raw-socket/capability/timer/signal work
-is explicit.
+1. external ptrace/procfs process capture;
+2. native process-image validation;
+3. mapping materialization planning;
+4. resource translation/refusal classification;
+5. first target-code boundary check.
 
-## Boundary
+The proof intentionally refuses before any target jump unless a matching amd64 target binary/module/RVA map is available. It reports:
 
-This issue does not claim arbitrary utility continuation. It is a first real
-utility probe that exercises external capture and resource classification beyond
-controlled fixtures.
+```json
+{
+  "sourceTextReusedAsTargetCode": false,
+  "targetBinarySource": "not-provided"
+}
+```
+
+That is the important safety property for this issue: source arm64 text is never treated as target-native amd64 code.
+
+## Current result
+
+The expected current result is a fail-closed refusal at the first exact boundary, usually:
+
+- `code-location-unknown` when capture, resources, and mappings are clean but no matching amd64 target code map is provided; or
+- an earlier exact boundary such as `kernel-state-unsupported`, `mapping-ambiguous`, or `mapping-unreadable` if the host utility exposes that state.
+
+A passing run emits an execution string like:
+
+```text
+real-arm64-sleep-refused-at-target-code-location
+```
+
+## Non-claim
+
+This does **not** claim arbitrary native utility migration yet. It proves the real-utility attempt uses the native process-image validation pipeline and stops at a precise known boundary rather than falling back to source-ISA emulation, sidecars, app hooks, or raw source virtual addresses.

--- a/packages/runtime/src/__tests__/native-real-utility.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility.test.ts
@@ -10,13 +10,19 @@ const TMP: string[] = [];
 
 interface NativeRealUtilitySummary {
   skipped?: boolean;
-  attempts: Array<{
+  reason?: string;
+  utility: {
     name: string;
-    state: "captured" | "refused" | "skipped";
-    resourceKinds?: string[];
-    resourceRefusals?: Array<{ code: string }>;
-    refusal?: { code: string };
-  }>;
+    state: "refused" | "resumed";
+    dynamicallyLinked?: boolean;
+    processImageValidated: boolean;
+    blockingBoundary: string;
+    blockingRefusal: { code: string };
+    attemptedResume: boolean;
+    sourceTextReusedAsTargetCode: boolean;
+    targetBinarySource?: string;
+    execution: string;
+  };
 }
 
 afterEach(() => {
@@ -25,9 +31,9 @@ afterEach(() => {
   }
 });
 
-describe("native real utility attempts", () => {
+describe("native real utility continuation attempt", () => {
   it.skipIf(process.platform !== "linux")(
-    "captures or precisely refuses real utilities including ping",
+    "captures a real dynamically linked utility and stops at an exact boundary",
     { timeout: 120_000 },
     () => {
       const outDir = mkdtempSync(join(tmpdir(), "native-real-utility-test-"));
@@ -41,23 +47,26 @@ describe("native real utility attempts", () => {
 
       expect(result.status, result.stderr).toBe(0);
       const summary = JSON.parse(result.stdout) as NativeRealUtilitySummary;
-      expect(summary.skipped).not.toBe(true);
-      expect(summary.attempts.map((attempt) => attempt.name)).toEqual(["sleep", "cat", "ping"]);
-      expect(
-        summary.attempts.some(
-          (attempt) => attempt.state === "captured" || attempt.state === "refused",
-        ),
-      ).toBe(true);
-      expect(summary.attempts.find((attempt) => attempt.name === "cat")?.refusal?.code).toBe(
-        "thread-state-unsupported",
-      );
-      const ping = summary.attempts.find((attempt) => attempt.name === "ping");
-      if (ping?.state !== "skipped") {
-        expect([
-          ...(ping?.resourceKinds ?? []),
-          ...(ping?.resourceRefusals ?? []).map((r) => r.code),
-        ]).not.toHaveLength(0);
+      if (summary.skipped) {
+        expect(summary.reason).toMatch(/arm64 Linux source utility|Linux procfs/);
+        return;
       }
+
+      expect(summary.utility).toMatchObject({
+        name: "sleep",
+        state: "refused",
+        dynamicallyLinked: true,
+        processImageValidated: true,
+        attemptedResume: false,
+        sourceTextReusedAsTargetCode: false,
+      });
+      expect([
+        "code-location-unknown",
+        "kernel-state-unsupported",
+        "mapping-ambiguous",
+        "mapping-unreadable",
+      ]).toContain(summary.utility.blockingRefusal.code);
+      expect(summary.utility.execution).toContain(`real-arm64-sleep-refused-at-`);
     },
   );
 });

--- a/packages/runtime/src/native-support-boundary.ts
+++ b/packages/runtime/src/native-support-boundary.ts
@@ -61,11 +61,11 @@ export const nativeAmbiguityClasses: NativeAmbiguityClass[] = [
   {
     id: "kernel-resource",
     description:
-      "fds, sockets, PTYs, timers, epoll, namespaces, credentials, and raw sockets need broker recipes.",
-    requiredMetadata: ["fd table", "resource kind", "host broker capability"],
+      "fds, sockets, PTYs, timers, epoll, namespaces, credentials, and raw sockets need broker recipes or modeled kernel state.",
+    requiredMetadata: ["fd table", "resource kind", "host broker capability", "kernel state"],
     translationRule:
-      "Regular files can reopen/reseek; brokered resources require declared capability.",
-    refusalCode: "resource-kind-unsupported",
+      "Regular files can reopen/reseek; brokered resources require declared capability; kernel-stateful fds fail closed.",
+    refusalCode: "kernel-state-unsupported",
   },
   {
     id: "vdso-vvar-special-mapping",

--- a/scripts/native-real-utility.ts
+++ b/scripts/native-real-utility.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env tsx
-import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { planNativeMappingMaterialization } from "../packages/runtime/src/native-mapping-materialization.ts";
+import {
+  validateNativeProcessImageBundle,
+  type NativeProcessImageRefusal,
+} from "../packages/runtime/src/native-process-image.ts";
 import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
 import {
   NATIVE_CAPTURE_SOURCE,
@@ -10,154 +15,196 @@ import {
   compileNativeProcessCapturer,
   ensureSourcesExist,
   hostArch,
-  readJson,
 } from "./controlled-corpus-utils.mjs";
 import {
+  assert,
   cleanupWorkspace,
   createWorkspace,
   emitResult,
   emitSkip,
   parseVerifyArgs,
+  runCommand,
 } from "./proof-script-utils.mjs";
 
 const USAGE =
   "usage: tsx scripts/native-real-utility.ts [verify] [--out-dir path] [--json] [--keep]";
+const UTILITY_NAME = "sleep";
+const SETTLE_MS = "150";
+
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
   if (process.platform !== "linux") {
-    emitSkip(args, "native-real-utility", "real utility capture uses Linux /proc and ptrace");
+    emitSkip(args, "native-real-utility", "real utility continuation attempt uses Linux procfs");
+    return;
+  }
+  if (process.arch !== "arm64") {
+    emitSkip(
+      args,
+      "native-real-utility",
+      "real utility continuation attempt currently captures an arm64 Linux source utility",
+    );
     return;
   }
   const workspace = createWorkspace(args, "machinen-native-real-utility-");
   try {
-    emitResult(verifyRealUtilities(workspace.outDir), args, workspace, printSummary);
+    emitResult(verifyRealUtilityContinuation(workspace.outDir), args, workspace, printSummary);
   } finally {
     cleanupWorkspace(workspace, args);
   }
 }
 
-function verifyRealUtilities(outDir: string) {
+function verifyRealUtilityContinuation(outDir: string) {
   ensureSourcesExist([NATIVE_CAPTURE_SOURCE]);
   const binDir = join(outDir, "bin");
   mkdirSync(binDir, { recursive: true });
   const capturer = compileNativeProcessCapturer(binDir);
-  const attempts = [
-    attemptSleep(outDir, capturer),
-    attemptCat(outDir),
-    attemptPing(outDir, capturer),
-  ];
-  if (!attempts.some((attempt) => attempt.state === "captured" || attempt.state === "refused")) {
-    throw new Error("native real utility proof produced no captured/refused utility attempts");
-  }
-  return { formatVersion: 1, hostArch: hostArch(), capturer, attempts };
-}
-
-function attemptSleep(outDir: string, capturer: string) {
-  const sleep = firstExisting(["/bin/sleep", "/usr/bin/sleep"]);
-  if (!sleep) {
-    return skipped("sleep", "sleep binary not found");
-  }
-  return captureUtility(outDir, capturer, "sleep", [sleep, "30"]);
-}
-
-function attemptCat(outDir: string) {
-  const cat = firstExisting(["/bin/cat", "/usr/bin/cat"]);
-  if (!cat) {
-    return skipped("cat", "cat binary not found");
-  }
+  const utility = requireUtility(["/bin/sleep", "/usr/bin/sleep"]);
+  const dynamicLinking = inspectDynamicLinking(utility);
+  const attempt = attemptSleepContinuation(outDir, capturer, utility, dynamicLinking);
   return {
-    name: "cat",
-    state: "refused",
-    command: [cat, join(outDir, "cat-input.txt")],
-    refusal: {
-      code: "thread-state-unsupported",
-      message:
-        "plain cat on a regular file exits before an external live-process capture point; use a stopped process or a long-lived fd workload",
-    },
+    formatVersion: 1,
+    hostArch: hostArch(),
+    targetArch: "amd64",
+    capturer,
+    utility: attempt,
   };
 }
 
-function attemptPing(outDir: string, capturer: string) {
-  const ping = firstExisting(["/bin/ping", "/usr/bin/ping"]);
-  if (!ping) {
-    return skipped("ping", "ping binary not found");
-  }
-  return captureUtility(outDir, capturer, "ping", [ping, "127.0.0.1"]);
-}
-
-function captureUtility(outDir: string, capturer: string, name: string, command: string[]) {
-  const bundleDir = join(outDir, `bundle-${name}`);
+function attemptSleepContinuation(
+  outDir: string,
+  capturer: string,
+  utility: string,
+  dynamicLinking: ReturnType<typeof inspectDynamicLinking>,
+) {
+  const bundleDir = join(outDir, "sleep-source-bundle");
   mkdirSync(bundleDir, { recursive: true });
-  const result = spawnSync(
+  const command = [utility, "30"];
+  const capture = spawnSync(
     capturer,
-    [
-      "--output",
-      bundleDir,
-      "--target-arch",
-      oppositeArch(hostArch()),
-      "--settle-ms",
-      "150",
-      "--",
-      ...command,
-    ],
-    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+    ["--output", bundleDir, "--target-arch", "amd64", "--settle-ms", SETTLE_MS, "--", ...command],
+    {
+      encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
   );
-  if (result.status !== 0) {
-    return {
-      name,
-      state: "refused",
-      command,
-      refusal: {
-        code: "thread-state-unsupported",
-        message: `external capture failed for ${name}`,
-        detail: { stderr: result.stderr.trim() },
-      },
-    };
+  if (capture.status !== 0) {
+    return refusedUtility(command, "thread-state-unsupported", "external live capture failed", {
+      stderr: capture.stderr.trim(),
+    });
   }
-  const resources = readJson(join(bundleDir, "native-resources.json"));
-  const translatedResources = translateNativeResources({ resources: resources.resources });
+
+  const bundle = validateNativeProcessImageBundle(bundleDir);
+  assert(
+    bundle.manifest.capture.sourceArch === "arm64",
+    "real utility source capture was not arm64",
+  );
+  assert(bundle.manifest.target.arch === "amd64", "real utility target arch was not amd64");
+  const resources = translateNativeResources({ resources: bundle.resources.resources });
+  const memoryBytes = statSync(join(bundleDir, "native-memory.bin")).size;
+  const mappings = planNativeMappingMaterialization({
+    mappings: bundle.mappings.mappings,
+    memorySizeBytes: memoryBytes,
+  });
+  const blocking = firstBlockingBoundary(resources.refusals, mappings.refusals);
+  const codeBoundary = blocking ?? codeLocationBoundary(bundle.manifest.process.exe);
   return {
-    name,
-    state: translatedResources.refusals.length > 0 ? "refused" : "captured",
+    name: UTILITY_NAME,
+    state: "refused" as const,
     command,
-    pid: readJson(join(bundleDir, "native-process.json")).capture.pid,
-    mappingCount: readJson(join(bundleDir, "native-mappings.json")).mappings.length,
-    threadCount: readJson(join(bundleDir, "native-threads.json")).threads.length,
-    resourceKinds: [
-      ...new Set(resources.resources.map((resource: { kind: string }) => resource.kind)),
-    ],
-    resourceRefusals: translatedResources.refusals,
+    pid: bundle.manifest.capture.pid,
+    executable: bundle.manifest.process.exe,
+    dynamicallyLinked: dynamicLinking.dynamicallyLinked,
+    interpreter: dynamicLinking.interpreter,
+    processImageValidated: true,
+    mappingSteps: mappings.steps.length,
+    mappingRefusals: mappings.refusals,
+    threadCount: bundle.threads.threads.length,
+    mappingCount: bundle.mappings.mappings.length,
+    resourceKinds: [...new Set(bundle.resources.resources.map((resource) => resource.kind))].sort(),
+    resourceRefusals: resources.refusals,
+    blockingBoundary: codeBoundary.boundary,
+    blockingRefusal: codeBoundary.refusal,
+    attemptedResume: false,
+    sourceTextReusedAsTargetCode: false,
+    targetBinarySource: "not-provided",
+    execution: `real-arm64-${UTILITY_NAME}-refused-at-${codeBoundary.boundary}`,
     bundleFiles: bundleFileStats(bundleDir, NATIVE_PROCESS_IMAGE_BUNDLE_FILES),
   };
 }
 
-function firstExisting(paths: string[]) {
-  return paths.find((path) => existsSync(path));
+function firstBlockingBoundary(
+  resourceRefusals: NativeProcessImageRefusal[],
+  mappingRefusals: NativeProcessImageRefusal[],
+) {
+  const resource = resourceRefusals[0];
+  if (resource) {
+    return { boundary: "resource-boundary" as const, refusal: resource };
+  }
+  const mapping = mappingRefusals[0];
+  if (mapping) {
+    return { boundary: "mapping-materialization" as const, refusal: mapping };
+  }
+  return undefined;
 }
 
-function oppositeArch(arch: string) {
-  if (arch === "arm64") {
-    return "amd64";
-  }
-  if (arch === "amd64") {
-    return "arm64";
-  }
-  return "unknown";
+function codeLocationBoundary(executable: string) {
+  return {
+    boundary: "target-code-location" as const,
+    refusal: {
+      code: "code-location-unknown" as const,
+      message:
+        "real utility continuation has no matching amd64 target module/RVA and will not reuse arm64 source text",
+      detail: {
+        executable,
+        required: ["matching target binary", "module/RVA code map", "unwind-derived landing"],
+      },
+    },
+  };
 }
 
-function skipped(name: string, reason: string) {
-  return { name, state: "skipped", reason };
+function refusedUtility(
+  command: string[],
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+  detail: Record<string, unknown>,
+) {
+  return {
+    name: UTILITY_NAME,
+    state: "refused" as const,
+    command,
+    processImageValidated: false,
+    blockingBoundary: "capture" as const,
+    blockingRefusal: { code, message, detail },
+    attemptedResume: false,
+    sourceTextReusedAsTargetCode: false,
+    execution: `real-arm64-${UTILITY_NAME}-refused-at-capture`,
+  };
 }
 
-// fallow-ignore-next-line complexity
-function printSummary(summary: ReturnType<typeof verifyRealUtilities>) {
-  for (const attempt of summary.attempts) {
-    const detail =
-      attempt.state === "captured" || attempt.state === "refused"
-        ? `state=${attempt.state} resources=${"resourceKinds" in attempt ? attempt.resourceKinds.join(",") : "n/a"}`
-        : `state=${attempt.state} reason=${"reason" in attempt ? attempt.reason : "unknown"}`;
-    console.log(`native-real-utility: ${attempt.name} ${detail}`);
-  }
+function requireUtility(paths: string[]) {
+  const utility = paths.find((path) => existsSync(path));
+  assert(utility, `${UTILITY_NAME} utility not found`);
+  return utility;
+}
+
+function inspectDynamicLinking(path: string) {
+  const programHeaders = runCommand("readelf", ["-l", path], {
+    label: "real utility ELF scan",
+  }).stdout;
+  const dynamic = runCommand("readelf", ["-d", path], { label: "real utility dynamic scan" });
+  const interpreter = /Requesting program interpreter:\s*([^\]]+)/.exec(programHeaders)?.[1];
+  const dynamicallyLinked = programHeaders.includes("INTERP") && dynamic.status === 0;
+  assert(dynamicallyLinked, `${path} is not a dynamically linked ELF utility`);
+  return { dynamicallyLinked, interpreter: interpreter?.trim() ?? "unknown" };
+}
+
+function printSummary(summary: ReturnType<typeof verifyRealUtilityContinuation>) {
+  const attempt = summary.utility;
+  console.log(
+    `native-real-utility: ${attempt.name} state=${attempt.state} boundary=${attempt.blockingBoundary} refusal=${attempt.blockingRefusal.code}`,
+  );
+  console.log(`native-real-utility: execution=${attempt.execution}`);
 }
 
 main();


### PR DESCRIPTION
## Problem

The native-transparent stack had only controlled proof binaries. We needed the first attempt against a tiny real dynamically linked Linux utility, while still failing closed at a precise boundary if resume is not safe.

## Solution

This updates the real-utility proof to capture `sleep 30` as an unmodified arm64 Linux utility. The proof validates the native process-image bundle, plans mapping materialization, classifies resources, confirms the utility is dynamically linked, and then refuses at the first exact boundary. Today that is usually `code-location-unknown` because no matching amd64 target module/RVA map is provided. The summary explicitly reports that source arm64 text is not reused as target-native code.

Closes #485

## Validation

- `pnpm exec fallow audit --changed-since origin/pp-484-native-nonfile-resource-boundary`
- `pnpm native-real-utility --json` (skips on macOS)
- focused Vitest for native real utility
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p`
