### PR TITLE
Recreate safe guard mappings

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -27,9 +27,13 @@ text is target code.
 
 ## Current result
 
-The default real utility is `sleep`, so the first observed blocker is expected
-to be thread state: the process is usually inside `clock_nanosleep`. The proof
-therefore refuses before resume with `active-syscall`.
+The default real utility is `sleep`, so default policy still refuses at thread
+state when the process is inside `clock_nanosleep`. With the explicit
+`MACHINEN_ACTUAL_REAL_UTILITY_SLEEP_SYSCALL_POLICY=defer-target-resume` policy,
+the proof records a deferred target timer continuation, recreates safe
+`PROT_NONE` guard/protection mappings, and exposes the next blocker
+(`target-code-location` for the current `/bin/sleep` capture) instead of
+granting success.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-guard-mapping-materialization.md
+++ b/docs/snapshot/native-guard-mapping-materialization.md
@@ -1,0 +1,38 @@
+# Native guard mapping materialization
+
+Issue #514 narrows `mapping-unreadable` for actual real utilities.
+
+## Policy
+
+A mapping may be recreated as a target guard mapping only when it is all of:
+
+- not readable;
+- not writable;
+- not executable;
+- private, not shared;
+- not captured in `native-memory.bin`;
+- anonymous, stack-like, or file-backed protection-gap shaped.
+
+Those mappings have no current source bytes to preserve. The target may recreate
+them as `PROT_NONE` reservations and the planner does not treat them as a resume
+blocker.
+
+## Unsafe unreadable mappings
+
+Unreadable mappings that are writable, executable, shared, or otherwise
+ambiguous still refuse with `mapping-unreadable`. Refusals include the mapping
+id, kind, source range, permission string, path, and permission object so the
+next policy can be precise.
+
+## Actual utility effect
+
+With the explicit sleep policy:
+
+```bash
+MACHINEN_ACTUAL_REAL_UTILITY_SLEEP_SYSCALL_POLICY=defer-target-resume \
+  pnpm native-actual-real-utility-continuation --json
+```
+
+the actual `/bin/sleep` proof can move past `thread-state` and safe guard mapping
+materialization. The next blocker remains fail-closed; this change does not claim
+native resume.

--- a/docs/snapshot/native-mapping-materializer.md
+++ b/docs/snapshot/native-mapping-materializer.md
@@ -14,8 +14,9 @@ materializes it with `mmap`:
 
 - file-backed executable text comes from a target artifact;
 - anonymous data and heap pages are copied from `native-memory.bin`;
-- stack and kernel-style mappings are recreated without copied source bytes;
-- an unreadable mapping remains refused with `mapping-unreadable`;
+- stack, kernel-style, and no-access guard mappings are recreated without
+  copied source bytes;
+- an unsafe unreadable mapping remains refused with `mapping-unreadable`;
 - final permissions are checked through `/proc/self/maps`.
 
 ## Runtime planner
@@ -25,13 +26,14 @@ loader steps:
 
 - `map-target-file` for executable target-file mappings;
 - `copy-captured-bytes` for safe anonymous/data/heap mappings;
-- `recreate` for target-owned stack/kernel mappings;
+- `recreate` for target-owned stack/kernel mappings and safe guard mappings;
 - `omit` for source-only mappings intentionally dropped;
 - `refuse` for fail-closed mappings.
 
 ## Refusals
 
-- `mapping-unreadable` is preserved from capture for unreadable mappings.
+- `mapping-unreadable` is preserved from capture for unsafe unreadable mappings
+  and includes mapping details when the planner reports it.
 - `mapping-ambiguous` is used for missing target addresses, missing captured
   bytes, invalid byte ranges, or recreated mappings that still carry source
   bytes.

--- a/docs/snapshot/native-mapping-policy.md
+++ b/docs/snapshot/native-mapping-policy.md
@@ -1,7 +1,7 @@
 # Native mapping policy proof
 
 This proof checks the native process-image mapping boundary for kernel-supplied
-and unreadable mappings.
+mappings and no-access guard mappings.
 
 ## Command
 
@@ -24,8 +24,9 @@ A passing run proves:
 1. kernel mappings such as `vdso`, `vvar`, or other special mappings are marked
    `target.materialization: "recreate"`;
 2. recreated kernel mappings are not copied into `native-memory.bin`;
-3. the unreadable `PROT_NONE` mapping refuses with `mapping-unreadable`;
-4. the mapping refusal is also present in the bundle-level mapping refusal list.
+3. private unreadable `PROT_NONE` guard/protection mappings are also marked
+   `target.materialization: "recreate"`;
+4. the recreated protection mappings are not copied into `native-memory.bin`.
 
 ## Boundary
 
@@ -33,5 +34,6 @@ This does not implement target vdso/vvar reconstruction. It only prevents a bad
 restore from copying source kernel pages as normal user memory. The follow-up
 [Native mapping materializer](./native-mapping-materializer.md) applies this
 policy to target mappings. Real target kernels must supply their own
-vdso/vvar/special mappings, and any mapping that cannot be read through
-`/proc/<pid>/mem` must remain a precise refusal.
+vdso/vvar/special mappings. Unreadable mappings that are writable, executable,
+shared, or otherwise ambiguous still remain precise `mapping-unreadable`
+refusals with mapping details.

--- a/docs/snapshot/native-memory-translation.md
+++ b/docs/snapshot/native-memory-translation.md
@@ -11,7 +11,7 @@ pnpm native-memory-translate
 
 The proof preserves an integer word, relocates a metadata-proven pointer, and
 refuses an ambiguous pointer-like word. The mapping-policy proof separately
-checks whole mapping decisions for kernel and unreadable mappings.
+checks whole mapping decisions for kernel, guard, and unreadable mappings.
 
 ## Contract
 
@@ -33,5 +33,6 @@ proven its meaning.
 
 The result is a relocation report that later restore stages can apply to
 `native-memory.bin` after target mappings are materialized. Whole mappings still
-have their own policy: kernel mappings are recreated on the target, and unreadable
-source mappings refuse with `mapping-unreadable`.
+have their own policy: kernel and safe guard mappings are recreated on the
+target, while unsafe unreadable source mappings refuse with
+`mapping-unreadable`.

--- a/docs/snapshot/native-process-capture.md
+++ b/docs/snapshot/native-process-capture.md
@@ -70,8 +70,11 @@ Every captured thread is listed in `native-translation.json` with state
 
 ## Refusal discipline
 
-Readable mappings that cannot be read through `/proc/<pid>/mem` are emitted with
-`mapping-unreadable`. Mappings that exceed the capture policy are emitted with
-`mapping-ambiguous`. Threads stopped inside a syscall or restart block are later
-refused by register translation with `active-syscall`. Non-regular fd kinds are
-emitted as resource refusals until a broker recipe exists.
+Private no-access guard/protection mappings are emitted as target `recreate`
+mappings and are not copied into `native-memory.bin`. Other mappings that cannot
+be read through `/proc/<pid>/mem` are emitted with `mapping-unreadable` and
+include the mapping kind, range, path, and permission details. Mappings that
+exceed the capture policy are emitted with `mapping-ambiguous`. Threads stopped
+inside a syscall or restart block are later refused by register translation with
+`active-syscall`. Non-regular fd kinds are emitted as resource refusals until a
+broker recipe exists.

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -74,3 +74,4 @@ See also:
 - [Native actual real utility continuation](./native-actual-real-utility-continuation.md)
 - [Native active syscall policy](./native-active-syscall-policy.md)
 - [Native sleep syscall continuation policy](./native-sleep-syscall-policy.md)
+- [Native guard mapping materialization](./native-guard-mapping-materialization.md)

--- a/packages/microvm/assets/native-mapping-policy-target.c
+++ b/packages/microvm/assets/native-mapping-policy-target.c
@@ -1,9 +1,9 @@
 // Non-cooperative target for native mapping policy capture.
 //
-// The process creates an unreadable anonymous mapping and then spins. The
-// external capturer should refuse that mapping precisely while treating kernel
-// supplied vdso/vvar/special mappings as target-recreated rather than copied
-// source bytes.
+// The process creates an unreadable anonymous guard mapping and then spins.
+// The external capturer should recreate that mapping as target PROT_NONE while
+// treating kernel supplied vdso/vvar/special mappings as target-recreated rather
+// than copied source bytes.
 
 #define _GNU_SOURCE
 

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -617,6 +617,13 @@ static bool kernel_mapping(const char *kind) {
   return streq(kind, "vdso") || streq(kind, "vvar") || streq(kind, "special");
 }
 
+static bool no_access_protection_mapping(const struct MappingCapture *mapping) {
+  return !mapping->read && !mapping->write && !mapping->execute &&
+         mapping->private_mapping && !mapping->shared_mapping &&
+         (streq(mapping->kind, "anonymous") || streq(mapping->kind, "stack") ||
+             streq(mapping->kind, "file"));
+}
+
 static void set_mapping_refusal(struct MappingCapture *mapping, const char *code,
     const char *message) {
   mapping->has_refusal = true;
@@ -676,7 +683,13 @@ static uint32_t parse_maps(pid_t pid, struct MappingCapture mappings[NATIVE_CAPT
       snprintf(mapping->materialization, sizeof(mapping->materialization), "recreate");
       snprintf(mapping->reason, sizeof(mapping->reason), "kernel mapping is recreated on target");
     } else if (!mapping->read) {
-      set_mapping_refusal(mapping, "mapping-unreadable", "mapping is not readable through /proc/pid/mem");
+      if (no_access_protection_mapping(mapping)) {
+        snprintf(mapping->materialization, sizeof(mapping->materialization), "recreate");
+        snprintf(mapping->reason, sizeof(mapping->reason),
+            "guard/protection mapping is recreated as target PROT_NONE");
+      } else {
+        set_mapping_refusal(mapping, "mapping-unreadable", "mapping is not readable through /proc/pid/mem");
+      }
     } else {
       snprintf(mapping->materialization, sizeof(mapping->materialization), "translate");
     }
@@ -781,6 +794,41 @@ static void write_refusal(FILE *out, const char *code, const char *message) {
   fputc('}', out);
 }
 
+static void mapping_perm_string(const struct MappingCapture *mapping, char perms[5]) {
+  perms[0] = mapping->read ? 'r' : '-';
+  perms[1] = mapping->write ? 'w' : '-';
+  perms[2] = mapping->execute ? 'x' : '-';
+  perms[3] = mapping->shared_mapping ? 's' : mapping->private_mapping ? 'p' : '-';
+  perms[4] = '\0';
+}
+
+static void write_mapping_refusal(FILE *out, const struct MappingCapture *mapping) {
+  char perms[5];
+  mapping_perm_string(mapping, perms);
+  fputs("{\"code\":", out);
+  json_string(out, mapping->refusal_code);
+  fputs(",\"message\":", out);
+  json_string(out, mapping->refusal_message);
+  fputs(",\"detail\":{\"mapping\":", out);
+  json_string(out, mapping->id);
+  fputs(",\"kind\":", out);
+  json_string(out, mapping->kind);
+  fputs(",\"sourceStart\":", out);
+  json_hex_u64(out, mapping->start);
+  fputs(",\"sourceEnd\":", out);
+  json_hex_u64(out, mapping->end);
+  fprintf(out, ",\"sizeBytes\":%" PRIu64, mapping->size_bytes);
+  fputs(",\"perms\":", out);
+  json_string(out, perms);
+  fputs(",\"path\":", out);
+  json_string(out, mapping->path);
+  fprintf(out,
+      ",\"permissions\":{\"read\":%s,\"write\":%s,\"execute\":%s,\"private\":%s,\"shared\":%s}}}",
+      mapping->read ? "true" : "false", mapping->write ? "true" : "false",
+      mapping->execute ? "true" : "false", mapping->private_mapping ? "true" : "false",
+      mapping->shared_mapping ? "true" : "false");
+}
+
 static void write_mapping(const struct MappingCapture *mapping, FILE *out) {
   fputs("{\"id\":", out);
   json_string(out, mapping->id);
@@ -819,7 +867,7 @@ static void write_mapping(const struct MappingCapture *mapping, FILE *out) {
   fputc('}', out);
   if (mapping->has_refusal) {
     fputs(",\"refusal\":", out);
-    write_refusal(out, mapping->refusal_code, mapping->refusal_message);
+    write_mapping_refusal(out, mapping);
   }
   fputc('}', out);
 }
@@ -844,7 +892,7 @@ static void write_mappings(const struct Options *opts,
       fputc(',', out);
     }
     first = false;
-    write_refusal(out, mappings[i].refusal_code, mappings[i].refusal_message);
+    write_mapping_refusal(out, &mappings[i]);
   }
   fputs("]}}\n", out);
   fclose(out);

--- a/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
@@ -77,6 +77,30 @@ describe("native actual real utility continuation planner", () => {
     });
   });
 
+  it("exposes target code location after guarded mappings stop refusing", () => {
+    expect(
+      planNativeActualRealUtilityContinuationAttempt({
+        ...readyInput(),
+        codeLocations: [
+          {
+            id: "code:thread:pc",
+            sourceMapping: "mapping:text",
+            sourceAddress: "0x401000",
+            state: "refused",
+            refusal: {
+              code: "active-syscall",
+              message: "thread is still inside a deferred sleep syscall",
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({
+      state: "refused",
+      blockingBoundary: "target-code-location",
+      blockingRefusal: { code: "active-syscall" },
+    });
+  });
+
   it("refuses missing or failed target module bytes only after unwind matching", () => {
     expect(
       planNativeActualRealUtilityContinuationAttempt({

--- a/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
@@ -61,9 +61,23 @@ function request(): NativeMappingMaterializationRequest {
         target: { materialization: "recreate", targetStart: "0x75000000" },
       }),
       mapping({
-        id: "mapping:unreadable",
+        id: "mapping:guard",
         permissions: { read: false, write: false, execute: false, private: true, shared: false },
-        target: { materialization: "refuse", reason: "unreadable" },
+        target: { materialization: "refuse", reason: "guard page was unreadable at capture" },
+        refusal: { code: "mapping-unreadable", message: "guard mapping has no bytes" },
+      }),
+      mapping({
+        id: "mapping:file-protection",
+        kind: "file",
+        permissions: { read: false, write: false, execute: false, private: true, shared: false },
+        file: { path: "/target/protected-gap.dat", offset: 0 },
+        target: { materialization: "refuse", reason: "file-backed protection mapping" },
+        refusal: { code: "mapping-unreadable", message: "file gap has no current access" },
+      }),
+      mapping({
+        id: "mapping:unreadable-shared",
+        permissions: { read: false, write: false, execute: false, private: false, shared: true },
+        target: { materialization: "refuse", reason: "shared unreadable mapping" },
         refusal: { code: "mapping-unreadable", message: "mapping is unreadable" },
       }),
     ],
@@ -71,10 +85,19 @@ function request(): NativeMappingMaterializationRequest {
 }
 
 describe("native mapping materialization", () => {
-  it("plans target file, captured byte, recreated, and refused mappings", () => {
+  it("plans target file, captured byte, recreated, guard, and refused mappings", () => {
     const result = planNativeMappingMaterialization(request());
 
-    expect(result.refusals).toEqual([expect.objectContaining({ code: "mapping-unreadable" })]);
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "mapping-unreadable",
+        detail: expect.objectContaining({
+          mapping: "mapping:unreadable-shared",
+          perms: "---s",
+          path: "",
+        }),
+      }),
+    ]);
     expect(result.steps).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ mapping: "mapping:text", action: "map-target-file" }),
@@ -82,7 +105,17 @@ describe("native mapping materialization", () => {
         expect.objectContaining({ mapping: "mapping:heap", action: "copy-captured-bytes" }),
         expect.objectContaining({ mapping: "mapping:stack", action: "recreate" }),
         expect.objectContaining({ mapping: "mapping:vdso", action: "recreate" }),
-        expect.objectContaining({ mapping: "mapping:unreadable", action: "refuse" }),
+        expect.objectContaining({
+          mapping: "mapping:guard",
+          action: "recreate",
+          targetStart: "0x1000",
+        }),
+        expect.objectContaining({
+          mapping: "mapping:file-protection",
+          action: "recreate",
+          targetStart: "0x1000",
+        }),
+        expect.objectContaining({ mapping: "mapping:unreadable-shared", action: "refuse" }),
       ]),
     );
     expect(

--- a/packages/runtime/src/__tests__/native-mapping-materializer.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materializer.test.ts
@@ -71,6 +71,7 @@ describe("native mapping materializer proof", () => {
           expect.objectContaining({ mapping: "mapping:heap", action: "copy-captured-bytes" }),
           expect.objectContaining({ mapping: "mapping:stack", action: "recreate" }),
           expect.objectContaining({ mapping: "mapping:vdso", action: "recreate" }),
+          expect.objectContaining({ mapping: "mapping:guard", action: "recreate" }),
           expect.objectContaining({ mapping: "mapping:unreadable", action: "refuse" }),
         ]),
       );

--- a/packages/runtime/src/__tests__/native-mapping-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-policy.test.ts
@@ -20,13 +20,12 @@ interface NativeMappingPolicySummary {
     materialization: string;
     capturedBytes: number;
   }>;
-  unreadableRefusals?: Array<{
+  guardRecreatedMappings?: Array<{
     kind: string;
     materialization: string;
-    refusalCode: string;
     capturedBytes: number;
   }>;
-  mappingRefusals?: Array<{ code: string; message: string }>;
+  mappingRefusals?: Array<{ code: string; message: string; detail?: Record<string, unknown> }>;
 }
 
 afterEach(() => {
@@ -37,7 +36,7 @@ afterEach(() => {
 
 describe("native mapping policy", () => {
   it(
-    "recreates kernel mappings and refuses unreadable mappings precisely",
+    "recreates kernel and guard mappings without copying source bytes",
     { timeout: 120_000 },
     () => {
       const outDir = mkdtempSync(join(tmpdir(), "native-mapping-policy-test-"));
@@ -69,18 +68,21 @@ describe("native mapping policy", () => {
           expect.objectContaining({ materialization: "recreate", capturedBytes: 0 }),
         ]),
       );
-      expect(summary.unreadableRefusals).toEqual(
+      expect(summary.guardRecreatedMappings).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            materialization: "refuse",
-            refusalCode: "mapping-unreadable",
+            materialization: "recreate",
             capturedBytes: 0,
           }),
         ]),
       );
-      expect(summary.mappingRefusals).toEqual(
-        expect.arrayContaining([expect.objectContaining({ code: "mapping-unreadable" })]),
-      );
+      expect(
+        summary.mappingRefusals?.every(
+          (refusal) =>
+            refusal.code !== "mapping-unreadable" ||
+            (refusal.detail?.perms && refusal.detail.sourceStart && refusal.detail.sourceEnd),
+        ),
+      ).toBe(true);
 
       const bundle = validateNativeProcessImageBundle(summary.bundleDir!);
       expect(

--- a/packages/runtime/src/native-mapping-materialization.ts
+++ b/packages/runtime/src/native-mapping-materialization.ts
@@ -54,6 +54,10 @@ function planMapping(
   mapping: NativeMemoryMapping,
   request: NativeMappingMaterializationRequest,
 ): NativeMappingMaterializationStep {
+  if (mapping.target.materialization === "refuse") {
+    return refusedPolicyStep(mapping);
+  }
+
   const permissionRefusal = validatePermissions(mapping);
   if (permissionRefusal) {
     return refusedStep(mapping, permissionRefusal);
@@ -66,12 +70,6 @@ function planMapping(
       return recreatedStep(mapping);
     case "omit":
       return baseStep(mapping, "omit");
-    case "refuse":
-      return refusedStep(
-        mapping,
-        mapping.refusal ??
-          refusal("mapping-ambiguous", `${mapping.id} is refused without a reason`),
-      );
   }
 }
 
@@ -104,6 +102,18 @@ function translatedStep(
   };
 }
 
+function refusedPolicyStep(mapping: NativeMemoryMapping): NativeMappingMaterializationStep {
+  const reason =
+    mapping.refusal ?? refusal("mapping-ambiguous", `${mapping.id} is refused without a reason`);
+  if (reason.code === "mapping-unreadable" && isRecreatableNoAccessProtectionMapping(mapping)) {
+    return noAccessProtectionRecreatedStep(mapping);
+  }
+  if (reason.code === "mapping-unreadable") {
+    return refusedStep(mapping, withMappingDetail(mapping, reason));
+  }
+  return refusedStep(mapping, reason);
+}
+
 function recreatedStep(mapping: NativeMemoryMapping): NativeMappingMaterializationStep {
   if (mapping.captured) {
     return refusedStep(
@@ -115,6 +125,15 @@ function recreatedStep(mapping: NativeMemoryMapping): NativeMappingMaterializati
     );
   }
   return baseStep(mapping, "recreate");
+}
+
+function noAccessProtectionRecreatedStep(
+  mapping: NativeMemoryMapping,
+): NativeMappingMaterializationStep {
+  return {
+    ...baseStep(mapping, "recreate"),
+    targetStart: mapping.target.targetStart ?? mapping.sourceStart,
+  };
 }
 
 function baseStep(
@@ -143,6 +162,50 @@ function validatePermissions(mapping: NativeMemoryMapping): NativeProcessImageRe
     return refusal("mapping-permission-unsupported", `${mapping.id} is writable and executable`);
   }
   return undefined;
+}
+
+function isRecreatableNoAccessProtectionMapping(mapping: NativeMemoryMapping): boolean {
+  return (
+    noAccessPrivate(mapping) &&
+    !mapping.captured &&
+    ["anonymous", "stack", "file"].includes(mapping.kind)
+  );
+}
+
+function noAccessPrivate(mapping: NativeMemoryMapping): boolean {
+  return [
+    !mapping.permissions.read,
+    !mapping.permissions.write,
+    !mapping.permissions.execute,
+    mapping.permissions.private,
+    !mapping.permissions.shared,
+  ].every(Boolean);
+}
+
+function withMappingDetail(
+  mapping: NativeMemoryMapping,
+  reason: NativeProcessImageRefusal,
+): NativeProcessImageRefusal {
+  return {
+    ...reason,
+    detail: {
+      ...reason.detail,
+      mapping: mapping.id,
+      kind: mapping.kind,
+      sourceStart: mapping.sourceStart,
+      sourceEnd: mapping.sourceEnd,
+      sizeBytes: mapping.sizeBytes,
+      perms: permissionString(mapping),
+      path: mapping.file?.path ?? "",
+      permissions: mapping.permissions,
+    },
+  };
+}
+
+function permissionString(mapping: NativeMemoryMapping): string {
+  return `${mapping.permissions.read ? "r" : "-"}${mapping.permissions.write ? "w" : "-"}${
+    mapping.permissions.execute ? "x" : "-"
+  }${mapping.permissions.shared ? "s" : mapping.permissions.private ? "p" : "-"}`;
 }
 
 function validateTargetStart(mapping: NativeMemoryMapping): NativeProcessImageRefusal | undefined {

--- a/scripts/native-mapping-materializer.ts
+++ b/scripts/native-mapping-materializer.ts
@@ -68,10 +68,11 @@ function verifyNativeMappingMaterializer(outDir: string) {
   assertAction(plan, "mapping:heap", "copy-captured-bytes");
   assertAction(plan, "mapping:stack", "recreate");
   assertAction(plan, "mapping:vdso", "recreate");
+  assertAction(plan, "mapping:guard", "recreate");
   assertAction(plan, "mapping:unreadable", "refuse");
   assert(
     plan.refusals.some((refusal) => refusal.code === "mapping-unreadable"),
-    "unreadable mapping refusal was not preserved",
+    "unsafe unreadable mapping refusal was not preserved",
   );
 
   const materializerEvent = runMaterializer(materializer, textFile, memoryFile);
@@ -115,14 +116,24 @@ function mappingPlan(textFile: string, textBuildId: string): NativeMemoryMapping
     recreatedMapping("mapping:stack", "stack", STACK_TARGET_START, PAGE_SIZE * 2),
     recreatedMapping("mapping:vdso", "vdso", RECREATE_TARGET_START, PAGE_SIZE),
     {
-      id: "mapping:unreadable",
+      id: "mapping:guard",
       kind: "anonymous",
       sourceStart: "0x800000",
       sourceEnd: "0x801000",
       sizeBytes: PAGE_SIZE,
       permissions: { read: false, write: false, execute: false, private: true, shared: false },
-      target: { materialization: "refuse", reason: "mapping is not readable" },
-      refusal: { code: "mapping-unreadable", message: "mapping is not readable" },
+      target: { materialization: "refuse", reason: "guard mapping is not readable" },
+      refusal: { code: "mapping-unreadable", message: "guard mapping is not readable" },
+    },
+    {
+      id: "mapping:unreadable",
+      kind: "anonymous",
+      sourceStart: "0xa00000",
+      sourceEnd: "0xa01000",
+      sizeBytes: PAGE_SIZE,
+      permissions: { read: false, write: false, execute: false, private: false, shared: true },
+      target: { materialization: "refuse", reason: "shared mapping is not readable" },
+      refusal: { code: "mapping-unreadable", message: "shared mapping is not readable" },
     },
   ];
 }

--- a/scripts/native-mapping-policy.ts
+++ b/scripts/native-mapping-policy.ts
@@ -66,11 +66,11 @@ function verifyNativeMappingPolicy(outDir: string) {
 
   const bundle = validateNativeProcessImageBundle(bundleDir);
   const kernelMappings = bundle.mappings.mappings.filter(isKernelRecreatedMapping);
-  const unreadableMappings = bundle.mappings.mappings.filter(isUnreadableRefusal);
+  const guardMappings = bundle.mappings.mappings.filter(isGuardRecreatedMapping);
   assert(kernelMappings.length > 0, "capture did not report kernel recreated mappings");
-  assert(unreadableMappings.length > 0, "capture did not refuse the PROT_NONE mapping");
-  for (const mapping of kernelMappings) {
-    assert(!mapping.captured, `${mapping.id} kernel mapping unexpectedly copied source bytes`);
+  assert(guardMappings.length > 0, "capture did not recreate the PROT_NONE guard mapping");
+  for (const mapping of [...kernelMappings, ...guardMappings]) {
+    assert(!mapping.captured, `${mapping.id} recreated mapping unexpectedly copied source bytes`);
   }
 
   return {
@@ -83,7 +83,7 @@ function verifyNativeMappingPolicy(outDir: string) {
     targetArch: bundle.manifest.target.arch,
     mappingCount: bundle.mappings.mappings.length,
     kernelRecreatedMappings: kernelMappings.map(mappingSummary),
-    unreadableRefusals: unreadableMappings.map(mappingSummary),
+    guardRecreatedMappings: guardMappings.map(mappingSummary),
     mappingRefusals: bundle.mappings.refusals.refusals,
     bundleFiles: bundleFileStats(bundleDir, NATIVE_PROCESS_IMAGE_BUNDLE_FILES),
   };
@@ -96,12 +96,18 @@ function isKernelRecreatedMapping(mapping: NativeMemoryMapping) {
   );
 }
 
-function isUnreadableRefusal(mapping: NativeMemoryMapping) {
-  return (
-    !mapping.permissions.read &&
-    mapping.target.materialization === "refuse" &&
-    mapping.refusal?.code === "mapping-unreadable"
-  );
+function isGuardRecreatedMapping(mapping: NativeMemoryMapping) {
+  return noAccessPrivate(mapping) && mapping.target.materialization === "recreate";
+}
+
+function noAccessPrivate(mapping: NativeMemoryMapping) {
+  return [
+    !mapping.permissions.read,
+    !mapping.permissions.write,
+    !mapping.permissions.execute,
+    mapping.permissions.private,
+    !mapping.permissions.shared,
+  ].every(Boolean);
 }
 
 function mappingSummary(mapping: NativeMemoryMapping) {
@@ -128,7 +134,7 @@ function oppositeArch(arch: string) {
 
 function printSummary(summary: ReturnType<typeof verifyNativeMappingPolicy>) {
   console.log(
-    `native-mapping-policy: mappings=${summary.mappingCount} kernelRecreated=${summary.kernelRecreatedMappings.length} unreadableRefusals=${summary.unreadableRefusals.length}`,
+    `native-mapping-policy: mappings=${summary.mappingCount} kernelRecreated=${summary.kernelRecreatedMappings.length} guardRecreated=${summary.guardRecreatedMappings.length}`,
   );
 }
 


### PR DESCRIPTION
## Problem

The real `/bin/sleep` proof got past the sleep syscall only to stop on no-access memory mappings. Some of those mappings are just guard pages. They have no bytes to copy, so treating all of them as fatal hid the next real blocker.

## Solution

The capturer and planner now recreate private no-access guard/protection mappings as target `PROT_NONE` reservations. Unsafe unreadable mappings still fail closed with exact details like range, path, kind, and permissions. With the explicit sleep policy, the actual utility proof now gets past mapping materialization and stops at the next gate, `target-code-location`.

Closes #514
