### PR TITLE
Map code for deferred sleep syscalls

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -31,9 +31,10 @@ The default real utility is `sleep`, so default policy still refuses at thread
 state when the process is inside `clock_nanosleep`. With the explicit
 `MACHINEN_ACTUAL_REAL_UTILITY_SLEEP_SYSCALL_POLICY=defer-target-resume` policy,
 the proof records a deferred target timer continuation, recreates safe
-`PROT_NONE` guard/protection mappings, and exposes the next blocker
-(`target-code-location` for the current `/bin/sleep` capture) instead of
-granting success.
+`PROT_NONE` guard/protection mappings, and lets the target-code-location gate
+consume the deferred sleep metadata. Without an explicit amd64 target root, the
+current proof then refuses precisely with `target-module-missing` for the active
+libc frame instead of granting success.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-deferred-sleep-code-location.md
+++ b/docs/snapshot/native-deferred-sleep-code-location.md
@@ -1,0 +1,35 @@
+# Native deferred sleep code-location policy
+
+Issue #516 lets the target-code-location gate consume the explicit sleep/timer
+continuation metadata from #512.
+
+## Default behavior
+
+Active syscalls still refuse before target code mapping by default. A thread in
+`clock_nanosleep` without a deferred continuation produces `active-syscall` at
+the target-code-location gate.
+
+## Explicit deferred sleep path
+
+When a thread has a `sleep-timer` continuation with
+`action: "defer-target-resume"`, code-location mapping may move past the generic
+`active-syscall` refusal and use the captured PC for normal module/RVA matching.
+If a target module is available, the result records a deferred active syscall
+landing:
+
+- thread id;
+- source PC;
+- target address;
+- syscall class and syscall metadata;
+- conservative timer re-arm policy.
+
+This does not resume the source syscall. It only proves where target-native code
+would continue after the target timer policy is satisfied. If no explicit target
+module matches, the proof now refuses precisely with `target-module-missing`
+instead of falling back to `active-syscall`.
+
+## Boundary
+
+Fd-blocking, restart, unknown, or missing continuation states still fail closed.
+The policy does not use source-ISA emulation, source text reuse, sidecars, or app
+hooks.

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -75,3 +75,4 @@ See also:
 - [Native active syscall policy](./native-active-syscall-policy.md)
 - [Native sleep syscall continuation policy](./native-sleep-syscall-policy.md)
 - [Native guard mapping materialization](./native-guard-mapping-materialization.md)
+- [Native deferred sleep code-location policy](./native-deferred-sleep-code-location.md)

--- a/docs/snapshot/native-real-utility-code-map.md
+++ b/docs/snapshot/native-real-utility-code-map.md
@@ -9,8 +9,9 @@ or raw source virtual addresses as amd64 code.
 
 For each captured thread:
 
-1. Refuse first if the thread is not `outside-syscall`. That keeps #492's
-   active-syscall safety gate ahead of target-code work.
+1. Refuse first if the thread is not `outside-syscall`, unless it carries an
+   explicit deferred sleep/timer continuation. That keeps #492's active-syscall
+   safety gate ahead of target-code work by default.
 2. Find the executable source mapping that contains the captured PC.
 3. Build source module identity from the mapping path, kind, source arch,
    build identity, load bias, and text mapping id.
@@ -20,6 +21,8 @@ For each captured thread:
 6. Accept only if the target module is executable, has the expected target build
    id, and maps that RVA as executable target code.
 7. Produce `targetAddress = targetModule.loadBias + sourceRva`.
+8. If the thread was inside a deferred sleep/timer syscall, record a deferred
+   target landing without marking the source syscall resumed.
 
 The proof reports `sourceTextReusedAsTargetCode: false` and does not attempt a
 resume. It only proves that the next native continuation address is selected
@@ -27,7 +30,8 @@ from target-native module metadata.
 
 ## Precise refusals
 
-- `active-syscall` — thread-state safety wins before code mapping.
+- `active-syscall` — thread-state safety wins before code mapping unless an
+  explicit deferred sleep/timer continuation is present.
 - `target-module-missing` — no explicit target module matches the source module.
 - `target-module-not-executable` — the matched target module is not executable
   code.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -99,6 +99,7 @@
 - [`NativeRealUtilitySourceModule`](#nativerealutilitysourcemodule)
 - [`NativeRealUtilityTargetModule`](#nativerealutilitytargetmodule)
 - [`NativeRealUtilityModuleExpectation`](#nativerealutilitymoduleexpectation)
+- [`NativeRealUtilityDeferredActiveSyscallLanding`](#nativerealutilitydeferredactivesyscalllanding)
 - [`NativeRealUtilityResolvedLocation`](#nativerealutilityresolvedlocation)
 - [`NativeRealUtilityCodeLocationRequest`](#nativerealutilitycodelocationrequest)
 - [`NativeRealUtilityCodeLocationResult`](#nativerealutilitycodelocationresult)
@@ -3817,6 +3818,60 @@ by default when `output` is a TTY.
 
 ***
 
+### NativeRealUtilityDeferredActiveSyscallLanding
+
+#### Properties
+
+##### threadId
+
+> **threadId**: `string`
+
+##### sourceAddress
+
+> **sourceAddress**: `string`
+
+##### targetAddress
+
+> **targetAddress**: `string`
+
+##### syscallClass
+
+> **syscallClass**: `"sleep-timer"`
+
+##### action
+
+> **action**: `"defer-target-resume"`
+
+##### syscall
+
+> **syscall**: `object`
+
+###### state
+
+> **state**: `"outside-syscall"` \| `"inside-syscall"` \| `"restart-block"`
+
+###### number?
+
+> `optional` **number?**: `number`
+
+###### name?
+
+> `optional` **name?**: `string`
+
+##### metadata
+
+> **metadata**: `object`
+
+###### remainingTime
+
+> **remainingTime**: `"not-captured"`
+
+###### policy
+
+> **policy**: `"conservative-target-timer-rearm-required"`
+
+***
+
 ### NativeRealUtilityResolvedLocation
 
 #### Properties
@@ -3845,6 +3900,10 @@ by default when `output` is a TTY.
 
 > **codeLocation**: [`NativeCodeLocationMapping`](#nativecodelocationmapping)
 
+##### deferredActiveSyscallLanding?
+
+> `optional` **deferredActiveSyscallLanding?**: [`NativeRealUtilityDeferredActiveSyscallLanding`](#nativerealutilitydeferredactivesyscalllanding)
+
 ***
 
 ### NativeRealUtilityCodeLocationRequest
@@ -3870,6 +3929,10 @@ by default when `output` is a TTY.
 ##### threadIds?
 
 > `optional` **threadIds?**: `string`[]
+
+##### activeSyscallContinuations?
+
+> `optional` **activeSyscallContinuations?**: [`NativeActiveSyscallContinuation`](#nativeactivesyscallcontinuation)[]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-real-utility-code-map.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility-code-map.test.ts
@@ -164,6 +164,51 @@ describe("native real utility code-location map", () => {
     expect(result.codeLocations[0]).toMatchObject({ state: "refused" });
   });
 
+  it("maps deferred sleep/timer syscall code locations without marking the syscall resumed", () => {
+    const activeThread = thread({
+      syscall: { state: "inside-syscall", number: 230, name: "clock_nanosleep" },
+    });
+    const continuation = {
+      threadId: activeThread.id,
+      syscallClass: "sleep-timer" as const,
+      action: "defer-target-resume" as const,
+      syscall: activeThread.syscall,
+      metadata: {
+        remainingTime: "not-captured" as const,
+        policy: "conservative-target-timer-rearm-required" as const,
+      },
+    };
+    const result = resolveNativeRealUtilityCodeLocations({
+      documents: documents({ activeThread }),
+      targetArch: "amd64",
+      targetModules: [targetModule()],
+      activeSyscallContinuations: [continuation],
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.codeLocations[0]).toMatchObject({
+      state: "mapped",
+      targetAddress: "0x700000001234",
+    });
+    expect(result.resolved[0]?.deferredActiveSyscallLanding).toMatchObject({
+      threadId: activeThread.id,
+      syscallClass: "sleep-timer",
+      action: "defer-target-resume",
+      sourceAddress: "0x401234",
+      targetAddress: "0x700000001234",
+      metadata: { remainingTime: "not-captured" },
+    });
+
+    expect(
+      resolveNativeRealUtilityCodeLocations({
+        documents: documents({ activeThread }),
+        targetArch: "amd64",
+        targetModules: [],
+        activeSyscallContinuations: [continuation],
+      }).refusals[0]?.code,
+    ).toBe("target-module-missing");
+  });
+
   it("uses precise refusals for missing, non-executable, mismatched, and unmapped targets", () => {
     const source = documents();
     const baseRequest = {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -127,6 +127,7 @@ export { materializeNativeTargetModuleBytes } from "./native-target-module-bytes
 export type {
   NativeRealUtilityCodeLocationRequest,
   NativeRealUtilityCodeLocationResult,
+  NativeRealUtilityDeferredActiveSyscallLanding,
   NativeRealUtilityExecutableRange,
   NativeRealUtilityModuleExpectation,
   NativeRealUtilityResolvedLocation,

--- a/packages/runtime/src/native-real-utility-code-map.ts
+++ b/packages/runtime/src/native-real-utility-code-map.ts
@@ -1,6 +1,8 @@
 /** Real utility module/RVA code-location resolution. */
 
 import { basename } from "node:path";
+import type { NativeActiveSyscallContinuation } from "./native-active-syscall-policy.ts";
+import type { NativeCodeModule } from "./native-code-map.ts";
 import type {
   NativeCodeLocationMapping,
   NativeMemoryMapping,
@@ -10,7 +12,6 @@ import type {
   NativeRegisterState,
   NativeThreadState,
 } from "./native-process-image.ts";
-import type { NativeCodeModule } from "./native-code-map.ts";
 
 export interface NativeRealUtilityExecutableRange {
   relativeStart: string;
@@ -35,6 +36,16 @@ export interface NativeRealUtilityModuleExpectation {
   expectedTargetBuildId?: string;
 }
 
+export interface NativeRealUtilityDeferredActiveSyscallLanding {
+  threadId: string;
+  sourceAddress: string;
+  targetAddress: string;
+  syscallClass: NativeActiveSyscallContinuation["syscallClass"];
+  action: NativeActiveSyscallContinuation["action"];
+  syscall: NativeActiveSyscallContinuation["syscall"];
+  metadata: NativeActiveSyscallContinuation["metadata"];
+}
+
 export interface NativeRealUtilityResolvedLocation {
   threadId: string;
   sourceModule: NativeRealUtilitySourceModule;
@@ -42,6 +53,7 @@ export interface NativeRealUtilityResolvedLocation {
   sourceRva: string;
   targetAddress: string;
   codeLocation: NativeCodeLocationMapping;
+  deferredActiveSyscallLanding?: NativeRealUtilityDeferredActiveSyscallLanding;
 }
 
 export interface NativeRealUtilityCodeLocationRequest {
@@ -50,6 +62,7 @@ export interface NativeRealUtilityCodeLocationRequest {
   targetModules: NativeRealUtilityTargetModule[];
   moduleExpectations?: NativeRealUtilityModuleExpectation[];
   threadIds?: string[];
+  activeSyscallContinuations?: NativeActiveSyscallContinuation[];
 }
 
 export interface NativeRealUtilityCodeLocationResult {
@@ -110,7 +123,11 @@ function resolveThreadCodeLocation(
   sourceModules: NativeRealUtilitySourceModule[],
   thread: NativeThreadState,
 ): NativeRealUtilityResolvedLocation | { refusal: NativeProcessImageRefusal } {
-  if (thread.syscall.state !== "outside-syscall") {
+  const deferredContinuation = deferredContinuationForThread(
+    request.activeSyscallContinuations ?? [],
+    thread,
+  );
+  if (thread.syscall.state !== "outside-syscall" && !deferredContinuation) {
     return {
       refusal: refusal("active-syscall", `thread ${thread.id} is ${thread.syscall.state}`, {
         threadId: thread.id,
@@ -155,6 +172,49 @@ function resolveThreadCodeLocation(
     sourceRva: hex(sourceRva),
     targetAddress: hex(targetAddress),
     codeLocation,
+    deferredActiveSyscallLanding: deferredContinuation
+      ? deferredLanding(thread, deferredContinuation, sourcePc, targetAddress)
+      : undefined,
+  };
+}
+
+function deferredContinuationForThread(
+  continuations: NativeActiveSyscallContinuation[],
+  thread: NativeThreadState,
+): NativeActiveSyscallContinuation | undefined {
+  if (thread.syscall.state === "outside-syscall") {
+    return undefined;
+  }
+  return continuations.find(
+    (continuation) =>
+      continuation.threadId === thread.id &&
+      continuation.action === "defer-target-resume" &&
+      continuation.syscallClass === "sleep-timer" &&
+      sameSyscall(continuation.syscall, thread.syscall),
+  );
+}
+
+function sameSyscall(
+  left: NativeActiveSyscallContinuation["syscall"],
+  right: NativeThreadState["syscall"],
+): boolean {
+  return left.state === right.state && left.number === right.number && left.name === right.name;
+}
+
+function deferredLanding(
+  thread: NativeThreadState,
+  continuation: NativeActiveSyscallContinuation,
+  sourcePc: bigint,
+  targetAddress: bigint,
+): NativeRealUtilityDeferredActiveSyscallLanding {
+  return {
+    threadId: thread.id,
+    sourceAddress: hex(sourcePc),
+    targetAddress: hex(targetAddress),
+    syscallClass: continuation.syscallClass,
+    action: continuation.action,
+    syscall: continuation.syscall,
+    metadata: continuation.metadata,
   };
 }
 

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -121,6 +121,7 @@ const TOC = {
     "NativeRealUtilitySourceModule",
     "NativeRealUtilityTargetModule",
     "NativeRealUtilityModuleExpectation",
+    "NativeRealUtilityDeferredActiveSyscallLanding",
     "NativeRealUtilityResolvedLocation",
     "NativeRealUtilityCodeLocationRequest",
     "NativeRealUtilityCodeLocationResult",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -192,6 +192,7 @@ function planCapturedActualUtilityBundle(
     documents: bundle,
     targetArch: "amd64",
     targetModules,
+    activeSyscallContinuations: activeSyscalls.continuations,
   });
   const targetBytes = materializeResolvedTargetBytes(code.resolved, options.targetRoot);
   const plan = planNativeActualRealUtilityContinuationAttempt({
@@ -330,6 +331,7 @@ function actualUtilitySummary(context: {
     resourceRefusals: planned.resources.refusals,
     mappingRefusals: planned.mappings.refusals,
     codeLocationRefusals: planned.code.refusals,
+    deferredActiveSyscallLandings: deferredActiveSyscallLandingSummaries(planned),
     sourceUnwindFrames: planned.sourceFrames.length,
     targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
     targetModuleByteRefusals: planned.targetBytes.refusals,
@@ -381,6 +383,26 @@ function effectiveThreadRefusals(
     return planned.registers.refusals.filter((refusal) => refusal.code !== "active-syscall");
   }
   return planned.registers.refusals;
+}
+
+function deferredActiveSyscallLandingSummaries(
+  planned: ReturnType<typeof planCapturedActualUtilityBundle>,
+) {
+  return planned.code.resolved.flatMap((location) => {
+    const landing = location.deferredActiveSyscallLanding;
+    return landing
+      ? [
+          {
+            threadId: landing.threadId,
+            syscallClass: landing.syscallClass,
+            action: landing.action,
+            sourceAddress: landing.sourceAddress,
+            targetAddress: landing.targetAddress,
+            remainingTime: landing.metadata.remainingTime,
+          },
+        ]
+      : [];
+  });
 }
 
 function materializedTargetByteSummaries(


### PR DESCRIPTION
## Problem

After the sleep and mapping gates, the real `/bin/sleep` proof still stopped at target code mapping. The mapper saw an active syscall and refused before it could even check whether target-native code existed.

## Solution

The mapper now has one narrow exception. If a thread has the explicit deferred sleep/timer continuation, it may map the captured PC by module and RVA. It still does not resume the source syscall, and active fd, restart, unknown, or missing continuation states still fail closed.

Closes #516
