### PR TITLE
Discover actual source unwind frames

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -34,8 +34,9 @@ the proof records a deferred target timer continuation, recreates safe
 `PROT_NONE` guard/protection mappings, and lets the target-code-location gate
 consume the deferred sleep metadata. Without an explicit amd64 target root, the current proof then refuses precisely
 with `target-module-missing` for the active libc frame instead of granting
-success. With a target root, the proof can inventory target libc, materialize
-native libc bytes, and expose the `source-unwind` gate.
+success. With a target root and source unwind sidecar, the proof can inventory
+target libc, materialize native libc bytes, discover the source libc frame, and
+expose the target-unwind gate.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-actual-source-unwind.md
+++ b/docs/snapshot/native-actual-source-unwind.md
@@ -1,0 +1,31 @@
+# Native actual source unwind discovery
+
+Issue #520 discovers source unwind metadata for actual real-utility libc frames.
+
+## What is new
+
+The actual arm64 `/bin/sleep` proof can now parse source `.eh_frame` metadata for
+the active libc frame and write a `native-source-unwind.json` proof sidecar into
+the source bundle. A later amd64 target-planning run consumes that sidecar and
+passes the source-unwind gate.
+
+## Shared-object support
+
+Real libc `.eh_frame` FDE program counters are module-relative. The parser now
+accepts a source module load bias, matches the module-relative PC, and emits a
+loaded rule whose range covers the captured absolute source PC.
+
+The arm64 libc frame shape observed for `clock_nanosleep` uses:
+
+- CFA based on `sp` plus an offset;
+- saved `x30` at a CFA-relative slot.
+
+That shape is modeled explicitly. Unsupported unwind rules still fail closed with
+`unwind-rule-unsupported`.
+
+## Boundary
+
+The sidecar contains unwind rules and discovered source frames, not source text.
+It does not resume the process, emulate arm64, or claim that target unwind state
+matches yet. Missing metadata, missing stack bytes, or unreadable return slots
+remain precise refusals.

--- a/docs/snapshot/native-actual-target-module-inventory.md
+++ b/docs/snapshot/native-actual-target-module-inventory.md
@@ -29,7 +29,8 @@ load bias, and an executable RVA range. Source text is never used as target code
 
 With explicit sleep deferral and an amd64 target root, the actual `/bin/sleep`
 proof can move past the previous `target-module-missing` blocker for libc,
-materialize target-native libc bytes, and expose the next `source-unwind` gate.
+materialize target-native libc bytes, and, when source unwind metadata is
+available, expose the next target-unwind gate.
 If no target root is supplied, the proof still fails closed with
 `target-module-missing`.
 

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -77,3 +77,4 @@ See also:
 - [Native guard mapping materialization](./native-guard-mapping-materialization.md)
 - [Native deferred sleep code-location policy](./native-deferred-sleep-code-location.md)
 - [Native actual target module inventory](./native-actual-target-module-inventory.md)
+- [Native actual source unwind discovery](./native-actual-source-unwind.md)

--- a/docs/snapshot/native-real-utility-eh-frame.md
+++ b/docs/snapshot/native-real-utility-eh-frame.md
@@ -10,11 +10,14 @@ stack-walking tools need it.
 The parser consumes `readelf --debug-dump=frames` output from a real binary or a
 stripped fixture and extracts the FDE covering the captured source PC.
 
-The first modeled arm64 rule is intentionally narrow:
+The first modeled arm64 rules are intentionally narrow:
 
-- CFA is based on `x29` with a constant offset.
+- CFA is based on `x29` or `sp` with a constant offset.
 - saved return address `x30` is at a CFA-relative stack slot.
 - captured stack bytes must include that return-address slot.
+
+For loaded shared objects, callers can provide a load bias so module-relative FDE
+PC ranges are relocated to captured process addresses.
 
 When those rules are present, `discoverNativeUnwindFrames()` produces a
 `NativeStackFrame` with the source SP, CFA, return address, and return-address

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2416,6 +2416,14 @@ by default when `output` is a TTY.
 
 [`NativeRealUtilityContinuationRequest`](#nativerealutilitycontinuationrequest).[`sourceFrames`](#sourceframes-1)
 
+##### sourceFrameRefusals?
+
+> `optional` **sourceFrameRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+###### Inherited from
+
+[`NativeRealUtilityContinuationRequest`](#nativerealutilitycontinuationrequest).[`sourceFrameRefusals`](#sourceframerefusals-1)
+
 ##### targetUnwind?
 
 > `optional` **targetUnwind?**: [`NativeTargetUnwindMatchResult`](#nativetargetunwindmatchresult)
@@ -4029,6 +4037,10 @@ by default when `output` is a TTY.
 
 > **sourceFrames**: [`NativeDiscoveredUnwindFrame`](#nativediscoveredunwindframe)[]
 
+##### sourceFrameRefusals?
+
+> `optional` **sourceFrameRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
 ##### targetUnwind?
 
 > `optional` **targetUnwind?**: [`NativeTargetUnwindMatchResult`](#nativetargetunwindmatchresult)
@@ -4640,6 +4652,10 @@ by default when `output` is a TTY.
 ##### pc
 
 > **pc**: `string`
+
+##### loadBias?
+
+> `optional` **loadBias?**: `string`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-unwind-frames.test.ts
+++ b/packages/runtime/src/__tests__/native-unwind-frames.test.ts
@@ -126,6 +126,30 @@ describe("native unwind frame discovery", () => {
     ]);
   });
 
+  it("parses loaded shared-object .eh_frame text with sp CFA rules", () => {
+    const result = parseNativeEhFrameText({
+      readelfFrames: `
+00011130 0000000000000034 00011134 FDE cie=00000000 pc=00000000000b6c60..00000000000b6d0c
+  DW_CFA_advance_loc: 12 to 00000000000b6c6c
+  DW_CFA_def_cfa_offset: 48
+  DW_CFA_offset: r29 (x29) at cfa-48
+  DW_CFA_offset: r30 (x30) at cfa-40
+`,
+      mapping: "mapping:libc-text",
+      functionName: "libc.so.6",
+      pc: "0xec3f389e6ca0",
+      loadBias: "0xec3f38930000",
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.rules[0]).toMatchObject({
+      pcStart: "0xec3f389e6c60",
+      pcEnd: "0xec3f389e6d0c",
+      cfa: { register: "sp", offset: 48 },
+      returnAddress: { location: "cfa-relative", offset: -40 },
+    });
+  });
+
   it("uses precise .eh_frame parse refusals", () => {
     expect(
       parseNativeEhFrameText({

--- a/packages/runtime/src/native-real-utility-continuation.ts
+++ b/packages/runtime/src/native-real-utility-continuation.ts
@@ -22,6 +22,7 @@ export interface NativeRealUtilityContinuationRequest {
   mappingRefusals?: NativeProcessImageRefusal[];
   codeLocations: NativeCodeLocationMapping[];
   sourceFrames: NativeDiscoveredUnwindFrame[];
+  sourceFrameRefusals?: NativeProcessImageRefusal[];
   targetUnwind?: NativeTargetUnwindMatchResult;
   targetUnwindMatched?: boolean;
 }
@@ -67,6 +68,7 @@ function firstOrderedRefusal(
     firstRefusal("resource-boundary", request.resourceRefusals) ??
     firstRefusal("mapping-materialization", request.mappingRefusals) ??
     codeLocationRefusal(request.codeLocations) ??
+    firstRefusal("source-unwind", request.sourceFrameRefusals) ??
     sourceUnwindRefusal(request.sourceFrames)
   );
 }

--- a/packages/runtime/src/native-unwind-frames.ts
+++ b/packages/runtime/src/native-unwind-frames.ts
@@ -45,6 +45,7 @@ export interface NativeEhFrameTextParseRequest {
   mapping: string;
   functionName: string;
   pc: string;
+  loadBias?: string;
 }
 
 export interface NativeEhFrameTextParseResult {
@@ -102,8 +103,10 @@ export function parseNativeEhFrameText(
     };
   }
   const pc = BigInt(request.pc);
+  const loadBias = BigInt(request.loadBias ?? "0x0");
+  const metadataPc = pc - loadBias;
   const block = nativeEhFrameTextBlocks(request.readelfFrames).find(
-    (candidate) => pc >= candidate.start && pc < candidate.end,
+    (candidate) => metadataPc >= candidate.start && metadataPc < candidate.end,
   );
   if (!block) {
     return {
@@ -139,50 +142,59 @@ function ehFrameRuleFromBlock(
   request: NativeEhFrameTextParseRequest,
   block: { start: bigint; end: bigint; lines: string[] },
 ): { rule: NativeUnwindFrameRule } | { refusal: NativeProcessImageRefusal } {
-  const cfaOffset = cfaOffsetFromX29(block.lines);
+  const cfa = cfaRuleFromBlock(block.lines);
   const returnAddressOffset = nativeLastCapture(
     block.lines,
     /DW_CFA_offset: r30(?: \([^)]*\))? at cfa([+-]\d+)/,
   );
-  if (!cfaOffset || !returnAddressOffset) {
+  if (!cfa || !returnAddressOffset) {
     return {
       refusal: unwindRefusal(
         "unwind-rule-unsupported",
-        `.eh_frame FDE for ${request.functionName} does not use modeled x29 CFA and cfa-relative x30 rules`,
+        `.eh_frame FDE for ${request.functionName} does not use modeled arm64 CFA and cfa-relative x30 rules`,
       ),
     };
   }
+  const loadBias = BigInt(request.loadBias ?? "0x0");
   return {
     rule: {
-      id: `eh-frame:${request.functionName}:${hex(block.start)}`,
+      id: `eh-frame:${request.functionName}:${hex(block.start + loadBias)}`,
       functionName: request.functionName,
       mapping: request.mapping,
-      pcStart: hex(block.start),
-      pcEnd: hex(block.end),
+      pcStart: hex(block.start + loadBias),
+      pcEnd: hex(block.end + loadBias),
       metadata: "eh-frame",
-      cfa: { register: "x29", offset: Number.parseInt(cfaOffset, 10) },
+      cfa,
       returnAddress: { location: "cfa-relative", offset: Number.parseInt(returnAddressOffset, 10) },
     },
   };
 }
 
-function cfaOffsetFromX29(lines: string[]) {
-  const combined = nativeLastCapture(lines, /DW_CFA_def_cfa: r29(?: \([^)]*\))? ofs:? (\d+)/);
-  if (combined) {
-    return combined;
+function cfaRuleFromBlock(lines: string[]): NativeUnwindFrameRule["cfa"] | undefined {
+  const combinedX29 = nativeLastCapture(lines, /DW_CFA_def_cfa: r29(?: \([^)]*\))? ofs:? (\d+)/);
+  if (combinedX29) {
+    return { register: "x29", offset: Number.parseInt(combinedX29, 10) };
   }
+  const combinedSp = nativeLastCapture(lines, /DW_CFA_def_cfa: r31(?: \([^)]*\))? ofs:? (\d+)/);
+  if (combinedSp) {
+    return { register: "sp", offset: Number.parseInt(combinedSp, 10) };
+  }
+
   let offset: string | undefined;
-  let registerIsX29 = false;
+  let register: "sp" | "x29" = "sp";
   for (const line of lines) {
     const offsetMatch = /DW_CFA_def_cfa_offset: (\d+)/.exec(line);
     if (offsetMatch?.[1]) {
       offset = offsetMatch[1];
     }
     if (/DW_CFA_def_cfa_register: r29(?: \([^)]*\))?/.test(line)) {
-      registerIsX29 = true;
+      register = "x29";
+    }
+    if (/DW_CFA_def_cfa_register: r31(?: \([^)]*\))?/.test(line)) {
+      register = "sp";
     }
   }
-  return registerIsX29 ? offset : undefined;
+  return offset ? { register, offset: Number.parseInt(offset, 10) } : undefined;
 }
 
 function resolveUnwindRule(

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { existsSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { classifyNativeActiveSyscalls } from "../packages/runtime/src/native-active-syscall-policy.ts";
 import { planNativeMappingMaterialization } from "../packages/runtime/src/native-mapping-materialization.ts";
@@ -11,7 +11,18 @@ import {
 import { planNativeActualRealUtilityContinuationAttempt } from "../packages/runtime/src/native-actual-real-utility-continuation.ts";
 import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/native-target-module-bytes.ts";
 import {
+  discoverNativeUnwindFrames,
+  nativeUnwindReturnAddressSlot,
+  parseNativeEhFrameText,
+  type NativeDiscoveredUnwindFrame,
+  type NativeUnwindFrameRule,
+} from "../packages/runtime/src/native-unwind-frames.ts";
+import {
   validateNativeProcessImageBundle,
+  type NativeArm64Registers,
+  type NativeMemoryMapping,
+  type NativeProcessImageDocuments,
+  type NativeProcessImageRefusal,
   type NativeThreadState,
 } from "../packages/runtime/src/native-process-image.ts";
 import { translateNativeRegisterState } from "../packages/runtime/src/native-register-translation.ts";
@@ -31,12 +42,14 @@ import {
   emitResult,
   emitSkip,
   parseVerifyArgs,
+  runCommand,
 } from "./proof-script-utils.mjs";
 import {
   FINAL_JUMP_TARGET_ENTRY,
   FINAL_JUMP_TARGET_STACK_POINTER,
   finalJumpHex,
 } from "./native-final-jump-utils.ts";
+import { readCapturedU64 } from "./native-captured-source-utils.ts";
 import { spawnSync } from "node:child_process";
 
 const USAGE =
@@ -48,6 +61,7 @@ const SLEEP_SYSCALL_POLICY_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_SLEEP_SYSCALL_POL
 const UTILITY_NAME = "sleep";
 const SETTLE_MS = "150";
 const TARGET_BYTE_WINDOW = 32;
+const SOURCE_UNWIND_FILE = "native-source-unwind.json";
 
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
@@ -125,6 +139,7 @@ function captureArm64ActualUtility(outDir: string) {
     };
   }
 
+  writeActualSourceUnwindSidecar(bundleDir);
   const planned = planCapturedActualUtilityBundle(bundleDir, { targetRoot: undefined });
   assert(
     planned.bundle.manifest.capture.sourceArch === "arm64",
@@ -163,6 +178,31 @@ function planCapturedActualUtilityBundle(
   bundleDir: string,
   options: { targetRoot?: string; explicitTargetModulePath?: string },
 ) {
+  const inputs = actualUtilityPlanningInputs(bundleDir, options);
+  const plan = planNativeActualRealUtilityContinuationAttempt({
+    threadRefusals: effectiveThreadRefusals(inputs),
+    resourceRefusals: inputs.resources.refusals,
+    mappingRefusals: inputs.mappings.refusals,
+    codeLocations: inputs.code.codeLocations,
+    sourceFrames: inputs.sourceUnwind.frames,
+    sourceFrameRefusals: inputs.sourceUnwind.refusals,
+    targetModuleByteRefusals: inputs.targetBytes.refusals,
+    targetModuleBytesMaterialized: inputs.targetBytes.materialized.length > 0,
+  });
+  return {
+    ...inputs,
+    sourceFrames: inputs.sourceUnwind.frames,
+    sourceUnwindRefusals: inputs.sourceUnwind.refusals,
+    sourceUnwindRules: inputs.sourceUnwind.rules,
+    targetUnwind: undefined,
+    plan,
+  };
+}
+
+function actualUtilityPlanningInputs(
+  bundleDir: string,
+  options: { targetRoot?: string; explicitTargetModulePath?: string },
+) {
   const bundle = validateNativeProcessImageBundle(bundleDir);
   const memoryBytes = statSync(join(bundleDir, "native-memory.bin")).size;
   const activeSyscalls = classifyNativeActiveSyscalls(bundle.threads.threads, {
@@ -197,16 +237,8 @@ function planCapturedActualUtilityBundle(
     targetModules,
     activeSyscallContinuations: activeSyscalls.continuations,
   });
+  const sourceUnwind = readActualSourceUnwindSidecar(bundleDir);
   const targetBytes = materializeResolvedTargetBytes(code.resolved, options.targetRoot);
-  const plan = planNativeActualRealUtilityContinuationAttempt({
-    threadRefusals: effectiveThreadRefusals({ activeSyscalls, registers }),
-    resourceRefusals: resources.refusals,
-    mappingRefusals: mappings.refusals,
-    codeLocations: code.codeLocations,
-    sourceFrames: [],
-    targetModuleByteRefusals: targetBytes.refusals,
-    targetModuleBytesMaterialized: targetBytes.materialized.length > 0,
-  });
   return {
     bundle,
     memoryBytes,
@@ -217,10 +249,8 @@ function planCapturedActualUtilityBundle(
     sourceModules,
     targetModules,
     code,
-    sourceFrames: [],
-    targetUnwind: undefined,
+    sourceUnwind,
     targetBytes,
-    plan,
   };
 }
 
@@ -237,6 +267,226 @@ function threadPc(thread: NativeThreadState): string {
   return thread.sourceRegisters.arch === "arm64"
     ? thread.sourceRegisters.pc
     : thread.sourceRegisters.rip;
+}
+
+interface ActualSourceUnwindSidecar {
+  formatVersion: 1;
+  rules: NativeUnwindFrameRule[];
+  frames: NativeDiscoveredUnwindFrame[];
+  refusals: NativeProcessImageRefusal[];
+}
+
+function writeActualSourceUnwindSidecar(bundleDir: string) {
+  const bundle = validateNativeProcessImageBundle(bundleDir);
+  const sidecar = discoverActualSourceUnwind(bundle);
+  writeFileSync(join(bundleDir, SOURCE_UNWIND_FILE), `${JSON.stringify(sidecar, null, 2)}\n`);
+}
+
+function readActualSourceUnwindSidecar(bundleDir: string): ActualSourceUnwindSidecar {
+  const path = join(bundleDir, SOURCE_UNWIND_FILE);
+  return existsSync(path)
+    ? normalizeActualSourceUnwindSidecar(JSON.parse(readFileSync(path, "utf8")))
+    : emptyActualSourceUnwindSidecar();
+}
+
+function normalizeActualSourceUnwindSidecar(value: unknown): ActualSourceUnwindSidecar {
+  const parsed = value as Partial<ActualSourceUnwindSidecar>;
+  return {
+    formatVersion: 1,
+    rules: parsed.rules ?? [],
+    frames: parsed.frames ?? [],
+    refusals: parsed.refusals ?? [],
+  };
+}
+
+function emptyActualSourceUnwindSidecar(): ActualSourceUnwindSidecar {
+  return { formatVersion: 1, rules: [], frames: [], refusals: [] };
+}
+
+function discoverActualSourceUnwind(
+  bundle: NativeProcessImageDocuments,
+): ActualSourceUnwindSidecar {
+  const rules: NativeUnwindFrameRule[] = [];
+  const frames: NativeDiscoveredUnwindFrame[] = [];
+  const refusals: NativeProcessImageRefusal[] = [];
+
+  for (const thread of bundle.threads.threads) {
+    const discovered = discoverActualThreadSourceUnwind(bundle, thread);
+    rules.push(...discovered.rules);
+    frames.push(...discovered.frames);
+    refusals.push(...discovered.refusals);
+  }
+
+  return { formatVersion: 1, rules, frames, refusals };
+}
+
+function discoverActualThreadSourceUnwind(
+  bundle: NativeProcessImageDocuments,
+  thread: NativeThreadState,
+): Omit<ActualSourceUnwindSidecar, "formatVersion"> {
+  const input = actualThreadUnwindInput(bundle, thread);
+  if ("refusals" in input) {
+    return emptyThreadSourceUnwind(input.refusals);
+  }
+  return sourceUnwindFromParsedRule(
+    bundle,
+    input.thread,
+    parseActualSourceUnwindRule(input.mapping, input.thread),
+  );
+}
+
+function actualThreadUnwindInput(
+  bundle: NativeProcessImageDocuments,
+  thread: NativeThreadState,
+):
+  | {
+      thread: NativeThreadState & { sourceRegisters: NativeArm64Registers };
+      mapping: NativeMemoryMapping & { file: { path: string; offset: number } };
+    }
+  | { refusals: NativeProcessImageRefusal[] } {
+  const arm64Thread = arm64UnwindThread(thread);
+  if ("refusals" in arm64Thread) {
+    return arm64Thread;
+  }
+  const mapping = sourceUnwindMapping(bundle, arm64Thread.thread);
+  return "refusals" in mapping ? mapping : { thread: arm64Thread.thread, mapping: mapping.mapping };
+}
+
+function sourceUnwindFromParsedRule(
+  bundle: NativeProcessImageDocuments,
+  thread: NativeThreadState & { sourceRegisters: NativeArm64Registers },
+  parsed: ReturnType<typeof parseNativeEhFrameText>,
+): Omit<ActualSourceUnwindSidecar, "formatVersion"> {
+  if (parsed.refusals.length > 0) {
+    return emptyThreadSourceUnwind(parsed.refusals);
+  }
+  const rule = parsed.rules[0];
+  if (!rule) {
+    return emptyThreadSourceUnwind([sourceUnwindRefusal("unwind-fde-missing")]);
+  }
+  const discovered = discoverFrameFromActualRule(bundle, thread, rule);
+  return { rules: [rule], frames: discovered.frames, refusals: discovered.refusals };
+}
+
+function emptyThreadSourceUnwind(
+  refusals: NativeProcessImageRefusal[],
+): Omit<ActualSourceUnwindSidecar, "formatVersion"> {
+  return { rules: [], frames: [], refusals };
+}
+
+function arm64UnwindThread(
+  thread: NativeThreadState,
+):
+  | { thread: NativeThreadState & { sourceRegisters: NativeArm64Registers } }
+  | { refusals: NativeProcessImageRefusal[] } {
+  if (thread.sourceRegisters.arch === "arm64") {
+    return { thread: thread as NativeThreadState & { sourceRegisters: NativeArm64Registers } };
+  }
+  return { refusals: [sourceUnwindRefusal("architecture-unsupported")] };
+}
+
+function sourceUnwindMapping(
+  bundle: NativeProcessImageDocuments,
+  thread: NativeThreadState & { sourceRegisters: NativeArm64Registers },
+):
+  | { mapping: NativeMemoryMapping & { file: { path: string; offset: number } } }
+  | {
+      refusals: NativeProcessImageRefusal[];
+    } {
+  const pc = BigInt(thread.sourceRegisters.pc);
+  const mapping = executableMappingForPc(bundle, pc);
+  if (!mapping?.file?.path) {
+    return {
+      refusals: [
+        sourceUnwindRefusal(
+          "unwind-metadata-missing",
+          `thread ${thread.id} pc ${thread.sourceRegisters.pc} has no executable file mapping for .eh_frame discovery`,
+        ),
+      ],
+    };
+  }
+  if (!existsSync(mapping.file.path)) {
+    return {
+      refusals: [
+        sourceUnwindRefusal(
+          "unwind-metadata-missing",
+          `source module is unavailable for .eh_frame discovery: ${mapping.file.path}`,
+        ),
+      ],
+    };
+  }
+  return { mapping: mapping as NativeMemoryMapping & { file: { path: string; offset: number } } };
+}
+
+function parseActualSourceUnwindRule(
+  mapping: NativeMemoryMapping & { file: { path: string; offset: number } },
+  thread: NativeThreadState & { sourceRegisters: NativeArm64Registers },
+) {
+  const loadBias = finalJumpHex(BigInt(mapping.sourceStart) - BigInt(mapping.file.offset));
+  const readelfFrames = runCommand("readelf", ["--debug-dump=frames", mapping.file.path], {
+    label: `actual source .eh_frame scan ${basename(mapping.file.path)}`,
+  }).stdout;
+  return parseNativeEhFrameText({
+    readelfFrames,
+    mapping: mapping.id,
+    functionName: basename(mapping.file.path),
+    pc: thread.sourceRegisters.pc,
+    loadBias,
+  });
+}
+
+function sourceUnwindRefusal(
+  code: NativeProcessImageRefusal["code"],
+  message = "source unwind metadata is unavailable for actual utility frame",
+): NativeProcessImageRefusal {
+  return { code, message };
+}
+
+function discoverFrameFromActualRule(
+  bundle: NativeProcessImageDocuments,
+  thread: NativeThreadState & { sourceRegisters: NativeArm64Registers },
+  rule: NativeUnwindFrameRule,
+) {
+  const returnAddressSlot = nativeUnwindReturnAddressSlot({
+    rule,
+    sourceRegisters: thread.sourceRegisters,
+  });
+  if (!returnAddressSlot) {
+    return {
+      frames: [],
+      refusals: [
+        {
+          code: "unwind-rule-unsupported" as const,
+          message: `source unwind rule ${rule.id} does not expose a return-address slot`,
+        },
+      ],
+    };
+  }
+
+  const stackMapping = mappingById(bundle, thread.stackMapping);
+  const returnAddress = readCapturedU64(bundle, stackMapping, BigInt(returnAddressSlot));
+  return discoverNativeUnwindFrames({
+    threadId: thread.id,
+    stackMapping: thread.stackMapping,
+    sourceRegisters: thread.sourceRegisters,
+    rules: [rule],
+    stackWords: [{ address: returnAddressSlot, value: finalJumpHex(returnAddress) }],
+  });
+}
+
+function executableMappingForPc(bundle: NativeProcessImageDocuments, pc: bigint) {
+  return bundle.mappings.mappings.find(
+    (mapping) =>
+      mapping.permissions.execute &&
+      pc >= BigInt(mapping.sourceStart) &&
+      pc < BigInt(mapping.sourceEnd),
+  );
+}
+
+function mappingById(bundle: NativeProcessImageDocuments, id: string): NativeMemoryMapping {
+  const mapping = bundle.mappings.mappings.find((candidate) => candidate.id === id);
+  assert(mapping, `source bundle references missing mapping ${id}`);
+  return mapping;
 }
 
 function materializeResolvedTargetBytes(
@@ -292,6 +542,8 @@ function actualUtilitySummary(context: {
     codeLocationRefusals: planned.code.refusals,
     deferredActiveSyscallLandings: deferredActiveSyscallLandingSummaries(planned),
     sourceUnwindFrames: planned.sourceFrames.length,
+    sourceUnwindRules: planned.sourceUnwindRules.length,
+    sourceUnwindRefusals: planned.sourceUnwindRefusals,
     targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),


### PR DESCRIPTION
## Problem

The real `/bin/sleep` proof could find amd64 libc, but it still stopped at source unwind. The active arm64 libc frame had no modeled `.eh_frame` frame, so the planner refused with `unwind-fde-missing`.

## Solution

This teaches the source unwind parser to handle loaded shared-library frames. It applies the module load bias, supports the arm64 libc `sp`-based CFA shape, and writes discovered source unwind frames into the actual source bundle. With an amd64 target root, the proof now gets past source unwind and stops at the next safe gate: target unwind matching.

Closes #520
