### PR TITLE
Discover actual target unwind state

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -36,7 +36,8 @@ consume the deferred sleep metadata. Without an explicit amd64 target root, the 
 with `target-module-missing` for the active libc frame instead of granting
 success. With a target root and source unwind sidecar, the proof can inventory
 target libc, materialize native libc bytes, discover the source libc frame, and
-expose the target-unwind gate.
+attempt target `.eh_frame` matching. Actual libc frames that save unmodeled
+callee registers still refuse precisely at `target-callee-saved-state-unsupported`.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-actual-target-unwind.md
+++ b/docs/snapshot/native-actual-target-unwind.md
@@ -1,0 +1,23 @@
+# Native actual target unwind discovery
+
+Issue #522 wires actual captured `/bin/sleep` target unwind discovery into the fail-closed continuation planner.
+
+## What is new
+
+The amd64 target-planning proof now reads `.eh_frame` metadata from the explicit target module inventory and tries to match the mapped target-native libc landing against the discovered arm64 source frame.
+
+Target shared objects use module-relative FDE program counters, so the parser applies the target module load bias before matching the target address. It also inherits the CIE return-address rule used by real amd64 libc FDEs.
+
+## Boundary
+
+This is still a safety gate, not a resume claim. The matcher only accepts narrow target frame contracts:
+
+- CFA based on `rsp` or `rbp` with a constant offset;
+- return address stored in a CFA-relative target stack slot;
+- no unmodeled callee-saved target register state.
+
+If actual libc target unwind metadata is present but the frame saves registers that are not modeled yet, planning refuses with `target-callee-saved-state-unsupported` instead of pretending the continuation is safe.
+
+## Proof effect
+
+With explicit sleep deferral, an arm64 source bundle, and an amd64 target root, the actual proof advances beyond generic `target-unwind-mismatch` and reports the precise target unwind rule refusal for the libc sleep frame.

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -78,3 +78,4 @@ See also:
 - [Native deferred sleep code-location policy](./native-deferred-sleep-code-location.md)
 - [Native actual target module inventory](./native-actual-target-module-inventory.md)
 - [Native actual source unwind discovery](./native-actual-source-unwind.md)
+- [Native actual target unwind discovery](./native-actual-target-unwind.md)

--- a/docs/snapshot/native-real-utility-target-unwind.md
+++ b/docs/snapshot/native-real-utility-target-unwind.md
@@ -7,7 +7,9 @@ can be considered safe.
 ## Rule
 
 The matcher consumes the target module's `.eh_frame` metadata for the mapped
-target RVA. The first modeled target frame shape is narrow:
+target RVA. Shared-object FDE ranges are matched with the target module load bias,
+and real amd64 CIE return-address slots are inherited by their FDEs. The first
+modeled target frame shape is narrow:
 
 - CFA is based on `rsp` or `rbp` with a constant offset.
 - the target return address is a CFA-relative stack slot, normally `cfa-8`.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -4473,6 +4473,10 @@ by default when `output` is a TTY.
 
 > **targetAddress**: `string`
 
+##### loadBias?
+
+> `optional` **loadBias?**: `string`
+
 ***
 
 ### NativeTargetEhFrameTextParseResult

--- a/packages/runtime/src/__tests__/native-target-unwind.test.ts
+++ b/packages/runtime/src/__tests__/native-target-unwind.test.ts
@@ -38,6 +38,17 @@ function targetReadelfFrames() {
 `;
 }
 
+function targetSharedObjectReadelfFrames() {
+  return `
+00000000 0000000000000014 00000000 CIE
+  DW_CFA_def_cfa: r7 (rsp) ofs 8
+  DW_CFA_offset: r16 (rip) at cfa-8
+
+00000018 0000000000000010 0000001c FDE cie=00000000 pc=0000000000001200..0000000000001280
+  DW_CFA_nop
+`;
+}
+
 describe("native target unwind matching", () => {
   it("parses target amd64 .eh_frame text and matches a source frame return contract", () => {
     const parsed = parseNativeTargetEhFrameText({
@@ -68,6 +79,24 @@ describe("native target unwind matching", () => {
       targetAddress: "0x700000001234",
       targetReturnAddressSlotOffset: -8,
       preservesReturnContract: true,
+    });
+  });
+
+  it("relocates shared-object target FDEs by load bias and inherits CIE return slots", () => {
+    const parsed = parseNativeTargetEhFrameText({
+      readelfFrames: targetSharedObjectReadelfFrames(),
+      mapping: "target:mapping:libc",
+      functionName: "libc.so.6",
+      targetAddress: "0x700100001234",
+      loadBias: "0x700100000000",
+    });
+
+    expect(parsed.refusals).toEqual([]);
+    expect(parsed.rules[0]).toMatchObject({
+      pcStart: "0x700100001200",
+      pcEnd: "0x700100001280",
+      cfa: { register: "rsp", offset: 8 },
+      returnAddress: { location: "cfa-relative", offset: -8 },
     });
   });
 

--- a/packages/runtime/src/native-target-unwind.ts
+++ b/packages/runtime/src/native-target-unwind.ts
@@ -1,6 +1,6 @@
 /** Target-native unwind matching for real utility continuation planning. */
 
-import { nativeEhFrameTextBlocks, nativeLastCapture } from "./native-eh-frame-text.ts";
+import { nativeLastCapture } from "./native-eh-frame-text.ts";
 import type { NativeProcessImageRefusal } from "./native-process-image.ts";
 import type {
   NativeDiscoveredUnwindFrame,
@@ -38,6 +38,7 @@ export interface NativeTargetEhFrameTextParseRequest {
   mapping: string;
   functionName: string;
   targetAddress: string;
+  loadBias?: string;
 }
 
 export interface NativeTargetEhFrameTextParseResult {
@@ -71,8 +72,10 @@ export function parseNativeTargetEhFrameText(
     return refusedParse("unwind-metadata-missing", "target readelf did not emit .eh_frame data");
   }
   const targetAddress = BigInt(request.targetAddress);
-  const block = nativeEhFrameTextBlocks(request.readelfFrames).find(
-    (candidate) => targetAddress >= candidate.start && targetAddress < candidate.end,
+  const loadBias = BigInt(request.loadBias ?? "0x0");
+  const metadataAddress = targetAddress - loadBias;
+  const block = targetEhFrameTextBlocks(request.readelfFrames).find(
+    (candidate) => metadataAddress >= candidate.start && metadataAddress < candidate.end,
   );
   if (!block) {
     return refusedParse(
@@ -155,6 +158,7 @@ function targetRuleFromBlock(
   request: NativeTargetEhFrameTextParseRequest,
   block: { start: bigint; end: bigint; lines: string[] },
 ): { rule: NativeTargetUnwindFrameRule } | { refusal: NativeProcessImageRefusal } {
+  const loadBias = BigInt(request.loadBias ?? "0x0");
   const cfa = targetCfa(block.lines);
   const returnAddressOffset = nativeLastCapture(
     block.lines,
@@ -173,19 +177,101 @@ function targetRuleFromBlock(
       ),
     };
   }
+  return { rule: targetRule(request, block, cfa, returnAddressOffset, loadBias) };
+}
+
+function targetRule(
+  request: NativeTargetEhFrameTextParseRequest,
+  block: TargetEhFrameTextBlock,
+  cfa: NativeTargetUnwindFrameRule["cfa"],
+  returnAddressOffset: string,
+  loadBias: bigint,
+): NativeTargetUnwindFrameRule {
   return {
-    rule: {
-      id: `target-eh-frame:${request.functionName}:${hex(block.start)}`,
-      functionName: request.functionName,
-      mapping: request.mapping,
-      pcStart: hex(block.start),
-      pcEnd: hex(block.end),
-      metadata: "eh-frame",
-      cfa,
-      returnAddress: { location: "cfa-relative", offset: Number.parseInt(returnAddressOffset, 10) },
-      calleeSaved: targetCalleeSaved(block.lines),
-    },
+    id: `target-eh-frame:${request.functionName}:${hex(block.start + loadBias)}`,
+    functionName: request.functionName,
+    mapping: request.mapping,
+    pcStart: hex(block.start + loadBias),
+    pcEnd: hex(block.end + loadBias),
+    metadata: "eh-frame",
+    cfa,
+    returnAddress: { location: "cfa-relative", offset: Number.parseInt(returnAddressOffset, 10) },
+    calleeSaved: targetCalleeSaved(block.lines),
   };
+}
+
+interface TargetEhFrameTextBlock {
+  start: bigint;
+  end: bigint;
+  lines: string[];
+}
+
+interface TargetEhFrameTextCursor {
+  cieLines: Map<string, string[]>;
+  blocks: TargetEhFrameTextBlock[];
+  currentCie?: { offset: string; lines: string[] };
+  currentFde?: TargetEhFrameTextBlock;
+}
+
+function targetEhFrameTextBlocks(stdout: string): TargetEhFrameTextBlock[] {
+  const cursor: TargetEhFrameTextCursor = { cieLines: new Map(), blocks: [] };
+  for (const line of stdout.split(/\r?\n/)) {
+    consumeTargetEhFrameLine(cursor, line);
+  }
+  return cursor.blocks;
+}
+
+function consumeTargetEhFrameLine(cursor: TargetEhFrameTextCursor, line: string): void {
+  if (startTargetCie(cursor, line) || startTargetFde(cursor, line)) {
+    return;
+  }
+  if (cursor.currentCie) {
+    cursor.currentCie.lines.push(line);
+    return;
+  }
+  cursor.currentFde?.lines.push(line);
+}
+
+function startTargetCie(cursor: TargetEhFrameTextCursor, line: string): boolean {
+  const cie = /^([0-9a-fA-F]+)\s+[0-9a-fA-F]+\s+[0-9a-fA-F]+\s+CIE\b/.exec(line);
+  if (!cie?.[1]) {
+    return false;
+  }
+  cursor.currentCie = { offset: normalizeFrameOffset(cie[1]), lines: [] };
+  cursor.cieLines.set(cursor.currentCie.offset, cursor.currentCie.lines);
+  cursor.currentFde = undefined;
+  return true;
+}
+
+function startTargetFde(cursor: TargetEhFrameTextCursor, line: string): boolean {
+  const fde = targetFdeHeader(line);
+  if (!fde) {
+    return false;
+  }
+  cursor.currentFde = fdeBlock(cursor, fde);
+  cursor.blocks.push(cursor.currentFde);
+  cursor.currentCie = undefined;
+  return true;
+}
+
+function targetFdeHeader(line: string) {
+  const match =
+    /^(?:[0-9a-fA-F]+\s+[0-9a-fA-F]+\s+[0-9a-fA-F]+\s+)?FDE(?:\s+cie=([0-9a-fA-F]+))?\s+pc=([0-9a-fA-F]+)\.\.([0-9a-fA-F]+)/.exec(
+      line,
+    );
+  return match?.[2] && match[3] ? { cie: match[1], start: match[2], end: match[3] } : undefined;
+}
+
+function fdeBlock(
+  cursor: TargetEhFrameTextCursor,
+  fde: { cie?: string; start: string; end: string },
+): TargetEhFrameTextBlock {
+  const inherited = fde.cie ? (cursor.cieLines.get(normalizeFrameOffset(fde.cie)) ?? []) : [];
+  return { start: BigInt(`0x${fde.start}`), end: BigInt(`0x${fde.end}`), lines: [...inherited] };
+}
+
+function normalizeFrameOffset(offset: string): string {
+  return BigInt(`0x${offset}`).toString(16);
 }
 
 function targetCfa(lines: string[]): NativeTargetUnwindFrameRule["cfa"] | undefined {

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { classifyNativeActiveSyscalls } from "../packages/runtime/src/native-active-syscall-policy.ts";
 import { planNativeMappingMaterialization } from "../packages/runtime/src/native-mapping-materialization.ts";
 import { inventoryNativeActualTargetModules } from "../packages/runtime/src/native-actual-target-module-inventory.ts";
@@ -10,6 +10,11 @@ import {
 } from "../packages/runtime/src/native-real-utility-code-map.ts";
 import { planNativeActualRealUtilityContinuationAttempt } from "../packages/runtime/src/native-actual-real-utility-continuation.ts";
 import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/native-target-module-bytes.ts";
+import {
+  matchNativeTargetUnwindFrame,
+  parseNativeTargetEhFrameText,
+  type NativeTargetUnwindMatchResult,
+} from "../packages/runtime/src/native-target-unwind.ts";
 import {
   discoverNativeUnwindFrames,
   nativeUnwindReturnAddressSlot,
@@ -186,6 +191,7 @@ function planCapturedActualUtilityBundle(
     codeLocations: inputs.code.codeLocations,
     sourceFrames: inputs.sourceUnwind.frames,
     sourceFrameRefusals: inputs.sourceUnwind.refusals,
+    targetUnwind: inputs.targetUnwind,
     targetModuleByteRefusals: inputs.targetBytes.refusals,
     targetModuleBytesMaterialized: inputs.targetBytes.materialized.length > 0,
   });
@@ -194,7 +200,7 @@ function planCapturedActualUtilityBundle(
     sourceFrames: inputs.sourceUnwind.frames,
     sourceUnwindRefusals: inputs.sourceUnwind.refusals,
     sourceUnwindRules: inputs.sourceUnwind.rules,
-    targetUnwind: undefined,
+    targetUnwind: inputs.targetUnwind,
     plan,
   };
 }
@@ -238,6 +244,11 @@ function actualUtilityPlanningInputs(
     activeSyscallContinuations: activeSyscalls.continuations,
   });
   const sourceUnwind = readActualSourceUnwindSidecar(bundleDir);
+  const targetUnwind = discoverActualTargetUnwind({
+    resolved: code.resolved,
+    sourceFrames: sourceUnwind.frames,
+    targetRoot: options.targetRoot,
+  });
   const targetBytes = materializeResolvedTargetBytes(code.resolved, options.targetRoot);
   return {
     bundle,
@@ -250,6 +261,7 @@ function actualUtilityPlanningInputs(
     targetModules,
     code,
     sourceUnwind,
+    targetUnwind,
     targetBytes,
   };
 }
@@ -510,6 +522,100 @@ function materializeResolvedTargetBytes(
   return { materialized, refusals };
 }
 
+function discoverActualTargetUnwind(options: {
+  resolved: ReturnType<typeof resolveNativeRealUtilityCodeLocations>["resolved"];
+  sourceFrames: NativeDiscoveredUnwindFrame[];
+  targetRoot?: string;
+}): NativeTargetUnwindMatchResult {
+  const result: NativeTargetUnwindMatchResult = { matches: [], refusals: [] };
+  for (const location of options.resolved) {
+    const matched = discoverActualTargetUnwindForLocation(
+      location,
+      options.sourceFrames,
+      options.targetRoot,
+    );
+    result.matches.push(...matched.matches);
+    result.refusals.push(...matched.refusals);
+  }
+  return result;
+}
+
+function discoverActualTargetUnwindForLocation(
+  location: ReturnType<typeof resolveNativeRealUtilityCodeLocations>["resolved"][number],
+  sourceFrames: NativeDiscoveredUnwindFrame[],
+  targetRoot: string | undefined,
+): NativeTargetUnwindMatchResult {
+  const sourceFrame = sourceFrameForTargetLocation(
+    sourceFrames,
+    location.threadId,
+    location.codeLocation.sourceAddress,
+  );
+  if (!sourceFrame) {
+    return targetUnwindRefused(
+      "target-unwind-mismatch",
+      `no source unwind frame matches target location ${location.codeLocation.id}`,
+    );
+  }
+  const targetPath = resolveActualTargetPath(targetRoot, location.targetModule.path);
+  if (!existsSync(targetPath)) {
+    return targetUnwindRefused(
+      "target-module-file-missing",
+      `target module file is unavailable for .eh_frame discovery: ${location.targetModule.path}`,
+    );
+  }
+  const parsed = parseTargetUnwindForLocation(location, targetPath);
+  if (parsed.refusals.length > 0) {
+    return { matches: [], refusals: parsed.refusals };
+  }
+  return matchNativeTargetUnwindFrame({
+    sourceFrame,
+    targetAddress: location.targetAddress,
+    targetRules: parsed.rules,
+  });
+}
+
+function parseTargetUnwindForLocation(
+  location: ReturnType<typeof resolveNativeRealUtilityCodeLocations>["resolved"][number],
+  targetPath: string,
+) {
+  const readelfFrames = runCommand("readelf", ["--debug-dump=frames", targetPath], {
+    label: `actual target .eh_frame scan ${basename(targetPath)}`,
+  }).stdout;
+  return parseNativeTargetEhFrameText({
+    readelfFrames,
+    mapping: location.targetModule.textMapping,
+    functionName: basename(location.targetModule.path),
+    targetAddress: location.targetAddress,
+    loadBias: location.targetModule.loadBias,
+  });
+}
+
+function sourceFrameForTargetLocation(
+  frames: NativeDiscoveredUnwindFrame[],
+  threadId: string,
+  sourceAddress: string,
+) {
+  return (
+    frames.find(
+      (frame) => frame.id.startsWith(`frame:${threadId}:`) && frame.sourcePc === sourceAddress,
+    ) ?? frames.find((frame) => frame.sourcePc === sourceAddress)
+  );
+}
+
+function targetUnwindRefused(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeTargetUnwindMatchResult {
+  return { matches: [], refusals: [{ code, message }] };
+}
+
+function resolveActualTargetPath(targetRoot: string | undefined, modulePath: string): string {
+  if (!targetRoot) {
+    return modulePath;
+  }
+  return join(targetRoot, isAbsolute(modulePath) ? modulePath.slice(1) : modulePath);
+}
+
 function actualUtilitySummary(context: {
   phase: string;
   hostArch: "arm64" | "amd64";
@@ -545,6 +651,7 @@ function actualUtilitySummary(context: {
     sourceUnwindRules: planned.sourceUnwindRules.length,
     sourceUnwindRefusals: planned.sourceUnwindRefusals,
     targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
+    targetUnwindRefusals: planned.targetUnwind?.refusals ?? [],
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),
     sourceModules: planned.sourceModules.length,


### PR DESCRIPTION
## Problem

The actual `/bin/sleep` proof could find the arm64 source unwind frame, but it still did not inspect the amd64 target unwind frame. It stopped with a generic target unwind mismatch, so we could not tell whether target libc had usable frame metadata or a precise unsupported state.

## Solution

This PR reads target `.eh_frame` data from the explicit amd64 target module. It applies the target module load bias, inherits the CIE return-address rule used by real libc, and feeds the match attempt into the actual continuation planner. The proof now fails closed with `target-callee-saved-state-unsupported` for the real libc frame instead of a generic mismatch.

Closes #522
