### PR TITLE
Gate actual target frame state

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -18,7 +18,8 @@ The actual captured path preserves the native-transparent gate order:
 4. target module/RVA code-location mapping;
 5. source `.eh_frame` frame discovery;
 6. target amd64 unwind matching;
-7. target module byte materialization from explicit target inventory/root.
+7. target frame/callee-saved state materialization;
+8. target module byte materialization from explicit target inventory/root.
 
 The new actual-real-utility planner adds a final `target-module-bytes` gate. If
 all earlier gates pass but no target bytes were explicitly materialized, it
@@ -35,9 +36,10 @@ the proof records a deferred target timer continuation, recreates safe
 consume the deferred sleep metadata. Without an explicit amd64 target root, the current proof then refuses precisely
 with `target-module-missing` for the active libc frame instead of granting
 success. With a target root and source unwind sidecar, the proof can inventory
-target libc, materialize native libc bytes, discover the source libc frame, and
-attempt target `.eh_frame` matching. Actual libc frames that save unmodeled
-callee registers still refuse precisely at `target-callee-saved-state-unsupported`.
+target libc, materialize native libc bytes, discover the source libc frame, match
+the target `.eh_frame` return contract, and then refuse at the later
+`target-frame-state` gate. Actual libc frames that save unmodeled callee
+registers still refuse precisely with `target-callee-saved-state-unsupported`.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-actual-target-frame-state.md
+++ b/docs/snapshot/native-actual-target-frame-state.md
@@ -1,0 +1,19 @@
+# Native actual target frame-state gate
+
+Issue #524 separates finding target unwind metadata from proving the target frame state is safe.
+
+## What changed
+
+Actual `/bin/sleep` target planning can now record amd64 callee-saved stack slots from the matched target libc FDE. That means the target unwind rule can be found and matched for its return-address contract without pretending the saved registers are already safe.
+
+The existing strict matcher remains the default for older proofs. The actual utility path opts into recording callee-saved slots and then lets the continuation planner apply a later safety gate.
+
+## Fail-closed boundary
+
+If the matched target frame needs non-modeled callee-saved state, the planner refuses at `target-frame-state` with `target-callee-saved-state-unsupported`.
+
+This is more precise than treating the FDE as missing. It says: target unwind was found, but the target stack/register state needed by that native frame has not been materialized yet.
+
+## Non-claims
+
+This does not synthesize target register values, does not build a real target stack frame, and does not resume `/bin/sleep`. It only moves the proof to the next honest blocker.

--- a/docs/snapshot/native-actual-target-unwind.md
+++ b/docs/snapshot/native-actual-target-unwind.md
@@ -16,8 +16,8 @@ This is still a safety gate, not a resume claim. The matcher only accepts narrow
 - return address stored in a CFA-relative target stack slot;
 - no unmodeled callee-saved target register state.
 
-If actual libc target unwind metadata is present but the frame saves registers that are not modeled yet, planning refuses with `target-callee-saved-state-unsupported` instead of pretending the continuation is safe.
+If actual libc target unwind metadata is present but the frame saves registers that are not modeled yet, the actual path records those slots and lets the later target frame-state gate refuse instead of pretending the continuation is safe.
 
 ## Proof effect
 
-With explicit sleep deferral, an arm64 source bundle, and an amd64 target root, the actual proof advances beyond generic `target-unwind-mismatch` and reports the precise target unwind rule refusal for the libc sleep frame.
+With explicit sleep deferral, an arm64 source bundle, and an amd64 target root, the actual proof advances beyond generic `target-unwind-mismatch` and exposes the target frame-state blocker for the libc sleep frame.

--- a/docs/snapshot/native-real-utilities.md
+++ b/docs/snapshot/native-real-utilities.md
@@ -79,3 +79,4 @@ See also:
 - [Native actual target module inventory](./native-actual-target-module-inventory.md)
 - [Native actual source unwind discovery](./native-actual-source-unwind.md)
 - [Native actual target unwind discovery](./native-actual-target-unwind.md)
+- [Native actual target frame-state gate](./native-actual-target-frame-state.md)

--- a/docs/snapshot/native-real-utility-continuation.md
+++ b/docs/snapshot/native-real-utility-continuation.md
@@ -13,7 +13,8 @@ The planner checks boundaries in this order:
 3. mapping materialization;
 4. target code-location mapping from #494;
 5. source unwind discovery from #495;
-6. target unwind/layout match.
+6. target unwind/layout match;
+7. target frame-state materialization for actual utilities.
 
 Only when every gate is modeled can a later implementation perform a final jump.
 The planner itself never jumps. It reports:
@@ -34,7 +35,8 @@ Issue #502 adds a separate target unwind matching proof. See
 
 The original connected attempt still documents the fail-closed behavior when no
 target match is supplied: it refuses at `target-unwind-mismatch` instead of
-jumping.
+jumping. Actual utility planning can also refuse later at `target-frame-state`
+when target unwind is found but unmodeled callee-saved slots remain.
 
 ## Proof
 

--- a/docs/snapshot/native-real-utility-target-unwind.md
+++ b/docs/snapshot/native-real-utility-target-unwind.md
@@ -16,6 +16,11 @@ modeled target frame shape is narrow:
 - only the frame pointer (`rbp`) may be described as saved callee state.
 - any other callee-saved register state refuses until modeled.
 
+The strict behavior remains the default. Actual-utility planning may explicitly
+record those callee-saved slots and move the refusal to a later target
+frame-state gate so the proof can distinguish "no target FDE" from "target frame
+state is not materialized yet".
+
 A source frame being discovered is not enough. The target landing must expose a
 compatible return contract so later stack materialization knows where target
 native code will return.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -121,6 +121,8 @@
 - [`NativeTargetModuleByteMaterializationResult`](#nativetargetmodulebytematerializationresult)
 - [`materializeNativeTargetModuleBytes`](#materializenativetargetmodulebytes)
 - [`NativeTargetUnwindRegister`](#nativetargetunwindregister)
+- [`NativeTargetCalleeSavedPolicy`](#nativetargetcalleesavedpolicy)
+- [`NativeTargetCalleeSavedSlot`](#nativetargetcalleesavedslot)
 - [`NativeTargetUnwindFrameRule`](#nativetargetunwindframerule)
 - [`NativeTargetEhFrameTextParseRequest`](#nativetargetehframetextparserequest)
 - [`NativeTargetEhFrameTextParseResult`](#nativetargetehframetextparseresult)
@@ -2440,6 +2442,14 @@ by default when `output` is a TTY.
 
 [`NativeRealUtilityContinuationRequest`](#nativerealutilitycontinuationrequest).[`targetUnwindMatched`](#targetunwindmatched-1)
 
+##### targetFrameStateMaterialized?
+
+> `optional` **targetFrameStateMaterialized?**: `boolean`
+
+###### Inherited from
+
+[`NativeRealUtilityContinuationRequest`](#nativerealutilitycontinuationrequest).[`targetFrameStateMaterialized`](#targetframestatematerialized-1)
+
 ***
 
 ### NativeActualRealUtilityContinuationPlan
@@ -4049,6 +4059,10 @@ by default when `output` is a TTY.
 
 > `optional` **targetUnwindMatched?**: `boolean`
 
+##### targetFrameStateMaterialized?
+
+> `optional` **targetFrameStateMaterialized?**: `boolean`
+
 ***
 
 ### NativeRealUtilityContinuationPlan
@@ -4509,6 +4523,24 @@ by default when `output` is a TTY.
 
 > **targetRules**: [`NativeTargetUnwindFrameRule`](#nativetargetunwindframerule)[]
 
+##### calleeSavedPolicy?
+
+> `optional` **calleeSavedPolicy?**: [`NativeTargetCalleeSavedPolicy`](#nativetargetcalleesavedpolicy)
+
+***
+
+### NativeTargetCalleeSavedSlot
+
+#### Properties
+
+##### register
+
+> **register**: `"rbx"` \| `"rbp"` \| `"r12"` \| `"r13"` \| `"r14"` \| `"r15"`
+
+##### offset
+
+> **offset**: `number`
+
 ***
 
 ### NativeTargetUnwindFrameMatch
@@ -4530,6 +4562,10 @@ by default when `output` is a TTY.
 ##### targetReturnAddressSlotOffset
 
 > **targetReturnAddressSlotOffset**: `number`
+
+##### targetCalleeSavedSlots?
+
+> `optional` **targetCalleeSavedSlots?**: [`NativeTargetCalleeSavedSlot`](#nativetargetcalleesavedslot)[]
 
 ##### preservesReturnContract
 
@@ -7601,13 +7637,19 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeRealUtilityContinuationBoundary
 
-> **NativeRealUtilityContinuationBoundary** = `"thread-state"` \| `"resource-boundary"` \| `"mapping-materialization"` \| `"target-code-location"` \| `"source-unwind"` \| `"target-unwind"` \| `"ready"`
+> **NativeRealUtilityContinuationBoundary** = `"thread-state"` \| `"resource-boundary"` \| `"mapping-materialization"` \| `"target-code-location"` \| `"source-unwind"` \| `"target-unwind"` \| `"target-frame-state"` \| `"ready"`
 
 ***
 
 ### NativeTargetUnwindRegister
 
 > **NativeTargetUnwindRegister** = `"rsp"` \| `"rbp"` \| `"rip"` \| `"rbx"` \| `"r12"` \| `"r13"` \| `"r14"` \| `"r15"`
+
+***
+
+### NativeTargetCalleeSavedPolicy
+
+> **NativeTargetCalleeSavedPolicy** = `"strict"` \| `"record"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
@@ -127,6 +127,26 @@ describe("native real utility continuation planner", () => {
     });
   });
 
+  it("moves recorded target callee-saved slots to a later frame-state gate", () => {
+    expect(
+      planNativeRealUtilityContinuationAttempt({
+        ...readyInput(),
+        targetUnwind: {
+          matches: [
+            {
+              ...readyInput().targetUnwind.matches[0],
+              targetCalleeSavedSlots: [{ register: "r15", offset: -16 }],
+            },
+          ],
+          refusals: [],
+        },
+      }),
+    ).toMatchObject({
+      blockingBoundary: "target-frame-state",
+      blockingRefusal: { code: "target-callee-saved-state-unsupported" },
+    });
+  });
+
   it("can report ready without performing the jump", () => {
     expect(planNativeRealUtilityContinuationAttempt(readyInput())).toMatchObject({
       state: "ready",

--- a/packages/runtime/src/__tests__/native-target-unwind.test.ts
+++ b/packages/runtime/src/__tests__/native-target-unwind.test.ts
@@ -163,4 +163,28 @@ describe("native target unwind matching", () => {
       }).refusals[0]?.code,
     ).toBe("target-callee-saved-state-unsupported");
   });
+
+  it("can record target callee-saved slots for a later frame-state gate", () => {
+    const matched = matchNativeTargetUnwindFrame({
+      sourceFrame,
+      targetAddress: "0x700000001234",
+      targetRules: [
+        {
+          id: "target:record-callee",
+          functionName: "realspin_loop",
+          mapping: "target:mapping:text",
+          pcStart: "0x700000001200",
+          pcEnd: "0x700000001280",
+          metadata: "eh-frame",
+          cfa: { register: "rsp", offset: 56 },
+          returnAddress: { location: "cfa-relative", offset: -8 },
+          calleeSaved: [{ register: "r15", location: "cfa-relative", offset: -16 }],
+        },
+      ],
+      calleeSavedPolicy: "record",
+    });
+
+    expect(matched.refusals).toEqual([]);
+    expect(matched.matches[0]?.targetCalleeSavedSlots).toEqual([{ register: "r15", offset: -16 }]);
+  });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -163,6 +163,8 @@ export type {
   NativeTargetModuleByteMaterializationResult,
 } from "./native-target-module-bytes.ts";
 export type {
+  NativeTargetCalleeSavedPolicy,
+  NativeTargetCalleeSavedSlot,
   NativeTargetEhFrameTextParseRequest,
   NativeTargetEhFrameTextParseResult,
   NativeTargetUnwindFrameMatch,

--- a/packages/runtime/src/native-real-utility-continuation.ts
+++ b/packages/runtime/src/native-real-utility-continuation.ts
@@ -14,6 +14,7 @@ export type NativeRealUtilityContinuationBoundary =
   | "target-code-location"
   | "source-unwind"
   | "target-unwind"
+  | "target-frame-state"
   | "ready";
 
 export interface NativeRealUtilityContinuationRequest {
@@ -25,6 +26,7 @@ export interface NativeRealUtilityContinuationRequest {
   sourceFrameRefusals?: NativeProcessImageRefusal[];
   targetUnwind?: NativeTargetUnwindMatchResult;
   targetUnwindMatched?: boolean;
+  targetFrameStateMaterialized?: boolean;
 }
 
 export interface NativeRealUtilityContinuationPlan {
@@ -47,6 +49,10 @@ export function planNativeRealUtilityContinuationAttempt(
   const targetUnwind = targetUnwindRefusal(request);
   if (targetUnwind) {
     return refusedPlan("target-unwind", targetUnwind);
+  }
+  const targetFrameState = targetFrameStateRefusal(request);
+  if (targetFrameState) {
+    return refusedPlan("target-frame-state", targetFrameState);
   }
   return {
     state: "ready",
@@ -129,6 +135,25 @@ function targetUnwindRefusal(
     };
   }
   return undefined;
+}
+
+function targetFrameStateRefusal(
+  request: NativeRealUtilityContinuationRequest,
+): NativeProcessImageRefusal | undefined {
+  if (request.targetFrameStateMaterialized) {
+    return undefined;
+  }
+  const unsupportedSlot = request.targetUnwind?.matches
+    .flatMap((match) => match.targetCalleeSavedSlots ?? [])
+    .find((slot) => slot.register !== "rbp");
+  if (!unsupportedSlot) {
+    return undefined;
+  }
+  return {
+    code: "target-callee-saved-state-unsupported",
+    message: `target callee-saved ${unsupportedSlot.register} slot is not materialized yet`,
+    detail: { register: unsupportedSlot.register, offset: unsupportedSlot.offset },
+  };
 }
 
 function refusedPlan(

--- a/packages/runtime/src/native-target-unwind.ts
+++ b/packages/runtime/src/native-target-unwind.ts
@@ -46,10 +46,18 @@ export interface NativeTargetEhFrameTextParseResult {
   refusals: NativeProcessImageRefusal[];
 }
 
+export type NativeTargetCalleeSavedPolicy = "strict" | "record";
+
 export interface NativeTargetUnwindMatchRequest {
   sourceFrame: NativeDiscoveredUnwindFrame;
   targetAddress: string;
   targetRules: NativeTargetUnwindFrameRule[];
+  calleeSavedPolicy?: NativeTargetCalleeSavedPolicy;
+}
+
+export interface NativeTargetCalleeSavedSlot {
+  register: Exclude<NativeTargetUnwindRegister, "rsp" | "rip">;
+  offset: number;
 }
 
 export interface NativeTargetUnwindFrameMatch {
@@ -57,6 +65,7 @@ export interface NativeTargetUnwindFrameMatch {
   targetRule: NativeTargetUnwindFrameRule;
   targetAddress: string;
   targetReturnAddressSlotOffset: number;
+  targetCalleeSavedSlots?: NativeTargetCalleeSavedSlot[];
   preservesReturnContract: true;
 }
 
@@ -104,7 +113,11 @@ export function matchNativeTargetUnwindFrame(
       `no target unwind rule covers ${request.targetAddress}`,
     );
   }
-  const refusal = validateTargetRule(request.sourceFrame, rule);
+  const refusal = validateTargetRule(
+    request.sourceFrame,
+    rule,
+    request.calleeSavedPolicy ?? "strict",
+  );
   if (refusal) {
     return { matches: [], refusals: [refusal] };
   }
@@ -115,6 +128,7 @@ export function matchNativeTargetUnwindFrame(
         targetRule: rule,
         targetAddress: request.targetAddress,
         targetReturnAddressSlotOffset: rule.returnAddress.offset,
+        targetCalleeSavedSlots: targetCalleeSavedSlots(rule),
         preservesReturnContract: true,
       },
     ],
@@ -125,6 +139,7 @@ export function matchNativeTargetUnwindFrame(
 function validateTargetRule(
   sourceFrame: NativeDiscoveredUnwindFrame,
   rule: NativeTargetUnwindFrameRule,
+  calleeSavedPolicy: NativeTargetCalleeSavedPolicy,
 ): NativeProcessImageRefusal | undefined {
   if (!sourceFrame.returnAddressSlot) {
     return refusal(
@@ -145,13 +160,21 @@ function validateTargetRule(
     );
   }
   const unsupportedSaved = rule.calleeSaved?.find((saved) => saved.register !== "rbp");
-  if (unsupportedSaved) {
+  if (unsupportedSaved && calleeSavedPolicy === "strict") {
     return refusal(
       "target-callee-saved-state-unsupported",
       `target rule ${rule.id} saves ${unsupportedSaved.register}, which is not modeled yet`,
     );
   }
   return undefined;
+}
+
+function targetCalleeSavedSlots(rule: NativeTargetUnwindFrameRule): NativeTargetCalleeSavedSlot[] {
+  return (rule.calleeSaved ?? []).flatMap((saved) =>
+    saved.location === "cfa-relative" && saved.offset !== undefined
+      ? [{ register: saved.register, offset: saved.offset }]
+      : [],
+  );
 }
 
 function targetRuleFromBlock(

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -143,6 +143,8 @@ const TOC = {
     "NativeTargetModuleByteMaterializationResult",
     "materializeNativeTargetModuleBytes",
     "NativeTargetUnwindRegister",
+    "NativeTargetCalleeSavedPolicy",
+    "NativeTargetCalleeSavedSlot",
     "NativeTargetUnwindFrameRule",
     "NativeTargetEhFrameTextParseRequest",
     "NativeTargetEhFrameTextParseResult",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -571,6 +571,7 @@ function discoverActualTargetUnwindForLocation(
     sourceFrame,
     targetAddress: location.targetAddress,
     targetRules: parsed.rules,
+    calleeSavedPolicy: "record",
   });
 }
 


### PR DESCRIPTION
## Problem

After the target libc unwind data was found, the proof still treated saved target registers as part of target unwind matching. That made the next blocker less clear. We knew the target frame existed, but we could not show that the real missing piece was target frame state.

## Solution

This PR keeps strict target unwind matching as the default, but lets the actual utility proof record target callee-saved slots. The planner then stops at a new `target-frame-state` gate when those slots are not materialized. The actual proof now reports one target unwind match and refuses with `target-callee-saved-state-unsupported` at the later frame-state boundary.

Closes #524
