### PR TITLE
Plan synthetic target caller frame state

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -19,7 +19,8 @@ The actual captured path preserves the native-transparent gate order:
 5. source `.eh_frame` frame discovery;
 6. target amd64 unwind matching;
 7. target frame/callee-saved state materialization;
-8. target module byte materialization from explicit target inventory/root.
+8. target module byte materialization from explicit target inventory/root;
+9. synthetic target-caller frame installation.
 
 The new actual-real-utility planner adds a final `target-module-bytes` gate. If
 all earlier gates pass but no target bytes were explicitly materialized, it
@@ -38,9 +39,10 @@ with `target-module-missing` for the active libc frame instead of granting
 success. With a target root and source unwind sidecar, the proof can inventory
 target libc, materialize native libc bytes, discover the source libc frame, match
 the target `.eh_frame` return contract, and then refuse at the later
-`target-frame-state` gate. Actual libc frames that need unmaterialized target
-callee-saved register values now refuse precisely with
-`target-frame-register-value-unavailable`.
+`target-frame-state` gate. With an explicit synthetic target-caller policy, it can
+materialize caller-owned callee-saved slots as synthetic target values, then
+refuse at `target-caller-frame` until the synthetic caller frame itself is
+installed.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-actual-target-frame-state.md
+++ b/docs/snapshot/native-actual-target-frame-state.md
@@ -1,12 +1,14 @@
 # Native actual target frame-state gate
 
-Issues #524 and #526 separate finding target unwind metadata from proving the target frame state is safe.
+Issues #524, #526, and #528 separate finding target unwind metadata from proving the target frame state is safe.
 
 ## What changed
 
 Actual `/bin/sleep` target planning can now record amd64 callee-saved stack slots from the matched target libc FDE. That means the target unwind rule can be found and matched for its return-address contract without pretending the saved registers are already safe.
 
 The actual utility path also inventories the target-native value required for each slot. If no value is available, the frame-state planner refuses with a value-specific code instead of saying the whole frame shape is unknown.
+
+When an explicit synthetic target-caller policy is provided, the planner can fill caller-owned callee-saved slots with ABI-neutral synthetic values. Those values are marked `synthetic-target-caller`; they are not source register translations.
 
 The existing strict matcher remains the default for older proofs. The actual utility path opts into recording callee-saved slots and then lets the continuation planner apply a later safety gate.
 
@@ -18,4 +20,4 @@ This is more precise than treating the FDE as missing. It says: target unwind wa
 
 ## Non-claims
 
-This does not synthesize target register values, does not build a real target stack frame, and does not resume `/bin/sleep`. It only moves the proof to the next honest blocker.
+This does not translate source registers into amd64 callee-saved registers, does not build a real target stack frame, and does not resume `/bin/sleep`. It only moves the proof to the next honest blocker: `target-caller-frame` / `target-caller-frame-unavailable`.

--- a/docs/snapshot/native-process-image.md
+++ b/docs/snapshot/native-process-image.md
@@ -78,6 +78,7 @@ first native-translation blockers:
 - `target-unwind-mismatch`
 - `target-frame-layout-unsupported`
 - `target-frame-register-value-unavailable`
+- `target-caller-frame-unavailable`
 - `target-return-slot-unsupported`
 - `target-callee-saved-state-unsupported`
 

--- a/docs/snapshot/native-real-utility-continuation.md
+++ b/docs/snapshot/native-real-utility-continuation.md
@@ -14,7 +14,8 @@ The planner checks boundaries in this order:
 4. target code-location mapping from #494;
 5. source unwind discovery from #495;
 6. target unwind/layout match;
-7. target frame-state materialization for actual utilities.
+7. target frame-state materialization for actual utilities;
+8. synthetic target-caller frame installation for actual utilities.
 
 Only when every gate is modeled can a later implementation perform a final jump.
 The planner itself never jumps. It reports:
@@ -36,7 +37,9 @@ Issue #502 adds a separate target unwind matching proof. See
 The original connected attempt still documents the fail-closed behavior when no
 target match is supplied: it refuses at `target-unwind-mismatch` instead of
 jumping. Actual utility planning can also refuse later at `target-frame-state`
-when target unwind is found but unmodeled callee-saved slots remain.
+when target unwind is found but unmodeled callee-saved slots remain, or at
+`target-caller-frame` when synthetic caller-owned values exist but no target
+caller frame has been installed.
 
 ## Proof
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -133,6 +133,7 @@
 - [`matchNativeTargetUnwindFrame`](#matchnativetargetunwindframe)
 - [`NativeTargetFrameStateRegister`](#nativetargetframestateregister)
 - [`NativeTargetFrameStateValueSource`](#nativetargetframestatevaluesource)
+- [`NativeSyntheticTargetCallerFrameStatePolicy`](#nativesynthetictargetcallerframestatepolicy)
 - [`NativeTargetFrameRegisterValue`](#nativetargetframeregistervalue)
 - [`NativeTargetFrameStateRequirement`](#nativetargetframestaterequirement)
 - [`NativeTargetFrameStateMaterialization`](#nativetargetframestatematerialization)
@@ -2386,6 +2387,14 @@ by default when `output` is a TTY.
 
 > `optional` **targetModuleBytesMaterialized?**: `boolean`
 
+##### targetCallerFrameRefusals?
+
+> `optional` **targetCallerFrameRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+##### targetCallerFrameMaterialized?
+
+> `optional` **targetCallerFrameMaterialized?**: `boolean`
+
 ##### threadRefusals?
 
 > `optional` **threadRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
@@ -2979,7 +2988,7 @@ by default when `output` is a TTY.
 
 ##### code
 
-> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
+> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
 
 ##### message
 
@@ -4331,6 +4340,20 @@ by default when `output` is a TTY.
 
 ***
 
+### NativeSyntheticTargetCallerFrameStatePolicy
+
+#### Properties
+
+##### mode
+
+> **mode**: `"abi-neutral-sentinel"`
+
+##### value?
+
+> `optional` **value?**: `string`
+
+***
+
 ### NativeTargetFrameRegisterValue
 
 #### Properties
@@ -4345,7 +4368,7 @@ by default when `output` is a TTY.
 
 ##### source
 
-> **source**: `"target-register"`
+> **source**: [`NativeTargetFrameStateValueSource`](#nativetargetframestatevaluesource)
 
 ***
 
@@ -4385,7 +4408,7 @@ by default when `output` is a TTY.
 
 ##### valueSource
 
-> **valueSource**: `"target-register"`
+> **valueSource**: [`NativeTargetFrameStateValueSource`](#nativetargetframestatevaluesource)
 
 ***
 
@@ -4400,6 +4423,10 @@ by default when `output` is a TTY.
 ##### registerValues?
 
 > `optional` **registerValues?**: [`NativeTargetFrameRegisterValue`](#nativetargetframeregistervalue)[]
+
+##### syntheticTargetCaller?
+
+> `optional` **syntheticTargetCaller?**: [`NativeSyntheticTargetCallerFrameStatePolicy`](#nativesynthetictargetcallerframestatepolicy)
 
 ***
 
@@ -7687,7 +7714,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeActualRealUtilityContinuationBoundary
 
-> **NativeActualRealUtilityContinuationBoundary** = [`NativeRealUtilityContinuationBoundary`](#nativerealutilitycontinuationboundary) \| `"target-module-bytes"`
+> **NativeActualRealUtilityContinuationBoundary** = [`NativeRealUtilityContinuationBoundary`](#nativerealutilitycontinuationboundary) \| `"target-module-bytes"` \| `"target-caller-frame"`
 
 ***
 
@@ -7759,7 +7786,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeTargetFrameStateValueSource
 
-> **NativeTargetFrameStateValueSource** = `"target-register"`
+> **NativeTargetFrameStateValueSource** = `"target-register"` \| `"synthetic-target-caller"`
 
 ***
 
@@ -8335,7 +8362,7 @@ loops; anything looser stops being a meaningful gate.
 
 ### nativeProcessImageRefusalCodes
 
-> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
+> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
@@ -128,8 +128,21 @@ describe("native actual real utility continuation planner", () => {
     });
   });
 
-  it("reports ready only when target bytes are explicitly materialized", () => {
+  it("requires a synthetic target caller frame after target bytes", () => {
     expect(planNativeActualRealUtilityContinuationAttempt(readyInput())).toMatchObject({
+      state: "refused",
+      blockingBoundary: "target-caller-frame",
+      blockingRefusal: { code: "target-caller-frame-unavailable" },
+    });
+  });
+
+  it("reports ready only when target bytes and caller frame are explicitly materialized", () => {
+    expect(
+      planNativeActualRealUtilityContinuationAttempt({
+        ...readyInput(),
+        targetCallerFrameMaterialized: true,
+      }),
+    ).toMatchObject({
       state: "ready",
       blockingBoundary: "ready",
       attemptedResume: false,

--- a/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
@@ -148,6 +148,37 @@ describe("native real utility continuation planner", () => {
     });
   });
 
+  it("accepts complete target frame-state materialization", () => {
+    expect(
+      planNativeRealUtilityContinuationAttempt({
+        ...readyInput(),
+        targetFrameState: {
+          requirements: [
+            {
+              sourceFrameId: frame.id,
+              targetAddress: "0x700000001000",
+              register: "r15",
+              slot: { register: "r15", offset: -16 },
+            },
+          ],
+          materialized: [
+            {
+              requirement: {
+                sourceFrameId: frame.id,
+                targetAddress: "0x700000001000",
+                register: "r15",
+                slot: { register: "r15", offset: -16 },
+              },
+              value: "0x0",
+              valueSource: "synthetic-target-caller",
+            },
+          ],
+          refusals: [],
+        },
+      }),
+    ).toMatchObject({ state: "ready", blockingBoundary: "ready" });
+  });
+
   it("moves recorded target callee-saved slots to a later frame-state gate", () => {
     expect(
       planNativeRealUtilityContinuationAttempt({

--- a/packages/runtime/src/__tests__/native-target-frame-state.test.ts
+++ b/packages/runtime/src/__tests__/native-target-frame-state.test.ts
@@ -44,7 +44,20 @@ describe("native target frame-state materialization", () => {
     });
   });
 
-  it("materializes slots only when explicit target-native values are supplied", () => {
+  it("materializes synthetic target-caller slots only with an explicit policy", () => {
+    const planned = planNativeTargetFrameStateMaterialization({
+      targetUnwind,
+      syntheticTargetCaller: { mode: "abi-neutral-sentinel" },
+    });
+
+    expect(planned.refusals).toEqual([]);
+    expect(planned.materialized).toMatchObject([
+      { requirement: { register: "r15" }, value: "0x0", valueSource: "synthetic-target-caller" },
+      { requirement: { register: "r14" }, value: "0x0", valueSource: "synthetic-target-caller" },
+    ]);
+  });
+
+  it("materializes slots when explicit target-native values are supplied", () => {
     const planned = planNativeTargetFrameStateMaterialization({
       targetUnwind,
       registerValues: [

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -164,6 +164,7 @@ export type {
   NativeTargetModuleByteMaterializationResult,
 } from "./native-target-module-bytes.ts";
 export type {
+  NativeSyntheticTargetCallerFrameStatePolicy,
   NativeTargetFrameRegisterValue,
   NativeTargetFrameStateMaterialization,
   NativeTargetFrameStateMaterializationRequest,

--- a/packages/runtime/src/native-actual-real-utility-continuation.ts
+++ b/packages/runtime/src/native-actual-real-utility-continuation.ts
@@ -9,11 +9,14 @@ import {
 
 export type NativeActualRealUtilityContinuationBoundary =
   | NativeRealUtilityContinuationBoundary
-  | "target-module-bytes";
+  | "target-module-bytes"
+  | "target-caller-frame";
 
 export interface NativeActualRealUtilityContinuationRequest extends NativeRealUtilityContinuationRequest {
   targetModuleByteRefusals?: NativeProcessImageRefusal[];
   targetModuleBytesMaterialized?: boolean;
+  targetCallerFrameRefusals?: NativeProcessImageRefusal[];
+  targetCallerFrameMaterialized?: boolean;
 }
 
 export interface NativeActualRealUtilityContinuationPlan {
@@ -45,6 +48,11 @@ export function planNativeActualRealUtilityContinuationAttempt(
     });
   }
 
+  const callerFrameRefusal = targetCallerFrameRefusal(request);
+  if (callerFrameRefusal) {
+    return refusedPlan("target-caller-frame", callerFrameRefusal);
+  }
+
   return {
     state: "ready",
     blockingBoundary: "ready",
@@ -52,6 +60,22 @@ export function planNativeActualRealUtilityContinuationAttempt(
     sourceTextReusedAsTargetCode: false,
     sourceIsaEmulationUsed: false,
     sidecarRuntimeUsed: false,
+  };
+}
+
+function targetCallerFrameRefusal(
+  request: NativeActualRealUtilityContinuationRequest,
+): NativeProcessImageRefusal | undefined {
+  if (request.targetCallerFrameRefusals?.[0]) {
+    return request.targetCallerFrameRefusals[0];
+  }
+  if (request.targetCallerFrameMaterialized) {
+    return undefined;
+  }
+  return {
+    code: "target-caller-frame-unavailable",
+    message:
+      "synthetic target caller frame has not been materialized for actual real utility resume",
   };
 }
 

--- a/packages/runtime/src/native-process-image.ts
+++ b/packages/runtime/src/native-process-image.ts
@@ -51,6 +51,7 @@ export const nativeProcessImageRefusalCodes = [
   "target-build-mismatch",
   "target-code-location-unresolved",
   "target-callee-saved-state-unsupported",
+  "target-caller-frame-unavailable",
   "target-code-rva-unmapped",
   "target-frame-layout-unsupported",
   "target-frame-register-value-unavailable",

--- a/packages/runtime/src/native-real-utility-continuation.ts
+++ b/packages/runtime/src/native-real-utility-continuation.ts
@@ -145,7 +145,7 @@ function targetFrameStateRefusal(
   if (request.targetFrameState?.refusals[0]) {
     return request.targetFrameState.refusals[0];
   }
-  if (request.targetFrameStateMaterialized) {
+  if (request.targetFrameStateMaterialized || targetFrameStateComplete(request.targetFrameState)) {
     return undefined;
   }
   const unsupportedSlot = request.targetUnwind?.matches
@@ -159,6 +159,16 @@ function targetFrameStateRefusal(
     message: `target callee-saved ${unsupportedSlot.register} slot is not materialized yet`,
     detail: { register: unsupportedSlot.register, offset: unsupportedSlot.offset },
   };
+}
+
+function targetFrameStateComplete(
+  targetFrameState: NativeTargetFrameStateMaterializationResult | undefined,
+): boolean {
+  return Boolean(
+    targetFrameState &&
+    targetFrameState.requirements.length > 0 &&
+    targetFrameState.materialized.length === targetFrameState.requirements.length,
+  );
 }
 
 function refusedPlan(

--- a/packages/runtime/src/native-target-frame-state.ts
+++ b/packages/runtime/src/native-target-frame-state.ts
@@ -9,7 +9,12 @@ import type {
 } from "./native-target-unwind.ts";
 
 export type NativeTargetFrameStateRegister = Exclude<NativeTargetUnwindRegister, "rsp" | "rip">;
-export type NativeTargetFrameStateValueSource = "target-register";
+export type NativeTargetFrameStateValueSource = "target-register" | "synthetic-target-caller";
+
+export interface NativeSyntheticTargetCallerFrameStatePolicy {
+  mode: "abi-neutral-sentinel";
+  value?: string;
+}
 
 export interface NativeTargetFrameRegisterValue {
   register: NativeTargetFrameStateRegister;
@@ -33,6 +38,7 @@ export interface NativeTargetFrameStateMaterialization {
 export interface NativeTargetFrameStateMaterializationRequest {
   targetUnwind: NativeTargetUnwindMatchResult;
   registerValues?: NativeTargetFrameRegisterValue[];
+  syntheticTargetCaller?: NativeSyntheticTargetCallerFrameStatePolicy;
 }
 
 export interface NativeTargetFrameStateMaterializationResult {
@@ -51,11 +57,15 @@ export function planNativeTargetFrameStateMaterialization(
 
   for (const requirement of requirements) {
     const value = values.get(requirement.register);
-    if (!value) {
-      refusals.push(missingRegisterValueRefusal(requirement));
+    if (value) {
+      materialized.push({ requirement, value: value.value, valueSource: value.source });
       continue;
     }
-    materialized.push({ requirement, value: value.value, valueSource: value.source });
+    if (request.syntheticTargetCaller) {
+      materialized.push(syntheticCallerMaterialization(requirement, request.syntheticTargetCaller));
+      continue;
+    }
+    refusals.push(missingRegisterValueRefusal(requirement));
   }
 
   return { requirements, materialized, refusals };
@@ -83,6 +93,17 @@ function requirementFromSlot(
 
 function registerValueMap(values: NativeTargetFrameRegisterValue[]) {
   return new Map(values.map((value) => [value.register, value]));
+}
+
+function syntheticCallerMaterialization(
+  requirement: NativeTargetFrameStateRequirement,
+  policy: NativeSyntheticTargetCallerFrameStatePolicy,
+): NativeTargetFrameStateMaterialization {
+  return {
+    requirement,
+    value: policy.value ?? "0x0",
+    valueSource: "synthetic-target-caller",
+  };
 }
 
 function missingRegisterValueRefusal(

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -155,6 +155,7 @@ const TOC = {
     "matchNativeTargetUnwindFrame",
     "NativeTargetFrameStateRegister",
     "NativeTargetFrameStateValueSource",
+    "NativeSyntheticTargetCallerFrameStatePolicy",
     "NativeTargetFrameRegisterValue",
     "NativeTargetFrameStateRequirement",
     "NativeTargetFrameStateMaterialization",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -195,6 +195,7 @@ function planCapturedActualUtilityBundle(
     targetUnwind: inputs.targetUnwind,
     targetFrameState: inputs.targetFrameState,
     targetModuleByteRefusals: inputs.targetBytes.refusals,
+    targetCallerFrameRefusals: syntheticTargetCallerFrameRefusals(inputs.targetFrameState),
     targetModuleBytesMaterialized: inputs.targetBytes.materialized.length > 0,
   });
   return {
@@ -251,7 +252,10 @@ function actualUtilityPlanningInputs(
     sourceFrames: sourceUnwind.frames,
     targetRoot: options.targetRoot,
   });
-  const targetFrameState = planNativeTargetFrameStateMaterialization({ targetUnwind });
+  const targetFrameState = planNativeTargetFrameStateMaterialization({
+    targetUnwind,
+    syntheticTargetCaller: { mode: "abi-neutral-sentinel" },
+  });
   const targetBytes = materializeResolvedTargetBytes(code.resolved, options.targetRoot);
   return {
     bundle,
@@ -658,8 +662,9 @@ function actualUtilitySummary(context: {
     targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
     targetUnwindRefusals: planned.targetUnwind?.refusals ?? [],
     targetFrameStateRequirements: planned.targetFrameState.requirements,
-    targetFrameStateMaterialized: planned.targetFrameState.materialized.length,
+    targetFrameStateMaterialized: planned.targetFrameState.materialized,
     targetFrameStateRefusals: planned.targetFrameState.refusals,
+    targetCallerFrameRefusals: syntheticTargetCallerFrameRefusals(planned.targetFrameState),
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),
     sourceModules: planned.sourceModules.length,
@@ -729,6 +734,27 @@ function deferredActiveSyscallLandingSummaries(
         ]
       : [];
   });
+}
+
+function syntheticTargetCallerFrameRefusals(
+  targetFrameState: ReturnType<typeof planNativeTargetFrameStateMaterialization>,
+): NativeProcessImageRefusal[] {
+  const syntheticValues = targetFrameState.materialized.filter(
+    (state) => state.valueSource === "synthetic-target-caller",
+  );
+  return syntheticValues.length > 0
+    ? [
+        {
+          code: "target-caller-frame-unavailable",
+          message:
+            "synthetic target caller frame has not been materialized for actual real utility resume",
+          detail: {
+            syntheticValues: syntheticValues.length,
+            valueSource: "synthetic-target-caller",
+          },
+        },
+      ]
+    : [];
 }
 
 function materializedTargetByteSummaries(


### PR DESCRIPTION
## Problem

The actual `/bin/sleep` proof knew which amd64 callee-saved slots target libc needs, but it still stopped because no target-native values existed for them. For a synthetic target caller, those are caller-owned values, but we should not invent them silently or claim the process can resume.

## Solution

This PR adds an explicit synthetic target-caller frame-state policy. With that policy, the planner fills the required callee-saved slots with synthetic target-caller values and marks them as synthetic, not source-register translations. The proof now gets past the frame-value blocker and stops at `target-caller-frame-unavailable`, where the synthetic caller frame still needs to be installed.

Closes #528
