### PR TITLE
Gate actual target resume execution

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -20,7 +20,8 @@ The actual captured path preserves the native-transparent gate order:
 6. target amd64 unwind matching;
 7. target frame/callee-saved state materialization;
 8. target module byte materialization from explicit target inventory/root;
-9. synthetic target-caller frame installation.
+9. synthetic target-caller frame installation;
+10. target-native resume execution path.
 
 The new actual-real-utility planner adds a final `target-module-bytes` gate. If
 all earlier gates pass but no target bytes were explicitly materialized, it
@@ -41,8 +42,9 @@ target libc, materialize native libc bytes, discover the source libc frame, matc
 the target `.eh_frame` return contract, and then refuse at the later
 `target-frame-state` gate. With an explicit synthetic target-caller policy, it can
 materialize caller-owned callee-saved slots as synthetic target values and plan a
-synthetic caller frame. The planner can then reach `ready`, while still reporting
-`attemptedResume: false` because no native jump has executed yet.
+synthetic caller frame. The actual planner then refuses at
+`target-resume-execution` with `target-resume-execution-unavailable`, while still
+reporting `attemptedResume: false` because no native jump has executed yet.
 
 That refusal is intentional. It proves the real capture path is wired into the
 same fail-closed planner as the final-jump fixture, without granting success for

--- a/docs/snapshot/native-actual-target-caller-frame.md
+++ b/docs/snapshot/native-actual-target-caller-frame.md
@@ -12,4 +12,4 @@ The synthetic values are marked as `synthetic-target-caller`. They are not copie
 
 Planning the caller frame is not the same thing as resuming the process. The proof still emits `attemptedResume: false`, `sourceIsaEmulationUsed: false`, and `sidecarRuntimeUsed: false`.
 
-With the caller-frame plan present, the continuation planner can reach its `ready` state. That means the current modeled gates have data. It does not mean a native jump has executed yet.
+With the caller-frame plan present, the continuation planner can move to the final target-resume-execution gate. That means the current modeled data gates have data. It does not mean a native jump has executed yet.

--- a/docs/snapshot/native-process-image.md
+++ b/docs/snapshot/native-process-image.md
@@ -80,6 +80,7 @@ first native-translation blockers:
 - `target-frame-register-value-unavailable`
 - `target-caller-frame-unavailable`
 - `target-return-slot-unsupported`
+- `target-resume-execution-unavailable`
 - `target-callee-saved-state-unsupported`
 
 Unsupported work must emit a precise refusal instead of silently copying source

--- a/docs/snapshot/native-real-utility-continuation.md
+++ b/docs/snapshot/native-real-utility-continuation.md
@@ -15,7 +15,8 @@ The planner checks boundaries in this order:
 5. source unwind discovery from #495;
 6. target unwind/layout match;
 7. target frame-state materialization for actual utilities;
-8. synthetic target-caller frame installation for actual utilities.
+8. synthetic target-caller frame installation for actual utilities;
+9. target-native resume execution for actual utilities.
 
 Only when every gate is modeled can a later implementation perform a final jump.
 The planner itself never jumps. It reports:
@@ -39,7 +40,8 @@ target match is supplied: it refuses at `target-unwind-mismatch` instead of
 jumping. Actual utility planning can also refuse later at `target-frame-state`
 when target unwind is found but unmodeled callee-saved slots remain, or at
 `target-caller-frame` when synthetic caller-owned values exist but no target
-caller frame has been installed.
+caller frame has been installed, or at `target-resume-execution` when no actual
+native execution path has been planned.
 
 ## Proof
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2401,6 +2401,14 @@ by default when `output` is a TTY.
 
 > `optional` **targetCallerFrameMaterialized?**: `boolean`
 
+##### targetResumeExecutionRefusals?
+
+> `optional` **targetResumeExecutionRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+##### targetResumeExecutionPlanned?
+
+> `optional` **targetResumeExecutionPlanned?**: `boolean`
+
 ##### threadRefusals?
 
 > `optional` **threadRefusals?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
@@ -2994,7 +3002,7 @@ by default when `output` is a TTY.
 
 ##### code
 
-> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
+> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"target-resume-execution-unavailable"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
 
 ##### message
 
@@ -7826,7 +7834,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeActualRealUtilityContinuationBoundary
 
-> **NativeActualRealUtilityContinuationBoundary** = [`NativeRealUtilityContinuationBoundary`](#nativerealutilitycontinuationboundary) \| `"target-module-bytes"` \| `"target-caller-frame"`
+> **NativeActualRealUtilityContinuationBoundary** = [`NativeRealUtilityContinuationBoundary`](#nativerealutilitycontinuationboundary) \| `"target-module-bytes"` \| `"target-caller-frame"` \| `"target-resume-execution"`
 
 ***
 
@@ -8474,7 +8482,7 @@ loops; anything looser stops being a meaningful gate.
 
 ### nativeProcessImageRefusalCodes
 
-> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
+> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"target-resume-execution-unavailable"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-real-utility-continuation.test.ts
@@ -136,11 +136,26 @@ describe("native actual real utility continuation planner", () => {
     });
   });
 
-  it("reports ready only when target bytes and caller frame are explicitly materialized", () => {
+  it("requires a target-native resume execution path after caller frame", () => {
     expect(
       planNativeActualRealUtilityContinuationAttempt({
         ...readyInput(),
         targetCallerFrameMaterialized: true,
+      }),
+    ).toMatchObject({
+      state: "refused",
+      blockingBoundary: "target-resume-execution",
+      blockingRefusal: { code: "target-resume-execution-unavailable" },
+      attemptedResume: false,
+    });
+  });
+
+  it("reports ready only when target bytes, caller frame, and resume execution are planned", () => {
+    expect(
+      planNativeActualRealUtilityContinuationAttempt({
+        ...readyInput(),
+        targetCallerFrameMaterialized: true,
+        targetResumeExecutionPlanned: true,
       }),
     ).toMatchObject({
       state: "ready",

--- a/packages/runtime/src/native-actual-real-utility-continuation.ts
+++ b/packages/runtime/src/native-actual-real-utility-continuation.ts
@@ -10,13 +10,16 @@ import {
 export type NativeActualRealUtilityContinuationBoundary =
   | NativeRealUtilityContinuationBoundary
   | "target-module-bytes"
-  | "target-caller-frame";
+  | "target-caller-frame"
+  | "target-resume-execution";
 
 export interface NativeActualRealUtilityContinuationRequest extends NativeRealUtilityContinuationRequest {
   targetModuleByteRefusals?: NativeProcessImageRefusal[];
   targetModuleBytesMaterialized?: boolean;
   targetCallerFrameRefusals?: NativeProcessImageRefusal[];
   targetCallerFrameMaterialized?: boolean;
+  targetResumeExecutionRefusals?: NativeProcessImageRefusal[];
+  targetResumeExecutionPlanned?: boolean;
 }
 
 export interface NativeActualRealUtilityContinuationPlan {
@@ -53,6 +56,11 @@ export function planNativeActualRealUtilityContinuationAttempt(
     return refusedPlan("target-caller-frame", callerFrameRefusal);
   }
 
+  const resumeExecutionRefusal = targetResumeExecutionRefusal(request);
+  if (resumeExecutionRefusal) {
+    return refusedPlan("target-resume-execution", resumeExecutionRefusal);
+  }
+
   return {
     state: "ready",
     blockingBoundary: "ready",
@@ -76,6 +84,21 @@ function targetCallerFrameRefusal(
     code: "target-caller-frame-unavailable",
     message:
       "synthetic target caller frame has not been materialized for actual real utility resume",
+  };
+}
+
+function targetResumeExecutionRefusal(
+  request: NativeActualRealUtilityContinuationRequest,
+): NativeProcessImageRefusal | undefined {
+  if (request.targetResumeExecutionRefusals?.[0]) {
+    return request.targetResumeExecutionRefusals[0];
+  }
+  if (request.targetResumeExecutionPlanned) {
+    return undefined;
+  }
+  return {
+    code: "target-resume-execution-unavailable",
+    message: "target-native resume execution path has not been planned for actual real utility",
   };
 }
 

--- a/packages/runtime/src/native-process-image.ts
+++ b/packages/runtime/src/native-process-image.ts
@@ -61,6 +61,7 @@ export const nativeProcessImageRefusalCodes = [
   "target-module-not-executable",
   "target-module-range-unreadable",
   "target-return-slot-unsupported",
+  "target-resume-execution-unavailable",
   "thread-state-unsupported",
   "tls-state-unsupported",
   "return-slot-unreadable",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -198,6 +198,7 @@ function planCapturedActualUtilityBundle(
     targetModuleByteRefusals: inputs.targetBytes.refusals,
     targetCallerFrameRefusals: inputs.targetCallerFrame.refusals,
     targetCallerFrameMaterialized: inputs.targetCallerFrame.state === "planned",
+    targetResumeExecutionRefusals: targetResumeExecutionRefusals(inputs.targetCallerFrame.state),
     targetModuleBytesMaterialized: inputs.targetBytes.materialized.length > 0,
   });
   return {
@@ -673,6 +674,7 @@ function actualUtilitySummary(context: {
     targetFrameStateRefusals: planned.targetFrameState.refusals,
     targetCallerFrame: planned.targetCallerFrame.frame,
     targetCallerFrameRefusals: planned.targetCallerFrame.refusals,
+    targetResumeExecutionRefusals: targetResumeExecutionRefusals(planned.targetCallerFrame.state),
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),
     sourceModules: planned.sourceModules.length,
@@ -742,6 +744,20 @@ function deferredActiveSyscallLandingSummaries(
         ]
       : [];
   });
+}
+
+function targetResumeExecutionRefusals(
+  targetCallerFrameState: "planned" | "refused",
+): NativeProcessImageRefusal[] {
+  return targetCallerFrameState === "planned"
+    ? [
+        {
+          code: "target-resume-execution-unavailable",
+          message:
+            "target-native resume execution path has not been planned for actual real utility",
+        },
+      ]
+    : [];
 }
 
 function materializedTargetByteSummaries(


### PR DESCRIPTION
## Problem

The actual `/bin/sleep` proof could reach `ready`, but that word was too broad. It meant the modeled data was present. It did not mean a target-native resume path had been planned or run.

## Solution

This PR adds a final actual-only gate for target-native resume execution. The proof keeps all the useful data from the ready plan, like target unwind, frame state, caller frame, and target bytes. It now stops at `target-resume-execution` with `target-resume-execution-unavailable`, while still saying `attemptedResume: false`.

Closes #532
