### PR TITLE
Execute actual target resume trampoline

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -42,12 +42,18 @@ target libc, materialize native libc bytes, discover the source libc frame, matc
 the target `.eh_frame` return contract, materialize caller-owned callee-saved
 slots as synthetic target values, plan a synthetic caller frame, and create a
 target-native resume execution plan. With that explicit plan present, the actual
-planner can reach `ready`, while still reporting `attemptedResume: false` because
-no native jump has executed yet.
+planner can reach `ready`.
 
-That ready state is intentional but not a migration success claim. It proves the
-real capture path has explicit data for every modeled planning gate, without
-granting success for unexecuted native resume.
+On Linux/amd64, the proof now runs a bounded target-native trampoline for that
+ready plan. The trampoline maps the explicit target amd64 bytes and transfers
+control to them on the synthetic target stack. The current actual `/bin/sleep`
+continuation faults after entering target bytes, so the proof reports
+`attemptedResume: true` and `migrationCompleted: false` instead of claiming a
+complete migration.
+
+That ready-plus-attempt state is intentional but not a migration success claim. It
+proves the real capture path has explicit data for every modeled planning gate
+and that the first execution transfer reaches target-native bytes.
 
 ## Non-claims
 

--- a/docs/snapshot/native-actual-target-resume-execution.md
+++ b/docs/snapshot/native-actual-target-resume-execution.md
@@ -1,10 +1,10 @@
-# Native actual target resume execution plan
+# Native actual target resume execution
 
-Issue #534 adds an explicit target-native resume execution plan for the actual `/bin/sleep` proof.
+Issue #534 added the explicit target-native resume execution plan for the actual `/bin/sleep` proof. Issue #536 adds the first bounded execution attempt for that plan.
 
-## What is new
+## Plan gate
 
-The proof now creates a resume execution plan only after these earlier gates have data:
+The proof creates a resume execution plan only after these earlier gates have data:
 
 - mapped target-native code location;
 - target-native module bytes from the explicit amd64 target root;
@@ -12,19 +12,30 @@ The proof now creates a resume execution plan only after these earlier gates hav
 - target frame-state materialization;
 - synthetic target caller frame.
 
-The plan records the target architecture, entry address, stack pointer, caller-frame id, target byte modules, and the intended executor (`native-resume-trampoline`).
+The plan records the target architecture, entry address, stack pointer, caller-frame id, target byte modules, and the intended executor (`native-resume-trampoline`). The planner itself still reports `attemptedResume: false`; it does not jump.
 
-## Boundary
+## Execution attempt
 
-This is still not a native jump. The plan mode is `planned-not-executed`, and the summary keeps:
+On Linux/amd64, the actual proof now runs a short-lived native helper. The helper maps the explicit target amd64 byte window at the planned target address, installs the synthetic target stack, transfers control to the target bytes, and records what happened.
+
+The current `/bin/sleep` continuation is still not a completed migration. The attempt is expected to fault until more libc/kernel continuation state is modeled. A fault is still useful proof: it shows that control reached the target-native amd64 instruction stream without source text reuse, source-ISA emulation, or a Node/Bun sidecar.
+
+The summary reports the attempt separately:
 
 ```json
 {
-  "attemptedResume": false,
+  "targetResumeExecutionAttempt": {
+    "status": "faulted",
+    "targetArch": "amd64",
+    "instructionPointerInTargetBytes": true,
+    "attemptedResume": true
+  },
+  "attemptedResume": true,
+  "migrationCompleted": false,
   "sourceTextReusedAsTargetCode": false,
   "sourceIsaEmulationUsed": false,
   "sidecarRuntimeUsed": false
 }
 ```
 
-With this plan present, the actual continuation planner can reach `ready`. That means all modeled planning gates have explicit data. It does not mean `/bin/sleep` has resumed on amd64 yet.
+`migrationCompleted: false` is intentional. This proves the first native execution transfer, not full transparent process migration.

--- a/docs/snapshot/native-real-utility-continuation.md
+++ b/docs/snapshot/native-real-utility-continuation.md
@@ -42,8 +42,9 @@ when target unwind is found but unmodeled callee-saved slots remain, or at
 `target-caller-frame` when synthetic caller-owned values exist but no target
 caller frame has been installed, or at `target-resume-execution` when no actual
 native execution path has been planned. When that execution path is planned, the
-actual planner can reach `ready` while still reporting that no resume was
-attempted.
+actual planner can reach `ready`. The actual two-host proof may then run a
+bounded native trampoline and report a separate `targetResumeExecutionAttempt`,
+without treating a fault as completed process migration.
 
 ## Proof
 

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1,0 +1,402 @@
+// Actual target-native resume probe for captured real-utility continuations.
+//
+// This helper is intentionally narrow. It runs only as a short-lived
+// Linux/amd64 subprocess. It maps an explicit window of target-native bytes at
+// the planned target address, installs a target stack, transfers control to the
+// bytes, and reports whether the CPU reached that target instruction stream.
+// Faults are expected while broader process state is still unmodeled; they are
+// reported as proof data instead of being treated as a completed migration.
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
+#if defined(__linux__) && defined(__x86_64__)
+#include <setjmp.h>
+#include <signal.h>
+#include <ucontext.h>
+#endif
+
+struct Options {
+  const char *code_file;
+  uint64_t file_offset;
+  uint64_t code_size;
+  uint64_t target_address;
+  uint64_t stack_target_start;
+  uint64_t stack_size;
+  uint64_t stack_pointer;
+};
+
+static void usage(void) {
+  fprintf(stderr,
+      "usage: machinen-native-actual-resume-trampoline --code-file path "
+      "--file-offset n --code-size n --target-address addr "
+      "--stack-target-start addr --stack-size n --stack-pointer addr\n");
+  exit(2);
+}
+
+static uint64_t parse_u64(const char *value, const char *field) {
+  errno = 0;
+  char *end = NULL;
+  uint64_t parsed = strtoull(value, &end, 0);
+  if (errno != 0 || end == value || *end != '\0') {
+    fprintf(stderr, "native-actual-resume-trampoline: invalid %s: %s\n", field, value);
+    exit(2);
+  }
+  return parsed;
+}
+
+static bool streq(const char *left, const char *right) {
+  return strcmp(left, right) == 0;
+}
+
+static struct Options parse_args(int argc, char **argv) {
+  struct Options opts = {0};
+  for (int i = 1; i < argc; i++) {
+    if (streq(argv[i], "--code-file")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.code_file = argv[i];
+    } else if (streq(argv[i], "--file-offset")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.file_offset = parse_u64(argv[i], "file-offset");
+    } else if (streq(argv[i], "--code-size")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.code_size = parse_u64(argv[i], "code-size");
+    } else if (streq(argv[i], "--target-address")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.target_address = parse_u64(argv[i], "target-address");
+    } else if (streq(argv[i], "--stack-target-start")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.stack_target_start = parse_u64(argv[i], "stack-target-start");
+    } else if (streq(argv[i], "--stack-size")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.stack_size = parse_u64(argv[i], "stack-size");
+    } else if (streq(argv[i], "--stack-pointer")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.stack_pointer = parse_u64(argv[i], "stack-pointer");
+    } else {
+      usage();
+    }
+  }
+  if (!opts.code_file || opts.code_size == 0 || opts.stack_size == 0 ||
+      opts.stack_pointer == 0) {
+    usage();
+  }
+  return opts;
+}
+
+#if defined(__linux__) && defined(__x86_64__)
+
+static sigjmp_buf resume_fault_jmp;
+static volatile sig_atomic_t observed_signal = 0;
+static volatile uintptr_t observed_fault_address = 0;
+static volatile uintptr_t observed_rip = 0;
+static volatile uintptr_t observed_rsp = 0;
+static uint64_t mapped_target_start = 0;
+static uint64_t mapped_target_end = 0;
+static uint64_t resume_return_value = 0;
+static uint64_t host_rsp_before_jump __attribute__((used)) = 0;
+
+static long page_size(void) {
+  long size = sysconf(_SC_PAGESIZE);
+  if (size <= 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: sysconf(_SC_PAGESIZE) failed\n");
+    exit(1);
+  }
+  return size;
+}
+
+static uint64_t align_down(uint64_t value, uint64_t alignment) {
+  return value & ~(alignment - 1u);
+}
+
+static uint64_t align_up(uint64_t value, uint64_t alignment) {
+  return (value + alignment - 1u) & ~(alignment - 1u);
+}
+
+static void validate_page_aligned(uint64_t value, const char *field) {
+  uint64_t size = (uint64_t)page_size();
+  if (value % size != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: %s must be page-aligned\n", field);
+    exit(2);
+  }
+}
+
+static void read_exact(int fd, void *dst, uint64_t size, uint64_t offset) {
+  uint8_t *bytes = dst;
+  uint64_t cursor = 0;
+  while (cursor < size) {
+    size_t chunk = size - cursor > 1024u * 1024u ? 1024u * 1024u : (size_t)(size - cursor);
+    ssize_t got = pread(fd, bytes + cursor, chunk, (off_t)(offset + cursor));
+    if (got < 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: code read failed: %s\n", strerror(errno));
+      exit(1);
+    }
+    if (got == 0) {
+      fprintf(stderr,
+          "native-actual-resume-trampoline: code read was short at offset 0x%" PRIx64 "\n",
+          offset + cursor);
+      exit(1);
+    }
+    cursor += (uint64_t)got;
+  }
+}
+
+static void *map_fixed(uint64_t target_start, uint64_t size, int prot, const char *label) {
+  validate_page_aligned(target_start, label);
+  validate_page_aligned(size, label);
+  void *target = (void *)(uintptr_t)target_start;
+  void *mapped = mmap(
+      target, (size_t)size, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+  if (mapped == MAP_FAILED) {
+    fprintf(stderr,
+        "native-actual-resume-trampoline: %s mmap at 0x%" PRIx64 " failed: %s\n",
+        label,
+        target_start,
+        strerror(errno));
+    exit(1);
+  }
+  if (mapped != target) {
+    fprintf(stderr, "native-actual-resume-trampoline: %s mmap ignored target address\n", label);
+    exit(1);
+  }
+  return mapped;
+}
+
+static void *map_target_code(const struct Options *opts, uint64_t *mapped_start, uint64_t *mapped_size) {
+  uint64_t size = (uint64_t)page_size();
+  uint64_t page_start = align_down(opts->target_address, size);
+  uint64_t page_offset = opts->target_address - page_start;
+  uint64_t total_size = align_up(page_offset + opts->code_size, size);
+  void *mapped = map_fixed(page_start, total_size, PROT_READ | PROT_WRITE, "target-code");
+  int fd = open(opts->code_file, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr,
+        "native-actual-resume-trampoline: open target code failed for %s: %s\n",
+        opts->code_file,
+        strerror(errno));
+    exit(1);
+  }
+  read_exact(fd, (uint8_t *)mapped + page_offset, opts->code_size, opts->file_offset);
+  close(fd);
+  if (mprotect(mapped, (size_t)total_size, PROT_READ | PROT_EXEC) != 0) {
+    fprintf(stderr,
+        "native-actual-resume-trampoline: target code mprotect failed: %s\n",
+        strerror(errno));
+    exit(1);
+  }
+  *mapped_start = page_start;
+  *mapped_size = total_size;
+  return mapped;
+}
+
+static const char *signal_name(int signum) {
+  switch (signum) {
+  case SIGSEGV:
+    return "SIGSEGV";
+  case SIGILL:
+    return "SIGILL";
+  case SIGBUS:
+    return "SIGBUS";
+  case SIGFPE:
+    return "SIGFPE";
+  case SIGSYS:
+    return "SIGSYS";
+  case SIGALRM:
+    return "SIGALRM";
+  default:
+    return "SIGNAL";
+  }
+}
+
+static void signal_handler(int signum, siginfo_t *info, void *context) {
+  ucontext_t *uc = (ucontext_t *)context;
+  observed_signal = signum;
+  observed_fault_address = (uintptr_t)info->si_addr;
+  observed_rip = (uintptr_t)uc->uc_mcontext.gregs[REG_RIP];
+  observed_rsp = (uintptr_t)uc->uc_mcontext.gregs[REG_RSP];
+  siglongjmp(resume_fault_jmp, 1);
+}
+
+static void install_signal_handlers(void) {
+  stack_t signal_stack = {0};
+  signal_stack.ss_size = SIGSTKSZ;
+  signal_stack.ss_sp = malloc(signal_stack.ss_size);
+  if (!signal_stack.ss_sp) {
+    fprintf(stderr, "native-actual-resume-trampoline: signal stack allocation failed\n");
+    exit(1);
+  }
+  if (sigaltstack(&signal_stack, NULL) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: sigaltstack failed: %s\n", strerror(errno));
+    exit(1);
+  }
+
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  sigemptyset(&action.sa_mask);
+  action.sa_sigaction = signal_handler;
+  action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  int signals[] = {SIGSEGV, SIGILL, SIGBUS, SIGFPE, SIGSYS, SIGALRM};
+  for (size_t i = 0; i < sizeof(signals) / sizeof(signals[0]); i++) {
+    if (sigaction(signals[i], &action, NULL) != 0) {
+      fprintf(stderr,
+          "native-actual-resume-trampoline: sigaction failed for %s: %s\n",
+          signal_name(signals[i]),
+          strerror(errno));
+      exit(1);
+    }
+  }
+}
+
+static void validate_stack_options(const struct Options *opts) {
+  validate_page_aligned(opts->stack_target_start, "stack-target-start");
+  validate_page_aligned(opts->stack_size, "stack-size");
+  uint64_t stack_end = opts->stack_target_start + opts->stack_size;
+  if (opts->stack_pointer < opts->stack_target_start + 16u || opts->stack_pointer > stack_end) {
+    fprintf(stderr, "native-actual-resume-trampoline: stack pointer is outside target stack\n");
+    exit(2);
+  }
+  if (opts->stack_pointer % 16u != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: stack pointer must be 16-byte aligned\n");
+    exit(2);
+  }
+}
+
+static void jump_to_target(uint64_t entry, uint64_t initial_rsp) {
+  __asm__ __volatile__(
+      "movq %%rsp, host_rsp_before_jump(%%rip)\n"
+      "movq %[initial_rsp], %%rsp\n"
+      "leaq 1f(%%rip), %%rax\n"
+      "movq %%rax, (%%rsp)\n"
+      "xorl %%eax, %%eax\n"
+      "xorl %%edi, %%edi\n"
+      "xorl %%esi, %%esi\n"
+      "xorl %%edx, %%edx\n"
+      "xorl %%ecx, %%ecx\n"
+      "xorl %%r8d, %%r8d\n"
+      "xorl %%r9d, %%r9d\n"
+      "xorl %%r10d, %%r10d\n"
+      "xorl %%r11d, %%r11d\n"
+      "jmp *%[entry]\n"
+      "1:\n"
+      "movq %%rax, resume_return_value(%%rip)\n"
+      "movq host_rsp_before_jump(%%rip), %%rsp\n"
+      :
+      : [entry] "r"((void *)(uintptr_t)entry), [initial_rsp] "r"(initial_rsp)
+      : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "memory");
+}
+
+static bool rip_inside_target_bytes(uint64_t rip) {
+  return rip >= mapped_target_start && rip < mapped_target_end;
+}
+
+static void print_fault_event(const struct Options *opts) {
+  uint64_t rip = (uint64_t)observed_rip;
+  printf(
+      "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"faulted\"," 
+      "\"targetArch\":\"amd64\",\"entry\":\"0x%" PRIx64 "\"," 
+      "\"signal\":\"%s\",\"signalNumber\":%d," 
+      "\"faultAddress\":\"0x%" PRIx64 "\"," 
+      "\"targetInstructionPointer\":\"0x%" PRIx64 "\"," 
+      "\"observedRsp\":\"0x%" PRIx64 "\"," 
+      "\"stackPointer\":\"0x%" PRIx64 "\"," 
+      "\"targetBytesStart\":\"0x%" PRIx64 "\"," 
+      "\"targetBytesEnd\":\"0x%" PRIx64 "\"," 
+      "\"instructionPointerInTargetBytes\":%s,"
+      "\"attemptedResume\":true,\"sourceTextReusedAsTargetCode\":false,"
+      "\"sourceIsaEmulationUsed\":false,\"sidecarRuntimeUsed\":false}\n",
+      opts->target_address,
+      signal_name(observed_signal),
+      observed_signal,
+      (uint64_t)observed_fault_address,
+      rip,
+      (uint64_t)observed_rsp,
+      opts->stack_pointer,
+      mapped_target_start,
+      mapped_target_end,
+      rip_inside_target_bytes(rip) ? "true" : "false");
+}
+
+static void print_return_event(const struct Options *opts) {
+  printf(
+      "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
+      "\"targetArch\":\"amd64\",\"entry\":\"0x%" PRIx64 "\"," 
+      "\"returnValue\":\"0x%" PRIx64 "\"," 
+      "\"stackPointer\":\"0x%" PRIx64 "\"," 
+      "\"targetBytesStart\":\"0x%" PRIx64 "\"," 
+      "\"targetBytesEnd\":\"0x%" PRIx64 "\"," 
+      "\"instructionPointerInTargetBytes\":true,"
+      "\"attemptedResume\":true,\"sourceTextReusedAsTargetCode\":false,"
+      "\"sourceIsaEmulationUsed\":false,\"sidecarRuntimeUsed\":false}\n",
+      opts->target_address,
+      resume_return_value,
+      opts->stack_pointer,
+      mapped_target_start,
+      mapped_target_end);
+}
+
+int main(int argc, char **argv) {
+  struct Options opts = parse_args(argc, argv);
+  validate_stack_options(&opts);
+  mapped_target_start = opts.target_address;
+  mapped_target_end = opts.target_address + opts.code_size;
+
+  uint64_t mapped_code_start = 0;
+  uint64_t mapped_code_size = 0;
+  void *code = map_target_code(&opts, &mapped_code_start, &mapped_code_size);
+  void *stack = map_fixed(
+      opts.stack_target_start, opts.stack_size, PROT_READ | PROT_WRITE, "target-stack");
+
+  install_signal_handlers();
+  alarm(1);
+  if (sigsetjmp(resume_fault_jmp, 1) == 0) {
+    jump_to_target(opts.target_address, opts.stack_pointer - 8u);
+    alarm(0);
+    print_return_event(&opts);
+  } else {
+    alarm(0);
+    print_fault_event(&opts);
+  }
+
+  munmap(stack, (size_t)opts.stack_size);
+  munmap(code, (size_t)mapped_code_size);
+  (void)mapped_code_start;
+  return 0;
+}
+
+#else
+
+int main(int argc, char **argv) {
+  (void)parse_args(argc, argv);
+  fprintf(stderr, "native-actual-resume-trampoline: target-native resume requires linux/amd64\n");
+  return 77;
+}
+
+#endif

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -146,6 +146,8 @@
 - [`NativeSyntheticTargetCallerFramePlanRequest`](#nativesynthetictargetcallerframeplanrequest)
 - [`NativeSyntheticTargetCallerFramePlanResult`](#nativesynthetictargetcallerframeplanresult)
 - [`planNativeSyntheticTargetCallerFrame`](#plannativesynthetictargetcallerframe)
+- [`NativeTargetResumeExecutionAttempt`](#nativetargetresumeexecutionattempt)
+- [`NativeTargetResumeExecutionAttemptStatus`](#nativetargetresumeexecutionattemptstatus)
 - [`NativeTargetResumeExecutionMode`](#nativetargetresumeexecutionmode)
 - [`NativeTargetResumeExecutor`](#nativetargetresumeexecutor)
 - [`NativeTargetResumeExecutionPlan`](#nativetargetresumeexecutionplan)
@@ -4660,6 +4662,76 @@ by default when `output` is a TTY.
 
 ***
 
+### NativeTargetResumeExecutionAttempt
+
+#### Properties
+
+##### status
+
+> **status**: [`NativeTargetResumeExecutionAttemptStatus`](#nativetargetresumeexecutionattemptstatus)
+
+##### targetArch
+
+> **targetArch**: `"amd64"`
+
+##### entryAddress
+
+> **entryAddress**: `string`
+
+##### stackPointer
+
+> **stackPointer**: `string`
+
+##### targetBytesStart
+
+> **targetBytesStart**: `string`
+
+##### targetBytesEnd
+
+> **targetBytesEnd**: `string`
+
+##### targetInstructionPointer?
+
+> `optional` **targetInstructionPointer?**: `string`
+
+##### signal?
+
+> `optional` **signal?**: `string`
+
+##### signalNumber?
+
+> `optional` **signalNumber?**: `number`
+
+##### faultAddress?
+
+> `optional` **faultAddress?**: `string`
+
+##### returnValue?
+
+> `optional` **returnValue?**: `string`
+
+##### instructionPointerInTargetBytes
+
+> **instructionPointerInTargetBytes**: `boolean`
+
+##### attemptedResume
+
+> **attemptedResume**: `true`
+
+##### sourceTextReusedAsTargetCode
+
+> **sourceTextReusedAsTargetCode**: `false`
+
+##### sourceIsaEmulationUsed
+
+> **sourceIsaEmulationUsed**: `false`
+
+##### sidecarRuntimeUsed
+
+> **sidecarRuntimeUsed**: `false`
+
+***
+
 ### NativeTargetResumeExecutionPlan
 
 #### Properties
@@ -8011,6 +8083,12 @@ Poll interval in ms while retrying. Default 250.
 ### NativeTargetResumeExecutor
 
 > **NativeTargetResumeExecutor** = `"native-resume-trampoline"`
+
+***
+
+### NativeTargetResumeExecutionAttemptStatus
+
+> **NativeTargetResumeExecutionAttemptStatus** = `"returned"` \| `"faulted"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-real-utility-continuation-script.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-real-utility-continuation-script.test.ts
@@ -19,6 +19,11 @@ interface ActualRealUtilitySummary {
   blockingRefusal?: { code: string };
   plan?: { state: string; blockingBoundary: string; blockingRefusal?: { code: string } };
   attemptedResume?: boolean;
+  migrationCompleted?: boolean;
+  targetResumeExecutionAttempt?: {
+    attemptedResume: boolean;
+    instructionPointerInTargetBytes: boolean;
+  };
   sourceTextReusedAsTargetCode?: boolean;
   sourceIsaEmulationUsed?: boolean;
   sidecarRuntimeUsed?: boolean;
@@ -56,14 +61,23 @@ describe("native actual real utility continuation proof script", () => {
       expect(summary.phase).toBe("actual-real-utility-capture");
       expect(summary.actualCapturedUtility).toBe(true);
       expect(summary.processImageValidated).toBe(true);
-      expect(summary.attemptedResume).toBe(false);
+      expect(summary.attemptedResume).toBe(
+        summary.targetResumeExecutionAttempt?.attemptedResume ?? false,
+      );
+      expect(summary.migrationCompleted).toBe(false);
       expect(summary.sourceTextReusedAsTargetCode).toBe(false);
       expect(summary.sourceIsaEmulationUsed).toBe(false);
       expect(summary.sidecarRuntimeUsed).toBe(false);
       expect(summary.plan?.state).toBe("refused");
       expect(summary.blockingBoundary).toBe(summary.plan?.blockingBoundary);
       expect(summary.blockingRefusal?.code).toBe(summary.plan?.blockingRefusal?.code);
-      expect(summary.execution).toBe(`actual-real-utility-refused-at-${summary.blockingBoundary}`);
+      if (summary.plan?.state === "refused") {
+        expect(summary.execution).toBe(
+          `actual-real-utility-refused-at-${summary.blockingBoundary}`,
+        );
+      } else {
+        expect(summary.targetResumeExecutionAttempt?.instructionPointerInTargetBytes).toBe(true);
+      }
       expect(summary.threadSyscalls?.length).toBeGreaterThan(0);
     },
   );

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const SOURCE = join(REPO_ROOT, "packages/microvm/assets/native-actual-resume-trampoline.c");
+const PREFIX = "MACHINEN_ACTUAL_RESUME_TRAMPOLINE ";
+
+function compileHelper(outDir: string) {
+  const helper = join(outDir, "machinen-native-actual-resume-trampoline");
+  const result = spawnSync(
+    "cc",
+    [
+      "-std=c11",
+      "-O0",
+      "-g",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-pie",
+      "-no-pie",
+      SOURCE,
+      "-o",
+      helper,
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return helper;
+}
+
+function runHelper(helper: string, codeFile: string, codeSize: number) {
+  const result = spawnSync(
+    helper,
+    [
+      "--code-file",
+      codeFile,
+      "--file-offset",
+      "0",
+      "--code-size",
+      String(codeSize),
+      "--target-address",
+      "0x710000001000",
+      "--stack-target-start",
+      "0x520000000000",
+      "--stack-size",
+      String(64 * 1024),
+      "--stack-pointer",
+      "0x520000010000",
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  const line = result.stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(PREFIX));
+  expect(line).toBeTruthy();
+  return JSON.parse(line!.slice(PREFIX.length));
+}
+
+describe("native actual resume trampoline", () => {
+  it.skipIf(process.platform !== "linux" || process.arch !== "x64")(
+    "reports returned and faulted target-native attempts",
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "native-actual-resume-trampoline-test-"));
+      const helper = compileHelper(outDir);
+
+      const returnCode = join(outDir, "return.bin");
+      writeFileSync(returnCode, Buffer.from([0xc3]));
+      expect(runHelper(helper, returnCode, 1)).toMatchObject({
+        status: "returned",
+        targetArch: "amd64",
+        entry: "0x710000001000",
+        instructionPointerInTargetBytes: true,
+        attemptedResume: true,
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      });
+
+      const faultCode = join(outDir, "fault.bin");
+      writeFileSync(faultCode, Buffer.from([0x48, 0x8b, 0x00]));
+      expect(runHelper(helper, faultCode, 3)).toMatchObject({
+        status: "faulted",
+        targetArch: "amd64",
+        entry: "0x710000001000",
+        signal: "SIGSEGV",
+        targetInstructionPointer: "0x710000001000",
+        instructionPointerInTargetBytes: true,
+        attemptedResume: true,
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      });
+    },
+  );
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -166,6 +166,8 @@ export type {
   NativeTargetModuleByteMaterializationResult,
 } from "./native-target-module-bytes.ts";
 export type {
+  NativeTargetResumeExecutionAttempt,
+  NativeTargetResumeExecutionAttemptStatus,
   NativeTargetResumeExecutionMode,
   NativeTargetResumeExecutionPlan,
   NativeTargetResumeExecutionPlanRequest,

--- a/packages/runtime/src/native-target-resume-execution.ts
+++ b/packages/runtime/src/native-target-resume-execution.ts
@@ -9,6 +9,26 @@ import type { NativeTargetModuleByteMaterialization } from "./native-target-modu
 
 export type NativeTargetResumeExecutionMode = "planned-not-executed";
 export type NativeTargetResumeExecutor = "native-resume-trampoline";
+export type NativeTargetResumeExecutionAttemptStatus = "returned" | "faulted";
+
+export interface NativeTargetResumeExecutionAttempt {
+  status: NativeTargetResumeExecutionAttemptStatus;
+  targetArch: "amd64";
+  entryAddress: string;
+  stackPointer: string;
+  targetBytesStart: string;
+  targetBytesEnd: string;
+  targetInstructionPointer?: string;
+  signal?: string;
+  signalNumber?: number;
+  faultAddress?: string;
+  returnValue?: string;
+  instructionPointerInTargetBytes: boolean;
+  attemptedResume: true;
+  sourceTextReusedAsTargetCode: false;
+  sourceIsaEmulationUsed: false;
+  sidecarRuntimeUsed: false;
+}
 
 export interface NativeTargetResumeExecutionPlan {
   mode: NativeTargetResumeExecutionMode;

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -168,6 +168,8 @@ const TOC = {
     "NativeSyntheticTargetCallerFramePlanRequest",
     "NativeSyntheticTargetCallerFramePlanResult",
     "planNativeSyntheticTargetCallerFrame",
+    "NativeTargetResumeExecutionAttempt",
+    "NativeTargetResumeExecutionAttemptStatus",
     "NativeTargetResumeExecutionMode",
     "NativeTargetResumeExecutor",
     "NativeTargetResumeExecutionPlan",

--- a/scripts/controlled-corpus-utils.mjs
+++ b/scripts/controlled-corpus-utils.mjs
@@ -49,6 +49,10 @@ export const NATIVE_RESUME_TRAMPOLINE_SOURCE = join(
   REPO_ROOT,
   "packages/microvm/assets/native-resume-trampoline.c",
 );
+export const NATIVE_ACTUAL_RESUME_TRAMPOLINE_SOURCE = join(
+  REPO_ROOT,
+  "packages/microvm/assets/native-actual-resume-trampoline.c",
+);
 export const NATIVE_FINAL_JUMP_SOURCE_TARGET_SOURCE = join(
   REPO_ROOT,
   "packages/microvm/assets/native-final-jump-source.c",
@@ -423,6 +427,28 @@ export function compileNativeResumeTrampoline(binDir) {
       executable,
     ],
     { label: "native resume trampoline build" },
+  );
+  return executable;
+}
+
+export function compileNativeActualResumeTrampoline(binDir) {
+  const executable = join(binDir, "machinen-native-actual-resume-trampoline");
+  runCommand(
+    "cc",
+    [
+      "-std=c11",
+      "-O0",
+      "-g",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-fno-pie",
+      "-no-pie",
+      NATIVE_ACTUAL_RESUME_TRAMPOLINE_SOURCE,
+      "-o",
+      executable,
+    ],
+    { label: "native actual resume trampoline build" },
   );
   return executable;
 }

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -12,7 +12,10 @@ import { planNativeActualRealUtilityContinuationAttempt } from "../packages/runt
 import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/native-target-module-bytes.ts";
 import { planNativeTargetFrameStateMaterialization } from "../packages/runtime/src/native-target-frame-state.ts";
 import { planNativeSyntheticTargetCallerFrame } from "../packages/runtime/src/native-target-caller-frame.ts";
-import { planNativeTargetResumeExecution } from "../packages/runtime/src/native-target-resume-execution.ts";
+import {
+  planNativeTargetResumeExecution,
+  type NativeTargetResumeExecutionAttempt,
+} from "../packages/runtime/src/native-target-resume-execution.ts";
 import {
   matchNativeTargetUnwindFrame,
   parseNativeTargetEhFrameText,
@@ -36,9 +39,11 @@ import {
 import { translateNativeRegisterState } from "../packages/runtime/src/native-register-translation.ts";
 import { translateNativeResources } from "../packages/runtime/src/native-resource-translation.ts";
 import {
+  NATIVE_ACTUAL_RESUME_TRAMPOLINE_SOURCE,
   NATIVE_CAPTURE_SOURCE,
   NATIVE_PROCESS_IMAGE_BUNDLE_FILES,
   bundleFileStats,
+  compileNativeActualResumeTrampoline,
   compileNativeProcessCapturer,
   ensureSourcesExist,
   hostArch,
@@ -70,6 +75,10 @@ const UTILITY_NAME = "sleep";
 const SETTLE_MS = "150";
 const TARGET_BYTE_WINDOW = 32;
 const SOURCE_UNWIND_FILE = "native-source-unwind.json";
+const ACTUAL_RESUME_STACK_SIZE = 64 * 1024;
+const ACTUAL_RESUME_TARGET_STACK_START = 0x500000000000n;
+const ACTUAL_RESUME_TARGET_STACK_POINTER =
+  ACTUAL_RESUME_TARGET_STACK_START + BigInt(ACTUAL_RESUME_STACK_SIZE);
 
 function main() {
   const args = parseVerifyArgs(process.argv.slice(2), USAGE);
@@ -171,6 +180,7 @@ function consumeAmd64ActualUtility(outDir: string, sourceBundleDir: string) {
   });
   assert(planned.bundle.manifest.capture.sourceArch === "arm64", "source bundle must be arm64");
   assert(planned.bundle.manifest.target.arch === "amd64", "source bundle target must be amd64");
+  const resumeAttempt = executeActualTargetResumeAttempt(outDir, planned);
   return actualUtilitySummary({
     phase: "actual-real-utility-target-plan",
     hostArch: "amd64",
@@ -178,6 +188,7 @@ function consumeAmd64ActualUtility(outDir: string, sourceBundleDir: string) {
     targetRoot,
     command: planned.bundle.manifest.process.argv,
     planned,
+    resumeAttempt,
     outDir,
   });
 }
@@ -263,7 +274,10 @@ function actualUtilityPlanningInputs(
   });
   const targetCallerFrame = planNativeSyntheticTargetCallerFrame({
     frameState: targetFrameState,
-    policy: { mode: "abi-neutral-sentinel" },
+    policy: {
+      mode: "abi-neutral-sentinel",
+      stackPointer: finalJumpHex(ACTUAL_RESUME_TARGET_STACK_POINTER),
+    },
   });
   const targetBytes = materializeResolvedTargetBytes(code.resolved, options.targetRoot);
   const targetResumeExecution = planNativeTargetResumeExecution({
@@ -641,6 +655,106 @@ function resolveActualTargetPath(targetRoot: string | undefined, modulePath: str
   return join(targetRoot, isAbsolute(modulePath) ? modulePath.slice(1) : modulePath);
 }
 
+function executeActualTargetResumeAttempt(
+  outDir: string,
+  planned: ReturnType<typeof planCapturedActualUtilityBundle>,
+): NativeTargetResumeExecutionAttempt | undefined {
+  if (planned.plan.state !== "ready" || !planned.targetResumeExecution.plan) {
+    return undefined;
+  }
+  const targetBytes = planned.targetBytes.materialized[0];
+  assert(targetBytes, "ready actual resume plan has no target bytes");
+  ensureSourcesExist([NATIVE_ACTUAL_RESUME_TRAMPOLINE_SOURCE]);
+  const binDir = join(outDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const trampoline = compileNativeActualResumeTrampoline(binDir);
+  const result = spawnSync(
+    trampoline,
+    [
+      "--code-file",
+      targetBytes.path,
+      "--file-offset",
+      String(targetBytes.fileOffset),
+      "--code-size",
+      String(targetBytes.sizeBytes),
+      "--target-address",
+      planned.targetResumeExecution.plan.entryAddress,
+      "--stack-target-start",
+      finalJumpHex(ACTUAL_RESUME_TARGET_STACK_START),
+      "--stack-size",
+      String(ACTUAL_RESUME_STACK_SIZE),
+      "--stack-pointer",
+      planned.targetResumeExecution.plan.stackPointer,
+    ],
+    { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 },
+  );
+  assert(
+    result.status === 0,
+    `native actual target resume trampoline failed: ${result.stderr || result.stdout}`,
+  );
+  const line = result.stdout
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith("MACHINEN_ACTUAL_RESUME_TRAMPOLINE "));
+  assert(line, "native actual target resume trampoline did not emit an event");
+  return normalizeActualResumeAttempt(
+    JSON.parse(line.slice("MACHINEN_ACTUAL_RESUME_TRAMPOLINE ".length)),
+  );
+}
+
+function normalizeActualResumeAttempt(
+  event: Record<string, unknown>,
+): NativeTargetResumeExecutionAttempt {
+  assertActualResumeEventInvariants(event);
+  return {
+    status: actualResumeStatus(event.status),
+    targetArch: "amd64",
+    entryAddress: String(event.entry),
+    stackPointer: String(event.stackPointer),
+    targetBytesStart: String(event.targetBytesStart),
+    targetBytesEnd: String(event.targetBytesEnd),
+    targetInstructionPointer: optionalString(event.targetInstructionPointer),
+    signal: optionalString(event.signal),
+    signalNumber: optionalNumber(event.signalNumber),
+    faultAddress: optionalString(event.faultAddress),
+    returnValue: optionalString(event.returnValue),
+    instructionPointerInTargetBytes: true,
+    attemptedResume: true,
+    sourceTextReusedAsTargetCode: false,
+    sourceIsaEmulationUsed: false,
+    sidecarRuntimeUsed: false,
+  };
+}
+
+function assertActualResumeEventInvariants(event: Record<string, unknown>) {
+  assert(event.targetArch === "amd64", "actual target resume event used the wrong architecture");
+  assert(event.attemptedResume === true, "actual target resume event did not attempt resume");
+  assert(
+    event.sourceTextReusedAsTargetCode === false,
+    "actual target resume event reused source text as target code",
+  );
+  assert(
+    event.sourceIsaEmulationUsed === false,
+    "actual target resume event used source ISA emulation",
+  );
+  assert(event.sidecarRuntimeUsed === false, "actual target resume event used a sidecar runtime");
+  assert(
+    event.instructionPointerInTargetBytes === true,
+    "actual target resume event did not enter the target byte window",
+  );
+}
+
+function actualResumeStatus(value: unknown): NativeTargetResumeExecutionAttempt["status"] {
+  return value === "returned" ? "returned" : "faulted";
+}
+
+function optionalString(value: unknown): string | undefined {
+  return value === undefined ? undefined : String(value);
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return value === undefined ? undefined : Number(value);
+}
+
 function actualUtilitySummary(context: {
   phase: string;
   hostArch: "arm64" | "amd64";
@@ -648,10 +762,12 @@ function actualUtilitySummary(context: {
   targetRoot?: string;
   capturer?: string;
   command: string[];
+  resumeAttempt?: NativeTargetResumeExecutionAttempt;
   outDir?: string;
   planned: ReturnType<typeof planCapturedActualUtilityBundle>;
 }) {
   const { planned } = context;
+  const resumeFields = resumeAttemptSummaryFields(context.resumeAttempt);
   return {
     formatVersion: 1,
     phase: context.phase,
@@ -675,14 +791,14 @@ function actualUtilitySummary(context: {
     sourceUnwindFrames: planned.sourceFrames.length,
     sourceUnwindRules: planned.sourceUnwindRules.length,
     sourceUnwindRefusals: planned.sourceUnwindRefusals,
-    targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
-    targetUnwindRefusals: planned.targetUnwind?.refusals ?? [],
+    ...targetUnwindSummaryFields(planned),
     targetFrameStateRequirements: planned.targetFrameState.requirements,
     targetFrameStateMaterialized: planned.targetFrameState.materialized,
     targetFrameStateRefusals: planned.targetFrameState.refusals,
     targetCallerFrame: planned.targetCallerFrame.frame,
     targetCallerFrameRefusals: planned.targetCallerFrame.refusals,
     targetResumeExecution: planned.targetResumeExecution.plan,
+    targetResumeExecutionAttempt: resumeFields.targetResumeExecutionAttempt,
     targetResumeExecutionRefusals: planned.targetResumeExecution.refusals,
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),
@@ -693,12 +809,28 @@ function actualUtilitySummary(context: {
     plan: planned.plan,
     blockingBoundary: planned.plan.blockingBoundary,
     blockingRefusal: planned.plan.blockingRefusal,
-    attemptedResume: false,
+    attemptedResume: resumeFields.attemptedResume,
+    migrationCompleted: resumeFields.migrationCompleted,
     sourceTextReusedAsTargetCode: false,
     sourceIsaEmulationUsed: false,
     sidecarRuntimeUsed: false,
-    execution: executionForPlan(planned),
+    execution: executionForPlan(planned, context.resumeAttempt),
     bundleFiles: bundleFileStats(context.sourceBundleDir, NATIVE_PROCESS_IMAGE_BUNDLE_FILES),
+  };
+}
+
+function targetUnwindSummaryFields(planned: ReturnType<typeof planCapturedActualUtilityBundle>) {
+  return {
+    targetUnwindMatches: planned.targetUnwind?.matches.length ?? 0,
+    targetUnwindRefusals: planned.targetUnwind?.refusals ?? [],
+  };
+}
+
+function resumeAttemptSummaryFields(resumeAttempt: NativeTargetResumeExecutionAttempt | undefined) {
+  return {
+    targetResumeExecutionAttempt: resumeAttempt,
+    attemptedResume: resumeAttempt?.attemptedResume ?? false,
+    migrationCompleted: false,
   };
 }
 
@@ -779,10 +911,19 @@ function resourceRecipeCount(planned: ReturnType<typeof planCapturedActualUtilit
   return planned.resources.resources.filter((resource) => resource.state === "recipe").length;
 }
 
-function executionForPlan(planned: ReturnType<typeof planCapturedActualUtilityBundle>) {
-  return planned.plan.state === "ready"
-    ? "actual-real-utility-ready-for-target-native-resume"
-    : `actual-real-utility-refused-at-${planned.plan.blockingBoundary}`;
+function executionForPlan(
+  planned: ReturnType<typeof planCapturedActualUtilityBundle>,
+  resumeAttempt: NativeTargetResumeExecutionAttempt | undefined,
+) {
+  if (planned.plan.state !== "ready") {
+    return `actual-real-utility-refused-at-${planned.plan.blockingBoundary}`;
+  }
+  if (resumeAttempt) {
+    return resumeAttempt.status === "returned"
+      ? "actual-real-utility-target-native-resume-returned"
+      : "actual-real-utility-target-native-resume-faulted";
+  }
+  return "actual-real-utility-ready-for-target-native-resume";
 }
 
 function sleepTimerPolicy() {


### PR DESCRIPTION
## Problem

The actual `/bin/sleep` proof could plan a target-native resume path, but it still never transferred control to target amd64 code. That left the most important step untested. We also needed to keep the line clear between "we jumped" and "the process fully migrated".

## Solution

This PR adds a short-lived Linux/amd64 resume trampoline. It maps the explicit target amd64 byte window, installs the synthetic target stack, jumps to the planned target address, and records the result. The current real `/bin/sleep` attempt reaches target bytes and faults, so the proof reports `attemptedResume: true` and `migrationCompleted: false` instead of claiming full migration.

Closes #536
