### PR TITLE
Generalize synthetic syscall failure gates

### DIFF
--- a/docs/snapshot/native-actual-target-resume-execution.md
+++ b/docs/snapshot/native-actual-target-resume-execution.md
@@ -56,10 +56,11 @@ synthetic amd64 syscall continuation instead of the source RVA or target libc:
 
 `migrationCompleted: true` is intentionally narrow here. It applies to this
 modeled `/bin/sleep` path only, after the generated amd64 sleep syscall bytes
-exit the target process with status `0`. Other planned, faulted, timed-out, trampoline-return-only, or interrupted sleep
-attempts still keep `migrationCompleted: false`. A synthetic sleep failure exit
-status of `111` is classified as `target-sleep-signal-restart-unsupported` so
-EINTR/restart behavior never looks like success before it is modeled. Synthetic
-sleep summaries also carry generated-byte, syscall-argument, stack/register, and
-no-source-reuse provenance so the completed proof is auditable without trusting
-libc internals.
+exit the target process with status `0`. Other planned, faulted, timed-out, trampoline-return-only, or interrupted
+synthetic syscall attempts still keep `migrationCompleted: false`. Descriptor
+failure exits are classified as `target-synthetic-signal-restart-unsupported` or
+`target-synthetic-syscall-return-unmodeled`, depending on the shared synthetic
+completion policy. Legacy descriptor-less sleep failure exits still map to
+`target-sleep-signal-restart-unsupported`. Synthetic sleep summaries also carry
+generated-byte, syscall-argument, stack/register, and no-source-reuse provenance
+so the completed proof is auditable without trusting libc internals.

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -42,7 +42,9 @@ The next issues should stay narrow and stacked:
    [Native synthetic continuation descriptor](./native-synthetic-continuation-descriptor.md).
 2. Model interrupted syscall returns before expanding success cases. `EINTR`,
    `ERESTART*`, and signal-delivery states must keep precise fail-closed
-   refusals until restart behavior is modeled.
+   refusals such as `target-synthetic-signal-restart-unsupported` and
+   `target-synthetic-syscall-return-unmodeled` until restart behavior is
+   modeled.
 3. Add one additional blocking syscall family with a captured real utility and a
    synthesized amd64 continuation. Prefer a syscall whose resource model is
    already explicit or can be refused precisely.

--- a/docs/snapshot/native-real-utility-code-map.md
+++ b/docs/snapshot/native-real-utility-code-map.md
@@ -59,9 +59,14 @@ from target-native module metadata.
   duration from captured syscall state.
 - `target-sleep-syscall-continuation-missing` — modeled sleep state exists, but
   the synthetic amd64 syscall continuation cannot be generated safely.
-- `target-sleep-signal-restart-unsupported` — the generated target sleep syscall
-  did not return success, so EINTR/restart behavior must be modeled before the
-  proof can continue.
+- `target-sleep-signal-restart-unsupported` — a legacy descriptor-less generated
+  target sleep syscall did not return success, so EINTR/restart behavior must be
+  modeled before the proof can continue.
+- `target-synthetic-signal-restart-unsupported` — a generated target-native
+  syscall descriptor reported a restart-like failure exit.
+- `target-synthetic-syscall-return-unmodeled` — a generated target-native
+  syscall descriptor reported a non-success return whose target semantics are
+  not modeled yet.
 
 ## Proof
 

--- a/docs/snapshot/native-sleep-syscall-policy.md
+++ b/docs/snapshot/native-sleep-syscall-policy.md
@@ -57,10 +57,11 @@ is only reported after target process exit.
 
 Issue #551 keeps interrupted sleep semantics fail-closed. If the synthetic sleep
 syscall does not return success, the generated code exits with the reserved
-status `111`. The proof classifies that as
-`target-sleep-signal-restart-unsupported` and keeps `migrationCompleted: false`.
-This covers EINTR/restart-like outcomes until signal delivery, remaining time,
-and restart contracts are modeled explicitly.
+status `111`. Descriptor-aware proofs classify that as
+`target-synthetic-signal-restart-unsupported`; legacy descriptor-less attempts
+still use `target-sleep-signal-restart-unsupported`. Both paths keep
+`migrationCompleted: false`. This covers EINTR/restart-like outcomes until
+signal delivery, remaining time, and restart contracts are modeled explicitly.
 
 ## Provenance
 

--- a/docs/snapshot/native-synthetic-continuation-descriptor.md
+++ b/docs/snapshot/native-synthetic-continuation-descriptor.md
@@ -14,6 +14,8 @@ for now and records:
 - register setup and syscall-clobbered registers
 - stack setup assumptions
 - completion policy, such as returning to the trampoline or exiting the process
+- failure exit status and whether that failure means restart handling is
+  unsupported or syscall-return semantics are unmodeled
 - invariants that source text was not reused, source-ISA emulation was not used,
   and no sidecar runtime participated
 
@@ -29,4 +31,6 @@ instead of inventing a separate byte/syscall/register/stack schema.
 The descriptor is provenance, not a blanket success rule. A generated
 continuation still succeeds only when its modeled syscall contract and completion
 policy are satisfied. Unsupported states continue to fail closed with precise
-refusals.
+refusals. Descriptor failure exits are classified as
+`target-synthetic-signal-restart-unsupported` for restart-like outcomes or
+`target-synthetic-syscall-return-unmodeled` for other non-success returns.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -135,6 +135,7 @@
 - [`NativeSyntheticContinuationByteEncoding`](#nativesyntheticcontinuationbyteencoding)
 - [`NativeSyntheticContinuationSyscallAbi`](#nativesyntheticcontinuationsyscallabi)
 - [`NativeSyntheticContinuationRegisterSetupAbi`](#nativesyntheticcontinuationregistersetupabi)
+- [`NativeSyntheticContinuationFailureKind`](#nativesyntheticcontinuationfailurekind)
 - [`NativeSyntheticContinuationRegister`](#nativesyntheticcontinuationregister)
 - [`NativeSyntheticContinuationProvenanceSource`](#nativesyntheticcontinuationprovenancesource)
 - [`NativeSyntheticSyscallArgumentDescriptor`](#nativesyntheticsyscallargumentdescriptor)
@@ -3192,7 +3193,7 @@ by default when `output` is a TTY.
 
 ##### code
 
-> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"target-resume-execution-unavailable"` \| `"target-resume-fault-invalid-code-landing"` \| `"target-resume-fault-outside-target-bytes"` \| `"target-resume-fault-privileged-instruction"` \| `"target-resume-fault-signal-unsupported"` \| `"target-resume-fault-timeout"` \| `"target-resume-fault-unmodeled-memory"` \| `"target-semantic-continuation-missing"` \| `"target-sleep-remaining-time-missing"` \| `"target-sleep-signal-restart-unsupported"` \| `"target-sleep-syscall-continuation-missing"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
+> **code**: `"fd-kind-unsupported"` \| `"target-build-mismatch"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"active-syscall"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-permission-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-return-slot-unsupported"` \| `"target-resume-execution-unavailable"` \| `"target-resume-fault-invalid-code-landing"` \| `"target-resume-fault-outside-target-bytes"` \| `"target-resume-fault-privileged-instruction"` \| `"target-resume-fault-signal-unsupported"` \| `"target-resume-fault-timeout"` \| `"target-resume-fault-unmodeled-memory"` \| `"target-semantic-continuation-missing"` \| `"target-sleep-remaining-time-missing"` \| `"target-sleep-signal-restart-unsupported"` \| `"target-sleep-syscall-continuation-missing"` \| `"target-synthetic-signal-restart-unsupported"` \| `"target-synthetic-syscall-return-unmodeled"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
 
 ##### message
 
@@ -4874,6 +4875,14 @@ by default when `output` is a TTY.
 
 > `optional` **failureExitStatus?**: `number`
 
+##### failureKind?
+
+> `optional` **failureKind?**: [`NativeSyntheticContinuationFailureKind`](#nativesyntheticcontinuationfailurekind)
+
+##### failureReason?
+
+> `optional` **failureReason?**: `string`
+
 ***
 
 ### NativeSyntheticSyscallContinuationDescriptorRequest
@@ -5137,6 +5146,22 @@ by default when `output` is a TTY.
 - [`NativeSyntheticContinuationCompletionDescriptor`](#nativesyntheticcontinuationcompletiondescriptor)
 
 #### Properties
+
+##### failureKind?
+
+> `optional` **failureKind?**: [`NativeSyntheticContinuationFailureKind`](#nativesyntheticcontinuationfailurekind)
+
+###### Inherited from
+
+[`NativeSyntheticContinuationCompletionDescriptor`](#nativesyntheticcontinuationcompletiondescriptor).[`failureKind`](#failurekind)
+
+##### failureReason?
+
+> `optional` **failureReason?**: `string`
+
+###### Inherited from
+
+[`NativeSyntheticContinuationCompletionDescriptor`](#nativesyntheticcontinuationcompletiondescriptor).[`failureReason`](#failurereason)
 
 ##### mode
 
@@ -9702,6 +9727,12 @@ Poll interval in ms while retrying. Default 250.
 
 ***
 
+### NativeSyntheticContinuationFailureKind
+
+> **NativeSyntheticContinuationFailureKind** = `"signal-restart-unsupported"` \| `"syscall-return-unmodeled"`
+
+***
+
 ### NativeSyntheticContinuationRegister
 
 > **NativeSyntheticContinuationRegister** = `"rax"` \| `"rdi"` \| `"rsi"` \| `"rdx"` \| `"r10"` \| `"r8"` \| `"r9"` \| `"rcx"` \| `"r11"`
@@ -10340,7 +10371,7 @@ loops; anything looser stops being a meaningful gate.
 
 ### nativeProcessImageRefusalCodes
 
-> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"target-resume-execution-unavailable"`, `"target-resume-fault-invalid-code-landing"`, `"target-resume-fault-outside-target-bytes"`, `"target-resume-fault-privileged-instruction"`, `"target-resume-fault-signal-unsupported"`, `"target-resume-fault-timeout"`, `"target-resume-fault-unmodeled-memory"`, `"target-semantic-continuation-missing"`, `"target-sleep-remaining-time-missing"`, `"target-sleep-signal-restart-unsupported"`, `"target-sleep-syscall-continuation-missing"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
+> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-permission-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-return-slot-unsupported"`, `"target-resume-execution-unavailable"`, `"target-resume-fault-invalid-code-landing"`, `"target-resume-fault-outside-target-bytes"`, `"target-resume-fault-privileged-instruction"`, `"target-resume-fault-signal-unsupported"`, `"target-resume-fault-timeout"`, `"target-resume-fault-unmodeled-memory"`, `"target-semantic-continuation-missing"`, `"target-sleep-remaining-time-missing"`, `"target-sleep-signal-restart-unsupported"`, `"target-sleep-syscall-continuation-missing"`, `"target-synthetic-signal-restart-unsupported"`, `"target-synthetic-syscall-return-unmodeled"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-synthetic-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-synthetic-continuation.test.ts
@@ -41,7 +41,12 @@ describe("native synthetic continuation descriptor", () => {
         returnAddress: "trampoline-sentinel-return-address",
         requiresSourceStackBytes: false,
       },
-      completion: { mode: "return-to-trampoline" },
+      completion: {
+        mode: "return-to-trampoline",
+        failureExitStatus: 112,
+        failureKind: "syscall-return-unmodeled",
+        failureReason: "getpid failure is only a descriptor test",
+      },
     });
 
     expect(descriptor).toMatchObject({
@@ -61,7 +66,11 @@ describe("native synthetic continuation descriptor", () => {
       syscall: { abi: "linux-amd64", name: "getpid", number: 39, arguments: args },
       registerSetup: { abi: "linux-amd64-syscall", arguments: args },
       stackSetup: { requiresSourceStackBytes: false },
-      completion: { mode: "return-to-trampoline" },
+      completion: {
+        mode: "return-to-trampoline",
+        failureExitStatus: 112,
+        failureKind: "syscall-return-unmodeled",
+      },
     });
     expect(descriptor.byteSha256).toBe(nativeSyntheticContinuationBytesSha256(bytes));
     expect(nativeSyntheticContinuationBytesHex(bytes)).toBe("b8270000000f05");

--- a/packages/runtime/src/__tests__/native-synthetic-sleep-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-synthetic-sleep-continuation.test.ts
@@ -122,10 +122,17 @@ describe("synthetic sleep syscall continuation", () => {
       "7509b83c00000031ff0f05b83c000000bf6f0000000f05",
     );
     expect(new DataView(result.continuation!.bytes.buffer).getBigUint64(48, true)).toBe(0n);
-    expect(result.continuation!.provenance.completion).toEqual({
+    expect(result.continuation!.descriptor.completion).toMatchObject({
       mode: "exit-process",
       successExitStatus: 0,
       failureExitStatus: 111,
+      failureKind: "signal-restart-unsupported",
+    });
+    expect(result.continuation!.provenance.completion).toMatchObject({
+      mode: "exit-process",
+      successExitStatus: 0,
+      failureExitStatus: 111,
+      failureKind: "signal-restart-unsupported",
     });
   });
 

--- a/packages/runtime/src/__tests__/native-target-resume-execution.test.ts
+++ b/packages/runtime/src/__tests__/native-target-resume-execution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { buildNativeSyntheticSyscallContinuationDescriptor } from "../native-synthetic-continuation.ts";
 import {
   classifyNativeTargetResumeExecutionAttempt,
   planNativeTargetResumeExecution,
@@ -56,6 +57,48 @@ const invalidLanding: NativeTargetResumeLandingProvenance = {
     message: "entry is inside a decoded instruction",
   },
 };
+
+function syntheticLanding(
+  failureKind: "signal-restart-unsupported" | "syscall-return-unmodeled",
+  failureExitStatus: number,
+): NativeTargetResumeLandingProvenance {
+  const descriptor = buildNativeSyntheticSyscallContinuationDescriptor({
+    targetArch: "amd64",
+    entryAddress: "0x700200000000",
+    relativeAddress: "0x0",
+    generatorBuildId: "test-synthetic-syscall",
+    bytes: new Uint8Array([0x0f, 0x05]),
+    syscall: {
+      name: failureKind === "signal-restart-unsupported" ? "clock_nanosleep" : "ppoll",
+      number: failureKind === "signal-restart-unsupported" ? 230 : 271,
+      arguments: [],
+    },
+    registerSetup: {
+      abi: "linux-amd64-syscall",
+      arguments: [],
+      clobberedBySyscall: ["rax", "rcx", "r11"],
+      notes: [],
+    },
+    stackSetup: {
+      entryStackPointer: "target-caller-frame-stack-pointer",
+      stackBytesWrittenByContinuation: 0,
+      returnAddress: "not-used-exit-process-completion",
+      requiresSourceStackBytes: false,
+    },
+    completion: { mode: "exit-process", failureExitStatus, failureKind },
+  });
+  return {
+    ...invalidLanding,
+    id: `target-resume-landing:synthetic:${failureKind}`,
+    targetRva: "0x0",
+    targetAddress: "0x700200000000",
+    targetRelativeAddress: "0x0",
+    continuationStrategy: "synthetic-sleep-syscall",
+    syntheticContinuation: { descriptor },
+    instructionBoundary: { state: "known-valid", reason: "generated synthetic entry" },
+    refusal: undefined,
+  } as NativeTargetResumeLandingProvenance;
+}
 
 const targetBytes: NativeTargetModuleByteMaterialization[] = [
   {
@@ -204,7 +247,75 @@ describe("native target resume execution planning", () => {
     ).toBe("target-resume-fault-privileged-instruction");
   });
 
-  it("classifies synthetic sleep EINTR/restart exits fail-closed", () => {
+  it("classifies descriptor synthetic restart exits fail-closed through the shared gate", () => {
+    const classified = classifyNativeTargetResumeExecutionAttempt(
+      {
+        status: "exited",
+        targetArch: "amd64",
+        entryAddress: "0x700200000000",
+        stackPointer: "0x500000010000",
+        targetBytesStart: "0x700200000000",
+        targetBytesEnd: "0x700200000040",
+        exitStatus: 111,
+        instructionPointerInTargetBytes: true,
+        attemptedResume: true,
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      },
+      { landingProvenance: [syntheticLanding("signal-restart-unsupported", 111)] },
+    );
+
+    expect(classified).toMatchObject({
+      state: "classified",
+      refusals: [
+        {
+          code: "target-synthetic-signal-restart-unsupported",
+          detail: {
+            syntheticContinuation: {
+              kind: "synthetic-syscall-continuation",
+              syscall: { name: "clock_nanosleep", number: 230 },
+              completion: { failureExitStatus: 111, failureKind: "signal-restart-unsupported" },
+            },
+          },
+        },
+      ],
+      classification: { attemptedResume: true, migrationCompleted: false },
+    });
+  });
+
+  it("classifies descriptor synthetic syscall returns fail-closed through the shared gate", () => {
+    const classified = classifyNativeTargetResumeExecutionAttempt(
+      {
+        status: "exited",
+        targetArch: "amd64",
+        entryAddress: "0x700200000000",
+        stackPointer: "0x500000010000",
+        targetBytesStart: "0x700200000000",
+        targetBytesEnd: "0x700200000040",
+        exitStatus: 112,
+        instructionPointerInTargetBytes: true,
+        attemptedResume: true,
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      },
+      { landingProvenance: [syntheticLanding("syscall-return-unmodeled", 112)] },
+    );
+
+    expect(classified).toMatchObject({
+      state: "classified",
+      refusals: [
+        {
+          code: "target-synthetic-syscall-return-unmodeled",
+          detail: { syntheticContinuation: { syscall: { name: "ppoll", number: 271 } } },
+        },
+      ],
+      classification: { attemptedResume: true, migrationCompleted: false },
+    });
+  });
+
+  it("keeps legacy synthetic sleep EINTR/restart exits fail-closed without descriptors", () => {
     const classified = classifyNativeTargetResumeExecutionAttempt({
       status: "exited",
       targetArch: "amd64",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -199,6 +199,7 @@ export type {
   NativeSyntheticContinuationByteEncoding,
   NativeSyntheticContinuationByteSource,
   NativeSyntheticContinuationCompletionDescriptor,
+  NativeSyntheticContinuationFailureKind,
   NativeSyntheticContinuationProvenanceSource,
   NativeSyntheticContinuationRegister,
   NativeSyntheticContinuationRegisterSetupAbi,

--- a/packages/runtime/src/native-process-image.ts
+++ b/packages/runtime/src/native-process-image.ts
@@ -72,6 +72,8 @@ export const nativeProcessImageRefusalCodes = [
   "target-sleep-remaining-time-missing",
   "target-sleep-signal-restart-unsupported",
   "target-sleep-syscall-continuation-missing",
+  "target-synthetic-signal-restart-unsupported",
+  "target-synthetic-syscall-return-unmodeled",
   "thread-state-unsupported",
   "tls-state-unsupported",
   "return-slot-unreadable",

--- a/packages/runtime/src/native-synthetic-continuation.ts
+++ b/packages/runtime/src/native-synthetic-continuation.ts
@@ -8,6 +8,9 @@ export type NativeSyntheticContinuationByteSource =
 export type NativeSyntheticContinuationByteEncoding = "amd64-machine-code";
 export type NativeSyntheticContinuationSyscallAbi = "linux-amd64";
 export type NativeSyntheticContinuationRegisterSetupAbi = "linux-amd64-syscall";
+export type NativeSyntheticContinuationFailureKind =
+  | "signal-restart-unsupported"
+  | "syscall-return-unmodeled";
 export type NativeSyntheticContinuationRegister =
   | "rax"
   | "rdi"
@@ -57,6 +60,8 @@ export interface NativeSyntheticContinuationCompletionDescriptor {
   mode: string;
   successExitStatus?: number;
   failureExitStatus?: number;
+  failureKind?: NativeSyntheticContinuationFailureKind;
+  failureReason?: string;
 }
 
 export interface NativeSyntheticSyscallContinuationDescriptorRequest {

--- a/packages/runtime/src/native-synthetic-sleep-continuation.ts
+++ b/packages/runtime/src/native-synthetic-sleep-continuation.ts
@@ -269,6 +269,11 @@ function syntheticClockNanosleepDescriptor(
         completionMode === "exit-process"
           ? NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS
           : undefined,
+      failureKind: completionMode === "exit-process" ? "signal-restart-unsupported" : undefined,
+      failureReason:
+        completionMode === "exit-process"
+          ? "sleep syscall failure may need EINTR/restart handling, which is not modeled"
+          : undefined,
     },
   });
 }

--- a/packages/runtime/src/native-target-resume-execution.ts
+++ b/packages/runtime/src/native-target-resume-execution.ts
@@ -6,6 +6,7 @@ import type {
 } from "./native-process-image.ts";
 import type { NativeSyntheticTargetCallerFrame } from "./native-target-caller-frame.ts";
 import type { NativeTargetResumeLandingProvenance } from "./native-target-landing-provenance.ts";
+import type { NativeSyntheticSyscallContinuationDescriptor } from "./native-synthetic-continuation.ts";
 import { NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS } from "./native-synthetic-sleep-continuation.ts";
 import type { NativeTargetModuleByteMaterialization } from "./native-target-module-bytes.ts";
 
@@ -142,7 +143,7 @@ export function classifyNativeTargetResumeExecutionAttempt(
   if (!attempt) {
     return { state: "unattempted", refusals: [] };
   }
-  const nonFaultRefusal = classifyNonFaultResumeRefusal(attempt);
+  const nonFaultRefusal = classifyNonFaultResumeRefusal(attempt, options);
   if (nonFaultRefusal) {
     return classifiedAttempt(attempt, nonFaultRefusal);
   }
@@ -176,11 +177,19 @@ function classifiedAttempt(
 
 function classifyNonFaultResumeRefusal(
   attempt: NativeTargetResumeExecutionAttempt,
+  options: NativeTargetResumeFaultClassificationOptions,
 ): NativeProcessImageRefusal | undefined {
-  if (
-    attempt.status === "exited" &&
-    attempt.exitStatus === NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS
-  ) {
+  if (attempt.status !== "exited" || attempt.exitStatus === undefined) {
+    return undefined;
+  }
+  const synthetic = syntheticFailureForAttempt(attempt, options.landingProvenance ?? []);
+  if (synthetic) {
+    const refusal = syntheticFailureRefusal(attempt, synthetic);
+    if (refusal) {
+      return refusal;
+    }
+  }
+  if (attempt.exitStatus === NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS) {
     return faultRefusal(
       "target-sleep-signal-restart-unsupported",
       "synthetic target sleep syscall did not complete successfully; EINTR/restart semantics are not modeled",
@@ -189,6 +198,51 @@ function classifyNonFaultResumeRefusal(
     );
   }
   return undefined;
+}
+
+function syntheticFailureForAttempt(
+  attempt: NativeTargetResumeExecutionAttempt,
+  provenances: NativeTargetResumeLandingProvenance[],
+): NativeSyntheticSyscallContinuationDescriptor | undefined {
+  return provenances.find((provenance) => sameHex(provenance.targetAddress, attempt.entryAddress))
+    ?.syntheticContinuation?.descriptor as NativeSyntheticSyscallContinuationDescriptor | undefined;
+}
+
+function syntheticFailureRefusal(
+  attempt: NativeTargetResumeExecutionAttempt,
+  descriptor: NativeSyntheticSyscallContinuationDescriptor,
+): NativeProcessImageRefusal | undefined {
+  if (descriptor.completion.failureExitStatus !== attempt.exitStatus) {
+    return undefined;
+  }
+  const code = syntheticFailureRefusalCode(descriptor);
+  return faultRefusal(code, syntheticFailureMessage(descriptor, attempt), attempt, {
+    syntheticContinuation: {
+      kind: descriptor.kind,
+      entryAddress: descriptor.entryAddress,
+      byteSha256: descriptor.byteSha256,
+      syscall: descriptor.syscall,
+      completion: descriptor.completion,
+    },
+    exitStatus: attempt.exitStatus,
+  });
+}
+
+function syntheticFailureRefusalCode(
+  descriptor: NativeSyntheticSyscallContinuationDescriptor,
+): NativeProcessImageRefusal["code"] {
+  return descriptor.completion.failureKind === "signal-restart-unsupported"
+    ? "target-synthetic-signal-restart-unsupported"
+    : "target-synthetic-syscall-return-unmodeled";
+}
+
+function syntheticFailureMessage(
+  descriptor: NativeSyntheticSyscallContinuationDescriptor,
+  attempt: NativeTargetResumeExecutionAttempt,
+): string {
+  return descriptor.completion.failureKind === "signal-restart-unsupported"
+    ? `synthetic target ${descriptor.syscall.name} syscall exited with status ${attempt.exitStatus}; signal/restart semantics are not modeled`
+    : `synthetic target ${descriptor.syscall.name} syscall exited with status ${attempt.exitStatus}; syscall return semantics are not modeled`;
 }
 
 function classifyTargetResumeFaultRefusal(

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -157,6 +157,7 @@ const TOC = {
     "NativeSyntheticContinuationByteEncoding",
     "NativeSyntheticContinuationSyscallAbi",
     "NativeSyntheticContinuationRegisterSetupAbi",
+    "NativeSyntheticContinuationFailureKind",
     "NativeSyntheticContinuationRegister",
     "NativeSyntheticContinuationProvenanceSource",
     "NativeSyntheticSyscallArgumentDescriptor",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -1004,7 +1004,7 @@ function executeActualTargetResumeAttempt(
     .split(/\r?\n/)
     .find((candidate) => candidate.startsWith("MACHINEN_ACTUAL_RESUME_TRAMPOLINE "));
   const synthetic = syntheticSleepContinuationSummaries(planned)[0];
-  if (!line && synthetic && syntheticExitStatus(result.status)) {
+  if (!line && synthetic && syntheticExitStatus(result.status, synthetic)) {
     return normalizeActualProcessExitAttempt(planned, targetBytes, result.status!);
   }
   assert(
@@ -1017,8 +1017,15 @@ function executeActualTargetResumeAttempt(
   );
 }
 
-function syntheticExitStatus(status: number | null): boolean {
-  return status === 0 || status === NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS;
+function syntheticExitStatus(
+  status: number | null,
+  synthetic: ReturnType<typeof syntheticSleepContinuationSummaries>[number],
+): boolean {
+  return (
+    status === 0 ||
+    status === synthetic.descriptor?.completion.failureExitStatus ||
+    status === NATIVE_SYNTHETIC_SLEEP_SYSCALL_FAILURE_EXIT_STATUS
+  );
 }
 
 function actualResumeCodeFile(


### PR DESCRIPTION
## Problem

Synthetic syscall failures were still handled as a sleep-only case. That would make every new synthetic syscall add its own special failure rule.

## Solution

This PR moves failure classification onto the shared synthetic syscall descriptor. Descriptor failure exits now fail closed as either restart-unsupported or syscall-return-unmodeled.

Sleep keeps its legacy fallback for old descriptor-less attempts, but descriptor-aware sleep now uses the shared synthetic gate.

Closes #561
