### PR TITLE
Share synthetic syscall bytecode helpers

### DIFF
--- a/packages/runtime/src/__tests__/native-synthetic-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-synthetic-continuation.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildNativeSyntheticSyscallContinuationDescriptor,
+  buildNativeSyntheticTimespecSyscallBytes,
+  nativeSyntheticAmd64LeaRdxRipRelativePlaceholder,
+  nativeSyntheticAmd64SyscallPrefix,
+  nativeSyntheticAmd64ZeroRegister32,
   nativeSyntheticContinuationBytesHex,
   nativeSyntheticContinuationBytesSha256,
   nativeSyntheticContinuationDescriptorSha256,
+  nativeSyntheticTimespecBoundsRefusal,
 } from "../native-synthetic-continuation.ts";
 
 const args = [
@@ -17,6 +22,89 @@ const args = [
 ];
 
 describe("native synthetic continuation descriptor", () => {
+  it("builds shared amd64 syscall prefixes and timespec byte layouts", () => {
+    expect(
+      Buffer.from(
+        nativeSyntheticAmd64SyscallPrefix({
+          syscallNumber: 271,
+          argumentSetup: [
+            nativeSyntheticAmd64ZeroRegister32("rdi"),
+            nativeSyntheticAmd64ZeroRegister32("rsi"),
+            nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(),
+            nativeSyntheticAmd64ZeroRegister32("r10"),
+            nativeSyntheticAmd64ZeroRegister32("r8"),
+          ],
+        }),
+      ).toString("hex"),
+    ).toBe("b80f01000031ff31f6488d15000000004531d24531c00f05");
+
+    const returning = buildNativeSyntheticTimespecSyscallBytes({
+      syscallNumber: 230,
+      argumentSetup: [
+        nativeSyntheticAmd64ZeroRegister32("rdi"),
+        nativeSyntheticAmd64ZeroRegister32("rsi"),
+        nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(),
+        nativeSyntheticAmd64ZeroRegister32("r10"),
+      ],
+      completionMode: "return-to-trampoline",
+      returningTimespecOffset: 24,
+      returningCodeSize: 40,
+      exitingTimespecOffset: 104,
+      exitingCodeSize: 120,
+      remainingTime: { seconds: "2", nanoseconds: 500 },
+    });
+
+    expect(Buffer.from(returning.subarray(0, 24)).toString("hex")).toBe(
+      "b8e600000031ff31f6488d15080000004531d20f05c39090",
+    );
+    expect(new DataView(returning.buffer).getBigUint64(24, true)).toBe(2n);
+
+    const exiting = buildNativeSyntheticTimespecSyscallBytes({
+      syscallNumber: 271,
+      argumentSetup: [
+        nativeSyntheticAmd64ZeroRegister32("rdi"),
+        nativeSyntheticAmd64ZeroRegister32("rsi"),
+        nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(),
+        nativeSyntheticAmd64ZeroRegister32("r10"),
+        nativeSyntheticAmd64ZeroRegister32("r8"),
+      ],
+      completionMode: "exit-process",
+      returningTimespecOffset: 32,
+      returningCodeSize: 48,
+      exitingTimespecOffset: 112,
+      exitingCodeSize: 128,
+      remainingTime: { seconds: "0", nanoseconds: 0 },
+    });
+
+    expect(Buffer.from(exiting.subarray(0, 24)).toString("hex")).toBe(
+      "b80f01000031ff31f6488d15600000004531d24531c00f05",
+    );
+    expect(Buffer.from(exiting.subarray(107, 112)).toString("hex")).toBe("9090909090");
+    expect(new DataView(exiting.buffer).getBigUint64(112, true)).toBe(0n);
+  });
+
+  it("shares amd64 timespec bounds refusals", () => {
+    expect(
+      nativeSyntheticTimespecBoundsRefusal({
+        threadId: "thread:1",
+        remainingTime: { seconds: "1", nanoseconds: 0 },
+        refusalCode: "target-sleep-syscall-continuation-missing",
+        message: "ok",
+      }),
+    ).toBeUndefined();
+    expect(
+      nativeSyntheticTimespecBoundsRefusal({
+        threadId: "thread:1",
+        remainingTime: { seconds: "9223372036854775808", nanoseconds: 0 },
+        refusalCode: "target-sleep-syscall-continuation-missing",
+        message: "too large",
+      }),
+    ).toMatchObject({
+      code: "target-sleep-syscall-continuation-missing",
+      detail: { remainingTime: { seconds: "9223372036854775808" } },
+    });
+  });
+
   it("describes generated amd64 syscall bytes, ABI setup, and completion policy", () => {
     const bytes = new Uint8Array([0xb8, 0x27, 0x00, 0x00, 0x00, 0x0f, 0x05]);
     const descriptor = buildNativeSyntheticSyscallContinuationDescriptor({

--- a/packages/runtime/src/native-synthetic-continuation.ts
+++ b/packages/runtime/src/native-synthetic-continuation.ts
@@ -2,6 +2,11 @@
 
 import { createHash } from "node:crypto";
 
+import type {
+  NativeProcessImageRefusal,
+  NativeProcessImageRefusalCode,
+} from "./native-process-image.ts";
+
 export const NATIVE_SYNTHETIC_SYSCALL_RESTART_EXIT_STATUS = 111;
 export const NATIVE_SYNTHETIC_SYSCALL_UNMODELED_RETURN_EXIT_STATUS = 112;
 
@@ -92,6 +97,11 @@ export interface NativeSyntheticContinuationCompletionDescriptor {
   failureExitBuckets?: NativeSyntheticContinuationFailureExitBucket[];
 }
 
+interface NativeSyntheticTimespecDuration {
+  seconds: string;
+  nanoseconds: number;
+}
+
 interface NativeSyntheticTimespecEmbeddedDataDescriptor {
   kind: "timespec";
   offset: number;
@@ -100,6 +110,25 @@ interface NativeSyntheticTimespecEmbeddedDataDescriptor {
   byteOrder: "little-endian";
   pointerRegister: "rdx";
   pointerEncoding: "rip-relative";
+}
+
+interface NativeSyntheticTimespecSyscallBytecodeRequest {
+  syscallNumber: number;
+  argumentSetup: number[][];
+  completionMode: string;
+  returningTimespecOffset: number;
+  returningCodeSize: number;
+  exitingTimespecOffset: number;
+  exitingCodeSize: number;
+  remainingTime: NativeSyntheticTimespecDuration;
+}
+
+interface NativeSyntheticTimespecBoundsRefusalRequest {
+  threadId: string;
+  remainingTime: NativeSyntheticTimespecDuration;
+  refusalCode: NativeProcessImageRefusalCode;
+  message: string;
+  detail?: Record<string, unknown>;
 }
 
 export interface NativeSyntheticSyscallContinuationDescriptorRequest {
@@ -223,6 +252,93 @@ export function nativeSyntheticContinuationDescriptorSha256(
   return createHash("sha256").update(JSON.stringify(descriptor)).digest("hex");
 }
 
+export function buildNativeSyntheticTimespecSyscallBytes(
+  request: NativeSyntheticTimespecSyscallBytecodeRequest,
+): Uint8Array {
+  const timespecOffset = nativeSyntheticTimespecOffset(request);
+  const bytes = new Uint8Array(
+    request.completionMode === "exit-process" ? request.exitingCodeSize : request.returningCodeSize,
+  );
+  const prefix = nativeSyntheticAmd64SyscallPrefix({
+    syscallNumber: request.syscallNumber,
+    argumentSetup: request.argumentSetup,
+  });
+  bytes.set(prefix, 0);
+  if (request.completionMode === "exit-process") {
+    const suffix = nativeSyntheticExitProcessSuffix();
+    bytes.set(suffix, prefix.length);
+    bytes.fill(0x90, prefix.length + suffix.length, timespecOffset);
+  } else {
+    bytes.set([0xc3], prefix.length);
+    bytes.fill(0x90, prefix.length + 1, timespecOffset);
+  }
+  writeNativeSyntheticRipRelativeTimespec(bytes, timespecOffset, request.remainingTime);
+  return bytes;
+}
+
+export function nativeSyntheticTimespecOffset(
+  request: Pick<
+    NativeSyntheticTimespecSyscallBytecodeRequest,
+    "completionMode" | "returningTimespecOffset" | "exitingTimespecOffset"
+  >,
+): number {
+  return request.completionMode === "exit-process"
+    ? request.exitingTimespecOffset
+    : request.returningTimespecOffset;
+}
+
+export function nativeSyntheticAmd64SyscallPrefix(request: {
+  syscallNumber: number;
+  argumentSetup: number[][];
+}): number[] {
+  return [
+    ...nativeSyntheticAmd64MovEaxImmediate32(request.syscallNumber),
+    ...request.argumentSetup.flat(),
+    ...nativeSyntheticAmd64SyscallInstruction(),
+  ];
+}
+
+function nativeSyntheticAmd64MovEaxImmediate32(value: number): number[] {
+  return [0xb8, value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >> 24) & 0xff];
+}
+
+export function nativeSyntheticAmd64ZeroRegister32(
+  register: "rdi" | "rsi" | "r10" | "r8",
+): number[] {
+  switch (register) {
+    case "rdi":
+      return [0x31, 0xff];
+    case "rsi":
+      return [0x31, 0xf6];
+    case "r10":
+      return [0x45, 0x31, 0xd2];
+    case "r8":
+      return [0x45, 0x31, 0xc0];
+  }
+}
+
+export function nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(): number[] {
+  return [0x48, 0x8d, 0x15, 0x00, 0x00, 0x00, 0x00];
+}
+
+function nativeSyntheticAmd64SyscallInstruction(): number[] {
+  return [0x0f, 0x05];
+}
+
+export function nativeSyntheticTimespecBoundsRefusal(
+  request: NativeSyntheticTimespecBoundsRefusalRequest,
+): NativeProcessImageRefusal | undefined {
+  const seconds = BigInt(request.remainingTime.seconds);
+  if (seconds <= 0x7fff_ffff_ffff_ffffn && request.remainingTime.nanoseconds <= 999_999_999) {
+    return undefined;
+  }
+  return {
+    code: request.refusalCode,
+    message: request.message,
+    detail: { remainingTime: request.remainingTime, ...request.detail },
+  };
+}
+
 export function nativeSyntheticRestartLikeErrnos(): { errno: number; errnoName: string }[] {
   return [
     { errno: 4, errnoName: "EINTR" },
@@ -329,7 +445,7 @@ export function nativeSyntheticSyscallTimespecProvenance(
   };
 }
 
-export function writeNativeSyntheticRipRelativeTimespec(
+function writeNativeSyntheticRipRelativeTimespec(
   bytes: Uint8Array,
   timespecOffset: number,
   remainingTime: { seconds: string; nanoseconds: number },

--- a/packages/runtime/src/native-synthetic-ppoll-continuation.ts
+++ b/packages/runtime/src/native-synthetic-ppoll-continuation.ts
@@ -4,9 +4,12 @@ import type { NativeModeledPpollTimeoutRemainingTime } from "./native-active-sys
 import type { NativeProcessImageRefusal } from "./native-process-image.ts";
 import {
   buildNativeSyntheticModeledSyscallDescriptor,
-  nativeSyntheticExitProcessSuffix,
+  buildNativeSyntheticTimespecSyscallBytes,
+  nativeSyntheticAmd64LeaRdxRipRelativePlaceholder,
+  nativeSyntheticAmd64ZeroRegister32,
   nativeSyntheticSyscallTimespecProvenance,
-  writeNativeSyntheticRipRelativeTimespec,
+  nativeSyntheticTimespecBoundsRefusal,
+  nativeSyntheticTimespecOffset,
   type NativeSyntheticContinuationCompletionDescriptor,
   type NativeSyntheticContinuationFailureExitBucket,
   type NativeSyntheticContinuationProvenanceSource,
@@ -122,8 +125,6 @@ const RETURNING_PPOLL_TIMESPEC_OFFSET = 32;
 const RETURNING_PPOLL_CODE_SIZE = 48;
 const EXITING_PPOLL_TIMESPEC_OFFSET = 112;
 const EXITING_PPOLL_CODE_SIZE = 128;
-const MAX_SIGNED_I64 = 0x7fff_ffff_ffff_ffffn;
-const MAX_NANOSECONDS = 999_999_999;
 
 export function buildNativeSyntheticPpollSyscallContinuation(
   request: NativeSyntheticPpollSyscallContinuationRequest,
@@ -172,68 +173,34 @@ export function buildNativeSyntheticPpollSyscallContinuation(
 function validateRemainingTime(
   request: NativeSyntheticPpollSyscallContinuationRequest,
 ): NativeProcessImageRefusal | undefined {
-  const seconds = BigInt(request.remainingTime.seconds);
-  if (seconds > MAX_SIGNED_I64 || request.remainingTime.nanoseconds > MAX_NANOSECONDS) {
-    return {
-      code: "target-ppoll-syscall-continuation-missing",
-      message: `thread ${request.threadId} modeled ppoll timeout is outside amd64 timespec bounds`,
-      detail: { remainingTime: request.remainingTime },
-    };
-  }
-  return undefined;
+  return nativeSyntheticTimespecBoundsRefusal({
+    threadId: request.threadId,
+    remainingTime: request.remainingTime,
+    refusalCode: "target-ppoll-syscall-continuation-missing",
+    message: `thread ${request.threadId} modeled ppoll timeout is outside amd64 timespec bounds`,
+  });
 }
 
 function syntheticPpollBytes(
   remainingTime: NativeModeledPpollTimeoutRemainingTime,
   completionMode: NativeSyntheticPpollCompletionMode,
 ): Uint8Array {
-  const bytes = new Uint8Array(ppollCodeSize(completionMode));
-  bytes.set(
-    [
-      0xb8,
-      0x0f,
-      0x01,
-      0x00,
-      0x00, // mov eax, 271 (ppoll)
-      0x31,
-      0xff, // xor edi, edi (NULL fds)
-      0x31,
-      0xf6, // xor esi, esi (nfds = 0)
-      0x48,
-      0x8d,
-      0x15, // lea rdx, [rip + timespec]
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x45,
-      0x31,
-      0xd2, // xor r10d, r10d (NULL sigmask)
-      0x45,
-      0x31,
-      0xc0, // xor r8d, r8d (sigsetsize = 0)
-      0x0f,
-      0x05, // syscall
-      0xc3, // ret to trampoline sentinel
-      0x90,
-      0x90,
-      0x90,
-      0x90,
-      0x90,
-      0x90,
-      0x90, // align embedded timespec to 8 bytes
+  return buildNativeSyntheticTimespecSyscallBytes({
+    syscallNumber: PPOLL_SYSCALL_AMD64,
+    argumentSetup: [
+      nativeSyntheticAmd64ZeroRegister32("rdi"),
+      nativeSyntheticAmd64ZeroRegister32("rsi"),
+      nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(),
+      nativeSyntheticAmd64ZeroRegister32("r10"),
+      nativeSyntheticAmd64ZeroRegister32("r8"),
     ],
-    0,
-  );
-  if (completionMode === "exit-process") {
-    const suffixOffset = 24;
-    const suffix = nativeSyntheticExitProcessSuffix();
-    bytes.set(suffix, suffixOffset);
-    bytes.fill(0x90, suffixOffset + suffix.length, ppollTimespecOffset(completionMode));
-  }
-  const timespecOffset = ppollTimespecOffset(completionMode);
-  writeNativeSyntheticRipRelativeTimespec(bytes, timespecOffset, remainingTime);
-  return bytes;
+    completionMode,
+    returningTimespecOffset: RETURNING_PPOLL_TIMESPEC_OFFSET,
+    returningCodeSize: RETURNING_PPOLL_CODE_SIZE,
+    exitingTimespecOffset: EXITING_PPOLL_TIMESPEC_OFFSET,
+    exitingCodeSize: EXITING_PPOLL_CODE_SIZE,
+    remainingTime,
+  });
 }
 
 function syntheticPpollDescriptor(
@@ -293,11 +260,9 @@ function syscallArgumentsProvenance(): NativeSyntheticPpollSyscallArgumentProven
 }
 
 function ppollTimespecOffset(completionMode: NativeSyntheticPpollCompletionMode): number {
-  return completionMode === "exit-process"
-    ? EXITING_PPOLL_TIMESPEC_OFFSET
-    : RETURNING_PPOLL_TIMESPEC_OFFSET;
-}
-
-function ppollCodeSize(completionMode: NativeSyntheticPpollCompletionMode): number {
-  return completionMode === "exit-process" ? EXITING_PPOLL_CODE_SIZE : RETURNING_PPOLL_CODE_SIZE;
+  return nativeSyntheticTimespecOffset({
+    completionMode,
+    returningTimespecOffset: RETURNING_PPOLL_TIMESPEC_OFFSET,
+    exitingTimespecOffset: EXITING_PPOLL_TIMESPEC_OFFSET,
+  });
 }

--- a/packages/runtime/src/native-synthetic-sleep-continuation.ts
+++ b/packages/runtime/src/native-synthetic-sleep-continuation.ts
@@ -5,9 +5,12 @@ import {
   NATIVE_SYNTHETIC_SYSCALL_RESTART_EXIT_STATUS,
   NATIVE_SYNTHETIC_SYSCALL_UNMODELED_RETURN_EXIT_STATUS,
   buildNativeSyntheticModeledSyscallDescriptor,
-  nativeSyntheticExitProcessSuffix,
+  buildNativeSyntheticTimespecSyscallBytes,
+  nativeSyntheticAmd64LeaRdxRipRelativePlaceholder,
+  nativeSyntheticAmd64ZeroRegister32,
   nativeSyntheticSyscallTimespecProvenance,
-  writeNativeSyntheticRipRelativeTimespec,
+  nativeSyntheticTimespecBoundsRefusal,
+  nativeSyntheticTimespecOffset,
   type NativeSyntheticContinuationCompletionDescriptor,
   type NativeSyntheticContinuationFailureExitBucket,
   type NativeSyntheticContinuationProvenanceSource,
@@ -128,8 +131,6 @@ const RETURNING_SLEEP_TIMESPEC_OFFSET = 24;
 const RETURNING_SLEEP_CODE_SIZE = 40;
 const EXITING_SLEEP_TIMESPEC_OFFSET = 104;
 const EXITING_SLEEP_CODE_SIZE = 120;
-const MAX_SIGNED_I64 = 0x7fff_ffff_ffff_ffffn;
-const MAX_NANOSECONDS = 999_999_999;
 
 export function buildNativeSyntheticSleepSyscallContinuation(
   request: NativeSyntheticSleepSyscallContinuationRequest,
@@ -181,57 +182,34 @@ export function buildNativeSyntheticSleepSyscallContinuation(
 function validateRemainingTime(
   request: NativeSyntheticSleepSyscallContinuationRequest,
 ): NativeProcessImageRefusal | undefined {
-  const seconds = BigInt(request.remainingTime.seconds);
-  if (seconds > MAX_SIGNED_I64 || request.remainingTime.nanoseconds > MAX_NANOSECONDS) {
-    return {
-      code: "target-sleep-syscall-continuation-missing",
-      message: `thread ${request.threadId} modeled sleep duration is outside amd64 timespec bounds`,
-      detail: { remainingTime: request.remainingTime, sleepTimer: request.sleepTimer },
-    };
-  }
-  return undefined;
+  return nativeSyntheticTimespecBoundsRefusal({
+    threadId: request.threadId,
+    remainingTime: request.remainingTime,
+    refusalCode: "target-sleep-syscall-continuation-missing",
+    message: `thread ${request.threadId} modeled sleep duration is outside amd64 timespec bounds`,
+    detail: { sleepTimer: request.sleepTimer },
+  });
 }
 
 function syntheticClockNanosleepBytes(
   remainingTime: NativeModeledSleepTimerRemainingTime,
   completionMode: NativeSyntheticSleepCompletionMode,
 ): Uint8Array {
-  const bytes = new Uint8Array(sleepCodeSize(completionMode));
-  bytes.set(
-    [
-      0xb8,
-      0xe6,
-      0x00,
-      0x00,
-      0x00, // mov eax, 230 (clock_nanosleep)
-      0x31,
-      0xff, // xor edi, edi (CLOCK_REALTIME)
-      0x31,
-      0xf6, // xor esi, esi (relative flags)
-      0x48,
-      0x8d,
-      0x15, // lea rdx, [rip + timespec]
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x45,
-      0x31,
-      0xd2, // xor r10d, r10d (NULL remainder)
-      0x0f,
-      0x05, // syscall
-      0xc3, // ret to trampoline sentinel
-      0x90,
-      0x90, // align embedded timespec to 8 bytes
+  return buildNativeSyntheticTimespecSyscallBytes({
+    syscallNumber: CLOCK_NANOSLEEP_SYSCALL_AMD64,
+    argumentSetup: [
+      nativeSyntheticAmd64ZeroRegister32("rdi"),
+      nativeSyntheticAmd64ZeroRegister32("rsi"),
+      nativeSyntheticAmd64LeaRdxRipRelativePlaceholder(),
+      nativeSyntheticAmd64ZeroRegister32("r10"),
     ],
-    0,
-  );
-  if (completionMode === "exit-process") {
-    bytes.set(nativeSyntheticExitProcessSuffix(), 21);
-  }
-  const timespecOffset = sleepTimespecOffset(completionMode);
-  writeNativeSyntheticRipRelativeTimespec(bytes, timespecOffset, remainingTime);
-  return bytes;
+    completionMode,
+    returningTimespecOffset: RETURNING_SLEEP_TIMESPEC_OFFSET,
+    returningCodeSize: RETURNING_SLEEP_CODE_SIZE,
+    exitingTimespecOffset: EXITING_SLEEP_TIMESPEC_OFFSET,
+    exitingCodeSize: EXITING_SLEEP_CODE_SIZE,
+    remainingTime,
+  });
 }
 
 function syntheticClockNanosleepDescriptor(
@@ -300,11 +278,9 @@ function syscallArgumentsProvenance(): NativeSyntheticSleepSyscallArgumentProven
 }
 
 function sleepTimespecOffset(completionMode: NativeSyntheticSleepCompletionMode): number {
-  return completionMode === "exit-process"
-    ? EXITING_SLEEP_TIMESPEC_OFFSET
-    : RETURNING_SLEEP_TIMESPEC_OFFSET;
-}
-
-function sleepCodeSize(completionMode: NativeSyntheticSleepCompletionMode): number {
-  return completionMode === "exit-process" ? EXITING_SLEEP_CODE_SIZE : RETURNING_SLEEP_CODE_SIZE;
+  return nativeSyntheticTimespecOffset({
+    completionMode,
+    returningTimespecOffset: RETURNING_SLEEP_TIMESPEC_OFFSET,
+    exitingTimespecOffset: EXITING_SLEEP_TIMESPEC_OFFSET,
+  });
 }


### PR DESCRIPTION
## Problem

Sleep and zero-fd ppoll now both use generated amd64 syscall bytes. But some byte-building pieces still lived separately in each syscall file. That made it easier for the two paths to drift apart by accident.

## Solution

This moves the common syscall byte pieces into shared helpers. The sleep and ppoll continuations now share the amd64 syscall prefix builder, zero-register helpers, RIP-relative timespec layout, exit-process suffix wiring, and timespec bounds refusal helper. The generated bytes and behavior stay the same.

Closes #571.

## Validation

- `pnpm run format:check` — 1s
- `pnpm run lint` — 0s
- `pnpm run build:docs` — 1s
- `pnpm run typecheck` — 2s
- targeted `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run ...` — 1s
- `pnpm exec fallow audit --changed-since origin/main` — 0s
- arm64 remote `/bin/sleep` capture/model proof on `friend@100.126.46.90` — 34.97s, plan ready
- arm64 remote ppoll capture/model proof on `friend@100.126.46.90` — 2.34s, plan ready
- amd64 remote `/bin/sleep` target execution proof on `root@192.168.0.40` — 52.19s, exited 0
- amd64 remote ppoll target execution proof on `root@192.168.0.40` — 31.50s, exited 0

Agent CI and full smoke tests were skipped because this is narrow runtime/native synthetic syscall refactoring. It does not touch VM lifecycle, VMM devices, rootfs/base assets, CLI boot/exec/mount, snapshot/restore plumbing, memory/ballooning, or FUSE/live mounts.
