### PR TITLE
Prove synthetic syscall return to caller

### DIFF
--- a/docs/snapshot/native-cross-isa-proof-roadmap.md
+++ b/docs/snapshot/native-cross-isa-proof-roadmap.md
@@ -81,10 +81,10 @@ Done when:
 - success/failure completion snippets are shared;
 - sleep and `ppoll` tests assert the same invariants.
 
-### 4. Continue after a target-native syscall
+### 4. Continue after a target-native syscall — in progress
 
-Goal: prove a generated target-native syscall can return into a modeled target
-continuation instead of exiting the process immediately.
+Goal: prove a generated target-native syscall can return into a controlled
+target-native caller frame instead of exiting the process immediately.
 
 Done when:
 

--- a/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-real-utility-continuation.test.ts
@@ -127,7 +127,7 @@ describe("native real utility continuation planner", () => {
     });
   });
 
-  it("allows exit-process synthetic continuations to bypass source unwind", () => {
+  it("allows controlled synthetic continuations to bypass source unwind", () => {
     expect(
       planNativeRealUtilityContinuationAttempt({
         ...readyInput(),

--- a/packages/runtime/src/__tests__/native-target-resume-execution.test.ts
+++ b/packages/runtime/src/__tests__/native-target-resume-execution.test.ts
@@ -273,6 +273,25 @@ describe("native target resume execution planning", () => {
     ).toBe("target-resume-fault-privileged-instruction");
   });
 
+  it("treats target-native returns to the controlled caller as non-faulted", () => {
+    const classified = classifyNativeTargetResumeExecutionAttempt({
+      status: "returned",
+      targetArch: "amd64",
+      entryAddress: "0x700200000000",
+      stackPointer: "0x500000010000",
+      targetBytesStart: "0x700200000000",
+      targetBytesEnd: "0x700200000040",
+      returnValue: "0x0",
+      instructionPointerInTargetBytes: true,
+      attemptedResume: true,
+      sourceTextReusedAsTargetCode: false,
+      sourceIsaEmulationUsed: false,
+      sidecarRuntimeUsed: false,
+    });
+
+    expect(classified).toEqual({ state: "not-faulted", refusals: [] });
+  });
+
   it("classifies descriptor synthetic restart exits fail-closed through the shared gate", () => {
     const classified = classifyNativeTargetResumeExecutionAttempt(
       {

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -93,6 +93,7 @@ const TARGET_ROOT_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_TARGET_ROOT";
 const TARGET_MODULE_PATH_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_TARGET_MODULE";
 const SLEEP_SYSCALL_POLICY_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_SLEEP_SYSCALL_POLICY";
 const PPOLL_SYSCALL_POLICY_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_PPOLL_SYSCALL_POLICY";
+const SYNTHETIC_COMPLETION_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_SYNTHETIC_COMPLETION";
 const WORKLOAD_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_WORKLOAD";
 const UTILITY_NAME = "sleep";
 const SETTLE_MS = "150";
@@ -269,21 +270,30 @@ function planCapturedActualUtilityBundle(
 }
 
 function targetUnwindMatched(inputs: ReturnType<typeof actualUtilityPlanningInputs>): boolean {
-  return inputs.targetUnwind.matches.length > 0 || hasExitProcessSyntheticContinuation(inputs);
+  return inputs.targetUnwind.matches.length > 0 || hasControlledSyntheticContinuation(inputs);
 }
 
 function sourceUnwindRequired(inputs: ReturnType<typeof actualUtilityPlanningInputs>): boolean {
-  return !hasExitProcessSyntheticContinuation(inputs);
+  return !hasControlledSyntheticContinuation(inputs);
 }
 
-function hasExitProcessSyntheticContinuation(
+function hasControlledSyntheticContinuation(
   inputs: ReturnType<typeof actualUtilityPlanningInputs>,
 ): boolean {
-  return inputs.code.resolved.some(
-    (location) =>
-      isSyntheticSyscallStrategy(location.continuationStrategy) &&
-      location.syntheticContinuation?.completionMode === "exit-process",
+  return inputs.code.resolved.some(isControlledSyntheticLocation);
+}
+
+function isControlledSyntheticLocation(
+  location: ReturnType<typeof resolveNativeRealUtilityCodeLocations>["resolved"][number],
+): boolean {
+  return (
+    isSyntheticSyscallStrategy(location.continuationStrategy) &&
+    isControlledSyntheticCompletion(location.syntheticContinuation?.completionMode)
   );
+}
+
+function isControlledSyntheticCompletion(completionMode: string | undefined): boolean {
+  return completionMode === "exit-process" || completionMode === "return-to-trampoline";
 }
 
 function hasActiveContinuation(
@@ -349,8 +359,8 @@ function actualUtilityPlanningInputs(
     pollTimeoutContinuationStrategy: hasActiveContinuation(activeSyscalls, "poll-timeout")
       ? "synthetic-syscall"
       : "refuse",
-    syntheticSleepCompletionMode: "exit-process",
-    syntheticPpollCompletionMode: "exit-process",
+    syntheticSleepCompletionMode: syntheticCompletionMode(),
+    syntheticPpollCompletionMode: syntheticCompletionMode(),
   });
   const sourceUnwind = readActualSourceUnwindSidecar(bundleDir);
   const targetUnwind = discoverActualTargetUnwind({
@@ -1331,6 +1341,8 @@ function actualUtilitySummary(context: {
     targetResumeExecutionAttempt: resumeFields.targetResumeExecutionAttempt,
     targetResumeFaultClassification: resumeFields.targetResumeFaultClassification,
     targetResumeFaultRefusals: resumeFields.targetResumeFaultRefusals,
+    targetContinuationReturned: resumeFields.targetContinuationReturned,
+    targetContinuationReturnValue: resumeFields.targetContinuationReturnValue,
     targetResumeExecutionRefusals: planned.targetResumeExecution.refusals,
     targetModuleByteRefusals: planned.targetBytes.refusals,
     materializedTargetBytes: materializedTargetByteSummaries(planned),
@@ -1374,6 +1386,9 @@ function resumeAttemptSummaryFields(
     targetResumeFaultRefusals: fault.refusals,
     attemptedResume: resumeAttempt?.attemptedResume ?? false,
     migrationCompleted: resumeAttempt?.status === "exited" && resumeAttempt.exitStatus === 0,
+    targetContinuationReturned:
+      resumeAttempt?.status === "returned" && resumeAttempt.returnValue === "0x0",
+    targetContinuationReturnValue: resumeAttempt?.returnValue,
   };
 }
 
@@ -1547,6 +1562,12 @@ function ppollTimeoutPolicy() {
   return process.env[PPOLL_SYSCALL_POLICY_ENV] === "defer-target-resume"
     ? "defer-target-resume"
     : "refuse";
+}
+
+function syntheticCompletionMode() {
+  return process.env[SYNTHETIC_COMPLETION_ENV] === "return-to-trampoline"
+    ? "return-to-trampoline"
+    : "exit-process";
 }
 
 function refusedCapturePlan(stderr: string) {


### PR DESCRIPTION
## Problem

The synthetic syscall proofs could only finish by exiting the target process. That proved the generated syscall bytes ran, but it did not prove a caller could receive the syscall result and keep control.

## Solution

This adds a proof switch for `return-to-trampoline`. In that mode, sleep and zero-fd ppoll return to the controlled amd64 caller frame with `rax = 0`. The old `exit-process` mode is still the default and still works.

Closes #573.

## Validation

- `pnpm run format:check` — 0s
- `pnpm run lint` — 1s
- `pnpm run build:docs` — 1s
- `pnpm run typecheck` — 2s
- targeted `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run ...` — 1s
- `pnpm exec fallow audit --changed-since origin/main` — 0s
- arm64 remote `/bin/sleep` return-to-trampoline capture/model proof on `friend@100.126.46.90` — 23.23s, plan ready
- arm64 remote ppoll return-to-trampoline capture/model proof on `friend@100.126.46.90` — 2.45s, plan ready
- amd64 remote `/bin/sleep` return-to-trampoline execution proof on `root@192.168.0.40` — 51.38s, `status: returned`, `returnValue: 0x0`
- amd64 remote ppoll return-to-trampoline execution proof on `root@192.168.0.40` — 31.47s, `status: returned`, `returnValue: 0x0`
- amd64 remote ppoll default exit-process regression on `root@192.168.0.40` — 31.46s, exited 0

Agent CI and full smoke tests were skipped because this is narrow runtime/native synthetic syscall proof work. It does not touch VM lifecycle, VMM devices, rootfs/base assets, CLI boot/exec/mount, snapshot/restore plumbing, memory/ballooning, or FUSE/live mounts.
