### PR TITLE
Prove packaged utility ppoll timeout

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -58,11 +58,15 @@ The optional `"synthetic-empty-pipe"` fd policy accepts exactly one captured
 - `nfds == 1` and the pollfd array is readable in captured memory;
 - the entry is `POLLIN` with `revents == 0`;
 - the entry's fd maps to a captured pipe resource;
+- fd flags identify a read end, including read-only fds with extra flags such as
+  close-on-exec;
 - the signal mask is still null.
 
 The target recipe creates a fresh empty pipe read end at the same fd and keeps a
 write end open. This preserves a timeout-driven proof without claiming general fd
-readiness migration.
+readiness migration. Missing fd resources, non-pipe resources, write-end fds,
+wrong events, non-empty `revents`, `nfds > 1`, and non-null signal masks all fail
+closed as `target-ppoll-timeout-missing`.
 
 ## Proof
 

--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -55,11 +55,13 @@ when the syscall returns successfully. That is the first narrow proof state wher
 `migrationCompleted` can be `true`.
 
 The same proof harness can select `MACHINEN_ACTUAL_REAL_UTILITY_WORKLOAD=ppoll`
-for zero-fd ppoll or `ppoll-pipe` for the one-fd synthetic empty-pipe proof. The
-one-fd mode also requires
-`MACHINEN_ACTUAL_REAL_UTILITY_PPOLL_FD_POLICY=synthetic-empty-pipe`; it installs a
-fresh empty pipe read end at the captured fd before jumping to generated amd64
-`ppoll` bytes.
+for zero-fd ppoll, `ppoll-pipe` for the compiled one-fd synthetic empty-pipe
+fixture, or `perl-ppoll-pipe` for an unmodified packaged `/usr/bin/perl`
+executable using its standard `IO::Poll` module. The one-fd modes also require
+`MACHINEN_ACTUAL_REAL_UTILITY_PPOLL_FD_POLICY=synthetic-empty-pipe`; they install
+a fresh empty pipe read end at the captured fd before jumping to generated amd64
+`ppoll` bytes. The Perl command text is only used to put the source utility into
+the modeled wait. It is not reused as target code.
 
 The summary reports `attemptedResume: true` and, for modeled synthetic syscall
 paths, `migrationCompleted: true` only after the target process exits with status

--- a/docs/snapshot/native-cross-isa-proof-roadmap.md
+++ b/docs/snapshot/native-cross-isa-proof-roadmap.md
@@ -106,7 +106,7 @@ Done when:
   specific reason;
 - remaining-time contracts are explicit for each blocking syscall family.
 
-### 6. FD-backed blocking syscalls — in progress
+### 6. FD-backed blocking syscalls — done
 
 Goal: extend the second-family proof from zero fds to one modeled fd/resource.
 The first resource is deliberately narrow: a captured `struct pollfd` with one
@@ -122,10 +122,13 @@ Done when:
 - non-one-fd, non-pipe, non-`POLLIN`, non-empty-`revents`, and signal-mask cases
   keep refusing as `target-ppoll-timeout-missing`.
 
-### 7. Real utility beyond `/bin/sleep`
+### 7. Real utility beyond `/bin/sleep` — in progress
 
 Goal: prove a real unmodified utility whose blocked syscall matches the expanded
-blocking-family model.
+blocking-family model. The first narrow utility is the packaged `/usr/bin/perl`
+executable using its standard `IO::Poll` module to block in one-fd `ppoll` on an
+empty pipe. The command text shapes the source wait only; target execution still
+uses generated amd64 syscall bytes, not source text.
 
 Done when:
 
@@ -133,7 +136,8 @@ Done when:
 - the target continuation runs as amd64 without sidecars or emulation;
 - observable behavior continues or exits successfully according to the modeled
   utility contract;
-- unrelated resources still refuse precisely.
+- missing fd resources, non-pipe fds, pipe write ends, wrong events, non-empty
+  `revents`, `nfds > 1`, and non-null signal masks refuse precisely.
 
 ### 8. Target process memory materialization
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -65,6 +65,9 @@ function documentsWithTimespec(options: {
   seconds?: bigint;
   nanoseconds?: bigint;
   pollFd?: { fd: number; events: number; revents: number };
+  pollFdResource?:
+    | "missing"
+    | { kind?: "pipe" | "file" | "socket"; flags?: string[]; path?: string };
 }): NativeProcessImageDocuments {
   const rootDir = mkdtempSync(join(tmpdir(), "machinen-sleep-timer-state-"));
   tempDirs.push(rootDir);
@@ -106,17 +109,19 @@ function documentsWithTimespec(options: {
     threads: { formatVersion: 1, threads: [options.activeThread], refusals: emptyRefusals() },
     resources: {
       formatVersion: 1,
-      resources: options.pollFd
-        ? [
-            {
-              id: `fd:${options.pollFd.fd}`,
-              kind: "pipe",
-              state: "refused",
-              fd: options.pollFd.fd,
-              path: "pipe:[123]",
-            },
-          ]
-        : [],
+      resources:
+        options.pollFd && options.pollFdResource !== "missing"
+          ? [
+              {
+                id: `fd:${options.pollFd.fd}`,
+                kind: options.pollFdResource?.kind ?? "pipe",
+                state: "refused",
+                fd: options.pollFd.fd,
+                path: options.pollFdResource?.path ?? "pipe:[123]",
+                flags: options.pollFdResource?.flags ?? ["octal:0"],
+              },
+            ]
+          : [],
       refusals: emptyRefusals(),
     },
     translation: {
@@ -338,6 +343,71 @@ describe("native active syscall classification", () => {
             },
           ],
         },
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "missing fd resource",
+      x: ["0x3100", "0x1", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 0 },
+      pollFdResource: "missing" as const,
+      reason: "ppoll one-fd proof requires a captured pipe fd",
+    },
+    {
+      name: "non-pipe fd resource",
+      x: ["0x3100", "0x1", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 0 },
+      pollFdResource: { kind: "file" as const, path: "/tmp/input" },
+      reason: "ppoll one-fd proof requires a captured pipe fd",
+    },
+    {
+      name: "write-end pipe fd",
+      x: ["0x3100", "0x1", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 0 },
+      pollFdResource: { kind: "pipe" as const, flags: ["octal:1"] },
+      reason: "ppoll one-fd proof requires a pipe read end",
+    },
+    {
+      name: "wrong events",
+      x: ["0x3100", "0x1", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 4, revents: 0 },
+      reason: "ppoll one-fd proof only models POLLIN with empty revents",
+    },
+    {
+      name: "non-empty revents",
+      x: ["0x3100", "0x1", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 1 },
+      reason: "ppoll one-fd proof only models POLLIN with empty revents",
+    },
+    {
+      name: "nfds greater than one",
+      x: ["0x3100", "0x2", "0x3000", "0x0", "0x0", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 0 },
+      reason: "ppoll synthetic empty-pipe proof supports exactly one fd",
+    },
+    {
+      name: "non-null signal mask",
+      x: ["0x3100", "0x1", "0x3000", "0x4000", "0x8", "0x0"],
+      pollFd: { fd: 3, events: 1, revents: 0 },
+      reason: "ppoll signal masks are not modeled yet",
+    },
+  ])("refuses one-fd ppoll unsafe state: $name", (scenario) => {
+    const activeThread = arm64PpollThread(undefined, scenario.x);
+    const documents = documentsWithTimespec({
+      activeThread,
+      pollFd: scenario.pollFd,
+      pollFdResource: scenario.pollFdResource,
+    });
+
+    expect(
+      modelNativePpollTimeoutState(activeThread, documents, "synthetic-empty-pipe"),
+    ).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-ppoll-timeout-missing",
+        detail: { reason: scenario.reason },
       },
     });
   });

--- a/packages/runtime/src/__tests__/native-synthetic-ppoll-continuation.test.ts
+++ b/packages/runtime/src/__tests__/native-synthetic-ppoll-continuation.test.ts
@@ -16,6 +16,30 @@ function remainingTime(seconds = "1", nanoseconds = 250) {
   };
 }
 
+function oneFdPpollTimeout() {
+  return {
+    kind: "relative-duration" as const,
+    syscallName: "ppoll" as const,
+    argumentSource: "registers" as const,
+    fdsPointer: "0x3100",
+    nfds: 1 as const,
+    pollFds: [
+      {
+        fd: 3,
+        events: 1,
+        revents: 0,
+        sourceAddress: "0x3100",
+        resourceId: "fd:3",
+        targetResource: "synthetic-empty-pipe-read-end" as const,
+      },
+    ],
+    timeoutPointer: "0x3000",
+    sigmaskPointer: "0x0" as const,
+    requestedTime: { seconds: "1", nanoseconds: 250 },
+    remainingTime: remainingTime("1", 250),
+  };
+}
+
 describe("synthetic ppoll syscall continuation", () => {
   it("generates target-native amd64 ppoll bytes with an embedded timeout", () => {
     const result = buildNativeSyntheticPpollSyscallContinuation({
@@ -85,27 +109,7 @@ describe("synthetic ppoll syscall continuation", () => {
     const result = buildNativeSyntheticPpollSyscallContinuation({
       threadId: "thread:1",
       remainingTime: remainingTime("1", 250),
-      ppollTimeout: {
-        kind: "relative-duration",
-        syscallName: "ppoll",
-        argumentSource: "registers",
-        fdsPointer: "0x3100",
-        nfds: 1,
-        pollFds: [
-          {
-            fd: 3,
-            events: 1,
-            revents: 0,
-            sourceAddress: "0x3100",
-            resourceId: "fd:3",
-            targetResource: "synthetic-empty-pipe-read-end",
-          },
-        ],
-        timeoutPointer: "0x3000",
-        sigmaskPointer: "0x0",
-        requestedTime: { seconds: "1", nanoseconds: 250 },
-        remainingTime: remainingTime("1", 250),
-      },
+      ppollTimeout: oneFdPpollTimeout(),
     });
 
     expect(result.refusals).toEqual([]);
@@ -129,6 +133,27 @@ describe("synthetic ppoll syscall continuation", () => {
         entries: [{ fd: 3, targetResource: "synthetic-empty-pipe-read-end" }],
       },
       embeddedData: { offset: 56 },
+    });
+  });
+
+  it("keeps exit-process completion available for one-fd ppoll", () => {
+    const result = buildNativeSyntheticPpollSyscallContinuation({
+      threadId: "thread:1",
+      remainingTime: remainingTime("1", 250),
+      ppollTimeout: oneFdPpollTimeout(),
+      completionMode: "exit-process",
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuation).toMatchObject({
+      completionMode: "exit-process",
+      exitStatusOnSuccess: 0,
+      syscall: { nfds: 1, fdsPointer: "stack-relative-pollfd-array" },
+      sizeBytes: 160,
+      provenance: {
+        embeddedPollFds: { offset: -8 },
+        embeddedData: { offset: 144 },
+      },
     });
   });
 

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { nativeFdAccessMode } from "./native-fd-flags.ts";
 import {
   NATIVE_PROCESS_IMAGE_FILES,
   type NativeMemoryMapping,
@@ -714,7 +715,7 @@ function validatePpollPipeResource(
       resourceId: resource?.id,
     });
   }
-  return resource.flags && !resource.flags.includes("octal:0")
+  return nativeFdAccessMode(resource.flags) !== 0
     ? missingPpollTimeout(thread, "ppoll one-fd proof requires a pipe read end", {
         ...pollFd,
         resourceId: resource.id,

--- a/packages/runtime/src/native-fd-flags.ts
+++ b/packages/runtime/src/native-fd-flags.ts
@@ -1,0 +1,6 @@
+/** Helpers for native Linux fd flag strings captured from /proc/<pid>/fdinfo. */
+
+export function nativeFdAccessMode(flags: string[] | undefined): number | undefined {
+  const octal = flags?.find((flag) => flag.startsWith("octal:"));
+  return octal ? Number.parseInt(octal.slice("octal:".length), 8) & 0x3 : undefined;
+}

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -1,5 +1,6 @@
 /** Kernel-resource recipes and refusals for native process restore. */
 
+import { nativeFdAccessMode } from "./native-fd-flags.ts";
 import type { NativeProcessImageRefusal, NativeProcessResource } from "./native-process-image.ts";
 
 export interface NativeInheritedStdioPolicy {
@@ -87,7 +88,7 @@ function translateResource(
       };
     }
     const pairedReadFd = resource.path ? syntheticPipePaths.get(resource.path) : undefined;
-    if (pairedReadFd !== undefined && resource.flags?.includes("octal:1")) {
+    if (pairedReadFd !== undefined && nativeFdAccessMode(resource.flags) === 1) {
       return {
         ...resource,
         state: "recipe",

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -99,6 +99,8 @@ const PPOLL_FD_POLICY_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_PPOLL_FD_POLICY";
 const SYNTHETIC_COMPLETION_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_SYNTHETIC_COMPLETION";
 const WORKLOAD_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_WORKLOAD";
 const UTILITY_NAME = "sleep";
+const PERL_PPOLL_PIPE_SNIPPET =
+  "use IO::Poll qw(POLLIN); pipe(my $r, my $w) or die qq(pipe: $!); my $p = IO::Poll->new(); $p->mask($r => POLLIN); $p->poll(30);";
 const SETTLE_MS = "150";
 const TARGET_BYTE_WINDOW = 32;
 const SOURCE_UNWIND_FILE = "native-source-unwind.json";
@@ -216,6 +218,18 @@ function actualUtilityWorkload(): {
       name: "ppoll-pipe-timeout",
       requiredSources: [NATIVE_CAPTURE_SOURCE, NATIVE_PPOLL_PIPE_TIMEOUT_TARGET_SOURCE],
       command: (binDir) => [compileNativePpollPipeTimeoutTarget(binDir)],
+    };
+  }
+  if (process.env[WORKLOAD_ENV] === "perl-ppoll-pipe") {
+    return {
+      name: "perl-ppoll-pipe-timeout",
+      requiredSources: [NATIVE_CAPTURE_SOURCE],
+      command: () => [
+        requireUtility(["/usr/bin/perl", "/bin/perl"]),
+        "-MIO::Poll=POLLIN",
+        "-e",
+        PERL_PPOLL_PIPE_SNIPPET,
+      ],
     };
   }
   return {


### PR DESCRIPTION
## Problem

The portable snapshot branch could model one safe fd-backed `ppoll` case, but the proof still used a Machinen-built C target. That did not show the same path working for an unmodified packaged Linux utility. Nearby unsafe `ppoll` states also needed explicit refusal tests.

## Solution

This adds a `perl-ppoll-pipe` proof workload. It runs the normal packaged `/usr/bin/perl` executable with its standard `IO::Poll` module, captures it blocked in one-fd `ppoll`, and resumes the modeled wait through generated amd64 syscall bytes. It also adds refusal coverage for missing fd resources, non-pipe fds, pipe write ends, wrong events, non-empty `revents`, `nfds > 1`, and non-null signal masks.

Refs #578.

## Validation

- `pnpm run format:check` — 0.55s
- `pnpm run lint` — 0.19s
- `pnpm run build:docs` — 1.39s
- `pnpm run typecheck` — 2.01s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-active-syscall-policy.test.ts packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/native-synthetic-ppoll-continuation.test.ts packages/runtime/src/__tests__/native-real-utility-code-map.test.ts packages/runtime/src/__tests__/native-actual-real-utility-continuation-script.test.ts` — 0.49s, 5 files / 40 tests
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.34s
- arm64 Docker proof: `perl-ppoll-pipe` capture/model plan ready, one fd, stack-relative pollfd, 6 resource recipes — 36.92s
- amd64 Proxmox CT proof: target-native synthetic `ppoll` returned `0x0` — 61.31s

Agent CI was not run because no workflow or CI files changed. Full smoke tests were skipped because this is narrow runtime/native synthetic syscall work on the `portable-snapshots` branch, not VM lifecycle/rootfs/VMM/FUSE/snapshot plumbing; the targeted unit tests plus arm64/amd64 proof pair cover the changed path.
