### PR TITLE
Prove packaged ppoll target exit

### DIFF
--- a/docs/snapshot/native-actual-real-utility-continuation.md
+++ b/docs/snapshot/native-actual-real-utility-continuation.md
@@ -61,11 +61,16 @@ executable using its standard `IO::Poll` module. The one-fd modes also require
 `MACHINEN_ACTUAL_REAL_UTILITY_PPOLL_FD_POLICY=synthetic-empty-pipe`; they install
 a fresh empty pipe read end at the captured fd before jumping to generated amd64
 `ppoll` bytes. The Perl command text is only used to put the source utility into
-the modeled wait. It is not reused as target code.
+the modeled wait. It is not reused as target code. The Perl workload uses a short
+modeled timeout so both return-to-trampoline and target-exit proof modes stay
+bounded.
 
 The summary reports `attemptedResume: true` and, for modeled synthetic syscall
 paths, `migrationCompleted: true` only after the target process exits with status
-`0` or the controlled trampoline observes the expected target-native return.
+`0` or the controlled trampoline observes the expected target-native return. For
+the packaged Perl one-fd `ppoll` workload, default `exit-process` completion now
+proves native target exit `0`; `return-to-trampoline` remains the register-return
+inspection mode.
 
 That ready-plus-attempt state is intentional but not a migration success claim. It
 proves the real capture path has explicit data for every modeled planning gate,

--- a/docs/snapshot/native-cross-isa-proof-roadmap.md
+++ b/docs/snapshot/native-cross-isa-proof-roadmap.md
@@ -122,7 +122,7 @@ Done when:
 - non-one-fd, non-pipe, non-`POLLIN`, non-empty-`revents`, and signal-mask cases
   keep refusing as `target-ppoll-timeout-missing`.
 
-### 7. Real utility beyond `/bin/sleep` — in progress
+### 7. Real utility beyond `/bin/sleep` — done
 
 Goal: prove a real unmodified utility whose blocked syscall matches the expanded
 blocking-family model. The first narrow utility is the packaged `/usr/bin/perl`
@@ -135,7 +135,8 @@ Done when:
 - the source utility is captured live on arm64;
 - the target continuation runs as amd64 without sidecars or emulation;
 - observable behavior continues or exits successfully according to the modeled
-  utility contract;
+  utility contract, including target-native exit `0` for the packaged Perl
+  one-fd `ppoll` proof;
 - missing fd resources, non-pipe fds, pipe write ends, wrong events, non-empty
   `revents`, `nfds > 1`, and non-null signal masks refuse precisely.
 

--- a/scripts/native-actual-real-utility-continuation.ts
+++ b/scripts/native-actual-real-utility-continuation.ts
@@ -100,7 +100,7 @@ const SYNTHETIC_COMPLETION_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_SYNTHETIC_COMPLET
 const WORKLOAD_ENV = "MACHINEN_ACTUAL_REAL_UTILITY_WORKLOAD";
 const UTILITY_NAME = "sleep";
 const PERL_PPOLL_PIPE_SNIPPET =
-  "use IO::Poll qw(POLLIN); pipe(my $r, my $w) or die qq(pipe: $!); my $p = IO::Poll->new(); $p->mask($r => POLLIN); $p->poll(30);";
+  "use IO::Poll qw(POLLIN); pipe(my $r, my $w) or die qq(pipe: $!); my $p = IO::Poll->new(); $p->mask($r => POLLIN); $p->poll(2);";
 const SETTLE_MS = "150";
 const TARGET_BYTE_WINDOW = 32;
 const SOURCE_UNWIND_FILE = "native-source-unwind.json";


### PR DESCRIPTION
## Problem

The packaged Perl `ppoll` proof could return to the controlled trampoline, but it had not yet shown the target process finishing with native exit status `0`. That meant the proof showed the generated amd64 syscall returned, but not the stronger target-exit completion mode for this real utility workload.

## Solution

This keeps the same narrow one-fd Perl `ppoll` model and documents the target-exit proof. The Perl workload now uses a short modeled timeout so the exit-process proof stays bounded. In default `exit-process` mode, the generated amd64 `ppoll` bytes run, the modeled timeout succeeds, and the target process exits `0`.

Closes #580.

## Validation

- `pnpm run format:check` — 0.53s
- `pnpm run lint` — 0.20s
- `pnpm run build:docs` — 1.35s
- `pnpm run typecheck` — 2.10s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-actual-real-utility-continuation-script.test.ts packages/runtime/src/__tests__/native-active-syscall-policy.test.ts packages/runtime/src/__tests__/native-synthetic-ppoll-continuation.test.ts` — 0.60s, 3 files / 26 tests
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.34s
- arm64 Docker proof: `perl-ppoll-pipe` capture/model plan ready in `exit-process` mode, one fd, size 160, 6 resource recipes — 25.27s
- amd64 Proxmox CT proof: target-native synthetic `ppoll` exited `0`, `migrationCompleted: true` — 34.93s

Agent CI was not run because no workflow or CI files changed. Full smoke tests were skipped because this is narrow runtime/native synthetic syscall work on `portable-snapshots`, not VM lifecycle/rootfs/VMM/FUSE/snapshot plumbing; the targeted unit tests plus arm64/amd64 proof pair cover the changed path.
