### PR TITLE
Release amd64 Linux support

### DIFF
--- a/.changeset/blue-dingos-build.md
+++ b/.changeset/blue-dingos-build.md
@@ -1,0 +1,10 @@
+---
+"@machinen/runtime": minor
+"@machinen/cli": minor
+"@machinen/microvm": minor
+"@machinen/native-x64-linux": minor
+---
+
+Ship x86_64 Linux/KVM guest support.
+
+The release now publishes the `@machinen/native-x64-linux` host package and amd64 base assets (`bzImage-x86_64`, `rootfs-debian-amd64.tar.gz`, and the prebaked rootfs image). On x86_64 Linux hosts, the CLI/runtime select amd64 guest assets by default and same-architecture amd64 snapshot/restore uses the vmstate path.

--- a/.changeset/blue-dingos-build.md
+++ b/.changeset/blue-dingos-build.md
@@ -5,6 +5,6 @@
 "@machinen/native-x64-linux": minor
 ---
 
-Ship x86_64 Linux/KVM guest support.
+Ship amd64 Linux/KVM guest support.
 
-The release now publishes the `@machinen/native-x64-linux` host package and amd64 base assets (`bzImage-x86_64`, `rootfs-debian-amd64.tar.gz`, and the prebaked rootfs image). On x86_64 Linux hosts, the CLI/runtime select amd64 guest assets by default and same-architecture amd64 snapshot/restore uses the vmstate path.
+The release now publishes the `@machinen/native-x64-linux` host package and amd64 base assets (`bzImage-x86_64`, `rootfs-debian-amd64.tar.gz`, and the prebaked rootfs image). On amd64 Linux hosts, the CLI/runtime select amd64 guest assets by default and same-architecture amd64 snapshot/restore uses the vmstate path.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,8 @@
       "@machinen/microvm",
       "@machinen/mount-server",
       "@machinen/native-arm64-darwin",
-      "@machinen/native-arm64-linux"
+      "@machinen/native-arm64-linux",
+      "@machinen/native-x64-linux"
     ]
   ],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,8 @@ jobs:
           version: 0.16.0
       - run: pnpm install --frozen-lockfile
 
-      # Stage VMM binaries into the consolidated native-arm64-* packages
-      # so `changeset publish` picks them up. Each package's `files`
+      # Stage VMM binaries into the consolidated native packages so
+      # `changeset publish` picks them up. Each package's `files`
       # field includes `vmm/`.
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -226,27 +226,30 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: base-assets-arm64
-          path: release-assets-arm64/
+          path: ${{ runner.temp }}/release-assets-arm64/
       - name: Download amd64 base assets (for guest binaries)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: base-assets-amd64
-          path: release-assets-amd64/
+          path: ${{ runner.temp }}/release-assets-amd64/
       - name: Stage guest binaries into native packages and merge public assets
         run: |
           set -euo pipefail
+          arm64_assets="${RUNNER_TEMP}/release-assets-arm64"
+          amd64_assets="${RUNNER_TEMP}/release-assets-amd64"
+
           for pkg in packages/native-arm64-darwin packages/native-arm64-linux; do
             mkdir -p "$pkg/vmm/guest"
-            cp release-assets-arm64/init        "$pkg/vmm/guest/init"
-            cp release-assets-arm64/exec-agent  "$pkg/vmm/guest/exec-agent"
+            cp "$arm64_assets/init"        "$pkg/vmm/guest/init"
+            cp "$arm64_assets/exec-agent"  "$pkg/vmm/guest/exec-agent"
           done
           mkdir -p packages/native-x64-linux/vmm/guest
-          cp release-assets-amd64/init        packages/native-x64-linux/vmm/guest/init
-          cp release-assets-amd64/exec-agent  packages/native-x64-linux/vmm/guest/exec-agent
+          cp "$amd64_assets/init"        packages/native-x64-linux/vmm/guest/init
+          cp "$amd64_assets/exec-agent"  packages/native-x64-linux/vmm/guest/exec-agent
 
           rm -rf release-assets
           mkdir -p release-assets
-          for src in release-assets-arm64 release-assets-amd64; do
+          for src in "$arm64_assets" "$amd64_assets"; do
             find "$src" -maxdepth 1 -type f \
               ! -name init ! -name exec-agent \
               -exec cp {} release-assets/ \;

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .fallow/
 dist/
 release-assets/
+release-assets-*/
 .build-stage/
 .kernel-build/
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on a server, resume it next week. The program picks up exactly where it left
 off — like waking a laptop from sleep, except on a different computer.
 
 A native microVM runtime under the hood: arm64 on Apple Silicon/Linux and
-x86_64 on Linux/KVM. Node.js is the first-class target; Python, bash, and
+amd64 on Linux/KVM. Node.js is the first-class target; Python, bash, and
 anything else that boots in a Linux VM works too.
 
 > **Note:** the source code isn't published yet — it'll be available here soon.
@@ -27,7 +27,7 @@ too.
 The right native package is pulled automatically via optional dependencies:
 `@machinen/native-arm64-darwin` on Apple Silicon Macs,
 `@machinen/native-arm64-linux` on arm64 Linux, and
-`@machinen/native-x64-linux` on x86_64 Linux. No system dependencies.
+`@machinen/native-x64-linux` on amd64 Linux. No system dependencies.
 
 First run fetches the matching kernel + rootfs from a GitHub release on the
 companion repo over plain HTTPS — no auth required.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,9 @@
 
 Machinen uses [Changesets](https://github.com/changesets/changesets) for
 versioning and publishing. The public packages are in a `fixed` group
-and bump together, so `@machinen/cli`, `@machinen/runtime`,
-`@machinen/vmm-arm64-darwin`, and `@machinen/vmm-arm64-linux` always
+and bump together, so `@machinen/cli`, `@machinen/runtime`, `@machinen/microvm`,
+`@machinen/mount-server`, `@machinen/native-arm64-darwin`,
+`@machinen/native-arm64-linux`, and `@machinen/native-x64-linux` always
 share a version. That keeps the VMM protocol and the base rootfs from
 ever drifting.
 
@@ -35,11 +36,14 @@ Multiple changesets accumulate into a single Version PR.
 
 Merge the Version PR. The release workflow runs again and:
 
-1. Natively builds the Zig VMM on `macos-14` (arm64) and `ubuntu-24.04-arm`.
-   Ad-hoc codesigns the darwin binary with the hypervisor entitlement.
-2. Builds the base assets: `Image-arm64`, `virt-arm64.dtb`,
-   `rootfs-debian-arm64.tar.gz` + `.sha256` sidecars.
-3. Stages each VMM binary into its subpackage's `bin/` directory.
+1. Natively builds the Zig VMM on `macos-15` (arm64),
+   `ubuntu-24.04-arm`, and `ubuntu-latest` (x86_64 Linux). Ad-hoc
+   codesigns the darwin binary with the hypervisor entitlement.
+2. Builds the arm64 and amd64 base assets: `Image-arm64`,
+   `virt-arm64.dtb`, `rootfs-debian-arm64.tar.gz`, `bzImage-x86_64`,
+   `rootfs-debian-amd64.tar.gz`, plus `.img.gz` fast-boot images and
+   `.sha256` sidecars.
+3. Stages each VMM binary into its native subpackage's `bin/` directory.
 4. Publishes every `fixed`-group package to npm.
 5. Creates a GitHub Release at the tag and uploads the base assets to it.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ Multiple changesets accumulate into a single Version PR.
 Merge the Version PR. The release workflow runs again and:
 
 1. Natively builds the Zig VMM on `macos-15` (arm64),
-   `ubuntu-24.04-arm`, and `ubuntu-latest` (x86_64 Linux). Ad-hoc
+   `ubuntu-24.04-arm`, and `ubuntu-latest` (amd64 Linux). Ad-hoc
    codesigns the darwin binary with the hypervisor entitlement.
 2. Builds the arm64 and amd64 base assets: `Image-arm64`,
    `virt-arm64.dtb`, `rootfs-debian-arm64.tar.gz`, `bzImage-x86_64`,

--- a/docs/guides/nested-virtualization.md
+++ b/docs/guides/nested-virtualization.md
@@ -33,7 +33,7 @@ fails in a confusing way.
 | macOS 15+ on M3/M4-class Apple Silicon             | Supported path |
 | M1/M2 Macs                                         | Not supported  |
 | macOS before 15                                    | Not supported  |
-| x86_64 hosts                                       | Not supported  |
+| amd64 hosts                                        | Not supported  |
 | Cloud VMs that hide EL2 from the guest             | Not supported  |
 
 The runtime does a quick host check first. The VMM then does the real

--- a/docs/guides/snapshot-restore-fork.md
+++ b/docs/guides/snapshot-restore-fork.md
@@ -15,7 +15,7 @@ Two patterns get a lot of mileage out of that:
 
 This guide covers both. There's a constraint worth getting out of the way
 first: same guest architecture only. arm64 to arm64 works, and amd64 to amd64
-works on x86_64 Linux/KVM. arm64 to x86 does not — the snapshot includes
+works on amd64 Linux/KVM. arm64 to amd64 does not — the snapshot includes
 machine-code register state, and that doesn't translate.
 
 ## Vmstate restore contract

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,7 +85,7 @@ it just resumed on a different host. Same heap, same TCP listener, same
 counter. The Node runtime never noticed the move.
 
 A constraint to know about: the guest architecture has to match. arm64 to
-arm64 works, and amd64 to amd64 works on x86_64 Linux/KVM. arm64 to x86 does
+arm64 works, and amd64 to amd64 works on amd64 Linux/KVM. arm64 to amd64 does
 not — vmstate restores actual machine-code register state, and that doesn't
 translate.
 

--- a/packages/microvm/README.md
+++ b/packages/microvm/README.md
@@ -5,7 +5,7 @@ Zig source for the native microVM that powers
 
 - **darwin arm64** (Apple Silicon) — uses HVF (`Hypervisor.framework`)
 - **linux arm64** — uses KVM
-- **linux x86_64** — uses KVM
+- **linux amd64** — uses KVM
 
 The pre-built binaries ship inside the consolidated native packages:
 [`@machinen/native-arm64-darwin`](../native-arm64-darwin),
@@ -58,7 +58,7 @@ practice you drive it through `@machinen/runtime`:
 import { boot } from "@machinen/runtime";
 const vm = await boot({
   binary: "./zig-out/bin/microvm",
-  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on x64 Linux
+  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on amd64 Linux
   cmd: ["/bin/sh"],
 });
 ```

--- a/packages/microvm/package.json
+++ b/packages/microvm/package.json
@@ -2,7 +2,7 @@
   "name": "@machinen/microvm",
   "version": "0.3.4",
   "private": true,
-  "description": "Zig-native arm64 microVM for machinen (HVF on darwin, KVM on Linux). Source-only workspace package; the built binary ships inside @machinen/native-arm64-{darwin,linux}.",
+  "description": "Zig-native microVM for machinen (HVF on Darwin arm64, KVM on Linux arm64/x86_64). Source-only workspace package; built binaries ship inside @machinen/native-arm64-{darwin,linux} and @machinen/native-x64-linux.",
   "license": "FSL-1.1-MIT",
   "repository": {
     "type": "git",

--- a/packages/microvm/package.json
+++ b/packages/microvm/package.json
@@ -2,7 +2,7 @@
   "name": "@machinen/microvm",
   "version": "0.3.4",
   "private": true,
-  "description": "Zig-native microVM for machinen (HVF on Darwin arm64, KVM on Linux arm64/x86_64). Source-only workspace package; built binaries ship inside @machinen/native-arm64-{darwin,linux} and @machinen/native-x64-linux.",
+  "description": "Zig-native microVM for machinen (HVF on Darwin arm64, KVM on Linux arm64/amd64). Source-only workspace package; built binaries ship inside @machinen/native-arm64-{darwin,linux} and @machinen/native-x64-linux.",
   "license": "FSL-1.1-MIT",
   "repository": {
     "type": "git",

--- a/packages/native-x64-linux/README.md
+++ b/packages/native-x64-linux/README.md
@@ -1,7 +1,7 @@
 # @machinen/native-x64-linux
 
-All of machinen's host-side native binaries for x64 linux, in one
-package:
+All of machinen's host-side native binaries for amd64 Linux, in one
+package. The npm package name uses Node's `x64` CPU label:
 
 | subdir       | contents                                           |
 | ------------ | -------------------------------------------------- |

--- a/packages/native-x64-linux/package.json
+++ b/packages/native-x64-linux/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@machinen/native-x64-linux",
   "version": "0.3.4",
-  "description": "Machinen host-side native binaries for x64 linux — VMM (KVM) + gvproxy + guest ELFs, mke2fs, and mksquashfs.",
+  "description": "Machinen host-side native binaries for amd64 Linux — VMM (KVM) + gvproxy + guest ELFs, mke2fs, and mksquashfs.",
   "license": "FSL-1.1-MIT",
   "repository": {
     "type": "git",

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -46,7 +46,7 @@ companion GitHub release over HTTPS; no `gh auth login` is needed.
 import { boot } from "@machinen/runtime";
 
 const vm = await boot({
-  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on x64 Linux
+  image: "./rootfs-debian-arm64.tar.gz", // or rootfs-debian-amd64.tar.gz on amd64 Linux
   cmd: ["/bin/sh"],
 });
 

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -15,6 +15,11 @@
 #                                    tar -xf + mke2fs (#223). Sparse
 #                                    inside the gzip — wire size is
 #                                    close to the tarball.
+#
+# For amd64 guests (`MACHINEN_GUEST_ARCH=amd64`), the same flow emits
+# `bzImage-x86_64`, `rootfs-debian-amd64.tar.gz`, and
+# `rootfs-debian-amd64.img.gz` instead. amd64 does not use a dtb.
+#
 #   *.sha256                       ← integrity sidecars
 #
 # We no longer ship modules-arm64.tar.gz — the boot-path drivers are


### PR DESCRIPTION
## Problem

We added amd64 Linux support, but the release setup still treated the native packages like they were arm64-only. That meant `@machinen/native-x64-linux` would not be released with the rest of the packages. Some docs also mixed `x86_64`, `x64`, and `amd64`, which made the support story harder to follow.

## Solution

This PR adds `@machinen/native-x64-linux` to the fixed Changesets group and adds a changeset for the amd64 Linux release. It keeps downloaded release assets in the runner temp directory, ignores local `release-assets-*` folders, and updates user-facing docs to say `arm64` / `amd64`. The npm package name still uses `x64`, because that is Node's CPU label.

## Validation

- `pnpm changeset status --verbose` — 0.365s
- `pnpm run format:check` — 305ms
- `pnpm run lint` — 24ms
- `git diff --check` — 0.020s
