### PR TITLE
Harden remote portable restore e2e

### DIFF
--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -296,7 +296,7 @@ static uint64_t mapped_target_end = 0;
 static uint8_t *mapped_code_bytes = NULL;
 static uint64_t mapped_code_page_start = 0;
 static uint64_t mapped_code_page_size = 0;
-static uint64_t resume_return_value = 0;
+static volatile uint64_t resume_return_value __attribute__((used)) = 0;
 static uint64_t host_rsp_before_jump __attribute__((used)) = 0;
 
 struct ObservedRegisters {

--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -423,7 +423,7 @@ fn write_e820(bp: []u8, idx: usize, addr: u64, size: u64, typ: u32) void {
 }
 
 fn default_cmdline() []const u8 {
-    return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 panic=1 loglevel=3 quiet reboot=k acpi=force pci=off " ++
+    return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 panic=1 loglevel=3 quiet reboot=k noapic acpi=force pci=off " ++
         "virtio_mmio.device=512@0x0a000000:5 " ++
         "virtio_mmio.device=512@0x0a000200:6 " ++
         "virtio_mmio.device=512@0x0a000400:7 " ++
@@ -1618,8 +1618,9 @@ test "x86 bzImage parser rejects non-bzImage" {
     try std.testing.expectError(error.TruncatedSetup, BzImage.parse(bytes[0..1024]));
 }
 
-test "x86 cmdline advertises ttyS0 and virtio-mmio" {
+test "x86 cmdline advertises ttyS0, noapic, and virtio-mmio" {
     const cmd = default_cmdline();
     try std.testing.expect(std.mem.indexOf(u8, cmd, "console=ttyS0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cmd, "noapic") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a000200:6") != null);
 }

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -14,7 +14,7 @@ function compileHelper(outDir: string) {
     "cc",
     [
       "-std=c11",
-      "-O0",
+      "-O2",
       "-g",
       "-Wall",
       "-Wextra",

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -540,7 +540,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // (`(none)` on Linux). Subsequent shells (e.g. via
   // `machinen attach`) read the post-call value. Suppressed when
   // we have no vsock UDS (boot-without-exec-agent paths).
-  if (vsockUdsPath) {
+  if (vsockUdsPath && env.MACHINEN_SKIP_GUEST_HOSTNAME !== "1") {
     void setGuestHostname(handle, buildGuestHostname(handle.pid, handle.name));
   }
 

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -107,11 +107,16 @@ async function runTargetVmProof(args: Args) {
     "machinen-target-guest-restore-loader",
   );
   const vm = await bootTargetVm(args.image!);
+  await waitForTargetGuestBoot();
   try {
     return await executeTargetVmProof(args, { trampoline, loader }, vm);
   } finally {
     await killUnlessKept(vm, args.keep);
   }
+}
+
+function waitForTargetGuestBoot(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1000));
 }
 
 function skipReason(args: Args): string | undefined {
@@ -136,7 +141,12 @@ async function bootTargetVm(image: string) {
     image: resolve(image),
     name: `target-vm-synthetic-${process.pid}`,
     cmd: ["/bin/sleep", "infinity"],
-    vmmEnv: { ...process.env, MACHINEN_GUEST_ARCH: "amd64" },
+    snapshot: false,
+    vmmEnv: {
+      ...process.env,
+      MACHINEN_GUEST_ARCH: "amd64",
+      MACHINEN_SKIP_GUEST_HOSTNAME: "1",
+    },
   });
 }
 

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -7,6 +7,12 @@ AMD64_SSH=${PORTABLE_AMD64_SSH:-root@192.168.0.8}
 TARGET_IMAGE=${PORTABLE_MACHINE_TARGET_VM_IMAGE:-${MACHINEN_TARGET_VM_IMAGE:-}}
 REQUIRE_REMOTES=${PORTABLE_MACHINE_SMOKE_REQUIRE_REMOTES:-0}
 AMD64_REPO=${PORTABLE_AMD64_REPO:-}
+ARM64_NODE=${PORTABLE_ARM64_NODE:-node}
+AMD64_PNPM=${PORTABLE_AMD64_PNPM:-pnpm}
+AMD64_PATH_PREFIX=${PORTABLE_AMD64_PATH_PREFIX:-}
+AMD64_VMM=${PORTABLE_AMD64_VMM:-${MACHINEN_VMM:-}}
+AMD64_KERNEL=${PORTABLE_AMD64_KERNEL:-${MACHINEN_KERNEL:-}}
+AMD64_ASSETS_DIR=${PORTABLE_AMD64_ASSETS_DIR:-${MACHINEN_ASSETS_DIR:-}}
 KEEP=0
 JSON=0
 DRY_RUN=0
@@ -94,6 +100,11 @@ write_summary() {
   "arm64Ssh": "$(json_escape "$ARM64_SSH")",
   "amd64Ssh": "$(json_escape "$AMD64_SSH")",
   "amd64Repo": "$(json_escape "$AMD64_REPO")",
+  "arm64Node": "$(json_escape "$ARM64_NODE")",
+  "amd64Pnpm": "$(json_escape "$AMD64_PNPM")",
+  "amd64Vmm": "$(json_escape "$AMD64_VMM")",
+  "amd64Kernel": "$(json_escape "$AMD64_KERNEL")",
+  "amd64AssetsDir": "$(json_escape "$AMD64_ASSETS_DIR")",
   "remotePortableMachineBundle": "$(json_escape "$REMOTE_PORTABLE_BUNDLE")",
   "remoteTargetCodeFile": "$(json_escape "$REMOTE_TARGET_CODE")",
   "timings": [$joined]
@@ -243,7 +254,7 @@ capture_remote_native_process_bundle() {
     packages/microvm/assets/native-capture-target.c | \
     ssh "$ARM64_SSH" "tar -xzf - -C '$ARM64_REMOTE_WORK/repo'"
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && node scripts/native-process-capture.mjs verify --out-dir '$ARM64_REMOTE_WORK/capture' --json --keep > '$ARM64_REMOTE_WORK/capture.json'"
+    "cd '$ARM64_REMOTE_WORK/repo' && '$ARM64_NODE' scripts/native-process-capture.mjs verify --out-dir '$ARM64_REMOTE_WORK/capture' --json --keep > '$ARM64_REMOTE_WORK/capture.json'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.json'" >"$WORK/arm64-capture.json"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \
@@ -288,8 +299,12 @@ run_target_restore() {
     return 20
   fi
   if [[ $REMOTE_E2E -eq 1 ]]; then
+    local remote_path_assignment="PATH=\$PATH"
+    if [[ -n "$AMD64_PATH_PREFIX" ]]; then
+      remote_path_assignment="PATH='$AMD64_PATH_PREFIX':\$PATH"
+    fi
     if ! ssh "$AMD64_SSH" \
-      "cd '$AMD64_REPO' && pnpm --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --json" \
+      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --json" \
       >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
       record_timing "target-boot-restore" "failed" "$start" "remote runner failed"
       return 21


### PR DESCRIPTION
## Problem

The real remote restore test needed a temporary setup on two different machines. The script assumed normal `node`, `pnpm`, kernel, VMM, and asset paths already existed on those machines. On the Proxmox amd64 host, the target VM also got stuck before the guest was ready because the x86_64 KVM boot path used APIC mode that did not work reliably there.

## Solution

The remote smoke test can now point at temporary tool and asset paths under `/tmp`. The target VM proof skips unneeded snapshot disk setup and avoids a cosmetic early hostname exec, so the real restore path is less noisy. The x86_64 KVM guest now boots with `noapic`, and the trampoline stays safe when built with optimized Zig/clang.

## Validation

- `pnpm run format` — 0.545s
- `pnpm run format:check` — 0.532s
- `pnpm run lint` — 0.219s
- `pnpm run typecheck` — 3.705s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.068s, 836 passed / 12 skipped
- `pnpm smoke-tests` — 2m16.810s
- remote portable machine restore e2e — 24.299s, `state=completed`, `migrationCompleted=true`
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.368s
