### PR TITLE
Prove combined target VM restore path

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -15,6 +15,7 @@ harness then boots the amd64 target VM through the target-guest loader path. A
 run is successful only when the target VM reports target-native completion with:
 
 - `migrationCompleted: true`
+- `descriptorGateCompleted: true`
 - `sourceTextReusedAsTargetCode: false`
 - `sourceIsaEmulationUsed: false`
 - `sidecarRuntimeUsed: false`
@@ -26,7 +27,7 @@ MACHINEN_TARGET_VM_IMAGE=/path/to/rootfs-amd64.tar.gz \
   pnpm portable-machine-vm-restore-proof -- \
   --bundle-dir /tmp/portable-machine \
   --target-code-file /tmp/portable-machine/target/continuation.bin \
-  --synthetic-empty-eventfd 3 \
+  --combined-descriptor \
   --json
 ```
 
@@ -67,9 +68,11 @@ remote target image path. Dry-run mode never contacts remotes, so it can validat
 summary shape on any host.
 
 The smoke profile creates or captures a narrow arm64 native-process bundle,
-wraps it in a portable machine snapshot, stages target-native amd64 `exit(0)`
-continuation bytes inside the bundle, and runs the portable machine VM restore
-proof. It reports timing for:
+wraps it in a portable machine snapshot, stages a target-native amd64 verifier
+inside the bundle, and runs the portable machine VM restore proof with a combined
+restore descriptor. The verifier checks one safe captured memory byte and one
+planned fd-table `reopen-file` recipe before exiting successfully. It reports
+timing for:
 
 1. preflight / optional remote reachability gates;
 2. arm64 source capture bundle creation;

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -8067,6 +8067,10 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > **migrationCompleted**: `boolean`
 
+##### descriptorGateCompleted
+
+> **descriptorGateCompleted**: `boolean`
+
 ##### sourceTextReusedAsTargetCode
 
 > **sourceTextReusedAsTargetCode**: `false`
@@ -8108,6 +8112,10 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ##### migrationCompleted?
 
 > `optional` **migrationCompleted?**: `boolean`
+
+##### descriptorGateCompleted?
+
+> `optional` **descriptorGateCompleted?**: `boolean`
 
 ##### sourceTextReusedAsTargetCode?
 

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -141,6 +141,7 @@ describe("portable machine VM restore proof", () => {
       targetVmRequired: true,
       targetNativeCompletionRequired: true,
       migrationCompleted: false,
+      descriptorGateCompleted: false,
       sourceTextReusedAsTargetCode: false,
       sourceIsaEmulationUsed: false,
       sidecarRuntimeUsed: false,
@@ -150,20 +151,41 @@ describe("portable machine VM restore proof", () => {
       completePortableMachineVmRestoreProof(plan, {
         exitCode: 0,
         migrationCompleted: true,
+        descriptorGateCompleted: true,
         sourceTextReusedAsTargetCode: false,
         sourceIsaEmulationUsed: false,
         sidecarRuntimeUsed: false,
       }),
-    ).toMatchObject({ state: "completed", migrationCompleted: true });
+    ).toMatchObject({
+      state: "completed",
+      migrationCompleted: true,
+      descriptorGateCompleted: true,
+    });
 
     expect(
       completePortableMachineVmRestoreProof(plan, {
         exitCode: 0,
         migrationCompleted: true,
+        descriptorGateCompleted: true,
         sourceTextReusedAsTargetCode: true,
         sourceIsaEmulationUsed: false,
         sidecarRuntimeUsed: false,
       }),
-    ).toMatchObject({ state: "ready", migrationCompleted: false });
+    ).toMatchObject({ state: "ready", migrationCompleted: false, descriptorGateCompleted: true });
+
+    expect(
+      completePortableMachineVmRestoreProof(plan, {
+        exitCode: 0,
+        migrationCompleted: true,
+        descriptorGateCompleted: false,
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      }),
+    ).toMatchObject({
+      state: "ready",
+      migrationCompleted: false,
+      descriptorGateCompleted: false,
+    });
   });
 });

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -30,6 +30,7 @@ export interface PortableMachineVmRestoreProofPlan {
   targetVmRequired: true;
   targetNativeCompletionRequired: true;
   migrationCompleted: boolean;
+  descriptorGateCompleted: boolean;
   sourceTextReusedAsTargetCode: false;
   sourceIsaEmulationUsed: false;
   sidecarRuntimeUsed: false;
@@ -40,6 +41,7 @@ export interface PortableMachineVmRestoreProofPlan {
 export interface PortableMachineVmRestoreTargetResult {
   exitCode: number;
   migrationCompleted?: boolean;
+  descriptorGateCompleted?: boolean;
   sourceTextReusedAsTargetCode?: boolean;
   sourceIsaEmulationUsed?: boolean;
   sidecarRuntimeUsed?: boolean;
@@ -147,13 +149,19 @@ export function completePortableMachineVmRestoreProof(
   result: PortableMachineVmRestoreTargetResult,
 ): PortableMachineVmRestoreProofPlan {
   const completed = targetNativeCompleted(result);
-  return { ...plan, state: completed ? "completed" : plan.state, migrationCompleted: completed };
+  return {
+    ...plan,
+    state: completed ? "completed" : plan.state,
+    migrationCompleted: completed,
+    descriptorGateCompleted: result.descriptorGateCompleted === true,
+  };
 }
 
 function targetNativeCompleted(result: PortableMachineVmRestoreTargetResult): boolean {
   return [
     result.exitCode === 0,
     result.migrationCompleted === true,
+    result.descriptorGateCompleted === true,
     result.sourceTextReusedAsTargetCode === false,
     result.sourceIsaEmulationUsed === false,
     result.sidecarRuntimeUsed === false,
@@ -183,6 +191,7 @@ function base(): Omit<
     phase: "portable-machine-vm-restore-proof",
     targetVmRequired: true,
     targetNativeCompletionRequired: true,
+    descriptorGateCompleted: false,
     sourceTextReusedAsTargetCode: false,
     sourceIsaEmulationUsed: false,
     sidecarRuntimeUsed: false,

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -19,9 +19,17 @@ const GUEST_TRAMPOLINE = "/tmp/machinen-resume-trampoline";
 const GUEST_LOADER = "/tmp/machinen-target-guest-restore-loader";
 const GUEST_CODE = "/tmp/machinen-target-bytes.bin";
 const GUEST_DESCRIPTOR = "/tmp/machinen-target-guest-restore.desc";
+const GUEST_MEMORY_DEFAULT = "/tmp/machinen-combined-native-memory.bin";
+const GUEST_FD_FILE_DEFAULT = "/tmp/machinen-combined-fd.txt";
+const LOADER_PREFIX = "MACHINEN_TARGET_GUEST_RESTORE_LOADER ";
 
 interface Args {
   codeFile?: string;
+  descriptorFile?: string;
+  memoryFile?: string;
+  guestMemoryFile: string;
+  fdFile?: string;
+  guestFdFile: string;
   image?: string;
   json: boolean;
   keep: boolean;
@@ -39,7 +47,8 @@ interface Args {
 function usage(): never {
   console.error(
     "usage: tsx scripts/native-target-vm-synthetic-continuation.ts verify " +
-      "--code-file path [--image rootfs.tar.gz] [--entry-address hex] " +
+      "--code-file path [--descriptor-file path] [--memory-file path] " +
+      "[--fd-file path] [--image rootfs.tar.gz] [--entry-address hex] " +
       "[--stack-target-start hex] [--stack-size n] [--stack-pointer hex] [--json]",
   );
   process.exit(2);
@@ -65,6 +74,11 @@ function parseArgs(argv: string[]): Args {
   const read = flagReader(argv);
   return {
     codeFile: read("--code-file"),
+    descriptorFile: read("--descriptor-file"),
+    memoryFile: read("--memory-file"),
+    guestMemoryFile: withDefault(read("--guest-memory-file"), GUEST_MEMORY_DEFAULT),
+    fdFile: read("--fd-file"),
+    guestFdFile: withDefault(read("--guest-fd-file"), GUEST_FD_FILE_DEFAULT),
     image: read("--image") ?? process.env[IMAGE_ENV],
     json: argv.includes("--json"),
     keep: argv.includes("--keep"),
@@ -120,11 +134,18 @@ function waitForTargetGuestBoot(): Promise<void> {
 }
 
 function skipReason(args: Args): string | undefined {
-  return (
-    hostSkipReason() ||
-    missingFileReason(args.codeFile, "--code-file") ||
-    missingFileReason(args.image, IMAGE_ENV)
-  );
+  return firstReason([
+    hostSkipReason(),
+    missingFileReason(args.codeFile, "--code-file"),
+    missingOptionalFileReason(args.descriptorFile, "--descriptor-file"),
+    missingOptionalFileReason(args.memoryFile, "--memory-file"),
+    missingOptionalFileReason(args.fdFile, "--fd-file"),
+    missingFileReason(args.image, IMAGE_ENV),
+  ]);
+}
+
+function firstReason(reasons: Array<string | undefined>): string | undefined {
+  return reasons.find((reason) => reason !== undefined);
 }
 
 function hostSkipReason(): string | undefined {
@@ -134,6 +155,10 @@ function hostSkipReason(): string | undefined {
 
 function missingFileReason(path: string | undefined, label: string): string | undefined {
   return path && existsSync(path) ? undefined : `${label} must point at an existing file`;
+}
+
+function missingOptionalFileReason(path: string | undefined, label: string): string | undefined {
+  return path === undefined ? undefined : missingFileReason(path, label);
 }
 
 async function bootTargetVm(image: string) {
@@ -155,17 +180,61 @@ async function executeTargetVmProof(
   helpers: { trampoline: string; loader: string },
   vm: Awaited<ReturnType<typeof boot>>,
 ) {
+  await stageTargetGuestInputs(args, helpers, vm);
+  const result = await vm.execRaw(targetLoaderCommand(), {
+    execTimeoutMs: (args.timeoutSeconds + 20) * 1000,
+  });
+  const descriptorGateCompleted = loaderCompleted(result.stdout);
+  return {
+    ...targetSummary(args),
+    descriptorGateCompleted,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    migrationCompleted: result.exitCode === 0 && descriptorGateCompleted,
+    sourceTextReusedAsTargetCode: false,
+    sourceIsaEmulationUsed: false,
+    sidecarRuntimeUsed: false,
+  };
+}
+
+async function stageTargetGuestInputs(
+  args: Args,
+  helpers: { trampoline: string; loader: string },
+  vm: Awaited<ReturnType<typeof boot>>,
+): Promise<void> {
   const codeSize = statSync(args.codeFile!).size;
   await vm.writeFile(GUEST_TRAMPOLINE, readFileSync(helpers.trampoline), { mode: 0o755 });
   await vm.writeFile(GUEST_LOADER, readFileSync(helpers.loader), { mode: 0o755 });
   await vm.writeFile(GUEST_CODE, readFileSync(args.codeFile!));
-  await vm.writeFile(
-    GUEST_DESCRIPTOR,
-    serializeTargetGuestRestoreDescriptor(targetDescriptor(args, codeSize)),
-  );
-  const result = await vm.execRaw(targetLoaderCommand(), {
-    execTimeoutMs: (args.timeoutSeconds + 20) * 1000,
-  });
+  await writeOptionalGuestFiles(args, vm);
+  await vm.writeFile(GUEST_DESCRIPTOR, descriptorText(args, codeSize));
+}
+
+async function writeOptionalGuestFiles(
+  args: Args,
+  vm: Awaited<ReturnType<typeof boot>>,
+): Promise<void> {
+  for (const file of optionalGuestFiles(args)) {
+    await vm.writeFile(file.guest, readFileSync(file.host));
+  }
+}
+
+function optionalGuestFiles(args: Args): Array<{ host: string; guest: string }> {
+  return [
+    optionalGuestFile(args.memoryFile, args.guestMemoryFile),
+    optionalGuestFile(args.fdFile, args.guestFdFile),
+  ].filter((file) => file !== undefined);
+}
+
+function optionalGuestFile(
+  host: string | undefined,
+  guest: string,
+): { host: string; guest: string } | undefined {
+  return host ? { host, guest } : undefined;
+}
+
+function targetSummary(args: Args) {
   return {
     phase: "target-vm-synthetic-continuation",
     targetVmAttempted: true,
@@ -173,14 +242,36 @@ async function executeTargetVmProof(
     targetArch: "amd64",
     codeFile: resolve(args.codeFile!),
     codeFileBasename: basename(args.codeFile!),
-    exitCode: result.exitCode,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    migrationCompleted: result.exitCode === 0,
-    sourceTextReusedAsTargetCode: false,
-    sourceIsaEmulationUsed: false,
-    sidecarRuntimeUsed: false,
+    descriptorFile: optionalResolve(args.descriptorFile),
+    memoryFile: optionalResolve(args.memoryFile),
+    fdFile: optionalResolve(args.fdFile),
   };
+}
+
+function optionalResolve(path: string | undefined): string | undefined {
+  return path ? resolve(path) : undefined;
+}
+
+function descriptorText(args: Args, codeSize: number): string {
+  return args.descriptorFile
+    ? readFileSync(args.descriptorFile, "utf8")
+    : serializeTargetGuestRestoreDescriptor(targetDescriptor(args, codeSize));
+}
+
+function loaderCompleted(stdout: string): boolean {
+  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(LOADER_PREFIX));
+  if (!line) {
+    return false;
+  }
+  try {
+    const payload = JSON.parse(line.slice(LOADER_PREFIX.length)) as {
+      status?: string;
+      exitCode?: number;
+    };
+    return payload.status === "completed" && payload.exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 async function killUnlessKept(vm: Awaited<ReturnType<typeof boot>>, keep: boolean): Promise<void> {

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -1,41 +1,68 @@
 #!/usr/bin/env tsx
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import {
   completePortableMachineVmRestoreProof,
+  planPortableMachineTargetRestoreDescriptor,
   planPortableMachineVmRestoreProof,
 } from "../packages/runtime/src/portable-machine-restore-proof.ts";
+import {
+  NATIVE_PROCESS_IMAGE_FILES,
+  type NativeMemoryMapping,
+  type NativeProcessResource,
+} from "../packages/runtime/src/native-process-image.ts";
+import { planNativeTargetFdTable } from "../packages/runtime/src/native-resource-translation.ts";
+import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
+import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
+import { serializeTargetGuestRestoreDescriptor } from "../packages/runtime/src/target-guest-restore-loader.ts";
 
 interface Args {
   bundleDir?: string;
   targetCodeFile?: string;
   image?: string;
   json: boolean;
+  combinedDescriptor: boolean;
   syntheticEmptyPipeReadFd?: string;
   syntheticEmptyPipeWriteFd?: string;
   syntheticEmptyEventFd?: string;
   syntheticTimerFd?: string;
 }
 
+interface TargetInvocation {
+  descriptorFile?: string;
+  memoryFile?: string;
+  fdFile?: string;
+}
+
+const GUEST_CODE = "/tmp/machinen-target-bytes.bin";
+const GUEST_MEMORY = "/tmp/machinen-combined-native-memory.bin";
+const GUEST_FD_FILE = "/tmp/machinen-combined-fd.txt";
+const PROOF_MEMORY_TARGET = "0x600000000000";
+const PROOF_MEMORY_SIZE = 4096;
+const PROOF_FD = 7;
+const PROOF_FD_BYTES = Buffer.from("FD");
+
 function usage(): never {
   console.error(
     "usage: tsx scripts/portable-machine-vm-restore-proof.ts verify " +
-      "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] [--json]",
+      "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
+      "[--combined-descriptor] [--json]",
   );
   process.exit(2);
 }
 
 function parseArgs(argv: string[]): Args {
-  return argsFromReader((flag) => readFlag(argv, flag), argv.includes("--json"));
+  return argsFromReader((flag) => readFlag(argv, flag), argv);
 }
 
-function argsFromReader(read: (flag: string) => string | undefined, json: boolean): Args {
+function argsFromReader(read: (flag: string) => string | undefined, argv: string[]): Args {
   return {
     bundleDir: read("--bundle-dir"),
     targetCodeFile: read("--target-code-file"),
     image: read("--image") ?? process.env.MACHINEN_TARGET_VM_IMAGE,
-    json,
+    json: argv.includes("--json"),
+    combinedDescriptor: argv.includes("--combined-descriptor"),
     syntheticEmptyPipeReadFd: read("--synthetic-empty-pipe-read-fd"),
     syntheticEmptyPipeWriteFd: read("--synthetic-empty-pipe-write-fd"),
     syntheticEmptyEventFd: read("--synthetic-empty-eventfd"),
@@ -66,13 +93,195 @@ function runProof(args: Args) {
 
 function runReadyProof(args: Args, plan: ReturnType<typeof planPortableMachineVmRestoreProof>) {
   const targetSkip = targetVmSkipReason(args.image);
-  return targetSkip
-    ? { ...plan, state: "skipped" as const, skipReason: targetSkip }
-    : runTargetProof(args, plan);
+  if (targetSkip) {
+    return { ...plan, state: "skipped" as const, skipReason: targetSkip };
+  }
+  const prepared = args.combinedDescriptor ? prepareCombinedDescriptor(args, plan) : undefined;
+  if (isRestorePlan(prepared)) {
+    return prepared;
+  }
+  return runTargetProof(args, plan, prepared);
 }
 
-function runTargetProof(args: Args, plan: ReturnType<typeof planPortableMachineVmRestoreProof>) {
-  const target = spawnSync(process.execPath, targetCommand(args), targetSpawnOptions());
+function isRestorePlan(
+  prepared: TargetInvocation | ReturnType<typeof planPortableMachineVmRestoreProof> | undefined,
+): prepared is ReturnType<typeof planPortableMachineVmRestoreProof> {
+  return prepared !== undefined && "state" in prepared;
+}
+
+function prepareCombinedDescriptor(
+  args: Args,
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+): TargetInvocation | ReturnType<typeof planPortableMachineVmRestoreProof> {
+  const bundle = validatePortableMachineSnapshotBundle(args.bundleDir!);
+  const nativeRoot = bundle.nativeProcessImage.rootDir!;
+  const memoryFile = join(nativeRoot, NATIVE_PROCESS_IMAGE_FILES.memory);
+  const memorySizeBytes = statSync(memoryFile).size;
+  const mapping = selectProofMemoryMapping(
+    bundle.nativeProcessImage.mappings.mappings,
+    memorySizeBytes,
+  );
+  if (!mapping) {
+    return refusedPlan(
+      plan,
+      "mapping-ambiguous",
+      "portable machine proof needs one safe captured writable memory page",
+    );
+  }
+
+  const targetCodeFile = resolve(args.targetCodeFile!);
+  const targetDir = dirname(targetCodeFile);
+  const fdFile = join(targetDir, "combined-fd-resource.txt");
+  const descriptorFile = join(targetDir, "combined-target-restore.desc");
+  writeFileSync(fdFile, PROOF_FD_BYTES);
+  writeFileSync(targetCodeFile, combinedProofTargetCode(firstByte(memoryFile, mapping)));
+
+  const continuation = {
+    codeFile: GUEST_CODE,
+    fileOffset: 0,
+    codeSize: statSync(targetCodeFile).size,
+    targetAddress: "0x700300000000",
+    timeoutSeconds: 5,
+    stackTargetStart: "0x500000000000",
+    stackSize: 65_536,
+    stackPointer: "0x500000010000",
+  };
+  const memory = planTargetGuestMemoryMaterialization({
+    mappings: [mapping],
+    memorySizeBytes,
+    memoryFile: GUEST_MEMORY,
+  });
+  const fdTable = planNativeTargetFdTable({ resources: [proofFdResource()] });
+  const descriptorPlan = planPortableMachineTargetRestoreDescriptor({
+    continuation,
+    fdTable,
+    memory,
+  });
+  if (descriptorPlan.state === "refused") {
+    const first = descriptorPlan.refusals[0]!;
+    return refusedPlan(plan, first.code, first.message);
+  }
+  writeFileSync(descriptorFile, serializeTargetGuestRestoreDescriptor(descriptorPlan.descriptor));
+  return { descriptorFile, memoryFile, fdFile };
+}
+
+function selectProofMemoryMapping(
+  mappings: NativeMemoryMapping[],
+  memorySizeBytes: number,
+): NativeMemoryMapping | undefined {
+  const candidate = mappings.find((mapping) => {
+    const captured = mapping.captured;
+    return [
+      mapping.permissions.write,
+      !mapping.permissions.execute,
+      mapping.target.materialization === "translate",
+      captured !== undefined,
+      captured ? captured.offset + PROOF_MEMORY_SIZE <= memorySizeBytes : false,
+      captured ? captured.sizeBytes >= PROOF_MEMORY_SIZE : false,
+    ].every(Boolean);
+  });
+  if (!candidate?.captured) {
+    return undefined;
+  }
+  return {
+    ...candidate,
+    id: `${candidate.id}:combined-proof-page`,
+    sizeBytes: PROOF_MEMORY_SIZE,
+    captured: {
+      file: NATIVE_PROCESS_IMAGE_FILES.memory,
+      offset: candidate.captured.offset,
+      sizeBytes: PROOF_MEMORY_SIZE,
+    },
+    target: {
+      materialization: "translate",
+      targetStart: PROOF_MEMORY_TARGET,
+      reason: "combined target VM proof materializes one safe captured page",
+    },
+  };
+}
+
+function proofFdResource(): NativeProcessResource {
+  return {
+    id: `fd:${PROOF_FD}:combined-proof`,
+    kind: "file",
+    state: "recipe",
+    fd: PROOF_FD,
+    path: GUEST_FD_FILE,
+    offset: 0,
+    flags: ["octal:0"],
+    recipe: { reopen: GUEST_FD_FILE, offset: 0 },
+  };
+}
+
+function firstByte(memoryFile: string, mapping: NativeMemoryMapping): number {
+  const bytes = readFileSync(memoryFile);
+  return bytes[mapping.captured!.offset] ?? 0;
+}
+
+function combinedProofTargetCode(expectedMemoryByte: number): Buffer {
+  const bytes: number[] = [];
+  const jumps: number[] = [];
+  const push = (...values: number[]) => bytes.push(...values.map((value) => value & 0xff));
+  const pushU32 = (value: number) => push(value, value >> 8, value >> 16, value >> 24);
+  const pushU64 = (value: bigint) => {
+    for (let i = 0n; i < 8n; i++) {
+      push(Number((value >> (8n * i)) & 0xffn));
+    }
+  };
+  const jumpToFail = () => {
+    push(0x75, 0x00);
+    jumps.push(bytes.length - 1);
+  };
+
+  push(0x48, 0xbb);
+  pushU64(BigInt(PROOF_MEMORY_TARGET));
+  push(0x80, 0x3b, expectedMemoryByte);
+  jumpToFail();
+  push(0x48, 0x83, 0xec, 0x10);
+  push(0x31, 0xc0);
+  push(0xbf);
+  pushU32(PROOF_FD);
+  push(0x48, 0x89, 0xe6);
+  push(0xba);
+  pushU32(PROOF_FD_BYTES.length);
+  push(0x0f, 0x05);
+  push(0x83, 0xf8, PROOF_FD_BYTES.length);
+  jumpToFail();
+  push(0x80, 0x3c, 0x24, PROOF_FD_BYTES[0]!);
+  jumpToFail();
+  push(0x80, 0x7c, 0x24, 0x01, PROOF_FD_BYTES[1]!);
+  jumpToFail();
+  push(0xb8);
+  pushU32(60);
+  push(0x31, 0xff, 0x0f, 0x05);
+
+  const failOffset = bytes.length;
+  push(0xb8);
+  pushU32(60);
+  push(0xbf);
+  pushU32(42);
+  push(0x0f, 0x05);
+
+  for (const index of jumps) {
+    bytes[index] = failOffset - (index + 1);
+  }
+  return Buffer.from(bytes);
+}
+
+function refusedPlan(
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  code: string,
+  message: string,
+): ReturnType<typeof planPortableMachineVmRestoreProof> {
+  return { ...plan, state: "refused", migrationCompleted: false, refusal: { code, message } };
+}
+
+function runTargetProof(
+  args: Args,
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  invocation: TargetInvocation = {},
+) {
+  const target = spawnSync(process.execPath, targetCommand(args, invocation), targetSpawnOptions());
   return target.status === 0
     ? completePortableMachineVmRestoreProof(plan, JSON.parse(target.stdout))
     : {
@@ -82,13 +291,13 @@ function runTargetProof(args: Args, plan: ReturnType<typeof planPortableMachineV
       };
 }
 
-function targetCommand(args: Args): string[] {
+function targetCommand(args: Args, invocation: TargetInvocation): string[] {
   return [
     "--import",
     "tsx",
     "scripts/native-target-vm-synthetic-continuation.ts",
     "verify",
-    ...targetArgs(args),
+    ...targetArgs(args, invocation),
   ];
 }
 
@@ -116,15 +325,30 @@ function imageSkipReason(image: string | undefined): string | undefined {
     : "--image or MACHINEN_TARGET_VM_IMAGE must point at a target rootfs";
 }
 
-function targetArgs(args: Args): string[] {
+function targetArgs(args: Args, invocation: TargetInvocation): string[] {
   return [
     "--code-file",
     args.targetCodeFile!,
     "--image",
     args.image!,
     "--json",
+    ...combinedInvocationArgs(invocation),
     ...resourceArgs(args),
   ];
+}
+
+function combinedInvocationArgs(invocation: TargetInvocation): string[] {
+  return [
+    ...optionalArg("--descriptor-file", invocation.descriptorFile),
+    ...optionalArg("--memory-file", invocation.memoryFile),
+    ...optionalArg("--guest-memory-file", invocation.memoryFile ? GUEST_MEMORY : undefined),
+    ...optionalArg("--fd-file", invocation.fdFile),
+    ...optionalArg("--guest-fd-file", invocation.fdFile ? GUEST_FD_FILE : undefined),
+  ];
+}
+
+function optionalArg(flag: string, value: string | undefined): string[] {
+  return value ? [flag, value] : [];
 }
 
 function resourceArgs(args: Args): string[] {

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -217,8 +217,8 @@ writeFileSync(join(dir, 'native-mappings.json'), JSON.stringify({
   mappings: [{
     id: 'mapping:stack', kind: 'stack', sourceStart: '0x1000', sourceEnd: '0x2000', sizeBytes: 4096,
     permissions: { read: true, write: true, execute: false, private: true, shared: false },
-    captured: { file: 'native-memory.bin', offset: 0, sizeBytes: 16 },
-    target: { materialization: 'translate' },
+    captured: { file: 'native-memory.bin', offset: 0, sizeBytes: 4096 },
+    target: { materialization: 'translate', targetStart: '0x600000000000' },
   }],
   refusals,
 }, null, 2));
@@ -238,7 +238,9 @@ writeFileSync(join(dir, 'native-translation.json'), JSON.stringify({
   formatVersion: 1, mode: 'native-cross-isa', sourceArch: 'arm64', targetArch: 'amd64',
   codeLocations: [], threads: [], memoryRelocations: [], refusals,
 }, null, 2));
-writeFileSync(join(dir, 'native-memory.bin'), Buffer.alloc(16));
+const memory = Buffer.alloc(4096);
+memory[0] = 'M'.charCodeAt(0);
+writeFileSync(join(dir, 'native-memory.bin'), memory);
 NODE
   record_timing "capture" "ok" "$start" "arm64 native-process bundle synthesized"
 }
@@ -275,9 +277,10 @@ create_portable_bundle() {
   local start=$1
   pnpm --silent portable-machine-snapshot -- --native-process-bundle "$NATIVE_BUNDLE" --out-dir "$PORTABLE_BUNDLE" --json >"$WORK/portable-machine-snapshot.json"
   mkdir -p "$TARGET_DIR"
-  # amd64: mov eax,60; xor edi,edi; syscall
+  # Placeholder target bytes. The restore proof replaces these with a
+  # generated amd64 verifier when --combined-descriptor is used.
   printf '\270\074\000\000\000\061\377\017\005' >"$TARGET_CODE"
-  record_timing "bundle" "ok" "$start" "portable bundle validated and target bytes staged"
+  record_timing "bundle" "ok" "$start" "portable bundle validated and target byte slot staged"
 }
 
 transfer_bundle() {
@@ -304,7 +307,7 @@ run_target_restore() {
       remote_path_assignment="PATH='$AMD64_PATH_PREFIX':\$PATH"
     fi
     if ! ssh "$AMD64_SSH" \
-      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --json" \
+      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --combined-descriptor --json" \
       >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
       record_timing "target-boot-restore" "failed" "$start" "remote runner failed"
       return 21
@@ -313,6 +316,7 @@ run_target_restore() {
     --bundle-dir "$PORTABLE_BUNDLE" \
     --target-code-file "$TARGET_CODE" \
     --image "$TARGET_IMAGE" \
+    --combined-descriptor \
     --json >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
     record_timing "target-boot-restore" "failed" "$start" "runner failed"
     return 21


### PR DESCRIPTION
## Problem

The portable machine restore proof could boot the amd64 target VM and run packaged amd64 bytes.
That was useful, but it did not prove the combined restore path.
It did not prove that captured memory, fd recipes, and the continuation all passed through the in-guest descriptor gate before success was reported.

## Solution

This PR adds a `--combined-descriptor` proof path.
It materializes one safe captured memory page, loads a planned reopened file descriptor, and runs target-native amd64 verifier bytes that check both before exiting.
`migrationCompleted` is now accepted only after the target guest loader reports `descriptorGateCompleted: true`.
The portable machine restore smoke now exercises this combined path locally and in remote e2e mode.

Closes #599.

## Validation

- `pnpm run format:check` — 0.518s
- `pnpm run lint` — 0.203s
- `pnpm run typecheck` — 1.881s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.848s, 836 passed / 12 skipped
- `pnpm smoke-tests` — 2m8.681s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.323s
- remote arm64→amd64 e2e smoke — 37.117s, `state=completed`, `migrationCompleted=true`, `descriptorGateCompleted=true`
