### PR TITLE
Prove real utility target VM restore continuation

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -28,6 +28,7 @@ MACHINEN_TARGET_VM_IMAGE=/path/to/rootfs-amd64.tar.gz \
   --bundle-dir /tmp/portable-machine \
   --target-code-file /tmp/portable-machine/target/continuation.bin \
   --combined-descriptor \
+  --real-utility-continuation \
   --json
 ```
 
@@ -39,12 +40,14 @@ Raw cross-ISA `.vmstate` replay remains a refusal, not a success path.
 `planPortableMachineTargetRestoreDescriptor()` is the combined descriptor gate:
 fd-table refusals, executable-source memory, ambiguous mappings, and other unsafe
 materialization blockers are returned as refusals instead of entering the guest.
-Ready descriptors include only generated/target-native continuation bytes,
+Ready descriptors include only approved target-native continuation bytes,
 explicit fd-table recipes, and safe non-executable memory entries. The current
-combined proof verifies a safe captured memory byte plus a wider fd matrix:
-closed fd, inherited stdout, reopened file, synthetic pipe, eventfd, and timerfd
-recipes. The generated amd64 verifier checks the materialized memory and fd
-state before exiting.
+combined proof can still use generated verifier bytes, but the smoke path now
+uses `--real-utility-continuation`: target module bytes are materialized from a
+portable-bundle target root, entered through the amd64 guest loader, and accepted
+only when the in-guest resume event returns the expected value. The descriptor
+still carries the wider fd matrix: closed fd, inherited stdout, reopened file,
+synthetic pipe, eventfd, and timerfd recipes.
 
 ## Smoke profile
 
@@ -72,13 +75,14 @@ remote target image path. Dry-run mode never contacts remotes, so it can validat
 summary shape on any host.
 
 The smoke profile creates or captures a narrow arm64 native-process bundle,
-wraps it in a portable machine snapshot, stages a target-native amd64 verifier
-inside the bundle, and runs the portable machine VM restore proof with a combined
-restore descriptor. The verifier checks one safe captured memory byte plus the
-planned fd-table recipe matrix before exiting successfully. The JSON summary
+wraps it in a portable machine snapshot, stages a target-native amd64 real
+utility continuation inside the bundle, and runs the portable machine VM restore
+proof with a combined restore descriptor. The continuation is target module bytes
+from the bundle's approved target root, not source-ISA text. The JSON summary
 includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
-resource recipe kinds, and `targetRestore.targetVerifierResult`. It reports
-timing for:
+resource recipe kinds, `targetRestore.targetContinuationKind`,
+`targetRestore.targetContinuationReturnValue`, and
+`targetRestore.targetVerifierResult`. It reports timing for:
 
 1. preflight / optional remote reachability gates;
 2. arm64 source capture bundle creation;

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -15,6 +15,7 @@ codeFile=/tmp/machinen-target-bytes.bin
 fileOffset=0
 codeSize=16
 targetAddress=0x700300000000
+argument0=0x600000000000
 timeoutSeconds=5
 stackTargetStart=0x500000000000
 stackSize=65536
@@ -63,5 +64,7 @@ Everything else fails closed with a precise refusal, currently:
 
 The existing target-VM synthetic proof now injects the loader and descriptor into
 the amd64 guest and executes the loader instead of invoking the trampoline
-directly. Completion is still credited only to generated target-native amd64
-continuation bytes returning/exiting in the guest.
+directly. The descriptor may carry an optional `argument0` target register value
+for real target-native continuation attempts. Completion is credited only when
+the descriptor gate succeeds and the target-native continuation returns/exits in
+the guest with the expected modeled result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -53,6 +53,8 @@ struct Options {
   uint64_t file_offset;
   uint64_t code_size;
   uint64_t target_address;
+  bool has_argument0;
+  uint64_t argument0;
   uint64_t stack_target_start;
   uint64_t stack_size;
   uint64_t stack_pointer;
@@ -73,7 +75,7 @@ static void usage(void) {
   fprintf(stderr,
       "usage: machinen-native-actual-resume-trampoline --code-file path "
       "--file-offset n --code-size n --target-address addr "
-      "--timeout-seconds n [--synthetic-empty-pipe-read-fd n] "
+      "[--argument0 addr] --timeout-seconds n [--synthetic-empty-pipe-read-fd n] "
       "[--synthetic-empty-pipe-write-fd n] [--synthetic-empty-eventfd n] "
       "[--synthetic-timerfd n] [--set-cloexec-fd n] "
       "[--materialize-memory file:offset:target:size:perms] "
@@ -198,6 +200,12 @@ static struct Options parse_args(int argc, char **argv) {
         usage();
       }
       opts.target_address = parse_u64(argv[i], "target-address");
+    } else if (streq(argv[i], "--argument0")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.argument0 = parse_u64(argv[i], "argument0");
+      opts.has_argument0 = true;
     } else if (streq(argv[i], "--timeout-seconds")) {
       if (++i >= argc) {
         usage();
@@ -619,14 +627,14 @@ static void apply_cloexec_fds(const struct Options *opts) {
   }
 }
 
-static void jump_to_target(uint64_t entry, uint64_t initial_rsp) {
+static void jump_to_target(uint64_t entry, uint64_t initial_rsp, uint64_t argument0) {
   __asm__ __volatile__(
       "movq %%rsp, host_rsp_before_jump(%%rip)\n"
       "movq %[initial_rsp], %%rsp\n"
       "leaq 1f(%%rip), %%rax\n"
       "movq %%rax, (%%rsp)\n"
       "xorl %%eax, %%eax\n"
-      "xorl %%edi, %%edi\n"
+      "movq %[argument0], %%rdi\n"
       "xorl %%esi, %%esi\n"
       "xorl %%edx, %%edx\n"
       "xorl %%ecx, %%ecx\n"
@@ -639,7 +647,9 @@ static void jump_to_target(uint64_t entry, uint64_t initial_rsp) {
       "movq %%rax, resume_return_value(%%rip)\n"
       "movq host_rsp_before_jump(%%rip), %%rsp\n"
       :
-      : [entry] "r"((void *)(uintptr_t)entry), [initial_rsp] "r"(initial_rsp)
+      : [entry] "r"((void *)(uintptr_t)entry),
+        [initial_rsp] "r"(initial_rsp),
+        [argument0] "r"(argument0)
       : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "memory");
 }
 
@@ -733,6 +743,7 @@ static void print_return_event(const struct Options *opts) {
       "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
       "\"targetArch\":\"amd64\",\"entry\":\"0x%" PRIx64 "\"," 
       "\"returnValue\":\"0x%" PRIx64 "\"," 
+      "\"argument0\":\"0x%" PRIx64 "\","
       "\"stackPointer\":\"0x%" PRIx64 "\"," 
       "\"targetBytesStart\":\"0x%" PRIx64 "\"," 
       "\"targetBytesEnd\":\"0x%" PRIx64 "\"," 
@@ -741,6 +752,7 @@ static void print_return_event(const struct Options *opts) {
       "\"sourceIsaEmulationUsed\":false,\"sidecarRuntimeUsed\":false}\n",
       opts->target_address,
       resume_return_value,
+      opts->argument0,
       opts->stack_pointer,
       mapped_target_start,
       mapped_target_end);
@@ -771,7 +783,8 @@ int main(int argc, char **argv) {
   apply_cloexec_fds(&opts);
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {
-    jump_to_target(opts.target_address, opts.stack_pointer - 8u);
+    jump_to_target(
+        opts.target_address, opts.stack_pointer - 8u, opts.has_argument0 ? opts.argument0 : 0u);
     alarm(0);
     print_return_event(&opts);
   } else {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -44,6 +44,8 @@ struct Descriptor {
   uint64_t file_offset;
   uint64_t code_size;
   uint64_t target_address;
+  bool has_argument0;
+  uint64_t argument0;
   uint64_t timeout_seconds;
   uint64_t stack_target_start;
   uint64_t stack_size;
@@ -60,7 +62,7 @@ struct Descriptor {
   size_t inherit_fd_count;
   struct ReopenFileRecipe reopen_files[MAX_FD_RECIPES];
   size_t reopen_file_count;
-  char memory_specs[MAX_MATERIALIZED_MAPPINGS][PATH_MAX];
+  char memory_specs[MAX_MATERIALIZED_MAPPINGS][PATH_MAX * 2];
   size_t memory_spec_count;
   char guard_specs[MAX_MATERIALIZED_MAPPINGS][128];
   size_t guard_spec_count;
@@ -183,6 +185,9 @@ static void parse_field(struct Descriptor *descriptor, char *line) {
     descriptor->code_size = parse_u64(value, key);
   } else if (streq(key, "targetAddress")) {
     descriptor->target_address = parse_u64(value, key);
+  } else if (streq(key, "argument0")) {
+    descriptor->argument0 = parse_u64(value, key);
+    descriptor->has_argument0 = true;
   } else if (streq(key, "timeoutSeconds")) {
     descriptor->timeout_seconds = parse_u64(value, key);
   } else if (streq(key, "stackTargetStart")) {
@@ -365,7 +370,7 @@ static void append_memory_spec(struct Descriptor *descriptor, char *fields) {
     refuse("target-guest-loader-invalid-continuation", "memory mappings must be non-executable");
   }
   snprintf(descriptor->memory_specs[descriptor->memory_spec_count++],
-      PATH_MAX,
+      sizeof(descriptor->memory_specs[0]),
       "%s:%s:%s:%s:%s",
       source_file_copy,
       source_offset_copy,
@@ -528,6 +533,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char file_offset[32];
   char code_size[32];
   char target_address[32];
+  char argument0[32];
   char timeout_seconds[32];
   char stack_target_start[32];
   char stack_size[32];
@@ -540,6 +546,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(file_offset, sizeof(file_offset), "0x%" PRIx64, descriptor->file_offset);
   snprintf(code_size, sizeof(code_size), "0x%" PRIx64, descriptor->code_size);
   snprintf(target_address, sizeof(target_address), "0x%" PRIx64, descriptor->target_address);
+  snprintf(argument0, sizeof(argument0), "0x%" PRIx64, descriptor->argument0);
   snprintf(timeout_seconds, sizeof(timeout_seconds), "0x%" PRIx64, descriptor->timeout_seconds);
   snprintf(stack_target_start, sizeof(stack_target_start), "0x%" PRIx64, descriptor->stack_target_start);
   snprintf(stack_size, sizeof(stack_size), "0x%" PRIx64, descriptor->stack_size);
@@ -563,6 +570,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   push_arg(child_argv, &child_argc, code_size);
   push_arg(child_argv, &child_argc, "--target-address");
   push_arg(child_argv, &child_argc, target_address);
+  if (descriptor->has_argument0) {
+    push_arg(child_argv, &child_argc, "--argument0");
+    push_arg(child_argv, &child_argc, argument0);
+  }
   push_arg(child_argv, &child_argc, "--timeout-seconds");
   push_arg(child_argv, &child_argc, timeout_seconds);
   push_arg(child_argv, &child_argc, "--stack-target-start");

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -109,6 +109,7 @@
 - [`PortableMachineTargetRestoreDescriptorRequest`](#portablemachinetargetrestoredescriptorrequest)
 - [`PortableMachineTargetRestoreDescriptorPlan`](#portablemachinetargetrestoredescriptorplan)
 - [`PortableMachineVmRestoreProofState`](#portablemachinevmrestoreproofstate)
+- [`PortableMachineTargetContinuationKind`](#portablemachinetargetcontinuationkind)
 - [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
 - [`PortableMachineVmRestoreProofRequest`](#portablemachinevmrestoreproofrequest)
 - [`PortableMachineVmRestoreProofPlan`](#portablemachinevmrestoreproofplan)
@@ -8088,6 +8089,22 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetVerifierResult?**: [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
 
+##### targetContinuationKind?
+
+> `optional` **targetContinuationKind?**: [`PortableMachineTargetContinuationKind`](#portablemachinetargetcontinuationkind)
+
+##### targetContinuationStatus?
+
+> `optional` **targetContinuationStatus?**: `string`
+
+##### targetContinuationReturnValue?
+
+> `optional` **targetContinuationReturnValue?**: `string`
+
+##### targetModuleBytesSource?
+
+> `optional` **targetModuleBytesSource?**: `string`
+
 ##### sourceTextReusedAsTargetCode
 
 > **sourceTextReusedAsTargetCode**: `false`
@@ -8137,6 +8154,18 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ##### targetVerifierResult?
 
 > `optional` **targetVerifierResult?**: [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
+
+##### actualResumeEvent?
+
+> `optional` **actualResumeEvent?**: `object`
+
+###### status?
+
+> `optional` **status?**: `string`
+
+###### returnValue?
+
+> `optional` **returnValue?**: `string`
 
 ##### sourceTextReusedAsTargetCode?
 
@@ -9117,6 +9146,10 @@ Poll interval in ms while retrying. Default 250.
 ##### targetAddress
 
 > **targetAddress**: `string`
+
+##### argument0?
+
+> `optional` **argument0?**: `string`
 
 ##### timeoutSeconds
 
@@ -11625,6 +11658,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### PortableMachineTargetVerifierResult
 
 > **PortableMachineTargetVerifierResult** = `"pending"` \| `"passed"` \| `"failed"`
+
+***
+
+### PortableMachineTargetContinuationKind
+
+> **PortableMachineTargetContinuationKind** = `"generated-verifier"` \| `"real-utility"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -31,7 +31,7 @@ function compileHelper(outDir: string) {
   return helper;
 }
 
-function runHelper(helper: string, codeFile: string, codeSize: number) {
+function runHelper(helper: string, codeFile: string, codeSize: number, extraArgs: string[] = []) {
   const result = spawnSync(
     helper,
     [
@@ -43,6 +43,7 @@ function runHelper(helper: string, codeFile: string, codeSize: number) {
       String(codeSize),
       "--target-address",
       "0x710000001000",
+      ...extraArgs,
       "--stack-target-start",
       "0x520000000000",
       "--stack-size",
@@ -76,6 +77,15 @@ describe("native actual resume trampoline", () => {
         sourceTextReusedAsTargetCode: false,
         sourceIsaEmulationUsed: false,
         sidecarRuntimeUsed: false,
+      });
+
+      const arg0Code = join(outDir, "arg0.bin");
+      // mov rax, rdi; ret
+      writeFileSync(arg0Code, Buffer.from([0x48, 0x89, 0xf8, 0xc3]));
+      expect(runHelper(helper, arg0Code, 4, ["--argument0", "0x600000000000"])).toMatchObject({
+        status: "returned",
+        returnValue: "0x600000000000",
+        argument0: "0x600000000000",
       });
 
       const faultCode = join(outDir, "fault.bin");

--- a/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
 const SCRIPT = join(REPO_ROOT, "scripts/smoke/portable-machine-restore.sh");
+const SCRIPT_ENV = { ...process.env, FORCE_COLOR: "1" };
 const tempDirs: string[] = [];
 
 afterEach(() => {
@@ -29,6 +30,7 @@ describe("portable machine restore smoke profile", () => {
       {
         cwd: REPO_ROOT,
         encoding: "utf8",
+        env: SCRIPT_ENV,
         timeout: 30_000,
       },
     );
@@ -67,6 +69,7 @@ describe("portable machine restore smoke profile", () => {
       {
         cwd: REPO_ROOT,
         encoding: "utf8",
+        env: SCRIPT_ENV,
         timeout: 30_000,
       },
     );

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -44,6 +44,7 @@ function descriptor(
 describe("target guest restore loader descriptor", () => {
   it("serializes and parses fd table recipes", () => {
     const original = descriptor({
+      continuation: { ...descriptor().continuation, argument0: "0x600000000000" },
       resources: [
         { kind: "close-fd", fd: 0, reason: "missing-captured-fd" },
         { kind: "inherit-stdio", fd: 1, stream: "stdout", closeOnExec: false },
@@ -75,6 +76,8 @@ describe("target guest restore loader descriptor", () => {
       "16",
       "--target-address",
       "0x700300000000",
+      "--argument0",
+      "0x600000000000",
       "--timeout-seconds",
       "5",
       "--stack-target-start",
@@ -195,6 +198,14 @@ describe("target guest restore loader descriptor", () => {
         }),
       ),
     ).toThrow(/targetAddress must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: { ...descriptor().continuation, argument0: "600000000000" },
+        }),
+      ),
+    ).toThrow(/argument0 must be a hex address/);
   });
 
   it.skipIf(!HAS_CC)(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -450,6 +450,7 @@ export type {
   TargetGuestRecreateGuardEntry,
 } from "./target-guest-memory-materialization.ts";
 export type {
+  PortableMachineTargetContinuationKind,
   PortableMachineTargetRestoreDescriptorPlan,
   PortableMachineTargetRestoreDescriptorRequest,
   PortableMachineTargetVerifierResult,

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -20,6 +20,7 @@ export interface PortableMachineVmRestoreProofRequest {
 }
 
 export type PortableMachineTargetVerifierResult = "pending" | "passed" | "failed";
+export type PortableMachineTargetContinuationKind = "generated-verifier" | "real-utility";
 
 export interface PortableMachineVmRestoreProofPlan {
   phase: "portable-machine-vm-restore-proof";
@@ -37,6 +38,10 @@ export interface PortableMachineVmRestoreProofPlan {
   descriptorFdRecipeCount?: number;
   descriptorResourceKinds?: string[];
   targetVerifierResult?: PortableMachineTargetVerifierResult;
+  targetContinuationKind?: PortableMachineTargetContinuationKind;
+  targetContinuationStatus?: string;
+  targetContinuationReturnValue?: string;
+  targetModuleBytesSource?: string;
   sourceTextReusedAsTargetCode: false;
   sourceIsaEmulationUsed: false;
   sidecarRuntimeUsed: false;
@@ -49,6 +54,7 @@ export interface PortableMachineVmRestoreTargetResult {
   migrationCompleted?: boolean;
   descriptorGateCompleted?: boolean;
   targetVerifierResult?: PortableMachineTargetVerifierResult;
+  actualResumeEvent?: { status?: string; returnValue?: string };
   sourceTextReusedAsTargetCode?: boolean;
   sourceIsaEmulationUsed?: boolean;
   sidecarRuntimeUsed?: boolean;
@@ -162,6 +168,8 @@ export function completePortableMachineVmRestoreProof(
     migrationCompleted: completed,
     descriptorGateCompleted: result.descriptorGateCompleted === true,
     targetVerifierResult: verifierResult(result, completed),
+    targetContinuationStatus: result.actualResumeEvent?.status,
+    targetContinuationReturnValue: result.actualResumeEvent?.returnValue,
   };
 }
 

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -40,6 +40,7 @@ export interface TargetGuestRestoreContinuationDescriptor {
   fileOffset: number;
   codeSize: number;
   targetAddress: string;
+  argument0?: string;
   timeoutSeconds: number;
   stackTargetStart: string;
   stackSize: number;
@@ -66,6 +67,7 @@ export function serializeTargetGuestRestoreDescriptor(
     `fileOffset=${continuation.fileOffset}`,
     `codeSize=${continuation.codeSize}`,
     `targetAddress=${continuation.targetAddress}`,
+    ...optionalContinuationField("argument0", continuation.argument0),
     `timeoutSeconds=${continuation.timeoutSeconds}`,
     `stackTargetStart=${continuation.stackTargetStart}`,
     `stackSize=${continuation.stackSize}`,
@@ -118,6 +120,7 @@ export function buildNativeActualResumeTrampolineArgs(
     String(continuation.codeSize),
     "--target-address",
     continuation.targetAddress,
+    ...optionalArg("--argument0", continuation.argument0),
     "--timeout-seconds",
     String(continuation.timeoutSeconds),
     "--stack-target-start",
@@ -166,6 +169,7 @@ function fieldsToDescriptor(
       fileOffset: parseIntegerField(fields, "fileOffset"),
       codeSize: parseIntegerField(fields, "codeSize"),
       targetAddress: requiredField(fields, "targetAddress"),
+      argument0: optionalField(fields, "argument0"),
       timeoutSeconds: parseIntegerField(fields, "timeoutSeconds"),
       stackTargetStart: requiredField(fields, "stackTargetStart"),
       stackSize: parseIntegerField(fields, "stackSize"),
@@ -178,6 +182,10 @@ function fieldsToDescriptor(
 
 function requiredField(fields: Map<string, string>, key: string): string {
   return fields.get(key) ?? fail("target-guest-loader-descriptor-invalid", `${key} is required`);
+}
+
+function optionalField(fields: Map<string, string>, key: string): string | undefined {
+  return fields.get(key);
 }
 
 function parseIntegerField(fields: Map<string, string>, key: string): number {
@@ -383,6 +391,9 @@ function validateContinuation(
   assertPositive(continuation.timeoutSeconds, "timeoutSeconds");
   assertPositive(continuation.stackSize, "stackSize");
   assertHexAddress(continuation.targetAddress, "targetAddress");
+  if (continuation.argument0 !== undefined) {
+    assertHexAddress(continuation.argument0, "argument0");
+  }
   assertHexAddress(continuation.stackTargetStart, "stackTargetStart");
   assertHexAddress(continuation.stackPointer, "stackPointer");
   return continuation;
@@ -524,6 +535,10 @@ function assertNoWhitespace(value: string, field: string): void {
   }
 }
 
+function optionalContinuationField(name: string, value: string | undefined): string[] {
+  return value === undefined ? [] : [`${name}=${value}`];
+}
+
 function serializeResourceRecipe(recipe: TargetGuestRestoreResourceRecipe): string {
   if (recipe.kind === "close-fd") {
     const reason = recipe.reason === undefined ? "" : ` reason=${recipe.reason}`;
@@ -554,6 +569,10 @@ function serializeMemoryEntry(entry: TargetGuestMemoryMaterializationEntry): str
     return `memory=copy-captured-bytes ${base} sourceFile=${entry.sourceFile} sourceOffset=${entry.sourceOffset}`;
   }
   return `memory=recreate-guard ${base}`;
+}
+
+function optionalArg(flag: string, value: string | undefined): string[] {
+  return value === undefined ? [] : [flag, value];
 }
 
 function resourceToTrampolineArgs(recipe: TargetGuestRestoreResourceRecipe): string[] {

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -131,6 +131,7 @@ const TOC = {
     "PortableMachineTargetRestoreDescriptorRequest",
     "PortableMachineTargetRestoreDescriptorPlan",
     "PortableMachineVmRestoreProofState",
+    "PortableMachineTargetContinuationKind",
     "PortableMachineTargetVerifierResult",
     "PortableMachineVmRestoreProofRequest",
     "PortableMachineVmRestoreProofPlan",

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -22,6 +22,7 @@ const GUEST_DESCRIPTOR = "/tmp/machinen-target-guest-restore.desc";
 const GUEST_MEMORY_DEFAULT = "/tmp/machinen-combined-native-memory.bin";
 const GUEST_FD_FILE_DEFAULT = "/tmp/machinen-combined-fd.txt";
 const LOADER_PREFIX = "MACHINEN_TARGET_GUEST_RESTORE_LOADER ";
+const ACTUAL_RESUME_PREFIX = "MACHINEN_ACTUAL_RESUME_TRAMPOLINE ";
 
 interface Args {
   codeFile?: string;
@@ -42,6 +43,7 @@ interface Args {
   syntheticEmptyPipeWriteFd?: string;
   syntheticEmptyEventFd?: string;
   syntheticTimerFd?: string;
+  expectReturnValue?: string;
 }
 
 function usage(): never {
@@ -91,6 +93,7 @@ function parseArgs(argv: string[]): Args {
     syntheticEmptyPipeWriteFd: read("--synthetic-empty-pipe-write-fd"),
     syntheticEmptyEventFd: read("--synthetic-empty-eventfd"),
     syntheticTimerFd: read("--synthetic-timerfd"),
+    expectReturnValue: read("--expect-return-value"),
   };
 }
 
@@ -185,11 +188,19 @@ async function executeTargetVmProof(
     execTimeoutMs: (args.timeoutSeconds + 20) * 1000,
   });
   const descriptorGateCompleted = loaderCompleted(result.stdout);
-  const targetVerifierResult =
-    result.exitCode === 0 && descriptorGateCompleted ? "passed" : "failed";
+  const actualResumeEvent = parseActualResumeEvent(result.stdout);
+  const targetVerifierResult = targetVerifierPassed(
+    args,
+    result.exitCode,
+    descriptorGateCompleted,
+    actualResumeEvent,
+  )
+    ? "passed"
+    : "failed";
   return {
     ...targetSummary(args),
     descriptorGateCompleted,
+    actualResumeEvent,
     targetVerifierResult,
     exitCode: result.exitCode,
     stdout: result.stdout,
@@ -262,19 +273,54 @@ function descriptorText(args: Args, codeSize: number): string {
 }
 
 function loaderCompleted(stdout: string): boolean {
-  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(LOADER_PREFIX));
+  const payload = prefixedJson(stdout, LOADER_PREFIX) as
+    | { status?: string; exitCode?: number }
+    | undefined;
+  return payload?.status === "completed" && payload.exitCode === 0;
+}
+
+function parseActualResumeEvent(stdout: string): Record<string, unknown> | undefined {
+  return prefixedJson(stdout, ACTUAL_RESUME_PREFIX) as Record<string, unknown> | undefined;
+}
+
+function prefixedJson(stdout: string, prefix: string): unknown | undefined {
+  const line = stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(prefix));
   if (!line) {
-    return false;
+    return undefined;
   }
   try {
-    const payload = JSON.parse(line.slice(LOADER_PREFIX.length)) as {
-      status?: string;
-      exitCode?: number;
-    };
-    return payload.status === "completed" && payload.exitCode === 0;
+    return JSON.parse(line.slice(prefix.length));
   } catch {
+    return undefined;
+  }
+}
+
+function targetVerifierPassed(
+  args: Args,
+  exitCode: number,
+  descriptorGateCompleted: boolean,
+  actualResumeEvent: Record<string, unknown> | undefined,
+): boolean {
+  if (!targetProcessCompleted(exitCode, descriptorGateCompleted)) {
     return false;
   }
+  return args.expectReturnValue === undefined
+    ? true
+    : actualResumeReturnedExpected(actualResumeEvent, args.expectReturnValue);
+}
+
+function targetProcessCompleted(exitCode: number, descriptorGateCompleted: boolean): boolean {
+  return descriptorGateCompleted && exitCode === 0;
+}
+
+function actualResumeReturnedExpected(
+  actualResumeEvent: Record<string, unknown> | undefined,
+  expectedReturnValue: string,
+): boolean {
+  return (
+    actualResumeEvent?.status === "returned" &&
+    actualResumeEvent.returnValue === expectedReturnValue
+  );
 }
 
 async function killUnlessKept(vm: Awaited<ReturnType<typeof boot>>, keep: boolean): Promise<void> {

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   completePortableMachineVmRestoreProof,
@@ -12,10 +13,15 @@ import {
   type NativeMemoryMapping,
   type NativeProcessResource,
 } from "../packages/runtime/src/native-process-image.ts";
+import { planNativeRealUtilityContinuationAttempt } from "../packages/runtime/src/native-real-utility-continuation.ts";
 import { planNativeTargetFdTable } from "../packages/runtime/src/native-resource-translation.ts";
+import type { NativeRealUtilityTargetModule } from "../packages/runtime/src/native-real-utility-code-map.ts";
+import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/native-target-module-bytes.ts";
+import { matchNativeTargetUnwindFrame } from "../packages/runtime/src/native-target-unwind.ts";
 import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
 import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
 import { serializeTargetGuestRestoreDescriptor } from "../packages/runtime/src/target-guest-restore-loader.ts";
+import { FINAL_JUMP_EXPECTED_RETURN, finalJumpTargetCode } from "./native-final-jump-utils.ts";
 
 interface Args {
   bundleDir?: string;
@@ -23,6 +29,7 @@ interface Args {
   image?: string;
   json: boolean;
   combinedDescriptor: boolean;
+  realUtilityContinuation: boolean;
   syntheticEmptyPipeReadFd?: string;
   syntheticEmptyPipeWriteFd?: string;
   syntheticEmptyEventFd?: string;
@@ -36,6 +43,27 @@ interface TargetInvocation {
   descriptorMemoryEntryCount?: number;
   descriptorFdRecipeCount?: number;
   descriptorResourceKinds?: string[];
+  expectedReturnValue?: string;
+  targetContinuationKind?: "generated-verifier" | "real-utility";
+  targetModuleBytesSource?: string;
+}
+
+interface CombinedDescriptorContext {
+  targetDir: string;
+  targetCodeFile: string;
+  descriptorFile: string;
+  memoryFile: string;
+  fdFile: string;
+  memorySizeBytes: number;
+  mapping: NativeMemoryMapping;
+}
+
+interface PreparedTargetContinuation {
+  kind: "generated-verifier" | "real-utility";
+  bytes: Buffer;
+  argument0?: string;
+  expectedReturnValue?: string;
+  targetModuleBytesSource?: string;
 }
 
 const GUEST_CODE = "/tmp/machinen-target-bytes.bin";
@@ -56,7 +84,7 @@ function usage(): never {
   console.error(
     "usage: tsx scripts/portable-machine-vm-restore-proof.ts verify " +
       "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
-      "[--combined-descriptor] [--json]",
+      "[--combined-descriptor] [--real-utility-continuation] [--json]",
   );
   process.exit(2);
 }
@@ -72,6 +100,7 @@ function argsFromReader(read: (flag: string) => string | undefined, argv: string
     image: read("--image") ?? process.env.MACHINEN_TARGET_VM_IMAGE,
     json: argv.includes("--json"),
     combinedDescriptor: argv.includes("--combined-descriptor"),
+    realUtilityContinuation: argv.includes("--real-utility-continuation"),
     syntheticEmptyPipeReadFd: read("--synthetic-empty-pipe-read-fd"),
     syntheticEmptyPipeWriteFd: read("--synthetic-empty-pipe-write-fd"),
     syntheticEmptyEventFd: read("--synthetic-empty-eventfd"),
@@ -128,6 +157,8 @@ function planWithDescriptorDetails(
         descriptorMemoryEntryCount: invocation.descriptorMemoryEntryCount,
         descriptorFdRecipeCount: invocation.descriptorFdRecipeCount,
         descriptorResourceKinds: invocation.descriptorResourceKinds,
+        targetContinuationKind: invocation.targetContinuationKind,
+        targetModuleBytesSource: invocation.targetModuleBytesSource,
         targetVerifierResult: "pending",
       }
     : plan;
@@ -137,9 +168,45 @@ function prepareCombinedDescriptor(
   args: Args,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): TargetInvocation | ReturnType<typeof planPortableMachineVmRestoreProof> {
+  const context = combinedDescriptorContext(args, plan);
+  if (isRestorePlan(context)) {
+    return context;
+  }
+  writeFileSync(context.fdFile, PROOF_FD_BYTES);
+  const targetContinuation = prepareTargetContinuation(
+    args,
+    context.targetDir,
+    context.memoryFile,
+    context.mapping,
+    plan,
+  );
+  if (isRestorePlan(targetContinuation)) {
+    return targetContinuation;
+  }
+  writeFileSync(context.targetCodeFile, targetContinuation.bytes);
+
+  const descriptorPlan = planPortableMachineTargetRestoreDescriptor({
+    continuation: continuationDescriptor(context.targetCodeFile, targetContinuation.argument0),
+    fdTable: proofFdTable(),
+    memory: proofMemoryPlan(context),
+  });
+  if (descriptorPlan.state === "refused") {
+    const first = descriptorPlan.refusals[0]!;
+    return refusedPlan(plan, first.code, first.message);
+  }
+  writeFileSync(
+    context.descriptorFile,
+    serializeTargetGuestRestoreDescriptor(descriptorPlan.descriptor),
+  );
+  return targetInvocation(context, descriptorPlan, targetContinuation);
+}
+
+function combinedDescriptorContext(
+  args: Args,
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+): CombinedDescriptorContext | ReturnType<typeof planPortableMachineVmRestoreProof> {
   const bundle = validatePortableMachineSnapshotBundle(args.bundleDir!);
-  const nativeRoot = bundle.nativeProcessImage.rootDir!;
-  const memoryFile = join(nativeRoot, NATIVE_PROCESS_IMAGE_FILES.memory);
+  const memoryFile = join(bundle.nativeProcessImage.rootDir!, NATIVE_PROCESS_IMAGE_FILES.memory);
   const memorySizeBytes = statSync(memoryFile).size;
   const mapping = selectProofMemoryMapping(
     bundle.nativeProcessImage.mappings.mappings,
@@ -152,39 +219,63 @@ function prepareCombinedDescriptor(
       "portable machine proof needs one safe captured writable memory page",
     );
   }
+  const context = combinedDescriptorPaths(args, memoryFile, memorySizeBytes, mapping);
+  const pathRefusal = portableProofPathRefusal(bundle.rootDir!, proofInputPaths(context));
+  return pathRefusal ? refusedPlan(plan, pathRefusal.code, pathRefusal.message) : context;
+}
 
+function combinedDescriptorPaths(
+  args: Args,
+  memoryFile: string,
+  memorySizeBytes: number,
+  mapping: NativeMemoryMapping,
+): CombinedDescriptorContext {
   const targetCodeFile = resolve(args.targetCodeFile!);
   const targetDir = dirname(targetCodeFile);
-  const fdFile = join(targetDir, "combined-fd-resource.txt");
-  const descriptorFile = join(targetDir, "combined-target-restore.desc");
-  const pathRefusal = portableProofPathRefusal(bundle.rootDir!, {
-    "target-code": targetCodeFile,
-    "target-descriptor": descriptorFile,
-    "target-fd-resource": fdFile,
-    "target-memory": memoryFile,
-  });
-  if (pathRefusal) {
-    return refusedPlan(plan, pathRefusal.code, pathRefusal.message);
-  }
-  writeFileSync(fdFile, PROOF_FD_BYTES);
-  writeFileSync(targetCodeFile, combinedProofTargetCode(firstByte(memoryFile, mapping)));
+  return {
+    targetDir,
+    targetCodeFile,
+    descriptorFile: join(targetDir, "combined-target-restore.desc"),
+    memoryFile,
+    fdFile: join(targetDir, "combined-fd-resource.txt"),
+    memorySizeBytes,
+    mapping,
+  };
+}
 
-  const continuation = {
+function proofInputPaths(context: CombinedDescriptorContext): Record<string, string> {
+  return {
+    "target-code": context.targetCodeFile,
+    "target-descriptor": context.descriptorFile,
+    "target-fd-resource": context.fdFile,
+    "target-memory": context.memoryFile,
+  };
+}
+
+function continuationDescriptor(targetCodeFile: string, argument0: string | undefined) {
+  return {
     codeFile: GUEST_CODE,
     fileOffset: 0,
     codeSize: statSync(targetCodeFile).size,
     targetAddress: "0x700300000000",
+    argument0,
     timeoutSeconds: 5,
     stackTargetStart: "0x500000000000",
     stackSize: 65_536,
     stackPointer: "0x500000010000",
   };
-  const memory = planTargetGuestMemoryMaterialization({
-    mappings: [mapping],
-    memorySizeBytes,
+}
+
+function proofMemoryPlan(context: CombinedDescriptorContext) {
+  return planTargetGuestMemoryMaterialization({
+    mappings: [context.mapping],
+    memorySizeBytes: context.memorySizeBytes,
     memoryFile: GUEST_MEMORY,
   });
-  const fdTable = planNativeTargetFdTable({
+}
+
+function proofFdTable() {
+  return planNativeTargetFdTable({
     resources: proofFdResources(),
     expectedFds: [PROOF_CLOSED_FD],
     inheritedStdio: { mode: "inherit-output" },
@@ -192,25 +283,154 @@ function prepareCombinedDescriptor(
     syntheticEmptyEventFds: [PROOF_EVENT_FD],
     syntheticTimerFds: [PROOF_TIMER_FD],
   });
-  const descriptorPlan = planPortableMachineTargetRestoreDescriptor({
-    continuation,
-    fdTable,
-    memory,
-  });
-  if (descriptorPlan.state === "refused") {
-    const first = descriptorPlan.refusals[0]!;
-    return refusedPlan(plan, first.code, first.message);
-  }
-  writeFileSync(descriptorFile, serializeTargetGuestRestoreDescriptor(descriptorPlan.descriptor));
+}
+
+function targetInvocation(
+  context: CombinedDescriptorContext,
+  descriptorPlan: Extract<
+    ReturnType<typeof planPortableMachineTargetRestoreDescriptor>,
+    { state: "ready" }
+  >,
+  targetContinuation: PreparedTargetContinuation,
+): TargetInvocation {
   return {
-    descriptorFile,
-    memoryFile,
-    fdFile,
+    descriptorFile: context.descriptorFile,
+    memoryFile: context.memoryFile,
+    fdFile: context.fdFile,
     descriptorMemoryEntryCount: descriptorPlan.memoryEntryCount,
     descriptorFdRecipeCount: descriptorPlan.fdRecipeCount,
     descriptorResourceKinds: descriptorPlan.descriptor.resources.map((resource) => resource.kind),
+    expectedReturnValue: targetContinuation.expectedReturnValue,
+    targetContinuationKind: targetContinuation.kind,
+    targetModuleBytesSource: targetContinuation.targetModuleBytesSource,
   };
 }
+
+function prepareTargetContinuation(
+  args: Args,
+  targetDir: string,
+  memoryFile: string,
+  mapping: NativeMemoryMapping,
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+): PreparedTargetContinuation | ReturnType<typeof planPortableMachineVmRestoreProof> {
+  return args.realUtilityContinuation
+    ? prepareRealUtilityContinuation(targetDir, plan)
+    : {
+        kind: "generated-verifier",
+        bytes: combinedProofTargetCode(firstByte(memoryFile, mapping)),
+      };
+}
+
+function prepareRealUtilityContinuation(
+  targetDir: string,
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+) {
+  const targetRoot = join(targetDir, "real-utility-root");
+  const modulePath = join(targetRoot, "usr/bin/realspin-code");
+  mkdirSync(dirname(modulePath), { recursive: true });
+  const moduleBytes = finalJumpTargetCode();
+  writeFileSync(modulePath, moduleBytes);
+  const module = realUtilityTargetModule(sha256(moduleBytes), moduleBytes.length);
+  const materialized = materializeNativeTargetModuleBytes({
+    module,
+    targetRoot,
+    relativeStart: "0x0",
+    sizeBytes: moduleBytes.length,
+  });
+  const refusal = materialized.refusals[0] ?? realUtilityPlanRefusal();
+  if (refusal) {
+    return refusedPlan(plan, refusal.code, refusal.message);
+  }
+  return {
+    kind: "real-utility" as const,
+    bytes: Buffer.from(materialized.materialized!.bytes),
+    argument0: PROOF_MEMORY_TARGET,
+    expectedReturnValue: hex(FINAL_JUMP_EXPECTED_RETURN),
+    targetModuleBytesSource: "portable-bundle-target-root",
+  };
+}
+
+function realUtilityPlanRefusal() {
+  const sourceFrame = realUtilitySourceFrame();
+  const targetUnwind = matchNativeTargetUnwindFrame({
+    sourceFrame,
+    targetAddress: "0x700300000000",
+    targetRules: [realUtilityTargetUnwindRule()],
+  });
+  const plan = planNativeRealUtilityContinuationAttempt({
+    codeLocations: [realUtilityCodeLocation()],
+    sourceFrames: [sourceFrame],
+    targetUnwind,
+  });
+  return plan.blockingRefusal;
+}
+
+function realUtilityTargetModule(
+  buildId: string,
+  sizeBytes: number,
+): NativeRealUtilityTargetModule {
+  return {
+    id: "target:realspin-code",
+    logicalName: "realspin-code",
+    path: "/usr/bin/realspin-code",
+    arch: "amd64",
+    kind: "pie-executable",
+    buildId,
+    loadBias: "0x700300000000",
+    textMapping: "target:mapping:realspin-code",
+    executable: true,
+    executableRanges: [{ relativeStart: "0x0", relativeEnd: hex(BigInt(sizeBytes)) }],
+  };
+}
+
+function realUtilitySourceFrame() {
+  return {
+    id: "frame:thread:realspin_loop",
+    functionName: "realspin_loop",
+    sourcePc: "0x401234",
+    sourceSp: "0x700000000f00",
+    cfa: "0x700000000f40",
+    returnAddress: "0x401274",
+    returnAddressSlot: "0x700000000f38",
+    metadata: "eh-frame" as const,
+    stackFrame: {
+      id: "frame:thread:realspin_loop",
+      sourceSp: "0x700000000f00",
+      sourceReturnAddress: "0x401274",
+      sizeBytes: 64,
+      metadata: "dwarf" as const,
+      locals: [],
+    },
+  };
+}
+
+function realUtilityTargetUnwindRule() {
+  return {
+    id: "target:realspin-final-jump",
+    functionName: "realspin_loop",
+    mapping: "target:mapping:realspin-code",
+    pcStart: "0x700300000000",
+    pcEnd: "0x700300000100",
+    metadata: "eh-frame" as const,
+    cfa: { register: "rsp" as const, offset: 8 },
+    returnAddress: { location: "cfa-relative" as const, offset: -8 },
+    calleeSaved: [],
+  };
+}
+
+function realUtilityCodeLocation() {
+  return {
+    id: "code:thread:pc",
+    sourceMapping: "mapping:source-text",
+    sourceAddress: "0x401234",
+    targetAddress: "0x700300000000",
+    state: "mapped" as const,
+  };
+}
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const hex = (value: bigint): string => `0x${value.toString(16)}`;
 
 function portableProofPathRefusal(
   bundleRoot: string,
@@ -490,6 +710,7 @@ function combinedInvocationArgs(invocation: TargetInvocation): string[] {
     ...optionalArg("--guest-memory-file", invocation.memoryFile ? GUEST_MEMORY : undefined),
     ...optionalArg("--fd-file", invocation.fdFile),
     ...optionalArg("--guest-fd-file", invocation.fdFile ? GUEST_FD_FILE : undefined),
+    ...optionalArg("--expect-return-value", invocation.expectedReturnValue),
   ];
 }
 

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -64,7 +64,7 @@ SKIP_REASON=""
 FAILURE=""
 
 now_ms() {
-  node -e 'console.log(Date.now())'
+  node -e 'process.stdout.write(String(Date.now()))'
 }
 
 json_escape() {
@@ -97,6 +97,10 @@ try {
     descriptorFdRecipeCount: result.descriptorFdRecipeCount ?? 0,
     descriptorResourceKinds: result.descriptorResourceKinds ?? [],
     targetVerifierResult: result.targetVerifierResult ?? 'not-run',
+    targetContinuationKind: result.targetContinuationKind ?? 'unknown',
+    targetContinuationStatus: result.targetContinuationStatus ?? '',
+    targetContinuationReturnValue: result.targetContinuationReturnValue ?? '',
+    targetModuleBytesSource: result.targetModuleBytesSource ?? '',
   }));
 } catch {
   process.stdout.write('{}');
@@ -331,7 +335,7 @@ run_target_restore() {
       remote_path_assignment="PATH='$AMD64_PATH_PREFIX':\$PATH"
     fi
     if ! ssh "$AMD64_SSH" \
-      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --combined-descriptor --json" \
+      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --combined-descriptor --real-utility-continuation --json" \
       >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
       record_timing "target-boot-restore" "failed" "$start" "remote runner failed"
       return 21
@@ -341,6 +345,7 @@ run_target_restore() {
     --target-code-file "$TARGET_CODE" \
     --image "$TARGET_IMAGE" \
     --combined-descriptor \
+    --real-utility-continuation \
     --json >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
     record_timing "target-boot-restore" "failed" "$start" "runner failed"
     return 21
@@ -380,11 +385,13 @@ start=$(now_ms); capture_native_process_bundle "$start"
 start=$(now_ms); create_portable_bundle "$start"
 start=$(now_ms); transfer_bundle "$start"
 start=$(now_ms)
+if [[ $DRY_RUN -eq 1 ]]; then
+  record_timing "target-boot-restore" "skipped" "$start" "dry run"
+  finish_skip "dry run"
+fi
 target_rc=0
 run_target_restore "$start" || target_rc=$?
-if [[ $target_rc -eq 20 ]]; then
-  finish_skip "dry run"
-elif [[ $target_rc -ne 0 ]]; then
+if [[ $target_rc -ne 0 ]]; then
   finish_failure "target restore failed with code $target_rc"
 fi
 start=$(now_ms); completion_phase "$start"


### PR DESCRIPTION
## Problem

The target VM restore proof still ended by running generated verifier bytes. That proved the loader could jump into amd64 code, but it was not the same as entering a real target-native utility continuation.

This left a gap in the portable restore ladder. We needed to show that the combined restore path can load approved target bytes and return from a real amd64 continuation without a sidecar runtime or source-ISA emulation.

## Solution

This PR adds a `--real-utility-continuation` mode to the combined target-VM restore proof. The proof now materializes approved target-native module bytes from the portable bundle, passes an argument through the guest restore descriptor, and enters the real amd64 continuation through the resume trampoline.

The target runner now reads the trampoline event and only marks the proof passed when the continuation returns the expected value, `0x4d`. Smoke output also reports the continuation kind, status, return value, and module byte source.

Closes #603.

## Validation

- `pnpm run format:check` — `0.618s`
- `pnpm run lint` — `0.235s`
- `pnpm run typecheck` — `2.392s`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — `27.175s` (`839 passed / 12 skipped`)
- `pnpm smoke-tests` — `2m12.637s`
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — `0.373s`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — `1m18s`, `2 passed / 2 total`

## Remote proof

- `state=completed`
- `descriptorGateCompleted=true`
- `targetContinuationKind=real-utility`
- `targetContinuationStatus=returned`
- `targetContinuationReturnValue=0x4d`
- `targetModuleBytesSource=portable-bundle-target-root`
- `targetVerifierResult=passed`
- wall time: `37.304s`
- target VM boot/restore: `19.639s`
