### PR TITLE
Have real utility consume restored state

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -45,8 +45,10 @@ explicit fd-table recipes, and safe non-executable memory entries. The current
 combined proof can still use generated verifier bytes, but the smoke path now
 uses `--real-utility-continuation`: target module bytes are materialized from a
 portable-bundle target root, entered through the amd64 guest loader, and accepted
-only when the in-guest resume event returns the expected value. The descriptor
-still carries the wider fd matrix: closed fd, inherited stdout, reopened file,
+only when the in-guest resume event returns the expected value. The real utility
+now consumes restored state before returning: it checks the materialized captured
+memory byte, validates the descriptor-provided argument/register handoff, and
+exercises the wider fd matrix: closed fd, inherited stdout, reopened file,
 synthetic pipe, eventfd, and timerfd recipes.
 
 ## Smoke profile
@@ -81,7 +83,8 @@ proof with a combined restore descriptor. The continuation is target module byte
 from the bundle's approved target root, not source-ISA text. The JSON summary
 includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
 resource recipe kinds, `targetRestore.targetContinuationKind`,
-`targetRestore.targetContinuationReturnValue`, and
+`targetRestore.targetContinuationReturnValue`,
+`targetRestore.targetStateConsumptionResult`, per-resource status, and
 `targetRestore.targetVerifierResult`. It reports timing for:
 
 1. preflight / optional remote reachability gates;

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -16,6 +16,7 @@ fileOffset=0
 codeSize=16
 targetAddress=0x700300000000
 argument0=0x600000000000
+stateReportAddress=0x600000000000
 timeoutSeconds=5
 stackTargetStart=0x500000000000
 stackSize=65536
@@ -65,6 +66,9 @@ Everything else fails closed with a precise refusal, currently:
 The existing target-VM synthetic proof now injects the loader and descriptor into
 the amd64 guest and executes the loader instead of invoking the trampoline
 directly. The descriptor may carry an optional `argument0` target register value
-for real target-native continuation attempts. Completion is credited only when
-the descriptor gate succeeds and the target-native continuation returns/exits in
-the guest with the expected modeled result.
+and an optional `stateReportAddress` for real target-native continuation
+attempts. The state report address lets the trampoline read a small report that
+the continuation writes after consuming restored memory and fd/resource state.
+Completion is credited only when the descriptor gate succeeds and the
+target-native continuation returns/exits in the guest with the expected modeled
+result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -34,6 +34,15 @@
 
 #define MAX_MATERIALIZED_MAPPINGS 32
 #define MAX_CLOEXEC_FDS 64
+#define STATE_CONSUMPTION_MARKER UINT64_C(0x5354415445434f4e)
+#define STATE_CONSUMPTION_MASK UINT64_C(0x7f)
+#define STATE_CHECK_MEMORY UINT64_C(0x01)
+#define STATE_CHECK_STDIO UINT64_C(0x02)
+#define STATE_CHECK_CLOSE_FD UINT64_C(0x04)
+#define STATE_CHECK_REOPEN_FILE UINT64_C(0x08)
+#define STATE_CHECK_PIPE UINT64_C(0x10)
+#define STATE_CHECK_EVENTFD UINT64_C(0x20)
+#define STATE_CHECK_TIMERFD UINT64_C(0x40)
 
 struct MemoryMaterialization {
   const char *source_file;
@@ -55,6 +64,8 @@ struct Options {
   uint64_t target_address;
   bool has_argument0;
   uint64_t argument0;
+  bool has_state_report_address;
+  uint64_t state_report_address;
   uint64_t stack_target_start;
   uint64_t stack_size;
   uint64_t stack_pointer;
@@ -75,8 +86,9 @@ static void usage(void) {
   fprintf(stderr,
       "usage: machinen-native-actual-resume-trampoline --code-file path "
       "--file-offset n --code-size n --target-address addr "
-      "[--argument0 addr] --timeout-seconds n [--synthetic-empty-pipe-read-fd n] "
-      "[--synthetic-empty-pipe-write-fd n] [--synthetic-empty-eventfd n] "
+      "[--argument0 addr] [--state-report-address addr] --timeout-seconds n "
+      "[--synthetic-empty-pipe-read-fd n] [--synthetic-empty-pipe-write-fd n] "
+      "[--synthetic-empty-eventfd n] "
       "[--synthetic-timerfd n] [--set-cloexec-fd n] "
       "[--materialize-memory file:offset:target:size:perms] "
       "[--materialize-guard target:size] "
@@ -206,6 +218,12 @@ static struct Options parse_args(int argc, char **argv) {
       }
       opts.argument0 = parse_u64(argv[i], "argument0");
       opts.has_argument0 = true;
+    } else if (streq(argv[i], "--state-report-address")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.state_report_address = parse_u64(argv[i], "state-report-address");
+      opts.has_state_report_address = true;
     } else if (streq(argv[i], "--timeout-seconds")) {
       if (++i >= argc) {
         usage();
@@ -738,6 +756,73 @@ static void print_fault_event(const struct Options *opts) {
       rip_inside_target_bytes(rip) ? "true" : "false");
 }
 
+static uint64_t read_state_report_u64(uint64_t base, uint64_t offset) {
+  volatile uint64_t *slot = (volatile uint64_t *)(uintptr_t)(base + offset);
+  return *slot;
+}
+
+static uint8_t read_state_report_u8(uint64_t base, uint64_t offset) {
+  volatile uint8_t *slot = (volatile uint8_t *)(uintptr_t)(base + offset);
+  return *slot;
+}
+
+static void print_check_status(const char *kind, uint64_t mask, uint64_t bit) {
+  printf("{\"kind\":\"%s\",\"status\":\"%s\"}",
+      kind,
+      (mask & bit) == bit ? "passed" : "failed");
+}
+
+static void print_state_consumption(const struct Options *opts) {
+  if (!opts->has_state_report_address) {
+    return;
+  }
+  uint64_t base = opts->state_report_address;
+  uint8_t memory_byte = read_state_report_u8(base, 0);
+  uint64_t marker = read_state_report_u64(base, 8);
+  uint64_t mask = read_state_report_u64(base, 16);
+  bool passed = marker == STATE_CONSUMPTION_MARKER && mask == STATE_CONSUMPTION_MASK;
+  printf(
+      ",\"stateConsumption\":{\"status\":\"%s\","
+      "\"reportAddress\":\"0x%" PRIx64 "\","
+      "\"memoryByte\":\"0x%02x\","
+      "\"reportMarker\":\"0x%" PRIx64 "\","
+      "\"resourceMask\":\"0x%" PRIx64 "\","
+      "\"expectedResourceMask\":\"0x%" PRIx64 "\","
+      "\"checks\":[",
+      passed ? "passed" : "failed",
+      base,
+      memory_byte,
+      marker,
+      mask,
+      STATE_CONSUMPTION_MASK);
+  print_check_status("captured-memory", mask, STATE_CHECK_MEMORY);
+  printf(",");
+  print_check_status("inherit-stdio", mask, STATE_CHECK_STDIO);
+  printf(",");
+  print_check_status("close-fd", mask, STATE_CHECK_CLOSE_FD);
+  printf(",");
+  print_check_status("reopen-file", mask, STATE_CHECK_REOPEN_FILE);
+  printf(",");
+  print_check_status("synthetic-empty-pipe", mask, STATE_CHECK_PIPE);
+  printf(",");
+  print_check_status("synthetic-empty-eventfd", mask, STATE_CHECK_EVENTFD);
+  printf(",");
+  print_check_status("synthetic-timerfd", mask, STATE_CHECK_TIMERFD);
+  printf("],\"resourceStatuses\":[");
+  print_check_status("inherit-stdio", mask, STATE_CHECK_STDIO);
+  printf(",");
+  print_check_status("close-fd", mask, STATE_CHECK_CLOSE_FD);
+  printf(",");
+  print_check_status("reopen-file", mask, STATE_CHECK_REOPEN_FILE);
+  printf(",");
+  print_check_status("synthetic-empty-pipe", mask, STATE_CHECK_PIPE);
+  printf(",");
+  print_check_status("synthetic-empty-eventfd", mask, STATE_CHECK_EVENTFD);
+  printf(",");
+  print_check_status("synthetic-timerfd", mask, STATE_CHECK_TIMERFD);
+  printf("]}");
+}
+
 static void print_return_event(const struct Options *opts) {
   printf(
       "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
@@ -749,13 +834,15 @@ static void print_return_event(const struct Options *opts) {
       "\"targetBytesEnd\":\"0x%" PRIx64 "\"," 
       "\"instructionPointerInTargetBytes\":true,"
       "\"attemptedResume\":true,\"sourceTextReusedAsTargetCode\":false,"
-      "\"sourceIsaEmulationUsed\":false,\"sidecarRuntimeUsed\":false}\n",
+      "\"sourceIsaEmulationUsed\":false,\"sidecarRuntimeUsed\":false",
       opts->target_address,
       resume_return_value,
       opts->argument0,
       opts->stack_pointer,
       mapped_target_start,
       mapped_target_end);
+  print_state_consumption(opts);
+  printf("}\n");
 }
 
 int main(int argc, char **argv) {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -46,6 +46,8 @@ struct Descriptor {
   uint64_t target_address;
   bool has_argument0;
   uint64_t argument0;
+  bool has_state_report_address;
+  uint64_t state_report_address;
   uint64_t timeout_seconds;
   uint64_t stack_target_start;
   uint64_t stack_size;
@@ -188,6 +190,9 @@ static void parse_field(struct Descriptor *descriptor, char *line) {
   } else if (streq(key, "argument0")) {
     descriptor->argument0 = parse_u64(value, key);
     descriptor->has_argument0 = true;
+  } else if (streq(key, "stateReportAddress")) {
+    descriptor->state_report_address = parse_u64(value, key);
+    descriptor->has_state_report_address = true;
   } else if (streq(key, "timeoutSeconds")) {
     descriptor->timeout_seconds = parse_u64(value, key);
   } else if (streq(key, "stackTargetStart")) {
@@ -534,6 +539,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char code_size[32];
   char target_address[32];
   char argument0[32];
+  char state_report_address[32];
   char timeout_seconds[32];
   char stack_target_start[32];
   char stack_size[32];
@@ -547,6 +553,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(code_size, sizeof(code_size), "0x%" PRIx64, descriptor->code_size);
   snprintf(target_address, sizeof(target_address), "0x%" PRIx64, descriptor->target_address);
   snprintf(argument0, sizeof(argument0), "0x%" PRIx64, descriptor->argument0);
+  snprintf(state_report_address, sizeof(state_report_address), "0x%" PRIx64, descriptor->state_report_address);
   snprintf(timeout_seconds, sizeof(timeout_seconds), "0x%" PRIx64, descriptor->timeout_seconds);
   snprintf(stack_target_start, sizeof(stack_target_start), "0x%" PRIx64, descriptor->stack_target_start);
   snprintf(stack_size, sizeof(stack_size), "0x%" PRIx64, descriptor->stack_size);
@@ -573,6 +580,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   if (descriptor->has_argument0) {
     push_arg(child_argv, &child_argc, "--argument0");
     push_arg(child_argv, &child_argc, argument0);
+  }
+  if (descriptor->has_state_report_address) {
+    push_arg(child_argv, &child_argc, "--state-report-address");
+    push_arg(child_argv, &child_argc, state_report_address);
   }
   push_arg(child_argv, &child_argc, "--timeout-seconds");
   push_arg(child_argv, &child_argc, timeout_seconds);

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -110,6 +110,8 @@
 - [`PortableMachineTargetRestoreDescriptorPlan`](#portablemachinetargetrestoredescriptorplan)
 - [`PortableMachineVmRestoreProofState`](#portablemachinevmrestoreproofstate)
 - [`PortableMachineTargetContinuationKind`](#portablemachinetargetcontinuationkind)
+- [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)
+- [`PortableMachineTargetStateConsumptionResult`](#portablemachinetargetstateconsumptionresult)
 - [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
 - [`PortableMachineVmRestoreProofRequest`](#portablemachinevmrestoreproofrequest)
 - [`PortableMachineVmRestoreProofPlan`](#portablemachinevmrestoreproofplan)
@@ -8025,6 +8027,20 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ***
 
+### PortableMachineTargetResourceStatus
+
+#### Properties
+
+##### kind
+
+> **kind**: `string`
+
+##### status
+
+> **status**: `"passed"` \| `"failed"`
+
+***
+
 ### PortableMachineVmRestoreProofPlan
 
 #### Properties
@@ -8105,6 +8121,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetModuleBytesSource?**: `string`
 
+##### targetStateConsumptionResult?
+
+> `optional` **targetStateConsumptionResult?**: [`PortableMachineTargetStateConsumptionResult`](#portablemachinetargetstateconsumptionresult)
+
+##### targetResourceStatuses?
+
+> `optional` **targetResourceStatuses?**: [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)[]
+
 ##### sourceTextReusedAsTargetCode
 
 > **sourceTextReusedAsTargetCode**: `false`
@@ -8166,6 +8190,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ###### returnValue?
 
 > `optional` **returnValue?**: `string`
+
+##### targetStateConsumptionResult?
+
+> `optional` **targetStateConsumptionResult?**: [`PortableMachineTargetStateConsumptionResult`](#portablemachinetargetstateconsumptionresult)
+
+##### targetResourceStatuses?
+
+> `optional` **targetResourceStatuses?**: [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)[]
 
 ##### sourceTextReusedAsTargetCode?
 
@@ -9150,6 +9182,10 @@ Poll interval in ms while retrying. Default 250.
 ##### argument0?
 
 > `optional` **argument0?**: `string`
+
+##### stateReportAddress?
+
+> `optional` **stateReportAddress?**: `string`
 
 ##### timeoutSeconds
 
@@ -11664,6 +11700,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### PortableMachineTargetContinuationKind
 
 > **PortableMachineTargetContinuationKind** = `"generated-verifier"` \| `"real-utility"`
+
+***
+
+### PortableMachineTargetStateConsumptionResult
+
+> **PortableMachineTargetStateConsumptionResult** = `"pending"` \| `"passed"` \| `"failed"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -88,6 +88,45 @@ describe("native actual resume trampoline", () => {
         argument0: "0x600000000000",
       });
 
+      const stateMemory = join(outDir, "state-memory.bin");
+      const memory = Buffer.alloc(4096);
+      memory[0] = 0x4d;
+      writeFileSync(stateMemory, memory);
+      const stateCode = Buffer.from([
+        0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x08, 0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0,
+        0, 0x48, 0x89, 0x47, 0x10, 0xb8, 0x4d, 0, 0, 0, 0xc3,
+      ]);
+      stateCode.writeBigUInt64LE(0x5354415445434f4en, 2);
+      stateCode.writeBigUInt64LE(0x7fn, 16);
+      const stateCodePath = join(outDir, "state.bin");
+      writeFileSync(stateCodePath, stateCode);
+      expect(
+        runHelper(helper, stateCodePath, stateCode.length, [
+          "--argument0",
+          "0x600000000000",
+          "--state-report-address",
+          "0x600000000000",
+          "--materialize-memory",
+          `${stateMemory}:0:0x600000000000:4096:rw-p`,
+        ]),
+      ).toMatchObject({
+        status: "returned",
+        returnValue: "0x4d",
+        stateConsumption: {
+          status: "passed",
+          memoryByte: "0x4d",
+          resourceMask: "0x7f",
+          resourceStatuses: [
+            { kind: "inherit-stdio", status: "passed" },
+            { kind: "close-fd", status: "passed" },
+            { kind: "reopen-file", status: "passed" },
+            { kind: "synthetic-empty-pipe", status: "passed" },
+            { kind: "synthetic-empty-eventfd", status: "passed" },
+            { kind: "synthetic-timerfd", status: "passed" },
+          ],
+        },
+      });
+
       const faultCode = join(outDir, "fault.bin");
       writeFileSync(faultCode, Buffer.from([0x48, 0x8b, 0x00]));
       expect(runHelper(helper, faultCode, 3)).toMatchObject({

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -153,6 +153,8 @@ describe("portable machine VM restore proof", () => {
         migrationCompleted: true,
         descriptorGateCompleted: true,
         targetVerifierResult: "passed",
+        targetStateConsumptionResult: "passed",
+        targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
         sourceTextReusedAsTargetCode: false,
         sourceIsaEmulationUsed: false,
         sidecarRuntimeUsed: false,
@@ -161,6 +163,26 @@ describe("portable machine VM restore proof", () => {
       state: "completed",
       migrationCompleted: true,
       descriptorGateCompleted: true,
+      targetStateConsumptionResult: "passed",
+      targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
+    });
+
+    expect(
+      completePortableMachineVmRestoreProof(plan, {
+        exitCode: 0,
+        migrationCompleted: true,
+        descriptorGateCompleted: true,
+        targetVerifierResult: "passed",
+        targetStateConsumptionResult: "failed",
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      }),
+    ).toMatchObject({
+      state: "ready",
+      migrationCompleted: false,
+      descriptorGateCompleted: true,
+      targetStateConsumptionResult: "failed",
     });
 
     expect(

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -44,7 +44,11 @@ function descriptor(
 describe("target guest restore loader descriptor", () => {
   it("serializes and parses fd table recipes", () => {
     const original = descriptor({
-      continuation: { ...descriptor().continuation, argument0: "0x600000000000" },
+      continuation: {
+        ...descriptor().continuation,
+        argument0: "0x600000000000",
+        stateReportAddress: "0x600000000000",
+      },
       resources: [
         { kind: "close-fd", fd: 0, reason: "missing-captured-fd" },
         { kind: "inherit-stdio", fd: 1, stream: "stdout", closeOnExec: false },
@@ -77,6 +81,8 @@ describe("target guest restore loader descriptor", () => {
       "--target-address",
       "0x700300000000",
       "--argument0",
+      "0x600000000000",
+      "--state-report-address",
       "0x600000000000",
       "--timeout-seconds",
       "5",
@@ -206,6 +212,14 @@ describe("target guest restore loader descriptor", () => {
         }),
       ),
     ).toThrow(/argument0 must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: { ...descriptor().continuation, stateReportAddress: "600000000000" },
+        }),
+      ),
+    ).toThrow(/stateReportAddress must be a hex address/);
   });
 
   it.skipIf(!HAS_CC)(
@@ -224,7 +238,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",
@@ -242,6 +256,10 @@ describe("target guest restore loader descriptor", () => {
         descriptorPath,
         serializeTargetGuestRestoreDescriptor(
           descriptor({
+            continuation: {
+              ...descriptor().continuation,
+              stateReportAddress: "0x600000000000",
+            },
             resources: [
               {
                 kind: "reopen-file",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -451,8 +451,10 @@ export type {
 } from "./target-guest-memory-materialization.ts";
 export type {
   PortableMachineTargetContinuationKind,
+  PortableMachineTargetResourceStatus,
   PortableMachineTargetRestoreDescriptorPlan,
   PortableMachineTargetRestoreDescriptorRequest,
+  PortableMachineTargetStateConsumptionResult,
   PortableMachineTargetVerifierResult,
   PortableMachineVmRestoreProofPlan,
   PortableMachineVmRestoreProofRequest,

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -21,6 +21,12 @@ export interface PortableMachineVmRestoreProofRequest {
 
 export type PortableMachineTargetVerifierResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetContinuationKind = "generated-verifier" | "real-utility";
+export type PortableMachineTargetStateConsumptionResult = "pending" | "passed" | "failed";
+
+export interface PortableMachineTargetResourceStatus {
+  kind: string;
+  status: "passed" | "failed";
+}
 
 export interface PortableMachineVmRestoreProofPlan {
   phase: "portable-machine-vm-restore-proof";
@@ -42,6 +48,8 @@ export interface PortableMachineVmRestoreProofPlan {
   targetContinuationStatus?: string;
   targetContinuationReturnValue?: string;
   targetModuleBytesSource?: string;
+  targetStateConsumptionResult?: PortableMachineTargetStateConsumptionResult;
+  targetResourceStatuses?: PortableMachineTargetResourceStatus[];
   sourceTextReusedAsTargetCode: false;
   sourceIsaEmulationUsed: false;
   sidecarRuntimeUsed: false;
@@ -55,6 +63,8 @@ export interface PortableMachineVmRestoreTargetResult {
   descriptorGateCompleted?: boolean;
   targetVerifierResult?: PortableMachineTargetVerifierResult;
   actualResumeEvent?: { status?: string; returnValue?: string };
+  targetStateConsumptionResult?: PortableMachineTargetStateConsumptionResult;
+  targetResourceStatuses?: PortableMachineTargetResourceStatus[];
   sourceTextReusedAsTargetCode?: boolean;
   sourceIsaEmulationUsed?: boolean;
   sidecarRuntimeUsed?: boolean;
@@ -170,6 +180,8 @@ export function completePortableMachineVmRestoreProof(
     targetVerifierResult: verifierResult(result, completed),
     targetContinuationStatus: result.actualResumeEvent?.status,
     targetContinuationReturnValue: result.actualResumeEvent?.returnValue,
+    targetStateConsumptionResult: result.targetStateConsumptionResult,
+    targetResourceStatuses: result.targetResourceStatuses,
   };
 }
 
@@ -186,6 +198,8 @@ function targetNativeCompleted(result: PortableMachineVmRestoreTargetResult): bo
     result.migrationCompleted === true,
     result.descriptorGateCompleted === true,
     result.targetVerifierResult === undefined || result.targetVerifierResult === "passed",
+    result.targetStateConsumptionResult === undefined ||
+      result.targetStateConsumptionResult === "passed",
     result.sourceTextReusedAsTargetCode === false,
     result.sourceIsaEmulationUsed === false,
     result.sidecarRuntimeUsed === false,

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -41,6 +41,7 @@ export interface TargetGuestRestoreContinuationDescriptor {
   codeSize: number;
   targetAddress: string;
   argument0?: string;
+  stateReportAddress?: string;
   timeoutSeconds: number;
   stackTargetStart: string;
   stackSize: number;
@@ -68,6 +69,7 @@ export function serializeTargetGuestRestoreDescriptor(
     `codeSize=${continuation.codeSize}`,
     `targetAddress=${continuation.targetAddress}`,
     ...optionalContinuationField("argument0", continuation.argument0),
+    ...optionalContinuationField("stateReportAddress", continuation.stateReportAddress),
     `timeoutSeconds=${continuation.timeoutSeconds}`,
     `stackTargetStart=${continuation.stackTargetStart}`,
     `stackSize=${continuation.stackSize}`,
@@ -121,6 +123,7 @@ export function buildNativeActualResumeTrampolineArgs(
     "--target-address",
     continuation.targetAddress,
     ...optionalArg("--argument0", continuation.argument0),
+    ...optionalArg("--state-report-address", continuation.stateReportAddress),
     "--timeout-seconds",
     String(continuation.timeoutSeconds),
     "--stack-target-start",
@@ -170,6 +173,7 @@ function fieldsToDescriptor(
       codeSize: parseIntegerField(fields, "codeSize"),
       targetAddress: requiredField(fields, "targetAddress"),
       argument0: optionalField(fields, "argument0"),
+      stateReportAddress: optionalField(fields, "stateReportAddress"),
       timeoutSeconds: parseIntegerField(fields, "timeoutSeconds"),
       stackTargetStart: requiredField(fields, "stackTargetStart"),
       stackSize: parseIntegerField(fields, "stackSize"),
@@ -393,6 +397,9 @@ function validateContinuation(
   assertHexAddress(continuation.targetAddress, "targetAddress");
   if (continuation.argument0 !== undefined) {
     assertHexAddress(continuation.argument0, "argument0");
+  }
+  if (continuation.stateReportAddress !== undefined) {
+    assertHexAddress(continuation.stateReportAddress, "stateReportAddress");
   }
   assertHexAddress(continuation.stackTargetStart, "stackTargetStart");
   assertHexAddress(continuation.stackPointer, "stackPointer");

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -132,6 +132,8 @@ const TOC = {
     "PortableMachineTargetRestoreDescriptorPlan",
     "PortableMachineVmRestoreProofState",
     "PortableMachineTargetContinuationKind",
+    "PortableMachineTargetResourceStatus",
+    "PortableMachineTargetStateConsumptionResult",
     "PortableMachineTargetVerifierResult",
     "PortableMachineVmRestoreProofRequest",
     "PortableMachineVmRestoreProofPlan",

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -24,6 +24,18 @@ const GUEST_FD_FILE_DEFAULT = "/tmp/machinen-combined-fd.txt";
 const LOADER_PREFIX = "MACHINEN_TARGET_GUEST_RESTORE_LOADER ";
 const ACTUAL_RESUME_PREFIX = "MACHINEN_ACTUAL_RESUME_TRAMPOLINE ";
 
+type StateConsumptionStatus = "passed" | "failed";
+
+interface StateConsumptionResourceStatus {
+  kind: string;
+  status: StateConsumptionStatus;
+}
+
+interface StateConsumptionEvent {
+  status?: StateConsumptionStatus;
+  resourceStatuses?: StateConsumptionResourceStatus[];
+}
+
 interface Args {
   codeFile?: string;
   descriptorFile?: string;
@@ -187,29 +199,54 @@ async function executeTargetVmProof(
   const result = await vm.execRaw(targetLoaderCommand(), {
     execTimeoutMs: (args.timeoutSeconds + 20) * 1000,
   });
-  const descriptorGateCompleted = loaderCompleted(result.stdout);
-  const actualResumeEvent = parseActualResumeEvent(result.stdout);
-  const targetVerifierResult = targetVerifierPassed(
-    args,
-    result.exitCode,
-    descriptorGateCompleted,
-    actualResumeEvent,
-  )
-    ? "passed"
-    : "failed";
+  return targetExecutionSummary(args, result);
+}
+
+function targetExecutionSummary(
+  args: Args,
+  result: { exitCode: number; stdout: string; stderr: string },
+) {
+  const events = targetExecutionEvents(result.stdout);
   return {
     ...targetSummary(args),
-    descriptorGateCompleted,
-    actualResumeEvent,
-    targetVerifierResult,
+    ...events,
+    targetVerifierResult: targetVerifierResult(args, result.exitCode, events),
+    targetStateConsumptionResult: events.stateConsumption?.status,
+    targetResourceStatuses: events.stateConsumption?.resourceStatuses,
     exitCode: result.exitCode,
     stdout: result.stdout,
     stderr: result.stderr,
-    migrationCompleted: result.exitCode === 0 && descriptorGateCompleted,
+    migrationCompleted: result.exitCode === 0 && events.descriptorGateCompleted,
     sourceTextReusedAsTargetCode: false,
     sourceIsaEmulationUsed: false,
     sidecarRuntimeUsed: false,
   };
+}
+
+function targetExecutionEvents(stdout: string) {
+  const descriptorGateCompleted = loaderCompleted(stdout);
+  const actualResumeEvent = parseActualResumeEvent(stdout);
+  return {
+    descriptorGateCompleted,
+    actualResumeEvent,
+    stateConsumption: parseStateConsumption(actualResumeEvent),
+  };
+}
+
+function targetVerifierResult(
+  args: Args,
+  exitCode: number,
+  events: ReturnType<typeof targetExecutionEvents>,
+): "passed" | "failed" {
+  return targetVerifierPassed(
+    args,
+    exitCode,
+    events.descriptorGateCompleted,
+    events.actualResumeEvent,
+    events.stateConsumption,
+  )
+    ? "passed"
+    : "failed";
 }
 
 async function stageTargetGuestInputs(
@@ -300,8 +337,12 @@ function targetVerifierPassed(
   exitCode: number,
   descriptorGateCompleted: boolean,
   actualResumeEvent: Record<string, unknown> | undefined,
+  stateConsumption: StateConsumptionEvent | undefined,
 ): boolean {
   if (!targetProcessCompleted(exitCode, descriptorGateCompleted)) {
+    return false;
+  }
+  if (!targetStateConsumed(stateConsumption)) {
     return false;
   }
   return args.expectReturnValue === undefined
@@ -311,6 +352,25 @@ function targetVerifierPassed(
 
 function targetProcessCompleted(exitCode: number, descriptorGateCompleted: boolean): boolean {
   return descriptorGateCompleted && exitCode === 0;
+}
+
+function targetStateConsumed(stateConsumption: StateConsumptionEvent | undefined): boolean {
+  return stateConsumption === undefined || stateConsumption.status === "passed";
+}
+
+function parseStateConsumption(
+  actualResumeEvent: Record<string, unknown> | undefined,
+): StateConsumptionEvent | undefined {
+  const value = actualResumeEvent?.stateConsumption;
+  return isStateConsumptionEvent(value) ? value : undefined;
+}
+
+function isStateConsumptionEvent(value: unknown): value is StateConsumptionEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const status = (value as { status?: unknown }).status;
+  return status === "passed" || status === "failed";
 }
 
 function actualResumeReturnedExpected(

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -21,7 +21,7 @@ import { matchNativeTargetUnwindFrame } from "../packages/runtime/src/native-tar
 import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
 import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
 import { serializeTargetGuestRestoreDescriptor } from "../packages/runtime/src/target-guest-restore-loader.ts";
-import { FINAL_JUMP_EXPECTED_RETURN, finalJumpTargetCode } from "./native-final-jump-utils.ts";
+import { FINAL_JUMP_EXPECTED_RETURN } from "./native-final-jump-utils.ts";
 
 interface Args {
   bundleDir?: string;
@@ -62,6 +62,7 @@ interface PreparedTargetContinuation {
   kind: "generated-verifier" | "real-utility";
   bytes: Buffer;
   argument0?: string;
+  stateReportAddress?: string;
   expectedReturnValue?: string;
   targetModuleBytesSource?: string;
 }
@@ -79,6 +80,14 @@ const PROOF_PIPE_WRITE_FD = 9;
 const PROOF_EVENT_FD = 10;
 const PROOF_TIMER_FD = 11;
 const PROOF_FD_BYTES = Buffer.from("FD");
+const STATE_CONSUMPTION_MARKER = 0x5354415445434f4en;
+const STATE_CHECK_MEMORY = 0x01;
+const STATE_CHECK_STDIO = 0x02;
+const STATE_CHECK_CLOSE_FD = 0x04;
+const STATE_CHECK_REOPEN_FILE = 0x08;
+const STATE_CHECK_PIPE = 0x10;
+const STATE_CHECK_EVENTFD = 0x20;
+const STATE_CHECK_TIMERFD = 0x40;
 
 function usage(): never {
   console.error(
@@ -159,6 +168,8 @@ function planWithDescriptorDetails(
         descriptorResourceKinds: invocation.descriptorResourceKinds,
         targetContinuationKind: invocation.targetContinuationKind,
         targetModuleBytesSource: invocation.targetModuleBytesSource,
+        targetStateConsumptionResult:
+          invocation.targetContinuationKind === "real-utility" ? "pending" : undefined,
         targetVerifierResult: "pending",
       }
     : plan;
@@ -186,7 +197,11 @@ function prepareCombinedDescriptor(
   writeFileSync(context.targetCodeFile, targetContinuation.bytes);
 
   const descriptorPlan = planPortableMachineTargetRestoreDescriptor({
-    continuation: continuationDescriptor(context.targetCodeFile, targetContinuation.argument0),
+    continuation: continuationDescriptor(
+      context.targetCodeFile,
+      targetContinuation.argument0,
+      targetContinuation.stateReportAddress,
+    ),
     fdTable: proofFdTable(),
     memory: proofMemoryPlan(context),
   });
@@ -252,13 +267,18 @@ function proofInputPaths(context: CombinedDescriptorContext): Record<string, str
   };
 }
 
-function continuationDescriptor(targetCodeFile: string, argument0: string | undefined) {
+function continuationDescriptor(
+  targetCodeFile: string,
+  argument0: string | undefined,
+  stateReportAddress: string | undefined,
+) {
   return {
     codeFile: GUEST_CODE,
     fileOffset: 0,
     codeSize: statSync(targetCodeFile).size,
     targetAddress: "0x700300000000",
     argument0,
+    stateReportAddress,
     timeoutSeconds: 5,
     stackTargetStart: "0x500000000000",
     stackSize: 65_536,
@@ -313,22 +333,24 @@ function prepareTargetContinuation(
   mapping: NativeMemoryMapping,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): PreparedTargetContinuation | ReturnType<typeof planPortableMachineVmRestoreProof> {
+  const expectedMemoryByte = firstByte(memoryFile, mapping);
   return args.realUtilityContinuation
-    ? prepareRealUtilityContinuation(targetDir, plan)
+    ? prepareRealUtilityContinuation(targetDir, expectedMemoryByte, plan)
     : {
         kind: "generated-verifier",
-        bytes: combinedProofTargetCode(firstByte(memoryFile, mapping)),
+        bytes: combinedProofTargetCode(expectedMemoryByte),
       };
 }
 
 function prepareRealUtilityContinuation(
   targetDir: string,
+  expectedMemoryByte: number,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ) {
   const targetRoot = join(targetDir, "real-utility-root");
   const modulePath = join(targetRoot, "usr/bin/realspin-code");
   mkdirSync(dirname(modulePath), { recursive: true });
-  const moduleBytes = finalJumpTargetCode();
+  const moduleBytes = stateConsumingRealUtilityTargetCode(expectedMemoryByte);
   writeFileSync(modulePath, moduleBytes);
   const module = realUtilityTargetModule(sha256(moduleBytes), moduleBytes.length);
   const materialized = materializeNativeTargetModuleBytes({
@@ -345,6 +367,7 @@ function prepareRealUtilityContinuation(
     kind: "real-utility" as const,
     bytes: Buffer.from(materialized.materialized!.bytes),
     argument0: PROOF_MEMORY_TARGET,
+    stateReportAddress: PROOF_MEMORY_TARGET,
     expectedReturnValue: hex(FINAL_JUMP_EXPECTED_RETURN),
     targetModuleBytesSource: "portable-bundle-target-root",
   };
@@ -548,90 +571,190 @@ function firstByte(memoryFile: string, mapping: NativeMemoryMapping): number {
 }
 
 function combinedProofTargetCode(expectedMemoryByte: number): Buffer {
-  const bytes: number[] = [];
-  const jumps: number[] = [];
-  const push = (...values: number[]) => bytes.push(...values.map((value) => value & 0xff));
-  const pushU32 = (value: number) => push(value, value >> 8, value >> 16, value >> 24);
-  const pushU64 = (value: bigint) => {
-    for (let i = 0n; i < 8n; i++) {
-      push(Number((value >> (8n * i)) & 0xffn));
-    }
-  };
-  const jumpToFail = (condition: number) => {
-    push(0x0f, condition, 0x00, 0x00, 0x00, 0x00);
-    jumps.push(bytes.length - 4);
-  };
-  const jumpIfNotEqual = () => jumpToFail(0x85);
-  const jumpIfSign = () => jumpToFail(0x88);
-  const syscall = (number: number) => {
-    push(0xb8);
-    pushU32(number);
-  };
-  const movFd = (fd: number) => {
-    push(0xbf);
-    pushU32(fd);
-  };
-  const checkFdOpen = (fd: number) => {
-    syscall(72);
-    movFd(fd);
-    push(0xbe);
-    pushU32(1);
-    push(0x31, 0xd2, 0x0f, 0x05, 0x48, 0x85, 0xc0);
-    jumpIfSign();
-  };
-  const checkFdClosed = (fd: number) => {
-    syscall(72);
-    movFd(fd);
-    push(0xbe);
-    pushU32(1);
-    push(0x31, 0xd2, 0x0f, 0x05, 0x83, 0xf8, 0xf7);
-    jumpIfNotEqual();
-  };
-  const readAndCheck = (fd: number, expected: Buffer) => {
-    push(0x48, 0x83, 0xec, 0x10, 0x31, 0xc0);
-    movFd(fd);
-    push(0x48, 0x89, 0xe6, 0xba);
-    pushU32(expected.length);
-    push(0x0f, 0x05, 0x83, 0xf8, expected.length);
-    jumpIfNotEqual();
-    for (const [index, byte] of expected.entries()) {
-      push(0x80, index === 0 ? 0x3c : 0x7c, 0x24);
-      if (index !== 0) {
-        push(index);
-      }
-      push(byte);
-      jumpIfNotEqual();
-    }
-  };
+  return proofStateVerifierTargetCode(expectedMemoryByte, "exit");
+}
 
-  push(0x48, 0xbb);
-  pushU64(BigInt(PROOF_MEMORY_TARGET));
-  push(0x80, 0x3b, expectedMemoryByte);
-  jumpIfNotEqual();
-  checkFdClosed(PROOF_CLOSED_FD);
-  checkFdOpen(PROOF_STDOUT_FD);
-  readAndCheck(PROOF_FILE_FD, PROOF_FD_BYTES);
-  checkFdOpen(PROOF_PIPE_READ_FD);
-  checkFdOpen(PROOF_PIPE_WRITE_FD);
-  checkFdOpen(PROOF_EVENT_FD);
-  checkFdOpen(PROOF_TIMER_FD);
-  syscall(60);
-  push(0x31, 0xff, 0x0f, 0x05);
+function stateConsumingRealUtilityTargetCode(expectedMemoryByte: number): Buffer {
+  return proofStateVerifierTargetCode(expectedMemoryByte, "return");
+}
 
-  const failOffset = bytes.length;
-  syscall(60);
-  push(0xbf);
-  pushU32(42);
-  push(0x0f, 0x05);
+type ProofCompletionMode = "exit" | "return";
 
-  for (const index of jumps) {
-    const relative = failOffset - (index + 4);
-    bytes[index] = relative & 0xff;
-    bytes[index + 1] = (relative >> 8) & 0xff;
-    bytes[index + 2] = (relative >> 16) & 0xff;
-    bytes[index + 3] = (relative >> 24) & 0xff;
+function proofStateVerifierTargetCode(
+  expectedMemoryByte: number,
+  completion: ProofCompletionMode,
+): Buffer {
+  const asm = new Amd64ProofAssembler();
+  if (completion === "return") {
+    asm.preserveRbx();
+    asm.movRbxFromRdi();
+    asm.storeReportWord(16, 0n);
+  } else {
+    asm.movRbxImmediate(BigInt(PROOF_MEMORY_TARGET));
   }
-  return Buffer.from(bytes);
+  asm.checkMemoryByte(expectedMemoryByte);
+  asm.markStateCheck(completion, STATE_CHECK_MEMORY);
+  asm.checkFdClosed(PROOF_CLOSED_FD);
+  asm.markStateCheck(completion, STATE_CHECK_CLOSE_FD);
+  asm.checkFdOpen(PROOF_STDOUT_FD);
+  asm.markStateCheck(completion, STATE_CHECK_STDIO);
+  asm.readAndCheck(PROOF_FILE_FD, PROOF_FD_BYTES);
+  asm.markStateCheck(completion, STATE_CHECK_REOPEN_FILE);
+  asm.checkFdOpen(PROOF_PIPE_READ_FD);
+  asm.checkFdOpen(PROOF_PIPE_WRITE_FD);
+  asm.markStateCheck(completion, STATE_CHECK_PIPE);
+  asm.checkFdOpen(PROOF_EVENT_FD);
+  asm.markStateCheck(completion, STATE_CHECK_EVENTFD);
+  asm.checkFdOpen(PROOF_TIMER_FD);
+  asm.markStateCheck(completion, STATE_CHECK_TIMERFD);
+  asm.completeSuccessfully(completion);
+  return asm.toBuffer(completion);
+}
+
+class Amd64ProofAssembler {
+  private readonly bytes: number[] = [];
+  private readonly jumps: number[] = [];
+
+  preserveRbx(): void {
+    this.push(0x53);
+  }
+
+  movRbxFromRdi(): void {
+    this.push(0x48, 0x89, 0xfb);
+  }
+
+  movRbxImmediate(value: bigint): void {
+    this.push(0x48, 0xbb);
+    this.pushU64(value);
+  }
+
+  checkMemoryByte(expected: number): void {
+    this.push(0x80, 0x3b, expected);
+    this.jumpIfNotEqual();
+  }
+
+  checkFdOpen(fd: number): void {
+    this.fcntlGetFd(fd);
+    this.push(0x48, 0x85, 0xc0);
+    this.jumpIfSign();
+  }
+
+  checkFdClosed(fd: number): void {
+    this.fcntlGetFd(fd);
+    this.push(0x83, 0xf8, 0xf7);
+    this.jumpIfNotEqual();
+  }
+
+  readAndCheck(fd: number, expected: Buffer): void {
+    this.push(0x31, 0xc0);
+    this.movFd(fd);
+    this.push(0x48, 0x8d, 0x73, 0x40, 0xba);
+    this.pushU32(expected.length);
+    this.push(0x0f, 0x05, 0x83, 0xf8, expected.length);
+    this.jumpIfNotEqual();
+    for (const [index, byte] of expected.entries()) {
+      this.push(0x80, 0x7b, 0x40 + index, byte);
+      this.jumpIfNotEqual();
+    }
+  }
+
+  markStateCheck(completion: ProofCompletionMode, bit: number): void {
+    if (completion === "return") {
+      this.push(0x48, 0x83, 0x4b, 0x10, bit);
+    }
+  }
+
+  completeSuccessfully(completion: ProofCompletionMode): void {
+    if (completion === "return") {
+      this.storeReportWord(8, STATE_CONSUMPTION_MARKER);
+      this.push(0xb8);
+      this.pushU32(Number(FINAL_JUMP_EXPECTED_RETURN));
+      this.push(0x5b, 0xc3);
+      return;
+    }
+    this.syscall(60);
+    this.push(0x31, 0xff, 0x0f, 0x05);
+  }
+
+  storeReportWord(offset: number, value: bigint): void {
+    this.push(0x48, 0xb8);
+    this.pushU64(value);
+    this.push(0x48, 0x89, 0x43, offset);
+  }
+
+  toBuffer(completion: ProofCompletionMode): Buffer {
+    const failOffset = this.bytes.length;
+    this.completeWithFailure(completion);
+    this.patchJumps(failOffset);
+    return Buffer.from(this.bytes);
+  }
+
+  private fcntlGetFd(fd: number): void {
+    this.syscall(72);
+    this.movFd(fd);
+    this.push(0xbe);
+    this.pushU32(1);
+    this.push(0x31, 0xd2, 0x0f, 0x05);
+  }
+
+  private completeWithFailure(completion: ProofCompletionMode): void {
+    if (completion === "return") {
+      this.push(0xb8);
+      this.pushU32(42);
+      this.push(0x5b, 0xc3);
+      return;
+    }
+    this.syscall(60);
+    this.movFd(42);
+    this.push(0x0f, 0x05);
+  }
+
+  private syscall(number: number): void {
+    this.push(0xb8);
+    this.pushU32(number);
+  }
+
+  private movFd(fd: number): void {
+    this.push(0xbf);
+    this.pushU32(fd);
+  }
+
+  private jumpIfNotEqual(): void {
+    this.jumpToFail(0x85);
+  }
+
+  private jumpIfSign(): void {
+    this.jumpToFail(0x88);
+  }
+
+  private jumpToFail(condition: number): void {
+    this.push(0x0f, condition, 0x00, 0x00, 0x00, 0x00);
+    this.jumps.push(this.bytes.length - 4);
+  }
+
+  private patchJumps(failOffset: number): void {
+    for (const index of this.jumps) {
+      const relative = failOffset - (index + 4);
+      this.bytes[index] = relative & 0xff;
+      this.bytes[index + 1] = (relative >> 8) & 0xff;
+      this.bytes[index + 2] = (relative >> 16) & 0xff;
+      this.bytes[index + 3] = (relative >> 24) & 0xff;
+    }
+  }
+
+  private push(...values: number[]): void {
+    this.bytes.push(...values.map((value) => value & 0xff));
+  }
+
+  private pushU32(value: number): void {
+    this.push(value, value >> 8, value >> 16, value >> 24);
+  }
+
+  private pushU64(value: bigint): void {
+    for (let i = 0n; i < 8n; i++) {
+      this.push(Number((value >> (8n * i)) & 0xffn));
+    }
+  }
 }
 
 function refusedPlan(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -101,6 +101,8 @@ try {
     targetContinuationStatus: result.targetContinuationStatus ?? '',
     targetContinuationReturnValue: result.targetContinuationReturnValue ?? '',
     targetModuleBytesSource: result.targetModuleBytesSource ?? '',
+    targetStateConsumptionResult: result.targetStateConsumptionResult ?? '',
+    targetResourceStatuses: result.targetResourceStatuses ?? [],
   }));
 } catch {
   process.stdout.write('{}');


### PR DESCRIPTION
## Problem

The target VM restore proof could now enter a real amd64 utility continuation. But that continuation only proved the jump and return path. It did not prove that the restored memory and file descriptor state were actually used by target-native code.

That left an important gap. A restore can only count as useful if the target code can read the restored state and reject bad state.

## Solution

This PR makes the real utility continuation consume restored state before it returns. The amd64 continuation now checks the materialized memory byte, validates the argument handoff, and exercises the descriptor fd/resource matrix: inherited stdout, closed fd, reopened file, pipe, eventfd, and timerfd.

The trampoline can now read a small state report from restored memory. The proof summary reports `targetStateConsumptionResult` plus per-resource status, and completion fails if state consumption fails.

Closes #605.

## Validation

- `pnpm run format:check` — `0.574s`
- `pnpm run lint` — `0.227s`
- `pnpm run typecheck` — `2.351s`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — `27.072s` (`839 passed / 12 skipped`)
- `pnpm smoke-tests` — `2m12.815s`
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — `0.409s`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — `1m40s`, `2 passed / 2 total`

## Remote proof

- `state=completed`
- `descriptorGateCompleted=true`
- `targetContinuationKind=real-utility`
- `targetContinuationStatus=returned`
- `targetContinuationReturnValue=0x4d`
- `targetStateConsumptionResult=passed`
- `targetResourceStatuses=[inherit-stdio:passed, close-fd:passed, reopen-file:passed, synthetic-empty-pipe:passed, synthetic-empty-eventfd:passed, synthetic-timerfd:passed]`
- wall time: `36.939s`
- target VM boot/restore: `19.685s`
