### PR TITLE
Prove translated return-chain restore

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -49,7 +49,9 @@ only when the in-guest resume event returns the expected value. The real utility
 now consumes restored state before returning: it checks the materialized captured
 memory byte, validates the descriptor-provided argument/register handoff, and
 exercises the wider fd matrix: closed fd, inherited stdout, reopened file,
-synthetic pipe, eventfd, and timerfd recipes.
+synthetic pipe, eventfd, and timerfd recipes. The descriptor also seeds a
+translated target return address so the continuation returns through a
+target-native landing before the trampoline records completion.
 
 ## Smoke profile
 
@@ -84,7 +86,9 @@ from the bundle's approved target root, not source-ISA text. The JSON summary
 includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
 resource recipe kinds, `targetRestore.targetContinuationKind`,
 `targetRestore.targetContinuationReturnValue`,
-`targetRestore.targetStateConsumptionResult`, per-resource status, and
+`targetRestore.targetStateConsumptionResult`, per-resource status,
+`targetRestore.targetReturnChainResult`,
+`targetRestore.targetTranslatedReturnAddress`, and
 `targetRestore.targetVerifierResult`. It reports timing for:
 
 1. preflight / optional remote reachability gates;

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -17,6 +17,7 @@ codeSize=16
 targetAddress=0x700300000000
 argument0=0x600000000000
 stateReportAddress=0x600000000000
+translatedReturnAddress=0x700300000080
 timeoutSeconds=5
 stackTargetStart=0x500000000000
 stackSize=65536
@@ -66,9 +67,12 @@ Everything else fails closed with a precise refusal, currently:
 The existing target-VM synthetic proof now injects the loader and descriptor into
 the amd64 guest and executes the loader instead of invoking the trampoline
 directly. The descriptor may carry an optional `argument0` target register value
-and an optional `stateReportAddress` for real target-native continuation
-attempts. The state report address lets the trampoline read a small report that
-the continuation writes after consuming restored memory and fd/resource state.
-Completion is credited only when the descriptor gate succeeds and the
-target-native continuation returns/exits in the guest with the expected modeled
-result.
+an optional `stateReportAddress`, and an optional `translatedReturnAddress` for
+real target-native continuation attempts. The state report address lets the
+trampoline read a small report that the continuation writes after consuming
+restored memory and fd/resource state. The translated return address lets the
+trampoline seed a modeled target return slot before the host return slot, so the
+continuation can return through target-native landing code before control comes
+back to the trampoline. Completion is credited only when the descriptor gate
+succeeds and the target-native continuation returns/exits in the guest with the
+expected modeled result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -43,6 +43,7 @@
 #define STATE_CHECK_PIPE UINT64_C(0x10)
 #define STATE_CHECK_EVENTFD UINT64_C(0x20)
 #define STATE_CHECK_TIMERFD UINT64_C(0x40)
+#define TRANSLATED_RETURN_MARKER UINT64_C(0x52455455524e4a50)
 
 struct MemoryMaterialization {
   const char *source_file;
@@ -66,6 +67,8 @@ struct Options {
   uint64_t argument0;
   bool has_state_report_address;
   uint64_t state_report_address;
+  bool has_translated_return_address;
+  uint64_t translated_return_address;
   uint64_t stack_target_start;
   uint64_t stack_size;
   uint64_t stack_pointer;
@@ -86,7 +89,8 @@ static void usage(void) {
   fprintf(stderr,
       "usage: machinen-native-actual-resume-trampoline --code-file path "
       "--file-offset n --code-size n --target-address addr "
-      "[--argument0 addr] [--state-report-address addr] --timeout-seconds n "
+      "[--argument0 addr] [--state-report-address addr] "
+      "[--translated-return-address addr] --timeout-seconds n "
       "[--synthetic-empty-pipe-read-fd n] [--synthetic-empty-pipe-write-fd n] "
       "[--synthetic-empty-eventfd n] "
       "[--synthetic-timerfd n] [--set-cloexec-fd n] "
@@ -224,6 +228,12 @@ static struct Options parse_args(int argc, char **argv) {
       }
       opts.state_report_address = parse_u64(argv[i], "state-report-address");
       opts.has_state_report_address = true;
+    } else if (streq(argv[i], "--translated-return-address")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.translated_return_address = parse_u64(argv[i], "translated-return-address");
+      opts.has_translated_return_address = true;
     } else if (streq(argv[i], "--timeout-seconds")) {
       if (++i >= argc) {
         usage();
@@ -645,12 +655,21 @@ static void apply_cloexec_fds(const struct Options *opts) {
   }
 }
 
-static void jump_to_target(uint64_t entry, uint64_t initial_rsp, uint64_t argument0) {
+static void jump_to_target(
+    uint64_t entry, uint64_t initial_rsp, uint64_t argument0, uint64_t translated_return_address) {
   __asm__ __volatile__(
       "movq %%rsp, host_rsp_before_jump(%%rip)\n"
       "movq %[initial_rsp], %%rsp\n"
       "leaq 1f(%%rip), %%rax\n"
+      "movq %[translated_return_address], %%rdx\n"
+      "testq %%rdx, %%rdx\n"
+      "jz 2f\n"
+      "movq %%rdx, (%%rsp)\n"
+      "movq %%rax, 8(%%rsp)\n"
+      "jmp 3f\n"
+      "2:\n"
       "movq %%rax, (%%rsp)\n"
+      "3:\n"
       "xorl %%eax, %%eax\n"
       "movq %[argument0], %%rdi\n"
       "xorl %%esi, %%esi\n"
@@ -667,7 +686,8 @@ static void jump_to_target(uint64_t entry, uint64_t initial_rsp, uint64_t argume
       :
       : [entry] "r"((void *)(uintptr_t)entry),
         [initial_rsp] "r"(initial_rsp),
-        [argument0] "r"(argument0)
+        [argument0] "r"(argument0),
+        [translated_return_address] "r"(translated_return_address)
       : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11", "memory");
 }
 
@@ -823,6 +843,23 @@ static void print_state_consumption(const struct Options *opts) {
   printf("]}");
 }
 
+static void print_return_chain(const struct Options *opts) {
+  if (!opts->has_translated_return_address || !opts->has_state_report_address) {
+    return;
+  }
+  uint64_t marker = read_state_report_u64(opts->state_report_address, 24);
+  bool passed = marker == TRANSLATED_RETURN_MARKER;
+  printf(
+      ",\"returnChain\":{\"status\":\"%s\","
+      "\"translatedReturnAddress\":\"0x%" PRIx64 "\","
+      "\"returnMarker\":\"0x%" PRIx64 "\","
+      "\"expectedReturnMarker\":\"0x%" PRIx64 "\"}",
+      passed ? "passed" : "failed",
+      opts->translated_return_address,
+      marker,
+      TRANSLATED_RETURN_MARKER);
+}
+
 static void print_return_event(const struct Options *opts) {
   printf(
       "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
@@ -842,6 +879,7 @@ static void print_return_event(const struct Options *opts) {
       mapped_target_start,
       mapped_target_end);
   print_state_consumption(opts);
+  print_return_chain(opts);
   printf("}\n");
 }
 
@@ -870,8 +908,12 @@ int main(int argc, char **argv) {
   apply_cloexec_fds(&opts);
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {
+    uint64_t initial_rsp = opts.has_translated_return_address ? opts.stack_pointer - 16u : opts.stack_pointer - 8u;
     jump_to_target(
-        opts.target_address, opts.stack_pointer - 8u, opts.has_argument0 ? opts.argument0 : 0u);
+        opts.target_address,
+        initial_rsp,
+        opts.has_argument0 ? opts.argument0 : 0u,
+        opts.has_translated_return_address ? opts.translated_return_address : 0u);
     alarm(0);
     print_return_event(&opts);
   } else {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -48,6 +48,8 @@ struct Descriptor {
   uint64_t argument0;
   bool has_state_report_address;
   uint64_t state_report_address;
+  bool has_translated_return_address;
+  uint64_t translated_return_address;
   uint64_t timeout_seconds;
   uint64_t stack_target_start;
   uint64_t stack_size;
@@ -193,6 +195,9 @@ static void parse_field(struct Descriptor *descriptor, char *line) {
   } else if (streq(key, "stateReportAddress")) {
     descriptor->state_report_address = parse_u64(value, key);
     descriptor->has_state_report_address = true;
+  } else if (streq(key, "translatedReturnAddress")) {
+    descriptor->translated_return_address = parse_u64(value, key);
+    descriptor->has_translated_return_address = true;
   } else if (streq(key, "timeoutSeconds")) {
     descriptor->timeout_seconds = parse_u64(value, key);
   } else if (streq(key, "stackTargetStart")) {
@@ -540,6 +545,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char target_address[32];
   char argument0[32];
   char state_report_address[32];
+  char translated_return_address[32];
   char timeout_seconds[32];
   char stack_target_start[32];
   char stack_size[32];
@@ -554,6 +560,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(target_address, sizeof(target_address), "0x%" PRIx64, descriptor->target_address);
   snprintf(argument0, sizeof(argument0), "0x%" PRIx64, descriptor->argument0);
   snprintf(state_report_address, sizeof(state_report_address), "0x%" PRIx64, descriptor->state_report_address);
+  snprintf(translated_return_address, sizeof(translated_return_address), "0x%" PRIx64, descriptor->translated_return_address);
   snprintf(timeout_seconds, sizeof(timeout_seconds), "0x%" PRIx64, descriptor->timeout_seconds);
   snprintf(stack_target_start, sizeof(stack_target_start), "0x%" PRIx64, descriptor->stack_target_start);
   snprintf(stack_size, sizeof(stack_size), "0x%" PRIx64, descriptor->stack_size);
@@ -584,6 +591,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   if (descriptor->has_state_report_address) {
     push_arg(child_argv, &child_argc, "--state-report-address");
     push_arg(child_argv, &child_argc, state_report_address);
+  }
+  if (descriptor->has_translated_return_address) {
+    push_arg(child_argv, &child_argc, "--translated-return-address");
+    push_arg(child_argv, &child_argc, translated_return_address);
   }
   push_arg(child_argv, &child_argc, "--timeout-seconds");
   push_arg(child_argv, &child_argc, timeout_seconds);

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -111,6 +111,7 @@
 - [`PortableMachineVmRestoreProofState`](#portablemachinevmrestoreproofstate)
 - [`PortableMachineTargetContinuationKind`](#portablemachinetargetcontinuationkind)
 - [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)
+- [`PortableMachineTargetReturnChainResult`](#portablemachinetargetreturnchainresult)
 - [`PortableMachineTargetStateConsumptionResult`](#portablemachinetargetstateconsumptionresult)
 - [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
 - [`PortableMachineVmRestoreProofRequest`](#portablemachinevmrestoreproofrequest)
@@ -8129,6 +8130,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetResourceStatuses?**: [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)[]
 
+##### targetReturnChainResult?
+
+> `optional` **targetReturnChainResult?**: [`PortableMachineTargetReturnChainResult`](#portablemachinetargetreturnchainresult)
+
+##### targetTranslatedReturnAddress?
+
+> `optional` **targetTranslatedReturnAddress?**: `string`
+
 ##### sourceTextReusedAsTargetCode
 
 > **sourceTextReusedAsTargetCode**: `false`
@@ -8198,6 +8207,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ##### targetResourceStatuses?
 
 > `optional` **targetResourceStatuses?**: [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)[]
+
+##### targetReturnChainResult?
+
+> `optional` **targetReturnChainResult?**: [`PortableMachineTargetReturnChainResult`](#portablemachinetargetreturnchainresult)
+
+##### targetTranslatedReturnAddress?
+
+> `optional` **targetTranslatedReturnAddress?**: `string`
 
 ##### sourceTextReusedAsTargetCode?
 
@@ -9186,6 +9203,10 @@ Poll interval in ms while retrying. Default 250.
 ##### stateReportAddress?
 
 > `optional` **stateReportAddress?**: `string`
+
+##### translatedReturnAddress?
+
+> `optional` **translatedReturnAddress?**: `string`
 
 ##### timeoutSeconds
 
@@ -11706,6 +11727,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### PortableMachineTargetStateConsumptionResult
 
 > **PortableMachineTargetStateConsumptionResult** = `"pending"` \| `"passed"` \| `"failed"`
+
+***
+
+### PortableMachineTargetReturnChainResult
+
+> **PortableMachineTargetReturnChainResult** = `"pending"` \| `"passed"` \| `"failed"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -92,12 +92,18 @@ describe("native actual resume trampoline", () => {
       const memory = Buffer.alloc(4096);
       memory[0] = 0x4d;
       writeFileSync(stateMemory, memory);
-      const stateCode = Buffer.from([
+      const stateEntry = Buffer.from([
         0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x08, 0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0,
         0, 0x48, 0x89, 0x47, 0x10, 0xb8, 0x4d, 0, 0, 0, 0xc3,
       ]);
-      stateCode.writeBigUInt64LE(0x5354415445434f4en, 2);
-      stateCode.writeBigUInt64LE(0x7fn, 16);
+      stateEntry.writeBigUInt64LE(0x5354415445434f4en, 2);
+      stateEntry.writeBigUInt64LE(0x7fn, 16);
+      const returnLanding = Buffer.from([
+        0x48, 0xba, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x57, 0x18, 0xb8, 0x4d, 0, 0, 0, 0xc3,
+      ]);
+      returnLanding.writeBigUInt64LE(0x52455455524e4a50n, 2);
+      const translatedReturnAddress = `0x${(0x710000001000n + BigInt(stateEntry.length)).toString(16)}`;
+      const stateCode = Buffer.concat([stateEntry, returnLanding]);
       const stateCodePath = join(outDir, "state.bin");
       writeFileSync(stateCodePath, stateCode);
       expect(
@@ -106,12 +112,19 @@ describe("native actual resume trampoline", () => {
           "0x600000000000",
           "--state-report-address",
           "0x600000000000",
+          "--translated-return-address",
+          translatedReturnAddress,
           "--materialize-memory",
           `${stateMemory}:0:0x600000000000:4096:rw-p`,
         ]),
       ).toMatchObject({
         status: "returned",
         returnValue: "0x4d",
+        returnChain: {
+          status: "passed",
+          translatedReturnAddress,
+          returnMarker: "0x52455455524e4a50",
+        },
         stateConsumption: {
           status: "passed",
           memoryByte: "0x4d",

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -155,6 +155,8 @@ describe("portable machine VM restore proof", () => {
         targetVerifierResult: "passed",
         targetStateConsumptionResult: "passed",
         targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
+        targetReturnChainResult: "passed",
+        targetTranslatedReturnAddress: "0x700300000080",
         sourceTextReusedAsTargetCode: false,
         sourceIsaEmulationUsed: false,
         sidecarRuntimeUsed: false,
@@ -165,6 +167,26 @@ describe("portable machine VM restore proof", () => {
       descriptorGateCompleted: true,
       targetStateConsumptionResult: "passed",
       targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
+      targetReturnChainResult: "passed",
+      targetTranslatedReturnAddress: "0x700300000080",
+    });
+
+    expect(
+      completePortableMachineVmRestoreProof(plan, {
+        exitCode: 0,
+        migrationCompleted: true,
+        descriptorGateCompleted: true,
+        targetVerifierResult: "passed",
+        targetReturnChainResult: "failed",
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      }),
+    ).toMatchObject({
+      state: "ready",
+      migrationCompleted: false,
+      descriptorGateCompleted: true,
+      targetReturnChainResult: "failed",
     });
 
     expect(

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -48,6 +48,7 @@ describe("target guest restore loader descriptor", () => {
         ...descriptor().continuation,
         argument0: "0x600000000000",
         stateReportAddress: "0x600000000000",
+        translatedReturnAddress: "0x700300000080",
       },
       resources: [
         { kind: "close-fd", fd: 0, reason: "missing-captured-fd" },
@@ -84,6 +85,8 @@ describe("target guest restore loader descriptor", () => {
       "0x600000000000",
       "--state-report-address",
       "0x600000000000",
+      "--translated-return-address",
+      "0x700300000080",
       "--timeout-seconds",
       "5",
       "--stack-target-start",
@@ -220,6 +223,17 @@ describe("target guest restore loader descriptor", () => {
         }),
       ),
     ).toThrow(/stateReportAddress must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            translatedReturnAddress: "700300000080",
+          },
+        }),
+      ),
+    ).toThrow(/translatedReturnAddress must be a hex address/);
   });
 
   it.skipIf(!HAS_CC)(
@@ -238,7 +252,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",
@@ -259,6 +273,7 @@ describe("target guest restore loader descriptor", () => {
             continuation: {
               ...descriptor().continuation,
               stateReportAddress: "0x600000000000",
+              translatedReturnAddress: "0x700300000080",
             },
             resources: [
               {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -452,6 +452,7 @@ export type {
 export type {
   PortableMachineTargetContinuationKind,
   PortableMachineTargetResourceStatus,
+  PortableMachineTargetReturnChainResult,
   PortableMachineTargetRestoreDescriptorPlan,
   PortableMachineTargetRestoreDescriptorRequest,
   PortableMachineTargetStateConsumptionResult,

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -22,6 +22,7 @@ export interface PortableMachineVmRestoreProofRequest {
 export type PortableMachineTargetVerifierResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetContinuationKind = "generated-verifier" | "real-utility";
 export type PortableMachineTargetStateConsumptionResult = "pending" | "passed" | "failed";
+export type PortableMachineTargetReturnChainResult = "pending" | "passed" | "failed";
 
 export interface PortableMachineTargetResourceStatus {
   kind: string;
@@ -50,6 +51,8 @@ export interface PortableMachineVmRestoreProofPlan {
   targetModuleBytesSource?: string;
   targetStateConsumptionResult?: PortableMachineTargetStateConsumptionResult;
   targetResourceStatuses?: PortableMachineTargetResourceStatus[];
+  targetReturnChainResult?: PortableMachineTargetReturnChainResult;
+  targetTranslatedReturnAddress?: string;
   sourceTextReusedAsTargetCode: false;
   sourceIsaEmulationUsed: false;
   sidecarRuntimeUsed: false;
@@ -65,6 +68,8 @@ export interface PortableMachineVmRestoreTargetResult {
   actualResumeEvent?: { status?: string; returnValue?: string };
   targetStateConsumptionResult?: PortableMachineTargetStateConsumptionResult;
   targetResourceStatuses?: PortableMachineTargetResourceStatus[];
+  targetReturnChainResult?: PortableMachineTargetReturnChainResult;
+  targetTranslatedReturnAddress?: string;
   sourceTextReusedAsTargetCode?: boolean;
   sourceIsaEmulationUsed?: boolean;
   sidecarRuntimeUsed?: boolean;
@@ -182,6 +187,8 @@ export function completePortableMachineVmRestoreProof(
     targetContinuationReturnValue: result.actualResumeEvent?.returnValue,
     targetStateConsumptionResult: result.targetStateConsumptionResult,
     targetResourceStatuses: result.targetResourceStatuses,
+    targetReturnChainResult: result.targetReturnChainResult,
+    targetTranslatedReturnAddress: result.targetTranslatedReturnAddress,
   };
 }
 
@@ -200,6 +207,7 @@ function targetNativeCompleted(result: PortableMachineVmRestoreTargetResult): bo
     result.targetVerifierResult === undefined || result.targetVerifierResult === "passed",
     result.targetStateConsumptionResult === undefined ||
       result.targetStateConsumptionResult === "passed",
+    result.targetReturnChainResult === undefined || result.targetReturnChainResult === "passed",
     result.sourceTextReusedAsTargetCode === false,
     result.sourceIsaEmulationUsed === false,
     result.sidecarRuntimeUsed === false,

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -42,6 +42,7 @@ export interface TargetGuestRestoreContinuationDescriptor {
   targetAddress: string;
   argument0?: string;
   stateReportAddress?: string;
+  translatedReturnAddress?: string;
   timeoutSeconds: number;
   stackTargetStart: string;
   stackSize: number;
@@ -70,6 +71,7 @@ export function serializeTargetGuestRestoreDescriptor(
     `targetAddress=${continuation.targetAddress}`,
     ...optionalContinuationField("argument0", continuation.argument0),
     ...optionalContinuationField("stateReportAddress", continuation.stateReportAddress),
+    ...optionalContinuationField("translatedReturnAddress", continuation.translatedReturnAddress),
     `timeoutSeconds=${continuation.timeoutSeconds}`,
     `stackTargetStart=${continuation.stackTargetStart}`,
     `stackSize=${continuation.stackSize}`,
@@ -124,6 +126,7 @@ export function buildNativeActualResumeTrampolineArgs(
     continuation.targetAddress,
     ...optionalArg("--argument0", continuation.argument0),
     ...optionalArg("--state-report-address", continuation.stateReportAddress),
+    ...optionalArg("--translated-return-address", continuation.translatedReturnAddress),
     "--timeout-seconds",
     String(continuation.timeoutSeconds),
     "--stack-target-start",
@@ -174,6 +177,7 @@ function fieldsToDescriptor(
       targetAddress: requiredField(fields, "targetAddress"),
       argument0: optionalField(fields, "argument0"),
       stateReportAddress: optionalField(fields, "stateReportAddress"),
+      translatedReturnAddress: optionalField(fields, "translatedReturnAddress"),
       timeoutSeconds: parseIntegerField(fields, "timeoutSeconds"),
       stackTargetStart: requiredField(fields, "stackTargetStart"),
       stackSize: parseIntegerField(fields, "stackSize"),
@@ -400,6 +404,9 @@ function validateContinuation(
   }
   if (continuation.stateReportAddress !== undefined) {
     assertHexAddress(continuation.stateReportAddress, "stateReportAddress");
+  }
+  if (continuation.translatedReturnAddress !== undefined) {
+    assertHexAddress(continuation.translatedReturnAddress, "translatedReturnAddress");
   }
   assertHexAddress(continuation.stackTargetStart, "stackTargetStart");
   assertHexAddress(continuation.stackPointer, "stackPointer");

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -133,6 +133,7 @@ const TOC = {
     "PortableMachineVmRestoreProofState",
     "PortableMachineTargetContinuationKind",
     "PortableMachineTargetResourceStatus",
+    "PortableMachineTargetReturnChainResult",
     "PortableMachineTargetStateConsumptionResult",
     "PortableMachineTargetVerifierResult",
     "PortableMachineVmRestoreProofRequest",

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -36,6 +36,11 @@ interface StateConsumptionEvent {
   resourceStatuses?: StateConsumptionResourceStatus[];
 }
 
+interface ReturnChainEvent {
+  status?: StateConsumptionStatus;
+  translatedReturnAddress?: string;
+}
+
 interface Args {
   codeFile?: string;
   descriptorFile?: string;
@@ -210,9 +215,9 @@ function targetExecutionSummary(
   return {
     ...targetSummary(args),
     ...events,
+    ...targetStateConsumptionFields(events.stateConsumption),
+    ...targetReturnChainFields(events.returnChain),
     targetVerifierResult: targetVerifierResult(args, result.exitCode, events),
-    targetStateConsumptionResult: events.stateConsumption?.status,
-    targetResourceStatuses: events.stateConsumption?.resourceStatuses,
     exitCode: result.exitCode,
     stdout: result.stdout,
     stderr: result.stderr,
@@ -223,6 +228,20 @@ function targetExecutionSummary(
   };
 }
 
+function targetStateConsumptionFields(stateConsumption: StateConsumptionEvent | undefined) {
+  return {
+    targetStateConsumptionResult: stateConsumption?.status,
+    targetResourceStatuses: stateConsumption?.resourceStatuses,
+  };
+}
+
+function targetReturnChainFields(returnChain: ReturnChainEvent | undefined) {
+  return {
+    targetReturnChainResult: returnChain?.status,
+    targetTranslatedReturnAddress: returnChain?.translatedReturnAddress,
+  };
+}
+
 function targetExecutionEvents(stdout: string) {
   const descriptorGateCompleted = loaderCompleted(stdout);
   const actualResumeEvent = parseActualResumeEvent(stdout);
@@ -230,6 +249,7 @@ function targetExecutionEvents(stdout: string) {
     descriptorGateCompleted,
     actualResumeEvent,
     stateConsumption: parseStateConsumption(actualResumeEvent),
+    returnChain: parseReturnChain(actualResumeEvent),
   };
 }
 
@@ -244,6 +264,7 @@ function targetVerifierResult(
     events.descriptorGateCompleted,
     events.actualResumeEvent,
     events.stateConsumption,
+    events.returnChain,
   )
     ? "passed"
     : "failed";
@@ -338,16 +359,14 @@ function targetVerifierPassed(
   descriptorGateCompleted: boolean,
   actualResumeEvent: Record<string, unknown> | undefined,
   stateConsumption: StateConsumptionEvent | undefined,
+  returnChain: ReturnChainEvent | undefined,
 ): boolean {
-  if (!targetProcessCompleted(exitCode, descriptorGateCompleted)) {
-    return false;
-  }
-  if (!targetStateConsumed(stateConsumption)) {
-    return false;
-  }
-  return args.expectReturnValue === undefined
-    ? true
-    : actualResumeReturnedExpected(actualResumeEvent, args.expectReturnValue);
+  return [
+    targetProcessCompleted(exitCode, descriptorGateCompleted),
+    targetStateConsumed(stateConsumption),
+    targetReturnChained(returnChain),
+    targetReturnValueMatched(args, actualResumeEvent),
+  ].every(Boolean);
 }
 
 function targetProcessCompleted(exitCode: number, descriptorGateCompleted: boolean): boolean {
@@ -356,6 +375,19 @@ function targetProcessCompleted(exitCode: number, descriptorGateCompleted: boole
 
 function targetStateConsumed(stateConsumption: StateConsumptionEvent | undefined): boolean {
   return stateConsumption === undefined || stateConsumption.status === "passed";
+}
+
+function targetReturnChained(returnChain: ReturnChainEvent | undefined): boolean {
+  return returnChain === undefined || returnChain.status === "passed";
+}
+
+function targetReturnValueMatched(
+  args: Args,
+  actualResumeEvent: Record<string, unknown> | undefined,
+): boolean {
+  return args.expectReturnValue === undefined
+    ? true
+    : actualResumeReturnedExpected(actualResumeEvent, args.expectReturnValue);
 }
 
 function parseStateConsumption(
@@ -371,6 +403,13 @@ function isStateConsumptionEvent(value: unknown): value is StateConsumptionEvent
   }
   const status = (value as { status?: unknown }).status;
   return status === "passed" || status === "failed";
+}
+
+function parseReturnChain(
+  actualResumeEvent: Record<string, unknown> | undefined,
+): ReturnChainEvent | undefined {
+  const value = actualResumeEvent?.returnChain;
+  return isStateConsumptionEvent(value) ? value : undefined;
 }
 
 function actualResumeReturnedExpected(

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -21,7 +21,7 @@ import { matchNativeTargetUnwindFrame } from "../packages/runtime/src/native-tar
 import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
 import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
 import { serializeTargetGuestRestoreDescriptor } from "../packages/runtime/src/target-guest-restore-loader.ts";
-import { FINAL_JUMP_EXPECTED_RETURN } from "./native-final-jump-utils.ts";
+import { FINAL_JUMP_EXPECTED_RETURN, FINAL_JUMP_RETURN_MARKER } from "./native-final-jump-utils.ts";
 
 interface Args {
   bundleDir?: string;
@@ -46,6 +46,7 @@ interface TargetInvocation {
   expectedReturnValue?: string;
   targetContinuationKind?: "generated-verifier" | "real-utility";
   targetModuleBytesSource?: string;
+  targetTranslatedReturnAddress?: string;
 }
 
 interface CombinedDescriptorContext {
@@ -63,6 +64,7 @@ interface PreparedTargetContinuation {
   bytes: Buffer;
   argument0?: string;
   stateReportAddress?: string;
+  translatedReturnAddress?: string;
   expectedReturnValue?: string;
   targetModuleBytesSource?: string;
 }
@@ -170,6 +172,9 @@ function planWithDescriptorDetails(
         targetModuleBytesSource: invocation.targetModuleBytesSource,
         targetStateConsumptionResult:
           invocation.targetContinuationKind === "real-utility" ? "pending" : undefined,
+        targetReturnChainResult:
+          invocation.targetContinuationKind === "real-utility" ? "pending" : undefined,
+        targetTranslatedReturnAddress: invocation.targetTranslatedReturnAddress,
         targetVerifierResult: "pending",
       }
     : plan;
@@ -201,6 +206,7 @@ function prepareCombinedDescriptor(
       context.targetCodeFile,
       targetContinuation.argument0,
       targetContinuation.stateReportAddress,
+      targetContinuation.translatedReturnAddress,
     ),
     fdTable: proofFdTable(),
     memory: proofMemoryPlan(context),
@@ -271,6 +277,7 @@ function continuationDescriptor(
   targetCodeFile: string,
   argument0: string | undefined,
   stateReportAddress: string | undefined,
+  translatedReturnAddress: string | undefined,
 ) {
   return {
     codeFile: GUEST_CODE,
@@ -279,6 +286,7 @@ function continuationDescriptor(
     targetAddress: "0x700300000000",
     argument0,
     stateReportAddress,
+    translatedReturnAddress,
     timeoutSeconds: 5,
     stackTargetStart: "0x500000000000",
     stackSize: 65_536,
@@ -323,6 +331,7 @@ function targetInvocation(
     expectedReturnValue: targetContinuation.expectedReturnValue,
     targetContinuationKind: targetContinuation.kind,
     targetModuleBytesSource: targetContinuation.targetModuleBytesSource,
+    targetTranslatedReturnAddress: targetContinuation.translatedReturnAddress,
   };
 }
 
@@ -350,7 +359,8 @@ function prepareRealUtilityContinuation(
   const targetRoot = join(targetDir, "real-utility-root");
   const modulePath = join(targetRoot, "usr/bin/realspin-code");
   mkdirSync(dirname(modulePath), { recursive: true });
-  const moduleBytes = stateConsumingRealUtilityTargetCode(expectedMemoryByte);
+  const targetCode = stateConsumingRealUtilityTargetCode(expectedMemoryByte);
+  const moduleBytes = targetCode.bytes;
   writeFileSync(modulePath, moduleBytes);
   const module = realUtilityTargetModule(sha256(moduleBytes), moduleBytes.length);
   const materialized = materializeNativeTargetModuleBytes({
@@ -368,6 +378,7 @@ function prepareRealUtilityContinuation(
     bytes: Buffer.from(materialized.materialized!.bytes),
     argument0: PROOF_MEMORY_TARGET,
     stateReportAddress: PROOF_MEMORY_TARGET,
+    translatedReturnAddress: targetCode.translatedReturnAddress,
     expectedReturnValue: hex(FINAL_JUMP_EXPECTED_RETURN),
     targetModuleBytesSource: "portable-bundle-target-root",
   };
@@ -571,11 +582,18 @@ function firstByte(memoryFile: string, mapping: NativeMemoryMapping): number {
 }
 
 function combinedProofTargetCode(expectedMemoryByte: number): Buffer {
-  return proofStateVerifierTargetCode(expectedMemoryByte, "exit");
+  return proofStateVerifierTargetCode(expectedMemoryByte, "exit").bytes;
 }
 
-function stateConsumingRealUtilityTargetCode(expectedMemoryByte: number): Buffer {
-  return proofStateVerifierTargetCode(expectedMemoryByte, "return");
+function stateConsumingRealUtilityTargetCode(expectedMemoryByte: number): {
+  bytes: Buffer;
+  translatedReturnAddress: string;
+} {
+  const code = proofStateVerifierTargetCode(expectedMemoryByte, "return");
+  return {
+    bytes: code.bytes,
+    translatedReturnAddress: hex(0x700300000000n + BigInt(code.translatedReturnOffset)),
+  };
 }
 
 type ProofCompletionMode = "exit" | "return";
@@ -583,7 +601,7 @@ type ProofCompletionMode = "exit" | "return";
 function proofStateVerifierTargetCode(
   expectedMemoryByte: number,
   completion: ProofCompletionMode,
-): Buffer {
+): { bytes: Buffer; translatedReturnOffset: number } {
   const asm = new Amd64ProofAssembler();
   if (completion === "return") {
     asm.preserveRbx();
@@ -608,7 +626,7 @@ function proofStateVerifierTargetCode(
   asm.checkFdOpen(PROOF_TIMER_FD);
   asm.markStateCheck(completion, STATE_CHECK_TIMERFD);
   asm.completeSuccessfully(completion);
-  return asm.toBuffer(completion);
+  return asm.toTargetCode(completion);
 }
 
 class Amd64ProofAssembler {
@@ -667,7 +685,7 @@ class Amd64ProofAssembler {
   completeSuccessfully(completion: ProofCompletionMode): void {
     if (completion === "return") {
       this.storeReportWord(8, STATE_CONSUMPTION_MARKER);
-      this.push(0xb8);
+      this.push(0x48, 0x89, 0xdf, 0xb8);
       this.pushU32(Number(FINAL_JUMP_EXPECTED_RETURN));
       this.push(0x5b, 0xc3);
       return;
@@ -682,11 +700,12 @@ class Amd64ProofAssembler {
     this.push(0x48, 0x89, 0x43, offset);
   }
 
-  toBuffer(completion: ProofCompletionMode): Buffer {
+  toTargetCode(completion: ProofCompletionMode): { bytes: Buffer; translatedReturnOffset: number } {
+    const translatedReturnOffset = this.appendTranslatedReturnLanding(completion);
     const failOffset = this.bytes.length;
     this.completeWithFailure(completion);
     this.patchJumps(failOffset);
-    return Buffer.from(this.bytes);
+    return { bytes: Buffer.from(this.bytes), translatedReturnOffset };
   }
 
   private fcntlGetFd(fd: number): void {
@@ -697,11 +716,23 @@ class Amd64ProofAssembler {
     this.push(0x31, 0xd2, 0x0f, 0x05);
   }
 
+  private appendTranslatedReturnLanding(completion: ProofCompletionMode): number {
+    const offset = this.bytes.length;
+    if (completion === "return") {
+      this.push(0x48, 0xba);
+      this.pushU64(FINAL_JUMP_RETURN_MARKER);
+      this.push(0x48, 0x89, 0x57, 0x18, 0xb8);
+      this.pushU32(Number(FINAL_JUMP_EXPECTED_RETURN));
+      this.push(0xc3);
+    }
+    return offset;
+  }
+
   private completeWithFailure(completion: ProofCompletionMode): void {
     if (completion === "return") {
       this.push(0xb8);
       this.pushU32(42);
-      this.push(0x5b, 0xc3);
+      this.push(0x5b, 0x48, 0x83, 0xc4, 0x08, 0xc3);
       return;
     }
     this.syscall(60);

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -103,6 +103,8 @@ try {
     targetModuleBytesSource: result.targetModuleBytesSource ?? '',
     targetStateConsumptionResult: result.targetStateConsumptionResult ?? '',
     targetResourceStatuses: result.targetResourceStatuses ?? [],
+    targetReturnChainResult: result.targetReturnChainResult ?? '',
+    targetTranslatedReturnAddress: result.targetTranslatedReturnAddress ?? '',
   }));
 } catch {
   process.stdout.write('{}');


### PR DESCRIPTION
## Problem

The real utility continuation could consume restored memory and fd state. But it still returned straight back to the trampoline. That was useful, but it did not prove a target-side return slot or modeled caller frame path.

The next restore step needs to look more like a real translated thread frame. Target code should return through target-native landing code before the trampoline records success.

## Solution

This PR adds a modeled translated return address to the target guest restore descriptor. The trampoline now seeds a target return slot before the host return slot, so the real amd64 continuation returns through target-native landing code first.

The landing writes a return-chain marker into restored memory. The target VM summary reports `targetReturnChainResult` and `targetTranslatedReturnAddress`, and completion fails if the return chain does not pass.

Closes #606.

## Validation

- `pnpm run format:check` — 0.690s
- `pnpm run lint` — 0.325s
- `pnpm run typecheck` — 2.536s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.476s, 839 passed / 12 skipped
- `pnpm smoke-tests` — 2m16.267s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.598s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m33s, 2 passed / 2 total
- Remote arm64→amd64 e2e — 39.290s wall, target VM boot/restore 21.691s, `targetReturnChainResult=passed`, `targetContinuationReturnValue=0x4d`
