### PR TITLE
Restore translated callee-saved register bank

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -57,9 +57,9 @@ the target-native continuation validates the frame before returning through the
 target-native landing. The restore boundary accepts only one safe stopped thread
 for this proof; multi-thread, futex, signal-delivery, ptrace/debug,
 shared-stack, unknown-TLS, and ambiguous register states refuse before the target
-VM is entered. The descriptor now uses `resumeMode=translated-frame`, so the
-success path records a target-native resume-path marker after the real
-continuation observes the translated frame and stack.
+VM is entered. The descriptor uses `resumeMode=translated-frame`, so the success
+path records a target-native resume-path marker after the real continuation
+observes the translated frame, stack, and amd64 callee-saved register bank.
 
 ## Smoke profile
 

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -23,7 +23,7 @@ timeoutSeconds=5
 stackTargetStart=0x500000000000
 stackSize=65536
 stackPointer=0x500000010000
-frame=single-target-caller-frame framePointer=0x50000000ff80 canonicalFrameAddress=0x50000000fff0 returnAddressSlot=0x50000000fff0 returnAddress=0x700300000080 unwindId=target:realspin-final-jump calleeSavedR12=0x1234567890abcdef slot0Offset=0 slot0Value=0x4652414d45504153 slot0Class=non-pointer-data
+frame=single-target-caller-frame framePointer=0x50000000ff80 canonicalFrameAddress=0x50000000fff0 returnAddressSlot=0x50000000fff0 returnAddress=0x700300000080 unwindId=target:realspin-final-jump calleeSavedRbx=0x1111111122222222 calleeSavedR12=0x1234567890abcdef calleeSavedR13=0x1313131313131313 calleeSavedR14=0x1414141414141414 calleeSavedR15=0x1515151515151515 slot0Offset=0 slot0Value=0x4652414d45504153 slot0Class=non-pointer-data
 resource=close-fd fd=0 reason=missing-captured-fd
 resource=inherit-stdio fd=1 stream=stdout closeOnExec=false
 resource=reopen-file fd=7 path=/tmp/data.txt offset=9 access=0 closeOnExec=true
@@ -46,8 +46,9 @@ Supported fd-table resources and memory materialization are intentionally narrow
 - `copy-captured-bytes` for explicitly safe, non-executable writable mappings;
 - `recreate-guard` for guard / `PROT_NONE` ranges;
 - `frame=single-target-caller-frame` for the current modeled translated caller
-  frame: one return slot, one `r12` callee-saved value, one non-pointer data
-  stack slot, and a target unwind identity.
+  frame: one return slot, the amd64 callee-saved register bank (`rbx`, `r12`,
+  `r13`, `r14`, `r15`), one non-pointer data stack slot, and a target unwind
+  identity.
 
 The runtime fd-table planner emits these resource lines from translated native
 resources. The in-guest loader validates duplicate fd ownership before launching
@@ -82,8 +83,9 @@ translated return address lets the trampoline seed a modeled target return slot
 before the host return slot, so the continuation can return through
 target-native landing code before control comes back to the trampoline. The
 translated frame lets the trampoline materialize a small target stack frame,
-seed `rbp`/`r12`, and require the target code to validate that modeled frame
-state. Translated resume mode additionally requires the target code to write a
+seed `rbp` plus the modeled callee-saved register bank, and require the target
+code to validate that modeled frame state. Translated resume mode additionally
+requires the target code to write a
 resume-path marker after observing the modeled frame/stack state. Completion is
 credited only when the descriptor gate succeeds and the target-native
 continuation returns/exits in the guest with the expected modeled result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -46,6 +46,12 @@
 #define TRANSLATED_RETURN_MARKER UINT64_C(0x52455455524e4a50)
 #define TRANSLATED_FRAME_MARKER UINT64_C(0x4652414d45504153)
 #define TRANSLATED_RESUME_MARKER UINT64_C(0x524553554d455041)
+#define TRANSLATED_FRAME_REGISTER_MASK UINT64_C(0x1f)
+#define TRANSLATED_FRAME_REGISTER_RBX UINT64_C(0x01)
+#define TRANSLATED_FRAME_REGISTER_R12 UINT64_C(0x02)
+#define TRANSLATED_FRAME_REGISTER_R13 UINT64_C(0x04)
+#define TRANSLATED_FRAME_REGISTER_R14 UINT64_C(0x08)
+#define TRANSLATED_FRAME_REGISTER_R15 UINT64_C(0x10)
 #define MAX_UNWIND_ID 128
 
 struct MemoryMaterialization {
@@ -79,8 +85,16 @@ struct Options {
   uint64_t translated_frame_cfa;
   uint64_t translated_frame_return_address_slot;
   uint64_t translated_frame_return_address;
+  bool has_translated_frame_callee_rbx;
+  uint64_t translated_frame_callee_rbx;
   bool has_translated_frame_callee_r12;
   uint64_t translated_frame_callee_r12;
+  bool has_translated_frame_callee_r13;
+  uint64_t translated_frame_callee_r13;
+  bool has_translated_frame_callee_r14;
+  uint64_t translated_frame_callee_r14;
+  bool has_translated_frame_callee_r15;
+  uint64_t translated_frame_callee_r15;
   bool has_translated_frame_slot;
   uint64_t translated_frame_slot_offset;
   uint64_t translated_frame_slot_value;
@@ -110,7 +124,9 @@ static void usage(void) {
       "[--translated-return-address addr] [--translated-frame-pointer addr] "
       "[--translated-frame-cfa addr] [--translated-frame-return-address-slot addr] "
       "[--translated-frame-return-address addr] [--translated-frame-unwind-id id] "
-      "[--translated-frame-callee-r12 addr] [--translated-frame-slot offset:value:class] "
+      "[--translated-frame-callee-rbx addr] [--translated-frame-callee-r12 addr] "
+      "[--translated-frame-callee-r13 addr] [--translated-frame-callee-r14 addr] "
+      "[--translated-frame-callee-r15 addr] [--translated-frame-slot offset:value:class] "
       "[--resume-mode translated-frame] --timeout-seconds n "
       "[--synthetic-empty-pipe-read-fd n] [--synthetic-empty-pipe-write-fd n] "
       "[--synthetic-empty-eventfd n] "
@@ -317,12 +333,36 @@ static struct Options parse_args(int argc, char **argv) {
         usage();
       }
       copy_unwind_id(&opts, argv[i]);
+    } else if (streq(argv[i], "--translated-frame-callee-rbx")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.translated_frame_callee_rbx = parse_u64(argv[i], "translated-frame-callee-rbx");
+      opts.has_translated_frame_callee_rbx = true;
     } else if (streq(argv[i], "--translated-frame-callee-r12")) {
       if (++i >= argc) {
         usage();
       }
       opts.translated_frame_callee_r12 = parse_u64(argv[i], "translated-frame-callee-r12");
       opts.has_translated_frame_callee_r12 = true;
+    } else if (streq(argv[i], "--translated-frame-callee-r13")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.translated_frame_callee_r13 = parse_u64(argv[i], "translated-frame-callee-r13");
+      opts.has_translated_frame_callee_r13 = true;
+    } else if (streq(argv[i], "--translated-frame-callee-r14")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.translated_frame_callee_r14 = parse_u64(argv[i], "translated-frame-callee-r14");
+      opts.has_translated_frame_callee_r14 = true;
+    } else if (streq(argv[i], "--translated-frame-callee-r15")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.translated_frame_callee_r15 = parse_u64(argv[i], "translated-frame-callee-r15");
+      opts.has_translated_frame_callee_r15 = true;
     } else if (streq(argv[i], "--translated-frame-slot")) {
       if (++i >= argc) {
         usage();
@@ -433,6 +473,7 @@ static uint64_t mapped_code_page_start = 0;
 static uint64_t mapped_code_page_size = 0;
 static volatile uint64_t resume_return_value __attribute__((used)) = 0;
 static uint64_t host_rsp_before_jump __attribute__((used)) = 0;
+static uint64_t host_rbx_before_jump __attribute__((used)) = 0;
 static uint64_t host_rbp_before_jump __attribute__((used)) = 0;
 static uint64_t host_r12_before_jump __attribute__((used)) = 0;
 static uint64_t host_r13_before_jump __attribute__((used)) = 0;
@@ -443,7 +484,11 @@ static uint64_t jump_initial_rsp __attribute__((used)) = 0;
 static uint64_t jump_argument0 __attribute__((used)) = 0;
 static uint64_t jump_translated_return_address __attribute__((used)) = 0;
 static uint64_t jump_translated_frame_pointer __attribute__((used)) = 0;
+static uint64_t jump_translated_frame_rbx __attribute__((used)) = 0;
 static uint64_t jump_translated_frame_r12 __attribute__((used)) = 0;
+static uint64_t jump_translated_frame_r13 __attribute__((used)) = 0;
+static uint64_t jump_translated_frame_r14 __attribute__((used)) = 0;
+static uint64_t jump_translated_frame_r15 __attribute__((used)) = 0;
 
 struct ObservedRegisters {
   uint64_t rax;
@@ -699,7 +744,9 @@ static void validate_translated_frame_options(const struct Options *opts) {
     fprintf(stderr, "native-actual-resume-trampoline: translated frame return address is unresolved\n");
     exit(2);
   }
-  if (!opts->has_translated_frame_callee_r12 || !opts->has_translated_frame_slot) {
+  if (!opts->has_translated_frame_callee_rbx || !opts->has_translated_frame_callee_r12 ||
+      !opts->has_translated_frame_callee_r13 || !opts->has_translated_frame_callee_r14 ||
+      !opts->has_translated_frame_callee_r15 || !opts->has_translated_frame_slot) {
     fprintf(stderr, "native-actual-resume-trampoline: translated frame is incomplete\n");
     exit(2);
   }
@@ -822,15 +869,24 @@ static void jump_to_target(uint64_t entry,
     uint64_t argument0,
     uint64_t translated_return_address,
     uint64_t translated_frame_pointer,
-    uint64_t translated_frame_r12) {
+    uint64_t translated_frame_rbx,
+    uint64_t translated_frame_r12,
+    uint64_t translated_frame_r13,
+    uint64_t translated_frame_r14,
+    uint64_t translated_frame_r15) {
   jump_entry_address = entry;
   jump_initial_rsp = initial_rsp;
   jump_argument0 = argument0;
   jump_translated_return_address = translated_return_address;
   jump_translated_frame_pointer = translated_frame_pointer;
+  jump_translated_frame_rbx = translated_frame_rbx;
   jump_translated_frame_r12 = translated_frame_r12;
+  jump_translated_frame_r13 = translated_frame_r13;
+  jump_translated_frame_r14 = translated_frame_r14;
+  jump_translated_frame_r15 = translated_frame_r15;
   __asm__ __volatile__(
       "movq %%rsp, host_rsp_before_jump(%%rip)\n"
+      "movq %%rbx, host_rbx_before_jump(%%rip)\n"
       "movq %%rbp, host_rbp_before_jump(%%rip)\n"
       "movq %%r12, host_r12_before_jump(%%rip)\n"
       "movq %%r13, host_r13_before_jump(%%rip)\n"
@@ -848,7 +904,11 @@ static void jump_to_target(uint64_t entry,
       "movq %%rax, (%%rsp)\n"
       "3:\n"
       "movq jump_translated_frame_pointer(%%rip), %%rbp\n"
+      "movq jump_translated_frame_rbx(%%rip), %%rbx\n"
       "movq jump_translated_frame_r12(%%rip), %%r12\n"
+      "movq jump_translated_frame_r13(%%rip), %%r13\n"
+      "movq jump_translated_frame_r14(%%rip), %%r14\n"
+      "movq jump_translated_frame_r15(%%rip), %%r15\n"
       "xorl %%eax, %%eax\n"
       "movq jump_argument0(%%rip), %%rdi\n"
       "xorl %%esi, %%esi\n"
@@ -863,6 +923,7 @@ static void jump_to_target(uint64_t entry,
       "1:\n"
       "movq %%rax, resume_return_value(%%rip)\n"
       "movq host_rsp_before_jump(%%rip), %%rsp\n"
+      "movq host_rbx_before_jump(%%rip), %%rbx\n"
       "movq host_rbp_before_jump(%%rip), %%rbp\n"
       "movq host_r12_before_jump(%%rip), %%r12\n"
       "movq host_r13_before_jump(%%rip), %%r13\n"
@@ -1059,14 +1120,24 @@ static void print_resume_path(const struct Options *opts) {
       TRANSLATED_RESUME_MARKER);
 }
 
+static void print_callee_saved_status(const char *name, uint64_t value, uint64_t mask, uint64_t bit) {
+  printf("{\"register\":\"%s\",\"status\":\"%s\",\"value\":\"0x%" PRIx64 "\"}",
+      name,
+      (mask & bit) == bit ? "passed" : "failed",
+      value);
+}
+
 static void print_frame_restoration(const struct Options *opts) {
   if (!opts->has_translated_frame || !opts->has_state_report_address) {
     return;
   }
   uint64_t report_marker = read_state_report_u64(opts->state_report_address, 32);
+  uint64_t register_mask = read_state_report_u64(opts->state_report_address, 48);
   uint64_t slot_value = read_state_report_u64(
       opts->translated_frame_pointer, opts->translated_frame_slot_offset);
-  bool passed = report_marker == TRANSLATED_FRAME_MARKER && slot_value == opts->translated_frame_slot_value;
+  bool passed = report_marker == TRANSLATED_FRAME_MARKER &&
+      register_mask == TRANSLATED_FRAME_REGISTER_MASK &&
+      slot_value == opts->translated_frame_slot_value;
   printf(
       ",\"frameRestoration\":{\"status\":\"%s\","
       "\"framePointer\":\"0x%" PRIx64 "\","
@@ -1076,8 +1147,9 @@ static void print_frame_restoration(const struct Options *opts) {
       "\"unwindId\":\"%s\","
       "\"reportMarker\":\"0x%" PRIx64 "\","
       "\"expectedFrameMarker\":\"0x%" PRIx64 "\","
-      "\"calleeSaved\":[{\"register\":\"r12\",\"status\":\"passed\",\"value\":\"0x%" PRIx64 "\"}],"
-      "\"slots\":[{\"offset\":%" PRIu64 ",\"classification\":\"%s\",\"status\":\"%s\",\"value\":\"0x%" PRIx64 "\"}]}",
+      "\"calleeSavedMask\":\"0x%" PRIx64 "\","
+      "\"expectedCalleeSavedMask\":\"0x%" PRIx64 "\","
+      "\"calleeSaved\":[",
       passed ? "passed" : "failed",
       opts->translated_frame_pointer,
       opts->translated_frame_cfa,
@@ -1086,7 +1158,19 @@ static void print_frame_restoration(const struct Options *opts) {
       opts->translated_frame_unwind_id,
       report_marker,
       TRANSLATED_FRAME_MARKER,
-      opts->translated_frame_callee_r12,
+      register_mask,
+      TRANSLATED_FRAME_REGISTER_MASK);
+  print_callee_saved_status("rbx", opts->translated_frame_callee_rbx, register_mask, TRANSLATED_FRAME_REGISTER_RBX);
+  printf(",");
+  print_callee_saved_status("r12", opts->translated_frame_callee_r12, register_mask, TRANSLATED_FRAME_REGISTER_R12);
+  printf(",");
+  print_callee_saved_status("r13", opts->translated_frame_callee_r13, register_mask, TRANSLATED_FRAME_REGISTER_R13);
+  printf(",");
+  print_callee_saved_status("r14", opts->translated_frame_callee_r14, register_mask, TRANSLATED_FRAME_REGISTER_R14);
+  printf(",");
+  print_callee_saved_status("r15", opts->translated_frame_callee_r15, register_mask, TRANSLATED_FRAME_REGISTER_R15);
+  printf(
+      "],\"slots\":[{\"offset\":%" PRIu64 ",\"classification\":\"%s\",\"status\":\"%s\",\"value\":\"0x%" PRIx64 "\"}]}",
       opts->translated_frame_slot_offset,
       opts->translated_frame_slot_class,
       slot_value == opts->translated_frame_slot_value ? "passed" : "failed",
@@ -1152,7 +1236,11 @@ int main(int argc, char **argv) {
         opts.has_argument0 ? opts.argument0 : 0u,
         opts.has_translated_return_address ? opts.translated_return_address : 0u,
         opts.has_translated_frame ? opts.translated_frame_pointer : 0u,
-        opts.has_translated_frame_callee_r12 ? opts.translated_frame_callee_r12 : 0u);
+        opts.has_translated_frame_callee_rbx ? opts.translated_frame_callee_rbx : 0u,
+        opts.has_translated_frame_callee_r12 ? opts.translated_frame_callee_r12 : 0u,
+        opts.has_translated_frame_callee_r13 ? opts.translated_frame_callee_r13 : 0u,
+        opts.has_translated_frame_callee_r14 ? opts.translated_frame_callee_r14 : 0u,
+        opts.has_translated_frame_callee_r15 ? opts.translated_frame_callee_r15 : 0u);
     alarm(0);
     print_return_event(&opts);
   } else {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -58,7 +58,11 @@ struct Descriptor {
   uint64_t translated_frame_cfa;
   uint64_t translated_frame_return_address_slot;
   uint64_t translated_frame_return_address;
+  uint64_t translated_frame_callee_rbx;
   uint64_t translated_frame_callee_r12;
+  uint64_t translated_frame_callee_r13;
+  uint64_t translated_frame_callee_r14;
+  uint64_t translated_frame_callee_r15;
   bool has_translated_frame_slot;
   uint64_t translated_frame_slot_offset;
   uint64_t translated_frame_slot_value;
@@ -437,7 +441,17 @@ static void parse_memory(struct Descriptor *descriptor, char *line) {
 
 static const char *required_frame_token(char *scratch, size_t scratch_size, char *fields, const char *name) {
   snprintf(scratch, scratch_size, "%s", fields);
-  const char *value = find_token_value(scratch, name);
+  size_t name_length = strlen(name);
+  const char *value = NULL;
+  char *save = NULL;
+  for (char *token = strtok_r(scratch, " ", &save); token; token = strtok_r(NULL, " ", &save)) {
+    if (starts_with(token, name) && token[name_length] == '=') {
+      if (value != NULL) {
+        refuse("target-guest-loader-frame-unsupported", "duplicate translated frame field");
+      }
+      value = token + name_length + 1u;
+    }
+  }
   if (!value) {
     refuse("target-guest-loader-descriptor-invalid", "translated frame field is required");
   }
@@ -465,8 +479,16 @@ static void parse_translated_frame(struct Descriptor *descriptor, char *line) {
     refuse("target-guest-loader-frame-unsupported", "translated frame unwind identity is unsupported");
   }
   snprintf(descriptor->translated_frame_unwind_id, sizeof(descriptor->translated_frame_unwind_id), "%s", unwind_id);
+  descriptor->translated_frame_callee_rbx = parse_u64(
+      required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedRbx"), "calleeSavedRbx");
   descriptor->translated_frame_callee_r12 = parse_u64(
       required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR12"), "calleeSavedR12");
+  descriptor->translated_frame_callee_r13 = parse_u64(
+      required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR13"), "calleeSavedR13");
+  descriptor->translated_frame_callee_r14 = parse_u64(
+      required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR14"), "calleeSavedR14");
+  descriptor->translated_frame_callee_r15 = parse_u64(
+      required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR15"), "calleeSavedR15");
   descriptor->translated_frame_slot_offset = parse_u64(
       required_frame_token(scratch, sizeof(scratch), fields, "slot0Offset"), "slot0Offset");
   descriptor->translated_frame_slot_value = parse_u64(
@@ -624,7 +646,11 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char translated_frame_cfa[32];
   char translated_frame_return_address_slot[32];
   char translated_frame_return_address[32];
+  char translated_frame_callee_rbx[32];
   char translated_frame_callee_r12[32];
+  char translated_frame_callee_r13[32];
+  char translated_frame_callee_r14[32];
+  char translated_frame_callee_r15[32];
   char translated_frame_slot[128];
   char timeout_seconds[32];
   char stack_target_start[32];
@@ -645,7 +671,11 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(translated_frame_cfa, sizeof(translated_frame_cfa), "0x%" PRIx64, descriptor->translated_frame_cfa);
   snprintf(translated_frame_return_address_slot, sizeof(translated_frame_return_address_slot), "0x%" PRIx64, descriptor->translated_frame_return_address_slot);
   snprintf(translated_frame_return_address, sizeof(translated_frame_return_address), "0x%" PRIx64, descriptor->translated_frame_return_address);
+  snprintf(translated_frame_callee_rbx, sizeof(translated_frame_callee_rbx), "0x%" PRIx64, descriptor->translated_frame_callee_rbx);
   snprintf(translated_frame_callee_r12, sizeof(translated_frame_callee_r12), "0x%" PRIx64, descriptor->translated_frame_callee_r12);
+  snprintf(translated_frame_callee_r13, sizeof(translated_frame_callee_r13), "0x%" PRIx64, descriptor->translated_frame_callee_r13);
+  snprintf(translated_frame_callee_r14, sizeof(translated_frame_callee_r14), "0x%" PRIx64, descriptor->translated_frame_callee_r14);
+  snprintf(translated_frame_callee_r15, sizeof(translated_frame_callee_r15), "0x%" PRIx64, descriptor->translated_frame_callee_r15);
   snprintf(translated_frame_slot,
       sizeof(translated_frame_slot),
       "0x%" PRIx64 ":0x%" PRIx64 ":%s",
@@ -702,8 +732,16 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
     push_arg(child_argv, &child_argc, translated_frame_return_address);
     push_arg(child_argv, &child_argc, "--translated-frame-unwind-id");
     push_arg(child_argv, &child_argc, descriptor->translated_frame_unwind_id);
+    push_arg(child_argv, &child_argc, "--translated-frame-callee-rbx");
+    push_arg(child_argv, &child_argc, translated_frame_callee_rbx);
     push_arg(child_argv, &child_argc, "--translated-frame-callee-r12");
     push_arg(child_argv, &child_argc, translated_frame_callee_r12);
+    push_arg(child_argv, &child_argc, "--translated-frame-callee-r13");
+    push_arg(child_argv, &child_argc, translated_frame_callee_r13);
+    push_arg(child_argv, &child_argc, "--translated-frame-callee-r14");
+    push_arg(child_argv, &child_argc, translated_frame_callee_r14);
+    push_arg(child_argv, &child_argc, "--translated-frame-callee-r15");
+    push_arg(child_argv, &child_argc, translated_frame_callee_r15);
     push_arg(child_argv, &child_argc, "--translated-frame-slot");
     push_arg(child_argv, &child_argc, translated_frame_slot);
   }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -103,6 +103,7 @@
 - [`TargetGuestRestoreDescriptor`](#targetguestrestoredescriptor)
 - [`TargetGuestTranslatedFrameDescriptor`](#targetguesttranslatedframedescriptor)
 - [`TargetGuestTranslatedFrameRegister`](#targetguesttranslatedframeregister)
+- [`TargetGuestTranslatedFrameRegisterName`](#targetguesttranslatedframeregistername)
 - [`TargetGuestTranslatedFrameSlot`](#targetguesttranslatedframeslot)
 - [`TargetGuestMemoryMaterializationKind`](#targetguestmemorymaterializationkind)
 - [`TargetGuestMemoryMaterializationEntry`](#targetguestmemorymaterializationentry)
@@ -9354,7 +9355,7 @@ Poll interval in ms while retrying. Default 250.
 
 ##### register
 
-> **register**: `"r12"`
+> **register**: [`TargetGuestTranslatedFrameRegisterName`](#targetguesttranslatedframeregistername)
 
 ##### value
 
@@ -11963,6 +11964,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### TargetGuestRestoreResumeMode
 
 > **TargetGuestRestoreResumeMode** = `"translated-frame"`
+
+***
+
+### TargetGuestTranslatedFrameRegisterName
+
+> **TargetGuestTranslatedFrameRegisterName** = `"rbx"` \| `"r12"` \| `"r13"` \| `"r14"` \| `"r15"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -95,12 +95,14 @@ describe("native actual resume trampoline", () => {
       const stateEntry = Buffer.from([
         0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x08, 0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0,
         0, 0x48, 0x89, 0x47, 0x10, 0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x20, 0x48,
-        0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x28, 0xb8, 0x4d, 0, 0, 0, 0xc3,
+        0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x47, 0x28, 0x48, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0,
+        0x48, 0x89, 0x47, 0x30, 0xb8, 0x4d, 0, 0, 0, 0xc3,
       ]);
       stateEntry.writeBigUInt64LE(0x5354415445434f4en, 2);
       stateEntry.writeBigUInt64LE(0x7fn, 16);
       stateEntry.writeBigUInt64LE(0x4652414d45504153n, 30);
       stateEntry.writeBigUInt64LE(0x524553554d455041n, 44);
+      stateEntry.writeBigUInt64LE(0x1fn, 58);
       const returnLanding = Buffer.from([
         0x48, 0xba, 0, 0, 0, 0, 0, 0, 0, 0, 0x48, 0x89, 0x57, 0x18, 0xb8, 0x4d, 0, 0, 0, 0xc3,
       ]);
@@ -129,8 +131,16 @@ describe("native actual resume trampoline", () => {
           translatedReturnAddress,
           "--translated-frame-unwind-id",
           "target:realspin-final-jump",
+          "--translated-frame-callee-rbx",
+          "0x1111111122222222",
           "--translated-frame-callee-r12",
           "0x1234567890abcdef",
+          "--translated-frame-callee-r13",
+          "0x1313131313131313",
+          "--translated-frame-callee-r14",
+          "0x1414141414141414",
+          "--translated-frame-callee-r15",
+          "0x1515151515151515",
           "--translated-frame-slot",
           "0:0x4652414d45504153:non-pointer-data",
           "--materialize-memory",
@@ -148,6 +158,14 @@ describe("native actual resume trampoline", () => {
           status: "passed",
           framePointer: "0x52000000ff80",
           returnAddress: translatedReturnAddress,
+          calleeSavedMask: "0x1f",
+          calleeSaved: [
+            { register: "rbx", status: "passed", value: "0x1111111122222222" },
+            { register: "r12", status: "passed", value: "0x1234567890abcdef" },
+            { register: "r13", status: "passed", value: "0x1313131313131313" },
+            { register: "r14", status: "passed", value: "0x1414141414141414" },
+            { register: "r15", status: "passed", value: "0x1515151515151515" },
+          ],
         },
         resumePath: {
           status: "passed",

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -35,7 +35,13 @@ describe("portable machine VM restore proof", () => {
         returnAddressSlot: "0x50000000fff0",
         returnAddress: "0x700300000080",
         unwindId: "target:realspin-final-jump",
-        calleeSaved: [{ register: "r12", value: "0x1234567890abcdef" }],
+        calleeSaved: [
+          { register: "rbx", value: "0x1111111122222222" },
+          { register: "r12", value: "0x1234567890abcdef" },
+          { register: "r13", value: "0x1313131313131313" },
+          { register: "r14", value: "0x1414141414141414" },
+          { register: "r15", value: "0x1515151515151515" },
+        ],
         slots: [
           {
             offset: 0,

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -26,7 +26,13 @@ const translatedFrame = {
   returnAddressSlot: "0x50000000fff0",
   returnAddress: "0x700300000080",
   unwindId: "target:realspin-final-jump",
-  calleeSaved: [{ register: "r12" as const, value: "0x1234567890abcdef" }],
+  calleeSaved: [
+    { register: "rbx" as const, value: "0x1111111122222222" },
+    { register: "r12" as const, value: "0x1234567890abcdef" },
+    { register: "r13" as const, value: "0x1313131313131313" },
+    { register: "r14" as const, value: "0x1414141414141414" },
+    { register: "r15" as const, value: "0x1515151515151515" },
+  ],
   slots: [
     {
       offset: 0,
@@ -126,8 +132,16 @@ describe("target guest restore loader descriptor", () => {
       "0x700300000080",
       "--translated-frame-unwind-id",
       "target:realspin-final-jump",
+      "--translated-frame-callee-rbx",
+      "0x1111111122222222",
       "--translated-frame-callee-r12",
       "0x1234567890abcdef",
+      "--translated-frame-callee-r13",
+      "0x1313131313131313",
+      "--translated-frame-callee-r14",
+      "0x1414141414141414",
+      "--translated-frame-callee-r15",
+      "0x1515151515151515",
       "--translated-frame-slot",
       "0:0x4652414d45504153:non-pointer-data",
       "--set-cloexec-fd",
@@ -268,6 +282,50 @@ describe("target guest restore loader descriptor", () => {
           },
           translatedFrame: {
             ...translatedFrame,
+            calleeSaved: translatedFrame.calleeSaved.slice(1),
+          },
+        }),
+      ),
+    ).toThrow(/register bank is incomplete/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            translatedReturnAddress: "0x700300000080",
+          },
+          translatedFrame: {
+            ...translatedFrame,
+            calleeSaved: [translatedFrame.calleeSaved[0]!, translatedFrame.calleeSaved[0]!],
+          },
+        }),
+      ),
+    ).toThrow(/duplicate translated frame register/);
+
+    expect(() =>
+      parseTargetGuestRestoreDescriptor(
+        serializeTargetGuestRestoreDescriptor(
+          descriptor({
+            continuation: {
+              ...descriptor().continuation,
+              translatedReturnAddress: "0x700300000080",
+            },
+            translatedFrame,
+          }),
+        ).replace(" slot0Offset=", " calleeSavedR12=0x1 slot0Offset="),
+      ),
+    ).toThrow(/duplicate translated frame field/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            translatedReturnAddress: "0x700300000080",
+          },
+          translatedFrame: {
+            ...translatedFrame,
             slots: [{ ...translatedFrame.slots[0]!, classification: "pointer" as never }],
           },
         }),
@@ -328,7 +386,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_resume_mode = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_resume_mode) return 47;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_mode = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_mode) return 48;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -444,6 +444,7 @@ export type {
   TargetGuestRestoreResumeMode,
   TargetGuestTranslatedFrameDescriptor,
   TargetGuestTranslatedFrameRegister,
+  TargetGuestTranslatedFrameRegisterName,
   TargetGuestTranslatedFrameSlot,
 } from "./target-guest-restore-loader.ts";
 export type {

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -64,8 +64,10 @@ export interface TargetGuestTranslatedFrameDescriptor {
   slots: TargetGuestTranslatedFrameSlot[];
 }
 
+export type TargetGuestTranslatedFrameRegisterName = "rbx" | "r12" | "r13" | "r14" | "r15";
+
 export interface TargetGuestTranslatedFrameRegister {
-  register: "r12";
+  register: TargetGuestTranslatedFrameRegisterName;
   value: string;
 }
 
@@ -233,7 +235,7 @@ function fieldsToDescriptor(
 function parseTranslatedFrame(line: string): TargetGuestTranslatedFrameDescriptor {
   const [head, ...fields] = line.split(/\s+/);
   const kind = head!.slice("frame=".length);
-  const values = new Map(fields.map(splitField));
+  const values = translatedFrameFieldMap(fields);
   if (kind !== "single-target-caller-frame") {
     fail("target-guest-loader-frame-unsupported", `unsupported translated frame: ${kind}`);
   }
@@ -249,9 +251,33 @@ function parseTranslatedFrame(line: string): TargetGuestTranslatedFrameDescripto
   };
 }
 
+const TARGET_FRAME_CALLEE_SAVED_REGISTERS = ["rbx", "r12", "r13", "r14", "r15"] as const;
+
+const TARGET_FRAME_REGISTER_FIELDS: Record<TargetGuestTranslatedFrameRegisterName, string> = {
+  rbx: "calleeSavedRbx",
+  r12: "calleeSavedR12",
+  r13: "calleeSavedR13",
+  r14: "calleeSavedR14",
+  r15: "calleeSavedR15",
+};
+
+function translatedFrameFieldMap(fields: string[]): Map<string, string> {
+  const values = new Map<string, string>();
+  for (const field of fields) {
+    const [key, value] = splitField(field);
+    if (values.has(key)) {
+      fail("target-guest-loader-frame-unsupported", "duplicate translated frame field");
+    }
+    values.set(key, value);
+  }
+  return values;
+}
+
 function parseFrameRegisters(fields: Map<string, string>): TargetGuestTranslatedFrameRegister[] {
-  const value = fields.get("calleeSavedR12");
-  return value === undefined ? [] : [{ register: "r12", value }];
+  return TARGET_FRAME_CALLEE_SAVED_REGISTERS.flatMap((register) => {
+    const value = fields.get(TARGET_FRAME_REGISTER_FIELDS[register]);
+    return value === undefined ? [] : [{ register, value }];
+  });
 }
 
 function parseFrameSlots(fields: Map<string, string>): TargetGuestTranslatedFrameSlot[] {
@@ -647,15 +673,28 @@ function assertFrameShape(
 }
 
 function validateFrameRegisters(registers: TargetGuestTranslatedFrameRegister[]): void {
-  if (registers.length > 1) {
-    fail("target-guest-loader-frame-unsupported", "too many translated frame registers");
-  }
+  const values = new Map<TargetGuestTranslatedFrameRegisterName, string>();
   for (const register of registers) {
-    if (register.register !== "r12") {
+    if (!isTargetFrameCalleeSavedRegister(register.register)) {
       fail("target-guest-loader-frame-unsupported", "translated frame register is unsupported");
     }
+    if (values.has(register.register)) {
+      fail("target-guest-loader-frame-unsupported", "duplicate translated frame register");
+    }
     assertHexAddress(register.value, register.register);
+    values.set(register.register, register.value);
   }
+  if (values.size !== TARGET_FRAME_CALLEE_SAVED_REGISTERS.length) {
+    fail("target-guest-loader-frame-unsupported", "translated frame register bank is incomplete");
+  }
+}
+
+function isTargetFrameCalleeSavedRegister(
+  register: string,
+): register is TargetGuestTranslatedFrameRegisterName {
+  return TARGET_FRAME_CALLEE_SAVED_REGISTERS.includes(
+    register as TargetGuestTranslatedFrameRegisterName,
+  );
 }
 
 function validateFrameSlots(slots: TargetGuestTranslatedFrameSlot[]): void {
@@ -730,7 +769,7 @@ function optionalTranslatedFrameField(
 }
 
 function serializeTranslatedFrame(frame: TargetGuestTranslatedFrameDescriptor): string {
-  const r12 = frame.calleeSaved.find((register) => register.register === "r12");
+  const registers = frameRegisterMap(frame.calleeSaved);
   const slot = frame.slots[0];
   return [
     `frame=${frame.kind}`,
@@ -739,11 +778,19 @@ function serializeTranslatedFrame(frame: TargetGuestTranslatedFrameDescriptor): 
     `returnAddressSlot=${frame.returnAddressSlot}`,
     `returnAddress=${frame.returnAddress}`,
     `unwindId=${frame.unwindId}`,
-    ...optionalFrameToken("calleeSavedR12", r12?.value),
+    ...TARGET_FRAME_CALLEE_SAVED_REGISTERS.flatMap((register) =>
+      optionalFrameToken(TARGET_FRAME_REGISTER_FIELDS[register], registers.get(register)),
+    ),
     ...optionalFrameToken("slot0Offset", slot?.offset),
     ...optionalFrameToken("slot0Value", slot?.value),
     ...optionalFrameToken("slot0Class", slot?.classification),
   ].join(" ");
+}
+
+function frameRegisterMap(
+  registers: TargetGuestTranslatedFrameRegister[],
+): Map<TargetGuestTranslatedFrameRegisterName, string> {
+  return new Map(registers.map((register) => [register.register, register.value]));
 }
 
 function optionalFrameToken(name: string, value: string | number | undefined): string[] {
@@ -823,7 +870,7 @@ function translatedFrameToTrampolineArgs(
   if (frame === undefined) {
     return [];
   }
-  const r12 = frame.calleeSaved.find((register) => register.register === "r12");
+  const registers = frameRegisterMap(frame.calleeSaved);
   const slot = frame.slots[0];
   return [
     "--translated-frame-pointer",
@@ -836,7 +883,9 @@ function translatedFrameToTrampolineArgs(
     frame.returnAddress,
     "--translated-frame-unwind-id",
     frame.unwindId,
-    ...optionalArg("--translated-frame-callee-r12", r12?.value),
+    ...TARGET_FRAME_CALLEE_SAVED_REGISTERS.flatMap((register) =>
+      optionalArg(`--translated-frame-callee-${register}`, registers.get(register)),
+    ),
     ...optionalArg("--translated-frame-slot", slot ? frameSlotSpec(slot) : undefined),
   ];
 }

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -125,6 +125,7 @@ const TOC = {
     "TargetGuestRestoreDescriptor",
     "TargetGuestTranslatedFrameDescriptor",
     "TargetGuestTranslatedFrameRegister",
+    "TargetGuestTranslatedFrameRegisterName",
     "TargetGuestTranslatedFrameSlot",
     "TargetGuestMemoryMaterializationKind",
     "TargetGuestMemoryMaterializationEntry",

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -111,8 +111,18 @@ const TRANSLATED_FRAME_POINTER = "0x50000000ff80";
 const TRANSLATED_FRAME_CFA = "0x50000000fff0";
 const TRANSLATED_FRAME_RETURN_ADDRESS_SLOT = "0x50000000fff0";
 const TRANSLATED_FRAME_SLOT_OFFSET = 0;
+const TRANSLATED_FRAME_RBX = "0x1111111122222222";
 const TRANSLATED_FRAME_R12 = "0x1234567890abcdef";
+const TRANSLATED_FRAME_R13 = "0x1313131313131313";
+const TRANSLATED_FRAME_R14 = "0x1414141414141414";
+const TRANSLATED_FRAME_R15 = "0x1515151515151515";
 const TRANSLATED_FRAME_UNWIND_ID = "target:realspin-final-jump";
+const TRANSLATED_FRAME_REGISTER_MASK_OFFSET = 48;
+const TRANSLATED_FRAME_REGISTER_MASK_RBX = 0x01;
+const TRANSLATED_FRAME_REGISTER_MASK_R12 = 0x02;
+const TRANSLATED_FRAME_REGISTER_MASK_R13 = 0x04;
+const TRANSLATED_FRAME_REGISTER_MASK_R14 = 0x08;
+const TRANSLATED_FRAME_REGISTER_MASK_R15 = 0x10;
 
 function usage(): never {
   console.error(
@@ -487,7 +497,13 @@ function translatedFrameDescriptor(returnAddress: string): TargetGuestTranslated
     returnAddressSlot: TRANSLATED_FRAME_RETURN_ADDRESS_SLOT,
     returnAddress,
     unwindId: TRANSLATED_FRAME_UNWIND_ID,
-    calleeSaved: [{ register: "r12", value: TRANSLATED_FRAME_R12 }],
+    calleeSaved: [
+      { register: "rbx", value: TRANSLATED_FRAME_RBX },
+      { register: "r12", value: TRANSLATED_FRAME_R12 },
+      { register: "r13", value: TRANSLATED_FRAME_R13 },
+      { register: "r14", value: TRANSLATED_FRAME_R14 },
+      { register: "r15", value: TRANSLATED_FRAME_R15 },
+    ],
     slots: [
       {
         offset: TRANSLATED_FRAME_SLOT_OFFSET,
@@ -704,6 +720,7 @@ function proofStateVerifierTargetCode(
   const asm = new Amd64ProofAssembler();
   if (completion === "return") {
     asm.preserveRbx();
+    asm.checkTranslatedRbx();
     asm.movRbxFromRdi();
     asm.storeReportWord(16, 0n);
     asm.checkTranslatedFrame();
@@ -738,6 +755,10 @@ class Amd64ProofAssembler {
     this.push(0x53);
   }
 
+  checkTranslatedRbx(): void {
+    this.checkRbxImmediate(BigInt(TRANSLATED_FRAME_RBX));
+  }
+
   movRbxFromRdi(): void {
     this.push(0x48, 0x89, 0xfb);
   }
@@ -754,12 +775,25 @@ class Amd64ProofAssembler {
 
   checkTranslatedFrame(): void {
     this.checkRbpImmediate(BigInt(TRANSLATED_FRAME_POINTER));
+    this.storeReportWord(TRANSLATED_FRAME_REGISTER_MASK_OFFSET, 0n);
+    this.markTranslatedRegister(TRANSLATED_FRAME_REGISTER_MASK_RBX);
     this.checkR12Immediate(BigInt(TRANSLATED_FRAME_R12));
+    this.markTranslatedRegister(TRANSLATED_FRAME_REGISTER_MASK_R12);
+    this.checkR13Immediate(BigInt(TRANSLATED_FRAME_R13));
+    this.markTranslatedRegister(TRANSLATED_FRAME_REGISTER_MASK_R13);
+    this.checkR14Immediate(BigInt(TRANSLATED_FRAME_R14));
+    this.markTranslatedRegister(TRANSLATED_FRAME_REGISTER_MASK_R14);
+    this.checkR15Immediate(BigInt(TRANSLATED_FRAME_R15));
+    this.markTranslatedRegister(TRANSLATED_FRAME_REGISTER_MASK_R15);
     this.checkAbsoluteU64(
       BigInt(TRANSLATED_FRAME_POINTER) + BigInt(TRANSLATED_FRAME_SLOT_OFFSET),
       TRANSLATED_FRAME_MARKER,
     );
     this.storeReportWord(32, TRANSLATED_FRAME_MARKER);
+  }
+
+  markTranslatedRegister(bit: number): void {
+    this.push(0x48, 0x83, 0x4b, TRANSLATED_FRAME_REGISTER_MASK_OFFSET, bit);
   }
 
   checkTranslatedResumePath(): void {
@@ -838,9 +872,33 @@ class Amd64ProofAssembler {
     this.jumpIfNotEqual();
   }
 
+  private checkRbxImmediate(expected: bigint): void {
+    this.movRaxImmediate(expected);
+    this.push(0x48, 0x39, 0xc3);
+    this.jumpIfNotEqual();
+  }
+
   private checkR12Immediate(expected: bigint): void {
     this.movRaxImmediate(expected);
     this.push(0x49, 0x39, 0xc4);
+    this.jumpIfNotEqual();
+  }
+
+  private checkR13Immediate(expected: bigint): void {
+    this.movRaxImmediate(expected);
+    this.push(0x49, 0x39, 0xc5);
+    this.jumpIfNotEqual();
+  }
+
+  private checkR14Immediate(expected: bigint): void {
+    this.movRaxImmediate(expected);
+    this.push(0x49, 0x39, 0xc6);
+    this.jumpIfNotEqual();
+  }
+
+  private checkR15Immediate(expected: bigint): void {
+    this.movRaxImmediate(expected);
+    this.push(0x49, 0x39, 0xc7);
     this.jumpIfNotEqual();
   }
 


### PR DESCRIPTION
## Problem

The restore proof could rebuild a target caller frame, but it only carried one callee-saved register. Real native code depends on the whole callee-saved register bank. If we only prove `r12`, we can miss bad restores for `rbx`, `r13`, `r14`, or `r15`.

## Solution

This PR expands the translated frame descriptor to include `rbx`, `r12`, `r13`, `r14`, and `r15`. The loader forwards the whole bank to the native trampoline. The trampoline seeds those registers before the jump, and the target-native continuation checks them before it reports frame success.

Fixes #615

## Validation

- `pnpm run format:check` — 0.511s
- `pnpm run lint` — 0.210s
- `pnpm run typecheck` — 2.180s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.870s
- `pnpm smoke-tests` — 2m11.284s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.357s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m17s, 2 passed / 2 total
- remote arm64→amd64 e2e — 36.669s wall, target VM boot/restore 19.285s, `targetFrameRestoreResult=passed`, `targetResumePathResult=passed`
