### PR TITLE
Materialize translated stack slot vector

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -59,7 +59,8 @@ for this proof; multi-thread, futex, signal-delivery, ptrace/debug,
 shared-stack, unknown-TLS, and ambiguous register states refuse before the target
 VM is entered. The descriptor uses `resumeMode=translated-frame`, so the success
 path records a target-native resume-path marker after the real continuation
-observes the translated frame, stack, and amd64 callee-saved register bank.
+observes the translated frame, stack-slot vector, and amd64 callee-saved
+register bank.
 
 ## Smoke profile
 

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -23,7 +23,7 @@ timeoutSeconds=5
 stackTargetStart=0x500000000000
 stackSize=65536
 stackPointer=0x500000010000
-frame=single-target-caller-frame framePointer=0x50000000ff80 canonicalFrameAddress=0x50000000fff0 returnAddressSlot=0x50000000fff0 returnAddress=0x700300000080 unwindId=target:realspin-final-jump calleeSavedRbx=0x1111111122222222 calleeSavedR12=0x1234567890abcdef calleeSavedR13=0x1313131313131313 calleeSavedR14=0x1414141414141414 calleeSavedR15=0x1515151515151515 slot0Offset=0 slot0Value=0x4652414d45504153 slot0Class=non-pointer-data
+frame=single-target-caller-frame framePointer=0x50000000ff80 canonicalFrameAddress=0x50000000fff0 returnAddressSlot=0x50000000fff0 returnAddress=0x700300000080 unwindId=target:realspin-final-jump calleeSavedRbx=0x1111111122222222 calleeSavedR12=0x1234567890abcdef calleeSavedR13=0x1313131313131313 calleeSavedR14=0x1414141414141414 calleeSavedR15=0x1515151515151515 slot0Offset=0 slot0Value=0x4652414d45504153 slot0Class=non-pointer-data slot1Offset=8 slot1Value=0x535441434b534c54 slot1Class=non-pointer-data
 resource=close-fd fd=0 reason=missing-captured-fd
 resource=inherit-stdio fd=1 stream=stdout closeOnExec=false
 resource=reopen-file fd=7 path=/tmp/data.txt offset=9 access=0 closeOnExec=true
@@ -47,8 +47,8 @@ Supported fd-table resources and memory materialization are intentionally narrow
 - `recreate-guard` for guard / `PROT_NONE` ranges;
 - `frame=single-target-caller-frame` for the current modeled translated caller
   frame: one return slot, the amd64 callee-saved register bank (`rbx`, `r12`,
-  `r13`, `r14`, `r15`), one non-pointer data stack slot, and a target unwind
-  identity.
+  `r13`, `r14`, `r15`), a bounded dense vector of non-pointer data stack
+  slots, and a target unwind identity.
 
 The runtime fd-table planner emits these resource lines from translated native
 resources. The in-guest loader validates duplicate fd ownership before launching
@@ -84,8 +84,8 @@ before the host return slot, so the continuation can return through
 target-native landing code before control comes back to the trampoline. The
 translated frame lets the trampoline materialize a small target stack frame,
 seed `rbp` plus the modeled callee-saved register bank, and require the target
-code to validate that modeled frame state. Translated resume mode additionally
-requires the target code to write a
+code to validate that modeled frame/register/slot state. Translated resume mode
+additionally requires the target code to write a
 resume-path marker after observing the modeled frame/stack state. Completion is
 credited only when the descriptor gate succeeds and the target-native
 continuation returns/exits in the guest with the expected modeled result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -34,6 +34,7 @@
 
 #define MAX_MATERIALIZED_MAPPINGS 32
 #define MAX_CLOEXEC_FDS 64
+#define MAX_TRANSLATED_FRAME_SLOTS 8
 #define STATE_CONSUMPTION_MARKER UINT64_C(0x5354415445434f4e)
 #define STATE_CONSUMPTION_MASK UINT64_C(0x7f)
 #define STATE_CHECK_MEMORY UINT64_C(0x01)
@@ -95,10 +96,10 @@ struct Options {
   uint64_t translated_frame_callee_r14;
   bool has_translated_frame_callee_r15;
   uint64_t translated_frame_callee_r15;
-  bool has_translated_frame_slot;
-  uint64_t translated_frame_slot_offset;
-  uint64_t translated_frame_slot_value;
-  char translated_frame_slot_class[32];
+  size_t translated_frame_slot_count;
+  uint64_t translated_frame_slot_offsets[MAX_TRANSLATED_FRAME_SLOTS];
+  uint64_t translated_frame_slot_values[MAX_TRANSLATED_FRAME_SLOTS];
+  char translated_frame_slot_classes[MAX_TRANSLATED_FRAME_SLOTS][32];
   char translated_frame_unwind_id[MAX_UNWIND_ID];
   uint64_t stack_target_start;
   uint64_t stack_size;
@@ -228,21 +229,25 @@ static void copy_unwind_id(struct Options *opts, const char *value) {
 }
 
 static void add_translated_frame_slot(struct Options *opts, const char *spec) {
+  if (opts->translated_frame_slot_count >= MAX_TRANSLATED_FRAME_SLOTS) {
+    fprintf(stderr, "native-actual-resume-trampoline: too many translated frame slots\n");
+    exit(2);
+  }
   char *copy = strdup(spec);
   if (!copy) {
     fprintf(stderr, "native-actual-resume-trampoline: frame slot allocation failed\n");
     exit(1);
   }
   char *cursor = copy;
-  opts->translated_frame_slot_offset = parse_u64(next_spec_field(&cursor, "frame slot offset"), "frame slot offset");
-  opts->translated_frame_slot_value = parse_u64(next_spec_field(&cursor, "frame slot value"), "frame slot value");
+  size_t index = opts->translated_frame_slot_count++;
+  opts->translated_frame_slot_offsets[index] = parse_u64(next_spec_field(&cursor, "frame slot offset"), "frame slot offset");
+  opts->translated_frame_slot_values[index] = parse_u64(next_spec_field(&cursor, "frame slot value"), "frame slot value");
   const char *slot_class = next_spec_field(&cursor, "frame slot class");
   if (!streq(slot_class, "non-pointer-data")) {
     fprintf(stderr, "native-actual-resume-trampoline: frame slot class is unsupported\n");
     exit(2);
   }
-  snprintf(opts->translated_frame_slot_class, sizeof(opts->translated_frame_slot_class), "%s", slot_class);
-  opts->has_translated_frame_slot = true;
+  snprintf(opts->translated_frame_slot_classes[index], sizeof(opts->translated_frame_slot_classes[0]), "%s", slot_class);
 }
 
 static void add_materialized_guard(struct Options *opts, const char *spec) {
@@ -746,7 +751,7 @@ static void validate_translated_frame_options(const struct Options *opts) {
   }
   if (!opts->has_translated_frame_callee_rbx || !opts->has_translated_frame_callee_r12 ||
       !opts->has_translated_frame_callee_r13 || !opts->has_translated_frame_callee_r14 ||
-      !opts->has_translated_frame_callee_r15 || !opts->has_translated_frame_slot) {
+      !opts->has_translated_frame_callee_r15 || opts->translated_frame_slot_count == 0) {
     fprintf(stderr, "native-actual-resume-trampoline: translated frame is incomplete\n");
     exit(2);
   }
@@ -757,10 +762,15 @@ static void validate_translated_frame_options(const struct Options *opts) {
   }
   if (!address_inside_stack(opts, opts->translated_frame_pointer, 8u) ||
       !address_inside_stack(opts, opts->translated_frame_cfa, 8u) ||
-      !address_inside_stack(opts, opts->translated_frame_return_address_slot, 8u) ||
-      !address_inside_stack(opts, opts->translated_frame_pointer + opts->translated_frame_slot_offset, 8u)) {
+      !address_inside_stack(opts, opts->translated_frame_return_address_slot, 8u)) {
     fprintf(stderr, "native-actual-resume-trampoline: translated frame addresses are outside target stack\n");
     exit(2);
+  }
+  for (size_t i = 0; i < opts->translated_frame_slot_count; i++) {
+    if (!address_inside_stack(opts, opts->translated_frame_pointer + opts->translated_frame_slot_offsets[i], 8u)) {
+      fprintf(stderr, "native-actual-resume-trampoline: translated frame slot is outside target stack\n");
+      exit(2);
+    }
   }
 }
 
@@ -860,8 +870,10 @@ static void materialize_translated_frame(const struct Options *opts) {
   if (!opts->has_translated_frame) {
     return;
   }
-  write_stack_u64(opts->translated_frame_pointer + opts->translated_frame_slot_offset,
-      opts->translated_frame_slot_value);
+  for (size_t i = 0; i < opts->translated_frame_slot_count; i++) {
+    write_stack_u64(opts->translated_frame_pointer + opts->translated_frame_slot_offsets[i],
+        opts->translated_frame_slot_values[i]);
+  }
 }
 
 static void jump_to_target(uint64_t entry,
@@ -1127,17 +1139,40 @@ static void print_callee_saved_status(const char *name, uint64_t value, uint64_t
       value);
 }
 
+static bool translated_frame_slots_passed(const struct Options *opts) {
+  for (size_t i = 0; i < opts->translated_frame_slot_count; i++) {
+    uint64_t slot_value = read_state_report_u64(
+        opts->translated_frame_pointer, opts->translated_frame_slot_offsets[i]);
+    if (slot_value != opts->translated_frame_slot_values[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void print_frame_slots(const struct Options *opts) {
+  for (size_t i = 0; i < opts->translated_frame_slot_count; i++) {
+    uint64_t slot_value = read_state_report_u64(
+        opts->translated_frame_pointer, opts->translated_frame_slot_offsets[i]);
+    if (i > 0) {
+      printf(",");
+    }
+    printf("{\"offset\":%" PRIu64 ",\"classification\":\"%s\",\"status\":\"%s\",\"value\":\"0x%" PRIx64 "\"}",
+        opts->translated_frame_slot_offsets[i],
+        opts->translated_frame_slot_classes[i],
+        slot_value == opts->translated_frame_slot_values[i] ? "passed" : "failed",
+        slot_value);
+  }
+}
+
 static void print_frame_restoration(const struct Options *opts) {
   if (!opts->has_translated_frame || !opts->has_state_report_address) {
     return;
   }
   uint64_t report_marker = read_state_report_u64(opts->state_report_address, 32);
   uint64_t register_mask = read_state_report_u64(opts->state_report_address, 48);
-  uint64_t slot_value = read_state_report_u64(
-      opts->translated_frame_pointer, opts->translated_frame_slot_offset);
   bool passed = report_marker == TRANSLATED_FRAME_MARKER &&
-      register_mask == TRANSLATED_FRAME_REGISTER_MASK &&
-      slot_value == opts->translated_frame_slot_value;
+      register_mask == TRANSLATED_FRAME_REGISTER_MASK && translated_frame_slots_passed(opts);
   printf(
       ",\"frameRestoration\":{\"status\":\"%s\","
       "\"framePointer\":\"0x%" PRIx64 "\","
@@ -1169,12 +1204,9 @@ static void print_frame_restoration(const struct Options *opts) {
   print_callee_saved_status("r14", opts->translated_frame_callee_r14, register_mask, TRANSLATED_FRAME_REGISTER_R14);
   printf(",");
   print_callee_saved_status("r15", opts->translated_frame_callee_r15, register_mask, TRANSLATED_FRAME_REGISTER_R15);
-  printf(
-      "],\"slots\":[{\"offset\":%" PRIu64 ",\"classification\":\"%s\",\"status\":\"%s\",\"value\":\"0x%" PRIx64 "\"}]}",
-      opts->translated_frame_slot_offset,
-      opts->translated_frame_slot_class,
-      slot_value == opts->translated_frame_slot_value ? "passed" : "failed",
-      slot_value);
+  printf("],\"slots\":[");
+  print_frame_slots(opts);
+  printf("]}");
 }
 
 static void print_return_event(const struct Options *opts) {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -24,6 +24,7 @@
 #define MAX_MATERIALIZED_MAPPINGS 32
 #define MAX_FD_RECIPES 64
 #define MAX_UNWIND_ID 128
+#define MAX_TRANSLATED_FRAME_SLOTS 8
 
 struct Options {
   const char *descriptor_path;
@@ -63,10 +64,10 @@ struct Descriptor {
   uint64_t translated_frame_callee_r13;
   uint64_t translated_frame_callee_r14;
   uint64_t translated_frame_callee_r15;
-  bool has_translated_frame_slot;
-  uint64_t translated_frame_slot_offset;
-  uint64_t translated_frame_slot_value;
-  char translated_frame_slot_class[32];
+  size_t translated_frame_slot_count;
+  uint64_t translated_frame_slot_offsets[MAX_TRANSLATED_FRAME_SLOTS];
+  uint64_t translated_frame_slot_values[MAX_TRANSLATED_FRAME_SLOTS];
+  char translated_frame_slot_classes[MAX_TRANSLATED_FRAME_SLOTS][32];
   char translated_frame_unwind_id[MAX_UNWIND_ID];
   uint64_t timeout_seconds;
   uint64_t stack_target_start;
@@ -439,7 +440,7 @@ static void parse_memory(struct Descriptor *descriptor, char *line) {
   }
 }
 
-static const char *required_frame_token(char *scratch, size_t scratch_size, char *fields, const char *name) {
+static const char *optional_frame_token(char *scratch, size_t scratch_size, char *fields, const char *name) {
   snprintf(scratch, scratch_size, "%s", fields);
   size_t name_length = strlen(name);
   const char *value = NULL;
@@ -452,10 +453,77 @@ static const char *required_frame_token(char *scratch, size_t scratch_size, char
       value = token + name_length + 1u;
     }
   }
+  return value;
+}
+
+static const char *required_frame_token(char *scratch, size_t scratch_size, char *fields, const char *name) {
+  const char *value = optional_frame_token(scratch, scratch_size, fields, name);
   if (!value) {
     refuse("target-guest-loader-descriptor-invalid", "translated frame field is required");
   }
   return value;
+}
+
+static void reject_unsupported_frame_slot_indexes(char *fields) {
+  char scratch[4096];
+  snprintf(scratch, sizeof(scratch), "%s", fields);
+  char *save = NULL;
+  for (char *token = strtok_r(scratch, " ", &save); token; token = strtok_r(NULL, " ", &save)) {
+    if (!starts_with(token, "slot")) {
+      continue;
+    }
+    char *end = NULL;
+    uint64_t index = strtoull(token + strlen("slot"), &end, 10);
+    if (end == token + strlen("slot")) {
+      continue;
+    }
+    if (!(starts_with(end, "Offset=") || starts_with(end, "Value=") || starts_with(end, "Class="))) {
+      refuse("target-guest-loader-frame-unsupported", "translated frame slot field is unsupported");
+    }
+    if (index >= MAX_TRANSLATED_FRAME_SLOTS) {
+      refuse("target-guest-loader-frame-unsupported", "too many translated frame slots");
+    }
+  }
+}
+
+static void parse_frame_slots(struct Descriptor *descriptor, char *fields) {
+  reject_unsupported_frame_slot_indexes(fields);
+  bool saw_gap = false;
+  for (size_t index = 0; index < MAX_TRANSLATED_FRAME_SLOTS; index++) {
+    char offset_name[32];
+    char value_name[32];
+    char class_name[32];
+    snprintf(offset_name, sizeof(offset_name), "slot%zuOffset", index);
+    snprintf(value_name, sizeof(value_name), "slot%zuValue", index);
+    snprintf(class_name, sizeof(class_name), "slot%zuClass", index);
+    char scratch[4096];
+    const char *offset = optional_frame_token(scratch, sizeof(scratch), fields, offset_name);
+    const char *value = optional_frame_token(scratch, sizeof(scratch), fields, value_name);
+    const char *slot_class = optional_frame_token(scratch, sizeof(scratch), fields, class_name);
+    if (!offset && !value && !slot_class) {
+      saw_gap = true;
+      continue;
+    }
+    if (saw_gap) {
+      refuse("target-guest-loader-frame-unsupported", "translated frame slots must be dense");
+    }
+    if (!offset || !value || !slot_class) {
+      refuse("target-guest-loader-descriptor-invalid", "translated frame slot field is required");
+    }
+    if (!streq(slot_class, "non-pointer-data")) {
+      refuse("target-guest-loader-frame-unsupported", "pointer-bearing frame slots are unsupported");
+    }
+    descriptor->translated_frame_slot_offsets[descriptor->translated_frame_slot_count] = parse_u64(offset, offset_name);
+    descriptor->translated_frame_slot_values[descriptor->translated_frame_slot_count] = parse_u64(value, value_name);
+    snprintf(descriptor->translated_frame_slot_classes[descriptor->translated_frame_slot_count],
+        sizeof(descriptor->translated_frame_slot_classes[0]),
+        "%s",
+        slot_class);
+    descriptor->translated_frame_slot_count++;
+  }
+  if (descriptor->translated_frame_slot_count == 0) {
+    refuse("target-guest-loader-frame-unsupported", "translated frame slots are incomplete");
+  }
 }
 
 static void parse_translated_frame(struct Descriptor *descriptor, char *line) {
@@ -489,16 +557,7 @@ static void parse_translated_frame(struct Descriptor *descriptor, char *line) {
       required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR14"), "calleeSavedR14");
   descriptor->translated_frame_callee_r15 = parse_u64(
       required_frame_token(scratch, sizeof(scratch), fields, "calleeSavedR15"), "calleeSavedR15");
-  descriptor->translated_frame_slot_offset = parse_u64(
-      required_frame_token(scratch, sizeof(scratch), fields, "slot0Offset"), "slot0Offset");
-  descriptor->translated_frame_slot_value = parse_u64(
-      required_frame_token(scratch, sizeof(scratch), fields, "slot0Value"), "slot0Value");
-  const char *slot_class = required_frame_token(scratch, sizeof(scratch), fields, "slot0Class");
-  if (!streq(slot_class, "non-pointer-data")) {
-    refuse("target-guest-loader-frame-unsupported", "pointer-bearing frame slots are unsupported");
-  }
-  snprintf(descriptor->translated_frame_slot_class, sizeof(descriptor->translated_frame_slot_class), "%s", slot_class);
-  descriptor->has_translated_frame_slot = true;
+  parse_frame_slots(descriptor, fields);
 }
 
 static void parse_resource(struct Descriptor *descriptor, char *line) {
@@ -572,7 +631,7 @@ static void validate_descriptor(const struct Descriptor *descriptor) {
     refuse("target-guest-loader-frame-unsupported", "translated resume mode requires a frame");
   }
   if (descriptor->has_translated_frame &&
-      (!descriptor->has_translated_return_address || !descriptor->has_translated_frame_slot ||
+      (!descriptor->has_translated_return_address || descriptor->translated_frame_slot_count == 0 ||
           descriptor->translated_frame_return_address != descriptor->translated_return_address)) {
     refuse("target-guest-loader-frame-unsupported", "translated frame return address is unresolved");
   }
@@ -651,7 +710,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char translated_frame_callee_r13[32];
   char translated_frame_callee_r14[32];
   char translated_frame_callee_r15[32];
-  char translated_frame_slot[128];
+  char translated_frame_slots[MAX_TRANSLATED_FRAME_SLOTS][128];
   char timeout_seconds[32];
   char stack_target_start[32];
   char stack_size[32];
@@ -676,12 +735,14 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(translated_frame_callee_r13, sizeof(translated_frame_callee_r13), "0x%" PRIx64, descriptor->translated_frame_callee_r13);
   snprintf(translated_frame_callee_r14, sizeof(translated_frame_callee_r14), "0x%" PRIx64, descriptor->translated_frame_callee_r14);
   snprintf(translated_frame_callee_r15, sizeof(translated_frame_callee_r15), "0x%" PRIx64, descriptor->translated_frame_callee_r15);
-  snprintf(translated_frame_slot,
-      sizeof(translated_frame_slot),
-      "0x%" PRIx64 ":0x%" PRIx64 ":%s",
-      descriptor->translated_frame_slot_offset,
-      descriptor->translated_frame_slot_value,
-      descriptor->translated_frame_slot_class);
+  for (size_t i = 0; i < descriptor->translated_frame_slot_count; i++) {
+    snprintf(translated_frame_slots[i],
+        sizeof(translated_frame_slots[i]),
+        "0x%" PRIx64 ":0x%" PRIx64 ":%s",
+        descriptor->translated_frame_slot_offsets[i],
+        descriptor->translated_frame_slot_values[i],
+        descriptor->translated_frame_slot_classes[i]);
+  }
   snprintf(timeout_seconds, sizeof(timeout_seconds), "0x%" PRIx64, descriptor->timeout_seconds);
   snprintf(stack_target_start, sizeof(stack_target_start), "0x%" PRIx64, descriptor->stack_target_start);
   snprintf(stack_size, sizeof(stack_size), "0x%" PRIx64, descriptor->stack_size);
@@ -742,8 +803,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
     push_arg(child_argv, &child_argc, translated_frame_callee_r14);
     push_arg(child_argv, &child_argc, "--translated-frame-callee-r15");
     push_arg(child_argv, &child_argc, translated_frame_callee_r15);
-    push_arg(child_argv, &child_argc, "--translated-frame-slot");
-    push_arg(child_argv, &child_argc, translated_frame_slot);
+    for (size_t i = 0; i < descriptor->translated_frame_slot_count; i++) {
+      push_arg(child_argv, &child_argc, "--translated-frame-slot");
+      push_arg(child_argv, &child_argc, translated_frame_slots[i]);
+    }
   }
   push_arg(child_argv, &child_argc, "--timeout-seconds");
   push_arg(child_argv, &child_argc, timeout_seconds);

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -143,6 +143,8 @@ describe("native actual resume trampoline", () => {
           "0x1515151515151515",
           "--translated-frame-slot",
           "0:0x4652414d45504153:non-pointer-data",
+          "--translated-frame-slot",
+          "8:0x535441434b534c54:non-pointer-data",
           "--materialize-memory",
           `${stateMemory}:0:0x600000000000:4096:rw-p`,
         ]),
@@ -165,6 +167,10 @@ describe("native actual resume trampoline", () => {
             { register: "r13", status: "passed", value: "0x1313131313131313" },
             { register: "r14", status: "passed", value: "0x1414141414141414" },
             { register: "r15", status: "passed", value: "0x1515151515151515" },
+          ],
+          slots: [
+            { offset: 0, classification: "non-pointer-data", status: "passed" },
+            { offset: 8, classification: "non-pointer-data", status: "passed" },
           ],
         },
         resumePath: {

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -48,6 +48,11 @@ describe("portable machine VM restore proof", () => {
             value: "0x4652414d45504153",
             classification: "non-pointer-data",
           },
+          {
+            offset: 8,
+            value: "0x535441434b534c54",
+            classification: "non-pointer-data",
+          },
         ],
       },
       fdTable: {

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -39,6 +39,11 @@ const translatedFrame = {
       value: "0x4652414d45504153",
       classification: "non-pointer-data" as const,
     },
+    {
+      offset: 8,
+      value: "0x535441434b534c54",
+      classification: "non-pointer-data" as const,
+    },
   ],
 };
 
@@ -144,6 +149,8 @@ describe("target guest restore loader descriptor", () => {
       "0x1515151515151515",
       "--translated-frame-slot",
       "0:0x4652414d45504153:non-pointer-data",
+      "--translated-frame-slot",
+      "8:0x535441434b534c54:non-pointer-data",
       "--set-cloexec-fd",
       "7",
       "--synthetic-empty-pipe-read-fd",
@@ -316,6 +323,41 @@ describe("target guest restore loader descriptor", () => {
         ).replace(" slot0Offset=", " calleeSavedR12=0x1 slot0Offset="),
       ),
     ).toThrow(/duplicate translated frame field/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            translatedReturnAddress: "0x700300000080",
+          },
+          translatedFrame: {
+            ...translatedFrame,
+            slots: [
+              { ...translatedFrame.slots[0]!, offset: 0 },
+              { ...translatedFrame.slots[1]!, offset: 0 },
+            ],
+          },
+        }),
+      ),
+    ).toThrow(/duplicate translated frame slot offset/);
+
+    expect(() =>
+      parseTargetGuestRestoreDescriptor(
+        serializeTargetGuestRestoreDescriptor(
+          descriptor({
+            continuation: {
+              ...descriptor().continuation,
+              translatedReturnAddress: "0x700300000080",
+            },
+            translatedFrame,
+          }),
+        )
+          .replace(" slot1Offset=", " slot2Offset=")
+          .replace(" slot1Value=", " slot2Value=")
+          .replace(" slot1Class=", " slot2Class="),
+      ),
+    ).toThrow(/translated frame slots must be dense/);
 
     expect(() =>
       validateTargetGuestRestoreDescriptor(

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -252,6 +252,7 @@ function parseTranslatedFrame(line: string): TargetGuestTranslatedFrameDescripto
 }
 
 const TARGET_FRAME_CALLEE_SAVED_REGISTERS = ["rbx", "r12", "r13", "r14", "r15"] as const;
+const TARGET_FRAME_MAX_SLOTS = 8;
 
 const TARGET_FRAME_REGISTER_FIELDS: Record<TargetGuestTranslatedFrameRegisterName, string> = {
   rbx: "calleeSavedRbx",
@@ -281,22 +282,51 @@ function parseFrameRegisters(fields: Map<string, string>): TargetGuestTranslated
 }
 
 function parseFrameSlots(fields: Map<string, string>): TargetGuestTranslatedFrameSlot[] {
-  const offset = fields.get("slot0Offset");
-  const value = fields.get("slot0Value");
-  const classification = fields.get("slot0Class");
-  if (offset === undefined && value === undefined && classification === undefined) {
+  const indexes = frameSlotIndexes(fields);
+  if (indexes.length === 0) {
     return [];
   }
+  assertDenseFrameSlotIndexes(indexes);
+  return indexes.map((index) => parseFrameSlot(fields, index));
+}
+
+function frameSlotIndexes(fields: Map<string, string>): number[] {
+  const indexes = new Set<number>();
+  for (const key of fields.keys()) {
+    const match = /^slot(\d+)(?:Offset|Value|Class)$/.exec(key);
+    if (!match) {
+      continue;
+    }
+    const index = Number(match[1]);
+    if (!Number.isSafeInteger(index) || index < 0 || index >= TARGET_FRAME_MAX_SLOTS) {
+      fail("target-guest-loader-frame-unsupported", "too many translated frame slots");
+    }
+    indexes.add(index);
+  }
+  return [...indexes].sort((left, right) => left - right);
+}
+
+function assertDenseFrameSlotIndexes(indexes: number[]): void {
+  indexes.forEach((index, expected) => {
+    if (index !== expected) {
+      fail("target-guest-loader-frame-unsupported", "translated frame slots must be dense");
+    }
+  });
+}
+
+function parseFrameSlot(
+  fields: Map<string, string>,
+  index: number,
+): TargetGuestTranslatedFrameSlot {
+  const classification = requiredFrameField(fields, `slot${index}Class`);
   if (classification !== "non-pointer-data") {
     fail("target-guest-loader-frame-unsupported", "frame slot classification is unsupported");
   }
-  return [
-    {
-      offset: parseFrameInteger(fields, "slot0Offset"),
-      value: requiredFrameField(fields, "slot0Value"),
-      classification,
-    },
-  ];
+  return {
+    offset: parseFrameInteger(fields, `slot${index}Offset`),
+    value: requiredFrameField(fields, `slot${index}Value`),
+    classification,
+  };
 }
 
 function requiredFrameField(fields: Map<string, string>, key: string): string {
@@ -698,11 +728,19 @@ function isTargetFrameCalleeSavedRegister(
 }
 
 function validateFrameSlots(slots: TargetGuestTranslatedFrameSlot[]): void {
-  if (slots.length > 1) {
+  if (slots.length === 0) {
+    fail("target-guest-loader-frame-unsupported", "translated frame slots are incomplete");
+  }
+  if (slots.length > TARGET_FRAME_MAX_SLOTS) {
     fail("target-guest-loader-frame-unsupported", "too many translated frame slots");
   }
+  const offsets = new Set<number>();
   for (const slot of slots) {
     assertNonNegative(slot.offset, "slot offset");
+    if (offsets.has(slot.offset)) {
+      fail("target-guest-loader-frame-unsupported", "duplicate translated frame slot offset");
+    }
+    offsets.add(slot.offset);
     assertHexAddress(slot.value, "slot value");
     if (slot.classification !== "non-pointer-data") {
       fail("target-guest-loader-frame-unsupported", "pointer-bearing frame slots are unsupported");
@@ -770,7 +808,6 @@ function optionalTranslatedFrameField(
 
 function serializeTranslatedFrame(frame: TargetGuestTranslatedFrameDescriptor): string {
   const registers = frameRegisterMap(frame.calleeSaved);
-  const slot = frame.slots[0];
   return [
     `frame=${frame.kind}`,
     `framePointer=${frame.framePointer}`,
@@ -781,9 +818,7 @@ function serializeTranslatedFrame(frame: TargetGuestTranslatedFrameDescriptor): 
     ...TARGET_FRAME_CALLEE_SAVED_REGISTERS.flatMap((register) =>
       optionalFrameToken(TARGET_FRAME_REGISTER_FIELDS[register], registers.get(register)),
     ),
-    ...optionalFrameToken("slot0Offset", slot?.offset),
-    ...optionalFrameToken("slot0Value", slot?.value),
-    ...optionalFrameToken("slot0Class", slot?.classification),
+    ...frame.slots.flatMap((slot, index) => frameSlotTokens(slot, index)),
   ].join(" ");
 }
 
@@ -791,6 +826,14 @@ function frameRegisterMap(
   registers: TargetGuestTranslatedFrameRegister[],
 ): Map<TargetGuestTranslatedFrameRegisterName, string> {
   return new Map(registers.map((register) => [register.register, register.value]));
+}
+
+function frameSlotTokens(slot: TargetGuestTranslatedFrameSlot, index: number): string[] {
+  return [
+    `slot${index}Offset=${slot.offset}`,
+    `slot${index}Value=${slot.value}`,
+    `slot${index}Class=${slot.classification}`,
+  ];
 }
 
 function optionalFrameToken(name: string, value: string | number | undefined): string[] {
@@ -871,7 +914,6 @@ function translatedFrameToTrampolineArgs(
     return [];
   }
   const registers = frameRegisterMap(frame.calleeSaved);
-  const slot = frame.slots[0];
   return [
     "--translated-frame-pointer",
     frame.framePointer,
@@ -886,7 +928,7 @@ function translatedFrameToTrampolineArgs(
     ...TARGET_FRAME_CALLEE_SAVED_REGISTERS.flatMap((register) =>
       optionalArg(`--translated-frame-callee-${register}`, registers.get(register)),
     ),
-    ...optionalArg("--translated-frame-slot", slot ? frameSlotSpec(slot) : undefined),
+    ...frame.slots.flatMap((slot) => ["--translated-frame-slot", frameSlotSpec(slot)]),
   ];
 }
 

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -111,6 +111,8 @@ const TRANSLATED_FRAME_POINTER = "0x50000000ff80";
 const TRANSLATED_FRAME_CFA = "0x50000000fff0";
 const TRANSLATED_FRAME_RETURN_ADDRESS_SLOT = "0x50000000fff0";
 const TRANSLATED_FRAME_SLOT_OFFSET = 0;
+const TRANSLATED_FRAME_SECOND_SLOT_OFFSET = 8;
+const TRANSLATED_FRAME_SECOND_SLOT_MARKER = 0x535441434b534c54n;
 const TRANSLATED_FRAME_RBX = "0x1111111122222222";
 const TRANSLATED_FRAME_R12 = "0x1234567890abcdef";
 const TRANSLATED_FRAME_R13 = "0x1313131313131313";
@@ -510,6 +512,11 @@ function translatedFrameDescriptor(returnAddress: string): TargetGuestTranslated
         value: hex(TRANSLATED_FRAME_MARKER),
         classification: "non-pointer-data",
       },
+      {
+        offset: TRANSLATED_FRAME_SECOND_SLOT_OFFSET,
+        value: hex(TRANSLATED_FRAME_SECOND_SLOT_MARKER),
+        classification: "non-pointer-data",
+      },
     ],
   };
 }
@@ -788,6 +795,10 @@ class Amd64ProofAssembler {
     this.checkAbsoluteU64(
       BigInt(TRANSLATED_FRAME_POINTER) + BigInt(TRANSLATED_FRAME_SLOT_OFFSET),
       TRANSLATED_FRAME_MARKER,
+    );
+    this.checkAbsoluteU64(
+      BigInt(TRANSLATED_FRAME_POINTER) + BigInt(TRANSLATED_FRAME_SECOND_SLOT_OFFSET),
+      TRANSLATED_FRAME_SECOND_SLOT_MARKER,
     );
     this.storeReportWord(32, TRANSLATED_FRAME_MARKER);
   }


### PR DESCRIPTION
## Problem

The translated frame proof could restore the register bank, but the stack part was still only one slot. Real frames need more than one modeled stack value. We also need bad slot layouts, like gaps or pointer-bearing slots, to fail before restore.

## Solution

This PR lets the frame descriptor carry a small dense vector of stack slots. The loader preserves the slot order, the trampoline writes every slot before jumping, and the target-native code checks both modeled slots before it reports frame success. Pointer slots, duplicate offsets, sparse indexes, and too many slots refuse closed.

Fixes #617

## Validation

- `pnpm run format:check` — 0.515s
- `pnpm run lint` — 0.198s
- `pnpm run typecheck` — 1.940s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.881s
- `pnpm smoke-tests` — 2m11.377s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.365s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m15s, 2 passed / 2 total
- remote arm64→amd64 e2e — 45.104s wall, target VM boot/restore 27.697s, `targetFrameRestoreResult=passed`, `targetResumePathResult=passed`
