### PR TITLE
Restore rdi in resume register handoff

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -48,8 +48,9 @@ uses `--real-utility-continuation`: target module bytes are materialized from a
 portable-bundle target root, entered through the amd64 guest loader, and accepted
 only when the in-guest resume event returns the expected value. The real utility
 now consumes restored state before returning: it checks the materialized captured
-memory byte, validates the descriptor-provided argument/register handoff, and
-exercises the wider fd matrix: closed fd, inherited stdout, reopened file,
+memory byte, validates the descriptor-provided register handoff without
+reserving `%rdi` for the proof ABI, and exercises the wider fd matrix: closed fd,
+inherited stdout, reopened file,
 synthetic pipe, eventfd, and timerfd recipes. The descriptor also seeds a
 translated target return address and a small translated caller frame. The
 trampoline materializes that target stack frame, seeds modeled `rbp`/`r12`, and
@@ -60,7 +61,7 @@ shared-stack, unknown-TLS, and ambiguous register states refuse before the targe
 VM is entered. The descriptor uses `resumeMode=translated-frame`, so the success
 path records a target-native resume-path marker after the real continuation
 observes the translated frame, stack-slot vector, amd64 callee-saved register
-bank, and modeled resume-register handoff.
+bank, and modeled resume-register handoff including `%rdi`.
 
 ## Smoke profile
 

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -15,11 +15,11 @@ codeFile=/tmp/machinen-target-bytes.bin
 fileOffset=0
 codeSize=16
 targetAddress=0x700300000000
-argument0=0x600000000000
 stateReportAddress=0x600000000000
 translatedReturnAddress=0x700300000080
 resumeMode=translated-frame
 resumeRegisterRax=0x2121212121212121
+resumeRegisterRdi=0x7171717171717171
 resumeRegisterRsi=0x6161616161616161
 resumeRegisterRdx=0x6262626262626262
 resumeRegisterRcx=0x6363636363636363
@@ -81,11 +81,13 @@ Everything else fails closed with a precise refusal, currently:
 
 The existing target-VM synthetic proof now injects the loader and descriptor into
 the amd64 guest and executes the loader instead of invoking the trampoline
-directly. The descriptor may carry an optional `argument0` target register value
-an optional `stateReportAddress`, an optional `translatedReturnAddress`, an
-optional `resumeMode=translated-frame`, optional modeled resume-register values,
-and an optional translated caller frame for real target-native continuation
-attempts.
+directly. The descriptor may carry an optional legacy `argument0` target register
+value for simple single-argument attempts, an optional `stateReportAddress`, an
+optional `translatedReturnAddress`, an optional `resumeMode=translated-frame`,
+optional modeled resume-register values, and an optional translated caller frame
+for real target-native continuation attempts. `argument0` is rejected when a
+resume-register bank is present so `%rdi` can be restored natively instead of
+being reserved for the proof ABI.
 The state report address lets the trampoline read a small report that the
 continuation writes after consuming restored memory and fd/resource state. The
 translated return address lets the trampoline seed a modeled target return slot
@@ -94,10 +96,12 @@ target-native landing code before control comes back to the trampoline. The
 translated frame lets the trampoline materialize a small target stack frame,
 seed `rbp` plus the modeled callee-saved register bank, and require the target
 code to validate that modeled frame/register/slot state. The resume-register
-handoff seeds caller-scratch registers (`rax`, `rsi`, `rdx`, `rcx`, `r8`, `r9`,
-`r10`, `r11`) immediately before the target-native jump and requires the target
-code to report the values it observed before clobbering them. Translated resume
-mode additionally requires the target code to write a
-resume-path marker after observing the modeled frame/stack state. Completion is
-credited only when the descriptor gate succeeds and the target-native
+handoff seeds caller-scratch registers (`rax`, `rdi`, `rsi`, `rdx`, `rcx`, `r8`,
+`r9`, `r10`, `r11`) immediately before the target-native jump and requires the
+target code to report the values it observed before clobbering them. The proof
+report address is carried out-of-band as `stateReportAddress`, so no target entry
+GPR is reserved by the reporting ABI. Translated resume mode additionally
+requires the target code to write a resume-path marker after observing the
+modeled frame/stack state. Completion is credited only when the descriptor gate
+succeeds and the target-native
 continuation returns/exits in the guest with the expected modeled result.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -54,7 +54,7 @@
 #define TRANSLATED_FRAME_REGISTER_R14 UINT64_C(0x08)
 #define TRANSLATED_FRAME_REGISTER_R15 UINT64_C(0x10)
 #define RESUME_REGISTER_MARKER UINT64_C(0x52454753544f5245)
-#define RESUME_REGISTER_MASK UINT64_C(0xff)
+#define RESUME_REGISTER_MASK UINT64_C(0x1ff)
 #define RESUME_REGISTER_RAX UINT64_C(0x01)
 #define RESUME_REGISTER_RSI UINT64_C(0x02)
 #define RESUME_REGISTER_RDX UINT64_C(0x04)
@@ -63,6 +63,7 @@
 #define RESUME_REGISTER_R9 UINT64_C(0x20)
 #define RESUME_REGISTER_R10 UINT64_C(0x40)
 #define RESUME_REGISTER_R11 UINT64_C(0x80)
+#define RESUME_REGISTER_RDI UINT64_C(0x100)
 #define MAX_UNWIND_ID 128
 
 struct MemoryMaterialization {
@@ -93,6 +94,7 @@ struct Options {
   char resume_mode[32];
   uint64_t resume_register_mask;
   uint64_t resume_register_rax;
+  uint64_t resume_register_rdi;
   uint64_t resume_register_rsi;
   uint64_t resume_register_rdx;
   uint64_t resume_register_rcx;
@@ -148,7 +150,7 @@ static void usage(void) {
       "[--translated-frame-callee-r13 addr] [--translated-frame-callee-r14 addr] "
       "[--translated-frame-callee-r15 addr] [--translated-frame-slot offset:value:class] "
       "[--resume-mode translated-frame] [--resume-register-rax addr] "
-      "[--resume-register-rsi addr] [--resume-register-rdx addr] "
+      "[--resume-register-rdi addr] [--resume-register-rsi addr] [--resume-register-rdx addr] "
       "[--resume-register-rcx addr] [--resume-register-r8 addr] "
       "[--resume-register-r9 addr] [--resume-register-r10 addr] "
       "[--resume-register-r11 addr] --timeout-seconds n "
@@ -407,6 +409,12 @@ static struct Options parse_args(int argc, char **argv) {
       }
       opts.resume_register_rax = parse_u64(argv[i], "resume-register-rax");
       opts.resume_register_mask |= RESUME_REGISTER_RAX;
+    } else if (streq(argv[i], "--resume-register-rdi")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.resume_register_rdi = parse_u64(argv[i], "resume-register-rdi");
+      opts.resume_register_mask |= RESUME_REGISTER_RDI;
     } else if (streq(argv[i], "--resume-register-rsi")) {
       if (++i >= argc) {
         usage();
@@ -566,6 +574,7 @@ static uint64_t jump_translated_frame_r13 __attribute__((used)) = 0;
 static uint64_t jump_translated_frame_r14 __attribute__((used)) = 0;
 static uint64_t jump_translated_frame_r15 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_rax __attribute__((used)) = 0;
+static uint64_t jump_resume_register_rdi __attribute__((used)) = 0;
 static uint64_t jump_resume_register_rsi __attribute__((used)) = 0;
 static uint64_t jump_resume_register_rdx __attribute__((used)) = 0;
 static uint64_t jump_resume_register_rcx __attribute__((used)) = 0;
@@ -824,6 +833,10 @@ static void validate_resume_register_options(const struct Options *opts) {
     fprintf(stderr, "native-actual-resume-trampoline: resume register restore requires a state report\n");
     exit(2);
   }
+  if (opts->has_argument0) {
+    fprintf(stderr, "native-actual-resume-trampoline: argument0 cannot be combined with a resume register bank\n");
+    exit(2);
+  }
 }
 
 static void validate_translated_frame_options(const struct Options *opts) {
@@ -980,6 +993,7 @@ static void jump_to_target(uint64_t entry,
     uint64_t translated_frame_r14,
     uint64_t translated_frame_r15,
     uint64_t resume_register_rax,
+    uint64_t resume_register_rdi,
     uint64_t resume_register_rsi,
     uint64_t resume_register_rdx,
     uint64_t resume_register_rcx,
@@ -998,6 +1012,7 @@ static void jump_to_target(uint64_t entry,
   jump_translated_frame_r14 = translated_frame_r14;
   jump_translated_frame_r15 = translated_frame_r15;
   jump_resume_register_rax = resume_register_rax;
+  jump_resume_register_rdi = resume_register_rdi;
   jump_resume_register_rsi = resume_register_rsi;
   jump_resume_register_rdx = resume_register_rdx;
   jump_resume_register_rcx = resume_register_rcx;
@@ -1030,7 +1045,7 @@ static void jump_to_target(uint64_t entry,
       "movq jump_translated_frame_r13(%%rip), %%r13\n"
       "movq jump_translated_frame_r14(%%rip), %%r14\n"
       "movq jump_translated_frame_r15(%%rip), %%r15\n"
-      "movq jump_argument0(%%rip), %%rdi\n"
+      "movq jump_resume_register_rdi(%%rip), %%rdi\n"
       "movq jump_resume_register_rax(%%rip), %%rax\n"
       "movq jump_resume_register_rsi(%%rip), %%rsi\n"
       "movq jump_resume_register_rdx(%%rip), %%rdx\n"
@@ -1240,6 +1255,7 @@ static void print_register_restore(const struct Options *opts) {
   uint64_t base = opts->state_report_address;
   uint64_t marker = read_state_report_u64(base, 128);
   uint64_t observed_rax = read_state_report_u64(base, 136);
+  uint64_t observed_rdi = read_state_report_u64(base, 200);
   uint64_t observed_rsi = read_state_report_u64(base, 144);
   uint64_t observed_rdx = read_state_report_u64(base, 152);
   uint64_t observed_rcx = read_state_report_u64(base, 160);
@@ -1248,7 +1264,8 @@ static void print_register_restore(const struct Options *opts) {
   uint64_t observed_r10 = read_state_report_u64(base, 184);
   uint64_t observed_r11 = read_state_report_u64(base, 192);
   bool passed = marker == RESUME_REGISTER_MARKER &&
-      observed_rax == opts->resume_register_rax && observed_rsi == opts->resume_register_rsi &&
+      observed_rax == opts->resume_register_rax && observed_rdi == opts->resume_register_rdi &&
+      observed_rsi == opts->resume_register_rsi &&
       observed_rdx == opts->resume_register_rdx && observed_rcx == opts->resume_register_rcx &&
       observed_r8 == opts->resume_register_r8 && observed_r9 == opts->resume_register_r9 &&
       observed_r10 == opts->resume_register_r10 && observed_r11 == opts->resume_register_r11;
@@ -1261,6 +1278,8 @@ static void print_register_restore(const struct Options *opts) {
       marker,
       RESUME_REGISTER_MARKER);
   print_resume_register_status("rax", observed_rax, opts->resume_register_rax, RESUME_REGISTER_MASK, RESUME_REGISTER_RAX);
+  printf(",");
+  print_resume_register_status("rdi", observed_rdi, opts->resume_register_rdi, RESUME_REGISTER_MASK, RESUME_REGISTER_RDI);
   printf(",");
   print_resume_register_status("rsi", observed_rsi, opts->resume_register_rsi, RESUME_REGISTER_MASK, RESUME_REGISTER_RSI);
   printf(",");
@@ -1427,6 +1446,9 @@ int main(int argc, char **argv) {
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {
     uint64_t initial_rsp = opts.has_translated_return_address ? opts.stack_pointer - 16u : opts.stack_pointer - 8u;
+    uint64_t entry_rdi = opts.resume_register_mask == 0
+        ? (opts.has_argument0 ? opts.argument0 : 0u)
+        : opts.resume_register_rdi;
     jump_to_target(
         opts.target_address,
         initial_rsp,
@@ -1439,6 +1461,7 @@ int main(int argc, char **argv) {
         opts.has_translated_frame_callee_r14 ? opts.translated_frame_callee_r14 : 0u,
         opts.has_translated_frame_callee_r15 ? opts.translated_frame_callee_r15 : 0u,
         opts.resume_register_rax,
+        entry_rdi,
         opts.resume_register_rsi,
         opts.resume_register_rdx,
         opts.resume_register_rcx,

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -57,6 +57,7 @@ struct Descriptor {
   bool has_resume_registers;
   uint32_t resume_register_mask;
   uint64_t resume_register_rax;
+  uint64_t resume_register_rdi;
   uint64_t resume_register_rsi;
   uint64_t resume_register_rdx;
   uint64_t resume_register_rcx;
@@ -236,6 +237,10 @@ static void parse_field(struct Descriptor *descriptor, char *line) {
   } else if (streq(key, "resumeRegisterRax")) {
     descriptor->resume_register_rax = parse_u64(value, key);
     descriptor->resume_register_mask |= 0x01u;
+    descriptor->has_resume_registers = true;
+  } else if (streq(key, "resumeRegisterRdi")) {
+    descriptor->resume_register_rdi = parse_u64(value, key);
+    descriptor->resume_register_mask |= 0x100u;
     descriptor->has_resume_registers = true;
   } else if (streq(key, "resumeRegisterRsi")) {
     descriptor->resume_register_rsi = parse_u64(value, key);
@@ -672,7 +677,10 @@ static void validate_descriptor(const struct Descriptor *descriptor) {
   if (descriptor->has_resume_mode && !descriptor->has_translated_frame) {
     refuse("target-guest-loader-frame-unsupported", "translated resume mode requires a frame");
   }
-  if (descriptor->has_resume_registers && descriptor->resume_register_mask != 0xffu) {
+  if (descriptor->has_argument0 && descriptor->has_resume_registers) {
+    refuse("target-guest-loader-invalid-continuation", "argument0 cannot be combined with a resume register bank");
+  }
+  if (descriptor->has_resume_registers && descriptor->resume_register_mask != 0x1ffu) {
     refuse("target-guest-loader-invalid-continuation", "resume register bank is incomplete");
   }
   if (descriptor->has_translated_frame &&
@@ -747,6 +755,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char state_report_address[32];
   char translated_return_address[32];
   char resume_register_rax[32];
+  char resume_register_rdi[32];
   char resume_register_rsi[32];
   char resume_register_rdx[32];
   char resume_register_rcx[32];
@@ -780,6 +789,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(state_report_address, sizeof(state_report_address), "0x%" PRIx64, descriptor->state_report_address);
   snprintf(translated_return_address, sizeof(translated_return_address), "0x%" PRIx64, descriptor->translated_return_address);
   snprintf(resume_register_rax, sizeof(resume_register_rax), "0x%" PRIx64, descriptor->resume_register_rax);
+  snprintf(resume_register_rdi, sizeof(resume_register_rdi), "0x%" PRIx64, descriptor->resume_register_rdi);
   snprintf(resume_register_rsi, sizeof(resume_register_rsi), "0x%" PRIx64, descriptor->resume_register_rsi);
   snprintf(resume_register_rdx, sizeof(resume_register_rdx), "0x%" PRIx64, descriptor->resume_register_rdx);
   snprintf(resume_register_rcx, sizeof(resume_register_rcx), "0x%" PRIx64, descriptor->resume_register_rcx);
@@ -846,6 +856,8 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   if (descriptor->has_resume_registers) {
     push_arg(child_argv, &child_argc, "--resume-register-rax");
     push_arg(child_argv, &child_argc, resume_register_rax);
+    push_arg(child_argv, &child_argc, "--resume-register-rdi");
+    push_arg(child_argv, &child_argc, resume_register_rdi);
     push_arg(child_argv, &child_argc, "--resume-register-rsi");
     push_arg(child_argv, &child_argc, resume_register_rsi);
     push_arg(child_argv, &child_argc, "--resume-register-rdx");

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -11990,7 +11990,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestResumeRegisterName
 
-> **TargetGuestResumeRegisterName** = `"rax"` \| `"rsi"` \| `"rdx"` \| `"rcx"` \| `"r8"` \| `"r9"` \| `"r10"` \| `"r11"`
+> **TargetGuestResumeRegisterName** = `"rax"` \| `"rdi"` \| `"rsi"` \| `"rdx"` \| `"rcx"` \| `"r8"` \| `"r9"` \| `"r10"` \| `"r11"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -94,15 +94,27 @@ describe("native actual resume trampoline", () => {
       writeFileSync(stateMemory, memory);
       const stateEntryBytes: number[] = [];
       const immediates: Array<{ offset: number; value: bigint }> = [];
+      const reportAddress = 0x600000000000n;
       const push = (...bytes: number[]) => stateEntryBytes.push(...bytes);
-      const storeRax = (reportOffset: number) => {
-        storeRegister(0x48, 0x47, 0x87, reportOffset);
-      };
-      const storeImmediate = (reportOffset: number, value: bigint) => {
-        push(0x48, 0xb8);
+      const pushU64Immediate = (value: bigint) => {
         immediates.push({ offset: stateEntryBytes.length, value });
         push(0, 0, 0, 0, 0, 0, 0, 0);
-        storeRax(reportOffset);
+      };
+      const movRaxImmediate = (value: bigint) => {
+        push(0x48, 0xb8);
+        pushU64Immediate(value);
+      };
+      const movRbxImmediate = (value: bigint) => {
+        push(0x48, 0xbb);
+        pushU64Immediate(value);
+      };
+      const storeRaxAbsolute = (reportOffset: number) => {
+        push(0x48, 0xa3);
+        pushU64Immediate(reportAddress + BigInt(reportOffset));
+      };
+      const storeImmediate = (reportOffset: number, value: bigint) => {
+        movRaxImmediate(value);
+        storeRegister(0x48, 0x43, 0x83, reportOffset);
       };
       function storeRegister(
         prefix: number,
@@ -117,21 +129,24 @@ describe("native actual resume trampoline", () => {
         push(prefix, 0x89, modrm32);
         push(reportOffset, reportOffset >> 8, reportOffset >> 16, reportOffset >> 24);
       }
-      storeRegister(0x48, 0x47, 0x87, 136);
-      storeRegister(0x48, 0x77, 0xb7, 144);
-      storeRegister(0x48, 0x57, 0x97, 152);
-      storeRegister(0x48, 0x4f, 0x8f, 160);
-      storeRegister(0x4c, 0x47, 0x87, 168);
-      storeRegister(0x4c, 0x4f, 0x8f, 176);
-      storeRegister(0x4c, 0x57, 0x97, 184);
-      storeRegister(0x4c, 0x5f, 0x9f, 192);
+      storeRaxAbsolute(136);
+      movRaxImmediate(reportAddress);
+      storeRegister(0x48, 0x78, 0xb8, 200);
+      storeRegister(0x48, 0x70, 0xb0, 144);
+      storeRegister(0x48, 0x50, 0x90, 152);
+      storeRegister(0x48, 0x48, 0x88, 160);
+      storeRegister(0x4c, 0x40, 0x80, 168);
+      storeRegister(0x4c, 0x48, 0x88, 176);
+      storeRegister(0x4c, 0x50, 0x90, 184);
+      storeRegister(0x4c, 0x58, 0x98, 192);
+      movRbxImmediate(reportAddress);
       storeImmediate(128, 0x52454753544f5245n);
       storeImmediate(8, 0x5354415445434f4en);
       storeImmediate(16, 0x7fn);
       storeImmediate(32, 0x4652414d45504153n);
       storeImmediate(40, 0x524553554d455041n);
       storeImmediate(48, 0x1fn);
-      push(0xb8, 0x4d, 0, 0, 0, 0xc3);
+      push(0x48, 0x89, 0xdf, 0xb8, 0x4d, 0, 0, 0, 0xc3);
       const stateEntry = Buffer.from(stateEntryBytes);
       for (const immediate of immediates) {
         stateEntry.writeBigUInt64LE(immediate.value, immediate.offset);
@@ -146,8 +161,6 @@ describe("native actual resume trampoline", () => {
       writeFileSync(stateCodePath, stateCode);
       expect(
         runHelper(helper, stateCodePath, stateCode.length, [
-          "--argument0",
-          "0x600000000000",
           "--state-report-address",
           "0x600000000000",
           "--translated-return-address",
@@ -156,6 +169,8 @@ describe("native actual resume trampoline", () => {
           "translated-frame",
           "--resume-register-rax",
           "0x2121212121212121",
+          "--resume-register-rdi",
+          "0x7171717171717171",
           "--resume-register-rsi",
           "0x6161616161616161",
           "--resume-register-rdx",
@@ -230,6 +245,7 @@ describe("native actual resume trampoline", () => {
           status: "passed",
           registers: [
             { register: "rax", status: "passed", value: "0x2121212121212121" },
+            { register: "rdi", status: "passed", value: "0x7171717171717171" },
             { register: "rsi", status: "passed", value: "0x6161616161616161" },
             { register: "rdx", status: "passed", value: "0x6262626262626262" },
             { register: "rcx", status: "passed", value: "0x6363636363636363" },

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -21,6 +21,7 @@ const HAS_CC = spawnSync("cc", ["--version"], { stdio: "ignore" }).status === 0;
 
 const resumeRegisters = {
   rax: "0x2121212121212121",
+  rdi: "0x7171717171717171",
   rsi: "0x6161616161616161",
   rdx: "0x6262626262626262",
   rcx: "0x6363636363636363",
@@ -85,7 +86,6 @@ describe("target guest restore loader descriptor", () => {
     const original = descriptor({
       continuation: {
         ...descriptor().continuation,
-        argument0: "0x600000000000",
         stateReportAddress: "0x600000000000",
         translatedReturnAddress: "0x700300000080",
         resumeMode: "translated-frame",
@@ -123,8 +123,6 @@ describe("target guest restore loader descriptor", () => {
       "16",
       "--target-address",
       "0x700300000000",
-      "--argument0",
-      "0x600000000000",
       "--state-report-address",
       "0x600000000000",
       "--translated-return-address",
@@ -133,6 +131,8 @@ describe("target guest restore loader descriptor", () => {
       "translated-frame",
       "--resume-register-rax",
       "0x2121212121212121",
+      "--resume-register-rdi",
+      "0x7171717171717171",
       "--resume-register-rsi",
       "0x6161616161616161",
       "--resume-register-rdx",
@@ -455,6 +455,18 @@ describe("target guest restore loader descriptor", () => {
         `${serializeTargetGuestRestoreDescriptor(descriptor())}resumeRegisterRax=0x1\n`,
       ),
     ).toThrow(/resume register bank is incomplete/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            argument0: "0x600000000000",
+            resumeRegisters,
+          },
+        }),
+      ),
+    ).toThrow(/argument0 cannot be combined with a resume register bank/);
   });
 
   it.skipIf(!HAS_CC)(
@@ -473,7 +485,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_mode = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-r11") == 0 && strcmp(argv[i + 1], "0x1111111111111111") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_mode) return 49;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_mode = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-rdi") == 0 && strcmp(argv[i + 1], "0x7171717171717171") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_mode) return 49;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -40,6 +40,7 @@ export type TargetGuestRestoreResumeMode = "translated-frame";
 
 export type TargetGuestResumeRegisterName =
   | "rax"
+  | "rdi"
   | "rsi"
   | "rdx"
   | "rcx"
@@ -571,6 +572,12 @@ function validateContinuation(
   if (continuation.argument0 !== undefined) {
     assertHexAddress(continuation.argument0, "argument0");
   }
+  if (continuation.argument0 !== undefined && continuation.resumeRegisters !== undefined) {
+    fail(
+      "target-guest-loader-invalid-continuation",
+      "argument0 cannot be combined with a resume register bank",
+    );
+  }
   if (continuation.stateReportAddress !== undefined) {
     assertHexAddress(continuation.stateReportAddress, "stateReportAddress");
   }
@@ -813,10 +820,21 @@ function assertNoWhitespace(value: string, field: string): void {
   }
 }
 
-const TARGET_RESUME_REGISTERS = ["rax", "rsi", "rdx", "rcx", "r8", "r9", "r10", "r11"] as const;
+const TARGET_RESUME_REGISTERS = [
+  "rax",
+  "rdi",
+  "rsi",
+  "rdx",
+  "rcx",
+  "r8",
+  "r9",
+  "r10",
+  "r11",
+] as const;
 
 const TARGET_RESUME_REGISTER_FIELDS: Record<TargetGuestResumeRegisterName, string> = {
   rax: "resumeRegisterRax",
+  rdi: "resumeRegisterRdi",
   rsi: "resumeRegisterRsi",
   rdx: "resumeRegisterRdx",
   rcx: "resumeRegisterRcx",

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -128,6 +128,7 @@ const TRANSLATED_FRAME_REGISTER_MASK_R14 = 0x08;
 const TRANSLATED_FRAME_REGISTER_MASK_R15 = 0x10;
 const RESUME_REGISTER_MARKER = 0x52454753544f5245n;
 const RESUME_REGISTER_RAX = "0x2121212121212121";
+const RESUME_REGISTER_RDI = "0x7171717171717171";
 const RESUME_REGISTER_RSI = "0x6161616161616161";
 const RESUME_REGISTER_RDX = "0x6262626262626262";
 const RESUME_REGISTER_RCX = "0x6363636363636363";
@@ -406,6 +407,7 @@ function proofMemoryPlan(context: CombinedDescriptorContext) {
 function proofResumeRegisters() {
   return {
     rax: RESUME_REGISTER_RAX,
+    rdi: RESUME_REGISTER_RDI,
     rsi: RESUME_REGISTER_RSI,
     rdx: RESUME_REGISTER_RDX,
     rcx: RESUME_REGISTER_RCX,
@@ -505,7 +507,6 @@ function prepareRealUtilityContinuation(
   return {
     kind: "real-utility" as const,
     bytes: Buffer.from(materialized.materialized!.bytes),
-    argument0: PROOF_MEMORY_TARGET,
     stateReportAddress: PROOF_MEMORY_TARGET,
     translatedReturnAddress: targetCode.translatedReturnAddress,
     translatedFrame: translatedFrameDescriptor(targetCode.translatedReturnAddress),
@@ -765,9 +766,9 @@ function proofStateVerifierTargetCode(
   const asm = new Amd64ProofAssembler();
   if (completion === "return") {
     asm.preserveRbx();
-    asm.captureResumeRegisters();
+    asm.captureResumeRegisters(BigInt(PROOF_MEMORY_TARGET));
     asm.checkTranslatedRbx();
-    asm.movRbxFromRdi();
+    asm.movRbxImmediate(BigInt(PROOF_MEMORY_TARGET));
     asm.storeReportWord(16, 0n);
     asm.checkTranslatedFrame();
     asm.checkTranslatedResumePath();
@@ -805,20 +806,18 @@ class Amd64ProofAssembler {
     this.checkRbxImmediate(BigInt(TRANSLATED_FRAME_RBX));
   }
 
-  captureResumeRegisters(): void {
-    this.storeRegisterAtReportOffset("rax", 136);
-    this.storeRegisterAtReportOffset("rsi", 144);
-    this.storeRegisterAtReportOffset("rdx", 152);
-    this.storeRegisterAtReportOffset("rcx", 160);
-    this.storeRegisterAtReportOffset("r8", 168);
-    this.storeRegisterAtReportOffset("r9", 176);
-    this.storeRegisterAtReportOffset("r10", 184);
-    this.storeRegisterAtReportOffset("r11", 192);
-    this.storeReportWordFromRdiBase(128, RESUME_REGISTER_MARKER);
-  }
-
-  movRbxFromRdi(): void {
-    this.push(0x48, 0x89, 0xfb);
+  captureResumeRegisters(reportAddress: bigint): void {
+    this.storeRaxAtAbsolute(reportAddress + 136n);
+    this.movRaxImmediate(reportAddress);
+    this.storeRegisterAtRaxReportOffset("rdi", 200);
+    this.storeRegisterAtRaxReportOffset("rsi", 144);
+    this.storeRegisterAtRaxReportOffset("rdx", 152);
+    this.storeRegisterAtRaxReportOffset("rcx", 160);
+    this.storeRegisterAtRaxReportOffset("r8", 168);
+    this.storeRegisterAtRaxReportOffset("r9", 176);
+    this.storeRegisterAtRaxReportOffset("r10", 184);
+    this.storeRegisterAtRaxReportOffset("r11", 192);
+    this.storeReportWordFromRaxBase(128, RESUME_REGISTER_MARKER);
   }
 
   movRbxImmediate(value: bigint): void {
@@ -912,35 +911,36 @@ class Amd64ProofAssembler {
     this.push(0x48, 0x89, 0x43, offset);
   }
 
-  storeReportWordFromRdiBase(offset: number, value: bigint): void {
-    this.push(0x48, 0xb8);
+  storeReportWordFromRaxBase(offset: number, value: bigint): void {
+    this.push(0x48, 0xba);
     this.pushU64(value);
-    this.storeRaxToRdiOffset(offset);
+    this.storeRegisterToRaxOffset(0x48, 0x50, 0x90, offset);
   }
 
-  storeRegisterAtReportOffset(
-    register: "rax" | "rsi" | "rdx" | "rcx" | "r8" | "r9" | "r10" | "r11",
+  storeRegisterAtRaxReportOffset(
+    register: "rdi" | "rsi" | "rdx" | "rcx" | "r8" | "r9" | "r10" | "r11",
     offset: number,
   ): void {
     const encodings = {
-      rax: { prefix: 0x48, modrm8: 0x47, modrm32: 0x87 },
-      rsi: { prefix: 0x48, modrm8: 0x77, modrm32: 0xb7 },
-      rdx: { prefix: 0x48, modrm8: 0x57, modrm32: 0x97 },
-      rcx: { prefix: 0x48, modrm8: 0x4f, modrm32: 0x8f },
-      r8: { prefix: 0x4c, modrm8: 0x47, modrm32: 0x87 },
-      r9: { prefix: 0x4c, modrm8: 0x4f, modrm32: 0x8f },
-      r10: { prefix: 0x4c, modrm8: 0x57, modrm32: 0x97 },
-      r11: { prefix: 0x4c, modrm8: 0x5f, modrm32: 0x9f },
+      rdi: { prefix: 0x48, modrm8: 0x78, modrm32: 0xb8 },
+      rsi: { prefix: 0x48, modrm8: 0x70, modrm32: 0xb0 },
+      rdx: { prefix: 0x48, modrm8: 0x50, modrm32: 0x90 },
+      rcx: { prefix: 0x48, modrm8: 0x48, modrm32: 0x88 },
+      r8: { prefix: 0x4c, modrm8: 0x40, modrm32: 0x80 },
+      r9: { prefix: 0x4c, modrm8: 0x48, modrm32: 0x88 },
+      r10: { prefix: 0x4c, modrm8: 0x50, modrm32: 0x90 },
+      r11: { prefix: 0x4c, modrm8: 0x58, modrm32: 0x98 },
     };
     const encoding = encodings[register];
-    this.storeRegisterToRdiOffset(encoding.prefix, encoding.modrm8, encoding.modrm32, offset);
+    this.storeRegisterToRaxOffset(encoding.prefix, encoding.modrm8, encoding.modrm32, offset);
   }
 
-  private storeRaxToRdiOffset(offset: number): void {
-    this.storeRegisterToRdiOffset(0x48, 0x47, 0x87, offset);
+  private storeRaxAtAbsolute(address: bigint): void {
+    this.push(0x48, 0xa3);
+    this.pushU64(address);
   }
 
-  private storeRegisterToRdiOffset(
+  private storeRegisterToRaxOffset(
     prefix: number,
     modrm8: number,
     modrm32: number,


### PR DESCRIPTION
## Problem

The resume-register proof still reserved `%rdi` as the proof report pointer. That meant the target-native entry did not prove that `%rdi` itself could be restored.

## Solution

This PR adds `rdi` to the modeled resume-register bank and decouples proof reporting from target entry registers. The descriptor/loader/trampoline now carry `resumeRegisterRdi`, reject ambiguous `argument0` plus resume-register descriptors, and seed `%rdi` immediately before the target jump. The proof target writes its report through the out-of-band `stateReportAddress` instead of using `%rdi` as an ABI reservation.

Fixes #621

## Validation

- `pnpm run format:check` — 0.585s
- `pnpm run lint` — 0.230s
- `pnpm run typecheck` — 2.499s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.819s
- `pnpm smoke-tests` — 2m14.719s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.352s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m14s, 2 passed / 2 total
- remote arm64→amd64 e2e — 46.352s wall, target VM boot/restore 28.327s, `targetRegisterRestoreResult=passed`
