### PR TITLE
Prove minimal amd64 TLS handoff

### DIFF
--- a/docs/snapshot/native-register-translation.md
+++ b/docs/snapshot/native-register-translation.md
@@ -46,7 +46,9 @@ Unsafe states refuse with stable codes:
 - `code-location-unknown` when the captured PC has no target continuation;
 - `tls-state-unsupported` when source TLS is unknown, the source thread-pointer
   register is not arm64 `TPIDR_EL0`, target segment bases are malformed, or the
-  continuation requires a target TCB that has not been materialized;
+  continuation requires a target TCB that has not been materialized. The current
+  machine proof accepts the explicit `target-tcb-materialized` policy for its
+  minimal amd64 TCB page;
 - `architecture-pair-unsupported` for anything other than the initial arm64 ->
   amd64 proof path.
 

--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -59,9 +59,9 @@ target-native landing. The restore boundary accepts only one safe stopped thread
 for this proof; multi-thread, futex, signal-delivery, ptrace/debug,
 shared-stack, unknown/ambiguous TLS or target segment-base, ambiguous register,
 and live/unknown SIMD/FPU states refuse before the target VM is entered. The
-current continuation declares target TLS not required and therefore uses zero
-amd64 `%fs`/`%gs`; later target-TCB materialization must opt into a non-zero
-segment-base policy. The descriptor uses `resumeMode=translated-frame`, so the success
+current continuation materializes a minimal target-owned amd64 TCB page, sets
+`%fs` to that page before the target-native jump, reads proof markers through
+`%fs`, and restores the host `%fs` on return. The descriptor uses `resumeMode=translated-frame`, so the success
 path records a target-native resume-path marker after the real continuation
 observes the translated frame, stack-slot vector, amd64 callee-saved register
 bank, modeled resume-register handoff including `%rdi`, and modeled RFLAGS
@@ -110,7 +110,8 @@ resource recipe kinds, `targetRestore.targetContinuationKind`,
 `targetRestore.targetResumePathResult`,
 `targetRestore.targetResumePathMode`,
 `targetRestore.targetRegisterRestoreResult`,
-`targetRestore.targetRflagsRestoreResult`, and
+`targetRestore.targetRflagsRestoreResult`,
+`targetRestore.targetTlsRestoreResult`, and
 `targetRestore.targetVerifierResult`. It reports timing for:
 
 1. preflight / optional remote reachability gates;

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -19,8 +19,13 @@
 #include <string.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
 #include <sys/timerfd.h>
 #include <unistd.h>
+
+#if defined(__linux__) && defined(__x86_64__)
+#include <asm/prctl.h>
+#endif
 
 #ifndef MAP_FIXED_NOREPLACE
 #define MAP_FIXED_NOREPLACE 0x100000
@@ -55,6 +60,10 @@
 #define TRANSLATED_FRAME_REGISTER_R15 UINT64_C(0x10)
 #define RESUME_REGISTER_MARKER UINT64_C(0x52454753544f5245)
 #define RESUME_RFLAGS_MARKER UINT64_C(0x52464c4147534f4b)
+#define TLS_RESTORE_MARKER UINT64_C(0x544c534f4b504153)
+#define TLS_TCB_MARKER UINT64_C(0x5443425041534f4b)
+#define TLS_TCB_SELF_OFFSET UINT64_C(0x0)
+#define TLS_TCB_MARKER_OFFSET UINT64_C(0x40)
 #define SUPPORTED_RESUME_RFLAGS_MASK UINT64_C(0x8d7)
 #define RESUME_RFLAGS_CONDITION_MASK UINT64_C(0x8d5)
 #define REQUIRED_RESUME_RFLAGS_MASK UINT64_C(0x2)
@@ -92,6 +101,8 @@ struct Options {
   uint64_t argument0;
   bool has_state_report_address;
   uint64_t state_report_address;
+  bool has_target_fs_base;
+  uint64_t target_fs_base;
   bool has_translated_return_address;
   uint64_t translated_return_address;
   bool has_resume_mode;
@@ -148,7 +159,7 @@ static void usage(void) {
   fprintf(stderr,
       "usage: machinen-native-actual-resume-trampoline --code-file path "
       "--file-offset n --code-size n --target-address addr "
-      "[--argument0 addr] [--state-report-address addr] "
+      "[--argument0 addr] [--state-report-address addr] [--target-fs-base addr] "
       "[--translated-return-address addr] [--translated-frame-pointer addr] "
       "[--translated-frame-cfa addr] [--translated-frame-return-address-slot addr] "
       "[--translated-frame-return-address addr] [--translated-frame-unwind-id id] "
@@ -337,6 +348,12 @@ static struct Options parse_args(int argc, char **argv) {
       }
       opts.state_report_address = parse_u64(argv[i], "state-report-address");
       opts.has_state_report_address = true;
+    } else if (streq(argv[i], "--target-fs-base")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.target_fs_base = parse_u64(argv[i], "target-fs-base");
+      opts.has_target_fs_base = true;
     } else if (streq(argv[i], "--translated-return-address")) {
       if (++i >= argc) {
         usage();
@@ -569,6 +586,8 @@ static uint64_t mapped_code_page_start = 0;
 static uint64_t mapped_code_page_size = 0;
 static volatile uint64_t resume_return_value __attribute__((used)) = 0;
 static uint64_t host_rsp_before_jump __attribute__((used)) = 0;
+static uint64_t host_fs_before_jump __attribute__((used)) = 0;
+static uint64_t jump_target_fs_base __attribute__((used)) = 0;
 static uint64_t host_rbx_before_jump __attribute__((used)) = 0;
 static uint64_t host_rbp_before_jump __attribute__((used)) = 0;
 static uint64_t host_r12_before_jump __attribute__((used)) = 0;
@@ -834,6 +853,40 @@ static bool address_inside_stack(const struct Options *opts, uint64_t address, u
       address + size <= opts->stack_target_start + opts->stack_size;
 }
 
+static bool address_inside_writable_materialized_memory(
+    const struct Options *opts, uint64_t address, uint64_t size) {
+  for (size_t i = 0; i < opts->materialized_memory_count; i++) {
+    const struct MemoryMaterialization *mapping = &opts->materialized_memory[i];
+    if ((mapping->prot & PROT_WRITE) == 0) {
+      continue;
+    }
+    if (address >= mapping->target_start && size <= mapping->size &&
+        address + size <= mapping->target_start + mapping->size) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void validate_target_tls_options(const struct Options *opts) {
+  if (!opts->has_target_fs_base) {
+    return;
+  }
+  if (!opts->has_state_report_address) {
+    fprintf(stderr, "native-actual-resume-trampoline: target fs base requires a state report\n");
+    exit(2);
+  }
+  if (opts->target_fs_base == 0 || opts->target_fs_base % 16u != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: target fs base must be non-zero and 16-byte aligned\n");
+    exit(2);
+  }
+  if (!address_inside_writable_materialized_memory(
+          opts, opts->target_fs_base + TLS_TCB_SELF_OFFSET, TLS_TCB_MARKER_OFFSET + sizeof(uint64_t))) {
+    fprintf(stderr, "native-actual-resume-trampoline: target fs base is outside writable materialized memory\n");
+    exit(2);
+  }
+}
+
 static void validate_resume_rflags_options(const struct Options *opts) {
   if (!opts->has_resume_rflags) {
     return;
@@ -1003,6 +1056,14 @@ static void write_stack_u64(uint64_t address, uint64_t value) {
   *slot = value;
 }
 
+static void materialize_target_tcb(const struct Options *opts) {
+  if (!opts->has_target_fs_base) {
+    return;
+  }
+  write_stack_u64(opts->target_fs_base + TLS_TCB_SELF_OFFSET, opts->target_fs_base);
+  write_stack_u64(opts->target_fs_base + TLS_TCB_MARKER_OFFSET, TLS_TCB_MARKER);
+}
+
 static void materialize_translated_frame(const struct Options *opts) {
   if (!opts->has_translated_frame) {
     return;
@@ -1013,8 +1074,19 @@ static void materialize_translated_frame(const struct Options *opts) {
   }
 }
 
+static void capture_host_fs_base(void) {
+  unsigned long fs_base = 0;
+  long rc = syscall(SYS_arch_prctl, ARCH_GET_FS, &fs_base);
+  if (rc != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: ARCH_GET_FS failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  host_fs_before_jump = (uint64_t)fs_base;
+}
+
 static void jump_to_target(uint64_t entry,
     uint64_t initial_rsp,
+    uint64_t target_fs_base,
     uint64_t argument0,
     uint64_t translated_return_address,
     uint64_t translated_frame_pointer,
@@ -1035,6 +1107,7 @@ static void jump_to_target(uint64_t entry,
     uint64_t resume_register_r11) {
   jump_entry_address = entry;
   jump_initial_rsp = initial_rsp;
+  jump_target_fs_base = target_fs_base;
   jump_argument0 = argument0;
   jump_translated_return_address = translated_return_address;
   jump_translated_frame_pointer = translated_frame_pointer;
@@ -1093,9 +1166,39 @@ static void jump_to_target(uint64_t entry,
       "movq jump_resume_register_r9(%%rip), %%r9\n"
       "movq jump_resume_register_r10(%%rip), %%r10\n"
       "movq jump_resume_register_r11(%%rip), %%r11\n"
+      "cmpq $0, jump_target_fs_base(%%rip)\n"
+      "jz 5f\n"
+      "movq $158, %%rax\n"
+      "movq $0x1002, %%rdi\n"
+      "movq jump_target_fs_base(%%rip), %%rsi\n"
+      "syscall\n"
+      "5:\n"
+      "movq jump_resume_rflags(%%rip), %%r11\n"
+      "testq %%r11, %%r11\n"
+      "jz 7f\n"
+      "pushq %%r11\n"
+      "popfq\n"
+      "7:\n"
+      "movq jump_resume_register_rdi(%%rip), %%rdi\n"
+      "movq jump_resume_register_rax(%%rip), %%rax\n"
+      "movq jump_resume_register_rsi(%%rip), %%rsi\n"
+      "movq jump_resume_register_rdx(%%rip), %%rdx\n"
+      "movq jump_resume_register_rcx(%%rip), %%rcx\n"
+      "movq jump_resume_register_r8(%%rip), %%r8\n"
+      "movq jump_resume_register_r9(%%rip), %%r9\n"
+      "movq jump_resume_register_r10(%%rip), %%r10\n"
+      "movq jump_resume_register_r11(%%rip), %%r11\n"
       "jmp *jump_entry_address(%%rip)\n"
       "1:\n"
       "movq %%rax, resume_return_value(%%rip)\n"
+      "movq jump_target_fs_base(%%rip), %%rsi\n"
+      "testq %%rsi, %%rsi\n"
+      "jz 6f\n"
+      "movq $158, %%rax\n"
+      "movq $0x1002, %%rdi\n"
+      "movq host_fs_before_jump(%%rip), %%rsi\n"
+      "syscall\n"
+      "6:\n"
       "movq host_rsp_before_jump(%%rip), %%rsp\n"
       "movq host_rbx_before_jump(%%rip), %%rbx\n"
       "movq host_rbp_before_jump(%%rip), %%rbp\n"
@@ -1455,6 +1558,32 @@ static void print_frame_restoration(const struct Options *opts) {
   printf("]}");
 }
 
+static void print_tls_restore(const struct Options *opts) {
+  if (!opts->has_target_fs_base || !opts->has_state_report_address) {
+    return;
+  }
+  uint64_t marker = read_state_report_u64(opts->state_report_address, 224);
+  uint64_t observed_marker = read_state_report_u64(opts->state_report_address, 232);
+  uint64_t observed_self = read_state_report_u64(opts->state_report_address, 240);
+  bool passed = marker == TLS_RESTORE_MARKER && observed_marker == TLS_TCB_MARKER &&
+      observed_self == opts->target_fs_base;
+  printf(
+      ",\"tlsRestore\":{\"status\":\"%s\","
+      "\"targetFsBase\":\"0x%" PRIx64 "\","
+      "\"reportMarker\":\"0x%" PRIx64 "\","
+      "\"expectedMarker\":\"0x%" PRIx64 "\","
+      "\"observedTcbMarker\":\"0x%" PRIx64 "\","
+      "\"expectedTcbMarker\":\"0x%" PRIx64 "\","
+      "\"observedSelfPointer\":\"0x%" PRIx64 "\"}",
+      passed ? "passed" : "failed",
+      opts->target_fs_base,
+      marker,
+      TLS_RESTORE_MARKER,
+      observed_marker,
+      TLS_TCB_MARKER,
+      observed_self);
+}
+
 static void print_return_event(const struct Options *opts) {
   printf(
       "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
@@ -1479,6 +1608,7 @@ static void print_return_event(const struct Options *opts) {
   print_resume_path(opts);
   print_register_restore(opts);
   print_rflags_restore(opts);
+  print_tls_restore(opts);
   printf("}\n");
 }
 
@@ -1488,10 +1618,12 @@ int main(int argc, char **argv) {
   validate_resume_rflags_options(&opts);
   validate_resume_register_options(&opts);
   validate_translated_frame_options(&opts);
+  validate_target_tls_options(&opts);
   mapped_target_start = opts.target_address;
   mapped_target_end = opts.target_address + opts.code_size;
 
   materialize_descriptor_memory(&opts);
+  materialize_target_tcb(&opts);
 
   uint64_t mapped_code_start = 0;
   uint64_t mapped_code_size = 0;
@@ -1509,6 +1641,7 @@ int main(int argc, char **argv) {
   install_synthetic_empty_eventfd(opts.synthetic_empty_eventfd);
   install_synthetic_timerfd(opts.synthetic_timerfd);
   apply_cloexec_fds(&opts);
+  capture_host_fs_base();
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {
     uint64_t initial_rsp = opts.has_translated_return_address ? opts.stack_pointer - 16u : opts.stack_pointer - 8u;
@@ -1518,6 +1651,7 @@ int main(int argc, char **argv) {
     jump_to_target(
         opts.target_address,
         initial_rsp,
+        opts.has_target_fs_base ? opts.target_fs_base : 0u,
         opts.has_argument0 ? opts.argument0 : 0u,
         opts.has_translated_return_address ? opts.translated_return_address : 0u,
         opts.has_translated_frame ? opts.translated_frame_pointer : 0u,

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -52,6 +52,8 @@ struct Descriptor {
   uint64_t argument0;
   bool has_state_report_address;
   uint64_t state_report_address;
+  bool has_target_fs_base;
+  uint64_t target_fs_base;
   bool has_translated_return_address;
   uint64_t translated_return_address;
   bool has_resume_mode;
@@ -229,6 +231,9 @@ static void parse_field(struct Descriptor *descriptor, char *line) {
   } else if (streq(key, "stateReportAddress")) {
     descriptor->state_report_address = parse_u64(value, key);
     descriptor->has_state_report_address = true;
+  } else if (streq(key, "targetFsBase")) {
+    descriptor->target_fs_base = parse_u64(value, key);
+    descriptor->has_target_fs_base = true;
   } else if (streq(key, "translatedReturnAddress")) {
     descriptor->translated_return_address = parse_u64(value, key);
     descriptor->has_translated_return_address = true;
@@ -684,6 +689,9 @@ static void validate_descriptor(const struct Descriptor *descriptor) {
   if (descriptor->has_resume_mode && !descriptor->has_translated_frame) {
     refuse("target-guest-loader-frame-unsupported", "translated resume mode requires a frame");
   }
+  if (descriptor->has_target_fs_base && !descriptor->has_state_report_address) {
+    refuse("target-guest-loader-invalid-continuation", "targetFsBase requires a state report");
+  }
   if (descriptor->has_argument0 && descriptor->has_resume_registers) {
     refuse("target-guest-loader-invalid-continuation", "argument0 cannot be combined with a resume register bank");
   }
@@ -768,6 +776,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   char target_address[32];
   char argument0[32];
   char state_report_address[32];
+  char target_fs_base[32];
   char translated_return_address[32];
   char resume_rflags[32];
   char resume_register_rax[32];
@@ -803,6 +812,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   snprintf(target_address, sizeof(target_address), "0x%" PRIx64, descriptor->target_address);
   snprintf(argument0, sizeof(argument0), "0x%" PRIx64, descriptor->argument0);
   snprintf(state_report_address, sizeof(state_report_address), "0x%" PRIx64, descriptor->state_report_address);
+  snprintf(target_fs_base, sizeof(target_fs_base), "0x%" PRIx64, descriptor->target_fs_base);
   snprintf(translated_return_address, sizeof(translated_return_address), "0x%" PRIx64, descriptor->translated_return_address);
   snprintf(resume_rflags, sizeof(resume_rflags), "0x%" PRIx64, descriptor->resume_rflags);
   snprintf(resume_register_rax, sizeof(resume_register_rax), "0x%" PRIx64, descriptor->resume_register_rax);
@@ -861,6 +871,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   if (descriptor->has_state_report_address) {
     push_arg(child_argv, &child_argc, "--state-report-address");
     push_arg(child_argv, &child_argc, state_report_address);
+  }
+  if (descriptor->has_target_fs_base) {
+    push_arg(child_argv, &child_argc, "--target-fs-base");
+    push_arg(child_argv, &child_argc, target_fs_base);
   }
   if (descriptor->has_translated_return_address) {
     push_arg(child_argv, &child_argc, "--translated-return-address");

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -122,6 +122,7 @@
 - [`PortableMachineTargetFrameRestoreResult`](#portablemachinetargetframerestoreresult)
 - [`PortableMachineTargetRegisterRestoreResult`](#portablemachinetargetregisterrestoreresult)
 - [`PortableMachineTargetRflagsRestoreResult`](#portablemachinetargetrflagsrestoreresult)
+- [`PortableMachineTargetTlsRestoreResult`](#portablemachinetargettlsrestoreresult)
 - [`PortableMachineTargetThreadRestoreResult`](#portablemachinetargetthreadrestoreresult)
 - [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)
 - [`PortableMachineTargetResumePathResult`](#portablemachinetargetresumepathresult)
@@ -8233,6 +8234,10 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetRflagsRestoreResult?**: [`PortableMachineTargetRflagsRestoreResult`](#portablemachinetargetrflagsrestoreresult)
 
+##### targetTlsRestoreResult?
+
+> `optional` **targetTlsRestoreResult?**: [`PortableMachineTargetTlsRestoreResult`](#portablemachinetargettlsrestoreresult)
+
 ##### targetThreadRestoreResult?
 
 > `optional` **targetThreadRestoreResult?**: [`PortableMachineTargetThreadRestoreResult`](#portablemachinetargetthreadrestoreresult)
@@ -8330,6 +8335,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ###### Inherited from
 
 [`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetRflagsRestoreResult`](#targetrflagsrestoreresult)
+
+##### targetTlsRestoreResult?
+
+> `optional` **targetTlsRestoreResult?**: [`PortableMachineTargetTlsRestoreResult`](#portablemachinetargettlsrestoreresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetTlsRestoreResult`](#targettlsrestoreresult)
 
 ##### targetThreadRestoreResult?
 
@@ -8544,6 +8557,14 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ###### Inherited from
 
 [`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetRflagsRestoreResult`](#targetrflagsrestoreresult)
+
+##### targetTlsRestoreResult?
+
+> `optional` **targetTlsRestoreResult?**: [`PortableMachineTargetTlsRestoreResult`](#portablemachinetargettlsrestoreresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetTlsRestoreResult`](#targettlsrestoreresult)
 
 ##### targetThreadRestoreResult?
 
@@ -9592,6 +9613,10 @@ Poll interval in ms while retrying. Default 250.
 ##### stateReportAddress?
 
 > `optional` **stateReportAddress?**: `string`
+
+##### targetFsBase?
+
+> `optional` **targetFsBase?**: `string`
 
 ##### translatedReturnAddress?
 
@@ -12193,7 +12218,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeTlsTargetAccessPolicy
 
-> **NativeTlsTargetAccessPolicy** = `"not-required"` \| `"segment-bases-provided"` \| `"target-tcb-required"`
+> **NativeTlsTargetAccessPolicy** = `"not-required"` \| `"segment-bases-provided"` \| `"target-tcb-materialized"` \| `"target-tcb-required"`
 
 ***
 
@@ -12268,6 +12293,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### PortableMachineTargetRflagsRestoreResult
 
 > **PortableMachineTargetRflagsRestoreResult** = `"pending"` \| `"passed"` \| `"failed"`
+
+***
+
+### PortableMachineTargetTlsRestoreResult
+
+> **PortableMachineTargetTlsRestoreResult** = `"pending"` \| `"passed"` \| `"failed"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-tls-segment-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-tls-segment-policy.test.ts
@@ -27,7 +27,7 @@ describe("native TLS segment-base handoff policy", () => {
     });
   });
 
-  it("accepts explicit target segment bases as modeled handoff state", () => {
+  it("accepts explicit target segment bases and materialized TCB state", () => {
     expect(
       planNativeTlsSegmentBaseHandoff({
         ...baseRequest,
@@ -41,6 +41,21 @@ describe("native TLS segment-base handoff policy", () => {
         fsBase: "0x7ffff7d00000",
         gsBase: "0x0",
         accessPolicy: "segment-bases-provided",
+      },
+    });
+    expect(
+      planNativeTlsSegmentBaseHandoff({
+        ...baseRequest,
+        targetFsBase: "0x600000000300",
+        targetGsBase: "0x0",
+        targetAccessPolicy: "target-tcb-materialized",
+      }),
+    ).toMatchObject({
+      state: "accepted",
+      targetSegmentBases: {
+        fsBase: "0x600000000300",
+        gsBase: "0x0",
+        accessPolicy: "target-tcb-materialized",
       },
     });
   });

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -193,6 +193,7 @@ describe("portable machine VM restore proof", () => {
         targetTranslatedFramePointer: "0x50000000ff80",
         targetRegisterRestoreResult: "passed",
         targetRflagsRestoreResult: "passed",
+        targetTlsRestoreResult: "passed",
         targetThreadRestoreResult: "accepted",
         targetThreadRestoreThreadId: "thread:1",
         targetResumePathResult: "passed",
@@ -213,6 +214,7 @@ describe("portable machine VM restore proof", () => {
       targetTranslatedFramePointer: "0x50000000ff80",
       targetRegisterRestoreResult: "passed",
       targetRflagsRestoreResult: "passed",
+      targetTlsRestoreResult: "passed",
       targetThreadRestoreResult: "accepted",
       targetThreadRestoreThreadId: "thread:1",
       targetResumePathResult: "passed",
@@ -289,6 +291,24 @@ describe("portable machine VM restore proof", () => {
       migrationCompleted: false,
       descriptorGateCompleted: true,
       targetRflagsRestoreResult: "failed",
+    });
+
+    expect(
+      completePortableMachineVmRestoreProof(plan, {
+        exitCode: 0,
+        migrationCompleted: true,
+        descriptorGateCompleted: true,
+        targetVerifierResult: "passed",
+        targetTlsRestoreResult: "failed",
+        sourceTextReusedAsTargetCode: false,
+        sourceIsaEmulationUsed: false,
+        sidecarRuntimeUsed: false,
+      }),
+    ).toMatchObject({
+      state: "ready",
+      migrationCompleted: false,
+      descriptorGateCompleted: true,
+      targetTlsRestoreResult: "failed",
     });
 
     expect(

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -87,6 +87,7 @@ describe("target guest restore loader descriptor", () => {
       continuation: {
         ...descriptor().continuation,
         stateReportAddress: "0x600000000000",
+        targetFsBase: "0x600000000300",
         translatedReturnAddress: "0x700300000080",
         resumeMode: "translated-frame",
         resumeRflags: "0x8d7",
@@ -126,6 +127,8 @@ describe("target guest restore loader descriptor", () => {
       "0x700300000000",
       "--state-report-address",
       "0x600000000000",
+      "--target-fs-base",
+      "0x600000000300",
       "--translated-return-address",
       "0x700300000080",
       "--resume-mode",
@@ -441,6 +444,29 @@ describe("target guest restore loader descriptor", () => {
         }),
       ),
     ).toThrow(/translatedReturnAddress must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            stateReportAddress: "0x600000000000",
+            targetFsBase: "600000000300",
+          },
+        }),
+      ),
+    ).toThrow(/targetFsBase must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          continuation: {
+            ...descriptor().continuation,
+            targetFsBase: "0x600000000300",
+          },
+        }),
+      ),
+    ).toThrow(/targetFsBase requires a state report/);
 
     expect(() =>
       validateTargetGuestRestoreDescriptor(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -467,6 +467,7 @@ export type {
   PortableMachineTargetFrameRestoreResult,
   PortableMachineTargetRegisterRestoreResult,
   PortableMachineTargetRflagsRestoreResult,
+  PortableMachineTargetTlsRestoreResult,
   PortableMachineTargetResourceStatus,
   PortableMachineTargetResumePathResult,
   PortableMachineTargetReturnChainResult,

--- a/packages/runtime/src/native-tls-segment-policy.ts
+++ b/packages/runtime/src/native-tls-segment-policy.ts
@@ -11,6 +11,7 @@ import type {
 export type NativeTlsTargetAccessPolicy =
   | "not-required"
   | "segment-bases-provided"
+  | "target-tcb-materialized"
   | "target-tcb-required";
 
 export type NativeTlsSegmentBaseHandoffResult =
@@ -206,7 +207,11 @@ function planRequestedSegmentBases(
     return policyRefusal;
   }
   const acceptedAccessPolicy =
-    accessPolicy === "not-required" ? "not-required" : "segment-bases-provided";
+    accessPolicy === "not-required"
+      ? "not-required"
+      : accessPolicy === "target-tcb-materialized"
+        ? "target-tcb-materialized"
+        : "segment-bases-provided";
   return {
     state: "accepted",
     targetSegmentBases: { fsBase, gsBase, accessPolicy: acceptedAccessPolicy },
@@ -231,6 +236,13 @@ function targetAccessRefusal(
       threadId,
       "tls-state-unsupported",
       `thread ${threadId} declares TLS not required but provides non-zero amd64 segment bases`,
+    );
+  }
+  if (accessPolicy === "target-tcb-materialized" && isZeroHex(fsBase)) {
+    return refused(
+      threadId,
+      "tls-state-unsupported",
+      `thread ${threadId} declares a materialized target TCB with a zero amd64 fs base`,
     );
   }
   return undefined;

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -27,6 +27,7 @@ export type PortableMachineTargetReturnChainResult = "pending" | "passed" | "fai
 export type PortableMachineTargetFrameRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetRegisterRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetRflagsRestoreResult = "pending" | "passed" | "failed";
+export type PortableMachineTargetTlsRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetThreadRestoreResult = "accepted" | "refused";
 export type PortableMachineTargetResumePathResult = "pending" | "passed" | "failed";
 
@@ -45,6 +46,7 @@ export interface PortableMachineTargetRestoreObservation {
   targetTranslatedFramePointer?: string;
   targetRegisterRestoreResult?: PortableMachineTargetRegisterRestoreResult;
   targetRflagsRestoreResult?: PortableMachineTargetRflagsRestoreResult;
+  targetTlsRestoreResult?: PortableMachineTargetTlsRestoreResult;
   targetThreadRestoreResult?: PortableMachineTargetThreadRestoreResult;
   targetThreadRestoreThreadId?: string;
   targetResumePathResult?: PortableMachineTargetResumePathResult;
@@ -207,6 +209,7 @@ export function completePortableMachineVmRestoreProof(
     targetTranslatedFramePointer: result.targetTranslatedFramePointer,
     targetRegisterRestoreResult: result.targetRegisterRestoreResult,
     targetRflagsRestoreResult: result.targetRflagsRestoreResult,
+    targetTlsRestoreResult: result.targetTlsRestoreResult,
     targetThreadRestoreResult: result.targetThreadRestoreResult ?? plan.targetThreadRestoreResult,
     targetThreadRestoreThreadId:
       result.targetThreadRestoreThreadId ?? plan.targetThreadRestoreThreadId,
@@ -227,21 +230,30 @@ function targetNativeCompleted(result: PortableMachineVmRestoreTargetResult): bo
     result.exitCode === 0,
     result.migrationCompleted === true,
     result.descriptorGateCompleted === true,
-    result.targetVerifierResult === undefined || result.targetVerifierResult === "passed",
-    result.targetStateConsumptionResult === undefined ||
-      result.targetStateConsumptionResult === "passed",
-    result.targetReturnChainResult === undefined || result.targetReturnChainResult === "passed",
-    result.targetFrameRestoreResult === undefined || result.targetFrameRestoreResult === "passed",
-    result.targetRegisterRestoreResult === undefined ||
-      result.targetRegisterRestoreResult === "passed",
-    result.targetRflagsRestoreResult === undefined || result.targetRflagsRestoreResult === "passed",
-    result.targetThreadRestoreResult === undefined ||
-      result.targetThreadRestoreResult === "accepted",
-    result.targetResumePathResult === undefined || result.targetResumePathResult === "passed",
+    optionalTargetChecksPassed(result),
     result.sourceTextReusedAsTargetCode === false,
     result.sourceIsaEmulationUsed === false,
     result.sidecarRuntimeUsed === false,
   ].every(Boolean);
+}
+
+function optionalTargetChecksPassed(result: PortableMachineVmRestoreTargetResult): boolean {
+  return [
+    passedOrUnset(result.targetVerifierResult),
+    passedOrUnset(result.targetStateConsumptionResult),
+    passedOrUnset(result.targetReturnChainResult),
+    passedOrUnset(result.targetFrameRestoreResult),
+    passedOrUnset(result.targetRegisterRestoreResult),
+    passedOrUnset(result.targetRflagsRestoreResult),
+    passedOrUnset(result.targetTlsRestoreResult),
+    result.targetThreadRestoreResult === undefined ||
+      result.targetThreadRestoreResult === "accepted",
+    passedOrUnset(result.targetResumePathResult),
+  ].every(Boolean);
+}
+
+function passedOrUnset(value: string | undefined): boolean {
+  return value === undefined || value === "passed";
 }
 
 function missingInputs(request: PortableMachineVmRestoreProofRequest): string | undefined {

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -58,6 +58,7 @@ export interface TargetGuestRestoreContinuationDescriptor {
   targetAddress: string;
   argument0?: string;
   stateReportAddress?: string;
+  targetFsBase?: string;
   translatedReturnAddress?: string;
   resumeMode?: TargetGuestRestoreResumeMode;
   resumeRflags?: string;
@@ -115,6 +116,7 @@ export function serializeTargetGuestRestoreDescriptor(
     `targetAddress=${continuation.targetAddress}`,
     ...optionalContinuationField("argument0", continuation.argument0),
     ...optionalContinuationField("stateReportAddress", continuation.stateReportAddress),
+    ...optionalContinuationField("targetFsBase", continuation.targetFsBase),
     ...optionalContinuationField("translatedReturnAddress", continuation.translatedReturnAddress),
     ...optionalContinuationField("resumeMode", continuation.resumeMode),
     ...optionalContinuationField("resumeRflags", continuation.resumeRflags),
@@ -182,6 +184,7 @@ export function buildNativeActualResumeTrampolineArgs(
     continuation.targetAddress,
     ...optionalArg("--argument0", continuation.argument0),
     ...optionalArg("--state-report-address", continuation.stateReportAddress),
+    ...optionalArg("--target-fs-base", continuation.targetFsBase),
     ...optionalArg("--translated-return-address", continuation.translatedReturnAddress),
     ...optionalArg("--resume-mode", continuation.resumeMode),
     ...optionalArg("--resume-rflags", continuation.resumeRflags),
@@ -238,6 +241,7 @@ function fieldsToDescriptor(
       targetAddress: requiredField(fields, "targetAddress"),
       argument0: optionalField(fields, "argument0"),
       stateReportAddress: optionalField(fields, "stateReportAddress"),
+      targetFsBase: optionalField(fields, "targetFsBase"),
       translatedReturnAddress: optionalField(fields, "translatedReturnAddress"),
       resumeMode: optionalField(fields, "resumeMode") as TargetGuestRestoreResumeMode | undefined,
       resumeRflags: optionalField(fields, "resumeRflags"),
@@ -573,21 +577,14 @@ function validateContinuation(
   assertPositive(continuation.timeoutSeconds, "timeoutSeconds");
   assertPositive(continuation.stackSize, "stackSize");
   assertHexAddress(continuation.targetAddress, "targetAddress");
-  if (continuation.argument0 !== undefined) {
-    assertHexAddress(continuation.argument0, "argument0");
-  }
-  if (continuation.argument0 !== undefined && continuation.resumeRegisters !== undefined) {
-    fail(
-      "target-guest-loader-invalid-continuation",
-      "argument0 cannot be combined with a resume register bank",
-    );
-  }
-  if (continuation.stateReportAddress !== undefined) {
-    assertHexAddress(continuation.stateReportAddress, "stateReportAddress");
-  }
-  if (continuation.translatedReturnAddress !== undefined) {
-    assertHexAddress(continuation.translatedReturnAddress, "translatedReturnAddress");
-  }
+  validateOptionalContinuationAddress(continuation.argument0, "argument0");
+  validateArgumentRegisterConflict(continuation);
+  validateOptionalContinuationAddress(continuation.stateReportAddress, "stateReportAddress");
+  validateTargetFsBase(continuation);
+  validateOptionalContinuationAddress(
+    continuation.translatedReturnAddress,
+    "translatedReturnAddress",
+  );
   if (continuation.resumeMode !== undefined && continuation.resumeMode !== "translated-frame") {
     fail("target-guest-loader-invalid-continuation", "resumeMode is unsupported");
   }
@@ -596,6 +593,33 @@ function validateContinuation(
   assertHexAddress(continuation.stackTargetStart, "stackTargetStart");
   assertHexAddress(continuation.stackPointer, "stackPointer");
   return continuation;
+}
+
+function validateOptionalContinuationAddress(value: string | undefined, field: string): void {
+  if (value !== undefined) {
+    assertHexAddress(value, field);
+  }
+}
+
+function validateArgumentRegisterConflict(
+  continuation: TargetGuestRestoreContinuationDescriptor,
+): void {
+  if (continuation.argument0 !== undefined && continuation.resumeRegisters !== undefined) {
+    fail(
+      "target-guest-loader-invalid-continuation",
+      "argument0 cannot be combined with a resume register bank",
+    );
+  }
+}
+
+function validateTargetFsBase(continuation: TargetGuestRestoreContinuationDescriptor): void {
+  if (continuation.targetFsBase === undefined) {
+    return;
+  }
+  assertHexAddress(continuation.targetFsBase, "targetFsBase");
+  if (continuation.stateReportAddress === undefined) {
+    fail("target-guest-loader-invalid-continuation", "targetFsBase requires a state report");
+  }
 }
 
 const RESOURCE_RECIPE_VALIDATORS = {

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -144,6 +144,7 @@ const TOC = {
     "PortableMachineTargetFrameRestoreResult",
     "PortableMachineTargetRegisterRestoreResult",
     "PortableMachineTargetRflagsRestoreResult",
+    "PortableMachineTargetTlsRestoreResult",
     "PortableMachineTargetThreadRestoreResult",
     "PortableMachineTargetResourceStatus",
     "PortableMachineTargetResumePathResult",

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -54,6 +54,10 @@ interface RflagsRestoreEvent {
   status?: StateConsumptionStatus;
 }
 
+interface TlsRestoreEvent {
+  status?: StateConsumptionStatus;
+}
+
 interface ResumePathEvent {
   status?: StateConsumptionStatus;
   mode?: string;
@@ -238,6 +242,7 @@ function targetExecutionSummary(
     ...targetFrameRestorationFields(events.frameRestoration),
     ...targetRegisterRestoreFields(events.registerRestore),
     ...targetRflagsRestoreFields(events.rflagsRestore),
+    ...targetTlsRestoreFields(events.tlsRestore),
     ...targetResumePathFields(events.resumePath),
     targetVerifierResult: targetVerifierResult(args, result.exitCode, events),
     exitCode: result.exitCode,
@@ -283,6 +288,12 @@ function targetRflagsRestoreFields(rflagsRestore: RflagsRestoreEvent | undefined
   };
 }
 
+function targetTlsRestoreFields(tlsRestore: TlsRestoreEvent | undefined) {
+  return {
+    targetTlsRestoreResult: tlsRestore?.status,
+  };
+}
+
 function targetResumePathFields(resumePath: ResumePathEvent | undefined) {
   return {
     targetResumePathResult: resumePath?.status,
@@ -301,6 +312,7 @@ function targetExecutionEvents(stdout: string) {
     frameRestoration: parseFrameRestoration(actualResumeEvent),
     registerRestore: parseRegisterRestore(actualResumeEvent),
     rflagsRestore: parseRflagsRestore(actualResumeEvent),
+    tlsRestore: parseTlsRestore(actualResumeEvent),
     resumePath: parseResumePath(actualResumeEvent),
   };
 }
@@ -320,6 +332,7 @@ function targetVerifierResult(
     events.frameRestoration,
     events.registerRestore,
     events.rflagsRestore,
+    events.tlsRestore,
     events.resumePath,
   )
     ? "passed"
@@ -419,6 +432,7 @@ function targetVerifierPassed(
   frameRestoration: FrameRestorationEvent | undefined,
   registerRestore: RegisterRestoreEvent | undefined,
   rflagsRestore: RflagsRestoreEvent | undefined,
+  tlsRestore: TlsRestoreEvent | undefined,
   resumePath: ResumePathEvent | undefined,
 ): boolean {
   return [
@@ -428,6 +442,7 @@ function targetVerifierPassed(
     targetFrameRestored(frameRestoration),
     targetRegistersRestored(registerRestore),
     targetRflagsRestored(rflagsRestore),
+    targetTlsRestored(tlsRestore),
     targetResumePathPassed(resumePath),
     targetReturnValueMatched(args, actualResumeEvent),
   ].every(Boolean);
@@ -455,6 +470,10 @@ function targetRegistersRestored(registerRestore: RegisterRestoreEvent | undefin
 
 function targetRflagsRestored(rflagsRestore: RflagsRestoreEvent | undefined): boolean {
   return rflagsRestore === undefined || rflagsRestore.status === "passed";
+}
+
+function targetTlsRestored(tlsRestore: TlsRestoreEvent | undefined): boolean {
+  return tlsRestore === undefined || tlsRestore.status === "passed";
 }
 
 function targetResumePathPassed(resumePath: ResumePathEvent | undefined): boolean {
@@ -510,6 +529,13 @@ function parseRflagsRestore(
   actualResumeEvent: Record<string, unknown> | undefined,
 ): RflagsRestoreEvent | undefined {
   const value = actualResumeEvent?.rflagsRestore;
+  return isStateConsumptionEvent(value) ? value : undefined;
+}
+
+function parseTlsRestore(
+  actualResumeEvent: Record<string, unknown> | undefined,
+): TlsRestoreEvent | undefined {
+  const value = actualResumeEvent?.tlsRestore;
   return isStateConsumptionEvent(value) ? value : undefined;
 }
 

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -54,6 +54,7 @@ interface TargetInvocation {
   targetTranslatedFramePointer?: string;
   targetRegisterRestoreResult?: "pending";
   targetRflagsRestoreResult?: "pending";
+  targetTlsRestoreResult?: "pending";
   targetThreadRestoreResult?: "accepted";
   targetThreadRestoreThreadId?: string;
   targetResumePathResult?: "pending";
@@ -80,6 +81,7 @@ interface PreparedTargetContinuation {
   bytes: Buffer;
   argument0?: string;
   stateReportAddress?: string;
+  targetFsBase?: string;
   translatedReturnAddress?: string;
   translatedFrame?: TargetGuestTranslatedFrameDescriptor;
   expectedReturnValue?: string;
@@ -129,6 +131,9 @@ const TRANSLATED_FRAME_REGISTER_MASK_R14 = 0x08;
 const TRANSLATED_FRAME_REGISTER_MASK_R15 = 0x10;
 const RESUME_REGISTER_MARKER = 0x52454753544f5245n;
 const RESUME_RFLAGS_MARKER = 0x52464c4147534f4bn;
+const TLS_RESTORE_MARKER = 0x544c534f4b504153n;
+const TLS_TCB_MARKER = 0x5443425041534f4bn;
+const TARGET_TLS_BASE = "0x600000000300";
 const RESUME_RFLAGS = "0x8d7";
 const RESUME_REGISTER_RAX = "0x2121212121212121";
 const RESUME_REGISTER_RDI = "0x7171717171717171";
@@ -290,6 +295,7 @@ function prepareTargetRestoreDescriptor(
       context.targetCodeFile,
       targetContinuation.argument0,
       targetContinuation.stateReportAddress,
+      targetContinuation.targetFsBase,
       targetContinuation.translatedReturnAddress,
       targetContinuation.translatedFrame ? "translated-frame" : undefined,
       targetContinuation.translatedFrame ? RESUME_RFLAGS : undefined,
@@ -320,6 +326,7 @@ function combinedDescriptorContext(
     threads: bundle.nativeProcessImage.threads.threads,
     mappings: bundle.nativeProcessImage.mappings.mappings,
     resources: bundle.nativeProcessImage.resources.resources,
+    tls: { targetFsBase: TARGET_TLS_BASE, targetAccessPolicy: "target-tcb-materialized" },
   });
   if (threadPlan.state === "refused") {
     const first = threadPlan.refusals[0]!;
@@ -379,6 +386,7 @@ function continuationDescriptor(
   targetCodeFile: string,
   argument0: string | undefined,
   stateReportAddress: string | undefined,
+  targetFsBase: string | undefined,
   translatedReturnAddress: string | undefined,
   resumeMode: "translated-frame" | undefined,
   resumeRflags: string | undefined,
@@ -391,6 +399,7 @@ function continuationDescriptor(
     targetAddress: "0x700300000000",
     argument0,
     stateReportAddress,
+    targetFsBase,
     translatedReturnAddress,
     resumeMode,
     resumeRflags,
@@ -455,6 +464,7 @@ function targetInvocation(
     targetContinuationKind: targetContinuation.kind,
     targetModuleBytesSource: targetContinuation.targetModuleBytesSource,
     targetTranslatedReturnAddress: targetContinuation.translatedReturnAddress,
+    targetTlsRestoreResult: targetContinuation.targetFsBase ? "pending" : undefined,
     ...frameSummary,
     targetThreadRestoreResult: context.targetThreadRestoreResult,
     targetThreadRestoreThreadId: context.targetThreadRestoreThreadId,
@@ -515,6 +525,7 @@ function prepareRealUtilityContinuation(
     kind: "real-utility" as const,
     bytes: Buffer.from(materialized.materialized!.bytes),
     stateReportAddress: PROOF_MEMORY_TARGET,
+    targetFsBase: TARGET_TLS_BASE,
     translatedReturnAddress: targetCode.translatedReturnAddress,
     translatedFrame: translatedFrameDescriptor(targetCode.translatedReturnAddress),
     expectedReturnValue: hex(FINAL_JUMP_EXPECTED_RETURN),
@@ -774,6 +785,7 @@ function proofStateVerifierTargetCode(
   if (completion === "return") {
     asm.preserveRbx();
     asm.captureResumeRegisters(BigInt(PROOF_MEMORY_TARGET));
+    asm.checkTargetTls(BigInt(PROOF_MEMORY_TARGET), BigInt(TARGET_TLS_BASE));
     asm.checkTranslatedRbx();
     asm.movRbxImmediate(BigInt(PROOF_MEMORY_TARGET));
     asm.storeReportWord(16, 0n);
@@ -827,6 +839,17 @@ class Amd64ProofAssembler {
     this.storeRegisterAtRaxReportOffset("r11", 192);
     this.storeReportWordFromRaxBase(128, RESUME_REGISTER_MARKER);
     this.storeReportWordFromRaxBase(208, RESUME_RFLAGS_MARKER);
+  }
+
+  checkTargetTls(reportAddress: bigint, targetFsBase: bigint): void {
+    this.loadFsU64(0);
+    this.storeRaxAtAbsolute(reportAddress + 240n);
+    this.checkRaxImmediate(targetFsBase);
+    this.loadFsU64(0x40);
+    this.storeRaxAtAbsolute(reportAddress + 232n);
+    this.checkRaxImmediate(TLS_TCB_MARKER);
+    this.movRaxImmediate(TLS_RESTORE_MARKER);
+    this.storeRaxAtAbsolute(reportAddress + 224n);
   }
 
   movRbxImmediate(value: bigint): void {
@@ -984,6 +1007,17 @@ class Amd64ProofAssembler {
     this.push(0x31, 0xd2, 0x0f, 0x05);
   }
 
+  private loadFsU64(offset: number): void {
+    this.push(0x64, 0x48, 0x8b, 0x04, 0x25);
+    this.pushU32(offset);
+  }
+
+  private checkRaxImmediate(expected: bigint): void {
+    this.movRdxImmediate(expected);
+    this.push(0x48, 0x39, 0xd0);
+    this.jumpIfNotEqual();
+  }
+
   private checkRbpImmediate(expected: bigint): void {
     this.movRaxImmediate(expected);
     this.push(0x48, 0x39, 0xe8);
@@ -1036,6 +1070,11 @@ class Amd64ProofAssembler {
 
   private movRaxImmediate(value: bigint): void {
     this.push(0x48, 0xb8);
+    this.pushU64(value);
+  }
+
+  private movRdxImmediate(value: bigint): void {
+    this.push(0x48, 0xba);
     this.pushU64(value);
   }
 

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -109,6 +109,7 @@ try {
     targetTranslatedFramePointer: result.targetTranslatedFramePointer ?? '',
     targetRegisterRestoreResult: result.targetRegisterRestoreResult ?? '',
     targetRflagsRestoreResult: result.targetRflagsRestoreResult ?? '',
+    targetTlsRestoreResult: result.targetTlsRestoreResult ?? '',
     targetThreadRestoreResult: result.targetThreadRestoreResult ?? '',
     targetThreadRestoreThreadId: result.targetThreadRestoreThreadId ?? '',
     targetResumePathResult: result.targetResumePathResult ?? '',


### PR DESCRIPTION
## Problem

The TLS handoff policy could describe target amd64 segment bases, but the restore proof still did not build a target TLS/TCB page, set `%fs`, or prove target-native TLS access.

## Solution

This PR adds a minimal amd64 TLS proof path:

- target descriptors carry `targetFsBase`
- loader/trampoline validate and pass the target `%fs` base
- trampoline materializes a tiny target-owned TCB page, sets `%fs` before the target-native jump, and restores the host `%fs` on return
- target-native proof bytes read the self pointer and marker through `%fs`
- completion gates on `targetTlsRestoreResult=passed`

The policy now distinguishes `target-tcb-materialized` from still-refused `target-tcb-required` state.

Fixes #631

## Validation

- `pnpm run build:docs` — passed
- `pnpm run format:check` — 0.698s
- `pnpm run lint` — 0.247s
- `pnpm run typecheck` — 2.200s after final refactor
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.228s
- `pnpm smoke-tests` — 2m12.810s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.345s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m16s, 2 passed / 2 total
- remote amd64 target proof on preserved arm64 bundle — completed, `targetTlsRestoreResult=passed`

Note: full fresh remote arm64→amd64 e2e could not run because `friend@100.126.46.90` timed out during preflight.
