### PR TITLE
Materialize private writable mappings

### DIFF
--- a/docs/snapshot/native-mapping-materializer.md
+++ b/docs/snapshot/native-mapping-materializer.md
@@ -13,7 +13,8 @@ The proof builds a small target mapping plan and runs a Linux helper that
 materializes it with `mmap`:
 
 - file-backed executable text comes from a target artifact;
-- anonymous data and heap pages are copied from `native-memory.bin`;
+- private anonymous data, heap, and writable mmap pages are copied from
+  `native-memory.bin` when captured ranges exactly cover the mapping;
 - stack, kernel-style, and no-access guard mappings are recreated without
   copied source bytes;
 - an unsafe unreadable mapping remains refused with `mapping-unreadable`;
@@ -25,7 +26,8 @@ materializes it with `mmap`:
 loader steps:
 
 - `map-target-file` for executable target-file mappings;
-- `copy-captured-bytes` for safe anonymous/data/heap mappings;
+- `copy-captured-bytes` for safe private anonymous/data/heap/writable mmap
+  mappings;
 - `recreate` for target-owned stack/kernel mappings and safe guard mappings;
 - `omit` for source-only mappings intentionally dropped;
 - `refuse` for fail-closed mappings.
@@ -34,14 +36,20 @@ loader steps:
 
 - `mapping-unreadable` is preserved from capture for unsafe unreadable mappings
   and includes mapping details when the planner reports it.
-- `mapping-ambiguous` is used for missing target addresses, missing captured
-  bytes, invalid byte ranges, or recreated mappings that still carry source
-  bytes.
+- `mapping-ambiguous` is used for missing target addresses, non-adjacent private
+  writable guards, or recreated mappings that still carry source bytes.
+- `mapping-captured-range-unsupported` rejects private writable mappings with
+  missing or invalid captured bytes.
 - `mapping-permission-unsupported` rejects writable+executable mappings.
+- `mapping-shared-unsupported` rejects shared writable memory.
 - `target-build-mismatch` rejects file-backed target mappings whose expected
   target build identity does not match.
 
 ## Boundary
+
+Private writable mappings remain target-private: shared writable memory is not
+copied, and optional `privateWritableGuards` must point at recreated no-access
+mappings directly adjacent to the protected target range.
 
 This proof materializes mappings and validates bytes/permissions. It does not
 unwind real stacks, discover pointer fields, replay non-file resources, or claim

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -380,6 +380,7 @@
 - [`NativeMappingMaterializationStep`](#nativemappingmaterializationstep)
 - [`NativeMappingMaterializationRequest`](#nativemappingmaterializationrequest)
 - [`NativeMappingMaterializationResult`](#nativemappingmaterializationresult)
+- [`NativePrivateWritableGuardRequest`](#nativeprivatewritableguardrequest)
 - [`planNativeMappingMaterialization`](#plannativemappingmaterialization)
 - [`NativeInheritedStdioPolicy`](#nativeinheritedstdiopolicy)
 - [`NativeResourceTranslationRequest`](#nativeresourcetranslationrequest)
@@ -3495,9 +3496,35 @@ by default when `output` is a TTY.
 
 > **sizeBytes**: `number`
 
+##### privateWritable?
+
+> `optional` **privateWritable?**: `object`
+
+###### guardMappings
+
+> **guardMappings**: `string`[]
+
 ##### refusal?
 
 > `optional` **refusal?**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)
+
+***
+
+### NativePrivateWritableGuardRequest
+
+#### Properties
+
+##### mapping
+
+> **mapping**: `string`
+
+##### belowMapping?
+
+> `optional` **belowMapping?**: `string`
+
+##### aboveMapping?
+
+> `optional` **aboveMapping?**: `string`
 
 ***
 
@@ -3516,6 +3543,10 @@ by default when `output` is a TTY.
 ##### targetFileBuildIds?
 
 > `optional` **targetFileBuildIds?**: `Record`\<`string`, `string`\>
+
+##### privateWritableGuards?
+
+> `optional` **privateWritableGuards?**: [`NativePrivateWritableGuardRequest`](#nativeprivatewritableguardrequest)[]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
@@ -140,7 +140,7 @@ describe("native mapping materialization", () => {
 
     expect(result.steps[0]).toMatchObject({
       action: "refuse",
-      refusal: { code: "mapping-ambiguous" },
+      refusal: { code: "mapping-captured-range-unsupported" },
     });
   });
 
@@ -176,5 +176,141 @@ describe("native mapping materialization", () => {
     expect(result.refusals).toEqual([
       expect.objectContaining({ code: "mapping-permission-unsupported" }),
     ]);
+  });
+
+  it("materializes private writable heap, data, and anonymous mappings with guards", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 12288,
+      privateWritableGuards: [
+        { mapping: "mapping:heap", belowMapping: "mapping:heap-guard-low" },
+        { mapping: "mapping:mmap", aboveMapping: "mapping:mmap-guard-high" },
+      ],
+      mappings: [
+        mapping({
+          id: "mapping:heap-guard-low",
+          permissions: { read: false, write: false, execute: false, private: true, shared: false },
+          target: { materialization: "refuse", reason: "heap guard" },
+          refusal: { code: "mapping-unreadable", message: "heap guard" },
+        }),
+        mapping({
+          id: "mapping:heap",
+          kind: "heap",
+          sourceStart: "0x2000",
+          sourceEnd: "0x3000",
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x2000" },
+        }),
+        mapping({
+          id: "mapping:data",
+          kind: "data",
+          captured: { file: "native-memory.bin", offset: 4096, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x5000" },
+        }),
+        mapping({
+          id: "mapping:mmap",
+          kind: "anonymous",
+          sourceStart: "0x8000",
+          sourceEnd: "0x9000",
+          captured: { file: "native-memory.bin", offset: 8192, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x8000" },
+        }),
+        mapping({
+          id: "mapping:mmap-guard-high",
+          sourceStart: "0x9000",
+          sourceEnd: "0xa000",
+          permissions: { read: false, write: false, execute: false, private: true, shared: false },
+          target: { materialization: "refuse", reason: "mmap guard" },
+          refusal: { code: "mapping-unreadable", message: "mmap guard" },
+        }),
+      ],
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mapping: "mapping:heap",
+          action: "copy-captured-bytes",
+          privateWritable: { guardMappings: ["mapping:heap-guard-low"] },
+        }),
+        expect.objectContaining({ mapping: "mapping:data", action: "copy-captured-bytes" }),
+        expect.objectContaining({
+          mapping: "mapping:mmap",
+          action: "copy-captured-bytes",
+          privateWritable: { guardMappings: ["mapping:mmap-guard-high"] },
+        }),
+        expect.objectContaining({ mapping: "mapping:heap-guard-low", action: "recreate" }),
+        expect.objectContaining({ mapping: "mapping:mmap-guard-high", action: "recreate" }),
+      ]),
+    );
+  });
+
+  it("refuses shared writable memory instead of copying it", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 4096,
+      mappings: [
+        mapping({
+          id: "mapping:shared-writable",
+          permissions: { read: true, write: true, execute: false, private: false, shared: true },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+        }),
+      ],
+    });
+
+    expect(result.refusals).toEqual([
+      expect.objectContaining({ code: "mapping-shared-unsupported" }),
+    ]);
+  });
+
+  it("refuses private writable mappings with missing or invalid captured bytes precisely", () => {
+    const missing = planNativeMappingMaterialization({
+      memorySizeBytes: 0,
+      mappings: [mapping({ id: "mapping:missing-private-bytes" })],
+    });
+    const invalid = planNativeMappingMaterialization({
+      memorySizeBytes: 1024,
+      mappings: [
+        mapping({
+          id: "mapping:bad-private-bytes",
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+        }),
+      ],
+    });
+
+    expect(missing.refusals).toEqual([
+      expect.objectContaining({ code: "mapping-captured-range-unsupported" }),
+    ]);
+    expect(invalid.refusals).toEqual([
+      expect.objectContaining({ code: "mapping-captured-range-unsupported" }),
+    ]);
+  });
+
+  it("refuses non-adjacent private writable guards", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 4096,
+      privateWritableGuards: [{ mapping: "mapping:heap", belowMapping: "mapping:guard" }],
+      mappings: [
+        mapping({
+          id: "mapping:guard",
+          sourceStart: "0x4000",
+          sourceEnd: "0x5000",
+          permissions: { read: false, write: false, execute: false, private: true, shared: false },
+          target: { materialization: "refuse", reason: "guard" },
+          refusal: { code: "mapping-unreadable", message: "guard" },
+        }),
+        mapping({
+          id: "mapping:heap",
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x9000" },
+        }),
+      ],
+    });
+
+    expect(result.refusals).toContainEqual(
+      expect.objectContaining({
+        code: "mapping-ambiguous",
+        message: expect.stringContaining("not adjacent"),
+      }),
+    );
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -353,6 +353,7 @@ export { planNativeMappingMaterialization } from "./native-mapping-materializati
 export type {
   NativeMappingMaterializationAction,
   NativeMappingMaterializationRequest,
+  NativePrivateWritableGuardRequest,
   NativeMappingMaterializationResult,
   NativeMappingMaterializationStep,
 } from "./native-mapping-materialization.ts";

--- a/packages/runtime/src/native-mapping-materialization.ts
+++ b/packages/runtime/src/native-mapping-materialization.ts
@@ -26,13 +26,23 @@ export interface NativeMappingMaterializationStep {
     offset: number;
     sizeBytes: number;
   };
+  privateWritable?: {
+    guardMappings: string[];
+  };
   refusal?: NativeProcessImageRefusal;
+}
+
+export interface NativePrivateWritableGuardRequest {
+  mapping: string;
+  belowMapping?: string;
+  aboveMapping?: string;
 }
 
 export interface NativeMappingMaterializationRequest {
   mappings: NativeMemoryMapping[];
   memorySizeBytes: number;
   targetFileBuildIds?: Record<string, string>;
+  privateWritableGuards?: NativePrivateWritableGuardRequest[];
 }
 
 export interface NativeMappingMaterializationResult {
@@ -43,10 +53,14 @@ export interface NativeMappingMaterializationResult {
 export function planNativeMappingMaterialization(
   request: NativeMappingMaterializationRequest,
 ): NativeMappingMaterializationResult {
-  const steps = request.mappings.map((mapping) => planMapping(mapping, request));
+  const plannedSteps = request.mappings.map((mapping) => planMapping(mapping, request));
+  const steps = attachPrivateWritableGuards(plannedSteps, request.privateWritableGuards ?? []);
   return {
     steps,
-    refusals: steps.flatMap((step) => (step.refusal ? [step.refusal] : [])),
+    refusals: [
+      ...steps.flatMap((step) => (step.refusal ? [step.refusal] : [])),
+      ...validatePrivateWritableGuards(steps, request.privateWritableGuards ?? []),
+    ],
   };
 }
 
@@ -61,6 +75,11 @@ function planMapping(
   const permissionRefusal = validatePermissions(mapping);
   if (permissionRefusal) {
     return refusedStep(mapping, permissionRefusal);
+  }
+
+  const privateWritableRefusal = validatePrivateWritable(mapping);
+  if (privateWritableRefusal) {
+    return refusedStep(mapping, privateWritableRefusal);
   }
 
   switch (mapping.target.materialization) {
@@ -99,6 +118,7 @@ function translatedStep(
       offset: mapping.captured!.offset,
       sizeBytes: mapping.captured!.sizeBytes,
     },
+    ...privateWritableStep(mapping),
   };
 }
 
@@ -157,11 +177,119 @@ function refusedStep(
   return { ...baseStep(mapping, "refuse"), refusal: reason };
 }
 
+function privateWritableStep(
+  mapping: NativeMemoryMapping,
+): Pick<NativeMappingMaterializationStep, "privateWritable"> | Record<string, never> {
+  return isPrivateWritableMapping(mapping) ? { privateWritable: { guardMappings: [] } } : {};
+}
+
+function attachPrivateWritableGuards(
+  steps: NativeMappingMaterializationStep[],
+  guards: NativePrivateWritableGuardRequest[],
+): NativeMappingMaterializationStep[] {
+  const guardMappings = new Map(
+    guards.map((guard) => [
+      guard.mapping,
+      [guard.belowMapping, guard.aboveMapping].flatMap((id) => (id ? [id] : [])),
+    ]),
+  );
+  return steps.map((step) => {
+    const mappingGuards = guardMappings.get(step.mapping);
+    return step.privateWritable && mappingGuards
+      ? { ...step, privateWritable: { guardMappings: mappingGuards } }
+      : step;
+  });
+}
+
+function validatePrivateWritableGuards(
+  steps: NativeMappingMaterializationStep[],
+  guards: NativePrivateWritableGuardRequest[],
+): NativeProcessImageRefusal[] {
+  const byId = new Map(steps.map((step) => [step.mapping, step]));
+  return guards.flatMap((guard) => validatePrivateWritableGuardRequest(guard, byId));
+}
+
+function validatePrivateWritableGuardRequest(
+  guard: NativePrivateWritableGuardRequest,
+  steps: Map<string, NativeMappingMaterializationStep>,
+): NativeProcessImageRefusal[] {
+  const mapping = steps.get(guard.mapping);
+  if (!mapping || !mapping.privateWritable || mapping.action !== "copy-captured-bytes") {
+    return [
+      refusal("mapping-ambiguous", `${guard.mapping} is not a copied private writable mapping`),
+    ];
+  }
+  return [
+    ...validateOnePrivateWritableGuard(mapping, guard.belowMapping, "below", steps),
+    ...validateOnePrivateWritableGuard(mapping, guard.aboveMapping, "above", steps),
+  ];
+}
+
+function validateOnePrivateWritableGuard(
+  mapping: NativeMappingMaterializationStep,
+  guardMapping: string | undefined,
+  placement: "below" | "above",
+  steps: Map<string, NativeMappingMaterializationStep>,
+): NativeProcessImageRefusal[] {
+  if (guardMapping === undefined) {
+    return [];
+  }
+  const guard = steps.get(guardMapping);
+  if (!guard || guard.action !== "recreate" || !noAccessPermissions(guard.permissions)) {
+    return [refusal("mapping-ambiguous", `${guardMapping} is not a recreated no-access guard`)];
+  }
+  return guardIsAdjacent(mapping, guard, placement)
+    ? []
+    : [refusal("mapping-ambiguous", `${guardMapping} is not adjacent to ${mapping.mapping}`)];
+}
+
+function guardIsAdjacent(
+  mapping: NativeMappingMaterializationStep,
+  guard: NativeMappingMaterializationStep,
+  placement: "below" | "above",
+): boolean {
+  if (!mapping.targetStart || !guard.targetStart) {
+    return false;
+  }
+  const mappingStart = BigInt(mapping.targetStart);
+  const mappingEnd = mappingStart + BigInt(mapping.sizeBytes);
+  const guardStart = BigInt(guard.targetStart);
+  const guardEnd = guardStart + BigInt(guard.sizeBytes);
+  return placement === "below" ? guardEnd === mappingStart : guardStart === mappingEnd;
+}
+
 function validatePermissions(mapping: NativeMemoryMapping): NativeProcessImageRefusal | undefined {
   if (mapping.permissions.write && mapping.permissions.execute) {
     return refusal("mapping-permission-unsupported", `${mapping.id} is writable and executable`);
   }
   return undefined;
+}
+
+function validatePrivateWritable(
+  mapping: NativeMemoryMapping,
+): NativeProcessImageRefusal | undefined {
+  if (!mapping.permissions.write) {
+    return undefined;
+  }
+  if (!mapping.permissions.private || mapping.permissions.shared) {
+    return refusal("mapping-shared-unsupported", `${mapping.id} is writable shared memory`);
+  }
+  if (!isPrivateWritableMapping(mapping)) {
+    return refusal(
+      "mapping-permission-unsupported",
+      `${mapping.id} writable permissions are ambiguous`,
+    );
+  }
+  return undefined;
+}
+
+function isPrivateWritableMapping(mapping: NativeMemoryMapping): boolean {
+  return [
+    mapping.permissions.write,
+    mapping.permissions.private,
+    !mapping.permissions.shared,
+    !mapping.permissions.execute,
+  ].every(Boolean);
 }
 
 function isRecreatableNoAccessProtectionMapping(mapping: NativeMemoryMapping): boolean {
@@ -173,12 +301,16 @@ function isRecreatableNoAccessProtectionMapping(mapping: NativeMemoryMapping): b
 }
 
 function noAccessPrivate(mapping: NativeMemoryMapping): boolean {
+  return noAccessPermissions(mapping.permissions);
+}
+
+function noAccessPermissions(permissions: NativeMemoryMapping["permissions"]): boolean {
   return [
-    !mapping.permissions.read,
-    !mapping.permissions.write,
-    !mapping.permissions.execute,
-    mapping.permissions.private,
-    !mapping.permissions.shared,
+    !permissions.read,
+    !permissions.write,
+    !permissions.execute,
+    permissions.private,
+    !permissions.shared,
   ].every(Boolean);
 }
 
@@ -241,11 +373,21 @@ function validateCapturedBytes(
   memorySizeBytes: number,
 ): NativeProcessImageRefusal | undefined {
   if (!mapping.captured) {
-    return refusal("mapping-ambiguous", `${mapping.id} needs captured bytes to translate`);
+    return refusal(
+      isPrivateWritableMapping(mapping)
+        ? "mapping-captured-range-unsupported"
+        : "mapping-ambiguous",
+      `${mapping.id} needs captured bytes to translate`,
+    );
   }
   const end = mapping.captured.offset + mapping.captured.sizeBytes;
   if (mapping.captured.sizeBytes !== mapping.sizeBytes || end > memorySizeBytes) {
-    return refusal("mapping-ambiguous", `${mapping.id} captured byte range is invalid`);
+    return refusal(
+      isPrivateWritableMapping(mapping)
+        ? "mapping-captured-range-unsupported"
+        : "mapping-ambiguous",
+      `${mapping.id} captured byte range is invalid`,
+    );
   }
   return undefined;
 }

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -402,6 +402,7 @@ const TOC = {
     "NativeMappingMaterializationStep",
     "NativeMappingMaterializationRequest",
     "NativeMappingMaterializationResult",
+    "NativePrivateWritableGuardRequest",
     "planNativeMappingMaterialization",
     "NativeInheritedStdioPolicy",
     "NativeResourceTranslationRequest",


### PR DESCRIPTION
## Problem

Private writable memory was still treated like a generic captured-byte case. We needed an explicit boundary for heap, data, and private writable mmap pages, plus guard-page checks and precise refusals.

## Solution

This PR updates the mapping materializer so private writable memory is accepted only when safe:

- private, non-executable writable mappings copy captured bytes
- missing or invalid captured ranges refuse with `mapping-captured-range-unsupported`
- shared writable memory refuses with `mapping-shared-unsupported`
- no-access private guards are recreated
- optional `privateWritableGuards` must point at adjacent recreated guard mappings

Fixes #639

## Validation

- `pnpm run build:docs` — passed
- `pnpm run format:check` — 0.623s
- `pnpm run lint` — 0.279s
- `pnpm run typecheck` — 2.550s
- focused mapping vitest — 0.450s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.986s
- `pnpm smoke-tests` — 2m16.187s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.649s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m28s, 2 passed / 2 total
