### PR TITLE
Harden executable mapping provenance

### DIFF
--- a/docs/snapshot/native-mapping-materializer.md
+++ b/docs/snapshot/native-mapping-materializer.md
@@ -25,7 +25,8 @@ materializes it with `mmap`:
 `planNativeMappingMaterialization()` converts `NativeMemoryMapping` entries into
 loader steps:
 
-- `map-target-file` for executable target-file mappings;
+- `map-target-file` for executable target-file mappings with build-id or hash
+  provenance;
 - `copy-captured-bytes` for safe private anonymous/data/heap/writable mmap
   mappings;
 - `recreate` for target-owned stack/kernel mappings and safe guard mappings;
@@ -40,6 +41,10 @@ loader steps:
   writable guards, or recreated mappings that still carry source bytes.
 - `mapping-captured-range-unsupported` rejects private writable mappings with
   missing or invalid captured bytes.
+- `mapping-executable-unsupported` rejects executable mappings that lack a
+  target-native file, so captured source text is never copied as target code.
+- `mapping-provenance-ambiguous` rejects executable target files without build-id
+  or hash provenance.
 - `mapping-permission-unsupported` rejects writable+executable mappings.
 - `mapping-shared-unsupported` rejects shared writable memory.
 - `target-build-mismatch` rejects file-backed target mappings whose expected

--- a/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
@@ -162,6 +162,45 @@ describe("native mapping materialization", () => {
     expect(result.refusals).toEqual([expect.objectContaining({ code: "target-build-mismatch" })]);
   });
 
+  it("refuses executable mappings without a target-native file", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 4096,
+      mappings: [
+        mapping({
+          id: "mapping:source-text-bytes",
+          kind: "text",
+          permissions: { read: true, write: false, execute: true, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x71000000" },
+        }),
+      ],
+    });
+
+    expect(result.refusals).toEqual([
+      expect.objectContaining({ code: "mapping-executable-unsupported" }),
+    ]);
+    expect(result.steps[0]).toMatchObject({ action: "refuse" });
+  });
+
+  it("refuses executable target files without build or hash provenance", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 0,
+      mappings: [
+        mapping({
+          id: "mapping:unproven-target-text",
+          kind: "text",
+          permissions: { read: true, write: false, execute: true, private: true, shared: false },
+          file: { path: "/target/no-build-id.so", offset: 0 },
+          target: { materialization: "translate", targetStart: "0x71000000" },
+        }),
+      ],
+    });
+
+    expect(result.refusals).toEqual([
+      expect.objectContaining({ code: "mapping-provenance-ambiguous" }),
+    ]);
+  });
+
   it("refuses writable executable mappings", () => {
     const result = planNativeMappingMaterialization({
       memorySizeBytes: 0,

--- a/packages/runtime/src/native-mapping-materialization.ts
+++ b/packages/runtime/src/native-mapping-materialization.ts
@@ -100,10 +100,13 @@ function translatedStep(
   if (targetRefusal) {
     return refusedStep(mapping, targetRefusal);
   }
-  if (mapping.permissions.execute && mapping.file) {
-    const buildRefusal = validateTargetFileBuild(mapping, request.targetFileBuildIds ?? {});
-    if (buildRefusal) {
-      return refusedStep(mapping, buildRefusal);
+  if (mapping.permissions.execute) {
+    const executableRefusal = validateExecutableTargetMapping(
+      mapping,
+      request.targetFileBuildIds ?? {},
+    );
+    if (executableRefusal) {
+      return refusedStep(mapping, executableRefusal);
     }
     return { ...baseStep(mapping, "map-target-file"), targetFile: mapping.file };
   }
@@ -347,12 +350,33 @@ function validateTargetStart(mapping: NativeMemoryMapping): NativeProcessImageRe
   return refusal("mapping-ambiguous", `${mapping.id} has no target start address`);
 }
 
+function validateExecutableTargetMapping(
+  mapping: NativeMemoryMapping,
+  targetFileBuildIds: Record<string, string>,
+): NativeProcessImageRefusal | undefined {
+  if (!mapping.file) {
+    return refusal(
+      "mapping-executable-unsupported",
+      `${mapping.id} executable bytes require a target-native file`,
+    );
+  }
+  if (!mapping.file.buildId && !mapping.file.sha256) {
+    return refusal(
+      "mapping-provenance-ambiguous",
+      `${mapping.id} executable target file has no build-id or hash provenance`,
+    );
+  }
+  return validateTargetFileBuild(mapping, targetFileBuildIds);
+}
+
 function validateTargetFileBuild(
   mapping: NativeMemoryMapping,
   targetFileBuildIds: Record<string, string>,
 ): NativeProcessImageRefusal | undefined {
-  const expected = mapping.file?.buildId;
-  const actual = mapping.file ? targetFileBuildIds[mapping.file.path] : undefined;
+  const expected = mapping.file?.buildId ?? mapping.file?.sha256;
+  const actual = mapping.file
+    ? (targetFileBuildIds[mapping.file.path] ?? mapping.file.sha256)
+    : undefined;
   if (!expected || !actual || normalizeBuildId(expected) === normalizeBuildId(actual)) {
     return undefined;
   }


### PR DESCRIPTION
## Problem

Executable mappings could still fall through to captured-byte copying if they had no target file. That is unsafe for native cross-ISA restore because source text bytes must never become target code.

## Solution

This PR hardens executable mapping materialization:

- executable mappings require a target-native file
- executable target files require build-id or hash provenance
- build/hash mismatches still refuse precisely
- captured source executable bytes are never copied as target code

Fixes #641

## Validation

- `pnpm run build:docs` — passed
- `pnpm run format:check` — 0.749s
- `pnpm run lint` — 0.333s
- `pnpm run typecheck` — 2.441s
- focused mapping vitest — 0.481s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.897s
- `pnpm smoke-tests` — 2m18.185s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.599s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m22s, 2 passed / 2 total
