### PR TITLE
Integrate modeled active syscalls into thread restore

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -2,7 +2,9 @@
 
 Issue #510 classifies active native syscalls before actual real-utility resume.
 The classifier is deliberately fail-closed by default: recognizing a syscall
-class does not make it resumable.
+class does not make it resumable. The full thread-restore boundary may consume
+an explicitly modeled `defer-target-resume` continuation for sleep/ppoll timeout
+state, but only after the same TLS/register/SIMD/stack/resource gates pass.
 
 ## Classes
 
@@ -42,9 +44,9 @@ with `remainingTime.state: "modeled"` and a conservative
 `requested-duration-upper-bound` rearm duration. When the model is missing, it
 fails closed with `target-sleep-remaining-time-missing`.
 
-The actual utility proof uses this to move past the `thread-state` gate only when
-there is explicit target timer metadata, without pretending that source kernel
-state was restored.
+The actual utility proof and thread-restore boundary use this to move past the
+`thread-state` gate only when there is explicit target timer metadata, without
+pretending that source kernel state was restored.
 
 ## Explicit ppoll timeout deferral
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -8281,6 +8281,10 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetAccessPolicy?**: [`NativeTlsTargetAccessPolicy`](#nativetlstargetaccesspolicy)
 
+##### activeSyscall?
+
+> `optional` **activeSyscall?**: [`NativeActiveSyscallPolicyOptions`](#nativeactivesyscallpolicyoptions)
+
 ***
 
 ### NativeTlsSegmentBaseHandoffRequest
@@ -12594,7 +12598,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeThreadRestorePlan
 
-> **NativeThreadRestorePlan** = \{ `state`: `"accepted"`; `threadId`: `string`; `targetThreadCount`: `1`; `refusals`: \[\]; \} \| \{ `state`: `"refused"`; `targetThreadCount`: `number`; `refusals`: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]; \}
+> **NativeThreadRestorePlan** = \{ `state`: `"accepted"`; `threadId`: `string`; `targetThreadCount`: `1`; `activeSyscallContinuations`: [`NativeActiveSyscallContinuation`](#nativeactivesyscallcontinuation)[]; `refusals`: \[\]; \} \| \{ `state`: `"refused"`; `targetThreadCount`: `number`; `refusals`: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]; \}
 
 ***
 

--- a/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from "vitest";
-import type {
-  NativeMemoryMapping,
-  NativeProcessResource,
-  NativeThreadState,
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  NATIVE_PROCESS_IMAGE_FILES,
+  type NativeMemoryMapping,
+  type NativeProcessImageDocuments,
+  type NativeProcessResource,
+  type NativeThreadState,
 } from "../native-process-image.ts";
 import { planNativeThreadRestoreBoundary } from "../native-thread-restore-policy.ts";
+
+const tempDirs: string[] = [];
 
 const stackMapping: NativeMemoryMapping = {
   id: "mapping:stack",
@@ -16,6 +23,12 @@ const stackMapping: NativeMemoryMapping = {
   target: { materialization: "translate", targetStart: "0x500000000000" },
 };
 
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
 describe("native thread restore boundary", () => {
   it("accepts one safe stopped thread", () => {
     expect(
@@ -25,6 +38,40 @@ describe("native thread restore boundary", () => {
       threadId: "thread:1",
       targetThreadCount: 1,
       refusals: [],
+    });
+  });
+
+  it("accepts a modeled active sleep syscall under the full thread gate", () => {
+    const active = thread("thread:active-sleep");
+    active.syscall = { state: "inside-syscall", number: 115, name: "clock_nanosleep" };
+    if (active.sourceRegisters.arch === "arm64") {
+      active.sourceRegisters.x = [
+        "0x0",
+        "0x0",
+        "0x700000000100",
+        "0x0",
+        ...Array.from({ length: 27 }, () => "0x0"),
+      ];
+    }
+
+    const result = planNativeThreadRestoreBoundary({
+      threads: [active],
+      mappings: [stackMapping],
+      activeSyscall: {
+        sleepTimerPolicy: "defer-target-resume",
+        documents: documentsWithTimespec(active),
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: "accepted",
+      threadId: "thread:active-sleep",
+      activeSyscallContinuations: [
+        expect.objectContaining({
+          syscallClass: "sleep-timer",
+          action: "defer-target-resume",
+        }),
+      ],
     });
   });
 
@@ -151,13 +198,69 @@ describe("native thread restore boundary", () => {
         mappings: entry.mappings ?? [stackMapping],
         resources: entry.resources ?? [],
       });
-      expect(result, entry.id).toMatchObject({
-        state: "refused",
-        refusals: [expect.objectContaining({ code: entry.expectedCode })],
-      });
+      expect(result, entry.id).toMatchObject({ state: "refused" });
+      expect(result.refusals, entry.id).toContainEqual(
+        expect.objectContaining({ code: entry.expectedCode }),
+      );
     }
   });
 });
+
+function documentsWithTimespec(activeThread: NativeThreadState): NativeProcessImageDocuments {
+  const rootDir = mkdtempSync(join(tmpdir(), "machinen-thread-restore-syscall-"));
+  tempDirs.push(rootDir);
+  const memory = Buffer.alloc(4096);
+  memory.writeBigUInt64LE(30n, 0x100);
+  memory.writeBigUInt64LE(123n, 0x108);
+  writeFileSync(join(rootDir, NATIVE_PROCESS_IMAGE_FILES.memory), memory);
+  return {
+    rootDir,
+    manifest: {
+      formatVersion: 1,
+      kind: "machinen.native-process-image",
+      capture: { method: "external-ptrace-procfs", sourceArch: "arm64" },
+      target: { mode: "native-cross-isa", arch: "amd64", abi: "linux-user" },
+      process: { exe: "/bin/sleep", argv: ["sleep"], env: {}, cwd: "/" },
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    mappings: {
+      formatVersion: 1,
+      mappings: [
+        {
+          id: "mapping:timespec",
+          kind: "data",
+          sourceStart: "0x700000000000",
+          sourceEnd: "0x700000001000",
+          sizeBytes: 4096,
+          permissions: { read: true, write: true, execute: false, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x500000001000" },
+        },
+      ],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    threads: {
+      formatVersion: 1,
+      threads: [activeThread],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    resources: {
+      formatVersion: 1,
+      resources: [],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    translation: {
+      formatVersion: 1,
+      mode: "native-cross-isa",
+      sourceArch: "arm64",
+      targetArch: "amd64",
+      codeLocations: [],
+      threads: [],
+      memoryRelocations: [],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+  };
+}
 
 function thread(id: string): NativeThreadState {
   return {

--- a/packages/runtime/src/native-thread-restore-policy.ts
+++ b/packages/runtime/src/native-thread-restore-policy.ts
@@ -1,3 +1,8 @@
+import {
+  classifyNativeThreadSyscall,
+  type NativeActiveSyscallContinuation,
+  type NativeActiveSyscallPolicyOptions,
+} from "./native-active-syscall-policy.ts";
 import { normalizeNativeHex } from "./native-hex.ts";
 import { safeSimdFpuRefusal } from "./native-simd-fpu-policy.ts";
 import {
@@ -20,6 +25,7 @@ export type NativeThreadRestorePlan =
       state: "accepted";
       threadId: string;
       targetThreadCount: 1;
+      activeSyscallContinuations: NativeActiveSyscallContinuation[];
       refusals: [];
     }
   | {
@@ -37,6 +43,7 @@ export interface NativeThreadRestorePlanRequest {
     targetGsBase?: string;
     targetAccessPolicy?: NativeTlsTargetAccessPolicy;
   };
+  activeSyscall?: NativeActiveSyscallPolicyOptions;
 }
 
 export function planNativeThreadRestoreBoundary(
@@ -48,10 +55,15 @@ export function planNativeThreadRestoreBoundary(
   }
 
   const thread = request.threads[0]!;
+  const activeSyscall = planModeledActiveSyscall(thread, request.activeSyscall);
   const refusals = [
     thread.refusal,
     safeStoppedThreadRefusal(thread),
-    unsafeNativeThreadExecutionState(thread),
+    activeSyscall.refusal,
+    unsafeNativeThreadExecutionState(thread, {
+      allowModeledActiveSyscall:
+        activeSyscall.continuation !== undefined || activeSyscall.refusal !== undefined,
+    }),
     safeTlsRefusal(thread, request.tls),
     safeRegisterRefusal(thread),
     safeSimdFpuRefusal(thread),
@@ -61,7 +73,26 @@ export function planNativeThreadRestoreBoundary(
 
   return refusals.length > 0
     ? refused(request.threads.length, refusals)
-    : { state: "accepted", threadId: thread.id, targetThreadCount: 1, refusals: [] };
+    : {
+        state: "accepted",
+        threadId: thread.id,
+        targetThreadCount: 1,
+        activeSyscallContinuations: activeSyscall.continuation ? [activeSyscall.continuation] : [],
+        refusals: [],
+      };
+}
+
+function planModeledActiveSyscall(
+  thread: NativeThreadState,
+  options: NativeActiveSyscallPolicyOptions | undefined,
+): { continuation?: NativeActiveSyscallContinuation; refusal?: NativeProcessImageRefusal } {
+  if (thread.syscall.state === "outside-syscall") {
+    return {};
+  }
+  const classification = classifyNativeThreadSyscall(thread, options ?? {});
+  return classification.continuation
+    ? { continuation: classification.continuation }
+    : { refusal: classification.refusal };
 }
 
 function singleThreadRefusal(threads: NativeThreadState[]): NativeProcessImageRefusal | undefined {

--- a/packages/runtime/src/native-thread-state-policy.ts
+++ b/packages/runtime/src/native-thread-state-policy.ts
@@ -1,9 +1,14 @@
 import type { NativeProcessImageRefusal, NativeThreadState } from "./native-process-image.ts";
 
+interface NativeThreadExecutionStateOptions {
+  allowModeledActiveSyscall?: boolean;
+}
+
 export function unsafeNativeThreadExecutionState(
   thread: NativeThreadState,
+  options: NativeThreadExecutionStateOptions = {},
 ): NativeProcessImageRefusal | undefined {
-  if (thread.syscall.state !== "outside-syscall") {
+  if (thread.syscall.state !== "outside-syscall" && !options.allowModeledActiveSyscall) {
     return nativeThreadRefusal("active-syscall", `thread ${thread.id} is ${thread.syscall.state}`);
   }
   if (thread.signal.activeFrame) {


### PR DESCRIPTION
## Problem

The active syscall classifier could model sleep/ppoll timeout continuations, but the full thread restore boundary still refused every active syscall before those models could be used.

## Solution

This PR integrates modeled active syscalls into `planNativeThreadRestoreBoundary()`:

- accepted plans expose `activeSyscallContinuations`
- modeled sleep/ppoll timeout continuations may pass when explicitly enabled
- all the existing TLS/register/SIMD/stack/resource gates still run
- unmodeled active syscalls remain refused with precise classifier codes

Fixes #643

## Validation

- `pnpm run build:docs` — passed
- `pnpm run format:check` — 0.567s
- `pnpm run lint` — 0.223s
- `pnpm run typecheck` — 2.659s after final refactor
- focused thread-restore vitest — 0.587s after final refactor
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.070s
- `pnpm smoke-tests` — 2m15.687s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.550s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m45s, 2 passed / 2 total
