### PR TITLE
Gate completion on native restore consumption

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -20,6 +20,9 @@ run is successful only when the target VM reports target-native completion with:
 - `sourceTextReusedAsTargetCode: false`
 - `sourceIsaEmulationUsed: false`
 - `sidecarRuntimeUsed: false`
+- every present native restore consumption marker is `passed`, including stack
+  window writes, private memory restore, executable mapping materialization,
+  signal-mask handoff, and active syscall re-arm
 
 Example:
 
@@ -101,6 +104,11 @@ includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
 resource recipe kinds, `targetRestore.targetContinuationKind`,
 `targetRestore.targetContinuationReturnValue`,
 `targetRestore.targetStateConsumptionResult`, per-resource status,
+`targetRestore.targetStackWindowMaterializationResult`,
+`targetRestore.targetPrivateMemoryRestoreResult`,
+`targetRestore.targetExecutableMappingResult`,
+`targetRestore.targetSignalRestoreResult`,
+`targetRestore.targetActiveSyscallRestoreResult`,
 `targetRestore.targetReturnChainResult`,
 `targetRestore.targetTranslatedReturnAddress`,
 `targetRestore.targetFrameRestoreResult`,

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -139,6 +139,7 @@
 - [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)
 - [`PortableMachineTargetResumePathResult`](#portablemachinetargetresumepathresult)
 - [`PortableMachineTargetReturnChainResult`](#portablemachinetargetreturnchainresult)
+- [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
 - [`PortableMachineTargetStateConsumptionResult`](#portablemachinetargetstateconsumptionresult)
 - [`PortableMachineTargetVerifierResult`](#portablemachinetargetverifierresult)
 - [`PortableMachineVmRestoreProofRequest`](#portablemachinevmrestoreproofrequest)
@@ -8928,6 +8929,26 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **targetResourceStatuses?**: [`PortableMachineTargetResourceStatus`](#portablemachinetargetresourcestatus)[]
 
+##### targetStackWindowMaterializationResult?
+
+> `optional` **targetStackWindowMaterializationResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+##### targetPrivateMemoryRestoreResult?
+
+> `optional` **targetPrivateMemoryRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+##### targetExecutableMappingResult?
+
+> `optional` **targetExecutableMappingResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+##### targetSignalRestoreResult?
+
+> `optional` **targetSignalRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+##### targetActiveSyscallRestoreResult?
+
+> `optional` **targetActiveSyscallRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
 ##### targetReturnChainResult?
 
 > `optional` **targetReturnChainResult?**: [`PortableMachineTargetReturnChainResult`](#portablemachinetargetreturnchainresult)
@@ -9005,6 +9026,46 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ###### Inherited from
 
 [`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetResourceStatuses`](#targetresourcestatuses)
+
+##### targetStackWindowMaterializationResult?
+
+> `optional` **targetStackWindowMaterializationResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetStackWindowMaterializationResult`](#targetstackwindowmaterializationresult)
+
+##### targetPrivateMemoryRestoreResult?
+
+> `optional` **targetPrivateMemoryRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetPrivateMemoryRestoreResult`](#targetprivatememoryrestoreresult)
+
+##### targetExecutableMappingResult?
+
+> `optional` **targetExecutableMappingResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetExecutableMappingResult`](#targetexecutablemappingresult)
+
+##### targetSignalRestoreResult?
+
+> `optional` **targetSignalRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetSignalRestoreResult`](#targetsignalrestoreresult)
+
+##### targetActiveSyscallRestoreResult?
+
+> `optional` **targetActiveSyscallRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetActiveSyscallRestoreResult`](#targetactivesyscallrestoreresult)
 
 ##### targetReturnChainResult?
 
@@ -9227,6 +9288,46 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 ###### Inherited from
 
 [`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetResourceStatuses`](#targetresourcestatuses)
+
+##### targetStackWindowMaterializationResult?
+
+> `optional` **targetStackWindowMaterializationResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetStackWindowMaterializationResult`](#targetstackwindowmaterializationresult)
+
+##### targetPrivateMemoryRestoreResult?
+
+> `optional` **targetPrivateMemoryRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetPrivateMemoryRestoreResult`](#targetprivatememoryrestoreresult)
+
+##### targetExecutableMappingResult?
+
+> `optional` **targetExecutableMappingResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetExecutableMappingResult`](#targetexecutablemappingresult)
+
+##### targetSignalRestoreResult?
+
+> `optional` **targetSignalRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetSignalRestoreResult`](#targetsignalrestoreresult)
+
+##### targetActiveSyscallRestoreResult?
+
+> `optional` **targetActiveSyscallRestoreResult?**: [`PortableMachineTargetNativePlanConsumptionResult`](#portablemachinetargetnativeplanconsumptionresult)
+
+###### Inherited from
+
+[`PortableMachineTargetRestoreObservation`](#portablemachinetargetrestoreobservation).[`targetActiveSyscallRestoreResult`](#targetactivesyscallrestoreresult)
 
 ##### targetReturnChainResult?
 
@@ -13179,6 +13280,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### PortableMachineTargetStateConsumptionResult
 
 > **PortableMachineTargetStateConsumptionResult** = `"pending"` \| `"passed"` \| `"failed"`
+
+***
+
+### PortableMachineTargetNativePlanConsumptionResult
+
+> **PortableMachineTargetNativePlanConsumptionResult** = `"pending"` \| `"passed"` \| `"failed"`
 
 ***
 

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -187,6 +187,11 @@ describe("portable machine VM restore proof", () => {
         targetVerifierResult: "passed",
         targetStateConsumptionResult: "passed",
         targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
+        targetStackWindowMaterializationResult: "passed",
+        targetPrivateMemoryRestoreResult: "passed",
+        targetExecutableMappingResult: "passed",
+        targetSignalRestoreResult: "passed",
+        targetActiveSyscallRestoreResult: "passed",
         targetReturnChainResult: "passed",
         targetTranslatedReturnAddress: "0x700300000080",
         targetFrameRestoreResult: "passed",
@@ -208,6 +213,11 @@ describe("portable machine VM restore proof", () => {
       descriptorGateCompleted: true,
       targetStateConsumptionResult: "passed",
       targetResourceStatuses: [{ kind: "reopen-file", status: "passed" }],
+      targetStackWindowMaterializationResult: "passed",
+      targetPrivateMemoryRestoreResult: "passed",
+      targetExecutableMappingResult: "passed",
+      targetSignalRestoreResult: "passed",
+      targetActiveSyscallRestoreResult: "passed",
       targetReturnChainResult: "passed",
       targetTranslatedReturnAddress: "0x700300000080",
       targetFrameRestoreResult: "passed",
@@ -364,6 +374,31 @@ describe("portable machine VM restore proof", () => {
       descriptorGateCompleted: true,
       targetStateConsumptionResult: "failed",
     });
+
+    for (const failedObservation of [
+      { targetStackWindowMaterializationResult: "failed" as const },
+      { targetPrivateMemoryRestoreResult: "failed" as const },
+      { targetSignalRestoreResult: "failed" as const },
+      { targetActiveSyscallRestoreResult: "failed" as const },
+    ]) {
+      expect(
+        completePortableMachineVmRestoreProof(plan, {
+          exitCode: 0,
+          migrationCompleted: true,
+          descriptorGateCompleted: true,
+          targetVerifierResult: "passed",
+          sourceTextReusedAsTargetCode: false,
+          sourceIsaEmulationUsed: false,
+          sidecarRuntimeUsed: false,
+          ...failedObservation,
+        }),
+      ).toMatchObject({
+        state: "ready",
+        migrationCompleted: false,
+        descriptorGateCompleted: true,
+        ...failedObservation,
+      });
+    }
 
     expect(
       completePortableMachineVmRestoreProof(plan, {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -548,6 +548,7 @@ export type {
   PortableMachineTargetRestoreObservation,
   PortableMachineTargetThreadRestoreResult,
   PortableMachineTargetRestoreDescriptorRequest,
+  PortableMachineTargetNativePlanConsumptionResult,
   PortableMachineTargetStateConsumptionResult,
   PortableMachineTargetVerifierResult,
   PortableMachineVmRestoreProofPlan,

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -23,6 +23,7 @@ export interface PortableMachineVmRestoreProofRequest {
 export type PortableMachineTargetVerifierResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetContinuationKind = "generated-verifier" | "real-utility";
 export type PortableMachineTargetStateConsumptionResult = "pending" | "passed" | "failed";
+export type PortableMachineTargetNativePlanConsumptionResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetReturnChainResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetFrameRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetRegisterRestoreResult = "pending" | "passed" | "failed";
@@ -40,6 +41,11 @@ export interface PortableMachineTargetRestoreObservation {
   targetVerifierResult?: PortableMachineTargetVerifierResult;
   targetStateConsumptionResult?: PortableMachineTargetStateConsumptionResult;
   targetResourceStatuses?: PortableMachineTargetResourceStatus[];
+  targetStackWindowMaterializationResult?: PortableMachineTargetNativePlanConsumptionResult;
+  targetPrivateMemoryRestoreResult?: PortableMachineTargetNativePlanConsumptionResult;
+  targetExecutableMappingResult?: PortableMachineTargetNativePlanConsumptionResult;
+  targetSignalRestoreResult?: PortableMachineTargetNativePlanConsumptionResult;
+  targetActiveSyscallRestoreResult?: PortableMachineTargetNativePlanConsumptionResult;
   targetReturnChainResult?: PortableMachineTargetReturnChainResult;
   targetTranslatedReturnAddress?: string;
   targetFrameRestoreResult?: PortableMachineTargetFrameRestoreResult;
@@ -203,6 +209,11 @@ export function completePortableMachineVmRestoreProof(
     targetContinuationReturnValue: result.actualResumeEvent?.returnValue,
     targetStateConsumptionResult: result.targetStateConsumptionResult,
     targetResourceStatuses: result.targetResourceStatuses,
+    targetStackWindowMaterializationResult: result.targetStackWindowMaterializationResult,
+    targetPrivateMemoryRestoreResult: result.targetPrivateMemoryRestoreResult,
+    targetExecutableMappingResult: result.targetExecutableMappingResult,
+    targetSignalRestoreResult: result.targetSignalRestoreResult,
+    targetActiveSyscallRestoreResult: result.targetActiveSyscallRestoreResult,
     targetReturnChainResult: result.targetReturnChainResult,
     targetTranslatedReturnAddress: result.targetTranslatedReturnAddress,
     targetFrameRestoreResult: result.targetFrameRestoreResult,
@@ -241,6 +252,11 @@ function optionalTargetChecksPassed(result: PortableMachineVmRestoreTargetResult
   return [
     passedOrUnset(result.targetVerifierResult),
     passedOrUnset(result.targetStateConsumptionResult),
+    passedOrUnset(result.targetStackWindowMaterializationResult),
+    passedOrUnset(result.targetPrivateMemoryRestoreResult),
+    passedOrUnset(result.targetExecutableMappingResult),
+    passedOrUnset(result.targetSignalRestoreResult),
+    passedOrUnset(result.targetActiveSyscallRestoreResult),
     passedOrUnset(result.targetReturnChainResult),
     passedOrUnset(result.targetFrameRestoreResult),
     passedOrUnset(result.targetRegisterRestoreResult),

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -161,6 +161,7 @@ const TOC = {
     "PortableMachineTargetResourceStatus",
     "PortableMachineTargetResumePathResult",
     "PortableMachineTargetReturnChainResult",
+    "PortableMachineTargetNativePlanConsumptionResult",
     "PortableMachineTargetStateConsumptionResult",
     "PortableMachineTargetVerifierResult",
     "PortableMachineVmRestoreProofRequest",


### PR DESCRIPTION
## Problem

The proof could report target-native completion while newer native restore materialization markers were not part of the completion gate.

## Solution

This PR adds consumption result fields for stack-window writes, private memory restore, executable mapping restore, signal handoff, and active syscall re-arm. If any present marker is not `passed`, `migrationCompleted` stays false.

Fixes #667

## Validation

- `pnpm run build:docs` — passed
- `pnpm run typecheck` — 2.721s
- focused vitest — 0.593s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.573s
