### PR TITLE
Thread native restore sections into target descriptor

### DIFF
--- a/docs/snapshot/target-guest-native-restore-sections.md
+++ b/docs/snapshot/target-guest-native-restore-sections.md
@@ -1,0 +1,18 @@
+# Target guest native restore sections
+
+Issue #669 extends the target guest restore descriptor with optional native
+restore sections.
+
+The descriptor can now carry line-oriented `native=` entries for:
+
+- stack-window u64 writes and stack guard ranges;
+- bounded return-chain frame writes;
+- private-memory restore steps;
+- target executable mapping provenance steps;
+- signal-mask restore steps;
+- modeled active-syscall re-arm steps.
+
+These sections are validated and round-trip through descriptor serialization.
+They also become explicit trampoline argv entries so the target loader can
+materialize them and report consumption. Unsafe or malformed native section
+entries fail closed before guest restore execution.

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -103,6 +103,7 @@
 - [`TargetGuestRestoreResumeMode`](#targetguestrestoreresumemode)
 - [`TargetGuestResumeRegisterName`](#targetguestresumeregistername)
 - [`TargetGuestResumeRegisters`](#targetguestresumeregisters)
+- [`TargetGuestNativeRestoreStep`](#targetguestnativerestorestep)
 - [`TargetGuestRestoreContinuationDescriptor`](#targetguestrestorecontinuationdescriptor)
 - [`TargetGuestRestoreDescriptor`](#targetguestrestoredescriptor)
 - [`TargetGuestTranslatedFrameDescriptor`](#targetguesttranslatedframedescriptor)
@@ -10671,6 +10672,10 @@ Poll interval in ms while retrying. Default 250.
 
 > **memory**: [`TargetGuestMemoryMaterializationEntry`](#targetguestmemorymaterializationentry)[]
 
+##### nativeRestore?
+
+> `optional` **nativeRestore?**: [`TargetGuestNativeRestoreStep`](#targetguestnativerestorestep)[]
+
 ***
 
 ### TargetGuestTwoThreadBinding
@@ -13412,6 +13417,12 @@ Result of `validatePid` — easy to switch on at the call site.
 ### TargetGuestTranslatedFrameRegisterName
 
 > **TargetGuestTranslatedFrameRegisterName** = `"rbx"` \| `"r12"` \| `"r13"` \| `"r14"` \| `"r15"`
+
+***
+
+### TargetGuestNativeRestoreStep
+
+> **TargetGuestNativeRestoreStep** = \{ `section`: `"stack-window-write"`; `write`: [`NativeStackWindowWrite`](#nativestackwindowwrite); \} \| \{ `section`: `"stack-window-guard"`; `guard`: [`NativeStackWindowGuardMapping`](#nativestackwindowguardmapping); \} \| \{ `section`: `"return-chain-write"`; `write`: [`NativeReturnChainFrameWrite`](#nativereturnchainframewrite); \} \| \{ `section`: `"private-memory"`; `step`: [`TargetGuestPrivateMemoryRestoreStep`](#targetguestprivatememoryrestorestep); \} \| \{ `section`: `"executable-mapping"`; `step`: [`TargetGuestExecutableMappingStep`](#targetguestexecutablemappingstep); \} \| \{ `section`: `"signal-restore"`; `step`: [`TargetGuestSignalRestoreStep`](#targetguestsignalrestorestep); \} \| \{ `section`: `"active-syscall"`; `step`: [`TargetGuestActiveSyscallRestoreStep`](#targetguestactivesyscallrestorestep); \}
 
 ***
 

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -232,6 +232,127 @@ describe("target guest restore loader descriptor", () => {
     expect(buildNativeActualResumeTrampolineArgs(parsed)).toContain("0x600000001000:4096");
   });
 
+  it("serializes native restore sections into descriptor and trampoline args", () => {
+    const nativeRestore = [
+      {
+        section: "stack-window-write" as const,
+        write: {
+          mapping: "mapping:stack",
+          targetAddress: "0x50000000f000",
+          offset: 0,
+          sizeBytes: 8 as const,
+          value: "0x700300000316",
+          bytes: "1603000003700000",
+          kind: "return-address" as const,
+        },
+      },
+      {
+        section: "stack-window-guard" as const,
+        guard: { targetStart: "0x50000000e000", sizeBytes: 4096, placement: "below" as const },
+      },
+      {
+        section: "return-chain-write" as const,
+        write: {
+          frameId: "frame:caller",
+          targetAddress: "0x50000000ff08",
+          value: "0x700300000516",
+          bytes: "1605000003700000",
+          kind: "return-address" as const,
+        },
+      },
+      {
+        section: "private-memory" as const,
+        step: {
+          action: "copy-captured-bytes" as const,
+          mapping: "mapping:heap",
+          sourceFile: "/tmp/native-memory.bin",
+          sourceOffset: 0,
+          targetStart: "0x600000000000",
+          sizeBytes: 4096,
+        },
+      },
+      {
+        section: "executable-mapping" as const,
+        step: {
+          action: "map-target-executable" as const,
+          mapping: "mapping:text",
+          targetStart: "0x700300000000",
+          sizeBytes: 8192,
+          permissions: { read: true, write: false, execute: true, private: true, shared: false },
+          path: "/usr/bin/target-tool",
+          fileOffset: 0,
+          buildId: "target-build-id",
+          sourceTextReusedAsTargetCode: false as const,
+        },
+      },
+      {
+        section: "signal-restore" as const,
+        step: {
+          action: "sigprocmask-set-blocked" as const,
+          threadId: "thread:1",
+          targetBlockedMasks: ["0x0"],
+        },
+      },
+      {
+        section: "active-syscall" as const,
+        step: {
+          action: "rearm-sleep-timer" as const,
+          threadId: "thread:1",
+          syscallName: "clock_nanosleep",
+          remainingTime: { seconds: "1", nanoseconds: 125 },
+          resumeMode: "defer-target-resume" as const,
+        },
+      },
+    ];
+
+    const parsed = parseTargetGuestRestoreDescriptor(
+      serializeTargetGuestRestoreDescriptor(descriptor({ nativeRestore })),
+    );
+
+    expect(parsed.nativeRestore).toEqual(nativeRestore);
+    expect(buildNativeActualResumeTrampolineArgs(parsed)).toEqual(
+      expect.arrayContaining([
+        "--native-stack-window-write",
+        "0x50000000f000:0x700300000316:1603000003700000:return-address",
+        "--native-return-chain-write",
+        "0x50000000ff08:0x700300000516:1605000003700000:return-address",
+        "--native-private-memory-step",
+        "action=copy-captured-bytes,mapping=mapping:heap,targetStart=0x600000000000,sizeBytes=4096,sourceFile=/tmp/native-memory.bin,sourceOffset=0",
+        "--native-signal-restore-step",
+        "action=sigprocmask-set-blocked,threadId=thread:1,targetBlockedMasks=0x0",
+      ]),
+    );
+  });
+
+  it("refuses malformed native restore sections", () => {
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          nativeRestore: [
+            {
+              section: "stack-window-write",
+              write: {
+                mapping: "mapping:stack",
+                targetAddress: "0x50000000f000",
+                offset: 0,
+                sizeBytes: 4 as 8,
+                value: "0x700300000316",
+                bytes: "1603000003700000",
+                kind: "return-address",
+              },
+            },
+          ],
+        }),
+      ),
+    ).toThrow(/stack-window writes must be u64/);
+
+    expect(() =>
+      parseTargetGuestRestoreDescriptor(
+        `${serializeTargetGuestRestoreDescriptor(descriptor())}native=return-chain-write frameId=frame:1 targetAddress=5000 value=0x1 bytes=0100000000000000 kind=return-address\n`,
+      ),
+    ).toThrow(/targetAddress must be a hex address/);
+  });
+
   it("builds the in-guest loader argv", () => {
     expect(buildTargetGuestRestoreLoaderArgv("/bundle/restore.desc", "/loader/trampoline")).toEqual(
       ["--descriptor", "/bundle/restore.desc", "--trampoline", "/loader/trampoline"],

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -494,6 +494,7 @@ export type {
   PortableMachineSnapshotRefusals,
 } from "./portable-machine-snapshot.ts";
 export type {
+  TargetGuestNativeRestoreStep,
   TargetGuestRestoreContinuationDescriptor,
   TargetGuestRestoreDescriptor,
   TargetGuestRestoreLoaderRefusalCode,

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -1,4 +1,14 @@
+import type { NativeModeledPpollTargetResource } from "./native-active-syscall-policy.ts";
+import type { NativeReturnChainFrameWrite } from "./native-return-chain-materializer.ts";
+import type {
+  NativeStackWindowGuardMapping,
+  NativeStackWindowWrite,
+} from "./native-stack-window-materializer.ts";
+import type { TargetGuestActiveSyscallRestoreStep } from "./target-guest-active-syscall-restore.ts";
+import type { TargetGuestExecutableMappingStep } from "./target-guest-executable-materialization.ts";
 import type { TargetGuestMemoryMaterializationEntry } from "./target-guest-memory-materialization.ts";
+import type { TargetGuestPrivateMemoryRestoreStep } from "./target-guest-private-memory-restore.ts";
+import type { TargetGuestSignalRestoreStep } from "./target-guest-signal-restore.ts";
 
 export const TARGET_GUEST_RESTORE_DESCRIPTOR_KIND = "machinen.target-guest-restore";
 
@@ -93,6 +103,15 @@ export interface TargetGuestTranslatedFrameSlot {
   classification: "non-pointer-data";
 }
 
+export type TargetGuestNativeRestoreStep =
+  | { section: "stack-window-write"; write: NativeStackWindowWrite }
+  | { section: "stack-window-guard"; guard: NativeStackWindowGuardMapping }
+  | { section: "return-chain-write"; write: NativeReturnChainFrameWrite }
+  | { section: "private-memory"; step: TargetGuestPrivateMemoryRestoreStep }
+  | { section: "executable-mapping"; step: TargetGuestExecutableMappingStep }
+  | { section: "signal-restore"; step: TargetGuestSignalRestoreStep }
+  | { section: "active-syscall"; step: TargetGuestActiveSyscallRestoreStep };
+
 export interface TargetGuestRestoreDescriptor {
   kind: typeof TARGET_GUEST_RESTORE_DESCRIPTOR_KIND;
   targetArch: "amd64";
@@ -100,6 +119,7 @@ export interface TargetGuestRestoreDescriptor {
   translatedFrame?: TargetGuestTranslatedFrameDescriptor;
   resources: TargetGuestRestoreResourceRecipe[];
   memory: TargetGuestMemoryMaterializationEntry[];
+  nativeRestore?: TargetGuestNativeRestoreStep[];
 }
 
 export function serializeTargetGuestRestoreDescriptor(
@@ -128,6 +148,7 @@ export function serializeTargetGuestRestoreDescriptor(
     ...optionalTranslatedFrameField(validated.translatedFrame),
     ...validated.resources.map(serializeResourceRecipe),
     ...validated.memory.map(serializeMemoryEntry),
+    ...(validated.nativeRestore ?? []).map(serializeNativeRestoreStep),
     "",
   ].join("\n");
 }
@@ -136,6 +157,7 @@ export function parseTargetGuestRestoreDescriptor(text: string): TargetGuestRest
   const fields = new Map<string, string>();
   const resources: TargetGuestRestoreResourceRecipe[] = [];
   const memory: TargetGuestMemoryMaterializationEntry[] = [];
+  const nativeRestore: TargetGuestNativeRestoreStep[] = [];
   let translatedFrame: TargetGuestTranslatedFrameDescriptor | undefined;
   for (const line of descriptorLines(text)) {
     if (line.startsWith("resource=")) {
@@ -144,13 +166,15 @@ export function parseTargetGuestRestoreDescriptor(text: string): TargetGuestRest
       memory.push(parseMemoryEntry(line));
     } else if (line.startsWith("frame=")) {
       translatedFrame = parseTranslatedFrame(line);
+    } else if (line.startsWith("native=")) {
+      nativeRestore.push(parseNativeRestoreStep(line));
     } else {
       const [key, value] = splitField(line);
       fields.set(key, value);
     }
   }
   return validateTargetGuestRestoreDescriptor(
-    fieldsToDescriptor(fields, resources, memory, translatedFrame),
+    fieldsToDescriptor(fields, resources, memory, translatedFrame, nativeRestore),
   );
 }
 
@@ -162,10 +186,13 @@ export function validateTargetGuestRestoreDescriptor(
   const resources = descriptor.resources.map(validateResourceRecipe);
   assertUniqueResourceFds(resources);
   const memory = descriptor.memory.map(validateMemoryEntry);
+  const nativeRestore = descriptor.nativeRestore?.map(validateNativeRestoreStep);
   const translatedFrame = validateTranslatedFrame(descriptor.translatedFrame, continuation);
-  return translatedFrame === undefined
-    ? { ...descriptor, continuation, resources, memory }
-    : { ...descriptor, continuation, translatedFrame, resources, memory };
+  const validated =
+    translatedFrame === undefined
+      ? { ...descriptor, continuation, resources, memory }
+      : { ...descriptor, continuation, translatedFrame, resources, memory };
+  return nativeRestore === undefined ? validated : { ...validated, nativeRestore };
 }
 
 export function buildNativeActualResumeTrampolineArgs(
@@ -200,6 +227,7 @@ export function buildNativeActualResumeTrampolineArgs(
     ...translatedFrameToTrampolineArgs(validated.translatedFrame),
     ...validated.resources.flatMap(resourceToTrampolineArgs),
     ...validated.memory.flatMap(memoryToTrampolineArgs),
+    ...(validated.nativeRestore ?? []).flatMap(nativeRestoreToTrampolineArgs),
   ];
 }
 
@@ -230,6 +258,7 @@ function fieldsToDescriptor(
   resources: TargetGuestRestoreResourceRecipe[],
   memory: TargetGuestMemoryMaterializationEntry[],
   translatedFrame: TargetGuestTranslatedFrameDescriptor | undefined,
+  nativeRestore: TargetGuestNativeRestoreStep[] = [],
 ): TargetGuestRestoreDescriptor {
   return {
     kind: requiredField(fields, "kind") as typeof TARGET_GUEST_RESTORE_DESCRIPTOR_KIND,
@@ -254,6 +283,7 @@ function fieldsToDescriptor(
     translatedFrame,
     resources,
     memory,
+    nativeRestore: nativeRestore.length === 0 ? undefined : nativeRestore,
   };
 }
 
@@ -560,6 +590,204 @@ function requiredMemoryField(fields: Map<string, string>, key: string): string {
   return fields.get(key) ?? fail("target-guest-loader-descriptor-invalid", `${key} is required`);
 }
 
+function parseNativeRestoreStep(line: string): TargetGuestNativeRestoreStep {
+  const [head, ...fields] = line.split(/\s+/);
+  const section = head!.slice("native=".length);
+  const values = new Map(fields.map(splitField));
+  switch (section) {
+    case "stack-window-write":
+      return { section, write: parseNativeStackWindowWrite(values) };
+    case "stack-window-guard":
+      return { section, guard: parseNativeStackWindowGuard(values) };
+    case "return-chain-write":
+      return { section, write: parseNativeReturnChainWrite(values) };
+    case "private-memory":
+      return { section, step: parseNativePrivateMemoryStep(values) };
+    case "executable-mapping":
+      return { section, step: parseNativeExecutableMappingStep(values) };
+    case "signal-restore":
+      return { section, step: parseNativeSignalRestoreStep(values) };
+    case "active-syscall":
+      return { section, step: parseNativeActiveSyscallStep(values) };
+    default:
+      return fail(
+        "target-guest-loader-descriptor-invalid",
+        `unsupported native restore section: ${section}`,
+      );
+  }
+}
+
+function parseNativeStackWindowWrite(fields: Map<string, string>): NativeStackWindowWrite {
+  return {
+    mapping: requiredNativeField(fields, "mapping"),
+    targetAddress: requiredNativeField(fields, "targetAddress"),
+    offset: parseNativeInteger(fields, "offset"),
+    sizeBytes: parseNativeInteger(fields, "sizeBytes") as 8,
+    value: requiredNativeField(fields, "value"),
+    bytes: requiredNativeField(fields, "bytes"),
+    kind: requiredNativeField(fields, "kind") as NativeStackWindowWrite["kind"],
+  };
+}
+
+function parseNativeStackWindowGuard(fields: Map<string, string>): NativeStackWindowGuardMapping {
+  return {
+    targetStart: requiredNativeField(fields, "targetStart"),
+    sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+    placement: requiredNativeField(
+      fields,
+      "placement",
+    ) as NativeStackWindowGuardMapping["placement"],
+  };
+}
+
+function parseNativeReturnChainWrite(fields: Map<string, string>): NativeReturnChainFrameWrite {
+  return {
+    frameId: requiredNativeField(fields, "frameId"),
+    targetAddress: requiredNativeField(fields, "targetAddress"),
+    value: requiredNativeField(fields, "value"),
+    bytes: requiredNativeField(fields, "bytes"),
+    kind: requiredNativeField(fields, "kind") as NativeReturnChainFrameWrite["kind"],
+  };
+}
+
+function parseNativePrivateMemoryStep(
+  fields: Map<string, string>,
+): TargetGuestPrivateMemoryRestoreStep {
+  const action = requiredNativeField(fields, "action");
+  if (action === "copy-captured-bytes") {
+    return {
+      action,
+      mapping: requiredNativeField(fields, "mapping"),
+      sourceFile: requiredNativeField(fields, "sourceFile"),
+      sourceOffset: parseNativeInteger(fields, "sourceOffset"),
+      targetStart: requiredNativeField(fields, "targetStart"),
+      sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+    };
+  }
+  if (action === "mmap-private-writable" || action === "mprotect-final") {
+    return {
+      action,
+      mapping: requiredNativeField(fields, "mapping"),
+      targetStart: requiredNativeField(fields, "targetStart"),
+      sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+      permissions: requiredNativeField(fields, "permissions"),
+    };
+  }
+  if (action === "mmap-guard") {
+    return {
+      action,
+      mapping: requiredNativeField(fields, "mapping"),
+      targetStart: requiredNativeField(fields, "targetStart"),
+      sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+      permissions: "---p",
+    };
+  }
+  return fail("target-guest-loader-descriptor-invalid", "unsupported native private-memory action");
+}
+
+function parseNativeExecutableMappingStep(
+  fields: Map<string, string>,
+): TargetGuestExecutableMappingStep {
+  const action = requiredNativeField(fields, "action");
+  if (action !== "map-target-executable") {
+    fail("target-guest-loader-descriptor-invalid", "unsupported native executable action");
+  }
+  return {
+    action,
+    mapping: requiredNativeField(fields, "mapping"),
+    targetStart: requiredNativeField(fields, "targetStart"),
+    sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+    permissions: {
+      read: parseNativeBoolean(fields, "read"),
+      write: parseNativeBoolean(fields, "write"),
+      execute: parseNativeBoolean(fields, "execute"),
+      private: parseNativeBoolean(fields, "private"),
+      shared: parseNativeBoolean(fields, "shared"),
+    },
+    path: requiredNativeField(fields, "path"),
+    fileOffset: parseNativeInteger(fields, "fileOffset"),
+    buildId: fields.get("buildId"),
+    sha256: fields.get("sha256"),
+    sourceTextReusedAsTargetCode: false,
+  };
+}
+
+function parseNativeSignalRestoreStep(fields: Map<string, string>): TargetGuestSignalRestoreStep {
+  const action = requiredNativeField(fields, "action");
+  const threadId = requiredNativeField(fields, "threadId");
+  if (action === "save-loader-signal-mask" || action === "restore-loader-signal-mask") {
+    return { action, threadId };
+  }
+  if (action === "sigprocmask-set-blocked" || action === "verify-blocked-signal-mask") {
+    return { action, threadId, targetBlockedMasks: parseNativeList(fields, "targetBlockedMasks") };
+  }
+  return fail("target-guest-loader-descriptor-invalid", "unsupported native signal restore action");
+}
+
+function parseNativeActiveSyscallStep(
+  fields: Map<string, string>,
+): TargetGuestActiveSyscallRestoreStep {
+  const action = requiredNativeField(fields, "action");
+  if (action === "rearm-sleep-timer") {
+    return {
+      action,
+      threadId: requiredNativeField(fields, "threadId"),
+      syscallName: requiredNativeField(fields, "syscallName"),
+      remainingTime: parseNativeDuration(fields),
+      resumeMode: "defer-target-resume",
+    };
+  }
+  if (action === "rearm-ppoll-timeout") {
+    return {
+      action,
+      threadId: requiredNativeField(fields, "threadId"),
+      remainingTime: parseNativeDuration(fields),
+      nfds: parseNativeInteger(fields, "nfds") as 0 | 1,
+      resources: parseNativeList(fields, "resources") as NativeModeledPpollTargetResource[],
+      resumeMode: "defer-target-resume",
+    };
+  }
+  return fail("target-guest-loader-descriptor-invalid", "unsupported native active-syscall action");
+}
+
+function parseNativeDuration(fields: Map<string, string>): {
+  seconds: string;
+  nanoseconds: number;
+} {
+  return {
+    seconds: requiredNativeField(fields, "seconds"),
+    nanoseconds: parseNativeInteger(fields, "nanoseconds"),
+  };
+}
+
+function requiredNativeField(fields: Map<string, string>, key: string): string {
+  return fields.get(key) ?? fail("target-guest-loader-descriptor-invalid", `${key} is required`);
+}
+
+function parseNativeInteger(fields: Map<string, string>, key: string): number {
+  const parsed = Number(requiredNativeField(fields, key));
+  if (!Number.isSafeInteger(parsed)) {
+    fail("target-guest-loader-invalid-continuation", `${key} must be an integer`);
+  }
+  return parsed;
+}
+
+function parseNativeBoolean(fields: Map<string, string>, key: string): boolean {
+  const value = requiredNativeField(fields, key);
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return fail("target-guest-loader-descriptor-invalid", `${key} must be true or false`);
+}
+
+function parseNativeList(fields: Map<string, string>, key: string): string[] {
+  const value = requiredNativeField(fields, key);
+  return value.length === 0 ? [] : value.split(",");
+}
+
 function assertDescriptorHeader(descriptor: TargetGuestRestoreDescriptor): void {
   if (descriptor.kind !== TARGET_GUEST_RESTORE_DESCRIPTOR_KIND) {
     fail("target-guest-loader-descriptor-invalid", "descriptor kind is not supported");
@@ -708,6 +936,122 @@ function validateMemoryEntry(
     assertNonNegative(entry.sourceOffset, "sourceOffset");
   }
   return entry;
+}
+
+function validateNativeRestoreStep(
+  step: TargetGuestNativeRestoreStep,
+): TargetGuestNativeRestoreStep {
+  switch (step.section) {
+    case "stack-window-write":
+      validateStackWindowWrite(step.write);
+      return step;
+    case "stack-window-guard":
+      validateStackWindowGuard(step.guard);
+      return step;
+    case "return-chain-write":
+      validateReturnChainWrite(step.write);
+      return step;
+    case "private-memory":
+      validatePrivateMemoryStep(step.step);
+      return step;
+    case "executable-mapping":
+      validateExecutableMappingStep(step.step);
+      return step;
+    case "signal-restore":
+      validateSignalRestoreStep(step.step);
+      return step;
+    case "active-syscall":
+      validateActiveSyscallRestoreStep(step.step);
+      return step;
+  }
+}
+
+function validateStackWindowWrite(write: NativeStackWindowWrite): void {
+  assertNoWhitespace(write.mapping, "mapping");
+  assertHexAddress(write.targetAddress, "targetAddress");
+  assertNonNegative(write.offset, "offset");
+  if (write.sizeBytes !== 8) {
+    fail("target-guest-loader-invalid-continuation", "stack-window writes must be u64");
+  }
+  assertHexAddress(write.value, "value");
+  assertBytesHex(write.bytes, "bytes");
+  if (!["pointer", "code-pointer", "return-address", "thread-pointer"].includes(write.kind)) {
+    fail("target-guest-loader-invalid-continuation", "stack-window write kind is unsupported");
+  }
+}
+
+function validateStackWindowGuard(guard: NativeStackWindowGuardMapping): void {
+  assertHexAddress(guard.targetStart, "targetStart");
+  assertPositive(guard.sizeBytes, "sizeBytes");
+  if (guard.placement !== "below" && guard.placement !== "above") {
+    fail("target-guest-loader-invalid-continuation", "stack-window guard placement is unsupported");
+  }
+}
+
+function validateReturnChainWrite(write: NativeReturnChainFrameWrite): void {
+  assertNoWhitespace(write.frameId, "frameId");
+  assertHexAddress(write.targetAddress, "targetAddress");
+  assertHexAddress(write.value, "value");
+  assertBytesHex(write.bytes, "bytes");
+  if (write.kind !== "caller-frame-pointer" && write.kind !== "return-address") {
+    fail("target-guest-loader-invalid-continuation", "return-chain write kind is unsupported");
+  }
+}
+
+function validatePrivateMemoryStep(step: TargetGuestPrivateMemoryRestoreStep): void {
+  assertNoWhitespace(step.mapping, "mapping");
+  assertHexAddress(step.targetStart, "targetStart");
+  assertPositive(step.sizeBytes, "sizeBytes");
+  if (step.action === "copy-captured-bytes") {
+    assertNoWhitespace(step.sourceFile, "sourceFile");
+    assertNonNegative(step.sourceOffset, "sourceOffset");
+    return;
+  }
+  assertMemoryPermissions(step.permissions);
+}
+
+function validateExecutableMappingStep(step: TargetGuestExecutableMappingStep): void {
+  if (step.action !== "map-target-executable") {
+    fail("target-guest-loader-descriptor-invalid", "unsupported native executable action");
+  }
+  assertNoWhitespace(step.mapping, "mapping");
+  assertHexAddress(step.targetStart, "targetStart");
+  assertPositive(step.sizeBytes, "sizeBytes");
+  assertNoWhitespace(step.path, "path");
+  assertNonNegative(step.fileOffset, "fileOffset");
+  if (!step.permissions.execute || step.permissions.shared || step.sourceTextReusedAsTargetCode) {
+    fail("target-guest-loader-invalid-continuation", "target executable mapping is not safe");
+  }
+  if (!step.buildId && !step.sha256) {
+    fail("target-guest-loader-invalid-continuation", "target executable mapping lacks provenance");
+  }
+}
+
+function validateSignalRestoreStep(step: TargetGuestSignalRestoreStep): void {
+  assertNoWhitespace(step.threadId, "threadId");
+  if ("targetBlockedMasks" in step) {
+    step.targetBlockedMasks.forEach((mask) => assertHexAddress(mask, "targetBlockedMasks"));
+  }
+}
+
+function validateActiveSyscallRestoreStep(step: TargetGuestActiveSyscallRestoreStep): void {
+  assertNoWhitespace(step.threadId, "threadId");
+  assertNoWhitespace(step.remainingTime.seconds, "seconds");
+  assertNonNegative(step.remainingTime.nanoseconds, "nanoseconds");
+  if (step.remainingTime.nanoseconds > 999_999_999) {
+    fail("target-guest-loader-invalid-continuation", "nanoseconds must be <= 999999999");
+  }
+  if (step.action === "rearm-sleep-timer") {
+    assertNoWhitespace(step.syscallName, "syscallName");
+  } else if (step.nfds !== 0 && step.nfds !== 1) {
+    fail("target-guest-loader-invalid-continuation", "ppoll nfds must be 0 or 1");
+  }
+}
+
+function assertBytesHex(value: string, field: string): void {
+  if (!/^[0-9a-f]{16}$/i.test(value)) {
+    fail("target-guest-loader-invalid-continuation", `${field} must be 8 little-endian bytes`);
+  }
 }
 
 function validateTranslatedFrame(
@@ -1000,6 +1344,81 @@ function serializeMemoryEntry(entry: TargetGuestMemoryMaterializationEntry): str
   return `memory=recreate-guard ${base}`;
 }
 
+function serializeNativeRestoreStep(step: TargetGuestNativeRestoreStep): string {
+  switch (step.section) {
+    case "stack-window-write":
+      return serializeStackWindowWrite(step.write);
+    case "stack-window-guard":
+      return serializeStackWindowGuard(step.guard);
+    case "return-chain-write":
+      return serializeReturnChainWrite(step.write);
+    case "private-memory":
+      return serializePrivateMemoryStep(step.step);
+    case "executable-mapping":
+      return serializeExecutableMappingStep(step.step);
+    case "signal-restore":
+      return serializeSignalRestoreStep(step.step);
+    case "active-syscall":
+      return serializeActiveSyscallStep(step.step);
+  }
+}
+
+function serializeStackWindowWrite(write: NativeStackWindowWrite): string {
+  return `native=stack-window-write mapping=${write.mapping} targetAddress=${write.targetAddress} offset=${write.offset} sizeBytes=${write.sizeBytes} value=${write.value} bytes=${write.bytes} kind=${write.kind}`;
+}
+
+function serializeStackWindowGuard(guard: NativeStackWindowGuardMapping): string {
+  return `native=stack-window-guard targetStart=${guard.targetStart} sizeBytes=${guard.sizeBytes} placement=${guard.placement}`;
+}
+
+function serializeReturnChainWrite(write: NativeReturnChainFrameWrite): string {
+  return `native=return-chain-write frameId=${write.frameId} targetAddress=${write.targetAddress} value=${write.value} bytes=${write.bytes} kind=${write.kind}`;
+}
+
+function serializePrivateMemoryStep(step: TargetGuestPrivateMemoryRestoreStep): string {
+  const base = `native=private-memory action=${step.action} mapping=${step.mapping} targetStart=${step.targetStart} sizeBytes=${step.sizeBytes}`;
+  if (step.action === "copy-captured-bytes") {
+    return `${base} sourceFile=${step.sourceFile} sourceOffset=${step.sourceOffset}`;
+  }
+  return `${base} permissions=${step.permissions}`;
+}
+
+function serializeExecutableMappingStep(step: TargetGuestExecutableMappingStep): string {
+  return [
+    `native=executable-mapping action=${step.action}`,
+    `mapping=${step.mapping}`,
+    `targetStart=${step.targetStart}`,
+    `sizeBytes=${step.sizeBytes}`,
+    `path=${step.path}`,
+    `fileOffset=${step.fileOffset}`,
+    `read=${step.permissions.read}`,
+    `write=${step.permissions.write}`,
+    `execute=${step.permissions.execute}`,
+    `private=${step.permissions.private}`,
+    `shared=${step.permissions.shared}`,
+    ...optionalNativeToken("buildId", step.buildId),
+    ...optionalNativeToken("sha256", step.sha256),
+  ].join(" ");
+}
+
+function serializeSignalRestoreStep(step: TargetGuestSignalRestoreStep): string {
+  const base = `native=signal-restore action=${step.action} threadId=${step.threadId}`;
+  return "targetBlockedMasks" in step
+    ? `${base} targetBlockedMasks=${step.targetBlockedMasks.join(",")}`
+    : base;
+}
+
+function serializeActiveSyscallStep(step: TargetGuestActiveSyscallRestoreStep): string {
+  const base = `native=active-syscall action=${step.action} threadId=${step.threadId} seconds=${step.remainingTime.seconds} nanoseconds=${step.remainingTime.nanoseconds} resumeMode=${step.resumeMode}`;
+  return step.action === "rearm-sleep-timer"
+    ? `${base} syscallName=${step.syscallName}`
+    : `${base} nfds=${step.nfds} resources=${step.resources.join(",")}`;
+}
+
+function optionalNativeToken(name: string, value: string | undefined): string[] {
+  return value === undefined ? [] : [`${name}=${value}`];
+}
+
 function optionalArg(flag: string, value: string | undefined): string[] {
   return value === undefined ? [] : [flag, value];
 }
@@ -1090,6 +1509,61 @@ function memorySpec(
     entry.sizeBytes,
     entry.permissions,
   ].join(":");
+}
+
+function nativeRestoreToTrampolineArgs(step: TargetGuestNativeRestoreStep): string[] {
+  switch (step.section) {
+    case "stack-window-write":
+      return ["--native-stack-window-write", nativeStackWindowWriteSpec(step.write)];
+    case "stack-window-guard":
+      return ["--native-stack-window-guard", nativeStackWindowGuardSpec(step.guard)];
+    case "return-chain-write":
+      return ["--native-return-chain-write", nativeReturnChainWriteSpec(step.write)];
+    case "private-memory":
+      return ["--native-private-memory-step", nativePrivateMemoryStepSpec(step.step)];
+    case "executable-mapping":
+      return ["--native-executable-mapping", nativeExecutableMappingSpec(step.step)];
+    case "signal-restore":
+      return ["--native-signal-restore-step", nativeSignalRestoreStepSpec(step.step)];
+    case "active-syscall":
+      return ["--native-active-syscall-step", nativeActiveSyscallStepSpec(step.step)];
+  }
+}
+
+function nativeStackWindowWriteSpec(write: NativeStackWindowWrite): string {
+  return [write.targetAddress, write.value, write.bytes, write.kind].join(":");
+}
+
+function nativeStackWindowGuardSpec(guard: NativeStackWindowGuardMapping): string {
+  return [guard.targetStart, guard.sizeBytes, guard.placement].join(":");
+}
+
+function nativeReturnChainWriteSpec(write: NativeReturnChainFrameWrite): string {
+  return [write.targetAddress, write.value, write.bytes, write.kind].join(":");
+}
+
+function nativePrivateMemoryStepSpec(step: TargetGuestPrivateMemoryRestoreStep): string {
+  return serializePrivateMemoryStep(step)
+    .slice("native=private-memory ".length)
+    .replaceAll(" ", ",");
+}
+
+function nativeExecutableMappingSpec(step: TargetGuestExecutableMappingStep): string {
+  return serializeExecutableMappingStep(step)
+    .slice("native=executable-mapping ".length)
+    .replaceAll(" ", ",");
+}
+
+function nativeSignalRestoreStepSpec(step: TargetGuestSignalRestoreStep): string {
+  return serializeSignalRestoreStep(step)
+    .slice("native=signal-restore ".length)
+    .replaceAll(" ", ",");
+}
+
+function nativeActiveSyscallStepSpec(step: TargetGuestActiveSyscallRestoreStep): string {
+  return serializeActiveSyscallStep(step)
+    .slice("native=active-syscall ".length)
+    .replaceAll(" ", ",");
 }
 
 function fail(code: TargetGuestRestoreLoaderRefusalCode, message: string): never {

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -125,6 +125,7 @@ const TOC = {
     "TargetGuestRestoreResumeMode",
     "TargetGuestResumeRegisterName",
     "TargetGuestResumeRegisters",
+    "TargetGuestNativeRestoreStep",
     "TargetGuestRestoreContinuationDescriptor",
     "TargetGuestRestoreDescriptor",
     "TargetGuestTranslatedFrameDescriptor",


### PR DESCRIPTION
## Problem

The target guest descriptor could carry continuation, fd, memory, and frame data, but not the native restore sections needed by the next loader wave.

## Solution

This PR adds optional `native=` restore sections for stack-window writes, return-chain writes, private memory steps, executable mapping provenance, signal handoff, and active syscall re-arm. They validate, round-trip through descriptor serialization, and produce explicit trampoline argv entries.

Fixes #669

## Validation

- `pnpm run build:docs` — passed
- `pnpm run typecheck` — 2.510s
- focused vitest — 1.545s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.387s
