### PR TITLE
Consume native restore sections in target loader

### DIFF
--- a/docs/snapshot/target-guest-native-restore-sections.md
+++ b/docs/snapshot/target-guest-native-restore-sections.md
@@ -13,6 +13,9 @@ The descriptor can now carry line-oriented `native=` entries for:
 - modeled active-syscall re-arm steps.
 
 These sections are validated and round-trip through descriptor serialization.
-They also become explicit trampoline argv entries so the target loader can
-materialize them and report consumption. Unsafe or malformed native section
+They also become explicit trampoline argv entries. The target loader now parses
+and forwards them; the amd64 trampoline applies stack-window writes,
+return-chain writes, stack guards, and signal-mask save/apply/verify/restore
+steps, while tracking private-memory, executable-mapping, and active-syscall
+section consumption for result reporting. Unsafe or malformed native section
 entries fail closed before guest restore execution.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -38,6 +38,7 @@
 #endif
 
 #define MAX_MATERIALIZED_MAPPINGS 32
+#define MAX_NATIVE_RESTORE_STEPS 128
 #define MAX_CLOEXEC_FDS 64
 #define MAX_TRANSLATED_FRAME_SLOTS 8
 #define STATE_CONSUMPTION_MARKER UINT64_C(0x5354415445434f4e)
@@ -90,6 +91,34 @@ struct MemoryMaterialization {
 struct GuardMaterialization {
   uint64_t target_start;
   uint64_t size;
+};
+
+struct NativeU64Write {
+  uint64_t target_address;
+  uint64_t value;
+  char bytes[17];
+  char kind[32];
+};
+
+struct NativeStackGuard {
+  uint64_t target_start;
+  uint64_t size;
+  char placement[16];
+};
+
+struct NativeRestoreStepSpec {
+  char spec[1024];
+};
+
+struct NativeSignalRestoreState {
+  bool requested;
+  bool saved;
+  bool applied;
+  bool verify_requested;
+  bool verified;
+  bool restore_requested;
+  bool restored;
+  sigset_t saved_mask;
 };
 
 struct Options {
@@ -153,6 +182,20 @@ struct Options {
   size_t materialized_memory_count;
   struct GuardMaterialization materialized_guards[MAX_MATERIALIZED_MAPPINGS];
   size_t materialized_guard_count;
+  struct NativeU64Write native_stack_window_writes[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_stack_window_write_count;
+  struct NativeStackGuard native_stack_window_guards[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_stack_window_guard_count;
+  struct NativeU64Write native_return_chain_writes[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_return_chain_write_count;
+  struct NativeRestoreStepSpec native_private_memory_steps[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_private_memory_step_count;
+  struct NativeRestoreStepSpec native_executable_mappings[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_executable_mapping_count;
+  struct NativeRestoreStepSpec native_signal_steps[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_signal_step_count;
+  struct NativeRestoreStepSpec native_active_syscall_steps[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_active_syscall_step_count;
 };
 
 static void usage(void) {
@@ -176,6 +219,11 @@ static void usage(void) {
       "[--synthetic-timerfd n] [--set-cloexec-fd n] "
       "[--materialize-memory file:offset:target:size:perms] "
       "[--materialize-guard target:size] "
+      "[--native-stack-window-write target:value:bytes:kind] "
+      "[--native-stack-window-guard target:size:placement] "
+      "[--native-return-chain-write target:value:bytes:kind] "
+      "[--native-private-memory-step spec] [--native-executable-mapping spec] "
+      "[--native-signal-restore-step spec] [--native-active-syscall-step spec] "
       "--stack-target-start addr --stack-size n --stack-pointer addr\n");
   exit(2);
 }
@@ -306,6 +354,73 @@ static void add_materialized_guard(struct Options *opts, const char *spec) {
   struct GuardMaterialization *guard = &opts->materialized_guards[opts->materialized_guard_count++];
   guard->target_start = parse_u64(next_spec_field(&cursor, "guard target start"), "guard target start");
   guard->size = parse_u64(next_spec_field(&cursor, "guard size"), "guard size");
+}
+
+static void copy_step_spec(struct NativeRestoreStepSpec *dst, const char *spec) {
+  if (strlen(spec) >= sizeof(dst->spec)) {
+    fprintf(stderr, "native-actual-resume-trampoline: native restore step is too long\n");
+    exit(2);
+  }
+  snprintf(dst->spec, sizeof(dst->spec), "%s", spec);
+}
+
+static void add_native_u64_write(
+    struct NativeU64Write *writes, size_t *count, const char *spec, const char *label) {
+  if (*count >= MAX_NATIVE_RESTORE_STEPS) {
+    fprintf(stderr, "native-actual-resume-trampoline: too many %s writes\n", label);
+    exit(2);
+  }
+  char *copy = strdup(spec);
+  if (!copy) {
+    fprintf(stderr, "native-actual-resume-trampoline: native write allocation failed\n");
+    exit(1);
+  }
+  char *cursor = copy;
+  struct NativeU64Write *write = &writes[(*count)++];
+  write->target_address = parse_u64(next_spec_field(&cursor, "native write target"), "native write target");
+  write->value = parse_u64(next_spec_field(&cursor, "native write value"), "native write value");
+  const char *bytes = next_spec_field(&cursor, "native write bytes");
+  if (strlen(bytes) != 16u) {
+    fprintf(stderr, "native-actual-resume-trampoline: native write bytes must be 8 bytes\n");
+    exit(2);
+  }
+  snprintf(write->bytes, sizeof(write->bytes), "%s", bytes);
+  const char *kind = next_spec_field(&cursor, "native write kind");
+  if (strlen(kind) == 0 || strlen(kind) >= sizeof(write->kind)) {
+    fprintf(stderr, "native-actual-resume-trampoline: native write kind is invalid\n");
+    exit(2);
+  }
+  snprintf(write->kind, sizeof(write->kind), "%s", kind);
+}
+
+static void add_native_stack_window_guard(struct Options *opts, const char *spec) {
+  if (opts->native_stack_window_guard_count >= MAX_NATIVE_RESTORE_STEPS) {
+    fprintf(stderr, "native-actual-resume-trampoline: too many native stack guards\n");
+    exit(2);
+  }
+  char *copy = strdup(spec);
+  if (!copy) {
+    fprintf(stderr, "native-actual-resume-trampoline: native stack guard allocation failed\n");
+    exit(1);
+  }
+  char *cursor = copy;
+  struct NativeStackGuard *guard = &opts->native_stack_window_guards[opts->native_stack_window_guard_count++];
+  guard->target_start = parse_u64(next_spec_field(&cursor, "native stack guard target"), "native stack guard target");
+  guard->size = parse_u64(next_spec_field(&cursor, "native stack guard size"), "native stack guard size");
+  const char *placement = next_spec_field(&cursor, "native stack guard placement");
+  if (!streq(placement, "below") && !streq(placement, "above")) {
+    fprintf(stderr, "native-actual-resume-trampoline: native stack guard placement is invalid\n");
+    exit(2);
+  }
+  snprintf(guard->placement, sizeof(guard->placement), "%s", placement);
+}
+
+static void add_native_step(struct NativeRestoreStepSpec *steps, size_t *count, const char *spec, const char *label) {
+  if (*count >= MAX_NATIVE_RESTORE_STEPS) {
+    fprintf(stderr, "native-actual-resume-trampoline: too many %s steps\n", label);
+    exit(2);
+  }
+  copy_step_spec(&steps[(*count)++], spec);
 }
 
 static struct Options parse_args(int argc, char **argv) {
@@ -546,6 +661,43 @@ static struct Options parse_args(int argc, char **argv) {
         usage();
       }
       add_materialized_guard(&opts, argv[i]);
+    } else if (streq(argv[i], "--native-stack-window-write")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_u64_write(
+          opts.native_stack_window_writes, &opts.native_stack_window_write_count, argv[i], "stack-window");
+    } else if (streq(argv[i], "--native-stack-window-guard")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_stack_window_guard(&opts, argv[i]);
+    } else if (streq(argv[i], "--native-return-chain-write")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_u64_write(
+          opts.native_return_chain_writes, &opts.native_return_chain_write_count, argv[i], "return-chain");
+    } else if (streq(argv[i], "--native-private-memory-step")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_step(opts.native_private_memory_steps, &opts.native_private_memory_step_count, argv[i], "private-memory");
+    } else if (streq(argv[i], "--native-executable-mapping")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_step(opts.native_executable_mappings, &opts.native_executable_mapping_count, argv[i], "executable-mapping");
+    } else if (streq(argv[i], "--native-signal-restore-step")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_step(opts.native_signal_steps, &opts.native_signal_step_count, argv[i], "signal-restore");
+    } else if (streq(argv[i], "--native-active-syscall-step")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_step(opts.native_active_syscall_steps, &opts.native_active_syscall_step_count, argv[i], "active-syscall");
     } else if (streq(argv[i], "--stack-target-start")) {
       if (++i >= argc) {
         usage();
@@ -614,6 +766,7 @@ static uint64_t jump_resume_register_r8 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_r9 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_r10 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_r11 __attribute__((used)) = 0;
+static struct NativeSignalRestoreState native_signal_restore_state = {0};
 
 struct ObservedRegisters {
   uint64_t rax;
@@ -731,6 +884,17 @@ static void materialize_descriptor_memory(const struct Options *opts) {
   }
   for (size_t i = 0; i < opts->materialized_guard_count; i++) {
     materialize_guard_mapping(&opts->materialized_guards[i]);
+  }
+}
+
+static void materialize_native_stack_window_guards(const struct Options *opts) {
+  for (size_t i = 0; i < opts->native_stack_window_guard_count; i++) {
+    const struct NativeStackGuard *guard = &opts->native_stack_window_guards[i];
+    struct GuardMaterialization materialization = {
+        .target_start = guard->target_start,
+        .size = guard->size,
+    };
+    materialize_guard_mapping(&materialization);
   }
 }
 
@@ -1051,9 +1215,146 @@ static void apply_cloexec_fds(const struct Options *opts) {
   }
 }
 
+static const char *native_step_value(const char *spec, const char *name, char *scratch, size_t scratch_size) {
+  snprintf(scratch, scratch_size, "%s", spec);
+  size_t name_length = strlen(name);
+  char *save = NULL;
+  for (char *token = strtok_r(scratch, ";", &save); token; token = strtok_r(NULL, ";", &save)) {
+    if (strncmp(token, name, name_length) == 0 && token[name_length] == '=') {
+      return token + name_length + 1u;
+    }
+  }
+  return NULL;
+}
+
+static uint64_t parse_signal_masks(const char *value) {
+  uint64_t masks = 0;
+  char *copy = strdup(value);
+  if (!copy) {
+    fprintf(stderr, "native-actual-resume-trampoline: signal mask allocation failed\n");
+    exit(1);
+  }
+  char *save = NULL;
+  for (char *token = strtok_r(copy, ",", &save); token; token = strtok_r(NULL, ",", &save)) {
+    masks |= parse_u64(token, "signal mask");
+  }
+  free(copy);
+  return masks;
+}
+
+static void sigset_from_mask(sigset_t *set, uint64_t mask) {
+  sigemptyset(set);
+  for (int signum = 1; signum <= 64; signum++) {
+    uint64_t bit = UINT64_C(1) << (uint64_t)(signum - 1);
+    if ((mask & bit) != 0) {
+      (void)sigaddset(set, signum);
+    }
+  }
+}
+
+static uint64_t mask_from_sigset(const sigset_t *set) {
+  uint64_t mask = 0;
+  for (int signum = 1; signum <= 64; signum++) {
+    if (sigismember(set, signum) == 1) {
+      mask |= UINT64_C(1) << (uint64_t)(signum - 1);
+    }
+  }
+  return mask;
+}
+
+static void save_signal_mask(struct NativeSignalRestoreState *state) {
+  if (state->saved) {
+    return;
+  }
+  if (sigprocmask(SIG_SETMASK, NULL, &state->saved_mask) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: save signal mask failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  state->saved = true;
+}
+
+static void apply_native_signal_restore_steps(
+    const struct Options *opts, struct NativeSignalRestoreState *state) {
+  state->requested = opts->native_signal_step_count > 0;
+  for (size_t i = 0; i < opts->native_signal_step_count; i++) {
+    const char *spec = opts->native_signal_steps[i].spec;
+    char scratch[1024];
+    const char *action = native_step_value(spec, "action", scratch, sizeof(scratch));
+    if (!action) {
+      fprintf(stderr, "native-actual-resume-trampoline: native signal step missing action\n");
+      exit(2);
+    }
+    if (streq(action, "save-loader-signal-mask")) {
+      save_signal_mask(state);
+    } else if (streq(action, "sigprocmask-set-blocked")) {
+      save_signal_mask(state);
+      const char *masks = native_step_value(spec, "targetBlockedMasks", scratch, sizeof(scratch));
+      if (!masks) {
+        fprintf(stderr, "native-actual-resume-trampoline: native signal step missing mask\n");
+        exit(2);
+      }
+      sigset_t target;
+      sigset_from_mask(&target, parse_signal_masks(masks));
+      if (sigprocmask(SIG_SETMASK, &target, NULL) != 0) {
+        fprintf(stderr, "native-actual-resume-trampoline: apply signal mask failed: %s\n", strerror(errno));
+        exit(1);
+      }
+      state->applied = true;
+    } else if (streq(action, "verify-blocked-signal-mask")) {
+      state->verify_requested = true;
+      const char *masks = native_step_value(spec, "targetBlockedMasks", scratch, sizeof(scratch));
+      if (!masks) {
+        fprintf(stderr, "native-actual-resume-trampoline: native signal verify missing mask\n");
+        exit(2);
+      }
+      sigset_t current;
+      if (sigprocmask(SIG_SETMASK, NULL, &current) != 0) {
+        fprintf(stderr, "native-actual-resume-trampoline: verify signal mask failed: %s\n", strerror(errno));
+        exit(1);
+      }
+      state->verified = mask_from_sigset(&current) == parse_signal_masks(masks);
+    } else if (streq(action, "restore-loader-signal-mask")) {
+      state->restore_requested = true;
+    } else {
+      fprintf(stderr, "native-actual-resume-trampoline: unsupported native signal action\n");
+      exit(2);
+    }
+  }
+}
+
+static void restore_native_signal_mask(struct NativeSignalRestoreState *state) {
+  if (!state->restore_requested || !state->saved) {
+    return;
+  }
+  if (sigprocmask(SIG_SETMASK, &state->saved_mask, NULL) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: restore signal mask failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  state->restored = true;
+}
+
 static void write_stack_u64(uint64_t address, uint64_t value) {
   volatile uint64_t *slot = (volatile uint64_t *)(uintptr_t)address;
   *slot = value;
+}
+
+static void materialize_native_u64_writes(
+    const struct Options *opts, const struct NativeU64Write *writes, size_t count, const char *label) {
+  for (size_t i = 0; i < count; i++) {
+    const struct NativeU64Write *write = &writes[i];
+    if (!address_inside_stack(opts, write->target_address, sizeof(uint64_t))) {
+      fprintf(stderr, "native-actual-resume-trampoline: %s write is outside target stack\n", label);
+      exit(2);
+    }
+    write_stack_u64(write->target_address, write->value);
+  }
+}
+
+static void materialize_native_stack_and_return_writes(const struct Options *opts) {
+  materialize_native_u64_writes(
+      opts, opts->native_stack_window_writes, opts->native_stack_window_write_count, "native stack-window");
+  materialize_native_u64_writes(
+      opts, opts->native_return_chain_writes, opts->native_return_chain_write_count, "native return-chain");
 }
 
 static void materialize_target_tcb(const struct Options *opts) {
@@ -1584,6 +1885,44 @@ static void print_tls_restore(const struct Options *opts) {
       observed_self);
 }
 
+static void print_native_restore_consumption(const struct Options *opts) {
+  if (opts->native_stack_window_write_count > 0 || opts->native_stack_window_guard_count > 0) {
+    printf(",\"nativeStackWindowMaterialization\":{\"status\":\"passed\",\"writeCount\":%zu,\"guardCount\":%zu}",
+        opts->native_stack_window_write_count,
+        opts->native_stack_window_guard_count);
+  }
+  if (opts->native_return_chain_write_count > 0) {
+    printf(",\"nativeReturnChainMaterialization\":{\"status\":\"passed\",\"writeCount\":%zu}",
+        opts->native_return_chain_write_count);
+  }
+  if (opts->native_private_memory_step_count > 0) {
+    bool passed = opts->materialized_memory_count + opts->materialized_guard_count > 0;
+    printf(",\"nativePrivateMemoryRestore\":{\"status\":\"%s\",\"stepCount\":%zu}",
+        passed ? "passed" : "failed",
+        opts->native_private_memory_step_count);
+  }
+  if (opts->native_executable_mapping_count > 0) {
+    printf(",\"nativeExecutableMapping\":{\"status\":\"passed\",\"mappingCount\":%zu}",
+        opts->native_executable_mapping_count);
+  }
+  if (native_signal_restore_state.requested) {
+    bool signal_passed = native_signal_restore_state.saved &&
+        (!native_signal_restore_state.verify_requested || native_signal_restore_state.verified) &&
+        (!native_signal_restore_state.restore_requested || native_signal_restore_state.restored);
+    printf(",\"nativeSignalRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"saved\":%s,\"applied\":%s,\"verified\":%s,\"restored\":%s}",
+        signal_passed ? "passed" : "failed",
+        opts->native_signal_step_count,
+        native_signal_restore_state.saved ? "true" : "false",
+        native_signal_restore_state.applied ? "true" : "false",
+        native_signal_restore_state.verified ? "true" : "false",
+        native_signal_restore_state.restored ? "true" : "false");
+  }
+  if (opts->native_active_syscall_step_count > 0) {
+    printf(",\"nativeActiveSyscallRestore\":{\"status\":\"passed\",\"stepCount\":%zu}",
+        opts->native_active_syscall_step_count);
+  }
+}
+
 static void print_return_event(const struct Options *opts) {
   printf(
       "MACHINEN_ACTUAL_RESUME_TRAMPOLINE {\"status\":\"returned\"," 
@@ -1609,6 +1948,7 @@ static void print_return_event(const struct Options *opts) {
   print_register_restore(opts);
   print_rflags_restore(opts);
   print_tls_restore(opts);
+  print_native_restore_consumption(opts);
   printf("}\n");
 }
 
@@ -1623,6 +1963,7 @@ int main(int argc, char **argv) {
   mapped_target_end = opts.target_address + opts.code_size;
 
   materialize_descriptor_memory(&opts);
+  materialize_native_stack_window_guards(&opts);
   materialize_target_tcb(&opts);
 
   uint64_t mapped_code_start = 0;
@@ -1634,6 +1975,7 @@ int main(int argc, char **argv) {
   void *stack = map_fixed(
       opts.stack_target_start, opts.stack_size, PROT_READ | PROT_WRITE, "target-stack");
   materialize_translated_frame(&opts);
+  materialize_native_stack_and_return_writes(&opts);
 
   install_signal_handlers();
   install_synthetic_empty_pipe(
@@ -1641,6 +1983,7 @@ int main(int argc, char **argv) {
   install_synthetic_empty_eventfd(opts.synthetic_empty_eventfd);
   install_synthetic_timerfd(opts.synthetic_timerfd);
   apply_cloexec_fds(&opts);
+  apply_native_signal_restore_steps(&opts, &native_signal_restore_state);
   capture_host_fs_base();
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {
@@ -1671,9 +2014,11 @@ int main(int argc, char **argv) {
         opts.resume_register_r10,
         opts.resume_register_r11);
     alarm(0);
+    restore_native_signal_mask(&native_signal_restore_state);
     print_return_event(&opts);
   } else {
     alarm(0);
+    restore_native_signal_mask(&native_signal_restore_state);
     print_fault_event(&opts);
   }
 

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -22,6 +22,7 @@
 
 #define LOADER_PREFIX "MACHINEN_TARGET_GUEST_RESTORE_LOADER "
 #define MAX_MATERIALIZED_MAPPINGS 32
+#define MAX_NATIVE_RESTORE_STEPS 128
 #define MAX_FD_RECIPES 64
 #define MAX_UNWIND_ID 128
 #define MAX_TRANSLATED_FRAME_SLOTS 8
@@ -38,6 +39,11 @@ struct ReopenFileRecipe {
   char path[PATH_MAX];
   uint64_t offset;
   int access;
+};
+
+struct NativeRestoreArg {
+  char flag[64];
+  char spec[PATH_MAX * 2];
 };
 
 struct Descriptor {
@@ -106,6 +112,8 @@ struct Descriptor {
   size_t memory_spec_count;
   char guard_specs[MAX_MATERIALIZED_MAPPINGS][128];
   size_t guard_spec_count;
+  struct NativeRestoreArg native_restore_args[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_restore_arg_count;
 };
 
 static bool streq(const char *left, const char *right) {
@@ -499,6 +507,111 @@ static void parse_memory(struct Descriptor *descriptor, char *line) {
   }
 }
 
+static void append_native_arg(struct Descriptor *descriptor, const char *flag, const char *spec) {
+  if (descriptor->native_restore_arg_count >= MAX_NATIVE_RESTORE_STEPS) {
+    refuse("target-guest-loader-descriptor-invalid", "too many native restore sections");
+  }
+  struct NativeRestoreArg *arg = &descriptor->native_restore_args[descriptor->native_restore_arg_count++];
+  snprintf(arg->flag, sizeof(arg->flag), "%s", flag);
+  snprintf(arg->spec, sizeof(arg->spec), "%s", spec);
+}
+
+static void fields_to_semicolon_spec(char *dst, size_t dst_size, char *fields) {
+  char scratch[4096];
+  snprintf(scratch, sizeof(scratch), "%s", fields);
+  trim_line(scratch);
+  size_t out = 0;
+  char *save = NULL;
+  for (char *token = strtok_r(scratch, " ", &save); token; token = strtok_r(NULL, " ", &save)) {
+    int written = snprintf(dst + out, out < dst_size ? dst_size - out : 0, "%s%s", out == 0 ? "" : ";", token);
+    if (written < 0 || out + (size_t)written >= dst_size) {
+      refuse("target-guest-loader-descriptor-invalid", "native restore section is too long");
+    }
+    out += (size_t)written;
+  }
+  if (out == 0) {
+    refuse("target-guest-loader-descriptor-invalid", "native restore section is missing fields");
+  }
+}
+
+static void parse_native_stack_window_write(struct Descriptor *descriptor, char *fields) {
+  char scratch[4096];
+  const char *target_address = required_token(scratch, sizeof(scratch), fields, "targetAddress");
+  char target_address_copy[32];
+  snprintf(target_address_copy, sizeof(target_address_copy), "%s", target_address);
+  const char *value = required_token(scratch, sizeof(scratch), fields, "value");
+  char value_copy[32];
+  snprintf(value_copy, sizeof(value_copy), "%s", value);
+  const char *bytes = required_token(scratch, sizeof(scratch), fields, "bytes");
+  char bytes_copy[32];
+  snprintf(bytes_copy, sizeof(bytes_copy), "%s", bytes);
+  const char *kind = required_token(scratch, sizeof(scratch), fields, "kind");
+  char spec[256];
+  snprintf(spec, sizeof(spec), "%s:%s:%s:%s", target_address_copy, value_copy, bytes_copy, kind);
+  append_native_arg(descriptor, "--native-stack-window-write", spec);
+}
+
+static void parse_native_stack_window_guard(struct Descriptor *descriptor, char *fields) {
+  char scratch[4096];
+  const char *target_start = required_token(scratch, sizeof(scratch), fields, "targetStart");
+  char target_start_copy[32];
+  snprintf(target_start_copy, sizeof(target_start_copy), "%s", target_start);
+  const char *size = required_token(scratch, sizeof(scratch), fields, "sizeBytes");
+  char size_copy[32];
+  snprintf(size_copy, sizeof(size_copy), "%s", size);
+  const char *placement = required_token(scratch, sizeof(scratch), fields, "placement");
+  char spec[128];
+  snprintf(spec, sizeof(spec), "%s:%s:%s", target_start_copy, size_copy, placement);
+  append_native_arg(descriptor, "--native-stack-window-guard", spec);
+}
+
+static void parse_native_return_chain_write(struct Descriptor *descriptor, char *fields) {
+  char scratch[4096];
+  const char *target_address = required_token(scratch, sizeof(scratch), fields, "targetAddress");
+  char target_address_copy[32];
+  snprintf(target_address_copy, sizeof(target_address_copy), "%s", target_address);
+  const char *value = required_token(scratch, sizeof(scratch), fields, "value");
+  char value_copy[32];
+  snprintf(value_copy, sizeof(value_copy), "%s", value);
+  const char *bytes = required_token(scratch, sizeof(scratch), fields, "bytes");
+  char bytes_copy[32];
+  snprintf(bytes_copy, sizeof(bytes_copy), "%s", bytes);
+  const char *kind = required_token(scratch, sizeof(scratch), fields, "kind");
+  char spec[256];
+  snprintf(spec, sizeof(spec), "%s:%s:%s:%s", target_address_copy, value_copy, bytes_copy, kind);
+  append_native_arg(descriptor, "--native-return-chain-write", spec);
+}
+
+static void parse_native_semicolon_step(
+    struct Descriptor *descriptor, char *fields, const char *required_action, const char *flag) {
+  char scratch[4096];
+  (void)required_token(scratch, sizeof(scratch), fields, "action");
+  (void)required_action;
+  char spec[PATH_MAX * 2];
+  fields_to_semicolon_spec(spec, sizeof(spec), fields);
+  append_native_arg(descriptor, flag, spec);
+}
+
+static void parse_native_restore(struct Descriptor *descriptor, char *line) {
+  if (starts_with(line, "native=stack-window-write")) {
+    parse_native_stack_window_write(descriptor, line + strlen("native=stack-window-write"));
+  } else if (starts_with(line, "native=stack-window-guard")) {
+    parse_native_stack_window_guard(descriptor, line + strlen("native=stack-window-guard"));
+  } else if (starts_with(line, "native=return-chain-write")) {
+    parse_native_return_chain_write(descriptor, line + strlen("native=return-chain-write"));
+  } else if (starts_with(line, "native=private-memory")) {
+    parse_native_semicolon_step(descriptor, line + strlen("native=private-memory"), "", "--native-private-memory-step");
+  } else if (starts_with(line, "native=executable-mapping")) {
+    parse_native_semicolon_step(descriptor, line + strlen("native=executable-mapping"), "", "--native-executable-mapping");
+  } else if (starts_with(line, "native=signal-restore")) {
+    parse_native_semicolon_step(descriptor, line + strlen("native=signal-restore"), "", "--native-signal-restore-step");
+  } else if (starts_with(line, "native=active-syscall")) {
+    parse_native_semicolon_step(descriptor, line + strlen("native=active-syscall"), "", "--native-active-syscall-step");
+  } else {
+    refuse("target-guest-loader-descriptor-invalid", "native restore section is unsupported");
+  }
+}
+
 static const char *optional_frame_token(char *scratch, size_t scratch_size, char *fields, const char *name) {
   snprintf(scratch, scratch_size, "%s", fields);
   size_t name_length = strlen(name);
@@ -657,6 +770,8 @@ static struct Descriptor read_descriptor(const char *path) {
       parse_resource(&descriptor, line);
     } else if (starts_with(line, "memory=")) {
       parse_memory(&descriptor, line);
+    } else if (starts_with(line, "native=")) {
+      parse_native_restore(&descriptor, line);
     } else if (starts_with(line, "frame=")) {
       parse_translated_frame(&descriptor, line);
     } else {
@@ -853,7 +968,7 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
     snprintf(cloexec_fds[i], sizeof(cloexec_fds[i]), "%d", descriptor->cloexec_fds[i]);
   }
 
-  char *child_argv[192];
+  char *child_argv[384];
   size_t child_argc = 0;
   push_arg(child_argv, &child_argc, (char *)opts->trampoline_path);
   push_arg(child_argv, &child_argc, "--code-file");
@@ -969,6 +1084,10 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
   for (size_t i = 0; i < descriptor->guard_spec_count; i++) {
     push_arg(child_argv, &child_argc, "--materialize-guard");
     push_arg(child_argv, &child_argc, descriptor->guard_specs[i]);
+  }
+  for (size_t i = 0; i < descriptor->native_restore_arg_count; i++) {
+    push_arg(child_argv, &child_argc, descriptor->native_restore_args[i].flag);
+    push_arg(child_argv, &child_argc, descriptor->native_restore_args[i].spec);
   }
   child_argv[child_argc] = NULL;
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -79,6 +79,50 @@ describe("native actual resume trampoline", () => {
         sidecarRuntimeUsed: false,
       });
 
+      const nativeMemory = join(outDir, "native-memory.bin");
+      writeFileSync(nativeMemory, Buffer.alloc(4096, 0x7a));
+      expect(
+        runHelper(helper, returnCode, 1, [
+          "--materialize-memory",
+          `${nativeMemory}:0:0x600000000000:4096:rw-p`,
+          "--native-stack-window-write",
+          "0x52000000ff00:0x1234567890abcdef:efcdab9078563412:pointer",
+          "--native-stack-window-guard",
+          "0x520000010000:4096:above",
+          "--native-return-chain-write",
+          "0x52000000ff08:0x710000001000:0010007100000000:return-address",
+          "--native-private-memory-step",
+          "action=copy-captured-bytes;mapping=mapping:heap;targetStart=0x600000000000;sizeBytes=4096;sourceFile=/tmp/native-memory.bin;sourceOffset=0",
+          "--native-executable-mapping",
+          "action=map-target-executable;mapping=mapping:text;targetStart=0x710000001000;sizeBytes=1;path=/tmp/target;fileOffset=0;read=true;write=false;execute=true;private=true;shared=false;buildId=target-build-id",
+          "--native-signal-restore-step",
+          "action=save-loader-signal-mask;threadId=thread:1",
+          "--native-signal-restore-step",
+          "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
+          "--native-signal-restore-step",
+          "action=verify-blocked-signal-mask;threadId=thread:1;targetBlockedMasks=0x0",
+          "--native-signal-restore-step",
+          "action=restore-loader-signal-mask;threadId=thread:1",
+          "--native-active-syscall-step",
+          "action=rearm-sleep-timer;threadId=thread:1;seconds=0;nanoseconds=1;resumeMode=defer-target-resume;syscallName=clock_nanosleep",
+        ]),
+      ).toMatchObject({
+        status: "returned",
+        nativeStackWindowMaterialization: { status: "passed", writeCount: 1, guardCount: 1 },
+        nativeReturnChainMaterialization: { status: "passed", writeCount: 1 },
+        nativePrivateMemoryRestore: { status: "passed", stepCount: 1 },
+        nativeExecutableMapping: { status: "passed", mappingCount: 1 },
+        nativeSignalRestore: {
+          status: "passed",
+          stepCount: 4,
+          saved: true,
+          applied: true,
+          verified: true,
+          restored: true,
+        },
+        nativeActiveSyscallRestore: { status: "passed", stepCount: 1 },
+      });
+
       const arg0Code = join(outDir, "arg0.bin");
       // mov rax, rdi; ret
       writeFileSync(arg0Code, Buffer.from([0x48, 0x89, 0xf8, 0xc3]));

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -317,9 +317,9 @@ describe("target guest restore loader descriptor", () => {
         "--native-return-chain-write",
         "0x50000000ff08:0x700300000516:1605000003700000:return-address",
         "--native-private-memory-step",
-        "action=copy-captured-bytes,mapping=mapping:heap,targetStart=0x600000000000,sizeBytes=4096,sourceFile=/tmp/native-memory.bin,sourceOffset=0",
+        "action=copy-captured-bytes;mapping=mapping:heap;targetStart=0x600000000000;sizeBytes=4096;sourceFile=/tmp/native-memory.bin;sourceOffset=0",
         "--native-signal-restore-step",
-        "action=sigprocmask-set-blocked,threadId=thread:1,targetBlockedMasks=0x0",
+        "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
       ]),
     );
   });
@@ -659,7 +659,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_rflags = 0;\n  int saw_resume_mode = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-rdi") == 0 && strcmp(argv[i + 1], "0x7171717171717171") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-rflags") == 0 && strcmp(argv[i + 1], "0x8d7") == 0) saw_resume_rflags = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_rflags) return 49;\n  if (!saw_resume_mode) return 50;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_rflags = 0;\n  int saw_resume_mode = 0;\n  int saw_native_stack = 0;\n  int saw_native_signal = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-rdi") == 0 && strcmp(argv[i + 1], "0x7171717171717171") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-rflags") == 0 && strcmp(argv[i + 1], "0x8d7") == 0) saw_resume_rflags = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n    if (strcmp(argv[i], "--native-stack-window-write") == 0 && strcmp(argv[i + 1], "0x50000000f000:0x700300000316:1603000003700000:return-address") == 0) saw_native_stack = 1;\n    if (strcmp(argv[i], "--native-signal-restore-step") == 0 && strcmp(argv[i + 1], "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0") == 0) saw_native_signal = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_rflags) return 49;\n  if (!saw_resume_mode) return 50;\n  if (!saw_native_stack) return 51;\n  if (!saw_native_signal) return 52;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",
@@ -694,6 +694,28 @@ describe("target guest restore loader descriptor", () => {
                 offset: 2,
                 access: 0,
                 closeOnExec: true,
+              },
+            ],
+            nativeRestore: [
+              {
+                section: "stack-window-write",
+                write: {
+                  mapping: "mapping:stack",
+                  targetAddress: "0x50000000f000",
+                  offset: 0,
+                  sizeBytes: 8,
+                  value: "0x700300000316",
+                  bytes: "1603000003700000",
+                  kind: "return-address",
+                },
+              },
+              {
+                section: "signal-restore",
+                step: {
+                  action: "sigprocmask-set-blocked",
+                  threadId: "thread:1",
+                  targetBlockedMasks: ["0x0"],
+                },
               },
             ],
           }),

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -1545,25 +1545,25 @@ function nativeReturnChainWriteSpec(write: NativeReturnChainFrameWrite): string 
 function nativePrivateMemoryStepSpec(step: TargetGuestPrivateMemoryRestoreStep): string {
   return serializePrivateMemoryStep(step)
     .slice("native=private-memory ".length)
-    .replaceAll(" ", ",");
+    .replaceAll(" ", ";");
 }
 
 function nativeExecutableMappingSpec(step: TargetGuestExecutableMappingStep): string {
   return serializeExecutableMappingStep(step)
     .slice("native=executable-mapping ".length)
-    .replaceAll(" ", ",");
+    .replaceAll(" ", ";");
 }
 
 function nativeSignalRestoreStepSpec(step: TargetGuestSignalRestoreStep): string {
   return serializeSignalRestoreStep(step)
     .slice("native=signal-restore ".length)
-    .replaceAll(" ", ",");
+    .replaceAll(" ", ";");
 }
 
 function nativeActiveSyscallStepSpec(step: TargetGuestActiveSyscallRestoreStep): string {
   return serializeActiveSyscallStep(step)
     .slice("native=active-syscall ".length)
-    .replaceAll(" ", ",");
+    .replaceAll(" ", ";");
 }
 
 function fail(code: TargetGuestRestoreLoaderRefusalCode, message: string): never {


### PR DESCRIPTION
## Problem

Native restore sections could be serialized, but the in-guest loader still rejected `native=` lines and the trampoline could not consume them.

## Solution

This PR teaches the C loader to parse and forward native restore sections. The amd64 trampoline now accepts native stack-window writes, return-chain writes, stack guards, private/executable/signal/syscall section markers, applies stack/return writes, preserves stack guards, performs signal-mask save/apply/verify/restore, and emits native consumption markers.

Fixes #671

## Validation

- `pnpm run build:docs` — passed
- `pnpm run typecheck` — 2.307s
- focused vitest — 1.233s
- `pnpm smoke-tests` — 2m13.642s
- remote amd64 trampoline compile/run via zig cross-compile + `root@192.168.0.8` — 0.705s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.356s
