### PR TITLE
Gate portable machine smoke on native consumption

### DIFF
--- a/packages/runtime/src/__tests__/native-target-vm-synthetic-continuation-script.test.ts
+++ b/packages/runtime/src/__tests__/native-target-vm-synthetic-continuation-script.test.ts
@@ -30,6 +30,19 @@ describe("native target VM synthetic continuation script", () => {
     expect(targetNativeConsumptionPassed(events)).toBe(true);
   });
 
+  it("fails native consumption gating when stack or memory consumption fails", () => {
+    const events = parseTargetNativeConsumptionEvents({
+      nativeStackWindowMaterialization: { status: "failed" },
+      nativePrivateMemoryRestore: { status: "passed" },
+    });
+
+    expect(targetNativeConsumptionFields(events)).toMatchObject({
+      targetStackWindowMaterializationResult: "failed",
+      targetPrivateMemoryRestoreResult: "passed",
+    });
+    expect(targetNativeConsumptionPassed(events)).toBe(false);
+  });
+
   it("fails native consumption gating when any native restore consumption event fails", () => {
     const events = parseTargetNativeConsumptionEvents({
       nativeSignalRestore: { status: "failed" },

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -110,6 +110,11 @@ try {
     targetRegisterRestoreResult: result.targetRegisterRestoreResult ?? '',
     targetRflagsRestoreResult: result.targetRflagsRestoreResult ?? '',
     targetTlsRestoreResult: result.targetTlsRestoreResult ?? '',
+    targetStackWindowMaterializationResult: result.targetStackWindowMaterializationResult ?? '',
+    targetPrivateMemoryRestoreResult: result.targetPrivateMemoryRestoreResult ?? '',
+    targetExecutableMappingResult: result.targetExecutableMappingResult ?? '',
+    targetSignalRestoreResult: result.targetSignalRestoreResult ?? '',
+    targetActiveSyscallRestoreResult: result.targetActiveSyscallRestoreResult ?? '',
     targetThreadRestoreResult: result.targetThreadRestoreResult ?? '',
     targetThreadRestoreThreadId: result.targetThreadRestoreThreadId ?? '',
     targetResumePathResult: result.targetResumePathResult ?? '',
@@ -370,7 +375,11 @@ process.exit(
   result.state === 'completed' &&
   result.migrationCompleted === true &&
   result.descriptorGateCompleted === true &&
-  result.targetVerifierResult === 'passed'
+  result.targetVerifierResult === 'passed' &&
+  result.targetStackWindowMaterializationResult === 'passed' &&
+  result.targetPrivateMemoryRestoreResult === 'passed' &&
+  result.targetExecutableMappingResult === 'passed' &&
+  result.targetSignalRestoreResult === 'passed'
     ? 0
     : 1,
 );


### PR DESCRIPTION
## Problem

The portable machine smoke profile accepted a target restore once the general verifier passed. It did not also require the native stack/memory consumption reports we now produce.

## Solution

This PR carries native consumption fields into the smoke summary and makes the target restore smoke gate require passed stack-window, private-memory, executable-mapping, and signal restore reports. Focused tests now cover stack/private consumption failure parsing.

Fixes #677

## Validation

- focused vitest — 4.370s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 29.028s
- `pnpm smoke-tests` — 2m16.107s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.487s
