### PR TITLE
Execute native private-memory restore steps

### DIFF
--- a/docs/snapshot/target-guest-native-restore-sections.md
+++ b/docs/snapshot/target-guest-native-restore-sections.md
@@ -15,10 +15,11 @@ The descriptor can now carry line-oriented `native=` entries for:
 These sections are validated and round-trip through descriptor serialization.
 They also become explicit trampoline argv entries. The target loader now parses
 and forwards them; the amd64 trampoline applies stack-window writes,
-return-chain writes, stack guards, and signal-mask save/apply/verify/restore
-steps, while tracking private-memory, executable-mapping, and active-syscall
-section consumption for result reporting. The target VM proof harness parses
-those native consumption events into `targetStackWindowMaterializationResult`,
+return-chain writes, stack guards, native private-memory mmap/copy/mprotect
+steps, and signal-mask save/apply/verify/restore steps, while tracking
+executable-mapping and active-syscall section consumption for result reporting.
+The target VM proof harness parses those native consumption events into
+`targetStackWindowMaterializationResult`,
 `targetPrivateMemoryRestoreResult`, `targetExecutableMappingResult`,
 `targetSignalRestoreResult`, and `targetActiveSyscallRestoreResult`; any present
 failed marker makes the verifier fail. Unsafe or malformed native section entries

--- a/docs/snapshot/target-guest-private-memory-restore.md
+++ b/docs/snapshot/target-guest-private-memory-restore.md
@@ -12,5 +12,8 @@ steps the target VM loader must perform for private writable memory.
 
 Executable entries and shared entries fail closed with
 `mapping-executable-unsupported` and `mapping-shared-unsupported`. Guard entries
-must be `---p`. This keeps private heap/data/mmap restoration separate from
-source executable bytes and shared-resource state.
+must be `---p`. The target amd64 trampoline now executes these native private
+memory steps directly; when they are present, the portable VM proof does not also
+emit duplicate legacy `memory=` mappings for the same ranges. This keeps private
+heap/data/mmap restoration separate from source executable bytes and
+shared-resource state.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1227,6 +1227,92 @@ static const char *native_step_value(const char *spec, const char *name, char *s
   return NULL;
 }
 
+static const char *required_native_step_value(
+    const char *spec, const char *name, char *scratch, size_t scratch_size, const char *label) {
+  const char *value = native_step_value(spec, name, scratch, scratch_size);
+  if (!value) {
+    fprintf(stderr, "native-actual-resume-trampoline: native %s step missing %s\n", label, name);
+    exit(2);
+  }
+  return value;
+}
+
+static uint64_t native_step_u64(const char *spec, const char *name, const char *label) {
+  char scratch[1024];
+  return parse_u64(required_native_step_value(spec, name, scratch, sizeof(scratch), label), name);
+}
+
+static void native_step_string(
+    const char *spec, const char *name, char *dst, size_t dst_size, const char *label) {
+  char scratch[1024];
+  const char *value = required_native_step_value(spec, name, scratch, sizeof(scratch), label);
+  if (strlen(value) >= dst_size) {
+    fprintf(stderr, "native-actual-resume-trampoline: native %s step %s is too long\n", label, name);
+    exit(2);
+  }
+  snprintf(dst, dst_size, "%s", value);
+}
+
+static void apply_native_private_memory_steps(const struct Options *opts) {
+  for (size_t i = 0; i < opts->native_private_memory_step_count; i++) {
+    const char *spec = opts->native_private_memory_steps[i].spec;
+    char action[64];
+    native_step_string(spec, "action", action, sizeof(action), "private-memory");
+    if (streq(action, "mmap-private-writable")) {
+      char permissions[16];
+      native_step_string(spec, "permissions", permissions, sizeof(permissions), "private-memory");
+      if (!streq(permissions, "rw-p")) {
+        fprintf(stderr, "native-actual-resume-trampoline: native private mmap permissions must be rw-p\n");
+        exit(2);
+      }
+      (void)map_fixed(native_step_u64(spec, "targetStart", "private-memory"),
+          native_step_u64(spec, "sizeBytes", "private-memory"),
+          PROT_READ | PROT_WRITE,
+          "native-private-memory");
+    } else if (streq(action, "copy-captured-bytes")) {
+      char source_file[1024];
+      native_step_string(spec, "sourceFile", source_file, sizeof(source_file), "private-memory");
+      int fd = open(source_file, O_RDONLY);
+      if (fd < 0) {
+        fprintf(stderr,
+            "native-actual-resume-trampoline: open native private memory failed for %s: %s\n",
+            source_file,
+            strerror(errno));
+        exit(1);
+      }
+      read_exact(fd,
+          (void *)(uintptr_t)native_step_u64(spec, "targetStart", "private-memory"),
+          native_step_u64(spec, "sizeBytes", "private-memory"),
+          native_step_u64(spec, "sourceOffset", "private-memory"));
+      close(fd);
+    } else if (streq(action, "mprotect-final")) {
+      char permissions[16];
+      native_step_string(spec, "permissions", permissions, sizeof(permissions), "private-memory");
+      void *target = (void *)(uintptr_t)native_step_u64(spec, "targetStart", "private-memory");
+      uint64_t size = native_step_u64(spec, "sizeBytes", "private-memory");
+      if (mprotect(target, (size_t)size, parse_memory_prot(permissions)) != 0) {
+        fprintf(stderr, "native-actual-resume-trampoline: native private mprotect failed: %s\n", strerror(errno));
+        exit(1);
+      }
+    } else if (streq(action, "mmap-guard")) {
+      char permissions[16];
+      native_step_string(spec, "permissions", permissions, sizeof(permissions), "private-memory");
+      if (!streq(permissions, "---p")) {
+        fprintf(stderr, "native-actual-resume-trampoline: native guard permissions must be ---p\n");
+        exit(2);
+      }
+      struct GuardMaterialization guard = {
+          .target_start = native_step_u64(spec, "targetStart", "private-memory"),
+          .size = native_step_u64(spec, "sizeBytes", "private-memory"),
+      };
+      materialize_guard_mapping(&guard);
+    } else {
+      fprintf(stderr, "native-actual-resume-trampoline: unsupported native private-memory action\n");
+      exit(2);
+    }
+  }
+}
+
 static uint64_t parse_signal_masks(const char *value) {
   uint64_t masks = 0;
   char *copy = strdup(value);
@@ -1896,9 +1982,7 @@ static void print_native_restore_consumption(const struct Options *opts) {
         opts->native_return_chain_write_count);
   }
   if (opts->native_private_memory_step_count > 0) {
-    bool passed = opts->materialized_memory_count + opts->materialized_guard_count > 0;
-    printf(",\"nativePrivateMemoryRestore\":{\"status\":\"%s\",\"stepCount\":%zu}",
-        passed ? "passed" : "failed",
+    printf(",\"nativePrivateMemoryRestore\":{\"status\":\"passed\",\"stepCount\":%zu}",
         opts->native_private_memory_step_count);
   }
   if (opts->native_executable_mapping_count > 0) {
@@ -1962,7 +2046,11 @@ int main(int argc, char **argv) {
   mapped_target_start = opts.target_address;
   mapped_target_end = opts.target_address + opts.code_size;
 
-  materialize_descriptor_memory(&opts);
+  if (opts.native_private_memory_step_count > 0) {
+    apply_native_private_memory_steps(&opts);
+  } else {
+    materialize_descriptor_memory(&opts);
+  }
   materialize_native_stack_window_guards(&opts);
   materialize_target_tcb(&opts);
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -59,6 +59,26 @@ function runHelper(helper: string, codeFile: string, codeSize: number, extraArgs
   return JSON.parse(line!.slice(PREFIX.length));
 }
 
+function loadU64FromAbsoluteCode(address: bigint): Buffer {
+  const code = Buffer.alloc(11);
+  code[0] = 0x48;
+  code[1] = 0xa1;
+  code.writeBigUInt64LE(address, 2);
+  code[10] = 0xc3;
+  return code;
+}
+
+function nativePrivateMemorySteps(sourceFile: string, targetStart = "0x600000000000") {
+  return [
+    "--native-private-memory-step",
+    `action=mmap-private-writable;mapping=mapping:heap;targetStart=${targetStart};sizeBytes=4096;permissions=rw-p`,
+    "--native-private-memory-step",
+    `action=copy-captured-bytes;mapping=mapping:heap;targetStart=${targetStart};sizeBytes=4096;sourceFile=${sourceFile};sourceOffset=0`,
+    "--native-private-memory-step",
+    `action=mprotect-final;mapping=mapping:heap;targetStart=${targetStart};sizeBytes=4096;permissions=rw-p`,
+  ];
+}
+
 describe("native actual resume trampoline", () => {
   it.skipIf(process.platform !== "linux" || process.arch !== "x64")(
     "reports returned and faulted target-native attempts",
@@ -83,16 +103,13 @@ describe("native actual resume trampoline", () => {
       writeFileSync(nativeMemory, Buffer.alloc(4096, 0x7a));
       expect(
         runHelper(helper, returnCode, 1, [
-          "--materialize-memory",
-          `${nativeMemory}:0:0x600000000000:4096:rw-p`,
+          ...nativePrivateMemorySteps(nativeMemory),
           "--native-stack-window-write",
           "0x52000000ff00:0x1234567890abcdef:efcdab9078563412:pointer",
           "--native-stack-window-guard",
           "0x520000010000:4096:above",
           "--native-return-chain-write",
           "0x52000000ff08:0x710000001000:0010007100000000:return-address",
-          "--native-private-memory-step",
-          "action=copy-captured-bytes;mapping=mapping:heap;targetStart=0x600000000000;sizeBytes=4096;sourceFile=/tmp/native-memory.bin;sourceOffset=0",
           "--native-executable-mapping",
           "action=map-target-executable;mapping=mapping:text;targetStart=0x710000001000;sizeBytes=1;path=/tmp/target;fileOffset=0;read=true;write=false;execute=true;private=true;shared=false;buildId=target-build-id",
           "--native-signal-restore-step",
@@ -110,7 +127,7 @@ describe("native actual resume trampoline", () => {
         status: "returned",
         nativeStackWindowMaterialization: { status: "passed", writeCount: 1, guardCount: 1 },
         nativeReturnChainMaterialization: { status: "passed", writeCount: 1 },
-        nativePrivateMemoryRestore: { status: "passed", stepCount: 1 },
+        nativePrivateMemoryRestore: { status: "passed", stepCount: 3 },
         nativeExecutableMapping: { status: "passed", mappingCount: 1 },
         nativeSignalRestore: {
           status: "passed",
@@ -121,6 +138,16 @@ describe("native actual resume trampoline", () => {
           restored: true,
         },
         nativeActiveSyscallRestore: { status: "passed", stepCount: 1 },
+      });
+
+      const nativeMemoryReader = join(outDir, "native-memory-reader.bin");
+      writeFileSync(nativeMemoryReader, loadU64FromAbsoluteCode(0x600000000000n));
+      expect(
+        runHelper(helper, nativeMemoryReader, 11, nativePrivateMemorySteps(nativeMemory)),
+      ).toMatchObject({
+        status: "returned",
+        returnValue: "0x7a7a7a7a7a7a7a7a",
+        nativePrivateMemoryRestore: { status: "passed", stepCount: 3 },
       });
 
       const arg0Code = join(outDir, "arg0.bin");

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -309,6 +309,7 @@ function prepareTargetRestoreDescriptor(
   targetContinuation: PreparedTargetContinuation,
 ) {
   const memory = proofMemoryPlan(context);
+  const nativeRestore = proofNativeRestoreSections(context, targetContinuation, memory.entries);
   return planPortableMachineTargetRestoreDescriptor({
     continuation: continuationDescriptor(
       context.targetCodeFile,
@@ -322,9 +323,18 @@ function prepareTargetRestoreDescriptor(
     ),
     translatedFrame: targetContinuation.translatedFrame,
     fdTable: proofFdTable(),
-    memory,
-    nativeRestore: proofNativeRestoreSections(context, targetContinuation, memory.entries),
+    memory: descriptorMemoryForNativeRestore(memory, nativeRestore),
+    nativeRestore,
   });
+}
+
+function descriptorMemoryForNativeRestore(
+  memory: ReturnType<typeof proofMemoryPlan>,
+  nativeRestore: TargetGuestNativeRestoreStep[],
+): ReturnType<typeof proofMemoryPlan> {
+  return nativeRestore.some((step) => step.section === "private-memory")
+    ? { entries: [], refusals: memory.refusals }
+    : memory;
 }
 
 function writeTargetRestoreDescriptor(


### PR DESCRIPTION
## Problem

Native private-memory restore sections were being forwarded to the target trampoline, but the actual bytes still came from the older `memory=` descriptor path. That meant the native private-memory consumption marker could pass without proving that the native restore section itself did the mmap/copy/mprotect work.

## Solution

This PR teaches the amd64 resume trampoline to execute native private-memory steps directly: `mmap-private-writable`, `copy-captured-bytes`, `mprotect-final`, and `mmap-guard`. The portable VM proof now avoids emitting duplicate legacy `memory=` mappings when native private-memory steps are present. A focused amd64 trampoline test proves target-native code can read bytes restored by the native private-memory section alone.

Fixes #679

## Validation

- `pnpm run build:docs` — 1.567s
- `pnpm run format:check` — 0.550s
- `pnpm run lint` — 0.220s
- `pnpm run typecheck` — 2.291s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.145s
- `pnpm smoke-tests` — 2m12.676s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.390s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m09.468s, 2/2 passed
- remote amd64 trampoline proof on `root@192.168.0.8` — native private-memory steps restored `0x7a7a7a7a7a7a7a7a`; malformed action exited 2
