### PR TITLE
Verify native executable mapping consumption

### DIFF
--- a/docs/snapshot/target-guest-executable-materialization.md
+++ b/docs/snapshot/target-guest-executable-materialization.md
@@ -13,5 +13,9 @@ artifacts.
 
 Executable mappings that would copy captured source bytes refuse with
 `mapping-executable-unsupported`. Executable mappings without target-file
-build/hash provenance refuse with `mapping-provenance-ambiguous`. Non-executable
-private data is ignored here and handled by the private-memory restore path.
+build/hash provenance refuse with `mapping-provenance-ambiguous`. On target, the
+amd64 trampoline now checks the native executable-mapping section against the
+actual target code path, address, size, file offset, safe execute/private flags,
+and build-id or sha256 provenance before reporting the mapping as consumed.
+Non-executable private data is ignored here and handled by the private-memory
+restore path.

--- a/docs/snapshot/target-guest-native-restore-sections.md
+++ b/docs/snapshot/target-guest-native-restore-sections.md
@@ -16,9 +16,10 @@ These sections are validated and round-trip through descriptor serialization.
 They also become explicit trampoline argv entries. The target loader now parses
 and forwards them; the amd64 trampoline applies stack-window writes,
 return-chain writes, stack guards, native private-memory mmap/copy/mprotect
-steps, and signal-mask save/apply/verify/restore steps, while tracking
-executable-mapping and active-syscall section consumption for result reporting.
-The target VM proof harness parses those native consumption events into
+steps, signal-mask save/apply/verify/restore steps, and executable-mapping
+checks against the target code file/path/address/size/provenance before reporting
+consumption. Active-syscall sections are still tracked for result reporting. The
+target VM proof harness parses those native consumption events into
 `targetStackWindowMaterializationResult`,
 `targetPrivateMemoryRestoreResult`, `targetExecutableMappingResult`,
 `targetSignalRestoreResult`, and `targetActiveSyscallRestoreResult`; any present

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1253,6 +1253,24 @@ static void native_step_string(
   snprintf(dst, dst_size, "%s", value);
 }
 
+static bool native_step_has_value(const char *spec, const char *name) {
+  char scratch[1024];
+  return native_step_value(spec, name, scratch, sizeof(scratch)) != NULL;
+}
+
+static bool native_step_bool(const char *spec, const char *name, const char *label) {
+  char value[8];
+  native_step_string(spec, name, value, sizeof(value), label);
+  if (streq(value, "true")) {
+    return true;
+  }
+  if (streq(value, "false")) {
+    return false;
+  }
+  fprintf(stderr, "native-actual-resume-trampoline: native %s step %s must be boolean\n", label, name);
+  exit(2);
+}
+
 static void apply_native_private_memory_steps(const struct Options *opts) {
   for (size_t i = 0; i < opts->native_private_memory_step_count; i++) {
     const char *spec = opts->native_private_memory_steps[i].spec;
@@ -1308,6 +1326,35 @@ static void apply_native_private_memory_steps(const struct Options *opts) {
       materialize_guard_mapping(&guard);
     } else {
       fprintf(stderr, "native-actual-resume-trampoline: unsupported native private-memory action\n");
+      exit(2);
+    }
+  }
+}
+
+static void verify_native_executable_mappings(const struct Options *opts) {
+  for (size_t i = 0; i < opts->native_executable_mapping_count; i++) {
+    const char *spec = opts->native_executable_mappings[i].spec;
+    char action[64];
+    char path[1024];
+    native_step_string(spec, "action", action, sizeof(action), "executable-mapping");
+    native_step_string(spec, "path", path, sizeof(path), "executable-mapping");
+    if (!streq(action, "map-target-executable") || !streq(path, opts->code_file) ||
+        native_step_u64(spec, "targetStart", "executable-mapping") != opts->target_address ||
+        native_step_u64(spec, "sizeBytes", "executable-mapping") != opts->code_size ||
+        native_step_u64(spec, "fileOffset", "executable-mapping") != opts->file_offset) {
+      fprintf(stderr, "native-actual-resume-trampoline: native executable mapping does not match target code\n");
+      exit(2);
+    }
+    if (!native_step_bool(spec, "read", "executable-mapping") ||
+        native_step_bool(spec, "write", "executable-mapping") ||
+        !native_step_bool(spec, "execute", "executable-mapping") ||
+        !native_step_bool(spec, "private", "executable-mapping") ||
+        native_step_bool(spec, "shared", "executable-mapping")) {
+      fprintf(stderr, "native-actual-resume-trampoline: native executable mapping permissions are unsafe\n");
+      exit(2);
+    }
+    if (!native_step_has_value(spec, "buildId") && !native_step_has_value(spec, "sha256")) {
+      fprintf(stderr, "native-actual-resume-trampoline: native executable mapping lacks provenance\n");
       exit(2);
     }
   }
@@ -2054,6 +2101,7 @@ int main(int argc, char **argv) {
   materialize_native_stack_window_guards(&opts);
   materialize_target_tcb(&opts);
 
+  verify_native_executable_mappings(&opts);
   uint64_t mapped_code_start = 0;
   uint64_t mapped_code_size = 0;
   void *code = map_target_code(&opts, &mapped_code_start, &mapped_code_size);

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -32,31 +32,31 @@ function compileHelper(outDir: string) {
 }
 
 function runHelper(helper: string, codeFile: string, codeSize: number, extraArgs: string[] = []) {
-  const result = spawnSync(
-    helper,
-    [
-      "--code-file",
-      codeFile,
-      "--file-offset",
-      "0",
-      "--code-size",
-      String(codeSize),
-      "--target-address",
-      "0x710000001000",
-      ...extraArgs,
-      "--stack-target-start",
-      "0x520000000000",
-      "--stack-size",
-      String(64 * 1024),
-      "--stack-pointer",
-      "0x520000010000",
-    ],
-    { encoding: "utf8" },
-  );
+  const result = spawnSync(helper, helperArgs(codeFile, codeSize, extraArgs), { encoding: "utf8" });
   expect(result.status, result.stderr).toBe(0);
   const line = result.stdout.split(/\r?\n/).find((candidate) => candidate.startsWith(PREFIX));
   expect(line).toBeTruthy();
   return JSON.parse(line!.slice(PREFIX.length));
+}
+
+function helperArgs(codeFile: string, codeSize: number, extraArgs: string[] = []) {
+  return [
+    "--code-file",
+    codeFile,
+    "--file-offset",
+    "0",
+    "--code-size",
+    String(codeSize),
+    "--target-address",
+    "0x710000001000",
+    ...extraArgs,
+    "--stack-target-start",
+    "0x520000000000",
+    "--stack-size",
+    String(64 * 1024),
+    "--stack-pointer",
+    "0x520000010000",
+  ];
 }
 
 function loadU64FromAbsoluteCode(address: bigint): Buffer {
@@ -111,7 +111,7 @@ describe("native actual resume trampoline", () => {
           "--native-return-chain-write",
           "0x52000000ff08:0x710000001000:0010007100000000:return-address",
           "--native-executable-mapping",
-          "action=map-target-executable;mapping=mapping:text;targetStart=0x710000001000;sizeBytes=1;path=/tmp/target;fileOffset=0;read=true;write=false;execute=true;private=true;shared=false;buildId=target-build-id",
+          `action=map-target-executable;mapping=mapping:text;targetStart=0x710000001000;sizeBytes=1;path=${returnCode};fileOffset=0;read=true;write=false;execute=true;private=true;shared=false;buildId=target-build-id`,
           "--native-signal-restore-step",
           "action=save-loader-signal-mask;threadId=thread:1",
           "--native-signal-restore-step",
@@ -158,6 +158,19 @@ describe("native actual resume trampoline", () => {
         returnValue: "0x600000000000",
         argument0: "0x600000000000",
       });
+
+      const badExecutableMapping = spawnSync(
+        helper,
+        helperArgs(returnCode, 1, [
+          "--native-executable-mapping",
+          "action=map-target-executable;mapping=mapping:text;targetStart=0x710000002000;sizeBytes=1;path=/tmp/mismatch;fileOffset=0;read=true;write=false;execute=true;private=true;shared=false;buildId=target-build-id",
+        ]),
+        { encoding: "utf8" },
+      );
+      expect(badExecutableMapping.status).toBe(2);
+      expect(badExecutableMapping.stderr).toContain(
+        "native executable mapping does not match target code",
+      );
 
       const stateMemory = join(outDir, "state-memory.bin");
       const memory = Buffer.alloc(4096);


### PR DESCRIPTION
## Problem

The target trampoline reported `nativeExecutableMapping=passed` whenever an executable-mapping section was present. It did not prove that the section matched the target code bytes actually mapped and executed.

## Solution

This PR parses `--native-executable-mapping` specs in the amd64 trampoline and verifies the action, path, target address, size, file offset, execute/private flags, and build-id/sha256 provenance before target execution. A mismatch now exits fail-closed instead of reporting consumption.

Fixes #681

## Validation

- `pnpm run build:docs` — 1.447s
- `pnpm run format:check` — 0.526s
- `pnpm run lint` — 0.208s
- `pnpm run typecheck` — 2.044s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.897s
- `pnpm smoke-tests` — 2m09.709s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.391s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m06.772s, 2/2 passed
- remote amd64 trampoline proof on `root@192.168.0.8` — matching executable mapping reported passed; mismatched target address exited 2
