### PR TITLE
Consume controlled thread-spawn restore steps

### DIFF
--- a/docs/snapshot/target-guest-native-restore-sections.md
+++ b/docs/snapshot/target-guest-native-restore-sections.md
@@ -10,16 +10,17 @@ The descriptor can now carry line-oriented `native=` entries for:
 - private-memory restore steps;
 - target executable mapping provenance steps;
 - signal-mask restore steps;
-- modeled active-syscall re-arm steps.
+- modeled active-syscall re-arm steps;
+- controlled thread-spawn steps.
 
 These sections are validated and round-trip through descriptor serialization.
 They also become explicit trampoline argv entries. The target loader now parses
 and forwards them; the amd64 trampoline applies stack-window writes,
 return-chain writes, stack guards, native private-memory mmap/copy/mprotect
 steps, signal-mask save/apply/verify/restore steps, executable-mapping checks
-against the target code file/path/address/size/provenance, and active-syscall
-timer re-arm steps before reporting consumption. The target VM proof harness
-parses those native consumption events into
+against the target code file/path/address/size/provenance, active-syscall timer
+re-arm steps, and controlled thread-spawn steps before reporting consumption.
+The target VM proof harness parses those native consumption events into
 `targetStackWindowMaterializationResult`,
 `targetPrivateMemoryRestoreResult`, `targetExecutableMappingResult`,
 `targetSignalRestoreResult`, and `targetActiveSyscallRestoreResult`; any present

--- a/docs/snapshot/target-guest-two-thread-restore.md
+++ b/docs/snapshot/target-guest-two-thread-restore.md
@@ -5,7 +5,11 @@ Issue #665 plans the controlled two-thread target proof.
 `planTargetGuestTwoThreadRestore()` consumes an accepted
 `NativeControlledTwoThreadRestorePlan` and two explicit target thread bindings.
 It emits one `spawn-target-thread` step per thread with independent target stack
-ranges and target register seeds.
+ranges and target register seeds. These steps can now be carried as
+`native=thread-spawn` target restore descriptor sections, forwarded by the target
+guest loader, and consumed by the amd64 trampoline. The trampoline maps each
+requested thread stack and creates a short-lived target task on that stack before
+reporting the thread restore section as passed.
 
 The planner refuses when:
 
@@ -15,5 +19,6 @@ The planner refuses when:
 - required `rip`/`rsp` seeds are absent;
 - target stack ranges are inverted or overlap.
 
-This remains a narrow two-thread proof boundary. It is not general multithread
-restore and does not accept futex or rseq synchronization state.
+This remains a narrow two-thread proof boundary. It proves loader/trampoline
+consumption of safe spawn steps only; it is not general multithread restore and
+does not accept futex or rseq synchronization state.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -16,11 +16,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sched.h>
 #include <string.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/timerfd.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -128,6 +130,11 @@ struct NativeActiveSyscallRestoreState {
   int timer_fds[MAX_NATIVE_RESTORE_STEPS];
 };
 
+struct NativeThreadRestoreState {
+  bool requested;
+  size_t spawned_count;
+};
+
 struct Options {
   const char *code_file;
   uint64_t file_offset;
@@ -203,6 +210,8 @@ struct Options {
   size_t native_signal_step_count;
   struct NativeRestoreStepSpec native_active_syscall_steps[MAX_NATIVE_RESTORE_STEPS];
   size_t native_active_syscall_step_count;
+  struct NativeRestoreStepSpec native_thread_spawn_steps[MAX_NATIVE_RESTORE_STEPS];
+  size_t native_thread_spawn_step_count;
 };
 
 static void usage(void) {
@@ -231,6 +240,7 @@ static void usage(void) {
       "[--native-return-chain-write target:value:bytes:kind] "
       "[--native-private-memory-step spec] [--native-executable-mapping spec] "
       "[--native-signal-restore-step spec] [--native-active-syscall-step spec] "
+      "[--native-thread-spawn-step spec] "
       "--stack-target-start addr --stack-size n --stack-pointer addr\n");
   exit(2);
 }
@@ -705,6 +715,11 @@ static struct Options parse_args(int argc, char **argv) {
         usage();
       }
       add_native_step(opts.native_active_syscall_steps, &opts.native_active_syscall_step_count, argv[i], "active-syscall");
+    } else if (streq(argv[i], "--native-thread-spawn-step")) {
+      if (++i >= argc) {
+        usage();
+      }
+      add_native_step(opts.native_thread_spawn_steps, &opts.native_thread_spawn_step_count, argv[i], "thread-spawn");
     } else if (streq(argv[i], "--stack-target-start")) {
       if (++i >= argc) {
         usage();
@@ -775,6 +790,7 @@ static uint64_t jump_resume_register_r10 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_r11 __attribute__((used)) = 0;
 static struct NativeSignalRestoreState native_signal_restore_state = {0};
 static struct NativeActiveSyscallRestoreState native_active_syscall_restore_state = {0};
+static struct NativeThreadRestoreState native_thread_restore_state = {0};
 
 struct ObservedRegisters {
   uint64_t rax;
@@ -1459,6 +1475,47 @@ static void close_native_active_syscall_timers(struct NativeActiveSyscallRestore
   for (size_t i = 0; i < state->armed_count; i++) {
     close(state->timer_fds[i]);
     state->timer_fds[i] = -1;
+  }
+}
+
+static int native_thread_spawn_child(void *arg) {
+  (void)arg;
+  return 0;
+}
+
+static void consume_native_thread_spawn_steps(
+    const struct Options *opts, struct NativeThreadRestoreState *state) {
+  state->requested = opts->native_thread_spawn_step_count > 0;
+  for (size_t i = 0; i < opts->native_thread_spawn_step_count; i++) {
+    const char *spec = opts->native_thread_spawn_steps[i].spec;
+    char action[64];
+    native_step_string(spec, "action", action, sizeof(action), "thread-spawn");
+    if (!streq(action, "spawn-target-thread")) {
+      fprintf(stderr, "native-actual-resume-trampoline: unsupported native thread action\n");
+      exit(2);
+    }
+    uint64_t stack_base = native_step_u64(spec, "stackBase", "thread-spawn");
+    uint64_t stack_limit = native_step_u64(spec, "stackLimit", "thread-spawn");
+    uint64_t rip = native_step_u64(spec, "rip", "thread-spawn");
+    uint64_t rsp = native_step_u64(spec, "rsp", "thread-spawn");
+    if (stack_base >= stack_limit || rsp <= stack_base || rsp > stack_limit || rip == 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: native thread spawn range is invalid\n");
+      exit(2);
+    }
+    uint64_t stack_size = stack_limit - stack_base;
+    void *mapped_stack = map_fixed(stack_base, stack_size, PROT_READ | PROT_WRITE, "native-thread-stack");
+    int child = clone(native_thread_spawn_child, (void *)(uintptr_t)stack_limit, SIGCHLD, NULL);
+    if (child < 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: native thread clone failed: %s\n", strerror(errno));
+      exit(1);
+    }
+    int status = 0;
+    if (waitpid((pid_t)child, &status, 0) < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: native thread wait failed\n");
+      exit(1);
+    }
+    munmap(mapped_stack, (size_t)stack_size);
+    state->spawned_count++;
   }
 }
 
@@ -2157,6 +2214,13 @@ static void print_native_restore_consumption(const struct Options *opts) {
         opts->native_active_syscall_step_count,
         native_active_syscall_restore_state.armed_count);
   }
+  if (native_thread_restore_state.requested) {
+    bool thread_passed = native_thread_restore_state.spawned_count == opts->native_thread_spawn_step_count;
+    printf(",\"nativeThreadRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"spawnedCount\":%zu}",
+        thread_passed ? "passed" : "failed",
+        opts->native_thread_spawn_step_count,
+        native_thread_restore_state.spawned_count);
+  }
 }
 
 static void print_return_event(const struct Options *opts) {
@@ -2226,6 +2290,7 @@ int main(int argc, char **argv) {
   apply_cloexec_fds(&opts);
   apply_native_signal_restore_steps(&opts, &native_signal_restore_state);
   apply_native_active_syscall_restore_steps(&opts, &native_active_syscall_restore_state);
+  consume_native_thread_spawn_steps(&opts, &native_thread_restore_state);
   capture_host_fs_base();
   alarm((unsigned int)opts.timeout_seconds);
   if (sigsetjmp(resume_fault_jmp, 1) == 0) {

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -607,6 +607,8 @@ static void parse_native_restore(struct Descriptor *descriptor, char *line) {
     parse_native_semicolon_step(descriptor, line + strlen("native=signal-restore"), "", "--native-signal-restore-step");
   } else if (starts_with(line, "native=active-syscall")) {
     parse_native_semicolon_step(descriptor, line + strlen("native=active-syscall"), "", "--native-active-syscall-step");
+  } else if (starts_with(line, "native=thread-spawn")) {
+    parse_native_semicolon_step(descriptor, line + strlen("native=thread-spawn"), "", "--native-thread-spawn-step");
   } else {
     refuse("target-guest-loader-descriptor-invalid", "native restore section is unsupported");
   }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -10770,6 +10770,10 @@ Poll interval in ms while retrying. Default 250.
 
 > `optional` **nativeActiveSyscallRestore?**: [`TargetNativeConsumptionEvent`](#targetnativeconsumptionevent)
 
+##### nativeThreadRestore?
+
+> `optional` **nativeThreadRestore?**: [`TargetNativeConsumptionEvent`](#targetnativeconsumptionevent)
+
 ***
 
 ### VmHandle
@@ -13372,7 +13376,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### PortableMachineTargetThreadRestoreResult
 
-> **PortableMachineTargetThreadRestoreResult** = `"accepted"` \| `"refused"`
+> **PortableMachineTargetThreadRestoreResult** = `"accepted"` \| `"refused"` \| `"passed"` \| `"failed"`
 
 ***
 
@@ -13468,7 +13472,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestNativeRestoreStep
 
-> **TargetGuestNativeRestoreStep** = \{ `section`: `"stack-window-write"`; `write`: [`NativeStackWindowWrite`](#nativestackwindowwrite); \} \| \{ `section`: `"stack-window-guard"`; `guard`: [`NativeStackWindowGuardMapping`](#nativestackwindowguardmapping); \} \| \{ `section`: `"return-chain-write"`; `write`: [`NativeReturnChainFrameWrite`](#nativereturnchainframewrite); \} \| \{ `section`: `"private-memory"`; `step`: [`TargetGuestPrivateMemoryRestoreStep`](#targetguestprivatememoryrestorestep); \} \| \{ `section`: `"executable-mapping"`; `step`: [`TargetGuestExecutableMappingStep`](#targetguestexecutablemappingstep); \} \| \{ `section`: `"signal-restore"`; `step`: [`TargetGuestSignalRestoreStep`](#targetguestsignalrestorestep); \} \| \{ `section`: `"active-syscall"`; `step`: [`TargetGuestActiveSyscallRestoreStep`](#targetguestactivesyscallrestorestep); \}
+> **TargetGuestNativeRestoreStep** = \{ `section`: `"stack-window-write"`; `write`: [`NativeStackWindowWrite`](#nativestackwindowwrite); \} \| \{ `section`: `"stack-window-guard"`; `guard`: [`NativeStackWindowGuardMapping`](#nativestackwindowguardmapping); \} \| \{ `section`: `"return-chain-write"`; `write`: [`NativeReturnChainFrameWrite`](#nativereturnchainframewrite); \} \| \{ `section`: `"private-memory"`; `step`: [`TargetGuestPrivateMemoryRestoreStep`](#targetguestprivatememoryrestorestep); \} \| \{ `section`: `"executable-mapping"`; `step`: [`TargetGuestExecutableMappingStep`](#targetguestexecutablemappingstep); \} \| \{ `section`: `"signal-restore"`; `step`: [`TargetGuestSignalRestoreStep`](#targetguestsignalrestorestep); \} \| \{ `section`: `"active-syscall"`; `step`: [`TargetGuestActiveSyscallRestoreStep`](#targetguestactivesyscallrestorestep); \} \| \{ `section`: `"thread-spawn"`; `step`: [`TargetGuestTwoThreadSpawnStep`](#targetguesttwothreadspawnstep); \}
 
 ***
 
@@ -17300,6 +17304,10 @@ resolve the binary through the same lookup chain.
 ##### targetActiveSyscallRestoreResult?
 
 > `optional` **targetActiveSyscallRestoreResult?**: [`TargetNativeConsumptionStatus`](#targetnativeconsumptionstatus)
+
+##### targetThreadRestoreResult?
+
+> `optional` **targetThreadRestoreResult?**: [`TargetNativeConsumptionStatus`](#targetnativeconsumptionstatus)
 
 ***
 

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -124,6 +124,8 @@ describe("native actual resume trampoline", () => {
           "action=rearm-sleep-timer;threadId=thread:1;seconds=0;nanoseconds=1000000;resumeMode=defer-target-resume;syscallName=clock_nanosleep",
           "--native-active-syscall-step",
           "action=rearm-ppoll-timeout;threadId=thread:1;seconds=0;nanoseconds=1000000;resumeMode=defer-target-resume;nfds=1;resources=synthetic-empty-eventfd",
+          "--native-thread-spawn-step",
+          "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x710000001000;rsp=0x530000010000",
         ]),
       ).toMatchObject({
         status: "returned",
@@ -140,6 +142,7 @@ describe("native actual resume trampoline", () => {
           restored: true,
         },
         nativeActiveSyscallRestore: { status: "passed", stepCount: 2, armedCount: 2 },
+        nativeThreadRestore: { status: "passed", stepCount: 1, spawnedCount: 1 },
       });
 
       const nativeMemoryReader = join(outDir, "native-memory-reader.bin");
@@ -184,6 +187,17 @@ describe("native actual resume trampoline", () => {
       );
       expect(badActiveSyscall.status).toBe(2);
       expect(badActiveSyscall.stderr).toContain("native active-syscall duration must be non-zero");
+
+      const badThreadSpawn = spawnSync(
+        helper,
+        helperArgs(returnCode, 1, [
+          "--native-thread-spawn-step",
+          "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000010000;stackLimit=0x530000000000;rip=0x710000001000;rsp=0x530000010000",
+        ]),
+        { encoding: "utf8" },
+      );
+      expect(badThreadSpawn.status).toBe(2);
+      expect(badThreadSpawn.stderr).toContain("native thread spawn range is invalid");
 
       const stateMemory = join(outDir, "state-memory.bin");
       const memory = Buffer.alloc(4096);

--- a/packages/runtime/src/__tests__/native-target-vm-synthetic-continuation-script.test.ts
+++ b/packages/runtime/src/__tests__/native-target-vm-synthetic-continuation-script.test.ts
@@ -18,6 +18,7 @@ describe("native target VM synthetic continuation script", () => {
       nativeExecutableMapping: { status: "passed" },
       nativeSignalRestore: { status: "passed" },
       nativeActiveSyscallRestore: { status: "passed" },
+      nativeThreadRestore: { status: "passed" },
     });
 
     expect(targetNativeConsumptionFields(events)).toEqual({
@@ -26,6 +27,7 @@ describe("native target VM synthetic continuation script", () => {
       targetExecutableMappingResult: "passed",
       targetSignalRestoreResult: "passed",
       targetActiveSyscallRestoreResult: "passed",
+      targetThreadRestoreResult: "passed",
     });
     expect(targetNativeConsumptionPassed(events)).toBe(true);
   });

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -303,6 +303,16 @@ describe("target guest restore loader descriptor", () => {
           resumeMode: "defer-target-resume" as const,
         },
       },
+      {
+        section: "thread-spawn" as const,
+        step: {
+          action: "spawn-target-thread" as const,
+          threadId: "thread:2",
+          stackBase: "0x530000000000",
+          stackLimit: "0x530000010000",
+          registers: { rip: "0x700300000000", rsp: "0x530000010000" },
+        },
+      },
     ];
 
     const parsed = parseTargetGuestRestoreDescriptor(
@@ -320,6 +330,8 @@ describe("target guest restore loader descriptor", () => {
         "action=copy-captured-bytes;mapping=mapping:heap;targetStart=0x600000000000;sizeBytes=4096;sourceFile=/tmp/native-memory.bin;sourceOffset=0",
         "--native-signal-restore-step",
         "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
+        "--native-thread-spawn-step",
+        "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x700300000000;rsp=0x530000010000",
       ]),
     );
   });
@@ -351,6 +363,12 @@ describe("target guest restore loader descriptor", () => {
         `${serializeTargetGuestRestoreDescriptor(descriptor())}native=return-chain-write frameId=frame:1 targetAddress=5000 value=0x1 bytes=0100000000000000 kind=return-address\n`,
       ),
     ).toThrow(/targetAddress must be a hex address/);
+
+    expect(() =>
+      parseTargetGuestRestoreDescriptor(
+        `${serializeTargetGuestRestoreDescriptor(descriptor())}native=thread-spawn action=spawn-target-thread threadId=thread:2 stackBase=0x530000010000 stackLimit=0x530000000000 rip=0x700300000000 rsp=0x530000010000\n`,
+      ),
+    ).toThrow(/thread stack range is inverted/);
   });
 
   it("builds the in-guest loader argv", () => {
@@ -659,7 +677,7 @@ describe("target guest restore loader descriptor", () => {
       const checker = join(outDir, "fd-checker");
       writeFileSync(
         checkerSource,
-        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_rflags = 0;\n  int saw_resume_mode = 0;\n  int saw_native_stack = 0;\n  int saw_native_signal = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-rdi") == 0 && strcmp(argv[i + 1], "0x7171717171717171") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-rflags") == 0 && strcmp(argv[i + 1], "0x8d7") == 0) saw_resume_rflags = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n    if (strcmp(argv[i], "--native-stack-window-write") == 0 && strcmp(argv[i + 1], "0x50000000f000:0x700300000316:1603000003700000:return-address") == 0) saw_native_stack = 1;\n    if (strcmp(argv[i], "--native-signal-restore-step") == 0 && strcmp(argv[i + 1], "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0") == 0) saw_native_signal = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_rflags) return 49;\n  if (!saw_resume_mode) return 50;\n  if (!saw_native_stack) return 51;\n  if (!saw_native_signal) return 52;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
+        `#include <string.h>\n#include <unistd.h>\n#include <stdio.h>\nint main(int argc, char **argv) {\n  char buf[3] = {0};\n  int saw_cloexec = 0;\n  int saw_state_report = 0;\n  int saw_translated_return = 0;\n  int saw_frame = 0;\n  int saw_register_bank = 0;\n  int saw_resume_register = 0;\n  int saw_resume_rflags = 0;\n  int saw_resume_mode = 0;\n  int saw_native_stack = 0;\n  int saw_native_signal = 0;\n  int saw_native_thread = 0;\n  for (int i = 1; i + 1 < argc; i++) {\n    if (strcmp(argv[i], "--set-cloexec-fd") == 0 && strcmp(argv[i + 1], "7") == 0) saw_cloexec = 1;\n    if (strcmp(argv[i], "--state-report-address") == 0 && strcmp(argv[i + 1], "0x600000000000") == 0) saw_state_report = 1;\n    if (strcmp(argv[i], "--translated-return-address") == 0 && strcmp(argv[i + 1], "0x700300000080") == 0) saw_translated_return = 1;\n    if (strcmp(argv[i], "--translated-frame-pointer") == 0 && strcmp(argv[i + 1], "0x50000000ff80") == 0) saw_frame = 1;\n    if (strcmp(argv[i], "--translated-frame-callee-r15") == 0 && strcmp(argv[i + 1], "0x1515151515151515") == 0) saw_register_bank = 1;\n    if (strcmp(argv[i], "--resume-register-rdi") == 0 && strcmp(argv[i + 1], "0x7171717171717171") == 0) saw_resume_register = 1;\n    if (strcmp(argv[i], "--resume-rflags") == 0 && strcmp(argv[i + 1], "0x8d7") == 0) saw_resume_rflags = 1;\n    if (strcmp(argv[i], "--resume-mode") == 0 && strcmp(argv[i + 1], "translated-frame") == 0) saw_resume_mode = 1;\n    if (strcmp(argv[i], "--native-stack-window-write") == 0 && strcmp(argv[i + 1], "0x50000000f000:0x700300000316:1603000003700000:return-address") == 0) saw_native_stack = 1;\n    if (strcmp(argv[i], "--native-signal-restore-step") == 0 && strcmp(argv[i + 1], "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0") == 0) saw_native_signal = 1;\n    if (strcmp(argv[i], "--native-thread-spawn-step") == 0 && strcmp(argv[i + 1], "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x700300000000;rsp=0x530000010000") == 0) saw_native_thread = 1;\n  }\n  if (read(7, buf, 2) != 2) return 41;\n  if (strcmp(buf, "cd") != 0) return 42;\n  if (!saw_cloexec) return 43;\n  if (!saw_state_report) return 44;\n  if (!saw_translated_return) return 45;\n  if (!saw_frame) return 46;\n  if (!saw_register_bank) return 47;\n  if (!saw_resume_register) return 48;\n  if (!saw_resume_rflags) return 49;\n  if (!saw_resume_mode) return 50;\n  if (!saw_native_stack) return 51;\n  if (!saw_native_signal) return 52;\n  if (!saw_native_thread) return 53;\n  printf("fd-check:%s\\n", buf);\n  return 0;\n}\n`,
       );
       const compileChecker = spawnSync(
         "cc",
@@ -715,6 +733,16 @@ describe("target guest restore loader descriptor", () => {
                   action: "sigprocmask-set-blocked",
                   threadId: "thread:1",
                   targetBlockedMasks: ["0x0"],
+                },
+              },
+              {
+                section: "thread-spawn",
+                step: {
+                  action: "spawn-target-thread",
+                  threadId: "thread:2",
+                  stackBase: "0x530000000000",
+                  stackLimit: "0x530000010000",
+                  registers: { rip: "0x700300000000", rsp: "0x530000010000" },
                 },
               },
             ],

--- a/packages/runtime/src/portable-machine-restore-proof.ts
+++ b/packages/runtime/src/portable-machine-restore-proof.ts
@@ -30,7 +30,7 @@ export type PortableMachineTargetFrameRestoreResult = "pending" | "passed" | "fa
 export type PortableMachineTargetRegisterRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetRflagsRestoreResult = "pending" | "passed" | "failed";
 export type PortableMachineTargetTlsRestoreResult = "pending" | "passed" | "failed";
-export type PortableMachineTargetThreadRestoreResult = "accepted" | "refused";
+export type PortableMachineTargetThreadRestoreResult = "accepted" | "refused" | "passed" | "failed";
 export type PortableMachineTargetResumePathResult = "pending" | "passed" | "failed";
 
 export interface PortableMachineTargetResourceStatus {
@@ -266,7 +266,8 @@ function optionalTargetChecksPassed(result: PortableMachineVmRestoreTargetResult
     passedOrUnset(result.targetRflagsRestoreResult),
     passedOrUnset(result.targetTlsRestoreResult),
     result.targetThreadRestoreResult === undefined ||
-      result.targetThreadRestoreResult === "accepted",
+      result.targetThreadRestoreResult === "accepted" ||
+      result.targetThreadRestoreResult === "passed",
     passedOrUnset(result.targetResumePathResult),
   ].every(Boolean);
 }

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -9,6 +9,7 @@ import type { TargetGuestExecutableMappingStep } from "./target-guest-executable
 import type { TargetGuestMemoryMaterializationEntry } from "./target-guest-memory-materialization.ts";
 import type { TargetGuestPrivateMemoryRestoreStep } from "./target-guest-private-memory-restore.ts";
 import type { TargetGuestSignalRestoreStep } from "./target-guest-signal-restore.ts";
+import type { TargetGuestTwoThreadSpawnStep } from "./target-guest-two-thread-restore.ts";
 
 export const TARGET_GUEST_RESTORE_DESCRIPTOR_KIND = "machinen.target-guest-restore";
 
@@ -110,7 +111,8 @@ export type TargetGuestNativeRestoreStep =
   | { section: "private-memory"; step: TargetGuestPrivateMemoryRestoreStep }
   | { section: "executable-mapping"; step: TargetGuestExecutableMappingStep }
   | { section: "signal-restore"; step: TargetGuestSignalRestoreStep }
-  | { section: "active-syscall"; step: TargetGuestActiveSyscallRestoreStep };
+  | { section: "active-syscall"; step: TargetGuestActiveSyscallRestoreStep }
+  | { section: "thread-spawn"; step: TargetGuestTwoThreadSpawnStep };
 
 export interface TargetGuestRestoreDescriptor {
   kind: typeof TARGET_GUEST_RESTORE_DESCRIPTOR_KIND;
@@ -609,6 +611,8 @@ function parseNativeRestoreStep(line: string): TargetGuestNativeRestoreStep {
       return { section, step: parseNativeSignalRestoreStep(values) };
     case "active-syscall":
       return { section, step: parseNativeActiveSyscallStep(values) };
+    case "thread-spawn":
+      return { section, step: parseNativeThreadSpawnStep(values) };
     default:
       return fail(
         "target-guest-loader-descriptor-invalid",
@@ -722,6 +726,19 @@ function parseNativeSignalRestoreStep(fields: Map<string, string>): TargetGuestS
     return { action, threadId, targetBlockedMasks: parseNativeList(fields, "targetBlockedMasks") };
   }
   return fail("target-guest-loader-descriptor-invalid", "unsupported native signal restore action");
+}
+
+function parseNativeThreadSpawnStep(fields: Map<string, string>): TargetGuestTwoThreadSpawnStep {
+  return {
+    action: "spawn-target-thread",
+    threadId: requiredNativeField(fields, "threadId"),
+    stackBase: requiredNativeField(fields, "stackBase"),
+    stackLimit: requiredNativeField(fields, "stackLimit"),
+    registers: {
+      rip: requiredNativeField(fields, "rip"),
+      rsp: requiredNativeField(fields, "rsp"),
+    },
+  };
 }
 
 function parseNativeActiveSyscallStep(
@@ -963,7 +980,24 @@ function validateNativeRestoreStep(
     case "active-syscall":
       validateActiveSyscallRestoreStep(step.step);
       return step;
+    case "thread-spawn":
+      validateThreadSpawnStep(step.step);
+      return step;
   }
+}
+
+function validateThreadSpawnStep(step: TargetGuestTwoThreadSpawnStep): void {
+  if (step.action !== "spawn-target-thread") {
+    fail("target-guest-loader-descriptor-invalid", "unsupported native thread action");
+  }
+  assertNoWhitespace(step.threadId, "threadId");
+  assertHexAddress(step.stackBase, "stackBase");
+  assertHexAddress(step.stackLimit, "stackLimit");
+  if (BigInt(step.stackBase) >= BigInt(step.stackLimit)) {
+    fail("target-guest-loader-invalid-continuation", "thread stack range is inverted");
+  }
+  assertHexAddress(step.registers.rip, "rip");
+  assertHexAddress(step.registers.rsp, "rsp");
 }
 
 function validateStackWindowWrite(write: NativeStackWindowWrite): void {
@@ -1360,7 +1394,13 @@ function serializeNativeRestoreStep(step: TargetGuestNativeRestoreStep): string 
       return serializeSignalRestoreStep(step.step);
     case "active-syscall":
       return serializeActiveSyscallStep(step.step);
+    case "thread-spawn":
+      return serializeThreadSpawnStep(step.step);
   }
+}
+
+function serializeThreadSpawnStep(step: TargetGuestTwoThreadSpawnStep): string {
+  return `native=thread-spawn action=${step.action} threadId=${step.threadId} stackBase=${step.stackBase} stackLimit=${step.stackLimit} rip=${step.registers.rip} rsp=${step.registers.rsp}`;
 }
 
 function serializeStackWindowWrite(write: NativeStackWindowWrite): string {
@@ -1527,7 +1567,13 @@ function nativeRestoreToTrampolineArgs(step: TargetGuestNativeRestoreStep): stri
       return ["--native-signal-restore-step", nativeSignalRestoreStepSpec(step.step)];
     case "active-syscall":
       return ["--native-active-syscall-step", nativeActiveSyscallStepSpec(step.step)];
+    case "thread-spawn":
+      return ["--native-thread-spawn-step", nativeThreadSpawnStepSpec(step.step)];
   }
+}
+
+function nativeThreadSpawnStepSpec(step: TargetGuestTwoThreadSpawnStep): string {
+  return serializeThreadSpawnStep(step).slice("native=thread-spawn ".length).replaceAll(" ", ";");
 }
 
 function nativeStackWindowWriteSpec(write: NativeStackWindowWrite): string {

--- a/packages/runtime/src/target-native-consumption-results.ts
+++ b/packages/runtime/src/target-native-consumption-results.ts
@@ -10,6 +10,7 @@ export interface TargetNativeConsumptionEvents {
   nativeExecutableMapping?: TargetNativeConsumptionEvent;
   nativeSignalRestore?: TargetNativeConsumptionEvent;
   nativeActiveSyscallRestore?: TargetNativeConsumptionEvent;
+  nativeThreadRestore?: TargetNativeConsumptionEvent;
 }
 
 export function parseTargetNativeConsumptionEvents(
@@ -30,6 +31,7 @@ export function parseTargetNativeConsumptionEvents(
       actualResumeEvent,
       "nativeActiveSyscallRestore",
     ),
+    nativeThreadRestore: parseNativeConsumption(actualResumeEvent, "nativeThreadRestore"),
   };
 }
 
@@ -39,6 +41,7 @@ export function targetNativeConsumptionFields(events: TargetNativeConsumptionEve
   targetExecutableMappingResult?: TargetNativeConsumptionStatus;
   targetSignalRestoreResult?: TargetNativeConsumptionStatus;
   targetActiveSyscallRestoreResult?: TargetNativeConsumptionStatus;
+  targetThreadRestoreResult?: TargetNativeConsumptionStatus;
 } {
   return {
     targetStackWindowMaterializationResult: events.nativeStackWindowMaterialization?.status,
@@ -46,6 +49,7 @@ export function targetNativeConsumptionFields(events: TargetNativeConsumptionEve
     targetExecutableMappingResult: events.nativeExecutableMapping?.status,
     targetSignalRestoreResult: events.nativeSignalRestore?.status,
     targetActiveSyscallRestoreResult: events.nativeActiveSyscallRestore?.status,
+    targetThreadRestoreResult: events.nativeThreadRestore?.status,
   };
 }
 
@@ -56,6 +60,7 @@ export function targetNativeConsumptionPassed(events: TargetNativeConsumptionEve
     events.nativeExecutableMapping,
     events.nativeSignalRestore,
     events.nativeActiveSyscallRestore,
+    events.nativeThreadRestore,
   ].every((event) => event === undefined || event.status === "passed");
 }
 


### PR DESCRIPTION
## Problem

The controlled two-thread planner produced target spawn steps, but those steps did not reach the target guest loader/trampoline as consumed target-side work.

## Solution

This PR adds a narrow `native=thread-spawn` descriptor section. The target guest loader forwards it as `--native-thread-spawn-step`, and the amd64 trampoline validates each step, maps the requested stack, creates a short-lived target task on that stack, waits for it, and reports `nativeThreadRestore=passed` only after all requested spawns succeed. Malformed stack/register/action state fails closed before target success.

Fixes #685

## Validation

- `pnpm run build:docs` — passed
- `pnpm run typecheck` — 2.132s
- focused vitest — 1.118s
- remote amd64 trampoline proof on `root@192.168.0.8` — thread-spawn step passed; inverted stack exited 2
- `pnpm run format:check` — 0.557s
- `pnpm run lint` — 0.221s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.987s
- `pnpm smoke-tests` — 2m12.814s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.379s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m11.917s, 2/2 passed
