### PR TITLE
Allow TLS restore on native private memory

### DIFF
--- a/docs/snapshot/target-guest-private-memory-restore.md
+++ b/docs/snapshot/target-guest-private-memory-restore.md
@@ -14,6 +14,7 @@ Executable entries and shared entries fail closed with
 `mapping-executable-unsupported` and `mapping-shared-unsupported`. Guard entries
 must be `---p`. The target amd64 trampoline now executes these native private
 memory steps directly; when they are present, the portable VM proof does not also
-emit duplicate legacy `memory=` mappings for the same ranges. This keeps private
-heap/data/mmap restoration separate from source executable bytes and
-shared-resource state.
+emit duplicate legacy `memory=` mappings for the same ranges. Target TLS/TCB
+restore now treats writable native private-memory ranges as valid backing for the
+TCB handoff. This keeps private heap/data/mmap restoration separate from source
+executable bytes and shared-resource state.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1068,11 +1068,6 @@ static void validate_target_tls_options(const struct Options *opts) {
     fprintf(stderr, "native-actual-resume-trampoline: target fs base must be non-zero and 16-byte aligned\n");
     exit(2);
   }
-  if (!address_inside_writable_materialized_memory(
-          opts, opts->target_fs_base + TLS_TCB_SELF_OFFSET, TLS_TCB_MARKER_OFFSET + sizeof(uint64_t))) {
-    fprintf(stderr, "native-actual-resume-trampoline: target fs base is outside writable materialized memory\n");
-    exit(2);
-  }
 }
 
 static void validate_resume_rflags_options(const struct Options *opts) {
@@ -1292,6 +1287,45 @@ static bool native_step_bool(const char *spec, const char *name, const char *lab
     return false;
   }
   fprintf(stderr, "native-actual-resume-trampoline: native %s step %s must be boolean\n", label, name);
+  exit(2);
+}
+
+static bool native_permissions_writable(const char *permissions) {
+  return strlen(permissions) >= 2u && permissions[1] == 'w';
+}
+
+static bool address_inside_writable_native_private_memory(
+    const struct Options *opts, uint64_t address, uint64_t size) {
+  for (size_t i = 0; i < opts->native_private_memory_step_count; i++) {
+    const char *spec = opts->native_private_memory_steps[i].spec;
+    char action[64];
+    native_step_string(spec, "action", action, sizeof(action), "private-memory");
+    if (!streq(action, "mmap-private-writable") && !streq(action, "mprotect-final")) {
+      continue;
+    }
+    char permissions[16];
+    native_step_string(spec, "permissions", permissions, sizeof(permissions), "private-memory");
+    uint64_t target_start = native_step_u64(spec, "targetStart", "private-memory");
+    uint64_t mapping_size = native_step_u64(spec, "sizeBytes", "private-memory");
+    if (native_permissions_writable(permissions) && address >= target_start && size <= mapping_size &&
+        address + size <= target_start + mapping_size) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void validate_target_tls_backing(const struct Options *opts) {
+  if (!opts->has_target_fs_base) {
+    return;
+  }
+  uint64_t address = opts->target_fs_base + TLS_TCB_SELF_OFFSET;
+  uint64_t size = TLS_TCB_MARKER_OFFSET + sizeof(uint64_t);
+  if (address_inside_writable_materialized_memory(opts, address, size) ||
+      address_inside_writable_native_private_memory(opts, address, size)) {
+    return;
+  }
+  fprintf(stderr, "native-actual-resume-trampoline: target fs base is outside writable materialized memory\n");
   exit(2);
 }
 
@@ -2268,6 +2302,7 @@ int main(int argc, char **argv) {
     materialize_descriptor_memory(&opts);
   }
   materialize_native_stack_window_guards(&opts);
+  validate_target_tls_backing(&opts);
   materialize_target_tcb(&opts);
 
   verify_native_executable_mappings(&opts);

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -154,6 +154,18 @@ describe("native actual resume trampoline", () => {
         returnValue: "0x7a7a7a7a7a7a7a7a",
         nativePrivateMemoryRestore: { status: "passed", stepCount: 3 },
       });
+      expect(
+        runHelper(helper, returnCode, 1, [
+          ...nativePrivateMemorySteps(nativeMemory),
+          "--state-report-address",
+          "0x600000000000",
+          "--target-fs-base",
+          "0x600000000300",
+        ]),
+      ).toMatchObject({
+        status: "returned",
+        nativePrivateMemoryRestore: { status: "passed", stepCount: 3 },
+      });
 
       const arg0Code = join(outDir, "arg0.bin");
       // mov rax, rdi; ret


### PR DESCRIPTION
## Problem

The portable VM proof now restores private memory through native private-memory sections instead of legacy `memory=` entries. But the amd64 trampoline still checked `targetFsBase` only against legacy materialized memory, so the remote target restore failed before descriptor consumption.

## Solution

This PR splits basic TLS argument validation from backing-range validation and treats writable native private-memory ranges as valid TCB backing. A focused trampoline test covers `--target-fs-base` backed only by native private-memory steps.

Fixes #687

## Validation

- `pnpm run build:docs` — passed
- `pnpm run typecheck` — 2.464s
- focused vitest — 0.480s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.436s
- remote arm64→amd64 proof — completed in 37.018s; target boot/restore 20.125s; stack/private/executable/signal/register/frame/TLS gates passed
- `pnpm run format:check` — 0.574s
- `pnpm run lint` — 0.239s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.058s
- `pnpm smoke-tests` — 2m12.804s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m14.645s, 2/2 passed
