### PR TITLE
Carry active syscall restore into VM proof

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -122,7 +122,10 @@ summary shape on any host.
 The smoke profile creates or captures a narrow arm64 native-process bundle,
 wraps it in a portable machine snapshot, stages a target-native amd64 real
 utility continuation inside the bundle, and runs the portable machine VM restore
-proof with a combined restore descriptor. The continuation is target module bytes
+proof with a combined restore descriptor. Remote e2e mode captures a real arm64
+process blocked in a modeled `ppoll` timeout and requires the emitted
+`native=active-syscall` section to report
+`targetActiveSyscallRestoreResult=passed`. The continuation is target module bytes
 from the bundle's approved target root, not source-ISA text. The JSON summary
 includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
 resource recipe kinds, `targetRestore.targetContinuationKind`,

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -1,6 +1,7 @@
 # Target guest active-syscall restore
 
-Issue #663 plans target re-arm for modeled active syscall continuations.
+Issue #663 plans target re-arm for modeled active syscall continuations. Issue
+#691 carries those planned steps into the full portable machine VM proof.
 
 `planTargetGuestActiveSyscallRestore()` consumes the active syscall
 classification result. If classification contains any refusal, target restore is
@@ -21,3 +22,10 @@ trampoline reports `nativeActiveSyscallRestore.status=passed` only when every
 step was parsed, validated, and armed; malformed durations, unknown actions,
 wrong resume modes, unsupported sleep syscall names, and unsupported `ppoll`
 resource shapes exit before target success.
+
+The remote portable-machine smoke path captures a real arm64 process blocked in
+a modeled `ppoll` timeout, wraps that bundle in a portable machine snapshot,
+serializes a `native=active-syscall` section in the combined target descriptor,
+and requires `targetActiveSyscallRestoreResult=passed` before the remote
+arm64→amd64 proof is accepted. Missing or unreadable timeout memory still
+refuses before VM target success with the active-syscall timeout refusal codes.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -81,6 +81,7 @@
 #define RESUME_REGISTER_R10 UINT64_C(0x40)
 #define RESUME_REGISTER_R11 UINT64_C(0x80)
 #define RESUME_REGISTER_RDI UINT64_C(0x100)
+#define NATIVE_INTERNAL_FD_MIN 64
 #define MAX_UNWIND_ID 128
 
 struct MemoryMaterialization {
@@ -1452,6 +1453,16 @@ static void record_active_timer_fd(struct NativeActiveSyscallRestoreState *state
   state->timer_fds[state->armed_count++] = fd;
 }
 
+static int move_to_internal_fd(int fd, const char *label) {
+  int internal_fd = fcntl(fd, F_DUPFD_CLOEXEC, NATIVE_INTERNAL_FD_MIN);
+  if (internal_fd < 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: native %s internal fd reserve failed: %s\n", label, strerror(errno));
+    exit(1);
+  }
+  close(fd);
+  return internal_fd;
+}
+
 static void arm_native_active_timer(
     const char *spec, const char *label, struct NativeActiveSyscallRestoreState *state) {
   int fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
@@ -1459,6 +1470,7 @@ static void arm_native_active_timer(
     fprintf(stderr, "native-actual-resume-trampoline: native %s timerfd failed: %s\n", label, strerror(errno));
     exit(1);
   }
+  fd = move_to_internal_fd(fd, label);
   struct itimerspec timer = native_active_timer_spec(spec, label);
   if (timerfd_settime(fd, 0, &timer, NULL) != 0) {
     fprintf(stderr, "native-actual-resume-trampoline: native %s timerfd arm failed: %s\n", label, strerror(errno));

--- a/packages/microvm/assets/native-ppoll-timeout-target.c
+++ b/packages/microvm/assets/native-ppoll-timeout-target.c
@@ -6,7 +6,52 @@
 #include <time.h>
 #include <unistd.h>
 
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
 int main(void) {
+  clear_simd_fpu_state();
   struct timespec timeout = {.tv_sec = 30, .tv_nsec = 0};
   long rc = syscall(SYS_ppoll, NULL, 0, &timeout, NULL, 0);
   if (rc == 0) {

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -145,6 +145,25 @@ describe("native actual resume trampoline", () => {
         nativeThreadRestore: { status: "passed", stepCount: 1, spawnedCount: 1 },
       });
 
+      const fd3ClosedCode = join(outDir, "fd3-closed.bin");
+      writeFileSync(
+        fd3ClosedCode,
+        Buffer.from([
+          0xb8, 0x48, 0, 0, 0, 0xbf, 0x03, 0, 0, 0, 0xbe, 0x01, 0, 0, 0, 0x31, 0xd2, 0x0f, 0x05,
+          0x83, 0xf8, 0xf7, 0x75, 0x06, 0xb8, 0x4d, 0, 0, 0, 0xc3, 0xb8, 0x2a, 0, 0, 0, 0xc3,
+        ]),
+      );
+      expect(
+        runHelper(helper, fd3ClosedCode, 36, [
+          "--native-active-syscall-step",
+          "action=rearm-sleep-timer;threadId=thread:1;seconds=0;nanoseconds=1000000;resumeMode=defer-target-resume;syscallName=clock_nanosleep",
+        ]),
+      ).toMatchObject({
+        status: "returned",
+        returnValue: "0x4d",
+        nativeActiveSyscallRestore: { status: "passed", stepCount: 1, armedCount: 1 },
+      });
+
       const nativeMemoryReader = join(outDir, "native-memory-reader.bin");
       writeFileSync(nativeMemoryReader, loadU64FromAbsoluteCode(0x600000000000n));
       expect(

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -20,6 +20,7 @@ import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/nati
 import { matchNativeTargetUnwindFrame } from "../packages/runtime/src/native-target-unwind.ts";
 import { planNativeThreadRestoreBoundary } from "../packages/runtime/src/native-thread-restore-policy.ts";
 import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
+import { planTargetGuestActiveSyscallRestore } from "../packages/runtime/src/target-guest-active-syscall-restore.ts";
 import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
 import { planTargetGuestPrivateMemoryRestore } from "../packages/runtime/src/target-guest-private-memory-restore.ts";
 import {
@@ -82,6 +83,10 @@ interface CombinedDescriptorContext extends CombinedDescriptorPaths {
   targetThreadRestoreResult: "accepted";
   targetThreadRestoreThreadId: string;
   targetSignalBlockedMasks: string[];
+  targetActiveSyscallSteps: Extract<
+    ReturnType<typeof planTargetGuestActiveSyscallRestore>,
+    { state: "planned" }
+  >["steps"];
 }
 
 interface PreparedTargetContinuation {
@@ -352,37 +357,77 @@ function combinedDescriptorContext(
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): CombinedDescriptorContext | ReturnType<typeof planPortableMachineVmRestoreProof> {
   const bundle = validatePortableMachineSnapshotBundle(args.bundleDir!);
-  const threadPlan = planNativeThreadRestoreBoundary({
-    threads: bundle.nativeProcessImage.threads.threads,
-    mappings: bundle.nativeProcessImage.mappings.mappings,
-    resources: bundle.nativeProcessImage.resources.resources,
-    tls: { targetFsBase: TARGET_TLS_BASE, targetAccessPolicy: "target-tcb-materialized" },
-  });
+  const threadPlan = proofThreadPlan(bundle);
   if (threadPlan.state === "refused") {
-    const first = threadPlan.refusals[0]!;
-    return refusedPlan(plan, first.code, first.message);
+    return firstRefusedPlan(plan, threadPlan.refusals);
   }
-  const memoryFile = join(bundle.nativeProcessImage.rootDir!, NATIVE_PROCESS_IMAGE_FILES.memory);
-  const memorySizeBytes = statSync(memoryFile).size;
-  const mapping = selectProofMemoryMapping(
-    bundle.nativeProcessImage.mappings.mappings,
-    memorySizeBytes,
-  );
-  if (!mapping) {
+  const memory = proofMemorySelection(bundle);
+  if (!memory.mapping) {
     return refusedPlan(
       plan,
       "mapping-ambiguous",
       "portable machine proof needs one safe captured writable memory page",
     );
   }
+  const activeSyscallPlan = proofActiveSyscallPlan(threadPlan.activeSyscallContinuations);
+  if (activeSyscallPlan.state === "refused") {
+    return firstRefusedPlan(plan, activeSyscallPlan.refusals);
+  }
   const context = {
-    ...combinedDescriptorPaths(args, memoryFile, memorySizeBytes, mapping),
+    ...combinedDescriptorPaths(args, memory.file, memory.sizeBytes, memory.mapping),
     targetThreadRestoreResult: threadPlan.state,
     targetThreadRestoreThreadId: threadPlan.threadId,
     targetSignalBlockedMasks: threadPlan.signalRestore.blockedMasks,
+    targetActiveSyscallSteps: activeSyscallPlan.steps,
   };
-  const pathRefusal = portableProofPathRefusal(bundle.rootDir!, proofInputPaths(context));
+  return contextAfterPathCheck(plan, bundle.rootDir!, context);
+}
+
+function contextAfterPathCheck(
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  rootDir: string,
+  context: CombinedDescriptorContext,
+): CombinedDescriptorContext | ReturnType<typeof planPortableMachineVmRestoreProof> {
+  const pathRefusal = portableProofPathRefusal(rootDir, proofInputPaths(context));
   return pathRefusal ? refusedPlan(plan, pathRefusal.code, pathRefusal.message) : context;
+}
+
+function proofThreadPlan(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
+  return planNativeThreadRestoreBoundary({
+    threads: bundle.nativeProcessImage.threads.threads,
+    mappings: bundle.nativeProcessImage.mappings.mappings,
+    resources: bundle.nativeProcessImage.resources.resources,
+    tls: { targetFsBase: TARGET_TLS_BASE, targetAccessPolicy: "target-tcb-materialized" },
+    activeSyscall: {
+      sleepTimerPolicy: "defer-target-resume",
+      pollTimeoutPolicy: "defer-target-resume",
+      pollTimeoutFdPolicy: "synthetic-timerfd",
+      documents: bundle.nativeProcessImage,
+    },
+  });
+}
+
+function proofMemorySelection(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
+  const file = join(bundle.nativeProcessImage.rootDir!, NATIVE_PROCESS_IMAGE_FILES.memory);
+  const sizeBytes = statSync(file).size;
+  return {
+    file,
+    sizeBytes,
+    mapping: selectProofMemoryMapping(bundle.nativeProcessImage.mappings.mappings, sizeBytes),
+  };
+}
+
+function proofActiveSyscallPlan(
+  continuations: Extract<
+    ReturnType<typeof planNativeThreadRestoreBoundary>,
+    { state: "accepted" }
+  >["activeSyscallContinuations"],
+) {
+  return planTargetGuestActiveSyscallRestore({
+    classifications: [],
+    refusals: [],
+    continuations,
+  });
 }
 
 function combinedDescriptorPaths(
@@ -461,6 +506,7 @@ function proofNativeRestoreSections(
     ...proofPrivateMemoryNativeSections(memoryEntries),
     ...proofExecutableNativeSections(targetContinuation),
     ...proofSignalNativeSections(context),
+    ...proofActiveSyscallNativeSections(context),
   ];
 }
 
@@ -582,6 +628,15 @@ function proofSignalNativeSections(
       },
     },
   ];
+}
+
+function proofActiveSyscallNativeSections(
+  context: CombinedDescriptorContext,
+): TargetGuestNativeRestoreStep[] {
+  return context.targetActiveSyscallSteps.map((step) => ({
+    section: "active-syscall" as const,
+    step,
+  }));
 }
 
 function continuationStackStart(): string {
@@ -1349,6 +1404,14 @@ class Amd64ProofAssembler {
       this.push(Number((value >> (8n * i)) & 0xffn));
     }
   }
+}
+
+function firstRefusedPlan(
+  plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  refusals: Array<{ code: string; message: string }>,
+): ReturnType<typeof planPortableMachineVmRestoreProof> {
+  const first = refusals[0]!;
+  return refusedPlan(plan, first.code, first.message);
 }
 
 function refusedPlan(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -293,21 +293,18 @@ NODE
 
 capture_remote_native_process_bundle() {
   local start=$1
-  ssh "$ARM64_SSH" "rm -rf '$ARM64_REMOTE_WORK' && mkdir -p '$ARM64_REMOTE_WORK/repo' '$ARM64_REMOTE_WORK/capture'"
+  ssh "$ARM64_SSH" "rm -rf '$ARM64_REMOTE_WORK' && mkdir -p '$ARM64_REMOTE_WORK/repo' '$ARM64_REMOTE_WORK/capture/bundle' '$ARM64_REMOTE_WORK/bin'"
   tar -czf - -C "$ROOT" \
-    scripts/native-process-capture.mjs \
-    scripts/controlled-corpus-utils.mjs \
-    scripts/proof-script-utils.mjs \
     packages/microvm/assets/native-process-capture.c \
-    packages/microvm/assets/native-capture-target.c | \
+    packages/microvm/assets/native-ppoll-timeout-target.c | \
     ssh "$ARM64_SSH" "tar -xzf - -C '$ARM64_REMOTE_WORK/repo'"
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && '$ARM64_NODE' scripts/native-process-capture.mjs verify --out-dir '$ARM64_REMOTE_WORK/capture' --json --keep > '$ARM64_REMOTE_WORK/capture.json'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
-  ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.json'" >"$WORK/arm64-capture.json"
+  ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \
     tar -xzf - -C "$NATIVE_BUNDLE"
-  record_timing "capture" "ok" "$start" "remote arm64 native-process bundle captured from $ARM64_SSH"
+  record_timing "capture" "ok" "$start" "remote arm64 ppoll native-process bundle captured from $ARM64_SSH"
 }
 
 capture_native_process_bundle() {
@@ -368,9 +365,10 @@ run_target_restore() {
     record_timing "target-boot-restore" "failed" "$start" "runner failed"
     return 21
   fi
-  if node --input-type=module - "$TARGET_LOG" <<'NODE'
+  if node --input-type=module - "$TARGET_LOG" "$REMOTE_E2E" <<'NODE'
 import { readFileSync } from 'node:fs';
 const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+const remoteE2e = process.argv[3] === '1';
 process.exit(
   result.state === 'completed' &&
   result.migrationCompleted === true &&
@@ -379,7 +377,8 @@ process.exit(
   result.targetStackWindowMaterializationResult === 'passed' &&
   result.targetPrivateMemoryRestoreResult === 'passed' &&
   result.targetExecutableMappingResult === 'passed' &&
-  result.targetSignalRestoreResult === 'passed'
+  result.targetSignalRestoreResult === 'passed' &&
+  (!remoteE2e || result.targetActiveSyscallRestoreResult === 'passed')
     ? 0
     : 1,
 );


### PR DESCRIPTION
## Problem

Active-syscall restore steps were executed by focused trampoline tests, but the full portable machine VM proof still did not carry a real captured blocked syscall into the target descriptor. The remote smoke could pass with `targetActiveSyscallRestoreResult` empty.

## Solution

This PR carries modeled active-syscall continuations from the captured native-process bundle into `native=active-syscall` descriptor sections. Remote e2e smoke now captures a real arm64 `ppoll` timeout process, requires the target result to include `targetActiveSyscallRestoreResult=passed`, and keeps missing or malformed timeout state fail-closed. The trampoline also moves internal active-syscall timerfds away from modeled guest fd slots so fd restoration remains observable.

Fixes #691

## Validation

- `pnpm run build:docs` — 1.595s
- `pnpm run format:check` — 0.596s
- `pnpm run lint` — 0.222s
- `pnpm run typecheck` — 2.364s
- focused trampoline vitest — 0.567s (skipped on darwin/arm64 as expected)
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.016s
- `pnpm smoke-tests` — 2m13.799s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.395s
- remote arm64→amd64 proof — completed in 35.816s; target boot/restore 19.007s; `targetActiveSyscallRestoreResult=passed`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m12.567s, 2/2 passed
