### PR TITLE
Add all-gates two-thread VM proof

### DIFF
--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -123,9 +123,10 @@ The smoke profile creates or captures a narrow arm64 native-process bundle,
 wraps it in a portable machine snapshot, stages a target-native amd64 real
 utility continuation inside the bundle, and runs the portable machine VM restore
 proof with a combined restore descriptor. Remote e2e mode captures a real arm64
-process blocked in a modeled `ppoll` timeout and requires the emitted
-`native=active-syscall` section to report
-`targetActiveSyscallRestoreResult=passed`. The continuation is target module bytes
+two-thread process with one thread blocked in a modeled `ppoll` timeout. It
+requires the emitted `native=active-syscall` and `native=thread-spawn` sections
+to report `targetActiveSyscallRestoreResult=passed` and
+`targetThreadRestoreResult=passed`. The continuation is target module bytes
 from the bundle's approved target root, not source-ISA text. The JSON summary
 includes `targetRestore.descriptorGateCompleted`, descriptor memory/fd counts,
 resource recipe kinds, `targetRestore.targetContinuationKind`,
@@ -188,5 +189,7 @@ Latest remote arm64→amd64 proof after native target-loader consumption hardeni
 - `targetPrivateMemoryRestoreResult=passed`
 - `targetExecutableMappingResult=passed`
 - `targetSignalRestoreResult=passed`
+- `targetActiveSyscallRestoreResult=passed`
+- `targetThreadRestoreResult=passed`
 - wall time: 37.018s
 - target VM boot/restore: 20.125s

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -23,9 +23,9 @@ step was parsed, validated, and armed; malformed durations, unknown actions,
 wrong resume modes, unsupported sleep syscall names, and unsupported `ppoll`
 resource shapes exit before target success.
 
-The remote portable-machine smoke path captures a real arm64 process blocked in
-a modeled `ppoll` timeout, wraps that bundle in a portable machine snapshot,
-serializes a `native=active-syscall` section in the combined target descriptor,
-and requires `targetActiveSyscallRestoreResult=passed` before the remote
-arm64→amd64 proof is accepted. Missing or unreadable timeout memory still
+The remote portable-machine smoke path captures a real arm64 two-thread process
+with one thread blocked in a modeled `ppoll` timeout, wraps that bundle in a
+portable machine snapshot, serializes a `native=active-syscall` section in the
+combined target descriptor, and requires `targetActiveSyscallRestoreResult=passed`
+before the remote arm64→amd64 proof is accepted. Missing or unreadable timeout memory still
 refuses before VM target success with the active-syscall timeout refusal codes.

--- a/docs/snapshot/target-guest-two-thread-restore.md
+++ b/docs/snapshot/target-guest-two-thread-restore.md
@@ -19,6 +19,13 @@ The planner refuses when:
 - required `rip`/`rsp` seeds are absent;
 - target stack ranges are inverted or overlap.
 
+Issue #693 wires this into the remote portable-machine proof. The remote smoke
+captures a real arm64 two-thread process with one user-space spinning thread and
+one thread blocked in a modeled `ppoll` timeout, emits `native=thread-spawn`
+sections for both controlled target tasks, and requires
+`targetThreadRestoreResult=passed` alongside the active-syscall and other native
+gates.
+
 This remains a narrow two-thread proof boundary. It proves loader/trampoline
 consumption of safe spawn steps only; it is not general multithread restore and
 does not accept futex or rseq synchronization state.

--- a/packages/microvm/assets/native-two-thread-ppoll-target.c
+++ b/packages/microvm/assets/native-two-thread-ppoll-target.c
@@ -1,0 +1,92 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+static _Atomic int worker_ready = 0;
+static volatile uint64_t main_spin_counter = 0;
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static void *worker_main(void *opaque) {
+  (void)opaque;
+  clear_simd_fpu_state();
+  atomic_store_explicit(&worker_ready, 1, memory_order_release);
+
+  struct timespec timeout = {.tv_sec = 30, .tv_nsec = 0};
+  long rc = syscall(SYS_ppoll, NULL, 0, &timeout, NULL, 0);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-two-thread-ppoll-target: ppoll: %s\n", strerror(errno));
+  }
+  return NULL;
+}
+
+int main(void) {
+  pthread_t worker;
+  int err = pthread_create(&worker, NULL, worker_main, NULL);
+  if (err != 0) {
+    fprintf(stderr, "machinen-two-thread-ppoll-target: pthread_create: %s\n", strerror(err));
+    return 1;
+  }
+
+  while (atomic_load_explicit(&worker_ready, memory_order_acquire) == 0) {
+    __asm__ __volatile__("" ::: "memory");
+  }
+  clear_simd_fpu_state();
+
+  for (;;) {
+    main_spin_counter++;
+    if ((main_spin_counter & 0xfffffu) == 0) {
+      __asm__ __volatile__("" ::: "memory");
+    }
+  }
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -8699,6 +8699,18 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 > `optional` **resources?**: [`NativeProcessResource`](#nativeprocessresource)[]
 
+##### activeSyscall?
+
+> `optional` **activeSyscall?**: [`NativeActiveSyscallPolicyOptions`](#nativeactivesyscallpolicyoptions)
+
+##### signal?
+
+> `optional` **signal?**: `object`
+
+###### blockedMaskPolicy?
+
+> `optional` **blockedMaskPolicy?**: [`NativeSignalBlockedMaskPolicy`](#nativesignalblockedmaskpolicy)
+
 ***
 
 ### NativeUnwindFrameRule

--- a/packages/runtime/src/__tests__/native-two-thread-boundary.test.ts
+++ b/packages/runtime/src/__tests__/native-two-thread-boundary.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it } from "vitest";
-import type { NativeMemoryMapping, NativeThreadState } from "../native-process-image.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  NATIVE_PROCESS_IMAGE_FILES,
+  type NativeMemoryMapping,
+  type NativeProcessImageDocuments,
+  type NativeThreadState,
+} from "../native-process-image.ts";
 import { planNativeControlledTwoThreadRestoreBoundary } from "../native-two-thread-boundary.ts";
 
 const stackA: NativeMemoryMapping = stackMapping("mapping:stack-a", "0x700000000000");
 const stackB: NativeMemoryMapping = stackMapping("mapping:stack-b", "0x700000010000");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
 
 function stackMapping(id: string, sourceStart: string): NativeMemoryMapping {
   const start = BigInt(sourceStart);
@@ -64,6 +79,36 @@ describe("controlled two-thread restore boundary", () => {
     });
   });
 
+  it("accepts a modeled active syscall on one controlled thread", () => {
+    const input = request();
+    input.threads[1]!.syscall = { state: "inside-syscall", number: 115, name: "clock_nanosleep" };
+    if (input.threads[1]!.sourceRegisters.arch === "arm64") {
+      input.threads[1]!.sourceRegisters.x = [
+        "0x0",
+        "0x0",
+        "0x700000000100",
+        "0x0",
+        ...Array.from({ length: 27 }, () => "0x0"),
+      ];
+    }
+
+    expect(
+      planNativeControlledTwoThreadRestoreBoundary({
+        ...input,
+        activeSyscall: {
+          sleepTimerPolicy: "defer-target-resume",
+          documents: documentsWithTimespec(input.threads[1]!),
+        },
+      }),
+    ).toMatchObject({
+      state: "accepted",
+      threadPlans: [
+        { activeSyscallContinuations: [] },
+        { activeSyscallContinuations: [expect.objectContaining({ syscallClass: "sleep-timer" })] },
+      ],
+    });
+  });
+
   it("refuses non-two-thread inputs", () => {
     const input = request();
     input.threads.pop();
@@ -104,3 +149,59 @@ describe("controlled two-thread restore boundary", () => {
     });
   });
 });
+
+function documentsWithTimespec(activeThread: NativeThreadState): NativeProcessImageDocuments {
+  const rootDir = mkdtempSync(join(tmpdir(), "machinen-two-thread-syscall-"));
+  tempDirs.push(rootDir);
+  const memory = Buffer.alloc(4096);
+  memory.writeBigUInt64LE(30n, 0x100);
+  memory.writeBigUInt64LE(123n, 0x108);
+  writeFileSync(join(rootDir, NATIVE_PROCESS_IMAGE_FILES.memory), memory);
+  return {
+    rootDir,
+    manifest: {
+      formatVersion: 1,
+      kind: "machinen.native-process-image",
+      capture: { method: "external-ptrace-procfs", sourceArch: "arm64" },
+      target: { mode: "native-cross-isa", arch: "amd64", abi: "linux-user" },
+      process: { exe: "/bin/sleep", argv: ["sleep"], env: {}, cwd: "/" },
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    mappings: {
+      formatVersion: 1,
+      mappings: [
+        {
+          id: "mapping:timespec",
+          kind: "data",
+          sourceStart: "0x700000000000",
+          sourceEnd: "0x700000001000",
+          sizeBytes: 4096,
+          permissions: { read: true, write: true, execute: false, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x500000001000" },
+        },
+      ],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    threads: {
+      formatVersion: 1,
+      threads: [activeThread],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    resources: {
+      formatVersion: 1,
+      resources: [],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+    translation: {
+      formatVersion: 1,
+      mode: "native-cross-isa",
+      sourceArch: "arm64",
+      targetArch: "amd64",
+      codeLocations: [],
+      threads: [],
+      memoryRelocations: [],
+      refusals: { vocabularyVersion: 1, refusals: [] },
+    },
+  };
+}

--- a/packages/runtime/src/native-two-thread-boundary.ts
+++ b/packages/runtime/src/native-two-thread-boundary.ts
@@ -4,6 +4,8 @@ import type {
   NativeProcessResource,
   NativeThreadState,
 } from "./native-process-image.ts";
+import type { NativeActiveSyscallPolicyOptions } from "./native-active-syscall-policy.ts";
+import type { NativeSignalBlockedMaskPolicy } from "./native-signal-policy.ts";
 import {
   planNativeThreadRestoreBoundary,
   type NativeThreadRestorePlan,
@@ -30,6 +32,10 @@ export interface NativeControlledTwoThreadRestorePlanRequest {
   threads: NativeThreadState[];
   mappings: NativeMemoryMapping[];
   resources?: NativeProcessResource[];
+  activeSyscall?: NativeActiveSyscallPolicyOptions;
+  signal?: {
+    blockedMaskPolicy?: NativeSignalBlockedMaskPolicy;
+  };
 }
 
 export function planNativeControlledTwoThreadRestoreBoundary(
@@ -47,6 +53,8 @@ export function planNativeControlledTwoThreadRestoreBoundary(
       threads: [thread],
       mappings: request.mappings,
       resources: nonFutexResources(request.resources ?? []),
+      activeSyscall: request.activeSyscall,
+      signal: request.signal,
     }),
   );
   const threadRefusals = threadPlans.flatMap((plan) =>

--- a/scripts/native-target-vm-synthetic-continuation.ts
+++ b/scripts/native-target-vm-synthetic-continuation.ts
@@ -348,6 +348,7 @@ function targetVerifierResult(
     events.nativeExecutableMapping,
     events.nativeSignalRestore,
     events.nativeActiveSyscallRestore,
+    events.nativeThreadRestore,
   )
     ? "passed"
     : "failed";
@@ -453,6 +454,7 @@ function targetVerifierPassed(
   nativeExecutableMapping: TargetNativeConsumptionEvent | undefined,
   nativeSignalRestore: TargetNativeConsumptionEvent | undefined,
   nativeActiveSyscallRestore: TargetNativeConsumptionEvent | undefined,
+  nativeThreadRestore: TargetNativeConsumptionEvent | undefined,
 ): boolean {
   return [
     targetProcessCompleted(exitCode, descriptorGateCompleted),
@@ -469,6 +471,7 @@ function targetVerifierPassed(
       nativeExecutableMapping,
       nativeSignalRestore,
       nativeActiveSyscallRestore,
+      nativeThreadRestore,
     }),
     targetReturnValueMatched(args, actualResumeEvent),
   ].every(Boolean);

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -19,6 +19,7 @@ import type { NativeRealUtilityTargetModule } from "../packages/runtime/src/nati
 import { materializeNativeTargetModuleBytes } from "../packages/runtime/src/native-target-module-bytes.ts";
 import { matchNativeTargetUnwindFrame } from "../packages/runtime/src/native-target-unwind.ts";
 import { planNativeThreadRestoreBoundary } from "../packages/runtime/src/native-thread-restore-policy.ts";
+import { planNativeControlledTwoThreadRestoreBoundary } from "../packages/runtime/src/native-two-thread-boundary.ts";
 import { validatePortableMachineSnapshotBundle } from "../packages/runtime/src/portable-machine-snapshot.ts";
 import { planTargetGuestActiveSyscallRestore } from "../packages/runtime/src/target-guest-active-syscall-restore.ts";
 import { planTargetGuestMemoryMaterialization } from "../packages/runtime/src/target-guest-memory-materialization.ts";
@@ -28,6 +29,10 @@ import {
   type TargetGuestNativeRestoreStep,
   type TargetGuestTranslatedFrameDescriptor,
 } from "../packages/runtime/src/target-guest-restore-loader.ts";
+import {
+  planTargetGuestTwoThreadRestore,
+  type TargetGuestTwoThreadSpawnStep,
+} from "../packages/runtime/src/target-guest-two-thread-restore.ts";
 import { FINAL_JUMP_EXPECTED_RETURN, FINAL_JUMP_RETURN_MARKER } from "./native-final-jump-utils.ts";
 
 interface Args {
@@ -87,6 +92,7 @@ interface CombinedDescriptorContext extends CombinedDescriptorPaths {
     ReturnType<typeof planTargetGuestActiveSyscallRestore>,
     { state: "planned" }
   >["steps"];
+  targetThreadSpawnSteps: TargetGuestTwoThreadSpawnStep[];
 }
 
 interface PreparedTargetContinuation {
@@ -100,6 +106,23 @@ interface PreparedTargetContinuation {
   expectedReturnValue?: string;
   targetModuleBytesSource?: string;
 }
+
+type AcceptedThreadPlan = Extract<
+  ReturnType<typeof planNativeThreadRestoreBoundary>,
+  { state: "accepted" }
+>;
+type ActiveSyscallContinuations = AcceptedThreadPlan["activeSyscallContinuations"];
+
+type ProofThreadContext =
+  | {
+      state: "accepted";
+      threadId: string;
+      signalBlockedMasks: string[];
+      activeSyscallContinuations: ActiveSyscallContinuations;
+      threadSpawnSteps: TargetGuestTwoThreadSpawnStep[];
+      refusals: [];
+    }
+  | { state: "refused"; refusals: Array<{ code: string; message: string }> };
 
 const GUEST_CODE = "/tmp/machinen-target-bytes.bin";
 const GUEST_MEMORY = "/tmp/machinen-combined-native-memory.bin";
@@ -147,6 +170,8 @@ const RESUME_RFLAGS_MARKER = 0x52464c4147534f4bn;
 const TLS_RESTORE_MARKER = 0x544c534f4b504153n;
 const TLS_TCB_MARKER = 0x5443425041534f4bn;
 const TARGET_TLS_BASE = "0x600000000300";
+const TARGET_THREAD_STACK_BASES = ["0x530000000000", "0x530000020000"] as const;
+const TARGET_THREAD_STACK_LIMITS = ["0x530000010000", "0x530000030000"] as const;
 const RESUME_RFLAGS = "0x8d7";
 const RESUME_REGISTER_RAX = "0x2121212121212121";
 const RESUME_REGISTER_RDI = "0x7171717171717171";
@@ -357,9 +382,9 @@ function combinedDescriptorContext(
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): CombinedDescriptorContext | ReturnType<typeof planPortableMachineVmRestoreProof> {
   const bundle = validatePortableMachineSnapshotBundle(args.bundleDir!);
-  const threadPlan = proofThreadPlan(bundle);
-  if (threadPlan.state === "refused") {
-    return firstRefusedPlan(plan, threadPlan.refusals);
+  const threads = proofThreadContext(bundle);
+  if (threads.state === "refused") {
+    return firstRefusedPlan(plan, threads.refusals);
   }
   const memory = proofMemorySelection(bundle);
   if (!memory.mapping) {
@@ -369,16 +394,17 @@ function combinedDescriptorContext(
       "portable machine proof needs one safe captured writable memory page",
     );
   }
-  const activeSyscallPlan = proofActiveSyscallPlan(threadPlan.activeSyscallContinuations);
+  const activeSyscallPlan = proofActiveSyscallPlan(threads.activeSyscallContinuations);
   if (activeSyscallPlan.state === "refused") {
     return firstRefusedPlan(plan, activeSyscallPlan.refusals);
   }
   const context = {
     ...combinedDescriptorPaths(args, memory.file, memory.sizeBytes, memory.mapping),
-    targetThreadRestoreResult: threadPlan.state,
-    targetThreadRestoreThreadId: threadPlan.threadId,
-    targetSignalBlockedMasks: threadPlan.signalRestore.blockedMasks,
+    targetThreadRestoreResult: threads.state,
+    targetThreadRestoreThreadId: threads.threadId,
+    targetSignalBlockedMasks: threads.signalBlockedMasks,
     targetActiveSyscallSteps: activeSyscallPlan.steps,
+    targetThreadSpawnSteps: threads.threadSpawnSteps,
   };
   return contextAfterPathCheck(plan, bundle.rootDir!, context);
 }
@@ -392,19 +418,82 @@ function contextAfterPathCheck(
   return pathRefusal ? refusedPlan(plan, pathRefusal.code, pathRefusal.message) : context;
 }
 
-function proofThreadPlan(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
-  return planNativeThreadRestoreBoundary({
-    threads: bundle.nativeProcessImage.threads.threads,
+function proofThreadContext(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+): ProofThreadContext {
+  const threads = bundle.nativeProcessImage.threads.threads;
+  if (threads.length === 2) {
+    return proofTwoThreadContext(bundle);
+  }
+  const plan = planNativeThreadRestoreBoundary({
+    threads,
     mappings: bundle.nativeProcessImage.mappings.mappings,
     resources: bundle.nativeProcessImage.resources.resources,
     tls: { targetFsBase: TARGET_TLS_BASE, targetAccessPolicy: "target-tcb-materialized" },
-    activeSyscall: {
-      sleepTimerPolicy: "defer-target-resume",
-      pollTimeoutPolicy: "defer-target-resume",
-      pollTimeoutFdPolicy: "synthetic-timerfd",
-      documents: bundle.nativeProcessImage,
-    },
+    activeSyscall: activeSyscallPolicy(bundle),
   });
+  return plan.state === "accepted"
+    ? {
+        state: "accepted",
+        threadId: plan.threadId,
+        signalBlockedMasks: plan.signalRestore.blockedMasks,
+        activeSyscallContinuations: plan.activeSyscallContinuations,
+        threadSpawnSteps: [],
+        refusals: [],
+      }
+    : plan;
+}
+
+function proofTwoThreadContext(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+): ProofThreadContext {
+  const boundary = planNativeControlledTwoThreadRestoreBoundary({
+    threads: bundle.nativeProcessImage.threads.threads,
+    mappings: bundle.nativeProcessImage.mappings.mappings,
+    resources: bundle.nativeProcessImage.resources.resources,
+    activeSyscall: activeSyscallPolicy(bundle),
+  });
+  if (boundary.state === "refused") {
+    return boundary;
+  }
+  const spawnPlan = planTargetGuestTwoThreadRestore(
+    boundary,
+    proofTwoThreadBindings(boundary.threadIds),
+  );
+  if (spawnPlan.state === "refused") {
+    return spawnPlan;
+  }
+  return {
+    state: "accepted",
+    threadId: boundary.threadIds.join(","),
+    signalBlockedMasks: boundary.threadPlans[0].signalRestore.blockedMasks,
+    activeSyscallContinuations: boundary.threadPlans.flatMap(
+      (threadPlan) => threadPlan.activeSyscallContinuations,
+    ),
+    threadSpawnSteps: spawnPlan.steps,
+    refusals: [],
+  };
+}
+
+function activeSyscallPolicy(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
+  return {
+    sleepTimerPolicy: "defer-target-resume" as const,
+    pollTimeoutPolicy: "defer-target-resume" as const,
+    pollTimeoutFdPolicy: "synthetic-timerfd" as const,
+    documents: bundle.nativeProcessImage,
+  };
+}
+
+function proofTwoThreadBindings(threadIds: [string, string]) {
+  return threadIds.map((threadId, index) => ({
+    threadId,
+    stackBase: TARGET_THREAD_STACK_BASES[index],
+    stackLimit: TARGET_THREAD_STACK_LIMITS[index],
+    registers: {
+      rip: "0x700300000000",
+      rsp: TARGET_THREAD_STACK_LIMITS[index],
+    },
+  }));
 }
 
 function proofMemorySelection(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
@@ -507,6 +596,7 @@ function proofNativeRestoreSections(
     ...proofExecutableNativeSections(targetContinuation),
     ...proofSignalNativeSections(context),
     ...proofActiveSyscallNativeSections(context),
+    ...proofThreadSpawnNativeSections(context),
   ];
 }
 
@@ -635,6 +725,15 @@ function proofActiveSyscallNativeSections(
 ): TargetGuestNativeRestoreStep[] {
   return context.targetActiveSyscallSteps.map((step) => ({
     section: "active-syscall" as const,
+    step,
+  }));
+}
+
+function proofThreadSpawnNativeSections(
+  context: CombinedDescriptorContext,
+): TargetGuestNativeRestoreStep[] {
+  return context.targetThreadSpawnSteps.map((step) => ({
+    section: "thread-spawn" as const,
     step,
   }));
 }

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -296,15 +296,15 @@ capture_remote_native_process_bundle() {
   ssh "$ARM64_SSH" "rm -rf '$ARM64_REMOTE_WORK' && mkdir -p '$ARM64_REMOTE_WORK/repo' '$ARM64_REMOTE_WORK/capture/bundle' '$ARM64_REMOTE_WORK/bin'"
   tar -czf - -C "$ROOT" \
     packages/microvm/assets/native-process-capture.c \
-    packages/microvm/assets/native-ppoll-timeout-target.c | \
+    packages/microvm/assets/native-two-thread-ppoll-target.c | \
     ssh "$ARM64_SSH" "tar -xzf - -C '$ARM64_REMOTE_WORK/repo'"
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \
     tar -xzf - -C "$NATIVE_BUNDLE"
-  record_timing "capture" "ok" "$start" "remote arm64 ppoll native-process bundle captured from $ARM64_SSH"
+  record_timing "capture" "ok" "$start" "remote arm64 two-thread ppoll native-process bundle captured from $ARM64_SSH"
 }
 
 capture_native_process_bundle() {
@@ -378,7 +378,8 @@ process.exit(
   result.targetPrivateMemoryRestoreResult === 'passed' &&
   result.targetExecutableMappingResult === 'passed' &&
   result.targetSignalRestoreResult === 'passed' &&
-  (!remoteE2e || result.targetActiveSyscallRestoreResult === 'passed')
+  (!remoteE2e || result.targetActiveSyscallRestoreResult === 'passed') &&
+  (!remoteE2e || result.targetThreadRestoreResult === 'passed')
     ? 0
     : 1,
 );


### PR DESCRIPTION
## Problem

The portable VM proof could consume active syscalls end-to-end, but controlled thread-spawn restore was still only a focused loader/trampoline path. The remote proof did not require the thread restore marker, so it was not yet an “all native gates present” run.

## Solution

This PR adds a narrow two-thread ppoll capture target for remote smoke, lets the controlled two-thread boundary accept modeled active-syscall continuations while still refusing futex/rseq/general unsafe state, emits `native=thread-spawn` sections in the combined descriptor, and requires the remote smoke to report both active-syscall and thread restore as `passed`. The target verifier now treats failed native thread consumption as a verifier failure.

Fixes #693

## Validation

- `pnpm run build:docs` — 1.548s
- `pnpm run format:check` — 0.591s
- `pnpm run lint` — 0.222s
- `pnpm run typecheck` — 2.296s
- focused vitest — 2.964s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.077s
- `pnpm smoke-tests` — 2m12.724s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.401s
- remote arm64→amd64 all-gates proof — completed in 1m19.244s; target boot/restore 62.342s; active syscall, thread restore, stack, private memory, executable mapping, signal, TLS, frame/register/RFLAGS, return-chain, and resources all passed
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m12.969s, 2/2 passed
