### PR TITLE
Update roadmap after all-gates proof

### DIFF
--- a/docs/snapshot/native-cross-isa-proof-roadmap.md
+++ b/docs/snapshot/native-cross-isa-proof-roadmap.md
@@ -29,16 +29,19 @@ consumes native restore sections for stack windows, bounded return-chain writes,
 private memory, executable provenance checks, signal masks, modeled active
 syscall timer re-arm, and controlled thread-spawn steps before reporting success.
 
-The latest remote arm64→amd64 proof completed with a real amd64 utility
-continuation returning `0x4d` and passed state-consumption, fd/resource,
-return-chain, translated-frame, register, RFLAGS, TLS, stack-window,
-private-memory, executable-mapping, and signal restore gates. This is still a
-narrow completion proof, not arbitrary process or whole-machine migration.
+The latest remote arm64→amd64 proof captured a real two-thread arm64 source
+bundle with one thread blocked in a modeled `ppoll` timeout. The amd64 target VM
+completed through a real utility continuation returning `0x4d` and passed
+state-consumption, fd/resource, return-chain, translated-frame, register,
+RFLAGS, TLS, stack-window, private-memory, executable-mapping, signal restore,
+active-syscall re-arm, and controlled thread-spawn gates. This is still a narrow
+completion proof, not arbitrary process or whole-machine migration.
 
-The active frontier is expanding accepted real-process shapes through this target
+The active frontier is now broader real-process coverage through this target
 loader path while preserving exact refusals for unsupported kernel/user ABI
-state. Broad libc/vDSO/vvar materialization, arbitrary restart semantics,
-futex/rseq handoff, and general multithread restore remain deferred.
+state. More syscall/resource families should come before broad libc/vDSO/vvar,
+argv/env/auxv/cwd, arbitrary restart semantics, futex/rseq handoff, or general
+multithread restore claims.
 
 ## Ordered proof ladder
 
@@ -216,7 +219,7 @@ Done when:
 - the descriptor preserves no-source-text, no-source-ISA-emulation, and no-sidecar
   invariants.
 
-### 11. Threads, futexes, and rseq — controlled boundary started
+### 11. Threads, futexes, and rseq — controlled target proof done
 
 Goal: move from single-thread proofs to controlled multi-thread restore.
 
@@ -225,15 +228,33 @@ Done so far:
 - multi-thread state refuses precisely by default;
 - exactly two safe threads can be planned at the boundary;
 - controlled `thread-spawn` target sections are forwarded to the loader and
-  consumed by the amd64 trampoline as short-lived target tasks.
+  consumed by the amd64 trampoline as short-lived target tasks;
+- the remote portable-machine proof captures a real two-thread arm64 source
+  bundle and requires `targetThreadRestoreResult=passed` alongside the other
+  native gates.
 
 Still future work:
 
-- connect a real two-thread portable bundle/proof case to those target steps;
 - model or refuse futex wait/wake and rseq with exact blockers before claiming
-  general multithread restore.
+  general multithread restore;
+- preserve exact refusals for scheduler-visible state beyond the controlled
+  two-thread proof.
 
-### 12. Full transparent restore claim
+### 12. Broader real-process coverage
+
+Goal: widen the constrained class of accepted native cross-ISA Linux processes
+without relaxing the all-gates success contract.
+
+Next steps:
+
+- add more real resource/syscall families with explicit target recipes;
+- model argv/env/auxv/cwd handoff as target-side state;
+- expand private target memory only when provenance, permissions, guards, and
+  pointer ownership are explicit;
+- revisit target libc/vDSO/vvar data dependencies after those narrower families
+  provide comparison points.
+
+### 13. Full transparent restore claim
 
 Goal: claim native cross-ISA live process migration for a constrained class of
 real Linux processes.

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -31,24 +31,27 @@ completion is reported:
 | active syscall             | arms target-side timerfds for modeled sleep/ppoll timeout continuations                                    |
 | controlled thread spawn    | maps requested stacks and consumes narrow spawn steps with short-lived target tasks                        |
 
-The latest remote arm64→amd64 proof completed with native target execution and
-passed stack, private-memory, executable, signal, register, frame, RFLAGS, TLS,
-state-consumption, and return-chain gates.
+The latest remote arm64→amd64 proof completed with native target execution from
+a two-thread arm64 `ppoll` source bundle. It passed stack, private-memory,
+executable, signal, active-syscall, controlled thread-spawn, register, frame,
+RFLAGS, TLS, state-consumption, fd/resource, and return-chain gates.
 
 ## Remaining frontier
 
 The next work should expand _accepted process shapes_, not relax the success
 criteria. Good next issues are:
 
-1. Feed modeled active-syscall continuations from captured real processes into
-   the combined portable VM proof so `targetActiveSyscallRestoreResult=passed`
-   appears in an end-to-end VM run, not only focused trampoline proof.
-2. Connect controlled two-thread planner output to a real two-thread portable
-   bundle/proof case while continuing to refuse futex/rseq/general scheduler
-   state.
-3. Broaden private target memory coverage only where provenance, permissions,
-   guards, and TLS/vDSO/libc dependencies are explicit.
-4. Keep expanding real utility coverage one resource/syscall family at a time.
+1. Add more real resource/syscall families one at a time, starting with cases
+   whose target fd/resource recipes can be proven without readiness ambiguity.
+2. Broaden private target memory coverage only where provenance, permissions,
+   guards, and pointer ownership are explicit.
+3. Model argv/env/auxv/cwd handoff as target-side state, with precise refusals
+   for malformed or source-only dependencies.
+4. Revisit target libc/vDSO/vvar data dependencies after the syscall/resource
+   cases provide comparison points for what must be materialized versus refused.
+5. Keep futex wait handoff, rseq, arbitrary signal restart, JIT/native code
+   migration, and general scheduler state refused until their kernel/user ABI
+   contracts are modeled.
 
 ## Deferred frontier
 

--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -191,5 +191,5 @@ Latest remote arm64→amd64 proof after native target-loader consumption hardeni
 - `targetSignalRestoreResult=passed`
 - `targetActiveSyscallRestoreResult=passed`
 - `targetThreadRestoreResult=passed`
-- wall time: 37.018s
-- target VM boot/restore: 20.125s
+- wall time: 1m19.244s
+- target VM boot/restore: 62.342s


### PR DESCRIPTION
## Problem

The roadmap still described active-syscall VM wiring and real two-thread VM proof as next steps, even though the latest remote proof now has those gates present and passed.

## Solution

This PR updates the docs to mark the all-gates remote proof as the current proven point and moves the frontier to broader real-process coverage: more resource/syscall families first, then carefully modeled argv/env/auxv/cwd and libc/vDSO/vvar dependencies.

Fixes #695

## Validation

- `pnpm run build:docs` — 1.649s
- `pnpm run format:check` — 0.547s
- `pnpm run lint` — 0.216s
- `pnpm run typecheck` — 2.364s
- focused docs/smoke vitest — 3.088s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.833s
- `pnpm smoke-tests` — 2m13.533s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.367s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m12.883s, 2/2 passed
