### PR TITLE
Add eventfd read active syscall proof

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -80,22 +80,27 @@ migration. Missing fd resources, wrong resource kinds, unsupported flags or
 state, wrong events, non-empty `revents`, `nfds > 1`, and non-null signal masks
 all fail closed as `target-ppoll-timeout-missing`.
 
-## Explicit pipe read deferral
+## Explicit fd read deferral
 
-The `fdReadPolicy: "defer-target-resume"` option currently accepts only a
-positive-count `read(fd, buf, count)` from a captured pipe read end under
-`fdReadResourcePolicy: "synthetic-empty-pipe"`. The model requires:
+The `fdReadPolicy: "defer-target-resume"` option currently accepts only narrow
+blocking `read(fd, buf, count)` cases under an explicit fd resource policy. Every
+modeled read requires captured syscall arguments from `/proc/<tid>/syscall` or
+source registers and a non-null buffer range contained in captured writable
+non-executable memory.
 
-- captured syscall arguments from `/proc/<tid>/syscall` or source registers;
-- a non-null buffer range contained in captured writable non-executable memory;
-- a captured pipe read-end resource for `fd`;
-- a paired pipe write end with the same pipe id still open, so the read is not an
-  EOF/readiness ambiguity.
+With `fdReadResourcePolicy: "synthetic-empty-pipe"`, the model additionally
+requires a captured pipe read-end resource for `fd` and a paired pipe write end
+with the same pipe id still open, so the read is not an EOF/readiness ambiguity.
 
-The target step recreates a fresh empty pipe and verifies with target-side
-`poll(POLLIN, timeout=0)` that the read fd would still block before reporting
-`nativeActiveSyscallRestore.status=passed`. Missing arguments, zero counts,
-missing writable buffer state, wrong resource kind/access, and missing paired
+With `fdReadResourcePolicy: "synthetic-empty-eventfd"`, the model requires a
+captured eventfd with supported read/write flags, counter `0`, non-semaphore
+mode, and `count >= 8`.
+
+The target step recreates a fresh empty pipe or empty eventfd and verifies with
+target-side `poll(POLLIN, timeout=0)` that the read fd would still block before
+reporting `nativeActiveSyscallRestore.status=passed`. Missing arguments, zero or
+short counts, missing writable buffer state, wrong resource kind/access,
+non-empty eventfds, semaphore mode, unsupported flags, and missing paired pipe
 write ends fail closed as `target-fd-read-state-missing`.
 
 ## Proof

--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -195,7 +195,8 @@ Latest default remote arm64→amd64 proof after native target-loader consumption
 - target VM boot/restore: 62.342s
 
 The same smoke script can set `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read`
-to capture a single-thread arm64 process blocked in `read` on an empty pipe. The
-pipe-read profile requires `targetActiveSyscallRestoreResult=passed` and keeps
-the existing native target-loader gates enabled, but does not require the
-controlled two-thread marker because no thread-spawn section is present.
+or `eventfd-read` to capture a single-thread arm64 process blocked in `read` on
+an empty pipe or eventfd. These fd-read profiles require
+`targetActiveSyscallRestoreResult=passed` and keep the existing native
+target-loader gates enabled, but do not require the controlled two-thread marker
+because no thread-spawn section is present.

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -19,8 +19,9 @@ state, and unsupported fd state continue to fail closed before target re-arm.
 The target amd64 trampoline now executes these sections by creating and arming a
 short-lived target-side timerfd for each `rearm-sleep-timer` or
 `rearm-ppoll-timeout` step before entering the restored continuation. For
-`restore-fd-read-block`, it recreates the target pipe read fd and verifies the fd
-would still block with a zero-timeout `poll(POLLIN)`. The trampoline reports
+`restore-fd-read-block`, it recreates the target pipe or eventfd read fd and
+verifies the fd would still block with a zero-timeout `poll(POLLIN)`. The
+trampoline reports
 `nativeActiveSyscallRestore.status=passed` only when every step was parsed,
 validated, and consumed; malformed durations, unknown actions, wrong resume
 modes, unsupported sleep syscall names, unsupported `ppoll` resource shapes, and
@@ -28,8 +29,9 @@ read fds that are ready/EOF/invalid exit before target success.
 
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
-`PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read`, a real arm64 process blocked
-in `read` on an empty pipe. It wraps that bundle in a portable machine snapshot,
+`PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read`, a real arm64
+process blocked in `read` on an empty pipe/eventfd. It wraps that bundle in a
+portable machine snapshot,
 serializes a `native=active-syscall` section in the combined target descriptor,
 and requires `targetActiveSyscallRestoreResult=passed` before the remote
 arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer memory

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1506,6 +1506,12 @@ static void restore_native_fd_read_block(const char *spec, struct NativeActiveSy
   }
   if (streq(resource, "synthetic-empty-pipe-read-end")) {
     install_synthetic_empty_pipe((int)fd, -1);
+  } else if (streq(resource, "synthetic-empty-eventfd")) {
+    if (count_bytes < 8u) {
+      fprintf(stderr, "native-actual-resume-trampoline: native eventfd read count is unsupported\n");
+      exit(2);
+    }
+    install_synthetic_empty_eventfd((int)fd);
   } else {
     fprintf(stderr, "native-actual-resume-trampoline: native fd read resource is unsupported\n");
     exit(2);

--- a/packages/microvm/assets/native-eventfd-read-target.c
+++ b/packages/microvm/assets/native-eventfd-read-target.c
@@ -1,0 +1,77 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define TARGET_EVENT_FD 34
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+int main(void) {
+  int fd = eventfd(0, EFD_CLOEXEC);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-eventfd-read-target: eventfd: %s\n", strerror(errno));
+    return 1;
+  }
+  if (fd != TARGET_EVENT_FD) {
+    if (dup2(fd, TARGET_EVENT_FD) < 0) {
+      fprintf(stderr, "machinen-eventfd-read-target: dup2: %s\n", strerror(errno));
+      return 1;
+    }
+    close(fd);
+  }
+
+  clear_simd_fpu_state();
+  uint64_t value = 0;
+  long rc = syscall(SYS_read, TARGET_EVENT_FD, &value, sizeof(value));
+  if (rc < 0) {
+    fprintf(stderr, "machinen-eventfd-read-target: read: %s\n", strerror(errno));
+  }
+  return 0;
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2655,7 +2655,7 @@ by default when `output` is a TTY.
 
 ##### fdReadResourcePolicy?
 
-> `optional` **fdReadResourcePolicy?**: `"synthetic-empty-pipe"`
+> `optional` **fdReadResourcePolicy?**: [`NativeFdReadResourcePolicy`](#nativefdreadresourcepolicy)
 
 ##### documents?
 
@@ -2924,13 +2924,13 @@ by default when `output` is a TTY.
 
 > **resourceId**: `string`
 
-##### pairedWriteResourceId
+##### pairedWriteResourceId?
 
-> **pairedWriteResourceId**: `string`
+> `optional` **pairedWriteResourceId?**: `string`
 
 ##### targetResource
 
-> **targetResource**: `"synthetic-empty-pipe-read-end"`
+> **targetResource**: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource)
 
 ***
 
@@ -13097,7 +13097,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeFdReadResourcePolicy
 
-> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"`
+> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"` \| `"synthetic-empty-eventfd"`
 
 ***
 
@@ -13109,7 +13109,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeModeledFdReadTargetResource
 
-> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"`
+> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-eventfd"`
 
 ***
 
@@ -15795,7 +15795,7 @@ available.
 
 ##### resourcePolicy?
 
-`"synthetic-empty-pipe"` = `"synthetic-empty-pipe"`
+[`NativeFdReadResourcePolicy`](#nativefdreadresourcepolicy) = `"synthetic-empty-pipe"`
 
 #### Returns
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -155,8 +155,9 @@ function documentsWithReadPipe(
   options: {
     readFd?: number;
     writeFd?: number;
-    readKind?: "pipe" | "file" | "socket";
+    readKind?: "pipe" | "file" | "socket" | "eventfd";
     readFlags?: string[];
+    readRecipe?: Record<string, unknown>;
     includeWriteEnd?: boolean;
     writableBuffer?: boolean;
   } = {},
@@ -172,8 +173,9 @@ function documentsWithReadPipe(
       kind: options.readKind ?? "pipe",
       state: "refused",
       fd: readFd,
-      path: "pipe:[321]",
+      path: options.readKind === "eventfd" ? "anon_inode:[eventfd]" : "pipe:[321]",
       flags: options.readFlags ?? ["octal:0"],
+      recipe: options.readRecipe,
     },
     ...(options.includeWriteEnd === false
       ? []
@@ -189,6 +191,33 @@ function documentsWithReadPipe(
         ]),
   ];
   return documents;
+}
+
+function documentsWithReadEventfd(
+  activeThread: NativeThreadState,
+  options: {
+    readFd?: number;
+    flags?: string[];
+    recipe?: Record<string, unknown>;
+    countBytes?: string;
+  } = {},
+): NativeProcessImageDocuments {
+  if (options.countBytes) {
+    activeThread.sourceRegisters = {
+      ...activeThread.sourceRegisters,
+      x:
+        activeThread.sourceRegisters.arch === "arm64"
+          ? ["0x22", "0x3100", options.countBytes, "0x0", "0x0", "0x0"]
+          : [],
+    } as NativeThreadState["sourceRegisters"];
+  }
+  return documentsWithReadPipe(activeThread, {
+    readFd: options.readFd ?? 34,
+    readKind: "eventfd",
+    readFlags: options.flags ?? ["octal:2000002"],
+    readRecipe: options.recipe ?? { eventfdCount: "0x0", eventfdSemaphore: 0 },
+    includeWriteEnd: false,
+  });
 }
 
 function emptyRefusals() {
@@ -843,6 +872,30 @@ describe("native active syscall classification", () => {
     expect(result.classifications[0]).toMatchObject({ class: "fd-blocking", resumable: false });
   });
 
+  it("models a blocked read from an empty eventfd", () => {
+    const activeThread = arm64ReadThread(["0x22", "0x3100", "0x8", "0x0", "0x0", "0x0"]);
+    const documents = documentsWithReadEventfd(activeThread);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdReadPolicy: "defer-target-resume",
+      fdReadResourcePolicy: "synthetic-empty-eventfd",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdRead: {
+          fd: 34,
+          countBytes: 8,
+          resourceId: "fd:34:read",
+          targetResource: "synthetic-empty-eventfd",
+        },
+        policy: "conservative-target-fd-read-block-preserved",
+      },
+    });
+  });
+
   it("prefers /proc syscall arguments for modeled read", () => {
     const activeThread = arm64ReadThread();
     activeThread.syscall.arguments = ["0x20", "0x3100", "0x1", "0x0", "0x0", "0x0"];
@@ -898,6 +951,56 @@ describe("native active syscall classification", () => {
       : documentsWithReadPipe(scenario.thread);
 
     expect(modelNativeFdReadState(scenario.thread, documents)).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-read-state-missing",
+        detail: { reason: scenario.reason },
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "short eventfd read",
+      thread: arm64ReadThread(["0x22", "0x3100", "0x4", "0x0", "0x0", "0x0"]),
+      reason: "read eventfd proof requires count >= 8",
+    },
+    {
+      name: "non-eventfd resource",
+      thread: arm64ReadThread(["0x22", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadPipe(thread, { readFd: 34, readKind: "pipe" }),
+      reason: "read proof requires a captured eventfd fd",
+    },
+    {
+      name: "non-empty counter",
+      thread: arm64ReadThread(["0x22", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadEventfd(thread, { recipe: { eventfdCount: "0x1", eventfdSemaphore: 0 } }),
+      reason: "read eventfd proof requires an empty eventfd",
+    },
+    {
+      name: "semaphore mode",
+      thread: arm64ReadThread(["0x22", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadEventfd(thread, { recipe: { eventfdCount: "0x0", eventfdSemaphore: 1 } }),
+      reason: "read eventfd proof does not model semaphore mode",
+    },
+    {
+      name: "unsupported flags",
+      thread: arm64ReadThread(["0x22", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadEventfd(thread, { flags: ["octal:2004002"] }),
+      reason: "read eventfd proof requires supported flags",
+    },
+  ])("refuses unsafe eventfd read state: $name", (scenario) => {
+    const documents = scenario.documents
+      ? scenario.documents(scenario.thread)
+      : documentsWithReadEventfd(scenario.thread);
+
+    expect(
+      modelNativeFdReadState(scenario.thread, documents, "synthetic-empty-eventfd"),
+    ).toMatchObject({
       state: "missing",
       refusal: {
         code: "target-fd-read-state-missing",

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -126,6 +126,8 @@ describe("native actual resume trampoline", () => {
           "action=rearm-ppoll-timeout;threadId=thread:1;seconds=0;nanoseconds=1000000;resumeMode=defer-target-resume;nfds=1;resources=synthetic-empty-eventfd",
           "--native-active-syscall-step",
           "action=restore-fd-read-block;threadId=thread:1;fd=32;countBytes=1;resource=synthetic-empty-pipe-read-end;resumeMode=defer-target-resume",
+          "--native-active-syscall-step",
+          "action=restore-fd-read-block;threadId=thread:1;fd=34;countBytes=8;resource=synthetic-empty-eventfd;resumeMode=defer-target-resume",
           "--native-thread-spawn-step",
           "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x710000001000;rsp=0x530000010000",
         ]),
@@ -145,9 +147,9 @@ describe("native actual resume trampoline", () => {
         },
         nativeActiveSyscallRestore: {
           status: "passed",
-          stepCount: 3,
+          stepCount: 4,
           armedCount: 2,
-          consumedCount: 3,
+          consumedCount: 4,
         },
         nativeThreadRestore: { status: "passed", stepCount: 1, spawnedCount: 1 },
       });

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -28,7 +28,7 @@ export type NativePollTimeoutFdPolicy =
   | "synthetic-empty-eventfd"
   | "synthetic-timerfd";
 export type NativeFdReadPolicy = "refuse" | "defer-target-resume";
-export type NativeFdReadResourcePolicy = "synthetic-empty-pipe";
+export type NativeFdReadResourcePolicy = "synthetic-empty-pipe" | "synthetic-empty-eventfd";
 
 export interface NativeActiveSyscallPolicyOptions {
   sleepTimerPolicy?: NativeSleepTimerSyscallPolicy;
@@ -98,7 +98,9 @@ export interface NativeModeledPpollTimeoutState {
   remainingTime: NativeModeledPpollTimeoutRemainingTime;
 }
 
-export type NativeModeledFdReadTargetResource = "synthetic-empty-pipe-read-end";
+export type NativeModeledFdReadTargetResource =
+  | "synthetic-empty-pipe-read-end"
+  | "synthetic-empty-eventfd";
 
 export interface NativeModeledFdReadState {
   kind: "fd-read-block";
@@ -109,7 +111,7 @@ export interface NativeModeledFdReadState {
   countBytes: number;
   bufferMapping: string;
   resourceId: string;
-  pairedWriteResourceId: string;
+  pairedWriteResourceId?: string;
   targetResource: NativeModeledFdReadTargetResource;
 }
 
@@ -205,6 +207,7 @@ const TIMESPEC_SIZE_BYTES = 16n;
 const POLLFD_SIZE_BYTES = 8n;
 const POLLIN = 0x1;
 const SUPPORTED_EMPTY_EVENTFD_FLAGS = 0o2000002;
+const SUPPORTED_EVENTFD_READ_FLAGS = new Set([0o2, SUPPORTED_EMPTY_EVENTFD_FLAGS]);
 const SUPPORTED_TIMERFD_FLAGS = 0o2000002;
 const MAX_SIGNED_I64 = 0x7fff_ffff_ffff_ffffn;
 const MAX_NANOSECONDS = 999_999_999n;
@@ -621,13 +624,17 @@ function decodeFdReadArguments(
   if ("state" in resource) {
     return resource;
   }
+  const countRefusal = validateFdReadResourceCount(thread, values, resource.targetResource);
+  if (countRefusal) {
+    return countRefusal;
+  }
   return {
     fd: values.fd,
     bufferPointer: hex(values.bufferPointer),
     countBytes: values.countBytes,
     bufferMapping: bufferMapping.id,
     resourceId: resource.resource.id,
-    pairedWriteResourceId: resource.pairedWriteResource.id,
+    pairedWriteResourceId: resource.pairedWriteResource?.id,
     targetResource: resource.targetResource,
   };
 }
@@ -704,6 +711,20 @@ function validateFdReadBuffer(
         countBytes: values.countBytes,
         argumentSource: args.source,
       });
+}
+
+function validateFdReadResourceCount(
+  thread: NativeThreadState,
+  values: FdReadArgumentValues,
+  targetResource: NativeModeledFdReadTargetResource,
+): { state: "missing"; refusal: NativeProcessImageRefusal } | undefined {
+  return targetResource === "synthetic-empty-eventfd" && values.countBytes < 8
+    ? missingFdRead(thread, "read eventfd proof requires count >= 8", {
+        fd: values.fd,
+        countBytes: values.countBytes,
+        targetResource,
+      })
+    : undefined;
 }
 
 function ppollArgumentValues(args: SleepTimerArguments): PpollArgumentValues {
@@ -981,16 +1002,26 @@ function validateFdReadModeledResource(
 ):
   | {
       resource: NativeProcessResource;
-      pairedWriteResource: NativeProcessResource;
+      pairedWriteResource?: NativeProcessResource;
       targetResource: NativeModeledFdReadTargetResource;
     }
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  if (resourcePolicy !== "synthetic-empty-pipe") {
-    return missingFdRead(thread, "read fd resource policy is not supported", {
-      fd,
-      resourcePolicy,
-    });
-  }
+  return resourcePolicy === "synthetic-empty-eventfd"
+    ? validateFdReadEventfdResource(thread, documents, fd)
+    : validateFdReadPipeResource(thread, documents, fd);
+}
+
+function validateFdReadPipeResource(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments,
+  fd: number,
+):
+  | {
+      resource: NativeProcessResource;
+      pairedWriteResource: NativeProcessResource;
+      targetResource: "synthetic-empty-pipe-read-end";
+    }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
   const resource = documents.resources.resources.find((candidate) => candidate.fd === fd);
   if (resource?.kind !== "pipe") {
     return missingFdRead(thread, "read proof requires a captured pipe fd", {
@@ -1020,6 +1051,66 @@ function validateFdReadModeledResource(
         resourceId: resource.id,
         pipeId: resource.path,
       });
+}
+
+function validateFdReadEventfdResource(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments,
+  fd: number,
+):
+  | { resource: NativeProcessResource; targetResource: "synthetic-empty-eventfd" }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const resource = documents.resources.resources.find((candidate) => candidate.fd === fd);
+  if (resource?.kind !== "eventfd") {
+    return missingFdRead(thread, "read proof requires a captured eventfd fd", {
+      fd,
+      resourceKind: resource?.kind,
+      resourceId: resource?.id,
+    });
+  }
+  const eventfdRefusal = validateFdReadEventfdState(thread, fd, resource);
+  return eventfdRefusal ?? { resource, targetResource: "synthetic-empty-eventfd" };
+}
+
+function validateFdReadEventfdState(
+  thread: NativeThreadState,
+  fd: number,
+  resource: NativeProcessResource,
+): { state: "missing"; refusal: NativeProcessImageRefusal } | undefined {
+  if (nativeFdAccessMode(resource.flags) !== 2) {
+    return missingFdRead(thread, "read eventfd proof requires read/write access", {
+      fd,
+      resourceId: resource.id,
+      resourceFlags: resource.flags,
+    });
+  }
+  if (!SUPPORTED_EVENTFD_READ_FLAGS.has(nativeFdFlagBits(resource.flags))) {
+    return missingFdRead(thread, "read eventfd proof requires supported flags", {
+      fd,
+      resourceId: resource.id,
+      resourceFlags: resource.flags,
+      supportedFlags: Array.from(
+        SUPPORTED_EVENTFD_READ_FLAGS,
+        (flags) => `octal:${flags.toString(8)}`,
+      ),
+    });
+  }
+  const eventfdCount = nativeResourceBigInt(resource, "eventfdCount");
+  if (eventfdCount !== 0n) {
+    return missingFdRead(thread, "read eventfd proof requires an empty eventfd", {
+      fd,
+      resourceId: resource.id,
+      eventfdCount: eventfdCount?.toString(10),
+    });
+  }
+  const eventfdSemaphore = nativeResourceBigInt(resource, "eventfdSemaphore");
+  return eventfdSemaphore !== 0n
+    ? missingFdRead(thread, "read eventfd proof does not model semaphore mode", {
+        fd,
+        resourceId: resource.id,
+        eventfdSemaphore: eventfdSemaphore?.toString(10),
+      })
+    : undefined;
 }
 
 function validatePpollEventfdResource(

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -1086,7 +1086,10 @@ function validateActiveSyscallRestoreStep(step: TargetGuestActiveSyscallRestoreS
   if (step.action === "restore-fd-read-block") {
     assertFd(step.fd, "fd");
     assertPositive(step.countBytes, "countBytes");
-    if (step.resource !== "synthetic-empty-pipe-read-end") {
+    if (
+      step.resource !== "synthetic-empty-pipe-read-end" &&
+      step.resource !== "synthetic-empty-eventfd"
+    ) {
       fail("target-guest-loader-invalid-continuation", "fd read resource is unsupported");
     }
     return;

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -481,9 +481,48 @@ function activeSyscallPolicy(bundle: ReturnType<typeof validatePortableMachineSn
     pollTimeoutPolicy: "defer-target-resume" as const,
     pollTimeoutFdPolicy: "synthetic-timerfd" as const,
     fdReadPolicy: "defer-target-resume" as const,
-    fdReadResourcePolicy: "synthetic-empty-pipe" as const,
+    fdReadResourcePolicy: fdReadResourcePolicy(bundle),
     documents: bundle.nativeProcessImage,
   };
+}
+
+function fdReadResourcePolicy(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+): "synthetic-empty-pipe" | "synthetic-empty-eventfd" {
+  const thread = bundle.nativeProcessImage.threads.threads.find(
+    (candidate) =>
+      candidate.syscall.state === "inside-syscall" && candidate.syscall.name === "read",
+  );
+  const fd = thread ? activeReadFd(thread) : undefined;
+  const resource = bundle.nativeProcessImage.resources.resources.find(
+    (candidate) => candidate.fd === fd,
+  );
+  return resource?.kind === "eventfd" ? "synthetic-empty-eventfd" : "synthetic-empty-pipe";
+}
+
+function activeReadFd(
+  thread: ReturnType<
+    typeof validatePortableMachineSnapshotBundle
+  >["nativeProcessImage"]["threads"]["threads"][number],
+): number | undefined {
+  const raw = thread.syscall.arguments?.[0] ?? activeReadRegisterFd(thread);
+  return raw === undefined ? undefined : safeBigIntNumber(raw);
+}
+
+function activeReadRegisterFd(
+  thread: ReturnType<
+    typeof validatePortableMachineSnapshotBundle
+  >["nativeProcessImage"]["threads"]["threads"][number],
+): string | undefined {
+  return thread.sourceRegisters.arch === "arm64" ? thread.sourceRegisters.x[0] : undefined;
+}
+
+function safeBigIntNumber(value: string): number | undefined {
+  try {
+    return Number(BigInt(value));
+  } catch {
+    return undefined;
+  }
 }
 
 function proofTwoThreadBindings(threadIds: [string, string]) {

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -298,6 +298,7 @@ capture_remote_native_process_bundle() {
   ssh "$ARM64_SSH" "rm -rf '$ARM64_REMOTE_WORK' && mkdir -p '$ARM64_REMOTE_WORK/repo' '$ARM64_REMOTE_WORK/capture/bundle' '$ARM64_REMOTE_WORK/bin'"
   tar -czf - -C "$ROOT" \
     packages/microvm/assets/native-process-capture.c \
+    packages/microvm/assets/native-eventfd-read-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
     packages/microvm/assets/native-two-thread-ppoll-target.c | \
     ssh "$ARM64_SSH" "tar -xzf - -C '$ARM64_REMOTE_WORK/repo'"
@@ -311,12 +312,16 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
       target_detail="remote arm64 pipe read native-process bundle captured from $ARM64_SSH"
       ;;
+    eventfd-read)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target"
+      target_detail="remote arm64 eventfd read native-process bundle captured from $ARM64_SSH"
+      ;;
     *)
       finish_failure "unsupported PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=$REMOTE_SOURCE_TARGET"
       ;;
   esac
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \


### PR DESCRIPTION
## Problem

Pipe reads were modeled, but `read` on an empty eventfd still failed closed even when the eventfd state was safe and unambiguous.

## Solution

This PR extends fd-read modeling to empty eventfds. It accepts only supported read/write eventfd flags, counter `0`, non-semaphore mode, and `count >= 8`. The target active-syscall step recreates an empty eventfd and verifies the fd would still block before reporting native consumption. Remote smoke can now use `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=eventfd-read`.

Fixes #699

## Validation

- `pnpm run build:docs` — 1.622s
- `pnpm run format:check` — 0.534s
- `pnpm run lint` — 0.223s
- `pnpm run typecheck` — 2.321s
- focused vitest — 3.100s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.118s
- `pnpm smoke-tests` — 2m12.092s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.347s
- remote eventfd-read arm64→amd64 proof — 36.116s; target boot/restore 19.180s; `targetActiveSyscallRestoreResult=passed`
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m9.050s, 2/2 passed
