### PR TITLE
Add timerfd read active syscall proof

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -96,12 +96,19 @@ With `fdReadResourcePolicy: "synthetic-empty-eventfd"`, the model requires a
 captured eventfd with supported read/write flags, counter `0`, non-semaphore
 mode, and `count >= 8`.
 
-The target step recreates a fresh empty pipe or empty eventfd and verifies with
-target-side `poll(POLLIN, timeout=0)` that the read fd would still block before
-reporting `nativeActiveSyscallRestore.status=passed`. Missing arguments, zero or
-short counts, missing writable buffer state, wrong resource kind/access,
-non-empty eventfds, semaphore mode, unsupported flags, and missing paired pipe
-write ends fail closed as `target-fd-read-state-missing`.
+With `fdReadResourcePolicy: "synthetic-timerfd"`, the model requires a captured
+timerfd with supported read/write flags, `count >= 8`, unread `ticks == 0`,
+non-periodic interval, and relative settime state. When captured fdinfo reports a
+non-zero remaining timer value, the target step carries that duration so the
+trampoline can arm the target timerfd before verifying it still blocks.
+
+The target step recreates a fresh empty pipe, empty eventfd, or timerfd and
+verifies with target-side `poll(POLLIN, timeout=0)` that the read fd would still
+block before reporting `nativeActiveSyscallRestore.status=passed`. Missing
+arguments, zero or short counts, missing writable buffer state, wrong resource
+kind/access, non-empty eventfds, semaphore mode, unsupported flags, expired or
+periodic timerfds, absolute timerfd state, and missing paired pipe write ends
+fail closed as `target-fd-read-state-missing`.
 
 ## Proof
 

--- a/docs/snapshot/portable-machine-vm-restore-proof.md
+++ b/docs/snapshot/portable-machine-vm-restore-proof.md
@@ -195,8 +195,8 @@ Latest default remote arm64→amd64 proof after native target-loader consumption
 - target VM boot/restore: 62.342s
 
 The same smoke script can set `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read`
-or `eventfd-read` to capture a single-thread arm64 process blocked in `read` on
-an empty pipe or eventfd. These fd-read profiles require
+`eventfd-read`, or `timerfd-read` to capture a single-thread arm64 process
+blocked in `read` on an empty pipe, eventfd, or timerfd. These fd-read profiles require
 `targetActiveSyscallRestoreResult=passed` and keep the existing native
 target-loader gates enabled, but do not require the controlled two-thread marker
 because no thread-spawn section is present.

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -19,9 +19,10 @@ state, and unsupported fd state continue to fail closed before target re-arm.
 The target amd64 trampoline now executes these sections by creating and arming a
 short-lived target-side timerfd for each `rearm-sleep-timer` or
 `rearm-ppoll-timeout` step before entering the restored continuation. For
-`restore-fd-read-block`, it recreates the target pipe or eventfd read fd and
-verifies the fd would still block with a zero-timeout `poll(POLLIN)`. The
-trampoline reports
+`restore-fd-read-block`, it recreates the target pipe, eventfd, or timerfd read
+fd. Timerfd read steps arm the target timer when modeled remaining time is
+present. The trampoline then verifies the fd would still block with a
+zero-timeout `poll(POLLIN)`. The trampoline reports
 `nativeActiveSyscallRestore.status=passed` only when every step was parsed,
 validated, and consumed; malformed durations, unknown actions, wrong resume
 modes, unsupported sleep syscall names, unsupported `ppoll` resource shapes, and
@@ -29,9 +30,9 @@ read fds that are ready/EOF/invalid exit before target success.
 
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
-`PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read`, a real arm64
-process blocked in `read` on an empty pipe/eventfd. It wraps that bundle in a
-portable machine snapshot,
+`PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read` /
+`timerfd-read`, a real arm64 process blocked in `read` on an empty pipe, eventfd,
+or timerfd. It wraps that bundle in a portable machine snapshot,
 serializes a `native=active-syscall` section in the combined target descriptor,
 and requires `targetActiveSyscallRestoreResult=passed` before the remote
 arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer memory

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -1512,6 +1512,19 @@ static void restore_native_fd_read_block(const char *spec, struct NativeActiveSy
       exit(2);
     }
     install_synthetic_empty_eventfd((int)fd);
+  } else if (streq(resource, "synthetic-timerfd")) {
+    if (count_bytes < 8u) {
+      fprintf(stderr, "native-actual-resume-trampoline: native timerfd read count is unsupported\n");
+      exit(2);
+    }
+    install_synthetic_timerfd((int)fd);
+    if (native_step_has_value(spec, "seconds")) {
+      struct itimerspec timer = native_active_timer_spec(spec, "active-syscall");
+      if (timerfd_settime((int)fd, 0, &timer, NULL) != 0) {
+        fprintf(stderr, "native-actual-resume-trampoline: native timerfd read arm failed: %s\n", strerror(errno));
+        exit(1);
+      }
+    }
   } else {
     fprintf(stderr, "native-actual-resume-trampoline: native fd read resource is unsupported\n");
     exit(2);

--- a/packages/microvm/assets/native-timerfd-read-target.c
+++ b/packages/microvm/assets/native-timerfd-read-target.c
@@ -1,0 +1,85 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+#define TARGET_TIMER_FD 36
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+int main(void) {
+  int fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-timerfd-read-target: timerfd_create: %s\n", strerror(errno));
+    return 1;
+  }
+  if (fd != TARGET_TIMER_FD) {
+    if (dup2(fd, TARGET_TIMER_FD) < 0) {
+      fprintf(stderr, "machinen-timerfd-read-target: dup2: %s\n", strerror(errno));
+      return 1;
+    }
+    close(fd);
+  }
+
+  struct itimerspec timer = {0};
+  timer.it_value.tv_sec = 30;
+  if (timerfd_settime(TARGET_TIMER_FD, 0, &timer, NULL) != 0) {
+    fprintf(stderr, "machinen-timerfd-read-target: timerfd_settime: %s\n", strerror(errno));
+    return 1;
+  }
+
+  clear_simd_fpu_state();
+  uint64_t expirations = 0;
+  long rc = syscall(SYS_read, TARGET_TIMER_FD, &expirations, sizeof(expirations));
+  if (rc < 0) {
+    fprintf(stderr, "machinen-timerfd-read-target: read: %s\n", strerror(errno));
+  }
+  return 0;
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -211,6 +211,7 @@
 - [`NativeModeledPpollFdState`](#nativemodeledppollfdstate)
 - [`NativeModeledPpollTimeoutState`](#nativemodeledppolltimeoutstate)
 - [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource)
+- [`NativeModeledFdReadTimerRemainingTime`](#nativemodeledfdreadtimerremainingtime)
 - [`NativeModeledFdReadState`](#nativemodeledfdreadstate)
 - [`NativeSleepTimerModelResult`](#nativesleeptimermodelresult)
 - [`NativePpollTimeoutModelResult`](#nativeppolltimeoutmodelresult)
@@ -2667,6 +2668,7 @@ by default when `output` is a TTY.
 
 #### Extended by
 
+- [`NativeModeledFdReadTimerRemainingTime`](#nativemodeledfdreadtimerremainingtime)
 - [`NativeModeledPpollTimeoutRemainingTime`](#nativemodeledppolltimeoutremainingtime)
 - [`NativeModeledSleepTimerRemainingTime`](#nativemodeledsleeptimerremainingtime)
 
@@ -2888,6 +2890,48 @@ by default when `output` is a TTY.
 
 ***
 
+### NativeModeledFdReadTimerRemainingTime
+
+#### Extends
+
+- [`NativeSleepTimerDuration`](#nativesleeptimerduration)
+
+#### Properties
+
+##### seconds
+
+> **seconds**: `string`
+
+###### Inherited from
+
+[`NativeSleepTimerDuration`](#nativesleeptimerduration).[`seconds`](#seconds)
+
+##### nanoseconds
+
+> **nanoseconds**: `number`
+
+###### Inherited from
+
+[`NativeSleepTimerDuration`](#nativesleeptimerduration).[`nanoseconds`](#nanoseconds)
+
+##### state
+
+> **state**: `"modeled"`
+
+##### kind
+
+> **kind**: `"relative-duration"`
+
+##### source
+
+> **source**: `"active-syscall-timerfd-read-timeout"`
+
+##### precision
+
+> **precision**: `"captured-fdinfo-upper-bound"`
+
+***
+
 ### NativeModeledFdReadState
 
 #### Properties
@@ -2931,6 +2975,10 @@ by default when `output` is a TTY.
 ##### targetResource
 
 > **targetResource**: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource)
+
+##### remainingTime?
+
+> `optional` **remainingTime?**: [`NativeModeledFdReadTimerRemainingTime`](#nativemodeledfdreadtimerremainingtime)
 
 ***
 
@@ -4767,7 +4815,7 @@ by default when `output` is a TTY.
 
 ###### Inherited from
 
-[`NativeCodeModule`](#nativecodemodule).[`kind`](#kind-6)
+[`NativeCodeModule`](#nativecodemodule).[`kind`](#kind-7)
 
 ##### buildId
 
@@ -4875,7 +4923,7 @@ by default when `output` is a TTY.
 
 ###### Inherited from
 
-[`NativeCodeModule`](#nativecodemodule).[`kind`](#kind-6)
+[`NativeCodeModule`](#nativecodemodule).[`kind`](#kind-7)
 
 ##### buildId
 
@@ -6496,7 +6544,7 @@ Legacy single-bucket failure reason. Prefer failureExitBuckets for new continuat
 
 ###### Overrides
 
-[`NativeSyntheticSyscallArgumentDescriptor`](#nativesyntheticsyscallargumentdescriptor).[`source`](#source-7)
+[`NativeSyntheticSyscallArgumentDescriptor`](#nativesyntheticsyscallargumentdescriptor).[`source`](#source-8)
 
 ***
 
@@ -6670,7 +6718,7 @@ Legacy single-bucket failure reason. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NativeSyntheticSyscallContinuationDescriptor`](#nativesyntheticsyscallcontinuationdescriptor).[`kind`](#kind-21)
+[`NativeSyntheticSyscallContinuationDescriptor`](#nativesyntheticsyscallcontinuationdescriptor).[`kind`](#kind-22)
 
 ##### targetArch
 
@@ -7084,7 +7132,7 @@ Legacy single-bucket failure reason. Prefer failureExitBuckets for new continuat
 
 ###### Overrides
 
-[`NativeSyntheticSyscallArgumentDescriptor`](#nativesyntheticsyscallargumentdescriptor).[`source`](#source-7)
+[`NativeSyntheticSyscallArgumentDescriptor`](#nativesyntheticsyscallargumentdescriptor).[`source`](#source-8)
 
 ***
 
@@ -7258,7 +7306,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NativeSyntheticSyscallContinuationDescriptor`](#nativesyntheticsyscallcontinuationdescriptor).[`kind`](#kind-21)
+[`NativeSyntheticSyscallContinuationDescriptor`](#nativesyntheticsyscallcontinuationdescriptor).[`kind`](#kind-22)
 
 ##### targetArch
 
@@ -13097,7 +13145,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeFdReadResourcePolicy
 
-> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"` \| `"synthetic-empty-eventfd"`
+> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"`
 
 ***
 
@@ -13109,7 +13157,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeModeledFdReadTargetResource
 
-> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-eventfd"`
+> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"`
 
 ***
 
@@ -13561,7 +13609,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestActiveSyscallRestoreStep
 
-> **TargetGuestActiveSyscallRestoreStep** = \{ `action`: `"rearm-sleep-timer"`; `threadId`: `string`; `syscallName`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"rearm-ppoll-timeout"`; `threadId`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `nfds`: `0` \| `1`; `resources`: [`NativeModeledPpollTargetResource`](#nativemodeledppolltargetresource)[]; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"restore-fd-read-block"`; `threadId`: `string`; `fd`: `number`; `countBytes`: `number`; `resource`: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource); `resumeMode`: `"defer-target-resume"`; \}
+> **TargetGuestActiveSyscallRestoreStep** = \{ `action`: `"rearm-sleep-timer"`; `threadId`: `string`; `syscallName`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"rearm-ppoll-timeout"`; `threadId`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `nfds`: `0` \| `1`; `resources`: [`NativeModeledPpollTargetResource`](#nativemodeledppolltargetresource)[]; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"restore-fd-read-block"`; `threadId`: `string`; `fd`: `number`; `countBytes`: `number`; `resource`: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource); `remainingTime?`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \}
 
 ***
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -220,6 +220,34 @@ function documentsWithReadEventfd(
   });
 }
 
+function documentsWithReadTimerfd(
+  activeThread: NativeThreadState,
+  options: { flags?: string[]; recipe?: Record<string, unknown> } = {},
+): NativeProcessImageDocuments {
+  const documents = documentsWithReadPipe(activeThread, {
+    readFd: 36,
+    readKind: "pipe",
+    readFlags: options.flags ?? ["octal:2000002"],
+    readRecipe: options.recipe ?? timerfdRecipe(),
+    includeWriteEnd: false,
+  });
+  documents.resources.resources[0]!.kind = "timer";
+  documents.resources.resources[0]!.path = "anon_inode:[timerfd]";
+  return documents;
+}
+
+function timerfdRecipe(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timerfdTicks: "0x0",
+    timerfdSettimeFlags: 0,
+    timerfdValueSeconds: 30,
+    timerfdValueNanoseconds: 0,
+    timerfdIntervalSeconds: 0,
+    timerfdIntervalNanoseconds: 0,
+    ...overrides,
+  };
+}
+
 function emptyRefusals() {
   return { vocabularyVersion: 1 as const, refusals: [] };
 }
@@ -896,6 +924,35 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("models a blocked read from a timerfd with remaining time", () => {
+    const activeThread = arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]);
+    const documents = documentsWithReadTimerfd(activeThread);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdReadPolicy: "defer-target-resume",
+      fdReadResourcePolicy: "synthetic-timerfd",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdRead: {
+          fd: 36,
+          countBytes: 8,
+          resourceId: "fd:36:read",
+          targetResource: "synthetic-timerfd",
+          remainingTime: {
+            state: "modeled",
+            source: "active-syscall-timerfd-read-timeout",
+            seconds: "30",
+            nanoseconds: 0,
+          },
+        },
+      },
+    });
+  });
+
   it("prefers /proc syscall arguments for modeled read", () => {
     const activeThread = arm64ReadThread();
     activeThread.syscall.arguments = ["0x20", "0x3100", "0x1", "0x0", "0x0", "0x0"];
@@ -1001,6 +1058,61 @@ describe("native active syscall classification", () => {
     expect(
       modelNativeFdReadState(scenario.thread, documents, "synthetic-empty-eventfd"),
     ).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-read-state-missing",
+        detail: { reason: scenario.reason },
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "short timerfd read",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x4", "0x0", "0x0", "0x0"]),
+      reason: "read timerfd proof requires count >= 8",
+    },
+    {
+      name: "non-timerfd resource",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadPipe(thread, { readFd: 36, readKind: "pipe" }),
+      reason: "read proof requires a captured timerfd fd",
+    },
+    {
+      name: "expired readable timer",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadTimerfd(thread, { recipe: timerfdRecipe({ timerfdTicks: "0x1" }) }),
+      reason: "read timerfd proof requires an unread timer",
+    },
+    {
+      name: "periodic timer",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadTimerfd(thread, { recipe: timerfdRecipe({ timerfdIntervalSeconds: 1 }) }),
+      reason: "read timerfd proof does not model periodic timers",
+    },
+    {
+      name: "absolute timer",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadTimerfd(thread, { recipe: timerfdRecipe({ timerfdSettimeFlags: 1 }) }),
+      reason: "read timerfd proof does not model absolute timers",
+    },
+    {
+      name: "unsupported flags",
+      thread: arm64ReadThread(["0x24", "0x3100", "0x8", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadTimerfd(thread, { flags: ["octal:2004002"] }),
+      reason: "read timerfd proof requires supported flags",
+    },
+  ])("refuses unsafe timerfd read state: $name", (scenario) => {
+    const documents = scenario.documents
+      ? scenario.documents(scenario.thread)
+      : documentsWithReadTimerfd(scenario.thread);
+
+    expect(modelNativeFdReadState(scenario.thread, documents, "synthetic-timerfd")).toMatchObject({
       state: "missing",
       refusal: {
         code: "target-fd-read-state-missing",

--- a/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
+++ b/packages/runtime/src/__tests__/native-actual-resume-trampoline.test.ts
@@ -128,6 +128,8 @@ describe("native actual resume trampoline", () => {
           "action=restore-fd-read-block;threadId=thread:1;fd=32;countBytes=1;resource=synthetic-empty-pipe-read-end;resumeMode=defer-target-resume",
           "--native-active-syscall-step",
           "action=restore-fd-read-block;threadId=thread:1;fd=34;countBytes=8;resource=synthetic-empty-eventfd;resumeMode=defer-target-resume",
+          "--native-active-syscall-step",
+          "action=restore-fd-read-block;threadId=thread:1;fd=36;countBytes=8;resource=synthetic-timerfd;seconds=1;nanoseconds=0;resumeMode=defer-target-resume",
           "--native-thread-spawn-step",
           "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x710000001000;rsp=0x530000010000",
         ]),
@@ -147,9 +149,9 @@ describe("native actual resume trampoline", () => {
         },
         nativeActiveSyscallRestore: {
           status: "passed",
-          stepCount: 4,
+          stepCount: 5,
           armedCount: 2,
-          consumedCount: 4,
+          consumedCount: 5,
         },
         nativeThreadRestore: { status: "passed", stepCount: 1, spawnedCount: 1 },
       });

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -315,6 +315,18 @@ describe("target guest restore loader descriptor", () => {
         },
       },
       {
+        section: "active-syscall" as const,
+        step: {
+          action: "restore-fd-read-block" as const,
+          threadId: "thread:1",
+          fd: 36,
+          countBytes: 8,
+          resource: "synthetic-timerfd" as const,
+          remainingTime: { seconds: "1", nanoseconds: 0 },
+          resumeMode: "defer-target-resume" as const,
+        },
+      },
+      {
         section: "thread-spawn" as const,
         step: {
           action: "spawn-target-thread" as const,
@@ -343,6 +355,8 @@ describe("target guest restore loader descriptor", () => {
         "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
         "--native-active-syscall-step",
         "action=restore-fd-read-block;threadId=thread:1;fd=32;countBytes=1;resource=synthetic-empty-pipe-read-end;resumeMode=defer-target-resume",
+        "--native-active-syscall-step",
+        "action=restore-fd-read-block;threadId=thread:1;fd=36;countBytes=8;resource=synthetic-timerfd;seconds=1;nanoseconds=0;resumeMode=defer-target-resume",
         "--native-thread-spawn-step",
         "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x700300000000;rsp=0x530000010000",
       ]),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -225,6 +225,7 @@ export type {
   NativeFdReadResourcePolicy,
   NativeModeledFdReadState,
   NativeModeledFdReadTargetResource,
+  NativeModeledFdReadTimerRemainingTime,
   NativeModeledPpollTimeoutRemainingTime,
   NativeModeledPpollTimeoutState,
   NativeModeledSleepTimerRemainingTime,

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -28,7 +28,10 @@ export type NativePollTimeoutFdPolicy =
   | "synthetic-empty-eventfd"
   | "synthetic-timerfd";
 export type NativeFdReadPolicy = "refuse" | "defer-target-resume";
-export type NativeFdReadResourcePolicy = "synthetic-empty-pipe" | "synthetic-empty-eventfd";
+export type NativeFdReadResourcePolicy =
+  | "synthetic-empty-pipe"
+  | "synthetic-empty-eventfd"
+  | "synthetic-timerfd";
 
 export interface NativeActiveSyscallPolicyOptions {
   sleepTimerPolicy?: NativeSleepTimerSyscallPolicy;
@@ -100,7 +103,15 @@ export interface NativeModeledPpollTimeoutState {
 
 export type NativeModeledFdReadTargetResource =
   | "synthetic-empty-pipe-read-end"
-  | "synthetic-empty-eventfd";
+  | "synthetic-empty-eventfd"
+  | "synthetic-timerfd";
+
+export interface NativeModeledFdReadTimerRemainingTime extends NativeSleepTimerDuration {
+  state: "modeled";
+  kind: "relative-duration";
+  source: "active-syscall-timerfd-read-timeout";
+  precision: "captured-fdinfo-upper-bound";
+}
 
 export interface NativeModeledFdReadState {
   kind: "fd-read-block";
@@ -113,6 +124,7 @@ export interface NativeModeledFdReadState {
   resourceId: string;
   pairedWriteResourceId?: string;
   targetResource: NativeModeledFdReadTargetResource;
+  remainingTime?: NativeModeledFdReadTimerRemainingTime;
 }
 
 export type NativeSleepTimerModelResult =
@@ -209,6 +221,7 @@ const POLLIN = 0x1;
 const SUPPORTED_EMPTY_EVENTFD_FLAGS = 0o2000002;
 const SUPPORTED_EVENTFD_READ_FLAGS = new Set([0o2, SUPPORTED_EMPTY_EVENTFD_FLAGS]);
 const SUPPORTED_TIMERFD_FLAGS = 0o2000002;
+const SUPPORTED_TIMERFD_READ_FLAGS = new Set([0o2, SUPPORTED_TIMERFD_FLAGS]);
 const MAX_SIGNED_I64 = 0x7fff_ffff_ffff_ffffn;
 const MAX_NANOSECONDS = 999_999_999n;
 const MAX_FD_READ_BYTES = 1024n * 1024n;
@@ -636,6 +649,7 @@ function decodeFdReadArguments(
     resourceId: resource.resource.id,
     pairedWriteResourceId: resource.pairedWriteResource?.id,
     targetResource: resource.targetResource,
+    remainingTime: resource.remainingTime,
   };
 }
 
@@ -718,8 +732,15 @@ function validateFdReadResourceCount(
   values: FdReadArgumentValues,
   targetResource: NativeModeledFdReadTargetResource,
 ): { state: "missing"; refusal: NativeProcessImageRefusal } | undefined {
-  return targetResource === "synthetic-empty-eventfd" && values.countBytes < 8
-    ? missingFdRead(thread, "read eventfd proof requires count >= 8", {
+  if (targetResource === "synthetic-empty-eventfd" && values.countBytes < 8) {
+    return missingFdRead(thread, "read eventfd proof requires count >= 8", {
+      fd: values.fd,
+      countBytes: values.countBytes,
+      targetResource,
+    });
+  }
+  return targetResource === "synthetic-timerfd" && values.countBytes < 8
+    ? missingFdRead(thread, "read timerfd proof requires count >= 8", {
         fd: values.fd,
         countBytes: values.countBytes,
         targetResource,
@@ -1004,10 +1025,14 @@ function validateFdReadModeledResource(
       resource: NativeProcessResource;
       pairedWriteResource?: NativeProcessResource;
       targetResource: NativeModeledFdReadTargetResource;
+      remainingTime?: NativeModeledFdReadTimerRemainingTime;
     }
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  return resourcePolicy === "synthetic-empty-eventfd"
-    ? validateFdReadEventfdResource(thread, documents, fd)
+  if (resourcePolicy === "synthetic-empty-eventfd") {
+    return validateFdReadEventfdResource(thread, documents, fd);
+  }
+  return resourcePolicy === "synthetic-timerfd"
+    ? validateFdReadTimerfdResource(thread, documents, fd)
     : validateFdReadPipeResource(thread, documents, fd);
 }
 
@@ -1111,6 +1136,137 @@ function validateFdReadEventfdState(
         eventfdSemaphore: eventfdSemaphore?.toString(10),
       })
     : undefined;
+}
+
+function validateFdReadTimerfdResource(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments,
+  fd: number,
+):
+  | {
+      resource: NativeProcessResource;
+      targetResource: "synthetic-timerfd";
+      remainingTime?: NativeModeledFdReadTimerRemainingTime;
+    }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const resource = documents.resources.resources.find((candidate) => candidate.fd === fd);
+  if (resource?.kind !== "timer") {
+    return missingFdRead(thread, "read proof requires a captured timerfd fd", {
+      fd,
+      resourceKind: resource?.kind,
+      resourceId: resource?.id,
+    });
+  }
+  const state = validateFdReadTimerfdState(thread, fd, resource);
+  if ("state" in state) {
+    return state;
+  }
+  return { resource, targetResource: "synthetic-timerfd", remainingTime: state.remainingTime };
+}
+
+function validateFdReadTimerfdState(
+  thread: NativeThreadState,
+  fd: number,
+  resource: NativeProcessResource,
+):
+  | { remainingTime?: NativeModeledFdReadTimerRemainingTime }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const flagRefusal = validateFdReadTimerfdFlags(thread, fd, resource);
+  if (flagRefusal) {
+    return flagRefusal;
+  }
+  const timerStateRefusal = validateFdReadTimerfdClockState(thread, fd, resource);
+  return timerStateRefusal ?? modeledTimerfdReadRemainingTime(thread, fd, resource);
+}
+
+function validateFdReadTimerfdFlags(
+  thread: NativeThreadState,
+  fd: number,
+  resource: NativeProcessResource,
+): { state: "missing"; refusal: NativeProcessImageRefusal } | undefined {
+  if (nativeFdAccessMode(resource.flags) !== 2) {
+    return missingFdRead(thread, "read timerfd proof requires read/write access", {
+      fd,
+      resourceId: resource.id,
+      resourceFlags: resource.flags,
+    });
+  }
+  return SUPPORTED_TIMERFD_READ_FLAGS.has(nativeFdFlagBits(resource.flags))
+    ? undefined
+    : missingFdRead(thread, "read timerfd proof requires supported flags", {
+        fd,
+        resourceId: resource.id,
+        resourceFlags: resource.flags,
+        supportedFlags: Array.from(
+          SUPPORTED_TIMERFD_READ_FLAGS,
+          (flags) => `octal:${flags.toString(8)}`,
+        ),
+      });
+}
+
+function validateFdReadTimerfdClockState(
+  thread: NativeThreadState,
+  fd: number,
+  resource: NativeProcessResource,
+): { state: "missing"; refusal: NativeProcessImageRefusal } | undefined {
+  const ticks = nativeResourceBigInt(resource, "timerfdTicks");
+  if (ticks !== 0n) {
+    return missingFdRead(thread, "read timerfd proof requires an unread timer", {
+      fd,
+      resourceId: resource.id,
+      timerfdTicks: ticks?.toString(10),
+    });
+  }
+  const intervalSeconds = nativeResourceBigInt(resource, "timerfdIntervalSeconds");
+  const intervalNanoseconds = nativeResourceBigInt(resource, "timerfdIntervalNanoseconds");
+  if (intervalSeconds !== 0n || intervalNanoseconds !== 0n) {
+    return missingFdRead(thread, "read timerfd proof does not model periodic timers", {
+      fd,
+      resourceId: resource.id,
+      timerfdIntervalSeconds: intervalSeconds?.toString(10),
+      timerfdIntervalNanoseconds: intervalNanoseconds?.toString(10),
+    });
+  }
+  const settimeFlags = nativeResourceBigInt(resource, "timerfdSettimeFlags");
+  return settimeFlags !== 0n
+    ? missingFdRead(thread, "read timerfd proof does not model absolute timers", {
+        fd,
+        resourceId: resource.id,
+        timerfdSettimeFlags: settimeFlags?.toString(10),
+      })
+    : undefined;
+}
+
+function modeledTimerfdReadRemainingTime(
+  thread: NativeThreadState,
+  fd: number,
+  resource: NativeProcessResource,
+):
+  | { remainingTime?: NativeModeledFdReadTimerRemainingTime }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const seconds = nativeResourceBigInt(resource, "timerfdValueSeconds") ?? 0n;
+  const nanoseconds = nativeResourceBigInt(resource, "timerfdValueNanoseconds") ?? 0n;
+  if (seconds === 0n && nanoseconds === 0n) {
+    return {};
+  }
+  if (seconds > MAX_SIGNED_I64 || nanoseconds > MAX_NANOSECONDS) {
+    return missingFdRead(thread, "read timerfd remaining time is outside supported bounds", {
+      fd,
+      resourceId: resource.id,
+      timerfdValueSeconds: seconds.toString(10),
+      timerfdValueNanoseconds: nanoseconds.toString(10),
+    });
+  }
+  return {
+    remainingTime: {
+      state: "modeled",
+      kind: "relative-duration",
+      source: "active-syscall-timerfd-read-timeout",
+      precision: "captured-fdinfo-upper-bound",
+      seconds: seconds.toString(10),
+      nanoseconds: Number(nanoseconds),
+    },
+  };
 }
 
 function validatePpollEventfdResource(

--- a/packages/runtime/src/target-guest-active-syscall-restore.ts
+++ b/packages/runtime/src/target-guest-active-syscall-restore.ts
@@ -28,6 +28,7 @@ export type TargetGuestActiveSyscallRestoreStep =
       fd: number;
       countBytes: number;
       resource: NativeModeledFdReadTargetResource;
+      remainingTime?: { seconds: string; nanoseconds: number };
       resumeMode: "defer-target-resume";
     };
 
@@ -75,6 +76,9 @@ function continuationStep(
       fd: continuation.metadata.fdRead.fd,
       countBytes: continuation.metadata.fdRead.countBytes,
       resource: continuation.metadata.fdRead.targetResource,
+      remainingTime: continuation.metadata.fdRead.remainingTime
+        ? duration(continuation.metadata.fdRead.remainingTime)
+        : undefined,
       resumeMode: "defer-target-resume",
     };
   }

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -774,6 +774,7 @@ function parseNativeActiveSyscallStep(
       fd: parseNativeInteger(fields, "fd"),
       countBytes: parseNativeInteger(fields, "countBytes"),
       resource: requiredNativeField(fields, "resource") as NativeModeledFdReadTargetResource,
+      remainingTime: fields.has("seconds") ? parseNativeDuration(fields) : undefined,
       resumeMode: "defer-target-resume",
     };
   }
@@ -1088,7 +1089,8 @@ function validateActiveSyscallRestoreStep(step: TargetGuestActiveSyscallRestoreS
     assertPositive(step.countBytes, "countBytes");
     if (
       step.resource !== "synthetic-empty-pipe-read-end" &&
-      step.resource !== "synthetic-empty-eventfd"
+      step.resource !== "synthetic-empty-eventfd" &&
+      step.resource !== "synthetic-timerfd"
     ) {
       fail("target-guest-loader-invalid-continuation", "fd read resource is unsupported");
     }
@@ -1474,7 +1476,10 @@ function serializeSignalRestoreStep(step: TargetGuestSignalRestoreStep): string 
 
 function serializeActiveSyscallStep(step: TargetGuestActiveSyscallRestoreStep): string {
   if (step.action === "restore-fd-read-block") {
-    return `native=active-syscall action=${step.action} threadId=${step.threadId} fd=${step.fd} countBytes=${step.countBytes} resource=${step.resource} resumeMode=${step.resumeMode}`;
+    const remainingTime = step.remainingTime
+      ? ` seconds=${step.remainingTime.seconds} nanoseconds=${step.remainingTime.nanoseconds}`
+      : "";
+    return `native=active-syscall action=${step.action} threadId=${step.threadId} fd=${step.fd} countBytes=${step.countBytes} resource=${step.resource}${remainingTime} resumeMode=${step.resumeMode}`;
   }
   const base = `native=active-syscall action=${step.action} threadId=${step.threadId} seconds=${step.remainingTime.seconds} nanoseconds=${step.remainingTime.nanoseconds} resumeMode=${step.resumeMode}`;
   return step.action === "rearm-sleep-timer"

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -233,6 +233,7 @@ const TOC = {
     "NativeModeledPpollFdState",
     "NativeModeledPpollTimeoutState",
     "NativeModeledFdReadTargetResource",
+    "NativeModeledFdReadTimerRemainingTime",
     "NativeModeledFdReadState",
     "NativeSleepTimerModelResult",
     "NativePpollTimeoutModelResult",

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -488,16 +488,34 @@ function activeSyscallPolicy(bundle: ReturnType<typeof validatePortableMachineSn
 
 function fdReadResourcePolicy(
   bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
-): "synthetic-empty-pipe" | "synthetic-empty-eventfd" {
-  const thread = bundle.nativeProcessImage.threads.threads.find(
-    (candidate) =>
-      candidate.syscall.state === "inside-syscall" && candidate.syscall.name === "read",
-  );
+): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" {
+  return fdReadResourcePolicyForKind(activeReadResourceKind(bundle));
+}
+
+function activeReadResourceKind(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+): NativeProcessResource["kind"] | undefined {
+  const thread = bundle.nativeProcessImage.threads.threads.find(isActiveReadThread);
   const fd = thread ? activeReadFd(thread) : undefined;
-  const resource = bundle.nativeProcessImage.resources.resources.find(
-    (candidate) => candidate.fd === fd,
-  );
-  return resource?.kind === "eventfd" ? "synthetic-empty-eventfd" : "synthetic-empty-pipe";
+  return bundle.nativeProcessImage.resources.resources.find((resource) => resource.fd === fd)?.kind;
+}
+
+function fdReadResourcePolicyForKind(
+  kind: NativeProcessResource["kind"] | undefined,
+): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" {
+  return kind === "eventfd"
+    ? "synthetic-empty-eventfd"
+    : kind === "timer"
+      ? "synthetic-timerfd"
+      : "synthetic-empty-pipe";
+}
+
+function isActiveReadThread(
+  thread: ReturnType<
+    typeof validatePortableMachineSnapshotBundle
+  >["nativeProcessImage"]["threads"]["threads"][number],
+): boolean {
+  return thread.syscall.state === "inside-syscall" && thread.syscall.name === "read";
 }
 
 function activeReadFd(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -300,6 +300,7 @@ capture_remote_native_process_bundle() {
     packages/microvm/assets/native-process-capture.c \
     packages/microvm/assets/native-eventfd-read-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
+    packages/microvm/assets/native-timerfd-read-target.c \
     packages/microvm/assets/native-two-thread-ppoll-target.c | \
     ssh "$ARM64_SSH" "tar -xzf - -C '$ARM64_REMOTE_WORK/repo'"
   local target_binary target_detail
@@ -316,12 +317,16 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target"
       target_detail="remote arm64 eventfd read native-process bundle captured from $ARM64_SSH"
       ;;
+    timerfd-read)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target"
+      target_detail="remote arm64 timerfd read native-process bundle captured from $ARM64_SSH"
+      ;;
     *)
       finish_failure "unsupported PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=$REMOTE_SOURCE_TARGET"
       ;;
   esac
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \


### PR DESCRIPTION
## Problem

We can now restore a process blocked in `read()` on an empty pipe or eventfd, but timerfd reads were still outside that proof. That meant a real process waiting on a timerfd had to be refused, even when the state was simple and safe.

## Solution

This adds a narrow, safe timerfd read proof:

- models only unread timerfds with supported flags, `count >= 8`, relative one-shot timer state, and no pending ticks
- carries optional remaining timer time into the target restore step
- recreates and arms a native target timerfd in the trampoline, then checks it would still block
- adds a remote `timerfd-read` smoke source target for arm64-to-amd64 VM restore
- documents the exact accepted and refused timerfd cases

Unsafe timerfd states still fail closed with `target-fd-read-state-missing`.

Closes #701.

## Validation

- `pnpm run build:docs` — 1.617s
- `pnpm run format:check` — 0.574s
- `pnpm run lint` — 0.227s
- `pnpm run typecheck` — 2.455s
- focused vitest suite — 3.208s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.125s
- `pnpm smoke-tests` — 2m13.422s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.394s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m11.495s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=timerfd-read` proof — 36.477s
  - `targetActiveSyscallRestoreResult: passed`
  - `targetVerifierResult: passed`
  - `targetStateConsumptionResult: passed`
  - `targetContinuationStatus: returned`
