### PR TITLE
Extend native context and fd syscall proofs

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -15,8 +15,9 @@ The current classifier reports:
 - `poll-timeout` — modeled `ppoll` timeout waits under an explicit deferral
   policy;
 - `fd-blocking` — `read`, `write`, `poll`, `ppoll`, `select`, `pselect6`, and
-  related fd waits. A narrow pipe `read` subset is modeled only under the
-  explicit fd-read deferral policy; other fd waits still refuse;
+  related fd waits. Narrow pipe/eventfd/timerfd reads and safe offset-backed
+  regular-file reads are modeled only under the explicit fd-read deferral
+  policy; other fd waits still refuse;
 - `restart` — `restart_syscall` or captured restart-block state;
 - `unknown-active` — any active syscall that has not been modeled.
 
@@ -34,6 +35,9 @@ Known blocking syscall classes refuse with precise codes:
   the capture cannot prove a blocking read contract;
 - `target-socket-syscall-state-unsupported` for active `accept`, `accept4`, and
   `connect` state;
+- `target-epoll-syscall-state-unsupported` for active `epoll_wait`,
+  `epoll_pwait`, and `epoll_pwait2` state;
+- `target-signalfd-state-unsupported` for active reads from signalfd resources;
 - `syscall-restart-unsupported` for restart state;
 - `active-syscall` for unknown active syscalls.
 
@@ -100,6 +104,21 @@ Missing arguments, missing resource rows, and non-socket fds remain refusals wit
 the same code and a specific `detail.reason`. This is refusal tightening only;
 no socket syscall is restarted or emulated.
 
+## Epoll/signalfd refusal tightening
+
+Active epoll waits now refuse with
+`target-epoll-syscall-state-unsupported`. The refusal records decoded epoll
+arguments when available, the captured epoll fd resource when present, and the
+unsupported kernel state family: interest list, ready-list ordering,
+edge-triggered delivery state, waiter wakeup races, and target fd resource
+mapping.
+
+Reads from captured signalfd resources refuse with
+`target-signalfd-state-unsupported`. The refusal records the read arguments,
+signalfd resource detail, and the unsupported pending signal queue / siginfo
+payload / signal-mask coordination state. Missing arguments, missing resource
+rows, and wrong resource kinds are still precise fail-closed refusals.
+
 ## Explicit fd read deferral
 
 The `fdReadPolicy: "defer-target-resume"` option currently accepts only narrow
@@ -122,13 +141,22 @@ non-periodic interval, and relative settime state. When captured fdinfo reports 
 non-zero remaining timer value, the target step carries that duration so the
 trampoline can arm the target timerfd before verifying it still blocks.
 
+With `fdReadResourcePolicy: "reopen-file"`, the model requires a captured
+regular-file fd with a reopen recipe, readable access flags, a safe non-negative
+file offset, and a translated writable target buffer. The target step uses
+bounded `pread()` at the captured offset into the translated buffer and refuses
+partial reads; this is an offset-backed completion proof, not a general file or
+page-cache migration.
+
 The target step recreates a fresh empty pipe, empty eventfd, or timerfd and
 verifies with target-side `poll(POLLIN, timeout=0)` that the read fd would still
-block before reporting `nativeActiveSyscallRestore.status=passed`. Missing
-arguments, zero or short counts, missing writable buffer state, wrong resource
-kind/access, non-empty eventfds, semaphore mode, unsupported flags, expired or
-periodic timerfds, absolute timerfd state, and missing paired pipe write ends
-fail closed as `target-fd-read-state-missing`.
+block before reporting `nativeActiveSyscallRestore.status=passed`, or completes
+the safe regular-file read with target-side `pread()`. Missing arguments, zero
+or short counts, missing writable buffer state, wrong resource kind/access,
+non-empty eventfds, semaphore mode, unsupported flags, expired or periodic
+timerfds, absolute timerfd state, missing paired pipe write ends, unsafe file
+offsets, and missing file reopen recipes fail closed as
+`target-fd-read-state-missing`.
 
 ## Proof
 

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -10,11 +10,16 @@ refused. Otherwise, modeled continuations become target steps:
 - `rearm-sleep-timer` for modeled `nanosleep`/`clock_nanosleep` remaining time;
 - `rearm-ppoll-timeout` for modeled `ppoll` timeout continuations, including
   the synthetic target resources required by the policy;
-- `restore-fd-read-block` for the narrow modeled pipe `read` case.
+- `restore-fd-read-block` for narrow modeled pipe, eventfd, and timerfd reads;
+- `complete-fd-read-from-file` for safe regular-file reads whose fd has a
+  reopen recipe, readable flags, a safe captured offset, and a translated target
+  read buffer.
 
 Only continuations that already passed the active-syscall policy are accepted.
 Generic blocking syscalls, restart state, missing timespecs, missing read-buffer
-state, and unsupported fd state continue to fail closed before target re-arm.
+state, signalfd reads, epoll waits, socket accept/connect, and unsupported fd
+state continue to fail closed before target re-arm with resource-specific
+detail.
 
 The target amd64 trampoline now executes these sections by creating and arming a
 short-lived target-side timerfd for each `rearm-sleep-timer` or
@@ -22,7 +27,9 @@ short-lived target-side timerfd for each `rearm-sleep-timer` or
 `restore-fd-read-block`, it recreates the target pipe, eventfd, or timerfd read
 fd. Timerfd read steps arm the target timer when modeled remaining time is
 present. The trampoline then verifies the fd would still block with a
-zero-timeout `poll(POLLIN)`. The trampoline reports
+zero-timeout `poll(POLLIN)`. For `complete-fd-read-from-file`, it performs a
+bounded `pread()` from the reopened target fd at the captured offset into the
+translated target read buffer, and refuses partial reads. The trampoline reports
 `nativeActiveSyscallRestore.status=passed` only when every step was parsed,
 validated, and consumed; malformed durations, unknown actions, wrong resume
 modes, unsupported sleep syscall names, unsupported `ppoll` resource shapes, and

--- a/docs/snapshot/target-guest-process-context-restore.md
+++ b/docs/snapshot/target-guest-process-context-restore.md
@@ -20,20 +20,28 @@ Malformed, missing, inconsistent, or oversized context refuses with
 
 ## Target-side consumption
 
-Descriptors use `native=process-context` steps. Two modes are available:
+Descriptors use `native=process-context` steps. Three modes are available:
 
 - `metadata-only` records argv/env/cwd/auxv counts and SHA-256 digests for a
   target-native consumption gate.
 - `apply-target-env-cwd` additionally clears the target environment, sets the
   captured env entries, verifies the env count, changes to the captured cwd, and
   verifies `getcwd()`.
+- `apply-target-visible-context` keeps the env/cwd application above and adds a
+  controlled target-visible proof: it materializes a bounded argv block for the
+  `--machinen-argv-token` profile, verifies `getenv("MACHINEN_CONTEXT_TOKEN")`,
+  verifies `getcwd()`, and compares selected safe auxv entries (`AT_PAGESZ`,
+  `AT_CLKTCK`) with target `getauxval()`.
+
+The visible mode refuses if the controlled env token, argv token, or selected
+safe auxv entries are missing. Source-only and target-variant auxv entries stay
+metadata-only; asking to materialize them remains unsupported.
 
 The trampoline reports `nativeProcessContextRestore.status=passed` only after it
 consumes all process-context steps. The VM proof maps that to
 `targetProcessContextRestoreResult=passed`, and failed markers block proof
 completion.
 
-`argv` and `auxv` are still carried as bounded metadata. Rebuilding the target
-initial stack, libc `argv`/`environ` globals, vDSO/vvar dependencies, and general
-auxv semantics remain outside this proof and must continue to fail closed until
-modeled explicitly.
+Full target initial-stack and libc process-start reconstruction, vDSO/vvar
+dependencies, and general auxv semantics remain outside this proof and must
+continue to fail closed until modeled explicitly.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <sched.h>
 #include <string.h>
+#include <sys/auxv.h>
 #include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
@@ -36,6 +37,12 @@ extern char **environ;
 #ifndef MAP_FIXED_NOREPLACE
 #define MAP_FIXED_NOREPLACE 0x100000
 #endif
+#ifndef AT_PAGESZ
+#define AT_PAGESZ 6
+#endif
+#ifndef AT_CLKTCK
+#define AT_CLKTCK 17
+#endif
 
 #if defined(__linux__) && defined(__x86_64__)
 #include <setjmp.h>
@@ -47,6 +54,7 @@ extern char **environ;
 #define MAX_NATIVE_RESTORE_STEPS 128
 #define MAX_CLOEXEC_FDS 64
 #define MAX_TRANSLATED_FRAME_SLOTS 8
+#define MAX_CONTEXT_ARGV 16
 #define STATE_CONSUMPTION_MARKER UINT64_C(0x5354415445434f4e)
 #define STATE_CONSUMPTION_MASK UINT64_C(0x7f)
 #define STATE_CHECK_MEMORY UINT64_C(0x01)
@@ -142,9 +150,13 @@ struct NativeThreadRestoreState {
 
 struct NativeProcessContextRestoreState {
   bool requested;
+  bool argv_materialized;
   bool env_cleared;
   bool env_verified;
+  bool env_value_verified;
   bool cwd_applied;
+  bool cwd_verified;
+  bool auxv_verified;
   size_t env_set_count;
   size_t metadata_count;
   size_t consumed_count;
@@ -812,6 +824,9 @@ static uint64_t jump_resume_register_r10 __attribute__((used)) = 0;
 static uint64_t jump_resume_register_r11 __attribute__((used)) = 0;
 static struct NativeSignalRestoreState native_signal_restore_state = {0};
 static struct NativeProcessContextRestoreState native_process_context_restore_state = {0};
+static char target_context_argv_token[256];
+static const char *target_context_argv[MAX_CONTEXT_ARGV + 1];
+static size_t target_context_argc = 0;
 static struct NativeActiveSyscallRestoreState native_active_syscall_restore_state = {0};
 static struct NativeThreadRestoreState native_thread_restore_state = {0};
 
@@ -1368,6 +1383,90 @@ static size_t target_environ_count(void) {
   return count;
 }
 
+static void materialize_target_argv_block(const char *spec, struct NativeProcessContextRestoreState *state) {
+  uint64_t argc = native_step_u64(spec, "argc", "process-context");
+  uint64_t token_index = native_step_u64(spec, "tokenIndex", "process-context");
+  char digest[80];
+  char token_digest[80];
+  char token_hex[512];
+  native_step_string(spec, "argvSha256", digest, sizeof(digest), "process-context");
+  native_step_string(spec, "tokenSha256", token_digest, sizeof(token_digest), "process-context");
+  native_step_string(spec, "tokenHex", token_hex, sizeof(token_hex), "process-context");
+  require_sha256_hex(digest, "argvSha256", "process-context");
+  require_sha256_hex(token_digest, "tokenSha256", "process-context");
+  if (argc == 0 || argc > MAX_CONTEXT_ARGV || token_index >= argc) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context argv shape is unsupported\n");
+    exit(2);
+  }
+  hex_to_string(token_hex, target_context_argv_token, sizeof(target_context_argv_token), "tokenHex", "process-context");
+  if (target_context_argv_token[0] == '\0') {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context argv token is empty\n");
+    exit(2);
+  }
+  for (uint64_t i = 0; i < argc; i++) {
+    target_context_argv[i] = "<machinen-argv-placeholder>";
+  }
+  target_context_argv[token_index] = target_context_argv_token;
+  target_context_argv[argc] = NULL;
+  target_context_argc = (size_t)argc;
+  if (target_context_argc != argc || strcmp(target_context_argv[token_index], target_context_argv_token) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context argv verify failed\n");
+    exit(1);
+  }
+  state->argv_materialized = true;
+}
+
+static void verify_target_env_value(const char *spec, struct NativeProcessContextRestoreState *state) {
+  char key_hex[512];
+  char value_hex[512];
+  char key[256];
+  char value[256];
+  char digest[80];
+  native_step_string(spec, "keyHex", key_hex, sizeof(key_hex), "process-context");
+  native_step_string(spec, "valueHex", value_hex, sizeof(value_hex), "process-context");
+  native_step_string(spec, "valueSha256", digest, sizeof(digest), "process-context");
+  require_sha256_hex(digest, "valueSha256", "process-context");
+  hex_to_string(key_hex, key, sizeof(key), "keyHex", "process-context");
+  hex_to_string(value_hex, value, sizeof(value), "valueHex", "process-context");
+  const char *observed = getenv(key);
+  if (!observed || strcmp(observed, value) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: getenv verify failed\n");
+    exit(1);
+  }
+  state->env_value_verified = true;
+}
+
+static void verify_target_cwd(const char *spec, struct NativeProcessContextRestoreState *state) {
+  char cwd_hex[1024];
+  char cwd[512];
+  char observed[512];
+  char digest[80];
+  native_step_string(spec, "cwdHex", cwd_hex, sizeof(cwd_hex), "process-context");
+  native_step_string(spec, "cwdSha256", digest, sizeof(digest), "process-context");
+  require_sha256_hex(digest, "cwdSha256", "process-context");
+  hex_to_string(cwd_hex, cwd, sizeof(cwd), "cwdHex", "process-context");
+  if (!getcwd(observed, sizeof(observed)) || strcmp(observed, cwd) != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: getcwd verify failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  state->cwd_verified = true;
+}
+
+static void verify_target_auxv_selected(const char *spec, struct NativeProcessContextRestoreState *state) {
+  char digest[80];
+  native_step_string(spec, "auxvSha256", digest, sizeof(digest), "process-context");
+  require_sha256_hex(digest, "auxvSha256", "process-context");
+  uint64_t expected_page_size = native_step_u64(spec, "pageSize", "process-context");
+  uint64_t expected_clock_tick = native_step_u64(spec, "clockTick", "process-context");
+  unsigned long observed_page_size = getauxval(AT_PAGESZ);
+  unsigned long observed_clock_tick = getauxval(AT_CLKTCK);
+  if (observed_page_size != expected_page_size || observed_clock_tick != expected_clock_tick) {
+    fprintf(stderr, "native-actual-resume-trampoline: selected auxv verify failed\n");
+    exit(1);
+  }
+  state->auxv_verified = true;
+}
+
 static void consume_native_process_context_steps(
     const struct Options *opts, struct NativeProcessContextRestoreState *state) {
   state->requested = opts->native_process_context_step_count > 0;
@@ -1382,6 +1481,8 @@ static void consume_native_process_context_steps(
       (void)native_step_u64(spec, "argc", "process-context");
       (void)native_step_u64(spec, "argvBytes", "process-context");
       state->metadata_count++;
+    } else if (streq(action, "materialize-argv")) {
+      materialize_target_argv_block(spec, state);
     } else if (streq(action, "record-env")) {
       char digest[80];
       native_step_string(spec, "envSha256", digest, sizeof(digest), "process-context");
@@ -1421,6 +1522,8 @@ static void consume_native_process_context_steps(
         exit(1);
       }
       state->env_set_count++;
+    } else if (streq(action, "verify-env-value")) {
+      verify_target_env_value(spec, state);
     } else if (streq(action, "verify-env")) {
       char digest[80];
       native_step_string(spec, "envSha256", digest, sizeof(digest), "process-context");
@@ -1431,7 +1534,7 @@ static void consume_native_process_context_steps(
         exit(1);
       }
       state->env_verified = true;
-    } else if (streq(action, "record-cwd") || streq(action, "chdir")) {
+    } else if (streq(action, "record-cwd") || streq(action, "chdir") || streq(action, "verify-cwd")) {
       char cwd_hex[1024];
       char cwd[512];
       char digest[80];
@@ -1446,6 +1549,8 @@ static void consume_native_process_context_steps(
           exit(1);
         }
         state->cwd_applied = true;
+      } else if (streq(action, "verify-cwd")) {
+        verify_target_cwd(spec, state);
       } else {
         state->metadata_count++;
       }
@@ -1455,6 +1560,8 @@ static void consume_native_process_context_steps(
       require_sha256_hex(digest, "auxvSha256", "process-context");
       (void)native_step_u64(spec, "auxvBytes", "process-context");
       state->metadata_count++;
+    } else if (streq(action, "verify-auxv-selected")) {
+      verify_target_auxv_selected(spec, state);
     } else {
       fprintf(stderr, "native-actual-resume-trampoline: unsupported native process-context action\n");
       exit(2);
@@ -1665,6 +1772,27 @@ static void verify_fd_read_would_block(int fd, const char *label) {
   }
 }
 
+static void complete_native_fd_read_from_file(const char *spec, struct NativeActiveSyscallRestoreState *state) {
+  uint64_t fd = native_step_u64(spec, "fd", "active-syscall");
+  uint64_t count_bytes = native_step_u64(spec, "countBytes", "active-syscall");
+  uint64_t target_buffer = native_step_u64(spec, "targetBufferPointer", "active-syscall");
+  uint64_t file_offset = native_step_u64(spec, "fileOffset", "active-syscall");
+  if (fd > 1024u || count_bytes == 0 || count_bytes > (1024u * 1024u) || target_buffer == 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: native file read arguments are unsupported\n");
+    exit(2);
+  }
+  ssize_t got = pread((int)fd, (void *)(uintptr_t)target_buffer, (size_t)count_bytes, (off_t)file_offset);
+  if (got < 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: native file read failed: %s\n", strerror(errno));
+    exit(1);
+  }
+  if ((uint64_t)got != count_bytes) {
+    fprintf(stderr, "native-actual-resume-trampoline: native file read was partial\n");
+    exit(2);
+  }
+  state->consumed_count++;
+}
+
 static void restore_native_fd_read_block(const char *spec, struct NativeActiveSyscallRestoreState *state) {
   uint64_t fd = native_step_u64(spec, "fd", "active-syscall");
   uint64_t count_bytes = native_step_u64(spec, "countBytes", "active-syscall");
@@ -1736,6 +1864,8 @@ static void apply_native_active_syscall_restore_steps(
       arm_native_active_timer(spec, "active-syscall", state);
     } else if (streq(action, "restore-fd-read-block")) {
       restore_native_fd_read_block(spec, state);
+    } else if (streq(action, "complete-fd-read-from-file")) {
+      complete_native_fd_read_from_file(spec, state);
     } else {
       fprintf(stderr, "native-actual-resume-trampoline: unsupported native active-syscall action\n");
       exit(2);
@@ -2470,14 +2600,18 @@ static void print_native_restore_consumption(const struct Options *opts) {
   if (native_process_context_restore_state.requested) {
     bool process_context_passed =
         native_process_context_restore_state.consumed_count == opts->native_process_context_step_count;
-    printf(",\"nativeProcessContextRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"metadataCount\":%zu,\"envSetCount\":%zu,\"envCleared\":%s,\"envVerified\":%s,\"cwdApplied\":%s}",
+    printf(",\"nativeProcessContextRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"metadataCount\":%zu,\"envSetCount\":%zu,\"argvMaterialized\":%s,\"envCleared\":%s,\"envVerified\":%s,\"envValueVerified\":%s,\"cwdApplied\":%s,\"cwdVerified\":%s,\"auxvVerified\":%s}",
         process_context_passed ? "passed" : "failed",
         opts->native_process_context_step_count,
         native_process_context_restore_state.metadata_count,
         native_process_context_restore_state.env_set_count,
+        native_process_context_restore_state.argv_materialized ? "true" : "false",
         native_process_context_restore_state.env_cleared ? "true" : "false",
         native_process_context_restore_state.env_verified ? "true" : "false",
-        native_process_context_restore_state.cwd_applied ? "true" : "false");
+        native_process_context_restore_state.env_value_verified ? "true" : "false",
+        native_process_context_restore_state.cwd_applied ? "true" : "false",
+        native_process_context_restore_state.cwd_verified ? "true" : "false",
+        native_process_context_restore_state.auxv_verified ? "true" : "false");
   }
   if (native_signal_restore_state.requested) {
     bool signal_passed = native_signal_restore_state.saved &&

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -1283,7 +1283,7 @@ static const char *fd_kind(const char *target) {
     return "timer";
   }
   if (strncmp(target, "anon_inode:[signalfd]", 21) == 0) {
-    return "signal";
+    return "signalfd";
   }
   if (target[0] == '/') {
     return "file";
@@ -1296,7 +1296,8 @@ static const char *fd_refusal_code(const char *kind) {
     return "fd-kind-unsupported";
   }
   if (streq(kind, "pipe") || streq(kind, "socket") || streq(kind, "epoll") ||
-      streq(kind, "eventfd") || streq(kind, "timer") || streq(kind, "signal")) {
+      streq(kind, "eventfd") || streq(kind, "timer") || streq(kind, "signal") ||
+      streq(kind, "signalfd")) {
     return "kernel-state-unsupported";
   }
   return "resource-kind-unsupported";

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2981,6 +2981,14 @@ by default when `output` is a TTY.
 
 > **targetResource**: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource)
 
+##### targetBufferPointer?
+
+> `optional` **targetBufferPointer?**: `string`
+
+##### fileOffset?
+
+> `optional` **fileOffset?**: `number`
+
 ##### remainingTime?
 
 > `optional` **remainingTime?**: [`NativeModeledFdReadTimerRemainingTime`](#nativemodeledfdreadtimerremainingtime)
@@ -4028,7 +4036,7 @@ by default when `output` is a TTY.
 
 ##### code
 
-> **code**: `"active-syscall"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"fd-kind-unsupported"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-captured-range-unsupported"` \| `"mapping-executable-unsupported"` \| `"mapping-permission-unsupported"` \| `"mapping-provenance-ambiguous"` \| `"mapping-shared-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"simd-fpu-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-build-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-fd-table-duplicate"` \| `"target-fd-read-state-missing"` \| `"target-fd-table-missing"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-ppoll-syscall-continuation-missing"` \| `"target-ppoll-timeout-missing"` \| `"target-process-context-unsupported"` \| `"target-return-slot-unsupported"` \| `"target-resume-execution-unavailable"` \| `"target-resume-fault-invalid-code-landing"` \| `"target-resume-fault-outside-target-bytes"` \| `"target-resume-fault-privileged-instruction"` \| `"target-resume-fault-signal-unsupported"` \| `"target-resume-fault-timeout"` \| `"target-resume-fault-unmodeled-memory"` \| `"target-semantic-continuation-missing"` \| `"target-sleep-remaining-time-missing"` \| `"target-socket-syscall-state-unsupported"` \| `"target-sleep-signal-restart-unsupported"` \| `"target-sleep-syscall-continuation-missing"` \| `"target-stack-window-unsupported"` \| `"target-synthetic-signal-interrupted-unsupported"` \| `"target-synthetic-signal-restart-unsupported"` \| `"target-synthetic-syscall-return-unmodeled"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
+> **code**: `"active-syscall"` \| `"architecture-pair-unsupported"` \| `"architecture-unsupported"` \| `"blocking-syscall-state-unsupported"` \| `"code-location-unknown"` \| `"fd-kind-unsupported"` \| `"futex-state-unsupported"` \| `"inherited-stdio-policy-required"` \| `"kernel-state-unsupported"` \| `"mapping-ambiguous"` \| `"mapping-captured-range-unsupported"` \| `"mapping-executable-unsupported"` \| `"mapping-permission-unsupported"` \| `"mapping-provenance-ambiguous"` \| `"mapping-shared-unsupported"` \| `"mapping-unreadable"` \| `"pointer-ambiguous"` \| `"resource-kind-unsupported"` \| `"non-stdio-kernel-state-unsupported"` \| `"rseq-state-unsupported"` \| `"signal-frame-active"` \| `"signal-state-unsupported"` \| `"simd-fpu-state-unsupported"` \| `"stdin-buffer-state-unsupported"` \| `"syscall-argument-state-unsupported"` \| `"syscall-restart-unsupported"` \| `"target-build-id-mismatch"` \| `"target-build-mismatch"` \| `"target-code-location-unresolved"` \| `"target-callee-saved-state-unsupported"` \| `"target-caller-frame-unavailable"` \| `"target-code-rva-unmapped"` \| `"target-epoll-syscall-state-unsupported"` \| `"target-fd-table-duplicate"` \| `"target-fd-read-state-missing"` \| `"target-fd-table-missing"` \| `"target-frame-layout-unsupported"` \| `"target-frame-register-value-unavailable"` \| `"target-module-bytes-missing"` \| `"target-module-file-missing"` \| `"target-module-missing"` \| `"target-module-not-executable"` \| `"target-module-range-unreadable"` \| `"target-ppoll-syscall-continuation-missing"` \| `"target-ppoll-timeout-missing"` \| `"target-process-context-unsupported"` \| `"target-return-slot-unsupported"` \| `"target-signalfd-state-unsupported"` \| `"target-resume-execution-unavailable"` \| `"target-resume-fault-invalid-code-landing"` \| `"target-resume-fault-outside-target-bytes"` \| `"target-resume-fault-privileged-instruction"` \| `"target-resume-fault-signal-unsupported"` \| `"target-resume-fault-timeout"` \| `"target-resume-fault-unmodeled-memory"` \| `"target-semantic-continuation-missing"` \| `"target-sleep-remaining-time-missing"` \| `"target-socket-syscall-state-unsupported"` \| `"target-sleep-signal-restart-unsupported"` \| `"target-sleep-syscall-continuation-missing"` \| `"target-stack-window-unsupported"` \| `"target-synthetic-signal-interrupted-unsupported"` \| `"target-synthetic-signal-restart-unsupported"` \| `"target-synthetic-syscall-return-unmodeled"` \| `"thread-state-unsupported"` \| `"tls-state-unsupported"` \| `"return-slot-unreadable"` \| `"target-unwind-mismatch"` \| `"unwind-fde-missing"` \| `"unwind-metadata-missing"` \| `"unwind-rule-unsupported"` \| `"vdso-policy-unsupported"`
 
 ##### message
 
@@ -13200,7 +13208,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeFdReadResourcePolicy
 
-> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"`
+> **NativeFdReadResourcePolicy** = `"synthetic-empty-pipe"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"` \| `"reopen-file"`
 
 ***
 
@@ -13212,7 +13220,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeModeledFdReadTargetResource
 
-> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"`
+> **NativeModeledFdReadTargetResource** = `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"` \| `"reopened-offset-file"`
 
 ***
 
@@ -13320,7 +13328,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeProcessResourceKind
 
-> **NativeProcessResourceKind** = `"argv"` \| `"env"` \| `"cwd"` \| `"exe"` \| `"auxv"` \| `"fd"` \| `"file"` \| `"pipe"` \| `"socket"` \| `"raw-socket"` \| `"pty"` \| `"timer"` \| `"eventfd"` \| `"signal"` \| `"namespace"` \| `"credential"` \| `"futex"` \| `"epoll"` \| `"unknown"`
+> **NativeProcessResourceKind** = `"argv"` \| `"env"` \| `"cwd"` \| `"exe"` \| `"auxv"` \| `"fd"` \| `"file"` \| `"pipe"` \| `"socket"` \| `"raw-socket"` \| `"pty"` \| `"timer"` \| `"eventfd"` \| `"signal"` \| `"signalfd"` \| `"namespace"` \| `"credential"` \| `"futex"` \| `"epoll"` \| `"unknown"`
 
 ***
 
@@ -13664,7 +13672,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestActiveSyscallRestoreStep
 
-> **TargetGuestActiveSyscallRestoreStep** = \{ `action`: `"rearm-sleep-timer"`; `threadId`: `string`; `syscallName`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"rearm-ppoll-timeout"`; `threadId`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `nfds`: `0` \| `1`; `resources`: [`NativeModeledPpollTargetResource`](#nativemodeledppolltargetresource)[]; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"restore-fd-read-block"`; `threadId`: `string`; `fd`: `number`; `countBytes`: `number`; `resource`: [`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource); `remainingTime?`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \}
+> **TargetGuestActiveSyscallRestoreStep** = \{ `action`: `"rearm-sleep-timer"`; `threadId`: `string`; `syscallName`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"rearm-ppoll-timeout"`; `threadId`: `string`; `remainingTime`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `nfds`: `0` \| `1`; `resources`: [`NativeModeledPpollTargetResource`](#nativemodeledppolltargetresource)[]; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"restore-fd-read-block"`; `threadId`: `string`; `fd`: `number`; `countBytes`: `number`; `resource`: `Exclude`\<[`NativeModeledFdReadTargetResource`](#nativemodeledfdreadtargetresource), `"reopened-offset-file"`\>; `remainingTime?`: \{ `seconds`: `string`; `nanoseconds`: `number`; \}; `resumeMode`: `"defer-target-resume"`; \} \| \{ `action`: `"complete-fd-read-from-file"`; `threadId`: `string`; `fd`: `number`; `countBytes`: `number`; `targetBufferPointer`: `string`; `fileOffset`: `number`; `resumeMode`: `"defer-target-resume"`; \}
 
 ***
 
@@ -13694,13 +13702,13 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestProcessContextRestoreMode
 
-> **TargetGuestProcessContextRestoreMode** = `"metadata-only"` \| `"apply-target-env-cwd"`
+> **TargetGuestProcessContextRestoreMode** = `"metadata-only"` \| `"apply-target-env-cwd"` \| `"apply-target-visible-context"`
 
 ***
 
 ### TargetGuestProcessContextRestoreStep
 
-> **TargetGuestProcessContextRestoreStep** = \{ `action`: `"record-argv"`; `argc`: `number`; `argvBytes`: `number`; `argvSha256`: `string`; \} \| \{ `action`: `"record-env"`; `envCount`: `number`; `envBytes`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"clear-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"set-env"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"verify-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"record-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"chdir"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"record-auxv"`; `auxvBytes`: `number`; `auxvSha256`: `string`; \}
+> **TargetGuestProcessContextRestoreStep** = \{ `action`: `"record-argv"`; `argc`: `number`; `argvBytes`: `number`; `argvSha256`: `string`; \} \| \{ `action`: `"materialize-argv"`; `argc`: `number`; `argvSha256`: `string`; `tokenIndex`: `number`; `tokenHex`: `string`; `tokenSha256`: `string`; \} \| \{ `action`: `"record-env"`; `envCount`: `number`; `envBytes`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"clear-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"set-env"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"verify-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"verify-env-value"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"record-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"chdir"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"verify-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"record-auxv"`; `auxvBytes`: `number`; `auxvSha256`: `string`; \} \| \{ `action`: `"verify-auxv-selected"`; `pageSize`: `number`; `clockTick`: `number`; `auxvSha256`: `string`; \}
 
 ***
 
@@ -14332,7 +14340,7 @@ loops; anything looser stops being a meaningful gate.
 
 ### nativeProcessImageRefusalCodes
 
-> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-captured-range-unsupported"`, `"mapping-executable-unsupported"`, `"mapping-permission-unsupported"`, `"mapping-provenance-ambiguous"`, `"mapping-shared-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"simd-fpu-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-fd-table-duplicate"`, `"target-fd-read-state-missing"`, `"target-fd-table-missing"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-ppoll-syscall-continuation-missing"`, `"target-ppoll-timeout-missing"`, `"target-process-context-unsupported"`, `"target-return-slot-unsupported"`, `"target-resume-execution-unavailable"`, `"target-resume-fault-invalid-code-landing"`, `"target-resume-fault-outside-target-bytes"`, `"target-resume-fault-privileged-instruction"`, `"target-resume-fault-signal-unsupported"`, `"target-resume-fault-timeout"`, `"target-resume-fault-unmodeled-memory"`, `"target-semantic-continuation-missing"`, `"target-sleep-remaining-time-missing"`, `"target-socket-syscall-state-unsupported"`, `"target-sleep-signal-restart-unsupported"`, `"target-sleep-syscall-continuation-missing"`, `"target-stack-window-unsupported"`, `"target-synthetic-signal-interrupted-unsupported"`, `"target-synthetic-signal-restart-unsupported"`, `"target-synthetic-syscall-return-unmodeled"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
+> `const` **nativeProcessImageRefusalCodes**: readonly \[`"active-syscall"`, `"architecture-pair-unsupported"`, `"architecture-unsupported"`, `"blocking-syscall-state-unsupported"`, `"code-location-unknown"`, `"fd-kind-unsupported"`, `"futex-state-unsupported"`, `"inherited-stdio-policy-required"`, `"kernel-state-unsupported"`, `"mapping-ambiguous"`, `"mapping-captured-range-unsupported"`, `"mapping-executable-unsupported"`, `"mapping-permission-unsupported"`, `"mapping-provenance-ambiguous"`, `"mapping-shared-unsupported"`, `"mapping-unreadable"`, `"pointer-ambiguous"`, `"resource-kind-unsupported"`, `"non-stdio-kernel-state-unsupported"`, `"rseq-state-unsupported"`, `"signal-frame-active"`, `"signal-state-unsupported"`, `"simd-fpu-state-unsupported"`, `"stdin-buffer-state-unsupported"`, `"syscall-argument-state-unsupported"`, `"syscall-restart-unsupported"`, `"target-build-id-mismatch"`, `"target-build-mismatch"`, `"target-code-location-unresolved"`, `"target-callee-saved-state-unsupported"`, `"target-caller-frame-unavailable"`, `"target-code-rva-unmapped"`, `"target-epoll-syscall-state-unsupported"`, `"target-fd-table-duplicate"`, `"target-fd-read-state-missing"`, `"target-fd-table-missing"`, `"target-frame-layout-unsupported"`, `"target-frame-register-value-unavailable"`, `"target-module-bytes-missing"`, `"target-module-file-missing"`, `"target-module-missing"`, `"target-module-not-executable"`, `"target-module-range-unreadable"`, `"target-ppoll-syscall-continuation-missing"`, `"target-ppoll-timeout-missing"`, `"target-process-context-unsupported"`, `"target-return-slot-unsupported"`, `"target-signalfd-state-unsupported"`, `"target-resume-execution-unavailable"`, `"target-resume-fault-invalid-code-landing"`, `"target-resume-fault-outside-target-bytes"`, `"target-resume-fault-privileged-instruction"`, `"target-resume-fault-signal-unsupported"`, `"target-resume-fault-timeout"`, `"target-resume-fault-unmodeled-memory"`, `"target-semantic-continuation-missing"`, `"target-sleep-remaining-time-missing"`, `"target-socket-syscall-state-unsupported"`, `"target-sleep-signal-restart-unsupported"`, `"target-sleep-syscall-continuation-missing"`, `"target-stack-window-unsupported"`, `"target-synthetic-signal-interrupted-unsupported"`, `"target-synthetic-signal-restart-unsupported"`, `"target-synthetic-syscall-return-unmodeled"`, `"thread-state-unsupported"`, `"tls-state-unsupported"`, `"return-slot-unreadable"`, `"target-unwind-mismatch"`, `"unwind-fde-missing"`, `"unwind-metadata-missing"`, `"unwind-rule-unsupported"`, `"vdso-policy-unsupported"`\]
 
 ***
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -75,6 +75,13 @@ function arm64SocketThread(
   return arm64SleepThread({ state: "inside-syscall", number, name }, x);
 }
 
+function arm64EpollThread(
+  name: "epoll_wait" | "epoll_pwait" | "epoll_pwait2" = "epoll_wait",
+  x: string[] = ["0x30", "0x4100", "0x4", "0xffffffff", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 22, name }, x);
+}
+
 function documentsWithTimespec(options: {
   activeThread: NativeThreadState;
   seconds?: bigint;
@@ -244,6 +251,26 @@ function documentsWithReadTimerfd(
   return documents;
 }
 
+function documentsWithReadFile(
+  activeThread: NativeThreadState,
+  options: { flags?: string[]; recipe?: Record<string, unknown>; offset?: number } = {},
+): NativeProcessImageDocuments {
+  const documents = documentsWithReadPipe(activeThread, {
+    readFd: 38,
+    readKind: "file",
+    readFlags: options.flags ?? ["octal:0"],
+    readRecipe: options.recipe ?? {
+      reopen: "/tmp/machinen-active-read.txt",
+      offset: options.offset ?? 5,
+    },
+    includeWriteEnd: false,
+  });
+  documents.mappings.mappings[0]!.target.targetStart = "0x600000000000";
+  documents.resources.resources[0]!.path = "/tmp/machinen-active-read.txt";
+  documents.resources.resources[0]!.offset = options.offset ?? 5;
+  return documents;
+}
+
 function timerfdRecipe(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     timerfdTicks: "0x0",
@@ -273,6 +300,28 @@ function documentsWithSocketResource(
             fd,
             path: "socket:[4242]",
             flags: ["octal:2"],
+          },
+        ];
+  return documents;
+}
+
+function documentsWithKernelFdResource(
+  activeThread: NativeThreadState,
+  fd: number,
+  kind: "epoll" | "signalfd" | "file" | "missing",
+): NativeProcessImageDocuments {
+  const documents = documentsWithTimespec({ activeThread });
+  documents.resources.resources =
+    kind === "missing"
+      ? []
+      : [
+          {
+            id: `fd:${fd}:${kind}`,
+            kind,
+            state: "refused",
+            fd,
+            path: `anon_inode:[${kind}]`,
+            flags: ["octal:0"],
           },
         ];
   return documents;
@@ -983,6 +1032,32 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("models a safe offset-backed read from a regular file", () => {
+    const activeThread = arm64ReadThread(["0x26", "0x3100", "0x4", "0x0", "0x0", "0x0"]);
+    const documents = documentsWithReadFile(activeThread, { offset: 7 });
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdReadPolicy: "defer-target-resume",
+      fdReadResourcePolicy: "reopen-file",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdRead: {
+          fd: 38,
+          countBytes: 4,
+          resourceId: "fd:38:read",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
+        },
+        policy: "conservative-target-fd-read-block-preserved",
+      },
+    });
+  });
+
   it("prefers /proc syscall arguments for modeled read", () => {
     const activeThread = arm64ReadThread();
     activeThread.syscall.arguments = ["0x20", "0x3100", "0x1", "0x0", "0x0", "0x0"];
@@ -1038,6 +1113,39 @@ describe("native active syscall classification", () => {
       : documentsWithReadPipe(scenario.thread);
 
     expect(modelNativeFdReadState(scenario.thread, documents)).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-read-state-missing",
+        detail: { reason: scenario.reason },
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "non-file resource",
+      thread: arm64ReadThread(["0x26", "0x3100", "0x4", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadPipe(thread, { readFd: 38, readKind: "pipe" }),
+      reason: "read file proof requires a captured regular file fd",
+    },
+    {
+      name: "write-only file",
+      thread: arm64ReadThread(["0x26", "0x3100", "0x4", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) =>
+        documentsWithReadFile(thread, { flags: ["octal:1"] }),
+      reason: "read file proof requires a readable file fd",
+    },
+    {
+      name: "missing reopen recipe",
+      thread: arm64ReadThread(["0x26", "0x3100", "0x4", "0x0", "0x0", "0x0"]),
+      documents: (thread: NativeThreadState) => documentsWithReadFile(thread, { recipe: {} }),
+      reason: "read file proof requires a reopen recipe",
+    },
+  ])("refuses unsafe regular-file read state: $name", (scenario) => {
+    expect(
+      modelNativeFdReadState(scenario.thread, scenario.documents(scenario.thread), "reopen-file"),
+    ).toMatchObject({
       state: "missing",
       refusal: {
         code: "target-fd-read-state-missing",
@@ -1151,6 +1259,56 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("refuses active epoll wait with epoll-specific detail", () => {
+    const activeThread = arm64EpollThread("epoll_pwait", [
+      "0x30",
+      "0x4100",
+      "0x4",
+      "0xffffffff",
+      "0x0",
+      "0x8",
+    ]);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      documents: documentsWithKernelFdResource(activeThread, 48, "epoll"),
+    });
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "fd-blocking",
+      refusal: {
+        code: "target-epoll-syscall-state-unsupported",
+        detail: {
+          reason: "epoll kernel ready list state is unsupported",
+          epollSyscall: {
+            arguments: { source: "registers", epfd: 48, eventsPointer: "0x4100" },
+            resource: { id: "fd:48:epoll", kind: "epoll", fd: 48 },
+          },
+        },
+      },
+    });
+  });
+
+  it("refuses signalfd reads with signal-queue-specific detail", () => {
+    const activeThread = arm64ReadThread(["0x32", "0x4100", "0x80", "0x0", "0x0", "0x0"]);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      documents: documentsWithKernelFdResource(activeThread, 50, "signalfd"),
+      fdReadPolicy: "defer-target-resume",
+    });
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "fd-blocking",
+      refusal: {
+        code: "target-signalfd-state-unsupported",
+        detail: {
+          reason: "signalfd pending signal queue state is unsupported",
+          signalfdRead: {
+            arguments: { source: "registers", fd: 50, bufferPointer: "0x4100" },
+            resource: { id: "fd:50:signalfd", kind: "signalfd", fd: 50 },
+          },
+        },
+      },
+    });
+  });
+
   it.each(["accept", "accept4", "connect"] as const)(
     "refuses active socket syscall %s with socket-specific detail",
     (name) => {
@@ -1182,6 +1340,34 @@ describe("native active syscall classification", () => {
       });
     },
   );
+
+  it.each([
+    {
+      name: "missing epoll resource",
+      thread: arm64EpollThread(),
+      documents: (activeThread: NativeThreadState) =>
+        documentsWithKernelFdResource(activeThread, 48, "missing"),
+      reason: "epoll fd resource is missing",
+      code: "target-epoll-syscall-state-unsupported",
+    },
+    {
+      name: "non-epoll fd",
+      thread: arm64EpollThread(),
+      documents: (activeThread: NativeThreadState) =>
+        documentsWithKernelFdResource(activeThread, 48, "file"),
+      reason: "epoll fd is not a captured epoll instance",
+      code: "target-epoll-syscall-state-unsupported",
+    },
+  ])("keeps active epoll syscall fail-closed for $name", (scenario) => {
+    const result = classifyNativeActiveSyscalls([scenario.thread], {
+      documents: scenario.documents(scenario.thread),
+    });
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "fd-blocking",
+      refusal: { code: scenario.code, detail: { reason: scenario.reason } },
+    });
+  });
 
   it.each([
     {

--- a/packages/runtime/src/__tests__/target-guest-active-syscall-restore.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-active-syscall-restore.test.ts
@@ -120,6 +120,35 @@ const fdReadResult: NativeActiveSyscallClassificationResult = {
   ],
 };
 
+const fileReadResult: NativeActiveSyscallClassificationResult = {
+  classifications: [],
+  refusals: [],
+  continuations: [
+    {
+      threadId: "thread:4",
+      syscallClass: "fd-blocking",
+      action: "defer-target-resume",
+      syscall: { state: "inside-syscall", name: "read" },
+      metadata: {
+        fdRead: {
+          kind: "fd-read-block",
+          syscallName: "read",
+          argumentSource: "registers",
+          fd: 38,
+          bufferPointer: "0x3100",
+          countBytes: 4,
+          bufferMapping: "mapping:stack",
+          resourceId: "fd:38:read",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
+        },
+        policy: "conservative-target-fd-read-block-preserved",
+      },
+    },
+  ],
+};
+
 describe("target guest active syscall restore", () => {
   it("plans target re-arm for modeled sleep timers", () => {
     expect(planTargetGuestActiveSyscallRestore(sleepResult)).toEqual({
@@ -165,6 +194,24 @@ describe("target guest active syscall restore", () => {
           fd: 32,
           countBytes: 1,
           resource: "synthetic-empty-pipe-read-end",
+          resumeMode: "defer-target-resume",
+        },
+      ],
+    });
+  });
+
+  it("plans target-side completion for modeled regular-file reads", () => {
+    expect(planTargetGuestActiveSyscallRestore(fileReadResult)).toEqual({
+      state: "planned",
+      refusals: [],
+      steps: [
+        {
+          action: "complete-fd-read-from-file",
+          threadId: "thread:4",
+          fd: 38,
+          countBytes: 4,
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
           resumeMode: "defer-target-resume",
         },
       ],

--- a/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
@@ -2,12 +2,21 @@ import { describe, expect, it } from "vitest";
 import { planTargetGuestProcessContextRestore } from "../target-guest-process-context-restore.ts";
 import type { NativeProcessImageDocuments } from "../native-process-image.ts";
 
+function auxvHex(values: { pageSize: number; clockTick: number }): string {
+  const bytes = Buffer.alloc(16 * 3);
+  bytes.writeBigUInt64LE(6n, 0);
+  bytes.writeBigUInt64LE(BigInt(values.pageSize), 8);
+  bytes.writeBigUInt64LE(17n, 16);
+  bytes.writeBigUInt64LE(BigInt(values.clockTick), 24);
+  return bytes.toString("hex");
+}
+
 function documents(
   overrides: Partial<NativeProcessImageDocuments["manifest"]["process"]> = {},
 ): NativeProcessImageDocuments {
   const process = {
     exe: "/bin/target",
-    argv: ["/bin/target", "--token", "ok"],
+    argv: ["/bin/target", "--machinen-argv-token", "ok"],
     env: { MACHINEN_CONTEXT_TOKEN: "process-context" },
     cwd: "/",
     ...overrides,
@@ -40,7 +49,7 @@ function documents(
           id: "auxv",
           kind: "auxv",
           state: "captured",
-          recipe: { bytesHex: "01000000000000000020000000000000" },
+          recipe: { bytesHex: auxvHex({ pageSize: 4096, clockTick: 100 }) },
         },
       ],
       refusals: { vocabularyVersion: 1, refusals: [] },
@@ -66,10 +75,10 @@ describe("target guest process-context restore", () => {
       state: "planned",
       mode: "metadata-only",
       steps: [
-        { action: "record-argv", argc: 3, argvBytes: 20 },
+        { action: "record-argv", argc: 3, argvBytes: 34 },
         { action: "record-env", envCount: 1 },
         { action: "record-cwd", cwdHex: "2f" },
-        { action: "record-auxv", auxvBytes: 16 },
+        { action: "record-auxv", auxvBytes: 48 },
       ],
     });
   });
@@ -94,6 +103,59 @@ describe("target guest process-context restore", () => {
         { action: "chdir", cwdHex: "2f" },
         { action: "record-auxv" },
       ],
+    });
+  });
+
+  it("plans target-visible argv/env/cwd/auxv verifier steps", () => {
+    const plan = planTargetGuestProcessContextRestore(documents(), {
+      mode: "apply-target-visible-context",
+    });
+
+    expect(plan).toMatchObject({
+      state: "planned",
+      mode: "apply-target-visible-context",
+      steps: expect.arrayContaining([
+        expect.objectContaining({
+          action: "materialize-argv",
+          tokenIndex: 1,
+          tokenHex: "2d2d6d616368696e656e2d617267762d746f6b656e",
+        }),
+        expect.objectContaining({ action: "verify-env-value" }),
+        expect.objectContaining({ action: "verify-cwd", cwdHex: "2f" }),
+        expect.objectContaining({ action: "verify-auxv-selected", pageSize: 4096, clockTick: 100 }),
+      ]),
+    });
+  });
+
+  it("refuses target-visible context without controlled tokens or selected auxv", () => {
+    const bad = documents({ argv: ["/bin/target"], env: {}, cwd: "/" });
+    bad.resources.resources.find((resource) => resource.kind === "auxv")!.recipe = {
+      bytesHex: "01000000000000000020000000000000",
+    };
+
+    const plan = planTargetGuestProcessContextRestore(bad, {
+      mode: "apply-target-visible-context",
+    });
+
+    expect(plan).toMatchObject({
+      state: "refused",
+      refusals: expect.arrayContaining([
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            reason: "target-visible context requires controlled argv token",
+          }),
+        }),
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            reason: "target-visible context requires MACHINEN_CONTEXT_TOKEN",
+          }),
+        }),
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            reason: "target-visible context requires selected safe auxv entries",
+          }),
+        }),
+      ]),
     });
   });
 

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -288,9 +288,29 @@ describe("target guest restore loader descriptor", () => {
       {
         section: "process-context" as const,
         step: {
+          action: "materialize-argv" as const,
+          argc: 2,
+          argvSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+          tokenIndex: 1,
+          tokenHex: "2d2d746f6b656e",
+          tokenSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        },
+      },
+      {
+        section: "process-context" as const,
+        step: {
           action: "chdir" as const,
           cwdHex: "2f",
           cwdSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        },
+      },
+      {
+        section: "process-context" as const,
+        step: {
+          action: "verify-auxv-selected" as const,
+          pageSize: 4096,
+          clockTick: 100,
+          auxvSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
         },
       },
       {
@@ -335,6 +355,18 @@ describe("target guest restore loader descriptor", () => {
         },
       },
       {
+        section: "active-syscall" as const,
+        step: {
+          action: "complete-fd-read-from-file" as const,
+          threadId: "thread:1",
+          fd: 38,
+          countBytes: 4,
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
+          resumeMode: "defer-target-resume" as const,
+        },
+      },
+      {
         section: "thread-spawn" as const,
         step: {
           action: "spawn-target-thread" as const,
@@ -360,13 +392,19 @@ describe("target guest restore loader descriptor", () => {
         "--native-private-memory-step",
         "action=copy-captured-bytes;mapping=mapping:heap;targetStart=0x600000000000;sizeBytes=4096;sourceFile=/tmp/native-memory.bin;sourceOffset=0",
         "--native-process-context-step",
+        "action=materialize-argv;argc=2;argvSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1;tokenIndex=1;tokenHex=2d2d746f6b656e;tokenSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
         "action=chdir;cwdHex=2f;cwdSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
+        "action=verify-auxv-selected;pageSize=4096;clockTick=100;auxvSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
         "--native-signal-restore-step",
         "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
         "--native-active-syscall-step",
         "action=restore-fd-read-block;threadId=thread:1;fd=32;countBytes=1;resource=synthetic-empty-pipe-read-end;resumeMode=defer-target-resume",
         "--native-active-syscall-step",
         "action=restore-fd-read-block;threadId=thread:1;fd=36;countBytes=8;resource=synthetic-timerfd;seconds=1;nanoseconds=0;resumeMode=defer-target-resume",
+        "--native-active-syscall-step",
+        "action=complete-fd-read-from-file;threadId=thread:1;fd=38;countBytes=4;targetBufferPointer=0x600000000100;fileOffset=7;resumeMode=defer-target-resume",
         "--native-thread-spawn-step",
         "action=spawn-target-thread;threadId=thread:2;stackBase=0x530000000000;stackLimit=0x530000010000;rip=0x700300000000;rsp=0x530000010000",
       ]),

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -31,7 +31,8 @@ export type NativeFdReadPolicy = "refuse" | "defer-target-resume";
 export type NativeFdReadResourcePolicy =
   | "synthetic-empty-pipe"
   | "synthetic-empty-eventfd"
-  | "synthetic-timerfd";
+  | "synthetic-timerfd"
+  | "reopen-file";
 
 export interface NativeActiveSyscallPolicyOptions {
   sleepTimerPolicy?: NativeSleepTimerSyscallPolicy;
@@ -104,7 +105,8 @@ export interface NativeModeledPpollTimeoutState {
 export type NativeModeledFdReadTargetResource =
   | "synthetic-empty-pipe-read-end"
   | "synthetic-empty-eventfd"
-  | "synthetic-timerfd";
+  | "synthetic-timerfd"
+  | "reopened-offset-file";
 
 export interface NativeModeledFdReadTimerRemainingTime extends NativeSleepTimerDuration {
   state: "modeled";
@@ -124,6 +126,8 @@ export interface NativeModeledFdReadState {
   resourceId: string;
   pairedWriteResourceId?: string;
   targetResource: NativeModeledFdReadTargetResource;
+  targetBufferPointer?: string;
+  fileOffset?: number;
   remainingTime?: NativeModeledFdReadTimerRemainingTime;
 }
 
@@ -198,6 +202,7 @@ export interface NativeActiveSyscallClassificationResult {
 
 const SLEEP_TIMER_SYSCALLS = new Set(["clock_nanosleep", "nanosleep"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
+const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
 const FD_BLOCKING_SYSCALLS = new Set([
   "read",
   "write",
@@ -273,11 +278,17 @@ export function classifyNativeThreadSyscall(
   if (name === "ppoll" && options.pollTimeoutPolicy === "defer-target-resume") {
     return deferredPpollTimeoutClassification(thread, options);
   }
+  if (name === "read" && isActiveSignalfdRead(thread, options.documents)) {
+    return refusedSignalfdActiveSyscallClassification(thread, options);
+  }
   if (name === "read" && options.fdReadPolicy === "defer-target-resume") {
     return deferredFdReadClassification(thread, options);
   }
   if (SOCKET_ACTIVE_SYSCALLS.has(name)) {
     return refusedSocketActiveSyscallClassification(thread, options);
+  }
+  if (EPOLL_ACTIVE_SYSCALLS.has(name)) {
+    return refusedEpollActiveSyscallClassification(thread, options);
   }
   if (FD_BLOCKING_SYSCALLS.has(name)) {
     return refusedClassification(thread, "fd-blocking", {
@@ -531,6 +542,28 @@ function refusedSocketActiveSyscallClassification(
   });
 }
 
+function refusedEpollActiveSyscallClassification(
+  thread: NativeThreadState,
+  options: NativeActiveSyscallPolicyOptions,
+): NativeActiveSyscallClassification {
+  return refusedClassification(thread, "fd-blocking", {
+    code: "target-epoll-syscall-state-unsupported",
+    message: `thread ${thread.id} is blocked in epoll syscall ${syscallName(thread)}`,
+    detail: epollActiveSyscallDetail(thread, options.documents),
+  });
+}
+
+function refusedSignalfdActiveSyscallClassification(
+  thread: NativeThreadState,
+  options: NativeActiveSyscallPolicyOptions,
+): NativeActiveSyscallClassification {
+  return refusedClassification(thread, "fd-blocking", {
+    code: "target-signalfd-state-unsupported",
+    message: `thread ${thread.id} is blocked reading a signalfd`,
+    detail: signalfdActiveSyscallDetail(thread, options.documents),
+  });
+}
+
 interface SocketActiveSyscallArguments {
   source: "proc-syscall" | "registers";
   fd: number;
@@ -603,7 +636,152 @@ function socketResourceDetail(resource: NativeProcessResource): Record<string, u
     path: resource.path,
     flags: resource.flags,
     state: resource.state,
+    recipe: resource.recipe,
   };
+}
+
+interface EpollActiveSyscallArguments {
+  source: "proc-syscall" | "registers";
+  epfd: number;
+  eventsPointer: string;
+  maxEvents: string;
+  timeoutMs?: string;
+  sigmaskPointer?: string;
+  sigsetSize?: string;
+}
+
+function epollActiveSyscallDetail(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments | undefined,
+): Record<string, unknown> {
+  const args = decodeEpollActiveSyscallArguments(thread);
+  const resource = args
+    ? documents?.resources.resources.find((candidate) => candidate.fd === args.epfd)
+    : undefined;
+  return detail(thread, "fd-blocking", {
+    reason: epollActiveSyscallRefusalReason(args, documents, resource),
+    epollSyscall: {
+      arguments: args,
+      resource: resource ? socketResourceDetail(resource) : undefined,
+      unsupportedState: [
+        "epoll interest list",
+        "ready list ordering",
+        "edge-triggered delivery state",
+        "waiter wakeup race state",
+        "target fd resource mapping",
+      ],
+    },
+  });
+}
+
+function epollActiveSyscallRefusalReason(
+  args: EpollActiveSyscallArguments | undefined,
+  documents: NativeProcessImageDocuments | undefined,
+  resource: NativeProcessResource | undefined,
+): string {
+  if (!args) {
+    return "epoll syscall arguments were not captured";
+  }
+  if (!documents?.resources) {
+    return "captured resource table is not available";
+  }
+  if (!resource) {
+    return "epoll fd resource is missing";
+  }
+  return resource.kind === "epoll"
+    ? "epoll kernel ready list state is unsupported"
+    : "epoll fd is not a captured epoll instance";
+}
+
+// fallow-ignore-next-line complexity
+function decodeEpollActiveSyscallArguments(
+  thread: NativeThreadState,
+): EpollActiveSyscallArguments | undefined {
+  const args = sleepTimerArguments(thread);
+  if (!args) {
+    return undefined;
+  }
+  const epfd = safeNumber(args.values[0] ?? -1n);
+  if (epfd === undefined || epfd < 0) {
+    return undefined;
+  }
+  const syscall = syscallName(thread);
+  return {
+    source: args.source,
+    epfd,
+    eventsPointer: hex(args.values[1] ?? 0n),
+    maxEvents: hex(args.values[2] ?? 0n),
+    timeoutMs: hex(args.values[3] ?? 0n),
+    sigmaskPointer:
+      syscall === "epoll_pwait" || syscall === "epoll_pwait2"
+        ? hex(args.values[4] ?? 0n)
+        : undefined,
+    sigsetSize: syscall === "epoll_pwait2" ? hex(args.values[5] ?? 0n) : undefined,
+  };
+}
+
+function isActiveSignalfdRead(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments | undefined,
+): boolean {
+  const args = sleepTimerArguments(thread);
+  const fd = args ? safeNumber(args.values[0] ?? -1n) : undefined;
+  return (
+    documents?.resources.resources.some(
+      (resource) => resource.fd === fd && resource.kind === "signalfd",
+    ) ?? false
+  );
+}
+
+function signalfdActiveSyscallDetail(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments | undefined,
+): Record<string, unknown> {
+  const args = sleepTimerArguments(thread);
+  const fd = args ? safeNumber(args.values[0] ?? -1n) : undefined;
+  const resource =
+    fd === undefined
+      ? undefined
+      : documents?.resources.resources.find((candidate) => candidate.fd === fd);
+  return detail(thread, "fd-blocking", {
+    reason: signalfdActiveSyscallRefusalReason(args, documents, resource),
+    signalfdRead: {
+      arguments: args
+        ? {
+            source: args.source,
+            fd,
+            bufferPointer: hex(args.values[1] ?? 0n),
+            countBytes: hex(args.values[2] ?? 0n),
+          }
+        : undefined,
+      resource: resource ? socketResourceDetail(resource) : undefined,
+      unsupportedState: [
+        "pending signal queue state",
+        "signalfd mask delivery ordering",
+        "siginfo payload provenance",
+        "target signal mask coordination",
+      ],
+    },
+  });
+}
+
+function signalfdActiveSyscallRefusalReason(
+  args: SleepTimerArguments | undefined,
+  documents: NativeProcessImageDocuments | undefined,
+  resource: NativeProcessResource | undefined,
+): string {
+  if (!args) {
+    return "signalfd read arguments were not captured";
+  }
+  if (!documents?.resources) {
+    return "captured resource table is not available";
+  }
+  if (!resource) {
+    return "signalfd resource is missing";
+  }
+  return resource.kind === "signalfd"
+    ? "signalfd pending signal queue state is unsupported"
+    : "read fd is not a captured signalfd";
 }
 
 function decodeSocketActiveSyscallArguments(
@@ -760,6 +938,13 @@ function decodeFdReadArguments(
   if (countRefusal) {
     return countRefusal;
   }
+  const targetBufferPointer = targetReadBufferPointer(bufferMapping, values.bufferPointer);
+  if (resource.targetResource === "reopened-offset-file" && !targetBufferPointer) {
+    return missingFdRead(thread, "read file proof requires a translated target buffer", {
+      fd: values.fd,
+      bufferMapping: bufferMapping.id,
+    });
+  }
   return {
     fd: values.fd,
     bufferPointer: hex(values.bufferPointer),
@@ -768,6 +953,8 @@ function decodeFdReadArguments(
     resourceId: resource.resource.id,
     pairedWriteResourceId: resource.pairedWriteResource?.id,
     targetResource: resource.targetResource,
+    targetBufferPointer,
+    fileOffset: resource.fileOffset,
     remainingTime: resource.remainingTime,
   };
 }
@@ -1144,14 +1331,18 @@ function validateFdReadModeledResource(
       resource: NativeProcessResource;
       pairedWriteResource?: NativeProcessResource;
       targetResource: NativeModeledFdReadTargetResource;
+      fileOffset?: number;
       remainingTime?: NativeModeledFdReadTimerRemainingTime;
     }
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
   if (resourcePolicy === "synthetic-empty-eventfd") {
     return validateFdReadEventfdResource(thread, documents, fd);
   }
-  return resourcePolicy === "synthetic-timerfd"
-    ? validateFdReadTimerfdResource(thread, documents, fd)
+  if (resourcePolicy === "synthetic-timerfd") {
+    return validateFdReadTimerfdResource(thread, documents, fd);
+  }
+  return resourcePolicy === "reopen-file"
+    ? validateFdReadFileResource(thread, documents, fd)
     : validateFdReadPipeResource(thread, documents, fd);
 }
 
@@ -1195,6 +1386,50 @@ function validateFdReadPipeResource(
         resourceId: resource.id,
         pipeId: resource.path,
       });
+}
+
+// fallow-ignore-next-line complexity
+function validateFdReadFileResource(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments,
+  fd: number,
+):
+  | { resource: NativeProcessResource; targetResource: "reopened-offset-file"; fileOffset: number }
+  | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const resource = documents.resources.resources.find((candidate) => candidate.fd === fd);
+  if (resource?.kind !== "file") {
+    return missingFdRead(thread, "read file proof requires a captured regular file fd", {
+      fd,
+      resourceKind: resource?.kind,
+      resourceId: resource?.id,
+    });
+  }
+  if (nativeFdAccessMode(resource.flags) === 1) {
+    return missingFdRead(thread, "read file proof requires a readable file fd", {
+      fd,
+      resourceId: resource.id,
+      resourceFlags: resource.flags,
+    });
+  }
+  if (typeof resource.recipe?.reopen !== "string") {
+    return missingFdRead(thread, "read file proof requires a reopen recipe", {
+      fd,
+      resourceId: resource.id,
+    });
+  }
+  const fileOffset = fdReadFileOffset(resource);
+  return Number.isSafeInteger(fileOffset) && fileOffset >= 0
+    ? { resource, targetResource: "reopened-offset-file", fileOffset }
+    : missingFdRead(thread, "read file proof requires a safe non-negative file offset", {
+        fd,
+        resourceId: resource.id,
+        offset: resource.offset,
+      });
+}
+
+function fdReadFileOffset(resource: NativeProcessResource): number {
+  const recipeOffset = resource.recipe?.offset;
+  return typeof recipeOffset === "number" ? recipeOffset : (resource.offset ?? 0);
 }
 
 function validateFdReadEventfdResource(
@@ -1611,6 +1846,16 @@ function writableMappingContainingRange(
       sourceAddress >= BigInt(mapping.sourceStart) &&
       sourceAddress + sizeBytes <= BigInt(mapping.sourceEnd),
   );
+}
+
+function targetReadBufferPointer(
+  mapping: NativeMemoryMapping,
+  sourceAddress: bigint,
+): string | undefined {
+  const targetStart = mapping.target.targetStart;
+  return targetStart
+    ? hex(BigInt(targetStart) + sourceAddress - BigInt(mapping.sourceStart))
+    : undefined;
 }
 
 function safeNumber(value: bigint): number | undefined {

--- a/packages/runtime/src/native-process-image.ts
+++ b/packages/runtime/src/native-process-image.ts
@@ -58,6 +58,7 @@ export const nativeProcessImageRefusalCodes = [
   "target-callee-saved-state-unsupported",
   "target-caller-frame-unavailable",
   "target-code-rva-unmapped",
+  "target-epoll-syscall-state-unsupported",
   "target-fd-table-duplicate",
   "target-fd-read-state-missing",
   "target-fd-table-missing",
@@ -72,6 +73,7 @@ export const nativeProcessImageRefusalCodes = [
   "target-ppoll-timeout-missing",
   "target-process-context-unsupported",
   "target-return-slot-unsupported",
+  "target-signalfd-state-unsupported",
   "target-resume-execution-unavailable",
   "target-resume-fault-invalid-code-landing",
   "target-resume-fault-outside-target-bytes",
@@ -312,6 +314,7 @@ export type NativeProcessResourceKind =
   | "timer"
   | "eventfd"
   | "signal"
+  | "signalfd"
   | "namespace"
   | "credential"
   | "futex"

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -554,7 +554,8 @@ function isStatefulKernelResource(resource: NativeProcessResource): boolean {
     resource.kind === "epoll" ||
     resource.kind === "timer" ||
     resource.kind === "eventfd" ||
-    resource.kind === "signal"
+    resource.kind === "signal" ||
+    resource.kind === "signalfd"
   );
 }
 

--- a/packages/runtime/src/target-guest-active-syscall-restore.ts
+++ b/packages/runtime/src/target-guest-active-syscall-restore.ts
@@ -27,8 +27,17 @@ export type TargetGuestActiveSyscallRestoreStep =
       threadId: string;
       fd: number;
       countBytes: number;
-      resource: NativeModeledFdReadTargetResource;
+      resource: Exclude<NativeModeledFdReadTargetResource, "reopened-offset-file">;
       remainingTime?: { seconds: string; nanoseconds: number };
+      resumeMode: "defer-target-resume";
+    }
+  | {
+      action: "complete-fd-read-from-file";
+      threadId: string;
+      fd: number;
+      countBytes: number;
+      targetBufferPointer: string;
+      fileOffset: number;
       resumeMode: "defer-target-resume";
     };
 
@@ -70,15 +79,25 @@ function continuationStep(
     };
   }
   if (continuation.syscallClass === "fd-blocking") {
+    const read = continuation.metadata.fdRead;
+    if (read.targetResource === "reopened-offset-file") {
+      return {
+        action: "complete-fd-read-from-file",
+        threadId: continuation.threadId,
+        fd: read.fd,
+        countBytes: read.countBytes,
+        targetBufferPointer: read.targetBufferPointer!,
+        fileOffset: read.fileOffset!,
+        resumeMode: "defer-target-resume",
+      };
+    }
     return {
       action: "restore-fd-read-block",
       threadId: continuation.threadId,
-      fd: continuation.metadata.fdRead.fd,
-      countBytes: continuation.metadata.fdRead.countBytes,
-      resource: continuation.metadata.fdRead.targetResource,
-      remainingTime: continuation.metadata.fdRead.remainingTime
-        ? duration(continuation.metadata.fdRead.remainingTime)
-        : undefined,
+      fd: read.fd,
+      countBytes: read.countBytes,
+      resource: read.targetResource,
+      remainingTime: read.remainingTime ? duration(read.remainingTime) : undefined,
       resumeMode: "defer-target-resume",
     };
   }

--- a/packages/runtime/src/target-guest-process-context-restore.ts
+++ b/packages/runtime/src/target-guest-process-context-restore.ts
@@ -4,7 +4,10 @@ import type {
   NativeProcessImageRefusal,
 } from "./native-process-image.ts";
 
-export type TargetGuestProcessContextRestoreMode = "metadata-only" | "apply-target-env-cwd";
+export type TargetGuestProcessContextRestoreMode =
+  | "metadata-only"
+  | "apply-target-env-cwd"
+  | "apply-target-visible-context";
 
 export type TargetGuestProcessContextRestoreStep =
   | {
@@ -12,6 +15,14 @@ export type TargetGuestProcessContextRestoreStep =
       argc: number;
       argvBytes: number;
       argvSha256: string;
+    }
+  | {
+      action: "materialize-argv";
+      argc: number;
+      argvSha256: string;
+      tokenIndex: number;
+      tokenHex: string;
+      tokenSha256: string;
     }
   | {
       action: "record-env";
@@ -36,6 +47,12 @@ export type TargetGuestProcessContextRestoreStep =
       envSha256: string;
     }
   | {
+      action: "verify-env-value";
+      keyHex: string;
+      valueHex: string;
+      valueSha256: string;
+    }
+  | {
       action: "record-cwd";
       cwdHex: string;
       cwdSha256: string;
@@ -46,8 +63,19 @@ export type TargetGuestProcessContextRestoreStep =
       cwdSha256: string;
     }
   | {
+      action: "verify-cwd";
+      cwdHex: string;
+      cwdSha256: string;
+    }
+  | {
       action: "record-auxv";
       auxvBytes: number;
+      auxvSha256: string;
+    }
+  | {
+      action: "verify-auxv-selected";
+      pageSize: number;
+      clockTick: number;
       auxvSha256: string;
     };
 
@@ -72,32 +100,48 @@ interface ProcessContextModel {
   envEntries: Array<[string, string]>;
   cwd: string;
   auxvHex: string;
+  selectedAuxv: SelectedAuxvContext;
+}
+
+interface SelectedAuxvContext {
+  pageSize: number;
+  clockTick: number;
 }
 
 const DEFAULT_MAX_ARGV_ENTRIES = 128;
 const DEFAULT_MAX_ENV_ENTRIES = 256;
 const DEFAULT_MAX_STRING_BYTES = 64 * 1024;
 const DEFAULT_MAX_AUXV_BYTES = 4096;
+const CONTEXT_ENV_TOKEN_KEY = "MACHINEN_CONTEXT_TOKEN";
+const CONTEXT_ARGV_TOKEN = "--machinen-argv-token";
+const AT_PAGESZ = 6n;
+const AT_CLKTCK = 17n;
+const AT_NULL = 0n;
+const AUXV_ENTRY_BYTES = 16;
 
 export function planTargetGuestProcessContextRestore(
   documents: NativeProcessImageDocuments,
   options: TargetGuestProcessContextRestoreOptions = {},
 ): TargetGuestProcessContextRestorePlan {
-  const model = processContextModel(documents, options);
+  const mode = options.mode ?? "metadata-only";
+  const model = processContextModel(documents, options, mode);
   if ("refusals" in model) {
     return { state: "refused", refusals: model.refusals };
   }
-  const mode = options.mode ?? "metadata-only";
   return { state: "planned", mode, steps: processContextSteps(model, mode) };
 }
 
 function processContextModel(
   documents: NativeProcessImageDocuments,
   options: TargetGuestProcessContextRestoreOptions,
+  mode: TargetGuestProcessContextRestoreMode,
 ): ProcessContextModel | { refusals: NativeProcessImageRefusal[] } {
+  const auxvHex = auxvResourceHex(documents);
+  const selectedAuxv = auxvHex ? selectedAuxvContext(auxvHex) : undefined;
   const refusals = [
     ...validateManifestProcessContext(documents, options),
     ...validateResourceConsistency(documents),
+    ...validateTargetVisibleContext(documents, selectedAuxv, mode),
   ];
   if (refusals.length > 0) {
     return { refusals };
@@ -106,7 +150,8 @@ function processContextModel(
     argv: documents.manifest.process.argv,
     envEntries: sortedEnvEntries(documents.manifest.process.env),
     cwd: documents.manifest.process.cwd,
-    auxvHex: auxvResourceHex(documents)!,
+    auxvHex: auxvHex!,
+    selectedAuxv: selectedAuxv!,
   };
 }
 
@@ -239,59 +284,189 @@ function resourceMismatch(
   return JSON.stringify(actual) === JSON.stringify(expected) ? [] : [processContextRefusal(reason)];
 }
 
+function validateTargetVisibleContext(
+  documents: NativeProcessImageDocuments,
+  selectedAuxv: SelectedAuxvContext | undefined,
+  mode: TargetGuestProcessContextRestoreMode,
+): NativeProcessImageRefusal[] {
+  if (mode !== "apply-target-visible-context") {
+    return [];
+  }
+  const env = documents.manifest.process.env;
+  const argvTokenIndex = documents.manifest.process.argv.indexOf(CONTEXT_ARGV_TOKEN);
+  return [
+    ...(env[CONTEXT_ENV_TOKEN_KEY]
+      ? []
+      : [processContextRefusal("target-visible context requires MACHINEN_CONTEXT_TOKEN")]),
+    ...(argvTokenIndex >= 0
+      ? []
+      : [processContextRefusal("target-visible context requires controlled argv token")]),
+    ...(selectedAuxv
+      ? []
+      : [
+          processContextRefusal("target-visible context requires selected safe auxv entries", {
+            requiredAuxv: ["AT_PAGESZ", "AT_CLKTCK"],
+          }),
+        ]),
+  ];
+}
+
 function processContextSteps(
   model: ProcessContextModel,
   mode: TargetGuestProcessContextRestoreMode,
 ): TargetGuestProcessContextRestoreStep[] {
   const envDigest = sha256(canonicalEnv(model.envEntries));
+  const argvDigest = sha256(JSON.stringify(model.argv));
+  const auxvDigest = sha256(Buffer.from(model.auxvHex, "hex"));
   return [
     {
       action: "record-argv",
       argc: model.argv.length,
       argvBytes: stringListBytes(model.argv),
-      argvSha256: sha256(JSON.stringify(model.argv)),
+      argvSha256: argvDigest,
     },
-    ...(mode === "apply-target-env-cwd"
-      ? [
-          { action: "clear-env" as const, envCount: model.envEntries.length, envSha256: envDigest },
-          ...model.envEntries.map(([key, value]) => ({
-            action: "set-env" as const,
-            keyHex: hexUtf8(key),
-            valueHex: hexUtf8(value),
-            valueSha256: sha256(value),
-          })),
-          {
-            action: "verify-env" as const,
-            envCount: model.envEntries.length,
-            envSha256: envDigest,
-          },
-          { action: "chdir" as const, cwdHex: hexUtf8(model.cwd), cwdSha256: sha256(model.cwd) },
-        ]
-      : [
-          {
-            action: "record-env" as const,
-            envCount: model.envEntries.length,
-            envBytes: stringListBytes(model.envEntries.flatMap(([key, value]) => [key, value])),
-            envSha256: envDigest,
-          },
-          {
-            action: "record-cwd" as const,
-            cwdHex: hexUtf8(model.cwd),
-            cwdSha256: sha256(model.cwd),
-          },
-        ]),
+    ...targetVisibleArgvSteps(model, mode, argvDigest),
+    ...envSteps(model, mode, envDigest),
+    ...cwdSteps(model, mode),
     {
       action: "record-auxv",
       auxvBytes: model.auxvHex.length / 2,
-      auxvSha256: sha256(Buffer.from(model.auxvHex, "hex")),
+      auxvSha256: auxvDigest,
+    },
+    ...targetVisibleAuxvSteps(model, mode, auxvDigest),
+  ];
+}
+
+function targetVisibleArgvSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+  argvDigest: string,
+): TargetGuestProcessContextRestoreStep[] {
+  if (mode !== "apply-target-visible-context") {
+    return [];
+  }
+  const tokenIndex = model.argv.indexOf(CONTEXT_ARGV_TOKEN);
+  return [
+    {
+      action: "materialize-argv",
+      argc: model.argv.length,
+      argvSha256: argvDigest,
+      tokenIndex,
+      tokenHex: hexUtf8(CONTEXT_ARGV_TOKEN),
+      tokenSha256: sha256(CONTEXT_ARGV_TOKEN),
     },
   ];
+}
+
+function envSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+  envDigest: string,
+): TargetGuestProcessContextRestoreStep[] {
+  if (mode === "metadata-only") {
+    return [
+      {
+        action: "record-env",
+        envCount: model.envEntries.length,
+        envBytes: stringListBytes(model.envEntries.flatMap(([key, value]) => [key, value])),
+        envSha256: envDigest,
+      },
+    ];
+  }
+  return [
+    { action: "clear-env", envCount: model.envEntries.length, envSha256: envDigest },
+    ...model.envEntries.map(([key, value]) => ({
+      action: "set-env" as const,
+      keyHex: hexUtf8(key),
+      valueHex: hexUtf8(value),
+      valueSha256: sha256(value),
+    })),
+    { action: "verify-env", envCount: model.envEntries.length, envSha256: envDigest },
+    ...targetVisibleEnvSteps(model, mode),
+  ];
+}
+
+function targetVisibleEnvSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+): TargetGuestProcessContextRestoreStep[] {
+  const token = Object.fromEntries(model.envEntries)[CONTEXT_ENV_TOKEN_KEY];
+  return mode === "apply-target-visible-context" && token
+    ? [
+        {
+          action: "verify-env-value",
+          keyHex: hexUtf8(CONTEXT_ENV_TOKEN_KEY),
+          valueHex: hexUtf8(token),
+          valueSha256: sha256(token),
+        },
+      ]
+    : [];
+}
+
+function cwdSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+): TargetGuestProcessContextRestoreStep[] {
+  if (mode === "metadata-only") {
+    return [{ action: "record-cwd", cwdHex: hexUtf8(model.cwd), cwdSha256: sha256(model.cwd) }];
+  }
+  const applyStep = {
+    action: "chdir" as const,
+    cwdHex: hexUtf8(model.cwd),
+    cwdSha256: sha256(model.cwd),
+  };
+  return mode === "apply-target-visible-context"
+    ? [
+        applyStep,
+        { action: "verify-cwd", cwdHex: applyStep.cwdHex, cwdSha256: applyStep.cwdSha256 },
+      ]
+    : [applyStep];
+}
+
+function targetVisibleAuxvSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+  auxvDigest: string,
+): TargetGuestProcessContextRestoreStep[] {
+  return mode === "apply-target-visible-context"
+    ? [
+        {
+          action: "verify-auxv-selected",
+          pageSize: model.selectedAuxv.pageSize,
+          clockTick: model.selectedAuxv.clockTick,
+          auxvSha256: auxvDigest,
+        },
+      ]
+    : [];
 }
 
 function auxvResourceHex(documents: NativeProcessImageDocuments): string | undefined {
   const value = documents.resources.resources.find((resource) => resource.kind === "auxv")?.recipe
     ?.bytesHex;
   return typeof value === "string" ? value.toLowerCase() : undefined;
+}
+
+function selectedAuxvContext(auxvHex: string): SelectedAuxvContext | undefined {
+  const entries = parseAuxvEntries(auxvHex);
+  const pageSize = entries.get(AT_PAGESZ);
+  const clockTick = entries.get(AT_CLKTCK);
+  return pageSize !== undefined && clockTick !== undefined
+    ? { pageSize: Number(pageSize), clockTick: Number(clockTick) }
+    : undefined;
+}
+
+function parseAuxvEntries(auxvHex: string): Map<bigint, bigint> {
+  const bytes = Buffer.from(auxvHex, "hex");
+  const entries = new Map<bigint, bigint>();
+  for (let offset = 0; offset + AUXV_ENTRY_BYTES <= bytes.length; offset += AUXV_ENTRY_BYTES) {
+    const key = bytes.readBigUInt64LE(offset);
+    const value = bytes.readBigUInt64LE(offset + 8);
+    if (key === AT_NULL) {
+      break;
+    }
+    entries.set(key, value);
+  }
+  return entries;
 }
 
 function sortedEnvEntries(env: Record<string, string>): Array<[string, string]> {

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -701,6 +701,19 @@ function parseNativeProcessContextStep(
   fields: Map<string, string>,
 ): TargetGuestProcessContextRestoreStep {
   const action = requiredNativeField(fields, "action");
+  return (
+    parseNativeArgvContextStep(action, fields) ??
+    parseNativeEnvContextStep(action, fields) ??
+    parseNativeCwdContextStep(action, fields) ??
+    parseNativeAuxvContextStep(action, fields) ??
+    fail("target-guest-loader-descriptor-invalid", "unsupported native process-context action")
+  );
+}
+
+function parseNativeArgvContextStep(
+  action: string,
+  fields: Map<string, string>,
+): TargetGuestProcessContextRestoreStep | undefined {
   if (action === "record-argv") {
     return {
       action,
@@ -709,6 +722,22 @@ function parseNativeProcessContextStep(
       argvSha256: requiredNativeField(fields, "argvSha256"),
     };
   }
+  return action === "materialize-argv"
+    ? {
+        action,
+        argc: parseNativeInteger(fields, "argc"),
+        argvSha256: requiredNativeField(fields, "argvSha256"),
+        tokenIndex: parseNativeInteger(fields, "tokenIndex"),
+        tokenHex: requiredNativeField(fields, "tokenHex"),
+        tokenSha256: requiredNativeField(fields, "tokenSha256"),
+      }
+    : undefined;
+}
+
+function parseNativeEnvContextStep(
+  action: string,
+  fields: Map<string, string>,
+): TargetGuestProcessContextRestoreStep | undefined {
   if (action === "record-env") {
     return {
       action,
@@ -724,21 +753,33 @@ function parseNativeProcessContextStep(
       envSha256: requiredNativeField(fields, "envSha256"),
     };
   }
-  if (action === "set-env") {
-    return {
-      action,
-      keyHex: requiredNativeField(fields, "keyHex"),
-      valueHex: requiredNativeField(fields, "valueHex"),
-      valueSha256: requiredNativeField(fields, "valueSha256"),
-    };
-  }
-  if (action === "record-cwd" || action === "chdir") {
-    return {
-      action,
-      cwdHex: requiredNativeField(fields, "cwdHex"),
-      cwdSha256: requiredNativeField(fields, "cwdSha256"),
-    };
-  }
+  return action === "set-env" || action === "verify-env-value"
+    ? {
+        action,
+        keyHex: requiredNativeField(fields, "keyHex"),
+        valueHex: requiredNativeField(fields, "valueHex"),
+        valueSha256: requiredNativeField(fields, "valueSha256"),
+      }
+    : undefined;
+}
+
+function parseNativeCwdContextStep(
+  action: string,
+  fields: Map<string, string>,
+): TargetGuestProcessContextRestoreStep | undefined {
+  return action === "record-cwd" || action === "chdir" || action === "verify-cwd"
+    ? {
+        action,
+        cwdHex: requiredNativeField(fields, "cwdHex"),
+        cwdSha256: requiredNativeField(fields, "cwdSha256"),
+      }
+    : undefined;
+}
+
+function parseNativeAuxvContextStep(
+  action: string,
+  fields: Map<string, string>,
+): TargetGuestProcessContextRestoreStep | undefined {
   if (action === "record-auxv") {
     return {
       action,
@@ -746,10 +787,14 @@ function parseNativeProcessContextStep(
       auxvSha256: requiredNativeField(fields, "auxvSha256"),
     };
   }
-  return fail(
-    "target-guest-loader-descriptor-invalid",
-    "unsupported native process-context action",
-  );
+  return action === "verify-auxv-selected"
+    ? {
+        action,
+        pageSize: parseNativeInteger(fields, "pageSize"),
+        clockTick: parseNativeInteger(fields, "clockTick"),
+        auxvSha256: requiredNativeField(fields, "auxvSha256"),
+      }
+    : undefined;
 }
 
 function parseNativeExecutableMappingStep(
@@ -833,8 +878,22 @@ function parseNativeActiveSyscallStep(
       threadId: requiredNativeField(fields, "threadId"),
       fd: parseNativeInteger(fields, "fd"),
       countBytes: parseNativeInteger(fields, "countBytes"),
-      resource: requiredNativeField(fields, "resource") as NativeModeledFdReadTargetResource,
+      resource: requiredNativeField(fields, "resource") as Exclude<
+        NativeModeledFdReadTargetResource,
+        "reopened-offset-file"
+      >,
       remainingTime: fields.has("seconds") ? parseNativeDuration(fields) : undefined,
+      resumeMode: "defer-target-resume",
+    };
+  }
+  if (action === "complete-fd-read-from-file") {
+    return {
+      action,
+      threadId: requiredNativeField(fields, "threadId"),
+      fd: parseNativeInteger(fields, "fd"),
+      countBytes: parseNativeInteger(fields, "countBytes"),
+      targetBufferPointer: requiredNativeField(fields, "targetBufferPointer"),
+      fileOffset: parseNativeInteger(fields, "fileOffset"),
       resumeMode: "defer-target-resume",
     };
   }
@@ -1064,12 +1123,20 @@ function validateNativeRestoreStep(
   }
 }
 
+// fallow-ignore-next-line complexity
 function validateProcessContextStep(step: TargetGuestProcessContextRestoreStep): void {
   switch (step.action) {
     case "record-argv":
       assertPositive(step.argc, "argc");
       assertNonNegative(step.argvBytes, "argvBytes");
       assertSha256(step.argvSha256, "argvSha256");
+      return;
+    case "materialize-argv":
+      assertPositive(step.argc, "argc");
+      assertSha256(step.argvSha256, "argvSha256");
+      assertNonNegative(step.tokenIndex, "tokenIndex");
+      assertEvenHex(step.tokenHex, "tokenHex");
+      assertSha256(step.tokenSha256, "tokenSha256");
       return;
     case "record-env":
       assertNonNegative(step.envCount, "envCount");
@@ -1082,17 +1149,24 @@ function validateProcessContextStep(step: TargetGuestProcessContextRestoreStep):
       assertSha256(step.envSha256, "envSha256");
       return;
     case "set-env":
+    case "verify-env-value":
       assertEvenHex(step.keyHex, "keyHex");
       assertEvenHex(step.valueHex, "valueHex");
       assertSha256(step.valueSha256, "valueSha256");
       return;
     case "record-cwd":
     case "chdir":
+    case "verify-cwd":
       assertEvenHex(step.cwdHex, "cwdHex");
       assertSha256(step.cwdSha256, "cwdSha256");
       return;
     case "record-auxv":
       assertNonNegative(step.auxvBytes, "auxvBytes");
+      assertSha256(step.auxvSha256, "auxvSha256");
+      return;
+    case "verify-auxv-selected":
+      assertPositive(step.pageSize, "pageSize");
+      assertPositive(step.clockTick, "clockTick");
       assertSha256(step.auxvSha256, "auxvSha256");
       return;
   }
@@ -1180,8 +1254,16 @@ function validateSignalRestoreStep(step: TargetGuestSignalRestoreStep): void {
   }
 }
 
+// fallow-ignore-next-line complexity
 function validateActiveSyscallRestoreStep(step: TargetGuestActiveSyscallRestoreStep): void {
   assertNoWhitespace(step.threadId, "threadId");
+  if (step.action === "complete-fd-read-from-file") {
+    assertFd(step.fd, "fd");
+    assertPositive(step.countBytes, "countBytes");
+    assertHexAddress(step.targetBufferPointer, "targetBufferPointer");
+    assertNonNegative(step.fileOffset, "fileOffset");
+    return;
+  }
   if (step.action === "restore-fd-read-block") {
     assertFd(step.fd, "fd");
     assertPositive(step.countBytes, "countBytes");
@@ -1562,22 +1644,29 @@ function serializePrivateMemoryStep(step: TargetGuestPrivateMemoryRestoreStep): 
   return `${base} permissions=${step.permissions}`;
 }
 
+// fallow-ignore-next-line complexity
 function serializeProcessContextStep(step: TargetGuestProcessContextRestoreStep): string {
   switch (step.action) {
     case "record-argv":
       return `native=process-context action=${step.action} argc=${step.argc} argvBytes=${step.argvBytes} argvSha256=${step.argvSha256}`;
+    case "materialize-argv":
+      return `native=process-context action=${step.action} argc=${step.argc} argvSha256=${step.argvSha256} tokenIndex=${step.tokenIndex} tokenHex=${step.tokenHex} tokenSha256=${step.tokenSha256}`;
     case "record-env":
       return `native=process-context action=${step.action} envCount=${step.envCount} envBytes=${step.envBytes} envSha256=${step.envSha256}`;
     case "clear-env":
     case "verify-env":
       return `native=process-context action=${step.action} envCount=${step.envCount} envSha256=${step.envSha256}`;
     case "set-env":
+    case "verify-env-value":
       return `native=process-context action=${step.action} keyHex=${step.keyHex} valueHex=${step.valueHex} valueSha256=${step.valueSha256}`;
     case "record-cwd":
     case "chdir":
+    case "verify-cwd":
       return `native=process-context action=${step.action} cwdHex=${step.cwdHex} cwdSha256=${step.cwdSha256}`;
     case "record-auxv":
       return `native=process-context action=${step.action} auxvBytes=${step.auxvBytes} auxvSha256=${step.auxvSha256}`;
+    case "verify-auxv-selected":
+      return `native=process-context action=${step.action} pageSize=${step.pageSize} clockTick=${step.clockTick} auxvSha256=${step.auxvSha256}`;
   }
 }
 
@@ -1607,6 +1696,9 @@ function serializeSignalRestoreStep(step: TargetGuestSignalRestoreStep): string 
 }
 
 function serializeActiveSyscallStep(step: TargetGuestActiveSyscallRestoreStep): string {
+  if (step.action === "complete-fd-read-from-file") {
+    return `native=active-syscall action=${step.action} threadId=${step.threadId} fd=${step.fd} countBytes=${step.countBytes} targetBufferPointer=${step.targetBufferPointer} fileOffset=${step.fileOffset} resumeMode=${step.resumeMode}`;
+  }
   if (step.action === "restore-fd-read-block") {
     const remainingTime = step.remainingTime
       ? ` seconds=${step.remainingTime.seconds} nanoseconds=${step.remainingTime.nanoseconds}`

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -47,7 +47,7 @@ interface Args {
   syntheticEmptyPipeWriteFd?: string;
   syntheticEmptyEventFd?: string;
   syntheticTimerFd?: string;
-  processContextRestore?: "metadata-only" | "apply-target-env-cwd";
+  processContextRestore?: "metadata-only" | "apply-target-env-cwd" | "apply-target-visible-context";
 }
 
 interface TargetInvocation {
@@ -192,7 +192,7 @@ function usage(): never {
     "usage: tsx scripts/portable-machine-vm-restore-proof.ts verify " +
       "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
       "[--combined-descriptor] [--real-utility-continuation] " +
-      "[--process-context-restore metadata-only|apply-target-env-cwd] [--json]",
+      "[--process-context-restore metadata-only|apply-target-env-cwd|apply-target-visible-context] [--json]",
   );
   process.exit(2);
 }
@@ -217,14 +217,21 @@ function argsFromReader(read: (flag: string) => string | undefined, argv: string
   };
 }
 
+const PROCESS_CONTEXT_RESTORE_MODES = [
+  "metadata-only",
+  "apply-target-env-cwd",
+  "apply-target-visible-context",
+] as const;
+
 function parseProcessContextRestoreMode(value: string | undefined): Args["processContextRestore"] {
   if (value === undefined) {
     return undefined;
   }
-  if (value === "metadata-only" || value === "apply-target-env-cwd") {
-    return value;
-  }
-  usage();
+  return PROCESS_CONTEXT_RESTORE_MODES.includes(
+    value as (typeof PROCESS_CONTEXT_RESTORE_MODES)[number],
+  )
+    ? (value as Args["processContextRestore"])
+    : usage();
 }
 
 function readFlag(argv: string[], flag: string): string | undefined {
@@ -530,7 +537,7 @@ function activeSyscallPolicy(bundle: ReturnType<typeof validatePortableMachineSn
 
 function fdReadResourcePolicy(
   bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
-): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" {
+): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" | "reopen-file" {
   return fdReadResourcePolicyForKind(activeReadResourceKind(bundle));
 }
 
@@ -544,12 +551,14 @@ function activeReadResourceKind(
 
 function fdReadResourcePolicyForKind(
   kind: NativeProcessResource["kind"] | undefined,
-): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" {
+): "synthetic-empty-pipe" | "synthetic-empty-eventfd" | "synthetic-timerfd" | "reopen-file" {
   return kind === "eventfd"
     ? "synthetic-empty-eventfd"
     : kind === "timer"
       ? "synthetic-timerfd"
-      : "synthetic-empty-pipe";
+      : kind === "file"
+        ? "reopen-file"
+        : "synthetic-empty-pipe";
 }
 
 function isActiveReadThread(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -383,7 +383,7 @@ run_target_restore() {
   fi
   local process_context_restore_args=()
   if [[ "$REMOTE_SOURCE_TARGET" == "process-context" ]]; then
-    process_context_restore_args=(--process-context-restore apply-target-env-cwd)
+    process_context_restore_args=(--process-context-restore apply-target-visible-context)
   fi
   if [[ $REMOTE_E2E -eq 1 ]]; then
     local remote_path_assignment="PATH=\$PATH"


### PR DESCRIPTION
## Problem

The portable native restore path still had three narrow gaps:

- process context was applied, but not proven visible through target-side argv/env/cwd/auxv checks
- active regular-file `read` state had no safe offset-backed target completion path
- epoll/signalfd refusals still fell back to generic fd-blocking detail, while sockets could carry more resource detail

## Solution

This adds the next proof slice:

- new `apply-target-visible-context` mode for target process context
  - materializes a controlled argv token block
  - verifies `getenv("MACHINEN_CONTEXT_TOKEN")`
  - verifies `getcwd()`
  - verifies selected safe auxv entries with `getauxval(AT_PAGESZ/AT_CLKTCK)`
  - refuses missing controlled tokens or selected auxv entries with `target-process-context-unsupported`
- safe regular-file active `read` modeling
  - requires readable file fd, reopen recipe, safe offset, translated writable buffer
  - emits `complete-fd-read-from-file`
  - target trampoline completes with bounded `pread()` and refuses partial reads
- tighter active syscall refusals
  - `target-epoll-syscall-state-unsupported`
  - `target-signalfd-state-unsupported`
  - socket detail now includes resource recipe when captured

Closes #707.

## Validation

- `pnpm run build:docs` — 1.551s
- `pnpm run format:check` — 0.560s
- `pnpm run lint` — 0.223s
- `pnpm run typecheck` — 2.309s
- focused vitest — 3.254s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.369s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=process-context` visible-context proof — 37.462s
  - `targetProcessContextRestoreResult: passed`
  - active syscall, stack, private memory, executable, signal, TLS, frame/register/RFLAGS, state consumption all passed
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.945s
- `pnpm smoke-tests` — 2m12.861s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m14.123s
