### PR TITLE
Add file read active syscall VM proof

### DIFF
--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -38,9 +38,14 @@ read fds that are ready/EOF/invalid exit before target success.
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read` /
-`timerfd-read`, a real arm64 process blocked in `read` on an empty pipe, eventfd,
-or timerfd. It wraps that bundle in a portable machine snapshot,
-serializes a `native=active-syscall` section in the combined target descriptor,
-and requires `targetActiveSyscallRestoreResult=passed` before the remote
-arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer memory
-still refuses before VM target success with the active-syscall refusal codes.
+`timerfd-read` / `file-read`, a real arm64 process stopped in `read` on an empty
+pipe, eventfd, timerfd, or a safe offset-backed regular file. The file-read
+profile uses a ptrace syscall-entry stop for fd 38 so the capture is inside the
+`read(fd, buf, count)` boundary; the target proof then completes the read with
+`pread()` and the target-native verifier checks the translated read buffer
+contains the expected bytes. It wraps that bundle in a portable machine
+snapshot, serializes a `native=active-syscall` section in the combined target
+descriptor, and requires `targetActiveSyscallRestoreResult=passed` before the
+remote arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer
+memory still refuses before VM target success with the active-syscall refusal
+codes.

--- a/packages/microvm/assets/native-file-read-target.c
+++ b/packages/microvm/assets/native-file-read-target.c
@@ -1,0 +1,113 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define TARGET_FILE_FD 38
+#define READ_OFFSET 7
+#define READ_COUNT 4
+#define DATA_FILE "/tmp/machinen-native-file-read-target-data.txt"
+
+static char file_read_buffer[READ_COUNT + 8] __attribute__((used));
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static int move_fd(int from, int to) {
+  if (from == to) {
+    return 0;
+  }
+  if (dup2(from, to) < 0) {
+    return -1;
+  }
+  close(from);
+  return 0;
+}
+
+static int write_data_file(void) {
+  int fd = open(DATA_FILE, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if (fd < 0) {
+    return -1;
+  }
+  const char bytes[] = "HEADER-FILE-READ-PROOF\n";
+  ssize_t wrote = write(fd, bytes, sizeof(bytes) - 1u);
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return wrote == (ssize_t)(sizeof(bytes) - 1u) ? 0 : -1;
+}
+
+int main(void) {
+  if (write_data_file() != 0) {
+    fprintf(stderr, "machinen-file-read-target: write data: %s\n", strerror(errno));
+    return 1;
+  }
+  int fd = open(DATA_FILE, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-file-read-target: open: %s\n", strerror(errno));
+    return 1;
+  }
+  if (move_fd(fd, TARGET_FILE_FD) != 0) {
+    fprintf(stderr, "machinen-file-read-target: dup2: %s\n", strerror(errno));
+    return 1;
+  }
+  if (lseek(TARGET_FILE_FD, READ_OFFSET, SEEK_SET) < 0) {
+    fprintf(stderr, "machinen-file-read-target: lseek: %s\n", strerror(errno));
+    return 1;
+  }
+
+  clear_simd_fpu_state();
+  long rc = syscall(SYS_read, TARGET_FILE_FD, file_read_buffer, READ_COUNT);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-file-read-target: read: %s\n", strerror(errno));
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+}

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -57,6 +57,8 @@ struct Options {
   pid_t pid;
   int command_index;
   uint32_t settle_ms;
+  const char *trace_syscall;
+  int64_t trace_syscall_fd;
 };
 
 #if defined(__aarch64__)
@@ -83,6 +85,7 @@ struct SyscallInfo {
   uint64_t instruction_pointer;
 };
 
+static const char *syscall_name(long long number);
 static void read_thread_syscall(pid_t tid, struct SyscallInfo *info);
 static void read_thread_simd_fpu(struct ThreadCapture *thread);
 
@@ -231,7 +234,7 @@ static const char *opposite_arch(void) {
 static void usage(void) {
   fprintf(stderr,
       "usage: machinen-native-process-capture --output dir [--target-arch arch] "
-      "[--settle-ms n] (--pid pid | -- command [args...])\n");
+      "[--settle-ms n] [--trace-syscall name] [--trace-syscall-fd n] (--pid pid | -- command [args...])\n");
   exit(2);
 }
 
@@ -240,7 +243,9 @@ static struct Options parse_args(int argc, char **argv) {
       .target_arch = NULL,
       .pid = 0,
       .command_index = -1,
-      .settle_ms = 200};
+      .settle_ms = 200,
+      .trace_syscall = NULL,
+      .trace_syscall_fd = -1};
   for (int i = 1; i < argc; i++) {
     if (streq(argv[i], "--output")) {
       if (++i >= argc) {
@@ -262,6 +267,16 @@ static struct Options parse_args(int argc, char **argv) {
         usage();
       }
       opts.settle_ms = (uint32_t)parse_u64(argv[i], "settle-ms");
+    } else if (streq(argv[i], "--trace-syscall")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.trace_syscall = argv[i];
+    } else if (streq(argv[i], "--trace-syscall-fd")) {
+      if (++i >= argc) {
+        usage();
+      }
+      opts.trace_syscall_fd = (int64_t)parse_u64(argv[i], "trace-syscall-fd");
     } else if (streq(argv[i], "--")) {
       opts.command_index = i + 1;
       break;
@@ -278,10 +293,102 @@ static struct Options parse_args(int argc, char **argv) {
   if ((opts.pid > 0) == (opts.command_index >= 0)) {
     usage();
   }
+  if (opts.trace_syscall && opts.command_index < 0) {
+    usage();
+  }
+  if (opts.trace_syscall_fd >= 0 && !opts.trace_syscall) {
+    usage();
+  }
   if (opts.command_index >= argc) {
     usage();
   }
   return opts;
+}
+
+static void wait_for_launch_stop(pid_t child) {
+  for (;;) {
+    int status = 0;
+    pid_t got = waitpid(child, &status, 0);
+    if (got == child && WIFSTOPPED(status)) {
+      return;
+    }
+    if (got == child && WIFEXITED(status)) {
+      fail("traced target exited before capture");
+    }
+    if (got < 0 && errno == EINTR) {
+      continue;
+    }
+    fail("traced target did not stop before capture");
+  }
+}
+
+struct TraceSyscallRegisters {
+  long long number;
+  uint64_t arg0;
+};
+
+static struct TraceSyscallRegisters current_ptrace_syscall_registers(pid_t child) {
+#if defined(__x86_64__)
+  struct user_regs_struct regs;
+  if (ptrace(PTRACE_GETREGS, child, NULL, &regs) != 0) {
+    die("ptrace getregs trace syscall");
+  }
+  return (struct TraceSyscallRegisters){.number = (long long)regs.orig_rax, .arg0 = regs.rdi};
+#elif defined(__aarch64__)
+  struct NativeArm64Regs regs;
+  struct iovec regs_iov = {.iov_base = &regs, .iov_len = sizeof(regs)};
+  if (ptrace(PTRACE_GETREGSET, child, (void *)NT_PRSTATUS, &regs_iov) != 0) {
+    die("ptrace getregset trace syscall");
+  }
+  return (struct TraceSyscallRegisters){.number = (long long)regs.regs[8], .arg0 = regs.regs[0]};
+#else
+  (void)child;
+  return (struct TraceSyscallRegisters){.number = -1, .arg0 = 0};
+#endif
+}
+
+static bool trace_syscall_matches(
+    const char *wanted_syscall, int64_t wanted_fd, struct TraceSyscallRegisters regs) {
+  if (!streq(syscall_name(regs.number), wanted_syscall)) {
+    return false;
+  }
+  return wanted_fd < 0 || regs.arg0 == (uint64_t)wanted_fd;
+}
+
+static void trace_target_to_syscall(pid_t child, const char *syscall, int64_t syscall_fd) {
+  wait_for_launch_stop(child);
+  if (ptrace(PTRACE_SETOPTIONS, child, NULL, (void *)(uintptr_t)PTRACE_O_TRACESYSGOOD) != 0) {
+    die("ptrace setoptions trace syscall");
+  }
+  bool entering = true;
+  for (;;) {
+    if (ptrace(PTRACE_SYSCALL, child, NULL, NULL) != 0) {
+      die("ptrace syscall trace");
+    }
+    int status = 0;
+    pid_t got = 0;
+    do {
+      got = waitpid(child, &status, 0);
+    } while (got < 0 && errno == EINTR);
+    if (got != child) {
+      fail("traced target wait failed");
+    }
+    if (WIFEXITED(status) || WIFSIGNALED(status)) {
+      fail("traced target exited before requested syscall");
+    }
+    if (!WIFSTOPPED(status)) {
+      continue;
+    }
+    int signal = WSTOPSIG(status);
+    if ((signal & 0x80) == 0) {
+      continue;
+    }
+    struct TraceSyscallRegisters regs = current_ptrace_syscall_registers(child);
+    if (entering && trace_syscall_matches(syscall, syscall_fd, regs)) {
+      return;
+    }
+    entering = !entering;
+  }
 }
 
 static pid_t launch_target(const struct Options *opts, char **argv) {
@@ -302,9 +409,21 @@ static pid_t launch_target(const struct Options *opts, char **argv) {
       dup2(log_fd, STDERR_FILENO);
       close(log_fd);
     }
+    if (opts->trace_syscall) {
+      if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) != 0) {
+        fprintf(stderr, "machinen-native-process-capture: ptrace traceme failed: %s\n", strerror(errno));
+        _exit(126);
+      }
+      raise(SIGSTOP);
+    }
     execvp(argv[opts->command_index], &argv[opts->command_index]);
     fprintf(stderr, "machinen-native-process-capture: exec target failed: %s\n", strerror(errno));
     _exit(127);
+  }
+
+  if (opts->trace_syscall) {
+    trace_target_to_syscall(child, opts->trace_syscall, opts->trace_syscall_fd);
+    return child;
   }
 
   struct timespec delay = {.tv_sec = opts->settle_ms / 1000u,
@@ -379,9 +498,14 @@ static void wait_for_ptrace_stop(pid_t tid, int *stop_signal) {
   }
 }
 
-static void attach_thread(struct ThreadCapture *thread) {
+static void attach_thread(struct ThreadCapture *thread, pid_t already_attached_tid) {
   thread->attached = false;
   thread->stop_signal = 0;
+  if (thread->tid == already_attached_tid) {
+    thread->attached = true;
+    thread->stop_signal = SIGTRAP;
+    return;
+  }
   if (ptrace(PTRACE_ATTACH, thread->tid, NULL, NULL) != 0) {
     return;
   }
@@ -449,7 +573,8 @@ static void read_thread_simd_fpu(struct ThreadCapture *thread) {
 #endif
 }
 
-static uint32_t attach_threads(pid_t pid, struct ThreadCapture threads[NATIVE_CAPTURE_MAX_THREADS]) {
+static uint32_t attach_threads(
+    pid_t pid, struct ThreadCapture threads[NATIVE_CAPTURE_MAX_THREADS], pid_t already_attached_tid) {
   pid_t tids[NATIVE_CAPTURE_MAX_THREADS];
   uint32_t count = list_threads(pid, tids);
   if (count == 0) {
@@ -458,7 +583,7 @@ static uint32_t attach_threads(pid_t pid, struct ThreadCapture threads[NATIVE_CA
   for (uint32_t i = 0; i < count; i++) {
     threads[i] = (struct ThreadCapture){.tid = tids[i]};
     read_thread_syscall(threads[i].tid, &threads[i].syscall);
-    attach_thread(&threads[i]);
+    attach_thread(&threads[i], already_attached_tid);
     capture_registers(&threads[i]);
     read_thread_simd_fpu(&threads[i]);
   }
@@ -1523,7 +1648,7 @@ int main(int argc, char **argv) {
   pid_t pid = launch_target(&opts, argv);
 
   struct ThreadCapture threads[NATIVE_CAPTURE_MAX_THREADS];
-  uint32_t thread_count = attach_threads(pid, threads);
+  uint32_t thread_count = attach_threads(pid, threads, opts.trace_syscall ? pid : -1);
   struct ProcessInfo info = read_process_info(pid);
   struct MappingCapture mappings[NATIVE_CAPTURE_MAX_MAPPINGS];
   uint32_t mapping_count = parse_maps(pid, mappings);

--- a/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
@@ -61,6 +61,29 @@ describe("portable machine restore smoke profile", () => {
     );
   });
 
+  it("accepts the file-read remote source profile in dry-run mode", () => {
+    const workDir = tempDir();
+    const result = spawnSync(
+      "bash",
+      [SCRIPT, "--json", "--remote-e2e", "--dry-run", "--keep", "--work-dir", workDir],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: { ...SCRIPT_ENV, PORTABLE_MACHINE_REMOTE_SOURCE_TARGET: "file-read" },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary).toMatchObject({
+      state: "skipped",
+      skipReason: "dry run",
+      remoteE2e: 1,
+      remoteSourceTarget: "file-read",
+    });
+  });
+
   it("accepts remote-e2e dry-run mode without live remotes", () => {
     const workDir = tempDir();
     const result = spawnSync(

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -11,6 +11,7 @@ import {
 import {
   NATIVE_PROCESS_IMAGE_FILES,
   type NativeMemoryMapping,
+  type NativeProcessImageDocuments,
   type NativeProcessResource,
 } from "../packages/runtime/src/native-process-image.ts";
 import { planNativeRealUtilityContinuationAttempt } from "../packages/runtime/src/native-real-utility-continuation.ts";
@@ -97,6 +98,14 @@ interface CombinedDescriptorContext extends CombinedDescriptorPaths {
   >["steps"];
   targetThreadSpawnSteps: TargetGuestTwoThreadSpawnStep[];
   targetProcessContextSteps: TargetGuestNativeRestoreStep[];
+  activeFileReadProof?: ActiveFileReadProof;
+}
+
+interface ActiveFileReadProof {
+  fd: number;
+  fileOffset: number;
+  targetBufferPointer: string;
+  expectedBytes: Buffer;
 }
 
 interface PreparedTargetContinuation {
@@ -141,6 +150,7 @@ const PROOF_PIPE_WRITE_FD = 9;
 const PROOF_EVENT_FD = 10;
 const PROOF_TIMER_FD = 11;
 const PROOF_FD_BYTES = Buffer.from("FD");
+const PROOF_FILE_READ_BYTES = Buffer.from("FILE");
 const STATE_CONSUMPTION_MARKER = 0x5354415445434f4en;
 const STATE_CHECK_MEMORY = 0x01;
 const STATE_CHECK_STDIO = 0x02;
@@ -337,12 +347,13 @@ function prepareCombinedDescriptor(
   if (isRestorePlan(context)) {
     return context;
   }
-  writeFileSync(context.fdFile, PROOF_FD_BYTES);
+  writeFileSync(context.fdFile, proofFdFileBytes(context));
   const targetContinuation = prepareTargetContinuation(
     args,
     context.targetDir,
     context.memoryFile,
     context.mapping,
+    context.activeFileReadProof,
     plan,
   );
   if (isRestorePlan(targetContinuation)) {
@@ -377,7 +388,7 @@ function prepareTargetRestoreDescriptor(
       targetContinuation.translatedFrame ? proofResumeRegisters() : undefined,
     ),
     translatedFrame: targetContinuation.translatedFrame,
-    fdTable: proofFdTable(),
+    fdTable: proofFdTable(context),
     memory: descriptorMemoryForNativeRestore(memory, nativeRestore),
     nativeRestore,
   });
@@ -408,10 +419,6 @@ function combinedDescriptorContext(
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): CombinedDescriptorContext | ReturnType<typeof planPortableMachineVmRestoreProof> {
   const bundle = validatePortableMachineSnapshotBundle(args.bundleDir!);
-  const threads = proofThreadContext(bundle);
-  if (threads.state === "refused") {
-    return firstRefusedPlan(plan, threads.refusals);
-  }
   const memory = proofMemorySelection(bundle);
   if (!memory.mapping) {
     return refusedPlan(
@@ -419,6 +426,10 @@ function combinedDescriptorContext(
       "mapping-ambiguous",
       "portable machine proof needs one safe captured writable memory page",
     );
+  }
+  const threads = proofThreadContext(bundle, memory.mapping);
+  if (threads.state === "refused") {
+    return firstRefusedPlan(plan, threads.refusals);
   }
   const activeSyscallPlan = proofActiveSyscallPlan(threads.activeSyscallContinuations);
   if (activeSyscallPlan.state === "refused") {
@@ -436,6 +447,7 @@ function combinedDescriptorContext(
     targetActiveSyscallSteps: activeSyscallPlan.steps,
     targetThreadSpawnSteps: threads.threadSpawnSteps,
     targetProcessContextSteps: processContextSteps.steps,
+    activeFileReadProof: activeFileReadProof(activeSyscallPlan.steps),
   };
   return contextAfterPathCheck(plan, bundle.rootDir!, context);
 }
@@ -469,17 +481,19 @@ function contextAfterPathCheck(
 
 function proofThreadContext(
   bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+  mapping: NativeMemoryMapping,
 ): ProofThreadContext {
-  const threads = bundle.nativeProcessImage.threads.threads;
+  const documents = bundleWithProofMemoryMapping(bundle, mapping);
+  const threads = documents.threads.threads;
   if (threads.length === 2) {
-    return proofTwoThreadContext(bundle);
+    return proofTwoThreadContext(bundle, documents);
   }
   const plan = planNativeThreadRestoreBoundary({
     threads,
-    mappings: bundle.nativeProcessImage.mappings.mappings,
-    resources: bundle.nativeProcessImage.resources.resources,
+    mappings: documents.mappings.mappings,
+    resources: documents.resources.resources,
     tls: { targetFsBase: TARGET_TLS_BASE, targetAccessPolicy: "target-tcb-materialized" },
-    activeSyscall: activeSyscallPolicy(bundle),
+    activeSyscall: activeSyscallPolicy(bundle, documents),
   });
   return plan.state === "accepted"
     ? {
@@ -495,12 +509,13 @@ function proofThreadContext(
 
 function proofTwoThreadContext(
   bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+  documents = bundle.nativeProcessImage,
 ): ProofThreadContext {
   const boundary = planNativeControlledTwoThreadRestoreBoundary({
-    threads: bundle.nativeProcessImage.threads.threads,
-    mappings: bundle.nativeProcessImage.mappings.mappings,
-    resources: bundle.nativeProcessImage.resources.resources,
-    activeSyscall: activeSyscallPolicy(bundle),
+    threads: documents.threads.threads,
+    mappings: documents.mappings.mappings,
+    resources: documents.resources.resources,
+    activeSyscall: activeSyscallPolicy(bundle, documents),
   });
   if (boundary.state === "refused") {
     return boundary;
@@ -524,14 +539,35 @@ function proofTwoThreadContext(
   };
 }
 
-function activeSyscallPolicy(bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>) {
+function activeSyscallPolicy(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+  documents = bundle.nativeProcessImage,
+) {
   return {
     sleepTimerPolicy: "defer-target-resume" as const,
     pollTimeoutPolicy: "defer-target-resume" as const,
     pollTimeoutFdPolicy: "synthetic-timerfd" as const,
     fdReadPolicy: "defer-target-resume" as const,
     fdReadResourcePolicy: fdReadResourcePolicy(bundle),
-    documents: bundle.nativeProcessImage,
+    documents,
+  };
+}
+
+function bundleWithProofMemoryMapping(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+  mapping: NativeMemoryMapping,
+): NativeProcessImageDocuments {
+  return {
+    ...bundle.nativeProcessImage,
+    mappings: {
+      ...bundle.nativeProcessImage.mappings,
+      mappings: bundle.nativeProcessImage.mappings.mappings.map((candidate) =>
+        candidate.id === mapping.id ||
+        candidate.id === mapping.id.replace(/:combined-proof-page$/, "")
+          ? mapping
+          : candidate,
+      ),
+    },
   };
 }
 
@@ -586,9 +622,33 @@ function activeReadRegisterFd(
   return thread.sourceRegisters.arch === "arm64" ? thread.sourceRegisters.x[0] : undefined;
 }
 
+// fallow-ignore-next-line complexity
+function activeReadBufferPointer(
+  bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
+): bigint | undefined {
+  const thread = bundle.nativeProcessImage.threads.threads.find(isActiveReadThread);
+  const raw = thread
+    ? (thread.syscall.arguments?.[1] ?? activeReadRegisterBuffer(thread))
+    : undefined;
+  return raw === undefined ? undefined : safeBigInt(raw);
+}
+
+function activeReadRegisterBuffer(
+  thread: ReturnType<
+    typeof validatePortableMachineSnapshotBundle
+  >["nativeProcessImage"]["threads"]["threads"][number],
+): string | undefined {
+  return thread.sourceRegisters.arch === "arm64" ? thread.sourceRegisters.x[1] : undefined;
+}
+
 function safeBigIntNumber(value: string): number | undefined {
+  const parsed = safeBigInt(value);
+  return parsed === undefined ? undefined : Number(parsed);
+}
+
+function safeBigInt(value: string): bigint | undefined {
   try {
-    return Number(BigInt(value));
+    return BigInt(value);
   } catch {
     return undefined;
   }
@@ -612,7 +672,11 @@ function proofMemorySelection(bundle: ReturnType<typeof validatePortableMachineS
   return {
     file,
     sizeBytes,
-    mapping: selectProofMemoryMapping(bundle.nativeProcessImage.mappings.mappings, sizeBytes),
+    mapping: selectProofMemoryMapping(
+      bundle.nativeProcessImage.mappings.mappings,
+      sizeBytes,
+      activeReadBufferPointer(bundle),
+    ),
   };
 }
 
@@ -840,6 +904,32 @@ function proofActiveSyscallNativeSections(
   }));
 }
 
+function activeFileReadProof(
+  steps: CombinedDescriptorContext["targetActiveSyscallSteps"],
+): ActiveFileReadProof | undefined {
+  const step = steps.find((candidate) => candidate.action === "complete-fd-read-from-file");
+  return step?.action === "complete-fd-read-from-file"
+    ? {
+        fd: step.fd,
+        fileOffset: step.fileOffset,
+        targetBufferPointer: step.targetBufferPointer,
+        expectedBytes: PROOF_FILE_READ_BYTES.subarray(0, step.countBytes),
+      }
+    : undefined;
+}
+
+function proofFdFileBytes(context: CombinedDescriptorContext): Buffer {
+  const active = context.activeFileReadProof;
+  if (!active) {
+    return PROOF_FD_BYTES;
+  }
+  const size = Math.max(PROOF_FD_BYTES.length, active.fileOffset + active.expectedBytes.length);
+  const bytes = Buffer.alloc(size, 0);
+  PROOF_FD_BYTES.copy(bytes, 0);
+  active.expectedBytes.copy(bytes, active.fileOffset);
+  return bytes;
+}
+
 function proofThreadSpawnNativeSections(
   context: CombinedDescriptorContext,
 ): TargetGuestNativeRestoreStep[] {
@@ -877,9 +967,9 @@ function proofResumeRegisters() {
   };
 }
 
-function proofFdTable() {
+function proofFdTable(context: CombinedDescriptorContext) {
   return planNativeTargetFdTable({
-    resources: proofFdResources(),
+    resources: proofFdResources(context),
     expectedFds: [PROOF_CLOSED_FD],
     inheritedStdio: { mode: "inherit-output" },
     syntheticEmptyPipeFds: [PROOF_PIPE_READ_FD],
@@ -955,26 +1045,28 @@ function prepareTargetContinuation(
   targetDir: string,
   memoryFile: string,
   mapping: NativeMemoryMapping,
+  activeFileRead: ActiveFileReadProof | undefined,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ): PreparedTargetContinuation | ReturnType<typeof planPortableMachineVmRestoreProof> {
   const expectedMemoryByte = firstByte(memoryFile, mapping);
   return args.realUtilityContinuation
-    ? prepareRealUtilityContinuation(targetDir, expectedMemoryByte, plan)
+    ? prepareRealUtilityContinuation(targetDir, expectedMemoryByte, activeFileRead, plan)
     : {
         kind: "generated-verifier",
-        bytes: combinedProofTargetCode(expectedMemoryByte),
+        bytes: combinedProofTargetCode(expectedMemoryByte, activeFileRead),
       };
 }
 
 function prepareRealUtilityContinuation(
   targetDir: string,
   expectedMemoryByte: number,
+  activeFileRead: ActiveFileReadProof | undefined,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
 ) {
   const targetRoot = join(targetDir, "real-utility-root");
   const modulePath = join(targetRoot, "usr/bin/realspin-code");
   mkdirSync(dirname(modulePath), { recursive: true });
-  const targetCode = stateConsumingRealUtilityTargetCode(expectedMemoryByte);
+  const targetCode = stateConsumingRealUtilityTargetCode(expectedMemoryByte, activeFileRead);
   const moduleBytes = targetCode.bytes;
   writeFileSync(modulePath, moduleBytes);
   const module = realUtilityTargetModule(sha256(moduleBytes), moduleBytes.length);
@@ -1132,32 +1224,64 @@ function inside(root: string, candidate: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
+// fallow-ignore-next-line complexity
 function selectProofMemoryMapping(
   mappings: NativeMemoryMapping[],
   memorySizeBytes: number,
+  preferredSourceAddress?: bigint,
 ): NativeMemoryMapping | undefined {
-  const candidate = mappings.find((mapping) => {
-    const captured = mapping.captured;
-    return [
-      mapping.permissions.write,
-      !mapping.permissions.execute,
-      mapping.target.materialization === "translate",
-      captured !== undefined,
-      captured ? captured.offset + PROOF_MEMORY_SIZE <= memorySizeBytes : false,
-      captured ? captured.sizeBytes >= PROOF_MEMORY_SIZE : false,
-    ].every(Boolean);
-  });
+  const candidates = mappings.filter((mapping) => proofMemoryCandidate(mapping, memorySizeBytes));
+  const candidate = preferredSourceAddress
+    ? (candidates.find((mapping) => mappingContains(mapping, preferredSourceAddress)) ??
+      candidates[0])
+    : candidates[0];
   if (!candidate?.captured) {
     return undefined;
   }
+  return proofMemoryPage(candidate, memorySizeBytes, preferredSourceAddress);
+}
+
+function proofMemoryCandidate(mapping: NativeMemoryMapping, memorySizeBytes: number): boolean {
+  const captured = mapping.captured;
+  return [
+    mapping.permissions.write,
+    !mapping.permissions.execute,
+    mapping.target.materialization === "translate",
+    captured !== undefined,
+    captured ? captured.offset < memorySizeBytes : false,
+    captured ? captured.sizeBytes > 0 : false,
+  ].every(Boolean);
+}
+
+function proofMemoryPage(
+  mapping: NativeMemoryMapping,
+  memorySizeBytes: number,
+  preferredSourceAddress?: bigint,
+): NativeMemoryMapping {
+  const captured = mapping.captured!;
+  const sourceStart = BigInt(mapping.sourceStart);
+  const pageStart =
+    preferredSourceAddress && mappingContains(mapping, preferredSourceAddress)
+      ? alignDown(preferredSourceAddress, BigInt(PROOF_MEMORY_SIZE))
+      : sourceStart;
+  const offsetInMapping = pageStart - sourceStart;
+  const capturedOffset = captured.offset + Number(offsetInMapping);
+  const capturedLimit = captured.offset + captured.sizeBytes;
+  const available = Math.min(
+    PROOF_MEMORY_SIZE,
+    memorySizeBytes - capturedOffset,
+    capturedLimit - capturedOffset,
+  );
   return {
-    ...candidate,
-    id: `${candidate.id}:combined-proof-page`,
-    sizeBytes: PROOF_MEMORY_SIZE,
+    ...mapping,
+    id: `${mapping.id}:combined-proof-page`,
+    sourceStart: hex(pageStart),
+    sourceEnd: hex(pageStart + BigInt(available)),
+    sizeBytes: available,
     captured: {
       file: NATIVE_PROCESS_IMAGE_FILES.memory,
-      offset: candidate.captured.offset,
-      sizeBytes: PROOF_MEMORY_SIZE,
+      offset: capturedOffset,
+      sizeBytes: available,
     },
     target: {
       materialization: "translate",
@@ -1167,15 +1291,42 @@ function selectProofMemoryMapping(
   };
 }
 
-function proofFdResources(): NativeProcessResource[] {
+function mappingContains(mapping: NativeMemoryMapping, address: bigint): boolean {
+  return address >= BigInt(mapping.sourceStart) && address < BigInt(mapping.sourceEnd);
+}
+
+function alignDown(value: bigint, alignment: bigint): bigint {
+  return value - (value % alignment);
+}
+
+function proofFdResources(context: CombinedDescriptorContext): NativeProcessResource[] {
   return [
     proofStdoutResource(),
     proofFileResource(),
+    ...activeFileReadResources(context),
     proofPipeResource(PROOF_PIPE_READ_FD, "read"),
     proofPipeResource(PROOF_PIPE_WRITE_FD, "write"),
     proofSyntheticResource("eventfd", PROOF_EVENT_FD),
     proofSyntheticResource("timer", PROOF_TIMER_FD),
   ];
+}
+
+function activeFileReadResources(context: CombinedDescriptorContext): NativeProcessResource[] {
+  const active = context.activeFileReadProof;
+  return active
+    ? [
+        {
+          id: `fd:${active.fd}:combined-proof-file-read`,
+          kind: "file" as const,
+          state: "recipe" as const,
+          fd: active.fd,
+          path: GUEST_FD_FILE,
+          offset: active.fileOffset,
+          flags: ["octal:0"],
+          recipe: { reopen: GUEST_FD_FILE, offset: active.fileOffset },
+        },
+      ]
+    : [];
 }
 
 function proofStdoutResource(): NativeProcessResource {
@@ -1227,15 +1378,21 @@ function firstByte(memoryFile: string, mapping: NativeMemoryMapping): number {
   return bytes[mapping.captured!.offset] ?? 0;
 }
 
-function combinedProofTargetCode(expectedMemoryByte: number): Buffer {
-  return proofStateVerifierTargetCode(expectedMemoryByte, "exit").bytes;
+function combinedProofTargetCode(
+  expectedMemoryByte: number,
+  activeFileRead: ActiveFileReadProof | undefined,
+): Buffer {
+  return proofStateVerifierTargetCode(expectedMemoryByte, "exit", activeFileRead).bytes;
 }
 
-function stateConsumingRealUtilityTargetCode(expectedMemoryByte: number): {
+function stateConsumingRealUtilityTargetCode(
+  expectedMemoryByte: number,
+  activeFileRead: ActiveFileReadProof | undefined,
+): {
   bytes: Buffer;
   translatedReturnAddress: string;
 } {
-  const code = proofStateVerifierTargetCode(expectedMemoryByte, "return");
+  const code = proofStateVerifierTargetCode(expectedMemoryByte, "return", activeFileRead);
   return {
     bytes: code.bytes,
     translatedReturnAddress: hex(0x700300000000n + BigInt(code.translatedReturnOffset)),
@@ -1247,6 +1404,7 @@ type ProofCompletionMode = "exit" | "return";
 function proofStateVerifierTargetCode(
   expectedMemoryByte: number,
   completion: ProofCompletionMode,
+  activeFileRead?: ActiveFileReadProof,
 ): { bytes: Buffer; translatedReturnOffset: number } {
   const asm = new Amd64ProofAssembler();
   if (completion === "return") {
@@ -1263,6 +1421,12 @@ function proofStateVerifierTargetCode(
   }
   asm.checkMemoryByte(expectedMemoryByte);
   asm.markStateCheck(completion, STATE_CHECK_MEMORY);
+  if (activeFileRead) {
+    asm.checkAbsoluteBytes(
+      BigInt(activeFileRead.targetBufferPointer),
+      activeFileRead.expectedBytes,
+    );
+  }
   asm.checkFdClosed(PROOF_CLOSED_FD);
   asm.markStateCheck(completion, STATE_CHECK_CLOSE_FD);
   asm.checkFdOpen(PROOF_STDOUT_FD);
@@ -1525,6 +1689,14 @@ class Amd64ProofAssembler {
     this.movRaxImmediate(expected);
     this.push(0x48, 0x39, 0xc4);
     this.jumpIfNotEqual();
+  }
+
+  checkAbsoluteBytes(address: bigint, expected: Buffer): void {
+    for (const [index, byte] of expected.entries()) {
+      this.movRaxImmediate(address + BigInt(index));
+      this.push(0x80, 0x38, byte);
+      this.jumpIfNotEqual();
+    }
   }
 
   private checkAbsoluteU64(address: bigint, expected: bigint): void {

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -300,6 +300,7 @@ capture_remote_native_process_bundle() {
   tar -czf - -C "$ROOT" \
     packages/microvm/assets/native-process-capture.c \
     packages/microvm/assets/native-eventfd-read-target.c \
+    packages/microvm/assets/native-file-read-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
     packages/microvm/assets/native-ppoll-timeout-target.c \
     packages/microvm/assets/native-timerfd-read-target.c \
@@ -319,6 +320,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target"
       target_detail="remote arm64 eventfd read native-process bundle captured from $ARM64_SSH"
       ;;
+    file-read)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target"
+      target_detail="remote arm64 regular-file read native-process bundle captured from $ARM64_SSH"
+      ;;
     timerfd-read)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target"
       target_detail="remote arm64 timerfd read native-process bundle captured from $ARM64_SSH"
@@ -334,9 +339,11 @@ capture_remote_native_process_bundle() {
   local capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary'"
   if [[ "$REMOTE_SOURCE_TARGET" == "process-context" ]]; then
     capture_command="cd / && env -i MACHINEN_CONTEXT_TOKEN=process-context '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' --machinen-argv-token"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "file-read" ]]; then
+    capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall read --trace-syscall-fd 38 -- '$target_binary'"
   fi
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \
@@ -382,8 +389,10 @@ run_target_restore() {
     return 20
   fi
   local process_context_restore_args=()
+  local process_context_restore_args_text=""
   if [[ "$REMOTE_SOURCE_TARGET" == "process-context" ]]; then
     process_context_restore_args=(--process-context-restore apply-target-visible-context)
+    process_context_restore_args_text="${process_context_restore_args[*]}"
   fi
   if [[ $REMOTE_E2E -eq 1 ]]; then
     local remote_path_assignment="PATH=\$PATH"
@@ -391,7 +400,7 @@ run_target_restore() {
       remote_path_assignment="PATH='$AMD64_PATH_PREFIX':\$PATH"
     fi
     if ! ssh "$AMD64_SSH" \
-      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --combined-descriptor --real-utility-continuation ${process_context_restore_args[*]} --json" \
+      "cd '$AMD64_REPO' && $remote_path_assignment MACHINEN_VMM='$AMD64_VMM' MACHINEN_KERNEL='$AMD64_KERNEL' MACHINEN_ASSETS_DIR='$AMD64_ASSETS_DIR' '$AMD64_PNPM' --silent portable-machine-vm-restore-proof -- --bundle-dir '$REMOTE_PORTABLE_BUNDLE' --target-code-file '$REMOTE_TARGET_CODE' --image '$TARGET_IMAGE' --combined-descriptor --real-utility-continuation $process_context_restore_args_text --json" \
       >"$TARGET_LOG" 2>"$WORK/target-restore.stderr"; then
       record_timing "target-boot-restore" "failed" "$start" "remote runner failed"
       return 21


### PR DESCRIPTION
## Problem

The regular-file active `read` planner/trampoline path existed, but it did not have an end-to-end VM proof. We needed a real arm64 capture that crosses to an amd64 restore and proves the target-side `pread()` populated the translated read buffer.

## Solution

This adds a narrow file-read proof:

- new `native-file-read-target.c` opens a regular file, seeks to a safe offset, and enters `read(fd, buf, count)`
- `native-process-capture` can stop a launched target at syscall entry, filtered by syscall name and fd
- `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-read` captures the arm64 target at `read(fd=38, ...)`
- the combined VM proof maps the captured read buffer page, reopens a target file at fd 38, completes the read with target-side `pread()`, and checks the translated target buffer contains `FILE`
- focused dry-run smoke coverage for the `file-read` profile

Closes #709.

## Validation

- `pnpm run build:docs` — 1.907s
- `pnpm run format:check` — 0.704s
- `pnpm run lint` — 0.242s
- `pnpm run typecheck` — 2.757s
- focused vitest — 5.805s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.382s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-read` proof — 37.431s
  - `targetActiveSyscallRestoreResult: passed`
  - target-native verifier passed after checking the `pread()` buffer bytes
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 29.063s
- `pnpm smoke-tests` — 2m16.731s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m23.571s
