### PR TITLE
Model target initial stack process context

### DIFF
--- a/docs/snapshot/target-guest-process-context-restore.md
+++ b/docs/snapshot/target-guest-process-context-restore.md
@@ -20,7 +20,7 @@ Malformed, missing, inconsistent, or oversized context refuses with
 
 ## Target-side consumption
 
-Descriptors use `native=process-context` steps. Three modes are available:
+Descriptors use `native=process-context` steps. Four modes are available:
 
 - `metadata-only` records argv/env/cwd/auxv counts and SHA-256 digests for a
   target-native consumption gate.
@@ -32,16 +32,28 @@ Descriptors use `native=process-context` steps. Three modes are available:
   `--machinen-argv-token` profile, verifies `getenv("MACHINEN_CONTEXT_TOKEN")`,
   verifies `getcwd()`, and compares selected safe auxv entries (`AT_PAGESZ`,
   `AT_CLKTCK`) with target `getauxval()`.
+- `apply-target-initial-stack` models a bounded target initial-stack block. It
+  materializes real target pointers for each captured argv string, target envp
+  entries, NULL terminators, and a selected-safe auxv array containing
+  `AT_PAGESZ`, `AT_CLKTCK`, and `AT_NULL`. The target-native trampoline verifies
+  the pointer layout and strings after materialization.
+
+The initial-stack mode also records an explicit auxv materialization policy:
+selected-safe entries are materialized, while target-variant/source-pointer
+entries such as `AT_SYSINFO_EHDR` (vDSO), `AT_RANDOM`, `AT_EXECFN`, and `AT_BASE`
+are listed as refused for this model rather than silently copied from the source.
+The vvar mapping dependency remains unsupported.
 
 The visible mode refuses if the controlled env token, argv token, or selected
 safe auxv entries are missing. Source-only and target-variant auxv entries stay
-metadata-only; asking to materialize them remains unsupported.
+metadata-only unless a mode explicitly models them.
 
 The trampoline reports `nativeProcessContextRestore.status=passed` only after it
 consumes all process-context steps. The VM proof maps that to
 `targetProcessContextRestoreResult=passed`, and failed markers block proof
 completion.
 
-Full target initial-stack and libc process-start reconstruction, vDSO/vvar
-dependencies, and general auxv semantics remain outside this proof and must
-continue to fail closed until modeled explicitly.
+Full libc process-start reconstruction remains outside this proof: the model
+creates a verified target-native pointer block and target libc env/cwd state, but
+it does not rewrite the already-running loader's original kernel-provided stack.
+Unsupported state must continue to fail closed until modeled explicitly.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -43,6 +43,9 @@ extern char **environ;
 #ifndef AT_CLKTCK
 #define AT_CLKTCK 17
 #endif
+#ifndef AT_NULL
+#define AT_NULL 0
+#endif
 
 #if defined(__linux__) && defined(__x86_64__)
 #include <setjmp.h>
@@ -55,6 +58,8 @@ extern char **environ;
 #define MAX_CLOEXEC_FDS 64
 #define MAX_TRANSLATED_FRAME_SLOTS 8
 #define MAX_CONTEXT_ARGV 16
+#define MAX_CONTEXT_ENV 256
+#define MAX_CONTEXT_STRING 512
 #define STATE_CONSUMPTION_MARKER UINT64_C(0x5354415445434f4e)
 #define STATE_CONSUMPTION_MASK UINT64_C(0x7f)
 #define STATE_CHECK_MEMORY UINT64_C(0x01)
@@ -157,6 +162,10 @@ struct NativeProcessContextRestoreState {
   bool cwd_applied;
   bool cwd_verified;
   bool auxv_verified;
+  bool auxv_policy_recorded;
+  bool initial_stack_materialized;
+  bool initial_stack_verified;
+  uint64_t initial_stack_start;
   size_t env_set_count;
   size_t metadata_count;
   size_t consumed_count;
@@ -825,8 +834,12 @@ static uint64_t jump_resume_register_r11 __attribute__((used)) = 0;
 static struct NativeSignalRestoreState native_signal_restore_state = {0};
 static struct NativeProcessContextRestoreState native_process_context_restore_state = {0};
 static char target_context_argv_token[256];
+static char target_context_argv_storage[MAX_CONTEXT_ARGV][MAX_CONTEXT_STRING];
 static const char *target_context_argv[MAX_CONTEXT_ARGV + 1];
+static char target_context_env_keys[MAX_CONTEXT_ENV][MAX_CONTEXT_STRING];
+static char target_context_env_values[MAX_CONTEXT_ENV][MAX_CONTEXT_STRING];
 static size_t target_context_argc = 0;
+static size_t target_context_env_count = 0;
 static struct NativeActiveSyscallRestoreState native_active_syscall_restore_state = {0};
 static struct NativeThreadRestoreState native_thread_restore_state = {0};
 
@@ -1383,6 +1396,25 @@ static size_t target_environ_count(void) {
   return count;
 }
 
+static void set_target_argv_entry(const char *spec) {
+  uint64_t index = native_step_u64(spec, "index", "process-context");
+  char value_hex[MAX_CONTEXT_STRING * 2 + 1];
+  char digest[80];
+  native_step_string(spec, "valueHex", value_hex, sizeof(value_hex), "process-context");
+  native_step_string(spec, "valueSha256", digest, sizeof(digest), "process-context");
+  require_sha256_hex(digest, "valueSha256", "process-context");
+  if (index >= MAX_CONTEXT_ARGV) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context argv index is unsupported\n");
+    exit(2);
+  }
+  hex_to_string(value_hex, target_context_argv_storage[index], sizeof(target_context_argv_storage[index]), "valueHex", "process-context");
+  target_context_argv[index] = target_context_argv_storage[index];
+  if (index + 1u > target_context_argc) {
+    target_context_argc = (size_t)(index + 1u);
+    target_context_argv[target_context_argc] = NULL;
+  }
+}
+
 static void materialize_target_argv_block(const char *spec, struct NativeProcessContextRestoreState *state) {
   uint64_t argc = native_step_u64(spec, "argc", "process-context");
   uint64_t token_index = native_step_u64(spec, "tokenIndex", "process-context");
@@ -1467,6 +1499,148 @@ static void verify_target_auxv_selected(const char *spec, struct NativeProcessCo
   state->auxv_verified = true;
 }
 
+static size_t align_size(size_t value, size_t alignment) {
+  return (value + alignment - 1u) & ~(alignment - 1u);
+}
+
+static char *write_initial_stack_string(uint8_t *base, size_t size, size_t *cursor, const char *value) {
+  size_t len = strlen(value) + 1u;
+  if (*cursor > size || len > size - *cursor) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack strings overflow\n");
+    exit(2);
+  }
+  char *target = (char *)(base + *cursor);
+  memcpy(target, value, len);
+  *cursor += len;
+  return target;
+}
+
+static void materialize_target_initial_stack(const char *spec, struct NativeProcessContextRestoreState *state) {
+  uint64_t target_start = native_step_u64(spec, "targetStart", "process-context");
+  uint64_t size = native_step_u64(spec, "sizeBytes", "process-context");
+  uint64_t argc = native_step_u64(spec, "argc", "process-context");
+  uint64_t env_count = native_step_u64(spec, "envCount", "process-context");
+  uint64_t page_size = native_step_u64(spec, "pageSize", "process-context");
+  uint64_t clock_tick = native_step_u64(spec, "clockTick", "process-context");
+  char argv_digest[80];
+  char env_digest[80];
+  native_step_string(spec, "argvSha256", argv_digest, sizeof(argv_digest), "process-context");
+  native_step_string(spec, "envSha256", env_digest, sizeof(env_digest), "process-context");
+  require_sha256_hex(argv_digest, "argvSha256", "process-context");
+  require_sha256_hex(env_digest, "envSha256", "process-context");
+  if (argc == 0 || argc > MAX_CONTEXT_ARGV || env_count > MAX_CONTEXT_ENV || argc != target_context_argc ||
+      env_count != target_context_env_count || size < 4096u) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack shape is unsupported\n");
+    exit(2);
+  }
+  uint8_t *base = (uint8_t *)map_fixed(target_start, size, PROT_READ | PROT_WRITE, "process-context-initial-stack");
+  memset(base, 0, (size_t)size);
+  uint64_t *words = (uint64_t *)base;
+  size_t word_index = 0;
+  words[word_index++] = argc;
+  size_t argv_index = word_index;
+  word_index += (size_t)argc + 1u;
+  size_t env_index = word_index;
+  word_index += (size_t)env_count + 1u;
+  size_t auxv_index = word_index;
+  word_index += 6u;
+  size_t cursor = align_size(word_index * sizeof(uint64_t), 8u);
+  if (cursor >= size) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack header overflow\n");
+    exit(2);
+  }
+  for (size_t i = 0; i < (size_t)argc; i++) {
+    if (!target_context_argv[i]) {
+      fprintf(stderr, "native-actual-resume-trampoline: native process-context argv entry missing\n");
+      exit(2);
+    }
+    words[argv_index + i] = (uint64_t)(uintptr_t)write_initial_stack_string(base, (size_t)size, &cursor, target_context_argv[i]);
+  }
+  words[argv_index + (size_t)argc] = 0;
+  for (size_t i = 0; i < (size_t)env_count; i++) {
+    char env_string[MAX_CONTEXT_STRING * 2];
+    int written = snprintf(env_string, sizeof(env_string), "%s=%s", target_context_env_keys[i], target_context_env_values[i]);
+    if (written <= 0 || (size_t)written >= sizeof(env_string)) {
+      fprintf(stderr, "native-actual-resume-trampoline: native process-context env entry is unsupported\n");
+      exit(2);
+    }
+    words[env_index + i] = (uint64_t)(uintptr_t)write_initial_stack_string(base, (size_t)size, &cursor, env_string);
+  }
+  words[env_index + (size_t)env_count] = 0;
+  words[auxv_index + 0u] = AT_PAGESZ;
+  words[auxv_index + 1u] = page_size;
+  words[auxv_index + 2u] = AT_CLKTCK;
+  words[auxv_index + 3u] = clock_tick;
+  words[auxv_index + 4u] = AT_NULL;
+  words[auxv_index + 5u] = 0;
+  state->initial_stack_start = target_start;
+  state->initial_stack_materialized = true;
+}
+
+static void verify_target_initial_stack(const char *spec, struct NativeProcessContextRestoreState *state) {
+  uint64_t target_start = native_step_u64(spec, "targetStart", "process-context");
+  uint64_t argc = native_step_u64(spec, "argc", "process-context");
+  uint64_t env_count = native_step_u64(spec, "envCount", "process-context");
+  if (!state->initial_stack_materialized || target_start != state->initial_stack_start || argc != target_context_argc ||
+      env_count != target_context_env_count) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack state mismatch\n");
+    exit(1);
+  }
+  uint64_t *words = (uint64_t *)(uintptr_t)target_start;
+  if (words[0] != argc) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack argc mismatch\n");
+    exit(1);
+  }
+  size_t argv_index = 1u;
+  size_t env_index = argv_index + (size_t)argc + 1u;
+  size_t auxv_index = env_index + (size_t)env_count + 1u;
+  for (size_t i = 0; i < (size_t)argc; i++) {
+    const char *value = (const char *)(uintptr_t)words[argv_index + i];
+    if (!value || strcmp(value, target_context_argv[i]) != 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack argv verify failed\n");
+      exit(1);
+    }
+  }
+  if (words[argv_index + (size_t)argc] != 0) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack argv terminator missing\n");
+    exit(1);
+  }
+  for (size_t i = 0; i < (size_t)env_count; i++) {
+    const char *value = (const char *)(uintptr_t)words[env_index + i];
+    char env_string[MAX_CONTEXT_STRING * 2];
+    int written = snprintf(env_string, sizeof(env_string), "%s=%s", target_context_env_keys[i], target_context_env_values[i]);
+    if (!value || written <= 0 || (size_t)written >= sizeof(env_string) || strcmp(value, env_string) != 0) {
+      fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack env verify failed\n");
+      exit(1);
+    }
+  }
+  if (words[env_index + (size_t)env_count] != 0 || words[auxv_index] != AT_PAGESZ || words[auxv_index + 2u] != AT_CLKTCK ||
+      words[auxv_index + 4u] != AT_NULL) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context initial stack auxv verify failed\n");
+    exit(1);
+  }
+  state->initial_stack_verified = true;
+}
+
+static void record_target_auxv_policy(const char *spec, struct NativeProcessContextRestoreState *state) {
+  char digest[80];
+  char materialized[128];
+  char refused[256];
+  char mode[64];
+  native_step_string(spec, "auxvSha256", digest, sizeof(digest), "process-context");
+  native_step_string(spec, "mode", mode, sizeof(mode), "process-context");
+  native_step_string(spec, "materializedKeys", materialized, sizeof(materialized), "process-context");
+  native_step_string(spec, "refusedKeys", refused, sizeof(refused), "process-context");
+  require_sha256_hex(digest, "auxvSha256", "process-context");
+  if (!streq(mode, "selected-safe-only") || strstr(materialized, "AT_PAGESZ") == NULL ||
+      strstr(materialized, "AT_CLKTCK") == NULL) {
+    fprintf(stderr, "native-actual-resume-trampoline: native process-context auxv policy verify failed\n");
+    exit(2);
+  }
+  (void)refused;
+  state->auxv_policy_recorded = true;
+}
+
 static void consume_native_process_context_steps(
     const struct Options *opts, struct NativeProcessContextRestoreState *state) {
   state->requested = opts->native_process_context_step_count > 0;
@@ -1483,6 +1657,9 @@ static void consume_native_process_context_steps(
       state->metadata_count++;
     } else if (streq(action, "materialize-argv")) {
       materialize_target_argv_block(spec, state);
+    } else if (streq(action, "set-argv-entry")) {
+      set_target_argv_entry(spec);
+      state->argv_materialized = true;
     } else if (streq(action, "record-env")) {
       char digest[80];
       native_step_string(spec, "envSha256", digest, sizeof(digest), "process-context");
@@ -1499,6 +1676,7 @@ static void consume_native_process_context_steps(
         fprintf(stderr, "native-actual-resume-trampoline: clearenv failed: %s\n", strerror(errno));
         exit(1);
       }
+      target_context_env_count = 0;
       state->env_cleared = true;
     } else if (streq(action, "set-env")) {
       char key_hex[512];
@@ -1516,6 +1694,14 @@ static void consume_native_process_context_steps(
         fprintf(stderr, "native-actual-resume-trampoline: setenv failed: %s\n", strerror(errno));
         exit(1);
       }
+      if (target_context_env_count >= MAX_CONTEXT_ENV) {
+        fprintf(stderr, "native-actual-resume-trampoline: native process-context env count is unsupported\n");
+        exit(2);
+      }
+      snprintf(
+          target_context_env_keys[target_context_env_count], sizeof(target_context_env_keys[target_context_env_count]), "%s", key);
+      snprintf(target_context_env_values[target_context_env_count], sizeof(target_context_env_values[target_context_env_count]), "%s", value);
+      target_context_env_count++;
       const char *observed = getenv(key);
       if (!observed || strcmp(observed, value) != 0) {
         fprintf(stderr, "native-actual-resume-trampoline: setenv verify failed\n");
@@ -1562,6 +1748,12 @@ static void consume_native_process_context_steps(
       state->metadata_count++;
     } else if (streq(action, "verify-auxv-selected")) {
       verify_target_auxv_selected(spec, state);
+    } else if (streq(action, "record-auxv-policy")) {
+      record_target_auxv_policy(spec, state);
+    } else if (streq(action, "materialize-initial-stack")) {
+      materialize_target_initial_stack(spec, state);
+    } else if (streq(action, "verify-initial-stack")) {
+      verify_target_initial_stack(spec, state);
     } else {
       fprintf(stderr, "native-actual-resume-trampoline: unsupported native process-context action\n");
       exit(2);
@@ -2600,7 +2792,7 @@ static void print_native_restore_consumption(const struct Options *opts) {
   if (native_process_context_restore_state.requested) {
     bool process_context_passed =
         native_process_context_restore_state.consumed_count == opts->native_process_context_step_count;
-    printf(",\"nativeProcessContextRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"metadataCount\":%zu,\"envSetCount\":%zu,\"argvMaterialized\":%s,\"envCleared\":%s,\"envVerified\":%s,\"envValueVerified\":%s,\"cwdApplied\":%s,\"cwdVerified\":%s,\"auxvVerified\":%s}",
+    printf(",\"nativeProcessContextRestore\":{\"status\":\"%s\",\"stepCount\":%zu,\"metadataCount\":%zu,\"envSetCount\":%zu,\"argvMaterialized\":%s,\"envCleared\":%s,\"envVerified\":%s,\"envValueVerified\":%s,\"cwdApplied\":%s,\"cwdVerified\":%s,\"auxvVerified\":%s,\"auxvPolicyRecorded\":%s,\"initialStackMaterialized\":%s,\"initialStackVerified\":%s,\"initialStackStart\":\"0x%llx\"}",
         process_context_passed ? "passed" : "failed",
         opts->native_process_context_step_count,
         native_process_context_restore_state.metadata_count,
@@ -2611,7 +2803,11 @@ static void print_native_restore_consumption(const struct Options *opts) {
         native_process_context_restore_state.env_value_verified ? "true" : "false",
         native_process_context_restore_state.cwd_applied ? "true" : "false",
         native_process_context_restore_state.cwd_verified ? "true" : "false",
-        native_process_context_restore_state.auxv_verified ? "true" : "false");
+        native_process_context_restore_state.auxv_verified ? "true" : "false",
+        native_process_context_restore_state.auxv_policy_recorded ? "true" : "false",
+        native_process_context_restore_state.initial_stack_materialized ? "true" : "false",
+        native_process_context_restore_state.initial_stack_verified ? "true" : "false",
+        (unsigned long long)native_process_context_restore_state.initial_stack_start);
   }
   if (native_signal_restore_state.requested) {
     bool signal_passed = native_signal_restore_state.saved &&

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -10754,6 +10754,14 @@ Poll interval in ms while retrying. Default 250.
 
 > `optional` **maxAuxvBytes?**: `number`
 
+##### initialStackTargetStart?
+
+> `optional` **initialStackTargetStart?**: `string`
+
+##### initialStackSizeBytes?
+
+> `optional` **initialStackSizeBytes?**: `number`
+
 ***
 
 ### TargetGuestRestoreContinuationDescriptor
@@ -13702,13 +13710,13 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestProcessContextRestoreMode
 
-> **TargetGuestProcessContextRestoreMode** = `"metadata-only"` \| `"apply-target-env-cwd"` \| `"apply-target-visible-context"`
+> **TargetGuestProcessContextRestoreMode** = `"metadata-only"` \| `"apply-target-env-cwd"` \| `"apply-target-visible-context"` \| `"apply-target-initial-stack"`
 
 ***
 
 ### TargetGuestProcessContextRestoreStep
 
-> **TargetGuestProcessContextRestoreStep** = \{ `action`: `"record-argv"`; `argc`: `number`; `argvBytes`: `number`; `argvSha256`: `string`; \} \| \{ `action`: `"materialize-argv"`; `argc`: `number`; `argvSha256`: `string`; `tokenIndex`: `number`; `tokenHex`: `string`; `tokenSha256`: `string`; \} \| \{ `action`: `"record-env"`; `envCount`: `number`; `envBytes`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"clear-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"set-env"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"verify-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"verify-env-value"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"record-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"chdir"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"verify-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"record-auxv"`; `auxvBytes`: `number`; `auxvSha256`: `string`; \} \| \{ `action`: `"verify-auxv-selected"`; `pageSize`: `number`; `clockTick`: `number`; `auxvSha256`: `string`; \}
+> **TargetGuestProcessContextRestoreStep** = \{ `action`: `"record-argv"`; `argc`: `number`; `argvBytes`: `number`; `argvSha256`: `string`; \} \| \{ `action`: `"materialize-argv"`; `argc`: `number`; `argvSha256`: `string`; `tokenIndex`: `number`; `tokenHex`: `string`; `tokenSha256`: `string`; \} \| \{ `action`: `"set-argv-entry"`; `index`: `number`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"record-env"`; `envCount`: `number`; `envBytes`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"clear-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"set-env"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"verify-env"`; `envCount`: `number`; `envSha256`: `string`; \} \| \{ `action`: `"verify-env-value"`; `keyHex`: `string`; `valueHex`: `string`; `valueSha256`: `string`; \} \| \{ `action`: `"record-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"chdir"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"verify-cwd"`; `cwdHex`: `string`; `cwdSha256`: `string`; \} \| \{ `action`: `"record-auxv"`; `auxvBytes`: `number`; `auxvSha256`: `string`; \} \| \{ `action`: `"verify-auxv-selected"`; `pageSize`: `number`; `clockTick`: `number`; `auxvSha256`: `string`; \} \| \{ `action`: `"record-auxv-policy"`; `mode`: `"selected-safe-only"`; `materializedKeys`: `string`; `refusedKeys`: `string`; `auxvSha256`: `string`; \} \| \{ `action`: `"materialize-initial-stack"`; `targetStart`: `string`; `sizeBytes`: `number`; `argc`: `number`; `envCount`: `number`; `pageSize`: `number`; `clockTick`: `number`; `argvSha256`: `string`; `envSha256`: `string`; \} \| \{ `action`: `"verify-initial-stack"`; `targetStart`: `string`; `argc`: `number`; `envCount`: `number`; \}
 
 ***
 

--- a/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
@@ -2,12 +2,24 @@ import { describe, expect, it } from "vitest";
 import { planTargetGuestProcessContextRestore } from "../target-guest-process-context-restore.ts";
 import type { NativeProcessImageDocuments } from "../native-process-image.ts";
 
-function auxvHex(values: { pageSize: number; clockTick: number }): string {
-  const bytes = Buffer.alloc(16 * 3);
-  bytes.writeBigUInt64LE(6n, 0);
-  bytes.writeBigUInt64LE(BigInt(values.pageSize), 8);
-  bytes.writeBigUInt64LE(17n, 16);
-  bytes.writeBigUInt64LE(BigInt(values.clockTick), 24);
+function auxvHex(values: { pageSize: number; clockTick: number; unsafe?: boolean }): string {
+  const pairs: Array<[bigint, bigint]> = [
+    [6n, BigInt(values.pageSize)],
+    [17n, BigInt(values.clockTick)],
+    ...(values.unsafe
+      ? ([
+          [33n, 0x7fff0000n],
+          [25n, 0x7fff0100n],
+          [31n, 0x7fff0200n],
+        ] satisfies Array<[bigint, bigint]>)
+      : []),
+    [0n, 0n],
+  ];
+  const bytes = Buffer.alloc(16 * pairs.length);
+  pairs.forEach(([key, value], index) => {
+    bytes.writeBigUInt64LE(key, index * 16);
+    bytes.writeBigUInt64LE(value, index * 16 + 8);
+  });
   return bytes.toString("hex");
 }
 
@@ -123,6 +135,49 @@ describe("target guest process-context restore", () => {
         expect.objectContaining({ action: "verify-env-value" }),
         expect.objectContaining({ action: "verify-cwd", cwdHex: "2f" }),
         expect.objectContaining({ action: "verify-auxv-selected", pageSize: 4096, clockTick: 100 }),
+      ]),
+    });
+  });
+
+  it("plans target initial-stack argv/env pointer materialization with selected auxv policy", () => {
+    const docs = documents({ env: { FIRST: "one", SECOND: "two" } });
+    docs.resources.resources.find((resource) => resource.kind === "env")!.recipe = {
+      env: docs.manifest.process.env,
+    };
+    docs.resources.resources.find((resource) => resource.kind === "auxv")!.recipe = {
+      bytesHex: auxvHex({ pageSize: 4096, clockTick: 100, unsafe: true }),
+    };
+
+    const plan = planTargetGuestProcessContextRestore(docs, {
+      mode: "apply-target-initial-stack",
+      initialStackTargetStart: "0x600000002000",
+    });
+
+    expect(plan).toMatchObject({
+      state: "planned",
+      mode: "apply-target-initial-stack",
+      steps: expect.arrayContaining([
+        expect.objectContaining({
+          action: "set-argv-entry",
+          index: 0,
+          valueHex: "2f62696e2f746172676574",
+        }),
+        expect.objectContaining({ action: "clear-env", envCount: 2 }),
+        expect.objectContaining({ action: "verify-cwd", cwdHex: "2f" }),
+        expect.objectContaining({
+          action: "record-auxv-policy",
+          materializedKeys: "AT_PAGESZ,AT_CLKTCK",
+          refusedKeys: "AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN",
+        }),
+        expect.objectContaining({
+          action: "materialize-initial-stack",
+          targetStart: "0x600000002000",
+          argc: 3,
+          envCount: 2,
+          pageSize: 4096,
+          clockTick: 100,
+        }),
+        expect.objectContaining({ action: "verify-initial-stack", targetStart: "0x600000002000" }),
       ]),
     });
   });

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -314,6 +314,48 @@ describe("target guest restore loader descriptor", () => {
         },
       },
       {
+        section: "process-context" as const,
+        step: {
+          action: "set-argv-entry" as const,
+          index: 0,
+          valueHex: "2f62696e2f746172676574",
+          valueSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        },
+      },
+      {
+        section: "process-context" as const,
+        step: {
+          action: "record-auxv-policy" as const,
+          mode: "selected-safe-only" as const,
+          materializedKeys: "AT_PAGESZ,AT_CLKTCK",
+          refusedKeys: "AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN",
+          auxvSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        },
+      },
+      {
+        section: "process-context" as const,
+        step: {
+          action: "materialize-initial-stack" as const,
+          targetStart: "0x600000002000",
+          sizeBytes: 16384,
+          argc: 1,
+          envCount: 0,
+          pageSize: 4096,
+          clockTick: 100,
+          argvSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+          envSha256: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        },
+      },
+      {
+        section: "process-context" as const,
+        step: {
+          action: "verify-initial-stack" as const,
+          targetStart: "0x600000002000",
+          argc: 1,
+          envCount: 0,
+        },
+      },
+      {
         section: "signal-restore" as const,
         step: {
           action: "sigprocmask-set-blocked" as const,
@@ -397,6 +439,14 @@ describe("target guest restore loader descriptor", () => {
         "action=chdir;cwdHex=2f;cwdSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
         "--native-process-context-step",
         "action=verify-auxv-selected;pageSize=4096;clockTick=100;auxvSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
+        "action=set-argv-entry;index=0;valueHex=2f62696e2f746172676574;valueSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
+        "action=record-auxv-policy;mode=selected-safe-only;materializedKeys=AT_PAGESZ,AT_CLKTCK;refusedKeys=AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN;auxvSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
+        "action=materialize-initial-stack;targetStart=0x600000002000;sizeBytes=16384;argc=1;envCount=0;pageSize=4096;clockTick=100;argvSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1;envSha256=8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
+        "--native-process-context-step",
+        "action=verify-initial-stack;targetStart=0x600000002000;argc=1;envCount=0",
         "--native-signal-restore-step",
         "action=sigprocmask-set-blocked;threadId=thread:1;targetBlockedMasks=0x0",
         "--native-active-syscall-step",

--- a/packages/runtime/src/target-guest-process-context-restore.ts
+++ b/packages/runtime/src/target-guest-process-context-restore.ts
@@ -7,7 +7,8 @@ import type {
 export type TargetGuestProcessContextRestoreMode =
   | "metadata-only"
   | "apply-target-env-cwd"
-  | "apply-target-visible-context";
+  | "apply-target-visible-context"
+  | "apply-target-initial-stack";
 
 export type TargetGuestProcessContextRestoreStep =
   | {
@@ -23,6 +24,12 @@ export type TargetGuestProcessContextRestoreStep =
       tokenIndex: number;
       tokenHex: string;
       tokenSha256: string;
+    }
+  | {
+      action: "set-argv-entry";
+      index: number;
+      valueHex: string;
+      valueSha256: string;
     }
   | {
       action: "record-env";
@@ -77,6 +84,30 @@ export type TargetGuestProcessContextRestoreStep =
       pageSize: number;
       clockTick: number;
       auxvSha256: string;
+    }
+  | {
+      action: "record-auxv-policy";
+      mode: "selected-safe-only";
+      materializedKeys: string;
+      refusedKeys: string;
+      auxvSha256: string;
+    }
+  | {
+      action: "materialize-initial-stack";
+      targetStart: string;
+      sizeBytes: number;
+      argc: number;
+      envCount: number;
+      pageSize: number;
+      clockTick: number;
+      argvSha256: string;
+      envSha256: string;
+    }
+  | {
+      action: "verify-initial-stack";
+      targetStart: string;
+      argc: number;
+      envCount: number;
     };
 
 export type TargetGuestProcessContextRestorePlan =
@@ -93,6 +124,8 @@ export interface TargetGuestProcessContextRestoreOptions {
   maxEnvEntries?: number;
   maxStringBytes?: number;
   maxAuxvBytes?: number;
+  initialStackTargetStart?: string;
+  initialStackSizeBytes?: number;
 }
 
 interface ProcessContextModel {
@@ -101,6 +134,18 @@ interface ProcessContextModel {
   cwd: string;
   auxvHex: string;
   selectedAuxv: SelectedAuxvContext;
+  initialStack: InitialStackContext;
+  auxvPolicy: AuxvMaterializationPolicy;
+}
+
+interface InitialStackContext {
+  targetStart: string;
+  sizeBytes: number;
+}
+
+interface AuxvMaterializationPolicy {
+  materializedKeys: string[];
+  refusedKeys: string[];
 }
 
 interface SelectedAuxvContext {
@@ -114,10 +159,26 @@ const DEFAULT_MAX_STRING_BYTES = 64 * 1024;
 const DEFAULT_MAX_AUXV_BYTES = 4096;
 const CONTEXT_ENV_TOKEN_KEY = "MACHINEN_CONTEXT_TOKEN";
 const CONTEXT_ARGV_TOKEN = "--machinen-argv-token";
+const DEFAULT_INITIAL_STACK_TARGET_START = "0x600000002000";
+const DEFAULT_INITIAL_STACK_SIZE_BYTES = 16 * 1024;
+const TARGET_CONTEXT_STRING_BYTES = 512;
 const AT_PAGESZ = 6n;
 const AT_CLKTCK = 17n;
+const AT_BASE = 7n;
+const AT_RANDOM = 25n;
+const AT_EXECFN = 31n;
+const AT_SYSINFO_EHDR = 33n;
 const AT_NULL = 0n;
 const AUXV_ENTRY_BYTES = 16;
+const AUXV_NAMES = new Map<bigint, string>([
+  [AT_PAGESZ, "AT_PAGESZ"],
+  [AT_CLKTCK, "AT_CLKTCK"],
+  [AT_BASE, "AT_BASE"],
+  [AT_RANDOM, "AT_RANDOM"],
+  [AT_EXECFN, "AT_EXECFN"],
+  [AT_SYSINFO_EHDR, "AT_SYSINFO_EHDR"],
+]);
+const UNSUPPORTED_INITIAL_STACK_AUXV = [AT_SYSINFO_EHDR, AT_RANDOM, AT_EXECFN, AT_BASE] as const;
 
 export function planTargetGuestProcessContextRestore(
   documents: NativeProcessImageDocuments,
@@ -142,6 +203,7 @@ function processContextModel(
     ...validateManifestProcessContext(documents, options),
     ...validateResourceConsistency(documents),
     ...validateTargetVisibleContext(documents, selectedAuxv, mode),
+    ...validateInitialStackContext(documents, options, mode),
   ];
   if (refusals.length > 0) {
     return { refusals };
@@ -152,6 +214,8 @@ function processContextModel(
     cwd: documents.manifest.process.cwd,
     auxvHex: auxvHex!,
     selectedAuxv: selectedAuxv!,
+    initialStack: initialStackContext(options),
+    auxvPolicy: auxvMaterializationPolicy(auxvHex!),
   };
 }
 
@@ -289,18 +353,18 @@ function validateTargetVisibleContext(
   selectedAuxv: SelectedAuxvContext | undefined,
   mode: TargetGuestProcessContextRestoreMode,
 ): NativeProcessImageRefusal[] {
-  if (mode !== "apply-target-visible-context") {
+  if (mode !== "apply-target-visible-context" && mode !== "apply-target-initial-stack") {
     return [];
   }
   const env = documents.manifest.process.env;
   const argvTokenIndex = documents.manifest.process.argv.indexOf(CONTEXT_ARGV_TOKEN);
   return [
-    ...(env[CONTEXT_ENV_TOKEN_KEY]
-      ? []
-      : [processContextRefusal("target-visible context requires MACHINEN_CONTEXT_TOKEN")]),
-    ...(argvTokenIndex >= 0
-      ? []
-      : [processContextRefusal("target-visible context requires controlled argv token")]),
+    ...(mode === "apply-target-visible-context" && !env[CONTEXT_ENV_TOKEN_KEY]
+      ? [processContextRefusal("target-visible context requires MACHINEN_CONTEXT_TOKEN")]
+      : []),
+    ...(mode === "apply-target-visible-context" && argvTokenIndex < 0
+      ? [processContextRefusal("target-visible context requires controlled argv token")]
+      : []),
     ...(selectedAuxv
       ? []
       : [
@@ -308,6 +372,47 @@ function validateTargetVisibleContext(
             requiredAuxv: ["AT_PAGESZ", "AT_CLKTCK"],
           }),
         ]),
+  ];
+}
+
+function validateInitialStackContext(
+  documents: NativeProcessImageDocuments,
+  options: TargetGuestProcessContextRestoreOptions,
+  mode: TargetGuestProcessContextRestoreMode,
+): NativeProcessImageRefusal[] {
+  if (mode !== "apply-target-initial-stack") {
+    return [];
+  }
+  const sizeBytes = options.initialStackSizeBytes ?? DEFAULT_INITIAL_STACK_SIZE_BYTES;
+  const requiredBytes = initialStackRequiredBytes(
+    documents.manifest.process.argv,
+    sortedEnvEntries(documents.manifest.process.env),
+  );
+  const envEntries = sortedEnvEntries(documents.manifest.process.env);
+  return [
+    ...(requiredBytes <= sizeBytes
+      ? []
+      : [
+          processContextRefusal("initial-stack process context exceeds target block", {
+            requiredBytes,
+            sizeBytes,
+          }),
+        ]),
+    ...(documents.manifest.process.argv.some(
+      (value) => utf8Bytes(value) >= TARGET_CONTEXT_STRING_BYTES,
+    ) ||
+    envEntries.some(
+      ([key, value]) =>
+        utf8Bytes(key) >= TARGET_CONTEXT_STRING_BYTES ||
+        utf8Bytes(value) >= TARGET_CONTEXT_STRING_BYTES ||
+        utf8Bytes(`${key}=${value}`) >= TARGET_CONTEXT_STRING_BYTES * 2,
+    )
+      ? [
+          processContextRefusal("initial-stack process context string exceeds target buffer", {
+            maxTargetStringBytes: TARGET_CONTEXT_STRING_BYTES,
+          }),
+        ]
+      : []),
   ];
 }
 
@@ -334,6 +439,7 @@ function processContextSteps(
       auxvSha256: auxvDigest,
     },
     ...targetVisibleAuxvSteps(model, mode, auxvDigest),
+    ...initialStackSteps(model, mode, argvDigest, envDigest, auxvDigest),
   ];
 }
 
@@ -342,6 +448,14 @@ function targetVisibleArgvSteps(
   mode: TargetGuestProcessContextRestoreMode,
   argvDigest: string,
 ): TargetGuestProcessContextRestoreStep[] {
+  if (mode === "apply-target-initial-stack") {
+    return model.argv.map((value, index) => ({
+      action: "set-argv-entry" as const,
+      index,
+      valueHex: hexUtf8(value),
+      valueSha256: sha256(value),
+    }));
+  }
   if (mode !== "apply-target-visible-context") {
     return [];
   }
@@ -415,7 +529,7 @@ function cwdSteps(
     cwdHex: hexUtf8(model.cwd),
     cwdSha256: sha256(model.cwd),
   };
-  return mode === "apply-target-visible-context"
+  return mode === "apply-target-visible-context" || mode === "apply-target-initial-stack"
     ? [
         applyStep,
         { action: "verify-cwd", cwdHex: applyStep.cwdHex, cwdSha256: applyStep.cwdSha256 },
@@ -440,6 +554,43 @@ function targetVisibleAuxvSteps(
     : [];
 }
 
+function initialStackSteps(
+  model: ProcessContextModel,
+  mode: TargetGuestProcessContextRestoreMode,
+  argvDigest: string,
+  envDigest: string,
+  auxvDigest: string,
+): TargetGuestProcessContextRestoreStep[] {
+  return mode === "apply-target-initial-stack"
+    ? [
+        {
+          action: "record-auxv-policy",
+          mode: "selected-safe-only",
+          materializedKeys: model.auxvPolicy.materializedKeys.join(","),
+          refusedKeys: model.auxvPolicy.refusedKeys.join(","),
+          auxvSha256: auxvDigest,
+        },
+        {
+          action: "materialize-initial-stack",
+          targetStart: model.initialStack.targetStart,
+          sizeBytes: model.initialStack.sizeBytes,
+          argc: model.argv.length,
+          envCount: model.envEntries.length,
+          pageSize: model.selectedAuxv.pageSize,
+          clockTick: model.selectedAuxv.clockTick,
+          argvSha256: argvDigest,
+          envSha256: envDigest,
+        },
+        {
+          action: "verify-initial-stack",
+          targetStart: model.initialStack.targetStart,
+          argc: model.argv.length,
+          envCount: model.envEntries.length,
+        },
+      ]
+    : [];
+}
+
 function auxvResourceHex(documents: NativeProcessImageDocuments): string | undefined {
   const value = documents.resources.resources.find((resource) => resource.kind === "auxv")?.recipe
     ?.bytesHex;
@@ -453,6 +604,41 @@ function selectedAuxvContext(auxvHex: string): SelectedAuxvContext | undefined {
   return pageSize !== undefined && clockTick !== undefined
     ? { pageSize: Number(pageSize), clockTick: Number(clockTick) }
     : undefined;
+}
+
+function initialStackContext(
+  options: TargetGuestProcessContextRestoreOptions,
+): InitialStackContext {
+  return {
+    targetStart: options.initialStackTargetStart ?? DEFAULT_INITIAL_STACK_TARGET_START,
+    sizeBytes: options.initialStackSizeBytes ?? DEFAULT_INITIAL_STACK_SIZE_BYTES,
+  };
+}
+
+function auxvMaterializationPolicy(auxvHex: string): AuxvMaterializationPolicy {
+  const entries = parseAuxvEntries(auxvHex);
+  return {
+    materializedKeys: [auxvName(AT_PAGESZ), auxvName(AT_CLKTCK)],
+    refusedKeys: UNSUPPORTED_INITIAL_STACK_AUXV.filter((key) => entries.has(key)).map(auxvName),
+  };
+}
+
+function auxvName(key: bigint): string {
+  return AUXV_NAMES.get(key) ?? `AT_${key.toString()}`;
+}
+
+function initialStackRequiredBytes(argv: string[], envEntries: Array<[string, string]>): number {
+  const headerBytes = (1 + argv.length + 1 + envEntries.length + 1 + 6) * 8;
+  const stringBytes =
+    stringListBytes(argv) +
+    envEntries.reduce((total, [key, value]) => total + utf8Bytes(`${key}=${value}`), 0) +
+    argv.length +
+    envEntries.length;
+  return alignUp(headerBytes, 8) + stringBytes;
+}
+
+function alignUp(value: number, alignment: number): number {
+  return Math.ceil(value / alignment) * alignment;
 }
 
 function parseAuxvEntries(auxvHex: string): Map<bigint, bigint> {

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -722,14 +722,22 @@ function parseNativeArgvContextStep(
       argvSha256: requiredNativeField(fields, "argvSha256"),
     };
   }
-  return action === "materialize-argv"
+  if (action === "materialize-argv") {
+    return {
+      action,
+      argc: parseNativeInteger(fields, "argc"),
+      argvSha256: requiredNativeField(fields, "argvSha256"),
+      tokenIndex: parseNativeInteger(fields, "tokenIndex"),
+      tokenHex: requiredNativeField(fields, "tokenHex"),
+      tokenSha256: requiredNativeField(fields, "tokenSha256"),
+    };
+  }
+  return action === "set-argv-entry"
     ? {
         action,
-        argc: parseNativeInteger(fields, "argc"),
-        argvSha256: requiredNativeField(fields, "argvSha256"),
-        tokenIndex: parseNativeInteger(fields, "tokenIndex"),
-        tokenHex: requiredNativeField(fields, "tokenHex"),
-        tokenSha256: requiredNativeField(fields, "tokenSha256"),
+        index: parseNativeInteger(fields, "index"),
+        valueHex: requiredNativeField(fields, "valueHex"),
+        valueSha256: requiredNativeField(fields, "valueSha256"),
       }
     : undefined;
 }
@@ -787,12 +795,42 @@ function parseNativeAuxvContextStep(
       auxvSha256: requiredNativeField(fields, "auxvSha256"),
     };
   }
-  return action === "verify-auxv-selected"
+  if (action === "verify-auxv-selected") {
+    return {
+      action,
+      pageSize: parseNativeInteger(fields, "pageSize"),
+      clockTick: parseNativeInteger(fields, "clockTick"),
+      auxvSha256: requiredNativeField(fields, "auxvSha256"),
+    };
+  }
+  if (action === "record-auxv-policy") {
+    return {
+      action,
+      mode: "selected-safe-only",
+      materializedKeys: requiredNativeField(fields, "materializedKeys"),
+      refusedKeys: requiredNativeField(fields, "refusedKeys"),
+      auxvSha256: requiredNativeField(fields, "auxvSha256"),
+    };
+  }
+  if (action === "materialize-initial-stack") {
+    return {
+      action,
+      targetStart: requiredNativeField(fields, "targetStart"),
+      sizeBytes: parseNativeInteger(fields, "sizeBytes"),
+      argc: parseNativeInteger(fields, "argc"),
+      envCount: parseNativeInteger(fields, "envCount"),
+      pageSize: parseNativeInteger(fields, "pageSize"),
+      clockTick: parseNativeInteger(fields, "clockTick"),
+      argvSha256: requiredNativeField(fields, "argvSha256"),
+      envSha256: requiredNativeField(fields, "envSha256"),
+    };
+  }
+  return action === "verify-initial-stack"
     ? {
         action,
-        pageSize: parseNativeInteger(fields, "pageSize"),
-        clockTick: parseNativeInteger(fields, "clockTick"),
-        auxvSha256: requiredNativeField(fields, "auxvSha256"),
+        targetStart: requiredNativeField(fields, "targetStart"),
+        argc: parseNativeInteger(fields, "argc"),
+        envCount: parseNativeInteger(fields, "envCount"),
       }
     : undefined;
 }
@@ -1651,6 +1689,8 @@ function serializeProcessContextStep(step: TargetGuestProcessContextRestoreStep)
       return `native=process-context action=${step.action} argc=${step.argc} argvBytes=${step.argvBytes} argvSha256=${step.argvSha256}`;
     case "materialize-argv":
       return `native=process-context action=${step.action} argc=${step.argc} argvSha256=${step.argvSha256} tokenIndex=${step.tokenIndex} tokenHex=${step.tokenHex} tokenSha256=${step.tokenSha256}`;
+    case "set-argv-entry":
+      return `native=process-context action=${step.action} index=${step.index} valueHex=${step.valueHex} valueSha256=${step.valueSha256}`;
     case "record-env":
       return `native=process-context action=${step.action} envCount=${step.envCount} envBytes=${step.envBytes} envSha256=${step.envSha256}`;
     case "clear-env":
@@ -1667,6 +1707,12 @@ function serializeProcessContextStep(step: TargetGuestProcessContextRestoreStep)
       return `native=process-context action=${step.action} auxvBytes=${step.auxvBytes} auxvSha256=${step.auxvSha256}`;
     case "verify-auxv-selected":
       return `native=process-context action=${step.action} pageSize=${step.pageSize} clockTick=${step.clockTick} auxvSha256=${step.auxvSha256}`;
+    case "record-auxv-policy":
+      return `native=process-context action=${step.action} mode=${step.mode} materializedKeys=${step.materializedKeys} refusedKeys=${step.refusedKeys} auxvSha256=${step.auxvSha256}`;
+    case "materialize-initial-stack":
+      return `native=process-context action=${step.action} targetStart=${step.targetStart} sizeBytes=${step.sizeBytes} argc=${step.argc} envCount=${step.envCount} pageSize=${step.pageSize} clockTick=${step.clockTick} argvSha256=${step.argvSha256} envSha256=${step.envSha256}`;
+    case "verify-initial-stack":
+      return `native=process-context action=${step.action} targetStart=${step.targetStart} argc=${step.argc} envCount=${step.envCount}`;
   }
 }
 

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -48,7 +48,11 @@ interface Args {
   syntheticEmptyPipeWriteFd?: string;
   syntheticEmptyEventFd?: string;
   syntheticTimerFd?: string;
-  processContextRestore?: "metadata-only" | "apply-target-env-cwd" | "apply-target-visible-context";
+  processContextRestore?:
+    | "metadata-only"
+    | "apply-target-env-cwd"
+    | "apply-target-visible-context"
+    | "apply-target-initial-stack";
 }
 
 interface TargetInvocation {
@@ -151,6 +155,7 @@ const PROOF_EVENT_FD = 10;
 const PROOF_TIMER_FD = 11;
 const PROOF_FD_BYTES = Buffer.from("FD");
 const PROOF_FILE_READ_BYTES = Buffer.from("FILE");
+const PROOF_INITIAL_STACK_TARGET = "0x600000002000";
 const STATE_CONSUMPTION_MARKER = 0x5354415445434f4en;
 const STATE_CHECK_MEMORY = 0x01;
 const STATE_CHECK_STDIO = 0x02;
@@ -202,7 +207,7 @@ function usage(): never {
     "usage: tsx scripts/portable-machine-vm-restore-proof.ts verify " +
       "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
       "[--combined-descriptor] [--real-utility-continuation] " +
-      "[--process-context-restore metadata-only|apply-target-env-cwd|apply-target-visible-context] [--json]",
+      "[--process-context-restore metadata-only|apply-target-env-cwd|apply-target-visible-context|apply-target-initial-stack] [--json]",
   );
   process.exit(2);
 }
@@ -231,6 +236,7 @@ const PROCESS_CONTEXT_RESTORE_MODES = [
   "metadata-only",
   "apply-target-env-cwd",
   "apply-target-visible-context",
+  "apply-target-initial-stack",
 ] as const;
 
 function parseProcessContextRestoreMode(value: string | undefined): Args["processContextRestore"] {
@@ -461,7 +467,10 @@ function proofProcessContextNativeSections(
   if (!mode) {
     return { state: "planned", steps: [] };
   }
-  const plan = planTargetGuestProcessContextRestore(bundle.nativeProcessImage, { mode });
+  const plan = planTargetGuestProcessContextRestore(bundle.nativeProcessImage, {
+    mode,
+    initialStackTargetStart: PROOF_INITIAL_STACK_TARGET,
+  });
   return plan.state === "planned"
     ? {
         state: "planned",

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -391,7 +391,7 @@ run_target_restore() {
   local process_context_restore_args=()
   local process_context_restore_args_text=""
   if [[ "$REMOTE_SOURCE_TARGET" == "process-context" ]]; then
-    process_context_restore_args=(--process-context-restore apply-target-visible-context)
+    process_context_restore_args=(--process-context-restore apply-target-initial-stack)
     process_context_restore_args_text="${process_context_restore_args[*]}"
   fi
   if [[ $REMOTE_E2E -eq 1 ]]; then


### PR DESCRIPTION
## Problem

The process-context proof only showed narrow env/cwd and token checks. It did not model a target-native argv/env pointer layout, and source auxv pointer entries like vDSO, `AT_RANDOM`, and `AT_EXECFN` were only generally out of scope.

## Solution

This adds a focused initial-stack process-context model:

- new `apply-target-initial-stack` mode
- materializes captured argv entries as real target pointers
- materializes captured envp strings with NULL terminators
- writes selected safe auxv entries (`AT_PAGESZ`, `AT_CLKTCK`, `AT_NULL`)
- records an explicit selected-safe auxv policy and refuses source/target-variant pointer entries from this model (`AT_SYSINFO_EHDR`, `AT_RANDOM`, `AT_EXECFN`, `AT_BASE`)
- target-native trampoline verifies the pointer block, env strings, cwd, and auxv layout before reporting pass
- remote `process-context` smoke now exercises the initial-stack mode

Closes #711.

## Validation

- `pnpm run build:docs` — 1.672s
- `pnpm run format:check` — 0.665s
- `pnpm run lint` — 0.230s
- `pnpm run typecheck` — 2.368s
- focused vitest — 6.836s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.440s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=process-context` initial-stack proof — 38.640s
  - `targetProcessContextRestoreResult: passed`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.215s
- `pnpm smoke-tests` — 2m13.426s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m13.084s
