### PR TITLE
Tighten futex and rseq boundaries

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -18,6 +18,7 @@ The current classifier reports:
   related fd waits. Narrow pipe/eventfd/timerfd reads and safe offset-backed
   regular-file reads are modeled only under the explicit fd-read deferral
   policy; other fd waits still refuse;
+- `futex-wait` — `futex`, `futex_time64`, and `futex_waitv` wait state;
 - `restart` — `restart_syscall` or captured restart-block state;
 - `unknown-active` — any active syscall that has not been modeled.
 
@@ -38,6 +39,8 @@ Known blocking syscall classes refuse with precise codes:
 - `target-epoll-syscall-state-unsupported` for active `epoll_wait`,
   `epoll_pwait`, and `epoll_pwait2` state;
 - `target-signalfd-state-unsupported` for active reads from signalfd resources;
+- `futex-state-unsupported` for active futex wait syscalls or captured futex
+  resources;
 - `syscall-restart-unsupported` for restart state;
 - `active-syscall` for unknown active syscalls.
 
@@ -86,6 +89,18 @@ These preserve timeout-driven proofs without claiming general fd readiness
 migration. Missing fd resources, wrong resource kinds, unsupported flags or
 state, wrong events, non-empty `revents`, `nfds > 1`, and non-null signal masks
 all fail closed as `target-ppoll-timeout-missing`.
+
+## Futex refusal tightening
+
+Active futex syscalls now fail closed with `futex-state-unsupported` instead of
+falling through to a generic active-syscall refusal. The refusal records decoded
+futex arguments when available (`uaddr`, operation, timeout, or `futex_waitv`
+waiter-vector arguments) and names the unsupported kernel state: futex word race,
+wait-queue membership, wake/requeue ordering, and robust-list owner-death
+semantics.
+
+This is refusal tightening only. No futex wait is restarted, emulated, or treated
+as target-native success.
 
 ## Socket accept/connect refusal
 

--- a/docs/snapshot/native-thread-refusal-matrix.md
+++ b/docs/snapshot/native-thread-refusal-matrix.md
@@ -24,7 +24,8 @@ current restore proof.
 
 The following unsafe states refuse before register translation:
 
-- `inside-syscall` -> `active-syscall`;
+- `inside-syscall` -> `active-syscall` unless a more precise active-syscall
+  boundary applies;
 - `restart-block` -> `active-syscall`;
 - active signal frame -> `signal-frame-active`;
 - non-zero pending signal mask -> `signal-state-unsupported`;
@@ -36,7 +37,7 @@ The following unsafe states refuse before register translation:
 The restore boundary also refuses:
 
 - more than one thread -> `thread-state-unsupported`;
-- futex wait resources -> `futex-state-unsupported`;
+- futex wait resources and active futex syscalls -> `futex-state-unsupported`;
 - signal-delivery stop -> `signal-state-unsupported`;
 - ptrace/debug leftovers -> `thread-state-unsupported`;
 - shared stack mappings -> `mapping-shared-unsupported`;

--- a/docs/snapshot/native-two-thread-boundary.md
+++ b/docs/snapshot/native-two-thread-boundary.md
@@ -17,13 +17,18 @@ when each thread independently passes the single-thread restore gates:
 - outside active syscalls.
 
 The planner rejects any futex resource before claiming a two-thread restore plan.
-It also rejects captured or unsupported rseq state on either thread.
+It also rejects active futex syscalls with futex-specific detail and captured or
+unsupported rseq state on either thread.
 
 ## Refusals
 
 - `thread-state-unsupported` for non-two-thread input or unsafe per-thread state;
-- `futex-state-unsupported` for captured futex wait/resource state;
-- `rseq-state-unsupported` for captured or unsupported rseq state;
+- `futex-state-unsupported` for captured futex wait/resource state or active
+  futex wait syscalls; refusal detail records the resource/syscall and the
+  missing futex model pieces;
+- `rseq-state-unsupported` for captured or unsupported rseq state; refusal
+  detail records the thread rseq state and the missing target rseq lifecycle,
+  critical-section abort IP, and TLS ownership model;
 - the underlying single-thread gate's precise refusals for stack, signal,
   register, TLS, SIMD/FPU, or active syscall failures.
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -13186,7 +13186,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeActiveSyscallClass
 
-> **NativeActiveSyscallClass** = `"outside-syscall"` \| `"sleep-timer"` \| `"poll-timeout"` \| `"fd-blocking"` \| `"restart"` \| `"unknown-active"`
+> **NativeActiveSyscallClass** = `"outside-syscall"` \| `"sleep-timer"` \| `"poll-timeout"` \| `"fd-blocking"` \| `"futex-wait"` \| `"restart"` \| `"unknown-active"`
 
 ***
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -82,6 +82,13 @@ function arm64EpollThread(
   return arm64SleepThread({ state: "inside-syscall", number: 22, name }, x);
 }
 
+function arm64FutexThread(
+  name: "futex" | "futex_waitv" = "futex",
+  x: string[] = ["0x5000", "0x0", "0x1", "0x0", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 98, name }, x);
+}
+
 function documentsWithTimespec(options: {
   activeThread: NativeThreadState;
   seconds?: bigint;
@@ -1255,6 +1262,58 @@ describe("native active syscall classification", () => {
       refusal: {
         code: "target-fd-read-state-missing",
         detail: { reason: scenario.reason },
+      },
+    });
+  });
+
+  it("refuses active futex wait with futex-specific detail", () => {
+    const activeThread = arm64FutexThread("futex", [
+      "0x5000",
+      "0x80",
+      "0x1",
+      "0x6000",
+      "0x0",
+      "0x0",
+    ]);
+    const result = classifyNativeActiveSyscalls([activeThread]);
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "futex-wait",
+      refusal: {
+        code: "futex-state-unsupported",
+        detail: {
+          reason: "futex waiter kernel queue state is unsupported",
+          futexSyscall: {
+            name: "futex",
+            arguments: { source: "registers", uaddr: "0x5000", operation: "0x80" },
+            unsupportedState: expect.arrayContaining(["kernel wait queue membership"]),
+          },
+        },
+      },
+    });
+  });
+
+  it("refuses futex_waitv with vector-wait argument detail", () => {
+    const activeThread = arm64FutexThread("futex_waitv", [
+      "0x5100",
+      "0x2",
+      "0x0",
+      "0x6200",
+      "0x0",
+      "0x0",
+    ]);
+    const result = classifyNativeActiveSyscalls([activeThread]);
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "futex-wait",
+      refusal: {
+        code: "futex-state-unsupported",
+        detail: {
+          futexSyscall: {
+            name: "futex_waitv",
+            arguments: { source: "registers", waitersPointer: "0x5100", waiterCount: "0x2" },
+          },
+        },
       },
     });
   });

--- a/packages/runtime/src/__tests__/native-thread-refusal-matrix.test.ts
+++ b/packages/runtime/src/__tests__/native-thread-refusal-matrix.test.ts
@@ -70,6 +70,10 @@ describe("native thread refusal matrix", () => {
         expect.objectContaining({ id: "multi-thread", refusalCode: "thread-state-unsupported" }),
         expect.objectContaining({ id: "futex-wait", refusalCode: "futex-state-unsupported" }),
         expect.objectContaining({
+          id: "active-futex-syscall",
+          refusalCode: "futex-state-unsupported",
+        }),
+        expect.objectContaining({
           id: "signal-delivery-stop",
           refusalCode: "signal-state-unsupported",
         }),

--- a/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
@@ -107,8 +107,8 @@ describe("native thread restore boundary", () => {
         threads: [thread("thread:1"), thread("thread:2")],
       },
       {
-        id: "active-syscall",
-        expectedCode: "active-syscall",
+        id: "active-futex-syscall",
+        expectedCode: "futex-state-unsupported",
         mutate: (value) => {
           value.syscall = { state: "inside-syscall", number: 202, name: "futex" };
         },

--- a/packages/runtime/src/__tests__/native-two-thread-boundary.test.ts
+++ b/packages/runtime/src/__tests__/native-two-thread-boundary.test.ts
@@ -125,7 +125,12 @@ describe("controlled two-thread restore boundary", () => {
 
     expect(planNativeControlledTwoThreadRestoreBoundary(input)).toMatchObject({
       state: "refused",
-      refusals: [expect.objectContaining({ code: "futex-state-unsupported" })],
+      refusals: [
+        expect.objectContaining({
+          code: "futex-state-unsupported",
+          detail: expect.objectContaining({ resourceId: "resource:futex" }),
+        }),
+      ],
     });
   });
 
@@ -139,13 +144,18 @@ describe("controlled two-thread restore boundary", () => {
     });
   });
 
-  it("refuses unsafe per-thread state", () => {
+  it("refuses active futex syscall state precisely", () => {
     const input = request();
     input.threads[0]!.syscall = { state: "inside-syscall", number: 202, name: "futex" };
 
     expect(planNativeControlledTwoThreadRestoreBoundary(input)).toMatchObject({
       state: "refused",
-      refusals: [expect.objectContaining({ code: "active-syscall" })],
+      refusals: [
+        expect.objectContaining({
+          code: "futex-state-unsupported",
+          detail: expect.objectContaining({ syscallClass: "futex-wait" }),
+        }),
+      ],
     });
   });
 });

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -17,6 +17,7 @@ export type NativeActiveSyscallClass =
   | "sleep-timer"
   | "poll-timeout"
   | "fd-blocking"
+  | "futex-wait"
   | "restart"
   | "unknown-active";
 
@@ -201,6 +202,7 @@ export interface NativeActiveSyscallClassificationResult {
 }
 
 const SLEEP_TIMER_SYSCALLS = new Set(["clock_nanosleep", "nanosleep"]);
+const FUTEX_ACTIVE_SYSCALLS = new Set(["futex", "futex_time64", "futex_waitv"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
 const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
 const FD_BLOCKING_SYSCALLS = new Set([
@@ -248,6 +250,7 @@ export function classifyNativeActiveSyscalls(
   };
 }
 
+// fallow-ignore-next-line complexity
 export function classifyNativeThreadSyscall(
   thread: NativeThreadState,
   options: NativeActiveSyscallPolicyOptions = {},
@@ -263,6 +266,9 @@ export function classifyNativeThreadSyscall(
     });
   }
   const name = syscallName(thread);
+  if (FUTEX_ACTIVE_SYSCALLS.has(name)) {
+    return refusedFutexActiveSyscallClassification(thread);
+  }
   if (SLEEP_TIMER_SYSCALLS.has(name)) {
     if (options.sleepTimerPolicy === "defer-target-resume") {
       return deferredSleepTimerClassification(thread, options);
@@ -531,6 +537,16 @@ function deferredFdReadClassification(
   };
 }
 
+function refusedFutexActiveSyscallClassification(
+  thread: NativeThreadState,
+): NativeActiveSyscallClassification {
+  return refusedClassification(thread, "futex-wait", {
+    code: "futex-state-unsupported",
+    message: `thread ${thread.id} is blocked in futex syscall ${syscallName(thread)}`,
+    detail: futexActiveSyscallDetail(thread),
+  });
+}
+
 function refusedSocketActiveSyscallClassification(
   thread: NativeThreadState,
   options: NativeActiveSyscallPolicyOptions,
@@ -562,6 +578,68 @@ function refusedSignalfdActiveSyscallClassification(
     message: `thread ${thread.id} is blocked reading a signalfd`,
     detail: signalfdActiveSyscallDetail(thread, options.documents),
   });
+}
+
+interface FutexActiveSyscallArguments {
+  source: "proc-syscall" | "registers";
+  uaddr?: string;
+  operation?: string;
+  value?: string;
+  timeoutPointer?: string;
+  uaddr2?: string;
+  value3?: string;
+  waitersPointer?: string;
+  waiterCount?: string;
+  flags?: string;
+  clockId?: string;
+}
+
+function futexActiveSyscallDetail(thread: NativeThreadState): Record<string, unknown> {
+  return detail(thread, "futex-wait", {
+    reason: "futex waiter kernel queue state is unsupported",
+    futexSyscall: {
+      name: syscallName(thread),
+      arguments: decodeFutexActiveSyscallArguments(thread),
+      unsupportedState: [
+        "source futex word address and value race",
+        "kernel wait queue membership",
+        "wake/requeue ordering",
+        "robust-list owner-death semantics",
+      ],
+    },
+  });
+}
+
+function decodeFutexActiveSyscallArguments(
+  thread: NativeThreadState,
+): FutexActiveSyscallArguments | undefined {
+  const args = sleepTimerArguments(thread);
+  if (!args) {
+    return undefined;
+  }
+  if (syscallName(thread) === "futex_waitv") {
+    return {
+      source: args.source,
+      waitersPointer: futexArgument(args, 0),
+      waiterCount: futexArgument(args, 1),
+      flags: futexArgument(args, 2),
+      timeoutPointer: futexArgument(args, 3),
+      clockId: futexArgument(args, 4),
+    };
+  }
+  return {
+    source: args.source,
+    uaddr: futexArgument(args, 0),
+    operation: futexArgument(args, 1),
+    value: futexArgument(args, 2),
+    timeoutPointer: futexArgument(args, 3),
+    uaddr2: futexArgument(args, 4),
+    value3: futexArgument(args, 5),
+  };
+}
+
+function futexArgument(args: SleepTimerArguments, index: number): string {
+  return hex(args.values[index] ?? 0n);
 }
 
 interface SocketActiveSyscallArguments {

--- a/packages/runtime/src/native-thread-restore-policy.ts
+++ b/packages/runtime/src/native-thread-restore-policy.ts
@@ -183,12 +183,26 @@ function resourceRefusal(resource: NativeProcessResource): NativeProcessImageRef
     return [resource.refusal];
   }
   if (resource.kind === "futex") {
-    return [refusal("futex-state-unsupported", `resource ${resource.id} has futex wait state`)];
+    return [futexResourceRefusal(resource)];
   }
   if (resource.kind === "unknown") {
     return [refusal("resource-kind-unsupported", `resource ${resource.id} is unknown`)];
   }
   return [];
+}
+
+function futexResourceRefusal(resource: NativeProcessResource): NativeProcessImageRefusal {
+  return refusal("futex-state-unsupported", `resource ${resource.id} has futex wait state`, {
+    resourceId: resource.id,
+    kind: resource.kind,
+    state: resource.state,
+    requiredModel: [
+      "futex word address translation",
+      "waiter queue membership",
+      "wake/requeue ordering",
+      "robust-list owner-death semantics",
+    ],
+  });
 }
 
 function isKnownHex(value: string | undefined): boolean {

--- a/packages/runtime/src/native-thread-state-policy.ts
+++ b/packages/runtime/src/native-thread-state-policy.ts
@@ -37,7 +37,15 @@ export function unsafeNativeThreadExecutionState(
     );
   }
   if (thread.tls.rseq.state !== "absent") {
-    return nativeThreadRefusal("rseq-state-unsupported", `thread ${thread.id} has rseq state`);
+    return nativeThreadRefusal("rseq-state-unsupported", `thread ${thread.id} has rseq state`, {
+      threadId: thread.id,
+      rseq: thread.tls.rseq,
+      requiredModel: [
+        "target rseq registration lifecycle",
+        "critical-section abort IP translation",
+        "per-thread TLS rseq area ownership",
+      ],
+    });
   }
   return undefined;
 }
@@ -52,6 +60,7 @@ function hasNonZeroNativeSignalMask(masks: string[]): boolean {
 export function nativeThreadRefusal(
   code: NativeProcessImageRefusal["code"],
   message: string,
+  detail?: Record<string, unknown>,
 ): NativeProcessImageRefusal {
-  return { code, message };
+  return detail ? { code, message, detail } : { code, message };
 }

--- a/packages/runtime/src/native-two-thread-boundary.ts
+++ b/packages/runtime/src/native-two-thread-boundary.ts
@@ -82,7 +82,17 @@ function futexResourceRefusals(resources: NativeProcessResource[]): NativeProces
   return resources
     .filter((resource) => resource.kind === "futex")
     .map((resource) =>
-      refusal("futex-state-unsupported", `resource ${resource.id} has futex wait state`),
+      refusal("futex-state-unsupported", `resource ${resource.id} has futex wait state`, {
+        resourceId: resource.id,
+        kind: resource.kind,
+        state: resource.state,
+        requiredModel: [
+          "futex word address translation",
+          "waiter queue membership",
+          "wake/requeue ordering",
+          "robust-list owner-death semantics",
+        ],
+      }),
     );
 }
 
@@ -100,6 +110,7 @@ function refused(
 function refusal(
   code: NativeProcessImageRefusal["code"],
   message: string,
+  detail?: Record<string, unknown>,
 ): NativeProcessImageRefusal {
-  return { code, message };
+  return detail ? { code, message, detail } : { code, message };
 }

--- a/scripts/native-thread-refusal-matrix.ts
+++ b/scripts/native-thread-refusal-matrix.ts
@@ -160,6 +160,13 @@ function restoreRefusalCases(): RestoreRefusalCase[] {
       resources: [{ id: "resource:futex", kind: "futex", state: "captured" }],
     },
     {
+      id: "active-futex-syscall",
+      expectedCode: "futex-state-unsupported",
+      mutate: (thread) => {
+        thread.syscall = { state: "inside-syscall", number: 98, name: "futex" };
+      },
+    },
+    {
       id: "signal-delivery-stop",
       expectedCode: "signal-state-unsupported",
       mutate: (thread) => {


### PR DESCRIPTION
## Problem

Futex and rseq state were refused, but some paths were still too broad. Active futex syscalls could fall through to generic active-syscall handling, and futex/rseq refusal details did not clearly say what model was missing.

## Solution

This tightens the boundary:

- classifies active `futex`, `futex_time64`, and `futex_waitv` as `futex-wait`
- refuses active futex waits with `futex-state-unsupported` and decoded syscall arguments
- adds required-model detail for futex resources: word address translation, wait queues, wake/requeue ordering, and robust-list owner-death semantics
- adds required-model detail for rseq state: target registration lifecycle, abort IP translation, and TLS rseq ownership
- extends thread restore, two-thread, active-syscall, and refusal-matrix tests
- updates docs so this remains a refusal-only boundary, not a restore/emulation claim

Closes #713.

## Validation

- `pnpm run build:docs` — 1.590s
- `pnpm run format:check` — 0.571s
- `pnpm run lint` — 0.220s
- `pnpm run typecheck` — 2.319s
- focused vitest — 2.098s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.377s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.014s
- `pnpm smoke-tests` — 2m12.473s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m9.330s
