### PR TITLE
Refresh native snapshot roadmap

### DIFF
--- a/docs/snapshot/native-cross-isa-proof-roadmap.md
+++ b/docs/snapshot/native-cross-isa-proof-roadmap.md
@@ -202,8 +202,10 @@ Done so far:
 Still future work:
 
 - broader heap/brk/mmap layout policy;
-- argv/env/auxv/cwd handoff beyond the current proof fixture;
-- target libc/vDSO/vvar data dependencies.
+- libc/vDSO/vvar data dependencies beyond the bounded target argv/envp/auxv
+  pointer block;
+- target-specific materialization or explicit refusal for `AT_RANDOM`,
+  `AT_EXECFN`, vDSO, and vvar semantics.
 
 ### 10. Combined descriptor gate — done
 
@@ -219,7 +221,7 @@ Done when:
 - the descriptor preserves no-source-text, no-source-ISA-emulation, and no-sidecar
   invariants.
 
-### 11. Threads, futexes, and rseq — controlled target proof done
+### 11. Threads, futexes, and rseq — controlled target proof and refusal tightening done
 
 Goal: move from single-thread proofs to controlled multi-thread restore.
 
@@ -229,14 +231,20 @@ Done so far:
 - exactly two safe threads can be planned at the boundary;
 - controlled `thread-spawn` target sections are forwarded to the loader and
   consumed by the amd64 trampoline as short-lived target tasks;
+- active futex syscalls and futex resources refuse with `futex-state-unsupported`
+  plus detail for word translation, waiter queues, wake/requeue ordering, and
+  robust-list owner-death semantics;
+- captured/unsupported rseq state refuses with `rseq-state-unsupported` plus
+  detail for target registration lifecycle, abort IP translation, and TLS rseq
+  ownership;
 - the remote portable-machine proof captures a real two-thread arm64 source
-  bundle and requires `targetThreadRestoreResult=passed` alongside the other
+  bundle and requires the controlled target thread gate alongside the other
   native gates.
 
 Still future work:
 
-- model or refuse futex wait/wake and rseq with exact blockers before claiming
-  general multithread restore;
+- model futex wait/wake and rseq resume before claiming general multithread
+  restore;
 - preserve exact refusals for scheduler-visible state beyond the controlled
   two-thread proof.
 
@@ -247,9 +255,12 @@ without relaxing the all-gates success contract.
 
 Next steps:
 
-- add more real resource/syscall families with explicit target recipes;
-- extend argv/env/auxv/cwd beyond the current bounded target-side handoff into
-  explicit libc/initial-stack modeling where needed;
+- add more real resource/syscall families with explicit target recipes, starting
+  with cases that avoid readiness ambiguity (for example safe offset-backed
+  regular-file `write`);
+- extend process-context modeling beyond the bounded target argv/envp/auxv
+  pointer block only where libc/vDSO/vvar, `AT_RANDOM`, and `AT_EXECFN`
+  dependencies are explicit;
 - expand private target memory only when provenance, permissions, guards, and
   pointer ownership are explicit;
 - revisit target libc/vDSO/vvar data dependencies after those narrower families

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -8,7 +8,7 @@ without weakening fail-closed boundaries**.
 
 ## Current proven target-loader point
 
-The target VM proof now runs a real amd64 target-native continuation through the
+The target VM proof runs a real amd64 target-native continuation through the
 in-guest restore loader. The success path still preserves the Option B
 invariants:
 
@@ -21,21 +21,25 @@ invariants:
 The following native restore sections are consumed as target-side work before
 completion is reported:
 
-| Native section             | Current target-side behavior                                                                               |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| stack-window writes/guards | writes target stack slots and maps guard pages                                                             |
-| return-chain writes        | writes bounded target return slots                                                                         |
-| private memory             | maps target private ranges, copies captured bytes, applies final permissions, and backs target TLS/TCB     |
-| executable mapping         | verifies target file/path/address/size/offset, executable/private flags, and build-id or sha256 provenance |
-| signal restore             | saves, applies, verifies, and restores the loader signal mask                                              |
-| process context            | carries bounded argv/env/cwd/auxv metadata and can apply/verify controlled target env+cwd                  |
-| active syscall             | arms target-side timerfds for modeled sleep/ppoll timeout continuations                                    |
-| controlled thread spawn    | maps requested stacks and consumes narrow spawn steps with short-lived target tasks                        |
+| Native section             | Current target-side behavior                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| stack-window writes/guards | writes target stack slots and maps guard pages                                                                                 |
+| return-chain writes        | writes bounded target return slots                                                                                             |
+| private memory             | maps target private ranges, copies captured bytes, applies final permissions, and backs target TLS/TCB                         |
+| executable mapping         | verifies target file/path/address/size/offset, executable/private flags, and build-id or sha256 provenance                     |
+| signal restore             | saves, applies, verifies, and restores the loader signal mask                                                                  |
+| process context            | carries bounded argv/env/cwd/auxv, applies/verifies env+cwd, and can materialize a bounded target argv/envp/auxv pointer block |
+| active syscall             | re-arms modeled sleep/ppoll timers, recreates pipe/eventfd/timerfd read blockers, and completes safe regular-file reads        |
+| controlled thread spawn    | maps requested stacks and consumes narrow spawn steps with short-lived target tasks                                            |
 
-The latest remote arm64→amd64 proof completed with native target execution from
-a two-thread arm64 `ppoll` source bundle. It passed stack, private-memory,
-executable, signal, active-syscall, controlled thread-spawn, register, frame,
-RFLAGS, TLS, state-consumption, fd/resource, and return-chain gates.
+Recent remote arm64→amd64 proofs now cover:
+
+- pipe, eventfd, timerfd, and regular-file active `read` profiles with
+  `targetActiveSyscallRestoreResult=passed`;
+- process-context handoff through the initial-stack pointer block model with
+  `targetProcessContextRestoreResult=passed`;
+- controlled two-thread restore with futex and rseq still fail-closed behind
+  precise refusal detail.
 
 ## Remaining frontier
 
@@ -43,21 +47,23 @@ The next work should expand _accepted process shapes_, not relax the success
 criteria. Good next issues are:
 
 1. Add more real resource/syscall families one at a time, starting with cases
-   whose target fd/resource recipes can be proven without readiness ambiguity.
+   whose target fd/resource recipes can be proven without readiness ambiguity
+   (for example, safe offset-backed regular-file `write`).
 2. Broaden private target memory coverage only where provenance, permissions,
    guards, and pointer ownership are explicit.
-3. Continue argv/env/auxv/cwd work beyond the current bounded handoff: rebuild
-   target argv/environ/auxv stack/global state only where libc dependencies are explicit.
+3. Continue process context work beyond the bounded pointer block: model libc
+   globals/startup expectations only where target libc, vDSO/vvar, `AT_RANDOM`,
+   and `AT_EXECFN` dependencies are explicit.
 4. Revisit target libc/vDSO/vvar data dependencies after the syscall/resource
    cases provide comparison points for what must be materialized versus refused.
-5. Keep futex wait handoff, rseq, arbitrary signal restart, JIT/native code
-   migration, and general scheduler state refused until their kernel/user ABI
-   contracts are modeled.
+5. Keep futex wait handoff, rseq resume, arbitrary signal restart, JIT/native
+   code migration, and general scheduler state refused until their kernel/user
+   ABI contracts are modeled.
 
 ## Deferred frontier
 
 Broad target libc/vDSO/vvar materialization, arbitrary signal restart, futex wait
-handoff, rseq state, JIT/native code migration, and general multithread restore
+handoff, rseq resume, JIT/native code migration, and general multithread restore
 remain deferred. They must keep refusing until their kernel/user ABI contracts
 are modeled precisely.
 


### PR DESCRIPTION
## Problem

The roadmap docs were behind the merged proof ladder. They still described regular-file read, initial-stack process context, and futex/rseq tightening as future or only partly covered work.

## Solution

This refreshes the snapshot roadmap docs to match the current branch:

- records file-read, process-context initial-stack, and futex/rseq refusal tightening as completed slices
- updates the target-loader section table with the current process-context and active-syscall behavior
- narrows the next frontier to more resource/syscall families, broader private memory only with explicit provenance, and deeper libc/vDSO/vvar process-context modeling
- keeps futex/rseq resume and broad scheduler state deferred until modeled precisely

Closes #715.

## Validation

- `pnpm run build:docs` — 1.581s
- `pnpm run format:check` — 0.528s
- `pnpm run lint` — 0.210s
- `pnpm run typecheck` — 2.276s
- focused API drift vitest — 1.879s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.360s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.886s
- `pnpm smoke-tests` — 2m12.461s
- `NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m9.151s
