### PR TITLE
Add pread64 active syscall VM proof

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -14,10 +14,11 @@ The current classifier reports:
 - `sleep-timer` — `clock_nanosleep` / `nanosleep` style waits;
 - `poll-timeout` — modeled `ppoll` timeout waits under an explicit deferral
   policy;
-- `fd-blocking` — `read`, `write`, `poll`, `ppoll`, `select`, `pselect6`, and
-  related fd waits. Narrow pipe/eventfd/timerfd reads, safe offset-backed
-  regular-file reads, and safe offset-backed regular-file writes are modeled only
-  under explicit fd deferral policies; other fd waits still refuse;
+- `fd-blocking` — `read`, `pread64`, `write`, `poll`, `ppoll`, `select`,
+  `pselect6`, and related fd waits. Narrow pipe/eventfd/timerfd reads, safe
+  offset-backed regular-file reads or `pread64` calls, and safe offset-backed
+  regular-file writes are modeled only under explicit fd deferral policies; other
+  fd waits still refuse;
 - `futex-wait` — `futex`, `futex_time64`, and `futex_waitv` wait state;
 - `restart` — `restart_syscall` or captured restart-block state;
 - `unknown-active` — any active syscall that has not been modeled.
@@ -154,9 +155,10 @@ closed as `target-fd-write-state-missing`.
 ## Explicit fd read deferral
 
 The `fdReadPolicy: "defer-target-resume"` option currently accepts only narrow
-blocking `read(fd, buf, count)` cases under an explicit fd resource policy. Every
-modeled read requires captured syscall arguments from `/proc/<tid>/syscall` or
-source registers and a non-null buffer range contained in captured writable
+blocking `read(fd, buf, count)` cases under an explicit fd resource policy plus
+safe regular-file `pread64(fd, buf, count, offset)` cases. Every modeled read
+requires captured syscall arguments from `/proc/<tid>/syscall` or source
+registers and a non-null buffer range contained in captured writable
 non-executable memory.
 
 With `fdReadResourcePolicy: "synthetic-empty-pipe"`, the model additionally
@@ -175,10 +177,11 @@ trampoline can arm the target timerfd before verifying it still blocks.
 
 With `fdReadResourcePolicy: "reopen-file"`, the model requires a captured
 regular-file fd with a reopen recipe, readable access flags, a safe non-negative
-file offset, and a translated writable target buffer. The target step uses
-bounded `pread()` at the captured offset into the translated buffer and refuses
-partial reads; this is an offset-backed completion proof, not a general file or
-page-cache migration.
+file offset, and a translated writable target buffer. Active `pread64` forces the
+same regular-file resource policy and uses the explicit syscall offset instead
+of the captured fd offset. The target step uses bounded `pread()` at the modeled
+offset into the translated buffer and refuses partial reads; this is an
+offset-backed completion proof, not a general file or page-cache migration.
 
 The target step recreates a fresh empty pipe, empty eventfd, or timerfd and
 verifies with target-side `poll(POLLIN, timeout=0)` that the read fd would still
@@ -187,7 +190,7 @@ the safe regular-file read with target-side `pread()`. Missing arguments, zero
 or short counts, missing writable buffer state, wrong resource kind/access,
 non-empty eventfds, semaphore mode, unsupported flags, expired or periodic
 timerfds, absolute timerfd state, missing paired pipe write ends, unsafe file
-offsets, and missing file reopen recipes fail closed as
+offsets or `pread64` offsets, and missing file reopen recipes fail closed as
 `target-fd-read-state-missing`.
 
 ## Proof

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -34,8 +34,9 @@ completion is reported:
 
 Recent remote arm64→amd64 proofs now cover:
 
-- pipe, eventfd, timerfd, and regular-file active `read` profiles plus a
-  regular-file active `write` profile with `targetActiveSyscallRestoreResult=passed`;
+- pipe, eventfd, timerfd, regular-file active `read`, regular-file active
+  `pread64`, and regular-file active `write` profiles with
+  `targetActiveSyscallRestoreResult=passed`;
 - process-context handoff through the initial-stack pointer block model with
   `targetProcessContextRestoreResult=passed`;
 - controlled two-thread restore with futex and rseq still fail-closed behind

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -11,9 +11,9 @@ refused. Otherwise, modeled continuations become target steps:
 - `rearm-ppoll-timeout` for modeled `ppoll` timeout continuations, including
   the synthetic target resources required by the policy;
 - `restore-fd-read-block` for narrow modeled pipe, eventfd, and timerfd reads;
-- `complete-fd-read-from-file` for safe regular-file reads whose fd has a
-  reopen recipe, readable flags, a safe captured offset, and a translated target
-  read buffer;
+- `complete-fd-read-from-file` for safe regular-file `read`/`pread64` calls
+  whose fd has a reopen recipe, readable flags, a safe modeled offset, and a
+  translated target read buffer;
 - `complete-fd-write-to-file` for safe regular-file writes whose fd has a
   reopen recipe, writable non-append flags, a safe captured offset, and a
   translated target write buffer.
@@ -44,16 +44,18 @@ read fds that are ready/EOF/invalid exit before target success.
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read` /
-`timerfd-read` / `file-read` / `file-write`, a real arm64 process stopped in
-`read` on an empty pipe, eventfd, timerfd, or safe offset-backed regular file, or
-stopped in `write` to a safe offset-backed regular file. The file-read and
-file-write profiles use ptrace syscall-entry stops for fd 38 and fd 39 so the
-capture is inside the `read(fd, buf, count)` / `write(fd, buf, count)` boundary;
-the target proof then completes the operation with `pread()` or `pwrite()`. The
+`timerfd-read` / `file-read` / `file-pread` / `file-write`, a real arm64 process
+stopped in `read` on an empty pipe, eventfd, timerfd, or safe offset-backed
+regular file, stopped in `pread64` on a safe offset-backed regular file, or
+stopped in `write` to a safe offset-backed regular file. The file-read,
+file-pread, and file-write profiles use ptrace syscall-entry stops for fd 38, fd
+40, and fd 39 so the capture is inside the `read(fd, buf, count)`,
+`pread64(fd, buf, count, offset)`, or `write(fd, buf, count)` boundary; the
+target proof then completes the operation with `pread()` or `pwrite()`. The
 target-native verifier checks the translated read buffer or reopened target file
-contains the expected bytes. It wraps that bundle in a portable machine
-snapshot, serializes a `native=active-syscall` section in the combined target
-descriptor, and requires `targetActiveSyscallRestoreResult=passed` before the
-remote arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer
-or write-buffer memory still refuses before VM target success with the
+contains the expected bytes. It wraps that bundle in a portable machine snapshot,
+serializes a `native=active-syscall` section in the combined target descriptor,
+and requires `targetActiveSyscallRestoreResult=passed` before the remote
+arm64→amd64 proof is accepted. Missing or unreadable timeout/read-buffer or
+write-buffer memory still refuses before VM target success with the
 active-syscall refusal codes.

--- a/packages/microvm/assets/native-file-pread-target.c
+++ b/packages/microvm/assets/native-file-pread-target.c
@@ -1,0 +1,108 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define TARGET_FILE_FD 40
+#define READ_OFFSET 7
+#define READ_COUNT 4
+#define DATA_FILE "/tmp/machinen-native-file-pread-target-data.txt"
+
+static char file_pread_buffer[READ_COUNT + 8] __attribute__((used));
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static int move_fd(int from, int to) {
+  if (from == to) {
+    return 0;
+  }
+  if (dup2(from, to) < 0) {
+    return -1;
+  }
+  close(from);
+  return 0;
+}
+
+static int write_data_file(void) {
+  int fd = open(DATA_FILE, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if (fd < 0) {
+    return -1;
+  }
+  const char bytes[] = "HEADER-FILE-PREAD-PROOF\n";
+  ssize_t wrote = write(fd, bytes, sizeof(bytes) - 1u);
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return wrote == (ssize_t)(sizeof(bytes) - 1u) ? 0 : -1;
+}
+
+int main(void) {
+  if (write_data_file() != 0) {
+    fprintf(stderr, "machinen-file-pread-target: write data: %s\n", strerror(errno));
+    return 1;
+  }
+  int fd = open(DATA_FILE, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-file-pread-target: open: %s\n", strerror(errno));
+    return 1;
+  }
+  if (move_fd(fd, TARGET_FILE_FD) != 0) {
+    fprintf(stderr, "machinen-file-pread-target: dup2: %s\n", strerror(errno));
+    return 1;
+  }
+  clear_simd_fpu_state();
+  long rc = syscall(SYS_pread64, TARGET_FILE_FD, file_pread_buffer, READ_COUNT, READ_OFFSET);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-file-pread-target: read: %s\n", strerror(errno));
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+}

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -1136,6 +1136,11 @@ static const char *syscall_name(long long number) {
     return "read";
   }
 #endif
+#ifdef __NR_pread64
+  if (number == __NR_pread64) {
+    return "pread64";
+  }
+#endif
 #ifdef __NR_write
   if (number == __NR_write) {
     return "write";

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2962,7 +2962,7 @@ by default when `output` is a TTY.
 
 ##### syscallName
 
-> **syscallName**: `"read"`
+> **syscallName**: `"read"` \| `"pread64"`
 
 ##### argumentSource
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -68,6 +68,12 @@ function arm64ReadThread(
   return arm64SleepThread({ state: "inside-syscall", number: 63, name: "read" }, x);
 }
 
+function arm64PreadThread(
+  x: string[] = ["0x28", "0x3100", "0x4", "0x9", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 67, name: "pread64" }, x);
+}
+
 function arm64WriteThread(
   x: string[] = ["0x27", "0x3100", "0x4", "0x0", "0x0", "0x0"],
 ): NativeThreadState {
@@ -1087,6 +1093,7 @@ describe("native active syscall classification", () => {
       syscallClass: "fd-blocking",
       metadata: {
         fdRead: {
+          syscallName: "read",
           fd: 38,
           countBytes: 4,
           resourceId: "fd:38:read",
@@ -1095,6 +1102,32 @@ describe("native active syscall classification", () => {
           fileOffset: 7,
         },
         policy: "conservative-target-fd-read-block-preserved",
+      },
+    });
+  });
+
+  it("models a safe explicit-offset pread64 from a regular file", () => {
+    const activeThread = arm64PreadThread(["0x26", "0x3100", "0x4", "0xb", "0x0", "0x0"]);
+    const documents = documentsWithReadFile(activeThread, { offset: 7 });
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdReadPolicy: "defer-target-resume",
+      fdReadResourcePolicy: "synthetic-empty-pipe",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdRead: {
+          syscallName: "pread64",
+          fd: 38,
+          countBytes: 4,
+          resourceId: "fd:38:read",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 11,
+        },
       },
     });
   });
@@ -1232,6 +1265,19 @@ describe("native active syscall classification", () => {
         detail: { reason: scenario.reason },
       },
     });
+  });
+
+  it("refuses pread64 with an unsafe explicit offset", () => {
+    const activeThread = arm64PreadThread(["0x26", "0x3100", "0x4", "-1", "0x0", "0x0"]);
+    expect(modelNativeFdReadState(activeThread, documentsWithReadFile(activeThread))).toMatchObject(
+      {
+        state: "missing",
+        refusal: {
+          code: "target-fd-read-state-missing",
+          detail: { reason: "pread64 file offset is outside supported bounds" },
+        },
+      },
+    );
   });
 
   it.each([

--- a/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
@@ -84,28 +84,31 @@ describe("portable machine restore smoke profile", () => {
     });
   });
 
-  it("accepts the file-write remote source profile in dry-run mode", () => {
-    const workDir = tempDir();
-    const result = spawnSync(
-      "bash",
-      [SCRIPT, "--json", "--remote-e2e", "--dry-run", "--keep", "--work-dir", workDir],
-      {
-        cwd: REPO_ROOT,
-        encoding: "utf8",
-        env: { ...SCRIPT_ENV, PORTABLE_MACHINE_REMOTE_SOURCE_TARGET: "file-write" },
-        timeout: 30_000,
-      },
-    );
+  it.each(["file-pread", "file-write"])(
+    "accepts the %s remote source profile in dry-run mode",
+    (sourceTarget) => {
+      const workDir = tempDir();
+      const result = spawnSync(
+        "bash",
+        [SCRIPT, "--json", "--remote-e2e", "--dry-run", "--keep", "--work-dir", workDir],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          env: { ...SCRIPT_ENV, PORTABLE_MACHINE_REMOTE_SOURCE_TARGET: sourceTarget },
+          timeout: 30_000,
+        },
+      );
 
-    expect(result.status, result.stderr).toBe(0);
-    const summary = JSON.parse(result.stdout);
-    expect(summary).toMatchObject({
-      state: "skipped",
-      skipReason: "dry run",
-      remoteE2e: 1,
-      remoteSourceTarget: "file-write",
-    });
-  });
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        state: "skipped",
+        skipReason: "dry run",
+        remoteE2e: 1,
+        remoteSourceTarget: sourceTarget,
+      });
+    },
+  );
 
   it("accepts remote-e2e dry-run mode without live remotes", () => {
     const workDir = tempDir();

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -122,7 +122,7 @@ export interface NativeModeledFdReadTimerRemainingTime extends NativeSleepTimerD
 
 export interface NativeModeledFdReadState {
   kind: "fd-read-block";
-  syscallName: "read";
+  syscallName: "read" | "pread64";
   argumentSource: "proc-syscall" | "registers";
   fd: number;
   bufferPointer: string;
@@ -241,8 +241,10 @@ const SLEEP_TIMER_SYSCALLS = new Set(["clock_nanosleep", "nanosleep"]);
 const FUTEX_ACTIVE_SYSCALLS = new Set(["futex", "futex_time64", "futex_waitv"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
 const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
+const FD_READ_ACTIVE_SYSCALLS = new Set(["read", "pread64"]);
 const FD_BLOCKING_SYSCALLS = new Set([
   "read",
+  "pread64",
   "write",
   "poll",
   "ppoll",
@@ -325,7 +327,7 @@ export function classifyNativeThreadSyscall(
   if (name === "read" && isActiveSignalfdRead(thread, options.documents)) {
     return refusedSignalfdActiveSyscallClassification(thread, options);
   }
-  if (name === "read" && options.fdReadPolicy === "defer-target-resume") {
+  if (FD_READ_ACTIVE_SYSCALLS.has(name) && options.fdReadPolicy === "defer-target-resume") {
     return deferredFdReadClassification(thread, options);
   }
   if (name === "write" && options.fdWritePolicy === "defer-target-resume") {
@@ -418,7 +420,8 @@ export function modelNativeFdReadState(
       argumentSource: args.source,
     });
   }
-  const decoded = decodeFdReadArguments(thread, args, documents, resourcePolicy);
+  const syscall = fdReadSyscallName(thread);
+  const decoded = decodeFdReadArguments(thread, args, documents, resourcePolicy, syscall);
   if ("refusal" in decoded) {
     return decoded;
   }
@@ -426,7 +429,7 @@ export function modelNativeFdReadState(
     state: "modeled",
     read: {
       kind: "fd-read-block",
-      syscallName: "read",
+      syscallName: syscall,
       argumentSource: args.source,
       ...decoded,
     },
@@ -1083,15 +1086,17 @@ function decodePpollTimeoutArguments(
   };
 }
 
+// fallow-ignore-next-line complexity
 function decodeFdReadArguments(
   thread: NativeThreadState,
   args: SleepTimerArguments,
   documents: NativeProcessImageDocuments,
   resourcePolicy: NativeFdReadResourcePolicy,
+  syscall: NativeModeledFdReadState["syscallName"],
 ):
   | Omit<NativeModeledFdReadState, "kind" | "syscallName" | "argumentSource">
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  const values = decodeFdReadArgumentValues(thread, args);
+  const values = decodeFdReadArgumentValues(thread, args, syscall);
   if ("state" in values) {
     return values;
   }
@@ -1099,7 +1104,12 @@ function decodeFdReadArguments(
   if ("state" in bufferMapping) {
     return bufferMapping;
   }
-  const resource = validateFdReadModeledResource(thread, documents, values.fd, resourcePolicy);
+  const resource = validateFdReadModeledResource(
+    thread,
+    documents,
+    values.fd,
+    syscall === "pread64" ? "reopen-file" : resourcePolicy,
+  );
   if ("state" in resource) {
     return resource;
   }
@@ -1123,7 +1133,7 @@ function decodeFdReadArguments(
     pairedWriteResourceId: resource.pairedWriteResource?.id,
     targetResource: resource.targetResource,
     targetBufferPointer,
-    fileOffset: resource.fileOffset,
+    fileOffset: values.explicitFileOffset ?? resource.fileOffset,
     remainingTime: resource.remainingTime,
   };
 }
@@ -1172,64 +1182,77 @@ interface FdReadArgumentValues {
   bufferPointer: bigint;
   count: bigint;
   countBytes: number;
+  explicitFileOffset?: number;
 }
 
 function decodeFdReadArgumentValues(
   thread: NativeThreadState,
   args: SleepTimerArguments,
+  syscall: NativeModeledFdReadState["syscallName"],
 ): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  const fd = safeNumber(args.values[0] ?? -1n);
-  const bufferPointer = args.values[1] ?? 0n;
-  const count = args.values[2] ?? 0n;
-  if (fd === undefined || fd < 0) {
-    return missingFdRead(thread, "read fd is missing or invalid", {
-      fd: hex(args.values[0] ?? -1n),
-    });
+  const values = decodeFdTransferArgumentValues(
+    thread,
+    args,
+    "read",
+    MAX_FD_READ_BYTES,
+    missingFdRead,
+  );
+  if ("state" in values || syscall === "read") {
+    return values;
   }
-  const countBytes = decodeFdReadCount(thread, args, fd, count);
-  return typeof countBytes === "number" ? { fd, bufferPointer, count, countBytes } : countBytes;
+  const explicitFileOffset = decodeFdReadExplicitOffset(thread, args, values.fd);
+  return typeof explicitFileOffset === "number"
+    ? { ...values, explicitFileOffset }
+    : explicitFileOffset;
 }
 
-function decodeFdReadCount(
+function decodeFdReadExplicitOffset(
   thread: NativeThreadState,
   args: SleepTimerArguments,
   fd: number,
-  count: bigint,
 ): number | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  return decodeFdTransferCount(thread, args, fd, count, "read", MAX_FD_READ_BYTES, missingFdRead);
+  const offset = args.values[3] ?? -1n;
+  if (offset < 0n) {
+    return missingFdRead(thread, "pread64 file offset is outside supported bounds", {
+      fd,
+      fileOffset: offset.toString(10),
+      argumentSource: args.source,
+    });
+  }
+  return (
+    safeNumber(offset) ??
+    missingFdRead(thread, "pread64 file offset does not fit in a safe integer", {
+      fd,
+      fileOffset: offset.toString(10),
+      argumentSource: args.source,
+    })
+  );
 }
 
 function decodeFdWriteArgumentValues(
   thread: NativeThreadState,
   args: SleepTimerArguments,
 ): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  return decodeFdTransferArgumentValues(thread, args, "write", MAX_FD_WRITE_BYTES, missingFdWrite);
+}
+
+function decodeFdTransferArgumentValues(
+  thread: NativeThreadState,
+  args: SleepTimerArguments,
+  operation: "read" | "write",
+  maxBytes: bigint,
+  missing: typeof missingFdRead,
+): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
   const fd = safeNumber(args.values[0] ?? -1n);
   const bufferPointer = args.values[1] ?? 0n;
   const count = args.values[2] ?? 0n;
   if (fd === undefined || fd < 0) {
-    return missingFdWrite(thread, "write fd is missing or invalid", {
+    return missing(thread, `${operation} fd is missing or invalid`, {
       fd: hex(args.values[0] ?? -1n),
     });
   }
-  const countBytes = decodeFdWriteCount(thread, args, fd, count);
+  const countBytes = decodeFdTransferCount(thread, args, fd, count, operation, maxBytes, missing);
   return typeof countBytes === "number" ? { fd, bufferPointer, count, countBytes } : countBytes;
-}
-
-function decodeFdWriteCount(
-  thread: NativeThreadState,
-  args: SleepTimerArguments,
-  fd: number,
-  count: bigint,
-): number | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  return decodeFdTransferCount(
-    thread,
-    args,
-    fd,
-    count,
-    "write",
-    MAX_FD_WRITE_BYTES,
-    missingFdWrite,
-  );
 }
 
 function decodeFdTransferCount(
@@ -2358,6 +2381,10 @@ function missingFdWriteRefusal(
 
 function decodedPpollDetail(decoded: { timeoutPointer: bigint; sigsetSize: bigint }) {
   return { timeoutPointer: hex(decoded.timeoutPointer), sigsetSize: hex(decoded.sigsetSize) };
+}
+
+function fdReadSyscallName(thread: NativeThreadState): NativeModeledFdReadState["syscallName"] {
+  return syscallName(thread) === "pread64" ? "pread64" : "read";
 }
 
 function syscallName(thread: NativeThreadState): string {

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -624,7 +624,10 @@ function isActiveReadThread(
     typeof validatePortableMachineSnapshotBundle
   >["nativeProcessImage"]["threads"]["threads"][number],
 ): boolean {
-  return thread.syscall.state === "inside-syscall" && thread.syscall.name === "read";
+  return (
+    thread.syscall.state === "inside-syscall" &&
+    (thread.syscall.name === "read" || thread.syscall.name === "pread64")
+  );
 }
 
 function isActiveWriteThread(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -301,6 +301,7 @@ capture_remote_native_process_bundle() {
     packages/microvm/assets/native-process-capture.c \
     packages/microvm/assets/native-eventfd-read-target.c \
     packages/microvm/assets/native-file-read-target.c \
+    packages/microvm/assets/native-file-pread-target.c \
     packages/microvm/assets/native-file-write-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
     packages/microvm/assets/native-ppoll-timeout-target.c \
@@ -325,6 +326,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target"
       target_detail="remote arm64 regular-file read native-process bundle captured from $ARM64_SSH"
       ;;
+    file-pread)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target"
+      target_detail="remote arm64 regular-file pread64 native-process bundle captured from $ARM64_SSH"
+      ;;
     file-write)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target"
       target_detail="remote arm64 regular-file write native-process bundle captured from $ARM64_SSH"
@@ -346,11 +351,13 @@ capture_remote_native_process_bundle() {
     capture_command="cd / && env -i MACHINEN_CONTEXT_TOKEN=process-context '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --settle-ms 150 -- '$target_binary' --machinen-argv-token"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-read" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall read --trace-syscall-fd 38 -- '$target_binary'"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "file-pread" ]]; then
+    capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall pread64 --trace-syscall-fd 40 -- '$target_binary'"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-write" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall write --trace-syscall-fd 39 -- '$target_binary'"
   fi
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pread-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \


### PR DESCRIPTION
## Problem

The restore proof could finish regular-file `read` and `write` syscalls. It still missed `pread64`, even though `pread64` is a safer file-read shape because the offset is in the syscall arguments. Without this, a real process stopped at that boundary had to fail closed.

## Solution

This PR adds a narrow `pread64` path for reopenable regular files. The policy requires a readable file fd, a translated writable buffer, and a safe explicit offset. The target VM proof now has a `file-pread` profile that captures arm64 `pread64` and completes it natively on amd64 with the existing target-side `pread()` step.

Closes #719.

## Validation

- `pnpm run build:docs` — 1.440s
- `pnpm run format:check` — 0.519s
- `pnpm run lint` — 0.221s
- `pnpm run typecheck` — 2.196s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.733s
- `pnpm smoke-tests` — 2m10.485s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-pread` proof — 36.794s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.335s
- `AGENT_CI_DOCKER_HOST=unix:///Users/peterp/.orbstack/run/docker.sock NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m7.019s
