### PR TITLE
Add pwrite64 active syscall VM proof

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -14,11 +14,11 @@ The current classifier reports:
 - `sleep-timer` — `clock_nanosleep` / `nanosleep` style waits;
 - `poll-timeout` — modeled `ppoll` timeout waits under an explicit deferral
   policy;
-- `fd-blocking` — `read`, `pread64`, `write`, `poll`, `ppoll`, `select`,
-  `pselect6`, and related fd waits. Narrow pipe/eventfd/timerfd reads, safe
-  offset-backed regular-file reads or `pread64` calls, and safe offset-backed
-  regular-file writes are modeled only under explicit fd deferral policies; other
-  fd waits still refuse;
+- `fd-blocking` — `read`, `pread64`, `write`, `pwrite64`, `poll`, `ppoll`,
+  `select`, `pselect6`, and related fd waits. Narrow pipe/eventfd/timerfd reads,
+  safe offset-backed regular-file reads or `pread64` calls, and safe
+  offset-backed regular-file writes or `pwrite64` calls are modeled only under
+  explicit fd deferral policies; other fd waits still refuse;
 - `futex-wait` — `futex`, `futex_time64`, and `futex_waitv` wait state;
 - `restart` — `restart_syscall` or captured restart-block state;
 - `unknown-active` — any active syscall that has not been modeled.
@@ -138,19 +138,20 @@ rows, and wrong resource kinds are still precise fail-closed refusals.
 ## Explicit fd write deferral
 
 The `fdWritePolicy: "defer-target-resume"` option currently accepts only narrow
-regular-file `write(fd, buf, count)` cases under
-`fdWriteResourcePolicy: "reopen-file"`. The model requires captured syscall
+regular-file `write(fd, buf, count)` and `pwrite64(fd, buf, count, offset)` cases
+under `fdWriteResourcePolicy: "reopen-file"`. The model requires captured syscall
 arguments, a non-null write buffer contained in captured readable non-executable
 memory, a translated target buffer, a captured regular-file fd with a reopen
 recipe, writable access flags, no `O_APPEND`, and a safe non-negative file
-offset.
+offset. Active `pwrite64` uses the explicit syscall offset instead of the
+captured fd offset.
 
 The target step performs a bounded `pwrite()` at the captured offset from the
 translated target buffer and refuses partial writes. This is an offset-backed
 completion proof, not a general page-cache, append, or writeback migration.
 Missing arguments, zero or oversized counts, missing readable buffer state, wrong
-resource kind/access, `O_APPEND`, unsafe offsets, and missing reopen recipes fail
-closed as `target-fd-write-state-missing`.
+resource kind/access, `O_APPEND`, unsafe file offsets or `pwrite64` offsets, and
+missing reopen recipes fail closed as `target-fd-write-state-missing`.
 
 ## Explicit fd read deferral
 

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -35,8 +35,8 @@ completion is reported:
 Recent remote arm64→amd64 proofs now cover:
 
 - pipe, eventfd, timerfd, regular-file active `read`, regular-file active
-  `pread64`, and regular-file active `write` profiles with
-  `targetActiveSyscallRestoreResult=passed`;
+  `pread64`, regular-file active `write`, and regular-file active `pwrite64`
+  profiles with `targetActiveSyscallRestoreResult=passed`;
 - process-context handoff through the initial-stack pointer block model with
   `targetProcessContextRestoreResult=passed`;
 - controlled two-thread restore with futex and rseq still fail-closed behind

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -14,9 +14,9 @@ refused. Otherwise, modeled continuations become target steps:
 - `complete-fd-read-from-file` for safe regular-file `read`/`pread64` calls
   whose fd has a reopen recipe, readable flags, a safe modeled offset, and a
   translated target read buffer;
-- `complete-fd-write-to-file` for safe regular-file writes whose fd has a
-  reopen recipe, writable non-append flags, a safe captured offset, and a
-  translated target write buffer.
+- `complete-fd-write-to-file` for safe regular-file `write`/`pwrite64` calls
+  whose fd has a reopen recipe, writable non-append flags, a safe modeled offset,
+  and a translated target write buffer.
 
 Only continuations that already passed the active-syscall policy are accepted.
 Generic blocking syscalls, restart state, missing timespecs, missing read/write
@@ -44,15 +44,17 @@ read fds that are ready/EOF/invalid exit before target success.
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read` /
-`timerfd-read` / `file-read` / `file-pread` / `file-write`, a real arm64 process
-stopped in `read` on an empty pipe, eventfd, timerfd, or safe offset-backed
-regular file, stopped in `pread64` on a safe offset-backed regular file, or
-stopped in `write` to a safe offset-backed regular file. The file-read,
-file-pread, and file-write profiles use ptrace syscall-entry stops for fd 38, fd
-40, and fd 39 so the capture is inside the `read(fd, buf, count)`,
-`pread64(fd, buf, count, offset)`, or `write(fd, buf, count)` boundary; the
-target proof then completes the operation with `pread()` or `pwrite()`. The
-target-native verifier checks the translated read buffer or reopened target file
+`timerfd-read` / `file-read` / `file-pread` / `file-write` / `file-pwrite`, a
+real arm64 process stopped in `read` on an empty pipe, eventfd, timerfd, or safe
+offset-backed regular file, stopped in `pread64` on a safe offset-backed regular
+file, stopped in `write` to a safe offset-backed regular file, or stopped in
+`pwrite64` to a safe offset-backed regular file. The file-read, file-pread,
+file-write, and file-pwrite profiles use ptrace syscall-entry stops for fd 38,
+fd 40, fd 39, and fd 41 so the capture is inside the `read(fd, buf, count)`,
+`pread64(fd, buf, count, offset)`, `write(fd, buf, count)`, or
+`pwrite64(fd, buf, count, offset)` boundary; the target proof then completes the
+operation with `pread()` or `pwrite()`. The target-native verifier checks the
+translated read buffer or reopened target file
 contains the expected bytes. It wraps that bundle in a portable machine snapshot,
 serializes a `native=active-syscall` section in the combined target descriptor,
 and requires `targetActiveSyscallRestoreResult=passed` before the remote

--- a/packages/microvm/assets/native-file-pwrite-target.c
+++ b/packages/microvm/assets/native-file-pwrite-target.c
@@ -1,0 +1,108 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define TARGET_FILE_FD 41
+#define WRITE_OFFSET 7
+#define WRITE_COUNT 4
+#define DATA_FILE "/tmp/machinen-native-file-pwrite-target-data.txt"
+
+static char file_pwrite_buffer[WRITE_COUNT + 8] __attribute__((used)) = "WRIT";
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static int move_fd(int from, int to) {
+  if (from == to) {
+    return 0;
+  }
+  if (dup2(from, to) < 0) {
+    return -1;
+  }
+  close(from);
+  return 0;
+}
+
+static int write_data_file(void) {
+  int fd = open(DATA_FILE, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if (fd < 0) {
+    return -1;
+  }
+  const char bytes[] = "HEADER----WRITE-PROOF\n";
+  ssize_t wrote = write(fd, bytes, sizeof(bytes) - 1u);
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return wrote == (ssize_t)(sizeof(bytes) - 1u) ? 0 : -1;
+}
+
+int main(void) {
+  if (write_data_file() != 0) {
+    fprintf(stderr, "machinen-file-pwrite-target: write data: %s\n", strerror(errno));
+    return 1;
+  }
+  int fd = open(DATA_FILE, O_WRONLY);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-file-pwrite-target: open: %s\n", strerror(errno));
+    return 1;
+  }
+  if (move_fd(fd, TARGET_FILE_FD) != 0) {
+    fprintf(stderr, "machinen-file-pwrite-target: dup2: %s\n", strerror(errno));
+    return 1;
+  }
+  clear_simd_fpu_state();
+  long rc = syscall(SYS_pwrite64, TARGET_FILE_FD, file_pwrite_buffer, WRITE_COUNT, WRITE_OFFSET);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-file-pwrite-target: write: %s\n", strerror(errno));
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+}

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -1146,6 +1146,11 @@ static const char *syscall_name(long long number) {
     return "write";
   }
 #endif
+#ifdef __NR_pwrite64
+  if (number == __NR_pwrite64) {
+    return "pwrite64";
+  }
+#endif
   return "unknown";
 }
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3020,7 +3020,7 @@ by default when `output` is a TTY.
 
 ##### syscallName
 
-> **syscallName**: `"write"`
+> **syscallName**: `"write"` \| `"pwrite64"`
 
 ##### argumentSource
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -80,6 +80,12 @@ function arm64WriteThread(
   return arm64SleepThread({ state: "inside-syscall", number: 64, name: "write" }, x);
 }
 
+function arm64PwriteThread(
+  x: string[] = ["0x29", "0x3100", "0x4", "0xb", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 68, name: "pwrite64" }, x);
+}
+
 function arm64SocketThread(
   name: "accept" | "accept4" | "connect",
   x: string[] = ["0x28", "0x0", "0x0", "0x0", "0x0", "0x0"],
@@ -1146,6 +1152,7 @@ describe("native active syscall classification", () => {
       syscallClass: "fd-blocking",
       metadata: {
         fdWrite: {
+          syscallName: "write",
           fd: 39,
           countBytes: 4,
           resourceId: "fd:39:write",
@@ -1158,6 +1165,32 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("models a safe explicit-offset pwrite64 to a regular file", () => {
+    const activeThread = arm64PwriteThread(["0x27", "0x3100", "0x4", "0xb", "0x0", "0x0"]);
+    const documents = documentsWithWriteFile(activeThread, { offset: 7 });
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdWritePolicy: "defer-target-resume",
+      fdWriteResourcePolicy: "reopen-file",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdWrite: {
+          syscallName: "pwrite64",
+          fd: 39,
+          countBytes: 4,
+          resourceId: "fd:39:write",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 11,
+        },
+      },
+    });
+  });
+
   it("prefers /proc syscall arguments for modeled read", () => {
     const activeThread = arm64ReadThread();
     activeThread.syscall.arguments = ["0x20", "0x3100", "0x1", "0x0", "0x0", "0x0"];
@@ -1166,6 +1199,19 @@ describe("native active syscall classification", () => {
     expect(modelNativeFdReadState(activeThread, documents)).toMatchObject({
       state: "modeled",
       read: { argumentSource: "proc-syscall", fd: 32, countBytes: 1 },
+    });
+  });
+
+  it("refuses pwrite64 with an unsafe explicit offset", () => {
+    const activeThread = arm64PwriteThread(["0x27", "0x3100", "0x4", "-1", "0x0", "0x0"]);
+    expect(
+      modelNativeFdWriteState(activeThread, documentsWithWriteFile(activeThread)),
+    ).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-write-state-missing",
+        detail: { reason: "pwrite64 file offset is outside supported bounds" },
+      },
     });
   });
 

--- a/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
@@ -84,7 +84,7 @@ describe("portable machine restore smoke profile", () => {
     });
   });
 
-  it.each(["file-pread", "file-write"])(
+  it.each(["file-pread", "file-write", "file-pwrite"])(
     "accepts the %s remote source profile in dry-run mode",
     (sourceTarget) => {
       const workDir = tempDir();

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -140,7 +140,7 @@ export type NativeModeledFdWriteTargetResource = "reopened-offset-file";
 
 export interface NativeModeledFdWriteState {
   kind: "fd-write-complete";
-  syscallName: "write";
+  syscallName: "write" | "pwrite64";
   argumentSource: "proc-syscall" | "registers";
   fd: number;
   bufferPointer: string;
@@ -242,10 +242,12 @@ const FUTEX_ACTIVE_SYSCALLS = new Set(["futex", "futex_time64", "futex_waitv"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
 const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
 const FD_READ_ACTIVE_SYSCALLS = new Set(["read", "pread64"]);
+const FD_WRITE_ACTIVE_SYSCALLS = new Set(["write", "pwrite64"]);
 const FD_BLOCKING_SYSCALLS = new Set([
   "read",
   "pread64",
   "write",
+  "pwrite64",
   "poll",
   "ppoll",
   "select",
@@ -330,7 +332,7 @@ export function classifyNativeThreadSyscall(
   if (FD_READ_ACTIVE_SYSCALLS.has(name) && options.fdReadPolicy === "defer-target-resume") {
     return deferredFdReadClassification(thread, options);
   }
-  if (name === "write" && options.fdWritePolicy === "defer-target-resume") {
+  if (FD_WRITE_ACTIVE_SYSCALLS.has(name) && options.fdWritePolicy === "defer-target-resume") {
     return deferredFdWriteClassification(thread, options);
   }
   if (SOCKET_ACTIVE_SYSCALLS.has(name)) {
@@ -450,7 +452,8 @@ export function modelNativeFdWriteState(
       argumentSource: args.source,
     });
   }
-  const decoded = decodeFdWriteArguments(thread, args, documents, resourcePolicy);
+  const syscall = fdWriteSyscallName(thread);
+  const decoded = decodeFdWriteArguments(thread, args, documents, resourcePolicy, syscall);
   if ("refusal" in decoded) {
     return decoded;
   }
@@ -458,7 +461,7 @@ export function modelNativeFdWriteState(
     state: "modeled",
     write: {
       kind: "fd-write-complete",
-      syscallName: "write",
+      syscallName: syscall,
       argumentSource: args.source,
       ...decoded,
     },
@@ -1143,10 +1146,11 @@ function decodeFdWriteArguments(
   args: SleepTimerArguments,
   documents: NativeProcessImageDocuments,
   resourcePolicy: NativeFdWriteResourcePolicy,
+  syscall: NativeModeledFdWriteState["syscallName"],
 ):
   | Omit<NativeModeledFdWriteState, "kind" | "syscallName" | "argumentSource">
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  const values = decodeFdWriteArgumentValues(thread, args);
+  const values = decodeFdWriteArgumentValues(thread, args, syscall);
   if ("state" in values) {
     return values;
   }
@@ -1173,7 +1177,7 @@ function decodeFdWriteArguments(
     resourceId: resource.resource.id,
     targetResource: resource.targetResource,
     targetBufferPointer,
-    fileOffset: resource.fileOffset,
+    fileOffset: values.explicitFileOffset ?? resource.fileOffset,
   };
 }
 
@@ -1211,9 +1215,46 @@ function decodeFdReadExplicitOffset(
   args: SleepTimerArguments,
   fd: number,
 ): number | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  return decodeFdExplicitOffset(thread, args, fd, "pread64", missingFdRead);
+}
+
+function decodeFdWriteArgumentValues(
+  thread: NativeThreadState,
+  args: SleepTimerArguments,
+  syscall: NativeModeledFdWriteState["syscallName"],
+): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const values = decodeFdTransferArgumentValues(
+    thread,
+    args,
+    "write",
+    MAX_FD_WRITE_BYTES,
+    missingFdWrite,
+  );
+  if ("state" in values || syscall === "write") {
+    return values;
+  }
+  const explicitFileOffset = decodeFdExplicitOffset(
+    thread,
+    args,
+    values.fd,
+    "pwrite64",
+    missingFdWrite,
+  );
+  return typeof explicitFileOffset === "number"
+    ? { ...values, explicitFileOffset }
+    : explicitFileOffset;
+}
+
+function decodeFdExplicitOffset(
+  thread: NativeThreadState,
+  args: SleepTimerArguments,
+  fd: number,
+  syscall: "pread64" | "pwrite64",
+  missing: typeof missingFdRead,
+): number | { state: "missing"; refusal: NativeProcessImageRefusal } {
   const offset = args.values[3] ?? -1n;
   if (offset < 0n) {
-    return missingFdRead(thread, "pread64 file offset is outside supported bounds", {
+    return missing(thread, `${syscall} file offset is outside supported bounds`, {
       fd,
       fileOffset: offset.toString(10),
       argumentSource: args.source,
@@ -1221,19 +1262,12 @@ function decodeFdReadExplicitOffset(
   }
   return (
     safeNumber(offset) ??
-    missingFdRead(thread, "pread64 file offset does not fit in a safe integer", {
+    missing(thread, `${syscall} file offset does not fit in a safe integer`, {
       fd,
       fileOffset: offset.toString(10),
       argumentSource: args.source,
     })
   );
-}
-
-function decodeFdWriteArgumentValues(
-  thread: NativeThreadState,
-  args: SleepTimerArguments,
-): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  return decodeFdTransferArgumentValues(thread, args, "write", MAX_FD_WRITE_BYTES, missingFdWrite);
 }
 
 function decodeFdTransferArgumentValues(
@@ -2385,6 +2419,10 @@ function decodedPpollDetail(decoded: { timeoutPointer: bigint; sigsetSize: bigin
 
 function fdReadSyscallName(thread: NativeThreadState): NativeModeledFdReadState["syscallName"] {
   return syscallName(thread) === "pread64" ? "pread64" : "read";
+}
+
+function fdWriteSyscallName(thread: NativeThreadState): NativeModeledFdWriteState["syscallName"] {
+  return syscallName(thread) === "pwrite64" ? "pwrite64" : "write";
 }
 
 function syscallName(thread: NativeThreadState): string {

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -635,7 +635,10 @@ function isActiveWriteThread(
     typeof validatePortableMachineSnapshotBundle
   >["nativeProcessImage"]["threads"]["threads"][number],
 ): boolean {
-  return thread.syscall.state === "inside-syscall" && thread.syscall.name === "write";
+  return (
+    thread.syscall.state === "inside-syscall" &&
+    (thread.syscall.name === "write" || thread.syscall.name === "pwrite64")
+  );
 }
 
 function activeReadFd(

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -302,6 +302,7 @@ capture_remote_native_process_bundle() {
     packages/microvm/assets/native-eventfd-read-target.c \
     packages/microvm/assets/native-file-read-target.c \
     packages/microvm/assets/native-file-pread-target.c \
+    packages/microvm/assets/native-file-pwrite-target.c \
     packages/microvm/assets/native-file-write-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
     packages/microvm/assets/native-ppoll-timeout-target.c \
@@ -334,6 +335,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target"
       target_detail="remote arm64 regular-file write native-process bundle captured from $ARM64_SSH"
       ;;
+    file-pwrite)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-pwrite-target"
+      target_detail="remote arm64 regular-file pwrite64 native-process bundle captured from $ARM64_SSH"
+      ;;
     timerfd-read)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target"
       target_detail="remote arm64 timerfd read native-process bundle captured from $ARM64_SSH"
@@ -355,9 +360,11 @@ capture_remote_native_process_bundle() {
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall pread64 --trace-syscall-fd 40 -- '$target_binary'"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-write" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall write --trace-syscall-fd 39 -- '$target_binary'"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "file-pwrite" ]]; then
+    capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall pwrite64 --trace-syscall-fd 41 -- '$target_binary'"
   fi
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pread-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pread-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pwrite-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pwrite-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \


### PR DESCRIPTION
## Problem

The restore proof could handle regular-file `write` and explicit-offset `pread64`. It still missed the matching explicit-offset write syscall, `pwrite64`. That meant a safe file write with the offset in the syscall arguments still had to fail closed.

## Solution

This PR adds a narrow `pwrite64` path for reopenable regular files. The policy requires a writable non-append file fd, a translated readable buffer, and a safe explicit offset. The target VM proof now has a `file-pwrite` profile that captures arm64 `pwrite64` and completes it natively on amd64 with `pwrite()`.

Closes #721.

## Validation

- `pnpm run build:docs` — 1.434s
- `pnpm run format:check` — 0.526s
- `pnpm run lint` — 0.239s
- `pnpm run typecheck` — 2.228s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.370s
- `pnpm smoke-tests` — 2m10.478s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-pwrite` proof — 44.732s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.349s
- `AGENT_CI_DOCKER_HOST=unix:///Users/peterp/.orbstack/run/docker.sock NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m6.978s
