### PR TITLE
Add single-iovec readv writev boundary

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -14,11 +14,12 @@ The current classifier reports:
 - `sleep-timer` — `clock_nanosleep` / `nanosleep` style waits;
 - `poll-timeout` — modeled `ppoll` timeout waits under an explicit deferral
   policy;
-- `fd-blocking` — `read`, `pread64`, `write`, `pwrite64`, `poll`, `ppoll`,
-  `select`, `pselect6`, and related fd waits. Narrow pipe/eventfd/timerfd reads,
-  safe offset-backed regular-file reads or `pread64` calls, and safe
-  offset-backed regular-file writes or `pwrite64` calls are modeled only under
-  explicit fd deferral policies; other fd waits still refuse;
+- `fd-blocking` — `read`, `pread64`, `readv`, `write`, `pwrite64`, `writev`,
+  `poll`, `ppoll`, `select`, `pselect6`, and related fd waits. Narrow
+  pipe/eventfd/timerfd reads, safe offset-backed regular-file reads, `pread64`,
+  or single-iovec `readv` calls, and safe offset-backed regular-file writes,
+  `pwrite64`, or single-iovec `writev` calls are modeled only under explicit fd
+  deferral policies; other fd waits still refuse;
 - `futex-wait` — `futex`, `futex_time64`, and `futex_waitv` wait state;
 - `restart` — `restart_syscall` or captured restart-block state;
 - `unknown-active` — any active syscall that has not been modeled.
@@ -138,29 +139,33 @@ rows, and wrong resource kinds are still precise fail-closed refusals.
 ## Explicit fd write deferral
 
 The `fdWritePolicy: "defer-target-resume"` option currently accepts only narrow
-regular-file `write(fd, buf, count)` and `pwrite64(fd, buf, count, offset)` cases
-under `fdWriteResourcePolicy: "reopen-file"`. The model requires captured syscall
+regular-file `write(fd, buf, count)`, `pwrite64(fd, buf, count, offset)`, and
+single-iovec `writev(fd, iov, 1)` cases under
+`fdWriteResourcePolicy: "reopen-file"`. The model requires captured syscall
 arguments, a non-null write buffer contained in captured readable non-executable
 memory, a translated target buffer, a captured regular-file fd with a reopen
 recipe, writable access flags, no `O_APPEND`, and a safe non-negative file
 offset. Active `pwrite64` uses the explicit syscall offset instead of the
-captured fd offset.
+captured fd offset. Active `writev` first decodes exactly one captured `struct
+iovec` from readable process memory and treats its `iov_base`/`iov_len` as the
+write buffer/count.
 
 The target step performs a bounded `pwrite()` at the captured offset from the
 translated target buffer and refuses partial writes. This is an offset-backed
 completion proof, not a general page-cache, append, or writeback migration.
 Missing arguments, zero or oversized counts, missing readable buffer state, wrong
-resource kind/access, `O_APPEND`, unsafe file offsets or `pwrite64` offsets, and
-missing reopen recipes fail closed as `target-fd-write-state-missing`.
+resource kind/access, `O_APPEND`, missing or non-one writev iovecs, unsafe file
+offsets or `pwrite64` offsets, and missing reopen recipes fail closed as
+`target-fd-write-state-missing`.
 
 ## Explicit fd read deferral
 
 The `fdReadPolicy: "defer-target-resume"` option currently accepts only narrow
 blocking `read(fd, buf, count)` cases under an explicit fd resource policy plus
-safe regular-file `pread64(fd, buf, count, offset)` cases. Every modeled read
-requires captured syscall arguments from `/proc/<tid>/syscall` or source
-registers and a non-null buffer range contained in captured writable
-non-executable memory.
+safe regular-file `pread64(fd, buf, count, offset)` and single-iovec
+`readv(fd, iov, 1)` cases. Every modeled read requires captured syscall
+arguments from `/proc/<tid>/syscall` or source registers and a non-null buffer
+range contained in captured writable non-executable memory.
 
 With `fdReadResourcePolicy: "synthetic-empty-pipe"`, the model additionally
 requires a captured pipe read-end resource for `fd` and a paired pipe write end
@@ -178,11 +183,14 @@ trampoline can arm the target timerfd before verifying it still blocks.
 
 With `fdReadResourcePolicy: "reopen-file"`, the model requires a captured
 regular-file fd with a reopen recipe, readable access flags, a safe non-negative
-file offset, and a translated writable target buffer. Active `pread64` forces the
-same regular-file resource policy and uses the explicit syscall offset instead
-of the captured fd offset. The target step uses bounded `pread()` at the modeled
-offset into the translated buffer and refuses partial reads; this is an
-offset-backed completion proof, not a general file or page-cache migration.
+file offset, and a translated writable target buffer. Active `pread64` and
+`readv` force the same regular-file resource policy; `pread64` uses the explicit
+syscall offset instead of the captured fd offset, while `readv` first decodes
+exactly one captured `struct iovec` from readable process memory and treats its
+`iov_base`/`iov_len` as the read buffer/count. The target step uses bounded
+`pread()` at the modeled offset into the translated buffer and refuses partial
+reads; this is an offset-backed completion proof, not a general file or
+page-cache migration.
 
 The target step recreates a fresh empty pipe, empty eventfd, or timerfd and
 verifies with target-side `poll(POLLIN, timeout=0)` that the read fd would still
@@ -190,9 +198,9 @@ block before reporting `nativeActiveSyscallRestore.status=passed`, or completes
 the safe regular-file read with target-side `pread()`. Missing arguments, zero
 or short counts, missing writable buffer state, wrong resource kind/access,
 non-empty eventfds, semaphore mode, unsupported flags, expired or periodic
-timerfds, absolute timerfd state, missing paired pipe write ends, unsafe file
-offsets or `pread64` offsets, and missing file reopen recipes fail closed as
-`target-fd-read-state-missing`.
+timerfds, absolute timerfd state, missing paired pipe write ends, missing or
+non-one readv iovecs, unsafe file offsets or `pread64` offsets, and missing file
+reopen recipes fail closed as `target-fd-read-state-missing`.
 
 ## Proof
 

--- a/docs/snapshot/native-next-frontier.md
+++ b/docs/snapshot/native-next-frontier.md
@@ -35,8 +35,9 @@ completion is reported:
 Recent remote arm64→amd64 proofs now cover:
 
 - pipe, eventfd, timerfd, regular-file active `read`, regular-file active
-  `pread64`, regular-file active `write`, and regular-file active `pwrite64`
-  profiles with `targetActiveSyscallRestoreResult=passed`;
+  `pread64`, single-iovec regular-file active `readv`, regular-file active
+  `write`, regular-file active `pwrite64`, and single-iovec regular-file active
+  `writev` profiles with `targetActiveSyscallRestoreResult=passed`;
 - process-context handoff through the initial-stack pointer block model with
   `targetProcessContextRestoreResult=passed`;
 - controlled two-thread restore with futex and rseq still fail-closed behind

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -11,12 +11,12 @@ refused. Otherwise, modeled continuations become target steps:
 - `rearm-ppoll-timeout` for modeled `ppoll` timeout continuations, including
   the synthetic target resources required by the policy;
 - `restore-fd-read-block` for narrow modeled pipe, eventfd, and timerfd reads;
-- `complete-fd-read-from-file` for safe regular-file `read`/`pread64` calls
-  whose fd has a reopen recipe, readable flags, a safe modeled offset, and a
-  translated target read buffer;
-- `complete-fd-write-to-file` for safe regular-file `write`/`pwrite64` calls
-  whose fd has a reopen recipe, writable non-append flags, a safe modeled offset,
-  and a translated target write buffer.
+- `complete-fd-read-from-file` for safe regular-file `read`/`pread64`/single-
+  iovec `readv` calls whose fd has a reopen recipe, readable flags, a safe
+  modeled offset, and a translated target read buffer;
+- `complete-fd-write-to-file` for safe regular-file `write`/`pwrite64`/single-
+  iovec `writev` calls whose fd has a reopen recipe, writable non-append flags,
+  a safe modeled offset, and a translated target write buffer.
 
 Only continuations that already passed the active-syscall policy are accepted.
 Generic blocking syscalls, restart state, missing timespecs, missing read/write
@@ -44,17 +44,19 @@ read fds that are ready/EOF/invalid exit before target success.
 The remote portable-machine smoke path captures either the default real arm64
 two-thread process with one thread blocked in a modeled `ppoll` timeout or, with
 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=pipe-read` / `eventfd-read` /
-`timerfd-read` / `file-read` / `file-pread` / `file-write` / `file-pwrite`, a
-real arm64 process stopped in `read` on an empty pipe, eventfd, timerfd, or safe
-offset-backed regular file, stopped in `pread64` on a safe offset-backed regular
-file, stopped in `write` to a safe offset-backed regular file, or stopped in
-`pwrite64` to a safe offset-backed regular file. The file-read, file-pread,
-file-write, and file-pwrite profiles use ptrace syscall-entry stops for fd 38,
-fd 40, fd 39, and fd 41 so the capture is inside the `read(fd, buf, count)`,
-`pread64(fd, buf, count, offset)`, `write(fd, buf, count)`, or
-`pwrite64(fd, buf, count, offset)` boundary; the target proof then completes the
-operation with `pread()` or `pwrite()`. The target-native verifier checks the
-translated read buffer or reopened target file
+`timerfd-read` / `file-read` / `file-pread` / `file-readv` / `file-write` /
+`file-pwrite` / `file-writev`, a real arm64 process stopped in `read` on an empty
+pipe, eventfd, timerfd, or safe offset-backed regular file, stopped in `pread64`
+or single-iovec `readv` on a safe offset-backed regular file, stopped in `write`
+to a safe offset-backed regular file, or stopped in `pwrite64` or single-iovec
+`writev` to a safe offset-backed regular file. The file-read, file-pread,
+file-readv, file-write, file-pwrite, and file-writev profiles use ptrace
+syscall-entry stops for fd 38, fd 40, fd 42, fd 39, fd 41, and fd 43 so the
+capture is inside the `read(fd, buf, count)`, `pread64(fd, buf, count, offset)`,
+`readv(fd, iov, 1)`, `write(fd, buf, count)`,
+`pwrite64(fd, buf, count, offset)`, or `writev(fd, iov, 1)` boundary; the target
+proof then completes the operation with `pread()` or `pwrite()`. The
+target-native verifier checks the translated read buffer or reopened target file
 contains the expected bytes. It wraps that bundle in a portable machine snapshot,
 serializes a `native=active-syscall` section in the combined target descriptor,
 and requires `targetActiveSyscallRestoreResult=passed` before the remote

--- a/packages/microvm/assets/native-file-readv-target.c
+++ b/packages/microvm/assets/native-file-readv-target.c
@@ -1,0 +1,122 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#define TARGET_FILE_FD 42
+#define READ_OFFSET 7
+#define READ_COUNT 4
+#define DATA_FILE "/tmp/machinen-native-file-readv-target-data.txt"
+
+struct ReadvState {
+  struct iovec iov;
+  char padding[240];
+  char buffer[READ_COUNT + 8];
+};
+
+static struct ReadvState file_readv_state __attribute__((used));
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static int move_fd(int from, int to) {
+  if (from == to) {
+    return 0;
+  }
+  if (dup2(from, to) < 0) {
+    return -1;
+  }
+  close(from);
+  return 0;
+}
+
+static int write_data_file(void) {
+  int fd = open(DATA_FILE, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if (fd < 0) {
+    return -1;
+  }
+  const char bytes[] = "HEADER-FILE-READV-PROOF\n";
+  ssize_t wrote = write(fd, bytes, sizeof(bytes) - 1u);
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return wrote == (ssize_t)(sizeof(bytes) - 1u) ? 0 : -1;
+}
+
+int main(void) {
+  if (write_data_file() != 0) {
+    fprintf(stderr, "machinen-file-readv-target: write data: %s\n", strerror(errno));
+    return 1;
+  }
+  int fd = open(DATA_FILE, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-file-readv-target: open: %s\n", strerror(errno));
+    return 1;
+  }
+  if (move_fd(fd, TARGET_FILE_FD) != 0) {
+    fprintf(stderr, "machinen-file-readv-target: dup2: %s\n", strerror(errno));
+    return 1;
+  }
+  if (lseek(TARGET_FILE_FD, READ_OFFSET, SEEK_SET) < 0) {
+    fprintf(stderr, "machinen-file-readv-target: lseek: %s\n", strerror(errno));
+    return 1;
+  }
+
+  file_readv_state.iov.iov_base = file_readv_state.buffer;
+  file_readv_state.iov.iov_len = READ_COUNT;
+  clear_simd_fpu_state();
+  long rc = syscall(SYS_readv, TARGET_FILE_FD, &file_readv_state.iov, 1);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-file-readv-target: readv: %s\n", strerror(errno));
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+}

--- a/packages/microvm/assets/native-file-writev-target.c
+++ b/packages/microvm/assets/native-file-writev-target.c
@@ -1,0 +1,124 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#define TARGET_FILE_FD 43
+#define WRITE_OFFSET 7
+#define WRITE_COUNT 4
+#define DATA_FILE "/tmp/machinen-native-file-writev-target-data.txt"
+
+struct WritevState {
+  struct iovec iov;
+  char padding[240];
+  char buffer[WRITE_COUNT + 8];
+};
+
+static struct WritevState file_writev_state __attribute__((used)) = {
+    .buffer = "WRIT",
+};
+
+static void clear_simd_fpu_state(void) {
+#if defined(__aarch64__)
+  __asm__ __volatile__(
+      "movi v0.16b, #0\n"
+      "movi v1.16b, #0\n"
+      "movi v2.16b, #0\n"
+      "movi v3.16b, #0\n"
+      "movi v4.16b, #0\n"
+      "movi v5.16b, #0\n"
+      "movi v6.16b, #0\n"
+      "movi v7.16b, #0\n"
+      "movi v8.16b, #0\n"
+      "movi v9.16b, #0\n"
+      "movi v10.16b, #0\n"
+      "movi v11.16b, #0\n"
+      "movi v12.16b, #0\n"
+      "movi v13.16b, #0\n"
+      "movi v14.16b, #0\n"
+      "movi v15.16b, #0\n"
+      "movi v16.16b, #0\n"
+      "movi v17.16b, #0\n"
+      "movi v18.16b, #0\n"
+      "movi v19.16b, #0\n"
+      "movi v20.16b, #0\n"
+      "movi v21.16b, #0\n"
+      "movi v22.16b, #0\n"
+      "movi v23.16b, #0\n"
+      "movi v24.16b, #0\n"
+      "movi v25.16b, #0\n"
+      "movi v26.16b, #0\n"
+      "movi v27.16b, #0\n"
+      "movi v28.16b, #0\n"
+      "movi v29.16b, #0\n"
+      "movi v30.16b, #0\n"
+      "movi v31.16b, #0\n"
+      "msr fpsr, xzr\n"
+      "msr fpcr, xzr\n"
+      ::: "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+      "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+      "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+      "v31", "memory");
+#endif
+}
+
+static int move_fd(int from, int to) {
+  if (from == to) {
+    return 0;
+  }
+  if (dup2(from, to) < 0) {
+    return -1;
+  }
+  close(from);
+  return 0;
+}
+
+static int write_data_file(void) {
+  int fd = open(DATA_FILE, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+  if (fd < 0) {
+    return -1;
+  }
+  const char bytes[] = "HEADER----WRITEV-PROOF\n";
+  ssize_t wrote = write(fd, bytes, sizeof(bytes) - 1u);
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return wrote == (ssize_t)(sizeof(bytes) - 1u) ? 0 : -1;
+}
+
+int main(void) {
+  if (write_data_file() != 0) {
+    fprintf(stderr, "machinen-file-writev-target: write data: %s\n", strerror(errno));
+    return 1;
+  }
+  int fd = open(DATA_FILE, O_WRONLY);
+  if (fd < 0) {
+    fprintf(stderr, "machinen-file-writev-target: open: %s\n", strerror(errno));
+    return 1;
+  }
+  if (move_fd(fd, TARGET_FILE_FD) != 0) {
+    fprintf(stderr, "machinen-file-writev-target: dup2: %s\n", strerror(errno));
+    return 1;
+  }
+  if (lseek(TARGET_FILE_FD, WRITE_OFFSET, SEEK_SET) < 0) {
+    fprintf(stderr, "machinen-file-writev-target: lseek: %s\n", strerror(errno));
+    return 1;
+  }
+
+  file_writev_state.iov.iov_base = file_writev_state.buffer;
+  file_writev_state.iov.iov_len = WRITE_COUNT;
+  clear_simd_fpu_state();
+  long rc = syscall(SYS_writev, TARGET_FILE_FD, &file_writev_state.iov, 1);
+  if (rc < 0) {
+    fprintf(stderr, "machinen-file-writev-target: writev: %s\n", strerror(errno));
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+}

--- a/packages/microvm/assets/native-process-capture.c
+++ b/packages/microvm/assets/native-process-capture.c
@@ -1141,6 +1141,11 @@ static const char *syscall_name(long long number) {
     return "pread64";
   }
 #endif
+#ifdef __NR_readv
+  if (number == __NR_readv) {
+    return "readv";
+  }
+#endif
 #ifdef __NR_write
   if (number == __NR_write) {
     return "write";
@@ -1149,6 +1154,11 @@ static const char *syscall_name(long long number) {
 #ifdef __NR_pwrite64
   if (number == __NR_pwrite64) {
     return "pwrite64";
+  }
+#endif
+#ifdef __NR_writev
+  if (number == __NR_writev) {
+    return "writev";
   }
 #endif
   return "unknown";

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2962,7 +2962,7 @@ by default when `output` is a TTY.
 
 ##### syscallName
 
-> **syscallName**: `"read"` \| `"pread64"`
+> **syscallName**: `"read"` \| `"pread64"` \| `"readv"`
 
 ##### argumentSource
 
@@ -2979,6 +2979,14 @@ by default when `output` is a TTY.
 ##### countBytes
 
 > **countBytes**: `number`
+
+##### iovPointer?
+
+> `optional` **iovPointer?**: `string`
+
+##### iovCount?
+
+> `optional` **iovCount?**: `1`
 
 ##### bufferMapping
 
@@ -3020,7 +3028,7 @@ by default when `output` is a TTY.
 
 ##### syscallName
 
-> **syscallName**: `"write"` \| `"pwrite64"`
+> **syscallName**: `"write"` \| `"pwrite64"` \| `"writev"`
 
 ##### argumentSource
 
@@ -3037,6 +3045,14 @@ by default when `output` is a TTY.
 ##### countBytes
 
 > **countBytes**: `number`
+
+##### iovPointer?
+
+> `optional` **iovPointer?**: `string`
+
+##### iovCount?
+
+> `optional` **iovCount?**: `1`
 
 ##### bufferMapping
 

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -74,6 +74,12 @@ function arm64PreadThread(
   return arm64SleepThread({ state: "inside-syscall", number: 67, name: "pread64" }, x);
 }
 
+function arm64ReadvThread(
+  x: string[] = ["0x26", "0x3180", "0x1", "0x0", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 65, name: "readv" }, x);
+}
+
 function arm64WriteThread(
   x: string[] = ["0x27", "0x3100", "0x4", "0x0", "0x0", "0x0"],
 ): NativeThreadState {
@@ -84,6 +90,12 @@ function arm64PwriteThread(
   x: string[] = ["0x29", "0x3100", "0x4", "0xb", "0x0", "0x0"],
 ): NativeThreadState {
   return arm64SleepThread({ state: "inside-syscall", number: 68, name: "pwrite64" }, x);
+}
+
+function arm64WritevThread(
+  x: string[] = ["0x27", "0x3180", "0x1", "0x0", "0x0", "0x0"],
+): NativeThreadState {
+  return arm64SleepThread({ state: "inside-syscall", number: 66, name: "writev" }, x);
 }
 
 function arm64SocketThread(
@@ -322,6 +334,22 @@ function documentsWithWriteFile(
   documents.resources.resources[0]!.path = "/tmp/machinen-active-write.txt";
   documents.resources.resources[0]!.offset = options.offset ?? 7;
   return documents;
+}
+
+function writeSingleIovec(
+  documents: NativeProcessImageDocuments,
+  options: { iovPointer?: bigint; bufferPointer?: bigint; countBytes?: bigint } = {},
+): void {
+  const iovPointer = options.iovPointer ?? 0x3180n;
+  const bufferPointer = options.bufferPointer ?? 0x3100n;
+  const countBytes = options.countBytes ?? 4n;
+  const mapping = documents.mappings.mappings[0]!;
+  const offset = Number(iovPointer - BigInt(mapping.sourceStart));
+  const memoryFile = join(documents.rootDir!, NATIVE_PROCESS_IMAGE_FILES.memory);
+  const memory = Buffer.from(readFileSync(memoryFile));
+  memory.writeBigUInt64LE(bufferPointer, offset);
+  memory.writeBigUInt64LE(countBytes, offset + 8);
+  writeFileSync(memoryFile, memory);
 }
 
 function timerfdRecipe(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -1138,6 +1166,36 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("models a safe single-iovec readv from a regular file", () => {
+    const activeThread = arm64ReadvThread();
+    const documents = documentsWithReadFile(activeThread, { offset: 7 });
+    writeSingleIovec(documents);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdReadPolicy: "defer-target-resume",
+      fdReadResourcePolicy: "synthetic-empty-pipe",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdRead: {
+          syscallName: "readv",
+          fd: 38,
+          bufferPointer: "0x3100",
+          countBytes: 4,
+          iovPointer: "0x3180",
+          iovCount: 1,
+          resourceId: "fd:38:read",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
+        },
+      },
+    });
+  });
+
   it("models a safe offset-backed write to a regular file", () => {
     const activeThread = arm64WriteThread(["0x27", "0x3100", "0x4", "0x0", "0x0", "0x0"]);
     const documents = documentsWithWriteFile(activeThread, { offset: 7 });
@@ -1191,6 +1249,36 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("models a safe single-iovec writev to a regular file", () => {
+    const activeThread = arm64WritevThread();
+    const documents = documentsWithWriteFile(activeThread, { offset: 7 });
+    writeSingleIovec(documents);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      fdWritePolicy: "defer-target-resume",
+      fdWriteResourcePolicy: "reopen-file",
+      documents,
+    });
+
+    expect(result.refusals).toEqual([]);
+    expect(result.continuations[0]).toMatchObject({
+      syscallClass: "fd-blocking",
+      metadata: {
+        fdWrite: {
+          syscallName: "writev",
+          fd: 39,
+          bufferPointer: "0x3100",
+          countBytes: 4,
+          iovPointer: "0x3180",
+          iovCount: 1,
+          resourceId: "fd:39:write",
+          targetResource: "reopened-offset-file",
+          targetBufferPointer: "0x600000000100",
+          fileOffset: 7,
+        },
+      },
+    });
+  });
+
   it("prefers /proc syscall arguments for modeled read", () => {
     const activeThread = arm64ReadThread();
     activeThread.syscall.arguments = ["0x20", "0x3100", "0x1", "0x0", "0x0", "0x0"];
@@ -1211,6 +1299,34 @@ describe("native active syscall classification", () => {
       refusal: {
         code: "target-fd-write-state-missing",
         detail: { reason: "pwrite64 file offset is outside supported bounds" },
+      },
+    });
+  });
+
+  it("refuses readv with more than one iovec", () => {
+    const activeThread = arm64ReadvThread(["0x26", "0x3180", "0x2", "0x0", "0x0", "0x0"]);
+    const documents = documentsWithReadFile(activeThread);
+    writeSingleIovec(documents);
+
+    expect(modelNativeFdReadState(activeThread, documents)).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-read-state-missing",
+        detail: { reason: "readv proof requires exactly one iovec" },
+      },
+    });
+  });
+
+  it("refuses writev with missing iovec memory", () => {
+    const activeThread = arm64WritevThread(["0x27", "0x9000", "0x1", "0x0", "0x0", "0x0"]);
+
+    expect(
+      modelNativeFdWriteState(activeThread, documentsWithWriteFile(activeThread)),
+    ).toMatchObject({
+      state: "missing",
+      refusal: {
+        code: "target-fd-write-state-missing",
+        detail: { reason: "writev iovec is not in captured memory" },
       },
     });
   });

--- a/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts
@@ -84,7 +84,7 @@ describe("portable machine restore smoke profile", () => {
     });
   });
 
-  it.each(["file-pread", "file-write", "file-pwrite"])(
+  it.each(["file-pread", "file-readv", "file-write", "file-pwrite", "file-writev"])(
     "accepts the %s remote source profile in dry-run mode",
     (sourceTarget) => {
       const workDir = tempDir();

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -122,11 +122,13 @@ export interface NativeModeledFdReadTimerRemainingTime extends NativeSleepTimerD
 
 export interface NativeModeledFdReadState {
   kind: "fd-read-block";
-  syscallName: "read" | "pread64";
+  syscallName: "read" | "pread64" | "readv";
   argumentSource: "proc-syscall" | "registers";
   fd: number;
   bufferPointer: string;
   countBytes: number;
+  iovPointer?: string;
+  iovCount?: 1;
   bufferMapping: string;
   resourceId: string;
   pairedWriteResourceId?: string;
@@ -140,11 +142,13 @@ export type NativeModeledFdWriteTargetResource = "reopened-offset-file";
 
 export interface NativeModeledFdWriteState {
   kind: "fd-write-complete";
-  syscallName: "write" | "pwrite64";
+  syscallName: "write" | "pwrite64" | "writev";
   argumentSource: "proc-syscall" | "registers";
   fd: number;
   bufferPointer: string;
   countBytes: number;
+  iovPointer?: string;
+  iovCount?: 1;
   bufferMapping: string;
   resourceId: string;
   targetResource: NativeModeledFdWriteTargetResource;
@@ -241,13 +245,15 @@ const SLEEP_TIMER_SYSCALLS = new Set(["clock_nanosleep", "nanosleep"]);
 const FUTEX_ACTIVE_SYSCALLS = new Set(["futex", "futex_time64", "futex_waitv"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
 const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
-const FD_READ_ACTIVE_SYSCALLS = new Set(["read", "pread64"]);
-const FD_WRITE_ACTIVE_SYSCALLS = new Set(["write", "pwrite64"]);
+const FD_READ_ACTIVE_SYSCALLS = new Set(["read", "pread64", "readv"]);
+const FD_WRITE_ACTIVE_SYSCALLS = new Set(["write", "pwrite64", "writev"]);
 const FD_BLOCKING_SYSCALLS = new Set([
   "read",
   "pread64",
+  "readv",
   "write",
   "pwrite64",
+  "writev",
   "poll",
   "ppoll",
   "select",
@@ -265,6 +271,7 @@ const FD_BLOCKING_SYSCALLS = new Set([
 const TIMER_ABSTIME = 1;
 const TIMESPEC_SIZE_BYTES = 16n;
 const POLLFD_SIZE_BYTES = 8n;
+const IOVEC_SIZE_BYTES = 16n;
 const POLLIN = 0x1;
 const SUPPORTED_EMPTY_EVENTFD_FLAGS = 0o2000002;
 const SUPPORTED_EVENTFD_READ_FLAGS = new Set([0o2, SUPPORTED_EMPTY_EVENTFD_FLAGS]);
@@ -1099,7 +1106,7 @@ function decodeFdReadArguments(
 ):
   | Omit<NativeModeledFdReadState, "kind" | "syscallName" | "argumentSource">
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  const values = decodeFdReadArgumentValues(thread, args, syscall);
+  const values = decodeFdReadArgumentValues(thread, args, documents, syscall);
   if ("state" in values) {
     return values;
   }
@@ -1111,7 +1118,7 @@ function decodeFdReadArguments(
     thread,
     documents,
     values.fd,
-    syscall === "pread64" ? "reopen-file" : resourcePolicy,
+    syscall === "pread64" || syscall === "readv" ? "reopen-file" : resourcePolicy,
   );
   if ("state" in resource) {
     return resource;
@@ -1128,15 +1135,8 @@ function decodeFdReadArguments(
     });
   }
   return {
-    fd: values.fd,
-    bufferPointer: hex(values.bufferPointer),
-    countBytes: values.countBytes,
-    bufferMapping: bufferMapping.id,
-    resourceId: resource.resource.id,
+    ...fdTransferModeledFields(values, bufferMapping, resource, targetBufferPointer),
     pairedWriteResourceId: resource.pairedWriteResource?.id,
-    targetResource: resource.targetResource,
-    targetBufferPointer,
-    fileOffset: values.explicitFileOffset ?? resource.fileOffset,
     remainingTime: resource.remainingTime,
   };
 }
@@ -1150,7 +1150,7 @@ function decodeFdWriteArguments(
 ):
   | Omit<NativeModeledFdWriteState, "kind" | "syscallName" | "argumentSource">
   | { state: "missing"; refusal: NativeProcessImageRefusal } {
-  const values = decodeFdWriteArgumentValues(thread, args, syscall);
+  const values = decodeFdWriteArgumentValues(thread, args, documents, syscall);
   if ("state" in values) {
     return values;
   }
@@ -1169,10 +1169,28 @@ function decodeFdWriteArguments(
       bufferMapping: bufferMapping.id,
     });
   }
+  return fdTransferModeledFields(values, bufferMapping, resource, targetBufferPointer);
+}
+
+function fdTransferModeledFields<
+  TTargetResource extends NativeModeledFdReadTargetResource | NativeModeledFdWriteTargetResource,
+  TTargetBufferPointer extends string | undefined,
+>(
+  values: FdReadArgumentValues,
+  bufferMapping: NativeMemoryMapping,
+  resource: {
+    resource: NativeProcessResource;
+    targetResource: TTargetResource;
+    fileOffset?: number;
+  },
+  targetBufferPointer: TTargetBufferPointer,
+) {
   return {
     fd: values.fd,
     bufferPointer: hex(values.bufferPointer),
     countBytes: values.countBytes,
+    iovPointer: values.iovPointer ? hex(values.iovPointer) : undefined,
+    iovCount: values.iovCount,
     bufferMapping: bufferMapping.id,
     resourceId: resource.resource.id,
     targetResource: resource.targetResource,
@@ -1187,13 +1205,26 @@ interface FdReadArgumentValues {
   count: bigint;
   countBytes: number;
   explicitFileOffset?: number;
+  iovPointer?: bigint;
+  iovCount?: 1;
 }
 
 function decodeFdReadArgumentValues(
   thread: NativeThreadState,
   args: SleepTimerArguments,
+  documents: NativeProcessImageDocuments,
   syscall: NativeModeledFdReadState["syscallName"],
 ): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  if (syscall === "readv") {
+    return decodeFdVectorArgumentValues(
+      thread,
+      args,
+      documents,
+      "read",
+      MAX_FD_READ_BYTES,
+      missingFdRead,
+    );
+  }
   const values = decodeFdTransferArgumentValues(
     thread,
     args,
@@ -1221,8 +1252,19 @@ function decodeFdReadExplicitOffset(
 function decodeFdWriteArgumentValues(
   thread: NativeThreadState,
   args: SleepTimerArguments,
+  documents: NativeProcessImageDocuments,
   syscall: NativeModeledFdWriteState["syscallName"],
 ): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  if (syscall === "writev") {
+    return decodeFdVectorArgumentValues(
+      thread,
+      args,
+      documents,
+      "write",
+      MAX_FD_WRITE_BYTES,
+      missingFdWrite,
+    );
+  }
   const values = decodeFdTransferArgumentValues(
     thread,
     args,
@@ -1268,6 +1310,51 @@ function decodeFdExplicitOffset(
       argumentSource: args.source,
     })
   );
+}
+
+// fallow-ignore-next-line complexity
+function decodeFdVectorArgumentValues(
+  thread: NativeThreadState,
+  args: SleepTimerArguments,
+  documents: NativeProcessImageDocuments,
+  operation: "read" | "write",
+  maxBytes: bigint,
+  missing: typeof missingFdRead,
+): FdReadArgumentValues | { state: "missing"; refusal: NativeProcessImageRefusal } {
+  const syscall = `${operation}v`;
+  const fd = safeNumber(args.values[0] ?? -1n);
+  const iovPointer = args.values[1] ?? 0n;
+  const iovCount = args.values[2] ?? 0n;
+  if (fd === undefined || fd < 0) {
+    return missing(thread, `${operation} fd is missing or invalid`, {
+      fd: hex(args.values[0] ?? -1n),
+    });
+  }
+  if (iovPointer === 0n) {
+    return missing(thread, `${syscall} iovec pointer is null`, { fd });
+  }
+  if (iovCount !== 1n) {
+    return missing(thread, `${syscall} proof requires exactly one iovec`, {
+      fd,
+      iovPointer: hex(iovPointer),
+      iovCount: iovCount.toString(10),
+    });
+  }
+  const iovec = readCapturedMemoryRange(
+    documents,
+    iovPointer,
+    IOVEC_SIZE_BYTES,
+    `${syscall} iovec`,
+  );
+  if ("refusal" in iovec) {
+    return missing(thread, iovec.reason, { fd, iovPointer: hex(iovPointer) });
+  }
+  const bufferPointer = iovec.bytes.readBigUInt64LE(0);
+  const count = iovec.bytes.readBigUInt64LE(8);
+  const countBytes = decodeFdTransferCount(thread, args, fd, count, operation, maxBytes, missing);
+  return typeof countBytes === "number"
+    ? { fd, bufferPointer, count, countBytes, iovPointer, iovCount: 1 }
+    : countBytes;
 }
 
 function decodeFdTransferArgumentValues(
@@ -2418,11 +2505,13 @@ function decodedPpollDetail(decoded: { timeoutPointer: bigint; sigsetSize: bigin
 }
 
 function fdReadSyscallName(thread: NativeThreadState): NativeModeledFdReadState["syscallName"] {
-  return syscallName(thread) === "pread64" ? "pread64" : "read";
+  const name = syscallName(thread);
+  return name === "pread64" || name === "readv" ? name : "read";
 }
 
 function fdWriteSyscallName(thread: NativeThreadState): NativeModeledFdWriteState["syscallName"] {
-  return syscallName(thread) === "pwrite64" ? "pwrite64" : "write";
+  const name = syscallName(thread);
+  return name === "pwrite64" || name === "writev" ? name : "write";
 }
 
 function syscallName(thread: NativeThreadState): string {

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -626,7 +626,9 @@ function isActiveReadThread(
 ): boolean {
   return (
     thread.syscall.state === "inside-syscall" &&
-    (thread.syscall.name === "read" || thread.syscall.name === "pread64")
+    (thread.syscall.name === "read" ||
+      thread.syscall.name === "pread64" ||
+      thread.syscall.name === "readv")
   );
 }
 
@@ -637,7 +639,9 @@ function isActiveWriteThread(
 ): boolean {
   return (
     thread.syscall.state === "inside-syscall" &&
-    (thread.syscall.name === "write" || thread.syscall.name === "pwrite64")
+    (thread.syscall.name === "write" ||
+      thread.syscall.name === "pwrite64" ||
+      thread.syscall.name === "writev")
   );
 }
 

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -301,9 +301,11 @@ capture_remote_native_process_bundle() {
     packages/microvm/assets/native-process-capture.c \
     packages/microvm/assets/native-eventfd-read-target.c \
     packages/microvm/assets/native-file-read-target.c \
+    packages/microvm/assets/native-file-readv-target.c \
     packages/microvm/assets/native-file-pread-target.c \
     packages/microvm/assets/native-file-pwrite-target.c \
     packages/microvm/assets/native-file-write-target.c \
+    packages/microvm/assets/native-file-writev-target.c \
     packages/microvm/assets/native-pipe-read-target.c \
     packages/microvm/assets/native-ppoll-timeout-target.c \
     packages/microvm/assets/native-timerfd-read-target.c \
@@ -331,6 +333,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target"
       target_detail="remote arm64 regular-file pread64 native-process bundle captured from $ARM64_SSH"
       ;;
+    file-readv)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-readv-target"
+      target_detail="remote arm64 regular-file readv native-process bundle captured from $ARM64_SSH"
+      ;;
     file-write)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target"
       target_detail="remote arm64 regular-file write native-process bundle captured from $ARM64_SSH"
@@ -338,6 +344,10 @@ capture_remote_native_process_bundle() {
     file-pwrite)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-pwrite-target"
       target_detail="remote arm64 regular-file pwrite64 native-process bundle captured from $ARM64_SSH"
+      ;;
+    file-writev)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-file-writev-target"
+      target_detail="remote arm64 regular-file writev native-process bundle captured from $ARM64_SSH"
       ;;
     timerfd-read)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target"
@@ -358,13 +368,17 @@ capture_remote_native_process_bundle() {
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall read --trace-syscall-fd 38 -- '$target_binary'"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-pread" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall pread64 --trace-syscall-fd 40 -- '$target_binary'"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "file-readv" ]]; then
+    capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall readv --trace-syscall-fd 42 -- '$target_binary'"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-write" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall write --trace-syscall-fd 39 -- '$target_binary'"
   elif [[ "$REMOTE_SOURCE_TARGET" == "file-pwrite" ]]; then
     capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall pwrite64 --trace-syscall-fd 41 -- '$target_binary'"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "file-writev" ]]; then
+    capture_command="'$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' --output '$ARM64_REMOTE_WORK/capture/bundle' --target-arch amd64 --trace-syscall writev --trace-syscall-fd 43 -- '$target_binary'"
   fi
   ssh "$ARM64_SSH" \
-    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pread-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pwrite-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pwrite-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
+    "cd '$ARM64_REMOTE_WORK/repo' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-process-capture.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-process-capture' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-eventfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-eventfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-readv-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-readv-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pread-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pread-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-pwrite-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-pwrite-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-write-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-write-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-file-writev-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-file-writev-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-pipe-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-ppoll-timeout-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror packages/microvm/assets/native-timerfd-read-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-timerfd-read-target' && cc -std=c11 -O0 -g -Wall -Wextra -Werror -pthread packages/microvm/assets/native-two-thread-ppoll-target.c -o '$ARM64_REMOTE_WORK/bin/machinen-native-two-thread-ppoll-target' && $capture_command > '$ARM64_REMOTE_WORK/capture.log'"
   mkdir -p "$NATIVE_BUNDLE"
   ssh "$ARM64_SSH" "cat '$ARM64_REMOTE_WORK/capture.log'" >"$WORK/arm64-capture.log"
   ssh "$ARM64_SSH" "tar -czf - -C '$ARM64_REMOTE_WORK/capture/bundle' ." | \


### PR DESCRIPTION
## Problem

The restore proof could handle simple file `read` and `write` syscalls. It could also handle `pread64` and `pwrite64`. But a process stopped in `readv` or `writev` still failed, even when it used only one iovec and was just a normal file read or write in another shape.

## Solution

This PR adds a narrow single-iovec path for `readv(fd, iov, 1)` and `writev(fd, iov, 1)`. The policy reads the captured iovec from process memory, checks the pointed-to buffer, and only accepts reopenable regular files. The remote proof now has `file-readv` and `file-writev` profiles that complete natively on amd64.

Closes #723.

## Validation

- `pnpm run build:docs` — 1.498s
- `pnpm run format:check` — 0.519s
- `pnpm run lint` — 0.186s
- `pnpm run typecheck` — 1.997s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.929s
- `pnpm smoke-tests` — 2m10.366s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-readv` proof — 41.823s
- remote arm64→amd64 `PORTABLE_MACHINE_REMOTE_SOURCE_TARGET=file-writev` proof — 37.019s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.338s
- `AGENT_CI_DOCKER_HOST=unix:///Users/peterp/.orbstack/run/docker.sock NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p` — 1m7.505s
