### PR TITLE
Tighten socket transfer active syscall refusals

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -36,8 +36,8 @@ Known blocking syscall classes refuse with precise codes:
   the capture cannot model the timeout, fd, or signal-mask contract;
 - `target-fd-read-state-missing` when explicit fd-read deferral is requested but
   the capture cannot prove a blocking read contract;
-- `target-socket-syscall-state-unsupported` for active `accept`, `accept4`, and
-  `connect` state;
+- `target-socket-syscall-state-unsupported` for active socket accept/connect and
+  socket transfer state;
 - `target-epoll-syscall-state-unsupported` for active `epoll_wait`,
   `epoll_pwait`, and `epoll_pwait2` state;
 - `target-signalfd-state-unsupported` for active reads from signalfd resources;
@@ -104,18 +104,27 @@ semantics.
 This is refusal tightening only. No futex wait is restarted, emulated, or treated
 as target-native success.
 
-## Socket accept/connect refusal
+## Socket refusal tightening
 
 Active socket `accept`, `accept4`, and `connect` remain unsupported for native
-restore. They now fail closed with `target-socket-syscall-state-unsupported`
-instead of the generic fd-blocking refusal. When syscall arguments and the
-captured resource table are available, the refusal detail records the socket fd,
-resource id/kind/path/flags, and the unsupported kernel state family:
+restore. Active socket transfer syscalls (`recvfrom`, `recvmsg`, `recvmmsg`,
+`sendto`, `sendmsg`, and `sendmmsg`) also refuse with
+`target-socket-syscall-state-unsupported`. Generic `read`, `readv`, `write`, and
+`writev` use the same socket refusal when their fd maps to a captured socket or
+raw-socket resource, instead of falling through to regular fd-read/write missing
+state.
+
+When syscall arguments and the captured resource table are available, the
+refusal detail records the socket fd, decoded pointer/count arguments, resource
+id/kind/path/flags, and the unsupported kernel state family:
 
 - `connect` needs endpoint identity, in-flight connection result, namespace and
   routing state, and target fd mapping;
 - `accept`/`accept4` need listening socket identity, backlog/queued connection
-  state, accepted peer endpoint state, and target fd mapping.
+  state, accepted peer endpoint state, and target fd mapping;
+- socket transfer needs receive/send queue state, peer endpoint identity, socket
+  shutdown/options, partial transfer and ancillary data state, and target fd
+  mapping.
 
 Missing arguments, missing resource rows, and non-socket fds remain refusals with
 the same code and a specific `detail.reason`. This is refusal tightening only;

--- a/docs/snapshot/target-guest-active-syscall-restore.md
+++ b/docs/snapshot/target-guest-active-syscall-restore.md
@@ -20,9 +20,9 @@ refused. Otherwise, modeled continuations become target steps:
 
 Only continuations that already passed the active-syscall policy are accepted.
 Generic blocking syscalls, restart state, missing timespecs, missing read/write
-buffer state, signalfd reads, epoll waits, socket accept/connect, and unsupported
-fd state continue to fail closed before target re-arm with resource-specific
-detail.
+buffer state, signalfd reads, epoll waits, socket accept/connect, socket
+transfers, and unsupported fd state continue to fail closed before target re-arm
+with resource-specific detail.
 
 The target amd64 trampoline now executes these sections by creating and arming a
 short-lived target-side timerfd for each `rearm-sleep-timer` or

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -106,6 +106,14 @@ function arm64SocketThread(
   return arm64SleepThread({ state: "inside-syscall", number, name }, x);
 }
 
+function arm64SocketTransferThread(
+  name: "recvfrom" | "recvmsg" | "sendto" | "sendmsg",
+  x: string[] = ["0x28", "0x4100", "0x20", "0x0", "0x0", "0x0"],
+): NativeThreadState {
+  const numbers = { recvfrom: 207, recvmsg: 212, sendto: 206, sendmsg: 211 };
+  return arm64SleepThread({ state: "inside-syscall", number: numbers[name], name }, x);
+}
+
 function arm64EpollThread(
   name: "epoll_wait" | "epoll_pwait" | "epoll_pwait2" = "epoll_wait",
   x: string[] = ["0x30", "0x4100", "0x4", "0xffffffff", "0x0", "0x0"],
@@ -1715,6 +1723,63 @@ describe("native active syscall classification", () => {
   );
 
   it.each([
+    ["read", arm64ReadThread(["0x28", "0x4100", "0x20", "0x0", "0x0", "0x0"])],
+    ["readv", arm64ReadvThread(["0x28", "0x4100", "0x2", "0x0", "0x0", "0x0"])],
+    ["write", arm64WriteThread(["0x28", "0x4100", "0x20", "0x0", "0x0", "0x0"])],
+    ["writev", arm64WritevThread(["0x28", "0x4100", "0x2", "0x0", "0x0", "0x0"])],
+  ] as const)(
+    "refuses active %s on a captured socket with socket-transfer detail",
+    (_, activeThread) => {
+      const result = classifyNativeActiveSyscalls([activeThread], {
+        documents: documentsWithSocketResource(activeThread),
+        fdReadPolicy: "defer-target-resume",
+        fdWritePolicy: "defer-target-resume",
+      });
+
+      expect(result.classifications[0]).toMatchObject({
+        class: "fd-blocking",
+        refusal: {
+          code: "target-socket-syscall-state-unsupported",
+          detail: {
+            reason: "socket endpoint kernel state is unsupported",
+            socketSyscall: {
+              family: "socket-transfer",
+              arguments: { source: "registers", fd: 40 },
+              resource: { id: "fd:40:socket", kind: "socket", fd: 40 },
+              unsupportedState: expect.arrayContaining(["socket receive/send queue state"]),
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it.each(["recvfrom", "recvmsg", "sendto", "sendmsg"] as const)(
+    "refuses active socket transfer syscall %s with socket-specific detail",
+    (name) => {
+      const activeThread = arm64SocketTransferThread(name);
+      const result = classifyNativeActiveSyscalls([activeThread], {
+        documents: documentsWithSocketResource(activeThread),
+      });
+
+      expect(result.classifications[0]).toMatchObject({
+        class: "fd-blocking",
+        refusal: {
+          code: "target-socket-syscall-state-unsupported",
+          detail: {
+            reason: "socket endpoint kernel state is unsupported",
+            socketSyscall: {
+              family: "socket-transfer",
+              arguments: { source: "registers", fd: 40 },
+              resource: { id: "fd:40:socket", kind: "socket", fd: 40 },
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it.each([
     {
       name: "missing epoll resource",
       thread: arm64EpollThread(),
@@ -1761,6 +1826,20 @@ describe("native active syscall classification", () => {
       thread: arm64SocketThread("accept"),
       documents: (activeThread: NativeThreadState) =>
         documentsWithSocketResource(activeThread, { kind: "file" }),
+      reason: "socket syscall fd is not a captured socket",
+    },
+    {
+      name: "socket transfer missing resource",
+      thread: arm64SocketTransferThread("recvfrom"),
+      documents: (activeThread: NativeThreadState) =>
+        documentsWithSocketResource(activeThread, { kind: "missing" }),
+      reason: "socket syscall fd resource is missing",
+    },
+    {
+      name: "socket transfer non-socket fd",
+      thread: arm64SocketTransferThread("sendto"),
+      documents: (activeThread: NativeThreadState) =>
+        documentsWithSocketResource(activeThread, { kind: "pipe" }),
       reason: "socket syscall fd is not a captured socket",
     },
   ])("keeps active socket syscall fail-closed for $name", (scenario) => {

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -244,6 +244,15 @@ export interface NativeActiveSyscallClassificationResult {
 const SLEEP_TIMER_SYSCALLS = new Set(["clock_nanosleep", "nanosleep"]);
 const FUTEX_ACTIVE_SYSCALLS = new Set(["futex", "futex_time64", "futex_waitv"]);
 const SOCKET_ACTIVE_SYSCALLS = new Set(["accept", "accept4", "connect"]);
+const SOCKET_TRANSFER_ACTIVE_SYSCALLS = new Set([
+  "recvfrom",
+  "recvmsg",
+  "recvmmsg",
+  "sendto",
+  "sendmsg",
+  "sendmmsg",
+]);
+const FD_SOCKET_TRANSFER_SYSCALLS = new Set(["read", "readv", "write", "writev"]);
 const EPOLL_ACTIVE_SYSCALLS = new Set(["epoll_wait", "epoll_pwait", "epoll_pwait2"]);
 const FD_READ_ACTIVE_SYSCALLS = new Set(["read", "pread64", "readv"]);
 const FD_WRITE_ACTIVE_SYSCALLS = new Set(["write", "pwrite64", "writev"]);
@@ -335,6 +344,9 @@ export function classifyNativeThreadSyscall(
   }
   if (name === "read" && isActiveSignalfdRead(thread, options.documents)) {
     return refusedSignalfdActiveSyscallClassification(thread, options);
+  }
+  if (isActiveSocketTransferSyscall(thread, options.documents)) {
+    return refusedSocketActiveSyscallClassification(thread, options);
   }
   if (FD_READ_ACTIVE_SYSCALLS.has(name) && options.fdReadPolicy === "defer-target-resume") {
     return deferredFdReadClassification(thread, options);
@@ -749,10 +761,39 @@ function futexArgument(args: SleepTimerArguments, index: number): string {
 interface SocketActiveSyscallArguments {
   source: "proc-syscall" | "registers";
   fd: number;
+  bufferPointer?: string;
+  countBytes?: string;
+  iovPointer?: string;
+  iovCount?: string;
+  messagePointer?: string;
+  messageCount?: string;
   addressPointer?: string;
   addressLengthPointer?: string;
   addressLengthBytes?: string;
   flags?: number;
+}
+
+function isActiveSocketTransferSyscall(
+  thread: NativeThreadState,
+  documents: NativeProcessImageDocuments | undefined,
+): boolean {
+  const syscall = syscallName(thread);
+  if (SOCKET_TRANSFER_ACTIVE_SYSCALLS.has(syscall)) {
+    return true;
+  }
+  if (!FD_SOCKET_TRANSFER_SYSCALLS.has(syscall)) {
+    return false;
+  }
+  const args = sleepTimerArguments(thread);
+  const fd = args ? safeNumber(args.values[0] ?? -1n) : undefined;
+  return (
+    fd !== undefined &&
+    (documents?.resources.resources.some(
+      (resource) =>
+        resource.fd === fd && (resource.kind === "socket" || resource.kind === "raw-socket"),
+    ) ??
+      false)
+  );
 }
 
 function socketActiveSyscallDetail(
@@ -766,7 +807,7 @@ function socketActiveSyscallDetail(
   return detail(thread, "fd-blocking", {
     reason: socketActiveSyscallRefusalReason(args, documents, resource),
     socketSyscall: {
-      family: "socket-accept-connect",
+      family: socketActiveSyscallFamily(syscallName(thread)),
       arguments: args,
       resource: resource ? socketResourceDetail(resource) : undefined,
       unsupportedState: socketActiveSyscallUnsupportedState(syscallName(thread)),
@@ -794,20 +835,34 @@ function socketActiveSyscallRefusalReason(
   return "socket endpoint kernel state is unsupported";
 }
 
+function socketActiveSyscallFamily(syscall: string): string {
+  return SOCKET_ACTIVE_SYSCALLS.has(syscall) ? "socket-accept-connect" : "socket-transfer";
+}
+
 function socketActiveSyscallUnsupportedState(syscall: string): string[] {
-  return syscall === "connect"
-    ? [
-        "socket endpoint identity",
-        "in-flight connection result",
-        "network namespace and routing state",
-        "target fd resource mapping",
-      ]
-    : [
-        "listening socket identity",
-        "listen backlog and queued connection state",
-        "accepted peer endpoint state",
-        "target fd resource mapping",
-      ];
+  if (syscall === "connect") {
+    return [
+      "socket endpoint identity",
+      "in-flight connection result",
+      "network namespace and routing state",
+      "target fd resource mapping",
+    ];
+  }
+  if (syscall === "accept" || syscall === "accept4") {
+    return [
+      "listening socket identity",
+      "listen backlog and queued connection state",
+      "accepted peer endpoint state",
+      "target fd resource mapping",
+    ];
+  }
+  return [
+    "socket receive/send queue state",
+    "peer endpoint identity",
+    "socket shutdown and option state",
+    "partial transfer and ancillary data state",
+    "target fd resource mapping",
+  ];
 }
 
 function socketResourceDetail(resource: NativeProcessResource): Record<string, unknown> {
@@ -966,6 +1021,7 @@ function signalfdActiveSyscallRefusalReason(
     : "read fd is not a captured signalfd";
 }
 
+// fallow-ignore-next-line complexity
 function decodeSocketActiveSyscallArguments(
   thread: NativeThreadState,
 ): SocketActiveSyscallArguments | undefined {
@@ -986,12 +1042,57 @@ function decodeSocketActiveSyscallArguments(
       addressLengthBytes: hex(args.values[2]),
     };
   }
+  if (syscall === "accept" || syscall === "accept4") {
+    return {
+      source: args.source,
+      fd,
+      addressPointer: hex(args.values[1]),
+      addressLengthPointer: hex(args.values[2]),
+      flags: syscall === "accept4" ? safeNumber(args.values[3] ?? 0n) : undefined,
+    };
+  }
+  if (syscall === "read" || syscall === "write") {
+    return {
+      source: args.source,
+      fd,
+      bufferPointer: hex(args.values[1]),
+      countBytes: hex(args.values[2]),
+    };
+  }
+  if (syscall === "readv" || syscall === "writev") {
+    return {
+      source: args.source,
+      fd,
+      iovPointer: hex(args.values[1]),
+      iovCount: hex(args.values[2]),
+    };
+  }
+  if (syscall === "recvmsg" || syscall === "sendmsg") {
+    return {
+      source: args.source,
+      fd,
+      messagePointer: hex(args.values[1]),
+      flags: safeNumber(args.values[2] ?? 0n),
+    };
+  }
+  if (syscall === "recvmmsg" || syscall === "sendmmsg") {
+    return {
+      source: args.source,
+      fd,
+      messagePointer: hex(args.values[1]),
+      messageCount: hex(args.values[2]),
+      flags: safeNumber(args.values[3] ?? 0n),
+    };
+  }
   return {
     source: args.source,
     fd,
-    addressPointer: hex(args.values[1]),
-    addressLengthPointer: hex(args.values[2]),
-    flags: syscall === "accept4" ? safeNumber(args.values[3] ?? 0n) : undefined,
+    bufferPointer: hex(args.values[1]),
+    countBytes: hex(args.values[2]),
+    flags: safeNumber(args.values[3] ?? 0n),
+    addressPointer: hex(args.values[4]),
+    addressLengthPointer: syscall === "recvfrom" ? hex(args.values[5]) : undefined,
+    addressLengthBytes: syscall === "sendto" ? hex(args.values[5]) : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem

Socket transfer syscalls were still too fuzzy at the active-syscall boundary. Some socket reads and writes could fall into generic fd-read or fd-write missing-state errors. That made it harder to see that the real unsafe state was socket queue and peer state.

## Solution

This PR keeps sockets refused, but makes the refusal sharper. Socket transfer syscalls now use `target-socket-syscall-state-unsupported`, and generic `read`/`readv`/`write`/`writev` do the same when the fd is a captured socket. The refusal detail now names the decoded args, socket resource, and unsupported queue/peer/partial-transfer state.

Closes #727.

## Validation

- `pnpm run build:docs` — 1.554s
- `pnpm run format:check` — 0.589s
- `pnpm run lint` — 0.201s
- `pnpm run typecheck` — 2.203s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.849s
- `pnpm smoke-tests` — 2m12.669s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.377s
