### PR TITLE
Add goal task automation command

### DIFF
--- a/docs/snapshot/goal-task-automation.md
+++ b/docs/snapshot/goal-task-automation.md
@@ -1,0 +1,77 @@
+# Goal task automation
+
+`goal.md` is the long-running task ledger for transparent native cross-ISA
+migration. The helper command below automates the repeated issue/branch/validate
+/PR loop while keeping validation timings in a JSON log.
+
+```sh
+pnpm goal-task -- run \
+  --title "Tighten one refusal boundary" \
+  --branch pp-tighten-one-boundary \
+  --issue-body-file /tmp/issue.md \
+  --implementation-command "pnpm native-active-syscall-policy" \
+  --validation-profile focused \
+  --focused-vitest packages/runtime/src/__tests__/native-active-syscall-policy.test.ts \
+  --validation-log /tmp/machinen-validation.json
+```
+
+Use `--dry-run --json` to see the exact `gh`, `git`, implementation, validation,
+push, and PR commands without changing the worktree or GitHub state.
+
+## Validation profiles
+
+- `docs` — `build:docs`, format, lint, typecheck, optional focused Vitest, and
+  fallow.
+- `focused` — format, lint, typecheck, focused Vitest, and fallow.
+- `vm` — `build:docs`, format, lint, typecheck, full Vitest, full
+  `pnpm smoke-tests`, and fallow.
+- `ci` — local Agent CI only.
+- `none` — no validation commands.
+
+Add `--include-ci` when a task explicitly needs local Agent CI after another
+profile.
+
+Every validation run writes a JSON log containing:
+
+- branch and commit;
+- base branch;
+- selected validation profile;
+- default or configured remote hosts/profile;
+- validation log and goal file paths;
+- every command, status, exit code, and elapsed time.
+
+## PR bodies
+
+Generate a reusable Problem/Solution/Validation body from a validation log:
+
+```sh
+pnpm goal-task -- pr-body \
+  --problem "The proof runner was hard to repeat by hand." \
+  --solution "This adds a checked command and records timings." \
+  --validation-log /tmp/machinen-validation.json \
+  --body-file /tmp/machinen-pr.md
+```
+
+## Goal ledger updates
+
+After a PR merges, mark a matching goal item complete:
+
+```sh
+pnpm goal-task -- update-goal \
+  --match "Add reusable PR body generation" \
+  --status x
+```
+
+The command replaces the first matching checkbox status in `goal.md` with the
+requested status. Use `--goal-file` to point at a fixture or alternate ledger.
+
+## Manual issue close
+
+GitHub may not auto-close issues when a PR targets `portable-snapshots` instead
+of the default branch. Close those issues explicitly:
+
+```sh
+pnpm goal-task -- close-issue \
+  --issue 729 \
+  --comment "Completed in #730."
+```

--- a/goal.md
+++ b/goal.md
@@ -251,19 +251,19 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### K. Automation and reporting
 
-- [ ] Create an automation command that opens an issue from a task template,
+- [x] Create an automation command that opens an issue from a task template,
       creates a branch, runs the requested implementation command, validates,
       pushes, and opens a PR against `portable-snapshots`.
-- [ ] Add reusable PR body generation with Problem/Solution/Validation and timing
+- [x] Add reusable PR body generation with Problem/Solution/Validation and timing
       sections.
-- [ ] Add validation log capture so every run records command, elapsed time,
+- [x] Add validation log capture so every run records command, elapsed time,
       commit, branch, remote hosts, profile, and paths.
-- [ ] Add a command to run only the relevant focused vitest set for a touched
+- [x] Add a command to run only the relevant focused vitest set for a touched
       subsystem.
-- [ ] Add a command to run the full required gate set when VM/VMM/rootfs/assets or
+- [x] Add a command to run the full required gate set when VM/VMM/rootfs/assets or
       target restore wiring changes.
-- [ ] Add a command to update `goal.md` task status after a PR merges.
-- [ ] Add a command to close non-default-base issues manually when GitHub does not
+- [x] Add a command to update `goal.md` task status after a PR merges.
+- [x] Add a command to close non-default-base issues manually when GitHub does not
       auto-close them after merging to `portable-snapshots`.
 
 ### L. Final transparent restore claim

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "native-target-vm-synthetic-continuation": "tsx scripts/native-target-vm-synthetic-continuation.ts verify",
     "portable-machine-vm-restore-proof": "tsx scripts/portable-machine-vm-restore-proof.ts verify",
     "portable-machine-proof-runner": "node scripts/portable-machine-proof-runner.mjs",
+    "goal-task": "node scripts/goal-task-automation.mjs",
     "smoke-test-snapshot-restore-fork": "bash scripts/smoke-test-snapshot-restore-fork.sh",
     "smoke-vmstate": "bash scripts/smoke/vmstate/all.sh",
     "smoke-vmstate-timers": "bash scripts/smoke/vmstate/timers.sh",

--- a/packages/runtime/src/__tests__/goal-task-automation.test.ts
+++ b/packages/runtime/src/__tests__/goal-task-automation.test.ts
@@ -1,0 +1,171 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+const SCRIPT = join(REPO_ROOT, "scripts/goal-task-automation.mjs");
+const SCRIPT_ENV = { ...process.env, FORCE_COLOR: "1" };
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "goal-task-automation-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function runGoalTask(args: string[]) {
+  return spawnSync("node", [SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: SCRIPT_ENV,
+    timeout: 30_000,
+  });
+}
+
+describe("goal task automation", () => {
+  it("plans issue, branch, implementation, validation, push, and PR steps", () => {
+    const dir = tempDir();
+    const issueBody = join(dir, "issue.md");
+    const validationLog = join(dir, "validation.json");
+    writeFileSync(issueBody, "Issue body");
+
+    const result = runGoalTask([
+      "run",
+      "--dry-run",
+      "--json",
+      "--title",
+      "Automate one goal task",
+      "--branch",
+      "pp-test-goal-task",
+      "--issue-body-file",
+      issueBody,
+      "--implementation-command",
+      "node -e 'console.log(1)'",
+      "--validation-profile",
+      "focused",
+      "--focused-vitest",
+      "packages/runtime/src/__tests__/goal-task-automation.test.ts",
+      "--validation-log",
+      validationLog,
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary.state).toBe("planned");
+    expect(summary.steps.map((step: { command: string }) => step.command)).toEqual([
+      expect.stringContaining("gh issue create"),
+      expect.stringContaining("git switch -c"),
+      "node -e 'console.log(1)'",
+      "git push -u origin HEAD",
+      expect.stringContaining("gh pr create"),
+    ]);
+    const log = JSON.parse(readFileSync(validationLog, "utf8"));
+    expect(log).toMatchObject({ state: "planned", validationProfile: "focused" });
+    expect(log.commands.map((entry: { command: string }) => entry.command)).toContain(
+      "NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/goal-task-automation.test.ts",
+    );
+  });
+
+  it("plans the full VM validation gate set", () => {
+    const dir = tempDir();
+    const validationLog = join(dir, "vm-validation.json");
+    const result = runGoalTask([
+      "validate",
+      "--dry-run",
+      "--json",
+      "--validation-profile",
+      "vm",
+      "--validation-log",
+      validationLog,
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary.commands.map((entry: { command: string }) => entry.command)).toEqual([
+      "pnpm run build:docs",
+      "pnpm run format:check",
+      "pnpm run lint",
+      "pnpm run typecheck",
+      "NPM_CONFIG_USERCONFIG=/dev/null npx vitest run",
+      "pnpm smoke-tests",
+      "pnpm exec fallow audit --changed-since origin/portable-snapshots",
+    ]);
+    expect(readFileSync(validationLog, "utf8")).toContain('"validationProfile": "vm"');
+  });
+
+  it("generates a reusable PR body from validation timings", () => {
+    const dir = tempDir();
+    const validationLog = join(dir, "validation.json");
+    const bodyFile = join(dir, "pr.md");
+    writeFileSync(
+      validationLog,
+      JSON.stringify({
+        commands: [{ command: "pnpm run lint", status: "passed", elapsedMs: 1234 }],
+      }),
+    );
+
+    const result = runGoalTask([
+      "pr-body",
+      "--json",
+      "--problem",
+      "A task needed a clear PR body.",
+      "--solution",
+      "The automation writes one.",
+      "--validation-log",
+      validationLog,
+      "--body-file",
+      bodyFile,
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const body = readFileSync(bodyFile, "utf8");
+    expect(body).toContain("## Problem");
+    expect(body).toContain("A task needed a clear PR body.");
+    expect(body).toContain("`pnpm run lint` — passed (1.234s)");
+  });
+
+  it("marks a matching goal checkbox line complete", () => {
+    const dir = tempDir();
+    const goalFile = join(dir, "goal.md");
+    writeFileSync(goalFile, "- [ ] Add reusable PR body generation\n- [ ] Other task\n");
+
+    const result = runGoalTask([
+      "update-goal",
+      "--json",
+      "--goal-file",
+      goalFile,
+      "--match",
+      "Add reusable PR body generation",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary).toMatchObject({ state: "completed", line: 1 });
+    expect(readFileSync(goalFile, "utf8")).toContain("- [x] Add reusable PR body generation");
+  });
+
+  it("plans manual closure of non-default-base issues", () => {
+    const result = runGoalTask([
+      "close-issue",
+      "--dry-run",
+      "--json",
+      "--issue",
+      "729",
+      "--comment",
+      "Completed in a portable-snapshots PR.",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const summary = JSON.parse(result.stdout);
+    expect(summary).toMatchObject({ state: "planned", issue: "729" });
+    expect(summary.command.command).toContain("gh issue close");
+  });
+});

--- a/scripts/goal-task-automation.mjs
+++ b/scripts/goal-task-automation.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const DEFAULT_BASE = "portable-snapshots";
+const DEFAULT_GOAL = "goal.md";
+const DEFAULT_LOG = "/tmp/machinen-goal-task-validation.json";
+const CI_COMMAND =
+  "AGENT_CI_DOCKER_HOST=unix:///Users/peterp/.orbstack/run/docker.sock NPM_CONFIG_USERCONFIG=/dev/null npx agent-ci run --all -q -p";
+
+const VALUE_OPTIONS = new Map([
+  ["--title", "title"],
+  ["--issue-body-file", "issueBodyFile"],
+  ["--branch", "branch"],
+  ["--base", "base"],
+  ["--implementation-command", "implementationCommand"],
+  ["--validation-profile", "validationProfile"],
+  ["--focused-vitest", "focusedVitest"],
+  ["--problem", "problem"],
+  ["--solution", "solution"],
+  ["--validation-log", "validationLog"],
+  ["--body-file", "bodyFile"],
+  ["--goal-file", "goalFile"],
+  ["--match", "match"],
+  ["--status", "status"],
+  ["--issue", "issue"],
+  ["--comment", "comment"],
+]);
+const FLAG_OPTIONS = new Map([
+  ["--dry-run", "dryRun"],
+  ["--json", "json"],
+  ["--include-ci", "includeCi"],
+]);
+const MULTI_VALUE_OPTIONS = new Set(["focusedVitest"]);
+
+function usage(exitCode = 2) {
+  console.error(
+    [
+      "usage: pnpm goal-task -- <command> [options]",
+      "",
+      "Commands:",
+      "  run           Open issue, create branch, run implementation, validate, push, open PR",
+      "  validate      Run or plan validation commands and write a timing log",
+      "  pr-body       Generate a reusable PR body",
+      "  update-goal   Mark a matching goal.md checkbox line complete",
+      "  close-issue   Close a GitHub issue with a comment",
+      "",
+      "Common options:",
+      "  --dry-run --json",
+      "  --validation-log path",
+      "",
+      "Validation profiles:",
+      "  docs      build docs, format, lint, typecheck, optional focused vitest, fallow",
+      "  focused   format, lint, typecheck, focused vitest, fallow",
+      "  vm        build docs, format, lint, typecheck, full vitest, smoke-tests, fallow",
+      "  ci        Agent CI only",
+      "  none      no validation",
+    ].join("\n"),
+  );
+  process.exit(exitCode);
+}
+
+function defaultOptions() {
+  const toggles = { dryRun: false, json: false, includeCi: false };
+  return Object.assign(toggles, {
+    base: DEFAULT_BASE,
+    validationProfile: "docs",
+    validationLog: DEFAULT_LOG,
+    goalFile: DEFAULT_GOAL,
+    status: "x",
+    focusedVitest: [],
+  });
+}
+
+function readValue(argv, index) {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    usage();
+  }
+  return [value, index + 1];
+}
+
+// fallow-ignore-next-line complexity
+function applyArg(options, argv, index) {
+  const arg = argv[index];
+  if (arg === "--help" || arg === "-h") {
+    usage(0);
+  }
+  if (VALUE_OPTIONS.has(arg)) {
+    const [value, next] = readValue(argv, index);
+    const key = VALUE_OPTIONS.get(arg);
+    if (MULTI_VALUE_OPTIONS.has(key)) {
+      options[key].push(value);
+    } else {
+      options[key] = value;
+    }
+    return next;
+  }
+  if (FLAG_OPTIONS.has(arg)) {
+    options[FLAG_OPTIONS.get(arg)] = true;
+    return index;
+  }
+  usage();
+}
+
+// fallow-ignore-next-line complexity
+function parseArgs(argv) {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    usage(argv.length === 0 ? 2 : 0);
+  }
+  const command = argv[0];
+  const options = defaultOptions();
+  for (let index = 1; index < argv.length; index += 1) {
+    index = applyArg(options, argv, index);
+  }
+  return { command, options };
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function gitValue(args, fallback = "") {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : fallback;
+}
+
+// fallow-ignore-next-line complexity
+function logContext(options) {
+  return {
+    startedAt: now(),
+    branch: gitValue(["branch", "--show-current"], "unknown"),
+    commit: gitValue(["rev-parse", "--short", "HEAD"], "unknown"),
+    base: options.base,
+    validationProfile: options.validationProfile,
+    remotes: {
+      arm64: process.env.PORTABLE_ARM64_SSH ?? "friend@100.126.46.90",
+      amd64: process.env.PORTABLE_AMD64_SSH ?? "root@192.168.0.8",
+      amd64Repo: process.env.PORTABLE_AMD64_REPO ?? "",
+      sourceTarget: process.env.PORTABLE_MACHINE_REMOTE_SOURCE_TARGET ?? "",
+    },
+    paths: {
+      validationLog: resolve(options.validationLog),
+      goalFile: resolve(options.goalFile),
+    },
+  };
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(resolve(path)), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runCommand(command, options) {
+  const started = Date.now();
+  if (options.dryRun) {
+    return { command, status: "planned", exitCode: 0, elapsedMs: 0 };
+  }
+  const result = spawnSync(command, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    shell: true,
+    stdio: "pipe",
+  });
+  return {
+    command,
+    status: result.status === 0 ? "passed" : "failed",
+    exitCode: result.status,
+    elapsedMs: Date.now() - started,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+// fallow-ignore-next-line complexity
+function validationCommands(options) {
+  const focused = options.focusedVitest;
+  const focusedVitest =
+    focused.length > 0
+      ? [`NPM_CONFIG_USERCONFIG=/dev/null npx vitest run ${focused.join(" ")}`]
+      : [];
+  const fallow = ["pnpm exec fallow audit --changed-since origin/portable-snapshots"];
+  const profiles = {
+    none: [],
+    docs: [
+      "pnpm run build:docs",
+      "pnpm run format:check",
+      "pnpm run lint",
+      "pnpm run typecheck",
+      ...focusedVitest,
+      ...fallow,
+    ],
+    focused: [
+      "pnpm run format:check",
+      "pnpm run lint",
+      "pnpm run typecheck",
+      ...focusedVitest,
+      ...fallow,
+    ],
+    vm: [
+      "pnpm run build:docs",
+      "pnpm run format:check",
+      "pnpm run lint",
+      "pnpm run typecheck",
+      "NPM_CONFIG_USERCONFIG=/dev/null npx vitest run",
+      "pnpm smoke-tests",
+      ...fallow,
+    ],
+    ci: [CI_COMMAND],
+  };
+  const commands = profiles[options.validationProfile];
+  if (!commands) {
+    throw new Error(`unknown validation profile: ${options.validationProfile}`);
+  }
+  return options.includeCi && options.validationProfile !== "ci"
+    ? [...commands, CI_COMMAND]
+    : commands;
+}
+
+function validate(options) {
+  const context = logContext(options);
+  const commands = validationCommands(options);
+  const results = commands.map((command) => runCommand(command, options));
+  const failed = results.find((entry) => entry.status === "failed");
+  const log = {
+    ...context,
+    completedAt: now(),
+    state: failed ? "failed" : options.dryRun ? "planned" : "passed",
+    commands: results,
+  };
+  writeJson(options.validationLog, log);
+  return log;
+}
+
+function validationLines(log) {
+  return (log.commands ?? []).map((entry) => {
+    const elapsed = entry.elapsedMs === 0 ? "planned" : `${(entry.elapsedMs / 1000).toFixed(3)}s`;
+    return `- \`${entry.command}\` — ${entry.status}${elapsed === "planned" ? "" : ` (${elapsed})`}`;
+  });
+}
+
+// fallow-ignore-next-line complexity
+function prBody(options) {
+  const validationLog = options.validationLog && readFileSync(options.validationLog, "utf8");
+  const log = validationLog ? JSON.parse(validationLog) : { commands: [] };
+  const body = [
+    "## Problem",
+    "",
+    options.problem ?? "This task was tracked in goal.md but did not have reusable automation yet.",
+    "",
+    "## Solution",
+    "",
+    options.solution ??
+      "This change adds the requested automation and records validation output with timings.",
+    "",
+    "## Validation",
+    "",
+    ...validationLines(log),
+    "",
+  ].join("\n");
+  if (options.bodyFile) {
+    mkdirSync(dirname(resolve(options.bodyFile)), { recursive: true });
+    writeFileSync(options.bodyFile, body);
+  }
+  return { state: "completed", body, bodyFile: options.bodyFile ?? "" };
+}
+
+function plannedOrRun(command, options, steps) {
+  const result = runCommand(command, options);
+  steps.push(result);
+  if (result.status === "failed") {
+    throw new Error(`command failed: ${command}`);
+  }
+  return result;
+}
+
+// fallow-ignore-next-line complexity
+function runTask(options) {
+  if (!options.title || !options.branch || !options.issueBodyFile) {
+    throw new Error("run requires --title, --branch, and --issue-body-file");
+  }
+  const steps = [];
+  plannedOrRun(
+    `gh issue create --title ${JSON.stringify(options.title)} --body-file ${JSON.stringify(options.issueBodyFile)}`,
+    options,
+    steps,
+  );
+  plannedOrRun(`git switch -c ${JSON.stringify(options.branch)}`, options, steps);
+  if (options.implementationCommand) {
+    plannedOrRun(options.implementationCommand, options, steps);
+  }
+  const validation = validate(options);
+  const bodyFile = options.bodyFile ?? `/tmp/machinen-pr-${options.branch}.md`;
+  const body = prBody({ ...options, bodyFile });
+  plannedOrRun("git push -u origin HEAD", options, steps);
+  plannedOrRun(
+    `gh pr create --base ${JSON.stringify(options.base)} --head ${JSON.stringify(options.branch)} --title ${JSON.stringify(options.title)} --body-file ${JSON.stringify(bodyFile)}`,
+    options,
+    steps,
+  );
+  return { state: options.dryRun ? "planned" : "completed", steps, validation, prBody: body };
+}
+
+// fallow-ignore-next-line complexity
+function updateGoal(options) {
+  if (!options.match) {
+    throw new Error("update-goal requires --match");
+  }
+  const goalPath = options.goalFile;
+  const text = readFileSync(goalPath, "utf8");
+  const lines = text.split("\n");
+  const index = lines.findIndex((line) => line.includes(options.match) && /\[[ x~!]\]/.test(line));
+  if (index < 0) {
+    throw new Error(`no matching goal checkbox line for: ${options.match}`);
+  }
+  const updatedLine = lines[index].replace(/\[[ x~!]\]/, `[${options.status}]`);
+  if (!options.dryRun) {
+    lines[index] = updatedLine;
+    writeFileSync(goalPath, lines.join("\n"));
+  }
+  return {
+    state: options.dryRun ? "planned" : "completed",
+    goalFile: goalPath,
+    line: index + 1,
+    before: lines[index],
+    after: updatedLine,
+  };
+}
+
+function closeIssue(options) {
+  if (!options.issue) {
+    throw new Error("close-issue requires --issue");
+  }
+  const comment = options.comment ?? "Completed on portable-snapshots.";
+  const result = runCommand(
+    `gh issue close ${JSON.stringify(options.issue)} --comment ${JSON.stringify(comment)}`,
+    options,
+  );
+  return {
+    state: options.dryRun ? "planned" : result.status,
+    issue: options.issue,
+    command: result,
+  };
+}
+
+// fallow-ignore-next-line complexity
+function print(value, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+    return;
+  }
+  console.log(
+    `${value.state}: ${value.command ?? value.validationProfile ?? value.issue ?? value.goalFile ?? "goal-task"}`,
+  );
+}
+
+function main() {
+  const { command, options } = parseArgs(process.argv.slice(2));
+  const handlers = {
+    run: runTask,
+    validate,
+    "pr-body": prBody,
+    "update-goal": updateGoal,
+    "close-issue": closeIssue,
+  };
+  const handler = handlers[command];
+  if (!handler) {
+    usage();
+  }
+  const result = handler(options);
+  print(result, options.json);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

Working through `goal.md` repeats the same steps again and again. Each task needs an issue, a branch, validation, a PR body with timings, and sometimes a manual issue close. Doing that by hand is easy to mess up.

## Solution

This adds `pnpm goal-task`. It can plan or run the issue/branch/implementation/validation/PR flow, write validation logs, generate PR bodies, update `goal.md`, and close issues after non-default-branch merges. The tests cover the dry-run path, focused validation, full VM validation planning, PR body generation, goal updates, and issue closing.

Closes #729.

## Validation

- `pnpm run build:docs` — 1.690s
- `pnpm run format:check` — 0.598s
- `pnpm run lint` — 0.243s
- `pnpm run typecheck` — 2.545s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.571s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.434s
