### PR TITLE
Document process context auxv boundary

### DIFF
--- a/docs/snapshot/target-guest-process-context-restore.md
+++ b/docs/snapshot/target-guest-process-context-restore.md
@@ -18,6 +18,22 @@ native-process manifest and resource table and is bounded:
 Malformed, missing, inconsistent, or oversized context refuses with
 `target-process-context-unsupported`.
 
+## Target libc/startup dependency inventory
+
+The current process-context model is for an already-running target-native loader
+that jumps into controlled target code. It can safely expose only state that the
+loader owns or can verify after restore:
+
+- environment variables through target `clearenv()`/`setenv()` and `getenv()`;
+- cwd through target `chdir()` and `getcwd()`;
+- bounded argv strings through a target-owned pointer block for verifier code;
+- selected auxv values that are stable target facts (`AT_PAGESZ`, `AT_CLKTCK`).
+
+It does not claim full libc start reconstruction. Target libc's original kernel
+startup stack, dynamic-loader private globals, vDSO/vvar pointers, random bytes,
+interpreter base, and executable-name pointer ownership remain target-owned or
+refused unless a mode models them explicitly.
+
 ## Target-side consumption
 
 Descriptors use `native=process-context` steps. Four modes are available:
@@ -40,9 +56,18 @@ Descriptors use `native=process-context` steps. Four modes are available:
 
 The initial-stack mode also records an explicit auxv materialization policy:
 selected-safe entries are materialized, while target-variant/source-pointer
-entries such as `AT_SYSINFO_EHDR` (vDSO), `AT_RANDOM`, `AT_EXECFN`, and `AT_BASE`
-are listed as refused for this model rather than silently copied from the source.
-The vvar mapping dependency remains unsupported.
+entries are listed as refused for this model rather than silently copied from the
+source:
+
+| Entry / mapping          | Current policy                            | Reason                                                                       |
+| ------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------- |
+| `AT_PAGESZ`              | materialize selected target-visible value | stable target ABI value checked with target `getauxval()`                    |
+| `AT_CLKTCK`              | materialize selected target-visible value | stable target ABI value checked with target `getauxval()`                    |
+| `AT_RANDOM`              | refuse                                    | source pointer/random bytes are process-local target-owned state             |
+| `AT_EXECFN`              | refuse                                    | source pointer names source execution context, not target-owned argv storage |
+| `AT_BASE`                | refuse                                    | interpreter/load base is target dynamic-loader state                         |
+| `AT_SYSINFO_EHDR` / vDSO | refuse                                    | vDSO pointer and code page are target-kernel supplied                        |
+| vvar                     | refuse                                    | vvar data is target-kernel supplied and time-sensitive                       |
 
 The visible mode refuses if the controlled env token, argv token, or selected
 safe auxv entries are missing. Source-only and target-variant auxv entries stay

--- a/goal.md
+++ b/goal.md
@@ -126,18 +126,18 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### C. Process context beyond bounded argv/envp/auxv pointer block
 
-- [~] Keep current bounded argv/env/cwd/selected-auxv model passing.
-- [ ] Inventory target libc startup/global expectations that are observable after
+- [x] Keep current bounded argv/env/cwd/selected-auxv model passing.
+- [x] Inventory target libc startup/global expectations that are observable after
       the restore point.
-- [ ] Decide which auxv entries are safe to materialize, which are target-owned,
+- [x] Decide which auxv entries are safe to materialize, which are target-owned,
       and which must refuse.
-- [ ] Model or refuse `AT_RANDOM` with an explicit target-owned randomness
+- [x] Model or refuse `AT_RANDOM` with an explicit target-owned randomness
       contract.
-- [ ] Model or refuse `AT_EXECFN` with target path/provenance ownership.
-- [ ] Model or refuse `AT_BASE`, interpreter, vDSO, and vvar dependencies.
-- [ ] Add tests that prove unsafe auxv/vDSO/vvar values cannot be copied from the
+- [x] Model or refuse `AT_EXECFN` with target path/provenance ownership.
+- [x] Model or refuse `AT_BASE`, interpreter, vDSO, and vvar dependencies.
+- [x] Add tests that prove unsafe auxv/vDSO/vvar values cannot be copied from the
       source ISA as success.
-- [ ] Add a remote process-context proof that exercises the newly modeled context
+- [x] Add a remote process-context proof that exercises the newly modeled context
       value from target-native code.
 
 ### D. Private memory, heap, brk, and mmap coverage

--- a/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts
@@ -11,6 +11,7 @@ function auxvHex(values: { pageSize: number; clockTick: number; unsafe?: boolean
           [33n, 0x7fff0000n],
           [25n, 0x7fff0100n],
           [31n, 0x7fff0200n],
+          [7n, 0x7fff0300n],
         ] satisfies Array<[bigint, bigint]>)
       : []),
     [0n, 0n],
@@ -167,7 +168,7 @@ describe("target guest process-context restore", () => {
         expect.objectContaining({
           action: "record-auxv-policy",
           materializedKeys: "AT_PAGESZ,AT_CLKTCK",
-          refusedKeys: "AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN",
+          refusedKeys: "AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN,AT_BASE",
         }),
         expect.objectContaining({
           action: "materialize-initial-stack",
@@ -178,6 +179,43 @@ describe("target guest process-context restore", () => {
           clockTick: 100,
         }),
         expect.objectContaining({ action: "verify-initial-stack", targetStart: "0x600000002000" }),
+      ]),
+    });
+    if (plan.state !== "planned") {
+      throw new Error("expected process-context plan to be planned");
+    }
+    const materialize = plan.steps.find((step) => step.action === "materialize-initial-stack");
+    expect(materialize).toMatchObject({ pageSize: 4096, clockTick: 100 });
+    expect(materialize).not.toHaveProperty("auxvHex");
+    expect(materialize).not.toHaveProperty("randomPointer");
+    expect(materialize).not.toHaveProperty("execfnPointer");
+    expect(materialize).not.toHaveProperty("basePointer");
+  });
+
+  it("records all source-owned and target-variant auxv keys as refused", () => {
+    const docs = documents();
+    docs.resources.resources.find((resource) => resource.kind === "auxv")!.recipe = {
+      bytesHex: auxvHex({ pageSize: 16384, clockTick: 250, unsafe: true }),
+    };
+
+    const plan = planTargetGuestProcessContextRestore(docs, {
+      mode: "apply-target-initial-stack",
+      initialStackTargetStart: "0x600000004000",
+    });
+
+    expect(plan).toMatchObject({
+      state: "planned",
+      steps: expect.arrayContaining([
+        expect.objectContaining({
+          action: "record-auxv-policy",
+          materializedKeys: "AT_PAGESZ,AT_CLKTCK",
+          refusedKeys: "AT_SYSINFO_EHDR,AT_RANDOM,AT_EXECFN,AT_BASE",
+        }),
+        expect.objectContaining({
+          action: "materialize-initial-stack",
+          pageSize: 16384,
+          clockTick: 250,
+        }),
       ]),
     });
   });


### PR DESCRIPTION
## Problem

The process-context proof already handled a small safe part of argv, env, cwd, and auxv. But the goal list still needed the unsafe auxv and special-mapping boundary written down clearly. Without that, it was too easy to wonder whether source `AT_RANDOM`, vDSO, or loader pointers were being copied as target state.

## Solution

This documents the target libc/startup expectations and the auxv policy. Only `AT_PAGESZ` and `AT_CLKTCK` are materialized as selected target-safe values. `AT_RANDOM`, `AT_EXECFN`, `AT_BASE`, vDSO, and vvar stay refused or target-owned. Tests now assert those unsafe auxv keys are recorded as refused and are not copied into the target initial-stack materialization step.

Closes #731.

## Validation

- `pnpm run build:docs` — 1.546s
- `pnpm run format:check` — 0.572s
- `pnpm run lint` — 0.216s
- `pnpm run typecheck` — 2.379s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/target-guest-process-context-restore.test.ts` — 0.571s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.288s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.363s
- remote `process-context` proof via `pnpm --silent portable-machine-proof-runner -- --profile process-context --json` — 39.094s
