### PR TITLE
Document private memory boundary

### DIFF
--- a/docs/snapshot/target-guest-private-memory-restore.md
+++ b/docs/snapshot/target-guest-private-memory-restore.md
@@ -10,11 +10,34 @@ steps the target VM loader must perform for private writable memory.
 - `mprotect-final` for the final private permissions;
 - `mmap-guard` for recreated no-access guard ranges.
 
-Executable entries and shared entries fail closed with
-`mapping-executable-unsupported` and `mapping-shared-unsupported`. Guard entries
-must be `---p`. The target amd64 trampoline now executes these native private
-memory steps directly; when they are present, the portable VM proof does not also
-emit duplicate legacy `memory=` mappings for the same ranges. Target TLS/TCB
-restore now treats writable native private-memory ranges as valid backing for the
-TCB handoff. This keeps private heap/data/mmap restoration separate from source
+## Accepted private-data class
+
+Private memory restore is limited to captured target-owned data ranges: heap,
+brk/data, and anonymous mmap ranges that are writable, non-executable, private,
+have an explicit target address, and are fully covered by `native-memory.bin`.
+The loader maps each accepted range writable, copies the captured bytes, then
+applies the final non-executable permissions. This models data bytes only; source
+text is never reused as target code.
+
+Guard pages are recreated as no-access private mappings (`---p`) adjacent to the
+accepted private range. They do not carry captured bytes and keep stack/heap/mmap
+fault boundaries visible to the target process.
+
+## Fail-closed mapping boundary
+
+| Mapping state                                               | Result                               |
+| ----------------------------------------------------------- | ------------------------------------ |
+| executable or writable+executable                           | `mapping-executable-unsupported`     |
+| shared writable/shared file-backed without coherence recipe | `mapping-shared-unsupported`         |
+| missing target address or overlapping target ranges         | `mapping-ambiguous`                  |
+| captured bytes missing or not from `native-memory.bin`      | `mapping-provenance-ambiguous`       |
+| partial/out-of-range captured bytes                         | `mapping-captured-range-unsupported` |
+| copied range is not writable/private data                   | `mapping-permission-unsupported`     |
+| guard range is not exactly `---p`                           | `mapping-permission-unsupported`     |
+
+The target amd64 trampoline now executes these native private memory steps
+directly; when they are present, the portable VM proof does not also emit
+duplicate legacy `memory=` mappings for the same ranges. Target TLS/TCB restore
+now treats writable native private-memory ranges as valid backing for the TCB
+handoff. This keeps private heap/data/mmap restoration separate from source
 executable bytes and shared-resource state.

--- a/goal.md
+++ b/goal.md
@@ -142,16 +142,16 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### D. Private memory, heap, brk, and mmap coverage
 
-- [~] Keep current private writable range materialization passing.
-- [ ] Broaden heap/brk/mmap layout policy only where provenance and ownership are
+- [x] Keep current private writable range materialization passing.
+- [x] Broaden heap/brk/mmap layout policy only where provenance and ownership are
       explicit.
-- [ ] Preserve guard-page semantics for every widened private memory range.
-- [ ] Refuse writable+executable memory unless a later JIT/code provenance task
+- [x] Preserve guard-page semantics for every widened private memory range.
+- [x] Refuse writable+executable memory unless a later JIT/code provenance task
       models it exactly.
-- [ ] Refuse shared writable memory unless coherence and ownership are modeled.
-- [ ] Refuse unreadable or partially captured mappings with stable detail.
-- [ ] Add target-side verification for every new materialized memory class.
-- [ ] Add tests for pointer ownership, permission transitions, guard behavior,
+- [x] Refuse shared writable memory unless coherence and ownership are modeled.
+- [x] Refuse unreadable or partially captured mappings with stable detail.
+- [x] Add target-side verification for every new materialized memory class.
+- [x] Add tests for pointer ownership, permission transitions, guard behavior,
       missing bytes, and overlapping target mappings.
 
 ### E. Target libc, vDSO, vvar, and special mappings

--- a/packages/runtime/src/__tests__/target-guest-private-memory-restore.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-private-memory-restore.test.ts
@@ -68,11 +68,43 @@ describe("target guest private memory restore", () => {
 
     expect(planTargetGuestPrivateMemoryRestore([executable])).toMatchObject({
       state: "refused",
+      steps: [],
       refusals: [expect.objectContaining({ code: "mapping-executable-unsupported" })],
     });
     expect(planTargetGuestPrivateMemoryRestore([shared])).toMatchObject({
       state: "refused",
+      steps: [],
       refusals: [expect.objectContaining({ code: "mapping-shared-unsupported" })],
+    });
+  });
+
+  it("refuses copied bytes without writable private permissions", () => {
+    const readOnlyCopy = { ...entries[0]!, permissions: "r--p" };
+
+    expect(planTargetGuestPrivateMemoryRestore([readOnlyCopy])).toMatchObject({
+      state: "refused",
+      steps: [],
+      refusals: [
+        expect.objectContaining({
+          code: "mapping-permission-unsupported",
+          message: "mapping:heap copied private memory must be writable",
+        }),
+      ],
+    });
+  });
+
+  it("refuses guard entries that would materialize readable or writable bytes", () => {
+    const readableGuard = { ...entries[1]!, permissions: "r--p" };
+
+    expect(planTargetGuestPrivateMemoryRestore([readableGuard])).toMatchObject({
+      state: "refused",
+      steps: [],
+      refusals: [
+        expect.objectContaining({
+          code: "mapping-permission-unsupported",
+          message: "mapping:heap-guard guard mapping must be no-access private",
+        }),
+      ],
     });
   });
 });


### PR DESCRIPTION
## Problem

The private memory part of the goal needed a clearer boundary. We already copy safe private data, but the docs and tests did not spell out each unsafe case at the target private-memory planner level.

## Solution

This documents the accepted heap/brk/mmap private-data class, guard-page handling, and fail-closed mapping refusals. It also adds target private-memory planner tests for non-writable copy attempts and invalid guard permissions, so unsafe memory cannot silently turn into target mappings.

Closes #733.

## Validation

- `pnpm run build:docs` — 1.775s
- `pnpm run format:check` — 0.602s
- `pnpm run lint` — 0.233s
- `pnpm run typecheck` — 2.604s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/target-guest-private-memory-restore.test.ts packages/runtime/src/__tests__/target-guest-memory-materialization.test.ts packages/runtime/src/__tests__/native-mapping-materialization.test.ts` — 0.666s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.134s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.420s
