### PR TITLE
Document special mapping boundary

### DIFF
--- a/docs/snapshot/native-mapping-policy.md
+++ b/docs/snapshot/native-mapping-policy.md
@@ -28,12 +28,28 @@ A passing run proves:
    `target.materialization: "recreate"`;
 4. the recreated protection mappings are not copied into `native-memory.bin`.
 
-## Boundary
+## Special-mapping inventory and policy
 
-This does not implement target vdso/vvar reconstruction. It only prevents a bad
-restore from copying source kernel pages as normal user memory. The follow-up
+Accepted proof bundles currently observe these special mapping families:
+
+| Source mapping                                         | Target policy                          | Copy source bytes? | Reason / refusal path                                                                                                                         |
+| ------------------------------------------------------ | -------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[vdso]` / `vdso`                                      | target-owned recreate/verify only      | no                 | target kernel supplies vDSO code and address; source vDSO is never target code                                                                |
+| `[vvar]` / `vvar`                                      | target-owned recreate/verify only      | no                 | target kernel supplies time data pages                                                                                                        |
+| other kernel `special` mappings                        | target-owned recreate/verify or refuse | no                 | kernel semantics must be explicit before use                                                                                                  |
+| stack/heap/file `PROT_NONE` guards                     | recreate as no-access guard            | no                 | preserves fault boundary without copying unreadable bytes                                                                                     |
+| executable source text                                 | map target-native file only            | no                 | requires target build-id/sha256/path provenance                                                                                               |
+| unreadable shared/writable/executable ambiguous ranges | refuse                                 | no                 | `mapping-unreadable`, `mapping-shared-unsupported`, `mapping-executable-unsupported`, or `mapping-permission-unsupported` with mapping detail |
+
+This does not implement target vDSO/vvar byte reconstruction. It only prevents a
+bad restore from copying source kernel pages as normal user memory. The follow-up
 [Native mapping materializer](./native-mapping-materializer.md) applies this
 policy to target mappings. Real target kernels must supply their own
-vdso/vvar/special mappings. Unreadable mappings that are writable, executable,
-shared, or otherwise ambiguous still remain precise `mapping-unreadable`
-refusals with mapping details.
+vDSO/vvar/special mappings. Unreadable mappings that are writable, executable,
+shared, or otherwise ambiguous still remain precise refusals with mapping
+details.
+
+Target-native verification for modeled special mappings is limited to verifying
+that target-owned mappings exist and are not sourced from the captured
+`native-memory.bin`. Data-dependent vDSO/vvar semantics stay unsupported until a
+future target-kernel contract models them explicitly.

--- a/goal.md
+++ b/goal.md
@@ -156,14 +156,14 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### E. Target libc, vDSO, vvar, and special mappings
 
-- [ ] Inventory every special mapping currently observed in accepted proof
+- [x] Inventory every special mapping currently observed in accepted proof
       profiles.
-- [ ] Decide per mapping: target-owned recreate, target-file provenance verify,
+- [x] Decide per mapping: target-owned recreate, target-file provenance verify,
       data materialize, or refuse.
-- [ ] Add stable refusal codes/details for every unsupported special mapping.
-- [ ] Model target vDSO/vvar only when target kernel semantics are explicit; do
+- [x] Add stable refusal codes/details for every unsupported special mapping.
+- [x] Model target vDSO/vvar only when target kernel semantics are explicit; do
       not copy source vDSO/vvar bytes as success.
-- [ ] Add target-native verification that modeled special mapping data is valid
+- [x] Add target-native verification that modeled special mapping data is valid
       on amd64.
 
 ### F. Signals, interrupted syscalls, and restart semantics

--- a/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
@@ -61,6 +61,18 @@ function request(): NativeMappingMaterializationRequest {
         target: { materialization: "recreate", targetStart: "0x75000000" },
       }),
       mapping({
+        id: "mapping:vvar",
+        kind: "vvar",
+        permissions: { read: true, write: false, execute: false, private: true, shared: false },
+        target: { materialization: "recreate", targetStart: "0x75001000" },
+      }),
+      mapping({
+        id: "mapping:special",
+        kind: "special",
+        permissions: { read: true, write: false, execute: false, private: true, shared: false },
+        target: { materialization: "recreate", targetStart: "0x75002000" },
+      }),
+      mapping({
         id: "mapping:guard",
         permissions: { read: false, write: false, execute: false, private: true, shared: false },
         target: { materialization: "refuse", reason: "guard page was unreadable at capture" },
@@ -105,6 +117,8 @@ describe("native mapping materialization", () => {
         expect.objectContaining({ mapping: "mapping:heap", action: "copy-captured-bytes" }),
         expect.objectContaining({ mapping: "mapping:stack", action: "recreate" }),
         expect.objectContaining({ mapping: "mapping:vdso", action: "recreate" }),
+        expect.objectContaining({ mapping: "mapping:vvar", action: "recreate" }),
+        expect.objectContaining({ mapping: "mapping:special", action: "recreate" }),
         expect.objectContaining({
           mapping: "mapping:guard",
           action: "recreate",
@@ -125,6 +139,9 @@ describe("native mapping materialization", () => {
       offset: 0,
       sizeBytes: 4096,
     });
+    for (const recreated of ["mapping:vdso", "mapping:vvar", "mapping:special"]) {
+      expect(result.steps.find((step) => step.mapping === recreated)?.sourceBytes).toBeUndefined();
+    }
   });
 
   it("refuses invalid captured byte ranges precisely", () => {


### PR DESCRIPTION
## Problem

The goal list still had open work for vDSO, vvar, and other special mappings. The policy was partly implemented, but it was not written as a clear inventory with each mapping's target ownership and refusal path.

## Solution

This documents the special-mapping boundary: vDSO, vvar, and kernel special mappings are target-owned recreate/verify state, guard mappings are recreated without source bytes, executable source text must use target-native file provenance, and ambiguous unreadable mappings fail closed with stable details. The materialization test now includes vDSO, vvar, and special mappings and asserts they never get copied from captured memory.

Closes #735.

## Validation

- `pnpm run build:docs` — 1.832s
- `pnpm run format:check` — 0.673s
- `pnpm run lint` — 0.301s
- `pnpm run typecheck` — 2.747s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-mapping-materialization.test.ts packages/runtime/src/__tests__/native-mapping-policy.test.ts` — 0.747s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.881s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.501s
