### PR TITLE
Document signal restart boundary

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -92,6 +92,23 @@ migration. Missing fd resources, wrong resource kinds, unsupported flags or
 state, wrong events, non-empty `revents`, `nfds > 1`, and non-null signal masks
 all fail closed as `target-ppoll-timeout-missing`.
 
+## Signal interruption and restart boundary
+
+The active-syscall model restarts only the narrow families whose target-side
+equivalence is explicitly modeled in this document. Plain interrupted syscalls,
+`ERESTART*`-style kernel restart blocks, and `restart_syscall` refuse with
+`syscall-restart-unsupported` unless a future family proves all of the following:
+remaining-time accounting, signal mask delivery semantics, syscall result/restart
+contract, and target resource rearm policy.
+
+For already accepted timeout families, remaining-time modeling is family-local:
+sleep and `ppoll` require captured relative timespec state, timerfd read may carry
+a captured remaining timer value, and fd/file transfer proofs complete bounded
+native `pread()`/`pwrite()` work instead of replaying source restart state.
+Pending signals, signalfd delivery, active signal frames, and non-null `ppoll`
+signal masks stay refused so `migrationCompleted=true` is never reported for an
+ambiguous signal/restart state.
+
 ## Futex refusal tightening
 
 Active futex syscalls now fail closed with `futex-state-unsupported` instead of

--- a/docs/snapshot/native-signal-policy.md
+++ b/docs/snapshot/native-signal-policy.md
@@ -8,6 +8,18 @@ Issue #645 adds a fail-closed signal boundary for native thread restore.
 explicit `blockedMaskPolicy: "restore-safe-mask"` option, it may also accept and
 report a parsed blocked signal mask for target restore.
 
+## Boundary matrix
+
+| Signal state                                     | Current policy                           | Reason                                                                               |
+| ------------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------ |
+| empty blocked/pending masks                      | accept                                   | no target signal state to recreate                                                   |
+| blocked mask with `restore-safe-mask`            | model target mask handoff                | mask bits can be set and verified before target resume                               |
+| pending signal queue / siginfo                   | refuse with `signal-state-unsupported`   | queued delivery order, payload ownership, and sender identity are kernel state       |
+| active signal frame/trampoline                   | refuse with `signal-frame-active`        | target frame, ucontext, restorer, and interrupted register ownership are not modeled |
+| enabled/active alt-stack                         | refuse with `signal-state-unsupported`   | target stack registration and active-frame ownership are not modeled                 |
+| malformed blocked/pending masks                  | refuse with `signal-state-unsupported`   | ambiguous source state fails closed                                                  |
+| dispositions/handlers beyond controlled defaults | metadata-only/refuse at broader boundary | handler code identity and target libc/kernel registration must be proven before use  |
+
 It still refuses:
 
 - active signal frames (`signal-frame-active`);

--- a/goal.md
+++ b/goal.md
@@ -170,15 +170,15 @@ narrow exact contract or fail closed with a stable refusal.
 
 - [!] Keep pending signals, active signal delivery, alt-stack frames, and generic
   restart blocks refused by default.
-- [ ] Capture pending signals, blocked masks, signal dispositions needed by the
+- [x] Capture pending signals, blocked masks, signal dispositions needed by the
       restore contract, and interrupted syscall state.
-- [ ] Model signal-mask restore for safe cases without allowing pending or active
+- [x] Model signal-mask restore for safe cases without allowing pending or active
       signal delivery to pass silently.
-- [ ] Define remaining-time accounting per blocking syscall family.
-- [ ] Restart only when target can prove equivalent signal/restart semantics.
-- [ ] Preserve current refusals for plain `EINTR`, `ERESTART*`-style results, and
+- [x] Define remaining-time accounting per blocking syscall family.
+- [x] Restart only when target can prove equivalent signal/restart semantics.
+- [x] Preserve current refusals for plain `EINTR`, `ERESTART*`-style results, and
       other unmodeled negative errno returns until modeled.
-- [ ] Add tests for pending signal queue, siginfo ownership, alt-stack state,
+- [x] Add tests for pending signal queue, siginfo ownership, alt-stack state,
       signal trampoline frames, restart-block state, and target timeout
       accounting.
 


### PR DESCRIPTION
## Problem

The signal/restart part of the goal still needed a clear boundary. The code already refused unsafe signal and restart state, but the docs did not list the exact signal states and restart conditions that remain unsupported.

## Solution

This adds a signal boundary matrix for blocked masks, pending signals, active frames, alt-stacks, malformed masks, and dispositions. It also documents that `restart_syscall` / `ERESTART*`-style state only becomes supported when a future proof models remaining time, signal delivery, result contracts, and target rearm policy. The goal checklist is updated to reflect the existing tests and refusals.

Closes #737.

## Validation

- `pnpm run build:docs` — 1.816s
- `pnpm run format:check` — 0.709s
- `pnpm run lint` — 0.310s
- `pnpm run typecheck` — 2.737s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-signal-policy.test.ts packages/runtime/src/__tests__/target-guest-signal-restore.test.ts packages/runtime/src/__tests__/native-active-syscall-policy.test.ts` — 0.743s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.318s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.396s
