### PR TITLE
Document resource fd boundary

### DIFF
--- a/docs/snapshot/native-resource-translation.md
+++ b/docs/snapshot/native-resource-translation.md
@@ -36,9 +36,28 @@ missing from the capture, carries close-on-exec provenance, and converts modeled
 resources into target-guest loader recipes (`reopen-file`, `inherit-stdio`,
 `synthetic-empty-pipe`, `synthetic-empty-eventfd`, and `synthetic-timerfd`).
 The loader/trampoline handoff applies close-on-exec after restore setup and
-before the target-native jump. Duplicate captured fds are refused before target execution with
-`target-fd-table-duplicate`; captured fds without any safe target recipe refuse
-with `target-fd-table-missing` or the underlying resource refusal.
+before the target-native jump. Duplicate captured fds are refused before target
+execution with `target-fd-table-duplicate`; captured fds without any safe target
+recipe refuse with `target-fd-table-missing` or the underlying resource refusal.
+
+## Resource boundary matrix
+
+| Resource / fd state          | Current policy                                                                               |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| regular file                 | reopen by path/offset/flags when provenance is safe                                          |
+| stdio                        | inherit stdout/stderr only with explicit stdio policy; stdin refused                         |
+| close-fd gap                 | explicit target `close-fd` recipe                                                            |
+| synthetic empty pipe         | only for modeled ppoll/read proof slices with paired read/write ends                         |
+| synthetic empty eventfd      | only counter-0, non-semaphore, modeled proof slices                                          |
+| synthetic timerfd            | only modeled disarmed/future one-shot timerfd proof slices                                   |
+| PTY                          | refuse unless a PTY broker capability is declared                                            |
+| raw socket                   | refuse unless a raw-socket broker capability is declared                                     |
+| sockets                      | refuse until queues, peer identity, shutdown/options, and namespace state are modeled        |
+| epoll                        | refuse until interest lists, ready-list ordering, wakeups, and target fd mapping are modeled |
+| signalfd                     | refuse until pending signal queue, siginfo payloads, and mask coordination are modeled       |
+| generic eventfd/timerfd      | refuse except for the narrow empty/disarmed modeled states above                             |
+| duplicate captured fd        | refuse with `target-fd-table-duplicate` before target execution                              |
+| unsupported descriptor shape | refuse before loader/trampoline args are built                                               |
 
 ## Refusals
 

--- a/goal.md
+++ b/goal.md
@@ -199,22 +199,22 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### H. Kernel resources and fd recipes beyond current proofs
 
-- [~] Keep current regular-file, stdio, close-fd, synthetic empty pipe, synthetic
-  empty eventfd, and synthetic timerfd recipes passing.
-- [ ] Add or refine refusals for unsupported descriptor state before target
+- [x] Keep current regular-file, stdio, close-fd, synthetic empty pipe, synthetic
+      empty eventfd, and synthetic timerfd recipes passing.
+- [x] Add or refine refusals for unsupported descriptor state before target
       execution.
-- [ ] Decide broker/model/refuse policy for PTYs.
-- [ ] Decide broker/model/refuse policy for raw sockets.
-- [ ] Keep sockets refused until accept/connect/listen queues, peer identity,
+- [x] Decide broker/model/refuse policy for PTYs.
+- [x] Decide broker/model/refuse policy for raw sockets.
+- [x] Keep sockets refused until accept/connect/listen queues, peer identity,
       credentials, namespaces, socket options, and readiness are modeled or
       brokered.
-- [ ] Keep epoll refused until interest lists, ready-list ordering, wakeups, and
+- [x] Keep epoll refused until interest lists, ready-list ordering, wakeups, and
       nested epoll semantics are modeled or brokered.
-- [ ] Keep signalfd refused until pending signal queue and siginfo ownership are
+- [x] Keep signalfd refused until pending signal queue and siginfo ownership are
       modeled.
-- [ ] Keep generic eventfd/timerfd state refused except for the already modeled
+- [x] Keep generic eventfd/timerfd state refused except for the already modeled
       narrow active-read recipes.
-- [ ] Add target fd-table tests for duplicate fds, unsupported descriptors,
+- [x] Add target fd-table tests for duplicate fds, unsupported descriptors,
       close-on-exec, safe flag filtering, and missing reopen recipes.
 
 ### I. Code identity, unwind, stack, and arbitrary binary boundary


### PR DESCRIPTION
## Problem

The resource/fd-table goal items were still open even though the implementation already has narrow fd recipes and precise refusals. The boundary needed one clear table that shows what is accepted, broker-gated, or refused.

## Solution

This adds a resource boundary matrix for regular files, stdio, close-fd gaps, synthetic pipe/eventfd/timerfd proof slices, PTYs, raw sockets, sockets, epoll, signalfd, duplicate fds, and unsupported descriptor shapes. It updates the goal checklist based on the existing fd-table and loader validation tests.

Closes #741.

## Validation

- `pnpm run build:docs` — 1.690s
- `pnpm run format:check` — 0.656s
- `pnpm run lint` — 0.309s
- `pnpm run typecheck` — 2.576s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/target-guest-restore-loader.test.ts packages/runtime/src/__tests__/native-active-syscall-policy.test.ts` — 1.602s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.258s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.357s
