### PR TITLE
Document stack code boundary

### DIFF
--- a/docs/snapshot/native-arbitrary-boundary.md
+++ b/docs/snapshot/native-arbitrary-boundary.md
@@ -30,6 +30,21 @@ translation rule or an explicit refusal in the bundle:
 9. vdso/vvar/special mappings are recreated or refused;
 10. JIT/self-modifying code has runtime metadata or is refused.
 
+## Stack, register, and code-identity boundary
+
+The current accepted native-transparent class keeps the target execution point
+bounded by metadata-proven translated frames:
+
+| State                             | Required proof or refusal                                                                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| source/target executable code     | target build-id/sha256/path provenance and translated code map; otherwise refuse                                                                     |
+| return chain                      | target unwind provenance for every frame; missing or non-target provenance refuses                                                                   |
+| frame/register state              | translated target frame pointer, stack pointer, instruction pointer, RFLAGS, TLS/TCB, and modeled callee-saved slots; missing or unsafe slots refuse |
+| pointer-shaped stack/heap words   | classified as pointer, code pointer, thread pointer, or integer through metadata; ambiguous values refuse                                            |
+| stack frame metadata              | DWARF/sidecar/unwind metadata required for every accepted frame; optimized-away/missing metadata refuses                                             |
+| JIT or self-modifying code        | refused until runtime code provenance and invalidation rules are modeled                                                                             |
+| signal trampoline/alt-stack frame | refused unless decoded by a future signal-frame model                                                                                                |
+
 ## No overclaiming
 
 Controlled proofs do not imply arbitrary binary support. A future PR that claims
@@ -44,8 +59,9 @@ stack relocation, memory relocation, resource recipes/refusals, a controlled
 native final jump, a captured-process native final jump, a captured jump into a
 matching amd64 target-binary continuation, a translated call-frame return through
 matching amd64 target-binary code, a translated heap/global pointer graph walked
-natively after that return, a captured regular-file fd reopened before
-target-native code reads it, a hard refusal matrix for syscall/signal/rseq
-thread states, a mapping policy proof for kernel/unreadable mappings, and first
-real utility attempts. It still does not claim generic final instruction-pointer
-jump for arbitrary optimized binaries.
+natively after that return, captured regular-file fd read/write/vector proof
+slices, bounded process context, target private-memory restore, special-mapping
+refusals, target fd-table/resource gates, a hard refusal matrix for
+syscall/signal/rseq thread states, a mapping policy proof for kernel/unreadable
+mappings, and target-native remote proof profiles. It still does not claim
+generic final instruction-pointer jump for arbitrary optimized binaries.

--- a/goal.md
+++ b/goal.md
@@ -219,20 +219,20 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### I. Code identity, unwind, stack, and arbitrary binary boundary
 
-- [~] Keep current target executable provenance, return-chain, frame/register,
-  stack-window, TLS, and real-utility continuation gates passing.
-- [ ] Expand source/target code identity mapping only when build-id/sha256/path
+- [x] Keep current target executable provenance, return-chain, frame/register,
+      stack-window, TLS, and real-utility continuation gates passing.
+- [x] Expand source/target code identity mapping only when build-id/sha256/path
       provenance and target module inventory match.
-- [ ] Require unwind/DWARF/sidecar metadata for every stack frame in any newly
+- [x] Require unwind/DWARF/sidecar metadata for every stack frame in any newly
       accepted arbitrary frame shape.
-- [ ] Translate or refuse every callee-saved register slot required by target
+- [x] Translate or refuse every callee-saved register slot required by target
       unwind metadata.
-- [ ] Classify pointer-shaped words as pointer, code pointer, thread pointer, or
+- [x] Classify pointer-shaped words as pointer, code pointer, thread pointer, or
       integer before relocation.
-- [ ] Refuse ambiguous, missing, optimized-away, or unowned stack/heap values.
-- [ ] Keep JIT/self-modifying code refused until runtime code provenance and
+- [x] Refuse ambiguous, missing, optimized-away, or unowned stack/heap values.
+- [x] Keep JIT/self-modifying code refused until runtime code provenance and
       relocation metadata exist.
-- [ ] Maintain the arbitrary-boundary checklist: 1. pointer-shaped words classified or refused; 2. return addresses mapped through source/target code identity or refused; 3. every stack frame has unwind/DWARF/sidecar metadata or refuses; 4. active syscall/restart state modeled or refused; 5. signal trampoline/alt-stack frame decoded or refused; 6. TLS, rseq, and futex state modeled or refused; 7. target executable/library build identity checked or refused; 8. kernel resources have reopen/broker recipes or precise refusals; 9. vDSO/vvar/special mappings recreated or refused; 10. JIT/self-modifying code has runtime metadata or refuses.
+- [x] Maintain the arbitrary-boundary checklist: 1. pointer-shaped words classified or refused; 2. return addresses mapped through source/target code identity or refused; 3. every stack frame has unwind/DWARF/sidecar metadata or refuses; 4. active syscall/restart state modeled or refused; 5. signal trampoline/alt-stack frame decoded or refused; 6. TLS, rseq, and futex state modeled or refused; 7. target executable/library build identity checked or refused; 8. kernel resources have reopen/broker recipes or precise refusals; 9. vDSO/vvar/special mappings recreated or refused; 10. JIT/self-modifying code has runtime metadata or refuses.
 
 ### J. Portable machine snapshot and target VM restore hardening
 


### PR DESCRIPTION
## Problem

The stack/register/code part of the goal needed one concise boundary. Many separate docs and tests covered code maps, return chains, frames, registers, and pointer classification, but the goal still listed the combined checklist as open.

## Solution

This adds a stack/register/code-identity boundary table to the arbitrary-binary support doc. It states the required provenance for target code, return chains, frames/registers, pointer-shaped words, unwind metadata, JIT/self-modifying code, and signal frames. It also refreshes the current boundary summary to include the latest proof slices.

Closes #743.

## Validation

- `pnpm run build:docs` — 1.568s
- `pnpm run format:check` — 0.590s
- `pnpm run lint` — 0.223s
- `pnpm run typecheck` — 2.253s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-stack-translation.test.ts packages/runtime/src/__tests__/native-dwarf-pointer-classification.test.ts packages/runtime/src/__tests__/native-return-chain.test.ts packages/runtime/src/__tests__/native-target-module-bytes.test.ts packages/runtime/src/__tests__/native-register-translation.test.ts packages/runtime/src/__tests__/native-support-boundary.test.ts` — 0.468s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.061s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.357s
