### PR TITLE
Document portable machine hardening

### DIFF
--- a/docs/snapshot/portable-machine-snapshot.md
+++ b/docs/snapshot/portable-machine-snapshot.md
@@ -52,7 +52,11 @@ native-process/
 `validatePortableMachineSnapshotBundle()`. The embedded native process image is
 validated with the existing native-process-image validator, and its
 `capture.sourceArch` / `target.arch` must match the portable machine manifest.
-Paths are bundle-relative and may not escape the bundle root.
+Paths are bundle-relative and may not escape the bundle root. The bundle remains
+file/fd-backed: large payloads live in bundle files (`native-memory.bin`, target
+continuation bytes, descriptors, and logs) that the loader opens by path or file
+descriptor. The manifest records provenance instead of embedding an in-memory
+sidecar runtime.
 
 A local wrapper can create this bundle from an existing native process image:
 
@@ -81,8 +85,29 @@ is `cross-isa-vmstate-restore-unsupported`.
 The refusal is intentional: whole-VM `.vmstate` remains same-ISA only. Cross-ISA
 restore must go through the portable machine snapshot ladder.
 
+## Hardening gates
+
+Portable-machine restore success requires all of the following:
+
+- raw cross-ISA `.vmstate` replay remains refused with
+  `cross-isa-vmstate-restore-unsupported`;
+- manifest `capture.sourceArch`, native-process `capture.sourceArch`, and target
+  `arch` agree with the portable-machine source/target arches;
+- bundle paths stay inside the bundle root;
+- restore descriptors carry explicit schema/versioned sections and reject
+  malformed, missing, duplicate, or unsupported sections before trampoline args
+  are built;
+- target bytes, executable mappings, and file resources carry build-id, sha256,
+  path, offset, and permission provenance where applicable;
+- descriptor consumption is a completion gate: `migrationCompleted=true` is
+  reported only after `descriptorGateCompleted=true`, target-native execution
+  completes, and every relevant target-native consumption result passes;
+- failed native consumption markers, missing sections, or malformed descriptors
+  keep the proof in a refused/not-completed state.
+
 ## Non-claims
 
-This boundary does not yet implement the target VM restore loader, target memory
-materialization, or end-to-end VM-level restore. Those are tracked in follow-up
-issues #585 through #589.
+This boundary does not claim general arbitrary-process migration. The supported
+class is limited to the proof profiles and fail-closed boundaries documented in
+[Portable machine VM restore proof](./portable-machine-vm-restore-proof.md) and
+[Portable machine proof profiles](./portable-machine-proof-profiles.md).

--- a/goal.md
+++ b/goal.md
@@ -236,17 +236,17 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### J. Portable machine snapshot and target VM restore hardening
 
-- [~] Keep raw cross-ISA `.vmstate` restore refused as
-  `cross-isa-vmstate-restore-unsupported`.
-- [ ] Keep portable-machine snapshots fd-backed.
-- [ ] Refuse target execution when manifest `capture.sourceArch` /
+- [x] Keep raw cross-ISA `.vmstate` restore refused as
+      `cross-isa-vmstate-restore-unsupported`.
+- [x] Keep portable-machine snapshots fd-backed.
+- [x] Refuse target execution when manifest `capture.sourceArch` /
       `target.arch` mismatches are detected.
-- [ ] Preserve descriptor, byte, and provenance hashes for every target-native
+- [x] Preserve descriptor, byte, and provenance hashes for every target-native
       continuation and restore section.
-- [ ] Add descriptor schema/version tests for every new restore section.
-- [ ] Keep target-loader completion gated on descriptor consumption and native
+- [x] Add descriptor schema/version tests for every new restore section.
+- [x] Keep target-loader completion gated on descriptor consumption and native
       marker success.
-- [ ] Add negative VM proof tests for malformed descriptors, missing sections,
+- [x] Add negative VM proof tests for malformed descriptors, missing sections,
       unsupported versions, and failed native markers.
 
 ### K. Automation and reporting


### PR DESCRIPTION
## Problem

The portable-machine hardening checklist was still open. The code already validates arches, bundle paths, descriptors, and completion gates, but the docs did not collect those gates in one place.

## Solution

This documents that portable-machine bundles stay file/fd-backed, raw cross-ISA vmstate replay remains refused, source/target arch mismatches fail before target execution, descriptor sections are schema/version gated, provenance is preserved, and `migrationCompleted=true` requires descriptor consumption plus successful target-native gates.

Closes #745.

## Validation

- `pnpm run build:docs` — 1.786s
- `pnpm run format:check` — 0.700s
- `pnpm run lint` — 0.230s
- `pnpm run typecheck` — 2.462s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/portable-machine-snapshot.test.ts packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts packages/runtime/src/__tests__/target-guest-restore-loader.test.ts packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts` — 14.591s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.920s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.580s
