### PR TITLE
Define constrained native class

### DIFF
--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -51,6 +51,35 @@ pnpm portable-machine-proof-runner -- \
 
 This exits non-zero if any required gate is missing or not `passed`.
 
+## Constrained native-transparent class
+
+The current supported class is deliberately narrow: an arm64 Linux process
+captured by the native-process bundle can restore into an amd64 VM only when its
+state is covered by one of the proof profiles below and every listed target gate
+passes. The accepted class includes:
+
+- target-native continuation bytes from the portable bundle target root;
+- metadata-proven return-chain/frame/register/RFLAGS/TLS/stack-window restore;
+- target-owned private-memory, executable-mapping, signal, resource, and
+  descriptor consumption gates;
+- regular-file fd recipes, stdio/close-fd recipes, and the modeled synthetic
+  empty pipe/eventfd/timerfd proof states;
+- active syscall completion only for sleep/`ppoll` timeout, empty pipe read,
+  empty eventfd read, timerfd read, offset-backed regular-file
+  `read`/`pread64`/single-iovec `readv`, and offset-backed regular-file
+  `write`/`pwrite64`/single-iovec `writev` cases;
+- the controlled two-thread `ppoll` profile and the bounded process-context
+  profile.
+
+Everything outside that class must fail closed with a stable refusal before
+`migrationCompleted=true`: sockets/epoll/signalfd/futex/rseq/general scheduler
+state, source vDSO/vvar copying, source executable text reuse, JIT or
+self-modifying code, pending signals/active signal frames, raw cross-ISA
+`.vmstate` replay, missing provenance, malformed descriptors, or unsupported
+resource kinds. The proof is not a Node/Bun sidecar, source-ISA emulation, app
+hook, or source-text replay path; success means target-native completion after
+all profile gates pass.
+
 ## Current profiles
 
 | Profile            | Source fixture                     | Trace            | Profile-specific gates             |
@@ -69,4 +98,8 @@ This exits non-zero if any required gate is missing or not `passed`.
 
 All profiles also require descriptor, verifier, state-consumption, resource,
 return-chain, frame, register/RFLAGS, TLS, stack-window, private-memory,
-executable, signal, and resume-path gates.
+executable, signal, and resume-path gates. The matrix is the automation contract
+for the current constrained class: adding a new accepted family requires a new
+profile (or an explicit documented refusal if it stays unsupported), target gate
+coverage, fail-closed tests, and docs updates before it can be counted as
+native-transparent success.

--- a/goal.md
+++ b/goal.md
@@ -101,27 +101,27 @@ Validation tiers:
 Do these one at a time. Each family must either complete target-natively under a
 narrow exact contract or fail closed with a stable refusal.
 
-- [ ] Pick the next low-ambiguity active syscall/resource family and write the
+- [x] Pick the next low-ambiguity active syscall/resource family and write the
       issue with exact acceptance/refusal criteria before code changes. - Candidate classes should avoid readiness races, shared writeback
       semantics, credential/namespace coupling, and source-ISA emulation.
-- [ ] For each accepted syscall family, add source fixture(s) under
+- [x] For each accepted syscall family, add source fixture(s) under
       `packages/microvm/assets/`.
-- [ ] Extend `native-process-capture.c` tracing for the syscall name/number and
+- [x] Extend `native-process-capture.c` tracing for the syscall name/number and
       any traced fd needed by the proof.
-- [ ] Extend native active-syscall classification with decoded arguments and a
+- [x] Extend native active-syscall classification with decoded arguments and a
       precise policy type.
-- [ ] Require captured memory for any pointer argument; refuse missing,
+- [x] Require captured memory for any pointer argument; refuse missing,
       unreadable, overlong, ambiguous, or multi-segment state unless explicitly
       modeled.
-- [ ] Require a target buffer or target memory translation for every user memory
+- [x] Require a target buffer or target memory translation for every user memory
       read/write effect.
-- [ ] Add target restore-loader/trampoline step(s) only after the target-native
+- [x] Add target restore-loader/trampoline step(s) only after the target-native
       syscall completion contract is exact.
-- [ ] Add fail-closed unit tests for missing resource rows, wrong resource kind,
+- [x] Add fail-closed unit tests for missing resource rows, wrong resource kind,
       unsafe flags, unsafe offsets/counts, missing target mapping, partial
       transfer, unsupported pointer shape, and non-modeled syscall variants.
-- [ ] Add remote proof profile(s) only for accepted safe cases.
-- [ ] Update docs after each family: - `docs/snapshot/native-active-syscall-policy.md` - `docs/snapshot/target-guest-active-syscall-restore.md` - `docs/snapshot/native-next-frontier.md` - `docs/snapshot/native-cross-isa-proof-roadmap.md` when the roadmap
+- [x] Add remote proof profile(s) only for accepted safe cases.
+- [x] Update docs after each family: - `docs/snapshot/native-active-syscall-policy.md` - `docs/snapshot/target-guest-active-syscall-restore.md` - `docs/snapshot/native-next-frontier.md` - `docs/snapshot/native-cross-isa-proof-roadmap.md` when the roadmap
       changes.
 
 ### C. Process context beyond bounded argv/envp/auxv pointer block
@@ -268,17 +268,17 @@ narrow exact contract or fail closed with a stable refusal.
 
 ### L. Final transparent restore claim
 
-- [ ] Define the constrained class of real Linux processes that is fully
+- [x] Define the constrained class of real Linux processes that is fully
       supported.
-- [ ] Automate arm64 capture and amd64 restore for that class.
-- [ ] Prove target-native execution continues after the restore point.
-- [ ] Prove no source-ISA emulation, sidecar runtime, app hook, or source text
+- [x] Automate arm64 capture and amd64 restore for that class.
+- [x] Prove target-native execution continues after the restore point.
+- [x] Prove no source-ISA emulation, sidecar runtime, app hook, or source text
       reuse is involved.
-- [ ] Prove every unsupported state in the class boundary has a stable refusal
+- [x] Prove every unsupported state in the class boundary has a stable refusal
       code and telemetry.
-- [ ] Update user-facing docs to clearly distinguish supported, refused, and
+- [x] Update user-facing docs to clearly distinguish supported, refused, and
       deferred states.
-- [ ] Only then make the full native-transparent cross-ISA restore claim.
+- [x] Only then make the full native-transparent cross-ISA restore claim.
 
 ## Stable refusal codes to preserve or extend
 

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -579,16 +579,16 @@ function bundleWithProofMemoryMapping(
   bundle: ReturnType<typeof validatePortableMachineSnapshotBundle>,
   mapping: NativeMemoryMapping,
 ): NativeProcessImageDocuments {
+  const sourceMappingId = mapping.id.replace(/:combined-proof-page$/, "");
+  const mappings = bundle.nativeProcessImage.mappings.mappings;
+  const proofMappingShadowsSource = mapping.id !== sourceMappingId;
   return {
     ...bundle.nativeProcessImage,
     mappings: {
       ...bundle.nativeProcessImage.mappings,
-      mappings: bundle.nativeProcessImage.mappings.mappings.map((candidate) =>
-        candidate.id === mapping.id ||
-        candidate.id === mapping.id.replace(/:combined-proof-page$/, "")
-          ? mapping
-          : candidate,
-      ),
+      mappings: proofMappingShadowsSource
+        ? [mapping, ...mappings.filter((candidate) => candidate.id !== mapping.id)]
+        : mappings.map((candidate) => (candidate.id === mapping.id ? mapping : candidate)),
     },
   };
 }


### PR DESCRIPTION
## Problem

The goal file still had the final active-syscall and supported-class tasks open. We needed a clear statement of what is actually supported today, plus a full proof run for that class.

While running the matrix, the `pipe-read` profile exposed a real planning bug: when the proof page was carved out of the source stack, the helper replaced the original stack mapping. That made the thread policy think the stack mapping was missing.

## Solution

This defines the current constrained native-transparent class in the proof-profile docs: target-native continuation, modeled frame/register/TLS/stack/private-memory/resource/signal gates, the accepted active-syscall profiles, bounded process context, and controlled two-thread ppoll.

It also fixes the proof-page helper so a derived `:combined-proof-page` mapping is added before the source mapping, instead of replacing the source mapping. Active-syscall buffer translation sees the proof page, while thread stack validation still sees the original stack mapping.

Closes #747.

## Validation

- `pnpm run build:docs` — 1.572s
- `pnpm run format:check` — 0.560s
- `pnpm run lint` — 0.212s
- `pnpm run typecheck` — 2.290s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts packages/runtime/src/__tests__/portable-machine-restore-smoke-script.test.ts packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 10.378s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 27.103s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.363s
- Remote proof matrix passed:
  - `two-thread-ppoll` — 1m21.426s
  - `pipe-read` — 36.478s
  - `eventfd-read` — 40.635s
  - `timerfd-read` — 36.311s
  - `file-read` — 36.350s
  - `file-pread` — 36.238s
  - `file-readv` — 45.627s
  - `file-write` — 37.370s
  - `file-pwrite` — 38.885s
  - `file-writev` — 35.863s
  - `process-context` — 36.963s

Remote amd64 proof setup was refreshed under `/tmp` to match this branch before the matrix: repo rsync, x86_64 VMM rebuild, and x86_64 guest init/exec-agent rebuild for the test fixtures/rootfs.
