### PR TITLE
Harden fail-closed native state boundaries

### DIFF
--- a/docs/snapshot/native-active-syscall-policy.md
+++ b/docs/snapshot/native-active-syscall-policy.md
@@ -115,8 +115,8 @@ Active futex syscalls now fail closed with `futex-state-unsupported` instead of
 falling through to a generic active-syscall refusal. The refusal records decoded
 futex arguments when available (`uaddr`, operation, timeout, or `futex_waitv`
 waiter-vector arguments) and names the unsupported kernel state: futex word race,
-wait-queue membership, wake/requeue ordering, and robust-list owner-death
-semantics.
+wait-queue membership, wake/requeue ordering, timeout accounting, robust-list
+owner-death semantics, and priority-inheritance futex ownership.
 
 This is refusal tightening only. No futex wait is restarted, emulated, or treated
 as target-native success.

--- a/docs/snapshot/native-arbitrary-boundary.md
+++ b/docs/snapshot/native-arbitrary-boundary.md
@@ -42,8 +42,20 @@ bounded by metadata-proven translated frames:
 | frame/register state              | translated target frame pointer, stack pointer, instruction pointer, RFLAGS, TLS/TCB, and modeled callee-saved slots; missing or unsafe slots refuse |
 | pointer-shaped stack/heap words   | classified as pointer, code pointer, thread pointer, or integer through metadata; ambiguous values refuse                                            |
 | stack frame metadata              | DWARF/sidecar/unwind metadata required for every accepted frame; optimized-away/missing metadata refuses                                             |
-| JIT or self-modifying code        | refused until runtime code provenance and invalidation rules are modeled                                                                             |
+| JIT or self-modifying code        | refused until runtime code provenance, target build identity, code-cache lifetime, permission-transition, and invalidation rules are modeled         |
 | signal trampoline/alt-stack frame | refused unless decoded by a future signal-frame model                                                                                                |
+
+## JIT and self-modifying-code refusal
+
+Writable+executable memory, executable anonymous mappings, target text whose
+build-id/sha256/path provenance is missing or mismatched, and code pointers into
+unowned regions remain outside the accepted class. A future JIT model would need
+runtime metadata for each generated code range, target-native code generation or
+verification, cache invalidation rules, permission-transition history, and a way
+to prove no captured source-ISA text is reused as target code. Until then these
+states refuse with `mapping-executable-unsupported`,
+`mapping-permission-unsupported`, `mapping-provenance-ambiguous`, or
+`target-build-mismatch`.
 
 ## No overclaiming
 

--- a/docs/snapshot/native-nonfile-resource-boundary.md
+++ b/docs/snapshot/native-nonfile-resource-boundary.md
@@ -40,6 +40,13 @@ captured-regular-file-coexists-with-precise-nonfile-resource-refusals
 | raw socket            | refuse unless a raw-socket broker capability is supplied | `resource-kind-unsupported` |
 | unknown fd            | refuse                                                   | `fd-kind-unsupported`       |
 
+The refusal detail records the missing model. Socket resources require
+accept/connect/listen queues, peer identity, credentials, namespaces, options,
+shutdown/readiness, and partial-transfer state. Epoll resources require interest
+lists, ready-list ordering, edge-triggered delivery state, nested epoll, and
+wakeup ordering. signalfd resources require pending signal queues, siginfo
+payload ownership, delivery ordering, and signal-mask coordination.
+
 ## Next broker candidates
 
 The first broker candidates are PTYs and raw sockets because the existing resource translator already has capability gates for those recipe shapes. Pipes, sockets, epoll, eventfd, timerfd, and signalfd carry kernel state that must be modeled or brokered before transparent restore can safely claim support.

--- a/docs/snapshot/target-guest-executable-materialization.md
+++ b/docs/snapshot/target-guest-executable-materialization.md
@@ -13,9 +13,12 @@ artifacts.
 
 Executable mappings that would copy captured source bytes refuse with
 `mapping-executable-unsupported`. Executable mappings without target-file
-build/hash provenance refuse with `mapping-provenance-ambiguous`. On target, the
-amd64 trampoline now checks the native executable-mapping section against the
-actual target code path, address, size, file offset, safe execute/private flags,
-and build-id or sha256 provenance before reporting the mapping as consumed.
-Non-executable private data is ignored here and handled by the private-memory
-restore path.
+build/hash provenance refuse with `mapping-provenance-ambiguous`, and mismatched
+target build identity refuses with `target-build-mismatch` before descriptor
+completion. Anonymous executable mappings, JIT code, and self-modifying text stay
+outside this model until target-native code provenance and invalidation rules are
+explicit. On target, the amd64 trampoline now checks the native
+executable-mapping section against the actual target code path, address, size,
+file offset, safe execute/private flags, and build-id or sha256 provenance before
+reporting the mapping as consumed. Non-executable private data is ignored here
+and handled by the private-memory restore path.

--- a/docs/snapshot/target-guest-memory-materialization.md
+++ b/docs/snapshot/target-guest-memory-materialization.md
@@ -13,11 +13,14 @@ emits descriptor entries for only two safe cases:
 
 Executable source mappings are refused with `mapping-executable-unsupported`
 unless a separate target-module materialization proof supplies target-native
-bytes. This keeps source text from becoming target code. Shared mappings are
-refused with `mapping-shared-unsupported` until an explicit shared-resource
-recipe exists. Captured bytes must come from `native-memory.bin`; ambiguous
-provenance returns `mapping-provenance-ambiguous`, and partial/out-of-range
-captures return `mapping-captured-range-unsupported`.
+bytes. This keeps source text from becoming target code. Source vDSO, vvar, and
+special mapping bytes are also refused with `vdso-policy-unsupported`; the target
+kernel owns those mappings and they must be recreated or verified on the target,
+not copied from the source. Shared mappings are refused with
+`mapping-shared-unsupported` until an explicit shared-resource recipe exists.
+Captured bytes must come from `native-memory.bin`; ambiguous provenance returns
+`mapping-provenance-ambiguous`, and partial/out-of-range captures return
+`mapping-captured-range-unsupported`.
 
 The target guest loader forwards memory descriptor entries to the native resume
 trampoline, and the trampoline maps those ranges before the target continuation

--- a/goal-2.md
+++ b/goal-2.md
@@ -64,16 +64,16 @@ unless a later task adds an exact model and proof.
 
 ## A. Refusal taxonomy and negative profile automation
 
-- [ ] Add an `expectedResult: "refusal"` path to proof-profile automation that
+- [x] Add an `expectedResult: "refusal"` path to proof-profile automation that
       can assert exact refusal code, target gate values, and
       `migrationCompleted=false` for negative profiles.
-- [ ] Add profile-matrix fields for unsafe-state family, required refusal code,
+- [x] Add profile-matrix fields for unsafe-state family, required refusal code,
       and whether descriptor consumption is expected to be attempted.
-- [ ] Add summary checks that fail if a negative profile reaches target-native
+- [x] Add summary checks that fail if a negative profile reaches target-native
       success or sets `migrationCompleted=true`.
-- [ ] Document the negative-profile contract in
+- [x] Document the negative-profile contract in
       `docs/snapshot/portable-machine-proof-profiles.md`.
-- [ ] Add a refusal-code inventory table covering all codes used by this goal,
+- [x] Add a refusal-code inventory table covering all codes used by this goal,
       with owner docs and test files.
 
 ## B. Socket state remains refused
@@ -81,14 +81,14 @@ unless a later task adds an exact model and proof.
 - [!] Keep sockets refused until accept/connect/listen queues, peer identity,
   credentials, namespaces, socket options, shutdown state, readiness, and
   partial transfer state are modeled or brokered.
-- [ ] Add negative tests for captured listening sockets, connected socketpairs,
+- [x] Add negative tests for captured listening sockets, connected socketpairs,
       in-flight `accept`/`accept4`, in-flight `connect`, and transfer syscalls
       with ancillary-data-shaped arguments.
-- [ ] Ensure generic `read`/`readv`/`write`/`writev` on socket resources always
+- [x] Ensure generic `read`/`readv`/`write`/`writev` on socket resources always
       returns `target-socket-syscall-state-unsupported` with fd/resource detail.
-- [ ] Add or document a negative proof profile for active socket transfer that
+- [x] Add or document a negative proof profile for active socket transfer that
       proves `migrationCompleted=false`.
-- [ ] Update socket refusal docs with queue/peer/credential/namespace fields
+- [x] Update socket refusal docs with queue/peer/credential/namespace fields
       that must be modeled before support can be claimed.
 
 ## C. Epoll state remains refused
@@ -96,13 +96,13 @@ unless a later task adds an exact model and proof.
 - [!] Keep epoll refused until interest lists, ready-list ordering,
   edge-triggered delivery state, nested epoll semantics, wakeups, and target
   fd mapping are modeled.
-- [ ] Add negative tests for epoll resources with multiple watched fds,
+- [x] Add negative tests for epoll resources with multiple watched fds,
       edge-triggered flags, nested epoll, and active `epoll_wait` /
       `epoll_pwait` / `epoll_pwait2`.
-- [ ] Ensure active epoll waits return
+- [x] Ensure active epoll waits return
       `target-epoll-syscall-state-unsupported` with decoded timeout/event/fd
       detail when arguments are available.
-- [ ] Add or document a negative proof profile for active epoll wait refusal.
+- [x] Add or document a negative proof profile for active epoll wait refusal.
 
 ## D. signalfd and pending signal queues remain refused
 
@@ -110,12 +110,12 @@ unless a later task adds an exact model and proof.
   ownership, delivery ordering, and signal-mask coordination are modeled.
 - [!] Keep pending signals, active signal-delivery stops, signal trampoline
   frames, and active alt-stacks refused by default.
-- [ ] Add negative tests for pending per-thread/process signals, queued siginfo,
+- [x] Add negative tests for pending per-thread/process signals, queued siginfo,
       signalfd masks, active signal frames, active alt-stack state, and malformed
       signal masks.
-- [ ] Ensure active signalfd reads return `target-signalfd-state-unsupported`
+- [x] Ensure active signalfd reads return `target-signalfd-state-unsupported`
       with queue/mask/siginfo detail.
-- [ ] Add or document a negative proof profile for signalfd read refusal.
+- [x] Add or document a negative proof profile for signalfd read refusal.
 
 ## E. Futex, rseq, and scheduler state remain refused
 
@@ -126,12 +126,12 @@ unless a later task adds an exact model and proof.
   translation, critical-section state, and TLS ownership are modeled.
 - [!] Keep general scheduler state refused until runnable/blocked relationships,
   priorities, affinity, robust lists, and cross-thread ordering are explicit.
-- [ ] Add negative tests for active `futex`, `futex_time64`, `futex_waitv`,
+- [x] Add negative tests for active `futex`, `futex_time64`, `futex_waitv`,
       robust-list metadata, captured futex resources, and unsupported rseq state.
-- [ ] Ensure futex refusals use `futex-state-unsupported` with required-model
+- [x] Ensure futex refusals use `futex-state-unsupported` with required-model
       detail and rseq refusals use `rseq-state-unsupported` with TLS/abort-IP
       detail.
-- [ ] Add or document negative proof profiles for futex/rseq refusal where a
+- [x] Add or document negative proof profiles for futex/rseq refusal where a
       deterministic fixture is practical.
 
 ## F. Interrupted syscall and restart state remains refused
@@ -140,24 +140,24 @@ unless a later task adds an exact model and proof.
   `restart_syscall` refused unless a family-specific model proves remaining
   time, restart/result contract, signal mask delivery, and target rearm
   policy.
-- [ ] Add negative tests for restart-block thread state, `restart_syscall`,
+- [x] Add negative tests for restart-block thread state, `restart_syscall`,
       interrupted blocking syscalls without modeled remaining time, and non-null
       signal masks for poll-style syscalls.
-- [ ] Ensure refusal detail names the missing remaining-time and restart/result
+- [x] Ensure refusal detail names the missing remaining-time and restart/result
       model.
-- [ ] Add or document a negative proof profile for restart-state refusal.
+- [x] Add or document a negative proof profile for restart-state refusal.
 
 ## G. JIT and self-modifying code remain refused
 
 - [!] Keep writable+executable memory, anonymous executable code, JIT code,
   self-modifying text, and code without target build identity refused.
-- [ ] Add tests for writable+executable mappings, executable anonymous mappings,
+- [x] Add tests for writable+executable mappings, executable anonymous mappings,
       changed text hashes, missing build-id/sha256/path provenance, and code
       pointers into unowned regions.
-- [ ] Ensure refusals distinguish `mapping-executable-unsupported`,
+- [x] Ensure refusals distinguish `mapping-executable-unsupported`,
       `mapping-permission-unsupported`, `mapping-provenance-ambiguous`, and
       `target-build-mismatch`.
-- [ ] Document the exact runtime metadata required before any JIT/self-modifying
+- [x] Document the exact runtime metadata required before any JIT/self-modifying
       code support can be considered.
 
 ## H. Source vDSO/vvar and target libc special state are target-owned or refused
@@ -166,22 +166,22 @@ unless a later task adds an exact model and proof.
   target vDSO/vvar mappings.
 - [!] Keep unsafe auxv pointers such as `AT_RANDOM`, `AT_EXECFN`, `AT_BASE`, and
   `AT_SYSINFO_EHDR` refused unless target ownership is explicit.
-- [ ] Add tests proving source vDSO/vvar pages cannot appear in copied target
+- [x] Add tests proving source vDSO/vvar pages cannot appear in copied target
       memory or executable mapping descriptors.
-- [ ] Add tests proving refused auxv entries are not copied into target initial
+- [x] Add tests proving refused auxv entries are not copied into target initial
       stack materialization.
-- [ ] Document target-owned recreate/verify policy for any special mapping that
+- [x] Document target-owned recreate/verify policy for any special mapping that
       remains visible after restore.
 
 ## I. Raw cross-ISA VM state remains refused
 
 - [!] Keep raw arm64 `.vmstate` restore into amd64 refused with
   `cross-isa-vmstate-restore-unsupported`.
-- [ ] Add negative tests for manifests or CLI paths that try to mark raw
+- [x] Add negative tests for manifests or CLI paths that try to mark raw
       cross-ISA VM state as translated, replayed, emulated, or successful.
-- [ ] Ensure refusal detail names source arch, target arch, and required portable
+- [x] Ensure refusal detail names source arch, target arch, and required portable
       machine process-restore path.
-- [ ] Document that raw whole-VM state remains same-ISA only unless a future
+- [x] Document that raw whole-VM state remains same-ISA only unless a future
       target-native machine-state model exists.
 
 ## J. Descriptor, manifest, and provenance ambiguity remains refused
@@ -189,12 +189,12 @@ unless a later task adds an exact model and proof.
 - [!] Keep malformed descriptors, missing restore sections, duplicate sections,
   unsupported resource recipes, path escapes, arch mismatches, and failed
   native gate markers refused.
-- [ ] Add negative tests for every restore section added by future work.
-- [ ] Add negative proof profiles for malformed descriptor and failed native gate
+- [x] Add negative tests for every restore section added by future work.
+- [x] Add negative proof profiles for malformed descriptor and failed native gate
       markers that assert `migrationCompleted=false`.
-- [ ] Ensure descriptor/provenance hashes are checked before target-native
+- [x] Ensure descriptor/provenance hashes are checked before target-native
       completion is reported.
-- [ ] Keep target-loader completion gated on descriptor consumption and all
+- [x] Keep target-loader completion gated on descriptor consumption and all
       relevant native restore results.
 
 ## K. Final done criteria for Goal 2

--- a/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-active-syscall-policy.test.ts
@@ -107,10 +107,17 @@ function arm64SocketThread(
 }
 
 function arm64SocketTransferThread(
-  name: "recvfrom" | "recvmsg" | "sendto" | "sendmsg",
+  name: "recvfrom" | "recvmsg" | "recvmmsg" | "sendto" | "sendmsg" | "sendmmsg",
   x: string[] = ["0x28", "0x4100", "0x20", "0x0", "0x0", "0x0"],
 ): NativeThreadState {
-  const numbers = { recvfrom: 207, recvmsg: 212, sendto: 206, sendmsg: 211 };
+  const numbers = {
+    recvfrom: 207,
+    recvmsg: 212,
+    recvmmsg: 243,
+    sendto: 206,
+    sendmsg: 211,
+    sendmmsg: 269,
+  };
   return arm64SleepThread({ state: "inside-syscall", number: numbers[name], name }, x);
 }
 
@@ -122,10 +129,11 @@ function arm64EpollThread(
 }
 
 function arm64FutexThread(
-  name: "futex" | "futex_waitv" = "futex",
+  name: "futex" | "futex_time64" | "futex_waitv" = "futex",
   x: string[] = ["0x5000", "0x0", "0x1", "0x0", "0x0", "0x0"],
 ): NativeThreadState {
-  return arm64SleepThread({ state: "inside-syscall", number: 98, name }, x);
+  const numbers = { futex: 98, futex_time64: 422, futex_waitv: 449 };
+  return arm64SleepThread({ state: "inside-syscall", number: numbers[name], name }, x);
 }
 
 function documentsWithTimespec(options: {
@@ -1608,7 +1616,36 @@ describe("native active syscall classification", () => {
           futexSyscall: {
             name: "futex",
             arguments: { source: "registers", uaddr: "0x5000", operation: "0x80" },
-            unsupportedState: expect.arrayContaining(["kernel wait queue membership"]),
+            unsupportedState: expect.arrayContaining([
+              "kernel wait queue membership",
+              "timeout accounting",
+              "priority-inheritance futex ownership",
+            ]),
+          },
+        },
+      },
+    });
+  });
+
+  it("refuses futex_time64 with timeout argument detail", () => {
+    const activeThread = arm64FutexThread("futex_time64", [
+      "0x5000",
+      "0x80",
+      "0x1",
+      "0x6000",
+      "0x0",
+      "0x0",
+    ]);
+    const result = classifyNativeActiveSyscalls([activeThread]);
+
+    expect(result.classifications[0]).toMatchObject({
+      class: "futex-wait",
+      refusal: {
+        code: "futex-state-unsupported",
+        detail: {
+          futexSyscall: {
+            name: "futex_time64",
+            arguments: { source: "registers", timeoutPointer: "0x6000" },
           },
         },
       },
@@ -1754,7 +1791,7 @@ describe("native active syscall classification", () => {
     },
   );
 
-  it.each(["recvfrom", "recvmsg", "sendto", "sendmsg"] as const)(
+  it.each(["recvfrom", "recvmsg", "recvmmsg", "sendto", "sendmsg", "sendmmsg"] as const)(
     "refuses active socket transfer syscall %s with socket-specific detail",
     (name) => {
       const activeThread = arm64SocketTransferThread(name);
@@ -1855,6 +1892,72 @@ describe("native active syscall classification", () => {
     });
   });
 
+  it("decodes ancillary-data-shaped socket message arguments but still refuses them", () => {
+    const activeThread = arm64SocketTransferThread("sendmmsg", [
+      "0x28",
+      "0x5100",
+      "0x3",
+      "0x40",
+      "0x0",
+      "0x0",
+    ]);
+    const result = classifyNativeActiveSyscalls([activeThread], {
+      documents: documentsWithSocketResource(activeThread),
+    });
+
+    expect(result.classifications[0]).toMatchObject({
+      refusal: {
+        code: "target-socket-syscall-state-unsupported",
+        detail: {
+          socketSyscall: {
+            family: "socket-transfer",
+            arguments: {
+              source: "registers",
+              fd: 40,
+              messagePointer: "0x5100",
+              messageCount: "0x3",
+              flags: 64,
+            },
+            unsupportedState: expect.arrayContaining(["partial transfer and ancillary data state"]),
+          },
+        },
+      },
+    });
+  });
+
+  it.each(["epoll_wait", "epoll_pwait", "epoll_pwait2"] as const)(
+    "keeps active %s fail-closed with timeout and signal-mask detail",
+    (name) => {
+      const activeThread = arm64EpollThread(name, [
+        "0x30",
+        "0x4100",
+        "0x4",
+        "0xffffffff",
+        "0x5200",
+        "0x8",
+      ]);
+      const result = classifyNativeActiveSyscalls([activeThread], {
+        documents: documentsWithKernelFdResource(activeThread, 48, "epoll"),
+      });
+
+      expect(result.classifications[0]).toMatchObject({
+        refusal: {
+          code: "target-epoll-syscall-state-unsupported",
+          detail: {
+            epollSyscall: {
+              arguments: expect.objectContaining({
+                epfd: 48,
+                eventsPointer: "0x4100",
+                timeoutMs: "0xffffffff",
+              }),
+              unsupportedState: expect.arrayContaining(["edge-triggered delivery state"]),
+            },
+          },
+        },
+      });
+    },
+  );
+
   it("classifies fd-blocking syscalls separately from sleep timers", () => {
     const result = classifyNativeActiveSyscalls([
       thread({ state: "inside-syscall", number: 63, name: "read" }),
@@ -1873,7 +1976,16 @@ describe("native active syscall classification", () => {
 
     expect(result.classifications[0]).toMatchObject({
       class: "restart",
-      refusal: { code: "syscall-restart-unsupported" },
+      refusal: {
+        code: "syscall-restart-unsupported",
+        detail: {
+          requiredModel: expect.arrayContaining([
+            "remaining time accounting",
+            "restart/result contract",
+            "signal mask delivery",
+          ]),
+        },
+      },
     });
   });
 

--- a/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
+++ b/packages/runtime/src/__tests__/native-mapping-materialization.test.ts
@@ -199,6 +199,45 @@ describe("native mapping materialization", () => {
     expect(result.steps[0]).toMatchObject({ action: "refuse" });
   });
 
+  it("refuses source vDSO/vvar/special bytes instead of translating target-owned mappings", () => {
+    const result = planNativeMappingMaterialization({
+      memorySizeBytes: 8192,
+      mappings: [
+        mapping({
+          id: "mapping:vdso-copy",
+          kind: "vdso",
+          permissions: { read: true, write: false, execute: true, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x75000000" },
+        }),
+        mapping({
+          id: "mapping:vvar-copy",
+          kind: "vvar",
+          permissions: { read: true, write: false, execute: false, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 4096, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x75001000" },
+        }),
+      ],
+    });
+
+    expect(result.steps).toEqual([
+      expect.objectContaining({
+        mapping: "mapping:vdso-copy",
+        action: "refuse",
+        refusal: expect.objectContaining({
+          code: "vdso-policy-unsupported",
+          detail: expect.objectContaining({ sourceBytesCopied: false, targetOwned: true }),
+        }),
+      }),
+      expect.objectContaining({
+        mapping: "mapping:vvar-copy",
+        action: "refuse",
+        refusal: expect.objectContaining({ code: "vdso-policy-unsupported" }),
+      }),
+    ]);
+    expect(result.steps.some((step) => step.sourceBytes)).toBe(false);
+  });
+
   it("refuses executable target files without build or hash provenance", () => {
     const result = planNativeMappingMaterialization({
       memorySizeBytes: 0,

--- a/packages/runtime/src/__tests__/native-resource-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-resource-translation.test.ts
@@ -202,6 +202,85 @@ describe("native resource translation", () => {
     ]);
   });
 
+  it("records required models for sockets, epoll, and signalfd before target execution", () => {
+    const result = translateNativeResources({
+      resources: [
+        {
+          id: "fd:listen",
+          kind: "socket",
+          state: "captured",
+          fd: 20,
+          path: "socket:[listen]",
+          recipe: { socketState: "listen", queuedConnections: 1 },
+        },
+        {
+          id: "fd:socketpair",
+          kind: "socket",
+          state: "captured",
+          fd: 23,
+          path: "socket:[pair]",
+          recipe: { socketState: "connected", peer: "socket:[other]" },
+        },
+        {
+          id: "fd:epoll-nested",
+          kind: "epoll",
+          state: "captured",
+          fd: 21,
+          path: "anon_inode:[eventpoll]",
+          recipe: { watchedFds: [20, 22], nested: true, edgeTriggered: true },
+        },
+        {
+          id: "fd:signalfd",
+          kind: "signalfd",
+          state: "captured",
+          fd: 22,
+          path: "anon_inode:[signalfd]",
+          recipe: { mask: "0x2", queuedSignals: [{ signo: 2 }] },
+        },
+      ],
+    });
+
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "kernel-state-unsupported",
+        detail: expect.objectContaining({
+          id: "fd:listen",
+          requiredModel: expect.arrayContaining([
+            "accept/connect/listen queue state",
+            "credentials and namespaces",
+          ]),
+        }),
+      }),
+      expect.objectContaining({
+        code: "kernel-state-unsupported",
+        detail: expect.objectContaining({
+          id: "fd:socketpair",
+          requiredModel: expect.arrayContaining(["peer endpoint identity"]),
+        }),
+      }),
+      expect.objectContaining({
+        code: "kernel-state-unsupported",
+        detail: expect.objectContaining({
+          id: "fd:epoll-nested",
+          requiredModel: expect.arrayContaining([
+            "interest list",
+            "nested epoll and wakeup ordering",
+          ]),
+        }),
+      }),
+      expect.objectContaining({
+        code: "kernel-state-unsupported",
+        detail: expect.objectContaining({
+          id: "fd:signalfd",
+          requiredModel: expect.arrayContaining([
+            "pending signal queue",
+            "siginfo payload provenance",
+          ]),
+        }),
+      }),
+    ]);
+  });
+
   it("plans a deterministic target fd table and target guest resource recipes", () => {
     const plan = planNativeTargetFdTable({
       inheritedStdio: { mode: "inherit-output" },

--- a/packages/runtime/src/__tests__/native-signal-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-signal-policy.test.ts
@@ -53,14 +53,41 @@ describe("native signal restore policy", () => {
   });
 
   it("refuses pending signals, active signal frames, altstack, and malformed masks", () => {
-    const cases: Array<{ name: string; mutate: (candidate: NativeThreadState) => void }> = [
-      { name: "pending", mutate: (candidate) => (candidate.signal.pending = ["0x1"]) },
-      { name: "active-frame", mutate: (candidate) => (candidate.signal.activeFrame = true) },
+    const cases: Array<{
+      name: string;
+      mutate: (candidate: NativeThreadState) => void;
+      detail: Record<string, unknown>;
+    }> = [
+      {
+        name: "pending",
+        mutate: (candidate) => (candidate.signal.pending = ["0x1"]),
+        detail: {
+          pendingMasks: ["0x1"],
+          requiredModel: expect.arrayContaining(["siginfo ownership", "delivery ordering"]),
+        },
+      },
+      {
+        name: "active-frame",
+        mutate: (candidate) => (candidate.signal.activeFrame = true),
+        detail: {
+          activeFrame: true,
+          requiredModel: expect.arrayContaining(["signal trampoline frame"]),
+        },
+      },
       {
         name: "altstack",
-        mutate: (candidate) => (candidate.signal.altStack = { state: "enabled" }),
+        mutate: (candidate) =>
+          (candidate.signal.altStack = { state: "enabled", sp: "0x7000", sizeBytes: 8192 }),
+        detail: {
+          altStack: { state: "enabled", sp: "0x7000", sizeBytes: 8192 },
+          requiredModel: expect.arrayContaining(["target alt-stack allocation"]),
+        },
       },
-      { name: "malformed", mutate: (candidate) => (candidate.signal.blocked = ["not-hex"]) },
+      {
+        name: "malformed",
+        mutate: (candidate) => (candidate.signal.blocked = ["not-hex"]),
+        detail: { maskKind: "blocked", masks: ["not-hex"] },
+      },
     ];
 
     for (const entry of cases) {
@@ -74,7 +101,12 @@ describe("native signal restore policy", () => {
         entry.name,
       ).toMatchObject({
         state: "refused",
-        refusals: [expect.objectContaining({ code: expect.stringMatching(/^signal-/) })],
+        refusals: [
+          expect.objectContaining({
+            code: expect.stringMatching(/^signal-/),
+            detail: expect.objectContaining({ threadId: candidate.id, ...entry.detail }),
+          }),
+        ],
       });
     }
   });

--- a/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
+++ b/packages/runtime/src/__tests__/native-thread-restore-policy.test.ts
@@ -221,6 +221,30 @@ describe("native thread restore boundary", () => {
       );
     }
   });
+
+  it("refuses general scheduler-visible multi-thread state with required model detail", () => {
+    const result = planNativeThreadRestoreBoundary({
+      threads: [thread("thread:one"), thread("thread:two")],
+      mappings: [stackMapping],
+    });
+
+    expect(result).toMatchObject({
+      state: "refused",
+      refusals: [
+        expect.objectContaining({
+          code: "thread-state-unsupported",
+          detail: expect.objectContaining({
+            targetThreadCount: 2,
+            requiredModel: expect.arrayContaining([
+              "runnable/blocked scheduler relationships",
+              "thread priorities and affinity",
+              "cross-thread ordering",
+            ]),
+          }),
+        }),
+      ],
+    });
+  });
 });
 
 function documentsWithTimespec(activeThread: NativeThreadState): NativeProcessImageDocuments {

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -58,19 +58,22 @@ function completedSummary(remoteSourceTarget = "file-write") {
   };
 }
 
-function refusedSummary(remoteSourceTarget = "socket-transfer-refusal") {
+function refusedSummary(
+  remoteSourceTarget = "socket-transfer-refusal",
+  code = "target-socket-syscall-state-unsupported",
+) {
   return {
     profile: "portable-machine-restore",
     state: "failed",
-    failure: "target restore refused with target-socket-syscall-state-unsupported",
+    failure: `target restore refused with ${code}`,
     remoteSourceTarget,
     targetRestore: {
       state: "refused",
       migrationCompleted: false,
       descriptorGateCompleted: false,
       refusal: {
-        code: "target-socket-syscall-state-unsupported",
-        message: "socket endpoint kernel state is unsupported",
+        code,
+        message: `${remoteSourceTarget} is unsupported`,
       },
       sourceTextReusedAsTargetCode: false,
       sourceIsaEmulationUsed: false,
@@ -79,6 +82,19 @@ function refusedSummary(remoteSourceTarget = "socket-transfer-refusal") {
     timings: [],
   };
 }
+
+const negativeProfiles = [
+  ["socket-transfer-refusal", "target-socket-syscall-state-unsupported"],
+  ["epoll-wait-refusal", "target-epoll-syscall-state-unsupported"],
+  ["signalfd-read-refusal", "target-signalfd-state-unsupported"],
+  ["futex-refusal", "futex-state-unsupported"],
+  ["rseq-refusal", "rseq-state-unsupported"],
+  ["restart-state-refusal", "syscall-restart-unsupported"],
+  ["jit-self-modifying-refusal", "mapping-executable-unsupported"],
+  ["source-vdso-vvar-refusal", "vdso-policy-unsupported"],
+  ["raw-cross-isa-vmstate-refusal", "cross-isa-vmstate-restore-unsupported"],
+  ["descriptor-provenance-refusal", "mapping-provenance-ambiguous"],
+] as const;
 
 describe("portable machine proof runner", () => {
   it("lists every current remote proof profile", () => {
@@ -236,34 +252,44 @@ describe("portable machine proof runner", () => {
     );
   });
 
-  it("checks an expected refusal summary without allowing migration completion", () => {
-    const dir = tempDir();
-    const summaryFile = join(dir, "summary.json");
-    writeFileSync(summaryFile, JSON.stringify(refusedSummary(), null, 2));
+  it.each(negativeProfiles)(
+    "checks expected refusal profile %s without allowing migration completion",
+    (profile, code) => {
+      const dir = tempDir();
+      const summaryFile = join(dir, "summary.json");
+      writeFileSync(summaryFile, JSON.stringify(refusedSummary(profile, code), null, 2));
 
-    const result = spawnSync(
-      "node",
-      [RUNNER, "--profile", "socket-transfer-refusal", "--check-summary", summaryFile, "--json"],
-      {
-        cwd: REPO_ROOT,
-        encoding: "utf8",
-        env: SCRIPT_ENV,
-        timeout: 30_000,
-      },
-    );
+      const result = spawnSync(
+        "node",
+        [RUNNER, "--profile", profile, "--check-summary", summaryFile, "--json"],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          env: SCRIPT_ENV,
+          timeout: 30_000,
+        },
+      );
 
-    expect(result.status, result.stderr).toBe(0);
-    const summary = JSON.parse(result.stdout);
-    expect(summary).toMatchObject({
-      profile: "socket-transfer-refusal",
-      state: "refused",
-      pass: true,
-      gateCheck: { passed: true, failures: [] },
-    });
-    expect(summary.gateCheck.checks).toContainEqual(
-      expect.objectContaining({ label: "targetRestore.migrationCompleted", actual: false }),
-    );
-  });
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        profile,
+        state: "refused",
+        pass: true,
+        gateCheck: { passed: true, failures: [] },
+      });
+      expect(summary.gateCheck.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "refusal.code", actual: code }),
+          expect.objectContaining({ label: "targetRestore.migrationCompleted", actual: false }),
+          expect.objectContaining({
+            label: "targetRestore.descriptorGateCompleted",
+            actual: false,
+          }),
+        ]),
+      );
+    },
+  );
 
   it("rejects a negative profile summary that reports target-native success", () => {
     const dir = tempDir();

--- a/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-restore-proof.test.ts
@@ -389,6 +389,7 @@ describe("portable machine VM restore proof", () => {
     for (const failedObservation of [
       { targetStackWindowMaterializationResult: "failed" as const },
       { targetPrivateMemoryRestoreResult: "failed" as const },
+      { targetExecutableMappingResult: "failed" as const },
       { targetProcessContextRestoreResult: "failed" as const },
       { targetSignalRestoreResult: "failed" as const },
       { targetActiveSyscallRestoreResult: "failed" as const },

--- a/packages/runtime/src/__tests__/portable-machine-snapshot.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-snapshot.test.ts
@@ -326,14 +326,17 @@ describe("portable machine snapshot boundary", () => {
     ).toThrow(PortableMachineSnapshotValidationError);
   });
 
-  it("refuses metadata that tries to replay raw vmstate", () => {
-    const unsafe = manifest() as unknown as { source: { vmstate: { rawRestore: string } } };
-    unsafe.source.vmstate.rawRestore = "translated";
+  it.each(["translated", "replayed", "emulated", "successful"])(
+    "refuses metadata that tries to mark raw vmstate as %s",
+    (rawRestore) => {
+      const unsafe = manifest() as unknown as { source: { vmstate: { rawRestore: string } } };
+      unsafe.source.vmstate.rawRestore = rawRestore;
 
-    expect(() => validatePortableMachineSnapshotManifest(unsafe)).toThrow(
-      /rawRestore must be "refused"/,
-    );
-  });
+      expect(() => validatePortableMachineSnapshotManifest(unsafe)).toThrow(
+        /rawRestore must be "refused"/,
+      );
+    },
+  );
 
   it("refuses metadata that would use source ISA or sidecar execution", () => {
     expect(() =>
@@ -348,10 +351,12 @@ describe("portable machine snapshot boundary", () => {
       ),
     ).not.toThrow();
 
-    const unsafe = manifest() as unknown as { target: { execution: string } };
-    unsafe.target.execution = "source-isa-emulation";
-    expect(() => validatePortableMachineSnapshotManifest(unsafe)).toThrow(
-      /execution must be "target-native"/,
-    );
+    for (const execution of ["source-isa-emulation", "sidecar-runtime", "source-text-replay"]) {
+      const unsafe = manifest() as unknown as { target: { execution: string } };
+      unsafe.target.execution = execution;
+      expect(() => validatePortableMachineSnapshotManifest(unsafe), execution).toThrow(
+        /execution must be "target-native"/,
+      );
+    }
   });
 });

--- a/packages/runtime/src/__tests__/target-guest-memory-materialization.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-memory-materialization.test.ts
@@ -89,6 +89,45 @@ describe("target guest memory materialization", () => {
     ]);
   });
 
+  it("refuses source vDSO/vvar pages instead of copying target-owned kernel mappings", () => {
+    const result = planTargetGuestMemoryMaterialization({
+      mappings: [
+        mapping({
+          id: "vdso-source",
+          kind: "vdso",
+          permissions: { read: true, write: false, execute: true, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 0, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x600000010000" },
+        }),
+        mapping({
+          id: "vvar-source",
+          kind: "vvar",
+          permissions: { read: true, write: true, execute: false, private: true, shared: false },
+          captured: { file: "native-memory.bin", offset: 4096, sizeBytes: 4096 },
+          target: { materialization: "translate", targetStart: "0x600000011000" },
+        }),
+      ],
+      memoryFile: "/tmp/native-memory.bin",
+      memorySizeBytes: 8192,
+    });
+
+    expect(result.entries).toEqual([]);
+    expect(result.refusals).toEqual([
+      expect.objectContaining({
+        code: "vdso-policy-unsupported",
+        detail: expect.objectContaining({
+          mapping: "vdso-source",
+          sourceBytesCopied: false,
+          targetOwned: true,
+        }),
+      }),
+      expect.objectContaining({
+        code: "vdso-policy-unsupported",
+        detail: expect.objectContaining({ mapping: "vvar-source", sourceBytesCopied: false }),
+      }),
+    ]);
+  });
+
   it("refuses shared mappings without an explicit shared-resource recipe", () => {
     const result = planTargetGuestMemoryMaterialization({
       mappings: [

--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -118,9 +118,21 @@ describe("vmstate portability metadata", () => {
         0n,
       );
 
-      await expect(restore({ snapDir: dir, image, binary: "/bin/sh" })).rejects.toMatchObject({
+      let error: unknown;
+      try {
+        await restore({ snapDir: dir, image, binary: "/bin/sh" });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toMatchObject({
         code: "BOOT_VMSTATE_CROSS_ISA_UNSUPPORTED",
         message: expect.stringContaining("cross-isa-vmstate-restore-unsupported"),
+      });
+      expect(error).toMatchObject({
+        message: expect.stringMatching(
+          /snapshot guest: arm64[\s\S]*restore guest:\s+amd64[\s\S]*target-isa-vm-process-restore/,
+        ),
       });
     } finally {
       if (original === undefined) {

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -320,7 +320,14 @@ export function classifyNativeThreadSyscall(
     return refusedClassification(thread, "restart", {
       code: "syscall-restart-unsupported",
       message: `thread ${thread.id} is in restartable syscall state`,
-      detail: detail(thread, "restart"),
+      detail: detail(thread, "restart", {
+        requiredModel: [
+          "remaining time accounting",
+          "restart/result contract",
+          "signal mask delivery",
+          "target syscall rearm policy",
+        ],
+      }),
     });
   }
   const name = syscallName(thread);
@@ -720,7 +727,9 @@ function futexActiveSyscallDetail(thread: NativeThreadState): Record<string, unk
         "source futex word address and value race",
         "kernel wait queue membership",
         "wake/requeue ordering",
+        "timeout accounting",
         "robust-list owner-death semantics",
+        "priority-inheritance futex ownership",
       ],
     },
   });

--- a/packages/runtime/src/native-mapping-materialization.ts
+++ b/packages/runtime/src/native-mapping-materialization.ts
@@ -77,6 +77,11 @@ function planMapping(
     return refusedStep(mapping, permissionRefusal);
   }
 
+  const targetOwnedSpecialRefusal = validateTargetOwnedSpecialMapping(mapping);
+  if (targetOwnedSpecialRefusal) {
+    return refusedStep(mapping, targetOwnedSpecialRefusal);
+  }
+
   const privateWritableRefusal = validatePrivateWritable(mapping);
   if (privateWritableRefusal) {
     return refusedStep(mapping, privateWritableRefusal);
@@ -266,6 +271,35 @@ function validatePermissions(mapping: NativeMemoryMapping): NativeProcessImageRe
     return refusal("mapping-permission-unsupported", `${mapping.id} is writable and executable`);
   }
   return undefined;
+}
+
+function validateTargetOwnedSpecialMapping(
+  mapping: NativeMemoryMapping,
+): NativeProcessImageRefusal | undefined {
+  if (!isTargetOwnedSpecialMapping(mapping)) {
+    return undefined;
+  }
+  if (mapping.target.materialization === "recreate" && !mapping.captured) {
+    return undefined;
+  }
+  return {
+    code: "vdso-policy-unsupported",
+    message: `${mapping.id} ${mapping.kind} mapping is target-owned and cannot copy source bytes`,
+    detail: {
+      mapping: mapping.id,
+      kind: mapping.kind,
+      sourceStart: mapping.sourceStart,
+      sourceEnd: mapping.sourceEnd,
+      requestedMaterialization: mapping.target.materialization,
+      sourceBytesCopied: false,
+      targetOwned: true,
+      requiredModel: ["target kernel vDSO/vvar recreation", "special mapping provenance"],
+    },
+  };
+}
+
+function isTargetOwnedSpecialMapping(mapping: NativeMemoryMapping): boolean {
+  return mapping.kind === "vdso" || mapping.kind === "vvar" || mapping.kind === "special";
 }
 
 function validatePrivateWritable(

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -530,6 +530,7 @@ function resourceRefusalWithCode(
       fd: resource.fd,
       path: resource.path,
       boundary: resourceBoundary(code),
+      requiredModel: resourceRequiredModel(resource),
     },
   };
 }
@@ -545,6 +546,42 @@ function resourceRefusalCode(
     return inheritedStdio ? "non-stdio-kernel-state-unsupported" : "kernel-state-unsupported";
   }
   return "resource-kind-unsupported";
+}
+
+const RESOURCE_REQUIRED_MODELS: Partial<Record<NativeProcessResource["kind"], string[]>> = {
+  socket: [
+    "accept/connect/listen queue state",
+    "peer endpoint identity",
+    "credentials and namespaces",
+    "socket options, shutdown state, readiness, and partial transfer state",
+  ],
+  epoll: [
+    "interest list",
+    "ready-list ordering",
+    "edge-triggered delivery state",
+    "nested epoll and wakeup ordering",
+  ],
+  signalfd: [
+    "pending signal queue",
+    "siginfo payload provenance",
+    "delivery ordering",
+    "signal-mask coordination",
+  ],
+  signal: [
+    "pending signal queue",
+    "siginfo payload provenance",
+    "delivery ordering",
+    "signal-mask coordination",
+  ],
+  eventfd: ["counter state", "semaphore mode", "readiness and wakeup ordering"],
+  timer: ["timerfd clock", "absolute/relative expiry", "interval and overrun state"],
+  pipe: ["pipe buffer contents", "peer fd ownership", "readiness and wakeup ordering"],
+  "raw-socket": ["explicit broker capability", "network namespace and credential policy"],
+  pty: ["explicit broker capability", "termios state", "session and foreground process group"],
+};
+
+function resourceRequiredModel(resource: NativeProcessResource): string[] {
+  return RESOURCE_REQUIRED_MODELS[resource.kind] ?? [];
 }
 
 function isStatefulKernelResource(resource: NativeProcessResource): boolean {

--- a/packages/runtime/src/native-signal-policy.ts
+++ b/packages/runtime/src/native-signal-policy.ts
@@ -61,19 +61,36 @@ function activeSignalFrameRefusal(
   thread: NativeThreadState,
 ): NativeProcessImageRefusal | undefined {
   return thread.signal.activeFrame
-    ? signalRefusal("signal-frame-active", thread, "is inside a signal frame")
+    ? signalRefusal("signal-frame-active", thread, "is inside a signal frame", {
+        activeFrame: true,
+        requiredModel: [
+          "signal trampoline frame",
+          "siginfo ownership",
+          "target signal return path",
+        ],
+      })
     : undefined;
 }
 
 function pendingSignalRefusal(thread: NativeThreadState): NativeProcessImageRefusal | undefined {
   return hasNonZeroMask(thread.signal.pending)
-    ? signalRefusal("signal-state-unsupported", thread, "has pending signal state")
+    ? signalRefusal("signal-state-unsupported", thread, "has pending signal state", {
+        pendingMasks: normalizedMasks(thread.signal.pending),
+        requiredModel: [
+          "pending per-thread/process signal queues",
+          "siginfo ownership",
+          "delivery ordering",
+        ],
+      })
     : undefined;
 }
 
 function altStackRefusal(thread: NativeThreadState): NativeProcessImageRefusal | undefined {
   return thread.signal.altStack.state !== "disabled"
-    ? signalRefusal("signal-state-unsupported", thread, "has active alt-stack state")
+    ? signalRefusal("signal-state-unsupported", thread, "has active alt-stack state", {
+        altStack: thread.signal.altStack,
+        requiredModel: ["target alt-stack allocation", "active signal-frame ownership"],
+      })
     : undefined;
 }
 
@@ -83,7 +100,11 @@ function malformedMaskRefusal(
   masks: string[],
 ): NativeProcessImageRefusal | undefined {
   return masks.some((mask) => normalizeMask(mask) === undefined)
-    ? signalRefusal("signal-state-unsupported", thread, `has malformed ${kind} signal mask`)
+    ? signalRefusal("signal-state-unsupported", thread, `has malformed ${kind} signal mask`, {
+        maskKind: kind,
+        masks,
+        requiredModel: ["well-formed signal mask"],
+      })
     : undefined;
 }
 
@@ -92,7 +113,11 @@ function blockedMaskRefusal(
   policy: NativeSignalBlockedMaskPolicy,
 ): NativeProcessImageRefusal | undefined {
   return policy === "require-empty" && hasNonZeroMask(thread.signal.blocked)
-    ? signalRefusal("signal-state-unsupported", thread, "has blocked signal state")
+    ? signalRefusal("signal-state-unsupported", thread, "has blocked signal state", {
+        blockedMasks: normalizedMasks(thread.signal.blocked),
+        policy,
+        requiredModel: ["explicit blocked-mask restore policy"],
+      })
     : undefined;
 }
 
@@ -116,6 +141,11 @@ function signalRefusal(
   code: NativeProcessImageRefusal["code"],
   thread: NativeThreadState,
   message: string,
+  detail: Record<string, unknown> = {},
 ): NativeProcessImageRefusal {
-  return { code, message: `thread ${thread.id} ${message}` };
+  return {
+    code,
+    message: `thread ${thread.id} ${message}`,
+    detail: { threadId: thread.id, ...detail },
+  };
 }

--- a/packages/runtime/src/native-thread-restore-policy.ts
+++ b/packages/runtime/src/native-thread-restore-policy.ts
@@ -120,7 +120,15 @@ function planThreadSignalRestore(
 function singleThreadRefusal(threads: NativeThreadState[]): NativeProcessImageRefusal | undefined {
   return threads.length === 1
     ? undefined
-    : refusal("thread-state-unsupported", "portable restore currently accepts exactly one thread");
+    : refusal("thread-state-unsupported", "portable restore currently accepts exactly one thread", {
+        targetThreadCount: threads.length,
+        requiredModel: [
+          "runnable/blocked scheduler relationships",
+          "thread priorities and affinity",
+          "cross-thread ordering",
+          "robust-list and futex ownership",
+        ],
+      });
 }
 
 function safeStoppedThreadRefusal(

--- a/packages/runtime/src/target-guest-memory-materialization.ts
+++ b/packages/runtime/src/target-guest-memory-materialization.ts
@@ -189,6 +189,12 @@ function overlapWithNext(
 }
 
 function unsafeMappingRefusal(mapping: NativeMemoryMapping): NativeProcessImageRefusal | undefined {
+  if (
+    isTargetOwnedSpecialMapping(mapping) &&
+    (mapping.captured || mapping.target.materialization !== "recreate")
+  ) {
+    return targetOwnedSpecialMappingRefusal(mapping);
+  }
   if (mapping.permissions.execute) {
     return executableSourceRefusal(mapping);
   }
@@ -196,6 +202,26 @@ function unsafeMappingRefusal(mapping: NativeMemoryMapping): NativeProcessImageR
     return sharedMappingRefusal(mapping);
   }
   return undefined;
+}
+
+function targetOwnedSpecialMappingRefusal(mapping: NativeMemoryMapping): NativeProcessImageRefusal {
+  return refusal(
+    "vdso-policy-unsupported",
+    `${mapping.id} ${mapping.kind} mapping must be recreated by the target kernel`,
+    {
+      mapping: mapping.id,
+      kind: mapping.kind,
+      sourceStart: mapping.sourceStart,
+      sourceEnd: mapping.sourceEnd,
+      requestedMaterialization: mapping.target.materialization,
+      sourceBytesCopied: false,
+      targetOwned: true,
+    },
+  );
+}
+
+function isTargetOwnedSpecialMapping(mapping: NativeMemoryMapping): boolean {
+  return mapping.kind === "vdso" || mapping.kind === "vvar" || mapping.kind === "special";
 }
 
 function executableSourceRefusal(mapping: NativeMemoryMapping): NativeProcessImageRefusal {


### PR DESCRIPTION
## Problem

Goal 2 says unsupported native state must fail closed. Some areas already refused, but the tests and refusal details were not explicit enough for every family. That left room for future code to accidentally turn unsafe state into a success report.

## Solution

This tightens the fail-closed boundaries for sockets, epoll, signalfd and signal queues, futex/rseq/scheduler state, restart blocks, JIT/self-modifying code, source vDSO/vvar copying, raw cross-ISA vmstate, and descriptor/provenance ambiguity. The tests now check exact refusal codes, required model details, and `migrationCompleted=false` negative profile behavior. The docs and `goal-2.md` now show these boundaries as covered.

Closes #753.

## Validation

- `pnpm run format -- ...` — 0.310s
- focused `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run ...` — 2.010s
- `pnpm run build:docs` — 1.612s
- `pnpm run format:check` — 0.636s
- `pnpm run lint` — 0.228s
- `pnpm run typecheck` — 2.458s
- full `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run` — 26.994s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.340s
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` — 2m14.050s
