### PR TITLE
Add refusal graduation proof harness

### DIFF
--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -41,6 +41,17 @@ TLS, stack-window, private-memory, executable mapping, signal restore,
 active-syscall restore, process-context restore, controlled thread restore, and
 resume-path checks.
 
+Every profile also carries a support status:
+
+- `baseline-success`: part of the original constrained success class.
+- `intentional-refusal`: fail-closed today, but may graduate after an exact
+  model lands.
+- `permanent-refusal`: an invariant of the native-transparent contract, not a
+  backlog support item.
+- `graduated-support`: a formerly refused family now has a positive target-native
+  subset. These profiles must record `graduatedFromRefusalCode`, an
+  `acceptedSubset`, and unsafe variants that still refuse.
+
 Negative profiles set `expectedResult: "refusal"`. They are pass/fail checks for
 unsafe states, not accepted migrations. The runner treats a negative profile as
 passing only when the checked summary matches the unsafe-state family, carries
@@ -60,6 +71,28 @@ pnpm portable-machine-proof-runner -- \
 ```
 
 This exits non-zero if any required gate is missing or not `passed`.
+
+## Refusal graduation checklist
+
+A refused family may move to `graduated-support` only when the same PR documents
+and tests all of the following:
+
+1. **Portable state model** — exact descriptor fields, provenance, and bounds.
+2. **Target restore recipe** — target-native syscalls or loader actions used to
+   recreate state.
+3. **Target gates** — checks proving descriptor consumption, target-native
+   completion, and resource-specific state.
+4. **Positive profile** — a profile with `expectedResult: "success"`,
+   `supportStatus: "graduated-support"`, `graduatedFromRefusalCode`, and an
+   accepted subset name.
+5. **Negative variants** — nearby unsafe states that still assert exact refusal
+   codes and `migrationCompleted=false`.
+6. **Docs and validation timings** — update the refusal inventory and the goal
+   ledger before claiming completion.
+
+The runner refuses a graduated success profile that reports
+`migrationCompleted=true` without descriptor completion and the listed target
+native gates.
 
 ## Constrained native-transparent class
 

--- a/goal-3.md
+++ b/goal-3.md
@@ -88,15 +88,15 @@ the native-transparent contract.
 Before implementing any specific family, make the refusal-to-support workflow
 repeatable.
 
-- [ ] Add a proof-runner convention for a profile graduating from refusal to
+- [x] Add a proof-runner convention for a profile graduating from refusal to
       support, including the old refusal code, accepted subset name, and unsafe
       variants that must still refuse.
-- [ ] Add reporting that shows which Goal 2 refusal profiles remain intentionally
-      refused and which have graduated to success.
-- [ ] Add a checklist template for every family: portable state model, target
+- [x] Add reporting that shows which Goal 2 refusal profiles remain
+      intentionally refused and which have graduated to success.
+- [x] Add a checklist template for every family: portable state model, target
       restore recipe, target gates, positive profile, negative variants, docs,
       and validation timings.
-- [ ] Ensure a graduated profile cannot pass if `migrationCompleted=true` is set
+- [x] Ensure a graduated profile cannot pass if `migrationCompleted=true` is set
       before descriptor and target-native gates complete.
 
 ## C. Epoll reconstruction for known fd recipes

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -149,10 +149,31 @@ describe("portable machine proof runner", () => {
       ),
     ).toMatchObject({
       expectedResult: "refusal",
+      supportStatus: "intentional-refusal",
       unsafeStateFamily: "socket",
       expectedRefusalCode: "target-socket-syscall-state-unsupported",
       descriptorConsumptionExpected: false,
+      refusalSupportContract: {
+        currentRefusalCode: "target-socket-syscall-state-unsupported",
+        graduationRequires: expect.arrayContaining(["portable-state-model", "target-gates"]),
+      },
     });
+    expect(summary.supportReport).toMatchObject({
+      counts: {
+        "baseline-success": 11,
+        "intentional-refusal": 7,
+        "permanent-refusal": 3,
+      },
+      graduated: [],
+    });
+    expect(summary.supportReport.intentionallyRefused).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "raw-cross-isa-vmstate-refusal",
+          supportStatus: "permanent-refusal",
+        }),
+      ]),
+    );
   });
 
   it("runs a named profile through dry-run smoke wiring without reporting success", () => {
@@ -319,6 +340,51 @@ describe("portable machine proof runner", () => {
       expect.arrayContaining([
         expect.objectContaining({ label: "summary.state" }),
         expect.objectContaining({ label: "targetRestore.migrationCompleted" }),
+        expect.objectContaining({ label: "targetRestore.descriptorGateCompleted" }),
+      ]),
+    );
+  });
+
+  it("rejects a graduated support profile unless descriptor and target gates pass", () => {
+    const dir = tempDir();
+    const profileFile = join(dir, "profiles.json");
+    const badSummaryFile = join(dir, "summary.json");
+    const profile = {
+      name: "graduated-epoll",
+      remoteSourceTarget: "graduated-epoll",
+      sourceFixture: "synthetic",
+      expectedResult: "success",
+      supportStatus: "graduated-support",
+      unsafeStateFamily: "epoll",
+      graduatedFromRefusalCode: "target-epoll-syscall-state-unsupported",
+      acceptedSubset: "single-level-triggered-watch",
+      unsafeVariants: ["epoll-wait-refusal"],
+      expectedGates: ["descriptor", "resources", "verifier"],
+    };
+    writeFileSync(profileFile, JSON.stringify([profile], null, 2));
+    const badSummary = completedSummary("graduated-epoll");
+    badSummary.targetRestore.descriptorGateCompleted = false;
+    writeFileSync(badSummaryFile, JSON.stringify(badSummary, null, 2));
+
+    const result = spawnSync(
+      "node",
+      [RUNNER, "--profile", "graduated-epoll", "--check-summary", badSummaryFile, "--json"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: { ...SCRIPT_ENV, PORTABLE_MACHINE_PROOF_PROFILES: profileFile },
+        timeout: 30_000,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const summary = JSON.parse(result.stdout);
+    expect(summary).toMatchObject({ profile: "graduated-epoll", pass: false });
+    expect(summary.gateCheck.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "graduated profile descriptor gate completed before success",
+        }),
         expect.objectContaining({ label: "targetRestore.descriptorGateCompleted" }),
       ]),
     );

--- a/scripts/portable-machine-proof-profiles.json
+++ b/scripts/portable-machine-proof-profiles.json
@@ -23,7 +23,8 @@
       "active-syscall",
       "controlled-thread",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "pipe-read",
@@ -48,7 +49,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "eventfd-read",
@@ -73,7 +75,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "timerfd-read",
@@ -98,7 +101,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-read",
@@ -123,7 +127,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-pread",
@@ -148,7 +153,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-readv",
@@ -173,7 +179,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-write",
@@ -198,7 +205,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-pwrite",
@@ -223,7 +231,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "file-writev",
@@ -248,7 +257,8 @@
       "signal",
       "active-syscall",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "process-context",
@@ -273,7 +283,8 @@
       "process-context",
       "signal",
       "resume-path"
-    ]
+    ],
+    "supportStatus": "baseline-success"
   },
   {
     "name": "socket-transfer-refusal",
@@ -290,7 +301,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "target-socket-syscall-state-unsupported",
+      "unsafeStateFamily": "socket",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "epoll-wait-refusal",
@@ -307,7 +332,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "target-epoll-syscall-state-unsupported",
+      "unsafeStateFamily": "epoll",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "signalfd-read-refusal",
@@ -324,7 +363,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "target-signalfd-state-unsupported",
+      "unsafeStateFamily": "signalfd",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "futex-refusal",
@@ -341,7 +394,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "futex-state-unsupported",
+      "unsafeStateFamily": "futex",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "rseq-refusal",
@@ -358,7 +425,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "rseq-state-unsupported",
+      "unsafeStateFamily": "rseq",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "restart-state-refusal",
@@ -375,7 +456,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "syscall-restart-unsupported",
+      "unsafeStateFamily": "restart",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "jit-self-modifying-refusal",
@@ -392,7 +487,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "mapping-executable-unsupported",
+      "unsafeStateFamily": "jit-self-modifying-code",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "source-vdso-vvar-refusal",
@@ -409,7 +518,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "permanent-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "vdso-policy-unsupported",
+      "unsafeStateFamily": "source-vdso-vvar",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "raw-cross-isa-vmstate-refusal",
@@ -426,7 +549,21 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "permanent-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "cross-isa-vmstate-restore-unsupported",
+      "unsafeStateFamily": "raw-cross-isa-vmstate",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   },
   {
     "name": "descriptor-provenance-refusal",
@@ -443,6 +580,20 @@
     "descriptorConsumptionExpected": false,
     "expectedDescriptorGateCompleted": false,
     "expectedMigrationCompleted": false,
-    "expectedGates": []
+    "expectedGates": [],
+    "supportStatus": "permanent-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "mapping-provenance-ambiguous",
+      "unsafeStateFamily": "descriptor-provenance",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
   }
 ]

--- a/scripts/portable-machine-proof-runner.mjs
+++ b/scripts/portable-machine-proof-runner.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const PROFILE_FILE = join(SCRIPT_DIR, "portable-machine-proof-profiles.json");
+const PROFILE_FILE_ENV = "PORTABLE_MACHINE_PROOF_PROFILES";
 const SMOKE_SCRIPT = join(SCRIPT_DIR, "smoke/portable-machine-restore.sh");
 const DEFAULT_TIMEOUT_MS = 900_000;
 
@@ -92,8 +93,12 @@ const GATE_FIELDS = {
   "resume-path": [["targetRestore.targetResumePathResult", "targetResumePathResult", "passed"]],
 };
 
+function profileFile() {
+  return process.env[PROFILE_FILE_ENV] ? resolve(process.env[PROFILE_FILE_ENV]) : PROFILE_FILE;
+}
+
 function loadProfiles() {
-  return JSON.parse(readFileSync(PROFILE_FILE, "utf8"));
+  return JSON.parse(readFileSync(profileFile(), "utf8"));
 }
 
 function profileByName(name) {
@@ -261,11 +266,15 @@ function gateChecksFor(summary, profile) {
     : successChecksFor(summary, profile);
 }
 
+// fallow-ignore-next-line complexity
 function successChecksFor(summary, profile) {
   const target = targetFromSummary(summary);
   const checks = [];
   checkEquals(checks, "profile expected result", profile.expectedResult, "success");
   checkEquals(checks, "summary.state", summary?.state, "completed");
+  if (profile.supportStatus === "graduated-support") {
+    checkGraduatedProfileContract(checks, profile, target);
+  }
   checkEquals(
     checks,
     "summary.remoteSourceTarget",
@@ -278,6 +287,33 @@ function successChecksFor(summary, profile) {
     applyGateCheck(checks, target, gate);
   }
   return checks;
+}
+
+function checkGraduatedProfileContract(checks, profile, target) {
+  checkEquals(
+    checks,
+    "graduated profile old refusal code recorded",
+    typeof profile.graduatedFromRefusalCode,
+    "string",
+  );
+  checkEquals(
+    checks,
+    "graduated profile accepted subset recorded",
+    typeof profile.acceptedSubset,
+    "string",
+  );
+  checkEquals(
+    checks,
+    "graduated profile descriptor gate completed before success",
+    target.descriptorGateCompleted,
+    true,
+  );
+  checkEquals(
+    checks,
+    "graduated profile keeps target-native completion gate",
+    target.migrationCompleted,
+    true,
+  );
 }
 
 // fallow-ignore-next-line complexity
@@ -520,15 +556,50 @@ function printSummary(summary, json) {
   }
 }
 
+function supportReport(profiles) {
+  const counts = profiles.reduce((acc, profile) => {
+    const status = profile.supportStatus ?? "unspecified";
+    acc[status] = (acc[status] ?? 0) + 1;
+    return acc;
+  }, {});
+  const graduated = profiles
+    .filter((profile) => profile.supportStatus === "graduated-support")
+    .map((profile) => ({
+      name: profile.name,
+      family: profile.unsafeStateFamily,
+      acceptedSubset: profile.acceptedSubset,
+      graduatedFromRefusalCode: profile.graduatedFromRefusalCode,
+      unsafeVariants: profile.unsafeVariants ?? [],
+    }));
+  const intentionallyRefused = profiles
+    .filter(
+      (profile) =>
+        profile.supportStatus === "intentional-refusal" ||
+        profile.supportStatus === "permanent-refusal",
+    )
+    .map((profile) => ({
+      name: profile.name,
+      family: profile.unsafeStateFamily,
+      expectedRefusalCode: profile.expectedRefusalCode,
+      supportStatus: profile.supportStatus,
+    }));
+  return { counts, graduated, intentionallyRefused };
+}
+
 function listProfiles(json) {
   const profiles = loadProfiles();
+  const report = supportReport(profiles);
   if (json) {
-    process.stdout.write(`${JSON.stringify({ profiles }, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify({ profiles, supportReport: report }, null, 2)}\n`);
     return;
   }
   for (const profile of profiles) {
-    console.log(`${profile.name}\t${profile.sourceFixture}\t${profile.description}`);
+    const status = profile.supportStatus ?? "unspecified";
+    console.log(`${profile.name}\t${status}\t${profile.sourceFixture}\t${profile.description}`);
   }
+  console.log(
+    `support-report\tgraduated=${report.graduated.length}\tintentionally-refused=${report.intentionallyRefused.length}`,
+  );
 }
 
 function checkExistingSummary(options, profile) {


### PR DESCRIPTION
## Problem

Goal 3 needs a safe way to move from stable refusals to real support. Without profile metadata and reporting, it is hard to tell which refusals are permanent, which are intentional for now, and what a supported subset must prove.

## Solution

Add a refusal-graduation harness:

- profile `supportStatus` metadata for baseline success, intentional refusal, and permanent refusal;
- a support report in `portable-machine-proof-runner --list --json`;
- a documented graduation checklist;
- runner checks for future `graduated-support` profiles so they still require descriptor and target-native completion gates;
- mark Goal 3 section B complete.

Closes #759.

## Validation

- `pnpm run format -- scripts/portable-machine-proof-runner.mjs scripts/portable-machine-proof-profiles.json packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts docs/snapshot/portable-machine-proof-profiles.md` — 0.313s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 2.192s
- `pnpm run build:docs` — 1.696s
- `pnpm run format:check` — 0.594s
- `pnpm run lint` — 0.222s
- `pnpm run typecheck` — 2.355s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.344s

Smoke tests were not run because this changes proof-runner metadata/docs/tests only, not VM/VMM/rootfs/CLI/snapshot/restore runtime behavior.
