### PR TITLE
Document Goal 3 futex rseq refusal boundary

### DIFF
--- a/docs/snapshot/native-fail-closed-refusal-inventory.md
+++ b/docs/snapshot/native-fail-closed-refusal-inventory.md
@@ -41,6 +41,12 @@ transfers, and unbrokered endpoints continue to require
 broker descriptor and authorization/provenance gates before any socket profile can
 move to `graduated-support`.
 
+Goal 3 leaves futex/rseq/scheduler state without a graduated support subset.
+Words in copied private memory are data only; active futex waits, PI futexes,
+robust-list owner-death transitions, rseq registration, active rseq critical
+sections, and scheduler-ordering claims continue to require
+`futex-state-unsupported` or `rseq-state-unsupported`.
+
 Goal 3 also leaves JIT and self-modifying code without a graduated support
 subset. Target-owned static executable mappings remain supported only through
 explicit target build/hash provenance. Source-only executable bytes, ambiguous

--- a/docs/snapshot/native-thread-refusal-matrix.md
+++ b/docs/snapshot/native-thread-refusal-matrix.md
@@ -37,7 +37,8 @@ The following unsafe states refuse before register translation:
 The restore boundary also refuses:
 
 - more than one thread -> `thread-state-unsupported`;
-- futex wait resources and active futex syscalls -> `futex-state-unsupported`;
+- futex wait resources, PI/robust-list state, and active futex syscalls ->
+  `futex-state-unsupported`;
 - signal-delivery stop -> `signal-state-unsupported`;
 - ptrace/debug leftovers -> `thread-state-unsupported`;
 - shared stack mappings -> `mapping-shared-unsupported`;
@@ -52,7 +53,11 @@ blocked signal state.
 ## Boundary
 
 This proof does not implement syscall restart, signal delivery replay, alt-stack
-reconstruction, rseq/TLS migration, target TCB construction beyond the minimal amd64 proof page, live SIMD/FPU
-register restoration, futex replay, ptrace/debug state, or multi-thread restore. It only
-makes the hard boundary explicit: those states must not silently pass into
-translated frame/resume restore until a later proof models them.
+reconstruction, rseq/TLS migration, target TCB construction beyond the minimal
+amd64 proof page, live SIMD/FPU register restoration, futex replay, ptrace/debug
+state, or general multi-thread restore. Goal 3 treats quiescent futex words only
+as ordinary private memory data; any kernel futex wait queue, robust-list
+transition, rseq registration, active rseq critical section, or scheduler
+ordering claim remains outside the accepted class. The matrix makes the hard
+boundary explicit: those states must not silently pass into translated
+frame/resume restore until a later proof models them.

--- a/docs/snapshot/native-two-thread-boundary.md
+++ b/docs/snapshot/native-two-thread-boundary.md
@@ -34,6 +34,12 @@ unsupported rseq state on either thread.
 
 ## Futex, rseq, and scheduler requirements
 
+Goal 3 defines the only quiescent futex-word rule currently allowed: a word in a
+safe private mapping may be copied as ordinary data, but it is not treated as a
+kernel futex object and does not imply any wait-queue, wake, robust-list, or
+scheduler claim. Any explicit futex resource, active futex syscall, PI futex,
+robust-list owner-death transition, or ambiguous scheduler state remains refused.
+
 General futex migration remains refused until a target model can prove all of the
 following at once:
 
@@ -43,11 +49,11 @@ following at once:
 - timeout and signal interruption semantics match the target restart policy;
 - every participating thread's scheduling relationship is represented.
 
-General rseq migration remains refused until the target can register a new rseq
-area, translate any active critical-section abort IP, prove whether execution is
-inside a critical section, and tie the rseq area to the target TLS/TCB owner.
-Captured or unsupported rseq state therefore fails closed with
-`rseq-state-unsupported`.
+Goal 3 does not recreate rseq registration from TLS. General rseq migration
+remains refused until the target can register a new rseq area, translate any
+active critical-section abort IP, prove whether execution is inside a critical
+section, and tie the rseq area to the target TLS/TCB owner. Captured or
+unsupported rseq state therefore fails closed with `rseq-state-unsupported`.
 
 The controlled two-thread proof intentionally avoids those states. Its target
 spawns are short-lived verifier tasks with independent stacks/registers/TLS and

--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -119,7 +119,8 @@ passes. The accepted class includes:
 Everything outside that class must fail closed with a stable refusal before
 `migrationCompleted=true`: sockets without an explicit broker contract,
 epoll/signalfd state outside their graduated subsets, futex/rseq/general scheduler
-state, source vDSO/vvar copying, source executable text reuse, JIT or
+state beyond ordinary private-memory data copying, source vDSO/vvar copying,
+source executable text reuse, JIT or
 self-modifying code without a target-native regeneration descriptor, pending
 signals/active signal frames, raw cross-ISA
 `.vmstate` replay, missing provenance, malformed descriptors, or unsupported

--- a/goal-3.md
+++ b/goal-3.md
@@ -228,9 +228,9 @@ Tasks:
 
 ## G. Futex, rseq, and scheduler state: likely quiescent-only
 
-General live futex/rseq/scheduler migration is the hardest class. The default is
-to keep it refused. Any support should start from quiescent constraints, not live
-kernel wait queues.
+General live futex/rseq/scheduler migration is the hardest class. Goal 3 keeps
+kernel futex/rseq/scheduler state refused. Ordinary private memory words may be
+copied only as data; no futex wait queue or rseq registration is recreated.
 
 Accepted subset to consider first:
 
@@ -244,19 +244,22 @@ Accepted subset to consider first:
 
 Tasks:
 
-- [ ] Define a quiescent futex-word model that treats futex memory as data only
+- [x] Define a quiescent futex-word model that treats futex memory as data only
       and refuses all active wait queues.
-- [ ] Add validation distinguishing ordinary futex words from active futex wait
-      state.
-- [ ] Define whether target rseq can be recreated safely from target TLS, or must
-      remain refused.
-- [ ] Add target gates for thread quiescence, robust-list state, rseq state, and
-      scheduler assumptions.
-- [ ] Add positive proof profiles only for quiescent accepted subsets, if any.
-- [ ] Keep/refine negative profiles for active futex waits, PI futexes,
+- [x] Add validation distinguishing ordinary futex words from active futex wait
+      state: Goal 3 accepts no explicit futex resource; active futex syscall,
+      wait queue, PI futex, or robust-list transition metadata remains refused.
+- [x] Define whether target rseq can be recreated safely from target TLS, or must
+      remain refused: target rseq registration remains refused in Goal 3.
+- [!] Add target gates for thread quiescence, robust-list state, rseq state, and
+  scheduler assumptions. Not supported in Goal 3 beyond existing controlled
+  thread gates; no futex/rseq target gate can mark migration success.
+- [!] Add positive proof profiles only for quiescent accepted subsets, if any. No
+  futex/rseq/scheduler subset graduates in Goal 3.
+- [x] Keep/refine negative profiles for active futex waits, PI futexes,
       robust-list owner death, active rseq critical sections, and scheduler
       ambiguity.
-- [ ] Keep general futex/rseq/scheduler migration refused with
+- [x] Keep general futex/rseq/scheduler migration refused with
       `futex-state-unsupported` and `rseq-state-unsupported`.
 
 ## H. Completion criteria for Goal 3


### PR DESCRIPTION
## Problem

Goal 3 asks whether futex/rseq/scheduler state can support a quiescent subset. Live kernel wait queues, robust-list transitions, rseq registration, active critical sections, and scheduler ordering are still too ambiguous to migrate safely.

## Solution

- Decide that Goal 3 does not graduate a futex/rseq/scheduler subset.
- Document the only safe quiescent rule: futex words in accepted private memory are copied as ordinary data only, not as kernel futex state.
- Keep active futex waits, PI futexes, robust-list owner-death transitions, rseq registration, active rseq critical sections, and scheduler-ordering claims refused with `futex-state-unsupported` / `rseq-state-unsupported`.
- Update the Goal 3 ledger and refusal docs.

Closes #769.

## Validation

- `pnpm run format -- goal-3.md docs/snapshot/native-two-thread-boundary.md docs/snapshot/native-thread-refusal-matrix.md docs/snapshot/native-fail-closed-refusal-inventory.md docs/snapshot/portable-machine-proof-profiles.md` — 0.349s
- `pnpm run build:docs` — 1.843s
- `pnpm run format:check` — 0.721s
- `pnpm run lint` — 0.240s
- `pnpm run typecheck` — 2.601s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.383s

No smoke run: this is a Markdown-only boundary decision with no VM/VMM/rootfs/CLI/restore behavior changes.
