### PR TITLE
Graduate Goal 4 eventfd counter descriptor recreation

### DIFF
--- a/docs/snapshot/native-fail-closed-refusal-inventory.md
+++ b/docs/snapshot/native-fail-closed-refusal-inventory.md
@@ -34,6 +34,13 @@ queued `siginfo`, active signal frames, active alt-stack state, unsupported
 flags, malformed masks, and active signalfd reads continue to use
 `target-signalfd-state-unsupported`.
 
+Goal 4 graduates only the eventfd `eventfd-counter-v1` descriptor subset to
+`eventfd-counter-recreate`: non-semaphore eventfds with exact nonzero counter,
+known-empty waiters, supported flags, and close-on-exec provenance. Semaphore
+mode, unknown waiters, unsupported flags, zero counters outside the existing
+empty-eventfd proof, and overflow counters continue to require
+`kernel-state-unsupported`.
+
 Goal 3 intentionally leaves sockets without a graduated support subset. Listening
 sockets, connected socketpairs, TCP/Unix sockets, ancillary data, partial
 transfers, and unbrokered endpoints continue to require

--- a/docs/snapshot/native-resource-translation.md
+++ b/docs/snapshot/native-resource-translation.md
@@ -23,6 +23,9 @@ Currently supported resource recipes:
   provenance;
 - explicitly modeled one-fd `ppoll` proofs may request synthetic empty pipe,
   empty eventfd, and disarmed/future one-shot timerfd recipes at the captured fd;
+- Goal 4 `eventfd-counter-v1` descriptors may recreate non-semaphore eventfds
+  with an exact nonzero counter, known-empty waiter state, supported fd flags,
+  and close-on-exec provenance;
 - epoll instances may be recreated only for the Goal 3 `interest-list-v1`
   subset: finite level-triggered watches whose watched fds already have accepted
   target recipes, with no nested epoll, no edge-triggered/one-shot delivery
@@ -42,8 +45,8 @@ into a deterministic target fd-table plan. The plan preserves the stable capture
 fd -> target fd mapping, emits explicit `close-fd` recipes for expected fd slots
 missing from the capture, carries close-on-exec provenance, and converts modeled
 resources into target-guest loader recipes (`reopen-file`, `inherit-stdio`,
-`synthetic-empty-pipe`, `synthetic-empty-eventfd`, `synthetic-timerfd`,
-`synthetic-epoll`, and `synthetic-signalfd`).
+`synthetic-empty-pipe`, `synthetic-empty-eventfd`, `synthetic-eventfd`,
+`synthetic-timerfd`, `synthetic-epoll`, and `synthetic-signalfd`).
 The loader/trampoline handoff applies close-on-exec after restore setup and
 before the target-native jump. Duplicate captured fds are refused before target
 execution with `target-fd-table-duplicate`; captured fds without any safe target
@@ -58,13 +61,14 @@ recipe refuse with `target-fd-table-missing` or the underlying resource refusal.
 | close-fd gap                 | explicit target `close-fd` recipe                                                          |
 | synthetic empty pipe         | only for modeled ppoll/read proof slices with paired read/write ends                       |
 | synthetic empty eventfd      | only counter-0, non-semaphore, modeled proof slices                                        |
+| synthetic eventfd counter    | only `eventfd-counter-v1`: nonzero counter, non-semaphore, supported flags, no waiters     |
 | synthetic timerfd            | only modeled disarmed/future one-shot timerfd proof slices                                 |
 | PTY                          | refuse unless a PTY broker capability is declared                                          |
 | raw socket                   | refuse unless a raw-socket broker capability is declared                                   |
 | sockets                      | Goal 3 keeps arbitrary/brokerless sockets refused until an explicit broker contract exists |
 | epoll                        | recreate `interest-list-v1` only when watched fds have accepted recipes; otherwise refuse  |
 | signalfd                     | recreate `empty-queue-v1` descriptors only; pending queues/active frames still refuse      |
-| generic eventfd/timerfd      | refuse except for the narrow empty/disarmed modeled states above                           |
+| generic eventfd/timerfd      | refuse except for the narrow empty/counter/disarmed modeled states above                   |
 | duplicate captured fd        | refuse with `target-fd-table-duplicate` before target execution                            |
 | unsupported descriptor shape | refuse before loader/trampoline args are built                                             |
 
@@ -75,7 +79,9 @@ Unsupported resources are not silently dropped. They are returned with:
 - `fd-kind-unsupported` for unknown generic fd entries;
 - `kernel-state-unsupported` for pipes, sockets, eventfd, timerfd, and signalfd
   resources whose kernel state is not explicitly modeled by a narrow proof
-  recipe;
+  recipe, including eventfd semaphore mode, unknown eventfd waiters, unsupported
+  eventfd flags, zero counters outside the empty-eventfd recipe, and overflow
+  counters outside `eventfd-counter-v1`;
 - `target-epoll-syscall-state-unsupported` for epoll resources outside the
   `interest-list-v1` subset, including unsupported watched fds, nested epoll,
   edge-triggered/one-shot flags, and malformed interest lists;

--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -106,9 +106,9 @@ passes. The accepted class includes:
 - target-owned private-memory, executable-mapping, signal, resource, and
   descriptor consumption gates;
 - regular-file fd recipes, stdio/close-fd recipes, the modeled synthetic empty
-  pipe/eventfd/timerfd proof states, the Goal 3 epoll `interest-list-v1`
-  reconstruction subset, and the Goal 3 signalfd `empty-queue-v1` descriptor
-  subset;
+  pipe/eventfd/timerfd proof states, the Goal 4 `eventfd-counter-v1` descriptor
+  subset, the Goal 3 epoll `interest-list-v1` reconstruction subset, and the
+  Goal 3 signalfd `empty-queue-v1` descriptor subset;
 - active syscall completion only for sleep/`ppoll` timeout, empty pipe read,
   empty eventfd read, timerfd read, offset-backed regular-file
   `read`/`pread64`/single-iovec `readv`, and offset-backed regular-file
@@ -130,21 +130,22 @@ all profile gates pass.
 
 ## Current positive profiles
 
-| Profile             | Source fixture                     | Trace            | Profile-specific gates              |
-| ------------------- | ---------------------------------- | ---------------- | ----------------------------------- |
-| `two-thread-ppoll`  | `native-two-thread-ppoll-target.c` | none             | active syscall + controlled thread  |
-| `pipe-read`         | `native-pipe-read-target.c`        | none             | active syscall                      |
-| `eventfd-read`      | `native-eventfd-read-target.c`     | none             | active syscall                      |
-| `timerfd-read`      | `native-timerfd-read-target.c`     | none             | active syscall                      |
-| `file-read`         | `native-file-read-target.c`        | `read` fd 38     | active syscall                      |
-| `file-pread`        | `native-file-pread-target.c`       | `pread64` fd 40  | active syscall                      |
-| `file-readv`        | `native-file-readv-target.c`       | `readv` fd 42    | active syscall                      |
-| `file-write`        | `native-file-write-target.c`       | `write` fd 39    | active syscall                      |
-| `file-pwrite`       | `native-file-pwrite-target.c`      | `pwrite64` fd 41 | active syscall                      |
-| `file-writev`       | `native-file-writev-target.c`      | `writev` fd 43   | active syscall                      |
-| `process-context`   | `native-ppoll-timeout-target.c`    | none             | process context                     |
-| `epoll-recreate`    | `native-pipe-read-target.c`        | none             | active syscall + epoll resources    |
-| `signalfd-recreate` | `native-pipe-read-target.c`        | none             | active syscall + signalfd resources |
+| Profile                    | Source fixture                     | Trace            | Profile-specific gates              |
+| -------------------------- | ---------------------------------- | ---------------- | ----------------------------------- |
+| `two-thread-ppoll`         | `native-two-thread-ppoll-target.c` | none             | active syscall + controlled thread  |
+| `pipe-read`                | `native-pipe-read-target.c`        | none             | active syscall                      |
+| `eventfd-read`             | `native-eventfd-read-target.c`     | none             | active syscall                      |
+| `eventfd-counter-recreate` | `native-pipe-read-target.c`        | none             | active syscall + eventfd resources  |
+| `timerfd-read`             | `native-timerfd-read-target.c`     | none             | active syscall                      |
+| `file-read`                | `native-file-read-target.c`        | `read` fd 38     | active syscall                      |
+| `file-pread`               | `native-file-pread-target.c`       | `pread64` fd 40  | active syscall                      |
+| `file-readv`               | `native-file-readv-target.c`       | `readv` fd 42    | active syscall                      |
+| `file-write`               | `native-file-write-target.c`       | `write` fd 39    | active syscall                      |
+| `file-pwrite`              | `native-file-pwrite-target.c`      | `pwrite64` fd 41 | active syscall                      |
+| `file-writev`              | `native-file-writev-target.c`      | `writev` fd 43   | active syscall                      |
+| `process-context`          | `native-ppoll-timeout-target.c`    | none             | process context                     |
+| `epoll-recreate`           | `native-pipe-read-target.c`        | none             | active syscall + epoll resources    |
+| `signalfd-recreate`        | `native-pipe-read-target.c`        | none             | active syscall + signalfd resources |
 
 ## Current negative profiles
 

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -38,6 +38,7 @@ resource=inherit-stdio fd=1 stream=stdout closeOnExec=false
 resource=reopen-file fd=7 path=/tmp/data.txt offset=9 access=0 closeOnExec=true
 resource=synthetic-empty-pipe readFd=3 writeFd=4 closeOnExec=false
 resource=synthetic-empty-eventfd fd=5 closeOnExec=false
+resource=synthetic-eventfd fd=10 initialValue=0x2a closeOnExec=false
 resource=synthetic-timerfd fd=6 closeOnExec=false
 resource=synthetic-signalfd fd=9 signalMask=0x200 flags=2048 closeOnExec=false
 resource=synthetic-epoll fd=8 watchCount=1 watch0Fd=5 watch0Events=1 watch0Data=0x45504f4c4c closeOnExec=false
@@ -54,6 +55,9 @@ Supported fd-table resources and memory materialization are intentionally narrow
   offset and access mode;
 - `synthetic-empty-pipe` with a modeled read fd and optional write fd;
 - `synthetic-empty-eventfd` with an empty non-semaphore eventfd;
+- `synthetic-eventfd` with a Goal 4 `eventfd-counter-v1` non-semaphore counter
+  value, refused unless the counter, waiter state, flags, and close-on-exec
+  provenance are exact;
 - `synthetic-timerfd` with a disarmed/future one-shot timerfd;
 - `synthetic-epoll` for the Goal 3 `interest-list-v1` subset: a finite
   level-triggered watch list over fds that already have target recipes;
@@ -75,8 +79,10 @@ The runtime fd-table planner emits these resource lines from translated native
 resources. The in-guest loader validates duplicate fd ownership before launching
 the trampoline, applies `close-fd` and `reopen-file` recipes in the child process,
 and forwards synthetic fd recipes plus `--set-cloexec-fd` intents to the
-trampoline. signalfd recipes are installed with `signalfd()` from the normalized
-mask and flags. Epoll recipes are installed after their watched synthetic fds,
+trampoline. Eventfd counter recipes are installed with a target-owned `eventfd()`
+followed by an exact 8-byte write of the modeled counter before the target-native
+jump. signalfd recipes are installed with `signalfd()` from the normalized mask
+and flags. Epoll recipes are installed after their watched synthetic fds,
 signalfds, and reopened files exist, then `epoll_ctl(EPOLL_CTL_ADD)` recreates
 the declared interest list. The trampoline applies close-on-exec flags after the
 loader-to-trampoline `exec` boundary and before the target-native jump, so modeled

--- a/goal-4.md
+++ b/goal-4.md
@@ -73,12 +73,12 @@ Accepted subset candidates:
 
 Tasks:
 
-- [ ] Define `eventfd-counter-v1` for non-semaphore eventfds with exact nonzero
+- [x] Define `eventfd-counter-v1` for non-semaphore eventfds with exact nonzero
       counter recreation, overflow bounds, close-on-exec handling, and refusal of
-      semaphore mode or unknown waiters.
-- [ ] Add target-native eventfd recreation, verifier reads/writes, positive proof
+      semaphore mode or unknown waiters. Issue/PR: #775 / #776.
+- [x] Add target-native eventfd recreation, verifier reads/writes, positive proof
       profile, and negative profiles for semaphore mode, overflow, pending
-      waiters, and unsupported flags.
+      waiters, and unsupported flags. Issue/PR: #775 / #776.
 - [ ] Define `timerfd-descriptor-v1` for disarmed and future one-shot timerfds,
       including clock source, absolute/relative mode, remaining time, interval,
       overrun, and cancellation semantics.

--- a/packages/microvm/assets/native-actual-resume-trampoline.c
+++ b/packages/microvm/assets/native-actual-resume-trampoline.c
@@ -229,6 +229,9 @@ struct Options {
   int synthetic_empty_pipe_read_fd;
   int synthetic_empty_pipe_write_fd;
   int synthetic_empty_eventfd;
+  bool has_synthetic_eventfd;
+  int synthetic_eventfd;
+  uint64_t synthetic_eventfd_initial_value;
   int synthetic_timerfd;
   struct NativeRestoreStepSpec synthetic_signalfds[MAX_NATIVE_RESTORE_STEPS];
   size_t synthetic_signalfd_count;
@@ -277,7 +280,7 @@ static void usage(void) {
       "[--resume-register-r9 addr] [--resume-register-r10 addr] "
       "[--resume-register-r11 addr] --timeout-seconds n "
       "[--synthetic-empty-pipe-read-fd n] [--synthetic-empty-pipe-write-fd n] "
-      "[--synthetic-empty-eventfd n] "
+      "[--synthetic-empty-eventfd n] [--synthetic-eventfd spec] "
       "[--synthetic-timerfd n] [--synthetic-signalfd spec] [--synthetic-epoll spec] "
       "[--set-cloexec-fd n] "
       "[--materialize-memory file:offset:target:size:perms] "
@@ -487,12 +490,15 @@ static void add_native_step(struct NativeRestoreStepSpec *steps, size_t *count, 
   copy_step_spec(&steps[(*count)++], spec);
 }
 
+static uint64_t native_step_u64(const char *spec, const char *name, const char *label);
+
 static struct Options parse_args(int argc, char **argv) {
   struct Options opts = {0};
   opts.timeout_seconds = 1;
   opts.synthetic_empty_pipe_read_fd = -1;
   opts.synthetic_empty_pipe_write_fd = -1;
   opts.synthetic_empty_eventfd = -1;
+  opts.synthetic_eventfd = -1;
   opts.synthetic_timerfd = -1;
   for (int i = 1; i < argc; i++) {
     if (streq(argv[i], "--code-file")) {
@@ -700,6 +706,19 @@ static struct Options parse_args(int argc, char **argv) {
         exit(2);
       }
       opts.synthetic_empty_pipe_write_fd = (int)fd;
+    } else if (streq(argv[i], "--synthetic-eventfd")) {
+      if (++i >= argc) {
+        usage();
+      }
+      uint64_t fd = native_step_u64(argv[i], "fd", "synthetic-eventfd");
+      uint64_t initial_value = native_step_u64(argv[i], "initialValue", "synthetic-eventfd");
+      if (fd > 1024u || initial_value == UINT64_MAX) {
+        fprintf(stderr, "native-actual-resume-trampoline: synthetic eventfd spec is invalid\n");
+        exit(2);
+      }
+      opts.has_synthetic_eventfd = true;
+      opts.synthetic_eventfd = (int)fd;
+      opts.synthetic_eventfd_initial_value = initial_value;
     } else if (streq(argv[i], "--synthetic-timerfd")) {
       if (++i >= argc) {
         usage();
@@ -1272,9 +1291,13 @@ static void install_synthetic_timerfd(int target_fd) {
   }
 }
 
-static void install_synthetic_empty_eventfd(int target_fd) {
+static void install_synthetic_eventfd(int target_fd, uint64_t initial_value) {
   if (target_fd < 0) {
     return;
+  }
+  if (initial_value == UINT64_MAX) {
+    fprintf(stderr, "native-actual-resume-trampoline: synthetic eventfd initial value is unsupported\n");
+    exit(2);
   }
   int fd = eventfd(0, EFD_CLOEXEC);
   if (fd < 0) {
@@ -1288,10 +1311,21 @@ static void install_synthetic_empty_eventfd(int target_fd) {
     }
     close(fd);
   }
+  if (initial_value != 0) {
+    ssize_t wrote = write(target_fd, &initial_value, sizeof(initial_value));
+    if (wrote != (ssize_t)sizeof(initial_value)) {
+      fprintf(stderr, "native-actual-resume-trampoline: synthetic eventfd write failed: %s\n", strerror(errno));
+      exit(1);
+    }
+  }
   if (fcntl(target_fd, F_SETFD, FD_CLOEXEC) != 0) {
     fprintf(stderr, "native-actual-resume-trampoline: synthetic eventfd cloexec failed: %s\n", strerror(errno));
     exit(1);
   }
+}
+
+static void install_synthetic_empty_eventfd(int target_fd) {
+  install_synthetic_eventfd(target_fd, 0);
 }
 
 static void sigset_from_mask(sigset_t *set, uint64_t mask);
@@ -3050,6 +3084,9 @@ int main(int argc, char **argv) {
   install_synthetic_empty_pipe(
       opts.synthetic_empty_pipe_read_fd, opts.synthetic_empty_pipe_write_fd);
   install_synthetic_empty_eventfd(opts.synthetic_empty_eventfd);
+  if (opts.has_synthetic_eventfd) {
+    install_synthetic_eventfd(opts.synthetic_eventfd, opts.synthetic_eventfd_initial_value);
+  }
   install_synthetic_timerfd(opts.synthetic_timerfd);
   install_synthetic_signalfds(&opts);
   install_synthetic_epolls(&opts);

--- a/packages/microvm/assets/target-guest-restore-loader.c
+++ b/packages/microvm/assets/target-guest-restore-loader.c
@@ -99,6 +99,8 @@ struct Descriptor {
   int pipe_read_fd;
   int pipe_write_fd;
   int event_fd;
+  bool has_eventfd_spec;
+  char eventfd_spec[1024];
   int timer_fd;
   int signalfd_fds[MAX_FD_RECIPES];
   char signalfd_specs[MAX_FD_RECIPES][1024];
@@ -380,8 +382,17 @@ static void add_cloexec_if_requested(struct Descriptor *descriptor, char *fields
 }
 
 static void parse_eventfd_resource(struct Descriptor *descriptor, char *fields) {
+  if (descriptor->event_fd >= 0) {
+    refuse("target-guest-loader-invalid-fd", "eventfd fd is assigned by multiple recipes");
+  }
   descriptor->event_fd = parse_single_fd_resource(fields, "eventfd fd is required");
   add_cloexec_if_requested(descriptor, fields, descriptor->event_fd);
+}
+
+static void parse_counter_eventfd_resource(struct Descriptor *descriptor, char *fields) {
+  parse_eventfd_resource(descriptor, fields);
+  fields_to_semicolon_spec(descriptor->eventfd_spec, sizeof(descriptor->eventfd_spec), fields);
+  descriptor->has_eventfd_spec = true;
 }
 
 static void parse_timerfd_resource(struct Descriptor *descriptor, char *fields) {
@@ -780,6 +791,8 @@ static void parse_resource(struct Descriptor *descriptor, char *line) {
     parse_pipe_resource(descriptor, line + strlen("resource=synthetic-empty-pipe"));
   } else if (starts_with(line, "resource=synthetic-empty-eventfd")) {
     parse_eventfd_resource(descriptor, line + strlen("resource=synthetic-empty-eventfd"));
+  } else if (starts_with(line, "resource=synthetic-eventfd")) {
+    parse_counter_eventfd_resource(descriptor, line + strlen("resource=synthetic-eventfd"));
   } else if (starts_with(line, "resource=synthetic-timerfd")) {
     parse_timerfd_resource(descriptor, line + strlen("resource=synthetic-timerfd"));
   } else if (starts_with(line, "resource=synthetic-signalfd")) {
@@ -1113,8 +1126,13 @@ static int run_trampoline(const struct Options *opts, const struct Descriptor *d
     push_arg(child_argv, &child_argc, pipe_write_fd);
   }
   if (descriptor->event_fd >= 0) {
-    push_arg(child_argv, &child_argc, "--synthetic-empty-eventfd");
-    push_arg(child_argv, &child_argc, event_fd);
+    if (descriptor->has_eventfd_spec) {
+      push_arg(child_argv, &child_argc, "--synthetic-eventfd");
+      push_arg(child_argv, &child_argc, descriptor->eventfd_spec);
+    } else {
+      push_arg(child_argv, &child_argc, "--synthetic-empty-eventfd");
+      push_arg(child_argv, &child_argc, event_fd);
+    }
   }
   if (descriptor->timer_fd >= 0) {
     push_arg(child_argv, &child_argc, "--synthetic-timerfd");

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -13554,7 +13554,7 @@ Poll interval in ms while retrying. Default 250.
 
 ### NativeTargetFdTableEntryKind
 
-> **NativeTargetFdTableEntryKind** = `"close-fd"` \| `"inherit-stdio"` \| `"reopen-file"` \| `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-pipe-write-end"` \| `"synthetic-empty-eventfd"` \| `"synthetic-timerfd"` \| `"synthetic-signalfd"` \| `"synthetic-epoll"` \| `"refused"`
+> **NativeTargetFdTableEntryKind** = `"close-fd"` \| `"inherit-stdio"` \| `"reopen-file"` \| `"synthetic-empty-pipe-read-end"` \| `"synthetic-empty-pipe-write-end"` \| `"synthetic-empty-eventfd"` \| `"synthetic-eventfd"` \| `"synthetic-timerfd"` \| `"synthetic-signalfd"` \| `"synthetic-epoll"` \| `"refused"`
 
 ***
 
@@ -13916,7 +13916,7 @@ Result of `validatePid` — easy to switch on at the call site.
 
 ### TargetGuestRestoreResourceRecipe
 
-> **TargetGuestRestoreResourceRecipe** = \{ `kind`: `"close-fd"`; `fd`: `number`; `reason?`: `string`; \} \| \{ `kind`: `"inherit-stdio"`; `fd`: `1` \| `2`; `stream`: `"stdout"` \| `"stderr"`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"reopen-file"`; `fd`: `number`; `path`: `string`; `offset`: `number`; `access`: `0` \| `1` \| `2`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-empty-pipe"`; `readFd`: `number`; `writeFd?`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-empty-eventfd"`; `fd`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-timerfd"`; `fd`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-signalfd"`; `fd`: `number`; `signalMask`: `string`; `flags`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-epoll"`; `fd`: `number`; `watches`: [`TargetGuestEpollWatchRecipe`](#targetguestepollwatchrecipe)[]; `closeOnExec?`: `boolean`; \}
+> **TargetGuestRestoreResourceRecipe** = \{ `kind`: `"close-fd"`; `fd`: `number`; `reason?`: `string`; \} \| \{ `kind`: `"inherit-stdio"`; `fd`: `1` \| `2`; `stream`: `"stdout"` \| `"stderr"`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"reopen-file"`; `fd`: `number`; `path`: `string`; `offset`: `number`; `access`: `0` \| `1` \| `2`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-empty-pipe"`; `readFd`: `number`; `writeFd?`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-empty-eventfd"`; `fd`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-eventfd"`; `fd`: `number`; `initialValue`: `string`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-timerfd"`; `fd`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-signalfd"`; `fd`: `number`; `signalMask`: `string`; `flags`: `number`; `closeOnExec?`: `boolean`; \} \| \{ `kind`: `"synthetic-epoll"`; `fd`: `number`; `watches`: [`TargetGuestEpollWatchRecipe`](#targetguestepollwatchrecipe)[]; `closeOnExec?`: `boolean`; \}
 
 ***
 

--- a/packages/runtime/src/__tests__/native-resource-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-resource-translation.test.ts
@@ -155,6 +155,106 @@ describe("native resource translation", () => {
     });
   });
 
+  it("plans an accepted eventfd-counter-v1 descriptor", () => {
+    const plan = planNativeTargetFdTable({
+      resources: [
+        {
+          id: "fd:11",
+          kind: "eventfd",
+          state: "captured",
+          fd: 11,
+          path: "anon_inode:[eventfd]",
+          flags: ["octal:2"],
+          recipe: {
+            eventfdModel: "counter-v1",
+            eventfdCount: "0x2a",
+            eventfdSemaphore: 0,
+            eventfdWaiters: "none",
+          },
+        },
+      ],
+    });
+
+    expect(plan.refusals).toEqual([]);
+    expect(plan.entries).toEqual([
+      expect.objectContaining({ targetFd: 11, kind: "synthetic-eventfd", action: "materialize" }),
+    ]);
+    expect(plan.targetGuestResources).toEqual([
+      { kind: "synthetic-eventfd", fd: 11, initialValue: "0x2a", closeOnExec: false },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "semaphore mode",
+      recipe: {
+        eventfdModel: "counter-v1",
+        eventfdCount: "0x2a",
+        eventfdSemaphore: 1,
+        eventfdWaiters: "none",
+      },
+      reason: "eventfd semaphore mode is unsupported",
+    },
+    {
+      name: "unknown waiters",
+      recipe: { eventfdModel: "counter-v1", eventfdCount: "0x2a", eventfdSemaphore: 0 },
+      reason: "eventfd waiters must be known empty",
+    },
+    {
+      name: "zero counter",
+      recipe: {
+        eventfdModel: "counter-v1",
+        eventfdCount: "0x0",
+        eventfdSemaphore: 0,
+        eventfdWaiters: "none",
+      },
+      reason: "eventfd counter is outside supported bounds",
+    },
+    {
+      name: "overflow counter",
+      recipe: {
+        eventfdModel: "counter-v1",
+        eventfdCount: "0xffffffffffffffff",
+        eventfdSemaphore: 0,
+        eventfdWaiters: "none",
+      },
+      reason: "eventfd counter is outside supported bounds",
+    },
+    {
+      name: "unsupported flags",
+      flags: ["octal:4002"],
+      recipe: {
+        eventfdModel: "counter-v1",
+        eventfdCount: "0x2a",
+        eventfdSemaphore: 0,
+        eventfdWaiters: "none",
+      },
+      reason: "eventfd flags are unsupported",
+    },
+  ])("keeps unsafe eventfd counter variants fail-closed: $name", ({ flags, recipe, reason }) => {
+    const plan = planNativeTargetFdTable({
+      resources: [
+        {
+          id: "fd:11",
+          kind: "eventfd",
+          state: "captured",
+          fd: 11,
+          path: "anon_inode:[eventfd]",
+          flags: flags ?? ["octal:2"],
+          recipe,
+        },
+      ],
+    });
+
+    expect(plan.refusals).toEqual([
+      expect.objectContaining({
+        code: "kernel-state-unsupported",
+        detail: expect.objectContaining({ boundary: "eventfd-counter-v1", reason }),
+      }),
+    ]);
+    expect(plan.targetGuestResources).toEqual([]);
+  });
+
   it("allows explicit synthetic timerfd resources for one-fd ppoll proofs", () => {
     const result = translateNativeResources({
       syntheticTimerFds: [12],

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -108,10 +108,11 @@ describe("portable machine proof runner", () => {
     expect(result.status, result.stderr).toBe(0);
     const summary = JSON.parse(result.stdout);
     const names = summary.profiles.map((profile: { name: string }) => profile.name);
-    expect(names.slice(0, 11)).toEqual([
+    expect(names.slice(0, 12)).toEqual([
       "two-thread-ppoll",
       "pipe-read",
       "eventfd-read",
+      "eventfd-counter-recreate",
       "timerfd-read",
       "file-read",
       "file-pread",
@@ -163,11 +164,16 @@ describe("portable machine proof runner", () => {
     expect(summary.supportReport).toMatchObject({
       counts: {
         "baseline-success": 11,
-        "graduated-support": 2,
+        "graduated-support": 3,
         "intentional-refusal": 7,
         "permanent-refusal": 3,
       },
       graduated: [
+        expect.objectContaining({
+          name: "eventfd-counter-recreate",
+          acceptedSubset: "eventfd-counter-v1-nonsemaphore-no-waiters",
+          graduatedFromRefusalCode: "kernel-state-unsupported",
+        }),
         expect.objectContaining({
           name: "epoll-recreate",
           acceptedSubset: "single-level-triggered-restorable-fd-watch",

--- a/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
+++ b/packages/runtime/src/__tests__/target-guest-restore-loader.test.ts
@@ -106,7 +106,7 @@ describe("target guest restore loader descriptor", () => {
           closeOnExec: true,
         },
         { kind: "synthetic-empty-pipe", readFd: 3, writeFd: 4, closeOnExec: false },
-        { kind: "synthetic-empty-eventfd", fd: 5, closeOnExec: false },
+        { kind: "synthetic-eventfd", fd: 5, initialValue: "0x2a", closeOnExec: false },
         { kind: "synthetic-timerfd", fd: 6, closeOnExec: false },
         {
           kind: "synthetic-signalfd",
@@ -204,8 +204,8 @@ describe("target guest restore loader descriptor", () => {
       "3",
       "--synthetic-empty-pipe-write-fd",
       "4",
-      "--synthetic-empty-eventfd",
-      "5",
+      "--synthetic-eventfd",
+      "fd=5;initialValue=0x2a",
       "--synthetic-timerfd",
       "6",
       "--synthetic-signalfd",
@@ -565,6 +565,20 @@ describe("target guest restore loader descriptor", () => {
         descriptor({ resources: [{ kind: "synthetic-empty-pipe", readFd: 4, writeFd: 4 }] }),
       ),
     ).toThrow(/pipe read\/write fds must differ/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({ resources: [{ kind: "synthetic-eventfd", fd: 5, initialValue: "42" }] }),
+      ),
+    ).toThrow(/initialValue must be a hex address/);
+
+    expect(() =>
+      validateTargetGuestRestoreDescriptor(
+        descriptor({
+          resources: [{ kind: "synthetic-eventfd", fd: 5, initialValue: "0xffffffffffffffff" }],
+        }),
+      ),
+    ).toThrow(/eventfd initialValue is unsupported/);
 
     expect(() =>
       validateTargetGuestRestoreDescriptor(

--- a/packages/runtime/src/native-active-syscall-policy.ts
+++ b/packages/runtime/src/native-active-syscall-policy.ts
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { nativeFdAccessMode, nativeFdFlagBits } from "./native-fd-flags.ts";
+import { nativeResourceRecipeBigInt } from "./native-resource-recipe.ts";
 import {
   NATIVE_PROCESS_IMAGE_FILES,
   type NativeMemoryMapping,
@@ -2369,17 +2370,7 @@ function validateTimerfdState(
     : undefined;
 }
 
-function nativeResourceBigInt(resource: NativeProcessResource, key: string): bigint | undefined {
-  const value = resource.recipe?.[key];
-  if (typeof value !== "string" && typeof value !== "number") {
-    return undefined;
-  }
-  try {
-    return BigInt(value);
-  } catch {
-    return undefined;
-  }
-}
+const nativeResourceBigInt = nativeResourceRecipeBigInt;
 
 function readCapturedTimespec(
   documents: NativeProcessImageDocuments,

--- a/packages/runtime/src/native-resource-recipe.ts
+++ b/packages/runtime/src/native-resource-recipe.ts
@@ -1,0 +1,16 @@
+import type { NativeProcessResource } from "./native-process-image.ts";
+
+export function nativeResourceRecipeBigInt(
+  resource: NativeProcessResource,
+  key: string,
+): bigint | undefined {
+  const value = resource.recipe?.[key];
+  if (typeof value !== "string" && typeof value !== "number") {
+    return undefined;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -1,6 +1,7 @@
 /** Kernel-resource recipes and refusals for native process restore. */
 
-import { nativeFdAccessMode, nativeFdCloseOnExec } from "./native-fd-flags.ts";
+import { nativeFdAccessMode, nativeFdCloseOnExec, nativeFdFlagBits } from "./native-fd-flags.ts";
+import { nativeResourceRecipeBigInt } from "./native-resource-recipe.ts";
 import type { NativeProcessImageRefusal, NativeProcessResource } from "./native-process-image.ts";
 import type { TargetGuestRestoreResourceRecipe } from "./target-guest-restore-loader.ts";
 
@@ -29,6 +30,7 @@ export type NativeTargetFdTableEntryKind =
   | "synthetic-empty-pipe-read-end"
   | "synthetic-empty-pipe-write-end"
   | "synthetic-empty-eventfd"
+  | "synthetic-eventfd"
   | "synthetic-timerfd"
   | "synthetic-signalfd"
   | "synthetic-epoll"
@@ -190,6 +192,7 @@ function fdTableEntryFromRecipe(
     inheritedStdioFdTableEntry(fd, resource, recipe, closeOnExec) ??
     reopenFileFdTableEntry(fd, resource, recipe, closeOnExec) ??
     syntheticFdTableEntry(fd, resource, recipe, closeOnExec) ??
+    syntheticEventfdFdTableEntry(resource, recipe, closeOnExec) ??
     syntheticSignalfdFdTableEntry(resource, recipe, closeOnExec) ??
     syntheticEpollFdTableEntry(resource, recipe, closeOnExec, resources)
   );
@@ -259,6 +262,64 @@ function syntheticFdTableEntry(
     }),
   };
   return typeof recipe.synthetic === "string" ? recipes[recipe.synthetic] : undefined;
+}
+
+function syntheticEventfdFdTableEntry(
+  resource: NativeProcessResource,
+  recipe: Record<string, unknown>,
+  closeOnExec: boolean,
+): NativeTargetFdTableEntry | undefined {
+  if (resource.kind !== "eventfd" || recipe.eventfdModel !== "counter-v1") {
+    return undefined;
+  }
+  const eventfdRecipe = normalizedEventfdCounterRecipe(resource, recipe);
+  if ("code" in eventfdRecipe) {
+    return refusedFdTableEntry(resource, eventfdRecipe);
+  }
+  return materializedFdTableEntry(resource, "synthetic-eventfd", closeOnExec, {
+    kind: "synthetic-eventfd",
+    fd: resource.fd!,
+    initialValue: eventfdRecipe.initialValue,
+    closeOnExec,
+  });
+}
+
+function normalizedEventfdCounterRecipe(
+  resource: NativeProcessResource,
+  recipe: Record<string, unknown>,
+): { initialValue: string } | NativeProcessImageRefusal {
+  if (nativeFdAccessMode(resource.flags) !== 2) {
+    return eventfdRefusal(resource, "eventfd counter recipe requires read/write access", {
+      flags: resource.flags,
+    });
+  }
+  if (!EVENTFD_COUNTER_SUPPORTED_FLAGS.has(nativeFdFlagBits(resource.flags))) {
+    return eventfdRefusal(resource, "eventfd flags are unsupported", {
+      flags: resource.flags,
+      supportedFlags: Array.from(
+        EVENTFD_COUNTER_SUPPORTED_FLAGS,
+        (flags) => `octal:${flags.toString(8)}`,
+      ),
+    });
+  }
+  if (recipe.eventfdWaiters !== "none") {
+    return eventfdRefusal(resource, "eventfd waiters must be known empty", {
+      eventfdWaiters: recipe.eventfdWaiters,
+    });
+  }
+  const count = nativeResourceBigInt(resource, "eventfdCount");
+  if (count === undefined || count <= 0n || count > EVENTFD_MAX_COUNTER) {
+    return eventfdRefusal(resource, "eventfd counter is outside supported bounds", {
+      eventfdCount: count?.toString(10),
+    });
+  }
+  const semaphore = nativeResourceBigInt(resource, "eventfdSemaphore");
+  if (semaphore !== 0n) {
+    return eventfdRefusal(resource, "eventfd semaphore mode is unsupported", {
+      eventfdSemaphore: semaphore?.toString(10),
+    });
+  }
+  return { initialValue: `0x${count.toString(16)}` };
 }
 
 function syntheticSignalfdFdTableEntry(
@@ -550,6 +611,13 @@ function translateResource(
       refusal: undefined,
     };
   }
+  if (resource.kind === "eventfd" && resource.recipe?.eventfdModel === "counter-v1") {
+    return {
+      ...resource,
+      state: "recipe",
+      refusal: undefined,
+    };
+  }
   if (
     resource.kind === "timer" &&
     resource.fd !== undefined &&
@@ -710,6 +778,8 @@ function resourceRefusalCode(
   return "resource-kind-unsupported";
 }
 
+const EVENTFD_COUNTER_SUPPORTED_FLAGS = new Set([0o2, 0o2000002]);
+const EVENTFD_MAX_COUNTER = 0xfffffffffffffffen;
 const SIGNALFD_SUPPORTED_FLAGS = 0x800;
 const EPOLL_EDGE_TRIGGERED = 0x80000000;
 const EPOLL_ONESHOT = 0x40000000;
@@ -734,6 +804,29 @@ function normalizeHex(value: string): string | undefined {
     return undefined;
   }
   return `0x${BigInt(value).toString(16)}`;
+}
+
+const nativeResourceBigInt = nativeResourceRecipeBigInt;
+
+function eventfdRefusal(
+  resource: NativeProcessResource,
+  reason: string,
+  detail: Record<string, unknown> = {},
+): NativeProcessImageRefusal {
+  return {
+    code: "kernel-state-unsupported",
+    message: `eventfd resource ${resource.id} cannot be recreated target-natively`,
+    detail: {
+      id: resource.id,
+      kind: resource.kind,
+      fd: resource.fd,
+      path: resource.path,
+      boundary: "eventfd-counter-v1",
+      reason,
+      requiredModel: RESOURCE_REQUIRED_MODELS.eventfd,
+      ...detail,
+    },
+  };
 }
 
 function signalfdRefusal(

--- a/packages/runtime/src/target-guest-restore-loader.ts
+++ b/packages/runtime/src/target-guest-restore-loader.ts
@@ -55,6 +55,7 @@ export type TargetGuestRestoreResourceRecipe =
     }
   | { kind: "synthetic-empty-pipe"; readFd: number; writeFd?: number; closeOnExec?: boolean }
   | { kind: "synthetic-empty-eventfd"; fd: number; closeOnExec?: boolean }
+  | { kind: "synthetic-eventfd"; fd: number; initialValue: string; closeOnExec?: boolean }
   | { kind: "synthetic-timerfd"; fd: number; closeOnExec?: boolean }
   | {
       kind: "synthetic-signalfd";
@@ -464,6 +465,7 @@ const RESOURCE_RECIPE_PARSERS: Record<
   }),
   "synthetic-empty-eventfd": (fields) =>
     parseSingleFdSyntheticRecipe("synthetic-empty-eventfd", fields),
+  "synthetic-eventfd": parseSyntheticEventfdRecipe,
   "synthetic-timerfd": (fields) => parseSingleFdSyntheticRecipe("synthetic-timerfd", fields),
   "synthetic-signalfd": parseSyntheticSignalfdRecipe,
   "synthetic-epoll": parseSyntheticEpollRecipe,
@@ -511,6 +513,17 @@ function parseSingleFdSyntheticRecipe(
   return {
     kind,
     fd: parseResourceInteger(fields, "fd"),
+    closeOnExec: parseResourceBoolean(fields, "closeOnExec"),
+  };
+}
+
+function parseSyntheticEventfdRecipe(
+  fields: Map<string, string>,
+): TargetGuestRestoreResourceRecipe {
+  return {
+    kind: "synthetic-eventfd",
+    fd: parseResourceInteger(fields, "fd"),
+    initialValue: requiredResourceField(fields, "initialValue"),
     closeOnExec: parseResourceBoolean(fields, "closeOnExec"),
   };
 }
@@ -1103,6 +1116,7 @@ const RESOURCE_RECIPE_VALIDATORS = {
     assertDistinctPipeFds(recipe);
   },
   "synthetic-empty-eventfd": validateSingleFdRecipe,
+  "synthetic-eventfd": validateSyntheticEventfdRecipe,
   "synthetic-timerfd": validateSingleFdRecipe,
   "synthetic-signalfd": validateSyntheticSignalfdRecipe,
   "synthetic-epoll": validateSyntheticEpollRecipe,
@@ -1142,6 +1156,17 @@ function validateSingleFdRecipe(
   >,
 ): void {
   assertFd(recipe.fd, "fd");
+}
+
+function validateSyntheticEventfdRecipe(
+  recipe: Extract<TargetGuestRestoreResourceRecipe, { kind: "synthetic-eventfd" }>,
+): void {
+  assertFd(recipe.fd, "fd");
+  assertHexAddress(recipe.initialValue, "initialValue");
+  const value = BigInt(recipe.initialValue);
+  if (value > 0xfffffffffffffffen) {
+    fail("target-guest-loader-descriptor-invalid", "eventfd initialValue is unsupported");
+  }
 }
 
 function validateSyntheticSignalfdRecipe(
@@ -1701,6 +1726,9 @@ function serializeResourceRecipe(recipe: TargetGuestRestoreResourceRecipe): stri
   if (recipe.kind === "synthetic-empty-eventfd") {
     return `resource=synthetic-empty-eventfd fd=${recipe.fd}${serializeCloseOnExec(recipe.closeOnExec)}`;
   }
+  if (recipe.kind === "synthetic-eventfd") {
+    return `resource=synthetic-eventfd fd=${recipe.fd} initialValue=${recipe.initialValue}${serializeCloseOnExec(recipe.closeOnExec)}`;
+  }
   if (recipe.kind === "synthetic-timerfd") {
     return `resource=synthetic-timerfd fd=${recipe.fd}${serializeCloseOnExec(recipe.closeOnExec)}`;
   }
@@ -1886,6 +1914,13 @@ function resourceToTrampolineArgs(recipe: TargetGuestRestoreResourceRecipe): str
       ...closeOnExecArgs(recipe.fd, recipe.closeOnExec),
     ];
   }
+  if (recipe.kind === "synthetic-eventfd") {
+    return [
+      "--synthetic-eventfd",
+      eventfdResourceSpec(recipe),
+      ...closeOnExecArgs(recipe.fd, recipe.closeOnExec),
+    ];
+  }
   if (recipe.kind === "synthetic-timerfd") {
     return [
       "--synthetic-timerfd",
@@ -1905,6 +1940,12 @@ function resourceToTrampolineArgs(recipe: TargetGuestRestoreResourceRecipe): str
     epollResourceSpec(recipe),
     ...closeOnExecArgs(recipe.fd, recipe.closeOnExec),
   ];
+}
+
+function eventfdResourceSpec(
+  recipe: Extract<TargetGuestRestoreResourceRecipe, { kind: "synthetic-eventfd" }>,
+): string {
+  return [`fd=${recipe.fd}`, `initialValue=${recipe.initialValue}`].join(";");
 }
 
 function signalfdResourceSpec(

--- a/scripts/portable-machine-proof-profiles.json
+++ b/scripts/portable-machine-proof-profiles.json
@@ -79,6 +79,36 @@
     "supportStatus": "baseline-success"
   },
   {
+    "name": "eventfd-counter-recreate",
+    "remoteSourceTarget": "eventfd-counter-recreate",
+    "description": "Target-native eventfd counter recreation for a non-semaphore descriptor with an exact counter.",
+    "sourceFixture": "packages/microvm/assets/native-pipe-read-target.c",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "success",
+    "supportStatus": "graduated-support",
+    "unsafeStateFamily": "eventfd",
+    "graduatedFromRefusalCode": "kernel-state-unsupported",
+    "acceptedSubset": "eventfd-counter-v1-nonsemaphore-no-waiters",
+    "unsafeVariants": ["eventfd-read"],
+    "expectedGates": [
+      "descriptor",
+      "verifier",
+      "state-consumption",
+      "resources",
+      "return-chain",
+      "frame",
+      "registers",
+      "tls",
+      "stack-window",
+      "private-memory",
+      "executable",
+      "signal",
+      "active-syscall",
+      "resume-path"
+    ]
+  },
+  {
     "name": "timerfd-read",
     "remoteSourceTarget": "timerfd-read",
     "description": "One-shot timerfd read active-syscall proof with modeled remaining time.",

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -53,6 +53,7 @@ interface Args {
     | "apply-target-env-cwd"
     | "apply-target-visible-context"
     | "apply-target-initial-stack";
+  includeEventfdCounterProof: boolean;
   includeEpollProof: boolean;
   includeSignalfdProof: boolean;
 }
@@ -106,6 +107,7 @@ interface CombinedDescriptorContext extends CombinedDescriptorPaths {
   targetProcessContextSteps: TargetGuestNativeRestoreStep[];
   activeFileReadProof?: ActiveFileReadProof;
   activeFileWriteProof?: ActiveFileWriteProof;
+  includeEventfdCounterProof: boolean;
   includeEpollProof: boolean;
   includeSignalfdProof: boolean;
 }
@@ -168,6 +170,7 @@ const PROOF_TIMER_FD = 11;
 const PROOF_EPOLL_FD = 12;
 const PROOF_SIGNALFD_FD = 13;
 const PROOF_EPOLL_DATA = "0x45504f4c4c504153";
+const PROOF_EVENTFD_COUNTER = "0x2a";
 const PROOF_SIGNALFD_MASK = "0x200";
 const PROOF_SIGNALFD_FLAGS = 0x800;
 const SIGUSR1 = 10;
@@ -229,7 +232,7 @@ function usage(): never {
       "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
       "[--combined-descriptor] [--real-utility-continuation] " +
       "[--process-context-restore metadata-only|apply-target-env-cwd|apply-target-visible-context|apply-target-initial-stack] " +
-      "[--include-epoll-proof] [--include-signalfd-proof] [--json]",
+      "[--include-eventfd-counter-proof] [--include-epoll-proof] [--include-signalfd-proof] [--json]",
   );
   process.exit(2);
 }
@@ -251,6 +254,7 @@ function argsFromReader(read: (flag: string) => string | undefined, argv: string
     syntheticEmptyEventFd: read("--synthetic-empty-eventfd"),
     syntheticTimerFd: read("--synthetic-timerfd"),
     processContextRestore: parseProcessContextRestoreMode(read("--process-context-restore")),
+    includeEventfdCounterProof: argv.includes("--include-eventfd-counter-proof"),
     includeEpollProof: argv.includes("--include-epoll-proof"),
     includeSignalfdProof: argv.includes("--include-signalfd-proof"),
   };
@@ -386,6 +390,7 @@ function prepareCombinedDescriptor(
     context.activeFileReadProof,
     proofFdVerifierBytes(context),
     plan,
+    context.includeEventfdCounterProof,
     context.includeEpollProof,
     context.includeSignalfdProof,
   );
@@ -482,6 +487,7 @@ function combinedDescriptorContext(
     targetProcessContextSteps: processContextSteps.steps,
     activeFileReadProof: activeFileReadProof(activeSyscallPlan.steps),
     activeFileWriteProof: activeFileWriteProof(activeSyscallPlan.steps),
+    includeEventfdCounterProof: args.includeEventfdCounterProof,
     includeEpollProof: args.includeEpollProof,
     includeSignalfdProof: args.includeSignalfdProof,
   };
@@ -1077,7 +1083,7 @@ function proofFdTable(context: CombinedDescriptorContext) {
     expectedFds: [PROOF_CLOSED_FD],
     inheritedStdio: { mode: "inherit-output" },
     syntheticEmptyPipeFds: [PROOF_PIPE_READ_FD],
-    syntheticEmptyEventFds: [PROOF_EVENT_FD],
+    syntheticEmptyEventFds: context.includeEventfdCounterProof ? [] : [PROOF_EVENT_FD],
     syntheticTimerFds: [PROOF_TIMER_FD],
   });
 }
@@ -1152,6 +1158,7 @@ function prepareTargetContinuation(
   activeFileRead: ActiveFileReadProof | undefined,
   expectedFdBytes: Buffer,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  includeEventfdCounterProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): PreparedTargetContinuation | ReturnType<typeof planPortableMachineVmRestoreProof> {
@@ -1163,6 +1170,7 @@ function prepareTargetContinuation(
         activeFileRead,
         expectedFdBytes,
         plan,
+        includeEventfdCounterProof,
         includeEpollProof,
         includeSignalfdProof,
       )
@@ -1172,6 +1180,7 @@ function prepareTargetContinuation(
           expectedMemoryByte,
           activeFileRead,
           expectedFdBytes,
+          includeEventfdCounterProof,
           includeEpollProof,
           includeSignalfdProof,
         ),
@@ -1184,6 +1193,7 @@ function prepareRealUtilityContinuation(
   activeFileRead: ActiveFileReadProof | undefined,
   expectedFdBytes: Buffer,
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
+  includeEventfdCounterProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ) {
@@ -1194,6 +1204,7 @@ function prepareRealUtilityContinuation(
     expectedMemoryByte,
     activeFileRead,
     expectedFdBytes,
+    includeEventfdCounterProof,
     includeEpollProof,
     includeSignalfdProof,
   );
@@ -1437,11 +1448,27 @@ function proofFdResources(context: CombinedDescriptorContext): NativeProcessReso
     ...activeFileWriteResources(context),
     proofPipeResource(PROOF_PIPE_READ_FD, "read"),
     proofPipeResource(PROOF_PIPE_WRITE_FD, "write"),
-    proofSyntheticResource("eventfd", PROOF_EVENT_FD),
+    proofEventfdResource(context),
     proofSyntheticResource("timer", PROOF_TIMER_FD),
     ...epollProofResources(context),
     ...signalfdProofResources(context),
   ];
+}
+
+function proofEventfdResource(context: CombinedDescriptorContext): NativeProcessResource {
+  const base = proofSyntheticResource("eventfd", PROOF_EVENT_FD);
+  return context.includeEventfdCounterProof
+    ? {
+        ...base,
+        flags: ["octal:2"],
+        recipe: {
+          eventfdModel: "counter-v1",
+          eventfdCount: PROOF_EVENTFD_COUNTER,
+          eventfdSemaphore: 0,
+          eventfdWaiters: "none",
+        },
+      }
+    : base;
 }
 
 function epollProofResources(context: CombinedDescriptorContext): NativeProcessResource[] {
@@ -1576,6 +1603,7 @@ function combinedProofTargetCode(
   expectedMemoryByte: number,
   activeFileRead: ActiveFileReadProof | undefined,
   expectedFdBytes: Buffer,
+  includeEventfdCounterProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): Buffer {
@@ -1584,6 +1612,7 @@ function combinedProofTargetCode(
     "exit",
     activeFileRead,
     expectedFdBytes,
+    includeEventfdCounterProof,
     includeEpollProof,
     includeSignalfdProof,
   ).bytes;
@@ -1593,6 +1622,7 @@ function stateConsumingRealUtilityTargetCode(
   expectedMemoryByte: number,
   activeFileRead: ActiveFileReadProof | undefined,
   expectedFdBytes: Buffer,
+  includeEventfdCounterProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): {
@@ -1604,6 +1634,7 @@ function stateConsumingRealUtilityTargetCode(
     "return",
     activeFileRead,
     expectedFdBytes,
+    includeEventfdCounterProof,
     includeEpollProof,
     includeSignalfdProof,
   );
@@ -1621,6 +1652,7 @@ function proofStateVerifierTargetCode(
   completion: ProofCompletionMode,
   activeFileRead: ActiveFileReadProof | undefined,
   expectedFdBytes: Buffer,
+  includeEventfdCounterProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): { bytes: Buffer; translatedReturnOffset: number } {
@@ -1654,7 +1686,11 @@ function proofStateVerifierTargetCode(
   asm.checkFdOpen(PROOF_PIPE_READ_FD);
   asm.checkFdOpen(PROOF_PIPE_WRITE_FD);
   asm.markStateCheck(completion, STATE_CHECK_PIPE);
-  asm.checkFdOpen(PROOF_EVENT_FD);
+  if (includeEventfdCounterProof) {
+    asm.readEventfdValueAndCheck(PROOF_EVENT_FD, BigInt(PROOF_EVENTFD_COUNTER));
+  } else {
+    asm.checkFdOpen(PROOF_EVENT_FD);
+  }
   asm.markStateCheck(completion, STATE_CHECK_EVENTFD);
   asm.checkFdOpen(PROOF_TIMER_FD);
   asm.markStateCheck(completion, STATE_CHECK_TIMERFD);
@@ -1774,6 +1810,18 @@ class Amd64ProofAssembler {
       this.push(0x80, 0x7b, 0x40 + index, byte);
       this.jumpIfNotEqual();
     }
+  }
+
+  readEventfdValueAndCheck(fd: number, expected: bigint): void {
+    this.syscall(0);
+    this.movFd(fd);
+    this.leaRsiRbxOffset(0x60);
+    this.push(0xba);
+    this.pushU32(8);
+    this.push(0x0f, 0x05, 0x83, 0xf8, 0x08);
+    this.jumpIfNotEqual();
+    this.loadU64FromRbxOffset(0x60);
+    this.checkRaxImmediate(expected);
   }
 
   checkEpollEvent(epollFd: number, watchedFd: number, expectedData: bigint, events: number): void {

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -364,6 +364,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-ppoll-timeout-target"
       target_detail="remote arm64 process-context native-process bundle captured from $ARM64_SSH"
       ;;
+    eventfd-counter-recreate)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
+      target_detail="remote arm64 pipe read bundle with target eventfd counter descriptor proof captured from $ARM64_SSH"
+      ;;
     epoll-recreate)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
       target_detail="remote arm64 pipe read bundle with target epoll reconstruction proof captured from $ARM64_SSH"
@@ -446,7 +450,10 @@ run_target_restore() {
     process_context_restore_args=(--process-context-restore apply-target-initial-stack)
     process_context_restore_args_text="${process_context_restore_args[*]}"
   fi
-  if [[ "$REMOTE_SOURCE_TARGET" == "epoll-recreate" ]]; then
+  if [[ "$REMOTE_SOURCE_TARGET" == "eventfd-counter-recreate" ]]; then
+    resource_model_args=(--include-eventfd-counter-proof)
+    resource_model_args_text="${resource_model_args[*]}"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "epoll-recreate" ]]; then
     resource_model_args=(--include-epoll-proof)
     resource_model_args_text="${resource_model_args[*]}"
   elif [[ "$REMOTE_SOURCE_TARGET" == "signalfd-recreate" ]]; then


### PR DESCRIPTION
## Problem

Goal 4 needed the first broader fd/resource recipe beyond empty eventfd state. Non-semaphore eventfds with a known counter can be recreated safely if the counter, flags, close-on-exec bit, and waiter state are exact. Semaphore mode, overflow, unsupported flags, and unknown waiters must still fail closed.

## Solution

- Added `eventfd-counter-v1` translation for exact nonzero, non-semaphore eventfds with known-empty waiter state.
- Added `synthetic-eventfd` target guest descriptor parsing, validation, serialization, and trampoline args.
- Added amd64 trampoline recreation with target-owned `eventfd()` plus an exact 8-byte counter write.
- Added a verifier/proof profile: `eventfd-counter-recreate`.
- Added negative unit coverage for semaphore mode, unknown waiters, zero/overflow counters, and unsupported flags.
- Updated docs and `goal-4.md`.

Closes #775.

## Validation

- `pnpm run format -- goal-4.md docs/snapshot/native-resource-translation.md docs/snapshot/target-guest-restore-loader.md docs/snapshot/portable-machine-proof-profiles.md docs/snapshot/native-fail-closed-refusal-inventory.md packages/runtime/src/native-resource-translation.ts packages/runtime/src/target-guest-restore-loader.ts packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/target-guest-restore-loader.test.ts packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts scripts/portable-machine-vm-restore-proof.ts scripts/smoke/portable-machine-restore.sh` — 0.349s
- `pnpm run format -- packages/runtime/src/native-active-syscall-policy.ts packages/runtime/src/native-resource-translation.ts packages/runtime/src/native-resource-recipe.ts` — 0.305s
- `pnpm run build:docs` — 1.873s
- `pnpm run format:check` — 0.622s
- `pnpm run lint` — 0.237s
- `pnpm run typecheck` — 2.833s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/target-guest-restore-loader.test.ts packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 2.680s, 57 passed
- remote C compile: target guest loader/trampoline — 0.664s
- remote proof `eventfd-counter-recreate` — 35.618s runner / 36s wall
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` — 2m19.413s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.377s
