### PR TITLE
Graduate Goal 4 empty pipe pair recreation

### DIFF
--- a/docs/snapshot/native-fail-closed-refusal-inventory.md
+++ b/docs/snapshot/native-fail-closed-refusal-inventory.md
@@ -44,7 +44,13 @@ subset to `timerfd-descriptor-recreate`: disarmed or relative future one-shot
 `CLOCK_MONOTONIC` timerfds with zero unread expirations, zero interval,
 supported fd flags, and close-on-exec provenance. Periodic timers, expired or
 overrun timers, absolute/cancel-on-set timers, unsupported clocks, and
-unsupported timerfd fd flags continue to require `kernel-state-unsupported`.
+unsupported timerfd fd flags continue to require `kernel-state-unsupported`. The
+`pipe-pair-v1` subset graduates to `pipe-pair-recreate`: exactly one read end and
+one write end for a known-empty pipe with open peer lifetime, no waiters,
+not-readable readiness, supported fd flags, and close-on-exec provenance.
+Non-empty/unknown buffers, missing or closed peers, waiter/readiness ambiguity,
+EOF-only shapes, and unsupported pipe fd flags continue to require
+`kernel-state-unsupported`.
 
 Goal 3 intentionally leaves sockets without a graduated support subset. Listening
 sockets, connected socketpairs, TCP/Unix sockets, ancillary data, partial

--- a/docs/snapshot/native-resource-translation.md
+++ b/docs/snapshot/native-resource-translation.md
@@ -23,6 +23,9 @@ Currently supported resource recipes:
   provenance;
 - explicitly modeled one-fd `ppoll` proofs may request synthetic empty pipe,
   empty eventfd, and disarmed/future one-shot timerfd recipes at the captured fd;
+- Goal 4 `pipe-pair-v1` descriptors may recreate exactly one read end plus one
+  write end for a known-empty pipe with open peer lifetime, no waiters,
+  not-readable readiness, supported fd flags, and close-on-exec provenance;
 - Goal 4 `eventfd-counter-v1` descriptors may recreate non-semaphore eventfds
   with an exact nonzero counter, known-empty waiter state, supported fd flags,
   and close-on-exec provenance;
@@ -62,7 +65,7 @@ recipe refuse with `target-fd-table-missing` or the underlying resource refusal.
 | regular file                 | reopen by path/offset/flags when provenance is safe                                        |
 | stdio                        | inherit stdout/stderr only with explicit stdio policy; stdin refused                       |
 | close-fd gap                 | explicit target `close-fd` recipe                                                          |
-| synthetic empty pipe         | only for modeled ppoll/read proof slices with paired read/write ends                       |
+| synthetic empty pipe         | `pipe-pair-v1` empty open-peer pairs, plus modeled ppoll/read proof slices                 |
 | synthetic empty eventfd      | only counter-0, non-semaphore, modeled proof slices                                        |
 | synthetic eventfd counter    | only `eventfd-counter-v1`: nonzero counter, non-semaphore, supported flags, no waiters     |
 | synthetic timerfd            | `timerfd-descriptor-v1` disarmed/relative one-shot descriptors, plus modeled proof slices  |
@@ -84,7 +87,9 @@ Unsupported resources are not silently dropped. They are returned with:
   resources whose kernel state is not explicitly modeled by a narrow proof
   recipe, including eventfd semaphore mode, unknown eventfd waiters, unsupported
   eventfd flags, zero counters outside the empty-eventfd recipe, overflow
-  counters outside `eventfd-counter-v1`, timerfd periodic intervals, expired or
+  counters outside `eventfd-counter-v1`, ambiguous/non-empty pipe buffers,
+  missing or closed pipe peers, pipe waiters/readiness ambiguity, unsupported
+  pipe fd flags, timerfd periodic intervals, expired or
   overrun timerfd state, absolute/cancel-on-set timerfd flags, unsupported
   timerfd clocks, and unsupported timerfd fd flags;
 - `target-epoll-syscall-state-unsupported` for epoll resources outside the

--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -106,9 +106,10 @@ passes. The accepted class includes:
 - target-owned private-memory, executable-mapping, signal, resource, and
   descriptor consumption gates;
 - regular-file fd recipes, stdio/close-fd recipes, the modeled synthetic empty
-  pipe/eventfd/timerfd proof states, the Goal 4 `eventfd-counter-v1` descriptor
-  subset, the Goal 4 `timerfd-descriptor-v1` disarmed/relative-one-shot
-  descriptor subset, the Goal 3 epoll `interest-list-v1` reconstruction subset,
+  pipe/eventfd/timerfd proof states, the Goal 4 `pipe-pair-v1` empty open-peer
+  descriptor subset, the Goal 4 `eventfd-counter-v1` descriptor subset, the Goal
+  4 `timerfd-descriptor-v1` disarmed/relative-one-shot descriptor subset, the
+  Goal 3 epoll `interest-list-v1` reconstruction subset,
   and the Goal 3 signalfd `empty-queue-v1` descriptor subset;
 - active syscall completion only for sleep/`ppoll` timeout, empty pipe read,
   empty eventfd read, timerfd read, offset-backed regular-file
@@ -138,6 +139,7 @@ all profile gates pass.
 | `eventfd-read`                | `native-eventfd-read-target.c`     | none             | active syscall                      |
 | `eventfd-counter-recreate`    | `native-pipe-read-target.c`        | none             | active syscall + eventfd resources  |
 | `timerfd-descriptor-recreate` | `native-pipe-read-target.c`        | none             | active syscall + timerfd resources  |
+| `pipe-pair-recreate`          | `native-pipe-read-target.c`        | none             | active syscall + pipe resources     |
 | `timerfd-read`                | `native-timerfd-read-target.c`     | none             | active syscall                      |
 | `file-read`                   | `native-file-read-target.c`        | `read` fd 38     | active syscall                      |
 | `file-pread`                  | `native-file-pread-target.c`       | `pread64` fd 40  | active syscall                      |

--- a/docs/snapshot/target-guest-restore-loader.md
+++ b/docs/snapshot/target-guest-restore-loader.md
@@ -53,7 +53,8 @@ Supported fd-table resources and memory materialization are intentionally narrow
 - `inherit-stdio` for explicitly allowed stdout/stderr inheritance;
 - `reopen-file` for regular files that can be reopened by path with a modeled
   offset and access mode;
-- `synthetic-empty-pipe` with a modeled read fd and optional write fd;
+- `synthetic-empty-pipe` with a modeled read fd and optional write fd, including
+  the Goal 4 `pipe-pair-v1` empty-buffer/open-peer descriptor subset;
 - `synthetic-empty-eventfd` with an empty non-semaphore eventfd;
 - `synthetic-eventfd` with a Goal 4 `eventfd-counter-v1` non-semaphore counter
   value, refused unless the counter, waiter state, flags, and close-on-exec
@@ -82,7 +83,8 @@ The runtime fd-table planner emits these resource lines from translated native
 resources. The in-guest loader validates duplicate fd ownership before launching
 the trampoline, applies `close-fd` and `reopen-file` recipes in the child process,
 and forwards synthetic fd recipes plus `--set-cloexec-fd` intents to the
-trampoline. Eventfd counter recipes are installed with a target-owned `eventfd()`
+trampoline. Pipe pair recipes are installed with target-owned `pipe2()` fds and
+verified as open plus not readable before target-native completion. Eventfd counter recipes are installed with a target-owned `eventfd()`
 followed by an exact 8-byte write of the modeled counter before the target-native
 jump. Timerfd descriptor recipes are installed with target-owned
 `timerfd_create()` and, when armed, `timerfd_settime()` using the modeled

--- a/goal-4.md
+++ b/goal-4.md
@@ -85,14 +85,16 @@ Tasks:
 - [x] Add target-native timerfd recreation and proof profiles for the accepted
       timerfd subset; keep expired, interval, ambiguous clock, and unmodeled
       overrun state refused. Issue/PR: #777 / #778.
-- [ ] Define pipe descriptor-pair provenance for empty-buffer pipes with known
-      read/write ends, peer lifetime, EOF behavior, and fd flags.
-- [ ] Add positive and negative proofs for empty pipe pairs only when readiness,
-      EOF, and peer ownership are exact.
-- [ ] Decide whether duplicate fd aliases can graduate; if not, keep
-      `target-fd-table-duplicate` as the stable boundary.
-- [ ] Update resource translation docs, target loader docs, proof-profile docs,
-      and refusal inventory after each graduated resource family.
+- [x] Define pipe descriptor-pair provenance for empty-buffer pipes with known
+      read/write ends, peer lifetime, EOF behavior, and fd flags. Issue/PR: #779
+      / #780.
+- [x] Add positive and negative proofs for empty pipe pairs only when readiness,
+      EOF, and peer ownership are exact. Issue/PR: #779 / #780.
+- [x] Decide whether duplicate fd aliases can graduate; if not, keep
+      `target-fd-table-duplicate` as the stable boundary. Issue/PR: #779 / #780.
+- [x] Update resource translation docs, target loader docs, proof-profile docs,
+      and refusal inventory after each graduated resource family. Issue/PR: #775
+      / #776, #777 / #778, #779 / #780.
 
 Refusal boundaries that remain unless explicitly modeled:
 

--- a/packages/runtime/src/__tests__/native-resource-translation.test.ts
+++ b/packages/runtime/src/__tests__/native-resource-translation.test.ts
@@ -127,6 +127,78 @@ describe("native resource translation", () => {
     ]);
   });
 
+  it("plans an accepted pipe-pair-v1 descriptor pair", () => {
+    const plan = planNativeTargetFdTable({
+      resources: [pipePairResource(10, "read"), pipePairResource(12, "write")],
+    });
+
+    expect(plan.refusals).toEqual([]);
+    expect(plan.entries.map((entry) => [entry.targetFd, entry.kind])).toEqual([
+      [10, "synthetic-empty-pipe-read-end"],
+      [12, "synthetic-empty-pipe-write-end"],
+    ]);
+    expect(plan.targetGuestResources).toEqual([
+      { kind: "synthetic-empty-pipe", readFd: 10, writeFd: 12, closeOnExec: false },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "unknown buffer",
+      resources: [
+        pipePairResource(10, "read", { pipeBuffer: "unknown" }),
+        pipePairResource(12, "write"),
+      ],
+      reason: "pipe buffer must be known empty",
+    },
+    {
+      name: "missing write peer",
+      resources: [pipePairResource(10, "read")],
+      reason: "pipe pair requires exactly one read end and one write end",
+    },
+    {
+      name: "closed peer lifetime",
+      resources: [
+        pipePairResource(10, "read", { peerLifetime: "closed" }),
+        pipePairResource(12, "write"),
+      ],
+      reason: "pipe peer lifetime must be known open",
+    },
+    {
+      name: "waiters",
+      resources: [
+        pipePairResource(10, "read", { pipeWaiters: "unknown" }),
+        pipePairResource(12, "write"),
+      ],
+      reason: "pipe waiters must be known empty",
+    },
+    {
+      name: "readable state",
+      resources: [
+        pipePairResource(10, "read", { readiness: "readable" }),
+        pipePairResource(12, "write"),
+      ],
+      reason: "pipe readiness must be known not-readable",
+    },
+    {
+      name: "unsupported flags",
+      resources: [pipePairResource(10, "read", {}, ["octal:4000"]), pipePairResource(12, "write")],
+      reason: "pipe fd flags are unsupported",
+    },
+  ])("keeps unsafe pipe pair variants fail-closed: $name", ({ resources, reason }) => {
+    const plan = planNativeTargetFdTable({ resources });
+
+    expect(plan.refusals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "kernel-state-unsupported",
+          detail: expect.objectContaining({ boundary: "pipe-pair-v1", reason }),
+        }),
+      ]),
+    );
+    expect(plan.targetGuestResources).toEqual([]);
+  });
+
   it("allows explicit synthetic empty-eventfd resources for one-fd ppoll proofs", () => {
     const result = translateNativeResources({
       syntheticEmptyEventFds: [11],
@@ -828,3 +900,27 @@ describe("native resource translation", () => {
     expect(plan.targetGuestResources).toEqual([]);
   });
 });
+
+function pipePairResource(
+  fd: number,
+  end: "read" | "write",
+  recipe: Record<string, unknown> = {},
+  flags = [end === "read" ? "octal:0" : "octal:1"],
+): NativeProcessResource {
+  return {
+    id: `fd:${fd}`,
+    kind: "pipe",
+    state: "captured",
+    fd,
+    path: "pipe:[pair]",
+    flags,
+    recipe: {
+      pipeModel: "empty-pair-v1",
+      pipeBuffer: "empty",
+      peerLifetime: "open",
+      pipeWaiters: "none",
+      readiness: "not-readable",
+      ...recipe,
+    },
+  };
+}

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -108,12 +108,13 @@ describe("portable machine proof runner", () => {
     expect(result.status, result.stderr).toBe(0);
     const summary = JSON.parse(result.stdout);
     const names = summary.profiles.map((profile: { name: string }) => profile.name);
-    expect(names.slice(0, 13)).toEqual([
+    expect(names.slice(0, 14)).toEqual([
       "two-thread-ppoll",
       "pipe-read",
       "eventfd-read",
       "eventfd-counter-recreate",
       "timerfd-descriptor-recreate",
+      "pipe-pair-recreate",
       "timerfd-read",
       "file-read",
       "file-pread",
@@ -127,6 +128,7 @@ describe("portable machine proof runner", () => {
       expect.arrayContaining([
         "epoll-recreate",
         "timerfd-descriptor-recreate",
+        "pipe-pair-recreate",
         "signalfd-recreate",
         "socket-transfer-refusal",
         "epoll-wait-refusal",
@@ -166,7 +168,7 @@ describe("portable machine proof runner", () => {
     expect(summary.supportReport).toMatchObject({
       counts: {
         "baseline-success": 11,
-        "graduated-support": 4,
+        "graduated-support": 5,
         "intentional-refusal": 7,
         "permanent-refusal": 3,
       },
@@ -179,6 +181,11 @@ describe("portable machine proof runner", () => {
         expect.objectContaining({
           name: "timerfd-descriptor-recreate",
           acceptedSubset: "timerfd-descriptor-v1-disarmed-or-relative-one-shot",
+          graduatedFromRefusalCode: "kernel-state-unsupported",
+        }),
+        expect.objectContaining({
+          name: "pipe-pair-recreate",
+          acceptedSubset: "pipe-pair-v1-empty-open-peer-no-waiters",
           graduatedFromRefusalCode: "kernel-state-unsupported",
         }),
         expect.objectContaining({

--- a/packages/runtime/src/native-resource-translation.ts
+++ b/packages/runtime/src/native-resource-translation.ts
@@ -191,6 +191,7 @@ function fdTableEntryFromRecipe(
   return (
     inheritedStdioFdTableEntry(fd, resource, recipe, closeOnExec) ??
     reopenFileFdTableEntry(fd, resource, recipe, closeOnExec) ??
+    syntheticPipePairFdTableEntry(fd, resource, recipe, closeOnExec, resources) ??
     syntheticFdTableEntry(fd, resource, recipe, closeOnExec) ??
     syntheticEventfdFdTableEntry(resource, recipe, closeOnExec) ??
     syntheticTimerfdFdTableEntry(resource, recipe, closeOnExec) ??
@@ -231,6 +232,117 @@ function reopenFileFdTableEntry(
         closeOnExec,
       })
     : undefined;
+}
+
+function syntheticPipePairFdTableEntry(
+  fd: number,
+  resource: NativeProcessResource,
+  recipe: Record<string, unknown>,
+  closeOnExec: boolean,
+  resources: NativeProcessResource[],
+): NativeTargetFdTableEntry | undefined {
+  if (resource.kind !== "pipe" || recipe.pipeModel !== "empty-pair-v1") {
+    return undefined;
+  }
+  const pipeRecipe = normalizedPipePairRecipe(resource, resources);
+  if ("code" in pipeRecipe) {
+    return refusedFdTableEntry(resource, pipeRecipe);
+  }
+  if (pipeRecipe.end === "read") {
+    return materializedFdTableEntry(resource, "synthetic-empty-pipe-read-end", closeOnExec, {
+      kind: "synthetic-empty-pipe",
+      readFd: fd,
+      closeOnExec,
+    });
+  }
+  const entry = materializedFdTableEntry(resource, "synthetic-empty-pipe-write-end", closeOnExec);
+  return { ...entry, recipe: { ...entry.recipe, pairedReadFd: pipeRecipe.readFd } };
+}
+
+// fallow-ignore-next-line complexity
+function normalizedPipePairRecipe(
+  resource: NativeProcessResource,
+  resources: NativeProcessResource[],
+): { end: "read"; readFd: number } | { end: "write"; readFd: number } | NativeProcessImageRefusal {
+  if (!resource.path || resource.fd === undefined) {
+    return pipePairRefusal(resource, "pipe pair requires fd and pipe identity");
+  }
+  const flags = nativeFdFlagBits(resource.flags);
+  const access = nativeFdAccessMode(resource.flags);
+  if (!PIPE_PAIR_SUPPORTED_FLAGS.has(flags)) {
+    return pipePairRefusal(resource, "pipe fd flags are unsupported", {
+      flags: resource.flags,
+      supportedFlags: Array.from(PIPE_PAIR_SUPPORTED_FLAGS, (flag) => `octal:${flag.toString(8)}`),
+    });
+  }
+  if (access !== 0 && access !== 1) {
+    return pipePairRefusal(resource, "pipe fd access mode must be read-only or write-only", {
+      flags: resource.flags,
+    });
+  }
+  const modelRefusal = pipePairModelRefusal(resource);
+  if (modelRefusal) {
+    return modelRefusal;
+  }
+  const peers = resources.filter(
+    (candidate) =>
+      candidate.kind === "pipe" &&
+      candidate.path === resource.path &&
+      candidate.recipe?.pipeModel === "empty-pair-v1",
+  );
+  for (const peer of peers) {
+    if (!PIPE_PAIR_SUPPORTED_FLAGS.has(nativeFdFlagBits(peer.flags))) {
+      return pipePairRefusal(resource, "pipe peer fd flags are unsupported", {
+        pipeId: resource.path,
+        peerFd: peer.fd,
+        peerFlags: peer.flags,
+      });
+    }
+  }
+  const readPeers = peers.filter((peer) => nativeFdAccessMode(peer.flags) === 0);
+  const writePeers = peers.filter((peer) => nativeFdAccessMode(peer.flags) === 1);
+  if (peers.length !== 2 || readPeers.length !== 1 || writePeers.length !== 1) {
+    return pipePairRefusal(resource, "pipe pair requires exactly one read end and one write end", {
+      pipeId: resource.path,
+      peerFds: peers.map((peer) => peer.fd),
+    });
+  }
+  const peerRefusal = pipePairModelRefusal(peers.find((peer) => peer.fd !== resource.fd)!);
+  if (peerRefusal) {
+    return peerRefusal;
+  }
+  const readFd = readPeers[0]!.fd;
+  if (readFd === undefined) {
+    return pipePairRefusal(resource, "pipe pair read end is missing an fd");
+  }
+  return access === 0 ? { end: "read", readFd } : { end: "write", readFd };
+}
+
+function pipePairModelRefusal(
+  resource: NativeProcessResource,
+): NativeProcessImageRefusal | undefined {
+  const recipe = resource.recipe ?? {};
+  if (recipe.pipeBuffer !== "empty") {
+    return pipePairRefusal(resource, "pipe buffer must be known empty", {
+      pipeBuffer: recipe.pipeBuffer,
+    });
+  }
+  if (recipe.peerLifetime !== "open") {
+    return pipePairRefusal(resource, "pipe peer lifetime must be known open", {
+      peerLifetime: recipe.peerLifetime,
+    });
+  }
+  if (recipe.pipeWaiters !== "none") {
+    return pipePairRefusal(resource, "pipe waiters must be known empty", {
+      pipeWaiters: recipe.pipeWaiters,
+    });
+  }
+  if (recipe.readiness !== "not-readable") {
+    return pipePairRefusal(resource, "pipe readiness must be known not-readable", {
+      readiness: recipe.readiness,
+    });
+  }
+  return undefined;
 }
 
 function syntheticFdTableEntry(
@@ -741,6 +853,13 @@ function translateResource(
       refusal: undefined,
     };
   }
+  if (resource.kind === "pipe" && resource.recipe?.pipeModel === "empty-pair-v1") {
+    return {
+      ...resource,
+      state: "recipe",
+      refusal: undefined,
+    };
+  }
   if (resource.kind === "pipe" && resource.fd !== undefined) {
     if (syntheticEmptyPipeFds.has(resource.fd)) {
       return {
@@ -891,6 +1010,7 @@ function resourceRefusalCode(
 
 const EVENTFD_COUNTER_SUPPORTED_FLAGS = new Set([0o2, 0o2000002]);
 const EVENTFD_MAX_COUNTER = 0xfffffffffffffffen;
+const PIPE_PAIR_SUPPORTED_FLAGS = new Set([0o0, 0o1, 0o2000000, 0o2000001]);
 const TIMERFD_DESCRIPTOR_SUPPORTED_FLAGS = new Set([0o2, 0o2000002]);
 const CLOCK_MONOTONIC = 1;
 const MAX_NANOSECONDS = 999_999_999;
@@ -931,6 +1051,27 @@ function nativeResourceSafeNumber(
     return undefined;
   }
   return Number(value);
+}
+
+function pipePairRefusal(
+  resource: NativeProcessResource,
+  reason: string,
+  detail: Record<string, unknown> = {},
+): NativeProcessImageRefusal {
+  return {
+    code: "kernel-state-unsupported",
+    message: `pipe resource ${resource.id} cannot be recreated target-natively`,
+    detail: {
+      id: resource.id,
+      kind: resource.kind,
+      fd: resource.fd,
+      path: resource.path,
+      boundary: "pipe-pair-v1",
+      reason,
+      requiredModel: RESOURCE_REQUIRED_MODELS.pipe,
+      ...detail,
+    },
+  };
 }
 
 function eventfdRefusal(

--- a/scripts/portable-machine-proof-profiles.json
+++ b/scripts/portable-machine-proof-profiles.json
@@ -139,6 +139,36 @@
     ]
   },
   {
+    "name": "pipe-pair-recreate",
+    "remoteSourceTarget": "pipe-pair-recreate",
+    "description": "Target-native empty pipe pair recreation with known open peer and not-readable state.",
+    "sourceFixture": "packages/microvm/assets/native-pipe-read-target.c",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "success",
+    "supportStatus": "graduated-support",
+    "unsafeStateFamily": "pipe",
+    "graduatedFromRefusalCode": "kernel-state-unsupported",
+    "acceptedSubset": "pipe-pair-v1-empty-open-peer-no-waiters",
+    "unsafeVariants": ["pipe-read"],
+    "expectedGates": [
+      "descriptor",
+      "verifier",
+      "state-consumption",
+      "resources",
+      "return-chain",
+      "frame",
+      "registers",
+      "tls",
+      "stack-window",
+      "private-memory",
+      "executable",
+      "signal",
+      "active-syscall",
+      "resume-path"
+    ]
+  },
+  {
     "name": "timerfd-read",
     "remoteSourceTarget": "timerfd-read",
     "description": "One-shot timerfd read active-syscall proof with modeled remaining time.",

--- a/scripts/portable-machine-vm-restore-proof.ts
+++ b/scripts/portable-machine-vm-restore-proof.ts
@@ -55,6 +55,7 @@ interface Args {
     | "apply-target-initial-stack";
   includeEventfdCounterProof: boolean;
   includeTimerfdDescriptorProof: boolean;
+  includePipePairProof: boolean;
   includeEpollProof: boolean;
   includeSignalfdProof: boolean;
 }
@@ -110,6 +111,7 @@ interface CombinedDescriptorContext extends CombinedDescriptorPaths {
   activeFileWriteProof?: ActiveFileWriteProof;
   includeEventfdCounterProof: boolean;
   includeTimerfdDescriptorProof: boolean;
+  includePipePairProof: boolean;
   includeEpollProof: boolean;
   includeSignalfdProof: boolean;
 }
@@ -234,7 +236,7 @@ function usage(): never {
       "--bundle-dir path --target-code-file path [--image rootfs.tar.gz] " +
       "[--combined-descriptor] [--real-utility-continuation] " +
       "[--process-context-restore metadata-only|apply-target-env-cwd|apply-target-visible-context|apply-target-initial-stack] " +
-      "[--include-eventfd-counter-proof] [--include-timerfd-descriptor-proof] [--include-epoll-proof] [--include-signalfd-proof] [--json]",
+      "[--include-eventfd-counter-proof] [--include-timerfd-descriptor-proof] [--include-pipe-pair-proof] [--include-epoll-proof] [--include-signalfd-proof] [--json]",
   );
   process.exit(2);
 }
@@ -258,6 +260,7 @@ function argsFromReader(read: (flag: string) => string | undefined, argv: string
     processContextRestore: parseProcessContextRestoreMode(read("--process-context-restore")),
     includeEventfdCounterProof: argv.includes("--include-eventfd-counter-proof"),
     includeTimerfdDescriptorProof: argv.includes("--include-timerfd-descriptor-proof"),
+    includePipePairProof: argv.includes("--include-pipe-pair-proof"),
     includeEpollProof: argv.includes("--include-epoll-proof"),
     includeSignalfdProof: argv.includes("--include-signalfd-proof"),
   };
@@ -395,6 +398,7 @@ function prepareCombinedDescriptor(
     plan,
     context.includeEventfdCounterProof,
     context.includeTimerfdDescriptorProof,
+    context.includePipePairProof,
     context.includeEpollProof,
     context.includeSignalfdProof,
   );
@@ -493,6 +497,7 @@ function combinedDescriptorContext(
     activeFileWriteProof: activeFileWriteProof(activeSyscallPlan.steps),
     includeEventfdCounterProof: args.includeEventfdCounterProof,
     includeTimerfdDescriptorProof: args.includeTimerfdDescriptorProof,
+    includePipePairProof: args.includePipePairProof,
     includeEpollProof: args.includeEpollProof,
     includeSignalfdProof: args.includeSignalfdProof,
   };
@@ -1087,7 +1092,7 @@ function proofFdTable(context: CombinedDescriptorContext) {
     resources: proofFdResources(context),
     expectedFds: [PROOF_CLOSED_FD],
     inheritedStdio: { mode: "inherit-output" },
-    syntheticEmptyPipeFds: [PROOF_PIPE_READ_FD],
+    syntheticEmptyPipeFds: context.includePipePairProof ? [] : [PROOF_PIPE_READ_FD],
     syntheticEmptyEventFds: context.includeEventfdCounterProof ? [] : [PROOF_EVENT_FD],
     syntheticTimerFds: context.includeTimerfdDescriptorProof ? [] : [PROOF_TIMER_FD],
   });
@@ -1165,6 +1170,7 @@ function prepareTargetContinuation(
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
   includeEventfdCounterProof: boolean,
   includeTimerfdDescriptorProof: boolean,
+  includePipePairProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): PreparedTargetContinuation | ReturnType<typeof planPortableMachineVmRestoreProof> {
@@ -1178,6 +1184,7 @@ function prepareTargetContinuation(
         plan,
         includeEventfdCounterProof,
         includeTimerfdDescriptorProof,
+        includePipePairProof,
         includeEpollProof,
         includeSignalfdProof,
       )
@@ -1189,6 +1196,7 @@ function prepareTargetContinuation(
           expectedFdBytes,
           includeEventfdCounterProof,
           includeTimerfdDescriptorProof,
+          includePipePairProof,
           includeEpollProof,
           includeSignalfdProof,
         ),
@@ -1203,6 +1211,7 @@ function prepareRealUtilityContinuation(
   plan: ReturnType<typeof planPortableMachineVmRestoreProof>,
   includeEventfdCounterProof: boolean,
   includeTimerfdDescriptorProof: boolean,
+  includePipePairProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ) {
@@ -1215,6 +1224,7 @@ function prepareRealUtilityContinuation(
     expectedFdBytes,
     includeEventfdCounterProof,
     includeTimerfdDescriptorProof,
+    includePipePairProof,
     includeEpollProof,
     includeSignalfdProof,
   );
@@ -1456,8 +1466,8 @@ function proofFdResources(context: CombinedDescriptorContext): NativeProcessReso
     proofFileResource(),
     ...activeFileReadResources(context),
     ...activeFileWriteResources(context),
-    proofPipeResource(PROOF_PIPE_READ_FD, "read"),
-    proofPipeResource(PROOF_PIPE_WRITE_FD, "write"),
+    proofPipeResource(PROOF_PIPE_READ_FD, "read", context),
+    proofPipeResource(PROOF_PIPE_WRITE_FD, "write", context),
     proofEventfdResource(context),
     proofTimerfdResource(context),
     ...epollProofResources(context),
@@ -1583,15 +1593,31 @@ function proofFileResource(): NativeProcessResource {
   };
 }
 
-function proofPipeResource(fd: number, end: "read" | "write"): NativeProcessResource {
-  return {
+function proofPipeResource(
+  fd: number,
+  end: "read" | "write",
+  context: CombinedDescriptorContext,
+): NativeProcessResource {
+  const base = {
     id: `fd:${fd}:combined-proof-pipe-${end}`,
-    kind: "pipe",
-    state: "captured",
+    kind: "pipe" as const,
+    state: "captured" as const,
     fd,
     path: "pipe:combined-proof",
     flags: [end === "read" ? "octal:0" : "octal:1"],
   };
+  return context.includePipePairProof
+    ? {
+        ...base,
+        recipe: {
+          pipeModel: "empty-pair-v1",
+          pipeBuffer: "empty",
+          peerLifetime: "open",
+          pipeWaiters: "none",
+          readiness: "not-readable",
+        },
+      }
+    : base;
 }
 
 function proofSyntheticResource(kind: "eventfd" | "timer", fd: number): NativeProcessResource {
@@ -1635,6 +1661,7 @@ function combinedProofTargetCode(
   expectedFdBytes: Buffer,
   includeEventfdCounterProof: boolean,
   includeTimerfdDescriptorProof: boolean,
+  includePipePairProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): Buffer {
@@ -1645,6 +1672,7 @@ function combinedProofTargetCode(
     expectedFdBytes,
     includeEventfdCounterProof,
     includeTimerfdDescriptorProof,
+    includePipePairProof,
     includeEpollProof,
     includeSignalfdProof,
   ).bytes;
@@ -1656,6 +1684,7 @@ function stateConsumingRealUtilityTargetCode(
   expectedFdBytes: Buffer,
   includeEventfdCounterProof: boolean,
   includeTimerfdDescriptorProof: boolean,
+  includePipePairProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): {
@@ -1669,6 +1698,7 @@ function stateConsumingRealUtilityTargetCode(
     expectedFdBytes,
     includeEventfdCounterProof,
     includeTimerfdDescriptorProof,
+    includePipePairProof,
     includeEpollProof,
     includeSignalfdProof,
   );
@@ -1688,6 +1718,7 @@ function proofStateVerifierTargetCode(
   expectedFdBytes: Buffer,
   includeEventfdCounterProof: boolean,
   includeTimerfdDescriptorProof: boolean,
+  includePipePairProof: boolean,
   includeEpollProof: boolean,
   includeSignalfdProof: boolean,
 ): { bytes: Buffer; translatedReturnOffset: number } {
@@ -1718,8 +1749,12 @@ function proofStateVerifierTargetCode(
   asm.markStateCheck(completion, STATE_CHECK_STDIO);
   asm.readAndCheck(PROOF_FILE_FD, expectedFdBytes);
   asm.markStateCheck(completion, STATE_CHECK_REOPEN_FILE);
-  asm.checkFdOpen(PROOF_PIPE_READ_FD);
-  asm.checkFdOpen(PROOF_PIPE_WRITE_FD);
+  if (includePipePairProof) {
+    asm.checkPipePairEmpty(PROOF_PIPE_READ_FD, PROOF_PIPE_WRITE_FD);
+  } else {
+    asm.checkFdOpen(PROOF_PIPE_READ_FD);
+    asm.checkFdOpen(PROOF_PIPE_WRITE_FD);
+  }
   asm.markStateCheck(completion, STATE_CHECK_PIPE);
   if (includeEventfdCounterProof) {
     asm.readEventfdValueAndCheck(PROOF_EVENT_FD, BigInt(PROOF_EVENTFD_COUNTER));
@@ -1861,6 +1896,18 @@ class Amd64ProofAssembler {
     this.jumpIfNotEqual();
     this.loadU64FromRbxOffset(0x60);
     this.checkRaxImmediate(expected);
+  }
+
+  checkPipePairEmpty(readFd: number, writeFd: number): void {
+    this.checkFdOpen(readFd);
+    this.checkFdOpen(writeFd);
+    this.storePollfd(readFd, 0x60, 0x0001);
+    this.syscall(7);
+    this.leaRdiRbxOffset(0x60);
+    this.push(0xbe);
+    this.pushU32(1);
+    this.push(0x31, 0xd2, 0x0f, 0x05, 0x48, 0x85, 0xc0);
+    this.jumpIfNotEqual();
   }
 
   checkTimerfdDisarmed(fd: number): void {
@@ -2045,6 +2092,22 @@ class Amd64ProofAssembler {
     }
     this.push(0x48, 0x8d, 0xb3);
     this.pushU32(offset);
+  }
+
+  private leaRdiRbxOffset(offset: number): void {
+    if (offset <= 127) {
+      this.push(0x48, 0x8d, 0x7b, offset);
+      return;
+    }
+    this.push(0x48, 0x8d, 0xbb);
+    this.pushU32(offset);
+  }
+
+  private storePollfd(fd: number, offset: number, events: number): void {
+    this.push(0xc7, 0x43, offset);
+    this.pushU32(fd);
+    this.push(0x66, 0xc7, 0x43, offset + 4, events & 0xff, (events >> 8) & 0xff);
+    this.push(0x66, 0xc7, 0x43, offset + 6, 0x00, 0x00);
   }
 
   private cmpDwordRbxOffsetImm8(offset: number, value: number): void {

--- a/scripts/smoke/portable-machine-restore.sh
+++ b/scripts/smoke/portable-machine-restore.sh
@@ -372,6 +372,10 @@ capture_remote_native_process_bundle() {
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
       target_detail="remote arm64 pipe read bundle with target timerfd descriptor proof captured from $ARM64_SSH"
       ;;
+    pipe-pair-recreate)
+      target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
+      target_detail="remote arm64 pipe read bundle with target pipe pair descriptor proof captured from $ARM64_SSH"
+      ;;
     epoll-recreate)
       target_binary="$ARM64_REMOTE_WORK/bin/machinen-native-pipe-read-target"
       target_detail="remote arm64 pipe read bundle with target epoll reconstruction proof captured from $ARM64_SSH"
@@ -459,6 +463,9 @@ run_target_restore() {
     resource_model_args_text="${resource_model_args[*]}"
   elif [[ "$REMOTE_SOURCE_TARGET" == "timerfd-descriptor-recreate" ]]; then
     resource_model_args=(--include-timerfd-descriptor-proof)
+    resource_model_args_text="${resource_model_args[*]}"
+  elif [[ "$REMOTE_SOURCE_TARGET" == "pipe-pair-recreate" ]]; then
+    resource_model_args=(--include-pipe-pair-proof)
     resource_model_args_text="${resource_model_args[*]}"
   elif [[ "$REMOTE_SOURCE_TARGET" == "epoll-recreate" ]]; then
     resource_model_args=(--include-epoll-proof)


### PR DESCRIPTION
## Problem

Goal 4 needed an exact pipe descriptor-pair model. A pipe is only safe to recreate when the buffer, peer ownership, EOF/readiness behavior, waiters, and fd flags are all known. Anything ambiguous must stay refused.

## Solution

- Added `pipe-pair-v1` for exactly one read end plus one write end of a known-empty pipe.
- Require open peer lifetime, no waiters, not-readable readiness, supported fd flags, and close-on-exec provenance.
- Reuse the target-owned synthetic pipe loader path and add a verifier check that both fds are open and the read end is not readable.
- Added `pipe-pair-recreate` proof profile and positive/negative unit coverage.
- Kept duplicate fd aliases refused with `target-fd-table-duplicate`; no shared open-file-description alias model is claimed.
- Updated docs and `goal-4.md`.

Closes #779.

## Validation

- `pnpm run format -- goal-4.md docs/snapshot/native-resource-translation.md docs/snapshot/target-guest-restore-loader.md docs/snapshot/portable-machine-proof-profiles.md docs/snapshot/native-fail-closed-refusal-inventory.md packages/runtime/src/native-resource-translation.ts packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts scripts/portable-machine-vm-restore-proof.ts scripts/smoke/portable-machine-restore.sh scripts/portable-machine-proof-profiles.json` — 0.322s
- `pnpm run build:docs` — 1.607s
- `pnpm run format:check` — 0.558s
- `pnpm run lint` — 0.208s
- `pnpm run typecheck` — 2.092s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/native-resource-translation.test.ts packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 1.899s, 57 passed
- remote proof `pipe-pair-recreate` — 35.779s runner / 36s wall
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` — 2m12.368s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.329s
