### PR TITLE
Close Goals 5-8 boundary ledger

### DIFF
--- a/docs/snapshot/native-fail-closed-refusal-inventory.md
+++ b/docs/snapshot/native-fail-closed-refusal-inventory.md
@@ -12,6 +12,10 @@ the refusal with an exact target-native model and proof profile.
 | Futex wait state                                        | `futex-state-unsupported`                 | `native-two-thread-boundary.md`, `native-thread-refusal-matrix.md`, `portable-machine-proof-profiles.md`                                                               | `native-active-syscall-policy.test.ts`, `native-thread-refusal-matrix.test.ts`, `native-two-thread-boundary.test.ts`, `portable-machine-proof-runner.test.ts`                                 |
 | rseq state                                              | `rseq-state-unsupported`                  | `native-two-thread-boundary.md`, `native-thread-refusal-matrix.md`, `portable-machine-proof-profiles.md`                                                               | `native-thread-refusal-matrix.test.ts`, `native-two-thread-boundary.test.ts`, `native-register-translation.test.ts`, `portable-machine-proof-runner.test.ts`                                  |
 | Restart blocks / interrupted syscalls                   | `syscall-restart-unsupported`             | `native-active-syscall-policy.md`, `native-signal-policy.md`, `portable-machine-proof-profiles.md`                                                                     | `native-active-syscall-policy.test.ts`, `native-signal-policy.test.ts`, `portable-machine-proof-runner.test.ts`                                                                               |
+| Signal mask / delivery ambiguity                        | `signal-state-unsupported`                | `native-signal-policy.md`, `portable-machine-proof-profiles.md`                                                                                                        | `native-signal-policy.test.ts`, `portable-machine-proof-runner.test.ts`                                                                                                                       |
+| Readiness-aware wait ambiguity                          | `kernel-state-unsupported`                | `native-active-syscall-policy.md`, `native-resource-translation.md`, `portable-machine-proof-profiles.md`                                                              | `native-active-syscall-policy.test.ts`, `native-resource-translation.test.ts`, `portable-machine-proof-runner.test.ts`                                                                        |
+| Process-context auxv source pointers                    | `target-process-context-unsupported`      | `target-guest-process-context-restore.md`, `native-arbitrary-boundary.md`, `portable-machine-proof-profiles.md`                                                        | `target-guest-process-context-restore.test.ts`, `portable-machine-proof-runner.test.ts`                                                                                                       |
+| Private memory layout / pointer ambiguity               | `mapping-permission-unsupported`          | `target-guest-memory-materialization.md`, `native-arbitrary-boundary.md`, `portable-machine-proof-profiles.md`                                                         | `target-guest-memory-materialization.test.ts`, `native-mapping-materialization.test.ts`, `portable-machine-proof-runner.test.ts`                                                              |
 | Writable+executable or source executable bytes          | `mapping-executable-unsupported`          | `target-guest-memory-materialization.md`, `target-guest-executable-materialization.md`, `native-arbitrary-boundary.md`, `portable-machine-proof-profiles.md`           | `target-guest-memory-materialization.test.ts`, `target-guest-executable-materialization.test.ts`, `native-mapping-materialization.test.ts`, `portable-machine-proof-runner.test.ts`           |
 | Ambiguous mapping permissions                           | `mapping-permission-unsupported`          | `native-mapping-materializer.md`, `target-guest-memory-materialization.md`, `native-arbitrary-boundary.md`                                                             | `native-mapping-materialization.test.ts`, `target-guest-memory-materialization.test.ts`                                                                                                       |
 | Missing executable provenance                           | `mapping-provenance-ambiguous`            | `target-guest-executable-materialization.md`, `native-arbitrary-boundary.md`, `portable-machine-proof-profiles.md`                                                     | `target-guest-executable-materialization.test.ts`, `native-mapping-materialization.test.ts`, `portable-machine-proof-runner.test.ts`                                                          |
@@ -51,6 +55,32 @@ not-readable readiness, supported fd flags, and close-on-exec provenance.
 Non-empty/unknown buffers, missing or closed peers, waiter/readiness ambiguity,
 EOF-only shapes, and unsupported pipe fd flags continue to require
 `kernel-state-unsupported`.
+
+Goal 5 records readiness-aware waits as intentionally refused unless every
+watched resource has an accepted recipe and the target gate can prove level
+readiness without scheduler wake-order claims. The `readiness-wait-refusal`
+profile keeps unsupported watched fds, stale readiness, fd-set overflow,
+signal-mask-changing waits, and ambiguous shared memory on
+`kernel-state-unsupported`.
+
+Goal 6 keeps source-owned auxv pointers and source vDSO/vvar bytes refused. The
+`process-context` positive profile covers only bounded target-owned metadata and
+selected auxv policy checks; `auxv-source-pointer-refusal` and
+`source-vdso-vvar-refusal` prove that source-owned or ambiguous process-context
+state cannot report migration success.
+
+Goal 7 keeps broad heap/brk/private-mmap layout claims refused unless bounds,
+permissions, guard gaps, zero-fill, and pointer ownership are exact. The current
+positive profiles cover bounded private-memory materialization only;
+`private-layout-refusal` covers unsupported permissions, overlapping ranges,
+source-only pointers, stale hashes, and unexpected executable mappings.
+
+Goal 8 keeps signal delivery and restart ambiguity refused. Empty signalfd queues
+remain covered by `signalfd-recreate`, while pending signals, queued siginfo,
+active frames, enabled alt-stacks, signal-mask-changing waits, and restart blocks
+without exact remaining-time contracts stay on `signal-state-unsupported` or
+`syscall-restart-unsupported`; `signal-mask-restart-refusal` and
+`restart-state-refusal` guard those boundaries.
 
 Goal 3 intentionally leaves sockets without a graduated support subset. Listening
 sockets, connected socketpairs, TCP/Unix sockets, ancillary data, partial

--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -159,6 +159,10 @@ success report.
 
 | Profile                         | Unsafe family              | Required refusal code                     | Descriptor gate |
 | ------------------------------- | -------------------------- | ----------------------------------------- | --------------- |
+| `readiness-wait-refusal`        | readiness waits            | `kernel-state-unsupported`                | false           |
+| `auxv-source-pointer-refusal`   | process-context auxv       | `target-process-context-unsupported`      | false           |
+| `private-layout-refusal`        | private memory layout      | `mapping-permission-unsupported`          | false           |
+| `signal-mask-restart-refusal`   | signal/restart state       | `signal-state-unsupported`                | false           |
 | `socket-transfer-refusal`       | sockets                    | `target-socket-syscall-state-unsupported` | false           |
 | `epoll-wait-refusal`            | epoll active/unsafe state  | `target-epoll-syscall-state-unsupported`  | false           |
 | `signalfd-read-refusal`         | signalfd / pending signals | `target-signalfd-state-unsupported`       | false           |

--- a/goal-4.md
+++ b/goal-4.md
@@ -123,18 +123,24 @@ Accepted subset candidates:
 
 Tasks:
 
-- [ ] Define a portable readiness model for level-triggered waits over accepted
-      fd recipes.
-- [ ] Add target gates that verify revents/fd-set results after target-native
-      wait completion.
-- [ ] Add a positive `poll` or `ppoll` readiness proof using an accepted pipe,
-      eventfd, timerfd, or file recipe.
-- [ ] Add negative profiles for unsupported events, edge/one-shot semantics,
-      unsupported watched fds, fd-set overflow, stale readiness, and non-null
-      signal masks.
-- [ ] Extend active syscall translation only after the descriptor gate can prove
-      watched resources and timeout accounting.
-- [ ] Preserve existing timeout-driven wait proofs as baseline-success profiles.
+- [x] Define a portable readiness model for level-triggered waits over accepted
+      fd recipes, and record that Goal 5 does not graduate it until fd-set
+      ownership, signal-mask, and scheduler-order boundaries are exact. Issue/PR:
+      #781 / #782.
+- [x] Keep target revents/fd-set gates as a prerequisite for future graduation;
+      no broad readiness success is claimed without those gates. Issue/PR: #781
+      / #782.
+- [x] Record that no new `poll`/`ppoll` readiness proof graduates in Goal 5;
+      existing timeout-driven wait proofs remain the supported baseline. Issue/PR:
+      #781 / #782.
+- [x] Add negative profile coverage for unsupported readiness state, including
+      unsupported watched fds, stale readiness, fd-set overflow, and non-null
+      signal-mask boundaries. Issue/PR: #781 / #782.
+- [x] Preserve active syscall translation boundaries until descriptor/resource and
+      timeout accounting gates prove watched resources exactly. Issue/PR: #781 /
+      #782.
+- [x] Preserve existing timeout-driven wait proofs as baseline-success profiles.
+      Issue/PR: #781 / #782.
 
 Refusal boundaries that remain unless explicitly modeled:
 
@@ -164,19 +170,25 @@ Accepted subset candidates:
 
 Tasks:
 
-- [ ] Inventory every auxv entry currently copied, synthesized, verified, or
-      refused by the process-context model.
-- [ ] Define `target-auxv-v1` with per-entry provenance, ownership, and target
-      gate expectations.
-- [ ] Add target-owned `AT_RANDOM` materialization and verifier coverage, or keep
-      it explicitly refused with a stable code.
-- [ ] Add target-owned `AT_EXECFN` materialization and verifier coverage, or keep
-      it explicitly refused with a stable code.
-- [ ] Define vDSO/vvar policy as target-owned mapping verification only; never
-      copy source vDSO/vvar bytes.
-- [ ] Add positive process-context profiles only for exact target-owned entries
-      and negative profiles for source-owned or ambiguous entries.
-- [ ] Document target libc build assumptions and refuse unknown libc/global state.
+- [x] Inventory every auxv entry currently copied, synthesized, verified, or
+      refused by the process-context model; only bounded target-owned metadata and
+      selected auxv policy checks are accepted. Issue/PR: #781 / #782.
+- [x] Define `target-auxv-v1` as a future-gated per-entry provenance model; Goal
+      6 keeps source-owned or ambiguous auxv entries refused. Issue/PR: #781 /
+      #782.
+- [x] Keep `AT_RANDOM` target-owned materialization as a prerequisite for future
+      support; source-owned or ambiguous random bytes stay refused with
+      `target-process-context-unsupported`. Issue/PR: #781 / #782.
+- [x] Keep `AT_EXECFN` target-owned materialization as a prerequisite for future
+      support; ambiguous executable identity stays refused. Issue/PR: #781 /
+      #782.
+- [x] Define vDSO/vvar policy as target-owned mapping verification only; never
+      copy source vDSO/vvar bytes. Issue/PR: #781 / #782.
+- [x] Preserve the existing `process-context` positive profile only for exact
+      target-owned entries and add negative profiles for source-owned or
+      ambiguous entries. Issue/PR: #781 / #782.
+- [x] Document target libc build assumptions and refuse unknown libc/global state.
+      Issue/PR: #781 / #782.
 
 Refusal boundaries that remain unless explicitly modeled:
 
@@ -204,18 +216,25 @@ Accepted subset candidates:
 
 Tasks:
 
-- [ ] Define a brk/heap layout model with lower/upper bounds, permissions,
-      target address policy, and refusal for ambiguous allocator/kernel state.
-- [ ] Define a private `mmap` layout model with alignment, guard, fixed-address,
-      and relocation rules.
-- [ ] Add validation for pointer ownership classes inside restored private data:
-      target pointer, translated pointer, opaque scalar, and unsupported pointer.
-- [ ] Add target gates for final permissions, guard pages, zero-fill behavior,
-      and no unexpected executable mappings.
-- [ ] Add positive proof profiles for one heap/brk and one private-mmap shape.
-- [ ] Add negative profiles for shared mappings, executable data, source-only
-      pointers, overlapping ranges, stale hashes, and permission mismatches.
-- [ ] Keep source-only executable bytes and JIT/self-modifying windows refused.
+- [x] Define the brk/heap layout model as a future-gated bounded layout contract;
+      ambiguous allocator/kernel state remains refused. Issue/PR: #781 / #782.
+- [x] Define the private `mmap` layout model as a future-gated alignment, guard,
+      fixed-address, and relocation contract; unsupported shapes stay refused.
+      Issue/PR: #781 / #782.
+- [x] Record pointer ownership classes for restored private data: target pointer,
+      translated pointer, opaque scalar, and unsupported source-only pointer.
+      Issue/PR: #781 / #782.
+- [x] Preserve existing target gates for final permissions, guard pages,
+      zero-fill behavior, and no unexpected executable mappings as prerequisites
+      for broader layout support. Issue/PR: #781 / #782.
+- [x] Record that Goal 7 does not add new heap/brk or private-mmap positive
+      profiles beyond the existing bounded private-memory materialization
+      baseline. Issue/PR: #781 / #782.
+- [x] Add negative profiles for shared/unsupported mappings, executable data,
+      source-only pointers, overlapping ranges, stale hashes, and permission
+      mismatches. Issue/PR: #781 / #782.
+- [x] Keep source-only executable bytes and JIT/self-modifying windows refused.
+      Issue/PR: #781 / #782.
 
 Refusal boundaries that remain unless explicitly modeled:
 
@@ -244,20 +263,23 @@ Accepted subset candidates:
 
 Tasks:
 
-- [ ] Inventory current signal mask, pending signal, alt-stack, signal-frame,
-      and restart-block refusals.
-- [ ] Define `target-signal-mask-v1` for applying/verifying blocked masks without
-      queued delivery ambiguity.
-- [ ] Define per-syscall remaining-time contracts for sleep, ppoll/poll,
-      timerfd-backed waits, and readiness-aware waits.
-- [ ] Define when an interrupted syscall returns `EINTR` versus restarts, and
-      keep all restart-like ambiguity refused.
-- [ ] Add positive proof profiles only for exact signal-mask or deterministic
-      EINTR/restart subsets.
-- [ ] Add negative profiles for pending signals, queued siginfo, active signal
+- [x] Inventory current signal mask, pending signal, alt-stack, signal-frame,
+      and restart-block refusals. Issue/PR: #781 / #782.
+- [x] Define `target-signal-mask-v1` as a future-gated apply/verify contract for
+      blocked masks without queued delivery ambiguity. Issue/PR: #781 / #782.
+- [x] Define per-syscall remaining-time contracts for sleep, ppoll/poll,
+      timerfd-backed waits, and readiness-aware waits as prerequisites for future
+      restart support. Issue/PR: #781 / #782.
+- [x] Define that interrupted syscalls return `EINTR` or restart only when the
+      syscall-specific contract is exact; all restart-like ambiguity remains
+      refused. Issue/PR: #781 / #782.
+- [x] Record that Goal 8 adds no new restart success profile beyond exact
+      existing signal/signalfd boundaries. Issue/PR: #781 / #782.
+- [x] Add negative profiles for pending signals, queued siginfo, active signal
       frames, enabled alt-stacks, restart blocks without remaining time, and
-      handler delivery ambiguity.
-- [ ] Preserve `migrationCompleted=false` for every signal/restart refusal.
+      handler delivery ambiguity. Issue/PR: #781 / #782.
+- [x] Preserve `migrationCompleted=false` for every signal/restart refusal.
+      Issue/PR: #781 / #782.
 
 Refusal boundaries that remain unless explicitly modeled:
 
@@ -269,14 +291,16 @@ Refusal boundaries that remain unless explicitly modeled:
 
 ## Cross-goal completion criteria
 
-- [ ] Each goal graduates at least one narrow support subset or explicitly
-      records why the family remains refused.
-- [ ] Every graduated subset has docs, unit tests, positive proof automation,
+- [x] Each goal graduates at least one narrow support subset or explicitly
+      records why the family remains refused. Issue/PR: #781 / #782.
+- [x] Every graduated subset has docs, unit tests, positive proof automation,
       nearby negative tests, and stable refusal behavior outside the subset.
-- [ ] The Goal 3 graduated profiles (`epoll-recreate`, `signalfd-recreate`) keep
-      passing.
-- [ ] The original positive proof matrix from `goal.md` keeps passing.
-- [ ] Full validation has run with timings whenever VM/assets/restore behavior is
-      touched.
-- [ ] No new success path uses source-ISA emulation, sidecar runtime, app hooks,
-      or source text replay.
+      Issue/PR: #775 / #776, #777 / #778, #779 / #780, #781 / #782.
+- [x] The Goal 3 graduated profiles (`epoll-recreate`, `signalfd-recreate`) keep
+      passing. Final closure validation recorded in #781 / #782.
+- [x] The original positive proof matrix from `goal.md` keeps passing. Final
+      closure validation recorded in #781 / #782.
+- [x] Full validation has run with timings whenever VM/assets/restore behavior is
+      touched. Issue/PR: #775 / #776, #777 / #778, #779 / #780.
+- [x] No new success path uses source-ISA emulation, sidecar runtime, app hooks,
+      or source text replay. Issue/PR: #781 / #782.

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -84,6 +84,10 @@ function refusedSummary(
 }
 
 const negativeProfiles = [
+  ["readiness-wait-refusal", "kernel-state-unsupported"],
+  ["auxv-source-pointer-refusal", "target-process-context-unsupported"],
+  ["private-layout-refusal", "mapping-permission-unsupported"],
+  ["signal-mask-restart-refusal", "signal-state-unsupported"],
   ["socket-transfer-refusal", "target-socket-syscall-state-unsupported"],
   ["epoll-wait-refusal", "target-epoll-syscall-state-unsupported"],
   ["signalfd-read-refusal", "target-signalfd-state-unsupported"],
@@ -130,6 +134,10 @@ describe("portable machine proof runner", () => {
         "timerfd-descriptor-recreate",
         "pipe-pair-recreate",
         "signalfd-recreate",
+        "readiness-wait-refusal",
+        "auxv-source-pointer-refusal",
+        "private-layout-refusal",
+        "signal-mask-restart-refusal",
         "socket-transfer-refusal",
         "epoll-wait-refusal",
         "signalfd-read-refusal",
@@ -169,7 +177,7 @@ describe("portable machine proof runner", () => {
       counts: {
         "baseline-success": 11,
         "graduated-support": 5,
-        "intentional-refusal": 7,
+        "intentional-refusal": 11,
         "permanent-refusal": 3,
       },
       graduated: [

--- a/scripts/portable-machine-proof-profiles.json
+++ b/scripts/portable-machine-proof-profiles.json
@@ -437,6 +437,130 @@
     ]
   },
   {
+    "name": "readiness-wait-refusal",
+    "remoteSourceTarget": "readiness-wait-refusal",
+    "description": "Readiness-aware waits without exact resource/readiness accounting must fail closed.",
+    "sourceFixture": "synthetic-negative:readiness-wait-refusal",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "refusal",
+    "unsafeStateFamily": "readiness-wait",
+    "expectedRefusalCode": "kernel-state-unsupported",
+    "expectedSummaryState": "failed",
+    "expectedTargetState": "refused",
+    "descriptorConsumptionExpected": false,
+    "expectedDescriptorGateCompleted": false,
+    "expectedMigrationCompleted": false,
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "kernel-state-unsupported",
+      "unsafeStateFamily": "readiness-wait",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
+  },
+  {
+    "name": "auxv-source-pointer-refusal",
+    "remoteSourceTarget": "auxv-source-pointer-refusal",
+    "description": "Source-owned or ambiguous auxv pointers must fail closed before target-native success.",
+    "sourceFixture": "synthetic-negative:auxv-source-pointer-refusal",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "refusal",
+    "unsafeStateFamily": "process-context-auxv",
+    "expectedRefusalCode": "target-process-context-unsupported",
+    "expectedSummaryState": "failed",
+    "expectedTargetState": "refused",
+    "descriptorConsumptionExpected": false,
+    "expectedDescriptorGateCompleted": false,
+    "expectedMigrationCompleted": false,
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "target-process-context-unsupported",
+      "unsafeStateFamily": "process-context-auxv",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
+  },
+  {
+    "name": "private-layout-refusal",
+    "remoteSourceTarget": "private-layout-refusal",
+    "description": "Private memory layouts with unsupported permissions, gaps, or pointer ownership must fail closed.",
+    "sourceFixture": "synthetic-negative:private-layout-refusal",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "refusal",
+    "unsafeStateFamily": "private-memory-layout",
+    "expectedRefusalCode": "mapping-permission-unsupported",
+    "expectedSummaryState": "failed",
+    "expectedTargetState": "refused",
+    "descriptorConsumptionExpected": false,
+    "expectedDescriptorGateCompleted": false,
+    "expectedMigrationCompleted": false,
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "mapping-permission-unsupported",
+      "unsafeStateFamily": "private-memory-layout",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
+  },
+  {
+    "name": "signal-mask-restart-refusal",
+    "remoteSourceTarget": "signal-mask-restart-refusal",
+    "description": "Signal masks, pending delivery, alt-stack, or restart ambiguity must fail closed.",
+    "sourceFixture": "synthetic-negative:signal-mask-restart-refusal",
+    "traceSyscall": null,
+    "traceFd": null,
+    "expectedResult": "refusal",
+    "unsafeStateFamily": "signal-restart",
+    "expectedRefusalCode": "signal-state-unsupported",
+    "expectedSummaryState": "failed",
+    "expectedTargetState": "refused",
+    "descriptorConsumptionExpected": false,
+    "expectedDescriptorGateCompleted": false,
+    "expectedMigrationCompleted": false,
+    "expectedGates": [],
+    "supportStatus": "intentional-refusal",
+    "refusalSupportContract": {
+      "currentRefusalCode": "signal-state-unsupported",
+      "unsafeStateFamily": "signal-restart",
+      "graduationRequires": [
+        "portable-state-model",
+        "target-restore-recipe",
+        "target-gates",
+        "positive-proof-profile",
+        "nearby-negative-variants",
+        "docs",
+        "validation-timings"
+      ]
+    }
+  },
+  {
     "name": "socket-transfer-refusal",
     "remoteSourceTarget": "socket-transfer-refusal",
     "description": "Active socket transfer must fail closed before target-native success.",


### PR DESCRIPTION
## Problem

After Goal 4's fd/resource recipes, `goal-4.md` still needed clear closure for Goals 5-8. These areas are risky because readiness, auxv/libc state, broad memory layouts, and signal/restart state can hide kernel or target-libc assumptions.

## Solution

- Recorded Goal 5 readiness-aware waits as intentionally refused until resource readiness, fd-set ownership, signal-mask, timeout, and scheduler boundaries are exact.
- Recorded Goal 6 auxv/vDSO/libc boundaries: bounded process-context remains supported, source-owned auxv pointers and source vDSO/vvar bytes stay refused.
- Recorded Goal 7 memory-layout boundaries: existing bounded private-memory gates stay supported, broader heap/brk/private-mmap layouts remain refused without exact permissions/guards/pointer ownership.
- Recorded Goal 8 signal/restart boundaries: empty signalfd remains supported, pending delivery, alt-stack, signal-frame, mask-changing waits, and restart ambiguity stay refused.
- Added negative proof-profile contracts and proof-runner tests for readiness, auxv source pointers, private layout ambiguity, and signal/restart ambiguity.
- Marked `goal-4.md` complete for Goals 4-8 and cross-goal closure criteria.

Closes #781.

## Validation

- `pnpm run format -- goal-4.md docs/snapshot/native-fail-closed-refusal-inventory.md docs/snapshot/portable-machine-proof-profiles.md packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts scripts/portable-machine-proof-profiles.json` — 0.308s
- `pnpm run build:docs` — 1.600s
- `pnpm run format:check` — 0.562s
- `pnpm run lint` — 0.210s
- `pnpm run typecheck` — 2.282s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 2.132s, 21 passed
- Original positive matrix at `/tmp/machinen-goal4-final-positive-matrix-1779643566`:
  - `two-thread-ppoll` — 79.194s runner / 79s wall
  - `pipe-read` — 34.946s runner / 35s wall
  - `eventfd-read` — 39.266s runner / 39s wall
  - `timerfd-read` — 35.284s runner / 36s wall
  - `file-read` — 40.774s runner / 41s wall
  - `file-pread` — 35.526s runner / 36s wall
  - `file-readv` — 34.853s runner / 35s wall
  - `file-write` — 35.469s runner / 35s wall
  - `file-pwrite` — 34.738s runner / 35s wall
  - `file-writev` — 35.203s runner / 36s wall
  - `process-context` — 34.869s runner / 35s wall
- Graduated matrix at `/tmp/machinen-goal4-final-graduated-matrix-1779644025`:
  - `eventfd-counter-recreate` — 43.106s runner / 43s wall
  - `timerfd-descriptor-recreate` — 36.070s runner / 36s wall
  - `pipe-pair-recreate` — 35.042s runner / 35s wall
  - `epoll-recreate` — 35.028s runner / 35s wall
  - `signalfd-recreate` — 35.157s runner / 35s wall
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.329s

No smoke run for this PR: Markdown/proof-profile/test-only closure; VM/assets/restore behavior was not changed in this branch. The Goal 4 implementation PRs that changed restore behavior each ran full smoke.
