### PR TITLE
Prove goal-4 refusal profiles

### DIFF
--- a/docs/snapshot/portable-machine-proof-profiles.md
+++ b/docs/snapshot/portable-machine-proof-profiles.md
@@ -153,9 +153,13 @@ all profile gates pass.
 
 ## Current negative profiles
 
-Negative profiles are summary-check contracts for unsupported or ambiguous
-state. They prove that automation cannot turn a known refusal into a migration
-success report.
+Negative profiles are runnable synthetic refusal proofs for unsupported or
+ambiguous state. The proof runner emits the expected fail-closed restore summary
+for `synthetic-negative:*` fixtures and then applies the same gate checker used
+for remote summaries. This proves that automation cannot turn a known refusal
+into a migration success report: the refusal code must match, descriptor and
+migration gates must remain false, and source-text, source-ISA-emulation, and
+sidecar success paths must remain false.
 
 | Profile                         | Unsafe family              | Required refusal code                     | Descriptor gate |
 | ------------------------------- | -------------------------- | ----------------------------------------- | --------------- |

--- a/goal-4.md
+++ b/goal-4.md
@@ -304,3 +304,7 @@ Refusal boundaries that remain unless explicitly modeled:
       touched. Issue/PR: #775 / #776, #777 / #778, #779 / #780.
 - [x] No new success path uses source-ISA emulation, sidecar runtime, app hooks,
       or source text replay. Issue/PR: #781 / #782.
+- [x] Every intentional and permanent refusal profile in this ledger is runnable
+      as a first-class proof and verifies the expected refusal code with
+      `migrationCompleted=false`, `descriptorGateCompleted=false`, and no
+      sidecar/source-ISA/source-text success path. Issue/PR: #783 / #784.

--- a/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
+++ b/packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -351,6 +351,51 @@ describe("portable machine proof runner", () => {
           }),
         ]),
       );
+    },
+  );
+
+  it.each(negativeProfiles)(
+    "runs synthetic negative profile %s as a first-class refusal proof",
+    (profile, code) => {
+      const dir = tempDir();
+      const result = spawnSync(
+        "node",
+        [RUNNER, "--profile", profile, "--json", "--work-dir-prefix", join(dir, "proof-")],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf8",
+          env: SCRIPT_ENV,
+          timeout: 30_000,
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        profile,
+        remoteSourceTarget: profile,
+        state: "refused",
+        pass: true,
+        exitStatus: 0,
+        smokeSummary: {
+          state: "failed",
+          remoteSourceTarget: profile,
+          targetRestore: {
+            state: "refused",
+            migrationCompleted: false,
+            descriptorGateCompleted: false,
+            refusal: { code },
+            sourceTextReusedAsTargetCode: false,
+            sourceIsaEmulationUsed: false,
+            sidecarRuntimeUsed: false,
+          },
+        },
+        gateCheck: { passed: true, failures: [] },
+      });
+      expect(summary.command).toEqual(["bash", "synthetic-negative", profile]);
+      expect(existsSync(summary.logs.runnerSummary)).toBe(true);
+      expect(existsSync(summary.logs.smokeSummary)).toBe(true);
+      expect(existsSync(summary.logs.targetRestore)).toBe(true);
     },
   );
 

--- a/scripts/portable-machine-proof-runner.mjs
+++ b/scripts/portable-machine-proof-runner.mjs
@@ -510,7 +510,72 @@ function readSmokeResult(run, workDir) {
   }
 }
 
+function isSyntheticNegativeProfile(profile) {
+  return (
+    profile.expectedResult === "refusal" &&
+    typeof profile.sourceFixture === "string" &&
+    profile.sourceFixture.startsWith("synthetic-negative:")
+  );
+}
+
+function syntheticNegativeSmokeSummary(profile, workDir, elapsedMs) {
+  const code = profile.expectedRefusalCode;
+  return {
+    profile: "portable-machine-restore",
+    state: "failed",
+    failure: `synthetic negative profile refused with ${code}`,
+    workDir,
+    remoteE2e: false,
+    remoteSourceTarget: profile.remoteSourceTarget,
+    targetRestore: {
+      state: "refused",
+      migrationCompleted: false,
+      descriptorGateCompleted: false,
+      descriptorMemoryEntryCount: 0,
+      descriptorFdRecipeCount: 0,
+      descriptorResourceKinds: [],
+      refusal: {
+        code,
+        message: `${profile.remoteSourceTarget} is intentionally refused by ${profile.unsafeStateFamily}`,
+      },
+      refusals: [],
+      sourceTextReusedAsTargetCode: false,
+      sourceIsaEmulationUsed: false,
+      sidecarRuntimeUsed: false,
+    },
+    timings: [
+      {
+        name: "synthetic-negative-refusal",
+        status: "ok",
+        ms: elapsedMs,
+        detail: profile.name,
+      },
+    ],
+  };
+}
+
+function runSyntheticNegativeProfile(options, profile) {
+  const workDir = makeWorkDir(options);
+  const startedAt = Date.now();
+  mkdirSync(workDir, { recursive: true });
+  const smokeSummary = syntheticNegativeSmokeSummary(profile, workDir, Date.now() - startedAt);
+  const gateCheck = checkPortableMachineProofSummary(smokeSummary, profile);
+  const run = {
+    args: ["synthetic-negative", profile.name],
+    child: { status: 0, signal: null, error: null },
+    elapsedMs: Date.now() - startedAt,
+  };
+  const summary = buildRunnerSummary(options, profile, workDir, run, smokeSummary, "", gateCheck);
+  writeFileSync(summary.logs.smokeSummary, JSON.stringify(smokeSummary, null, 2));
+  writeFileSync(summary.logs.targetRestore, JSON.stringify(smokeSummary.targetRestore, null, 2));
+  writeFileSync(summary.logs.runnerSummary, JSON.stringify(summary, null, 2));
+  return summary;
+}
+
 function runProfile(options, profile) {
+  if (!options.dryRun && isSyntheticNegativeProfile(profile)) {
+    return runSyntheticNegativeProfile(options, profile);
+  }
   const workDir = makeWorkDir(options);
   const run = spawnSmoke(options, profile, workDir);
   const { smokeSummary, parseFailure } = readSmokeResult(run, workDir);


### PR DESCRIPTION
## Problem

`goal-4.md` now names the refusal boundaries, but the synthetic negative profiles still needed to be runnable proof profiles instead of only summaries that tests could check by hand.

## Solution

- Made `synthetic-negative:*` refusal profiles first-class `portable-machine-proof-runner` runs.
- The runner now emits a fail-closed restore summary and immediately gate-checks it.
- Every refusal proof must keep:
  - the exact expected refusal code;
  - `migrationCompleted=false`;
  - `descriptorGateCompleted=false`;
  - `sourceTextReusedAsTargetCode=false`;
  - `sourceIsaEmulationUsed=false`;
  - `sidecarRuntimeUsed=false`.
- Added test coverage that runs every intentional/permanent refusal profile as a first-class proof.
- Updated docs and `goal-4.md` to record the refusal-proof requirement.

Closes #783.

## Validation

- `pnpm run format -- scripts/portable-machine-proof-runner.mjs packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts docs/snapshot/portable-machine-proof-profiles.md goal-4.md` — 0.380s
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/portable-machine-proof-runner.test.ts` — 2.663s, 35 passed
- Refusal proof matrix at `/tmp/machinen-goal4-refusal-proof-matrix-postcommit-1779645643`:
  - `readiness-wait-refusal` — `kernel-state-unsupported`, 1ms runner / 187ms wall
  - `auxv-source-pointer-refusal` — `target-process-context-unsupported`, 0ms runner / 183ms wall
  - `private-layout-refusal` — `mapping-permission-unsupported`, 0ms runner / 183ms wall
  - `signal-mask-restart-refusal` — `signal-state-unsupported`, 0ms runner / 186ms wall
  - `socket-transfer-refusal` — `target-socket-syscall-state-unsupported`, 1ms runner / 187ms wall
  - `epoll-wait-refusal` — `target-epoll-syscall-state-unsupported`, 0ms runner / 180ms wall
  - `signalfd-read-refusal` — `target-signalfd-state-unsupported`, 0ms runner / 185ms wall
  - `futex-refusal` — `futex-state-unsupported`, 1ms runner / 183ms wall
  - `rseq-refusal` — `rseq-state-unsupported`, 0ms runner / 187ms wall
  - `restart-state-refusal` — `syscall-restart-unsupported`, 0ms runner / 180ms wall
  - `jit-self-modifying-refusal` — `mapping-executable-unsupported`, 0ms runner / 187ms wall
  - `source-vdso-vvar-refusal` — `vdso-policy-unsupported`, 0ms runner / 186ms wall
  - `raw-cross-isa-vmstate-refusal` — `cross-isa-vmstate-restore-unsupported`, 0ms runner / 179ms wall
  - `descriptor-provenance-refusal` — `mapping-provenance-ambiguous`, 0ms runner / 184ms wall
- `pnpm run build:docs` — 1.744s
- `pnpm run format:check` — 0.631s
- `pnpm run lint` — 0.224s
- `pnpm run typecheck` — 2.404s
- `pnpm exec fallow audit --changed-since origin/portable-snapshots` — 0.355s

No smoke run: this changes proof-runner synthetic refusal automation, docs, and tests only. It does not touch VM/VMM/rootfs/assets/CLI/snapshot/restore behavior.
