### PR TITLE
Start Node event loop Level 4 resource map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ Snapshot internals:
 - [Goal 016 pipe Level 4 portable restore](./snapshot/level4-pipe-portable-restore.md) — third portable restore adapter and narrow target-native empty pipe pair reconstruction
 - [Goal 017 timerfd Level 4 portable restore](./snapshot/level4-timerfd-portable-restore.md) — fourth portable restore adapter and narrow target-native relative one-shot timerfd reconstruction
 - [Goal 018 TCP listener Level 4 portable restore](./snapshot/level4-tcp-listener-portable-restore.md) — fifth portable restore adapter and narrow target-native loopback listener reconstruction
+- [Goal 008 Node event-loop Level 4 resource map](./snapshot/level4-node-event-loop-resource-map.md) — planning map from Node/libuv handles to generic Level 4 descriptors and refusals
 - [portable machine proof profiles](./snapshot/portable-machine-proof-profiles.md) — positive and negative proof profiles for target-native completion and fail-closed refusals
 - [portable proof matrices](./snapshot/proof-matrices.md) — one-command matrix presets and JSON summary shape
 - [runtime-neutral adapter boundary](./snapshot/runtime-adapter-boundary.md) — shared adapter contract for future runtime-specific tracks

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-008-node-event-loop-resource-map.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-008-node-event-loop-resource-map.json
@@ -1,0 +1,50 @@
+{
+  "kind": "machinen.node-event-loop-level4-resource-map-summary",
+  "goal": "008",
+  "status": "started",
+  "evidenceStatus": "planning",
+  "productSupport": "not-yet-supported",
+  "implementationLevel": "not-implemented",
+  "graduationTargetLevel": "level-4-kernel-resource-reconstruction",
+  "mapKind": "machinen.node-event-loop-level4-resource-map",
+  "genericResourceMappings": [
+    {
+      "libuvHandle": "uv_tcp_t/server",
+      "genericProfile": "tcp-listener-v1-loopback-empty-accept-queue",
+      "decision": "mapped-to-generic-level4-descriptor"
+    },
+    {
+      "libuvHandle": "uv_pipe_t/runtime",
+      "genericProfile": "pipe-pair-v1-empty-no-waiters",
+      "decision": "mapped-to-target-runtime-startup"
+    },
+    {
+      "libuvHandle": "uv_async_t/event-loop-wakeup",
+      "genericProfile": "eventfd-counter-v1-nonsemaphore-no-waiters",
+      "decision": "mapped-to-target-runtime-startup"
+    },
+    {
+      "libuvHandle": "timerfd/deadline",
+      "genericProfile": "timerfd-relative-oneshot-v1-monotonic",
+      "decision": "refused-until-deadlines-modeled"
+    }
+  ],
+  "stableRefusals": [
+    "node-active-tcp-session-unsupported",
+    "node-child-process-tree-unsupported",
+    "node-fs-watcher-unsupported",
+    "node-native-addon-abi-state-unsupported",
+    "node-worker-thread-unsupported",
+    "node-inspector-session-unsupported",
+    "node-unsupported-v8-libuv-state",
+    "node-mmapped-durable-state-unsupported",
+    "node-timerfd-state-unsupported",
+    "node-unix-socket-unsupported"
+  ],
+  "nextGraduationRequirements": [
+    "extract explicit Node/libuv listen backlog for TCP listener product support",
+    "verify target-side libuv handle readiness and resource identity",
+    "promote accepted Node descriptors only after generic Level 4 resources remain checked",
+    "keep child/IPC, fs watchers, worker threads, inspector, and native addon state refused"
+  ]
+}

--- a/docs/snapshot/level4-node-event-loop-resource-map.md
+++ b/docs/snapshot/level4-node-event-loop-resource-map.md
@@ -1,0 +1,31 @@
+# Node event-loop Level 4 resource map
+
+Goal 008 starts mapping Node/libuv event-loop state onto the generic Level 4 resources. This is not product support for arbitrary Node process continuation. It is a planning/proof map that keeps unsafe states refused until each one has a generic descriptor and target-native verifier.
+
+## Current mapped resources
+
+Portable Node clean-service captures can now carry `eventLoopResources` with kind `machinen.node-event-loop-level4-resource-map`.
+
+The first map records:
+
+- `uv_tcp_t/server` -> `tcp-listener-v1-loopback-empty-accept-queue` planning descriptor;
+- `uv_pipe_t/runtime` -> `pipe-pair-v1-empty-no-waiters` target-runtime startup mapping;
+- `uv_async_t/event-loop-wakeup` -> `eventfd-counter-v1-nonsemaphore-no-waiters` target-runtime startup mapping.
+
+The TCP listener entry records the generic profile, loopback address, port, empty accept queue, and a backlog policy. The backlog still needs a Node verifier/extractor before this can become Node product support.
+
+## Stable refusals
+
+The map keeps these unsafe event-loop states fail-closed:
+
+- active TCP streams;
+- child process or IPC trees;
+- fs watchers;
+- native addon ABI state;
+- worker-thread/unsupported V8 or libuv state;
+- inspector/debug sessions;
+- timerfd deadlines;
+- Unix sockets;
+- mmapped durable/database-like state.
+
+Each refusal keeps `migrationCompleted=false`, `productSupport=unsupported`, and `implementationLevel=level-0-fail-closed-discovery`.

--- a/goals/008.md
+++ b/goals/008.md
@@ -6,6 +6,19 @@ Map Node/libuv event-loop state onto the generic Level 4 resources from earlier
 phases. This goal is a planning and integration slice. It should reduce Level 3
 runtime-aware debt, not create a Node-specific shortcut.
 
+## Current implementation start
+
+The first implementation slice records a `machinen.node-event-loop-level4-resource-map`
+inside portable Node clean-service captures. It keeps `productSupport` as
+`not-yet-supported` and `implementationLevel` as `not-implemented`, while wiring
+observed libuv resources to the generic Level 4 profiles:
+
+- `uv_tcp_t/server` -> `tcp-listener-v1-loopback-empty-accept-queue` planning descriptor;
+- `uv_pipe_t/runtime` -> `pipe-pair-v1-empty-no-waiters` target-runtime startup mapping;
+- `uv_async_t/event-loop-wakeup` -> `eventfd-counter-v1-nonsemaphore-no-waiters` target-runtime startup mapping;
+- timerfd deadlines -> fail-closed `node-timerfd-state-unsupported` until deadlines are modeled;
+- child/IPC, fs watcher, native addon, inspector, active TCP, and durable mmap states -> stable fail-closed Node refusals.
+
 ## Status language
 
 | Field                   | Target while this goal is in planning/proof mode                                      |

--- a/packages/cli/src/__tests__/node-event-loop-resource-map.test.ts
+++ b/packages/cli/src/__tests__/node-event-loop-resource-map.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addNodeLevel4Refusal,
+  addNodeLevel4MappedResource,
+  addNodeTcpListenerResource,
+  createNodeEventLoopLevel4ResourceMap,
+  nodeEventLoopLevel4StableRefusalCodes,
+} from "../clean-service/node-event-loop-resource-map.ts";
+
+describe("Node event-loop Level 4 resource map", () => {
+  it("maps libuv server sockets to the generic TCP listener profile", () => {
+    const map = createNodeEventLoopLevel4ResourceMap();
+
+    addNodeTcpListenerResource(map, {
+      fd: 19,
+      bindAddress: "127.0.0.1",
+      port: 3000,
+      backlog: "requires-node-verifier",
+    });
+
+    expect(map).toMatchObject({
+      kind: "machinen.node-event-loop-level4-resource-map",
+      sourceGoal: "008",
+      evidenceStatus: "planning",
+      productSupport: "not-yet-supported",
+      implementationLevel: "not-implemented",
+      graduationTargetLevel: "level-4-kernel-resource-reconstruction",
+      summary: { mapped: 1, refused: 0 },
+    });
+    expect(map.genericResources[0]).toMatchObject({
+      kind: "tcp-listener",
+      libuvHandle: "uv_tcp_t/server",
+      genericProfile: "tcp-listener-v1-loopback-empty-accept-queue",
+      decision: "mapped-to-generic-level4-descriptor",
+      details: {
+        bindAddress: "127.0.0.1",
+        port: 3000,
+        backlog: "requires-node-verifier",
+        acceptQueue: "empty",
+      },
+    });
+  });
+
+  it("records generic mappings for event-loop wakeups and pipes", () => {
+    const map = createNodeEventLoopLevel4ResourceMap();
+
+    addNodeLevel4MappedResource(map, {
+      kind: "eventfd",
+      libuvHandle: "uv_async_t/event-loop-wakeup",
+      genericProfile: "eventfd-counter-v1-nonsemaphore-no-waiters",
+      decision: "mapped-to-target-runtime-startup",
+      details: { policy: "target runtime recreates the wakeup fd" },
+    });
+    addNodeLevel4MappedResource(map, {
+      kind: "pipe",
+      libuvHandle: "uv_pipe_t/runtime",
+      genericProfile: "pipe-pair-v1-empty-no-waiters",
+      decision: "mapped-to-target-runtime-startup",
+      details: { policy: "target runtime recreates internal pipe handles" },
+    });
+
+    expect(map.summary).toEqual({ mapped: 2, refused: 0 });
+    expect(map.genericResources.map((resource) => resource.genericProfile)).toEqual([
+      "eventfd-counter-v1-nonsemaphore-no-waiters",
+      "pipe-pair-v1-empty-no-waiters",
+    ]);
+  });
+
+  it("keeps unsafe Node/libuv states as stable fail-closed refusals", () => {
+    const map = createNodeEventLoopLevel4ResourceMap();
+
+    const refusal = addNodeLevel4Refusal(map, {
+      code: "node-child-process-tree-unsupported",
+      message: "Node child process or IPC trees are not portable yet",
+    });
+
+    expect(nodeEventLoopLevel4StableRefusalCodes).toContain("node-child-process-tree-unsupported");
+    expect(refusal).toMatchObject({
+      migrationCompleted: false,
+      productSupport: "unsupported",
+      implementationLevel: "level-0-fail-closed-discovery",
+    });
+    expect(map.summary).toEqual({ mapped: 0, refused: 1 });
+  });
+});

--- a/packages/cli/src/clean-service/manifest.ts
+++ b/packages/cli/src/clean-service/manifest.ts
@@ -1,3 +1,5 @@
+import type { NodeEventLoopLevel4ResourceMap } from "./node-event-loop-resource-map.ts";
+
 type CleanServiceArch = "arm64" | "amd64";
 type CleanServiceRuntime = "node" | "python" | "go";
 type CleanServiceSubset =
@@ -56,6 +58,8 @@ export interface CleanServiceManifest {
   };
 }
 
+export type CleanServiceNodeEventLoopResources = NodeEventLoopLevel4ResourceMap;
+
 export interface CleanServiceComponent {
   id: string;
   runtime: CleanServiceRuntime;
@@ -65,6 +69,7 @@ export interface CleanServiceComponent {
   runtimeVersion: string;
   runtimePolicy?: CleanServiceRuntimePolicy;
   kernelResources?: CleanServiceKernelResourceReport;
+  eventLoopResources?: CleanServiceNodeEventLoopResources;
   guestPort: number;
   verifier: { kind: "http-get"; path: "/"; sha256: string; bytes: number };
   artifact: { path: string; sha256: string; bytes: number };
@@ -174,6 +179,7 @@ export const cleanServiceManifestSchema = {
           argv: { type: "array", items: { type: "string" }, minItems: 1 },
           runtimeVersion: { type: "string" },
           kernelResources: { type: "object", additionalProperties: true },
+          eventLoopResources: { type: "object", additionalProperties: true },
           runtimePolicy: {
             type: "object",
             required: ["compatibility", "provisioning", "remediation"],

--- a/packages/cli/src/clean-service/node-adapter.ts
+++ b/packages/cli/src/clean-service/node-adapter.ts
@@ -7,6 +7,7 @@ import {
   runtimePolicyFor,
   type CleanServiceCapture,
   type CleanServiceKernelResourceReport,
+  type CleanServiceNodeEventLoopResources,
 } from "./manifest.ts";
 
 export interface PortableNodeSnapshotBundle {
@@ -21,6 +22,7 @@ export interface PortableNodeSnapshotBundle {
   guestPort: number;
   verifier: { kind: "http-get"; path: "/"; sha256: string; bytes: number };
   kernelResources?: CleanServiceKernelResourceReport;
+  eventLoopResources?: CleanServiceNodeEventLoopResources;
   appTar: { path: "portable-node-app.tar.gz"; sha256: string; bytes: number };
   refusals: [];
 }
@@ -65,6 +67,7 @@ export async function inspectPortableNodeVm(
     guestPort: parsed.guestPort,
     verifier: parsed.verifier,
     kernelResources: parsed.kernelResources,
+    eventLoopResources: parsed.eventLoopResources,
     appTar: {
       path: "portable-node-app.tar.gz",
       sha256: opts.sha256Bytes(appBytes),
@@ -96,6 +99,7 @@ export function cleanServiceFromNode(bundle: PortableNodeSnapshotCapture): Clean
         guestPort: bundle.guestPort,
         verifier: bundle.verifier,
         kernelResources: bundle.kernelResources,
+        eventLoopResources: bundle.eventLoopResources,
         artifact: { ...bundle.appTar, path: artifactPath },
         provenance: {
           sourceCwd: bundle.sourceCwd,
@@ -141,19 +145,41 @@ if (cwd === '/mnt' || cwd.startsWith('/mnt/')) {
   console.log(JSON.stringify({ refusal: { code: 'node-host-mounted-state-ambiguous', message: 'Node cwd is on a host mount; dirty mounted state cannot be proven portable' } }));
   process.exit(0);
 }
+const eventLoopResources = {
+  kind: 'machinen.node-event-loop-level4-resource-map',
+  formatVersion: 1,
+  sourceGoal: '008',
+  evidenceStatus: 'planning',
+  productSupport: 'not-yet-supported',
+  implementationLevel: 'not-implemented',
+  graduationTargetLevel: 'level-4-kernel-resource-reconstruction',
+  genericResources: [],
+  refusals: [],
+  summary: { mapped: 0, refused: 0 }
+};
+function mapLevel4Resource(resource) { eventLoopResources.genericResources.push(resource); eventLoopResources.summary.mapped += 1; }
+function eventLoopRefusal(code, message, genericProfile) {
+  const refusal = { code, message, migrationCompleted: false, productSupport: 'unsupported', implementationLevel: 'level-0-fail-closed-discovery' };
+  if (genericProfile) refusal.genericProfile = genericProfile;
+  eventLoopResources.refusals.push(refusal);
+  eventLoopResources.summary.refused += 1;
+  return { code, message };
+}
 const child = pids.find((pid) => pid !== found.pid && existsSync('/proc/' + pid + '/stat') && readFileSync('/proc/' + pid + '/stat', 'utf8').split(' ')[3] === found.pid);
 if (child) {
-  console.log(JSON.stringify({ refusal: { code: 'node-child-process-tree-unsupported', message: 'Node child process or IPC trees are not portable yet' } }));
+  const refusal = eventLoopRefusal('node-child-process-tree-unsupported', 'Node child process or IPC trees are not portable yet');
+  console.log(JSON.stringify({ refusal, eventLoopResources }));
   process.exit(0);
 }
 const nativeAddon = sh("find " + JSON.stringify(cwd) + " -type f -name '*.node' -print -quit 2>/dev/null || true");
 if (nativeAddon) {
-  console.log(JSON.stringify({ refusal: { code: 'node-native-addon-abi-state-unsupported', message: 'Native addon state is architecture-specific and is not portable yet' } }));
+  const refusal = eventLoopRefusal('node-native-addon-abi-state-unsupported', 'Native addon state is architecture-specific and is not portable yet');
+  console.log(JSON.stringify({ refusal, eventLoopResources }));
   process.exit(0);
 }
 const kernelResources = { decisionModel: 'supported-irrelevant-refused', supported: [], irrelevant: [], refused: [], summary: { supported: 0, irrelevant: 0, refused: 0 } };
 function decision(kind, code, message) { kernelResources[kind].push(code); kernelResources.summary[kind] += 1; return { code, message }; }
-function refuse(code, message) { const refusal = decision('refused', code, message); console.log(JSON.stringify({ refusal, kernelResources })); process.exit(0); }
+function refuse(code, message, genericProfile) { const refusal = decision('refused', code, message); eventLoopRefusal(code, message, genericProfile); console.log(JSON.stringify({ refusal, kernelResources, eventLoopResources })); process.exit(0); }
 function inside(path, root) { return path === root || path.startsWith(root.replace(/\/+$/, '') + '/'); }
 const socketInodes = new Set();
 for (const fd of readdirSync('/proc/' + found.pid + '/fd')) {
@@ -164,11 +190,12 @@ for (const fd of readdirSync('/proc/' + found.pid + '/fd')) {
     const match = /^socket:\[(\d+)\]$/.exec(link);
     if (match) { socketInodes.add(match[1]); decision('supported', 'clean-service-socket-fd-modeled', 'socket fd will be evaluated by socket table inspection'); continue; }
     if (link.endsWith(' (deleted)')) refuse('node-deleted-open-file-unsupported', 'Deleted-but-open files are not portable clean-service state');
-    if (link.startsWith('pipe:[')) { decision('supported', 'clean-service-runtime-pipe-recreated-by-startup', 'runtime pipe fd is recreated by target-native process startup'); continue; }
+    if (link.startsWith('pipe:[')) { decision('supported', 'clean-service-runtime-pipe-recreated-by-startup', 'runtime pipe fd is recreated by target-native process startup'); mapLevel4Resource({ kind: 'pipe', libuvHandle: 'uv_pipe_t/runtime', genericProfile: 'pipe-pair-v1-empty-no-waiters', decision: 'mapped-to-target-runtime-startup', details: { fd: fdNum, policy: 'target runtime recreates internal pipe handles; user-visible pipes require the generic pipe descriptor' } }); continue; }
     if (link.startsWith('fifo:[')) refuse('node-open-fd-unsupported', 'FIFOs require an explicit clean-service descriptor model');
     if (link === 'anon_inode:[eventpoll]') { decision('supported', 'clean-service-epoll-recreated-by-runtime-start', 'epoll fd is recreated by target-native runtime startup'); continue; }
-    if (link === 'anon_inode:[eventfd]') { decision('supported', 'clean-service-eventfd-recreated-by-runtime-start', 'eventfd is recreated by target-native runtime startup'); continue; }
-    if (link === 'anon_inode:[timerfd]') refuse('node-timerfd-state-unsupported', 'timerfd deadlines are not replayed by clean-service restore');
+    if (link === 'anon_inode:[eventfd]') { decision('supported', 'clean-service-eventfd-recreated-by-runtime-start', 'eventfd is recreated by target-native runtime startup'); mapLevel4Resource({ kind: 'eventfd', libuvHandle: 'uv_async_t/event-loop-wakeup', genericProfile: 'eventfd-counter-v1-nonsemaphore-no-waiters', decision: 'mapped-to-target-runtime-startup', details: { fd: fdNum, policy: 'target runtime recreates async wakeup eventfd; captured counters/waiters require the generic eventfd descriptor' } }); continue; }
+    if (link === 'anon_inode:[timerfd]') refuse('node-timerfd-state-unsupported', 'timerfd deadlines are not replayed by clean-service restore', 'timerfd-relative-oneshot-v1-monotonic');
+    if (link === 'anon_inode:inotify' || link === 'anon_inode:[inotify]') refuse('node-fs-watcher-unsupported', 'Node/libuv fs watcher state requires an explicit generic descriptor before it can be portable');
     if (link === 'anon_inode:[signalfd]') refuse('node-signalfd-state-unsupported', 'signalfd and pending signal state are not modeled by clean-service restore');
     if (link.startsWith('/') && inside(link, cwd)) { decision('supported', 'clean-service-app-root-fd-captured', 'open file is inside the captured app root'); continue; }
     if (link.startsWith('/dev/')) { decision('irrelevant', 'clean-service-runtime-device-fd-irrelevant', 'runtime device fd is recreated by target-native startup'); continue; }
@@ -182,10 +209,11 @@ for (const net of ['/proc/net/tcp', '/proc/net/tcp6']) {
     if (!socketInodes.has(cols[9])) continue;
     const port = Number.parseInt(cols[1].split(':')[1], 16);
     if (cols[3] === '0A') {
-      if (port !== ${guestPort}) refuse('node-unexpected-listener-unsupported', 'Listening socket is not declared by the clean-service verifier model');
+      if (port !== ${guestPort}) refuse('node-unexpected-listener-unsupported', 'Listening socket is not declared by the clean-service verifier model', 'tcp-listener-v1-loopback-empty-accept-queue');
       decision('supported', 'clean-service-listener-rebound', 'expected listener socket will be rebound by target-native service start');
+      mapLevel4Resource({ kind: 'tcp-listener', libuvHandle: 'uv_tcp_t/server', genericProfile: 'tcp-listener-v1-loopback-empty-accept-queue', decision: 'mapped-to-generic-level4-descriptor', details: { family: 'inet', protocol: 'tcp', bindAddress: '127.0.0.1', port, backlog: 'requires-node-verifier', acceptQueue: 'empty', activeConnections: false, descriptorSource: 'goals/007.md generic TCP listener descriptor' } });
     } else {
-      refuse('node-active-tcp-session-unsupported', 'Active TCP/TLS sessions are not portable in the Node HTTP subset yet');
+      refuse('node-active-tcp-session-unsupported', 'Active TCP/TLS sessions are not portable in the Node HTTP subset yet', 'tcp-listener-v1-loopback-empty-accept-queue');
     }
   }
 }
@@ -227,6 +255,7 @@ const out = {
   guestPort: ${guestPort},
   verifier: { kind: 'http-get', path: '/', sha256: createHash('sha256').update(body).digest('hex'), bytes: Buffer.byteLength(body) },
   kernelResources,
+  eventLoopResources,
   refusals: [],
   appTarBase64
 };

--- a/packages/cli/src/clean-service/node-event-loop-resource-map.ts
+++ b/packages/cli/src/clean-service/node-event-loop-resource-map.ts
@@ -1,0 +1,115 @@
+const NODE_EVENT_LOOP_LEVEL4_RESOURCE_MAP_VERSION = 1 as const;
+
+export const nodeEventLoopLevel4StableRefusalCodes = [
+  "node-active-tcp-session-unsupported",
+  "node-child-process-tree-unsupported",
+  "node-fs-watcher-unsupported",
+  "node-native-addon-abi-state-unsupported",
+  "node-worker-thread-unsupported",
+  "node-inspector-session-unsupported",
+  "node-unsupported-v8-libuv-state",
+  "node-mmapped-durable-state-unsupported",
+  "node-timerfd-state-unsupported",
+  "node-unix-socket-unsupported",
+] as const;
+
+interface NodeEventLoopLevel4MappedResource {
+  kind: "tcp-listener" | "pipe" | "eventfd" | "timerfd" | "unsupported";
+  libuvHandle: string;
+  genericProfile: string;
+  decision: "mapped-to-generic-level4-descriptor" | "mapped-to-target-runtime-startup" | "refused";
+  details: Record<string, unknown>;
+}
+
+interface NodeEventLoopLevel4ResourceRefusal {
+  code: string;
+  message: string;
+  migrationCompleted: false;
+  productSupport: "unsupported";
+  implementationLevel: "level-0-fail-closed-discovery";
+  genericProfile?: string;
+}
+
+export interface NodeEventLoopLevel4ResourceMap {
+  kind: "machinen.node-event-loop-level4-resource-map";
+  formatVersion: typeof NODE_EVENT_LOOP_LEVEL4_RESOURCE_MAP_VERSION;
+  sourceGoal: "008";
+  evidenceStatus: "planning";
+  productSupport: "not-yet-supported";
+  implementationLevel: "not-implemented";
+  graduationTargetLevel: "level-4-kernel-resource-reconstruction";
+  genericResources: NodeEventLoopLevel4MappedResource[];
+  refusals: NodeEventLoopLevel4ResourceRefusal[];
+  summary: { mapped: number; refused: number };
+}
+
+export function createNodeEventLoopLevel4ResourceMap(): NodeEventLoopLevel4ResourceMap {
+  return {
+    kind: "machinen.node-event-loop-level4-resource-map",
+    formatVersion: NODE_EVENT_LOOP_LEVEL4_RESOURCE_MAP_VERSION,
+    sourceGoal: "008",
+    evidenceStatus: "planning",
+    productSupport: "not-yet-supported",
+    implementationLevel: "not-implemented",
+    graduationTargetLevel: "level-4-kernel-resource-reconstruction",
+    genericResources: [],
+    refusals: [],
+    summary: { mapped: 0, refused: 0 },
+  };
+}
+
+export function addNodeTcpListenerResource(
+  map: NodeEventLoopLevel4ResourceMap,
+  input: {
+    fd?: number;
+    bindAddress: string;
+    port: number;
+    backlog?: number | "requires-node-verifier";
+  },
+): void {
+  addNodeLevel4MappedResource(map, {
+    kind: "tcp-listener",
+    libuvHandle: "uv_tcp_t/server",
+    genericProfile: "tcp-listener-v1-loopback-empty-accept-queue",
+    decision: "mapped-to-generic-level4-descriptor",
+    details: {
+      family: "inet",
+      protocol: "tcp",
+      bindAddress: input.bindAddress,
+      port: input.port,
+      backlog: input.backlog ?? "requires-node-verifier",
+      acceptQueue: "empty",
+      activeConnections: false,
+      descriptorSource: "goals/007.md generic TCP listener descriptor",
+    },
+  });
+}
+
+export function addNodeLevel4MappedResource(
+  map: NodeEventLoopLevel4ResourceMap,
+  resource: NodeEventLoopLevel4MappedResource,
+): void {
+  map.genericResources.push(resource);
+  if (resource.decision === "refused") {
+    map.summary.refused += 1;
+  } else {
+    map.summary.mapped += 1;
+  }
+}
+
+export function addNodeLevel4Refusal(
+  map: NodeEventLoopLevel4ResourceMap,
+  input: { code: string; message: string; genericProfile?: string },
+): NodeEventLoopLevel4ResourceRefusal {
+  const refusal: NodeEventLoopLevel4ResourceRefusal = {
+    code: input.code,
+    message: input.message,
+    migrationCompleted: false,
+    productSupport: "unsupported",
+    implementationLevel: "level-0-fail-closed-discovery",
+    ...(input.genericProfile ? { genericProfile: input.genericProfile } : {}),
+  };
+  map.refusals.push(refusal);
+  map.summary.refused += 1;
+  return refusal;
+}


### PR DESCRIPTION
## Problem

Machinen now has generic Level 4 resources like pipes, eventfd, timerfd, and TCP listeners. Node clean-service capture did not yet say how its event loop maps to those generic resources. That made the next Node step vague, and it risked creating Node-only shortcuts instead of reusing the shared descriptors.

## Solution

This PR starts the Node event-loop Level 4 resource map. Node captures can now carry an `eventLoopResources` plan that maps server sockets, runtime pipes, and async wakeups to the generic Level 4 profiles. Unsafe Node states still fail closed with stable refusals, so this does not claim arbitrary Node process continuation.

## Technical Summary

- Added `node-event-loop-resource-map.ts` to model the Goal 008 planning map and stable Node/libuv refusals.
- Extended clean-service manifests so Node components can include `eventLoopResources` alongside existing kernel resource reports.
- Updated the Node probe to map `uv_tcp_t/server` to the TCP listener profile, runtime pipes to the pipe profile, and async wakeups to eventfd.
- Kept timerfd deadlines, active TCP streams, child/IPC trees, fs watchers, native addons, inspector state, Unix sockets, and durable mmap state as fail-closed refusals.
- Added tests and docs for the Goal 008 resource map and checked summary.
