### PR TITLE
Start Node Level 5 proof composition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Snapshot internals:
 - [Goal 017 timerfd Level 4 portable restore](./snapshot/level4-timerfd-portable-restore.md) — fourth portable restore adapter and narrow target-native relative one-shot timerfd reconstruction
 - [Goal 018 TCP listener Level 4 portable restore](./snapshot/level4-tcp-listener-portable-restore.md) — fifth portable restore adapter and narrow target-native loopback listener reconstruction
 - [Goal 008 Node event-loop Level 4 resource map](./snapshot/level4-node-event-loop-resource-map.md) — planning map from Node/libuv handles to generic Level 4 descriptors and refusals
+- [Goal 009 Node Level 5 proof composition](./snapshot/node-level5-proof-composition.md) — selected Node proof path composed from native/process evidence and the Goal 008 Level 4 resource map
 - [portable machine proof profiles](./snapshot/portable-machine-proof-profiles.md) — positive and negative proof profiles for target-native completion and fail-closed refusals
 - [portable proof matrices](./snapshot/proof-matrices.md) — one-command matrix presets and JSON summary shape
 - [runtime-neutral adapter boundary](./snapshot/runtime-adapter-boundary.md) — shared adapter contract for future runtime-specific tracks

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
@@ -1,0 +1,46 @@
+{
+  "kind": "machinen.node-level5-proof-composition-summary",
+  "goal": "009",
+  "status": "started",
+  "selectedSubset": "node-http-clean-root-v1-with-level4-event-loop-map",
+  "evidenceStatus": "proof",
+  "productSupport": "not-yet-supported",
+  "implementationLevel": "not-implemented",
+  "graduationTargetLevel": "level-5-cross-arch-process-continuation",
+  "requiredIngredients": [
+    "register-translation",
+    "stack-return-chain-translation",
+    "private-memory-materialization",
+    "executable-target-module-materialization",
+    "target-restore-loader",
+    "level4-event-loop-resource-map",
+    "target-native-verifier"
+  ],
+  "composesWith": [
+    "docs/snapshot/checked-summaries/level4-graduation/goal-008-node-event-loop-resource-map.json",
+    "docs/snapshot/checked-summaries/architecture-portable-snapshot/final-gauntlet.json",
+    "docs/snapshot/native-process-continuation-audit.md",
+    "scripts/native-restore-loader.mjs"
+  ],
+  "gates": {
+    "arbitraryV8HeapContinuationAllowed": false,
+    "arbitraryNativeStackContinuationAllowed": false,
+    "sourceIsaEmulationAllowed": false,
+    "sidecarRuntimeAllowed": false,
+    "metadataOnlyContinuationAllowed": false,
+    "publicProductVerbRequiredBeforeSupport": true
+  },
+  "stableRefusals": [
+    "node-level5-tls-rseq-unsupported",
+    "node-level5-simd-fpu-unsupported",
+    "node-level5-signal-frame-unsupported",
+    "node-level5-active-syscall-unsupported",
+    "node-level5-multithread-unsupported",
+    "node-level5-memory-mapping-unsupported",
+    "node-level5-kernel-resource-unsupported",
+    "node-level5-native-addon-abi-unsupported",
+    "node-level5-inspector-unsupported",
+    "node-level5-v8-libuv-state-unsupported",
+    "node-level5-arbitrary-heap-stack-continuation-refused"
+  ]
+}

--- a/docs/snapshot/node-level5-proof-composition.md
+++ b/docs/snapshot/node-level5-proof-composition.md
@@ -1,0 +1,48 @@
+# Node Level 5 proof composition
+
+Goal 009 starts the selected Node Level 5 proof path. This is not product support for arbitrary Node continuation. It composes checked native/process proof ingredients with the Goal 008 Level 4 event-loop resource map.
+
+## Selected subset
+
+The selected proof subset is:
+
+`node-http-clean-root-v1-with-level4-event-loop-map`
+
+It remains proof evidence with:
+
+- `evidenceStatus=proof`;
+- `productSupport=not-yet-supported`;
+- `implementationLevel=not-implemented`;
+- `graduationTargetLevel=level-5-cross-arch-process-continuation`.
+
+## Required ingredients
+
+The composition requires:
+
+- register translation;
+- stack and return-chain translation;
+- private memory materialization;
+- executable/target module materialization;
+- target restore loader;
+- Goal 008 Level 4 event-loop resource map;
+- target-native verifier evidence.
+
+The proof is not ready unless the Level 4 event-loop map and target-native verifier are both present.
+
+## Refusals
+
+The composition keeps unsafe Level 5 neighbors fail-closed:
+
+- TLS/rseq;
+- SIMD/FPU;
+- active signal frames and pending signal queues;
+- active syscalls and restart blocks;
+- multi-thread state;
+- unsupported memory mappings;
+- unsupported kernel resources;
+- native addon ABI state;
+- inspector/debug state;
+- unsupported V8/libuv state;
+- arbitrary V8 heap/native stack continuation.
+
+Every refusal keeps `migrationCompleted=false`, `productSupport=unsupported`, and `implementationLevel=level-0-fail-closed-discovery`.

--- a/goals/009.md
+++ b/goals/009.md
@@ -7,6 +7,29 @@ is the first Node process-continuation target, but it remains proof evidence
 until it is routed through public product verbs and all unsafe Level 5 neighbors
 are refused or modeled.
 
+## Current implementation start
+
+The first implementation slice adds a `machinen.node-level5-proof-composition`
+record for the selected `node-http-clean-root-v1-with-level4-event-loop-map`
+proof path. It composes checked native/process ingredients with the Goal 008
+Node event-loop Level 4 resource map, while keeping product support at
+`not-yet-supported` and implementation at `not-implemented`.
+
+The composition requires:
+
+- register translation;
+- stack and return-chain translation;
+- private memory materialization;
+- executable/target module materialization;
+- target restore loader;
+- Goal 008 Level 4 event-loop resource map;
+- target-native verifier evidence.
+
+It also records non-product refusals for TLS/rseq, SIMD/FPU, signal frames,
+active syscalls, multi-thread state, unsupported mappings, unsupported kernel
+resources, native addon ABI state, inspector/debug state, unsupported V8/libuv
+state, and arbitrary V8 heap/native stack continuation.
+
 ## Status language
 
 | Field                   | Target while this goal is in proof mode                                            |

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2,6 +2,19 @@
 
 ## Contents
 
+### Node Level 5 proof composition
+
+- [`NodeLevel5ProofComposition`](#nodelevel5proofcomposition)
+- [`NodeLevel5ProofCompositionInput`](#nodelevel5proofcompositioninput)
+- [`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal)
+- [`NodeLevel5ProofIngredient`](#nodelevel5proofingredient)
+- [`NodeLevel5ProofIngredientName`](#nodelevel5proofingredientname)
+- [`NodeLevel5ProofRefusalCode`](#nodelevel5proofrefusalcode)
+- [`NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION`](#node_level5_proof_composition_format_version)
+- [`buildNodeLevel5ProofComposition`](#buildnodelevel5proofcomposition)
+- [`nodeLevel5ProofIngredientNames`](#nodelevel5proofingredientnames)
+- [`nodeLevel5ProofRefusalCodes`](#nodelevel5proofrefusalcodes)
+
 ### Boot a VM
 
 - [`boot`](#boot)
@@ -10946,6 +10959,174 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ***
 
+### NodeLevel5ProofIngredient
+
+#### Properties
+
+##### name
+
+> **name**: `"register-translation"` \| `"stack-return-chain-translation"` \| `"private-memory-materialization"` \| `"executable-target-module-materialization"` \| `"target-restore-loader"` \| `"level4-event-loop-resource-map"` \| `"target-native-verifier"`
+
+##### evidenceStatus
+
+> **evidenceStatus**: `"proof"` \| `"checked"` \| `"missing"`
+
+##### checkedSummary?
+
+> `optional` **checkedSummary?**: `string`
+
+##### notes
+
+> **notes**: `string`
+
+***
+
+### NodeLevel5ProofCompositionInput
+
+#### Properties
+
+##### eventLoopResourceMapPresent
+
+> **eventLoopResourceMapPresent**: `boolean`
+
+##### targetNativeVerifierPresent
+
+> **targetNativeVerifierPresent**: `boolean`
+
+##### checkedSummaries?
+
+> `optional` **checkedSummaries?**: `Partial`\<`Record`\<[`NodeLevel5ProofIngredientName`](#nodelevel5proofingredientname), `string`\>\>
+
+***
+
+### NodeLevel5ProofCompositionRefusal
+
+#### Properties
+
+##### code
+
+> **code**: `"node-level5-tls-rseq-unsupported"` \| `"node-level5-simd-fpu-unsupported"` \| `"node-level5-signal-frame-unsupported"` \| `"node-level5-active-syscall-unsupported"` \| `"node-level5-multithread-unsupported"` \| `"node-level5-memory-mapping-unsupported"` \| `"node-level5-kernel-resource-unsupported"` \| `"node-level5-native-addon-abi-unsupported"` \| `"node-level5-inspector-unsupported"` \| `"node-level5-v8-libuv-state-unsupported"` \| `"node-level5-arbitrary-heap-stack-continuation-refused"`
+
+##### message
+
+> **message**: `string`
+
+##### migrationCompleted
+
+> **migrationCompleted**: `false`
+
+##### productSupport
+
+> **productSupport**: `"unsupported"`
+
+##### implementationLevel
+
+> **implementationLevel**: `"level-0-fail-closed-discovery"`
+
+##### evidenceStatus
+
+> **evidenceStatus**: `"refusal"`
+
+***
+
+### NodeLevel5ProofComposition
+
+#### Properties
+
+##### kind
+
+> **kind**: `"machinen.node-level5-proof-composition"`
+
+##### formatVersion
+
+> **formatVersion**: `1`
+
+##### sourceGoal
+
+> **sourceGoal**: `"009"`
+
+##### evidenceStatus
+
+> **evidenceStatus**: `"proof"`
+
+##### productSupport
+
+> **productSupport**: `"not-yet-supported"`
+
+##### implementationLevel
+
+> **implementationLevel**: `"not-implemented"`
+
+##### graduationTargetLevel
+
+> **graduationTargetLevel**: `"level-5-cross-arch-process-continuation"`
+
+##### selectedSubset
+
+> **selectedSubset**: `"node-http-clean-root-v1-with-level4-event-loop-map"`
+
+##### requiredIngredients
+
+> **requiredIngredients**: [`NodeLevel5ProofIngredient`](#nodelevel5proofingredient)[]
+
+##### refusals
+
+> **refusals**: [`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal)[]
+
+##### gates
+
+> **gates**: `object`
+
+###### arbitraryV8HeapContinuationAllowed
+
+> **arbitraryV8HeapContinuationAllowed**: `false`
+
+###### arbitraryNativeStackContinuationAllowed
+
+> **arbitraryNativeStackContinuationAllowed**: `false`
+
+###### sourceIsaEmulationAllowed
+
+> **sourceIsaEmulationAllowed**: `false`
+
+###### sidecarRuntimeAllowed
+
+> **sidecarRuntimeAllowed**: `false`
+
+###### metadataOnlyContinuationAllowed
+
+> **metadataOnlyContinuationAllowed**: `false`
+
+###### publicProductVerbRequiredBeforeSupport
+
+> **publicProductVerbRequiredBeforeSupport**: `true`
+
+##### summary
+
+> **summary**: `object`
+
+###### required
+
+> **required**: `number`
+
+###### present
+
+> **present**: `number`
+
+###### missing
+
+> **missing**: `number`
+
+###### refusalCount
+
+> **refusalCount**: `number`
+
+###### proofReady
+
+> **proofReady**: `boolean`
+
+***
+
 ### OppositeIsaVmExecutionProviderRoute
 
 #### Properties
@@ -12037,7 +12218,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Overrides
 
-[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`migrationCompleted`](#migrationcompleted-8)
+[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`migrationCompleted`](#migrationcompleted-9)
 
 ##### scope
 
@@ -12188,7 +12369,7 @@ pids that aren't machinen-managed; those fall back to ps.
 
 ##### productSupportLevel?
 
-> `optional` **productSupportLevel?**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"` \| `"level-5-cross-arch-process-continuation"`
+> `optional` **productSupportLevel?**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-5-cross-arch-process-continuation"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"`
 
 ##### observableStateDecisions?
 
@@ -12226,7 +12407,7 @@ pids that aren't machinen-managed; those fall back to ps.
 
 ##### supportLevel
 
-> **supportLevel**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"` \| `"level-5-cross-arch-process-continuation"`
+> **supportLevel**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-5-cross-arch-process-continuation"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"`
 
 ##### supportLevelName
 
@@ -12380,7 +12561,7 @@ pids that aren't machinen-managed; those fall back to ps.
 
 ##### supportLevel?
 
-> `optional` **supportLevel?**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"` \| `"level-5-cross-arch-process-continuation"`
+> `optional` **supportLevel?**: `"level-4-kernel-resource-reconstruction"` \| `"level-0-fail-closed-discovery"` \| `"level-5-cross-arch-process-continuation"` \| `"level-1-semantic-restart"` \| `"level-2-semantic-continuation"` \| `"level-3-runtime-aware-continuation"`
 
 ***
 
@@ -16013,7 +16194,7 @@ the breakdown shows up alongside the parent phase.
 
 ###### Overrides
 
-[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`migrationCompleted`](#migrationcompleted-25)
+[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`migrationCompleted`](#migrationcompleted-26)
 
 ##### scope
 
@@ -17622,7 +17803,7 @@ kicks in: `<sourceName>/<fork.pid>`.
 
 ###### Overrides
 
-[`RestoreOptions`](#restoreoptions).[`name`](#name-16)
+[`RestoreOptions`](#restoreoptions).[`name`](#name-17)
 
 ##### portForward?
 
@@ -19513,6 +19694,18 @@ Poll interval in ms while retrying. Default 250.
 
 ***
 
+### NodeLevel5ProofIngredientName
+
+> **NodeLevel5ProofIngredientName** = *typeof* [`nodeLevel5ProofIngredientNames`](#nodelevel5proofingredientnames)\[`number`\]
+
+***
+
+### NodeLevel5ProofRefusalCode
+
+> **NodeLevel5ProofRefusalCode** = *typeof* [`nodeLevel5ProofRefusalCodes`](#nodelevel5proofrefusalcodes)\[`number`\]
+
+***
+
 ### OppositeIsaVmExecutionRefusalCode
 
 > **OppositeIsaVmExecutionRefusalCode** = *typeof* [`oppositeIsaVmExecutionRefusalCodes`](#oppositeisavmexecutionrefusalcodes)\[`number`\]
@@ -21228,6 +21421,24 @@ loops; anything looser stops being a meaningful gate.
 ### nestedVirtualizationStretchProofRefusalCodes
 
 > `const` **nestedVirtualizationStretchProofRefusalCodes**: readonly \[`"nested-virtualization-unavailable"`, `"nested-smoke-failed"`, `"nested-verifier-ambiguous"`, `"nested-snapshot-fork-unsafe"`\]
+
+***
+
+### NODE\_LEVEL5\_PROOF\_COMPOSITION\_FORMAT\_VERSION
+
+> `const` **NODE\_LEVEL5\_PROOF\_COMPOSITION\_FORMAT\_VERSION**: `1`
+
+***
+
+### nodeLevel5ProofIngredientNames
+
+> `const` **nodeLevel5ProofIngredientNames**: readonly \[`"register-translation"`, `"stack-return-chain-translation"`, `"private-memory-materialization"`, `"executable-target-module-materialization"`, `"target-restore-loader"`, `"level4-event-loop-resource-map"`, `"target-native-verifier"`\]
+
+***
+
+### nodeLevel5ProofRefusalCodes
+
+> `const` **nodeLevel5ProofRefusalCodes**: readonly \[`"node-level5-tls-rseq-unsupported"`, `"node-level5-simd-fpu-unsupported"`, `"node-level5-signal-frame-unsupported"`, `"node-level5-active-syscall-unsupported"`, `"node-level5-multithread-unsupported"`, `"node-level5-memory-mapping-unsupported"`, `"node-level5-kernel-resource-unsupported"`, `"node-level5-native-addon-abi-unsupported"`, `"node-level5-inspector-unsupported"`, `"node-level5-v8-libuv-state-unsupported"`, `"node-level5-arbitrary-heap-stack-continuation-refused"`\]
 
 ***
 
@@ -23814,6 +24025,22 @@ available.
 #### Returns
 
 `string`[]
+
+***
+
+### buildNodeLevel5ProofComposition()
+
+> **buildNodeLevel5ProofComposition**(`input`): [`NodeLevel5ProofComposition`](#nodelevel5proofcomposition)
+
+#### Parameters
+
+##### input
+
+[`NodeLevel5ProofCompositionInput`](#nodelevel5proofcompositioninput)
+
+#### Returns
+
+[`NodeLevel5ProofComposition`](#nodelevel5proofcomposition)
 
 ***
 

--- a/packages/runtime/src/__tests__/node-level5-proof-composition.test.ts
+++ b/packages/runtime/src/__tests__/node-level5-proof-composition.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNodeLevel5ProofComposition,
+  nodeLevel5ProofIngredientNames,
+  nodeLevel5ProofRefusalCodes,
+} from "../node-level5-proof-composition.ts";
+
+describe("Node Level 5 proof composition", () => {
+  it("composes checked native/process ingredients with the Goal 008 Level 4 resource map", () => {
+    const composition = buildNodeLevel5ProofComposition({
+      eventLoopResourceMapPresent: true,
+      targetNativeVerifierPresent: true,
+    });
+
+    expect(composition).toMatchObject({
+      kind: "machinen.node-level5-proof-composition",
+      sourceGoal: "009",
+      evidenceStatus: "proof",
+      productSupport: "not-yet-supported",
+      implementationLevel: "not-implemented",
+      graduationTargetLevel: "level-5-cross-arch-process-continuation",
+      selectedSubset: "node-http-clean-root-v1-with-level4-event-loop-map",
+      summary: {
+        required: nodeLevel5ProofIngredientNames.length,
+        present: nodeLevel5ProofIngredientNames.length,
+        missing: 0,
+        refusalCount: nodeLevel5ProofRefusalCodes.length,
+        proofReady: true,
+      },
+    });
+    expect(composition.requiredIngredients.map((ingredient) => ingredient.name)).toEqual([
+      "register-translation",
+      "stack-return-chain-translation",
+      "private-memory-materialization",
+      "executable-target-module-materialization",
+      "target-restore-loader",
+      "level4-event-loop-resource-map",
+      "target-native-verifier",
+    ]);
+    expect(composition.gates).toMatchObject({
+      arbitraryV8HeapContinuationAllowed: false,
+      arbitraryNativeStackContinuationAllowed: false,
+      sourceIsaEmulationAllowed: false,
+      sidecarRuntimeAllowed: false,
+      metadataOnlyContinuationAllowed: false,
+    });
+  });
+
+  it("keeps the selected Level 5 path blocked until the Level 4 map and verifier are present", () => {
+    const composition = buildNodeLevel5ProofComposition({
+      eventLoopResourceMapPresent: false,
+      targetNativeVerifierPresent: false,
+    });
+
+    expect(composition.summary).toMatchObject({ missing: 2, proofReady: false });
+    expect(
+      composition.requiredIngredients.filter(
+        (ingredient) => ingredient.evidenceStatus === "missing",
+      ),
+    ).toEqual([
+      expect.objectContaining({ name: "level4-event-loop-resource-map" }),
+      expect.objectContaining({ name: "target-native-verifier" }),
+    ]);
+  });
+
+  it("records unsafe Level 5 neighbors as non-product refusals", () => {
+    const composition = buildNodeLevel5ProofComposition({
+      eventLoopResourceMapPresent: true,
+      targetNativeVerifierPresent: true,
+    });
+
+    expect(composition.refusals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "node-level5-arbitrary-heap-stack-continuation-refused",
+          migrationCompleted: false,
+          productSupport: "unsupported",
+          implementationLevel: "level-0-fail-closed-discovery",
+          evidenceStatus: "refusal",
+        }),
+        expect.objectContaining({
+          code: "node-level5-active-syscall-unsupported",
+          migrationCompleted: false,
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -102,6 +102,12 @@ export type {
   WriteFileOptions,
 } from "./vm-handle.ts";
 export type { SnapshotEngine } from "./vm/snapshot-engine.ts";
+export {
+  NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION,
+  buildNodeLevel5ProofComposition,
+  nodeLevel5ProofIngredientNames,
+  nodeLevel5ProofRefusalCodes,
+} from "./node-level5-proof-composition.ts";
 export { buildNativeCodeMap } from "./native-code-map.ts";
 export {
   classifyNativeActiveSyscalls,
@@ -112,6 +118,14 @@ export {
   modelNativePpollTimeoutState,
   modelNativeSleepTimerState,
 } from "./native-active-syscall-policy.ts";
+export type {
+  NodeLevel5ProofComposition,
+  NodeLevel5ProofCompositionInput,
+  NodeLevel5ProofCompositionRefusal,
+  NodeLevel5ProofIngredient,
+  NodeLevel5ProofIngredientName,
+  NodeLevel5ProofRefusalCode,
+} from "./node-level5-proof-composition.ts";
 export type {
   NativeCodeMapRequest,
   NativeCodeMapResult,

--- a/packages/runtime/src/node-level5-proof-composition.ts
+++ b/packages/runtime/src/node-level5-proof-composition.ts
@@ -1,0 +1,210 @@
+export const NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION = 1 as const;
+
+export const nodeLevel5ProofIngredientNames = [
+  "register-translation",
+  "stack-return-chain-translation",
+  "private-memory-materialization",
+  "executable-target-module-materialization",
+  "target-restore-loader",
+  "level4-event-loop-resource-map",
+  "target-native-verifier",
+] as const;
+
+export type NodeLevel5ProofIngredientName = (typeof nodeLevel5ProofIngredientNames)[number];
+
+export const nodeLevel5ProofRefusalCodes = [
+  "node-level5-tls-rseq-unsupported",
+  "node-level5-simd-fpu-unsupported",
+  "node-level5-signal-frame-unsupported",
+  "node-level5-active-syscall-unsupported",
+  "node-level5-multithread-unsupported",
+  "node-level5-memory-mapping-unsupported",
+  "node-level5-kernel-resource-unsupported",
+  "node-level5-native-addon-abi-unsupported",
+  "node-level5-inspector-unsupported",
+  "node-level5-v8-libuv-state-unsupported",
+  "node-level5-arbitrary-heap-stack-continuation-refused",
+] as const;
+
+export type NodeLevel5ProofRefusalCode = (typeof nodeLevel5ProofRefusalCodes)[number];
+
+export interface NodeLevel5ProofIngredient {
+  name: NodeLevel5ProofIngredientName;
+  evidenceStatus: "checked" | "proof" | "missing";
+  checkedSummary?: string;
+  notes: string;
+}
+
+export interface NodeLevel5ProofCompositionInput {
+  eventLoopResourceMapPresent: boolean;
+  targetNativeVerifierPresent: boolean;
+  checkedSummaries?: Partial<Record<NodeLevel5ProofIngredientName, string>>;
+}
+
+export interface NodeLevel5ProofCompositionRefusal {
+  code: NodeLevel5ProofRefusalCode;
+  message: string;
+  migrationCompleted: false;
+  productSupport: "unsupported";
+  implementationLevel: "level-0-fail-closed-discovery";
+  evidenceStatus: "refusal";
+}
+
+export interface NodeLevel5ProofComposition {
+  kind: "machinen.node-level5-proof-composition";
+  formatVersion: typeof NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION;
+  sourceGoal: "009";
+  evidenceStatus: "proof";
+  productSupport: "not-yet-supported";
+  implementationLevel: "not-implemented";
+  graduationTargetLevel: "level-5-cross-arch-process-continuation";
+  selectedSubset: "node-http-clean-root-v1-with-level4-event-loop-map";
+  requiredIngredients: NodeLevel5ProofIngredient[];
+  refusals: NodeLevel5ProofCompositionRefusal[];
+  gates: {
+    arbitraryV8HeapContinuationAllowed: false;
+    arbitraryNativeStackContinuationAllowed: false;
+    sourceIsaEmulationAllowed: false;
+    sidecarRuntimeAllowed: false;
+    metadataOnlyContinuationAllowed: false;
+    publicProductVerbRequiredBeforeSupport: true;
+  };
+  summary: {
+    required: number;
+    present: number;
+    missing: number;
+    refusalCount: number;
+    proofReady: boolean;
+  };
+}
+
+export function buildNodeLevel5ProofComposition(
+  input: NodeLevel5ProofCompositionInput,
+): NodeLevel5ProofComposition {
+  const requiredIngredients = nodeLevel5ProofIngredientNames.map((name) =>
+    nodeLevel5ProofIngredient(name, input),
+  );
+  const present = requiredIngredients.filter(
+    (ingredient) => ingredient.evidenceStatus !== "missing",
+  );
+  const refusals = nodeLevel5ProofRefusalCodes.map(nodeLevel5ProofRefusal);
+  return {
+    kind: "machinen.node-level5-proof-composition",
+    formatVersion: NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION,
+    sourceGoal: "009",
+    evidenceStatus: "proof",
+    productSupport: "not-yet-supported",
+    implementationLevel: "not-implemented",
+    graduationTargetLevel: "level-5-cross-arch-process-continuation",
+    selectedSubset: "node-http-clean-root-v1-with-level4-event-loop-map",
+    requiredIngredients,
+    refusals,
+    gates: {
+      arbitraryV8HeapContinuationAllowed: false,
+      arbitraryNativeStackContinuationAllowed: false,
+      sourceIsaEmulationAllowed: false,
+      sidecarRuntimeAllowed: false,
+      metadataOnlyContinuationAllowed: false,
+      publicProductVerbRequiredBeforeSupport: true,
+    },
+    summary: {
+      required: requiredIngredients.length,
+      present: present.length,
+      missing: requiredIngredients.length - present.length,
+      refusalCount: refusals.length,
+      proofReady: present.length === requiredIngredients.length,
+    },
+  };
+}
+
+function nodeLevel5ProofIngredient(
+  name: NodeLevel5ProofIngredientName,
+  input: NodeLevel5ProofCompositionInput,
+): NodeLevel5ProofIngredient {
+  const checkedSummary = input.checkedSummaries?.[name] ?? defaultCheckedSummary(name);
+  const eventLoopMapMissing =
+    name === "level4-event-loop-resource-map" && !input.eventLoopResourceMapPresent;
+  const verifierMissing = name === "target-native-verifier" && !input.targetNativeVerifierPresent;
+  const evidenceStatus = eventLoopMapMissing || verifierMissing ? "missing" : "checked";
+  return {
+    name,
+    evidenceStatus,
+    ...(evidenceStatus === "missing" ? {} : { checkedSummary }),
+    notes: ingredientNotes(name),
+  };
+}
+
+function nodeLevel5ProofRefusal(
+  code: NodeLevel5ProofRefusalCode,
+): NodeLevel5ProofCompositionRefusal {
+  return {
+    code,
+    message: nodeLevel5ProofRefusalMessage(code),
+    migrationCompleted: false,
+    productSupport: "unsupported",
+    implementationLevel: "level-0-fail-closed-discovery",
+    evidenceStatus: "refusal",
+  };
+}
+
+function defaultCheckedSummary(name: NodeLevel5ProofIngredientName): string {
+  switch (name) {
+    case "register-translation":
+      return "docs/snapshot/checked-summaries/architecture-portable-snapshot/final-gauntlet.json";
+    case "stack-return-chain-translation":
+      return "docs/snapshot/native-process-continuation-audit.md";
+    case "private-memory-materialization":
+      return "docs/snapshot/architecture-portable-snapshot-gauntlet.md";
+    case "executable-target-module-materialization":
+      return "docs/snapshot/architecture-portable-snapshot-gauntlet.md";
+    case "target-restore-loader":
+      return "scripts/native-restore-loader.mjs";
+    case "level4-event-loop-resource-map":
+      return "docs/snapshot/checked-summaries/level4-graduation/goal-008-node-event-loop-resource-map.json";
+    case "target-native-verifier":
+      return "docs/snapshot/checked-summaries/level4-graduation/goal-008-node-event-loop-resource-map.json";
+  }
+}
+
+function ingredientNotes(name: NodeLevel5ProofIngredientName): string {
+  switch (name) {
+    case "register-translation":
+      return "native register state must be translated into the target architecture ABI";
+    case "stack-return-chain-translation":
+      return "selected stack and return-chain frames must be rewritten, not replayed as source ISA";
+    case "private-memory-materialization":
+      return "private memory bytes are materialized in target process memory without accepting arbitrary V8 heap continuation as product support";
+    case "executable-target-module-materialization":
+      return "target executable/module mappings come from target-native artifacts";
+    case "target-restore-loader":
+      return "the loader enters target-native continuation and is not a sidecar output shortcut";
+    case "level4-event-loop-resource-map":
+      return "Node/libuv resources compose through the generic Level 4 resource map from Goal 008";
+    case "target-native-verifier":
+      return "verifier evidence must come from target-side process continuation";
+  }
+}
+
+const nodeLevel5ProofRefusalMessages: Record<NodeLevel5ProofRefusalCode, string> = {
+  "node-level5-tls-rseq-unsupported":
+    "TLS and rseq state are refused until modeled for the selected Node Level 5 subset",
+  "node-level5-simd-fpu-unsupported":
+    "SIMD and FPU state are refused until target translation is checked",
+  "node-level5-signal-frame-unsupported":
+    "active signal frames and pending signal queues are refused",
+  "node-level5-active-syscall-unsupported": "active syscalls and restart blocks are refused",
+  "node-level5-multithread-unsupported":
+    "multi-thread Node state is refused for this selected proof subset",
+  "node-level5-memory-mapping-unsupported": "unsupported memory mappings are refused",
+  "node-level5-kernel-resource-unsupported": "kernel resources outside the Level 4 map are refused",
+  "node-level5-native-addon-abi-unsupported":
+    "native addon ABI and hidden native state are refused",
+  "node-level5-inspector-unsupported": "inspector and debug state are refused",
+  "node-level5-v8-libuv-state-unsupported": "unsupported V8 or libuv state is refused",
+  "node-level5-arbitrary-heap-stack-continuation-refused":
+    "arbitrary V8 heap and native stack continuation is not product support",
+};
+
+function nodeLevel5ProofRefusalMessage(code: NodeLevel5ProofRefusalCode): string {
+  return nodeLevel5ProofRefusalMessages[code];
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -28,6 +28,18 @@ const API_PATH = process.argv[2] ?? "packages/runtime/API.md";
 // the list of H3 headers (i.e. symbol names) typedoc emits for that
 // category. Plain function/type names map 1:1 to typedoc's H3 text.
 const TOC = {
+  "Node Level 5 proof composition": [
+    "NodeLevel5ProofComposition",
+    "NodeLevel5ProofCompositionInput",
+    "NodeLevel5ProofCompositionRefusal",
+    "NodeLevel5ProofIngredient",
+    "NodeLevel5ProofIngredientName",
+    "NodeLevel5ProofRefusalCode",
+    "NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION",
+    "buildNodeLevel5ProofComposition",
+    "nodeLevel5ProofIngredientNames",
+    "nodeLevel5ProofRefusalCodes",
+  ],
   "Boot a VM": [
     "boot",
     "BootOptions",


### PR DESCRIPTION
## Problem

Node Level 5 continuation needs a clear proof shape before it can become a product path. Without that shape, it is too easy to imply broad Node support or hide unsafe states behind a vague "Node continuation" claim.

## Solution

This PR adds the first selected Node Level 5 proof-composition model. It keeps the path proof-only and not product support. It also records the required proof ingredients and the unsafe Level 5 neighbors that must keep refusing.

## Technical Summary

- Added `node-level5-proof-composition.ts` to describe the selected `node-http-clean-root-v1-with-level4-event-loop-map` proof path.
- Exported the proof-composition API from runtime and added API docs coverage.
- Added tests that assert the proof remains `productSupport=not-yet-supported`, `implementationLevel=not-implemented`, and blocks shortcut gates.
- Added Goal 009 docs and checked summary for the proof-composition record.
