### PR TITLE
Keep Node Level 5 proof refusals broad

### DIFF
--- a/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
@@ -48,6 +48,8 @@
     "node-level5-simd-fpu-unsupported",
     "node-level5-signal-frame-unsupported",
     "node-level5-active-syscall-unsupported",
+    "node-level5-active-tcp-unsupported",
+    "node-level5-worker-thread-unsupported",
     "node-level5-multithread-unsupported",
     "node-level5-memory-mapping-unsupported",
     "node-level5-kernel-resource-unsupported",

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-009-proof-run.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-009-proof-run.json
@@ -158,6 +158,22 @@
       "evidenceStatus": "refusal"
     },
     {
+      "code": "node-level5-active-tcp-unsupported",
+      "message": "active TCP streams and in-flight network I/O are refused",
+      "migrationCompleted": false,
+      "productSupport": "unsupported",
+      "implementationLevel": "level-0-fail-closed-discovery",
+      "evidenceStatus": "refusal"
+    },
+    {
+      "code": "node-level5-worker-thread-unsupported",
+      "message": "Node worker threads are refused until worker lifecycle and thread state are modeled",
+      "migrationCompleted": false,
+      "productSupport": "unsupported",
+      "implementationLevel": "level-0-fail-closed-discovery",
+      "evidenceStatus": "refusal"
+    },
+    {
       "code": "node-level5-multithread-unsupported",
       "message": "multi-thread Node state is refused for this selected proof subset",
       "migrationCompleted": false,
@@ -252,6 +268,24 @@
       "evidenceStatus": "refusal"
     },
     {
+      "code": "node-level5-active-tcp-unsupported",
+      "unsafeNeighbor": "active-tcp",
+      "message": "active TCP streams and in-flight network I/O are refused",
+      "migrationCompleted": false,
+      "productSupport": "unsupported",
+      "implementationLevel": "level-0-fail-closed-discovery",
+      "evidenceStatus": "refusal"
+    },
+    {
+      "code": "node-level5-worker-thread-unsupported",
+      "unsafeNeighbor": "worker-threads",
+      "message": "Node worker threads are refused until worker lifecycle and thread state are modeled",
+      "migrationCompleted": false,
+      "productSupport": "unsupported",
+      "implementationLevel": "level-0-fail-closed-discovery",
+      "evidenceStatus": "refusal"
+    },
+    {
       "code": "node-level5-multithread-unsupported",
       "unsafeNeighbor": "multithread",
       "message": "multi-thread Node state is refused for this selected proof subset",
@@ -327,7 +361,7 @@
     "required": 7,
     "present": 7,
     "missing": 0,
-    "refusalCount": 11,
+    "refusalCount": 13,
     "proofReady": true
   }
 }

--- a/docs/snapshot/node-level5-proof-composition.md
+++ b/docs/snapshot/node-level5-proof-composition.md
@@ -62,6 +62,8 @@ The composition keeps unsafe Level 5 neighbors fail-closed:
 - SIMD/FPU;
 - active signal frames and pending signal queues;
 - active syscalls and restart blocks;
+- active TCP streams and in-flight network I/O;
+- Node worker threads;
 - multi-thread state;
 - unsupported memory mappings;
 - unsupported kernel resources;

--- a/goals/009.md
+++ b/goals/009.md
@@ -26,9 +26,10 @@ The composition requires:
 - target-native verifier evidence.
 
 It also records non-product refusals for TLS/rseq, SIMD/FPU, signal frames,
-active syscalls, multi-thread state, unsupported mappings, unsupported kernel
-resources, native addon ABI state, inspector/debug state, unsupported V8/libuv
-state, and arbitrary V8 heap/native stack continuation.
+active syscalls, active TCP streams, Node worker threads, multi-thread state,
+unsupported mappings, unsupported kernel resources, native addon ABI state,
+inspector/debug state, unsupported V8/libuv state, and arbitrary V8 heap/native
+stack continuation.
 
 The second implementation slice adds `scripts/node-level5-proof-composition.ts`,
 which emits a checked `machinen.node-level5-proof-composition` artifact at
@@ -75,6 +76,8 @@ Refuse fail-closed for:
 - TLS/rseq/SIMD/FPU state until modeled;
 - active signal frames or pending signal queues;
 - active syscalls and restart blocks;
+- active TCP streams and in-flight network I/O;
+- Node worker threads;
 - multi-thread state;
 - unsupported memory mappings;
 - unsupported kernel resources;

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -11058,7 +11058,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### code
 
-> **code**: `"node-level5-tls-rseq-unsupported"` \| `"node-level5-simd-fpu-unsupported"` \| `"node-level5-signal-frame-unsupported"` \| `"node-level5-active-syscall-unsupported"` \| `"node-level5-multithread-unsupported"` \| `"node-level5-memory-mapping-unsupported"` \| `"node-level5-kernel-resource-unsupported"` \| `"node-level5-native-addon-abi-unsupported"` \| `"node-level5-inspector-unsupported"` \| `"node-level5-v8-libuv-state-unsupported"` \| `"node-level5-arbitrary-heap-stack-continuation-refused"`
+> **code**: `"node-level5-tls-rseq-unsupported"` \| `"node-level5-simd-fpu-unsupported"` \| `"node-level5-signal-frame-unsupported"` \| `"node-level5-active-syscall-unsupported"` \| `"node-level5-active-tcp-unsupported"` \| `"node-level5-worker-thread-unsupported"` \| `"node-level5-multithread-unsupported"` \| `"node-level5-memory-mapping-unsupported"` \| `"node-level5-kernel-resource-unsupported"` \| `"node-level5-native-addon-abi-unsupported"` \| `"node-level5-inspector-unsupported"` \| `"node-level5-v8-libuv-state-unsupported"` \| `"node-level5-arbitrary-heap-stack-continuation-refused"`
 
 ##### message
 
@@ -11118,7 +11118,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### code
 
-> **code**: `"node-level5-tls-rseq-unsupported"` \| `"node-level5-simd-fpu-unsupported"` \| `"node-level5-signal-frame-unsupported"` \| `"node-level5-active-syscall-unsupported"` \| `"node-level5-multithread-unsupported"` \| `"node-level5-memory-mapping-unsupported"` \| `"node-level5-kernel-resource-unsupported"` \| `"node-level5-native-addon-abi-unsupported"` \| `"node-level5-inspector-unsupported"` \| `"node-level5-v8-libuv-state-unsupported"` \| `"node-level5-arbitrary-heap-stack-continuation-refused"`
+> **code**: `"node-level5-tls-rseq-unsupported"` \| `"node-level5-simd-fpu-unsupported"` \| `"node-level5-signal-frame-unsupported"` \| `"node-level5-active-syscall-unsupported"` \| `"node-level5-active-tcp-unsupported"` \| `"node-level5-worker-thread-unsupported"` \| `"node-level5-multithread-unsupported"` \| `"node-level5-memory-mapping-unsupported"` \| `"node-level5-kernel-resource-unsupported"` \| `"node-level5-native-addon-abi-unsupported"` \| `"node-level5-inspector-unsupported"` \| `"node-level5-v8-libuv-state-unsupported"` \| `"node-level5-arbitrary-heap-stack-continuation-refused"`
 
 ###### Inherited from
 
@@ -11166,7 +11166,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### unsafeNeighbor
 
-> **unsafeNeighbor**: `"tls-rseq"` \| `"simd-fpu"` \| `"active-signals"` \| `"active-syscalls"` \| `"multithread"` \| `"unsupported-memory-mappings"` \| `"unsupported-kernel-resources"` \| `"native-addon-abi"` \| `"inspector-debug"` \| `"unsupported-v8-libuv-state"` \| `"arbitrary-heap-stack-continuation"`
+> **unsafeNeighbor**: `"tls-rseq"` \| `"simd-fpu"` \| `"active-signals"` \| `"active-syscalls"` \| `"active-tcp"` \| `"worker-threads"` \| `"multithread"` \| `"unsupported-memory-mappings"` \| `"unsupported-kernel-resources"` \| `"native-addon-abi"` \| `"inspector-debug"` \| `"unsupported-v8-libuv-state"` \| `"arbitrary-heap-stack-continuation"`
 
 ***
 
@@ -21771,7 +21771,7 @@ loops; anything looser stops being a meaningful gate.
 
 ### nodeLevel5ProofRefusalCodes
 
-> `const` **nodeLevel5ProofRefusalCodes**: readonly \[`"node-level5-tls-rseq-unsupported"`, `"node-level5-simd-fpu-unsupported"`, `"node-level5-signal-frame-unsupported"`, `"node-level5-active-syscall-unsupported"`, `"node-level5-multithread-unsupported"`, `"node-level5-memory-mapping-unsupported"`, `"node-level5-kernel-resource-unsupported"`, `"node-level5-native-addon-abi-unsupported"`, `"node-level5-inspector-unsupported"`, `"node-level5-v8-libuv-state-unsupported"`, `"node-level5-arbitrary-heap-stack-continuation-refused"`\]
+> `const` **nodeLevel5ProofRefusalCodes**: readonly \[`"node-level5-tls-rseq-unsupported"`, `"node-level5-simd-fpu-unsupported"`, `"node-level5-signal-frame-unsupported"`, `"node-level5-active-syscall-unsupported"`, `"node-level5-active-tcp-unsupported"`, `"node-level5-worker-thread-unsupported"`, `"node-level5-multithread-unsupported"`, `"node-level5-memory-mapping-unsupported"`, `"node-level5-kernel-resource-unsupported"`, `"node-level5-native-addon-abi-unsupported"`, `"node-level5-inspector-unsupported"`, `"node-level5-v8-libuv-state-unsupported"`, `"node-level5-arbitrary-heap-stack-continuation-refused"`\]
 
 ***
 

--- a/packages/runtime/src/__tests__/node-level5-proof-composition.test.ts
+++ b/packages/runtime/src/__tests__/node-level5-proof-composition.test.ts
@@ -75,6 +75,8 @@ describe("Node Level 5 proof composition", () => {
       "simd-fpu",
       "active-signals",
       "active-syscalls",
+      "active-tcp",
+      "worker-threads",
       "multithread",
       "unsupported-memory-mappings",
       "unsupported-kernel-resources",

--- a/packages/runtime/src/__tests__/node-level5-proof-runner-artifact.test.ts
+++ b/packages/runtime/src/__tests__/node-level5-proof-runner-artifact.test.ts
@@ -40,6 +40,8 @@ describe("Node Level 5 proof runner artifact", () => {
           expect.objectContaining({ unsafeNeighbor: "simd-fpu" }),
           expect.objectContaining({ unsafeNeighbor: "active-signals" }),
           expect.objectContaining({ unsafeNeighbor: "active-syscalls" }),
+          expect.objectContaining({ unsafeNeighbor: "active-tcp" }),
+          expect.objectContaining({ unsafeNeighbor: "worker-threads" }),
           expect.objectContaining({ unsafeNeighbor: "multithread" }),
           expect.objectContaining({ unsafeNeighbor: "native-addon-abi" }),
           expect.objectContaining({ unsafeNeighbor: "inspector-debug" }),

--- a/packages/runtime/src/node-level5-proof-composition.ts
+++ b/packages/runtime/src/node-level5-proof-composition.ts
@@ -17,6 +17,8 @@ export const nodeLevel5ProofRefusalCodes = [
   "node-level5-simd-fpu-unsupported",
   "node-level5-signal-frame-unsupported",
   "node-level5-active-syscall-unsupported",
+  "node-level5-active-tcp-unsupported",
+  "node-level5-worker-thread-unsupported",
   "node-level5-multithread-unsupported",
   "node-level5-memory-mapping-unsupported",
   "node-level5-kernel-resource-unsupported",
@@ -76,6 +78,8 @@ export interface NodeLevel5ProofRefusalMatrixRow extends NodeLevel5ProofComposit
     | "simd-fpu"
     | "active-signals"
     | "active-syscalls"
+    | "active-tcp"
+    | "worker-threads"
     | "multithread"
     | "unsupported-memory-mappings"
     | "unsupported-kernel-resources"
@@ -243,6 +247,8 @@ const nodeLevel5ProofUnsafeNeighbors: Record<
   "node-level5-simd-fpu-unsupported": "simd-fpu",
   "node-level5-signal-frame-unsupported": "active-signals",
   "node-level5-active-syscall-unsupported": "active-syscalls",
+  "node-level5-active-tcp-unsupported": "active-tcp",
+  "node-level5-worker-thread-unsupported": "worker-threads",
   "node-level5-multithread-unsupported": "multithread",
   "node-level5-memory-mapping-unsupported": "unsupported-memory-mappings",
   "node-level5-kernel-resource-unsupported": "unsupported-kernel-resources",
@@ -266,6 +272,9 @@ const nodeLevel5ProofRefusalMessages: Record<NodeLevel5ProofRefusalCode, string>
   "node-level5-signal-frame-unsupported":
     "active signal frames and pending signal queues are refused",
   "node-level5-active-syscall-unsupported": "active syscalls and restart blocks are refused",
+  "node-level5-active-tcp-unsupported": "active TCP streams and in-flight network I/O are refused",
+  "node-level5-worker-thread-unsupported":
+    "Node worker threads are refused until worker lifecycle and thread state are modeled",
   "node-level5-multithread-unsupported":
     "multi-thread Node state is refused for this selected proof subset",
   "node-level5-memory-mapping-unsupported": "unsupported memory mappings are refused",


### PR DESCRIPTION
## Problem

The Node Level 5 proof was already proof-only, but its refusal list did not name every risky Node case clearly. Worker threads and active TCP streams were covered by broader buckets, but that was too easy to miss.

## Solution

This PR names those refusals directly. The checked proof artifact now records active TCP and worker-thread cases as fail-closed, non-product rows. The docs and tests say the same thing.

## Technical Summary

- Added `node-level5-active-tcp-unsupported` and `node-level5-worker-thread-unsupported` to the Node Level 5 proof refusal matrix.
- Regenerated `goal-009-proof-run.json` so the checked artifact now has 13 refusal rows.
- Updated Goal 009 docs, API docs, and tests to keep broad unsafe-state refusals explicit while preserving `not-yet-supported` proof status.
