### PR TITLE
Run Node Level 5 proof on public restore

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Snapshot internals:
 - [Goal 017 timerfd Level 4 portable restore](./snapshot/level4-timerfd-portable-restore.md) — fourth portable restore adapter and narrow target-native relative one-shot timerfd reconstruction
 - [Goal 018 TCP listener Level 4 portable restore](./snapshot/level4-tcp-listener-portable-restore.md) — fifth portable restore adapter and narrow target-native loopback listener reconstruction
 - [Goal 008 Node event-loop Level 4 resource map](./snapshot/level4-node-event-loop-resource-map.md) — planning map from Node/libuv handles to generic Level 4 descriptors and refusals
-- [Goal 009 Node Level 5 proof composition](./snapshot/node-level5-proof-composition.md) — selected Node proof path composed from native/process evidence and the Goal 008 Level 4 resource map
+- [Goal 009/019 Node Level 5 proof composition](./snapshot/node-level5-proof-composition.md) — selected Node proof path composed from native/process evidence, the Goal 008 Level 4 resource map, and default public restore proof evidence
 - [portable machine proof profiles](./snapshot/portable-machine-proof-profiles.md) — positive and negative proof profiles for target-native completion and fail-closed refusals
 - [portable proof matrices](./snapshot/proof-matrices.md) — one-command matrix presets and JSON summary shape
 - [runtime-neutral adapter boundary](./snapshot/runtime-adapter-boundary.md) — shared adapter contract for future runtime-specific tracks

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
@@ -24,7 +24,8 @@
     "snapshotWrites": "node-level5-proof-composition.json",
     "restoreSummary": "node-level5-proof-restore-summary.json",
     "restoreRefusal": "node-level5-proof-only-not-product",
-    "proofVerifierFlag": "--verify-proof-only",
+    "proofVerifierRunsByDefault": true,
+    "proofVerifierCompatibilityFlag": "--verify-proof-only",
     "proofAutomationSuccessFlag": "--allow-proof-only-success",
     "migrationCompleted": false
   },

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json
@@ -1,0 +1,48 @@
+{
+  "kind": "machinen.node-level5-default-public-restore-proof-summary",
+  "goal": "019",
+  "status": "default-public-restore-proof-only",
+  "selectedSubset": "node-http-clean-root-v1-with-level4-event-loop-map",
+  "publicWorkflow": ["machinen snapshot <node-app>", "machinen restore <snapshot>"],
+  "snapshotArtifact": "node-level5-proof-composition.json",
+  "restoreSummaryArtifact": "node-level5-proof-restore-summary.json",
+  "targetProofArtifact": "node-level5-target-proof.json",
+  "restoreBehavior": {
+    "targetProofVerifierRunsByDefault": true,
+    "defaultExitCode": 1,
+    "proofAutomationSuccessFlag": "--allow-proof-only-success",
+    "proofAutomationExitCodeWhenPassed": 0,
+    "restoreRoutedThroughPublicVerb": true,
+    "refusal": "node-level5-proof-only-not-product"
+  },
+  "statusFields": {
+    "productSupport": "not-yet-supported",
+    "implementationLevel": "not-implemented",
+    "migrationCompleted": false,
+    "evidenceStatus": "proof",
+    "graduationTargetLevel": "level-5-cross-arch-process-continuation"
+  },
+  "targetProof": {
+    "status": "passed",
+    "kind": "machinen.node-level5-target-side-continuation-proof",
+    "noSourceIsaEmulation": true,
+    "noSidecarOutput": true,
+    "noMetadataOnlySuccess": true,
+    "targetVerifierObservedActualNodeContinuation": true,
+    "targetOutputRuntime": "node",
+    "targetNativeExecution": true
+  },
+  "visibleEvidence": {
+    "jsonSummaryIncludesTargetProof": true,
+    "textOutputIncludesProofVerifierLine": true
+  },
+  "stableRefusalsPreserved": [
+    "node-level5-native-addon-abi-unsupported",
+    "node-level5-worker-thread-unsupported",
+    "node-level5-inspector-unsupported",
+    "node-level5-active-syscall-unsupported",
+    "node-level5-active-tcp-unsupported",
+    "node-level5-arbitrary-heap-stack-continuation-refused",
+    "node-level5-v8-libuv-state-unsupported"
+  ]
+}

--- a/docs/snapshot/node-level5-proof-composition.md
+++ b/docs/snapshot/node-level5-proof-composition.md
@@ -50,9 +50,11 @@ pnpm node-level5-proof-composition -- \
 
 That fixture starts a small target-native Node HTTP app, captures a continuation token, asks the target-side harness to fetch `/continuation`, and records verifier output from the running Node process.
 
+The default public restore behavior is recorded in `docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json`.
+
 ## Public verb routing
 
-Selected Node snapshots now write `node-level5-proof-composition.json` next to the portable Node bundle. `machinen restore` detects that file and writes `node-level5-proof-restore-summary.json`, but returns the stable `node-level5-proof-only-not-product` refusal. This proves the public route is wired without claiming product restore support.
+Selected Node snapshots now write `node-level5-proof-composition.json` next to the portable Node bundle. `machinen restore` detects that file, runs the target-side proof verifier by default, writes `node-level5-proof-restore-summary.json`, and returns the stable `node-level5-proof-only-not-product` refusal. Non-JSON restore output prints a concise proof-verifier line so the target-native Node continuation evidence is visible. `--allow-proof-only-success` is only for proof automation: it may return exit code 0 for a passed proof, but it does not change `productSupport=not-yet-supported`, `implementationLevel=not-implemented`, or `migrationCompleted=false`.
 
 ## Refusals
 

--- a/goals/009.md
+++ b/goals/009.md
@@ -43,8 +43,8 @@ That fixture captures a continuation token, restores it into a target-native Nod
 HTTP proof harness, and verifies the target output came from a running Node
 process with no source-ISA emulation, no sidecar output, and no metadata-only
 success. Public-verb routing remains proof-only: Node snapshots write a
-proof-composition file, and `machinen restore --verify-proof-only` can run the
-proof verifier but still reports `node-level5-proof-only-not-product` unless
+proof-composition file, and `machinen restore` now runs the proof verifier by
+default while still reporting `node-level5-proof-only-not-product` unless
 `--allow-proof-only-success` is explicitly passed for proof automation.
 
 ## Status language

--- a/goals/019.md
+++ b/goals/019.md
@@ -1,0 +1,61 @@
+# Goal 019 / Node Level 5 Goal 010 — Make selected Node Level 5 proof run by default on public restore
+
+## Status
+
+Completed in this change. This goal is the next Node Level 5 proof-routing step after Goal 009. It does not graduate Node restore to product support.
+
+## Purpose
+
+Make selected Node Level 5 proof bundles behave like the public workflow users expect:
+
+```sh
+machinen snapshot <node-app>
+machinen restore <snapshot>
+```
+
+When `machinen restore` sees `node-level5-proof-composition.json`, it now runs the target-side Node proof verifier by default and writes visible target-native continuation evidence.
+
+## Required status language
+
+The default restore path still reports:
+
+```json
+{
+  "productSupport": "not-yet-supported",
+  "implementationLevel": "not-implemented",
+  "migrationCompleted": false,
+  "refusal": { "code": "node-level5-proof-only-not-product" }
+}
+```
+
+`--allow-proof-only-success` is only for proof automation. It can return exit code 0 when the verifier passes, but it must not change the product-support fields.
+
+## Evidence shown by default
+
+The restore summary includes `targetProof` with:
+
+- `noSourceIsaEmulation=true`;
+- `noSidecarOutput=true`;
+- `noMetadataOnlySuccess=true`;
+- `targetVerifierObservedActualNodeContinuation=true`.
+
+For non-JSON output, restore also prints a concise proof-verifier line before the proof-only refusal message.
+
+## Stable refusals preserved
+
+Unsafe Node Level 5 neighbors remain fail-closed, including:
+
+- native addons;
+- worker threads;
+- inspector/debug state;
+- active syscalls;
+- active TCP streams;
+- arbitrary V8 heap/native stack continuation;
+- unsupported V8/libuv state.
+
+## Checked evidence
+
+- Runtime proof artifact: `docs/snapshot/checked-summaries/level4-graduation/goal-009-proof-run.json`
+- Target-side continuation artifact: `docs/snapshot/checked-summaries/level4-graduation/goal-009-target-side-continuation.json`
+- Default public restore summary: `docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json`
+- CLI test: `packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts`

--- a/goals/README.md
+++ b/goals/README.md
@@ -22,6 +22,7 @@ Goal files are grouped by cohort so proof records for each project stay together
 - [`016.md`](./016.md) — Add pipes as the third portable restore adapter/resource.
 - [`017.md`](./017.md) — Add timerfd as the fourth portable restore adapter/resource.
 - [`018.md`](./018.md) — Add TCP listener as the fifth portable restore adapter/resource.
+- [`019.md`](./019.md) — Make selected Node Level 5 proof run by default on public restore.
 
 ## Cohorts
 

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -229,7 +229,7 @@ describe("Node Level 5 public proof routing", () => {
     expect(CLI_SRC).toContain("isNodeLevel5ProofCompositionBundle(snapDir)");
     expect(CLI_SRC).toContain("node-level5-proof-only-not-product");
     expect(CLI_SRC).toContain("restoreRoutedThroughPublicVerb: true");
-    expect(CLI_SRC).toContain("--verify-proof-only");
+    expect(CLI_SRC).toContain("targetProofVerifierRanByDefault: true");
     expect(CLI_SRC).toContain("runNodeLevel5RestoreProofOnlyVerifier");
     expect(CLI_SRC).toContain("--allow-proof-only-success");
   });

--- a/packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts
+++ b/packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const CLI = resolve("packages/cli/src/cli.ts");
+const PROOF_RUN = resolve(
+  "docs/snapshot/checked-summaries/level4-graduation/goal-009-proof-run.json",
+);
+
+describe("Node Level 5 default public restore proof", () => {
+  it("runs the target-side proof verifier by default while refusing product support", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-default-restore-"));
+    try {
+      copyFileSync(PROOF_RUN, join(dir, "node-level5-proof-composition.json"));
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", CLI, "restore", dir, "--json"],
+        {
+          encoding: "utf8",
+        },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe("");
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        kind: "machinen.node-level5-proof-restore-summary",
+        productSupport: "not-yet-supported",
+        implementationLevel: "not-implemented",
+        migrationCompleted: false,
+        restoreRoutedThroughPublicVerb: true,
+        targetProofVerifierRanByDefault: true,
+        refusal: { code: "node-level5-proof-only-not-product" },
+        targetProof: {
+          status: "passed",
+          noSourceIsaEmulation: true,
+          noSidecarOutput: true,
+          noMetadataOnlySuccess: true,
+          targetVerifierObservedActualNodeContinuation: true,
+        },
+      });
+      expect(
+        JSON.parse(readFileSync(join(dir, "node-level5-proof-restore-summary.json"), "utf8")),
+      ).toMatchObject({
+        targetProofVerifierRanByDefault: true,
+        targetProof: { targetVerifierObservedActualNodeContinuation: true },
+      });
+      expect(
+        JSON.parse(readFileSync(join(dir, "node-level5-target-proof.json"), "utf8")),
+      ).toMatchObject({
+        targetOutput: { runtime: "node", targetNativeExecution: true },
+        assertions: {
+          sourceIsaEmulationUsed: false,
+          sidecarOutputUsed: false,
+          metadataOnlySuccess: false,
+          targetVerifierObservedActualNodeContinuation: true,
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("only exits 0 for proof automation when explicitly allowed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-default-restore-ok-"));
+    try {
+      copyFileSync(PROOF_RUN, join(dir, "node-level5-proof-composition.json"));
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", CLI, "restore", dir, "--json", "--allow-proof-only-success"],
+        { encoding: "utf8" },
+      );
+      expect(result.status).toBe(0);
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        productSupport: "not-yet-supported",
+        implementationLevel: "not-implemented",
+        migrationCompleted: false,
+        refusal: { code: "node-level5-proof-only-not-product" },
+        targetProof: { status: "passed" },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -403,6 +403,18 @@ export const COMMANDS: CommandSpec[] = [
         description: "Target-native verifier output for portable product bundles.",
       },
       {
+        name: "--verify-proof-only",
+        type: "boolean",
+        description:
+          "Compatibility flag for Node Level 5 proof bundles; the target-side proof verifier now runs by default.",
+      },
+      {
+        name: "--allow-proof-only-success",
+        type: "boolean",
+        description:
+          "Return exit code 0 when the Node Level 5 proof-only verifier passes, while still reporting not-yet-supported product status.",
+      },
+      {
         name: "--json",
         type: "boolean",
         description: "Emit the portable product restore result as JSON.",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2125,7 +2125,7 @@ function restoreUsage(): string {
     "[--target-verifier-output <file>] [--json]\n" +
     "       machinen restore <portable-ping-socket-bundle> --target-arch <arm64|amd64> " +
     "[--target-verifier-output <file>] [--json]\n" +
-    "       machinen restore <node-level5-proof-bundle> [--verify-proof-only] " +
+    "       machinen restore <node-level5-proof-bundle> " +
     "[--allow-proof-only-success] [--json]"
   );
 }
@@ -3595,9 +3595,7 @@ async function cmdRestoreNodeLevel5ProofComposition(
   const proof = JSON.parse(
     readFileSync(join(snapDir, NODE_LEVEL5_PROOF_COMPOSITION_FILE), "utf8"),
   ) as NodeLevel5ProofComposition;
-  const targetProof = parsed.verifyProofOnly
-    ? await runNodeLevel5RestoreProofOnlyVerifier(snapDir)
-    : undefined;
+  const targetProof = await runNodeLevel5RestoreProofOnlyVerifier(snapDir);
   const summary = {
     kind: "machinen.node-level5-proof-restore-summary",
     sourceKind: proof.kind,
@@ -3607,6 +3605,8 @@ async function cmdRestoreNodeLevel5ProofComposition(
     graduationTargetLevel: proof.graduationTargetLevel,
     migrationCompleted: false,
     restoreRoutedThroughPublicVerb: true,
+    targetProofVerifierRanByDefault: true,
+    targetProofVerifierRequestedByFlag: parsed.verifyProofOnly === true,
     refusal: {
       code: "node-level5-proof-only-not-product",
       message:
@@ -3623,9 +3623,12 @@ async function cmdRestoreNodeLevel5ProofComposition(
   if (json) {
     emitJson({ schema_version: 1, ...summary });
   } else {
+    process.stderr.write(
+      `Node Level 5 proof verifier: ${targetProof.status}; target-native Node continuation observed=${targetProof.targetVerifierObservedActualNodeContinuation}; noSourceIsaEmulation=${targetProof.noSourceIsaEmulation}; noSidecarOutput=${targetProof.noSidecarOutput}; noMetadataOnlySuccess=${targetProof.noMetadataOnlySuccess}\n`,
+    );
     process.stderr.write(`${summary.refusal.message}\n`);
   }
-  return parsed.allowProofOnlySuccess && targetProof?.status === "passed" ? 0 : 1;
+  return parsed.allowProofOnlySuccess && targetProof.status === "passed" ? 0 : 1;
 }
 
 async function runNodeLevel5RestoreProofOnlyVerifier(

--- a/packages/cli/src/parse-restore-args.ts
+++ b/packages/cli/src/parse-restore-args.ts
@@ -55,7 +55,7 @@ export interface ParsedRestoreCommandArgs {
   targetArch?: "arm64" | "amd64";
   /** File containing target-native verifier output for semantic bundles. */
   targetVerifierOutput?: string;
-  /** Run the Node Level 5 proof-only verifier path when restoring a proof bundle. */
+  /** Compatibility flag; Node Level 5 proof bundles now run the verifier by default. */
   verifyProofOnly?: boolean;
   /** Return 0 for a passed proof-only verifier while still reporting proof-only status. */
   allowProofOnlySuccess?: boolean;


### PR DESCRIPTION
## Problem

The Node Level 5 proof verifier worked, but users had to know a special flag to see it during restore. That made the normal `machinen snapshot` / `machinen restore` path look like it only refused, even though we now have useful target-side proof evidence.

## Solution

`machinen restore` now runs the Node Level 5 target-side proof verifier by default when it sees a selected proof bundle. It still refuses product support by default. The proof evidence is shown in JSON and in text output, and `--allow-proof-only-success` remains the only way to get exit code 0 for proof automation.

## Technical Summary

- Changed Node Level 5 proof-bundle restore to always run `runNodeLevel5RestoreProofOnlyVerifier` and include `targetProof` in the restore summary.
- Kept `productSupport=not-yet-supported`, `implementationLevel=not-implemented`, `migrationCompleted=false`, and `node-level5-proof-only-not-product` on the default path.
- Added CLI coverage for default proof restore and explicit proof-automation success.
- Added Goal 019 docs and a checked summary for default public restore proof evidence.
