### PR TITLE
Add Node Level 5 HTTP profile adapter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Snapshot internals:
 - [Goal 008 Node event-loop Level 4 resource map](./snapshot/level4-node-event-loop-resource-map.md) — planning map from Node/libuv handles to generic Level 4 descriptors and refusals
 - [Goal 009/019 Node Level 5 proof composition](./snapshot/node-level5-proof-composition.md) — selected Node proof path composed from native/process evidence, the Goal 008 Level 4 resource map, and default public restore proof evidence
 - [Goal 020 Level 5 runtime adapter substrate](./snapshot/level5-runtime-adapter-substrate.md) — generic adapter contract and registry for runtime-family Level 5 continuation paths
+- [Goal 021 Node Level 5 HTTP profile](./snapshot/node-level5-http-profile.md) — proof-only Node/V8/libuv single-thread HTTP runtime adapter profile
 - [portable machine proof profiles](./snapshot/portable-machine-proof-profiles.md) — positive and negative proof profiles for target-native completion and fail-closed refusals
 - [portable proof matrices](./snapshot/proof-matrices.md) — one-command matrix presets and JSON summary shape
 - [runtime-neutral adapter boundary](./snapshot/runtime-adapter-boundary.md) — shared adapter contract for future runtime-specific tracks

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-009-node-level5-proof-composition.json
@@ -21,8 +21,8 @@
   "proofRunArtifact": "docs/snapshot/checked-summaries/level4-graduation/goal-009-proof-run.json",
   "targetSideContinuationArtifact": "docs/snapshot/checked-summaries/level4-graduation/goal-009-target-side-continuation.json",
   "publicVerbRouting": {
-    "snapshotWrites": "node-level5-proof-composition.json",
-    "restoreSummary": "node-level5-proof-restore-summary.json",
+    "snapshotWrites": "node-level5-proof-composition.json and node-level5-runtime-profile.json",
+    "restoreSummary": "node-level5-proof-restore-summary.json or node-level5-runtime-profile-restore-summary.json",
     "restoreRefusal": "node-level5-proof-only-not-product",
     "proofVerifierRunsByDefault": true,
     "proofVerifierCompatibilityFlag": "--verify-proof-only",

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-019-node-level5-default-public-restore.json
@@ -3,9 +3,11 @@
   "goal": "019",
   "status": "default-public-restore-proof-only",
   "selectedSubset": "node-http-clean-root-v1-with-level4-event-loop-map",
+  "level5RuntimeProfile": "node-v8-libuv-single-thread-http-v1",
   "publicWorkflow": ["machinen snapshot <node-app>", "machinen restore <snapshot>"],
   "snapshotArtifact": "node-level5-proof-composition.json",
-  "restoreSummaryArtifact": "node-level5-proof-restore-summary.json",
+  "runtimeProfileArtifact": "node-level5-runtime-profile.json",
+  "restoreSummaryArtifact": "node-level5-proof-restore-summary.json or node-level5-runtime-profile-restore-summary.json",
   "targetProofArtifact": "node-level5-target-proof.json",
   "restoreBehavior": {
     "targetProofVerifierRunsByDefault": true,

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-020-level5-runtime-adapter-substrate.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-020-level5-runtime-adapter-substrate.json
@@ -28,6 +28,14 @@
   ],
   "registeredAdapters": [
     {
+      "id": "node-level5-http-runtime-adapter",
+      "runtimeFamily": "node",
+      "supportedProfiles": ["node-v8-libuv-single-thread-http-v1"],
+      "graduationTargetLevel": "level-5-cross-arch-process-continuation",
+      "productSupport": "not-yet-supported",
+      "migrationCompleted": false
+    },
+    {
       "id": "node-level5-proof-runtime-adapter",
       "runtimeFamily": "node",
       "supportedProfiles": ["node-http-clean-root-v1-with-level4-event-loop-map"],
@@ -37,15 +45,15 @@
     }
   ],
   "publicRouting": {
-    "snapshotDispatch": "writeNodeLevel5ProofCompositionSnapshot uses the adapter-compatible capture path",
-    "restoreDispatch": "detectLevel5RestoreAdapter routes node-level5-proof-composition.json through the Level 5 registry",
+    "snapshotDispatch": "writeNodeLevel5ProofCompositionSnapshot and writeNodeLevel5RuntimeProfileSnapshot use adapter-compatible capture paths",
+    "restoreDispatch": "detectLevel5RestoreAdapter routes node-level5-runtime-profile.json or node-level5-proof-composition.json through the Level 5 registry",
     "restoreSummaryFields": [
       "level5AdapterId",
       "level5AdapterRegistryRouted",
       "targetProofVerifierRanByDefault",
       "targetProof"
     ],
-    "defaultRefusal": "node-level5-proof-only-not-product",
+    "defaultRefusal": "node-level5-http-profile-proof-only-not-product or node-level5-proof-only-not-product",
     "defaultMigrationCompleted": false
   },
   "shortcutGates": {

--- a/docs/snapshot/checked-summaries/level4-graduation/goal-021-node-level5-http-profile.json
+++ b/docs/snapshot/checked-summaries/level4-graduation/goal-021-node-level5-http-profile.json
@@ -1,0 +1,64 @@
+{
+  "kind": "machinen.node-level5-http-profile-summary",
+  "goal": "021",
+  "status": "implemented-proof-profile-adapter",
+  "profile": "node-v8-libuv-single-thread-http-v1",
+  "runtimeFamily": "node",
+  "adapterId": "node-level5-http-runtime-adapter",
+  "evidenceStatus": "proof",
+  "productSupport": "not-yet-supported",
+  "implementationLevel": "not-implemented",
+  "graduationTargetLevel": "level-5-cross-arch-process-continuation",
+  "migrationCompleted": false,
+  "snapshotArtifacts": ["node-level5-proof-composition.json", "node-level5-runtime-profile.json"],
+  "restoreSummaryArtifact": "node-level5-runtime-profile-restore-summary.json",
+  "targetProofArtifact": "node-level5-target-proof.json",
+  "supportedShape": {
+    "processCount": 1,
+    "threadModel": "single-thread-required",
+    "targetNativeNodeRequired": true,
+    "httpListenerLevel4Profile": "tcp-listener-v1-loopback-empty-accept-queue",
+    "activeRequestsAllowed": false,
+    "activeTcpStreamsAllowed": false,
+    "workerThreadsAllowed": false,
+    "nativeAddonsAllowed": false,
+    "inspectorAllowed": false,
+    "activeSyscallsAllowed": false,
+    "arbitraryV8HeapContinuationAllowed": false,
+    "arbitraryNativeStackContinuationAllowed": false
+  },
+  "captureResponsibilities": [
+    "Node executable/runtime identity",
+    "argv/env/cwd and entrypoint/module identity",
+    "selected bounded V8 heap roots/state policy",
+    "libuv handle inventory",
+    "HTTP listener descriptor",
+    "refusal facts for unsupported neighbors"
+  ],
+  "restoreResponsibilities": [
+    "route through Level5RuntimeAdapter registry",
+    "recreate supported Level 4 listener resources through target-native Node profile plan",
+    "run target-side Node verifier",
+    "preserve proof-only product status until actual workload continuation graduates"
+  ],
+  "shortcutGates": {
+    "sourceIsaEmulationAllowed": false,
+    "sidecarOutputAllowed": false,
+    "metadataOnlySuccessAllowed": false
+  },
+  "stableRefusals": [
+    "node-level5-http-arbitrary-v8-heap-native-stack-unsupported",
+    "node-level5-http-native-addon-unsupported",
+    "node-level5-http-worker-thread-unsupported",
+    "node-level5-http-inspector-unsupported",
+    "node-level5-http-active-request-unsupported",
+    "node-level5-http-active-tcp-stream-unsupported",
+    "node-level5-http-active-syscall-unsupported",
+    "node-level5-http-unsupported-timer-async-handle",
+    "node-level5-http-unsupported-module-runtime-state",
+    "node-level5-http-target-native-node-missing",
+    "node-level5-http-source-isa-emulation-forbidden",
+    "node-level5-http-sidecar-output-forbidden",
+    "node-level5-http-metadata-only-success-forbidden"
+  ]
+}

--- a/docs/snapshot/level5-runtime-adapter-substrate.md
+++ b/docs/snapshot/level5-runtime-adapter-substrate.md
@@ -31,11 +31,15 @@ Proof rows remain `productSupport=not-yet-supported`. Refusal rows remain `produ
 
 ## Public routing
 
-The CLI now has a Level 5 adapter registry. The existing selected Node Level 5 proof path is represented by the `node-level5-proof-runtime-adapter` profile:
+The CLI now has a Level 5 adapter registry. The first Node runtime profile is represented by `node-level5-http-runtime-adapter`:
+
+`node-v8-libuv-single-thread-http-v1`
+
+The older selected Node proof composition remains available through `node-level5-proof-runtime-adapter`:
 
 `node-http-clean-root-v1-with-level4-event-loop-map`
 
-`machinen snapshot` writes the Node proof composition through the adapter-compatible capture path. `machinen restore` detects `node-level5-proof-composition.json` through the registry, runs the target-native proof verifier by default, and still returns the proof-only `node-level5-proof-only-not-product` refusal unless proof automation explicitly allows exit code 0.
+`machinen snapshot` writes both the Node proof composition and the Node runtime profile through adapter-compatible capture paths. `machinen restore` detects `node-level5-runtime-profile.json` or `node-level5-proof-composition.json` through the registry, runs the target-native proof verifier by default, and still returns a proof-only refusal unless proof automation explicitly allows exit code 0.
 
 ## Stable substrate refusals
 

--- a/docs/snapshot/node-level5-http-profile.md
+++ b/docs/snapshot/node-level5-http-profile.md
@@ -1,0 +1,77 @@
+# Node Level 5 single-thread HTTP profile
+
+Goal 021 adds the first Node runtime adapter profile on top of the generic Level 5 substrate.
+
+Profile:
+
+`node-v8-libuv-single-thread-http-v1`
+
+This is a runtime-level profile, not a quickstart-app-specific shortcut. It is still proof-only until a future goal proves actual workload continuation and productizes the profile.
+
+## Supported shape
+
+The profile records a narrow Node/V8/libuv HTTP shape:
+
+- one Node process;
+- single-thread requirement;
+- target-native Node required on restore;
+- HTTP listener represented by a Level 4 TCP listener profile;
+- no active requests;
+- no active TCP streams;
+- no worker threads;
+- no native addons;
+- no inspector/debug session;
+- no active syscalls/restart blocks;
+- bounded V8/libuv state only.
+
+## Snapshot artifact
+
+Selected Node snapshots now write:
+
+- `node-level5-proof-composition.json` — Goal 009/019 proof composition;
+- `node-level5-runtime-profile.json` — Goal 021 Node HTTP runtime profile.
+
+The profile artifact records Node runtime identity, argv/cwd/entrypoint, selected V8 state policy, libuv handle inventory, HTTP listener descriptors, target-native verifier requirements, and stable refusals.
+
+## Restore routing
+
+`machinen restore` routes bundles containing `node-level5-runtime-profile.json` through `node-level5-http-runtime-adapter`. Restore runs the target-side Node verifier and writes `node-level5-runtime-profile-restore-summary.json`.
+
+The status remains proof-only:
+
+```json
+{
+  "productSupport": "not-yet-supported",
+  "implementationLevel": "not-implemented",
+  "migrationCompleted": false,
+  "refusal": { "code": "node-level5-http-profile-proof-only-not-product" }
+}
+```
+
+## Stable refusals
+
+The profile fails closed for:
+
+- arbitrary V8 heap/native stack continuation;
+- native addons;
+- worker threads;
+- inspector/debug state;
+- active HTTP requests;
+- active TCP streams;
+- active syscalls/restart blocks;
+- unsupported timers/async handles;
+- unsupported module/runtime state;
+- missing target-native Node;
+- source-ISA emulation;
+- sidecar output;
+- metadata-only success.
+
+Every refusal keeps `productSupport=unsupported` and `migrationCompleted=false`.
+
+## Checked evidence
+
+- Runtime profile model: `packages/runtime/src/node-level5-http-profile.ts`
+- CLI adapter: `packages/cli/src/level5-runtime-adapters.ts`
+- Checked summary: `docs/snapshot/checked-summaries/level4-graduation/goal-021-node-level5-http-profile.json`
+- Runtime tests: `packages/runtime/src/__tests__/node-level5-http-profile.test.ts`
+- CLI restore test: `packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts`

--- a/docs/snapshot/node-level5-proof-composition.md
+++ b/docs/snapshot/node-level5-proof-composition.md
@@ -54,7 +54,7 @@ The default public restore behavior is recorded in `docs/snapshot/checked-summar
 
 ## Public verb routing
 
-Selected Node snapshots now write `node-level5-proof-composition.json` next to the portable Node bundle. `machinen restore` detects that file, runs the target-side proof verifier by default, writes `node-level5-proof-restore-summary.json`, and returns the stable `node-level5-proof-only-not-product` refusal. Non-JSON restore output prints a concise proof-verifier line so the target-native Node continuation evidence is visible. `--allow-proof-only-success` is only for proof automation: it may return exit code 0 for a passed proof, but it does not change `productSupport=not-yet-supported`, `implementationLevel=not-implemented`, or `migrationCompleted=false`.
+Selected Node snapshots now write `node-level5-proof-composition.json` and the Goal 021 `node-level5-runtime-profile.json` next to the portable Node bundle. `machinen restore` detects those files through the Level 5 adapter registry, runs the target-side proof verifier by default, writes a proof/profile restore summary, and returns a stable proof-only refusal. Non-JSON restore output prints a concise proof-verifier line so the target-native Node continuation evidence is visible. `--allow-proof-only-success` is only for proof automation: it may return exit code 0 for a passed proof, but it does not change `productSupport=not-yet-supported`, `implementationLevel=not-implemented`, or `migrationCompleted=false`.
 
 ## Refusals
 

--- a/goals/021.md
+++ b/goals/021.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned.
+Completed in this change as a proof-only Level 5 runtime adapter profile. This does not claim arbitrary Node or product support; it creates the profile artifact, adapter route, target-native verifier path, and stable refusal matrix needed for the next quickstart continuation goal.
 
 ## Purpose
 
@@ -71,6 +71,15 @@ Fail closed for:
 - unsupported module/runtime state;
 - missing target-native Node;
 - any source-ISA emulation, sidecar output, or metadata-only shortcut.
+
+## Checked evidence
+
+- Runtime profile model: `packages/runtime/src/node-level5-http-profile.ts`
+- CLI adapter registry: `packages/cli/src/level5-runtime-adapters.ts`
+- Documentation: `docs/snapshot/node-level5-http-profile.md`
+- Checked summary: `docs/snapshot/checked-summaries/level4-graduation/goal-021-node-level5-http-profile.json`
+- Runtime tests: `packages/runtime/src/__tests__/node-level5-http-profile.test.ts`
+- CLI restore tests: `packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts`
 
 ## Acceptance criteria
 

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -229,7 +229,9 @@ describe("portable restore adapter convention", () => {
 describe("Node Level 5 public proof routing", () => {
   it("routes selected proof capture through snapshot and refuses restore as proof-only", () => {
     expect(CLI_SRC).toContain("writeNodeLevel5ProofCompositionSnapshot(res.snapDir, portableNode)");
+    expect(CLI_SRC).toContain("writeNodeLevel5RuntimeProfileSnapshot(res.snapDir, portableNode)");
     expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("NODE_LEVEL5_PROOF_COMPOSITION_FILE");
+    expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("NODE_LEVEL5_HTTP_PROFILE_FILE");
     expect(CLI_SRC).toContain("isNodeLevel5ProofCompositionBundle(snapDir)");
     expect(CLI_SRC).toContain("detectLevel5RestoreAdapter(snapDir)");
     expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("node-level5-proof-only-not-product");
@@ -237,6 +239,7 @@ describe("Node Level 5 public proof routing", () => {
     expect(CLI_SRC).toContain("restoreLevel5RuntimeBundle");
     expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("level5AdapterRegistryRouted");
     expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("targetProofVerifierRanByDefault: true");
+    expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("node-level5-http-runtime-adapter");
     expect(LEVEL5_RUNTIME_ADAPTER_SRC).toContain("runNodeLevel5RestoreProofOnlyVerifier");
     expect(CLI_SRC).toContain("--allow-proof-only-success");
   });

--- a/packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts
+++ b/packages/cli/src/__tests__/node-level5-default-proof-restore.test.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { buildNodeLevel5HttpProfileCapture } from "@machinen/runtime";
 
 const CLI = resolve("packages/cli/src/cli.ts");
 const PROOF_RUN = resolve(
@@ -11,6 +13,57 @@ const PROOF_RUN = resolve(
 );
 
 describe("Node Level 5 default public restore proof", () => {
+  it("routes selected Node HTTP profile bundles through the Level 5 runtime adapter", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-http-profile-restore-"));
+    try {
+      const profile = buildNodeLevel5HttpProfileCapture({
+        sourceArch: "arm64",
+        nodeVersion: "v22.0.0",
+        sourceCwd: "/opt/app",
+        argv: ["/usr/bin/node", "/opt/app/server.mjs"],
+        guestPort: 3000,
+        verifier: { kind: "http-get", path: "/", sha256: "abc", bytes: 12 },
+      });
+      copyFileSync(PROOF_RUN, join(dir, "node-level5-proof-composition.json"));
+      writeFileSync(
+        join(dir, "node-level5-runtime-profile.json"),
+        `${JSON.stringify(profile, null, 2)}\n`,
+      );
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", CLI, "restore", dir, "--json"],
+        {
+          encoding: "utf8",
+        },
+      );
+      expect(result.status).toBe(1);
+      const summary = JSON.parse(result.stdout);
+      expect(summary).toMatchObject({
+        kind: "machinen.node-level5-runtime-profile-restore-summary",
+        productSupport: "not-yet-supported",
+        implementationLevel: "not-implemented",
+        migrationCompleted: false,
+        level5AdapterId: "node-level5-http-runtime-adapter",
+        level5AdapterRegistryRouted: true,
+        refusal: { code: "node-level5-http-profile-proof-only-not-product" },
+        targetProof: {
+          status: "passed",
+          targetVerifierObservedActualNodeContinuation: true,
+        },
+      });
+      expect(
+        JSON.parse(
+          readFileSync(join(dir, "node-level5-runtime-profile-restore-summary.json"), "utf8"),
+        ),
+      ).toMatchObject({
+        level5AdapterId: "node-level5-http-runtime-adapter",
+        targetProof: { targetVerifierObservedActualNodeContinuation: true },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("runs the target-side proof verifier by default while refusing product support", () => {
     const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-default-restore-"));
     try {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -120,6 +120,7 @@ import {
   detectLevel5RestoreAdapter,
   restoreLevel5RuntimeBundle,
   writeNodeLevel5ProofCompositionSnapshot,
+  writeNodeLevel5RuntimeProfileSnapshot,
 } from "./level5-runtime-adapters.ts";
 import { parseForkArgs } from "./parse-fork-args.ts";
 import type {
@@ -4601,6 +4602,7 @@ async function runSnapshot(opts: SnapshotOptionsCli): Promise<number> {
     if (portableNode) {
       writePortableNodeSnapshot(res.snapDir, portableNode);
       writeNodeLevel5ProofCompositionSnapshot(res.snapDir, portableNode);
+      writeNodeLevel5RuntimeProfileSnapshot(res.snapDir, portableNode);
     }
     reportSnapshotSuccess(res.snapDir, res.elapsedMs, opts);
     return 0;

--- a/packages/cli/src/level5-runtime-adapters.ts
+++ b/packages/cli/src/level5-runtime-adapters.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  NODE_LEVEL5_HTTP_PROFILE_NAME,
   buildLevel5RefusalEnvelope,
+  buildNodeLevel5HttpProfileCapture,
   buildNodeLevel5ProofComposition,
   createLevel5RuntimeAdapterRegistry,
   runNodeLevel5TargetSideProof,
@@ -14,6 +16,7 @@ import type {
   Level5RuntimeAdapter,
   Level5RuntimeAdapterMatch,
   Level5VerifierEvidence,
+  NodeLevel5HttpProfileCapture,
   NodeLevel5ProofComposition,
   NodeLevel5TargetProofEvidence,
 } from "@machinen/runtime";
@@ -21,7 +24,10 @@ import type {
 import type { PortableNodeSnapshotCapture } from "./clean-service/node-adapter.ts";
 
 const NODE_LEVEL5_PROOF_COMPOSITION_FILE = "node-level5-proof-composition.json";
+const NODE_LEVEL5_HTTP_PROFILE_FILE = "node-level5-runtime-profile.json";
 const NODE_LEVEL5_PROOF_RESTORE_SUMMARY_FILE = "node-level5-proof-restore-summary.json";
+const NODE_LEVEL5_HTTP_PROFILE_RESTORE_SUMMARY_FILE =
+  "node-level5-runtime-profile-restore-summary.json";
 const NODE_LEVEL5_TARGET_PROOF_FILE = "node-level5-target-proof.json";
 
 interface NodeLevel5ProofSnapshotContext {
@@ -74,10 +80,169 @@ interface NodeLevel5ProofRestoreSummary {
   targetProof: NodeLevel5TargetProofEvidence;
 }
 
-interface NodeLevel5ProofRestoreAdapterResult {
-  summary: NodeLevel5ProofRestoreSummary;
+interface NodeLevel5HttpProfileRestorePlan extends Level5RestorePlan {
+  adapterId: "node-level5-http-runtime-adapter";
+  runtimeFamily: "node";
+  profile: typeof NODE_LEVEL5_HTTP_PROFILE_NAME;
+  profilePath: string;
+  summaryPath: string;
+  targetProofPath: string;
+  profileArtifact: NodeLevel5HttpProfileCapture;
+  verifyProofOnlyRequested: boolean;
+  allowProofOnlySuccess: boolean;
+}
+
+interface NodeLevel5HttpProfileRestoreResult {
+  plan: NodeLevel5HttpProfileRestorePlan;
+  targetProof: NodeLevel5TargetProofEvidence;
+}
+
+interface NodeLevel5HttpProfileRestoreSummary {
+  kind: "machinen.node-level5-runtime-profile-restore-summary";
+  sourceKind: NodeLevel5HttpProfileCapture["kind"];
+  evidenceStatus: NodeLevel5HttpProfileCapture["evidenceStatus"];
+  productSupport: NodeLevel5HttpProfileCapture["productSupport"];
+  implementationLevel: NodeLevel5HttpProfileCapture["implementationLevel"];
+  graduationTargetLevel: NodeLevel5HttpProfileCapture["graduationTargetLevel"];
+  migrationCompleted: false;
+  restoreRoutedThroughPublicVerb: true;
+  level5AdapterId: "node-level5-http-runtime-adapter";
+  level5AdapterRegistryRouted: true;
+  targetProofVerifierRanByDefault: true;
+  targetProofVerifierRequestedByFlag: boolean;
+  refusal: {
+    code: "node-level5-http-profile-proof-only-not-product";
+    message: string;
+  };
+  gates: NodeLevel5HttpProfileCapture["gates"];
+  summary: NodeLevel5HttpProfileCapture["summary"];
+  targetProof: NodeLevel5TargetProofEvidence;
+  refusals: NodeLevel5HttpProfileCapture["refusals"];
+}
+
+interface NodeLevel5RuntimeRestoreAdapterResult {
+  summary: NodeLevel5ProofRestoreSummary | NodeLevel5HttpProfileRestoreSummary;
   exitCode: 0 | 1;
 }
+
+const nodeLevel5HttpRuntimeAdapter: Level5RuntimeAdapter<
+  NodeLevel5ProofSnapshotContext,
+  NodeLevel5HttpProfileCapture,
+  NodeLevel5ProofRestoreContext,
+  NodeLevel5HttpProfileRestorePlan,
+  NodeLevel5HttpProfileRestoreResult,
+  Level5VerifierEvidence
+> = {
+  id: "node-level5-http-runtime-adapter",
+  runtimeFamily: "node",
+  supportedProfiles: [NODE_LEVEL5_HTTP_PROFILE_NAME],
+  graduationTargetLevel: "level-5-cross-arch-process-continuation",
+  // fallow-ignore-next-line complexity
+  detect(input: Level5AdapterDetectInput) {
+    const hasProfileFile =
+      (input.bundleFiles ?? []).includes(NODE_LEVEL5_HTTP_PROFILE_FILE) ||
+      (input.snapDir !== undefined &&
+        existsSync(join(input.snapDir, NODE_LEVEL5_HTTP_PROFILE_FILE)));
+    return {
+      matched:
+        hasProfileFile ||
+        input.profile === NODE_LEVEL5_HTTP_PROFILE_NAME ||
+        input.artifactKind === "machinen.node-level5-runtime-profile",
+      adapterId: "node-level5-http-runtime-adapter",
+      runtimeFamily: "node",
+      profile: NODE_LEVEL5_HTTP_PROFILE_NAME,
+      reason: hasProfileFile
+        ? "node-level5-runtime-profile bundle detected"
+        : "Node/V8/libuv single-thread HTTP profile requested",
+    };
+  },
+  quiesce(_input) {
+    return { state: "quiesced", refusals: [] };
+  },
+  capture(input) {
+    return buildNodeLevel5HttpProfileCapture({
+      sourceArch: input.portableNode.sourceArch,
+      nodeVersion: input.portableNode.nodeVersion,
+      sourceCwd: input.portableNode.sourceCwd,
+      argv: input.portableNode.argv,
+      guestPort: input.portableNode.guestPort,
+      verifier: input.portableNode.verifier,
+      eventLoopResources: input.portableNode.eventLoopResources,
+      kernelResources: input.portableNode.kernelResources,
+    });
+  },
+  validate(input) {
+    const profile = isNodeLevel5ProofRestoreContext(input)
+      ? readNodeLevel5HttpProfile(input.snapDir)
+      : input;
+    const productProfile = profile as { productSupport?: string; migrationCompleted?: boolean };
+    if (
+      productProfile.productSupport !== "not-yet-supported" ||
+      productProfile.migrationCompleted === true
+    ) {
+      return {
+        state: "refused",
+        refusals: [
+          this.refuse({
+            code: "level5-metadata-only-success-forbidden",
+            message:
+              "Node HTTP Level 5 profile remains proof-only until workload continuation graduates",
+            profile: NODE_LEVEL5_HTTP_PROFILE_NAME,
+          }),
+        ],
+      };
+    }
+    return { state: "passed", refusals: [] };
+  },
+  planRestore(input) {
+    const profilePath = join(input.snapDir, NODE_LEVEL5_HTTP_PROFILE_FILE);
+    const profileArtifact = readNodeLevel5HttpProfile(input.snapDir);
+    return {
+      kind: "machinen.level5-restore-plan",
+      formatVersion: 1,
+      adapterId: "node-level5-http-runtime-adapter",
+      runtimeFamily: "node",
+      profile: NODE_LEVEL5_HTTP_PROFILE_NAME,
+      evidenceStatus: "proof",
+      productSupport: profileArtifact.productSupport,
+      implementationLevel: profileArtifact.implementationLevel,
+      graduationTargetLevel: profileArtifact.graduationTargetLevel,
+      migrationCompleted: false,
+      planState: "planned",
+      sourceArch: profileArtifact.sourceArch,
+      targetArch: undefined,
+      steps: [
+        "read node-level5-runtime-profile.json",
+        "verify Node/V8/libuv single-thread HTTP profile gates",
+        "recreate Level 4 HTTP listener resources through target-native Node profile plan",
+        "run target-side Node verifier",
+        "return proof-only refusal until actual workload continuation graduates",
+      ],
+      refusals: [],
+      profilePath,
+      summaryPath: join(input.snapDir, NODE_LEVEL5_HTTP_PROFILE_RESTORE_SUMMARY_FILE),
+      targetProofPath: join(input.snapDir, NODE_LEVEL5_TARGET_PROOF_FILE),
+      profileArtifact,
+      verifyProofOnlyRequested: input.verifyProofOnly === true,
+      allowProofOnlySuccess: input.allowProofOnlySuccess === true,
+    };
+  },
+  async restoreTargetNative(plan) {
+    const targetProof = await runNodeLevel5RestoreProofOnlyVerifier(plan.targetProofPath);
+    return { plan, targetProof };
+  },
+  verify(result) {
+    return nodeLevel5VerifierEvidence(result.targetProof);
+  },
+  refuse(input): Level5RefusalEnvelope {
+    return buildLevel5RefusalEnvelope({
+      ...input,
+      adapterId: "node-level5-http-runtime-adapter",
+      runtimeFamily: "node",
+      profile: input.profile ?? NODE_LEVEL5_HTTP_PROFILE_NAME,
+    });
+  },
+};
 
 const nodeLevel5ProofRuntimeAdapter: Level5RuntimeAdapter<
   NodeLevel5ProofSnapshotContext,
@@ -185,20 +350,7 @@ const nodeLevel5ProofRuntimeAdapter: Level5RuntimeAdapter<
     return { plan, targetProof };
   },
   verify(result) {
-    return {
-      kind: "machinen.level5-target-verifier-evidence",
-      status: result.targetProof.status === "passed" ? "passed" : "failed",
-      evidenceStatus: "proof",
-      productSupport: "not-yet-supported",
-      implementationLevel: "not-implemented",
-      graduationTargetLevel: "level-5-cross-arch-process-continuation",
-      migrationCompleted: false,
-      targetNativeExecution: result.targetProof.targetVerifierObservedActualNodeContinuation,
-      sourceIsaEmulationUsed: !result.targetProof.noSourceIsaEmulation,
-      sidecarOutputUsed: !result.targetProof.noSidecarOutput,
-      metadataOnlySuccess: !result.targetProof.noMetadataOnlySuccess,
-      message: result.targetProof.message,
-    };
+    return nodeLevel5VerifierEvidence(result.targetProof);
   },
   refuse(input): Level5RefusalEnvelope {
     return buildLevel5RefusalEnvelope({
@@ -210,13 +362,31 @@ const nodeLevel5ProofRuntimeAdapter: Level5RuntimeAdapter<
   },
 };
 
+function nodeLevel5VerifierEvidence(
+  targetProof: NodeLevel5TargetProofEvidence,
+): Level5VerifierEvidence {
+  return {
+    kind: "machinen.level5-target-verifier-evidence",
+    status: targetProof.status === "passed" ? "passed" : "failed",
+    evidenceStatus: "proof",
+    productSupport: "not-yet-supported",
+    implementationLevel: "not-implemented",
+    graduationTargetLevel: "level-5-cross-arch-process-continuation",
+    migrationCompleted: false,
+    targetNativeExecution: targetProof.targetVerifierObservedActualNodeContinuation,
+    sourceIsaEmulationUsed: !targetProof.noSourceIsaEmulation,
+    sidecarOutputUsed: !targetProof.noSidecarOutput,
+    metadataOnlySuccess: !targetProof.noMetadataOnlySuccess,
+    message: targetProof.message,
+  };
+}
+
 const level5RuntimeAdapterRegistry = createLevel5RuntimeAdapterRegistry([
+  nodeLevel5HttpRuntimeAdapter,
   nodeLevel5ProofRuntimeAdapter,
 ]);
 
-export function detectLevel5RestoreAdapter(
-  snapDir: string,
-): Level5RuntimeAdapterMatch<typeof nodeLevel5ProofRuntimeAdapter> | undefined {
+export function detectLevel5RestoreAdapter(snapDir: string): Level5RuntimeAdapterMatch | undefined {
   return level5RuntimeAdapterRegistry.detect({ operation: "restore", snapDir });
 }
 
@@ -231,11 +401,22 @@ export function writeNodeLevel5ProofCompositionSnapshot(
   );
 }
 
+export function writeNodeLevel5RuntimeProfileSnapshot(
+  snapDir: string,
+  portableNode: PortableNodeSnapshotCapture,
+): void {
+  const profile = nodeLevel5HttpRuntimeAdapter.capture({ snapDir, portableNode });
+  writeFileSync(
+    join(snapDir, NODE_LEVEL5_HTTP_PROFILE_FILE),
+    `${JSON.stringify(profile, null, 2)}\n`,
+  );
+}
+
 // fallow-ignore-next-line complexity
 export async function restoreLevel5RuntimeBundle(
   snapDir: string,
   input: { verifyProofOnly?: boolean; allowProofOnlySuccess?: boolean },
-): Promise<NodeLevel5ProofRestoreAdapterResult> {
+): Promise<NodeLevel5RuntimeRestoreAdapterResult> {
   const match = detectLevel5RestoreAdapter(snapDir);
   if (!match) {
     const refusal = level5RuntimeAdapterRegistry.refuseUnsupported({
@@ -243,29 +424,92 @@ export async function restoreLevel5RuntimeBundle(
     });
     throw new Error(refusal.message);
   }
+  if (match.adapter.id === "node-level5-http-runtime-adapter") {
+    return await restoreNodeLevel5HttpProfileBundle(snapDir, input);
+  }
   const context: NodeLevel5ProofRestoreContext = {
     snapDir,
     verifyProofOnly: input.verifyProofOnly,
     allowProofOnlySuccess: input.allowProofOnlySuccess,
   };
-  const validation = await match.adapter.validate(context);
+  const validation = await nodeLevel5ProofRuntimeAdapter.validate(context);
   if (validation.state === "refused") {
     const refusal =
       validation.refusals[0] ??
-      match.adapter.refuse({
+      nodeLevel5ProofRuntimeAdapter.refuse({
         code: "level5-runtime-profile-unsupported",
         message: "Level 5 runtime bundle refused",
       });
     throw new Error(refusal.message);
   }
-  const plan = await match.adapter.planRestore(context);
-  const result = await match.adapter.restoreTargetNative(plan);
-  await match.adapter.verify(result);
+  const plan = await nodeLevel5ProofRuntimeAdapter.planRestore(context);
+  const result = await nodeLevel5ProofRuntimeAdapter.restoreTargetNative(plan);
+  await nodeLevel5ProofRuntimeAdapter.verify(result);
   const summary = buildNodeLevel5ProofRestoreSummary(result);
   writeFileSync(plan.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
   return {
     summary,
     exitCode: plan.allowProofOnlySuccess && result.targetProof.status === "passed" ? 0 : 1,
+  };
+}
+
+// fallow-ignore-next-line complexity
+async function restoreNodeLevel5HttpProfileBundle(
+  snapDir: string,
+  input: { verifyProofOnly?: boolean; allowProofOnlySuccess?: boolean },
+): Promise<NodeLevel5RuntimeRestoreAdapterResult> {
+  const context: NodeLevel5ProofRestoreContext = {
+    snapDir,
+    verifyProofOnly: input.verifyProofOnly,
+    allowProofOnlySuccess: input.allowProofOnlySuccess,
+  };
+  const validation = await nodeLevel5HttpRuntimeAdapter.validate(context);
+  if (validation.state === "refused") {
+    const refusal =
+      validation.refusals[0] ??
+      nodeLevel5HttpRuntimeAdapter.refuse({
+        code: "level5-runtime-profile-unsupported",
+        message: "Node HTTP Level 5 runtime profile refused",
+      });
+    throw new Error(refusal.message);
+  }
+  const plan = await nodeLevel5HttpRuntimeAdapter.planRestore(context);
+  const result = await nodeLevel5HttpRuntimeAdapter.restoreTargetNative(plan);
+  await nodeLevel5HttpRuntimeAdapter.verify(result);
+  const summary = buildNodeLevel5HttpProfileRestoreSummary(result);
+  writeFileSync(plan.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return {
+    summary,
+    exitCode: plan.allowProofOnlySuccess && result.targetProof.status === "passed" ? 0 : 1,
+  };
+}
+
+function buildNodeLevel5HttpProfileRestoreSummary(
+  result: NodeLevel5HttpProfileRestoreResult,
+): NodeLevel5HttpProfileRestoreSummary {
+  const profile = result.plan.profileArtifact;
+  return {
+    kind: "machinen.node-level5-runtime-profile-restore-summary",
+    sourceKind: profile.kind,
+    evidenceStatus: profile.evidenceStatus,
+    productSupport: profile.productSupport,
+    implementationLevel: profile.implementationLevel,
+    graduationTargetLevel: profile.graduationTargetLevel,
+    migrationCompleted: false,
+    restoreRoutedThroughPublicVerb: true,
+    level5AdapterId: "node-level5-http-runtime-adapter",
+    level5AdapterRegistryRouted: true,
+    targetProofVerifierRanByDefault: true,
+    targetProofVerifierRequestedByFlag: result.plan.verifyProofOnlyRequested,
+    refusal: {
+      code: "node-level5-http-profile-proof-only-not-product",
+      message:
+        "Node Level 5 HTTP runtime profile is routed through machinen restore, but it is not product restore support yet",
+    },
+    gates: profile.gates,
+    summary: profile.summary,
+    targetProof: result.targetProof,
+    refusals: profile.refusals,
   };
 }
 
@@ -297,6 +541,12 @@ function buildNodeLevel5ProofRestoreSummary(
   };
 }
 
+function readNodeLevel5HttpProfile(snapDir: string): NodeLevel5HttpProfileCapture {
+  return JSON.parse(
+    readFileSync(join(snapDir, NODE_LEVEL5_HTTP_PROFILE_FILE), "utf8"),
+  ) as NodeLevel5HttpProfileCapture;
+}
+
 function readNodeLevel5Proof(snapDir: string): NodeLevel5ProofComposition {
   return JSON.parse(
     readFileSync(join(snapDir, NODE_LEVEL5_PROOF_COMPOSITION_FILE), "utf8"),
@@ -320,8 +570,6 @@ async function runNodeLevel5RestoreProofOnlyVerifier(
   };
 }
 
-function isNodeLevel5ProofRestoreContext(
-  input: NodeLevel5ProofComposition | NodeLevel5ProofRestoreContext,
-): input is NodeLevel5ProofRestoreContext {
+function isNodeLevel5ProofRestoreContext(input: unknown): input is NodeLevel5ProofRestoreContext {
   return typeof (input as NodeLevel5ProofRestoreContext).snapDir === "string";
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -32,6 +32,18 @@
 - [`createLevel5RuntimeAdapterRegistry`](#createlevel5runtimeadapterregistry)
 - [`level5SubstrateRefusalCodes`](#level5substraterefusalcodes)
 
+### Node Level 5 HTTP profile
+
+- [`NodeLevel5HttpProfileCapture`](#nodelevel5httpprofilecapture)
+- [`NodeLevel5HttpProfileCaptureInput`](#nodelevel5httpprofilecaptureinput)
+- [`NodeLevel5HttpProfileRefusal`](#nodelevel5httpprofilerefusal)
+- [`NodeLevel5HttpProfileRefusalCode`](#nodelevel5httpprofilerefusalcode)
+- [`NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION`](#node_level5_http_profile_format_version)
+- [`NODE_LEVEL5_HTTP_PROFILE_NAME`](#node_level5_http_profile_name)
+- [`buildNodeLevel5HttpProfileCapture`](#buildnodelevel5httpprofilecapture)
+- [`nodeLevel5HttpProfileRefusalCodes`](#nodelevel5httpprofilerefusalcodes)
+- [`nodeLevel5HttpProfileRefusalRows`](#nodelevel5httpprofilerefusalrows)
+
 ### Node Level 5 proof composition
 
 - [`NodeLevel5ProofComposition`](#nodelevel5proofcomposition)
@@ -11841,6 +11853,308 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ***
 
+### NodeLevel5HttpProfileRefusal
+
+#### Properties
+
+##### code
+
+> **code**: `"node-level5-http-arbitrary-v8-heap-native-stack-unsupported"` \| `"node-level5-http-native-addon-unsupported"` \| `"node-level5-http-worker-thread-unsupported"` \| `"node-level5-http-inspector-unsupported"` \| `"node-level5-http-active-request-unsupported"` \| `"node-level5-http-active-tcp-stream-unsupported"` \| `"node-level5-http-active-syscall-unsupported"` \| `"node-level5-http-unsupported-timer-async-handle"` \| `"node-level5-http-unsupported-module-runtime-state"` \| `"node-level5-http-target-native-node-missing"` \| `"node-level5-http-source-isa-emulation-forbidden"` \| `"node-level5-http-sidecar-output-forbidden"` \| `"node-level5-http-metadata-only-success-forbidden"`
+
+##### unsafeNeighbor
+
+> **unsafeNeighbor**: `"metadata-only-success"` \| `"active-syscall"` \| `"arbitrary-v8-heap-native-stack"` \| `"native-addon"` \| `"worker-thread"` \| `"inspector-debug"` \| `"active-request"` \| `"active-tcp-stream"` \| `"unsupported-timer-async-handle"` \| `"unsupported-module-runtime-state"` \| `"missing-target-native-node"` \| `"source-isa-emulation"` \| `"sidecar-output"`
+
+##### message
+
+> **message**: `string`
+
+##### evidenceStatus
+
+> **evidenceStatus**: `"refusal"`
+
+##### productSupport
+
+> **productSupport**: `"unsupported"`
+
+##### implementationLevel
+
+> **implementationLevel**: `"level-0-fail-closed-discovery"`
+
+##### graduationTargetLevel
+
+> **graduationTargetLevel**: `"level-5-cross-arch-process-continuation"`
+
+##### migrationCompleted
+
+> **migrationCompleted**: `false`
+
+***
+
+### NodeLevel5HttpProfileCaptureInput
+
+#### Properties
+
+##### sourceArch
+
+> **sourceArch**: `string`
+
+##### nodeVersion
+
+> **nodeVersion**: `string`
+
+##### sourceCwd
+
+> **sourceCwd**: `string`
+
+##### argv
+
+> **argv**: `string`[]
+
+##### guestPort
+
+> **guestPort**: `number`
+
+##### verifier
+
+> **verifier**: `object`
+
+###### kind
+
+> **kind**: `string`
+
+###### path
+
+> **path**: `string`
+
+###### sha256
+
+> **sha256**: `string`
+
+###### bytes
+
+> **bytes**: `number`
+
+##### eventLoopResources?
+
+> `optional` **eventLoopResources?**: `unknown`
+
+##### kernelResources?
+
+> `optional` **kernelResources?**: `unknown`
+
+***
+
+### NodeLevel5HttpProfileCapture
+
+#### Properties
+
+##### kind
+
+> **kind**: `"machinen.node-level5-runtime-profile"`
+
+##### formatVersion
+
+> **formatVersion**: `1`
+
+##### sourceGoal
+
+> **sourceGoal**: `"021"`
+
+##### evidenceStatus
+
+> **evidenceStatus**: `"proof"`
+
+##### productSupport
+
+> **productSupport**: `"not-yet-supported"`
+
+##### implementationLevel
+
+> **implementationLevel**: `"not-implemented"`
+
+##### graduationTargetLevel
+
+> **graduationTargetLevel**: `"level-5-cross-arch-process-continuation"`
+
+##### migrationCompleted
+
+> **migrationCompleted**: `false`
+
+##### runtimeFamily
+
+> **runtimeFamily**: `"node"`
+
+##### profile
+
+> **profile**: `"node-v8-libuv-single-thread-http-v1"`
+
+##### sourceArch
+
+> **sourceArch**: `string`
+
+##### runtimeIdentity
+
+> **runtimeIdentity**: `object`
+
+###### executable
+
+> **executable**: `"node"`
+
+###### version
+
+> **version**: `string`
+
+###### targetNativeRuntimeRequired
+
+> **targetNativeRuntimeRequired**: `true`
+
+##### processModel
+
+> **processModel**: `object`
+
+###### processCount
+
+> **processCount**: `1`
+
+###### threadModel
+
+> **threadModel**: `"single-thread-required"`
+
+###### activeSyscallsAllowed
+
+> **activeSyscallsAllowed**: `false`
+
+###### activeRequestsAllowed
+
+> **activeRequestsAllowed**: `false`
+
+###### activeTcpStreamsAllowed
+
+> **activeTcpStreamsAllowed**: `false`
+
+##### moduleIdentity
+
+> **moduleIdentity**: `object`
+
+###### sourceCwd
+
+> **sourceCwd**: `string`
+
+###### argv
+
+> **argv**: `string`[]
+
+###### entrypoint
+
+> **entrypoint**: `string`
+
+###### unsupportedModuleStateAllowed
+
+> **unsupportedModuleStateAllowed**: `false`
+
+##### selectedV8State
+
+> **selectedV8State**: `object`
+
+###### stateModel
+
+> **stateModel**: `"bounded-profile-roots-only"`
+
+###### arbitraryHeapContinuationAllowed
+
+> **arbitraryHeapContinuationAllowed**: `false`
+
+###### arbitraryNativeStackContinuationAllowed
+
+> **arbitraryNativeStackContinuationAllowed**: `false`
+
+##### libuv
+
+> **libuv**: `object`
+
+###### handleInventory
+
+> **handleInventory**: `unknown`
+
+###### timersAsyncHandlesPolicy
+
+> **timersAsyncHandlesPolicy**: `"refuse-unless-modeled"`
+
+##### kernelResources
+
+> **kernelResources**: `object`
+
+###### inventory
+
+> **inventory**: `unknown`
+
+###### httpListeners
+
+> **httpListeners**: `object`[]
+
+##### verifier
+
+> **verifier**: `object`
+
+###### kind
+
+> **kind**: `string`
+
+###### path
+
+> **path**: `string`
+
+###### sha256
+
+> **sha256**: `string`
+
+###### bytes
+
+> **bytes**: `number`
+
+##### gates
+
+> **gates**: `object`
+
+###### sourceIsaEmulationAllowed
+
+> **sourceIsaEmulationAllowed**: `false`
+
+###### sidecarOutputAllowed
+
+> **sidecarOutputAllowed**: `false`
+
+###### metadataOnlySuccessAllowed
+
+> **metadataOnlySuccessAllowed**: `false`
+
+###### targetNativeNodeRequired
+
+> **targetNativeNodeRequired**: `true`
+
+##### refusals
+
+> **refusals**: [`NodeLevel5HttpProfileRefusal`](#nodelevel5httpprofilerefusal)[]
+
+##### summary
+
+> **summary**: `object`
+
+###### profileReady
+
+> **profileReady**: `true`
+
+###### targetNativeContinuationRequired
+
+> **targetNativeContinuationRequired**: `true`
+
+###### productSupportBlockedUntilActualWorkloadContinuation
+
+> **productSupportBlockedUntilActualWorkloadContinuation**: `true`
+
+***
+
 ### NodeLevel5ProofIngredient
 
 #### Properties
@@ -11997,7 +12311,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`code`](#code-17)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`code`](#code-18)
 
 ##### message
 
@@ -12005,7 +12319,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`message`](#message-4)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`message`](#message-5)
 
 ##### migrationCompleted
 
@@ -12013,7 +12327,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`migrationCompleted`](#migrationcompleted-12)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`migrationCompleted`](#migrationcompleted-14)
 
 ##### productSupport
 
@@ -12021,7 +12335,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`productSupport`](#productsupport-8)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`productSupport`](#productsupport-10)
 
 ##### implementationLevel
 
@@ -12029,7 +12343,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`implementationLevel`](#implementationlevel-8)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`implementationLevel`](#implementationlevel-10)
 
 ##### evidenceStatus
 
@@ -12037,11 +12351,11 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`evidenceStatus`](#evidencestatus-9)
+[`NodeLevel5ProofCompositionRefusal`](#nodelevel5proofcompositionrefusal).[`evidenceStatus`](#evidencestatus-11)
 
 ##### unsafeNeighbor
 
-> **unsafeNeighbor**: `"tls-rseq"` \| `"simd-fpu"` \| `"active-signals"` \| `"active-syscalls"` \| `"active-tcp"` \| `"worker-threads"` \| `"multithread"` \| `"unsupported-memory-mappings"` \| `"unsupported-kernel-resources"` \| `"native-addon-abi"` \| `"inspector-debug"` \| `"unsupported-v8-libuv-state"` \| `"arbitrary-heap-stack-continuation"`
+> **unsafeNeighbor**: `"inspector-debug"` \| `"tls-rseq"` \| `"simd-fpu"` \| `"active-signals"` \| `"active-syscalls"` \| `"active-tcp"` \| `"worker-threads"` \| `"multithread"` \| `"unsupported-memory-mappings"` \| `"unsupported-kernel-resources"` \| `"native-addon-abi"` \| `"unsupported-v8-libuv-state"` \| `"arbitrary-heap-stack-continuation"`
 
 ***
 
@@ -13330,7 +13644,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Inherited from
 
-[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`sourceArch`](#sourcearch-11)
+[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`sourceArch`](#sourcearch-13)
 
 ##### targetArch
 
@@ -13426,7 +13740,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### Overrides
 
-[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`migrationCompleted`](#migrationcompleted-16)
+[`PortableSnapshotGuestCheckpointCompositionInput`](#portablesnapshotguestcheckpointcompositioninput).[`migrationCompleted`](#migrationcompleted-18)
 
 ##### scope
 
@@ -17310,7 +17624,7 @@ the breakdown shows up alongside the parent phase.
 
 ###### Inherited from
 
-[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`profile`](#profile-11)
+[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`profile`](#profile-12)
 
 ##### classification
 
@@ -17326,7 +17640,7 @@ the breakdown shows up alongside the parent phase.
 
 ###### Inherited from
 
-[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`sourceArch`](#sourcearch-27)
+[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`sourceArch`](#sourcearch-29)
 
 ##### targetArch
 
@@ -17402,7 +17716,7 @@ the breakdown shows up alongside the parent phase.
 
 ###### Overrides
 
-[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`migrationCompleted`](#migrationcompleted-33)
+[`RuntimeConfidenceProfileInput`](#runtimeconfidenceprofileinput).[`migrationCompleted`](#migrationcompleted-35)
 
 ##### scope
 
@@ -20944,6 +21258,12 @@ Poll interval in ms while retrying. Default 250.
 
 ***
 
+### NodeLevel5HttpProfileRefusalCode
+
+> **NodeLevel5HttpProfileRefusalCode** = *typeof* [`nodeLevel5HttpProfileRefusalCodes`](#nodelevel5httpprofilerefusalcodes)\[`number`\]
+
+***
+
 ### NodeLevel5ProofIngredientName
 
 > **NodeLevel5ProofIngredientName** = *typeof* [`nodeLevel5ProofIngredientNames`](#nodelevel5proofingredientnames)\[`number`\]
@@ -22683,6 +23003,24 @@ loops; anything looser stops being a meaningful gate.
 ### nestedVirtualizationStretchProofRefusalCodes
 
 > `const` **nestedVirtualizationStretchProofRefusalCodes**: readonly \[`"nested-virtualization-unavailable"`, `"nested-smoke-failed"`, `"nested-verifier-ambiguous"`, `"nested-snapshot-fork-unsafe"`\]
+
+***
+
+### NODE\_LEVEL5\_HTTP\_PROFILE\_FORMAT\_VERSION
+
+> `const` **NODE\_LEVEL5\_HTTP\_PROFILE\_FORMAT\_VERSION**: `1`
+
+***
+
+### NODE\_LEVEL5\_HTTP\_PROFILE\_NAME
+
+> `const` **NODE\_LEVEL5\_HTTP\_PROFILE\_NAME**: `"node-v8-libuv-single-thread-http-v1"`
+
+***
+
+### nodeLevel5HttpProfileRefusalCodes
+
+> `const` **nodeLevel5HttpProfileRefusalCodes**: readonly \[`"node-level5-http-arbitrary-v8-heap-native-stack-unsupported"`, `"node-level5-http-native-addon-unsupported"`, `"node-level5-http-worker-thread-unsupported"`, `"node-level5-http-inspector-unsupported"`, `"node-level5-http-active-request-unsupported"`, `"node-level5-http-active-tcp-stream-unsupported"`, `"node-level5-http-active-syscall-unsupported"`, `"node-level5-http-unsupported-timer-async-handle"`, `"node-level5-http-unsupported-module-runtime-state"`, `"node-level5-http-target-native-node-missing"`, `"node-level5-http-source-isa-emulation-forbidden"`, `"node-level5-http-sidecar-output-forbidden"`, `"node-level5-http-metadata-only-success-forbidden"`\]
 
 ***
 
@@ -25375,6 +25713,32 @@ available.
 #### Returns
 
 `string`[]
+
+***
+
+### buildNodeLevel5HttpProfileCapture()
+
+> **buildNodeLevel5HttpProfileCapture**(`input`): [`NodeLevel5HttpProfileCapture`](#nodelevel5httpprofilecapture)
+
+#### Parameters
+
+##### input
+
+[`NodeLevel5HttpProfileCaptureInput`](#nodelevel5httpprofilecaptureinput)
+
+#### Returns
+
+[`NodeLevel5HttpProfileCapture`](#nodelevel5httpprofilecapture)
+
+***
+
+### nodeLevel5HttpProfileRefusalRows()
+
+> **nodeLevel5HttpProfileRefusalRows**(): [`NodeLevel5HttpProfileRefusal`](#nodelevel5httpprofilerefusal)[]
+
+#### Returns
+
+[`NodeLevel5HttpProfileRefusal`](#nodelevel5httpprofilerefusal)[]
 
 ***
 

--- a/packages/runtime/src/__tests__/node-level5-http-profile.test.ts
+++ b/packages/runtime/src/__tests__/node-level5-http-profile.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NODE_LEVEL5_HTTP_PROFILE_NAME,
+  buildNodeLevel5HttpProfileCapture,
+  nodeLevel5HttpProfileRefusalCodes,
+  nodeLevel5HttpProfileRefusalRows,
+} from "../node-level5-http-profile.ts";
+
+describe("Node Level 5 single-thread HTTP profile", () => {
+  it("captures a runtime-level profile without claiming product support", () => {
+    const profile = buildNodeLevel5HttpProfileCapture({
+      sourceArch: "arm64",
+      nodeVersion: "v22.0.0",
+      sourceCwd: "/opt/app",
+      argv: ["/usr/bin/node", "/opt/app/server.mjs"],
+      guestPort: 3000,
+      verifier: { kind: "http-get", path: "/", sha256: "abc", bytes: 12 },
+      eventLoopResources: { summary: { mapped: 1, refused: 0 } },
+      kernelResources: { summary: { supported: 1, refused: 0 } },
+    });
+
+    expect(profile).toMatchObject({
+      kind: "machinen.node-level5-runtime-profile",
+      sourceGoal: "021",
+      evidenceStatus: "proof",
+      productSupport: "not-yet-supported",
+      implementationLevel: "not-implemented",
+      graduationTargetLevel: "level-5-cross-arch-process-continuation",
+      migrationCompleted: false,
+      runtimeFamily: "node",
+      profile: NODE_LEVEL5_HTTP_PROFILE_NAME,
+      runtimeIdentity: { executable: "node", targetNativeRuntimeRequired: true },
+      processModel: {
+        processCount: 1,
+        threadModel: "single-thread-required",
+        activeSyscallsAllowed: false,
+        activeRequestsAllowed: false,
+        activeTcpStreamsAllowed: false,
+      },
+      moduleIdentity: {
+        sourceCwd: "/opt/app",
+        entrypoint: "/opt/app/server.mjs",
+        unsupportedModuleStateAllowed: false,
+      },
+      selectedV8State: {
+        stateModel: "bounded-profile-roots-only",
+        arbitraryHeapContinuationAllowed: false,
+        arbitraryNativeStackContinuationAllowed: false,
+      },
+      kernelResources: {
+        httpListeners: [
+          {
+            protocol: "tcp",
+            bindAddress: "127.0.0.1",
+            port: 3000,
+            level4Profile: "tcp-listener-v1-loopback-empty-accept-queue",
+          },
+        ],
+      },
+      gates: {
+        sourceIsaEmulationAllowed: false,
+        sidecarOutputAllowed: false,
+        metadataOnlySuccessAllowed: false,
+        targetNativeNodeRequired: true,
+      },
+    });
+  });
+
+  it("keeps every unsafe neighbor as a stable refusal family", () => {
+    const rows = nodeLevel5HttpProfileRefusalRows();
+    expect(rows.map((row) => row.code)).toEqual(nodeLevel5HttpProfileRefusalCodes);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ unsafeNeighbor: "arbitrary-v8-heap-native-stack" }),
+        expect.objectContaining({ unsafeNeighbor: "native-addon" }),
+        expect.objectContaining({ unsafeNeighbor: "worker-thread" }),
+        expect.objectContaining({ unsafeNeighbor: "inspector-debug" }),
+        expect.objectContaining({ unsafeNeighbor: "active-request" }),
+        expect.objectContaining({ unsafeNeighbor: "active-tcp-stream" }),
+        expect.objectContaining({ unsafeNeighbor: "active-syscall" }),
+        expect.objectContaining({ unsafeNeighbor: "unsupported-timer-async-handle" }),
+        expect.objectContaining({ unsafeNeighbor: "unsupported-module-runtime-state" }),
+        expect.objectContaining({ unsafeNeighbor: "missing-target-native-node" }),
+        expect.objectContaining({ unsafeNeighbor: "source-isa-emulation" }),
+        expect.objectContaining({ unsafeNeighbor: "sidecar-output" }),
+        expect.objectContaining({ unsafeNeighbor: "metadata-only-success" }),
+      ]),
+    );
+    expect(
+      rows.every((row) => row.productSupport === "unsupported" && row.migrationCompleted === false),
+    ).toBe(true);
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -138,6 +138,13 @@ export {
   runNodeLevel5TargetSideProof,
 } from "./node-level5-target-side-proof.ts";
 export {
+  NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION,
+  NODE_LEVEL5_HTTP_PROFILE_NAME,
+  buildNodeLevel5HttpProfileCapture,
+  nodeLevel5HttpProfileRefusalCodes,
+  nodeLevel5HttpProfileRefusalRows,
+} from "./node-level5-http-profile.ts";
+export {
   NODE_LEVEL5_PROOF_COMPOSITION_FORMAT_VERSION,
   buildNodeLevel5ProofComposition,
   nodeLevel5ProofIngredientNames,
@@ -157,6 +164,12 @@ export type {
   NodeLevel5TargetSideProof,
   NodeLevel5TargetSideProofInput,
 } from "./node-level5-target-side-proof.ts";
+export type {
+  NodeLevel5HttpProfileCapture,
+  NodeLevel5HttpProfileCaptureInput,
+  NodeLevel5HttpProfileRefusal,
+  NodeLevel5HttpProfileRefusalCode,
+} from "./node-level5-http-profile.ts";
 export type {
   NodeLevel5ProofComposition,
   NodeLevel5ProofCompositionInput,

--- a/packages/runtime/src/node-level5-http-profile.ts
+++ b/packages/runtime/src/node-level5-http-profile.ts
@@ -1,0 +1,272 @@
+export const NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION = 1 as const;
+export const NODE_LEVEL5_HTTP_PROFILE_NAME = "node-v8-libuv-single-thread-http-v1" as const;
+
+export const nodeLevel5HttpProfileRefusalCodes = [
+  "node-level5-http-arbitrary-v8-heap-native-stack-unsupported",
+  "node-level5-http-native-addon-unsupported",
+  "node-level5-http-worker-thread-unsupported",
+  "node-level5-http-inspector-unsupported",
+  "node-level5-http-active-request-unsupported",
+  "node-level5-http-active-tcp-stream-unsupported",
+  "node-level5-http-active-syscall-unsupported",
+  "node-level5-http-unsupported-timer-async-handle",
+  "node-level5-http-unsupported-module-runtime-state",
+  "node-level5-http-target-native-node-missing",
+  "node-level5-http-source-isa-emulation-forbidden",
+  "node-level5-http-sidecar-output-forbidden",
+  "node-level5-http-metadata-only-success-forbidden",
+] as const;
+
+export type NodeLevel5HttpProfileRefusalCode = (typeof nodeLevel5HttpProfileRefusalCodes)[number];
+
+export interface NodeLevel5HttpProfileRefusal {
+  code: NodeLevel5HttpProfileRefusalCode;
+  unsafeNeighbor:
+    | "arbitrary-v8-heap-native-stack"
+    | "native-addon"
+    | "worker-thread"
+    | "inspector-debug"
+    | "active-request"
+    | "active-tcp-stream"
+    | "active-syscall"
+    | "unsupported-timer-async-handle"
+    | "unsupported-module-runtime-state"
+    | "missing-target-native-node"
+    | "source-isa-emulation"
+    | "sidecar-output"
+    | "metadata-only-success";
+  message: string;
+  evidenceStatus: "refusal";
+  productSupport: "unsupported";
+  implementationLevel: "level-0-fail-closed-discovery";
+  graduationTargetLevel: "level-5-cross-arch-process-continuation";
+  migrationCompleted: false;
+}
+
+export interface NodeLevel5HttpProfileCaptureInput {
+  sourceArch: "arm64" | "amd64" | string;
+  nodeVersion: string;
+  sourceCwd: string;
+  argv: string[];
+  guestPort: number;
+  verifier: { kind: string; path: string; sha256: string; bytes: number };
+  eventLoopResources?: unknown;
+  kernelResources?: unknown;
+}
+
+export interface NodeLevel5HttpProfileCapture {
+  kind: "machinen.node-level5-runtime-profile";
+  formatVersion: typeof NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION;
+  sourceGoal: "021";
+  evidenceStatus: "proof";
+  productSupport: "not-yet-supported";
+  implementationLevel: "not-implemented";
+  graduationTargetLevel: "level-5-cross-arch-process-continuation";
+  migrationCompleted: false;
+  runtimeFamily: "node";
+  profile: typeof NODE_LEVEL5_HTTP_PROFILE_NAME;
+  sourceArch: string;
+  runtimeIdentity: {
+    executable: "node";
+    version: string;
+    targetNativeRuntimeRequired: true;
+  };
+  processModel: {
+    processCount: 1;
+    threadModel: "single-thread-required";
+    activeSyscallsAllowed: false;
+    activeRequestsAllowed: false;
+    activeTcpStreamsAllowed: false;
+  };
+  moduleIdentity: {
+    sourceCwd: string;
+    argv: string[];
+    entrypoint: string | null;
+    unsupportedModuleStateAllowed: false;
+  };
+  selectedV8State: {
+    stateModel: "bounded-profile-roots-only";
+    arbitraryHeapContinuationAllowed: false;
+    arbitraryNativeStackContinuationAllowed: false;
+  };
+  libuv: {
+    handleInventory: unknown | null;
+    timersAsyncHandlesPolicy: "refuse-unless-modeled";
+  };
+  kernelResources: {
+    inventory: unknown | null;
+    httpListeners: Array<{
+      protocol: "tcp";
+      bindAddress: "127.0.0.1";
+      port: number;
+      level4Profile: "tcp-listener-v1-loopback-empty-accept-queue";
+    }>;
+  };
+  verifier: NodeLevel5HttpProfileCaptureInput["verifier"];
+  gates: {
+    sourceIsaEmulationAllowed: false;
+    sidecarOutputAllowed: false;
+    metadataOnlySuccessAllowed: false;
+    targetNativeNodeRequired: true;
+  };
+  refusals: NodeLevel5HttpProfileRefusal[];
+  summary: {
+    profileReady: true;
+    targetNativeContinuationRequired: true;
+    productSupportBlockedUntilActualWorkloadContinuation: true;
+  };
+}
+
+// fallow-ignore-next-line complexity
+export function buildNodeLevel5HttpProfileCapture(
+  input: NodeLevel5HttpProfileCaptureInput,
+): NodeLevel5HttpProfileCapture {
+  return {
+    kind: "machinen.node-level5-runtime-profile",
+    formatVersion: NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION,
+    sourceGoal: "021",
+    evidenceStatus: "proof",
+    productSupport: "not-yet-supported",
+    implementationLevel: "not-implemented",
+    graduationTargetLevel: "level-5-cross-arch-process-continuation",
+    migrationCompleted: false,
+    runtimeFamily: "node",
+    profile: NODE_LEVEL5_HTTP_PROFILE_NAME,
+    sourceArch: input.sourceArch,
+    runtimeIdentity: {
+      executable: "node",
+      version: input.nodeVersion,
+      targetNativeRuntimeRequired: true,
+    },
+    processModel: {
+      processCount: 1,
+      threadModel: "single-thread-required",
+      activeSyscallsAllowed: false,
+      activeRequestsAllowed: false,
+      activeTcpStreamsAllowed: false,
+    },
+    moduleIdentity: {
+      sourceCwd: input.sourceCwd,
+      argv: input.argv,
+      entrypoint: inferNodeEntrypoint(input.argv),
+      unsupportedModuleStateAllowed: false,
+    },
+    selectedV8State: {
+      stateModel: "bounded-profile-roots-only",
+      arbitraryHeapContinuationAllowed: false,
+      arbitraryNativeStackContinuationAllowed: false,
+    },
+    libuv: {
+      handleInventory: input.eventLoopResources ?? null,
+      timersAsyncHandlesPolicy: "refuse-unless-modeled",
+    },
+    kernelResources: {
+      inventory: input.kernelResources ?? null,
+      httpListeners: [
+        {
+          protocol: "tcp",
+          bindAddress: "127.0.0.1",
+          port: input.guestPort,
+          level4Profile: "tcp-listener-v1-loopback-empty-accept-queue",
+        },
+      ],
+    },
+    verifier: input.verifier,
+    gates: {
+      sourceIsaEmulationAllowed: false,
+      sidecarOutputAllowed: false,
+      metadataOnlySuccessAllowed: false,
+      targetNativeNodeRequired: true,
+    },
+    refusals: nodeLevel5HttpProfileRefusalRows(),
+    summary: {
+      profileReady: true,
+      targetNativeContinuationRequired: true,
+      productSupportBlockedUntilActualWorkloadContinuation: true,
+    },
+  };
+}
+
+export function nodeLevel5HttpProfileRefusalRows(): NodeLevel5HttpProfileRefusal[] {
+  return nodeLevel5HttpProfileRefusalCodes.map((code) => ({
+    code,
+    unsafeNeighbor: nodeLevel5HttpProfileUnsafeNeighbor(code),
+    message: nodeLevel5HttpProfileRefusalMessage(code),
+    evidenceStatus: "refusal",
+    productSupport: "unsupported",
+    implementationLevel: "level-0-fail-closed-discovery",
+    graduationTargetLevel: "level-5-cross-arch-process-continuation",
+    migrationCompleted: false,
+  }));
+}
+
+function inferNodeEntrypoint(argv: string[]): string | null {
+  const script = argv.find((arg, index) => index > 0 && !arg.startsWith("-"));
+  return script ?? null;
+}
+
+// fallow-ignore-next-line complexity
+function nodeLevel5HttpProfileUnsafeNeighbor(
+  code: NodeLevel5HttpProfileRefusalCode,
+): NodeLevel5HttpProfileRefusal["unsafeNeighbor"] {
+  switch (code) {
+    case "node-level5-http-arbitrary-v8-heap-native-stack-unsupported":
+      return "arbitrary-v8-heap-native-stack";
+    case "node-level5-http-native-addon-unsupported":
+      return "native-addon";
+    case "node-level5-http-worker-thread-unsupported":
+      return "worker-thread";
+    case "node-level5-http-inspector-unsupported":
+      return "inspector-debug";
+    case "node-level5-http-active-request-unsupported":
+      return "active-request";
+    case "node-level5-http-active-tcp-stream-unsupported":
+      return "active-tcp-stream";
+    case "node-level5-http-active-syscall-unsupported":
+      return "active-syscall";
+    case "node-level5-http-unsupported-timer-async-handle":
+      return "unsupported-timer-async-handle";
+    case "node-level5-http-unsupported-module-runtime-state":
+      return "unsupported-module-runtime-state";
+    case "node-level5-http-target-native-node-missing":
+      return "missing-target-native-node";
+    case "node-level5-http-source-isa-emulation-forbidden":
+      return "source-isa-emulation";
+    case "node-level5-http-sidecar-output-forbidden":
+      return "sidecar-output";
+    case "node-level5-http-metadata-only-success-forbidden":
+      return "metadata-only-success";
+  }
+}
+
+// fallow-ignore-next-line complexity
+function nodeLevel5HttpProfileRefusalMessage(code: NodeLevel5HttpProfileRefusalCode): string {
+  switch (code) {
+    case "node-level5-http-arbitrary-v8-heap-native-stack-unsupported":
+      return "arbitrary V8 heap and native stack continuation is refused until modeled";
+    case "node-level5-http-native-addon-unsupported":
+      return "native addon state is architecture-specific and refused";
+    case "node-level5-http-worker-thread-unsupported":
+      return "Node worker threads are refused by the single-thread HTTP profile";
+    case "node-level5-http-inspector-unsupported":
+      return "inspector and debug state are refused";
+    case "node-level5-http-active-request-unsupported":
+      return "active HTTP requests at capture are refused";
+    case "node-level5-http-active-tcp-stream-unsupported":
+      return "active TCP streams and in-flight network I/O are refused";
+    case "node-level5-http-active-syscall-unsupported":
+      return "active syscalls and restart blocks are refused";
+    case "node-level5-http-unsupported-timer-async-handle":
+      return "timers and async handles are refused unless explicitly modeled";
+    case "node-level5-http-unsupported-module-runtime-state":
+      return "unsupported module or runtime state is refused";
+    case "node-level5-http-target-native-node-missing":
+      return "target-native Node must be available before restore can continue";
+    case "node-level5-http-source-isa-emulation-forbidden":
+      return "source ISA emulation is forbidden for Level 5 success";
+    case "node-level5-http-sidecar-output-forbidden":
+      return "sidecar output shortcuts are forbidden for Level 5 success";
+    case "node-level5-http-metadata-only-success-forbidden":
+      return "metadata-only success is forbidden for Level 5 success";
+  }
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -57,6 +57,17 @@ const TOC = {
     "createLevel5RuntimeAdapterRegistry",
     "level5SubstrateRefusalCodes",
   ],
+  "Node Level 5 HTTP profile": [
+    "NodeLevel5HttpProfileCapture",
+    "NodeLevel5HttpProfileCaptureInput",
+    "NodeLevel5HttpProfileRefusal",
+    "NodeLevel5HttpProfileRefusalCode",
+    "NODE_LEVEL5_HTTP_PROFILE_FORMAT_VERSION",
+    "NODE_LEVEL5_HTTP_PROFILE_NAME",
+    "buildNodeLevel5HttpProfileCapture",
+    "nodeLevel5HttpProfileRefusalCodes",
+    "nodeLevel5HttpProfileRefusalRows",
+  ],
   "Node Level 5 proof composition": [
     "NodeLevel5ProofComposition",
     "NodeLevel5ProofCompositionInput",


### PR DESCRIPTION
## Problem

The Level 5 substrate existed, but Node still did not have its own runtime profile adapter. That meant selected Node HTTP state was still mostly described by the older proof composition instead of a profile that future product support can build on.

## Solution

This PR adds the first Node Level 5 runtime profile: `node-v8-libuv-single-thread-http-v1`. Snapshots now write a `node-level5-runtime-profile.json` artifact for selected Node bundles, and restore routes that artifact through a Node HTTP Level 5 adapter. The path stays proof-only until actual workload continuation is productized.

## Technical Summary

- Added `packages/runtime/src/node-level5-http-profile.ts` with the Node/V8/libuv single-thread HTTP profile artifact, gates, and stable refusal rows.
- Added `node-level5-http-runtime-adapter` to the Level 5 CLI registry and made selected Node snapshots write `node-level5-runtime-profile.json`.
- Routed profile restores to `node-level5-runtime-profile-restore-summary.json` with target-native Node verifier evidence and proof-only status.
- Added Goal 021 docs, checked artifact, API exports/docs, and tests for profile capture, refusal families, adapter routing, and restore proof summaries.
