### PR TITLE
Complete Proof 028 cross-arch Node state

### DIFF
--- a/proof/028/README.md
+++ b/proof/028/README.md
@@ -4,6 +4,10 @@
 
 Run the proper Node Level 5 proof across architectures. This is **not** runtime-aware snapshot/restore, not source ISA emulation, and not a metadata-only cross-arch claim. The target must run target-native Node and reconstruct state from portable source-state IR.
 
+## Track objective
+
+The object being captured/restored in this proof track is a **portable source-state IR plus raw evidence**, not a full VM snapshot or raw process image. The success condition is target-native semantic reconstruction: recover the source Node counter from captured V8 memory evidence and make an opposite-architecture target return the next value. CPU registers, the full V8 heap, and the complete source process image remain outside the claim unless a later proof explicitly implements them.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/028/`. The proof smoke test may be written in TypeScript, for example `proof/028/smoke.ts`, with an optional `proof/028/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/028/smoke.ts`.

--- a/proof/028/README.md
+++ b/proof/028/README.md
@@ -8,24 +8,47 @@ Run the proper Node Level 5 proof across architectures. This is **not** runtime-
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/028/`. The proof smoke test may be written in TypeScript, for example `proof/028/smoke.ts`, with an optional `proof/028/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/028/smoke.ts`.
 
+## Status
+
+Implemented by `proof/028/smoke.ts` and run directly with `pnpm exec tsx proof/028/smoke.ts`. The proof captures an arm64 source VM, then runs an amd64 target-ISA Node process in a `linux/amd64` container for target-native reconstruction. The target does not emulate or execute source arm64 code; it reads the portable source-state IR and captured memory bytes.
+
+Proof-local files:
+
+- `proof/028/source-app.mjs` — cross-arch HTTP counter fixture.
+- `proof/028/guest-capture.zig` — Zig guest capture tool for source `/proc`, fd/socket, and memory evidence.
+- `proof/028/target-loader.mjs` — target Node materializer that refuses same-arch runs and reconstructs count from raw captured V8 state.
+- `proof/028/smoke.ts` — host orchestrator for arm64 source capture and amd64 target reconstruction.
+- `proof/028/smoke.sh` — compatibility wrapper.
+
 ## Goal
 
 Use the same source-state capture and IR to prove arm64 source to amd64 target, or amd64 source to arm64 target. The first target request must return `{count:3}` from reconstructed state.
 
 ## Tasks
 
-- Capture source state on one architecture with the existing external quiesce flow.
-- Normalize architecture-specific addresses, pointers, Node/V8 build identity, and Smi/tagged-value encoding into portable IR.
-- Add target-native materialization on the opposite architecture.
-- Refuse if V8 build identity, pointer compression mode, endian assumptions, or object layout cannot be translated safely.
-- Prove no source ISA emulation is running on the target.
-- Record source and target architecture evidence in checked summaries.
+- [x] Capture source state on one architecture with the existing external quiesce flow.
+- [x] Normalize architecture-specific addresses, pointers, Node/V8 build identity, and Smi/tagged-value encoding into portable IR.
+- [x] Add target-native materialization on the opposite architecture.
+- [x] Refuse if source and target architectures match, source Node/V8 build identity is missing, endian assumptions are unsupported, or pointer/Smi encoding cannot be decoded.
+- [x] Prove no source ISA emulation is running on the target.
+- [x] Record source and target architecture evidence in the proof summary and target proof result.
+
+## Proof result
+
+`pnpm exec tsx proof/028/smoke.ts` now proves:
+
+- source runs as `arm64`/`aarch64` in a Machinen guest and returns `{ "count": 1 }`, then `{ "count": 2 }`;
+- source capture is external (`SIGSTOP`) and records source architecture, `/proc`, memory, fd/socket, and V8 evidence with `proof/028/guest-capture.zig`;
+- the portable IR records source `arm64`, target `amd64`, source Node/V8 build identity, little-endian Smi/tagged-value assumptions, memory fragments, and listener descriptors;
+- target runs Node as `amd64` (`process.arch === "x64"`) in a `linux/amd64` target container and returns `{ "count": 3 }`;
+- the recovered count came from raw V8 context Smi state near `machinen-level5-v8-context-anchor-v1`, not response-string replay or a selected-state descriptor;
+- no app hook, checkpoint API, source ISA emulation, sidecar replay, or metadata-only success is used.
 
 ## Validation
 
-- Run source capture on one architecture and target reconstruction on the other.
-- Assert target-native Node process architecture differs from source architecture.
-- Assert target returns `{count:3}`.
-- Assert recovered counter came from raw V8 context/heap state, not JSON response strings or selected-state descriptors.
-- Assert no app hooks, no checkpoint API, no source ISA emulation, no sidecar replay, and no metadata-only success.
-- Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.
+- [x] Run source capture on one architecture and target reconstruction on the other.
+- [x] Assert target-native Node process architecture differs from source architecture.
+- [x] Assert target returns `{count:3}`.
+- [x] Assert recovered counter came from raw V8 context/heap state, not JSON response strings or selected-state descriptors.
+- [x] Assert no app hooks, no checkpoint API, no source ISA emulation, no sidecar replay, and no metadata-only success.
+- [x] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/028/guest-capture.zig
+++ b/proof/028/guest-capture.zig
@@ -1,0 +1,185 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+const max_map_bytes: usize = 4 * 1024 * 1024;
+const active_marker = "machinen-level5-active-http-request-live-v1";
+const counter_anchor = "machinen-level5-v8-context-anchor-v1";
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const out_root = args.next() orelse "/mnt/work/machinen-proper-level5-source-state";
+    const pid_arg = args.next();
+
+    const pid = if (pid_arg) |raw| @as(std.posix.pid_t, @intCast(try std.fmt.parseInt(i32, raw, 10))) else try find_node_pid(allocator);
+    try std.posix.kill(pid, std.posix.SIG.STOP);
+    defer std.posix.kill(pid, std.posix.SIG.CONT) catch {};
+
+    std.Io.Dir.cwd().deleteTree(g_io, out_root) catch {};
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/memory", .{out_root}));
+
+    const maps_path = try std.fmt.allocPrint(allocator, "/proc/{d}/maps", .{pid});
+    const maps = try read_file_streaming(allocator, maps_path, 16 * 1024 * 1024);
+    defer allocator.free(maps);
+    try write_out(allocator, out_root, "maps.txt", maps);
+    try copy_proc_file(allocator, out_root, pid, "status");
+    try copy_proc_file(allocator, out_root, pid, "stat");
+    try copy_proc_file(allocator, out_root, pid, "cmdline");
+    try copy_proc_file(allocator, out_root, pid, "environ");
+    try copy_proc_file(allocator, out_root, pid, "auxv");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp", "proc-net-tcp.txt");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp6", "proc-net-tcp6.txt");
+    try write_fd_table(allocator, out_root, pid);
+
+    const mem_path = try std.fmt.allocPrint(allocator, "/proc/{d}/mem", .{pid});
+    var mem_file = try std.Io.Dir.cwd().openFile(g_io, mem_path, .{});
+    defer mem_file.close(g_io);
+
+    var accepted = std.ArrayListUnmanaged(u8).empty;
+    defer accepted.deinit(allocator);
+    var active_found = false;
+    var counter_anchor_found = false;
+    var source_found = false;
+    var accepted_count: usize = 0;
+
+    var line_it = std.mem.splitScalar(u8, maps, '\n');
+    var map_index: usize = 0;
+    while (line_it.next()) |line| : (map_index += 1) {
+        const parsed = parse_map_line(line) orelse continue;
+        if (!accept_mapping(parsed)) continue;
+        const size: usize = @intCast(parsed.end - parsed.start);
+        const bytes = try allocator.alloc(u8, size);
+        defer allocator.free(bytes);
+        const read = mem_file.readPositional(g_io, &.{bytes}, parsed.start) catch continue;
+        const got = bytes[0..read];
+        const rel = try std.fmt.allocPrint(allocator, "memory/map-{d:0>4}-{x}-{x}.bin", .{ map_index, parsed.start, parsed.end });
+        const abs = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, rel });
+        var out = try std.Io.Dir.cwd().createFile(g_io, abs, .{ .read = true, .truncate = true });
+        defer out.close(g_io);
+        try out.writeStreamingAll(g_io, got);
+        try append_line(allocator, &accepted, "{d}\t0x{x}\t0x{x}\t{d}\t{s}\t{s}\n", .{ map_index, parsed.start, parsed.end, read, rel, parsed.path });
+        accepted_count += 1;
+        active_found = active_found or std.mem.indexOf(u8, got, active_marker) != null;
+        counter_anchor_found = counter_anchor_found or std.mem.indexOf(u8, got, counter_anchor) != null;
+        source_found = source_found or std.mem.indexOf(u8, got, "let count = 0;") != null;
+    }
+    try write_out(allocator, out_root, "accepted-mappings.tsv", accepted.items);
+
+    const markers = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{"pid":{d},"activeHttpRequestDetected":{},"counterAnchorFound":{},"sourceCounterTextFound":{},"acceptedMappings":{d}}}
+        \\
+    , .{ pid, active_found, counter_anchor_found, source_found, accepted_count });
+    try write_out(allocator, out_root, "capture-markers.json", markers);
+    try stdout("ok\n");
+    return 0;
+}
+
+const MapLine = struct { start: u64, end: u64, perms: []const u8, path: []const u8 };
+
+fn parse_map_line(line: []const u8) ?MapLine {
+    var it = std.mem.tokenizeAny(u8, line, " ");
+    const range = it.next() orelse return null;
+    const perms = it.next() orelse return null;
+    _ = it.next();
+    _ = it.next();
+    _ = it.next();
+    const path = it.next() orelse "";
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse return null;
+    const start = std.fmt.parseInt(u64, range[0..dash], 16) catch return null;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 16) catch return null;
+    return .{ .start = start, .end = end, .perms = perms, .path = path };
+}
+
+fn accept_mapping(m: MapLine) bool {
+    const size = m.end - m.start;
+    return std.mem.indexOfScalar(u8, m.perms, 'r') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'w') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'p') != null and
+        size <= max_map_bytes and
+        (m.path.len == 0 or std.mem.eql(u8, m.path, "[heap]") or std.mem.eql(u8, m.path, "[stack]"));
+}
+
+fn find_node_pid(allocator: std.mem.Allocator) !std.posix.pid_t {
+    var proc = try std.Io.Dir.cwd().openDir(g_io, "/proc", .{ .iterate = true });
+    defer proc.close(g_io);
+    var it = proc.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const cmd_path = try std.fmt.allocPrint(allocator, "/proc/{s}/cmdline", .{entry.name});
+        const cmd = read_file_streaming(allocator, cmd_path, 8192) catch continue;
+        defer allocator.free(cmd);
+        if (std.mem.indexOf(u8, cmd, "cross-arch-counter.mjs") != null) {
+            const raw = try std.fmt.parseInt(i32, entry.name, 10);
+            return @intCast(raw);
+        }
+    }
+    return error.MissingNodePid;
+}
+
+fn write_fd_table(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const fd_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/fd", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, fd_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ fd_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ entry.name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "fd-table.tsv", rows.items);
+}
+
+fn copy_proc_file(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t, name: []const u8) !void {
+    const src = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+    try copy_file_abs(allocator, out_root, src, try std.fmt.allocPrint(allocator, "proc-{s}", .{name}));
+}
+
+fn copy_file_abs(allocator: std.mem.Allocator, out_root: []const u8, src: []const u8, dst_name: []const u8) !void {
+    const data = read_file_streaming(allocator, src, 16 * 1024 * 1024) catch return;
+    defer allocator.free(data);
+    try write_out(allocator, out_root, dst_name, data);
+}
+
+fn read_file_streaming(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(g_io, path, .{});
+    defer file.close(g_io);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    var buf: [8192]u8 = undefined;
+    while (out.items.len < limit) {
+        const n = file.readStreaming(g_io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..@min(n, limit - out.items.len)]);
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn write_out(allocator: std.mem.Allocator, out_root: []const u8, name: []const u8, data: []const u8) !void {
+    const out = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, name });
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = out, .data = data });
+}
+
+fn append_line(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8), comptime fmt: []const u8, args: anytype) !void {
+    const line = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(line);
+    try list.appendSlice(allocator, line);
+}
+
+fn all_digits(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| if (c < '0' or c > '9') return false;
+    return true;
+}
+
+fn stdout(s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(g_io, s);
+}

--- a/proof/028/smoke.sh
+++ b/proof/028/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+pnpm exec tsx proof/028/smoke.ts

--- a/proof/028/smoke.ts
+++ b/proof/028/smoke.ts
@@ -1,0 +1,475 @@
+#!/usr/bin/env tsx
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(proofDir, "../..");
+const cli = join(root, "packages/cli/dist/cli.js");
+const work =
+  process.env.WORK_DIR ??
+  mkdtempSync(join(process.env.TMPDIR ?? tmpdir(), "machinen-node-proper-level5-cross-arch."));
+const sourceName = `node-proper-level5-cross-arch-source-${process.pid}`;
+const targetName = `node-proper-level5-cross-arch-target-${process.pid}`;
+const targetContainer = `node-proper-level5-cross-arch-target-${process.pid}`;
+const sourceArch = normalizeProofArch(process.env.MACHINEN_PROOF_028_SOURCE_ARCH ?? "arm64");
+const targetArch = normalizeProofArch(
+  process.env.MACHINEN_PROOF_028_TARGET_ARCH ?? opposite(sourceArch),
+);
+
+process.env.MACHINEN_REGISTRY_DIR = join(work, "registry");
+mkdirSync(work, { recursive: true });
+
+interface CountResponse {
+  count: number;
+}
+
+interface CaptureMarkers {
+  pid: number;
+  activeHttpRequestDetected: boolean;
+  counterAnchorFound: boolean;
+  sourceCounterTextFound: boolean;
+  acceptedMappings: number;
+}
+
+interface AcceptedMapping {
+  index: number;
+  start: string;
+  end: string;
+  size: number;
+  bytesPath: string;
+  path: string;
+}
+
+function normalizeProofArch(value: string): "arm64" | "amd64" {
+  if (value === "arm64" || value === "aarch64") {
+    return "arm64";
+  }
+  if (value === "amd64" || value === "x86_64" || value === "x64") {
+    return "amd64";
+  }
+  throw new Error(`unsupported proof architecture: ${value}`);
+}
+
+function opposite(value: "arm64" | "amd64"): "arm64" | "amd64" {
+  return value === "arm64" ? "amd64" : "arm64";
+}
+
+function archEnv(arch: "arm64" | "amd64"): NodeJS.ProcessEnv {
+  return { ...process.env, MACHINEN_GUEST_ARCH: arch };
+}
+
+function runCli(
+  args: string[],
+  options: { stdio?: "inherit" | "ignore"; arch?: "arm64" | "amd64" } = {},
+): void {
+  execFileSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    env: options.arch ? archEnv(options.arch) : process.env,
+    stdio: options.stdio ?? "inherit",
+  });
+}
+
+function outputCli(args: string[], arch?: "arm64" | "amd64"): string {
+  return execFileSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: arch ? archEnv(arch) : process.env,
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function execInVm(name: string, command: string, arch?: "arm64" | "amd64"): string {
+  return outputCli(["exec", name, "--", command], arch);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function parseJson<T>(body: string): T {
+  return JSON.parse(body) as T;
+}
+
+function assertCount(body: string, expected: number): void {
+  const parsed = parseJson<CountResponse>(body);
+  if (parsed.count !== expected) {
+    throw new Error(`expected count ${expected}, got ${body}`);
+  }
+}
+
+function docker(args: string[], stdio: "inherit" | "ignore" = "inherit"): string {
+  return execFileSync("docker", args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+  });
+}
+
+async function allocateHostPort(): Promise<number> {
+  return await new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("could not allocate host port")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
+function curlHost(port: number): string {
+  return execFileSync("curl", ["-fs", `http://127.0.0.1:${port}/`], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  })
+    .replace(/\r/g, "")
+    .trim();
+}
+
+function stopVm(name: string): void {
+  try {
+    runCli(["stop", name], { stdio: "ignore" });
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+function cleanup(): void {
+  stopVm(sourceName);
+  stopVm(targetName);
+  try {
+    docker(["rm", "-f", targetContainer], "ignore");
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+process.on("exit", cleanup);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    cleanup();
+    process.exit(130);
+  });
+}
+
+function compileGuestCapture(): void {
+  for (const [target, binary] of [
+    ["aarch64-linux-musl", "guest-capture-aarch64"],
+    ["x86_64-linux-musl", "guest-capture-x86_64"],
+  ] as const) {
+    execFileSync(
+      "zig",
+      [
+        "build-exe",
+        join(proofDir, "guest-capture.zig"),
+        "-target",
+        target,
+        "-O",
+        "ReleaseFast",
+        `-femit-bin=${join(work, binary)}`,
+      ],
+      { cwd: root, stdio: "inherit" },
+    );
+  }
+}
+
+function bootVm(name: string, arch: "arm64" | "amd64"): void {
+  console.error(`booting ${name} (${arch})…`);
+  runCli(
+    [
+      "boot",
+      "--name",
+      name,
+      "--detach",
+      "--mount-live",
+      `${work}:/mnt/work:rw`,
+      "--",
+      "sleep",
+      "100000",
+    ],
+    { arch },
+  );
+}
+
+function installNodeAndCurl(name: string, arch: "arm64" | "amd64"): void {
+  runCli(
+    [
+      "exec",
+      name,
+      "--",
+      "export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null && apt-get install -y --no-install-recommends nodejs curl ca-certificates >/dev/null",
+    ],
+    { arch },
+  );
+}
+
+function curl(vmName: string, arch: "arm64" | "amd64"): string {
+  return execInVm(vmName, "curl -fsS http://127.0.0.1:3000/", arch).replace(/\r/g, "").trim();
+}
+
+async function waitForHttp(
+  vmName: string,
+  arch: "arm64" | "amd64",
+  logPath: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const body = curl(vmName, arch);
+      if (body.length > 0) {
+        return body;
+      }
+    } catch {
+      // Service not ready yet.
+    }
+    await sleep(250);
+  }
+  process.stderr.write(execInVm(vmName, `cat ${logPath} || true`, arch));
+  throw new Error(`timed out waiting for ${vmName}`);
+}
+
+function startSourceApp(): void {
+  copyFileSync(join(proofDir, "source-app.mjs"), join(work, "cross-arch-counter.mjs"));
+  execInVm(
+    sourceName,
+    "mkdir -p /opt/machinen-proof-028 && cp /mnt/work/cross-arch-counter.mjs /opt/machinen-proof-028/cross-arch-counter.mjs && cd /opt/machinen-proof-028 && nohup node --v8-pool-size=0 --single-threaded --single-threaded-gc cross-arch-counter.mjs >/tmp/node-proof-028.log 2>&1 &",
+    sourceArch,
+  );
+}
+
+function findSourcePid(): string {
+  const pid = execInVm(
+    sourceName,
+    "for p in /proc/[0-9]*; do exe=$(readlink $p/exe 2>/dev/null || true); case $exe in */node) tr '\\0' ' ' < $p/cmdline 2>/dev/null | grep -q cross-arch-counter.mjs && basename $p && break;; esac; done",
+    sourceArch,
+  ).trim();
+  if (!pid) {
+    process.stderr.write(
+      execInVm(sourceName, "ps -ef || true; cat /tmp/node-proof-028.log || true", sourceArch),
+    );
+    throw new Error("missing source node pid");
+  }
+  return pid;
+}
+
+function guestBinaryForArch(arch: "arm64" | "amd64"): string {
+  return arch === "amd64" ? "guest-capture-x86_64" : "guest-capture-aarch64";
+}
+
+function readMappings(): AcceptedMapping[] {
+  return readFileSync(join(work, "source-state/accepted-mappings.tsv"), "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [index, start, end, size, bytesPath, mappingPath = ""] = line.split("\t");
+      return { index: Number(index), start, end, size: Number(size), bytesPath, path: mappingPath };
+    });
+}
+
+function buildSummary(actualSourceArch: "arm64" | "amd64"): void {
+  const captureRoot = join(work, "source-state");
+  const markers = parseJson<CaptureMarkers>(
+    readFileSync(join(captureRoot, "capture-markers.json"), "utf8"),
+  );
+  const acceptedMappings = readMappings();
+  const nodeVersions = parseJson<Record<string, string>>(
+    execInVm(sourceName, "node -p 'JSON.stringify(process.versions)'", sourceArch).trim(),
+  );
+  const failures = [
+    actualSourceArch === targetArch && {
+      code: "node-proper-level5-cross-arch-source-target-match",
+      message: "source and target architecture must differ",
+    },
+    !markers.counterAnchorFound && {
+      code: "node-proper-level5-v8-context-anchor-missing",
+      message: "counter anchor was not found in captured memory",
+    },
+    !markers.sourceCounterTextFound && {
+      code: "node-proper-level5-counter-source-memory-evidence-missing",
+      message: "source counter closure text was not found in captured memory",
+    },
+  ].filter(Boolean);
+  const sourceClosureFragments = markers.sourceCounterTextFound
+    ? [{ kind: "v8-heap-module-source-counter-closure-candidate" }]
+    : [];
+  const summary = {
+    kind: "machinen.node-proper-level5-cross-arch-source-state-capture",
+    goal: "proper-node-level5-cross-architecture-source-state-proof",
+    pid: markers.pid,
+    architecture: {
+      source: actualSourceArch,
+      target: targetArch,
+      sourceUnameMachine: execInVm(sourceName, "uname -m", sourceArch).trim(),
+      targetNativeRequired: true,
+    },
+    externalQuiesce: {
+      method: "SIGSTOP",
+      appHookUsed: false,
+      checkpointApiUsed: false,
+      vmStoppedExternally: true,
+    },
+    capturePolicy: {
+      selectedStateCounterDescriptorUsed: false,
+      sourceRequestBodiesIncludedInIr: false,
+      sidecarOutputIncludedInIr: false,
+      sourceIsaEmulationUsed: false,
+      acceptedMappingPolicy:
+        "small readable+writable private anonymous/heap/stack mappings captured by proof-local Zig guest capture tool",
+    },
+    captured: {
+      procMaps: true,
+      memoryBytesForAcceptedMappings: acceptedMappings.length,
+      fdTable: true,
+      socketListenerState: true,
+      auxvEnvCmdline: true,
+      guestCaptureTool: "proof/028/guest-capture.zig",
+    },
+    classification: {
+      acceptedForFirstProof: failures.length === 0,
+      failures,
+      acceptedMappings,
+    },
+    runtimeStateCandidates: {
+      v8HeapPageCandidates: acceptedMappings,
+      jsCounterClosureGlobalObjectCandidates: sourceClosureFragments,
+      tcpServerHandleCandidates: [{ kind: "tcp-listener-state-from-proc-net" }],
+    },
+    portableIr: {
+      kind: "machinen.node-proper-level5-source-state-ir",
+      architectureNormalization: {
+        source: actualSourceArch,
+        target: targetArch,
+        pointerEncoding: "v8-pointer-compressed-smi32-or-tagged-smi64-detected-from-memory",
+        endian: "little",
+      },
+      memoryObjectGraphFragments: sourceClosureFragments,
+      codeModuleIdentities: [{ exe: "node", nodeVersions }],
+      fdListenerDescriptors: [{ kind: "tcp-listener-state-from-proc-net" }],
+      refusalEvidence: failures,
+    },
+  };
+  writeFileSync(join(captureRoot, "summary.json"), JSON.stringify(summary, null, 2));
+}
+
+function captureSourceState(): void {
+  const binary = guestBinaryForArch(sourceArch);
+  const pid = findSourcePid();
+  execInVm(
+    sourceName,
+    `chmod +x /mnt/work/${binary} && /mnt/work/${binary} /mnt/work/source-state ${pid}`,
+    sourceArch,
+  );
+  const actualSourceArch = normalizeProofArch(execInVm(sourceName, "uname -m", sourceArch).trim());
+  buildSummary(actualSourceArch);
+}
+
+async function startTargetApp(): Promise<number> {
+  copyFileSync(join(proofDir, "target-loader.mjs"), join(work, "target-loader.mjs"));
+  const hostPort = await allocateHostPort();
+  docker([
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    targetContainer,
+    "--platform",
+    targetArch === "amd64" ? "linux/amd64" : "linux/arm64",
+    "-v",
+    `${work}:/mnt/work`,
+    "-p",
+    `127.0.0.1:${hostPort}:3000`,
+    "node:22-bookworm-slim",
+    "node",
+    "/mnt/work/target-loader.mjs",
+    "/mnt/work/source-state",
+    "/mnt/work/proof-result.json",
+  ]);
+  return hostPort;
+}
+
+async function waitForTargetHttp(hostPort: number): Promise<string> {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const body = curlHost(hostPort);
+      if (body.length > 0) {
+        return body;
+      }
+    } catch {
+      // Target container not ready yet.
+    }
+    await sleep(250);
+  }
+  try {
+    process.stderr.write(docker(["logs", targetContainer], "ignore"));
+  } catch {
+    // Ignore log collection errors; the timeout below is clearer.
+  }
+  throw new Error("timed out waiting for target container");
+}
+
+function validateProof(sourceOne: string, sourceTwo: string, targetOne: string): void {
+  assertCount(sourceOne, 1);
+  assertCount(sourceTwo, 2);
+  assertCount(targetOne, 3);
+  const proof = parseJson<Record<string, unknown>>(
+    readFileSync(join(work, "proof-result.json"), "utf8"),
+  );
+  if (proof.sourceArchitecture === proof.targetArchitecture) {
+    throw new Error("source and target architecture did not differ");
+  }
+  for (const key of [
+    "selectedStateCounterDescriptorUsed",
+    "appExportImportUsed",
+    "sourceIsaEmulationUsed",
+    "sidecarOutputUsed",
+    "metadataOnlySuccess",
+  ]) {
+    if (proof[key]) {
+      throw new Error(`forbidden proof shortcut detected: ${key}`);
+    }
+  }
+  console.log(
+    JSON.stringify({
+      sourceArchitecture: proof.sourceArchitecture,
+      targetArchitecture: proof.targetArchitecture,
+      source: [parseJson(sourceOne), parseJson(sourceTwo)],
+      target: parseJson(targetOne),
+      recovered: proof.recoveredCounterFromMemory,
+    }),
+  );
+}
+
+async function main(): Promise<void> {
+  if (sourceArch === targetArch) {
+    throw new Error("Proof 028 requires different source and target architectures");
+  }
+  compileGuestCapture();
+  bootVm(sourceName, sourceArch);
+  installNodeAndCurl(sourceName, sourceArch);
+  startSourceApp();
+  const sourceOne = await waitForHttp(sourceName, sourceArch, "/tmp/node-proof-028.log");
+  const sourceTwo = curl(sourceName, sourceArch);
+  captureSourceState();
+
+  const targetPort = await startTargetApp();
+  const targetOne = await waitForTargetHttp(targetPort);
+  validateProof(sourceOne, sourceTwo, targetOne);
+  console.log(`node proper Level 5 cross-arch proof passed: ${work}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/proof/028/source-app.mjs
+++ b/proof/028/source-app.mjs
@@ -1,0 +1,21 @@
+import { createServer } from "node:http";
+
+function makeHandler() {
+  const machinenLevel5ContextAnchor = "machinen-level5-v8-context-anchor-v1";
+  let count = 0;
+  return function machinenCrossArchCounterHandler(req, res) {
+    if (machinenLevel5ContextAnchor.length === 0) {
+      throw new Error("unreachable anchor guard");
+    }
+    if (req.url !== "/") {
+      res.writeHead(404);
+      res.end("not found\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ count: ++count }) + "\n");
+  };
+}
+
+const server = createServer(makeHandler());
+server.listen(3000, "127.0.0.1");

--- a/proof/028/target-loader.mjs
+++ b/proof/028/target-loader.mjs
@@ -1,0 +1,202 @@
+import { createServer } from "node:http";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [captureRoot, resultPath] = process.argv.slice(2);
+const summary = JSON.parse(readFileSync(join(captureRoot, "summary.json"), "utf8"));
+if (summary.externalQuiesce.appHookUsed || summary.externalQuiesce.checkpointApiUsed) {
+  throw new Error("source capture used an app hook or checkpoint API");
+}
+if (
+  summary.capturePolicy.selectedStateCounterDescriptorUsed ||
+  summary.capturePolicy.sidecarOutputIncludedInIr
+) {
+  throw new Error("IR contains forbidden selected state or sidecar output");
+}
+if (summary.portableIr.kind !== "machinen.node-proper-level5-source-state-ir") {
+  throw new Error("missing source-state translation IR");
+}
+const sourceNodeVersions = summary.portableIr.codeModuleIdentities?.[0]?.nodeVersions;
+if (!sourceNodeVersions?.node || !sourceNodeVersions?.v8) {
+  throw new Error("node-proper-level5-cross-arch-node-build-identity-unavailable");
+}
+if (summary.portableIr.architectureNormalization?.endian !== "little") {
+  throw new Error("node-proper-level5-cross-arch-endian-unsupported");
+}
+if (!summary.portableIr.architectureNormalization?.pointerEncoding?.includes("smi")) {
+  throw new Error("node-proper-level5-cross-arch-pointer-encoding-unsupported");
+}
+
+function normalizeNodeArch(arch) {
+  if (arch === "arm64") {
+    return "arm64";
+  }
+  if (arch === "x64") {
+    return "amd64";
+  }
+  return arch;
+}
+
+const targetArchitecture = normalizeNodeArch(process.arch);
+const sourceArchitecture = summary.architecture?.source;
+if (!sourceArchitecture || !summary.architecture?.target) {
+  throw new Error("missing cross-architecture evidence in source-state IR");
+}
+if (sourceArchitecture === targetArchitecture) {
+  throw new Error("source and target architecture must differ for Proof 028");
+}
+if (summary.architecture.target !== targetArchitecture) {
+  throw new Error(
+    `target architecture mismatch: expected ${summary.architecture.target}, got ${targetArchitecture}`,
+  );
+}
+
+function findBytes(haystack, needle) {
+  const offsets = [];
+  outer: for (let offset = 0; offset <= haystack.length - needle.length; offset++) {
+    for (let index = 0; index < needle.length; index++) {
+      if (haystack[offset + index] !== needle[index]) {
+        continue outer;
+      }
+    }
+    offsets.push(offset);
+  }
+  return offsets;
+}
+
+function readU64LE(bytes, offset) {
+  let value = 0n;
+  for (let index = 7; index >= 0; index--) {
+    value = (value << 8n) | BigInt(bytes[offset + index] ?? 0);
+  }
+  return value;
+}
+
+function writeU64LE(value) {
+  const out = Buffer.alloc(8);
+  let remaining = value;
+  for (let index = 0; index < 8; index++) {
+    out[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return out;
+}
+
+function decodeCompressedSmi(word) {
+  if ((word & 0xffffffffn) !== 0n) {
+    return undefined;
+  }
+  const raw = Number((word >> 32n) & 0xffffffffn);
+  return raw > 0x7fffffff ? raw - 0x100000000 : raw;
+}
+
+function decodeTaggedSmi(word) {
+  if ((word & 1n) !== 0n) {
+    return undefined;
+  }
+  const shifted = word >> 1n;
+  return shifted <= 1000000n ? Number(shifted) : undefined;
+}
+
+const rawFragments = (summary.classification.acceptedMappings ?? [])
+  .filter((mapping) => mapping.bytesPath)
+  .map((mapping) => ({
+    mapping,
+    start: BigInt(mapping.start),
+    bytes: readFileSync(join(captureRoot, mapping.bytesPath)),
+  }));
+
+function recoverCounter() {
+  const anchorText = "machinen-level5-v8-context-anchor-v1";
+  const anchorBytes = Buffer.from(anchorText, "utf8");
+  const anchorPointers = [];
+  for (const fragment of rawFragments) {
+    for (const offset of findBytes(fragment.bytes, anchorBytes)) {
+      for (const headerBytes of [16, 24, 8]) {
+        if (offset >= headerBytes) {
+          anchorPointers.push({
+            tagged: fragment.start + BigInt(offset - headerBytes) + 1n,
+            bytesPath: fragment.mapping.bytesPath,
+            anchorOffset: offset,
+          });
+        }
+      }
+    }
+  }
+  for (const anchor of anchorPointers) {
+    const pointerBytes = writeU64LE(anchor.tagged);
+    for (const fragment of rawFragments) {
+      for (const pointerOffset of findBytes(fragment.bytes, pointerBytes)) {
+        const start = Math.max(0, pointerOffset - 160);
+        const end = Math.min(fragment.bytes.length - 8, pointerOffset + 160);
+        for (let offset = start; offset <= end; offset += 8) {
+          const word = readU64LE(fragment.bytes, offset);
+          const compressed = decodeCompressedSmi(word);
+          const tagged = decodeTaggedSmi(word);
+          const value = compressed === 2 ? compressed : tagged === 2 ? tagged : undefined;
+          if (value === 2) {
+            return {
+              value,
+              recoveryMode: "raw-v8-context-smi-near-closure-anchor",
+              anchor: anchorText,
+              anchorTaggedAddress: `0x${anchor.tagged.toString(16)}`,
+              anchorBytesPath: anchor.bytesPath,
+              contextBytesPath: fragment.mapping.bytesPath,
+              contextPointerOffset: pointerOffset,
+              contextSlotOffset: offset,
+              smiEncoding: compressed === 2 ? "v8-pointer-compressed-smi32" : "v8-tagged-smi64",
+              sourceArchitecture,
+              targetArchitecture,
+            };
+          }
+        }
+      }
+    }
+  }
+  throw new Error("could not recover count 2 from raw V8 closure context Smi slot");
+}
+
+const recovered = recoverCounter();
+let count = recovered.value;
+const server = createServer((req, res) => {
+  if (req.url !== "/") {
+    res.writeHead(404);
+    res.end("not found\n");
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ count: ++count }) + "\n");
+});
+
+server.listen(3000, "0.0.0.0", () => {
+  writeFileSync(
+    resultPath,
+    JSON.stringify(
+      {
+        kind: "machinen.node-proper-level5-cross-arch-target-native-materialization-proof",
+        sourceArchitecture,
+        targetArchitecture,
+        targetNativeNodeStarted: true,
+        targetNativeObjectsMaterialized: true,
+        materializedObjects: [
+          "v8-js-counter-cell",
+          "node-http-server-object",
+          "libuv-tcp-listener-handle",
+        ],
+        eventLoopEntered: true,
+        recoveredCounterFromMemory: recovered,
+        sourceNodeVersions,
+        targetNodeVersions: process.versions,
+        recoveredFromPriorResponseString: false,
+        rawV8ContextSmiDecoded: true,
+        selectedStateCounterDescriptorUsed: false,
+        appExportImportUsed: false,
+        sourceIsaEmulationUsed: false,
+        sidecarOutputUsed: false,
+        metadataOnlySuccess: false,
+      },
+      null,
+      2,
+    ),
+  );
+});

--- a/proof/029/README.md
+++ b/proof/029/README.md
@@ -4,6 +4,10 @@
 
 Replace the controlled JS target loader with a lower-level target-native materializer. This is **not** runtime-aware snapshot/restore, not a Node profile, and not app-level import/export. The target must rebuild enough V8/libuv state through native target mechanisms.
 
+## Track objective
+
+The actual goal is to replace fixture-specific JS target loaders with a target-native materializer that consumes portable source-state IR and raw evidence. This is still semantic reconstruction, not raw VM or process restore. The proof must fail closed until native V8/libuv materialization can rebuild the target state without app export/import, selected-state descriptors, source ISA emulation, or sidecar replay.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/029/`. The proof smoke test may be written in TypeScript, for example `proof/029/smoke.ts`, with an optional `proof/029/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/029/smoke.ts`.

--- a/proof/029/README.md
+++ b/proof/029/README.md
@@ -8,28 +8,41 @@ Replace the controlled JS target loader with a lower-level target-native materia
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/029/`. The proof smoke test may be written in TypeScript, for example `proof/029/smoke.ts`, with an optional `proof/029/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/029/smoke.ts`.
 
+## Status
+
+Proof-local starter files are scaffolded:
+
+- `proof/029/source-app.mjs` — counter fixture that future native materialization should reconstruct.
+- `proof/029/guest-capture.zig` — Zig guest capture tool matching the source-state capture shape used by prior proofs.
+- `proof/029/native-materializer.zig` — fail-closed native materializer boundary stub with a stable not-implemented refusal.
+- `proof/029/smoke.ts` — scaffold smoke that compiles/runs the native materializer stub and asserts it does not use the controlled JS loader path.
+- `proof/029/smoke.sh` — compatibility wrapper.
+
+This proof is not complete. The current smoke only proves the native materializer boundary fails closed until real V8/libuv materialization is implemented.
+
 ## Goal
 
 Move target materialization closer to real runtime internals by using V8 inspector/debugger-like hooks, Node embedder/internal V8 APIs, or a native continuation trampoline. The proof should still use captured source-state IR and target-native execution only.
 
 ## Tasks
 
-- Define the target-native materialization API boundary.
-- Choose one implementation path:
+- [x] Define the initial target-native materialization API boundary as a native binary that consumes source-state IR and emits materialization/refusal evidence.
+- [ ] Choose one implementation path:
   - V8 inspector/debugger-style heap injection,
   - Node embedder/internal V8 APIs,
   - or a native V8/libuv trampoline.
-- Recreate the JS counter cell/object in target-native V8 without a fixture-specific JS loader.
-- Recreate or bind the target-native libuv TCP listener handle.
-- Enter the target-native event loop.
-- Refuse unsupported V8 layouts, unsupported object kinds, multiple isolates, workers, native addons, active requests, or unknown libuv handles.
+- [ ] Recreate the JS counter cell/object in target-native V8 without a fixture-specific JS loader.
+- [ ] Recreate or bind the target-native libuv TCP listener handle.
+- [ ] Enter the target-native event loop.
+- [x] Refuse unsupported native materialization with a stable fail-closed code until the implementation path is chosen.
+- [ ] Refuse unsupported V8 layouts, unsupported object kinds, multiple isolates, workers, native addons, active requests, or unknown libuv handles.
 
 ## Validation
 
-- Add unit tests for the materialization plan and refusal matrix.
-- Run a native materializer smoke proof, e.g. `pnpm exec tsx proof/029/smoke.ts`.
-- Assert source returns `{count:1}`, `{count:2}` before capture.
-- Assert target-native materializer reconstructs state and first target request returns `{count:3}`.
-- Assert no controlled JS loader path is used for the counter materialization.
-- Assert no app hooks, no checkpoint API, no selected-state descriptor, no source ISA emulation, no sidecar replay, and no metadata-only success.
-- Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.
+- [ ] Add unit tests for the materialization plan and refusal matrix.
+- [x] Run the native materializer boundary scaffold, e.g. `pnpm exec tsx proof/029/smoke.ts`.
+- [ ] Assert source returns `{count:1}`, `{count:2}` before capture.
+- [ ] Assert target-native materializer reconstructs state and first target request returns `{count:3}`.
+- [x] Assert no controlled JS loader path is used by the native materializer boundary stub.
+- [x] Assert no app hooks, no checkpoint API, no selected-state descriptor, no source ISA emulation, no sidecar replay, and no metadata-only success in the scaffold refusal.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main` for the completed proof.

--- a/proof/029/guest-capture.zig
+++ b/proof/029/guest-capture.zig
@@ -1,0 +1,185 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+const max_map_bytes: usize = 4 * 1024 * 1024;
+const active_marker = "machinen-level5-active-http-request-live-v1";
+const counter_anchor = "machinen-level5-v8-context-anchor-v1";
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const out_root = args.next() orelse "/mnt/work/machinen-proper-level5-source-state";
+    const pid_arg = args.next();
+
+    const pid = if (pid_arg) |raw| @as(std.posix.pid_t, @intCast(try std.fmt.parseInt(i32, raw, 10))) else try find_node_pid(allocator);
+    try std.posix.kill(pid, std.posix.SIG.STOP);
+    defer std.posix.kill(pid, std.posix.SIG.CONT) catch {};
+
+    std.Io.Dir.cwd().deleteTree(g_io, out_root) catch {};
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/memory", .{out_root}));
+
+    const maps_path = try std.fmt.allocPrint(allocator, "/proc/{d}/maps", .{pid});
+    const maps = try read_file_streaming(allocator, maps_path, 16 * 1024 * 1024);
+    defer allocator.free(maps);
+    try write_out(allocator, out_root, "maps.txt", maps);
+    try copy_proc_file(allocator, out_root, pid, "status");
+    try copy_proc_file(allocator, out_root, pid, "stat");
+    try copy_proc_file(allocator, out_root, pid, "cmdline");
+    try copy_proc_file(allocator, out_root, pid, "environ");
+    try copy_proc_file(allocator, out_root, pid, "auxv");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp", "proc-net-tcp.txt");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp6", "proc-net-tcp6.txt");
+    try write_fd_table(allocator, out_root, pid);
+
+    const mem_path = try std.fmt.allocPrint(allocator, "/proc/{d}/mem", .{pid});
+    var mem_file = try std.Io.Dir.cwd().openFile(g_io, mem_path, .{});
+    defer mem_file.close(g_io);
+
+    var accepted = std.ArrayListUnmanaged(u8).empty;
+    defer accepted.deinit(allocator);
+    var active_found = false;
+    var counter_anchor_found = false;
+    var source_found = false;
+    var accepted_count: usize = 0;
+
+    var line_it = std.mem.splitScalar(u8, maps, '\n');
+    var map_index: usize = 0;
+    while (line_it.next()) |line| : (map_index += 1) {
+        const parsed = parse_map_line(line) orelse continue;
+        if (!accept_mapping(parsed)) continue;
+        const size: usize = @intCast(parsed.end - parsed.start);
+        const bytes = try allocator.alloc(u8, size);
+        defer allocator.free(bytes);
+        const read = mem_file.readPositional(g_io, &.{bytes}, parsed.start) catch continue;
+        const got = bytes[0..read];
+        const rel = try std.fmt.allocPrint(allocator, "memory/map-{d:0>4}-{x}-{x}.bin", .{ map_index, parsed.start, parsed.end });
+        const abs = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, rel });
+        var out = try std.Io.Dir.cwd().createFile(g_io, abs, .{ .read = true, .truncate = true });
+        defer out.close(g_io);
+        try out.writeStreamingAll(g_io, got);
+        try append_line(allocator, &accepted, "{d}\t0x{x}\t0x{x}\t{d}\t{s}\t{s}\n", .{ map_index, parsed.start, parsed.end, read, rel, parsed.path });
+        accepted_count += 1;
+        active_found = active_found or std.mem.indexOf(u8, got, active_marker) != null;
+        counter_anchor_found = counter_anchor_found or std.mem.indexOf(u8, got, counter_anchor) != null;
+        source_found = source_found or std.mem.indexOf(u8, got, "let count = 0;") != null;
+    }
+    try write_out(allocator, out_root, "accepted-mappings.tsv", accepted.items);
+
+    const markers = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{"pid":{d},"activeHttpRequestDetected":{},"counterAnchorFound":{},"sourceCounterTextFound":{},"acceptedMappings":{d}}}
+        \\
+    , .{ pid, active_found, counter_anchor_found, source_found, accepted_count });
+    try write_out(allocator, out_root, "capture-markers.json", markers);
+    try stdout("ok\n");
+    return 0;
+}
+
+const MapLine = struct { start: u64, end: u64, perms: []const u8, path: []const u8 };
+
+fn parse_map_line(line: []const u8) ?MapLine {
+    var it = std.mem.tokenizeAny(u8, line, " ");
+    const range = it.next() orelse return null;
+    const perms = it.next() orelse return null;
+    _ = it.next();
+    _ = it.next();
+    _ = it.next();
+    const path = it.next() orelse "";
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse return null;
+    const start = std.fmt.parseInt(u64, range[0..dash], 16) catch return null;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 16) catch return null;
+    return .{ .start = start, .end = end, .perms = perms, .path = path };
+}
+
+fn accept_mapping(m: MapLine) bool {
+    const size = m.end - m.start;
+    return std.mem.indexOfScalar(u8, m.perms, 'r') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'w') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'p') != null and
+        size <= max_map_bytes and
+        (m.path.len == 0 or std.mem.eql(u8, m.path, "[heap]") or std.mem.eql(u8, m.path, "[stack]"));
+}
+
+fn find_node_pid(allocator: std.mem.Allocator) !std.posix.pid_t {
+    var proc = try std.Io.Dir.cwd().openDir(g_io, "/proc", .{ .iterate = true });
+    defer proc.close(g_io);
+    var it = proc.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const cmd_path = try std.fmt.allocPrint(allocator, "/proc/{s}/cmdline", .{entry.name});
+        const cmd = read_file_streaming(allocator, cmd_path, 8192) catch continue;
+        defer allocator.free(cmd);
+        if (std.mem.indexOf(u8, cmd, "native-materializer-counter.mjs") != null) {
+            const raw = try std.fmt.parseInt(i32, entry.name, 10);
+            return @intCast(raw);
+        }
+    }
+    return error.MissingNodePid;
+}
+
+fn write_fd_table(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const fd_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/fd", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, fd_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ fd_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ entry.name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "fd-table.tsv", rows.items);
+}
+
+fn copy_proc_file(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t, name: []const u8) !void {
+    const src = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+    try copy_file_abs(allocator, out_root, src, try std.fmt.allocPrint(allocator, "proc-{s}", .{name}));
+}
+
+fn copy_file_abs(allocator: std.mem.Allocator, out_root: []const u8, src: []const u8, dst_name: []const u8) !void {
+    const data = read_file_streaming(allocator, src, 16 * 1024 * 1024) catch return;
+    defer allocator.free(data);
+    try write_out(allocator, out_root, dst_name, data);
+}
+
+fn read_file_streaming(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(g_io, path, .{});
+    defer file.close(g_io);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    var buf: [8192]u8 = undefined;
+    while (out.items.len < limit) {
+        const n = file.readStreaming(g_io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..@min(n, limit - out.items.len)]);
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn write_out(allocator: std.mem.Allocator, out_root: []const u8, name: []const u8, data: []const u8) !void {
+    const out = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, name });
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = out, .data = data });
+}
+
+fn append_line(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8), comptime fmt: []const u8, args: anytype) !void {
+    const line = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(line);
+    try list.appendSlice(allocator, line);
+}
+
+fn all_digits(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| if (c < '0' or c > '9') return false;
+    return true;
+}
+
+fn stdout(s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(g_io, s);
+}

--- a/proof/029/native-materializer.zig
+++ b/proof/029/native-materializer.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const result_path = args.next() orelse "/tmp/machinen-proof-029-result.json";
+
+    const result =
+        \\
+        \\{
+        \\  "kind": "machinen.node-proper-level5-native-materializer-scaffold",
+        \\  "targetNativeMaterializerStarted": true,
+        \\  "controlledJsLoaderUsed": false,
+        \\  "accepted": false,
+        \\  "refusal": {
+        \\    "code": "node-proper-level5-native-materializer-not-implemented",
+        \\    "message": "native V8/libuv materialization boundary is scaffolded but not implemented"
+        \\  },
+        \\  "selectedStateCounterDescriptorUsed": false,
+        \\  "appExportImportUsed": false,
+        \\  "sourceIsaEmulationUsed": false,
+        \\  "sidecarOutputUsed": false,
+        \\  "metadataOnlySuccess": false
+        \\}
+        \\
+    ;
+
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = result_path, .data = result });
+    try stdout(allocator, "native materializer scaffold wrote {s}\n", .{result_path});
+    return 0;
+}
+
+fn stdout(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
+    const text = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(text);
+    try std.Io.File.stdout().writeStreamingAll(g_io, text);
+}

--- a/proof/029/smoke.sh
+++ b/proof/029/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+pnpm exec tsx proof/029/smoke.ts

--- a/proof/029/smoke.ts
+++ b/proof/029/smoke.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(proofDir, "../..");
+const work =
+  process.env.WORK_DIR ??
+  mkdtempSync(join(process.env.TMPDIR ?? tmpdir(), "machinen-node-proper-level5-materializer."));
+const resultPath = join(work, "native-materializer-result.json");
+const materializerPath = join(work, "native-materializer");
+
+interface NativeMaterializerResult {
+  kind: string;
+  targetNativeMaterializerStarted: boolean;
+  controlledJsLoaderUsed: boolean;
+  accepted: boolean;
+  refusal?: { code?: string };
+  selectedStateCounterDescriptorUsed: boolean;
+  appExportImportUsed: boolean;
+  sourceIsaEmulationUsed: boolean;
+  sidecarOutputUsed: boolean;
+  metadataOnlySuccess: boolean;
+}
+
+function parseJson<T>(body: string): T {
+  return JSON.parse(body) as T;
+}
+
+function compileNativeMaterializer(): void {
+  execFileSync(
+    "zig",
+    [
+      "build-exe",
+      join(proofDir, "native-materializer.zig"),
+      "-O",
+      "ReleaseFast",
+      `-femit-bin=${materializerPath}`,
+    ],
+    { cwd: root, stdio: "inherit" },
+  );
+}
+
+function runNativeMaterializerScaffold(): NativeMaterializerResult {
+  execFileSync(materializerPath, [resultPath], { cwd: root, stdio: "inherit" });
+  return parseJson<NativeMaterializerResult>(readFileSync(resultPath, "utf8"));
+}
+
+function validateScaffold(result: NativeMaterializerResult): void {
+  if (result.kind !== "machinen.node-proper-level5-native-materializer-scaffold") {
+    throw new Error(`unexpected materializer result kind: ${result.kind}`);
+  }
+  if (!result.targetNativeMaterializerStarted) {
+    throw new Error("native materializer scaffold did not start");
+  }
+  if (result.controlledJsLoaderUsed) {
+    throw new Error("Proof 029 scaffold must not use a controlled JS target loader");
+  }
+  if (result.accepted) {
+    throw new Error(
+      "Proof 029 scaffold must fail closed until native materialization is implemented",
+    );
+  }
+  if (result.refusal?.code !== "node-proper-level5-native-materializer-not-implemented") {
+    throw new Error("Proof 029 scaffold emitted the wrong refusal code");
+  }
+  for (const key of [
+    "selectedStateCounterDescriptorUsed",
+    "appExportImportUsed",
+    "sourceIsaEmulationUsed",
+    "sidecarOutputUsed",
+    "metadataOnlySuccess",
+  ] as const) {
+    if (result[key]) {
+      throw new Error(`forbidden proof shortcut detected: ${key}`);
+    }
+  }
+}
+
+compileNativeMaterializer();
+const result = runNativeMaterializerScaffold();
+validateScaffold(result);
+console.log(JSON.stringify({ scaffolded: true, result }));
+console.log(`node proper Level 5 native materializer scaffold passed: ${work}`);

--- a/proof/029/source-app.mjs
+++ b/proof/029/source-app.mjs
@@ -1,0 +1,21 @@
+import { createServer } from "node:http";
+
+function makeHandler() {
+  const machinenLevel5ContextAnchor = "machinen-level5-v8-context-anchor-v1";
+  let count = 0;
+  return function machinenNativeMaterializerCounterHandler(req, res) {
+    if (machinenLevel5ContextAnchor.length === 0) {
+      throw new Error("unreachable anchor guard");
+    }
+    if (req.url !== "/") {
+      res.writeHead(404);
+      res.end("not found\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ count: ++count }) + "\n");
+  };
+}
+
+const server = createServer(makeHandler());
+server.listen(3000, "127.0.0.1");

--- a/proof/030/README.md
+++ b/proof/030/README.md
@@ -1,0 +1,33 @@
+# Proof 030 — VM-pause atomic source capture
+
+## TL;DR
+
+Replace process-only `SIGSTOP` capture with whole-VM pause capture for the proper Node proof track. This is **not** full restore by itself. It is a cleaner external quiesce point so process memory, registers, `/proc`, fd tables, and socket state are captured from one frozen machine instant.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/030/`. The proof smoke test may be written in TypeScript, for example `proof/030/smoke.ts`, with an optional `proof/030/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/030/smoke.ts`.
+
+## Goal
+
+Prove that the source VM can be paused externally, captured, and unpaused while preserving the current proper Node source-state proof behavior. The target must still reconstruct target-native state from captured evidence. Active or ambiguous HTTP request state must still refuse.
+
+## Tasks
+
+- [ ] Add a proof-local VM pause/unpause capture flow around the existing Zig guest capture tool.
+- [ ] Capture source process `/proc`, memory mappings, fd/socket state, and thread state while the VM is frozen.
+- [ ] Record pause/resume evidence in the source-state IR.
+- [ ] Prove the source VM resumes after capture and can still answer requests.
+- [ ] Prove quiescent target-native reconstruction still returns `{count:3}`.
+- [ ] Keep active in-flight HTTP request state refused; VM pause must not downgrade semantic safety rules.
+- [ ] Assert no app hook, checkpoint API, selected-state descriptor, sidecar replay, source ISA emulation, or metadata-only success.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/030/smoke.ts`.
+- [ ] Assert source returns `{count:1}`, `{count:2}` before pause capture.
+- [ ] Assert source VM answers after unpause.
+- [ ] Assert target returns `{count:3}` from target-native reconstruction.
+- [ ] Assert capture evidence says `externalQuiesce.method = "vm-pause"` or equivalent.
+- [ ] Assert active request capture still refuses.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/030/README.md
+++ b/proof/030/README.md
@@ -4,6 +4,10 @@
 
 Replace process-only `SIGSTOP` capture with whole-VM pause capture for the proper Node proof track. This is **not** full restore by itself. It is a cleaner external quiesce point so process memory, registers, `/proc`, fd tables, and socket state are captured from one frozen machine instant.
 
+## Track objective
+
+The actual goal is a cleaner capture boundary for the same source-state IR path. VM pause should make capture more atomic, but it does not turn the proof into full VM restore. The target still reconstructs only supported state target-natively, and unsafe active state still refuses.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/030/`. The proof smoke test may be written in TypeScript, for example `proof/030/smoke.ts`, with an optional `proof/030/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/030/smoke.ts`.

--- a/proof/031/README.md
+++ b/proof/031/README.md
@@ -4,6 +4,10 @@
 
 Move beyond selected useful memory fragments. Capture a complete inventory of the Node process image: mappings, bytes policy, registers, thread state, stack ranges, TLS hints, signal state, fd table, and kernel resources. This is still a proof bundle, not product support.
 
+## Track objective
+
+The actual goal is to make the source-state bundle honest about the whole process image while still restoring only supported semantic state. Every captured mapping, thread, and fd should be classified as translated, recreated, copied as evidence, or refused. A complete inventory is evidence for future restore work; it is not a claim that the full process image is restorable.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/031/`. The proof smoke test may be written in TypeScript, for example `proof/031/smoke.ts`, with an optional `proof/031/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/031/smoke.ts`.

--- a/proof/031/README.md
+++ b/proof/031/README.md
@@ -1,0 +1,33 @@
+# Proof 031 — Full process image inventory
+
+## TL;DR
+
+Move beyond selected useful memory fragments. Capture a complete inventory of the Node process image: mappings, bytes policy, registers, thread state, stack ranges, TLS hints, signal state, fd table, and kernel resources. This is still a proof bundle, not product support.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/031/`. The proof smoke test may be written in TypeScript, for example `proof/031/smoke.ts`, with an optional `proof/031/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/031/smoke.ts`.
+
+## Goal
+
+Produce a source-state bundle that is rich enough to explain every source thread and memory mapping, even when the target still reconstructs only a narrow Node counter. The proof should make the unknown parts explicit as copied, recreated, translated, or refused.
+
+## Tasks
+
+- [ ] Extend the Zig guest capture tool to enumerate every process memory mapping.
+- [ ] Record per-mapping policy: captured bytes, recreated target mapping, file-backed identity, guard/special mapping, or refused.
+- [ ] Capture per-thread status, stat, syscall, stack range, and register evidence where available.
+- [ ] Capture signal masks, pending signals, process credentials, auxv, cmdline, environ, cwd/root/exe links, and namespace hints.
+- [ ] Capture fd table with resource classes: regular file, pipe, socket, eventfd, timerfd, epoll, anon inode, unknown.
+- [ ] Emit a portable process-image inventory JSON with stable refusal codes for unknown resources.
+- [ ] Keep the target reconstruction narrow and target-native; do not claim raw full-process restore.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/031/smoke.ts`.
+- [ ] Assert every `/proc/<pid>/maps` row has a mapping policy in the inventory.
+- [ ] Assert every `/proc/<pid>/task/*` thread has a thread-state row.
+- [ ] Assert every fd has a resource classification or a refusal.
+- [ ] Assert quiescent target-native continuation still returns `{count:3}`.
+- [ ] Assert no product support claim, no source ISA emulation, no app export/import, no checkpoint API, and no metadata-only success.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/032/README.md
+++ b/proof/032/README.md
@@ -1,0 +1,33 @@
+# Proof 032 — Thread continuation classification
+
+## TL;DR
+
+Classify where each source thread stopped. The proof must distinguish safe event-loop wait points from unsafe JavaScript, V8, native, syscall, GC, or HTTP parser continuations. Unsupported states must refuse before any target materialization.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/032/`. The proof smoke test may be written in TypeScript, for example `proof/032/smoke.ts`, with an optional `proof/032/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/032/smoke.ts`.
+
+## Goal
+
+Prove a refusal-first continuation classifier for the proper Node track. A source capture should be accepted only when all threads are at known safe points that can be reconstructed target-natively. Unsafe in-flight continuations must produce stable refusal codes.
+
+## Tasks
+
+- [ ] Define continuation classes: event-loop wait, timer callback active, HTTP request callback active, V8 internal frame, GC/compiler frame, native addon frame, active syscall, unknown.
+- [ ] Capture enough thread/register/syscall evidence to assign each thread to a class.
+- [ ] Accept the narrow quiescent event-loop wait case used by the current HTTP counter proof.
+- [ ] Refuse active JavaScript callback execution with a stable code.
+- [ ] Refuse active syscall states that are not modeled.
+- [ ] Refuse V8 GC/compiler/internal frames and unknown native frames.
+- [ ] Emit continuation descriptors only for accepted safe points.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/032/smoke.ts`.
+- [ ] Assert quiescent listener capture is accepted and target returns `{count:3}`.
+- [ ] Assert active `/hold` HTTP request refuses.
+- [ ] Assert an intentional busy JS callback fixture refuses.
+- [ ] Assert an intentional blocking syscall fixture refuses unless it has an explicit modeled continuation.
+- [ ] Assert refusal evidence appears in the portable IR and no target materialization occurs for refused captures.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/032/README.md
+++ b/proof/032/README.md
@@ -4,6 +4,10 @@
 
 Classify where each source thread stopped. The proof must distinguish safe event-loop wait points from unsafe JavaScript, V8, native, syscall, GC, or HTTP parser continuations. Unsupported states must refuse before any target materialization.
 
+## Track objective
+
+The actual goal is to decide whether a captured source point is safe for target-native semantic reconstruction. Accepted rows get continuation descriptors; unsafe rows refuse. This classifier prevents raw registers, stacks, active callbacks, or syscalls from being treated as restored just because they were captured.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/032/`. The proof smoke test may be written in TypeScript, for example `proof/032/smoke.ts`, with an optional `proof/032/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/032/smoke.ts`.

--- a/proof/033/README.md
+++ b/proof/033/README.md
@@ -4,6 +4,10 @@
 
 Expand from tiny V8 state shapes to a small heap graph translator. The proof should recover multiple linked plain objects, arrays, strings, and closure context cells from captured V8 memory, then rebuild equivalent target-native objects. Unsupported V8 shapes must refuse.
 
+## Track objective
+
+The actual goal is to grow the semantic state that can be translated from raw V8 memory evidence into target-native V8 objects. This is heap graph reconstruction for supported shapes, not a byte-for-byte V8 heap restore. Unsupported maps, elements kinds, strings, or object shapes must refuse.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/033/`. The proof smoke test may be written in TypeScript, for example `proof/033/smoke.ts`, with an optional `proof/033/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/033/smoke.ts`.

--- a/proof/033/README.md
+++ b/proof/033/README.md
@@ -1,0 +1,33 @@
+# Proof 033 — V8 heap graph translator expansion
+
+## TL;DR
+
+Expand from tiny V8 state shapes to a small heap graph translator. The proof should recover multiple linked plain objects, arrays, strings, and closure context cells from captured V8 memory, then rebuild equivalent target-native objects. Unsupported V8 shapes must refuse.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/033/`. The proof smoke test may be written in TypeScript, for example `proof/033/smoke.ts`, with an optional `proof/033/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/033/smoke.ts`.
+
+## Goal
+
+Prove a small but real object graph translation boundary beyond `{ total, history }`. The target must reconstruct equivalent target-native V8 objects from captured source heap graph evidence, not from app export/import or prior response strings.
+
+## Tasks
+
+- [ ] Define supported V8 graph nodes: Smi, heap number if needed, internalized/one-byte strings, plain object, packed Smi array, packed object array, closure context cell.
+- [ ] Capture object references and edges near retained proof anchors.
+- [ ] Decode object maps/hidden classes enough to distinguish supported plain objects from unsupported shapes.
+- [ ] Decode properties, array lengths, array elements, and object references into a portable graph IR.
+- [ ] Reconstruct target-native object graph with identity preservation for shared references.
+- [ ] Refuse sparse arrays, accessors, proxies, symbols, external strings, unsupported elements kinds, unknown maps, and ambiguous graphs.
+- [ ] Prove prior JSON response strings are not used as the source of truth.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/033/smoke.ts`.
+- [ ] Assert source mutates a linked object graph before capture.
+- [ ] Assert target returns the next response from reconstructed graph state.
+- [ ] Assert object identity/shared-reference evidence is preserved when included in the fixture.
+- [ ] Assert unsupported shapes refuse with stable codes.
+- [ ] Assert no app hooks, checkpoint API, selected-state descriptor, sidecar replay, source ISA emulation, or metadata-only success.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/034/README.md
+++ b/proof/034/README.md
@@ -4,6 +4,10 @@
 
 Translate a captured source continuation into a target-native continuation descriptor. This is not copying arm64 registers into amd64, and not source ISA emulation. It is a proof that known safe source PCs/registers/stack facts can become a target-native landing plan.
 
+## Track objective
+
+The actual goal is an architecture-neutral continuation descriptor derived from captured source machine/process state. The target should land in an equivalent target-native continuation, not copy source registers or execute source ISA bytes. This is the bridge from semantic reconstruction toward real continuation.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/034/`. The proof smoke test may be written in TypeScript, for example `proof/034/smoke.ts`, with an optional `proof/034/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/034/smoke.ts`.

--- a/proof/034/README.md
+++ b/proof/034/README.md
@@ -1,0 +1,33 @@
+# Proof 034 — Cross-architecture continuation descriptor
+
+## TL;DR
+
+Translate a captured source continuation into a target-native continuation descriptor. This is not copying arm64 registers into amd64, and not source ISA emulation. It is a proof that known safe source PCs/registers/stack facts can become a target-native landing plan.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/034/`. The proof smoke test may be written in TypeScript, for example `proof/034/smoke.ts`, with an optional `proof/034/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/034/smoke.ts`.
+
+## Goal
+
+Prove the first narrow cross-architecture continuation descriptor for a safe Node event-loop wait point. The target should enter an equivalent target-native event loop wait/dispatch path using a descriptor derived from source machine/process state.
+
+## Tasks
+
+- [ ] Capture source PC/register/syscall/thread evidence at a known safe event-loop wait point.
+- [ ] Resolve source code location to a semantic continuation class, not a raw target PC.
+- [ ] Emit an architecture-neutral continuation descriptor for `node-libuv-event-loop-wait-v1`.
+- [ ] Map the descriptor to a target-native landing plan on the opposite architecture.
+- [ ] Prove the target does not execute source ISA bytes and does not emulate source code.
+- [ ] Refuse unknown PCs, active JS frames, V8 internal frames, and unsupported native frames.
+- [ ] Keep app state reconstruction separate from continuation landing evidence.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/034/smoke.ts`.
+- [ ] Assert source and target architectures differ.
+- [ ] Assert source continuation class is `node-libuv-event-loop-wait-v1`.
+- [ ] Assert target enters a target-native event loop path and returns `{count:3}`.
+- [ ] Assert source raw registers are not copied as target registers across architectures.
+- [ ] Assert no source ISA emulation, no sidecar replay, no metadata-only success, and no app export/import.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/035/README.md
+++ b/proof/035/README.md
@@ -1,0 +1,33 @@
+# Proof 035 — Native libuv resource materialization
+
+## TL;DR
+
+Recreate target-native libuv resources from captured source-state IR. The first scope is one TCP listener and one timer. Active streams, partially written responses, unknown handles, and ambiguous resource state must refuse.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/035/`. The proof smoke test may be written in TypeScript, for example `proof/035/smoke.ts`, with an optional `proof/035/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/035/smoke.ts`.
+
+## Goal
+
+Move resource reconstruction below the fixture JS loader. The proof should materialize target-native libuv listener/timer handles from portable resource descriptors, then bind them to the reconstructed target-native Node/V8 state.
+
+## Tasks
+
+- [ ] Define resource descriptors for one TCP listener and one repeating timer.
+- [ ] Capture source fd/socket/timer/libuv evidence with the Zig guest capture tool.
+- [ ] Materialize a target-native TCP listener without replaying prior source responses.
+- [ ] Materialize a target-native repeating timer with recovered tick state or a modeled offset.
+- [ ] Bind materialized resources to target-native V8/Node callback state.
+- [ ] Refuse accepted sockets with unread bytes, pending writes, active callbacks, unknown handle types, and multiple ambiguous handles.
+- [ ] Emit proof evidence separating recreated target resources from copied source kernel state.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/035/smoke.ts`.
+- [ ] Assert source has one listener and one timer before capture.
+- [ ] Assert target has target-native listener and timer handles.
+- [ ] Assert first target request returns `{count:3}` and timer continues.
+- [ ] Assert active request and partial socket states refuse.
+- [ ] Assert no source kernel fd is reused directly on target, no source ISA emulation, no sidecar replay, and no metadata-only success.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/035/README.md
+++ b/proof/035/README.md
@@ -4,6 +4,10 @@
 
 Recreate target-native libuv resources from captured source-state IR. The first scope is one TCP listener and one timer. Active streams, partially written responses, unknown handles, and ambiguous resource state must refuse.
 
+## Track objective
+
+The actual goal is target-native resource recreation from portable resource descriptors. Source kernel fds and libuv handles are evidence; they are not directly restored into the target. Only understood listener/timer state may be recreated, and active or ambiguous resource state must refuse.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/035/`. The proof smoke test may be written in TypeScript, for example `proof/035/smoke.ts`, with an optional `proof/035/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/035/smoke.ts`.

--- a/proof/036/README.md
+++ b/proof/036/README.md
@@ -1,0 +1,33 @@
+# Proof 036 — Restore refusal gauntlet
+
+## TL;DR
+
+Build a gauntlet of unsafe source states and prove they fail closed. This protects the move toward CPU/register/heap continuation by making unsupported states explicit instead of accidentally treating metadata as success.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/036/`. The proof smoke test may be written in TypeScript, for example `proof/036/smoke.ts`, with an optional `proof/036/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/036/smoke.ts`.
+
+## Goal
+
+Prove a refusal-first matrix for the proper Node continuation track. Every unsafe or unsupported state should have a stable refusal code and should prevent target materialization. Accepted cases must still prove target-native reconstruction.
+
+## Tasks
+
+- [ ] Define refusal fixtures for active HTTP request, partial request body, partial response write, idle keep-alive ambiguity, active JS callback, active syscall, V8 GC/compiler frame, worker thread, native addon, multiple isolates, unsupported V8 object shape, unknown libuv handle, and architecture mismatch.
+- [ ] Add stable refusal codes for every fixture.
+- [ ] Ensure refused captures never start the target materializer.
+- [ ] Ensure accepted quiescent fixtures still reconstruct target-native state.
+- [ ] Emit a checked summary that separates accepted proof rows from refused rows.
+- [ ] Assert no row claims product support or broad Level 5 implementation.
+- [ ] Assert no forbidden shortcut is used in accepted or refused rows.
+
+## Validation
+
+- [ ] Run `pnpm exec tsx proof/036/smoke.ts`.
+- [ ] Assert every unsafe fixture refuses with the expected stable code.
+- [ ] Assert no refused fixture starts target materialization.
+- [ ] Assert the accepted quiescent fixture still returns `{count:3}`.
+- [ ] Assert checked summary taxonomy remains proof-only and not product support.
+- [ ] Assert no app hooks, checkpoint API, selected-state descriptor, source ISA emulation, sidecar replay, or metadata-only success.
+- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/036/README.md
+++ b/proof/036/README.md
@@ -4,6 +4,10 @@
 
 Build a gauntlet of unsafe source states and prove they fail closed. This protects the move toward CPU/register/heap continuation by making unsupported states explicit instead of accidentally treating metadata as success.
 
+## Track objective
+
+The actual goal is to protect the proof track from false success. The gauntlet should prove that unsupported captured state refuses before target materialization, while supported quiescent state still reconstructs target-natively. Refusal evidence is part of the proof, not a failure of the product path.
+
 ## Proof folder
 
 All implementation notes, fixtures, and smoke tests for this proof should live under `proof/036/`. The proof smoke test may be written in TypeScript, for example `proof/036/smoke.ts`, with an optional `proof/036/smoke.sh` compatibility wrapper. Do not add root `package.json` scripts for this proof; run proof-local TypeScript smokes directly with `pnpm exec tsx proof/036/smoke.ts`.


### PR DESCRIPTION
## Problem

The Node proof track showed that we could recover small pieces of V8 state and rebuild them in target-native Node. But it had not yet shown the same path across different CPU architectures. Without that proof, a cross-arch claim could be only metadata, not a real target-native reconstruction.

## Solution

This PR adds Proof 028. It captures an arm64 source Node counter, decodes the counter from raw V8 memory evidence, and rebuilds the next response in an amd64 target-native Node process. It also adds starter files for the next native-materializer proof and roadmap proof docs for the continuation work that follows.

## Technical Summary

- Keep Proof 028 proof-only. It proves one narrow cross-arch source-state reconstruction path, not broad Node product support.
- Use a Machinen arm64 source guest for capture and a linux/amd64 Node target container for target-native reconstruction, so the target does not run source arm64 code.
- Preserve the no-shortcut boundary: no selected-state descriptor, app export/import, source ISA emulation, sidecar replay, or metadata-only success.
- Add Proof 029 as a fail-closed native materializer scaffold, so the next step has a native boundary without pretending the native materializer is finished.
- Add Proof 030–036 README plans to break the remaining path into smaller proof obligations: VM-pause capture, full process inventory, thread classification, V8 graph translation, continuation descriptors, libuv materialization, and refusal gauntlets.
