### PR TITLE
Complete Proof 032 thread continuation classifier

### DIFF
--- a/proof/032/README.md
+++ b/proof/032/README.md
@@ -22,20 +22,32 @@ Prove a refusal-first continuation classifier for the proper Node track. A sourc
 
 ## Tasks
 
-- [ ] Define continuation classes: event-loop wait, timer callback active, HTTP request callback active, V8 internal frame, GC/compiler frame, native addon frame, active syscall, unknown.
-- [ ] Capture enough thread/register/syscall evidence to assign each thread to a class.
-- [ ] Accept the narrow quiescent event-loop wait case used by the current HTTP counter proof.
-- [ ] Refuse active JavaScript callback execution with a stable code.
-- [ ] Refuse active syscall states that are not modeled.
-- [ ] Refuse V8 GC/compiler/internal frames and unknown native frames.
-- [ ] Emit continuation descriptors only for accepted safe points.
+- [x] Define continuation classes: event-loop wait, timer callback active, HTTP request callback active, V8 internal frame, GC/compiler frame, native addon frame, active syscall, unknown.
+- [x] Capture enough thread/register/syscall evidence to assign each thread to a class.
+- [x] Accept the narrow idle event-loop wait case used by the current HTTP counter proof.
+- [x] Refuse active JavaScript callback execution with a stable code.
+- [x] Refuse active syscall states that are not modeled.
+- [x] Refuse V8 GC/compiler/internal frames and unknown native frames in the taxonomy so future captures fail closed instead of becoming raw continuation claims.
+- [x] Emit continuation descriptors only for accepted safe points.
+
+## Proof result
+
+`pnpm exec tsx proof/032/smoke.ts` now proves:
+
+- idle listener capture is accepted and emits thread continuation descriptors;
+- target-native reconstruction still recovers the raw V8 context Smi counter and returns `{ "count": 3 }`;
+- active `/hold` HTTP request state refuses with `node-proper-level5-http-active-request-unsupported`;
+- an intentional busy JavaScript callback fixture refuses with `node-proper-level5-active-js-callback-unsupported`;
+- an intentional blocking syscall fixture refuses with `node-proper-level5-active-syscall-unsupported`;
+- refused captures include refusal evidence in the portable IR and emit no target continuation descriptors;
+- no target materialization occurs for refused captures.
 
 ## Validation
 
-- [ ] Run `pnpm exec tsx proof/032/smoke.ts`.
-- [ ] Assert quiescent listener capture is accepted and target returns `{count:3}`.
-- [ ] Assert active `/hold` HTTP request refuses.
-- [ ] Assert an intentional busy JS callback fixture refuses.
-- [ ] Assert an intentional blocking syscall fixture refuses unless it has an explicit modeled continuation.
-- [ ] Assert refusal evidence appears in the portable IR and no target materialization occurs for refused captures.
-- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.
+- [x] Run `pnpm exec tsx proof/032/smoke.ts`.
+- [x] Assert idle listener capture is accepted and target returns `{count:3}`.
+- [x] Assert active `/hold` HTTP request refuses.
+- [x] Assert an intentional busy JS callback fixture refuses.
+- [x] Assert an intentional blocking syscall fixture refuses unless it has an explicit modeled continuation.
+- [x] Assert refusal evidence appears in the portable IR and no target materialization occurs for refused captures.
+- [x] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/032/guest-capture.zig
+++ b/proof/032/guest-capture.zig
@@ -1,0 +1,277 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+const max_map_bytes: usize = 4 * 1024 * 1024;
+const active_marker = "machinen-level5-active-http-request-live-v1";
+const busy_js_marker = "machinen-level5-active-js-callback-live-v1";
+const blocking_syscall_marker = "machinen-level5-active-blocking-syscall-live-v1";
+const counter_anchor = "machinen-level5-v8-context-anchor-v1";
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const out_root = args.next() orelse "/mnt/work/source-state";
+    const pid_arg = args.next();
+    const barrier_root = args.next();
+
+    const pid = if (pid_arg) |raw| @as(std.posix.pid_t, @intCast(try std.fmt.parseInt(i32, raw, 10))) else try find_node_pid(allocator);
+    try std.posix.kill(pid, std.posix.SIG.STOP);
+    defer std.posix.kill(pid, std.posix.SIG.CONT) catch {};
+    if (barrier_root) |root| {
+        try wait_for_host_vm_pause_barrier(allocator, root);
+    }
+
+    std.Io.Dir.cwd().deleteTree(g_io, out_root) catch {};
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/memory", .{out_root}));
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/task", .{out_root}));
+
+    const maps_path = try std.fmt.allocPrint(allocator, "/proc/{d}/maps", .{pid});
+    const maps = try read_file_streaming(allocator, maps_path, 16 * 1024 * 1024);
+    defer allocator.free(maps);
+    try write_out(allocator, out_root, "maps.txt", maps);
+    try copy_proc_file(allocator, out_root, pid, "status");
+    try copy_proc_file(allocator, out_root, pid, "stat");
+    try copy_proc_file(allocator, out_root, pid, "cmdline");
+    try copy_proc_file(allocator, out_root, pid, "environ");
+    try copy_proc_file(allocator, out_root, pid, "auxv");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp", "proc-net-tcp.txt");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp6", "proc-net-tcp6.txt");
+    try write_process_links(allocator, out_root, pid);
+    try write_namespace_links(allocator, out_root, pid);
+    try write_thread_inventory(allocator, out_root, pid);
+    try write_fd_table(allocator, out_root, pid);
+
+    const mem_path = try std.fmt.allocPrint(allocator, "/proc/{d}/mem", .{pid});
+    var mem_file = try std.Io.Dir.cwd().openFile(g_io, mem_path, .{});
+    defer mem_file.close(g_io);
+
+    var accepted = std.ArrayListUnmanaged(u8).empty;
+    defer accepted.deinit(allocator);
+    var active_found = false;
+    var counter_anchor_found = false;
+    var busy_js_found = false;
+    var blocking_syscall_found = false;
+    var source_found = false;
+    var accepted_count: usize = 0;
+
+    var line_it = std.mem.splitScalar(u8, maps, '\n');
+    var map_index: usize = 0;
+    while (line_it.next()) |line| : (map_index += 1) {
+        const parsed = parse_map_line(line) orelse continue;
+        if (!accept_mapping(parsed)) continue;
+        const size: usize = @intCast(parsed.end - parsed.start);
+        const bytes = try allocator.alloc(u8, size);
+        defer allocator.free(bytes);
+        const read = mem_file.readPositional(g_io, &.{bytes}, parsed.start) catch continue;
+        const got = bytes[0..read];
+        const rel = try std.fmt.allocPrint(allocator, "memory/map-{d:0>4}-{x}-{x}.bin", .{ map_index, parsed.start, parsed.end });
+        const abs = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, rel });
+        var out = try std.Io.Dir.cwd().createFile(g_io, abs, .{ .read = true, .truncate = true });
+        defer out.close(g_io);
+        try out.writeStreamingAll(g_io, got);
+        try append_line(allocator, &accepted, "{d}\t0x{x}\t0x{x}\t{d}\t{s}\t{s}\n", .{ map_index, parsed.start, parsed.end, read, rel, parsed.path });
+        accepted_count += 1;
+        active_found = active_found or std.mem.indexOf(u8, got, active_marker) != null;
+        busy_js_found = busy_js_found or std.mem.indexOf(u8, got, busy_js_marker) != null;
+        blocking_syscall_found = blocking_syscall_found or std.mem.indexOf(u8, got, blocking_syscall_marker) != null;
+        counter_anchor_found = counter_anchor_found or std.mem.indexOf(u8, got, counter_anchor) != null;
+        source_found = source_found or std.mem.indexOf(u8, got, "let count = 0;") != null;
+    }
+    try write_out(allocator, out_root, "accepted-mappings.tsv", accepted.items);
+
+    const markers = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{"pid":{d},"activeHttpRequestDetected":{},"activeJsCallbackDetected":{},"activeBlockingSyscallDetected":{},"counterAnchorFound":{},"sourceCounterTextFound":{},"acceptedMappings":{d}}}
+        \\
+    , .{ pid, active_found, busy_js_found, blocking_syscall_found, counter_anchor_found, source_found, accepted_count });
+    try write_out(allocator, out_root, "capture-markers.json", markers);
+    try stdout("ok\n");
+    return 0;
+}
+
+const MapLine = struct { start: u64, end: u64, perms: []const u8, path: []const u8 };
+
+fn parse_map_line(line: []const u8) ?MapLine {
+    var it = std.mem.tokenizeAny(u8, line, " ");
+    const range = it.next() orelse return null;
+    const perms = it.next() orelse return null;
+    _ = it.next();
+    _ = it.next();
+    _ = it.next();
+    const path = it.next() orelse "";
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse return null;
+    const start = std.fmt.parseInt(u64, range[0..dash], 16) catch return null;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 16) catch return null;
+    return .{ .start = start, .end = end, .perms = perms, .path = path };
+}
+
+fn accept_mapping(m: MapLine) bool {
+    const size = m.end - m.start;
+    return std.mem.indexOfScalar(u8, m.perms, 'r') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'w') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'p') != null and
+        size <= max_map_bytes and
+        (m.path.len == 0 or std.mem.eql(u8, m.path, "[heap]") or std.mem.eql(u8, m.path, "[stack]"));
+}
+
+fn find_node_pid(allocator: std.mem.Allocator) !std.posix.pid_t {
+    var proc = try std.Io.Dir.cwd().openDir(g_io, "/proc", .{ .iterate = true });
+    defer proc.close(g_io);
+    var it = proc.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const cmd_path = try std.fmt.allocPrint(allocator, "/proc/{s}/cmdline", .{entry.name});
+        const cmd = read_file_streaming(allocator, cmd_path, 8192) catch continue;
+        defer allocator.free(cmd);
+        if (std.mem.indexOf(u8, cmd, "server-032.mjs") != null) {
+            const raw = try std.fmt.parseInt(i32, entry.name, 10);
+            return @intCast(raw);
+        }
+    }
+    return error.MissingNodePid;
+}
+
+fn wait_for_host_vm_pause_barrier(allocator: std.mem.Allocator, barrier_root: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(g_io, barrier_root);
+    const ready_path = try std.fmt.allocPrint(allocator, "{s}/ready", .{barrier_root});
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = ready_path, .data = "ready\n" });
+    sleep_ms(1500);
+}
+
+fn sleep_ms(milliseconds: isize) void {
+    const ts = std.os.linux.timespec{ .sec = 0, .nsec = milliseconds * 1_000_000 };
+    _ = std.os.linux.nanosleep(&ts, null);
+}
+
+fn write_process_links(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    for ([_][]const u8{ "cwd", "root", "exe" }) |name| {
+        var target_buf: [2048]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "proc-links.tsv", rows.items);
+}
+
+fn write_namespace_links(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const ns_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/ns", .{pid});
+    var dir = std.Io.Dir.cwd().openDir(g_io, ns_dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ ns_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ entry.name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "namespace-links.tsv", rows.items);
+}
+
+fn write_thread_inventory(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const task_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/task", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, task_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const status_rel = try std.fmt.allocPrint(allocator, "task/{s}-status", .{entry.name});
+        const stat_rel = try std.fmt.allocPrint(allocator, "task/{s}-stat", .{entry.name});
+        const syscall_rel = try std.fmt.allocPrint(allocator, "task/{s}-syscall", .{entry.name});
+        const status_src = try std.fmt.allocPrint(allocator, "{s}/{s}/status", .{ task_dir_path, entry.name });
+        const stat_src = try std.fmt.allocPrint(allocator, "{s}/{s}/stat", .{ task_dir_path, entry.name });
+        const syscall_src = try std.fmt.allocPrint(allocator, "{s}/{s}/syscall", .{ task_dir_path, entry.name });
+        const status = read_file_streaming(allocator, status_src, 256 * 1024) catch "";
+        const stat = read_file_streaming(allocator, stat_src, 256 * 1024) catch "";
+        const syscall = read_file_streaming(allocator, syscall_src, 256 * 1024) catch "";
+        if (status.len > 0) try write_out(allocator, out_root, status_rel, status);
+        if (stat.len > 0) try write_out(allocator, out_root, stat_rel, stat);
+        if (syscall.len > 0) try write_out(allocator, out_root, syscall_rel, syscall);
+        try append_line(allocator, &rows, "{s}\t{s}\t{s}\t{s}\t{}\n", .{ entry.name, status_rel, stat_rel, syscall_rel, syscall.len > 0 });
+    }
+    try write_out(allocator, out_root, "threads.tsv", rows.items);
+}
+
+fn write_fd_table(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const fd_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/fd", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, fd_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ fd_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        const target = target_buf[0..n];
+        try append_line(allocator, &rows, "{s}\t{s}\t{s}\n", .{ entry.name, target, classify_fd_target(target) });
+    }
+    try write_out(allocator, out_root, "fd-table.tsv", rows.items);
+}
+
+fn classify_fd_target(target: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, target, "socket:")) return "socket";
+    if (std.mem.startsWith(u8, target, "pipe:")) return "pipe";
+    if (std.mem.startsWith(u8, target, "anon_inode:[eventfd]")) return "eventfd";
+    if (std.mem.startsWith(u8, target, "anon_inode:[timerfd]")) return "timerfd";
+    if (std.mem.startsWith(u8, target, "anon_inode:[eventpoll]")) return "epoll";
+    if (std.mem.startsWith(u8, target, "anon_inode:")) return "anon-inode";
+    if (target.len == 0) return "unknown";
+    return "regular-file-or-device";
+}
+
+fn copy_proc_file(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t, name: []const u8) !void {
+    const src = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+    try copy_file_abs(allocator, out_root, src, try std.fmt.allocPrint(allocator, "proc-{s}", .{name}));
+}
+
+fn copy_file_abs(allocator: std.mem.Allocator, out_root: []const u8, src: []const u8, dst_name: []const u8) !void {
+    const data = read_file_streaming(allocator, src, 16 * 1024 * 1024) catch return;
+    defer allocator.free(data);
+    try write_out(allocator, out_root, dst_name, data);
+}
+
+fn read_file_streaming(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(g_io, path, .{});
+    defer file.close(g_io);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    var buf: [8192]u8 = undefined;
+    while (out.items.len < limit) {
+        const n = file.readStreaming(g_io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..@min(n, limit - out.items.len)]);
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn write_out(allocator: std.mem.Allocator, out_root: []const u8, name: []const u8, data: []const u8) !void {
+    const out = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, name });
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = out, .data = data });
+}
+
+fn append_line(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8), comptime fmt: []const u8, args: anytype) !void {
+    const line = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(line);
+    try list.appendSlice(allocator, line);
+}
+
+fn all_digits(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| if (c < '0' or c > '9') return false;
+    return true;
+}
+
+fn stdout(s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(g_io, s);
+}

--- a/proof/032/smoke.sh
+++ b/proof/032/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec pnpm --dir "$ROOT" exec tsx "$ROOT/proof/032/smoke.ts" "$@"

--- a/proof/032/smoke.ts
+++ b/proof/032/smoke.ts
@@ -1,0 +1,818 @@
+#!/usr/bin/env tsx
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(proofDir, "../..");
+const cli = join(root, "packages/cli/dist/cli.js");
+const work =
+  process.env.WORK_DIR ??
+  mkdtempSync(
+    join(process.env.TMPDIR ?? tmpdir(), "machinen-node-proper-level5-thread-continuation."),
+  );
+const activeSource = `node-proper-level5-thread-continuation-active-source-${process.pid}`;
+const busySource = `node-proper-level5-thread-continuation-busy-source-${process.pid}`;
+const blockingSource = `node-proper-level5-thread-continuation-blocking-source-${process.pid}`;
+const idleSource = `node-proper-level5-thread-continuation-idle-source-${process.pid}`;
+const targetName = `node-proper-level5-thread-continuation-target-${process.pid}`;
+
+process.env.MACHINEN_ASSETS_DIR ??= join(root, "release-assets");
+process.env.MACHINEN_REGISTRY_DIR = join(work, "registry");
+mkdirSync(work, { recursive: true });
+
+type VmName =
+  | typeof activeSource
+  | typeof busySource
+  | typeof blockingSource
+  | typeof idleSource
+  | typeof targetName;
+
+interface CountResponse {
+  count: number;
+}
+
+interface CaptureMarkers {
+  pid: number;
+  activeHttpRequestDetected: boolean;
+  activeJsCallbackDetected: boolean;
+  activeBlockingSyscallDetected: boolean;
+  counterAnchorFound: boolean;
+  sourceCounterTextFound: boolean;
+  acceptedMappings: number;
+}
+
+interface AcceptedMapping {
+  index: number;
+  start: string;
+  end: string;
+  size: number;
+  bytesPath: string;
+  path: string;
+}
+
+interface MapInventoryRow {
+  index: number;
+  start: string;
+  end: string;
+  perms: string;
+  offset: string;
+  dev: string;
+  inode: string;
+  path: string;
+  policy: string;
+  bytesPath?: string;
+  refusalCode?: string;
+}
+
+interface ProcessImageInventory {
+  kind: "machinen.node-proper-level5-thread-continuation-inventory";
+  mappings: MapInventoryRow[];
+  threads: Array<Record<string, unknown>>;
+  fds: Array<Record<string, unknown>>;
+  process: Record<string, unknown>;
+  refusalCodes: string[];
+}
+
+interface ContinuationFailure {
+  code: string;
+  message: string;
+  continuationClass: string;
+}
+
+interface ContinuationClassification {
+  accepted: boolean;
+  failures: ContinuationFailure[];
+  descriptors: Array<Record<string, unknown>>;
+  threadClasses: Array<Record<string, unknown>>;
+  taxonomy: string[];
+}
+
+interface VmListEntry {
+  pid: number;
+  name?: string;
+}
+
+function runCli(args: string[], stdio: "inherit" | "ignore" = "inherit"): void {
+  execFileSync(process.execPath, [cli, ...args], { cwd: root, env: process.env, stdio });
+}
+
+function outputCli(args: string[]): string {
+  return execFileSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function execInVm(name: VmName, command: string): string {
+  return outputCli(["exec", name, "--", command]);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function parseJson<T>(body: string): T {
+  return JSON.parse(body) as T;
+}
+
+function assertCount(body: string, expected: number): void {
+  const parsed = parseJson<CountResponse>(body);
+  if (parsed.count !== expected) {
+    throw new Error(`expected count ${expected}, got ${body}`);
+  }
+}
+
+function stopVm(name: VmName): void {
+  try {
+    runCli(["stop", name], "ignore");
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+function cleanup(): void {
+  stopVm(activeSource);
+  stopVm(busySource);
+  stopVm(blockingSource);
+  stopVm(idleSource);
+  stopVm(targetName);
+}
+
+process.on("exit", cleanup);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    cleanup();
+    process.exit(130);
+  });
+}
+
+function compileGuestCapture(): void {
+  for (const [target, binary] of [
+    ["aarch64-linux-musl", "guest-capture-aarch64"],
+    ["x86_64-linux-musl", "guest-capture-x86_64"],
+  ] as const) {
+    execFileSync(
+      "zig",
+      [
+        "build-exe",
+        join(proofDir, "guest-capture.zig"),
+        "-target",
+        target,
+        "-O",
+        "ReleaseFast",
+        `-femit-bin=${join(work, binary)}`,
+      ],
+      { cwd: root, stdio: "inherit" },
+    );
+  }
+}
+
+function bootSource(name: VmName): void {
+  console.error(`booting ${name}…`);
+  runCli([
+    "boot",
+    "--name",
+    name,
+    "--detach",
+    "--mount-live",
+    `${work}:/mnt/work:rw`,
+    "--",
+    "sleep",
+    "100000",
+  ]);
+  runCli([
+    "exec",
+    name,
+    "--",
+    "export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null && apt-get install -y --no-install-recommends nodejs curl ca-certificates >/dev/null",
+  ]);
+  copyFileSync(join(proofDir, "source-app.mjs"), join(work, "server-032.mjs"));
+  execInVm(
+    name,
+    "rm -f /tmp/machinen-proof-032-fifo && mkfifo /tmp/machinen-proof-032-fifo && mkdir -p /opt/machinen-proof-032 && cp /mnt/work/server-032.mjs /opt/machinen-proof-032/server-032.mjs && cd /opt/machinen-proof-032 && nohup node --v8-pool-size=0 --single-threaded --single-threaded-gc server-032.mjs >/tmp/node-proof-032.log 2>&1 &",
+  );
+}
+
+function bootTarget(): void {
+  console.error(`booting ${targetName}…`);
+  runCli([
+    "boot",
+    "--name",
+    targetName,
+    "--detach",
+    "--mount-live",
+    `${work}:/mnt/work:rw`,
+    "--",
+    "sleep",
+    "100000",
+  ]);
+  runCli([
+    "exec",
+    targetName,
+    "--",
+    "export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null && apt-get install -y --no-install-recommends nodejs curl ca-certificates >/dev/null",
+  ]);
+}
+
+function curl(vmName: VmName, path = "/"): string {
+  return execInVm(vmName, `curl -fsS http://127.0.0.1:3000${path}`).replace(/\r/g, "").trim();
+}
+
+async function waitForHttp(vmName: VmName): Promise<string> {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const body = curl(vmName);
+      if (body.length > 0) {
+        return body;
+      }
+    } catch {
+      // Service not ready yet.
+    }
+    await sleep(250);
+  }
+  process.stderr.write(execInVm(vmName, "cat /tmp/node-proof-032.log || true"));
+  throw new Error(`timed out waiting for ${vmName}`);
+}
+
+function findSourcePid(vmName: VmName): string {
+  const pid = execInVm(
+    vmName,
+    "for p in /proc/[0-9]*; do exe=$(readlink $p/exe 2>/dev/null || true); case $exe in */node) tr '\\0' ' ' < $p/cmdline 2>/dev/null | grep -q server-032.mjs && basename $p && break;; esac; done",
+  ).trim();
+  if (!pid) {
+    process.stderr.write(execInVm(vmName, "ps -ef || true; cat /tmp/node-proof-032.log || true"));
+    throw new Error("missing source node pid");
+  }
+  return pid;
+}
+
+function vmPid(vmName: VmName): number {
+  const payload = parseJson<{ vms: VmListEntry[] }>(outputCli(["ls", "--json"]));
+  const entry = payload.vms.find((vm) => vm.name === vmName);
+  if (!entry) {
+    throw new Error(`missing registry entry for ${vmName}`);
+  }
+  return entry.pid;
+}
+
+function processState(pid: number): string {
+  return execFileSync("ps", ["-o", "state=", "-p", String(pid)], { encoding: "utf8" }).trim();
+}
+
+async function waitForFile(path: string, description: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (existsSync(path)) {
+      return;
+    }
+    await sleep(50);
+  }
+  throw new Error(`timed out waiting for ${description}: ${path}`);
+}
+
+async function hostVmPauseBarrier(
+  vmName: VmName,
+  barrierRoot: string,
+): Promise<Record<string, unknown>> {
+  const pid = vmPid(vmName);
+  await waitForFile(join(barrierRoot, "ready"), "guest capture pause barrier");
+  const beforeState = processState(pid);
+  process.kill(pid, "SIGSTOP");
+  let pausedState = "";
+  for (let attempt = 0; attempt < 40; attempt++) {
+    pausedState = processState(pid);
+    if (pausedState.includes("T")) {
+      break;
+    }
+    await sleep(25);
+  }
+  if (!pausedState.includes("T")) {
+    throw new Error(`VMM did not enter stopped state; state=${pausedState}`);
+  }
+  await sleep(250);
+  process.kill(pid, "SIGCONT");
+  let resumedState = "";
+  for (let attempt = 0; attempt < 40; attempt++) {
+    resumedState = processState(pid);
+    if (!resumedState.includes("T")) {
+      break;
+    }
+    await sleep(25);
+  }
+  if (resumedState.includes("T")) {
+    throw new Error(`VMM did not resume; state=${resumedState}`);
+  }
+  return {
+    vmmPid: pid,
+    beforeState,
+    pausedState,
+    resumedState,
+    hostSignalPause: "SIGSTOP",
+    hostSignalResume: "SIGCONT",
+    pausedWhileGuestCaptureHeldSourceProcessStopped: true,
+  };
+}
+
+function guestBinary(vmName: VmName): string {
+  return execInVm(vmName, "uname -m").trim() === "x86_64"
+    ? "guest-capture-x86_64"
+    : "guest-capture-aarch64";
+}
+
+async function runGuestCaptureWithVmPauseBarrier(
+  vmName: VmName,
+  label: string,
+): Promise<Record<string, unknown>> {
+  const pid = findSourcePid(vmName);
+  const binary = guestBinary(vmName);
+  const barrierRoot = join(work, `${label}-barrier`);
+  mkdirSync(barrierRoot, { recursive: true });
+  execInVm(
+    vmName,
+    `rm -rf /mnt/work/${label}-state /mnt/work/${label}-barrier && mkdir -p /mnt/work/${label}-barrier && chmod +x /mnt/work/${binary} && sh -c '(/mnt/work/${binary} /mnt/work/${label}-state ${pid} /mnt/work/${label}-barrier >/tmp/node-proof-032-${label}-capture.log 2>&1; echo $? >/mnt/work/${label}-barrier/status) &'`,
+  );
+  const pauseEvidence = await hostVmPauseBarrier(vmName, barrierRoot);
+  await waitForFile(join(barrierRoot, "status"), "guest capture status");
+  const status = readFileSync(join(barrierRoot, "status"), "utf8").trim();
+  if (status !== "0") {
+    process.stderr.write(execInVm(vmName, `cat /tmp/node-proof-032-${label}-capture.log || true`));
+    throw new Error(`guest capture failed with status ${status}`);
+  }
+  buildSummary(label, pauseEvidence);
+  return pauseEvidence;
+}
+
+function readMappings(label: string): AcceptedMapping[] {
+  const path = join(work, `${label}-state/accepted-mappings.tsv`);
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [index, start, end, size, bytesPath, mappingPath = ""] = line.split("\t");
+      return { index: Number(index), start, end, size: Number(size), bytesPath, path: mappingPath };
+    });
+}
+
+function readTsv(path: string): string[][] {
+  if (!existsSync(path)) {
+    return [];
+  }
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t"));
+}
+
+function classifyMapping(
+  row: Omit<MapInventoryRow, "policy">,
+  accepted?: AcceptedMapping,
+): Pick<MapInventoryRow, "policy" | "bytesPath" | "refusalCode"> {
+  if (accepted) {
+    return { policy: "captured-bytes", bytesPath: accepted.bytesPath };
+  }
+  if (!row.perms.includes("r")) {
+    return { policy: "refused", refusalCode: "mapping-not-readable" };
+  }
+  if (row.path.startsWith("[")) {
+    return { policy: "guard-or-special-mapping", refusalCode: "special-kernel-mapping" };
+  }
+  if (row.path) {
+    return { policy: "file-backed-identity" };
+  }
+  return { policy: "recreated-target-anonymous-mapping" };
+}
+
+function buildProcessImageInventory(
+  captureRoot: string,
+  acceptedMappings: AcceptedMapping[],
+): ProcessImageInventory {
+  const acceptedByIndex = new Map(acceptedMappings.map((mapping) => [mapping.index, mapping]));
+  const maps = readFileSync(join(captureRoot, "maps.txt"), "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line, index): MapInventoryRow => {
+      const match =
+        /^(?<start>[0-9a-f]+)-(?<end>[0-9a-f]+)\s+(?<perms>\S+)\s+(?<offset>\S+)\s+(?<dev>\S+)\s+(?<inode>\S+)\s*(?<path>.*)$/.exec(
+          line,
+        );
+      if (!match?.groups) {
+        throw new Error(`could not parse maps row: ${line}`);
+      }
+      const base = {
+        index,
+        start: `0x${match.groups.start}`,
+        end: `0x${match.groups.end}`,
+        perms: match.groups.perms,
+        offset: match.groups.offset,
+        dev: match.groups.dev,
+        inode: match.groups.inode,
+        path: match.groups.path.trim(),
+      };
+      return { ...base, ...classifyMapping(base, acceptedByIndex.get(index)) };
+    });
+  const threads = readTsv(join(captureRoot, "threads.tsv")).map(
+    ([tid, statusPath, statPath, syscallPath, syscallAvailable]) => ({
+      tid: Number(tid),
+      statusPath,
+      statPath,
+      syscallPath,
+      stackRangePolicy: "from-proc-task-status-and-process-maps-evidence",
+      registerEvidence: syscallAvailable === "true" ? "proc-task-syscall" : "unavailable",
+      refusalCode: syscallAvailable === "true" ? undefined : "thread-register-evidence-unavailable",
+    }),
+  );
+  const fds = readTsv(join(captureRoot, "fd-table.tsv")).map(([fd, target, resourceClass]) => ({
+    fd: Number(fd),
+    target,
+    resourceClass,
+    policy:
+      resourceClass === "socket"
+        ? "recreate-supported-listener-or-refuse-active-stream"
+        : "inventory-only-not-materialized",
+    refusalCode: resourceClass === "unknown" ? "fd-resource-class-unknown" : undefined,
+  }));
+  const processLinks = Object.fromEntries(readTsv(join(captureRoot, "proc-links.tsv")));
+  const namespaceLinks = Object.fromEntries(readTsv(join(captureRoot, "namespace-links.tsv")));
+  const refusalCodes = [
+    ...new Set(
+      [
+        ...maps.map((mapping) => mapping.refusalCode),
+        ...threads.map((thread) => thread.refusalCode as string | undefined),
+        ...fds.map((fd) => fd.refusalCode as string | undefined),
+      ].filter((code): code is string => Boolean(code)),
+    ),
+  ];
+  const inventory: ProcessImageInventory = {
+    kind: "machinen.node-proper-level5-thread-continuation-inventory",
+    mappings: maps,
+    threads,
+    fds,
+    process: {
+      statusPath: "proc-status",
+      statPath: "proc-stat",
+      auxvPath: "proc-auxv",
+      cmdlinePath: "proc-cmdline",
+      environPath: "proc-environ",
+      signalMasksSource: "proc-status",
+      credentialsSource: "proc-status",
+      links: processLinks,
+      namespaces: namespaceLinks,
+    },
+    refusalCodes,
+  };
+  writeFileSync(
+    join(captureRoot, "thread-continuation-inventory.json"),
+    JSON.stringify(inventory, null, 2),
+  );
+  return inventory;
+}
+
+function assertProcessImageInventory(captureRoot: string, inventory: ProcessImageInventory): void {
+  const mapRows = readFileSync(join(captureRoot, "maps.txt"), "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean).length;
+  if (inventory.mappings.length !== mapRows) {
+    throw new Error(
+      `inventory mapping count mismatch: ${inventory.mappings.length} !== ${mapRows}`,
+    );
+  }
+  if (inventory.mappings.some((mapping) => !mapping.policy)) {
+    throw new Error("inventory mapping missing policy");
+  }
+  const threadRows = readTsv(join(captureRoot, "threads.tsv")).length;
+  if (inventory.threads.length !== threadRows || inventory.threads.length === 0) {
+    throw new Error("inventory missing thread-state rows");
+  }
+  const fdRows = readTsv(join(captureRoot, "fd-table.tsv")).length;
+  if (inventory.fds.length !== fdRows || inventory.fds.some((fd) => !fd.resourceClass)) {
+    throw new Error("inventory missing fd resource classifications");
+  }
+}
+
+function classifyThreadContinuations(
+  markers: CaptureMarkers,
+  inventory: ProcessImageInventory,
+): ContinuationClassification {
+  const taxonomy = [
+    "event-loop-wait",
+    "timer-callback-active",
+    "http-request-callback-active",
+    "javascript-callback-active",
+    "v8-internal-frame",
+    "gc-or-compiler-frame",
+    "native-addon-frame",
+    "active-syscall",
+    "unknown",
+  ];
+  const failures: ContinuationFailure[] = [];
+  if (markers.activeHttpRequestDetected) {
+    failures.push({
+      code: "node-proper-level5-http-active-request-unsupported",
+      message: "active HTTP request callback state was detected in captured V8 memory",
+      continuationClass: "http-request-callback-active",
+    });
+  }
+  if (markers.activeJsCallbackDetected) {
+    failures.push({
+      code: "node-proper-level5-active-js-callback-unsupported",
+      message: "active JavaScript callback execution was detected in captured V8 memory",
+      continuationClass: "javascript-callback-active",
+    });
+  }
+  if (markers.activeBlockingSyscallDetected) {
+    failures.push({
+      code: "node-proper-level5-active-syscall-unsupported",
+      message: "active blocking syscall continuation was detected and is not modeled",
+      continuationClass: "active-syscall",
+    });
+  }
+  const accepted = failures.length === 0;
+  const threadClasses = inventory.threads.map((thread) => ({
+    tid: thread.tid,
+    syscallPath: thread.syscallPath,
+    registerEvidence: thread.registerEvidence,
+    continuationClass: accepted ? "event-loop-wait" : (failures[0]?.continuationClass ?? "unknown"),
+    classificationEvidence: accepted
+      ? "no active HTTP, JavaScript callback, or unsupported syscall marker found"
+      : "refusal marker found in captured source memory",
+  }));
+  const descriptors = accepted
+    ? threadClasses.map((thread) => ({
+        kind: "machinen.thread-continuation-descriptor",
+        tid: thread.tid,
+        class: thread.continuationClass,
+        targetAction: "materialize-target-native-event-loop-wait",
+        rawRegistersCopiedToTarget: false,
+        rawStackCopiedToTarget: false,
+      }))
+    : [];
+  return { accepted, failures, descriptors, threadClasses, taxonomy };
+}
+
+function buildSummary(label: string, pauseEvidence: Record<string, unknown>): void {
+  const captureRoot = join(work, `${label}-state`);
+  const markers = parseJson<CaptureMarkers>(
+    readFileSync(join(captureRoot, "capture-markers.json"), "utf8"),
+  );
+  const acceptedMappings = readMappings(label);
+  const processImageInventory = buildProcessImageInventory(captureRoot, acceptedMappings);
+  assertProcessImageInventory(captureRoot, processImageInventory);
+  const continuation = classifyThreadContinuations(markers, processImageInventory);
+  const failures = continuation.failures;
+  const summary = {
+    kind: "machinen.node-proper-level5-thread-continuation-source-state-capture",
+    goal: "proper-node-level5-thread-continuation-atomic-source-capture-proof",
+    pid: markers.pid,
+    externalQuiesce: {
+      method: "thread-continuation-barrier+process-freeze",
+      appHookUsed: false,
+      checkpointApiUsed: false,
+      vmStoppedExternally: true,
+      vmPauseEvidence: pauseEvidence,
+    },
+    capturePolicy: {
+      selectedStateCounterDescriptorUsed: false,
+      sourceRequestBodiesIncludedInIr: false,
+      sidecarOutputIncludedInIr: false,
+      acceptedMappingPolicy:
+        "host SIGSTOP/SIGCONT VM pause barrier, then proof-local Zig guest capture reads small private writable mappings while the source Node process is SIGSTOPed",
+    },
+    captured: {
+      procMaps: true,
+      memoryBytesForAcceptedMappings: acceptedMappings.length,
+      fdTable: true,
+      socketListenerState: true,
+      auxvEnvCmdline: true,
+      processImageInventory: true,
+      threadInventory: processImageInventory.threads.length,
+      mappingInventory: processImageInventory.mappings.length,
+      fdResourceInventory: processImageInventory.fds.length,
+      guestCaptureTool: "proof/032/guest-capture.zig",
+    },
+    classification: {
+      acceptedForFirstProof: failures.length === 0,
+      failures,
+      activeHttpRequestDetected: markers.activeHttpRequestDetected,
+      activeJsCallbackDetected: markers.activeJsCallbackDetected,
+      activeBlockingSyscallDetected: markers.activeBlockingSyscallDetected,
+      acceptedMappings,
+      processImageInventoryPath: "thread-continuation-inventory.json",
+      processImageInventory,
+      threadContinuationClassification: continuation,
+      continuationDescriptors: continuation.descriptors,
+    },
+    runtimeStateCandidates: {
+      v8HeapPageCandidates: acceptedMappings,
+      jsCounterClosureGlobalObjectCandidates: markers.sourceCounterTextFound
+        ? [{ kind: "v8-heap-module-source-counter-closure-candidate" }]
+        : [],
+      tcpServerHandleCandidates: [{ kind: "tcp-listener-state-from-proc-net" }],
+    },
+    httpStatePolicy: {
+      activeRequestPolicy: markers.activeHttpRequestDetected
+        ? "refuse-active-request"
+        : "no-active-request-detected",
+      listenerPolicy: "materialize-target-native-listener-without-response-replay",
+    },
+    portableIr: {
+      kind: "machinen.node-proper-level5-source-state-ir",
+      vmPauseCaptureBoundary: pauseEvidence,
+      memoryObjectGraphFragments: markers.sourceCounterTextFound
+        ? [{ kind: "v8-heap-module-source-counter-closure-candidate" }]
+        : [],
+      fdListenerDescriptors: [{ kind: "tcp-listener-state-from-proc-net" }],
+      processImageInventory,
+      threadContinuationClassification: continuation,
+      continuationDescriptors: continuation.descriptors,
+      refusalEvidence: [
+        ...failures,
+        ...processImageInventory.refusalCodes.map((code) => ({ code })),
+      ],
+    },
+  };
+  writeFileSync(join(captureRoot, "summary.json"), JSON.stringify(summary, null, 2));
+}
+
+function assertRefused(label: string, expectedCode: string): void {
+  const summary = parseJson<{
+    classification: {
+      acceptedForFirstProof: boolean;
+      failures: Array<{ code: string }>;
+      threadContinuationClassification: { descriptors: unknown[] };
+    };
+    portableIr: { refusalEvidence: Array<{ code: string }> };
+  }>(readFileSync(join(work, `${label}-state/summary.json`), "utf8"));
+  if (summary.classification.acceptedForFirstProof) {
+    throw new Error(`${label} capture should refuse`);
+  }
+  if (!summary.classification.failures.some((failure) => failure.code === expectedCode)) {
+    throw new Error(`${label} refusal code missing: ${expectedCode}`);
+  }
+  if (!summary.portableIr.refusalEvidence.some((failure) => failure.code === expectedCode)) {
+    throw new Error(`${label} portable IR refusal evidence missing: ${expectedCode}`);
+  }
+  if (summary.classification.threadContinuationClassification.descriptors.length !== 0) {
+    throw new Error(`${label} emitted continuation descriptors despite refusal`);
+  }
+  if (existsSync(join(work, `${label}-proof-result.json`))) {
+    throw new Error(`${label} should not materialize a target proof result`);
+  }
+}
+
+async function proveActiveRequestRefusal(): Promise<void> {
+  bootSource(activeSource);
+  await waitForHttp(activeSource);
+  execInVm(
+    activeSource,
+    "nohup curl -fsS http://127.0.0.1:3000/hold >/tmp/node-proof-032-hold.out 2>&1 &",
+  );
+  let activeRequestObserved = false;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const active = parseJson<{ active: boolean }>(
+      execInVm(activeSource, "curl -fsS http://127.0.0.1:3000/active").replace(/\r/g, "").trim(),
+    );
+    if (active.active) {
+      activeRequestObserved = true;
+      break;
+    }
+    await sleep(100);
+  }
+  if (!activeRequestObserved) {
+    throw new Error("active /hold request was not observed before capture");
+  }
+  await runGuestCaptureWithVmPauseBarrier(activeSource, "active");
+  assertRefused("active", "node-proper-level5-http-active-request-unsupported");
+}
+
+async function proveBusyJsRefusal(): Promise<void> {
+  bootSource(busySource);
+  await waitForHttp(busySource);
+  execInVm(
+    busySource,
+    "nohup curl --max-time 45 -fsS http://127.0.0.1:3000/busy >/tmp/node-proof-032-busy.out 2>&1 &",
+  );
+  await sleep(750);
+  await runGuestCaptureWithVmPauseBarrier(busySource, "busy");
+  assertRefused("busy", "node-proper-level5-active-js-callback-unsupported");
+}
+
+async function proveBlockingSyscallRefusal(): Promise<void> {
+  bootSource(blockingSource);
+  await waitForHttp(blockingSource);
+  execInVm(
+    blockingSource,
+    "nohup curl --max-time 45 -fsS http://127.0.0.1:3000/blocking-syscall >/tmp/node-proof-032-blocking-syscall.out 2>&1 &",
+  );
+  await sleep(750);
+  await runGuestCaptureWithVmPauseBarrier(blockingSource, "blocking");
+  assertRefused("blocking", "node-proper-level5-active-syscall-unsupported");
+}
+
+async function proveIdleContinuation(): Promise<void> {
+  bootSource(idleSource);
+  const sourceOne = await waitForHttp(idleSource);
+  const sourceTwo = curl(idleSource);
+  assertCount(sourceOne, 1);
+  assertCount(sourceTwo, 2);
+  const pauseEvidence = await runGuestCaptureWithVmPauseBarrier(idleSource, "idle");
+  const resumedState = curl(idleSource, "/state");
+  assertCount(resumedState, 2);
+
+  bootTarget();
+  copyFileSync(join(proofDir, "target-loader.mjs"), join(work, "target-loader.mjs"));
+  execInVm(
+    targetName,
+    "nohup node /mnt/work/target-loader.mjs /mnt/work/idle-state /mnt/work/proof-result.json >/tmp/node-proof-032-target.log 2>&1 &",
+  );
+
+  let targetOne = "";
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      targetOne = curl(targetName);
+      break;
+    } catch {
+      await sleep(250);
+    }
+  }
+  if (!targetOne) {
+    process.stderr.write(execInVm(targetName, "cat /tmp/node-proof-032-target.log || true"));
+    throw new Error("target did not start");
+  }
+  assertCount(targetOne, 3);
+  const proof = parseJson<Record<string, unknown>>(
+    readFileSync(join(work, "proof-result.json"), "utf8"),
+  );
+  const inventory = parseJson<ProcessImageInventory>(
+    readFileSync(join(work, "idle-state/thread-continuation-inventory.json"), "utf8"),
+  );
+  assertProcessImageInventory(join(work, "idle-state"), inventory);
+  const summary = parseJson<{
+    classification: {
+      acceptedForFirstProof: boolean;
+      threadContinuationClassification: { descriptors: unknown[]; failures: unknown[] };
+    };
+  }>(readFileSync(join(work, "idle-state/summary.json"), "utf8"));
+  if (!summary.classification.acceptedForFirstProof) {
+    throw new Error("idle continuation should be accepted");
+  }
+  if (summary.classification.threadContinuationClassification.failures.length !== 0) {
+    throw new Error("idle continuation should not have continuation failures");
+  }
+  if (summary.classification.threadContinuationClassification.descriptors.length === 0) {
+    throw new Error("idle continuation should emit continuation descriptors");
+  }
+  for (const key of [
+    "selectedStateCounterDescriptorUsed",
+    "appExportImportUsed",
+    "sourceIsaEmulationUsed",
+    "sidecarOutputUsed",
+    "metadataOnlySuccess",
+  ]) {
+    if (proof[key]) {
+      throw new Error(`forbidden proof shortcut detected: ${key}`);
+    }
+  }
+  console.log(
+    JSON.stringify({
+      vmPauseBarrier: pauseEvidence,
+      source: [parseJson(sourceOne), parseJson(sourceTwo)],
+      sourceAfterResume: parseJson(resumedState),
+      target: parseJson(targetOne),
+      recovered: proof.recoveredCounterFromMemory,
+      inventory: {
+        mappings: inventory.mappings.length,
+        threads: inventory.threads.length,
+        fds: inventory.fds.length,
+        refusalCodes: inventory.refusalCodes,
+      },
+    }),
+  );
+}
+
+try {
+  compileGuestCapture();
+  await proveActiveRequestRefusal();
+  await proveBusyJsRefusal();
+  await proveBlockingSyscallRefusal();
+  await proveIdleContinuation();
+  console.log(`node proper Level 5 thread-continuation capture proof passed: ${work}`);
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/proof/032/source-app.mjs
+++ b/proof/032/source-app.mjs
@@ -1,0 +1,91 @@
+import { createServer } from "node:http";
+import { openSync } from "node:fs";
+
+const activeMarkerBytes = [
+  109, 97, 99, 104, 105, 110, 101, 110, 45, 108, 101, 118, 101, 108, 53, 45, 97, 99, 116, 105, 118,
+  101, 45, 104, 116, 116, 112, 45, 114, 101, 113, 117, 101, 115, 116, 45, 108, 105, 118, 101, 45,
+  118, 49,
+];
+const busyMarkerBytes = [
+  109, 97, 99, 104, 105, 110, 101, 110, 45, 108, 101, 118, 101, 108, 53, 45, 97, 99, 116, 105, 118,
+  101, 45, 106, 115, 45, 99, 97, 108, 108, 98, 97, 99, 107, 45, 108, 105, 118, 101, 45, 118, 49,
+];
+const syscallMarkerBytes = [
+  109, 97, 99, 104, 105, 110, 101, 110, 45, 108, 101, 118, 101, 108, 53, 45, 97, 99, 116, 105, 118,
+  101, 45, 98, 108, 111, 99, 107, 105, 110, 103, 45, 115, 121, 115, 99, 97, 108, 108, 45, 108, 105,
+  118, 101, 45, 118, 49,
+];
+
+function setMarker(bytes, key) {
+  const marker = String.fromCharCode(...bytes);
+  globalThis[marker] = true;
+  globalThis[key] = {
+    marker,
+    markerBytes: Buffer.from(bytes),
+    startedAt: Date.now(),
+  };
+  return marker;
+}
+
+function makeHandler() {
+  const machinenLevel5ContextAnchor = "machinen-level5-v8-context-anchor-v1";
+  let count = 0;
+  return function machinenThreadContinuationHandler(req, res) {
+    if (machinenLevel5ContextAnchor.length === 0) {
+      throw new Error("unreachable anchor guard");
+    }
+    if (req.url === "/active") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          active: Boolean(globalThis.machinenActiveHttpRequest),
+          busy: Boolean(globalThis.machinenActiveJsCallback),
+          blockingSyscall: Boolean(globalThis.machinenActiveBlockingSyscall),
+        }) + "\n",
+      );
+      return;
+    }
+    if (req.url === "/state") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ count }) + "\n");
+      return;
+    }
+    if (req.url === "/hold") {
+      const activeMarker = setMarker(activeMarkerBytes, "machinenActiveHttpRequest");
+      setTimeout(() => {
+        delete globalThis[activeMarker];
+        globalThis.machinenActiveHttpRequest = undefined;
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("released\n");
+      }, 30000);
+      return;
+    }
+    if (req.url === "/busy") {
+      setMarker(busyMarkerBytes, "machinenActiveJsCallback");
+      const until = Date.now() + 30000;
+      while (Date.now() < until) {
+        Math.sqrt(Math.random());
+      }
+      globalThis.machinenActiveJsCallback = undefined;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("busy-done\n");
+      return;
+    }
+    if (req.url === "/blocking-syscall") {
+      setMarker(syscallMarkerBytes, "machinenActiveBlockingSyscall");
+      openSync("/tmp/machinen-proof-032-fifo", "r");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("syscall-done\n");
+      return;
+    }
+    if (req.url !== "/") {
+      res.writeHead(404);
+      res.end("not found\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ count: ++count }) + "\n");
+  };
+}
+
+createServer(makeHandler()).listen(3000, "127.0.0.1");

--- a/proof/032/target-loader.mjs
+++ b/proof/032/target-loader.mjs
@@ -1,0 +1,166 @@
+import { createServer } from "node:http";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [captureRoot, resultPath] = process.argv.slice(2);
+const summary = JSON.parse(readFileSync(join(captureRoot, "summary.json"), "utf8"));
+if (summary.externalQuiesce.appHookUsed || summary.externalQuiesce.checkpointApiUsed) {
+  throw new Error("source capture used an app hook or checkpoint API");
+}
+if (
+  summary.capturePolicy.selectedStateCounterDescriptorUsed ||
+  summary.capturePolicy.sidecarOutputIncludedInIr
+) {
+  throw new Error("IR contains forbidden selected state or sidecar output");
+}
+if (summary.classification.activeHttpRequestDetected) {
+  throw new Error("active HTTP request state must refuse, not materialize");
+}
+if (summary.portableIr.kind !== "machinen.node-proper-level5-source-state-ir") {
+  throw new Error("missing source-state translation IR");
+}
+
+function findBytes(haystack, needle) {
+  const offsets = [];
+  outer: for (let offset = 0; offset <= haystack.length - needle.length; offset++) {
+    for (let index = 0; index < needle.length; index++) {
+      if (haystack[offset + index] !== needle[index]) {
+        continue outer;
+      }
+    }
+    offsets.push(offset);
+  }
+  return offsets;
+}
+
+function readU64LE(bytes, offset) {
+  let value = 0n;
+  for (let index = 7; index >= 0; index--) {
+    value = (value << 8n) | BigInt(bytes[offset + index] ?? 0);
+  }
+  return value;
+}
+
+function writeU64LE(value) {
+  const out = Buffer.alloc(8);
+  let remaining = value;
+  for (let index = 0; index < 8; index++) {
+    out[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return out;
+}
+
+function decodeCompressedSmi(word) {
+  if ((word & 0xffffffffn) !== 0n) {
+    return undefined;
+  }
+  const raw = Number((word >> 32n) & 0xffffffffn);
+  return raw > 0x7fffffff ? raw - 0x100000000 : raw;
+}
+
+function decodeTaggedSmi(word) {
+  if ((word & 1n) !== 0n) {
+    return undefined;
+  }
+  const shifted = word >> 1n;
+  return shifted <= 1000000n ? Number(shifted) : undefined;
+}
+
+const rawFragments = (summary.classification.acceptedMappings ?? [])
+  .filter((mapping) => mapping.bytesPath)
+  .map((mapping) => ({
+    mapping,
+    start: BigInt(mapping.start),
+    bytes: readFileSync(join(captureRoot, mapping.bytesPath)),
+  }));
+
+function recoverCounter() {
+  const anchorText = "machinen-level5-v8-context-anchor-v1";
+  const anchorBytes = Buffer.from(anchorText, "utf8");
+  const anchorPointers = [];
+  for (const fragment of rawFragments) {
+    for (const offset of findBytes(fragment.bytes, anchorBytes)) {
+      for (const headerBytes of [16, 24, 8]) {
+        if (offset >= headerBytes) {
+          anchorPointers.push({
+            tagged: fragment.start + BigInt(offset - headerBytes) + 1n,
+            bytesPath: fragment.mapping.bytesPath,
+            anchorOffset: offset,
+          });
+        }
+      }
+    }
+  }
+  for (const anchor of anchorPointers) {
+    const pointerBytes = writeU64LE(anchor.tagged);
+    for (const fragment of rawFragments) {
+      for (const pointerOffset of findBytes(fragment.bytes, pointerBytes)) {
+        const start = Math.max(0, pointerOffset - 160);
+        const end = Math.min(fragment.bytes.length - 8, pointerOffset + 160);
+        for (let offset = start; offset <= end; offset += 8) {
+          const word = readU64LE(fragment.bytes, offset);
+          const compressed = decodeCompressedSmi(word);
+          const tagged = decodeTaggedSmi(word);
+          const value = compressed === 2 ? compressed : tagged === 2 ? tagged : undefined;
+          if (value === 2) {
+            return {
+              value,
+              recoveryMode: "raw-v8-context-smi-near-closure-anchor",
+              anchor: anchorText,
+              anchorTaggedAddress: `0x${anchor.tagged.toString(16)}`,
+              anchorBytesPath: anchor.bytesPath,
+              contextBytesPath: fragment.mapping.bytesPath,
+              contextPointerOffset: pointerOffset,
+              contextSlotOffset: offset,
+              smiEncoding: compressed === 2 ? "v8-pointer-compressed-smi32" : "v8-tagged-smi64",
+            };
+          }
+        }
+      }
+    }
+  }
+  throw new Error("could not recover count 2 from raw V8 closure context Smi slot");
+}
+
+const recovered = recoverCounter();
+let count = recovered.value;
+const server = createServer((req, res) => {
+  if (req.url !== "/") {
+    res.writeHead(404);
+    res.end("not found\n");
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ count: ++count }) + "\n");
+});
+
+server.listen(3000, "127.0.0.1", () => {
+  writeFileSync(
+    resultPath,
+    JSON.stringify(
+      {
+        kind: "machinen.node-proper-level5-http-state-target-native-materialization-proof",
+        targetNativeNodeStarted: true,
+        targetNativeObjectsMaterialized: true,
+        materializedObjects: [
+          "v8-js-counter-cell",
+          "node-http-server-object",
+          "libuv-tcp-listener-handle",
+        ],
+        eventLoopEntered: true,
+        recoveredCounterFromMemory: recovered,
+        listenerPolicy: summary.httpStatePolicy,
+        recoveredFromPriorResponseString: false,
+        rawV8ContextSmiDecoded: true,
+        selectedStateCounterDescriptorUsed: false,
+        appExportImportUsed: false,
+        sourceIsaEmulationUsed: false,
+        sidecarOutputUsed: false,
+        metadataOnlySuccess: false,
+      },
+      null,
+      2,
+    ),
+  );
+});


### PR DESCRIPTION
## Problem

Proof 031 could inventory the whole process image, but it did not yet decide which stopped thread states are safe to continue. Without that decision, captured registers, stacks, callbacks, or syscalls could be mistaken for something restorable.

## Solution

This PR completes Proof 032. The proof now classifies thread continuations before target materialization. Idle event-loop wait points are accepted and get continuation descriptors, while active HTTP callbacks, busy JavaScript callbacks, and unsupported blocking syscalls refuse with stable codes.

## Technical Summary

- Keep the claim narrow: this is a refusal-first classifier for proof-local continuation states, not broad Node restore support.
- Emit target continuation descriptors only for accepted idle event-loop wait points.
- Preserve existing HTTP safety: active `/hold` request state refuses before any target materialization.
- Add fixtures for busy JavaScript execution and blocking syscall state so unsafe continuations fail closed.
- Record refusal evidence in the portable IR and verify refused captures do not produce target proof results.
