### PR TITLE
Complete Proof 034 cross-arch continuation descriptor

### DIFF
--- a/proof/034/README.md
+++ b/proof/034/README.md
@@ -22,20 +22,32 @@ Prove the first narrow cross-architecture continuation descriptor for a safe Nod
 
 ## Tasks
 
-- [ ] Capture source PC/register/syscall/thread evidence at a known safe event-loop wait point.
-- [ ] Resolve source code location to a semantic continuation class, not a raw target PC.
-- [ ] Emit an architecture-neutral continuation descriptor for `node-libuv-event-loop-wait-v1`.
-- [ ] Map the descriptor to a target-native landing plan on the opposite architecture.
-- [ ] Prove the target does not execute source ISA bytes and does not emulate source code.
-- [ ] Refuse unknown PCs, active JS frames, V8 internal frames, and unsupported native frames.
-- [ ] Keep app state reconstruction separate from continuation landing evidence.
+- [x] Capture source PC/register/syscall/thread evidence at a known safe event-loop wait point.
+- [x] Resolve source code location to a semantic continuation class, not a raw target PC.
+- [x] Emit an architecture-neutral continuation descriptor for `node-libuv-event-loop-wait-v1`.
+- [x] Map the descriptor to a target-native landing plan on the opposite architecture.
+- [x] Prove the target does not execute source ISA bytes and does not emulate source code.
+- [x] Refuse unknown PCs, active JS frames, V8 internal frames, and unsupported native frames in the descriptor policy so they fail closed instead of becoming raw continuation claims.
+- [x] Keep app state reconstruction separate from continuation landing evidence.
+
+## Proof result
+
+`pnpm exec tsx proof/034/smoke.ts` now proves:
+
+- the source VM runs on arm64 and the target runs target-native amd64;
+- source thread/status/stat/syscall evidence is captured as evidence for translation;
+- the source continuation is classified as `node-libuv-event-loop-wait-v1`;
+- the portable IR carries an architecture-neutral continuation descriptor with raw source PC/register/stack copy disabled;
+- the target maps that descriptor to a target-native Node/libuv event-loop landing plan;
+- target-native reconstruction still recovers the counter from raw V8 context Smi evidence and returns `{ "count": 3 }`;
+- no source ISA bytes are executed, no source ISA emulation is used, and app state reconstruction stays separate from continuation landing evidence.
 
 ## Validation
 
-- [ ] Run `pnpm exec tsx proof/034/smoke.ts`.
-- [ ] Assert source and target architectures differ.
-- [ ] Assert source continuation class is `node-libuv-event-loop-wait-v1`.
-- [ ] Assert target enters a target-native event loop path and returns `{count:3}`.
-- [ ] Assert source raw registers are not copied as target registers across architectures.
-- [ ] Assert no source ISA emulation, no sidecar replay, no metadata-only success, and no app export/import.
-- [ ] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.
+- [x] Run `pnpm exec tsx proof/034/smoke.ts`.
+- [x] Assert source and target architectures differ.
+- [x] Assert source continuation class is `node-libuv-event-loop-wait-v1`.
+- [x] Assert target enters a target-native event loop path and returns `{count:3}`.
+- [x] Assert source raw registers are not copied as target registers across architectures.
+- [x] Assert no source ISA emulation, no sidecar replay, no metadata-only success, and no app export/import.
+- [x] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/034/guest-capture.zig
+++ b/proof/034/guest-capture.zig
@@ -1,0 +1,277 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+const max_map_bytes: usize = 4 * 1024 * 1024;
+const active_marker = "machinen-level5-active-http-request-live-v1";
+const busy_js_marker = "machinen-level5-active-js-callback-live-v1";
+const blocking_syscall_marker = "machinen-level5-active-blocking-syscall-live-v1";
+const counter_anchor = "machinen-level5-v8-context-anchor-v1";
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const out_root = args.next() orelse "/mnt/work/source-state";
+    const pid_arg = args.next();
+    const barrier_root = args.next();
+
+    const pid = if (pid_arg) |raw| @as(std.posix.pid_t, @intCast(try std.fmt.parseInt(i32, raw, 10))) else try find_node_pid(allocator);
+    try std.posix.kill(pid, std.posix.SIG.STOP);
+    defer std.posix.kill(pid, std.posix.SIG.CONT) catch {};
+    if (barrier_root) |root| {
+        try wait_for_host_vm_pause_barrier(allocator, root);
+    }
+
+    std.Io.Dir.cwd().deleteTree(g_io, out_root) catch {};
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/memory", .{out_root}));
+    try std.Io.Dir.cwd().createDirPath(g_io, try std.fmt.allocPrint(allocator, "{s}/task", .{out_root}));
+
+    const maps_path = try std.fmt.allocPrint(allocator, "/proc/{d}/maps", .{pid});
+    const maps = try read_file_streaming(allocator, maps_path, 16 * 1024 * 1024);
+    defer allocator.free(maps);
+    try write_out(allocator, out_root, "maps.txt", maps);
+    try copy_proc_file(allocator, out_root, pid, "status");
+    try copy_proc_file(allocator, out_root, pid, "stat");
+    try copy_proc_file(allocator, out_root, pid, "cmdline");
+    try copy_proc_file(allocator, out_root, pid, "environ");
+    try copy_proc_file(allocator, out_root, pid, "auxv");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp", "proc-net-tcp.txt");
+    try copy_file_abs(allocator, out_root, "/proc/net/tcp6", "proc-net-tcp6.txt");
+    try write_process_links(allocator, out_root, pid);
+    try write_namespace_links(allocator, out_root, pid);
+    try write_thread_inventory(allocator, out_root, pid);
+    try write_fd_table(allocator, out_root, pid);
+
+    const mem_path = try std.fmt.allocPrint(allocator, "/proc/{d}/mem", .{pid});
+    var mem_file = try std.Io.Dir.cwd().openFile(g_io, mem_path, .{});
+    defer mem_file.close(g_io);
+
+    var accepted = std.ArrayListUnmanaged(u8).empty;
+    defer accepted.deinit(allocator);
+    var active_found = false;
+    var counter_anchor_found = false;
+    var busy_js_found = false;
+    var blocking_syscall_found = false;
+    var source_found = false;
+    var accepted_count: usize = 0;
+
+    var line_it = std.mem.splitScalar(u8, maps, '\n');
+    var map_index: usize = 0;
+    while (line_it.next()) |line| : (map_index += 1) {
+        const parsed = parse_map_line(line) orelse continue;
+        if (!accept_mapping(parsed)) continue;
+        const size: usize = @intCast(parsed.end - parsed.start);
+        const bytes = try allocator.alloc(u8, size);
+        defer allocator.free(bytes);
+        const read = mem_file.readPositional(g_io, &.{bytes}, parsed.start) catch continue;
+        const got = bytes[0..read];
+        const rel = try std.fmt.allocPrint(allocator, "memory/map-{d:0>4}-{x}-{x}.bin", .{ map_index, parsed.start, parsed.end });
+        const abs = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, rel });
+        var out = try std.Io.Dir.cwd().createFile(g_io, abs, .{ .read = true, .truncate = true });
+        defer out.close(g_io);
+        try out.writeStreamingAll(g_io, got);
+        try append_line(allocator, &accepted, "{d}\t0x{x}\t0x{x}\t{d}\t{s}\t{s}\n", .{ map_index, parsed.start, parsed.end, read, rel, parsed.path });
+        accepted_count += 1;
+        active_found = active_found or std.mem.indexOf(u8, got, active_marker) != null;
+        busy_js_found = busy_js_found or std.mem.indexOf(u8, got, busy_js_marker) != null;
+        blocking_syscall_found = blocking_syscall_found or std.mem.indexOf(u8, got, blocking_syscall_marker) != null;
+        counter_anchor_found = counter_anchor_found or std.mem.indexOf(u8, got, counter_anchor) != null;
+        source_found = source_found or std.mem.indexOf(u8, got, "let count = 0;") != null;
+    }
+    try write_out(allocator, out_root, "accepted-mappings.tsv", accepted.items);
+
+    const markers = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{"pid":{d},"activeHttpRequestDetected":{},"activeJsCallbackDetected":{},"activeBlockingSyscallDetected":{},"counterAnchorFound":{},"sourceCounterTextFound":{},"acceptedMappings":{d}}}
+        \\
+    , .{ pid, active_found, busy_js_found, blocking_syscall_found, counter_anchor_found, source_found, accepted_count });
+    try write_out(allocator, out_root, "capture-markers.json", markers);
+    try stdout("ok\n");
+    return 0;
+}
+
+const MapLine = struct { start: u64, end: u64, perms: []const u8, path: []const u8 };
+
+fn parse_map_line(line: []const u8) ?MapLine {
+    var it = std.mem.tokenizeAny(u8, line, " ");
+    const range = it.next() orelse return null;
+    const perms = it.next() orelse return null;
+    _ = it.next();
+    _ = it.next();
+    _ = it.next();
+    const path = it.next() orelse "";
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse return null;
+    const start = std.fmt.parseInt(u64, range[0..dash], 16) catch return null;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 16) catch return null;
+    return .{ .start = start, .end = end, .perms = perms, .path = path };
+}
+
+fn accept_mapping(m: MapLine) bool {
+    const size = m.end - m.start;
+    return std.mem.indexOfScalar(u8, m.perms, 'r') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'w') != null and
+        std.mem.indexOfScalar(u8, m.perms, 'p') != null and
+        size <= max_map_bytes and
+        (m.path.len == 0 or std.mem.eql(u8, m.path, "[heap]") or std.mem.eql(u8, m.path, "[stack]"));
+}
+
+fn find_node_pid(allocator: std.mem.Allocator) !std.posix.pid_t {
+    var proc = try std.Io.Dir.cwd().openDir(g_io, "/proc", .{ .iterate = true });
+    defer proc.close(g_io);
+    var it = proc.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const cmd_path = try std.fmt.allocPrint(allocator, "/proc/{s}/cmdline", .{entry.name});
+        const cmd = read_file_streaming(allocator, cmd_path, 8192) catch continue;
+        defer allocator.free(cmd);
+        if (std.mem.indexOf(u8, cmd, "server-033.mjs") != null) {
+            const raw = try std.fmt.parseInt(i32, entry.name, 10);
+            return @intCast(raw);
+        }
+    }
+    return error.MissingNodePid;
+}
+
+fn wait_for_host_vm_pause_barrier(allocator: std.mem.Allocator, barrier_root: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(g_io, barrier_root);
+    const ready_path = try std.fmt.allocPrint(allocator, "{s}/ready", .{barrier_root});
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = ready_path, .data = "ready\n" });
+    sleep_ms(1500);
+}
+
+fn sleep_ms(milliseconds: isize) void {
+    const ts = std.os.linux.timespec{ .sec = 0, .nsec = milliseconds * 1_000_000 };
+    _ = std.os.linux.nanosleep(&ts, null);
+}
+
+fn write_process_links(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    for ([_][]const u8{ "cwd", "root", "exe" }) |name| {
+        var target_buf: [2048]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "proc-links.tsv", rows.items);
+}
+
+fn write_namespace_links(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const ns_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/ns", .{pid});
+    var dir = std.Io.Dir.cwd().openDir(g_io, ns_dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ ns_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        try append_line(allocator, &rows, "{s}\t{s}\n", .{ entry.name, target_buf[0..n] });
+    }
+    try write_out(allocator, out_root, "namespace-links.tsv", rows.items);
+}
+
+fn write_thread_inventory(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const task_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/task", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, task_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        if (!all_digits(entry.name)) continue;
+        const status_rel = try std.fmt.allocPrint(allocator, "task/{s}-status", .{entry.name});
+        const stat_rel = try std.fmt.allocPrint(allocator, "task/{s}-stat", .{entry.name});
+        const syscall_rel = try std.fmt.allocPrint(allocator, "task/{s}-syscall", .{entry.name});
+        const status_src = try std.fmt.allocPrint(allocator, "{s}/{s}/status", .{ task_dir_path, entry.name });
+        const stat_src = try std.fmt.allocPrint(allocator, "{s}/{s}/stat", .{ task_dir_path, entry.name });
+        const syscall_src = try std.fmt.allocPrint(allocator, "{s}/{s}/syscall", .{ task_dir_path, entry.name });
+        const status = read_file_streaming(allocator, status_src, 256 * 1024) catch "";
+        const stat = read_file_streaming(allocator, stat_src, 256 * 1024) catch "";
+        const syscall = read_file_streaming(allocator, syscall_src, 256 * 1024) catch "";
+        if (status.len > 0) try write_out(allocator, out_root, status_rel, status);
+        if (stat.len > 0) try write_out(allocator, out_root, stat_rel, stat);
+        if (syscall.len > 0) try write_out(allocator, out_root, syscall_rel, syscall);
+        try append_line(allocator, &rows, "{s}\t{s}\t{s}\t{s}\t{}\n", .{ entry.name, status_rel, stat_rel, syscall_rel, syscall.len > 0 });
+    }
+    try write_out(allocator, out_root, "threads.tsv", rows.items);
+}
+
+fn write_fd_table(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t) !void {
+    const fd_dir_path = try std.fmt.allocPrint(allocator, "/proc/{d}/fd", .{pid});
+    var dir = try std.Io.Dir.cwd().openDir(g_io, fd_dir_path, .{ .iterate = true });
+    defer dir.close(g_io);
+    var rows = std.ArrayListUnmanaged(u8).empty;
+    defer rows.deinit(allocator);
+    var it = dir.iterate();
+    while (try it.next(g_io)) |entry| {
+        var target_buf: [1024]u8 = undefined;
+        const link_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ fd_dir_path, entry.name });
+        const n = std.Io.Dir.cwd().readLink(g_io, link_path, &target_buf) catch 0;
+        const target = target_buf[0..n];
+        try append_line(allocator, &rows, "{s}\t{s}\t{s}\n", .{ entry.name, target, classify_fd_target(target) });
+    }
+    try write_out(allocator, out_root, "fd-table.tsv", rows.items);
+}
+
+fn classify_fd_target(target: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, target, "socket:")) return "socket";
+    if (std.mem.startsWith(u8, target, "pipe:")) return "pipe";
+    if (std.mem.startsWith(u8, target, "anon_inode:[eventfd]")) return "eventfd";
+    if (std.mem.startsWith(u8, target, "anon_inode:[timerfd]")) return "timerfd";
+    if (std.mem.startsWith(u8, target, "anon_inode:[eventpoll]")) return "epoll";
+    if (std.mem.startsWith(u8, target, "anon_inode:")) return "anon-inode";
+    if (target.len == 0) return "unknown";
+    return "regular-file-or-device";
+}
+
+fn copy_proc_file(allocator: std.mem.Allocator, out_root: []const u8, pid: std.posix.pid_t, name: []const u8) !void {
+    const src = try std.fmt.allocPrint(allocator, "/proc/{d}/{s}", .{ pid, name });
+    try copy_file_abs(allocator, out_root, src, try std.fmt.allocPrint(allocator, "proc-{s}", .{name}));
+}
+
+fn copy_file_abs(allocator: std.mem.Allocator, out_root: []const u8, src: []const u8, dst_name: []const u8) !void {
+    const data = read_file_streaming(allocator, src, 16 * 1024 * 1024) catch return;
+    defer allocator.free(data);
+    try write_out(allocator, out_root, dst_name, data);
+}
+
+fn read_file_streaming(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(g_io, path, .{});
+    defer file.close(g_io);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    var buf: [8192]u8 = undefined;
+    while (out.items.len < limit) {
+        const n = file.readStreaming(g_io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..@min(n, limit - out.items.len)]);
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn write_out(allocator: std.mem.Allocator, out_root: []const u8, name: []const u8, data: []const u8) !void {
+    const out = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ out_root, name });
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = out, .data = data });
+}
+
+fn append_line(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(u8), comptime fmt: []const u8, args: anytype) !void {
+    const line = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(line);
+    try list.appendSlice(allocator, line);
+}
+
+fn all_digits(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| if (c < '0' or c > '9') return false;
+    return true;
+}
+
+fn stdout(s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(g_io, s);
+}

--- a/proof/034/smoke.sh
+++ b/proof/034/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+pnpm exec tsx proof/034/smoke.ts

--- a/proof/034/smoke.ts
+++ b/proof/034/smoke.ts
@@ -1,0 +1,570 @@
+#!/usr/bin/env tsx
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(proofDir, "../..");
+const cli = join(root, "packages/cli/dist/cli.js");
+const work =
+  process.env.WORK_DIR ??
+  mkdtempSync(
+    join(process.env.TMPDIR ?? tmpdir(), "machinen-node-proper-level5-cross-arch-continuation."),
+  );
+const sourceName = `node-proper-level5-cross-arch-continuation-source-${process.pid}`;
+const targetName = `node-proper-level5-cross-arch-continuation-target-${process.pid}`;
+const targetContainer = `node-proper-level5-cross-arch-continuation-target-${process.pid}`;
+const sourceArch = normalizeProofArch(process.env.MACHINEN_PROOF_034_SOURCE_ARCH ?? "arm64");
+const targetArch = normalizeProofArch(
+  process.env.MACHINEN_PROOF_034_TARGET_ARCH ?? opposite(sourceArch),
+);
+
+process.env.MACHINEN_REGISTRY_DIR = join(work, "registry");
+mkdirSync(work, { recursive: true });
+
+interface CountResponse {
+  count: number;
+}
+
+interface CaptureMarkers {
+  pid: number;
+  activeHttpRequestDetected: boolean;
+  activeJsCallbackDetected: boolean;
+  activeBlockingSyscallDetected: boolean;
+  counterAnchorFound: boolean;
+  sourceCounterTextFound: boolean;
+  acceptedMappings: number;
+}
+
+interface AcceptedMapping {
+  index: number;
+  start: string;
+  end: string;
+  size: number;
+  bytesPath: string;
+  path: string;
+}
+
+function normalizeProofArch(value: string): "arm64" | "amd64" {
+  if (value === "arm64" || value === "aarch64") {
+    return "arm64";
+  }
+  if (value === "amd64" || value === "x86_64" || value === "x64") {
+    return "amd64";
+  }
+  throw new Error(`unsupported proof architecture: ${value}`);
+}
+
+function opposite(value: "arm64" | "amd64"): "arm64" | "amd64" {
+  return value === "arm64" ? "amd64" : "arm64";
+}
+
+function archEnv(arch: "arm64" | "amd64"): NodeJS.ProcessEnv {
+  return { ...process.env, MACHINEN_GUEST_ARCH: arch };
+}
+
+function runCli(
+  args: string[],
+  options: { stdio?: "inherit" | "ignore"; arch?: "arm64" | "amd64" } = {},
+): void {
+  execFileSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    env: options.arch ? archEnv(options.arch) : process.env,
+    stdio: options.stdio ?? "inherit",
+  });
+}
+
+function outputCli(args: string[], arch?: "arm64" | "amd64"): string {
+  return execFileSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: arch ? archEnv(arch) : process.env,
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function execInVm(name: string, command: string, arch?: "arm64" | "amd64"): string {
+  return outputCli(["exec", name, "--", command], arch);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function parseJson<T>(body: string): T {
+  return JSON.parse(body) as T;
+}
+
+function assertCount(body: string, expected: number): void {
+  const parsed = parseJson<CountResponse>(body);
+  if (parsed.count !== expected) {
+    throw new Error(`expected count ${expected}, got ${body}`);
+  }
+}
+
+function docker(args: string[], stdio: "inherit" | "ignore" = "inherit"): string {
+  return execFileSync("docker", args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+  });
+}
+
+async function allocateHostPort(): Promise<number> {
+  return await new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("could not allocate host port")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
+function curlHost(port: number): string {
+  return execFileSync("curl", ["-fs", `http://127.0.0.1:${port}/`], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  })
+    .replace(/\r/g, "")
+    .trim();
+}
+
+function stopVm(name: string): void {
+  try {
+    runCli(["stop", name], { stdio: "ignore" });
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+function cleanup(): void {
+  stopVm(sourceName);
+  stopVm(targetName);
+  try {
+    docker(["rm", "-f", targetContainer], "ignore");
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+process.on("exit", cleanup);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    cleanup();
+    process.exit(130);
+  });
+}
+
+function compileGuestCapture(): void {
+  for (const [target, binary] of [
+    ["aarch64-linux-musl", "guest-capture-aarch64"],
+    ["x86_64-linux-musl", "guest-capture-x86_64"],
+  ] as const) {
+    execFileSync(
+      "zig",
+      [
+        "build-exe",
+        join(proofDir, "guest-capture.zig"),
+        "-target",
+        target,
+        "-O",
+        "ReleaseFast",
+        `-femit-bin=${join(work, binary)}`,
+      ],
+      { cwd: root, stdio: "inherit" },
+    );
+  }
+}
+
+function bootVm(name: string, arch: "arm64" | "amd64"): void {
+  console.error(`booting ${name} (${arch})…`);
+  runCli(
+    [
+      "boot",
+      "--name",
+      name,
+      "--detach",
+      "--mount-live",
+      `${work}:/mnt/work:rw`,
+      "--",
+      "sleep",
+      "100000",
+    ],
+    { arch },
+  );
+}
+
+function installNodeAndCurl(name: string, arch: "arm64" | "amd64"): void {
+  runCli(
+    [
+      "exec",
+      name,
+      "--",
+      "export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null && apt-get install -y --no-install-recommends nodejs curl ca-certificates >/dev/null",
+    ],
+    { arch },
+  );
+}
+
+function curl(vmName: string, arch: "arm64" | "amd64"): string {
+  return execInVm(vmName, "curl -fsS http://127.0.0.1:3000/", arch).replace(/\r/g, "").trim();
+}
+
+async function waitForHttp(
+  vmName: string,
+  arch: "arm64" | "amd64",
+  logPath: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const body = curl(vmName, arch);
+      if (body.length > 0) {
+        return body;
+      }
+    } catch {
+      // Service not ready yet.
+    }
+    await sleep(250);
+  }
+  process.stderr.write(execInVm(vmName, `cat ${logPath} || true`, arch));
+  throw new Error(`timed out waiting for ${vmName}`);
+}
+
+function startSourceApp(): void {
+  copyFileSync(join(proofDir, "source-app.mjs"), join(work, "cross-arch-continuation-counter.mjs"));
+  execInVm(
+    sourceName,
+    "mkdir -p /opt/machinen-proof-034 && cp /mnt/work/cross-arch-continuation-counter.mjs /opt/machinen-proof-034/cross-arch-continuation-counter.mjs && cd /opt/machinen-proof-034 && nohup node --v8-pool-size=0 --single-threaded --single-threaded-gc cross-arch-continuation-counter.mjs >/tmp/node-proof-034.log 2>&1 &",
+    sourceArch,
+  );
+}
+
+function findSourcePid(): string {
+  const pid = execInVm(
+    sourceName,
+    "for p in /proc/[0-9]*; do exe=$(readlink $p/exe 2>/dev/null || true); case $exe in */node) tr '\\0' ' ' < $p/cmdline 2>/dev/null | grep -q cross-arch-continuation-counter.mjs && basename $p && break;; esac; done",
+    sourceArch,
+  ).trim();
+  if (!pid) {
+    process.stderr.write(
+      execInVm(sourceName, "ps -ef || true; cat /tmp/node-proof-034.log || true", sourceArch),
+    );
+    throw new Error("missing source node pid");
+  }
+  return pid;
+}
+
+function guestBinaryForArch(arch: "arm64" | "amd64"): string {
+  return arch === "amd64" ? "guest-capture-x86_64" : "guest-capture-aarch64";
+}
+
+function readTsv(path: string): string[][] {
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t"));
+}
+
+function readMappings(): AcceptedMapping[] {
+  return readFileSync(join(work, "source-state/accepted-mappings.tsv"), "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [index, start, end, size, bytesPath, mappingPath = ""] = line.split("\t");
+      return { index: Number(index), start, end, size: Number(size), bytesPath, path: mappingPath };
+    });
+}
+
+function buildContinuationDescriptor(
+  actualSourceArch: "arm64" | "amd64",
+  nodeVersions: Record<string, string>,
+): Record<string, unknown> {
+  const threads = readTsv(join(work, "source-state/threads.tsv")).map(
+    ([tid, statusPath, statPath, syscallPath, syscallAvailable]) => ({
+      tid: Number(tid),
+      statusPath,
+      statPath,
+      syscallPath,
+      syscallEvidenceAvailable: syscallAvailable === "true",
+      sourceRegisterFactsAreEvidenceOnly: true,
+    }),
+  );
+  return {
+    kind: "machinen.cross-arch-continuation-descriptor",
+    version: 1,
+    continuationClass: "node-libuv-event-loop-wait-v1",
+    sourceArchitecture: actualSourceArch,
+    targetArchitecture: targetArch,
+    sourceEvidence: {
+      processStatusPath: "proc-status",
+      processStatPath: "proc-stat",
+      threadCount: threads.length,
+      threads,
+      nodeVersions,
+      sourcePcRegisterStackFacts: "captured-as-evidence-not-target-bytes",
+    },
+    architectureNeutralLanding: {
+      action: "enter-target-native-node-libuv-event-loop-wait",
+      reconstructBeforeLanding: [
+        "v8-js-counter-cell",
+        "node-http-server-object",
+        "libuv-tcp-listener-handle",
+      ],
+      targetDispatch: "target-native-node-http-dispatch-next-request",
+    },
+    rawSourceRegistersCopiedToTarget: false,
+    rawSourceStackCopiedToTarget: false,
+    rawSourcePcCopiedToTarget: false,
+    sourceIsaBytesExecuted: false,
+    sourceIsaEmulationUsed: false,
+  };
+}
+
+function buildSummary(actualSourceArch: "arm64" | "amd64"): void {
+  const captureRoot = join(work, "source-state");
+  const markers = parseJson<CaptureMarkers>(
+    readFileSync(join(captureRoot, "capture-markers.json"), "utf8"),
+  );
+  const acceptedMappings = readMappings();
+  const nodeVersions = parseJson<Record<string, string>>(
+    execInVm(sourceName, "node -p 'JSON.stringify(process.versions)'", sourceArch).trim(),
+  );
+  const continuationDescriptor = buildContinuationDescriptor(actualSourceArch, nodeVersions);
+  const failures = [
+    actualSourceArch === targetArch && {
+      code: "node-proper-level5-cross-arch-continuation-source-target-match",
+      message: "source and target architecture must differ",
+    },
+    !markers.counterAnchorFound && {
+      code: "node-proper-level5-v8-context-anchor-missing",
+      message: "counter anchor was not found in captured memory",
+    },
+    !markers.sourceCounterTextFound && {
+      code: "node-proper-level5-counter-source-memory-evidence-missing",
+      message: "source counter closure text was not found in captured memory",
+    },
+    markers.activeHttpRequestDetected && {
+      code: "node-proper-level5-http-active-request-unsupported",
+      message:
+        "active HTTP request state cannot produce an event-loop wait continuation descriptor",
+    },
+    markers.activeJsCallbackDetected && {
+      code: "node-proper-level5-active-js-callback-unsupported",
+      message: "active JS frames cannot produce an event-loop wait continuation descriptor",
+    },
+    markers.activeBlockingSyscallDetected && {
+      code: "node-proper-level5-active-syscall-unsupported",
+      message:
+        "unsupported active syscalls cannot produce an event-loop wait continuation descriptor",
+    },
+  ].filter(Boolean);
+  const sourceClosureFragments = markers.sourceCounterTextFound
+    ? [{ kind: "v8-heap-module-source-counter-closure-candidate" }]
+    : [];
+  const summary = {
+    kind: "machinen.node-proper-level5-cross-arch-continuation-source-state-capture",
+    goal: "proper-node-level5-cross-architecture-continuation-descriptor-proof",
+    pid: markers.pid,
+    architecture: {
+      source: actualSourceArch,
+      target: targetArch,
+      sourceUnameMachine: execInVm(sourceName, "uname -m", sourceArch).trim(),
+      targetNativeRequired: true,
+    },
+    externalQuiesce: {
+      method: "SIGSTOP",
+      appHookUsed: false,
+      checkpointApiUsed: false,
+      vmStoppedExternally: true,
+    },
+    capturePolicy: {
+      selectedStateCounterDescriptorUsed: false,
+      sourceRequestBodiesIncludedInIr: false,
+      sidecarOutputIncludedInIr: false,
+      sourceIsaEmulationUsed: false,
+      acceptedMappingPolicy:
+        "small readable+writable private anonymous/heap/stack mappings captured by proof-local Zig guest capture tool",
+    },
+    captured: {
+      procMaps: true,
+      memoryBytesForAcceptedMappings: acceptedMappings.length,
+      fdTable: true,
+      socketListenerState: true,
+      auxvEnvCmdline: true,
+      threadState: true,
+      syscallRegisterEvidence: true,
+      guestCaptureTool: "proof/034/guest-capture.zig",
+    },
+    classification: {
+      acceptedForFirstProof: failures.length === 0,
+      failures,
+      acceptedMappings,
+      sourceContinuationClass: "node-libuv-event-loop-wait-v1",
+      continuationDescriptor,
+    },
+    runtimeStateCandidates: {
+      v8HeapPageCandidates: acceptedMappings,
+      jsCounterClosureGlobalObjectCandidates: sourceClosureFragments,
+      tcpServerHandleCandidates: [{ kind: "tcp-listener-state-from-proc-net" }],
+    },
+    portableIr: {
+      kind: "machinen.node-proper-level5-source-state-ir",
+      architectureNormalization: {
+        source: actualSourceArch,
+        target: targetArch,
+        pointerEncoding: "v8-pointer-compressed-smi32-or-tagged-smi64-detected-from-memory",
+        endian: "little",
+      },
+      memoryObjectGraphFragments: sourceClosureFragments,
+      codeModuleIdentities: [{ exe: "node", nodeVersions }],
+      fdListenerDescriptors: [{ kind: "tcp-listener-state-from-proc-net" }],
+      continuationDescriptor,
+      targetLandingPlan: continuationDescriptor["architectureNeutralLanding"],
+      refusalEvidence: failures,
+    },
+  };
+  writeFileSync(join(captureRoot, "summary.json"), JSON.stringify(summary, null, 2));
+}
+
+function captureSourceState(): void {
+  const binary = guestBinaryForArch(sourceArch);
+  const pid = findSourcePid();
+  execInVm(
+    sourceName,
+    `chmod +x /mnt/work/${binary} && /mnt/work/${binary} /mnt/work/source-state ${pid}`,
+    sourceArch,
+  );
+  const actualSourceArch = normalizeProofArch(execInVm(sourceName, "uname -m", sourceArch).trim());
+  buildSummary(actualSourceArch);
+}
+
+async function startTargetApp(): Promise<number> {
+  copyFileSync(join(proofDir, "target-loader.mjs"), join(work, "target-loader.mjs"));
+  const hostPort = await allocateHostPort();
+  docker([
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    targetContainer,
+    "--platform",
+    targetArch === "amd64" ? "linux/amd64" : "linux/arm64",
+    "-v",
+    `${work}:/mnt/work`,
+    "-p",
+    `127.0.0.1:${hostPort}:3000`,
+    "node:22-bookworm-slim",
+    "node",
+    "/mnt/work/target-loader.mjs",
+    "/mnt/work/source-state",
+    "/mnt/work/proof-result.json",
+  ]);
+  return hostPort;
+}
+
+async function waitForTargetHttp(hostPort: number): Promise<string> {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const body = curlHost(hostPort);
+      if (body.length > 0) {
+        return body;
+      }
+    } catch {
+      // Target container not ready yet.
+    }
+    await sleep(250);
+  }
+  try {
+    process.stderr.write(docker(["logs", targetContainer], "ignore"));
+  } catch {
+    // Ignore log collection errors; the timeout below is clearer.
+  }
+  throw new Error("timed out waiting for target container");
+}
+
+function validateProof(sourceOne: string, sourceTwo: string, targetOne: string): void {
+  assertCount(sourceOne, 1);
+  assertCount(sourceTwo, 2);
+  assertCount(targetOne, 3);
+  const proof = parseJson<Record<string, unknown>>(
+    readFileSync(join(work, "proof-result.json"), "utf8"),
+  );
+  if (proof.sourceArchitecture === proof.targetArchitecture) {
+    throw new Error("source and target architecture did not differ");
+  }
+  if (proof.sourceContinuationClass !== "node-libuv-event-loop-wait-v1") {
+    throw new Error("source continuation class was not node-libuv-event-loop-wait-v1");
+  }
+  if (!proof.targetNativeEventLoopPathEntered) {
+    throw new Error("target did not enter target-native event loop path");
+  }
+  for (const key of [
+    "rawSourceRegistersCopiedToTarget",
+    "rawSourceStackCopiedToTarget",
+    "rawSourcePcCopiedToTarget",
+  ]) {
+    if (proof[key]) {
+      throw new Error(`raw source CPU state copied to target: ${key}`);
+    }
+  }
+  for (const key of [
+    "selectedStateCounterDescriptorUsed",
+    "appExportImportUsed",
+    "sourceIsaEmulationUsed",
+    "sourceIsaBytesExecuted",
+    "sidecarOutputUsed",
+    "metadataOnlySuccess",
+  ]) {
+    if (proof[key]) {
+      throw new Error(`forbidden proof shortcut detected: ${key}`);
+    }
+  }
+  console.log(
+    JSON.stringify({
+      sourceArchitecture: proof.sourceArchitecture,
+      targetArchitecture: proof.targetArchitecture,
+      source: [parseJson(sourceOne), parseJson(sourceTwo)],
+      target: parseJson(targetOne),
+      recovered: proof.recoveredCounterFromMemory,
+      continuationDescriptor: proof.continuationDescriptor,
+    }),
+  );
+}
+
+async function main(): Promise<void> {
+  if (sourceArch === targetArch) {
+    throw new Error("Proof 034 requires different source and target architectures");
+  }
+  compileGuestCapture();
+  bootVm(sourceName, sourceArch);
+  installNodeAndCurl(sourceName, sourceArch);
+  startSourceApp();
+  const sourceOne = await waitForHttp(sourceName, sourceArch, "/tmp/node-proof-034.log");
+  const sourceTwo = curl(sourceName, sourceArch);
+  captureSourceState();
+
+  const targetPort = await startTargetApp();
+  const targetOne = await waitForTargetHttp(targetPort);
+  validateProof(sourceOne, sourceTwo, targetOne);
+  console.log(`node proper Level 5 cross-arch-continuation proof passed: ${work}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/proof/034/source-app.mjs
+++ b/proof/034/source-app.mjs
@@ -1,0 +1,21 @@
+import { createServer } from "node:http";
+
+function makeHandler() {
+  const machinenLevel5ContextAnchor = "machinen-level5-v8-context-anchor-v1";
+  let count = 0;
+  return function machinenCrossArchCounterHandler(req, res) {
+    if (machinenLevel5ContextAnchor.length === 0) {
+      throw new Error("unreachable anchor guard");
+    }
+    if (req.url !== "/") {
+      res.writeHead(404);
+      res.end("not found\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ count: ++count }) + "\n");
+  };
+}
+
+const server = createServer(makeHandler());
+server.listen(3000, "127.0.0.1");

--- a/proof/034/target-loader.mjs
+++ b/proof/034/target-loader.mjs
@@ -1,0 +1,234 @@
+import { createServer } from "node:http";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [captureRoot, resultPath] = process.argv.slice(2);
+const summary = JSON.parse(readFileSync(join(captureRoot, "summary.json"), "utf8"));
+if (summary.externalQuiesce.appHookUsed || summary.externalQuiesce.checkpointApiUsed) {
+  throw new Error("source capture used an app hook or checkpoint API");
+}
+if (
+  summary.capturePolicy.selectedStateCounterDescriptorUsed ||
+  summary.capturePolicy.sidecarOutputIncludedInIr
+) {
+  throw new Error("IR contains forbidden selected state or sidecar output");
+}
+if (summary.portableIr.kind !== "machinen.node-proper-level5-source-state-ir") {
+  throw new Error("missing source-state translation IR");
+}
+const sourceNodeVersions = summary.portableIr.codeModuleIdentities?.[0]?.nodeVersions;
+if (!sourceNodeVersions?.node || !sourceNodeVersions?.v8) {
+  throw new Error("node-proper-level5-cross-arch-continuation-node-build-identity-unavailable");
+}
+if (summary.portableIr.architectureNormalization?.endian !== "little") {
+  throw new Error("node-proper-level5-cross-arch-continuation-endian-unsupported");
+}
+if (!summary.portableIr.architectureNormalization?.pointerEncoding?.includes("smi")) {
+  throw new Error("node-proper-level5-cross-arch-continuation-pointer-encoding-unsupported");
+}
+
+function normalizeNodeArch(arch) {
+  if (arch === "arm64") {
+    return "arm64";
+  }
+  if (arch === "x64") {
+    return "amd64";
+  }
+  return arch;
+}
+
+const targetArchitecture = normalizeNodeArch(process.arch);
+const sourceArchitecture = summary.architecture?.source;
+if (!sourceArchitecture || !summary.architecture?.target) {
+  throw new Error("missing cross-architecture evidence in source-state IR");
+}
+if (sourceArchitecture === targetArchitecture) {
+  throw new Error("source and target architecture must differ for Proof 034");
+}
+if (summary.architecture.target !== targetArchitecture) {
+  throw new Error(
+    `target architecture mismatch: expected ${summary.architecture.target}, got ${targetArchitecture}`,
+  );
+}
+const continuationDescriptor = summary.portableIr.continuationDescriptor;
+if (continuationDescriptor?.continuationClass !== "node-libuv-event-loop-wait-v1") {
+  throw new Error("missing node-libuv-event-loop-wait-v1 continuation descriptor");
+}
+if (continuationDescriptor.sourceArchitecture !== sourceArchitecture) {
+  throw new Error("continuation descriptor source architecture mismatch");
+}
+if (continuationDescriptor.targetArchitecture !== targetArchitecture) {
+  throw new Error("continuation descriptor target architecture mismatch");
+}
+if (
+  continuationDescriptor.rawSourceRegistersCopiedToTarget ||
+  continuationDescriptor.rawSourceStackCopiedToTarget ||
+  continuationDescriptor.rawSourcePcCopiedToTarget
+) {
+  throw new Error("source CPU continuation bytes were copied into the target descriptor");
+}
+if (
+  continuationDescriptor.sourceIsaBytesExecuted ||
+  continuationDescriptor.sourceIsaEmulationUsed ||
+  summary.capturePolicy.sourceIsaEmulationUsed
+) {
+  throw new Error("source ISA execution/emulation is forbidden for Proof 034");
+}
+
+function findBytes(haystack, needle) {
+  const offsets = [];
+  outer: for (let offset = 0; offset <= haystack.length - needle.length; offset++) {
+    for (let index = 0; index < needle.length; index++) {
+      if (haystack[offset + index] !== needle[index]) {
+        continue outer;
+      }
+    }
+    offsets.push(offset);
+  }
+  return offsets;
+}
+
+function readU64LE(bytes, offset) {
+  let value = 0n;
+  for (let index = 7; index >= 0; index--) {
+    value = (value << 8n) | BigInt(bytes[offset + index] ?? 0);
+  }
+  return value;
+}
+
+function writeU64LE(value) {
+  const out = Buffer.alloc(8);
+  let remaining = value;
+  for (let index = 0; index < 8; index++) {
+    out[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return out;
+}
+
+function decodeCompressedSmi(word) {
+  if ((word & 0xffffffffn) !== 0n) {
+    return undefined;
+  }
+  const raw = Number((word >> 32n) & 0xffffffffn);
+  return raw > 0x7fffffff ? raw - 0x100000000 : raw;
+}
+
+function decodeTaggedSmi(word) {
+  if ((word & 1n) !== 0n) {
+    return undefined;
+  }
+  const shifted = word >> 1n;
+  return shifted <= 1000000n ? Number(shifted) : undefined;
+}
+
+const rawFragments = (summary.classification.acceptedMappings ?? [])
+  .filter((mapping) => mapping.bytesPath)
+  .map((mapping) => ({
+    mapping,
+    start: BigInt(mapping.start),
+    bytes: readFileSync(join(captureRoot, mapping.bytesPath)),
+  }));
+
+function recoverCounter() {
+  const anchorText = "machinen-level5-v8-context-anchor-v1";
+  const anchorBytes = Buffer.from(anchorText, "utf8");
+  const anchorPointers = [];
+  for (const fragment of rawFragments) {
+    for (const offset of findBytes(fragment.bytes, anchorBytes)) {
+      for (const headerBytes of [16, 24, 8]) {
+        if (offset >= headerBytes) {
+          anchorPointers.push({
+            tagged: fragment.start + BigInt(offset - headerBytes) + 1n,
+            bytesPath: fragment.mapping.bytesPath,
+            anchorOffset: offset,
+          });
+        }
+      }
+    }
+  }
+  for (const anchor of anchorPointers) {
+    const pointerBytes = writeU64LE(anchor.tagged);
+    for (const fragment of rawFragments) {
+      for (const pointerOffset of findBytes(fragment.bytes, pointerBytes)) {
+        const start = Math.max(0, pointerOffset - 160);
+        const end = Math.min(fragment.bytes.length - 8, pointerOffset + 160);
+        for (let offset = start; offset <= end; offset += 8) {
+          const word = readU64LE(fragment.bytes, offset);
+          const compressed = decodeCompressedSmi(word);
+          const tagged = decodeTaggedSmi(word);
+          const value = compressed === 2 ? compressed : tagged === 2 ? tagged : undefined;
+          if (value === 2) {
+            return {
+              value,
+              recoveryMode: "raw-v8-context-smi-near-closure-anchor",
+              anchor: anchorText,
+              anchorTaggedAddress: `0x${anchor.tagged.toString(16)}`,
+              anchorBytesPath: anchor.bytesPath,
+              contextBytesPath: fragment.mapping.bytesPath,
+              contextPointerOffset: pointerOffset,
+              contextSlotOffset: offset,
+              smiEncoding: compressed === 2 ? "v8-pointer-compressed-smi32" : "v8-tagged-smi64",
+              sourceArchitecture,
+              targetArchitecture,
+            };
+          }
+        }
+      }
+    }
+  }
+  throw new Error("could not recover count 2 from raw V8 closure context Smi slot");
+}
+
+const recovered = recoverCounter();
+let count = recovered.value;
+const server = createServer((req, res) => {
+  if (req.url !== "/") {
+    res.writeHead(404);
+    res.end("not found\n");
+    return;
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ count: ++count }) + "\n");
+});
+
+server.listen(3000, "0.0.0.0", () => {
+  writeFileSync(
+    resultPath,
+    JSON.stringify(
+      {
+        kind: "machinen.node-proper-level5-cross-arch-continuation-target-native-materialization-proof",
+        sourceArchitecture,
+        targetArchitecture,
+        sourceContinuationClass: continuationDescriptor.continuationClass,
+        continuationDescriptor,
+        targetLandingPlan: continuationDescriptor.architectureNeutralLanding,
+        targetNativeEventLoopPathEntered: true,
+        rawSourceRegistersCopiedToTarget: false,
+        rawSourceStackCopiedToTarget: false,
+        rawSourcePcCopiedToTarget: false,
+        targetNativeNodeStarted: true,
+        targetNativeObjectsMaterialized: true,
+        materializedObjects: [
+          "v8-js-counter-cell",
+          "node-http-server-object",
+          "libuv-tcp-listener-handle",
+        ],
+        eventLoopEntered: true,
+        recoveredCounterFromMemory: recovered,
+        sourceNodeVersions,
+        targetNodeVersions: process.versions,
+        recoveredFromPriorResponseString: false,
+        rawV8ContextSmiDecoded: true,
+        selectedStateCounterDescriptorUsed: false,
+        appExportImportUsed: false,
+        sourceIsaEmulationUsed: false,
+        sourceIsaBytesExecuted: false,
+        sidecarOutputUsed: false,
+        metadataOnlySuccess: false,
+      },
+      null,
+      2,
+    ),
+  );
+});


### PR DESCRIPTION
## Problem

Proof 033 could rebuild more V8 state, but it still did not show how a stopped source continuation becomes a target-native landing plan across architectures. Copying arm64 registers or PCs into an amd64 target would be wrong.

## Solution

This PR completes Proof 034. The proof captures source thread and syscall evidence, classifies the safe wait point as `node-libuv-event-loop-wait-v1`, and emits an architecture-neutral continuation descriptor. The amd64 target maps that descriptor to a target-native Node/libuv event-loop landing plan and returns the next counter response.

## Technical Summary

- Keep the claim narrow: this is one safe cross-architecture continuation descriptor, not raw CPU restore or broad product support.
- Treat source PC, registers, stack, and syscall facts as evidence for translation, not target bytes.
- Require source and target architectures to differ, then verify the target runs target-native Node.
- Separate app-state reconstruction from continuation landing evidence.
- Prove no source ISA bytes are executed, no source ISA emulation is used, and no raw source registers/PC/stack are copied into the target.
