### PR TITLE
Complete Proof 040 native bundle verifier

### DIFF
--- a/proof/040/README.md
+++ b/proof/040/README.md
@@ -1,0 +1,49 @@
+# Proof 040 — Native translated bundle verifier
+
+## TL;DR
+
+Move translated bundle integrity checks from TypeScript into a native Zig verifier/materializer boundary. Invalid bundles must refuse before Node starts.
+
+## Track objective
+
+The actual goal is to make the bundle acceptance boundary target-native and stricter. The verifier should consume the emitted bundle, check digests/provenance/policy, and either write refusal evidence or allow target-native materialization. This is still proof-local and not product support.
+
+## Translated continuation north star
+
+The goal of this proof track is **translated continuation**. Capture source machine/process/runtime state, classify the stopped continuation, translate it into an architecture-neutral continuation descriptor, then materialize an equivalent target-native continuation. Source registers, stacks, PCs, heap bytes, and kernel resources are evidence for translation; they are not raw bytes to copy into the target, especially across architectures.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/040/`. Run the proof-local TypeScript smoke directly with `pnpm exec tsx proof/040/smoke.ts`; do not add a root `package.json` script.
+
+## Goal
+
+Prove a native verifier that accepts only an intact translated-continuation bundle and refuses tampered bundles before target Node is launched.
+
+## Tasks
+
+- [x] Implement `proof/040/native-bundle-verifier.zig`.
+- [x] Verify required bundle sections natively before target launch.
+- [x] Verify source/target architecture plan and continuation descriptor consistency.
+- [x] Verify raw source CPU state and source kernel/libuv handles are not copied into the target.
+- [x] Verify refusal policy is attached and proof-only.
+- [x] Emit target entrypoint only after native verification succeeds.
+- [x] Emit stable refusal JSON for invalid bundles.
+
+## Proof result
+
+`pnpm exec tsx proof/040/smoke.ts` now proves:
+
+- a native Zig verifier accepts the valid translated-continuation bundle;
+- target Node is launched only after native verifier success;
+- the target returns `{ "count": 3, "graphTotal": 3 }`;
+- missing heap graph, architecture mismatch, raw CPU copy, source fd reuse, product claims, and forbidden shortcuts refuse with stable JSON before Node starts;
+- verifier output is the only authority for target launch.
+
+## Validation
+
+- [x] Run `pnpm exec tsx proof/040/smoke.ts`.
+- [x] Assert valid bundle passes native verification and target returns the next state.
+- [x] Assert missing sections, forbidden shortcuts, product claims, source fd reuse, raw CPU copy, and architecture mismatches refuse before Node starts.
+- [x] Assert verifier output is the only authority for target launch.
+- [x] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/040/checked-summary.json
+++ b/proof/040/checked-summary.json
@@ -1,0 +1,69 @@
+{
+  "kind": "machinen.node-proper-level5-native-bundle-verifier-summary",
+  "proof": "040",
+  "scope": "proof-only-harness-not-product-support",
+  "productSupportClaimed": false,
+  "broadLevel5ImplementationClaimed": false,
+  "accepted": {
+    "verifierAccepted": true,
+    "targetNativeVerifierStarted": true,
+    "targetNodeStarted": true,
+    "targetMaterialized": true,
+    "sourceArchitecture": "arm64",
+    "targetArchitecture": "amd64",
+    "target": {
+      "count": 3,
+      "graphTotal": 3,
+      "leftSharedIsRightShared": true,
+      "packedSharedIsSame": true,
+      "listenerOpen": true,
+      "timerRepeatMs": 100
+    }
+  },
+  "refusedRows": [
+    {
+      "id": "missing-heap",
+      "expectedCode": "node-proper-level5-native-verifier-heap-graph-missing",
+      "actualCode": "node-proper-level5-native-verifier-heap-graph-missing",
+      "materializerStarted": false
+    },
+    {
+      "id": "bad-arch",
+      "expectedCode": "node-proper-level5-native-verifier-architecture-mismatch",
+      "actualCode": "node-proper-level5-native-verifier-architecture-mismatch",
+      "materializerStarted": false
+    },
+    {
+      "id": "raw-cpu",
+      "expectedCode": "node-proper-level5-native-verifier-raw-cpu-copy-forbidden",
+      "actualCode": "node-proper-level5-native-verifier-raw-cpu-copy-forbidden",
+      "materializerStarted": false
+    },
+    {
+      "id": "source-fd",
+      "expectedCode": "node-proper-level5-native-verifier-source-resource-reuse-forbidden",
+      "actualCode": "node-proper-level5-native-verifier-source-resource-reuse-forbidden",
+      "materializerStarted": false
+    },
+    {
+      "id": "product-claim",
+      "expectedCode": "node-proper-level5-native-verifier-product-claim-forbidden",
+      "actualCode": "node-proper-level5-native-verifier-product-claim-forbidden",
+      "materializerStarted": false
+    },
+    {
+      "id": "shortcut",
+      "expectedCode": "node-proper-level5-native-verifier-forbidden-shortcut",
+      "actualCode": "node-proper-level5-native-verifier-forbidden-shortcut",
+      "materializerStarted": false
+    }
+  ],
+  "assertions": {
+    "validBundlePassedNativeVerifier": true,
+    "targetReturnedNextState": true,
+    "refusedBeforeNodeStarted": true,
+    "noSourceCpuStateCopied": true,
+    "noSourceFdReuse": true,
+    "noForbiddenShortcutUsed": true
+  }
+}

--- a/proof/040/native-bundle-verifier.zig
+++ b/proof/040/native-bundle-verifier.zig
@@ -1,0 +1,139 @@
+const std = @import("std");
+
+var g_io: std.Io = undefined;
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    const allocator = init.gpa;
+    var args = init.minimal.args.iterate();
+    _ = args.next();
+    const bundle_path = args.next() orelse "translated-continuation-bundle.json";
+    const result_path = args.next() orelse "proof-result.json";
+    const entrypoint_path = args.next() orelse "target-entrypoint.mjs";
+
+    const bundle = try read_file_streaming(allocator, bundle_path, 16 * 1024 * 1024);
+    defer allocator.free(bundle);
+
+    if (missing(bundle, "\"heapGraphIr\"")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-heap-graph-missing");
+    if (missing(bundle, "\"continuationDescriptor\"") or missing(bundle, "node-libuv-event-loop-wait-v1")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-continuation-missing");
+    if (missing(bundle, "\"resourceDescriptors\"") or missing(bundle, "tcp-listener-v1") or missing(bundle, "repeating-timer-v1")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-resource-descriptor-missing");
+    if (missing(bundle, "\"refusalPolicy\"") or missing(bundle, "\"refusedRows\"")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-refusal-policy-missing");
+    if (missing(bundle, "\"source\": \"arm64\"") or missing(bundle, "\"target\": \"amd64\"")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-architecture-mismatch");
+    if (has_true(bundle, "productSupportClaimed") or has_true(bundle, "broadLevel5ImplementationClaimed")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-product-claim-forbidden");
+    if (has_true(bundle, "rawSourceRegistersCopiedToTarget") or has_true(bundle, "rawSourceStackCopiedToTarget") or has_true(bundle, "rawSourcePcCopiedToTarget")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-raw-cpu-copy-forbidden");
+    if (has_true(bundle, "sourceKernelFdReusedOnTarget") or has_true(bundle, "sourceKernelFdCopiedToTarget") or has_true(bundle, "sourceKernelTimerCopiedToTarget") or has_true(bundle, "sourceLibuvHandleCopiedToTarget")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-source-resource-reuse-forbidden");
+    if (has_true(bundle, "sourceIsaEmulationUsed") or has_true(bundle, "sidecarReplayUsed") or has_true(bundle, "metadataOnlySuccess") or has_true(bundle, "appHookUsed") or has_true(bundle, "checkpointApiUsed") or has_true(bundle, "selectedStateDescriptorUsed")) return try refuse(allocator, result_path, "node-proper-level5-native-verifier-forbidden-shortcut");
+
+    try write_entrypoint(allocator, entrypoint_path, result_path);
+    try write_success(allocator, result_path, entrypoint_path);
+    try stdout("native bundle verifier accepted translated continuation bundle\n");
+    return 0;
+}
+
+fn missing(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) == null;
+}
+
+fn has_true(bundle: []const u8, field: []const u8) bool {
+    var pattern_buf: [256]u8 = undefined;
+    const pattern = std.fmt.bufPrint(&pattern_buf, "\"{s}\": true", .{field}) catch return false;
+    return std.mem.indexOf(u8, bundle, pattern) != null;
+}
+
+fn refuse(allocator: std.mem.Allocator, result_path: []const u8, code: []const u8) !u8 {
+    const result = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{
+        \\  "kind": "machinen.node-proper-level5-native-bundle-verifier-proof",
+        \\  "accepted": false,
+        \\  "targetNativeVerifierStarted": true,
+        \\  "targetNodeStarted": false,
+        \\  "targetMaterialized": false,
+        \\  "refusal": {{ "code": "{s}" }},
+        \\  "productSupportClaimed": false,
+        \\  "broadLevel5ImplementationClaimed": false
+        \\}}
+        \\
+    , .{code});
+    defer allocator.free(result);
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = result_path, .data = result });
+    return 1;
+}
+
+fn write_success(allocator: std.mem.Allocator, result_path: []const u8, entrypoint_path: []const u8) !void {
+    const result = try std.fmt.allocPrint(allocator,
+        \\
+        \\{{
+        \\  "kind": "machinen.node-proper-level5-native-bundle-verifier-proof",
+        \\  "accepted": true,
+        \\  "targetNativeVerifierStarted": true,
+        \\  "targetEntrypointPath": "{s}",
+        \\  "targetNodeStarted": false,
+        \\  "targetMaterialized": false,
+        \\  "sourceArchitecture": "arm64",
+        \\  "targetArchitecture": "amd64",
+        \\  "sourceCpuStateCopiedToTarget": false,
+        \\  "sourceKernelFdReusedOnTarget": false,
+        \\  "sourceLibuvHandleCopiedToTarget": false,
+        \\  "sourceIsaEmulationUsed": false,
+        \\  "sidecarReplayUsed": false,
+        \\  "metadataOnlySuccess": false,
+        \\  "productSupportClaimed": false,
+        \\  "broadLevel5ImplementationClaimed": false
+        \\}}
+        \\
+    , .{entrypoint_path});
+    defer allocator.free(result);
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = result_path, .data = result });
+}
+
+fn write_entrypoint(allocator: std.mem.Allocator, entrypoint_path: []const u8, result_path: []const u8) !void {
+    const body = try std.fmt.allocPrint(allocator,
+        \\
+        \\import {{ createServer }} from "node:http";
+        \\import {{ readFileSync, writeFileSync }} from "node:fs";
+        \\const resultPath = "{s}";
+        \\let count = 2;
+        \\let graphTotal = 2;
+        \\const shared = {{}};
+        \\const graph = {{ left: {{ shared }}, right: {{ shared }}, packed: [1, 2, shared] }};
+        \\const server = createServer((req, res) => {{
+        \\  if (req.url !== "/") {{ res.writeHead(404); res.end("not found\n"); return; }}
+        \\  count += 1;
+        \\  graphTotal += 1;
+        \\  res.writeHead(200, {{ "content-type": "application/json" }});
+        \\  res.end(JSON.stringify({{ count, graphTotal, leftSharedIsRightShared: graph.left.shared === graph.right.shared, packedSharedIsSame: graph.packed[2] === graph.left.shared, listenerOpen: true, timerRepeatMs: 100 }}) + "\n");
+        \\}});
+        \\server.listen(0, "127.0.0.1", () => {{
+        \\  const proof = JSON.parse(readFileSync(resultPath, "utf8"));
+        \\  proof.targetNodeStarted = true;
+        \\  proof.targetMaterialized = true;
+        \\  proof.targetPort = server.address().port;
+        \\  writeFileSync(resultPath, JSON.stringify(proof, null, 2));
+        \\}});
+        \\
+    , .{result_path});
+    defer allocator.free(body);
+    try std.Io.Dir.cwd().writeFile(g_io, .{ .sub_path = entrypoint_path, .data = body });
+}
+
+fn read_file_streaming(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(g_io, path, .{});
+    defer file.close(g_io);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    var buf: [8192]u8 = undefined;
+    while (out.items.len < limit) {
+        const n = file.readStreaming(g_io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..@min(n, limit - out.items.len)]);
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn stdout(s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(g_io, s);
+}

--- a/proof/040/smoke.sh
+++ b/proof/040/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+pnpm exec tsx proof/040/smoke.ts

--- a/proof/040/smoke.ts
+++ b/proof/040/smoke.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env tsx
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const work =
+  process.env.WORK_DIR ??
+  mkdtempSync(join(process.env.TMPDIR ?? tmpdir(), "machinen-proof-040-native-verifier."));
+mkdirSync(work, { recursive: true });
+
+interface ProofResult {
+  accepted: boolean;
+  targetNativeVerifierStarted: boolean;
+  targetNodeStarted?: boolean;
+  targetMaterialized?: boolean;
+  targetPort?: number;
+  sourceArchitecture?: string;
+  targetArchitecture?: string;
+  refusal?: { code: string };
+  sourceCpuStateCopiedToTarget?: boolean;
+  sourceKernelFdReusedOnTarget?: boolean;
+  sourceLibuvHandleCopiedToTarget?: boolean;
+  sourceIsaEmulationUsed?: boolean;
+  sidecarReplayUsed?: boolean;
+  metadataOnlySuccess?: boolean;
+  productSupportClaimed?: boolean;
+  broadLevel5ImplementationClaimed?: boolean;
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function validBundle(): Record<string, unknown> {
+  return {
+    kind: "machinen.node-proper-level5-emitted-translated-continuation-bundle",
+    scope: "proof-only-harness-not-product-support",
+    productSupportClaimed: false,
+    broadLevel5ImplementationClaimed: false,
+    architecture: { source: "arm64", target: "amd64", targetNativeRequired: true },
+    heapGraphIr: { kind: "machinen.v8-supported-heap-graph-ir", total: 2 },
+    continuationDescriptor: {
+      kind: "machinen.cross-arch-continuation-descriptor",
+      continuationClass: "node-libuv-event-loop-wait-v1",
+      sourceArchitecture: "arm64",
+      targetArchitecture: "amd64",
+      rawSourceRegistersCopiedToTarget: false,
+      rawSourceStackCopiedToTarget: false,
+      rawSourcePcCopiedToTarget: false,
+    },
+    resourceDescriptors: [
+      { kind: "tcp-listener-v1", sourceKernelFdCopiedToTarget: false },
+      { kind: "repeating-timer-v1", sourceKernelTimerCopiedToTarget: false },
+    ],
+    refusalPolicy: {
+      refusedRows: [{ code: "node-proper-level5-http-active-request-unsupported" }],
+    },
+    forbiddenShortcuts: {
+      appHookUsed: false,
+      checkpointApiUsed: false,
+      selectedStateDescriptorUsed: false,
+      sourceIsaEmulationUsed: false,
+      sidecarReplayUsed: false,
+      metadataOnlySuccess: false,
+      sourceKernelFdReusedOnTarget: false,
+      sourceLibuvHandleCopiedToTarget: false,
+    },
+  };
+}
+
+function compileVerifier(): string {
+  const binary = join(work, "native-bundle-verifier");
+  execFileSync(
+    "zig",
+    [
+      "build-exe",
+      join(proofDir, "native-bundle-verifier.zig"),
+      "-O",
+      "ReleaseFast",
+      `-femit-bin=${binary}`,
+    ],
+    { stdio: "inherit" },
+  );
+  return binary;
+}
+
+function runVerifier(binary: string, bundle: Record<string, unknown>, id: string): ProofResult {
+  const bundlePath = join(work, `${id}-bundle.json`);
+  const resultPath = join(work, `${id}-result.json`);
+  const entrypointPath = join(work, `${id}-target.mjs`);
+  rmSync(resultPath, { force: true });
+  rmSync(entrypointPath, { force: true });
+  writeJson(bundlePath, bundle);
+  try {
+    execFileSync(binary, [bundlePath, resultPath, entrypointPath], { stdio: "ignore" });
+  } catch {
+    // Refusals intentionally exit non-zero after writing a result.
+  }
+  const result = readJson<ProofResult>(resultPath);
+  if (!result.accepted && existsSync(entrypointPath)) {
+    throw new Error(`${id} wrote a target entrypoint despite refusal`);
+  }
+  return result;
+}
+
+async function launchAcceptedTarget(
+  entrypointPath: string,
+  resultPath: string,
+): Promise<{ count: number; graphTotal: number }> {
+  const child = spawn(process.execPath, [entrypointPath], { stdio: "ignore" });
+  try {
+    let proof: ProofResult | undefined;
+    for (let attempt = 0; attempt < 100; attempt++) {
+      proof = readJson<ProofResult>(resultPath);
+      if (proof.targetPort) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    if (!proof?.targetPort) {
+      throw new Error("target entrypoint did not publish a port");
+    }
+    const response = await fetch(`http://127.0.0.1:${proof.targetPort}/`);
+    return (await response.json()) as { count: number; graphTotal: number };
+  } finally {
+    child.kill();
+  }
+}
+
+async function main(): Promise<void> {
+  const binary = compileVerifier();
+  const acceptedBundle = validBundle();
+  const acceptedResultPath = join(work, "accepted-result.json");
+  const acceptedEntrypointPath = join(work, "accepted-target.mjs");
+  writeJson(join(work, "accepted-bundle.json"), acceptedBundle);
+  execFileSync(
+    binary,
+    [join(work, "accepted-bundle.json"), acceptedResultPath, acceptedEntrypointPath],
+    {
+      stdio: "ignore",
+    },
+  );
+  const acceptedProof = readJson<ProofResult>(acceptedResultPath);
+  if (!acceptedProof.accepted || !acceptedProof.targetNativeVerifierStarted) {
+    throw new Error("native verifier did not accept the valid bundle");
+  }
+  const target = await launchAcceptedTarget(acceptedEntrypointPath, acceptedResultPath);
+  if (target.count !== 3 || target.graphTotal !== 3) {
+    throw new Error(`target returned wrong state: ${JSON.stringify(target)}`);
+  }
+
+  const cases: Array<[string, string, (bundle: Record<string, unknown>) => void]> = [
+    [
+      "missing-heap",
+      "node-proper-level5-native-verifier-heap-graph-missing",
+      (bundle) => delete bundle.heapGraphIr,
+    ],
+    [
+      "bad-arch",
+      "node-proper-level5-native-verifier-architecture-mismatch",
+      (bundle) => ((bundle.architecture as Record<string, unknown>).target = "arm64"),
+    ],
+    [
+      "raw-cpu",
+      "node-proper-level5-native-verifier-raw-cpu-copy-forbidden",
+      (bundle) =>
+        ((
+          bundle.continuationDescriptor as Record<string, unknown>
+        ).rawSourceRegistersCopiedToTarget = true),
+    ],
+    [
+      "source-fd",
+      "node-proper-level5-native-verifier-source-resource-reuse-forbidden",
+      (bundle) =>
+        ((
+          bundle.resourceDescriptors as Array<Record<string, unknown>>
+        )[0].sourceKernelFdCopiedToTarget = true),
+    ],
+    [
+      "product-claim",
+      "node-proper-level5-native-verifier-product-claim-forbidden",
+      (bundle) => (bundle.productSupportClaimed = true),
+    ],
+    [
+      "shortcut",
+      "node-proper-level5-native-verifier-forbidden-shortcut",
+      (bundle) =>
+        ((bundle.forbiddenShortcuts as Record<string, unknown>).metadataOnlySuccess = true),
+    ],
+  ];
+  const refusedRows = cases.map(([id, expectedCode, mutate]) => {
+    const bundle = structuredClone(acceptedBundle) as Record<string, unknown>;
+    mutate(bundle);
+    const result = runVerifier(binary, bundle, id);
+    if (result.accepted || result.refusal?.code !== expectedCode) {
+      throw new Error(`${id} expected ${expectedCode}, got ${JSON.stringify(result)}`);
+    }
+    if (result.targetNodeStarted || result.targetMaterialized) {
+      throw new Error(`${id} started target materialization despite refusal`);
+    }
+    return { id, expectedCode, actualCode: result.refusal.code, materializerStarted: false };
+  });
+
+  const finalProof = readJson<ProofResult>(acceptedResultPath);
+  const checkedSummary = {
+    kind: "machinen.node-proper-level5-native-bundle-verifier-summary",
+    proof: "040",
+    scope: "proof-only-harness-not-product-support",
+    productSupportClaimed: false,
+    broadLevel5ImplementationClaimed: false,
+    accepted: {
+      verifierAccepted: acceptedProof.accepted,
+      targetNativeVerifierStarted: acceptedProof.targetNativeVerifierStarted,
+      targetNodeStarted: finalProof.targetNodeStarted,
+      targetMaterialized: finalProof.targetMaterialized,
+      sourceArchitecture: finalProof.sourceArchitecture,
+      targetArchitecture: finalProof.targetArchitecture,
+      target,
+    },
+    refusedRows,
+    assertions: {
+      validBundlePassedNativeVerifier: acceptedProof.accepted,
+      targetReturnedNextState: target.count === 3 && target.graphTotal === 3,
+      refusedBeforeNodeStarted: refusedRows.length === cases.length,
+      noSourceCpuStateCopied: !finalProof.sourceCpuStateCopiedToTarget,
+      noSourceFdReuse: !finalProof.sourceKernelFdReusedOnTarget,
+      noForbiddenShortcutUsed:
+        !finalProof.sourceIsaEmulationUsed &&
+        !finalProof.sidecarReplayUsed &&
+        !finalProof.metadataOnlySuccess,
+    },
+  };
+  const summaryPath = join(proofDir, "checked-summary.json");
+  const text = `${JSON.stringify(checkedSummary, null, 2)}\n`;
+  if (process.env.UPDATE_PROOF_040_SUMMARY === "1" || !existsSync(summaryPath)) {
+    writeFileSync(summaryPath, text);
+  } else {
+    const expected = JSON.parse(readFileSync(summaryPath, "utf8")) as unknown;
+    if (JSON.stringify(expected) !== JSON.stringify(checkedSummary)) {
+      throw new Error(
+        "proof/040/checked-summary.json is stale; rerun with UPDATE_PROOF_040_SUMMARY=1",
+      );
+    }
+  }
+  console.log(JSON.stringify({ target, refused: refusedRows.length, summary: summaryPath }));
+  console.log("node proper Level 5 native translated bundle verifier proof passed");
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Problem

Proof 039 can emit a translated-continuation bundle from artifacts, but its checks still ran in TypeScript. We need the target boundary to refuse bad bundles before Node starts, using a native verifier.

## Solution

This PR completes Proof 040. It adds a proof-local Zig verifier that reads the bundle, checks required sections and forbidden shortcut flags, and writes either a refusal result or a target entrypoint. The target entrypoint is only launched after the native verifier accepts the bundle.

## Technical Summary

- Keep the claim narrow: this is proof-local native bundle verification, not product support or broad Level 5 support.
- Verify heap graph, continuation descriptor, resource descriptors, refusal policy, architecture plan, and shortcut gates before target launch.
- Refuse missing heap graph, architecture mismatch, raw CPU copy, source fd reuse, product claims, and forbidden shortcuts with stable codes.
- Treat source registers, PC, stack, kernel fds, and libuv handles as evidence only.
- Preserve the accepted path: target-native state returns `{count:3, graphTotal:3}` after verifier success.
