### PR TITLE
Complete Proof 045 product boundary audit

### DIFF
--- a/proof/045/README.md
+++ b/proof/045/README.md
@@ -1,0 +1,48 @@
+# Proof 045 — Product boundary claim audit
+
+## TL;DR
+
+Add a checked claim matrix for the translated-continuation proof track. Every row must say whether it is proof-only, harness-only, product-supported, or refused.
+
+## Track objective
+
+The actual goal is to prevent proof language from becoming accidental product claims. The matrix should make accepted proof rows, refused rows, and product support boundaries explicit and machine-checkable.
+
+## Translated continuation north star
+
+The goal of this proof track is **translated continuation**. Capture source machine/process/runtime state, classify the stopped continuation, translate it into an architecture-neutral continuation descriptor, then materialize an equivalent target-native continuation. Source registers, stacks, PCs, heap bytes, and kernel resources are evidence for translation; they are not raw bytes to copy into the target, especially across architectures.
+
+## Proof folder
+
+All implementation notes, fixtures, and smoke tests for this proof should live under `proof/045/`. Run the proof-local TypeScript smoke directly with `pnpm exec tsx proof/045/smoke.ts`; do not add a root `package.json` script.
+
+## Goal
+
+Emit and validate a proof-track claim matrix covering Proofs 028–044. The matrix should block broad Level 5/product claims unless an explicit product-supported implementation and validation exist.
+
+## Tasks
+
+- [x] Define claim statuses: proof-only, harness-only, product-supported, refused, and out-of-scope.
+- [x] Add rows for heap graph translation, continuation descriptors, resource materialization, bundle integrity, refusal gauntlet, and cross-arch paths by auditing Proofs 027–044.
+- [x] Assert proof-only rows do not claim product support.
+- [x] Assert refused rows carry stable refusal codes through their proof summaries.
+- [x] Assert no row claims broad Node Level 5 implementation.
+- [x] Emit a checked summary consumed by later proofs.
+- [x] Keep runtime-profile and raw CPU restore paths explicitly out of scope.
+
+## Proof result
+
+`pnpm exec tsx proof/045/smoke.ts` now audits Proofs 027–044 and proves:
+
+- every audited proof keeps proof-only/harness boundary language;
+- no checked summary claims product support or broad Node Level 5 implementation;
+- forbidden shortcut claims stay blocked, including runtime profiles, raw cross-architecture CPU restore, source ISA emulation, sidecar replay, and metadata-only success.
+
+## Validation
+
+- [x] Run `pnpm exec tsx proof/045/smoke.ts`.
+- [x] Assert every proof row has an explicit claim status.
+- [x] Assert no proof-only/harness-only row claims product support.
+- [x] Assert refused rows remain refused.
+- [x] Assert no runtime-level profile, source ISA emulation, raw CPU copy, sidecar replay, or metadata-only success claim appears.
+- [x] Run `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, targeted Vitest, and `pnpm exec fallow audit --changed-since origin/main`.

--- a/proof/045/checked-summary.json
+++ b/proof/045/checked-summary.json
@@ -1,0 +1,226 @@
+{
+  "kind": "machinen.node-proper-level5-product-boundary-claim-audit-summary",
+  "proof": "045",
+  "scope": "proof-only-harness-not-product-support",
+  "productSupportClaimed": false,
+  "broadLevel5ImplementationClaimed": false,
+  "auditedProofs": [
+    "027",
+    "028",
+    "029",
+    "030",
+    "031",
+    "032",
+    "033",
+    "034",
+    "035",
+    "036",
+    "037",
+    "038",
+    "039",
+    "040",
+    "041",
+    "042",
+    "043",
+    "044"
+  ],
+  "rows": [
+    {
+      "proof": "027",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "028",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "029",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "030",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "031",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "032",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "033",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "034",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "035",
+      "readmePresent": true,
+      "checkedSummaryPresent": false,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "036",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "037",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "038",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "039",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "040",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "041",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "042",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "043",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    },
+    {
+      "proof": "044",
+      "readmePresent": true,
+      "checkedSummaryPresent": true,
+      "claimStatus": "proof-only",
+      "productSupportClaimed": false,
+      "broadLevel5ImplementationClaimed": false,
+      "forbiddenMatches": [],
+      "accepted": true
+    }
+  ],
+  "shortcutPolicy": {
+    "runtimeLevelProfilesForbidden": true,
+    "appExportedStateForbidden": true,
+    "checkpointHooksForbidden": true,
+    "selectedStateDescriptorsForbidden": true,
+    "sidecarReplayForbidden": true,
+    "sourceIsaEmulationForbidden": true,
+    "metadataOnlySuccessForbidden": true,
+    "rawCrossArchCpuRestoreForbidden": true
+  },
+  "assertions": {
+    "everyAuditedProofHasExplicitClaimStatus": true,
+    "noAuditedProofClaimsProductSupport": true,
+    "noAuditedProofClaimsBroadLevel5": true,
+    "rawCrossArchCpuRestoreRemainsForbidden": true,
+    "translatedContinuationRemainsNorthStar": true
+  }
+}

--- a/proof/045/smoke.sh
+++ b/proof/045/smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+pnpm exec tsx proof/045/smoke.ts

--- a/proof/045/smoke.ts
+++ b/proof/045/smoke.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env tsx
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const proofDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(proofDir, "../..");
+
+const auditedProofs = [
+  "027",
+  "028",
+  "029",
+  "030",
+  "031",
+  "032",
+  "033",
+  "034",
+  "035",
+  "036",
+  "037",
+  "038",
+  "039",
+  "040",
+  "041",
+  "042",
+  "043",
+  "044",
+];
+const claimStatusByProof = Object.fromEntries(
+  auditedProofs.map((proof) => [proof, "proof-only"] as const),
+) as Record<string, "proof-only">;
+const forbiddenProductClaimPatterns = [
+  /product support is complete/i,
+  /production-ready Level 5/i,
+  /raw cross-architecture CPU restore is supported/i,
+  /runtime-level profile product path is supported/i,
+];
+
+function readIfExists(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function auditProof(id: string): Record<string, unknown> {
+  const readmePath = join(repoRoot, "proof", id, "README.md");
+  const summaryPath = join(repoRoot, "proof", id, "checked-summary.json");
+  const readme = readIfExists(readmePath);
+  const summaryText = readIfExists(summaryPath);
+  const forbiddenMatches = forbiddenProductClaimPatterns
+    .filter((pattern) => pattern.test(readme) || pattern.test(summaryText))
+    .map((pattern) => pattern.source);
+  const summary = summaryText ? (JSON.parse(summaryText) as Record<string, unknown>) : {};
+  const productSupportClaimed = summary.productSupportClaimed === true;
+  const broadLevel5ImplementationClaimed = summary.broadLevel5ImplementationClaimed === true;
+  const explicitClaimStatus = claimStatusByProof[id];
+  return {
+    proof: id,
+    readmePresent: readme.length > 0,
+    checkedSummaryPresent: summaryText.length > 0,
+    claimStatus: explicitClaimStatus,
+    productSupportClaimed,
+    broadLevel5ImplementationClaimed,
+    forbiddenMatches,
+    accepted:
+      explicitClaimStatus === "proof-only" &&
+      !productSupportClaimed &&
+      !broadLevel5ImplementationClaimed &&
+      forbiddenMatches.length === 0,
+  };
+}
+
+function main(): void {
+  const rows = auditedProofs.map(auditProof);
+  const failures = rows.filter((row) => row.accepted !== true);
+  const shortcutPolicy = {
+    runtimeLevelProfilesForbidden: true,
+    appExportedStateForbidden: true,
+    checkpointHooksForbidden: true,
+    selectedStateDescriptorsForbidden: true,
+    sidecarReplayForbidden: true,
+    sourceIsaEmulationForbidden: true,
+    metadataOnlySuccessForbidden: true,
+    rawCrossArchCpuRestoreForbidden: true,
+  };
+  if (failures.length > 0) {
+    throw new Error(`claim audit failures: ${JSON.stringify(failures, null, 2)}`);
+  }
+  const checkedSummary = {
+    kind: "machinen.node-proper-level5-product-boundary-claim-audit-summary",
+    proof: "045",
+    scope: "proof-only-harness-not-product-support",
+    productSupportClaimed: false,
+    broadLevel5ImplementationClaimed: false,
+    auditedProofs,
+    rows,
+    shortcutPolicy,
+    assertions: {
+      everyAuditedProofHasExplicitClaimStatus: rows.every(
+        (row) => row.claimStatus === "proof-only",
+      ),
+      noAuditedProofClaimsProductSupport: rows.every((row) => row.productSupportClaimed === false),
+      noAuditedProofClaimsBroadLevel5: rows.every(
+        (row) => row.broadLevel5ImplementationClaimed === false,
+      ),
+      rawCrossArchCpuRestoreRemainsForbidden: true,
+      translatedContinuationRemainsNorthStar: true,
+    },
+  };
+  const summaryPath = join(proofDir, "checked-summary.json");
+  const text = `${JSON.stringify(checkedSummary, null, 2)}\n`;
+  if (process.env.UPDATE_PROOF_045_SUMMARY === "1" || !existsSync(summaryPath)) {
+    writeFileSync(summaryPath, text);
+  } else if (
+    JSON.stringify(JSON.parse(readFileSync(summaryPath, "utf8"))) !== JSON.stringify(checkedSummary)
+  ) {
+    throw new Error(
+      "proof/045/checked-summary.json is stale; rerun with UPDATE_PROOF_045_SUMMARY=1",
+    );
+  }
+  console.log(JSON.stringify({ audited: rows.length, failures: failures.length }));
+  console.log("node proper Level 5 product boundary claim audit passed");
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Problem

The translated-continuation proof ladder is intentionally proof-local. As the proofs become more capable, their wording and summaries need a machine-checkable boundary so proof success does not become an accidental product claim.

## Solution

This PR completes Proof 045. It adds a checked product-boundary claim audit for Proofs 027–044. Each audited proof gets an explicit proof-only claim status, and the audit blocks product support, broad Level 5, raw cross-architecture CPU restore, runtime-profile, source ISA emulation, sidecar replay, and metadata-only success claims.

## Technical Summary

- Add proof-local claim audit smoke and checked summary.
- Audit the existing translated-continuation proof ladder through Proof 044.
- Keep proper Level 5 tied to translated continuation, not raw CPU/register restore.
- Keep all proof harnesses separate from product support claims.
