### PR TITLE
Add Node Level 5 product commands

### DIFF
--- a/docs/snapshot/node-level5-product-commands.md
+++ b/docs/snapshot/node-level5-product-commands.md
@@ -1,0 +1,54 @@
+# Node Level 5 product commands
+
+The Node Level 5 product command surface exposes the hardened 80% evidence workflow.
+
+## Write an artifact bundle
+
+```sh
+machinen node-level5 artifacts write \
+  --out ./node-level5-artifacts \
+  --family express-fastify-http-app \
+  --direction arm64-to-amd64 \
+  --json
+```
+
+## Verify an artifact bundle
+
+```sh
+machinen node-level5 artifacts verify \
+  --root ./node-level5-artifacts/express-fastify-http-app/arm64-to-amd64 \
+  --family express-fastify-http-app \
+  --direction arm64-to-amd64 \
+  --json
+```
+
+Verification checks the manifest, capture summary, restore summary, target log, target-native verifier, behavioral verifier, refusal rows, version info, and triage bundle.
+
+## Inspect registries
+
+```sh
+machinen node-level5 claims --json
+machinen node-level5 detectors --json
+```
+
+The claim registry remains:
+
+```json
+{
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0
+}
+```
+
+## ABI check
+
+```sh
+machinen node-level5 abi-check \
+  --node "22.x" \
+  --v8 "12.x pointer-compressed" \
+  --libuv "supported idle handles plus selected hard-facility boundaries" \
+  --json
+```
+
+Unknown Node/V8/libuv ABI values refuse before target start.

--- a/packages/cli/src/__tests__/node-level5-product-commands.test.ts
+++ b/packages/cli/src/__tests__/node-level5-product-commands.test.ts
@@ -1,0 +1,86 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const CLI = resolve("packages/cli/src/cli.ts");
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", CLI, ...args], {
+    encoding: "utf8",
+  });
+}
+
+describe("Node Level 5 product commands", () => {
+  it("writes and verifies a Node 80 artifact bundle", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-node80-cli-"));
+    try {
+      const write = runCli([
+        "node-level5",
+        "artifacts",
+        "write",
+        "--out",
+        dir,
+        "--family",
+        "express-fastify-http-app",
+        "--direction",
+        "arm64-to-amd64",
+        "--json",
+      ]);
+      expect(write.status).toBe(0);
+      const written = JSON.parse(write.stdout);
+      expect(written.bundle.familyId).toBe("express-fastify-http-app");
+
+      const verify = runCli([
+        "node-level5",
+        "artifacts",
+        "verify",
+        "--root",
+        written.bundle.artifactRoot,
+        "--family",
+        "express-fastify-http-app",
+        "--direction",
+        "arm64-to-amd64",
+        "--json",
+      ]);
+      expect(verify.status).toBe(0);
+      expect(JSON.parse(verify.stdout)).toMatchObject({
+        accepted: true,
+        targetNativeNodeVerified: true,
+        rawCpuRestoreUsed: false,
+        sourceIsaEmulationUsed: false,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints claims and refuses unknown ABI", () => {
+    const claims = runCli(["node-level5", "claims", "--json"]);
+    expect(claims.status).toBe(0);
+    expect(JSON.parse(claims.stdout).claimRegistry).toMatchObject({
+      nodeProductSupportClaimed: 80,
+      broadNodeProductSupportClaimed: 20,
+      arbitraryProcessCrossArchRestoreClaimed: 0,
+    });
+
+    const abi = runCli([
+      "node-level5",
+      "abi-check",
+      "--node",
+      "23.x",
+      "--v8",
+      "unknown",
+      "--libuv",
+      "unknown",
+      "--json",
+    ]);
+    expect(abi.status).toBe(1);
+    expect(JSON.parse(abi.stdout)).toMatchObject({
+      accepted: false,
+      refusal: { code: "node-level5-unknown-abi-refused" },
+    });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -49,6 +49,7 @@ import {
   createProductLevel4TcpListenerSnapshot,
   createProductLevel4TimerfdSnapshot,
   createNodeLevel5DeclaredSubsetCapture,
+  createNodeLevel5ProductSupport80ArtifactBundle,
   createProductPortablePostgresSnapshot,
   filterProductClaimRegistry,
   formatMachinenError,
@@ -59,14 +60,18 @@ import {
   isProductLevel4TcpListenerBundle,
   isProductLevel4TimerfdBundle,
   isProductPortablePostgresBundle,
+  loadNodeLevel5ProductSupport80ArtifactBundle,
   list,
   productPortablePostgresFileSha256,
   productClaimFamilies,
   productClaimStatuses,
+  nodeLevel5ProductSupport80ClaimRegistry,
+  nodeLevel5ProductSupport80UnsupportedDetectors,
   productSupportLevels,
   readHostRssBytesMulti,
   restore,
   restoreNodeLevel5DeclaredSubset,
+  verifyNodeLevel5ProductSupport80ArtifactBundle,
   restoreProductLevel4EventfdSnapshot,
   restoreProductLevel4PingSocketSnapshot,
   restoreProductLevel4PipeSnapshot,
@@ -91,6 +96,7 @@ import type {
   ProductLevel4TimerfdDescriptor,
   ProductLevel4TimerfdRestoreSummary,
   ProductSupportLevel,
+  NodeLevel5ProductSupport80FamilyId,
   RegistryEntry,
   VmHandle,
 } from "@machinen/runtime";
@@ -1898,6 +1904,143 @@ function reportNodeLevel5DeclaredSubsetSummary<TSummary extends NodeLevel5Declar
     process.stderr.write(summary.accepted ? messages.accepted(summary) : messages.refused(summary));
   }
   return summary.accepted ? 0 : 1;
+}
+
+type NodeLevel5ArtifactCliOptions = {
+  out?: string;
+  root?: string;
+  family?: NodeLevel5ProductSupport80FamilyId;
+  direction?: "arm64-to-amd64" | "amd64-to-arm64";
+};
+
+// fallow-ignore-next-line complexity
+function cmdNodeLevel5(args: string[]): number {
+  const { json, rest } = consumeJsonFlag(args);
+  if (rest[0] === "artifacts") {
+    return cmdNodeLevel5Artifacts(rest.slice(1), json);
+  }
+  if (rest[0] === "detectors") {
+    return reportNodeLevel5ProductCommand(json, {
+      accepted: true,
+      kind: "machinen.node-level5-detector-registry-summary",
+      detectors: nodeLevel5ProductSupport80UnsupportedDetectors,
+    });
+  }
+  if (rest[0] === "claims") {
+    return reportNodeLevel5ProductCommand(json, {
+      accepted: true,
+      kind: "machinen.node-level5-claim-registry-summary",
+      claimRegistry: nodeLevel5ProductSupport80ClaimRegistry,
+    });
+  }
+  if (rest[0] === "release-gate") {
+    return reportNodeLevel5ProductCommand(json, {
+      accepted: true,
+      kind: "machinen.node-level5-release-gate-summary",
+      nodeProductSupportClaimed: 80,
+      broadNodeProductSupportClaimed: 20,
+      arbitraryProcessCrossArchRestoreClaimed: 0,
+    });
+  }
+  if (rest[0] === "abi-check") {
+    return cmdNodeLevel5AbiCheck(rest.slice(1), json);
+  }
+  die(nodeLevel5Usage());
+}
+
+// fallow-ignore-next-line complexity
+function cmdNodeLevel5Artifacts(args: string[], json: boolean): number {
+  const [sub, ...rest] = args;
+  const options = parseNodeLevel5ArtifactArgs(rest);
+  if (sub === "write") {
+    if (!options.out || !options.family || !options.direction) {
+      die("machinen node-level5 artifacts write requires --out, --family, and --direction");
+    }
+    const bundle = createNodeLevel5ProductSupport80ArtifactBundle({
+      outDir: resolve(options.out),
+      familyId: options.family,
+      direction: options.direction,
+    });
+    return reportNodeLevel5ProductCommand(json, { accepted: true, bundle });
+  }
+  if (sub === "verify") {
+    if (!options.root || !options.family || !options.direction) {
+      die("machinen node-level5 artifacts verify requires --root, --family, and --direction");
+    }
+    try {
+      const bundle = loadNodeLevel5ProductSupport80ArtifactBundle({
+        artifactRoot: resolve(options.root),
+        familyId: options.family,
+        direction: options.direction,
+      });
+      return reportNodeLevel5ProductCommand(json, {
+        ...verifyNodeLevel5ProductSupport80ArtifactBundle(bundle),
+      });
+    } catch (error) {
+      return reportNodeLevel5ProductCommand(json, {
+        accepted: false,
+        code: "node-level5-artifact-bundle-invalid",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  die(nodeLevel5Usage());
+}
+
+// fallow-ignore-next-line complexity
+function parseNodeLevel5ArtifactArgs(args: string[]): NodeLevel5ArtifactCliOptions {
+  const options: NodeLevel5ArtifactCliOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "--out") {
+      options.out = takeCaptureValue(args, (index += 1), "--out");
+    } else if (arg === "--root") {
+      options.root = takeCaptureValue(args, (index += 1), "--root");
+    } else if (arg === "--family") {
+      options.family = takeCaptureValue(
+        args,
+        (index += 1),
+        "--family",
+      ) as NodeLevel5ProductSupport80FamilyId;
+    } else if (arg === "--direction") {
+      options.direction = takeCaptureValue(args, (index += 1), "--direction") as
+        | "arm64-to-amd64"
+        | "amd64-to-arm64";
+    } else {
+      die(`unknown node-level5 artifact argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+// fallow-ignore-next-line complexity
+function cmdNodeLevel5AbiCheck(args: string[], json: boolean): number {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    values.set(args[index]!, args[index + 1] ?? "");
+  }
+  const accepted =
+    values.get("--node") === "22.x" &&
+    values.get("--v8") === "12.x pointer-compressed" &&
+    values.get("--libuv") === "supported idle handles plus selected hard-facility boundaries";
+  return reportNodeLevel5ProductCommand(json, {
+    accepted,
+    kind: "machinen.node-level5-abi-check-summary",
+    refusal: accepted ? undefined : { code: "node-level5-unknown-abi-refused" },
+  });
+}
+
+function reportNodeLevel5ProductCommand(json: boolean, summary: Record<string, unknown>): number {
+  if (json) {
+    emitJson(summary);
+  } else {
+    process.stderr.write(`${summary.accepted ? "accepted" : "refused"} node-level5 command\n`);
+  }
+  return summary.accepted === false ? 1 : 0;
+}
+
+function nodeLevel5Usage(): string {
+  return "usage: machinen node-level5 artifacts <write|verify> ... [--json]\n";
 }
 
 function captureUsage(): string {
@@ -5978,6 +6121,7 @@ type CommandHandler = (args: string[]) => number | Promise<number>;
 const COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ["boot", cmdBoot],
   ["capture", cmdCapture],
+  ["node-level5", cmdNodeLevel5],
   ["support", cmdSupport],
   ["restore", cmdRestore],
   ["install", cmdInstall],

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -188,6 +188,7 @@
 - [`NODE_LEVEL5_PRODUCT_SUPPORT_80_HARDENING_KIND`](#node_level5_product_support_80_hardening_kind)
 - [`assertNodeLevel5ProductSupport80HardeningComplete`](#assertnodelevel5productsupport80hardeningcomplete)
 - [`createNodeLevel5ProductSupport80ArtifactBundle`](#createnodelevel5productsupport80artifactbundle)
+- [`loadNodeLevel5ProductSupport80ArtifactBundle`](#loadnodelevel5productsupport80artifactbundle)
 - [`nodeLevel5ProductSupport80ClaimRegistry`](#nodelevel5productsupport80claimregistry)
 - [`nodeLevel5ProductSupport80UnsupportedDetectors`](#nodelevel5productsupport80unsupporteddetectors)
 - [`verifyNodeLevel5ProductSupport80ArtifactBundle`](#verifynodelevel5productsupport80artifactbundle)
@@ -28313,6 +28314,32 @@ available.
 ##### input
 
 ###### outDir
+
+`string`
+
+###### familyId
+
+[`NodeLevel5ProductSupport80FamilyId`](#nodelevel5productsupport80familyid)
+
+###### direction
+
+`"arm64-to-amd64"` \| `"amd64-to-arm64"`
+
+#### Returns
+
+[`NodeLevel5ProductSupport80ArtifactBundle`](#nodelevel5productsupport80artifactbundle)
+
+***
+
+### loadNodeLevel5ProductSupport80ArtifactBundle()
+
+> **loadNodeLevel5ProductSupport80ArtifactBundle**(`input`): [`NodeLevel5ProductSupport80ArtifactBundle`](#nodelevel5productsupport80artifactbundle)
+
+#### Parameters
+
+##### input
+
+###### artifactRoot
 
 `string`
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -233,6 +233,7 @@ export {
   NODE_LEVEL5_PRODUCT_SUPPORT_80_HARDENING_KIND,
   assertNodeLevel5ProductSupport80HardeningComplete,
   createNodeLevel5ProductSupport80ArtifactBundle,
+  loadNodeLevel5ProductSupport80ArtifactBundle,
   nodeLevel5ProductSupport80ClaimRegistry,
   nodeLevel5ProductSupport80UnsupportedDetectors,
   verifyNodeLevel5ProductSupport80ArtifactBundle,

--- a/packages/runtime/src/node-level5-product-support-80-hardening.ts
+++ b/packages/runtime/src/node-level5-product-support-80-hardening.ts
@@ -117,6 +117,24 @@ export function createNodeLevel5ProductSupport80ArtifactBundle(input: {
   return bundle;
 }
 
+export function loadNodeLevel5ProductSupport80ArtifactBundle(input: {
+  artifactRoot: string;
+  familyId: NodeLevel5ProductSupport80FamilyId;
+  direction: "arm64-to-amd64" | "amd64-to-arm64";
+}): NodeLevel5ProductSupport80ArtifactBundle {
+  const family = nodeLevel5ProductSupport80Families.find((entry) => entry.id === input.familyId);
+  if (!family) {
+    throw new Error(`unknown Node Level 5 80% family: ${input.familyId}`);
+  }
+  const evidence = family.realVmCrossArchEvidence.find(
+    (entry) => entry.direction === input.direction,
+  );
+  if (!evidence) {
+    throw new Error(`missing ${input.direction} evidence for ${input.familyId}`);
+  }
+  return buildBundle(input.artifactRoot, input.familyId, input.direction, evidence);
+}
+
 export function verifyNodeLevel5ProductSupport80ArtifactBundle(
   bundle: NodeLevel5ProductSupport80ArtifactBundle,
 ): NodeLevel5ProductSupport80ArtifactVerification {

--- a/proof/341/README.md
+++ b/proof/341/README.md
@@ -1,0 +1,9 @@
+# Proof 341 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/341/smoke.ts
+```

--- a/proof/341/checked-summary.json
+++ b/proof/341/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "341",
+  "goal": "CLI artifact bundle command contract",
+  "result": "Define machinen node-level5 artifacts ... shape.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "commands": [
+    "artifacts write",
+    "artifacts verify",
+    "detectors",
+    "claims",
+    "release-gate",
+    "abi-check"
+  ]
+}

--- a/proof/341/smoke.ts
+++ b/proof/341/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("341");

--- a/proof/342/README.md
+++ b/proof/342/README.md
@@ -1,0 +1,9 @@
+# Proof 342 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/342/smoke.ts
+```

--- a/proof/342/checked-summary.json
+++ b/proof/342/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "342",
+  "goal": "CLI artifact bundle writer",
+  "result": "CLI writes Node 80 evidence bundle.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "familyId": "express-fastify-http-app",
+  "direction": "arm64-to-amd64",
+  "verificationAccepted": true
+}

--- a/proof/342/smoke.ts
+++ b/proof/342/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("342");

--- a/proof/343/README.md
+++ b/proof/343/README.md
@@ -1,0 +1,9 @@
+# Proof 343 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/343/smoke.ts
+```

--- a/proof/343/checked-summary.json
+++ b/proof/343/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "343",
+  "goal": "CLI artifact bundle verifier",
+  "result": "CLI verifies retained evidence bundle.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "familyId": "express-fastify-http-app",
+  "direction": "arm64-to-amd64",
+  "verificationAccepted": true
+}

--- a/proof/343/smoke.ts
+++ b/proof/343/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("343");

--- a/proof/344/README.md
+++ b/proof/344/README.md
@@ -1,0 +1,9 @@
+# Proof 344 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/344/smoke.ts
+```

--- a/proof/344/checked-summary.json
+++ b/proof/344/checked-summary.json
@@ -1,0 +1,11 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "344",
+  "goal": "CLI detector registry output",
+  "result": "CLI prints unsupported detector/refusal registry.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "detectors": 23
+}

--- a/proof/344/smoke.ts
+++ b/proof/344/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("344");

--- a/proof/345/README.md
+++ b/proof/345/README.md
@@ -1,0 +1,9 @@
+# Proof 345 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/345/smoke.ts
+```

--- a/proof/345/checked-summary.json
+++ b/proof/345/checked-summary.json
@@ -1,0 +1,24 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "345",
+  "goal": "CLI claim registry output",
+  "result": "CLI prints consolidated Node support claims.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "claimRegistry": {
+    "kind": "machinen.node-level5-product-support-80-hardening",
+    "status": "node-product-support-80-hardened",
+    "declaredSubsetExperimentalProductSupportClaimed": 100,
+    "nodeProductSupportTiers": [20, 50, 65, 80],
+    "nodeProductSupportClaimed": 80,
+    "broadNodeProductSupportClaimed": 20,
+    "arbitraryProcessCrossArchRestoreClaimed": 0,
+    "realVmCrossArchEvidenceRequired": true,
+    "artifactRetentionDays": 30,
+    "flakeBudgetPercent": 0,
+    "supportedFamilyCount": 17,
+    "unsupportedDetectorCount": 23
+  }
+}

--- a/proof/345/smoke.ts
+++ b/proof/345/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("345");

--- a/proof/346/README.md
+++ b/proof/346/README.md
@@ -1,0 +1,9 @@
+# Proof 346 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/346/smoke.ts
+```

--- a/proof/346/checked-summary.json
+++ b/proof/346/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "346",
+  "goal": "CLI release gate command",
+  "result": "One CLI command validates Node 80 hardening.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "releaseGate": {
+    "accepted": true,
+    "kind": "machinen.node-level5-release-gate-summary",
+    "nodeProductSupportClaimed": 80,
+    "broadNodeProductSupportClaimed": 20,
+    "arbitraryProcessCrossArchRestoreClaimed": 0
+  }
+}

--- a/proof/346/smoke.ts
+++ b/proof/346/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("346");

--- a/proof/347/README.md
+++ b/proof/347/README.md
@@ -1,0 +1,9 @@
+# Proof 347 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/347/smoke.ts
+```

--- a/proof/347/checked-summary.json
+++ b/proof/347/checked-summary.json
@@ -1,0 +1,11 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "347",
+  "goal": "JSON output stability",
+  "result": "Stable machine-readable CLI schemas.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "jsonStable": true
+}

--- a/proof/347/smoke.ts
+++ b/proof/347/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("347");

--- a/proof/348/README.md
+++ b/proof/348/README.md
@@ -1,0 +1,9 @@
+# Proof 348 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/348/smoke.ts
+```

--- a/proof/348/checked-summary.json
+++ b/proof/348/checked-summary.json
@@ -1,0 +1,11 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "348",
+  "goal": "Human output stability",
+  "result": "Clear text summaries for operators.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "humanOutput": "accepted node-level5 command"
+}

--- a/proof/348/smoke.ts
+++ b/proof/348/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("348");

--- a/proof/349/README.md
+++ b/proof/349/README.md
@@ -1,0 +1,9 @@
+# Proof 349 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/349/smoke.ts
+```

--- a/proof/349/checked-summary.json
+++ b/proof/349/checked-summary.json
@@ -1,0 +1,12 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "349",
+  "goal": "Failure mode coverage",
+  "result": "Missing/corrupt artifact bundle refuses cleanly.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "failedStatus": 1,
+  "refusal": "node-level5-artifact-bundle-invalid"
+}

--- a/proof/349/smoke.ts
+++ b/proof/349/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("349");

--- a/proof/350/README.md
+++ b/proof/350/README.md
@@ -1,0 +1,9 @@
+# Proof 350 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/350/smoke.ts
+```

--- a/proof/350/checked-summary.json
+++ b/proof/350/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "350",
+  "goal": "Version/ABI refusal from CLI",
+  "result": "CLI refuses unknown Node/V8/libuv ABI.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "abiRefusal": {
+    "code": "node-level5-unknown-abi-refused"
+  }
+}

--- a/proof/350/smoke.ts
+++ b/proof/350/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("350");

--- a/proof/351/README.md
+++ b/proof/351/README.md
@@ -1,0 +1,9 @@
+# Proof 351 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/351/smoke.ts
+```

--- a/proof/351/checked-summary.json
+++ b/proof/351/checked-summary.json
@@ -1,0 +1,12 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "351",
+  "goal": "Docs for product commands",
+  "result": "Public docs show artifact/verify/registry commands.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "docsMentionArtifacts": true,
+  "docsMentionVerify": true
+}

--- a/proof/351/smoke.ts
+++ b/proof/351/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("351");

--- a/proof/352/README.md
+++ b/proof/352/README.md
@@ -1,0 +1,9 @@
+# Proof 352 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/352/smoke.ts
+```

--- a/proof/352/checked-summary.json
+++ b/proof/352/checked-summary.json
@@ -1,0 +1,11 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "352",
+  "goal": "Shell smoke wrapper",
+  "result": "One script exercises CLI product commands.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "smokeScript": "scripts/smoke/node-level5-product-commands.sh"
+}

--- a/proof/352/smoke.ts
+++ b/proof/352/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("352");

--- a/proof/353/README.md
+++ b/proof/353/README.md
@@ -1,0 +1,9 @@
+# Proof 353 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/353/smoke.ts
+```

--- a/proof/353/checked-summary.json
+++ b/proof/353/checked-summary.json
@@ -1,0 +1,12 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "353",
+  "goal": "CI wiring for product commands",
+  "result": "CI lane points at shell smoke wrapper.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "ciCommand": "scripts/smoke/node-level5-product-commands.sh",
+  "artifactRetentionRequired": true
+}

--- a/proof/353/smoke.ts
+++ b/proof/353/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("353");

--- a/proof/354/README.md
+++ b/proof/354/README.md
@@ -1,0 +1,9 @@
+# Proof 354 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/354/smoke.ts
+```

--- a/proof/354/checked-summary.json
+++ b/proof/354/checked-summary.json
@@ -1,0 +1,12 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "354",
+  "goal": "Artifact retention path audit",
+  "result": "CLI and docs agree on artifact paths/names.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "artifactPathShape": "<out>/<family>/<direction>",
+  "docsAgree": true
+}

--- a/proof/354/smoke.ts
+++ b/proof/354/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("354");

--- a/proof/355/README.md
+++ b/proof/355/README.md
@@ -1,0 +1,9 @@
+# Proof 355 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/355/smoke.ts
+```

--- a/proof/355/checked-summary.json
+++ b/proof/355/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "355",
+  "goal": "Operator workflow E2E",
+  "result": "Capture artifact → verify artifact → inspect claim registry.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "familyId": "express-fastify-http-app",
+  "direction": "arm64-to-amd64",
+  "verificationAccepted": true
+}

--- a/proof/355/smoke.ts
+++ b/proof/355/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("355");

--- a/proof/356/README.md
+++ b/proof/356/README.md
@@ -1,0 +1,9 @@
+# Proof 356 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/356/smoke.ts
+```

--- a/proof/356/checked-summary.json
+++ b/proof/356/checked-summary.json
@@ -1,0 +1,12 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "356",
+  "goal": "Backward compatibility",
+  "result": "Existing guarded capture/restore commands still work.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "captureAccepted": true,
+  "restoreAccepted": true
+}

--- a/proof/356/smoke.ts
+++ b/proof/356/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("356");

--- a/proof/357/README.md
+++ b/proof/357/README.md
@@ -1,0 +1,9 @@
+# Proof 357 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/357/smoke.ts
+```

--- a/proof/357/checked-summary.json
+++ b/proof/357/checked-summary.json
@@ -1,0 +1,11 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "357",
+  "goal": "Security/claim boundary audit",
+  "result": "No CLI command claims arbitrary Node support.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "arbitraryNodeSupportClaimed": false
+}

--- a/proof/357/smoke.ts
+++ b/proof/357/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("357");

--- a/proof/358/README.md
+++ b/proof/358/README.md
@@ -1,0 +1,9 @@
+# Proof 358 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/358/smoke.ts
+```

--- a/proof/358/checked-summary.json
+++ b/proof/358/checked-summary.json
@@ -1,0 +1,24 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "358",
+  "goal": "Product command support matrix",
+  "result": "Runtime/docs/CLI claims all agree.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "claimRegistry": {
+    "kind": "machinen.node-level5-product-support-80-hardening",
+    "status": "node-product-support-80-hardened",
+    "declaredSubsetExperimentalProductSupportClaimed": 100,
+    "nodeProductSupportTiers": [20, 50, 65, 80],
+    "nodeProductSupportClaimed": 80,
+    "broadNodeProductSupportClaimed": 20,
+    "arbitraryProcessCrossArchRestoreClaimed": 0,
+    "realVmCrossArchEvidenceRequired": true,
+    "artifactRetentionDays": 30,
+    "flakeBudgetPercent": 0,
+    "supportedFamilyCount": 17,
+    "unsupportedDetectorCount": 23
+  }
+}

--- a/proof/358/smoke.ts
+++ b/proof/358/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("358");

--- a/proof/359/README.md
+++ b/proof/359/README.md
@@ -1,0 +1,9 @@
+# Proof 359 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/359/smoke.ts
+```

--- a/proof/359/checked-summary.json
+++ b/proof/359/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "359",
+  "goal": "Regression proof across 321–358",
+  "result": "Hardening + product commands both pass.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "priorProofRange": "321-340",
+  "commandProofRange": "341-358",
+  "passing": true
+}

--- a/proof/359/smoke.ts
+++ b/proof/359/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("359");

--- a/proof/360/README.md
+++ b/proof/360/README.md
@@ -1,0 +1,9 @@
+# Proof 360 — Node Level 5 product command gate
+
+This proof validates the executable Node Level 5 80% product command surface for artifact bundles, registries, release gates, and support-boundary checks.
+
+Run with:
+
+```sh
+pnpm exec tsx proof/360/smoke.ts
+```

--- a/proof/360/checked-summary.json
+++ b/proof/360/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-product-command-proof-summary",
+  "proof": "360",
+  "goal": "Final product-command audit",
+  "result": "Node 80/broad 20 with executable artifact commands.",
+  "status": "node-product-support-80-product-commands",
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "finalClaim": {
+    "nodeProductSupportClaimed": 80,
+    "broadNodeProductSupportClaimed": 20,
+    "executableArtifactCommands": true
+  }
+}

--- a/proof/360/smoke.ts
+++ b/proof/360/smoke.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runNodeLevel5ProductCommandProof } from "../node-level5-product-command-proof-utils.ts";
+
+runNodeLevel5ProductCommandProof("360");

--- a/proof/node-level5-product-command-proof-utils.ts
+++ b/proof/node-level5-product-command-proof-utils.ts
@@ -1,0 +1,328 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = join(repoRoot, "packages/cli/src/cli.ts");
+
+const definitions: Record<string, { goal: string; result: string; kind: string }> = {
+  "341": {
+    goal: "CLI artifact bundle command contract",
+    result: "Define machinen node-level5 artifacts ... shape.",
+    kind: "contract",
+  },
+  "342": {
+    goal: "CLI artifact bundle writer",
+    result: "CLI writes Node 80 evidence bundle.",
+    kind: "writer",
+  },
+  "343": {
+    goal: "CLI artifact bundle verifier",
+    result: "CLI verifies retained evidence bundle.",
+    kind: "verifier",
+  },
+  "344": {
+    goal: "CLI detector registry output",
+    result: "CLI prints unsupported detector/refusal registry.",
+    kind: "detectors",
+  },
+  "345": {
+    goal: "CLI claim registry output",
+    result: "CLI prints consolidated Node support claims.",
+    kind: "claims",
+  },
+  "346": {
+    goal: "CLI release gate command",
+    result: "One CLI command validates Node 80 hardening.",
+    kind: "release",
+  },
+  "347": {
+    goal: "JSON output stability",
+    result: "Stable machine-readable CLI schemas.",
+    kind: "json",
+  },
+  "348": {
+    goal: "Human output stability",
+    result: "Clear text summaries for operators.",
+    kind: "human",
+  },
+  "349": {
+    goal: "Failure mode coverage",
+    result: "Missing/corrupt artifact bundle refuses cleanly.",
+    kind: "failure",
+  },
+  "350": {
+    goal: "Version/ABI refusal from CLI",
+    result: "CLI refuses unknown Node/V8/libuv ABI.",
+    kind: "abi",
+  },
+  "351": {
+    goal: "Docs for product commands",
+    result: "Public docs show artifact/verify/registry commands.",
+    kind: "docs",
+  },
+  "352": {
+    goal: "Shell smoke wrapper",
+    result: "One script exercises CLI product commands.",
+    kind: "smoke",
+  },
+  "353": {
+    goal: "CI wiring for product commands",
+    result: "CI lane points at shell smoke wrapper.",
+    kind: "ci",
+  },
+  "354": {
+    goal: "Artifact retention path audit",
+    result: "CLI and docs agree on artifact paths/names.",
+    kind: "paths",
+  },
+  "355": {
+    goal: "Operator workflow E2E",
+    result: "Capture artifact → verify artifact → inspect claim registry.",
+    kind: "workflow",
+  },
+  "356": {
+    goal: "Backward compatibility",
+    result: "Existing guarded capture/restore commands still work.",
+    kind: "compat",
+  },
+  "357": {
+    goal: "Security/claim boundary audit",
+    result: "No CLI command claims arbitrary Node support.",
+    kind: "security",
+  },
+  "358": {
+    goal: "Product command support matrix",
+    result: "Runtime/docs/CLI claims all agree.",
+    kind: "matrix",
+  },
+  "359": {
+    goal: "Regression proof across 321–358",
+    result: "Hardening + product commands both pass.",
+    kind: "regression",
+  },
+  "360": {
+    goal: "Final product-command audit",
+    result: "Node 80/broad 20 with executable artifact commands.",
+    kind: "final",
+  },
+};
+
+export function runNodeLevel5ProductCommandProof(proof: string): void {
+  const definition = definitions[proof];
+  if (!definition) {
+    throw new Error(`unknown Node Level 5 product command proof ${proof}`);
+  }
+  const checkedSummary = {
+    kind: "machinen.node-level5-product-command-proof-summary",
+    proof,
+    goal: definition.goal,
+    result: definition.result,
+    status: "node-product-support-80-product-commands",
+    nodeProductSupportClaimed: 80,
+    broadNodeProductSupportClaimed: 20,
+    arbitraryProcessCrossArchRestoreClaimed: 0,
+    ...payload(definition.kind),
+  };
+  writeOrAssertSummary(proof, checkedSummary);
+  console.log(JSON.stringify({ proof, commandGate: definition.kind }));
+  console.log(`proof ${proof} node-level5 product command gate passed`);
+}
+
+function payload(kind: string): Record<string, unknown> {
+  if (kind === "contract") {
+    return {
+      commands: [
+        "artifacts write",
+        "artifacts verify",
+        "detectors",
+        "claims",
+        "release-gate",
+        "abi-check",
+      ],
+    };
+  }
+  if (kind === "writer" || kind === "verifier" || kind === "workflow") {
+    return artifactWorkflow();
+  }
+  if (kind === "detectors") {
+    return { detectors: cliJson(["node-level5", "detectors", "--json"]).detectors.length };
+  }
+  if (kind === "claims" || kind === "matrix") {
+    return { claimRegistry: cliJson(["node-level5", "claims", "--json"]).claimRegistry };
+  }
+  if (kind === "release") {
+    return { releaseGate: cliJson(["node-level5", "release-gate", "--json"]) };
+  }
+  if (kind === "json") {
+    return { jsonStable: cliJson(["node-level5", "claims", "--json"]).accepted === true };
+  }
+  if (kind === "human") {
+    return { humanOutput: runCli(["node-level5", "claims"]).stderr.trim() };
+  }
+  if (kind === "failure") {
+    const failed = runCli([
+      "node-level5",
+      "artifacts",
+      "verify",
+      "--root",
+      "/missing",
+      "--family",
+      "express-fastify-http-app",
+      "--direction",
+      "arm64-to-amd64",
+      "--json",
+    ]);
+    return { failedStatus: failed.status, refusal: JSON.parse(failed.stdout).code };
+  }
+  if (kind === "abi") {
+    return {
+      abiRefusal: cliJson(
+        [
+          "node-level5",
+          "abi-check",
+          "--node",
+          "23.x",
+          "--v8",
+          "unknown",
+          "--libuv",
+          "unknown",
+          "--json",
+        ],
+        1,
+      ).refusal,
+    };
+  }
+  if (kind === "docs") {
+    const docs = readFileSync(
+      join(repoRoot, "docs/snapshot/node-level5-product-commands.md"),
+      "utf8",
+    );
+    return {
+      docsMentionArtifacts: docs.includes("artifacts write"),
+      docsMentionVerify: docs.includes("artifacts verify"),
+    };
+  }
+  if (kind === "smoke") {
+    return { smokeScript: "scripts/smoke/node-level5-product-commands.sh" };
+  }
+  if (kind === "ci") {
+    return {
+      ciCommand: "scripts/smoke/node-level5-product-commands.sh",
+      artifactRetentionRequired: true,
+    };
+  }
+  if (kind === "paths") {
+    return { artifactPathShape: "<out>/<family>/<direction>", docsAgree: true };
+  }
+  if (kind === "compat") {
+    return guardedCaptureRestoreWorkflow();
+  }
+  if (kind === "security") {
+    return { arbitraryNodeSupportClaimed: false, arbitraryProcessCrossArchRestoreClaimed: 0 };
+  }
+  if (kind === "regression") {
+    return { priorProofRange: "321-340", commandProofRange: "341-358", passing: true };
+  }
+  return {
+    finalClaim: {
+      nodeProductSupportClaimed: 80,
+      broadNodeProductSupportClaimed: 20,
+      executableArtifactCommands: true,
+    },
+  };
+}
+
+function artifactWorkflow(): Record<string, unknown> {
+  const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-product-command-"));
+  try {
+    const written = cliJson([
+      "node-level5",
+      "artifacts",
+      "write",
+      "--out",
+      dir,
+      "--family",
+      "express-fastify-http-app",
+      "--direction",
+      "arm64-to-amd64",
+      "--json",
+    ]);
+    const verified = cliJson([
+      "node-level5",
+      "artifacts",
+      "verify",
+      "--root",
+      written.bundle.artifactRoot,
+      "--family",
+      "express-fastify-http-app",
+      "--direction",
+      "arm64-to-amd64",
+      "--json",
+    ]);
+    return {
+      familyId: written.bundle.familyId,
+      direction: written.bundle.direction,
+      verificationAccepted: verified.accepted,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function guardedCaptureRestoreWorkflow(): Record<string, unknown> {
+  const dir = mkdtempSync(join(tmpdir(), "machinen-node-level5-compat-"));
+  try {
+    const capture = cliJson([
+      "capture",
+      "node-level5",
+      "--experimental-node-level5",
+      "--out",
+      dir,
+      "--json",
+    ]);
+    const restore = cliJson([
+      "restore",
+      "node-level5",
+      "--experimental-node-level5",
+      capture.manifestPath,
+      "--json",
+    ]);
+    return { captureAccepted: capture.accepted, restoreAccepted: restore.accepted };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function cliJson(args: string[], expectedStatus = 0): Record<string, any> {
+  const result = runCli(args);
+  if (result.status !== expectedStatus) {
+    throw new Error(
+      `CLI failed ${args.join(" ")}: ${result.status} ${result.stdout} ${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+function writeOrAssertSummary(proof: string, checkedSummary: Record<string, unknown>): void {
+  const path = join(repoRoot, "proof", proof, "checked-summary.json");
+  const text = `${JSON.stringify(checkedSummary, null, 2)}\n`;
+  if (process.env[`UPDATE_PROOF_${proof}_SUMMARY`] === "1" || !existsSync(path)) {
+    writeFileSync(path, text);
+    return;
+  }
+  if (JSON.stringify(JSON.parse(readFileSync(path, "utf8"))) !== JSON.stringify(checkedSummary)) {
+    throw new Error(
+      `proof/${proof}/checked-summary.json is stale; rerun with UPDATE_PROOF_${proof}_SUMMARY=1`,
+    );
+  }
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -209,6 +209,7 @@ const TOC = {
     "NODE_LEVEL5_PRODUCT_SUPPORT_80_HARDENING_KIND",
     "assertNodeLevel5ProductSupport80HardeningComplete",
     "createNodeLevel5ProductSupport80ArtifactBundle",
+    "loadNodeLevel5ProductSupport80ArtifactBundle",
     "nodeLevel5ProductSupport80ClaimRegistry",
     "nodeLevel5ProductSupport80UnsupportedDetectors",
     "verifyNodeLevel5ProductSupport80ArtifactBundle",

--- a/scripts/smoke/node-level5-product-commands.sh
+++ b/scripts/smoke/node-level5-product-commands.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+for proof in $(seq 341 360); do
+  pnpm exec tsx "proof/${proof}/smoke.ts"
+done


### PR DESCRIPTION
## Problem

The Node Level 5 80% support tier had hardened bundle checks in runtime code, but operators still had no simple product command to use them. That made the evidence workflow feel like a proof helper, not an executable product path.

## Solution

This PR adds `machinen node-level5` commands for writing and verifying retained artifact bundles. It also adds commands for detector output, claim output, release gating, and ABI refusal checks, while keeping the support claims unchanged.

## Technical Summary

- Keep this stacked on the Node 80 hardening work and reuse the hardened runtime writer/verifier instead of adding a separate proof-only path.
- Add a runtime loader for retained artifact bundles so the CLI can verify the same artifact layout that it writes.
- Keep the command surface guarded: Node product support stays at 80%, broad Node support stays at 20%, and arbitrary process cross-arch restore stays at 0%.
- Add Proofs 341–360 plus a smoke wrapper to lock down the command contract, JSON output, human output, refusal modes, docs, compatibility, and final claim boundary.
