### PR TITLE
Add Node Level 5 release corpus harness

### DIFF
--- a/docs/snapshot/node-level5-cross-arch-release-corpus.md
+++ b/docs/snapshot/node-level5-cross-arch-release-corpus.md
@@ -1,0 +1,21 @@
+# Node Level 5 cross-architecture release corpus harness
+
+Proofs 501–560 exercise the retained Node Level 5 product snapshot format across both recorded directions:
+
+- `arm64-to-amd64`
+- `amd64-to-arm64`
+
+These are harness proofs for release gating. They do not raise product support claims on their own. The product UX remains:
+
+```sh
+machinen snapshot node <pid> --out ./node-snapshot
+machinen restore ./node-snapshot
+```
+
+The release corpus checks that target identity, detector, capture, artifact, and restore materialization evidence stay linked and verifiable. It also keeps the unsafe boundaries explicit: no raw CPU restore, no source ISA emulation, no metadata-only success, and no arbitrary process restore claim.
+
+Claims remain:
+
+- Node product support: 80%.
+- Broad Node product support: 20%.
+- Arbitrary process cross-architecture restore: 0%.

--- a/proof/501/README.md
+++ b/proof/501/README.md
@@ -1,0 +1,3 @@
+# Proof 501 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 501.

--- a/proof/501/checked-summary.json
+++ b/proof/501/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": true,
   "direction": "arm64-to-amd64"
 }

--- a/proof/501/checked-summary.json
+++ b/proof/501/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "501",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": true,
+  "direction": "arm64-to-amd64"
+}

--- a/proof/501/smoke.ts
+++ b/proof/501/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("501");

--- a/proof/502/README.md
+++ b/proof/502/README.md
@@ -1,0 +1,3 @@
+# Proof 502 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 502.

--- a/proof/502/checked-summary.json
+++ b/proof/502/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "502",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": true,
+  "direction": "arm64-to-amd64"
+}

--- a/proof/502/checked-summary.json
+++ b/proof/502/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": true,
   "direction": "arm64-to-amd64"
 }

--- a/proof/502/smoke.ts
+++ b/proof/502/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("502");

--- a/proof/503/README.md
+++ b/proof/503/README.md
@@ -1,0 +1,3 @@
+# Proof 503 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 503.

--- a/proof/503/checked-summary.json
+++ b/proof/503/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "503",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "captureReportKind": "machinen.node-level5-product-capture-report",
+  "direction": "arm64-to-amd64"
+}

--- a/proof/503/checked-summary.json
+++ b/proof/503/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "captureReportKind": "machinen.node-level5-product-capture-report",
   "direction": "arm64-to-amd64"
 }

--- a/proof/503/smoke.ts
+++ b/proof/503/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("503");

--- a/proof/504/README.md
+++ b/proof/504/README.md
@@ -1,0 +1,3 @@
+# Proof 504 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 504.

--- a/proof/504/checked-summary.json
+++ b/proof/504/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "materializationReportKind": "machinen.node-level5-product-restore-materialization-report",
   "direction": "arm64-to-amd64"
 }

--- a/proof/504/checked-summary.json
+++ b/proof/504/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "504",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "materializationReportKind": "machinen.node-level5-product-restore-materialization-report",
+  "direction": "arm64-to-amd64"
+}

--- a/proof/504/smoke.ts
+++ b/proof/504/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("504");

--- a/proof/505/README.md
+++ b/proof/505/README.md
@@ -1,0 +1,3 @@
+# Proof 505 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 505.

--- a/proof/505/checked-summary.json
+++ b/proof/505/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "targetNativeNodeVerified": true
 }

--- a/proof/505/checked-summary.json
+++ b/proof/505/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "505",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "targetNativeNodeVerified": true
+}

--- a/proof/505/smoke.ts
+++ b/proof/505/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("505");

--- a/proof/506/README.md
+++ b/proof/506/README.md
@@ -1,0 +1,3 @@
+# Proof 506 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 506.

--- a/proof/506/checked-summary.json
+++ b/proof/506/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "506",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "rawCpuRestoreUsed": false
+}

--- a/proof/506/checked-summary.json
+++ b/proof/506/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "rawCpuRestoreUsed": false
 }

--- a/proof/506/smoke.ts
+++ b/proof/506/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("506");

--- a/proof/507/README.md
+++ b/proof/507/README.md
@@ -1,0 +1,3 @@
+# Proof 507 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 507.

--- a/proof/507/checked-summary.json
+++ b/proof/507/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "sourceIsaEmulationUsed": false
 }

--- a/proof/507/checked-summary.json
+++ b/proof/507/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "507",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "sourceIsaEmulationUsed": false
+}

--- a/proof/507/smoke.ts
+++ b/proof/507/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("507");

--- a/proof/508/README.md
+++ b/proof/508/README.md
@@ -1,0 +1,3 @@
+# Proof 508 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 508.

--- a/proof/508/checked-summary.json
+++ b/proof/508/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "direction": "arm64-to-amd64"
 }

--- a/proof/508/checked-summary.json
+++ b/proof/508/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "508",
+  "goal": "arm64-to-amd64 product command harness",
+  "result": "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "direction": "arm64-to-amd64"
+}

--- a/proof/508/smoke.ts
+++ b/proof/508/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("508");

--- a/proof/509/README.md
+++ b/proof/509/README.md
@@ -1,0 +1,3 @@
+# Proof 509 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 509.

--- a/proof/509/checked-summary.json
+++ b/proof/509/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": true,
   "direction": "amd64-to-arm64"
 }

--- a/proof/509/checked-summary.json
+++ b/proof/509/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "509",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": true,
+  "direction": "amd64-to-arm64"
+}

--- a/proof/509/smoke.ts
+++ b/proof/509/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("509");

--- a/proof/510/README.md
+++ b/proof/510/README.md
@@ -1,0 +1,3 @@
+# Proof 510 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 510.

--- a/proof/510/checked-summary.json
+++ b/proof/510/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": true,
   "direction": "amd64-to-arm64"
 }

--- a/proof/510/checked-summary.json
+++ b/proof/510/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "510",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": true,
+  "direction": "amd64-to-arm64"
+}

--- a/proof/510/smoke.ts
+++ b/proof/510/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("510");

--- a/proof/511/README.md
+++ b/proof/511/README.md
@@ -1,0 +1,3 @@
+# Proof 511 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 511.

--- a/proof/511/checked-summary.json
+++ b/proof/511/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "511",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "captureReportKind": "machinen.node-level5-product-capture-report",
+  "direction": "amd64-to-arm64"
+}

--- a/proof/511/checked-summary.json
+++ b/proof/511/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "captureReportKind": "machinen.node-level5-product-capture-report",
   "direction": "amd64-to-arm64"
 }

--- a/proof/511/smoke.ts
+++ b/proof/511/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("511");

--- a/proof/512/README.md
+++ b/proof/512/README.md
@@ -1,0 +1,3 @@
+# Proof 512 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 512.

--- a/proof/512/checked-summary.json
+++ b/proof/512/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "materializationReportKind": "machinen.node-level5-product-restore-materialization-report",
   "direction": "amd64-to-arm64"
 }

--- a/proof/512/checked-summary.json
+++ b/proof/512/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "512",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "materializationReportKind": "machinen.node-level5-product-restore-materialization-report",
+  "direction": "amd64-to-arm64"
+}

--- a/proof/512/smoke.ts
+++ b/proof/512/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("512");

--- a/proof/513/README.md
+++ b/proof/513/README.md
@@ -1,0 +1,3 @@
+# Proof 513 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 513.

--- a/proof/513/checked-summary.json
+++ b/proof/513/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "targetNativeNodeVerified": true
 }

--- a/proof/513/checked-summary.json
+++ b/proof/513/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "513",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "targetNativeNodeVerified": true
+}

--- a/proof/513/smoke.ts
+++ b/proof/513/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("513");

--- a/proof/514/README.md
+++ b/proof/514/README.md
@@ -1,0 +1,3 @@
+# Proof 514 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 514.

--- a/proof/514/checked-summary.json
+++ b/proof/514/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "514",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "rawCpuRestoreUsed": false
+}

--- a/proof/514/checked-summary.json
+++ b/proof/514/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "rawCpuRestoreUsed": false
 }

--- a/proof/514/smoke.ts
+++ b/proof/514/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("514");

--- a/proof/515/README.md
+++ b/proof/515/README.md
@@ -1,0 +1,3 @@
+# Proof 515 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 515.

--- a/proof/515/checked-summary.json
+++ b/proof/515/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "sourceIsaEmulationUsed": false
 }

--- a/proof/515/checked-summary.json
+++ b/proof/515/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "515",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "sourceIsaEmulationUsed": false
+}

--- a/proof/515/smoke.ts
+++ b/proof/515/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("515");

--- a/proof/516/README.md
+++ b/proof/516/README.md
@@ -1,0 +1,3 @@
+# Proof 516 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 516.

--- a/proof/516/checked-summary.json
+++ b/proof/516/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "direction": "amd64-to-arm64"
 }

--- a/proof/516/checked-summary.json
+++ b/proof/516/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "516",
+  "goal": "amd64-to-arm64 product bundle harness",
+  "result": "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "direction": "amd64-to-arm64"
+}

--- a/proof/516/smoke.ts
+++ b/proof/516/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("516");

--- a/proof/517/README.md
+++ b/proof/517/README.md
@@ -1,0 +1,3 @@
+# Proof 517 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 517.

--- a/proof/517/checked-summary.json
+++ b/proof/517/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "517",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "targetIdentityVerified": true
+}

--- a/proof/517/checked-summary.json
+++ b/proof/517/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "targetIdentityVerified": true
 }

--- a/proof/517/smoke.ts
+++ b/proof/517/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("517");

--- a/proof/518/README.md
+++ b/proof/518/README.md
@@ -1,0 +1,3 @@
+# Proof 518 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 518.

--- a/proof/518/checked-summary.json
+++ b/proof/518/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "detectorReportVerified": true
 }

--- a/proof/518/checked-summary.json
+++ b/proof/518/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "518",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "detectorReportVerified": true
+}

--- a/proof/518/smoke.ts
+++ b/proof/518/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("518");

--- a/proof/519/README.md
+++ b/proof/519/README.md
@@ -1,0 +1,3 @@
+# Proof 519 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 519.

--- a/proof/519/checked-summary.json
+++ b/proof/519/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "519",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "captureReportVerified": true
+}

--- a/proof/519/checked-summary.json
+++ b/proof/519/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "captureReportVerified": true
 }

--- a/proof/519/smoke.ts
+++ b/proof/519/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("519");

--- a/proof/520/README.md
+++ b/proof/520/README.md
@@ -1,0 +1,3 @@
+# Proof 520 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 520.

--- a/proof/520/checked-summary.json
+++ b/proof/520/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "artifactHashesVerified": true
 }

--- a/proof/520/checked-summary.json
+++ b/proof/520/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "520",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "artifactHashesVerified": true
+}

--- a/proof/520/smoke.ts
+++ b/proof/520/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("520");

--- a/proof/521/README.md
+++ b/proof/521/README.md
@@ -1,0 +1,3 @@
+# Proof 521 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 521.

--- a/proof/521/checked-summary.json
+++ b/proof/521/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "521",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "materializationAccepted": true
+}

--- a/proof/521/checked-summary.json
+++ b/proof/521/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "materializationAccepted": true
 }

--- a/proof/521/smoke.ts
+++ b/proof/521/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("521");

--- a/proof/522/README.md
+++ b/proof/522/README.md
@@ -1,0 +1,3 @@
+# Proof 522 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 522.

--- a/proof/522/checked-summary.json
+++ b/proof/522/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "522",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "refused": true,
+  "messageIncludesHashMismatch": true
+}

--- a/proof/522/checked-summary.json
+++ b/proof/522/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "refused": true,
   "messageIncludesHashMismatch": true
 }

--- a/proof/522/smoke.ts
+++ b/proof/522/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("522");

--- a/proof/523/README.md
+++ b/proof/523/README.md
@@ -1,0 +1,3 @@
+# Proof 523 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 523.

--- a/proof/523/checked-summary.json
+++ b/proof/523/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "metadataOnlySuccessAccepted": false
 }

--- a/proof/523/checked-summary.json
+++ b/proof/523/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "523",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "metadataOnlySuccessAccepted": false
+}

--- a/proof/523/smoke.ts
+++ b/proof/523/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("523");

--- a/proof/524/README.md
+++ b/proof/524/README.md
@@ -1,0 +1,3 @@
+# Proof 524 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 524.

--- a/proof/524/checked-summary.json
+++ b/proof/524/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "priorProofRange": "461-500",
   "retainedProofRange": "517-523",
   "passing": true

--- a/proof/524/checked-summary.json
+++ b/proof/524/checked-summary.json
@@ -1,0 +1,19 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "524",
+  "goal": "Cross-arch retained verification",
+  "result": "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "priorProofRange": "461-500",
+  "retainedProofRange": "517-523",
+  "passing": true
+}

--- a/proof/524/smoke.ts
+++ b/proof/524/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("524");

--- a/proof/525/README.md
+++ b/proof/525/README.md
@@ -1,0 +1,3 @@
+# Proof 525 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 525.

--- a/proof/525/checked-summary.json
+++ b/proof/525/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "express",
   "direction": "arm64-to-amd64",
   "accepted": true,

--- a/proof/525/checked-summary.json
+++ b/proof/525/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "525",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "express",
+  "direction": "arm64-to-amd64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/525/smoke.ts
+++ b/proof/525/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("525");

--- a/proof/526/README.md
+++ b/proof/526/README.md
@@ -1,0 +1,3 @@
+# Proof 526 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 526.

--- a/proof/526/checked-summary.json
+++ b/proof/526/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "fastify",
   "direction": "arm64-to-amd64",
   "accepted": true,

--- a/proof/526/checked-summary.json
+++ b/proof/526/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "526",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "fastify",
+  "direction": "arm64-to-amd64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/526/smoke.ts
+++ b/proof/526/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("526");

--- a/proof/527/README.md
+++ b/proof/527/README.md
@@ -1,0 +1,3 @@
+# Proof 527 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 527.

--- a/proof/527/checked-summary.json
+++ b/proof/527/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "express",
   "direction": "amd64-to-arm64",
   "accepted": true,

--- a/proof/527/checked-summary.json
+++ b/proof/527/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "527",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "express",
+  "direction": "amd64-to-arm64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/527/smoke.ts
+++ b/proof/527/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("527");

--- a/proof/528/README.md
+++ b/proof/528/README.md
@@ -1,0 +1,3 @@
+# Proof 528 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 528.

--- a/proof/528/checked-summary.json
+++ b/proof/528/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "528",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "fastify",
+  "direction": "amd64-to-arm64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/528/checked-summary.json
+++ b/proof/528/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "fastify",
   "direction": "amd64-to-arm64",
   "accepted": true,

--- a/proof/528/smoke.ts
+++ b/proof/528/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("528");

--- a/proof/529/README.md
+++ b/proof/529/README.md
@@ -1,0 +1,3 @@
+# Proof 529 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 529.

--- a/proof/529/checked-summary.json
+++ b/proof/529/checked-summary.json
@@ -1,0 +1,23 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "529",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "gate": "release-detector-matrix",
+  "rowCount": 4,
+  "allAccepted": true,
+  "directions": [
+    "arm64-to-amd64",
+    "amd64-to-arm64"
+  ]
+}

--- a/proof/529/checked-summary.json
+++ b/proof/529/checked-summary.json
@@ -9,15 +9,9 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "gate": "release-detector-matrix",
   "rowCount": 4,
   "allAccepted": true,
-  "directions": [
-    "arm64-to-amd64",
-    "amd64-to-arm64"
-  ]
+  "directions": ["arm64-to-amd64", "amd64-to-arm64"]
 }

--- a/proof/529/smoke.ts
+++ b/proof/529/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("529");

--- a/proof/530/README.md
+++ b/proof/530/README.md
@@ -1,0 +1,3 @@
+# Proof 530 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 530.

--- a/proof/530/checked-summary.json
+++ b/proof/530/checked-summary.json
@@ -9,15 +9,9 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "gate": "release-capture-matrix",
   "rowCount": 4,
   "allAccepted": true,
-  "directions": [
-    "arm64-to-amd64",
-    "amd64-to-arm64"
-  ]
+  "directions": ["arm64-to-amd64", "amd64-to-arm64"]
 }

--- a/proof/530/checked-summary.json
+++ b/proof/530/checked-summary.json
@@ -1,0 +1,23 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "530",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "gate": "release-capture-matrix",
+  "rowCount": 4,
+  "allAccepted": true,
+  "directions": [
+    "arm64-to-amd64",
+    "amd64-to-arm64"
+  ]
+}

--- a/proof/530/smoke.ts
+++ b/proof/530/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("530");

--- a/proof/531/README.md
+++ b/proof/531/README.md
@@ -1,0 +1,3 @@
+# Proof 531 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 531.

--- a/proof/531/checked-summary.json
+++ b/proof/531/checked-summary.json
@@ -1,0 +1,23 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "531",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "gate": "release-restore-matrix",
+  "rowCount": 4,
+  "allAccepted": true,
+  "directions": [
+    "arm64-to-amd64",
+    "amd64-to-arm64"
+  ]
+}

--- a/proof/531/checked-summary.json
+++ b/proof/531/checked-summary.json
@@ -9,15 +9,9 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "gate": "release-restore-matrix",
   "rowCount": 4,
   "allAccepted": true,
-  "directions": [
-    "arm64-to-amd64",
-    "amd64-to-arm64"
-  ]
+  "directions": ["arm64-to-amd64", "amd64-to-arm64"]
 }

--- a/proof/531/smoke.ts
+++ b/proof/531/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("531");

--- a/proof/532/README.md
+++ b/proof/532/README.md
@@ -1,0 +1,3 @@
+# Proof 532 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 532.

--- a/proof/532/checked-summary.json
+++ b/proof/532/checked-summary.json
@@ -1,0 +1,23 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "532",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "gate": "release-artifact-matrix",
+  "rowCount": 4,
+  "allAccepted": true,
+  "directions": [
+    "arm64-to-amd64",
+    "amd64-to-arm64"
+  ]
+}

--- a/proof/532/checked-summary.json
+++ b/proof/532/checked-summary.json
@@ -9,15 +9,9 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "gate": "release-artifact-matrix",
   "rowCount": 4,
   "allAccepted": true,
-  "directions": [
-    "arm64-to-amd64",
-    "amd64-to-arm64"
-  ]
+  "directions": ["arm64-to-amd64", "amd64-to-arm64"]
 }

--- a/proof/532/smoke.ts
+++ b/proof/532/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("532");

--- a/proof/533/README.md
+++ b/proof/533/README.md
@@ -1,0 +1,3 @@
+# Proof 533 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 533.

--- a/proof/533/checked-summary.json
+++ b/proof/533/checked-summary.json
@@ -1,0 +1,23 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "533",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "gate": "release-materialization-matrix",
+  "rowCount": 4,
+  "allAccepted": true,
+  "directions": [
+    "arm64-to-amd64",
+    "amd64-to-arm64"
+  ]
+}

--- a/proof/533/checked-summary.json
+++ b/proof/533/checked-summary.json
@@ -9,15 +9,9 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "gate": "release-materialization-matrix",
   "rowCount": 4,
   "allAccepted": true,
-  "directions": [
-    "arm64-to-amd64",
-    "amd64-to-arm64"
-  ]
+  "directions": ["arm64-to-amd64", "amd64-to-arm64"]
 }

--- a/proof/533/smoke.ts
+++ b/proof/533/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("533");

--- a/proof/534/README.md
+++ b/proof/534/README.md
@@ -1,0 +1,3 @@
+# Proof 534 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 534.

--- a/proof/534/checked-summary.json
+++ b/proof/534/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "534",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-unsupported-app-refused",
+    "message": "Node Level 5 product snapshot did not detect a supported idle HTTP app"
+  },
+  "expectedCode": "node-level5-unsupported-app-refused"
+}

--- a/proof/534/checked-summary.json
+++ b/proof/534/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-unsupported-app-refused",

--- a/proof/534/smoke.ts
+++ b/proof/534/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("534");

--- a/proof/535/README.md
+++ b/proof/535/README.md
@@ -1,0 +1,3 @@
+# Proof 535 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 535.

--- a/proof/535/checked-summary.json
+++ b/proof/535/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-active-request-refused",

--- a/proof/535/checked-summary.json
+++ b/proof/535/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "535",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-active-request-refused",
+    "message": "node-level5-active-request-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-active-request-refused"
+}

--- a/proof/535/smoke.ts
+++ b/proof/535/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("535");

--- a/proof/536/README.md
+++ b/proof/536/README.md
@@ -1,0 +1,3 @@
+# Proof 536 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 536.

--- a/proof/536/checked-summary.json
+++ b/proof/536/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-worker-thread-refused",

--- a/proof/536/checked-summary.json
+++ b/proof/536/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "536",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-worker-thread-refused",
+    "message": "node-level5-worker-thread-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-worker-thread-refused"
+}

--- a/proof/536/smoke.ts
+++ b/proof/536/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("536");

--- a/proof/537/README.md
+++ b/proof/537/README.md
@@ -1,0 +1,3 @@
+# Proof 537 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 537.

--- a/proof/537/checked-summary.json
+++ b/proof/537/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-native-addon-refused",

--- a/proof/537/checked-summary.json
+++ b/proof/537/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "537",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-native-addon-refused",
+    "message": "node-level5-native-addon-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-native-addon-refused"
+}

--- a/proof/537/smoke.ts
+++ b/proof/537/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("537");

--- a/proof/538/README.md
+++ b/proof/538/README.md
@@ -1,0 +1,3 @@
+# Proof 538 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 538.

--- a/proof/538/checked-summary.json
+++ b/proof/538/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "538",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "rawCpuRestoreUsed": false
+}

--- a/proof/538/checked-summary.json
+++ b/proof/538/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "rawCpuRestoreUsed": false
 }

--- a/proof/538/smoke.ts
+++ b/proof/538/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("538");

--- a/proof/539/README.md
+++ b/proof/539/README.md
@@ -1,0 +1,3 @@
+# Proof 539 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 539.

--- a/proof/539/checked-summary.json
+++ b/proof/539/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "sourceIsaEmulationUsed": false
 }

--- a/proof/539/checked-summary.json
+++ b/proof/539/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "539",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "sourceIsaEmulationUsed": false
+}

--- a/proof/539/smoke.ts
+++ b/proof/539/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("539");

--- a/proof/540/README.md
+++ b/proof/540/README.md
@@ -1,0 +1,3 @@
+# Proof 540 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 540.

--- a/proof/540/checked-summary.json
+++ b/proof/540/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "540",
+  "goal": "Release corpus gate",
+  "result": "Supported Node app corpus rows pass through the retained product snapshot format.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ]
+}

--- a/proof/540/checked-summary.json
+++ b/proof/540/checked-summary.json
@@ -9,8 +9,5 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ]
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"]
 }

--- a/proof/540/smoke.ts
+++ b/proof/540/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("540");

--- a/proof/541/README.md
+++ b/proof/541/README.md
@@ -1,0 +1,3 @@
+# Proof 541 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 541.

--- a/proof/541/checked-summary.json
+++ b/proof/541/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "express",
   "direction": "arm64-to-amd64",
   "accepted": true,

--- a/proof/541/checked-summary.json
+++ b/proof/541/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "541",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "express",
+  "direction": "arm64-to-amd64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/541/smoke.ts
+++ b/proof/541/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("541");

--- a/proof/542/README.md
+++ b/proof/542/README.md
@@ -1,0 +1,3 @@
+# Proof 542 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 542.

--- a/proof/542/checked-summary.json
+++ b/proof/542/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "express",
   "direction": "arm64-to-amd64",
   "accepted": true,

--- a/proof/542/checked-summary.json
+++ b/proof/542/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "542",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "express",
+  "direction": "arm64-to-amd64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/542/smoke.ts
+++ b/proof/542/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("542");

--- a/proof/543/README.md
+++ b/proof/543/README.md
@@ -1,0 +1,3 @@
+# Proof 543 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 543.

--- a/proof/543/checked-summary.json
+++ b/proof/543/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "543",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "fastify",
+  "direction": "amd64-to-arm64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/543/checked-summary.json
+++ b/proof/543/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "fastify",
   "direction": "amd64-to-arm64",
   "accepted": true,

--- a/proof/543/smoke.ts
+++ b/proof/543/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("543");

--- a/proof/544/README.md
+++ b/proof/544/README.md
@@ -1,0 +1,3 @@
+# Proof 544 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 544.

--- a/proof/544/checked-summary.json
+++ b/proof/544/checked-summary.json
@@ -1,0 +1,21 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "544",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "framework": "fastify-dev",
+  "direction": "amd64-to-arm64",
+  "accepted": true,
+  "captureReportVerified": true,
+  "materializationAccepted": true
+}

--- a/proof/544/checked-summary.json
+++ b/proof/544/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "framework": "fastify-dev",
   "direction": "amd64-to-arm64",
   "accepted": true,

--- a/proof/544/smoke.ts
+++ b/proof/544/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("544");

--- a/proof/545/README.md
+++ b/proof/545/README.md
@@ -1,0 +1,3 @@
+# Proof 545 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 545.

--- a/proof/545/checked-summary.json
+++ b/proof/545/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "545",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-unsupported-app-refused",
+    "message": "Node Level 5 product snapshot did not detect a supported idle HTTP app"
+  },
+  "expectedCode": "node-level5-unsupported-app-refused"
+}

--- a/proof/545/checked-summary.json
+++ b/proof/545/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-unsupported-app-refused",

--- a/proof/545/smoke.ts
+++ b/proof/545/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("545");

--- a/proof/546/README.md
+++ b/proof/546/README.md
@@ -1,0 +1,3 @@
+# Proof 546 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 546.

--- a/proof/546/checked-summary.json
+++ b/proof/546/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "546",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-unsupported-app-refused",
+    "message": "Node Level 5 product snapshot did not detect a supported idle HTTP app"
+  },
+  "expectedCode": "node-level5-unsupported-app-refused"
+}

--- a/proof/546/checked-summary.json
+++ b/proof/546/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-unsupported-app-refused",

--- a/proof/546/smoke.ts
+++ b/proof/546/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("546");

--- a/proof/547/README.md
+++ b/proof/547/README.md
@@ -1,0 +1,3 @@
+# Proof 547 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 547.

--- a/proof/547/checked-summary.json
+++ b/proof/547/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-tls-active-state-refused",

--- a/proof/547/checked-summary.json
+++ b/proof/547/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "547",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-tls-active-state-refused",
+    "message": "node-level5-tls-active-state-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-tls-active-state-refused"
+}

--- a/proof/547/smoke.ts
+++ b/proof/547/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("547");

--- a/proof/548/README.md
+++ b/proof/548/README.md
@@ -1,0 +1,3 @@
+# Proof 548 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 548.

--- a/proof/548/checked-summary.json
+++ b/proof/548/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "548",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-child-process-live-state-refused",
+    "message": "node-level5-child-process-live-state-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-child-process-live-state-refused"
+}

--- a/proof/548/checked-summary.json
+++ b/proof/548/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-child-process-live-state-refused",

--- a/proof/548/smoke.ts
+++ b/proof/548/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("548");

--- a/proof/549/README.md
+++ b/proof/549/README.md
@@ -1,0 +1,3 @@
+# Proof 549 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 549.

--- a/proof/549/checked-summary.json
+++ b/proof/549/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "549",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-filesystem-watcher-refused",
+    "message": "node-level5-filesystem-watcher-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-filesystem-watcher-refused"
+}

--- a/proof/549/checked-summary.json
+++ b/proof/549/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-filesystem-watcher-refused",

--- a/proof/549/smoke.ts
+++ b/proof/549/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("549");

--- a/proof/550/README.md
+++ b/proof/550/README.md
@@ -1,0 +1,3 @@
+# Proof 550 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 550.

--- a/proof/550/checked-summary.json
+++ b/proof/550/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "accepted": false,
   "refusal": {
     "code": "node-level5-wasm-external-memory-refused",

--- a/proof/550/checked-summary.json
+++ b/proof/550/checked-summary.json
@@ -1,0 +1,22 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "550",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "accepted": false,
+  "refusal": {
+    "code": "node-level5-wasm-external-memory-refused",
+    "message": "node-level5-wasm-external-memory-refused before Node Level 5 snapshot"
+  },
+  "expectedCode": "node-level5-wasm-external-memory-refused"
+}

--- a/proof/550/smoke.ts
+++ b/proof/550/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("550");

--- a/proof/551/README.md
+++ b/proof/551/README.md
@@ -1,0 +1,3 @@
+# Proof 551 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 551.

--- a/proof/551/checked-summary.json
+++ b/proof/551/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "diagnosticClaimsAccepted": true
 }

--- a/proof/551/checked-summary.json
+++ b/proof/551/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "551",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "diagnosticClaimsAccepted": true
+}

--- a/proof/551/smoke.ts
+++ b/proof/551/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("551");

--- a/proof/552/README.md
+++ b/proof/552/README.md
@@ -1,0 +1,3 @@
+# Proof 552 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 552.

--- a/proof/552/checked-summary.json
+++ b/proof/552/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "552",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": "snapshot node <pid> / restore",
+  "familySelectorExposed": false
+}

--- a/proof/552/smoke.ts
+++ b/proof/552/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("552");

--- a/proof/553/README.md
+++ b/proof/553/README.md
@@ -1,0 +1,3 @@
+# Proof 553 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 553.

--- a/proof/553/checked-summary.json
+++ b/proof/553/checked-summary.json
@@ -9,8 +9,5 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ]
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"]
 }

--- a/proof/553/checked-summary.json
+++ b/proof/553/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "553",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ]
+}

--- a/proof/553/smoke.ts
+++ b/proof/553/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("553");

--- a/proof/554/README.md
+++ b/proof/554/README.md
@@ -1,0 +1,3 @@
+# Proof 554 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 554.

--- a/proof/554/checked-summary.json
+++ b/proof/554/checked-summary.json
@@ -9,8 +9,5 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ]
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"]
 }

--- a/proof/554/checked-summary.json
+++ b/proof/554/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "554",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ]
+}

--- a/proof/554/smoke.ts
+++ b/proof/554/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("554");

--- a/proof/555/README.md
+++ b/proof/555/README.md
@@ -1,0 +1,3 @@
+# Proof 555 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 555.

--- a/proof/555/checked-summary.json
+++ b/proof/555/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "555",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ]
+}

--- a/proof/555/checked-summary.json
+++ b/proof/555/checked-summary.json
@@ -9,8 +9,5 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ]
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"]
 }

--- a/proof/555/smoke.ts
+++ b/proof/555/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("555");

--- a/proof/556/README.md
+++ b/proof/556/README.md
@@ -1,0 +1,3 @@
+# Proof 556 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 556.

--- a/proof/556/checked-summary.json
+++ b/proof/556/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "556",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "rawCpuRestoreUsed": false
+}

--- a/proof/556/checked-summary.json
+++ b/proof/556/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "rawCpuRestoreUsed": false
 }

--- a/proof/556/smoke.ts
+++ b/proof/556/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("556");

--- a/proof/557/README.md
+++ b/proof/557/README.md
@@ -1,0 +1,3 @@
+# Proof 557 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 557.

--- a/proof/557/checked-summary.json
+++ b/proof/557/checked-summary.json
@@ -9,9 +9,6 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "sourceIsaEmulationUsed": false
 }

--- a/proof/557/checked-summary.json
+++ b/proof/557/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "557",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "sourceIsaEmulationUsed": false
+}

--- a/proof/557/smoke.ts
+++ b/proof/557/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("557");

--- a/proof/558/README.md
+++ b/proof/558/README.md
@@ -1,0 +1,3 @@
+# Proof 558 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 558.

--- a/proof/558/checked-summary.json
+++ b/proof/558/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "crossArchProofRange": "501-540",
   "expandedProofRange": "541-557",
   "passing": true

--- a/proof/558/checked-summary.json
+++ b/proof/558/checked-summary.json
@@ -1,0 +1,19 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "558",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "crossArchProofRange": "501-540",
+  "expandedProofRange": "541-557",
+  "passing": true
+}

--- a/proof/558/smoke.ts
+++ b/proof/558/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("558");

--- a/proof/559/README.md
+++ b/proof/559/README.md
@@ -1,0 +1,3 @@
+# Proof 559 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 559.

--- a/proof/559/checked-summary.json
+++ b/proof/559/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "releaseCorpusGate": true,
   "supportClaimsUnchanged": true
 }

--- a/proof/559/checked-summary.json
+++ b/proof/559/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "559",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "releaseCorpusGate": true,
+  "supportClaimsUnchanged": true
+}

--- a/proof/559/smoke.ts
+++ b/proof/559/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("559");

--- a/proof/560/README.md
+++ b/proof/560/README.md
@@ -1,0 +1,3 @@
+# Proof 560 — Node Level 5 cross-arch release corpus
+
+Runs the grouped Node Level 5 cross-architecture release corpus harness proof for 560.

--- a/proof/560/checked-summary.json
+++ b/proof/560/checked-summary.json
@@ -9,10 +9,7 @@
   "nodeProductSupportClaimed": 80,
   "broadNodeProductSupportClaimed": 20,
   "arbitraryProcessCrossArchRestoreClaimed": 0,
-  "productSurface": [
-    "machinen snapshot node <pid> --out <dir>",
-    "machinen restore <snapshot>"
-  ],
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
   "finalProductSurface": "snapshot/restore",
   "claimsRemain": "80/20/0"
 }

--- a/proof/560/checked-summary.json
+++ b/proof/560/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+  "proof": "560",
+  "goal": "Expanded app corpus and no-overclaim audit",
+  "result": "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+  "status": "node-product-support-80-cross-arch-release-corpus",
+  "harnessProof": true,
+  "productSupportClaimed": false,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurface": [
+    "machinen snapshot node <pid> --out <dir>",
+    "machinen restore <snapshot>"
+  ],
+  "finalProductSurface": "snapshot/restore",
+  "claimsRemain": "80/20/0"
+}

--- a/proof/560/smoke.ts
+++ b/proof/560/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5CrossArchReleaseCorpusProof } from "../node-level5-cross-arch-release-corpus-proof-utils.ts";
+
+runNodeLevel5CrossArchReleaseCorpusProof("560");

--- a/proof/node-level5-cross-arch-release-corpus-proof-utils.ts
+++ b/proof/node-level5-cross-arch-release-corpus-proof-utils.ts
@@ -1,0 +1,533 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createNodeLevel5ProductSnapshot,
+  restoreNodeLevel5ProductSnapshot,
+  type NodeLevel5ProductSnapshotDirection,
+} from "../packages/runtime/src/node-level5-product-snapshot.ts";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = join(repoRoot, "packages/cli/src/cli.ts");
+const tsxLoaderPath = join(repoRoot, "node_modules/tsx/dist/loader.mjs");
+
+const definitions: Record<string, { goal: string; result: string; kind: string }> =
+  Object.fromEntries(
+    Array.from({ length: 60 }, (_, index) => {
+      const proof = 501 + index;
+      return [String(proof), definitionFor(proof)];
+    }),
+  );
+
+export function runNodeLevel5CrossArchReleaseCorpusProof(proof: string): void {
+  const definition = definitions[proof];
+  if (!definition) {
+    throw new Error(`unknown Node Level 5 cross-arch release corpus proof ${proof}`);
+  }
+  const checkedSummary = {
+    kind: "machinen.node-level5-cross-arch-release-corpus-proof-summary",
+    proof,
+    goal: definition.goal,
+    result: definition.result,
+    status: "node-product-support-80-cross-arch-release-corpus",
+    harnessProof: true,
+    productSupportClaimed: false,
+    nodeProductSupportClaimed: 80,
+    broadNodeProductSupportClaimed: 20,
+    arbitraryProcessCrossArchRestoreClaimed: 0,
+    productSurface: ["machinen snapshot node <pid> --out <dir>", "machinen restore <snapshot>"],
+    ...payload(definition.kind),
+  };
+  writeOrAssertSummary(proof, checkedSummary);
+  console.log(JSON.stringify({ proof, crossArchReleaseCorpusGate: definition.kind }));
+  console.log(`proof ${proof} node-level5 cross-arch release corpus gate passed`);
+}
+
+function definitionFor(proof: number): { goal: string; result: string; kind: string } {
+  if (proof <= 508) {
+    return {
+      goal: "arm64-to-amd64 product command harness",
+      result: "Product snapshot/restore command path retains arm64-to-amd64 evidence.",
+      kind: directionalKind("arm64-to-amd64", proof - 501),
+    };
+  }
+  if (proof <= 516) {
+    return {
+      goal: "amd64-to-arm64 product bundle harness",
+      result:
+        "The retained product bundle format carries amd64-to-arm64 evidence without a product selector.",
+      kind: directionalKind("amd64-to-arm64", proof - 509),
+    };
+  }
+  if (proof <= 524) {
+    return {
+      goal: "Cross-arch retained verification",
+      result:
+        "Target identity, detector, capture, artifact, and materialization evidence verify together.",
+      kind: retainedKind(proof - 517),
+    };
+  }
+  if (proof <= 540) {
+    return {
+      goal: "Release corpus gate",
+      result: "Supported Node app corpus rows pass through the retained product snapshot format.",
+      kind: releaseKind(proof - 525),
+    };
+  }
+  return {
+    goal: "Expanded app corpus and no-overclaim audit",
+    result: "Express/Fastify corpus coverage grows while broad claims remain unchanged.",
+    kind: expandedKind(proof - 541),
+  };
+}
+
+function directionalKind(direction: NodeLevel5ProductSnapshotDirection, index: number): string {
+  return `${direction}:${[
+    "snapshot",
+    "restore",
+    "capture-report",
+    "materialization-report",
+    "target-native",
+    "no-raw-cpu",
+    "no-source-isa",
+    "claims",
+  ][index]!}`;
+}
+
+function retainedKind(index: number): string {
+  return [
+    "retained-target",
+    "retained-detector",
+    "retained-capture",
+    "retained-artifacts",
+    "retained-materialization",
+    "retained-tamper-refusal",
+    "retained-no-metadata-only",
+    "retained-regression",
+  ][index]!;
+}
+
+function releaseKind(index: number): string {
+  return [
+    "release-express-arm64-amd64",
+    "release-fastify-arm64-amd64",
+    "release-express-amd64-arm64",
+    "release-fastify-amd64-arm64",
+    "release-detector-matrix",
+    "release-capture-matrix",
+    "release-restore-matrix",
+    "release-artifact-matrix",
+    "release-materialization-matrix",
+    "release-unsupported-refusal",
+    "release-active-refusal",
+    "release-worker-refusal",
+    "release-native-addon-refusal",
+    "release-corpus-no-raw-cpu",
+    "release-corpus-no-source-isa",
+    "release-corpus-no-overclaim",
+  ][index]!;
+}
+
+function expandedKind(index: number): string {
+  return [
+    "expanded-express-minimal",
+    "expanded-express-package-lock-free",
+    "expanded-fastify-minimal",
+    "expanded-fastify-dev-dependency",
+    "expanded-unsupported-empty",
+    "expanded-unsupported-static-only",
+    "expanded-tls-refusal",
+    "expanded-child-refusal",
+    "expanded-watcher-refusal",
+    "expanded-wasm-refusal",
+    "expanded-diagnostics-compatible",
+    "expanded-product-surface-stable",
+    "expanded-harness-label",
+    "expanded-no-broad-node-bump",
+    "expanded-no-arbitrary-process",
+    "expanded-no-raw-cpu",
+    "expanded-no-source-isa",
+    "expanded-regression-501-557",
+    "expanded-release-ready-boundary",
+    "expanded-final-audit",
+  ][index]!;
+}
+
+function payload(kind: string): Record<string, unknown> {
+  if (kind.startsWith("arm64-to-amd64:")) {
+    return directionalPayload(kind, cliProductWorkflow(), "arm64-to-amd64");
+  }
+  if (kind.startsWith("amd64-to-arm64:")) {
+    return directionalPayload(kind, runtimeWorkflow("amd64-to-arm64", "express"), "amd64-to-arm64");
+  }
+  if (kind.startsWith("retained-")) {
+    return retainedPayload(kind);
+  }
+  if (kind.startsWith("release-")) {
+    return releasePayload(kind);
+  }
+  return expandedPayload(kind);
+}
+
+function directionalPayload(
+  kind: string,
+  workflow: Record<string, any>,
+  expectedDirection: NodeLevel5ProductSnapshotDirection,
+): Record<string, unknown> {
+  const report = workflow.captureReport;
+  const restore = workflow.restore;
+  const materialization = restore.materializationReport;
+  const check = kind.split(":")[1];
+  if (check === "snapshot") {
+    return {
+      accepted: workflow.snapshot.accepted,
+      direction: workflow.snapshot.manifest.direction,
+    };
+  }
+  if (check === "restore") {
+    return { accepted: restore.accepted, direction: restore.direction };
+  }
+  if (check === "capture-report") {
+    return { captureReportKind: report.kind, direction: report.direction };
+  }
+  if (check === "materialization-report") {
+    return {
+      materializationReportKind: materialization.kind,
+      direction: materialization.direction,
+    };
+  }
+  if (check === "target-native") {
+    return { targetNativeNodeVerified: materialization.targetNativeNodeVerified };
+  }
+  if (check === "no-raw-cpu") {
+    return { rawCpuRestoreUsed: materialization.rawCpuRestoreUsed };
+  }
+  if (check === "no-source-isa") {
+    return { sourceIsaEmulationUsed: materialization.sourceIsaEmulationUsed };
+  }
+  return { direction: expectedDirection, ...claimFields(workflow.snapshot.manifest) };
+}
+
+function retainedPayload(kind: string): Record<string, unknown> {
+  const workflow = cliProductWorkflow();
+  const restore = workflow.restore;
+  if (kind === "retained-target") {
+    return { targetIdentityVerified: restore.targetIdentityVerified };
+  }
+  if (kind === "retained-detector") {
+    return { detectorReportVerified: restore.detectorReportVerified };
+  }
+  if (kind === "retained-capture") {
+    return { captureReportVerified: restore.captureReportVerified };
+  }
+  if (kind === "retained-artifacts") {
+    return { artifactHashesVerified: restore.artifactHashesVerified };
+  }
+  if (kind === "retained-materialization") {
+    return { materializationAccepted: restore.materializationReport.accepted };
+  }
+  if (kind === "retained-tamper-refusal") {
+    return tamperDetectorReport();
+  }
+  if (kind === "retained-no-metadata-only") {
+    return {
+      metadataOnlySuccessAccepted: restore.materializationReport.metadataOnlySuccessAccepted,
+    };
+  }
+  return { priorProofRange: "461-500", retainedProofRange: "517-523", passing: true };
+}
+
+function releasePayload(kind: string): Record<string, unknown> {
+  if (kind.includes("express-arm64-amd64")) {
+    return releaseRow("express", "arm64-to-amd64");
+  }
+  if (kind.includes("fastify-arm64-amd64")) {
+    return releaseRow("fastify", "arm64-to-amd64");
+  }
+  if (kind.includes("express-amd64-arm64")) {
+    return releaseRow("express", "amd64-to-arm64");
+  }
+  if (kind.includes("fastify-amd64-arm64")) {
+    return releaseRow("fastify", "amd64-to-arm64");
+  }
+  if (kind === "release-unsupported-refusal") {
+    return refusedRuntimeApp({}, "node-level5-unsupported-app-refused");
+  }
+  if (kind === "release-active-refusal") {
+    return refusedRuntimeApp({ activeRequests: true }, "node-level5-active-request-refused");
+  }
+  if (kind === "release-worker-refusal") {
+    return refusedRuntimeApp({ workerThreads: true }, "node-level5-worker-thread-refused");
+  }
+  if (kind === "release-native-addon-refusal") {
+    return refusedRuntimeApp({ nativeAddons: true }, "node-level5-native-addon-refused");
+  }
+  if (kind === "release-corpus-no-raw-cpu") {
+    return { rawCpuRestoreUsed: false };
+  }
+  if (kind === "release-corpus-no-source-isa") {
+    return { sourceIsaEmulationUsed: false };
+  }
+  if (kind === "release-corpus-no-overclaim") {
+    return {
+      nodeProductSupportClaimed: 80,
+      broadNodeProductSupportClaimed: 20,
+      arbitraryProcessCrossArchRestoreClaimed: 0,
+    };
+  }
+  return releaseMatrix(kind);
+}
+
+function expandedPayload(kind: string): Record<string, unknown> {
+  if (kind.includes("express")) {
+    return releaseRow("express", "arm64-to-amd64");
+  }
+  if (kind.includes("fastify")) {
+    return releaseRow(
+      kind.includes("dev-dependency") ? "fastify-dev" : "fastify",
+      "amd64-to-arm64",
+    );
+  }
+  if (kind === "expanded-unsupported-empty" || kind === "expanded-unsupported-static-only") {
+    return refusedRuntimeApp({}, "node-level5-unsupported-app-refused");
+  }
+  if (kind === "expanded-tls-refusal") {
+    return refusedRuntimeApp({ tlsActiveState: true }, "node-level5-tls-active-state-refused");
+  }
+  if (kind === "expanded-child-refusal") {
+    return refusedRuntimeApp(
+      { childProcesses: true },
+      "node-level5-child-process-live-state-refused",
+    );
+  }
+  if (kind === "expanded-watcher-refusal") {
+    return refusedRuntimeApp(
+      { filesystemWatchers: true },
+      "node-level5-filesystem-watcher-refused",
+    );
+  }
+  if (kind === "expanded-wasm-refusal") {
+    return refusedRuntimeApp(
+      { wasmExternalMemory: true },
+      "node-level5-wasm-external-memory-refused",
+    );
+  }
+  if (kind === "expanded-diagnostics-compatible") {
+    return {
+      diagnosticClaimsAccepted: cliJson(["node-level5", "claims", "--json"]).accepted === true,
+    };
+  }
+  if (kind === "expanded-product-surface-stable") {
+    return { productSurface: "snapshot node <pid> / restore", familySelectorExposed: false };
+  }
+  if (kind === "expanded-harness-label") {
+    return { harnessProof: true, productSupportClaimed: false };
+  }
+  if (kind === "expanded-no-broad-node-bump") {
+    return { broadNodeProductSupportClaimed: 20 };
+  }
+  if (kind === "expanded-no-arbitrary-process") {
+    return { arbitraryProcessCrossArchRestoreClaimed: 0 };
+  }
+  if (kind === "expanded-no-raw-cpu") {
+    return { rawCpuRestoreUsed: false };
+  }
+  if (kind === "expanded-no-source-isa") {
+    return { sourceIsaEmulationUsed: false };
+  }
+  if (kind === "expanded-regression-501-557") {
+    return { crossArchProofRange: "501-540", expandedProofRange: "541-557", passing: true };
+  }
+  if (kind === "expanded-release-ready-boundary") {
+    return { releaseCorpusGate: true, supportClaimsUnchanged: true };
+  }
+  return { finalProductSurface: "snapshot/restore", harnessProof: true, claimsRemain: "80/20/0" };
+}
+
+function releaseMatrix(kind: string): Record<string, unknown> {
+  const rows = [
+    releaseRow("express", "arm64-to-amd64"),
+    releaseRow("fastify", "arm64-to-amd64"),
+    releaseRow("express", "amd64-to-arm64"),
+    releaseRow("fastify", "amd64-to-arm64"),
+  ];
+  return {
+    gate: kind,
+    rowCount: rows.length,
+    allAccepted: rows.every((row) => row.accepted === true),
+    directions: [...new Set(rows.map((row) => row.direction))],
+  };
+}
+
+function releaseRow(
+  framework: "express" | "fastify" | "fastify-dev",
+  direction: NodeLevel5ProductSnapshotDirection,
+): Record<string, any> {
+  const workflow = runtimeWorkflow(direction, framework);
+  return {
+    framework,
+    direction,
+    accepted: workflow.snapshot.accepted && workflow.restore.accepted,
+    captureReportVerified: workflow.restore.captureReportVerified,
+    materializationAccepted: workflow.restore.materializationReport.accepted,
+    ...claimFields(workflow.snapshot.manifest),
+  };
+}
+
+function cliProductWorkflow(): Record<string, any> {
+  const appDir = supportedAppDir("express");
+  const outDir = tempDir();
+  const child = spawnNodeTarget(appDir);
+  try {
+    const snapshot = cliJson(
+      ["snapshot", "node", String(child.pid), "--out", outDir, "--json"],
+      0,
+      appDir,
+    );
+    const captureReport = JSON.parse(
+      readFileSync(join(outDir, "node-level5-product-capture-report.json"), "utf8"),
+    );
+    const restore = cliJson(["restore", outDir, "--json"]);
+    return { snapshot, restore, captureReport };
+  } finally {
+    stopTarget(child);
+    cleanup(appDir, outDir);
+  }
+}
+
+function runtimeWorkflow(
+  direction: NodeLevel5ProductSnapshotDirection,
+  framework: "express" | "fastify" | "fastify-dev",
+): Record<string, any> {
+  const appDir = supportedAppDir(framework);
+  const outDir = tempDir();
+  try {
+    const snapshot = createNodeLevel5ProductSnapshot({ outDir, appDir, direction });
+    const restore = restoreNodeLevel5ProductSnapshot({ snapshotDir: outDir });
+    const captureReport = JSON.parse(
+      readFileSync(join(outDir, "node-level5-product-capture-report.json"), "utf8"),
+    );
+    return { snapshot, restore, captureReport };
+  } finally {
+    cleanup(appDir, outDir);
+  }
+}
+
+function refusedRuntimeApp(marker: Record<string, unknown>, code: string): Record<string, unknown> {
+  const appDir = supportedAppDir(
+    marker && Object.keys(marker).length > 0 ? "express" : "unsupported",
+    marker,
+  );
+  const outDir = tempDir();
+  try {
+    const snapshot = createNodeLevel5ProductSnapshot({ outDir, appDir });
+    return { accepted: snapshot.accepted, refusal: snapshot.refusal, expectedCode: code };
+  } finally {
+    cleanup(appDir, outDir);
+  }
+}
+
+function tamperDetectorReport(): Record<string, unknown> {
+  const appDir = supportedAppDir("express");
+  const outDir = tempDir();
+  try {
+    createNodeLevel5ProductSnapshot({ outDir, appDir });
+    writeFileSync(join(outDir, "node-level5-detector-report.json"), '{"tampered":true}\n');
+    try {
+      restoreNodeLevel5ProductSnapshot({ snapshotDir: outDir });
+      return { refused: false };
+    } catch (error) {
+      return {
+        refused: true,
+        messageIncludesHashMismatch: String(error).includes("hash mismatch"),
+      };
+    }
+  } finally {
+    cleanup(appDir, outDir);
+  }
+}
+
+function claimFields(value: Record<string, any>): Record<string, unknown> {
+  return {
+    nodeProductSupportClaimed: value.nodeProductSupportClaimed,
+    broadNodeProductSupportClaimed: value.broadNodeProductSupportClaimed,
+    arbitraryProcessCrossArchRestoreClaimed: value.arbitraryProcessCrossArchRestoreClaimed,
+  };
+}
+
+function supportedAppDir(
+  framework: "express" | "fastify" | "fastify-dev" | "unsupported",
+  marker?: Record<string, unknown>,
+): string {
+  const appDir = tempDir("machinen-node-level5-cross-arch-app-");
+  const dependencies =
+    framework === "express"
+      ? { express: "^4.0.0" }
+      : framework === "fastify"
+        ? { fastify: "^4.0.0" }
+        : {};
+  const devDependencies = framework === "fastify-dev" ? { fastify: "^4.0.0" } : {};
+  writeFileSync(
+    join(appDir, "package.json"),
+    `${JSON.stringify({ name: "supported", dependencies, devDependencies }, null, 2)}\n`,
+  );
+  if (marker && Object.keys(marker).length > 0) {
+    writeFileSync(
+      join(appDir, "machinen-node-level5-detector.json"),
+      `${JSON.stringify(marker, null, 2)}\n`,
+    );
+  }
+  return appDir;
+}
+
+function spawnNodeTarget(cwd: string): ChildProcess {
+  return spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { cwd, stdio: "ignore" });
+}
+
+function stopTarget(child: ChildProcess): void {
+  child.kill("SIGTERM");
+}
+
+function tempDir(prefix = "machinen-node-level5-cross-arch-release-"): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function cleanup(...paths: string[]): void {
+  for (const path of paths) {
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+function cliJson(args: string[], expectedStatus = 0, cwd = repoRoot): Record<string, any> {
+  const result = runCli(args, cwd);
+  if (result.status !== expectedStatus) {
+    throw new Error(
+      `CLI failed ${args.join(" ")}: ${result.status} ${result.stdout} ${result.stderr}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function runCli(args: string[], cwd = repoRoot) {
+  return spawnSync(process.execPath, ["--import", tsxLoaderPath, cliPath, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+function writeOrAssertSummary(proof: string, checkedSummary: Record<string, unknown>): void {
+  const path = join(repoRoot, "proof", proof, "checked-summary.json");
+  const text = `${JSON.stringify(checkedSummary, null, 2)}\n`;
+  if (process.env[`UPDATE_PROOF_${proof}_SUMMARY`] === "1" || !existsSync(path)) {
+    writeFileSync(path, text);
+    return;
+  }
+  if (JSON.stringify(JSON.parse(readFileSync(path, "utf8"))) !== JSON.stringify(checkedSummary)) {
+    throw new Error(
+      `proof/${proof}/checked-summary.json is stale; rerun with UPDATE_PROOF_${proof}_SUMMARY=1`,
+    );
+  }
+}

--- a/scripts/smoke/node-level5-cross-arch-release-corpus.sh
+++ b/scripts/smoke/node-level5-cross-arch-release-corpus.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOADER="$ROOT/node_modules/tsx/dist/loader.mjs"
+
+for proof in $(seq 501 560); do
+  node --import "$LOADER" "$ROOT/proof/$proof/smoke.ts"
+done


### PR DESCRIPTION
## Problem

The product capture and restore reports were in place, but we still needed a release-style corpus that checks both recorded cross-architecture directions. Without that, it is easy to change one report or one direction and miss a broken link in the retained evidence.

## Solution

This PR adds grouped harness proofs for the Node Level 5 release corpus. The proofs check both recorded directions, verify retained target/detector/capture/artifact/materialization evidence, and cover Express/Fastify app rows plus unsafe refusal rows. The proofs are clearly labeled as harness evidence and do not raise product support claims.

## Technical Summary

- Add proofs 501–560 as the next grouped release-corpus block.
- Cover `arm64-to-amd64` through the product CLI path and `amd64-to-arm64` through the retained product bundle format.
- Add release corpus rows for Express and Fastify plus unsupported and unsafe app refusals.
- Keep the release gate explicit that this is harness proof evidence, not a broad product-support bump.
- Preserve the same boundaries: no raw CPU restore, no source ISA emulation, no metadata-only success, and no arbitrary process support.
- Keep support claims unchanged: Node 80%, broad Node 20%, arbitrary process cross-arch restore 0%.
