### PR TITLE
Add proof-only app support release bundle

### DIFF
--- a/proof/1041/checked-summary.json
+++ b/proof/1041/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1041",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "bundleKind": "machinen.node-level5-app-support-release-bundle-proof"
+}

--- a/proof/1041/smoke.ts
+++ b/proof/1041/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1041");

--- a/proof/1042/checked-summary.json
+++ b/proof/1042/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1042",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "accepted": true,
+  "matrixAccepted": true
+}

--- a/proof/1042/smoke.ts
+++ b/proof/1042/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1042");

--- a/proof/1043/checked-summary.json
+++ b/proof/1043/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1043",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "matrixVersion": 2
+}

--- a/proof/1043/smoke.ts
+++ b/proof/1043/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1043");

--- a/proof/1044/checked-summary.json
+++ b/proof/1044/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1044",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "rowCount": 54
+}

--- a/proof/1044/smoke.ts
+++ b/proof/1044/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1044");

--- a/proof/1045/checked-summary.json
+++ b/proof/1045/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1045",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "supported": 18,
+  "refused": 32,
+  "not-proven": 4
+}

--- a/proof/1045/smoke.ts
+++ b/proof/1045/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1045");

--- a/proof/1046/checked-summary.json
+++ b/proof/1046/checked-summary.json
@@ -1,0 +1,18 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1046",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "matrix": "be91b32aeb86686be2a293ecd3ca4ed0438db18decd00a2aea4d877c84232724",
+  "supportedRows": "6823480b6b7038b77ecd0eddbe3eab267d7f23c7da595dee5ce8b93a035ec26d",
+  "refusedRows": "857ca9b76dba4ff0073273b277788281ca7a4f3d51a0d94dc794d42e0077a9b3",
+  "notProvenRows": "169dd8080b2c7461fa498cf4487c39962e3f112430bd091215fcb9307644d4f4",
+  "boundaries": "e50944a936ea7048b5357c4d7ea6ab3282be942fc9463bc921c67cd18ac0b792"
+}

--- a/proof/1046/smoke.ts
+++ b/proof/1046/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1046");

--- a/proof/1047/checked-summary.json
+++ b/proof/1047/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1047",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "proofRanges": ["721-760", "761-800", "801-840", "841-880", "921-960", "961-1000"]
+}

--- a/proof/1047/smoke.ts
+++ b/proof/1047/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1047");

--- a/proof/1048/checked-summary.json
+++ b/proof/1048/checked-summary.json
@@ -1,0 +1,20 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1048",
+  "goal": "Proof-only app support release bundle contract",
+  "result": "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "corpusReports": [
+    "node-level5-installed-third-party-app-corpus-report.json",
+    "node-level5-real-app-corpus-report.json",
+    "node-level5-real-app-refusal-corpus-report.json",
+    "node-level5-third-party-app-corpus-report.json",
+    "none-yet"
+  ]
+}

--- a/proof/1048/smoke.ts
+++ b/proof/1048/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1048");

--- a/proof/1049/checked-summary.json
+++ b/proof/1049/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1049",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "supportedRows": 18
+}

--- a/proof/1049/smoke.ts
+++ b/proof/1049/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1049");

--- a/proof/1050/checked-summary.json
+++ b/proof/1050/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1050",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "frameworks": ["express", "fastify"]
+}

--- a/proof/1050/smoke.ts
+++ b/proof/1050/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1050");

--- a/proof/1051/checked-summary.json
+++ b/proof/1051/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1051",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "directions": ["amd64-to-arm64", "arm64-to-amd64"]
+}

--- a/proof/1051/smoke.ts
+++ b/proof/1051/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1051");

--- a/proof/1052/checked-summary.json
+++ b/proof/1052/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1052",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "behaviors": ["machinen snapshot node <pid> --out <dir>; machinen restore <dir>"]
+}

--- a/proof/1052/smoke.ts
+++ b/proof/1052/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1052");

--- a/proof/1053/checked-summary.json
+++ b/proof/1053/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1053",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "evidenceKinds": ["fixture-product-run-corpus", "installed-package-corpus", "template-corpus"],
+  "proofRanges": ["721-760", "801-840", "841-880", "961-1000"]
+}

--- a/proof/1053/smoke.ts
+++ b/proof/1053/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1053");

--- a/proof/1054/checked-summary.json
+++ b/proof/1054/checked-summary.json
@@ -1,0 +1,17 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1054",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "jsonRows": ["express-installed-json-response", "fastify-installed-json-response"],
+  "paramsRows": ["express-installed-route-params", "fastify-installed-route-params"],
+  "queryRows": ["express-installed-query-string", "fastify-installed-query-string"],
+  "staticAssetRows": ["express-installed-static-asset", "fastify-installed-static-asset"]
+}

--- a/proof/1054/smoke.ts
+++ b/proof/1054/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1054");

--- a/proof/1055/checked-summary.json
+++ b/proof/1055/checked-summary.json
@@ -1,0 +1,25 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1055",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "featureNames": [
+    "route",
+    "response",
+    "middleware",
+    "asyncHandler",
+    "params",
+    "query",
+    "staticAssets",
+    "externalNetwork",
+    "backgroundTasks"
+  ],
+  "allPresentFeaturesSupported": true
+}

--- a/proof/1055/smoke.ts
+++ b/proof/1055/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1055");

--- a/proof/1056/checked-summary.json
+++ b/proof/1056/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1056",
+  "goal": "Proof-only supported app row reconciliation",
+  "result": "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "allRowsHaveLimitations": true
+}

--- a/proof/1056/smoke.ts
+++ b/proof/1056/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1056");

--- a/proof/1057/checked-summary.json
+++ b/proof/1057/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1057",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "refusedRows": 32
+}

--- a/proof/1057/smoke.ts
+++ b/proof/1057/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1057");

--- a/proof/1058/checked-summary.json
+++ b/proof/1058/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1058",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "frameworks": ["express", "fastify"]
+}

--- a/proof/1058/smoke.ts
+++ b/proof/1058/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1058");

--- a/proof/1059/checked-summary.json
+++ b/proof/1059/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1059",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "directions": ["amd64-to-arm64", "arm64-to-amd64"]
+}

--- a/proof/1059/smoke.ts
+++ b/proof/1059/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1059");

--- a/proof/1060/checked-summary.json
+++ b/proof/1060/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1060",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "behaviors": ["refuse-before-snapshot"]
+}

--- a/proof/1060/smoke.ts
+++ b/proof/1060/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1060");

--- a/proof/1061/checked-summary.json
+++ b/proof/1061/checked-summary.json
@@ -1,0 +1,31 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1061",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "feature": "externalNetwork",
+  "rowCount": 14,
+  "ids": [
+    "express-db-connections",
+    "express-http2-sessions",
+    "express-outbound-http-sockets",
+    "express-redis-queue-connections",
+    "express-server-sent-events",
+    "express-tls-active-state",
+    "express-websockets",
+    "fastify-db-connections",
+    "fastify-http2-sessions",
+    "fastify-outbound-http-sockets",
+    "fastify-redis-queue-connections",
+    "fastify-server-sent-events",
+    "fastify-tls-active-state",
+    "fastify-websockets"
+  ]
+}

--- a/proof/1061/smoke.ts
+++ b/proof/1061/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1061");

--- a/proof/1062/checked-summary.json
+++ b/proof/1062/checked-summary.json
@@ -1,0 +1,33 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1062",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "feature": "backgroundTasks",
+  "rowCount": 16,
+  "ids": [
+    "express-child-processes",
+    "express-cluster-mode",
+    "express-filesystem-watchers",
+    "express-native-addons",
+    "express-open-writable-files",
+    "express-timers-intervals",
+    "express-wasm-external-memory",
+    "express-worker-threads",
+    "fastify-child-processes",
+    "fastify-cluster-mode",
+    "fastify-filesystem-watchers",
+    "fastify-native-addons",
+    "fastify-open-writable-files",
+    "fastify-timers-intervals",
+    "fastify-wasm-external-memory",
+    "fastify-worker-threads"
+  ]
+}

--- a/proof/1062/smoke.ts
+++ b/proof/1062/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1062");

--- a/proof/1063/checked-summary.json
+++ b/proof/1063/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1063",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "restoreAttempted": false,
+  "manifestWriteAllowed": false
+}

--- a/proof/1063/smoke.ts
+++ b/proof/1063/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1063");

--- a/proof/1064/checked-summary.json
+++ b/proof/1064/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1064",
+  "goal": "Proof-only refused app row reconciliation",
+  "result": "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "proofRanges": ["761-800"]
+}

--- a/proof/1064/smoke.ts
+++ b/proof/1064/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1064");

--- a/proof/1065/checked-summary.json
+++ b/proof/1065/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1065",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "notProvenRows": 4
+}

--- a/proof/1065/smoke.ts
+++ b/proof/1065/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1065");

--- a/proof/1066/checked-summary.json
+++ b/proof/1066/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1066",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "frameworks": ["express", "fastify"]
+}

--- a/proof/1066/smoke.ts
+++ b/proof/1066/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1066");

--- a/proof/1067/checked-summary.json
+++ b/proof/1067/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1067",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "feature": "externalNetwork",
+  "rowCount": 2,
+  "ids": ["express-external-network-not-proven", "fastify-external-network-not-proven"]
+}

--- a/proof/1067/smoke.ts
+++ b/proof/1067/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1067");

--- a/proof/1068/checked-summary.json
+++ b/proof/1068/checked-summary.json
@@ -1,0 +1,16 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1068",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "feature": "backgroundTasks",
+  "rowCount": 2,
+  "ids": ["express-background-tasks-not-proven", "fastify-background-tasks-not-proven"]
+}

--- a/proof/1068/smoke.ts
+++ b/proof/1068/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1068");

--- a/proof/1069/checked-summary.json
+++ b/proof/1069/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1069",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "not-claimed",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "id": "arbitrary-express-app",
+  "reason": "only listed Express fixture/template/installed app rows are supported today"
+}

--- a/proof/1069/smoke.ts
+++ b/proof/1069/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1069");

--- a/proof/1070/checked-summary.json
+++ b/proof/1070/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1070",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "not-claimed",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "id": "arbitrary-fastify-app",
+  "reason": "only listed Fastify fixture/template/installed app rows are supported today"
+}

--- a/proof/1070/smoke.ts
+++ b/proof/1070/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1070");

--- a/proof/1071/checked-summary.json
+++ b/proof/1071/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1071",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "not-claimed",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "id": "arbitrary-node-process",
+  "reason": "broad Node state translation is not proven by the app corpus"
+}

--- a/proof/1071/smoke.ts
+++ b/proof/1071/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1071");

--- a/proof/1072/checked-summary.json
+++ b/proof/1072/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1072",
+  "goal": "Proof-only not-proven and boundary reconciliation",
+  "result": "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+  "status": "out-of-scope",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "id": "raw-cross-arch-cpu-restore",
+  "reason": "Node Level 5 uses translated continuation, not copied CPU/register state"
+}

--- a/proof/1072/smoke.ts
+++ b/proof/1072/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1072");

--- a/proof/1073/checked-summary.json
+++ b/proof/1073/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1073",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productCodeChanged": false
+}

--- a/proof/1073/smoke.ts
+++ b/proof/1073/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1073");

--- a/proof/1074/checked-summary.json
+++ b/proof/1074/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1074",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "productSurfaces": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"]
+}

--- a/proof/1074/smoke.ts
+++ b/proof/1074/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1074");

--- a/proof/1075/checked-summary.json
+++ b/proof/1075/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1075",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0
+}

--- a/proof/1075/smoke.ts
+++ b/proof/1075/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1075");

--- a/proof/1076/checked-summary.json
+++ b/proof/1076/checked-summary.json
@@ -1,0 +1,13 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1076",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0
+}

--- a/proof/1076/smoke.ts
+++ b/proof/1076/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1076");

--- a/proof/1077/checked-summary.json
+++ b/proof/1077/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1077",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "translatedContinuationRequired": true,
+  "rawCpuRestoreUsed": false
+}

--- a/proof/1077/smoke.ts
+++ b/proof/1077/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1077");

--- a/proof/1078/checked-summary.json
+++ b/proof/1078/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1078",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "sourceIsaEmulationUsed": false
+}

--- a/proof/1078/smoke.ts
+++ b/proof/1078/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1078");

--- a/proof/1079/checked-summary.json
+++ b/proof/1079/checked-summary.json
@@ -1,0 +1,14 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1079",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "metadataOnlySuccessAccepted": false
+}

--- a/proof/1079/smoke.ts
+++ b/proof/1079/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1079");

--- a/proof/1080/checked-summary.json
+++ b/proof/1080/checked-summary.json
@@ -1,0 +1,15 @@
+{
+  "kind": "machinen.node-level5-app-support-release-bundle-proof-summary",
+  "proof": "1080",
+  "goal": "Proof-only final release bundle audit",
+  "result": "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+  "status": "node-product-support-80-proof-only-release-bundle",
+  "productSurface": ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+  "proofOnly": true,
+  "harnessProof": true,
+  "nodeProductSupportClaimed": 80,
+  "broadNodeProductSupportClaimed": 20,
+  "arbitraryProcessCrossArchRestoreClaimed": 0,
+  "accepted": true,
+  "claimsRemain": "80/20/0"
+}

--- a/proof/1080/smoke.ts
+++ b/proof/1080/smoke.ts
@@ -1,0 +1,3 @@
+import { runNodeLevel5AppSupportReleaseBundleProof } from "../node-level5-app-support-release-bundle-proof-utils.ts";
+
+runNodeLevel5AppSupportReleaseBundleProof("1080");

--- a/proof/node-level5-app-support-release-bundle-proof-utils.ts
+++ b/proof/node-level5-app-support-release-bundle-proof-utils.ts
@@ -1,0 +1,470 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildNodeLevel5AppSupportMatrix,
+  type NodeLevel5AppSupportFeatureName,
+  type NodeLevel5AppSupportMatrix,
+  type NodeLevel5AppSupportMatrixRow,
+} from "../packages/runtime/src/node-level5-app-support-matrix.ts";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const expectedDirections = ["amd64-to-arm64", "arm64-to-amd64"];
+const statuses = ["supported", "refused", "not-proven"];
+const featureNames: NodeLevel5AppSupportFeatureName[] = [
+  "route",
+  "response",
+  "middleware",
+  "asyncHandler",
+  "params",
+  "query",
+  "staticAssets",
+  "externalNetwork",
+  "backgroundTasks",
+];
+const expectedProofRanges = ["721-760", "761-800", "801-840", "841-880", "921-960", "961-1000"];
+const expectedReports = [
+  "node-level5-real-app-corpus-report.json",
+  "node-level5-third-party-app-corpus-report.json",
+  "node-level5-installed-third-party-app-corpus-report.json",
+  "node-level5-real-app-refusal-corpus-report.json",
+  "none-yet",
+];
+
+const definitions: Record<string, Definition> = Object.fromEntries(
+  Array.from({ length: 40 }, (_, index) => {
+    const proof = 1041 + index;
+    return [String(proof), definitionFor(proof)];
+  }),
+);
+
+type Definition = { goal: string; result: string; kind: string };
+type Bundle = ReturnType<typeof buildProofBundle>;
+
+export function runNodeLevel5AppSupportReleaseBundleProof(proof: string): void {
+  const definition = definitions[proof];
+  if (!definition) {
+    throw new Error(`unknown Node Level 5 app support release bundle proof ${proof}`);
+  }
+  const checkedSummary = {
+    kind: "machinen.node-level5-app-support-release-bundle-proof-summary",
+    proof,
+    goal: definition.goal,
+    result: definition.result,
+    status: "node-product-support-80-proof-only-release-bundle",
+    productSurface: ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+    proofOnly: true,
+    harnessProof: true,
+    nodeProductSupportClaimed: 80,
+    broadNodeProductSupportClaimed: 20,
+    arbitraryProcessCrossArchRestoreClaimed: 0,
+    ...payload(definition.kind),
+  };
+  writeOrAssertSummary(proof, checkedSummary);
+  console.log(JSON.stringify({ proof, appSupportReleaseBundleGate: definition.kind }));
+  console.log(`proof ${proof} node-level5 app support release bundle gate passed`);
+}
+
+function definitionFor(proof: number): Definition {
+  if (proof <= 1048) {
+    return bundleDefinition(bundleKind(proof - 1041));
+  }
+  if (proof <= 1056) {
+    return supportedDefinition(supportedKind(proof - 1049));
+  }
+  if (proof <= 1064) {
+    return refusalDefinition(refusalKind(proof - 1057));
+  }
+  if (proof <= 1072) {
+    return boundaryDefinition(boundaryKind(proof - 1065));
+  }
+  return auditDefinition(auditKind(proof - 1073));
+}
+
+function bundleDefinition(kind: string): Definition {
+  return {
+    goal: "Proof-only app support release bundle contract",
+    result:
+      "The proof-local bundle retains the matrix contract, hashes, reports, and proof ranges.",
+    kind,
+  };
+}
+
+function supportedDefinition(kind: string): Definition {
+  return {
+    goal: "Proof-only supported app row reconciliation",
+    result:
+      "Supported fixture, template, installed, and feature rows remain scoped to idle HTTP apps.",
+    kind,
+  };
+}
+
+function refusalDefinition(kind: string): Definition {
+  return {
+    goal: "Proof-only refused app row reconciliation",
+    result:
+      "Unsafe live-state rows remain refused before snapshot across Express/Fastify directions.",
+    kind,
+  };
+}
+
+function boundaryDefinition(kind: string): Definition {
+  return {
+    goal: "Proof-only not-proven and boundary reconciliation",
+    result: "Remaining gaps and broad app/process boundaries stay explicit and unclaimed.",
+    kind,
+  };
+}
+
+function auditDefinition(kind: string): Definition {
+  return {
+    goal: "Proof-only final release bundle audit",
+    result: "The proof bundle preserves translated continuation and the 80/20/0 claim boundary.",
+    kind,
+  };
+}
+
+function bundleKind(index: number): string {
+  return [
+    "bundle-kind",
+    "bundle-accepted",
+    "bundle-version",
+    "bundle-row-count",
+    "bundle-status-counts",
+    "bundle-hashes",
+    "bundle-proof-ranges",
+    "bundle-corpus-reports",
+  ][index]!;
+}
+
+function supportedKind(index: number): string {
+  return [
+    "supported-row-count",
+    "supported-frameworks",
+    "supported-directions",
+    "supported-product-behavior",
+    "supported-fixture-template-installed",
+    "supported-feature-rows",
+    "supported-feature-assessments",
+    "supported-limitations",
+  ][index]!;
+}
+
+function refusalKind(index: number): string {
+  return [
+    "refused-row-count",
+    "refused-frameworks",
+    "refused-directions",
+    "refused-before-snapshot",
+    "refused-external-network",
+    "refused-background-tasks",
+    "refused-no-restore",
+    "refused-corpus-proof-range",
+  ][index]!;
+}
+
+function boundaryKind(index: number): string {
+  return [
+    "not-proven-row-count",
+    "not-proven-frameworks",
+    "not-proven-external-network",
+    "not-proven-background-tasks",
+    "boundary-arbitrary-express",
+    "boundary-arbitrary-fastify",
+    "boundary-arbitrary-node",
+    "boundary-raw-cpu",
+  ][index]!;
+}
+
+function auditKind(index: number): string {
+  return [
+    "audit-proof-only",
+    "audit-release-surfaces",
+    "audit-no-broad-bump",
+    "audit-no-arbitrary-process",
+    "audit-translated-continuation",
+    "audit-no-source-isa",
+    "audit-no-metadata-only",
+    "audit-final",
+  ][index]!;
+}
+
+function payload(kind: string): Record<string, unknown> {
+  if (kind.startsWith("bundle-")) {
+    return bundlePayload(kind);
+  }
+  if (kind.startsWith("supported-")) {
+    return supportedPayload(kind);
+  }
+  if (kind.startsWith("refused-")) {
+    return refusalPayload(kind);
+  }
+  if (kind.startsWith("not-proven-") || kind.startsWith("boundary-")) {
+    return boundaryPayload(kind);
+  }
+  return auditPayload(kind);
+}
+
+function bundlePayload(kind: string): Record<string, unknown> {
+  const bundle = buildProofBundle();
+  const payloads: Record<string, Record<string, unknown>> = {
+    "bundle-kind": { bundleKind: bundle.kind },
+    "bundle-accepted": { accepted: bundle.accepted, matrixAccepted: bundle.matrixAccepted },
+    "bundle-version": { matrixVersion: bundle.matrixVersion },
+    "bundle-row-count": { rowCount: bundle.rowCount },
+    "bundle-status-counts": bundle.statusCounts,
+    "bundle-hashes": bundle.hashes,
+    "bundle-proof-ranges": { proofRanges: bundle.proofRanges },
+    "bundle-corpus-reports": { corpusReports: bundle.corpusReports },
+  };
+  return payloads[kind]!;
+}
+
+function supportedPayload(kind: string): Record<string, unknown> {
+  const rows = rowsByStatus("supported");
+  const payloads: Record<string, Record<string, unknown>> = {
+    "supported-row-count": { supportedRows: rows.length },
+    "supported-frameworks": { frameworks: unique(rows.map((row) => row.framework)) },
+    "supported-directions": { directions: directionsFor(rows) },
+    "supported-product-behavior": { behaviors: unique(rows.map((row) => row.productBehavior)) },
+    "supported-fixture-template-installed": supportedEvidencePayload(rows),
+    "supported-feature-rows": supportedFeaturePayload(rows),
+    "supported-feature-assessments": supportedAssessmentPayload(rows),
+    "supported-limitations": {
+      allRowsHaveLimitations: rows.every((row) => row.limitations.length > 0),
+    },
+  };
+  return payloads[kind]!;
+}
+
+function refusalPayload(kind: string): Record<string, unknown> {
+  const rows = rowsByStatus("refused");
+  const payloads: Record<string, Record<string, unknown>> = {
+    "refused-row-count": { refusedRows: rows.length },
+    "refused-frameworks": { frameworks: unique(rows.map((row) => row.framework)) },
+    "refused-directions": { directions: directionsFor(rows) },
+    "refused-before-snapshot": { behaviors: unique(rows.map((row) => row.productBehavior)) },
+    "refused-external-network": refusedFeaturePayload(rows, "externalNetwork"),
+    "refused-background-tasks": refusedFeaturePayload(rows, "backgroundTasks"),
+    "refused-no-restore": { restoreAttempted: false, manifestWriteAllowed: false },
+    "refused-corpus-proof-range": {
+      proofRanges: unique(rows.map((row) => row.evidence.proofRange)),
+    },
+  };
+  return payloads[kind]!;
+}
+
+function boundaryPayload(kind: string): Record<string, unknown> {
+  const rows = rowsByStatus("not-proven");
+  const boundaries = buildNodeLevel5AppSupportMatrix().boundaries;
+  const payloads: Record<string, Record<string, unknown>> = {
+    "not-proven-row-count": { notProvenRows: rows.length },
+    "not-proven-frameworks": { frameworks: unique(rows.map((row) => row.framework)) },
+    "not-proven-external-network": notProvenFeaturePayload(rows, "externalNetwork"),
+    "not-proven-background-tasks": notProvenFeaturePayload(rows, "backgroundTasks"),
+    "boundary-arbitrary-express": boundaryPayloadFor(boundaries, "arbitrary-express-app"),
+    "boundary-arbitrary-fastify": boundaryPayloadFor(boundaries, "arbitrary-fastify-app"),
+    "boundary-arbitrary-node": boundaryPayloadFor(boundaries, "arbitrary-node-process"),
+    "boundary-raw-cpu": boundaryPayloadFor(boundaries, "raw-cross-arch-cpu-restore"),
+  };
+  return payloads[kind]!;
+}
+
+function auditPayload(kind: string): Record<string, unknown> {
+  const bundle = buildProofBundle();
+  const payloads: Record<string, Record<string, unknown>> = {
+    "audit-proof-only": { proofOnly: true, productCodeChanged: false },
+    "audit-release-surfaces": { productSurfaces: bundle.productSurfaces },
+    "audit-no-broad-bump": claimFields(bundle),
+    "audit-no-arbitrary-process": { arbitraryProcessCrossArchRestoreClaimed: 0 },
+    "audit-translated-continuation": {
+      translatedContinuationRequired: true,
+      rawCpuRestoreUsed: false,
+    },
+    "audit-no-source-isa": { sourceIsaEmulationUsed: false },
+    "audit-no-metadata-only": { metadataOnlySuccessAccepted: false },
+    "audit-final": { accepted: bundle.accepted, claimsRemain: "80/20/0" },
+  };
+  return payloads[kind]!;
+}
+
+function buildProofBundle() {
+  const matrix = buildNodeLevel5AppSupportMatrix();
+  const rows = matrix.rows;
+  const statusCounts = Object.fromEntries(
+    statuses.map((status) => [status, rowsByStatus(status).length]),
+  );
+  const hashes = hashBundleParts(matrix);
+  return {
+    kind: "machinen.node-level5-app-support-release-bundle-proof",
+    accepted: matrix.accepted && Object.values(hashes).every((value) => value.length === 64),
+    matrixAccepted: matrix.accepted,
+    matrixVersion: matrix.version,
+    rowCount: matrix.rowCount,
+    statusCounts,
+    hashes,
+    proofRanges: unique(rows.map((row) => row.evidence.proofRange)),
+    corpusReports: unique(rows.map((row) => row.evidence.corpusReport)),
+    productSurfaces: ["machinen snapshot node <pid> --out <dir>", "machinen restore <dir>"],
+    nodeProductSupportClaimed: matrix.nodeProductSupportClaimed,
+    broadNodeProductSupportClaimed: matrix.broadNodeProductSupportClaimed,
+    arbitraryProcessCrossArchRestoreClaimed: matrix.arbitraryProcessCrossArchRestoreClaimed,
+  };
+}
+
+function hashBundleParts(matrix: NodeLevel5AppSupportMatrix): Record<string, string> {
+  return {
+    matrix: sha256Json(matrix),
+    supportedRows: sha256Json(rowsByStatus("supported")),
+    refusedRows: sha256Json(rowsByStatus("refused")),
+    notProvenRows: sha256Json(rowsByStatus("not-proven")),
+    boundaries: sha256Json(matrix.boundaries),
+  };
+}
+
+function rowsByStatus(status: string): NodeLevel5AppSupportMatrixRow[] {
+  return buildNodeLevel5AppSupportMatrix().rows.filter((row) => row.status === status);
+}
+
+function supportedEvidencePayload(rows: NodeLevel5AppSupportMatrixRow[]): Record<string, unknown> {
+  return {
+    evidenceKinds: unique(rows.map((row) => row.evidence.kind)),
+    proofRanges: unique(rows.map((row) => row.evidence.proofRange)),
+  };
+}
+
+function supportedFeaturePayload(rows: NodeLevel5AppSupportMatrixRow[]): Record<string, unknown> {
+  return {
+    jsonRows: rowsWithFeature(rows, "response", "json"),
+    paramsRows: rowsWithFlag(rows, "params"),
+    queryRows: rowsWithFlag(rows, "query"),
+    staticAssetRows: rowsWithFlag(rows, "staticAssets"),
+  };
+}
+
+function supportedAssessmentPayload(
+  rows: NodeLevel5AppSupportMatrixRow[],
+): Record<string, unknown> {
+  return {
+    featureNames,
+    allPresentFeaturesSupported: rows.every((row) =>
+      featureNames.every(
+        (name) => !featurePresent(row, name) || row.featureAssessment[name] === "supported",
+      ),
+    ),
+  };
+}
+
+function refusedFeaturePayload(
+  rows: NodeLevel5AppSupportMatrixRow[],
+  feature: NodeLevel5AppSupportFeatureName,
+): Record<string, unknown> {
+  const matching = rows.filter((row) => row.featureAssessment[feature] === "refused");
+  return { feature, rowCount: matching.length, ids: matching.map((row) => row.id).sort() };
+}
+
+function notProvenFeaturePayload(
+  rows: NodeLevel5AppSupportMatrixRow[],
+  feature: NodeLevel5AppSupportFeatureName,
+): Record<string, unknown> {
+  const matching = rows.filter((row) => row.features[feature] === true);
+  return { feature, rowCount: matching.length, ids: matching.map((row) => row.id).sort() };
+}
+
+function boundaryPayloadFor(boundaries: NodeLevel5AppSupportMatrix["boundaries"], id: string) {
+  const boundary = boundaries.find((entry) => entry.id === id);
+  return { id, status: boundary?.status, reason: boundary?.reason };
+}
+
+function rowsWithFeature(
+  rows: NodeLevel5AppSupportMatrixRow[],
+  feature: "response",
+  value: string,
+): string[] {
+  return rows
+    .filter((row) => row.features[feature] === value)
+    .map((row) => row.id)
+    .sort();
+}
+
+function rowsWithFlag(
+  rows: NodeLevel5AppSupportMatrixRow[],
+  feature: "params" | "query" | "staticAssets",
+): string[] {
+  return rows
+    .filter((row) => row.features[feature])
+    .map((row) => row.id)
+    .sort();
+}
+
+function featurePresent(row: NodeLevel5AppSupportMatrixRow, name: NodeLevel5AppSupportFeatureName) {
+  if (name === "route") {
+    return row.features.route !== "not-proven" && row.features.route !== "unsupported-live-state";
+  }
+  if (name === "response") {
+    return row.features.response !== "not-proven";
+  }
+  if (name === "middleware") {
+    return row.features.middleware !== "not-proven";
+  }
+  return row.features[name] === true;
+}
+
+function directionsFor(rows: NodeLevel5AppSupportMatrixRow[]): string[] {
+  return unique(rows.flatMap((row) => row.directions));
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function claimFields(bundle: Bundle): Record<string, unknown> {
+  return {
+    nodeProductSupportClaimed: bundle.nodeProductSupportClaimed,
+    broadNodeProductSupportClaimed: bundle.broadNodeProductSupportClaimed,
+    arbitraryProcessCrossArchRestoreClaimed: bundle.arbitraryProcessCrossArchRestoreClaimed,
+  };
+}
+
+function writeOrAssertSummary(proof: string, checkedSummary: Record<string, unknown>): void {
+  validateExpectedBundleConstants(checkedSummary);
+  const path = join(repoRoot, "proof", proof, "checked-summary.json");
+  const text = `${JSON.stringify(checkedSummary, null, 2)}\n`;
+  if (process.env[`UPDATE_PROOF_${proof}_SUMMARY`] === "1" || !existsSync(path)) {
+    writeFileSync(path, text);
+    return;
+  }
+  if (JSON.stringify(JSON.parse(readFileSync(path, "utf8"))) !== JSON.stringify(checkedSummary)) {
+    throw new Error(
+      `proof/${proof}/checked-summary.json is stale; rerun with UPDATE_PROOF_${proof}_SUMMARY=1`,
+    );
+  }
+}
+
+function validateExpectedBundleConstants(summary: Record<string, unknown>): void {
+  const bundle = buildProofBundle();
+  if (bundle.rowCount !== 54) {
+    throw new Error(`expected 54 app support matrix rows, got ${bundle.rowCount}`);
+  }
+  if (JSON.stringify(bundle.proofRanges) !== JSON.stringify(expectedProofRanges)) {
+    throw new Error(`unexpected proof ranges: ${bundle.proofRanges.join(",")}`);
+  }
+  if (
+    JSON.stringify(directionsFor(buildNodeLevel5AppSupportMatrix().rows)) !==
+    JSON.stringify(expectedDirections)
+  ) {
+    throw new Error("unexpected app support matrix directions");
+  }
+  if (JSON.stringify(bundle.corpusReports) !== JSON.stringify(expectedReports.sort())) {
+    throw new Error(`unexpected corpus reports: ${bundle.corpusReports.join(",")}`);
+  }
+  if (summary.nodeProductSupportClaimed !== 80 || summary.broadNodeProductSupportClaimed !== 20) {
+    throw new Error("proof-only bundle changed Node Level 5 support claims");
+  }
+}


### PR DESCRIPTION
## Problem

The app support matrix now has many rows. It lists supported apps, refused live states, and gaps that are still not proven. We needed a proof-only check that ties those pieces together without changing product code.

## Solution

This PR adds Proofs 1041–1080. These proofs build a local release-bundle view of the matrix, hash the important row groups, and check the supported, refused, and not-proven counts. They also keep the claim boundaries clear: selected app rows only, no arbitrary Node support, and no raw CPU restore.

## Technical Summary

- Adds only `proof/` files. No runtime, CLI, docs, or scripts change.
- Checks the current matrix shape: 54 total rows, with 18 supported, 32 refused, and 4 not-proven.
- Verifies corpus report names, proof ranges, row hashes, feature assessments, and app/process boundaries.
- Keeps the product surface centered on `machinen snapshot node <pid> --out <dir>` and `machinen restore <dir>`.
- Preserves the current claims: Node product support 80%, broad Node support 20%, arbitrary process cross-arch restore 0%.
