### PR TITLE
Share Node Level 5 corpus product-run helpers

### DIFF
--- a/scripts/node-level5-installed-third-party-app-corpus.ts
+++ b/scripts/node-level5-installed-third-party-app-corpus.ts
@@ -6,12 +6,7 @@ import expressPackage from "express/package.json" with { type: "json" };
 import fastifyPackage from "fastify/package.json" with { type: "json" };
 
 import type { NodeLevel5RealAppCorpusFramework } from "../packages/runtime/src/node-level5-real-app-corpus.ts";
-import type {
-  NodeLevel5ProductBehavioralVerifierReport,
-  NodeLevel5ProductRestoreSummary,
-  NodeLevel5ProductSnapshotDirection,
-  NodeLevel5ProductSnapshotSummary,
-} from "../packages/runtime/src/node-level5-product-snapshot.ts";
+import type { NodeLevel5ProductSnapshotDirection } from "../packages/runtime/src/node-level5-product-snapshot.ts";
 import {
   verifyNodeLevel5InstalledThirdPartyAppCorpusReport,
   writeNodeLevel5InstalledThirdPartyAppCorpusReport,
@@ -21,13 +16,14 @@ import {
 import {
   isNodeLevel5RealAppCorpusMain,
   nodeLevel5RealAppCorpusDirections,
+  nodeLevel5AppCorpusIdentity,
+  nodeLevel5DeclaredSubsetCorpusFields,
+  nodeLevel5HttpEvidenceFromProductRun,
   nodeLevel5RealAppCorpusRepoRoot,
   parseNodeLevel5RealAppCorpusOutArgs,
+  runNodeLevel5ProductPathForNamedApp,
   runNodeLevel5RealAppCorpusCliJson,
-  runNodeLevel5SnapshotRestoreForApp,
-  selectedNodeLevel5BehavioralHeaders,
-  spawnNodeLevel5RealAppCorpusTarget,
-  stopNodeLevel5RealAppCorpusTarget,
+  writeNodeLevel5BehaviorConfig,
 } from "./node-level5-real-app-corpus-script-utils.ts";
 
 type InstalledThirdPartyAppDefinition = {
@@ -875,19 +871,19 @@ function runAppProductCommands(
   direction: NodeLevel5ProductSnapshotDirection,
 ): NodeLevel5InstalledThirdPartyAppCorpusRow {
   const appDir = appDirFor(outDir, app, direction);
-  const snapshotDir = join(outDir, "snapshots", app.appName, direction);
-  const child = spawnNodeLevel5RealAppCorpusTarget(appDir);
-  try {
-    const { snapshot, restore } = runNodeLevel5SnapshotRestoreForApp({
-      child,
-      appDir,
-      snapshotDir,
-      direction,
-    });
-    return rowFromProductRun(app, direction, snapshot, restore);
-  } finally {
-    stopNodeLevel5RealAppCorpusTarget(child);
-  }
+  return runNodeLevel5ProductPathForNamedApp({
+    outDir,
+    appName: app.appName,
+    appDir,
+    direction,
+    row: ({ snapshot, restore }) => ({
+      ...nodeLevel5AppCorpusIdentity(app, direction),
+      installedPackage: app.installedPackage,
+      installedPackageVersion: app.installedPackageVersion,
+      ...nodeLevel5HttpEvidenceFromProductRun(snapshot, restore),
+      ...nodeLevel5DeclaredSubsetCorpusFields(),
+    }),
+  });
 }
 
 function appDirFor(
@@ -908,10 +904,7 @@ function appDirFor(
   writeSafeIdleTimerDetectorFixture(appDir, app);
   writeSafeOutboundReconnectDetectorFixture(appDir, app);
   writeFileSync(join(appDir, "server.mjs"), app.serverSource(app));
-  writeFileSync(
-    join(appDir, "machinen-node-level5-behavior.json"),
-    `${JSON.stringify(behaviorConfig(app), null, 2)}\n`,
-  );
+  writeNodeLevel5BehaviorConfig(appDir, behaviorConfig(app));
   return appDir;
 }
 
@@ -984,51 +977,6 @@ function linkInstalledNodeModules(appDir: string): void {
   if (!existsSync(nodeModules)) {
     symlinkSync(join(nodeLevel5RealAppCorpusRepoRoot, "node_modules"), nodeModules, "dir");
   }
-}
-
-function rowFromProductRun(
-  app: InstalledThirdPartyAppDefinition,
-  direction: NodeLevel5ProductSnapshotDirection,
-  snapshot: NodeLevel5ProductSnapshotSummary,
-  restore: NodeLevel5ProductRestoreSummary,
-): NodeLevel5InstalledThirdPartyAppCorpusRow {
-  const report = restore.behavioralVerifierReport;
-  return {
-    appName: app.appName,
-    source: app.source,
-    framework: app.framework,
-    direction,
-    installedPackage: app.installedPackage,
-    installedPackageVersion: app.installedPackageVersion,
-    routePath: report.routePath,
-    expectedStatus: report.expectedStatus,
-    actualStatus: verifierStatus(report),
-    expectedBody: report.expectedBody,
-    actualBody: verifierBody(report),
-    expectedHeaders: report.expectedHeaders ?? {},
-    actualHeaders: selectedNodeLevel5BehavioralHeaders(report),
-    snapshotAccepted: snapshot.accepted,
-    restoreAccepted: restore.accepted,
-    behavioralVerifierPassed: restore.behavioralVerifierPassed,
-    targetNativeNodeVerified: productRunTargetNativeVerified(restore, report),
-    declaredSubset: true,
-    unsupportedStateDetected: false,
-  };
-}
-
-function verifierStatus(report: NodeLevel5ProductBehavioralVerifierReport): number {
-  return report.actualStatus ?? 0;
-}
-
-function verifierBody(report: NodeLevel5ProductBehavioralVerifierReport): string {
-  return report.actualBody ?? "";
-}
-
-function productRunTargetNativeVerified(
-  restore: NodeLevel5ProductRestoreSummary,
-  report: NodeLevel5ProductBehavioralVerifierReport,
-): boolean {
-  return restore.targetNativeNodeVerified && report.targetNativeNodeVerified;
 }
 
 function behaviorConfig(app: InstalledThirdPartyAppDefinition): Record<string, unknown> {

--- a/scripts/node-level5-real-app-corpus-script-utils.ts
+++ b/scripts/node-level5-real-app-corpus-script-utils.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { NodeLevel5CorpusHttpEvidence } from "../packages/runtime/src/node-level5-corpus-common.ts";
 import type {
   NodeLevel5ProductBehavioralVerifierReport,
   NodeLevel5ProductRestoreSummary,
@@ -111,6 +112,112 @@ export function runNodeLevel5SnapshotRestoreForApp(input: {
     "--json",
   ]) as NodeLevel5ProductRestoreSummary;
   return { snapshot, restore };
+}
+
+export function runNodeLevel5ProductPathForApp<T>(input: {
+  appDir: string;
+  snapshotDir: string;
+  direction: NodeLevel5ProductSnapshotDirection;
+  row: (run: {
+    snapshot: NodeLevel5ProductSnapshotSummary;
+    restore: NodeLevel5ProductRestoreSummary;
+  }) => T;
+}): T {
+  const child = spawnNodeLevel5RealAppCorpusTarget(input.appDir);
+  try {
+    return input.row(
+      runNodeLevel5SnapshotRestoreForApp({
+        child,
+        appDir: input.appDir,
+        snapshotDir: input.snapshotDir,
+        direction: input.direction,
+      }),
+    );
+  } finally {
+    stopNodeLevel5RealAppCorpusTarget(child);
+  }
+}
+
+export function nodeLevel5AppCorpusIdentity<TSource extends string>(
+  app: { appName: string; source: TSource; framework: NodeLevel5RealAppCorpusFramework },
+  direction: NodeLevel5ProductSnapshotDirection,
+): {
+  appName: string;
+  source: TSource;
+  framework: NodeLevel5RealAppCorpusFramework;
+  direction: NodeLevel5ProductSnapshotDirection;
+} {
+  return { appName: app.appName, source: app.source, framework: app.framework, direction };
+}
+
+export function nodeLevel5DeclaredSubsetCorpusFields(): {
+  declaredSubset: true;
+  unsupportedStateDetected: false;
+} {
+  return { declaredSubset: true, unsupportedStateDetected: false };
+}
+
+export function runNodeLevel5ProductPathForNamedApp<T>(input: {
+  outDir: string;
+  appName: string;
+  appDir: string;
+  direction: NodeLevel5ProductSnapshotDirection;
+  row: (run: {
+    snapshot: NodeLevel5ProductSnapshotSummary;
+    restore: NodeLevel5ProductRestoreSummary;
+  }) => T;
+}): T {
+  return runNodeLevel5ProductPathForApp({
+    appDir: input.appDir,
+    snapshotDir: join(input.outDir, "snapshots", input.appName, input.direction),
+    direction: input.direction,
+    row: input.row,
+  });
+}
+
+export function nodeLevel5HttpEvidenceFromProductRun(
+  snapshot: NodeLevel5ProductSnapshotSummary,
+  restore: NodeLevel5ProductRestoreSummary,
+): NodeLevel5CorpusHttpEvidence {
+  const report = restore.behavioralVerifierReport;
+  return {
+    routePath: report.routePath,
+    expectedStatus: report.expectedStatus,
+    actualStatus: verifierStatus(report),
+    expectedBody: report.expectedBody,
+    actualBody: verifierBody(report),
+    expectedHeaders: report.expectedHeaders ?? {},
+    actualHeaders: selectedNodeLevel5BehavioralHeaders(report),
+    snapshotAccepted: snapshot.accepted,
+    restoreAccepted: restore.accepted,
+    behavioralVerifierPassed: restore.behavioralVerifierPassed,
+    targetNativeNodeVerified: productRunTargetNativeVerified(restore, report),
+  };
+}
+
+function verifierStatus(report: NodeLevel5ProductBehavioralVerifierReport): number {
+  return report.actualStatus ?? 0;
+}
+
+function verifierBody(report: NodeLevel5ProductBehavioralVerifierReport): string {
+  return report.actualBody ?? "";
+}
+
+function productRunTargetNativeVerified(
+  restore: NodeLevel5ProductRestoreSummary,
+  report: NodeLevel5ProductBehavioralVerifierReport,
+): boolean {
+  return restore.targetNativeNodeVerified && report.targetNativeNodeVerified;
+}
+
+export function writeNodeLevel5BehaviorConfig(
+  appDir: string,
+  config: Record<string, unknown>,
+): void {
+  writeFileSync(
+    join(appDir, "machinen-node-level5-behavior.json"),
+    `${JSON.stringify(config, null, 2)}\n`,
+  );
 }
 
 export function selectedNodeLevel5BehavioralHeaders(

--- a/scripts/node-level5-real-app-product-run-corpus.ts
+++ b/scripts/node-level5-real-app-product-run-corpus.ts
@@ -7,23 +7,17 @@ import {
   type NodeLevel5RealAppCorpusFramework,
   type NodeLevel5RealAppCorpusRow,
 } from "../packages/runtime/src/node-level5-real-app-corpus.ts";
-import type {
-  NodeLevel5ProductBehavioralVerifierReport,
-  NodeLevel5ProductRestoreSummary,
-  NodeLevel5ProductSnapshotDirection,
-  NodeLevel5ProductSnapshotSummary,
-} from "../packages/runtime/src/node-level5-product-snapshot.ts";
+import type { NodeLevel5ProductSnapshotDirection } from "../packages/runtime/src/node-level5-product-snapshot.ts";
 import {
   isNodeLevel5RealAppCorpusMain,
   nodeLevel5RealAppCorpusDirections,
   nodeLevel5RealAppCorpusFrameworks,
   parseNodeLevel5RealAppCorpusOutArgs,
+  nodeLevel5HttpEvidenceFromProductRun,
   nodeLevel5HttpServerSourceForRoutes,
+  runNodeLevel5ProductPathForApp,
   runNodeLevel5RealAppCorpusCliJson,
-  runNodeLevel5SnapshotRestoreForApp,
-  selectedNodeLevel5BehavioralHeaders,
-  spawnNodeLevel5RealAppCorpusTarget,
-  stopNodeLevel5RealAppCorpusTarget,
+  writeNodeLevel5BehaviorConfig,
   writeNodeLevel5RealAppFixturePackageJson,
 } from "./node-level5-real-app-corpus-script-utils.ts";
 
@@ -103,57 +97,16 @@ function runFixtureProductCommands(
 ): NodeLevel5RealAppCorpusRow {
   const appDir = fixtureAppDir(outDir, framework, direction);
   const snapshotDir = join(outDir, "snapshots", framework, direction);
-  const child = spawnNodeLevel5RealAppCorpusTarget(appDir);
-  try {
-    const { snapshot, restore } = runNodeLevel5SnapshotRestoreForApp({
-      child,
-      appDir,
-      snapshotDir,
-      direction,
-    });
-    return rowFromProductRun(framework, direction, snapshot, restore);
-  } finally {
-    stopNodeLevel5RealAppCorpusTarget(child);
-  }
-}
-
-function rowFromProductRun(
-  framework: NodeLevel5RealAppCorpusFramework,
-  direction: NodeLevel5ProductSnapshotDirection,
-  snapshot: NodeLevel5ProductSnapshotSummary,
-  restore: NodeLevel5ProductRestoreSummary,
-): NodeLevel5RealAppCorpusRow {
-  const report = restore.behavioralVerifierReport;
-  return {
-    framework,
+  return runNodeLevel5ProductPathForApp({
+    appDir,
+    snapshotDir,
     direction,
-    routePath: report.routePath,
-    expectedStatus: report.expectedStatus,
-    actualStatus: verifierStatus(report),
-    expectedBody: report.expectedBody,
-    actualBody: verifierBody(report),
-    expectedHeaders: report.expectedHeaders ?? {},
-    actualHeaders: selectedNodeLevel5BehavioralHeaders(report),
-    snapshotAccepted: snapshot.accepted,
-    restoreAccepted: restore.accepted,
-    behavioralVerifierPassed: restore.behavioralVerifierPassed,
-    targetNativeNodeVerified: productRunTargetNativeVerified(restore, report),
-  };
-}
-
-function verifierStatus(report: NodeLevel5ProductBehavioralVerifierReport): number {
-  return report.actualStatus ?? 0;
-}
-
-function verifierBody(report: NodeLevel5ProductBehavioralVerifierReport): string {
-  return report.actualBody ?? "";
-}
-
-function productRunTargetNativeVerified(
-  restore: NodeLevel5ProductRestoreSummary,
-  report: NodeLevel5ProductBehavioralVerifierReport,
-): boolean {
-  return restore.targetNativeNodeVerified && report.targetNativeNodeVerified;
+    row: ({ snapshot, restore }) => ({
+      framework,
+      direction,
+      ...nodeLevel5HttpEvidenceFromProductRun(snapshot, restore),
+    }),
+  });
 }
 
 function fixtureAppDir(
@@ -165,10 +118,7 @@ function fixtureAppDir(
   mkdirSync(appDir, { recursive: true });
   writeNodeLevel5RealAppFixturePackageJson(appDir, framework, "product-run-fixture");
   writeFileSync(join(appDir, "server.mjs"), serverSource(fixture(framework)));
-  writeFileSync(
-    join(appDir, "machinen-node-level5-behavior.json"),
-    `${JSON.stringify(behaviorConfig(framework), null, 2)}\n`,
-  );
+  writeNodeLevel5BehaviorConfig(appDir, behaviorConfig(framework));
   return appDir;
 }
 

--- a/scripts/node-level5-third-party-app-corpus.ts
+++ b/scripts/node-level5-third-party-app-corpus.ts
@@ -2,12 +2,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { NodeLevel5RealAppCorpusFramework } from "../packages/runtime/src/node-level5-real-app-corpus.ts";
-import type {
-  NodeLevel5ProductBehavioralVerifierReport,
-  NodeLevel5ProductRestoreSummary,
-  NodeLevel5ProductSnapshotDirection,
-  NodeLevel5ProductSnapshotSummary,
-} from "../packages/runtime/src/node-level5-product-snapshot.ts";
+import type { NodeLevel5ProductSnapshotDirection } from "../packages/runtime/src/node-level5-product-snapshot.ts";
 import {
   verifyNodeLevel5ThirdPartyAppCorpusReport,
   writeNodeLevel5ThirdPartyAppCorpusReport,
@@ -16,14 +11,15 @@ import {
 } from "../packages/runtime/src/node-level5-third-party-app-corpus.ts";
 import {
   isNodeLevel5RealAppCorpusMain,
+  nodeLevel5AppCorpusIdentity,
+  nodeLevel5DeclaredSubsetCorpusFields,
   nodeLevel5RealAppCorpusDirections,
   parseNodeLevel5RealAppCorpusOutArgs,
+  nodeLevel5HttpEvidenceFromProductRun,
   nodeLevel5HttpServerSourceForRoutes,
+  runNodeLevel5ProductPathForNamedApp,
   runNodeLevel5RealAppCorpusCliJson,
-  runNodeLevel5SnapshotRestoreForApp,
-  selectedNodeLevel5BehavioralHeaders,
-  spawnNodeLevel5RealAppCorpusTarget,
-  stopNodeLevel5RealAppCorpusTarget,
+  writeNodeLevel5BehaviorConfig,
   writeNodeLevel5RealAppFixturePackageJson,
 } from "./node-level5-real-app-corpus-script-utils.ts";
 
@@ -149,19 +145,17 @@ function runAppProductCommands(
   direction: NodeLevel5ProductSnapshotDirection,
 ): NodeLevel5ThirdPartyAppCorpusRow {
   const appDir = appDirFor(outDir, app, direction);
-  const snapshotDir = join(outDir, "snapshots", app.appName, direction);
-  const child = spawnNodeLevel5RealAppCorpusTarget(appDir);
-  try {
-    const { snapshot, restore } = runNodeLevel5SnapshotRestoreForApp({
-      child,
-      appDir,
-      snapshotDir,
-      direction,
-    });
-    return rowFromProductRun(app, direction, snapshot, restore);
-  } finally {
-    stopNodeLevel5RealAppCorpusTarget(child);
-  }
+  return runNodeLevel5ProductPathForNamedApp({
+    outDir,
+    appName: app.appName,
+    appDir,
+    direction,
+    row: ({ snapshot, restore }) => ({
+      ...nodeLevel5AppCorpusIdentity(app, direction),
+      ...nodeLevel5HttpEvidenceFromProductRun(snapshot, restore),
+      ...nodeLevel5DeclaredSubsetCorpusFields(),
+    }),
+  });
 }
 
 function appDirFor(
@@ -173,54 +167,8 @@ function appDirFor(
   mkdirSync(appDir, { recursive: true });
   writeNodeLevel5RealAppFixturePackageJson(appDir, app.framework, "third-party-fixture");
   writeFileSync(join(appDir, "server.mjs"), app.serverSource(app));
-  writeFileSync(
-    join(appDir, "machinen-node-level5-behavior.json"),
-    `${JSON.stringify(behaviorConfig(app), null, 2)}\n`,
-  );
+  writeNodeLevel5BehaviorConfig(appDir, behaviorConfig(app));
   return appDir;
-}
-
-function rowFromProductRun(
-  app: ThirdPartyAppDefinition,
-  direction: NodeLevel5ProductSnapshotDirection,
-  snapshot: NodeLevel5ProductSnapshotSummary,
-  restore: NodeLevel5ProductRestoreSummary,
-): NodeLevel5ThirdPartyAppCorpusRow {
-  const report = restore.behavioralVerifierReport;
-  return {
-    appName: app.appName,
-    source: app.source,
-    framework: app.framework,
-    direction,
-    routePath: report.routePath,
-    expectedStatus: report.expectedStatus,
-    actualStatus: verifierStatus(report),
-    expectedBody: report.expectedBody,
-    actualBody: verifierBody(report),
-    expectedHeaders: report.expectedHeaders ?? {},
-    actualHeaders: selectedNodeLevel5BehavioralHeaders(report),
-    snapshotAccepted: snapshot.accepted,
-    restoreAccepted: restore.accepted,
-    behavioralVerifierPassed: restore.behavioralVerifierPassed,
-    targetNativeNodeVerified: productRunTargetNativeVerified(restore, report),
-    declaredSubset: true,
-    unsupportedStateDetected: false,
-  };
-}
-
-function verifierStatus(report: NodeLevel5ProductBehavioralVerifierReport): number {
-  return report.actualStatus ?? 0;
-}
-
-function verifierBody(report: NodeLevel5ProductBehavioralVerifierReport): string {
-  return report.actualBody ?? "";
-}
-
-function productRunTargetNativeVerified(
-  restore: NodeLevel5ProductRestoreSummary,
-  report: NodeLevel5ProductBehavioralVerifierReport,
-): boolean {
-  return restore.targetNativeNodeVerified && report.targetNativeNodeVerified;
 }
 
 function behaviorConfig(app: ThirdPartyAppDefinition): Record<string, unknown> {


### PR DESCRIPTION
## Problem

The Node Level 5 corpus scripts repeated the same product-run steps in several places. That made the scripts harder to read and made future support rows easier to wire up slightly differently by mistake.

## Solution

This PR moves the shared snapshot/restore product-run flow into the common corpus script helper. The product-run, third-party app, and installed third-party app corpus scripts now use the same helper for app launch, snapshot, restore, and HTTP evidence shaping.

## Technical Summary

- Centralizes app product-path execution in `scripts/node-level5-real-app-corpus-script-utils.ts`.
- Shares the HTTP evidence mapping from behavioral verifier reports instead of rebuilding the same row fields in each corpus script.
- Keeps the generated corpus shape unchanged. This is a refactor of script plumbing, not a support-matrix or claim change.
- Keeps the same product commands and boundaries: selected app rows only, no broad Express/Fastify/Node claim, and no raw CPU restore path.
