### PR TITLE
Define next Node Level 5 claim milestone

### DIFF
--- a/docs/snapshot/node-level5-product-support-next-milestone.json
+++ b/docs/snapshot/node-level5-product-support-next-milestone.json
@@ -1,0 +1,41 @@
+{
+  "kind": "machinen.node-level5-product-support-next-milestone",
+  "status": "candidate-not-claimed",
+  "current": {
+    "nodeProductSupportClaimed": 80,
+    "broadNodeProductSupportClaimed": 20,
+    "arbitraryProcessCrossArchRestoreClaimed": 0
+  },
+  "candidateTarget": {
+    "nodeProductSupportClaimed": 85,
+    "broadNodeProductSupportClaimed": 25,
+    "arbitraryProcessCrossArchRestoreClaimed": 0
+  },
+  "productCommandPath": "machinen snapshot <vm-name> --out <dir>; machinen restore <dir>",
+  "nodeDetectedInsideVm": true,
+  "hostPidProductTargetingAllowed": false,
+  "hostPidHarnessEnv": "MACHINEN_NODE_LEVEL5_ALLOW_HOST_PID_SNAPSHOT=1",
+  "requiredDirections": ["arm64-to-amd64", "amd64-to-arm64"],
+  "requiredPositiveEvidence": [
+    "generic-vm-snapshot-command",
+    "whole-vm-capture",
+    "node-workload-detected-inside-vm",
+    "target-native-restore-verification",
+    "retained-artifact-bundle",
+    "zero-flake-repeatability"
+  ],
+  "requiredRefusalEvidence": [
+    "host-pid-product-targeting-refused-or-hidden",
+    "node-only-product-selector-not-public",
+    "active-request-refused",
+    "worker-thread-refused",
+    "native-addon-refused",
+    "wasm-external-memory-refused",
+    "tls-active-state-refused",
+    "child-process-refused",
+    "source-isa-emulation-refused",
+    "raw-cpu-restore-refused",
+    "metadata-only-success-refused"
+  ],
+  "claimChangeAllowed": false
+}

--- a/docs/snapshot/node-level5-product-support-next-milestone.md
+++ b/docs/snapshot/node-level5-product-support-next-milestone.md
@@ -1,0 +1,93 @@
+# Node Level 5 next claim milestone
+
+This milestone defines what must be true before Machinen can raise the current Node Level 5 product claims beyond `80 / 20 / 0`.
+
+## Current claim
+
+| Claim                                        | Current value | Meaning                                                                            |
+| -------------------------------------------- | ------------: | ---------------------------------------------------------------------------------- |
+| Node product support                         |           80% | Selected Node service/app families have product-path evidence.                     |
+| Broad Node product support                   |           20% | Broad Node remains partial and limited to proven app rows plus refusal boundaries. |
+| Arbitrary process cross-architecture restore |            0% | Machinen does not claim arbitrary process restore.                                 |
+
+## Proposed next target
+
+| Claim                                        | Candidate target | Required posture                                                                        |
+| -------------------------------------------- | ---------------: | --------------------------------------------------------------------------------------- |
+| Node product support                         |              85% | Add one new product-supported family with real VM snapshot evidence in both directions. |
+| Broad Node product support                   |              25% | Add broader ecosystem evidence without weakening refusal boundaries.                    |
+| Arbitrary process cross-architecture restore |               0% | Stay at zero. No arbitrary process claim is allowed.                                    |
+
+This is a candidate target only. The claim does not change until every gate below is implemented, retained, and release-gated.
+
+## Milestone family: detected Node VM workload
+
+The next family should prove the generic VM-first product path, not a Node-only selector:
+
+```sh
+machinen snapshot <vm-name> --out <dir>
+machinen restore <dir>
+```
+
+Machinen must detect the supported Node workload inside the VM and retain the evidence. Users must not pass `node` or a host PID on the product path.
+
+## Required positive evidence
+
+| Evidence                   | Requirement                                                                             |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| Generic product command    | Snapshot uses `machinen snapshot <vm-name> --out <dir>`.                                |
+| Whole-VM capture           | Snapshot captures VM state, root disk state, and retained workload evidence.            |
+| Node detection             | Detection happens inside the VM from the running workload.                              |
+| Restore path               | Restore uses `machinen restore <dir>`.                                                  |
+| Target-native verification | Restored behavior is verified target-natively.                                          |
+| Cross-architecture lanes   | Both `arm64 -> amd64` and `amd64 -> arm64` pass.                                        |
+| Artifact retention         | Bundle keeps manifests, logs, verifier output, Node detection report, and refusal rows. |
+| Repeatability              | Release gate passes with a zero flake budget.                                           |
+
+## Required refusal evidence
+
+| Boundary                           | Expected result                                                                                 |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Host PID product targeting         | Refused or hidden unless `MACHINEN_NODE_LEVEL5_ALLOW_HOST_PID_SNAPSHOT=1` is set for harnesses. |
+| Node-only product selector         | Not part of the public product path.                                                            |
+| Active requests                    | Refused before restore claim.                                                                   |
+| Worker threads                     | Refused.                                                                                        |
+| Native addons                      | Refused.                                                                                        |
+| Wasm / external memory             | Refused.                                                                                        |
+| TLS active state                   | Refused.                                                                                        |
+| Child processes                    | Refused.                                                                                        |
+| Source ISA emulation               | Refused.                                                                                        |
+| Raw CPU restore as Level 5 support | Refused.                                                                                        |
+| Metadata-only success              | Refused.                                                                                        |
+
+## Broad-support criteria
+
+Broad Node support can move from `20%` to `25%` only if the new evidence covers real ecosystem variation, not just more copies of the same fixture. Acceptable rows include:
+
+- installed package manager variants (`npm`, `pnpm`, and `yarn`) for the same selected app family;
+- Node 20, 22, and 24 runtime rows with retained version/ABI evidence;
+- CommonJS and ESM entry rows;
+- Express and Fastify installed-app rows using the generic VM snapshot command;
+- refusal rows for unsafe neighbors for each supported variation.
+
+These rows still do not prove arbitrary Express, arbitrary Fastify, or arbitrary Node support.
+
+## Claim-change gates
+
+Before changing any claim constants or claim registry values:
+
+1. Add product-path proof rows for the generic VM snapshot command.
+2. Add a release-gated corpus report for both cross-architecture directions.
+3. Add positive and negative rows to the support matrix.
+4. Add drift guards for the new counts and row IDs.
+5. Add a VM smoke that boots a Node workload, snapshots the VM with generic `--out`, restores the snapshot, and verifies behavior.
+6. Run format, lint, docs build, typecheck, Vitest, focused Node Level 5 smokes, full VM smoke, and `fallow audit --changed-since origin/main`.
+7. Only then update claim values to `85 / 25 / 0`.
+
+## Non-goals
+
+- Do not claim arbitrary Node app support.
+- Do not claim arbitrary Express or Fastify support.
+- Do not use app-exported state, checkpoint hooks, selected-state descriptors, sidecar replay, source-ISA emulation, or metadata-only success.
+- Do not implement runtime-profile snapshot/restore as the product path.
+- Do not raise arbitrary process cross-architecture restore above `0%` in this milestone.

--- a/docs/snapshot/node-level5-product-support-runbook.md
+++ b/docs/snapshot/node-level5-product-support-runbook.md
@@ -1,6 +1,6 @@
 # Node Level 5 product support runbook
 
-This runbook applies to the 20%, 50%, and 65% Node product support tiers. The 65% tier covers fourteen declared service and boundary families only.
+This runbook applies to the 20%, 50%, 65%, and 80% Node product support tiers. The current shipped claim is 80% Node product support, 20% broad Node product support, and 0% arbitrary process cross-architecture restore. The next candidate milestone is documented in [Node Level 5 next claim milestone](./node-level5-product-support-next-milestone.md), but it is not claimed yet.
 
 ## Collect artifacts
 
@@ -30,10 +30,12 @@ Common supported-boundary refusals include:
 
 ## Escalation boundary
 
-Treat a failure as a product bug only when it is inside one of the five supported idle service families, uses the pinned runtime versions, and has retained artifacts.
+Treat a failure as a product bug only when it is inside a supported matrix row, uses the public VM-first snapshot path, and has retained artifacts.
 
 For the 50% tier, also collect the compatibility matrix row and release-checklist evidence for the reported family.
 
 For the 65% tier, identify whether the case is an active async idle boundary, TLS boundary policy, or child process boundary issue. Live TLS migration, in-flight async work, and live child process continuation remain unsupported.
 
-Treat everything else as unsupported unless the product support matrix is expanded.
+For the 80% tier, also identify the selected app row, real-app corpus row, refusal-corpus row, or support-matrix row that covers the report. The product path is `machinen snapshot <vm-name> --out <dir>` followed by `machinen restore <dir>`; Node support is detected inside the VM.
+
+Treat everything else as unsupported unless the product support matrix is expanded and the claim registry is intentionally raised.


### PR DESCRIPTION
## Problem

We know the current Node Level 5 claim is `80 / 20 / 0`, but the next step was not written down clearly. That makes it easy to raise numbers too early or confuse proof harness work with real product support.

## Solution

This PR defines the next candidate milestone as `85 / 25 / 0`, without claiming it yet. It lists the evidence needed before any claim can change, including generic VM snapshot evidence, Node detection inside the VM, restore verification, cross-architecture lanes, and refusal coverage.

## Technical Summary

- Keep the shipped claim at `80 / 20 / 0`.
- Define `85 / 25 / 0` as a candidate only, with `claimChangeAllowed: false` in the JSON plan.
- Make the generic product path explicit: `machinen snapshot <vm-name> --out <dir>` and `machinen restore <dir>`.
- Require Node detection inside the VM, not a public Node-only selector or host PID path.
- Keep arbitrary process cross-architecture restore at `0%` for this milestone.
- Update the runbook so support triage points to the new milestone and keeps the current claim boundary clear.
