### PR TITLE
Keep snapshots VM-only and add ping move loader

### DIFF
--- a/docs/snapshot/README.md
+++ b/docs/snapshot/README.md
@@ -16,16 +16,16 @@ Use these commands to save and restore a Machinen VM snapshot. See:
 
 ## Cross-ISA movement
 
-`machinen move` is the only cross-ISA product entrypoint.
+`machinen move` is the only cross-ISA product entrypoint. Give it a running VM name or VMM pid, then a guest PID when saving a descriptor.
 
 ```sh
-machinen move scan
-machinen move save <pid> <out>
-machinen move save <pid> <out> --issue [--issue-repo <owner/repo>]
-machinen move load <descriptor>
+machinen move scan <vm>
+machinen move save <vm> <guest-pid> <out-dir>
+machinen move save <vm> <guest-pid> <out-dir> --issue [--issue-repo <owner/repo>]
+machinen move load <vm> <bundle-dir>
 ```
 
-`move` records the PID graph and refuses state classes that do not have a target-native reconstruction path.
+`move save` writes a bundle directory whose `move.json` records the target VM's guest PID graph and attaches a procfs-backed resource plan for the selected PID. The resource plan is captured by `/sbin/machinen-move-capture` when the guest image provides it, with a shell fallback for older dev rootfs images. It reuses the native fd-table/resource translator, so regular files and proof-backed socket recipes can graduate while unsupported fds, PTYs, and sockets stay fail-closed with typed evidence. External ICMP ping/raw-ICMP descriptors use the `external-*-v1:no-inflight-target-egress` contract: packet queues must be empty and future packets use the target VM's own route/NAT identity.
 
 ## Product boundary
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "proof-non-node-runtime": "bash scripts/smoke/non-node-runtime-proof.sh",
     "proof-goal40-hard-runtime-state": "bash scripts/smoke/goal40-hard-runtime-state.sh",
     "proof-hard-runtime-refusal-contract": "bash scripts/smoke/hard-runtime-refusal-contract.sh",
+    "proof-move-ping-cross-arch": "bash scripts/smoke/move-ping-cross-arch.sh",
     "proof-stateful-services": "bash scripts/smoke/stateful-services-proof.sh",
     "proof-stateful-database-portable-restore": "bash scripts/smoke/stateful-database-portable-restore.sh",
     "proof-guest-checkpoint-substrate": "bash scripts/smoke/guest-checkpoint-substrate.sh",

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -211,8 +211,9 @@ describe("move-only cross-ISA product route convention", () => {
     expect(CLI_SRC).not.toContain("const pingPortableRestoreAdapter");
     expect(CLI_SRC).not.toContain("detectPortableRestoreAdapter(snapDir)");
     expect(MOVE_COMMAND_SRC).toContain("function cmdMove(");
-    expect(MOVE_COMMAND_SRC).toContain("saveMoveDescriptor");
+    expect(MOVE_COMMAND_SRC).toContain("createMoveDescriptorInVm");
     expect(MOVE_COMMAND_SRC).toContain("loadMoveDescriptor");
+    expect(MOVE_COMMAND_SRC).toContain("runMoveTargetDirectLoaderInVm");
     expect(CLI_SRC).toContain('["move", cmdMove]');
     expect(PORTABLE_RESTORE_ADAPTER_SRC).toContain("PortableRestoreAdapter");
   });

--- a/packages/cli/src/__tests__/move-executable-identity.test.ts
+++ b/packages/cli/src/__tests__/move-executable-identity.test.ts
@@ -1,0 +1,98 @@
+import type { MoveDescriptor, VmHandle } from "@machinen/runtime";
+import { describe, expect, it } from "vitest";
+
+import { validateMoveLoadTargetInVm } from "../move-executable-identity.ts";
+
+const descriptor: MoveDescriptor = {
+  formatVersion: 1,
+  kind: "machinen.move.descriptor",
+  rootPid: 71,
+  scannedAt: "2026-06-08T00:00:00.000Z",
+  nodes: [],
+  edges: [],
+  translatedStateClasses: ["process-identity", "argv-env-cwd"],
+  refusedStateClasses: [],
+  target: "cross-isa-target-native-pid-translation",
+  productSurface: "machinen move",
+  resourcePlan: {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    resources: [],
+    fdTableEntries: [],
+    targetGuestResources: [],
+    refusals: [],
+    acceptedSubsets: [],
+    capture: {
+      sourceVm: { pid: 100, name: "source" },
+      executablePackage: {
+        path: "/usr/bin/ping",
+        realPath: "/usr/bin/ping",
+        packageName: "iputils-ping",
+        version: "3:20221126-1+deb12u1",
+        architecture: "arm64",
+      },
+    },
+  },
+};
+
+describe("move executable identity validation", () => {
+  it("accepts path/package/version parity on a distinct target VM", async () => {
+    const vm = mockVm(
+      200,
+      "PKG\tiputils-ping\t3:20221126-1+deb12u1\tamd64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation).toMatchObject({ state: "ready", refusals: [] });
+  });
+
+  it("refuses loading back into the same local VM", async () => {
+    const vm = mockVm(
+      100,
+      "PKG\tiputils-ping\t3:20221126-1+deb12u1\tarm64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation.refusals).toContainEqual(
+      expect.objectContaining({ code: "target-process-context-unsupported" }),
+    );
+  });
+
+  it("refuses target package version mismatch before native resume", async () => {
+    const vm = mockVm(
+      200,
+      "PKG\tiputils-ping\t3:older\tamd64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation.refusals).toContainEqual(
+      expect.objectContaining({
+        code: "target-build-mismatch",
+        detail: expect.objectContaining({ failure: "version" }),
+      }),
+    );
+  });
+});
+
+function mockVm(pid: number, stdout: string): VmHandle {
+  return {
+    pid,
+    stdin: undefined,
+    stdout: undefined,
+    stderr: undefined,
+    wait: undefined,
+    kill: undefined,
+    detach: undefined,
+    output: undefined,
+    errorOutput: undefined,
+    exec: undefined,
+    execRaw: async () => ({ exitCode: 0, stdout, stderr: "" }),
+    execPty: undefined,
+    writeFile: undefined,
+    snapshot: undefined,
+    memory: undefined,
+  } as unknown as VmHandle;
+}

--- a/packages/cli/src/__tests__/move-native-bundle.test.ts
+++ b/packages/cli/src/__tests__/move-native-bundle.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateNativeProcessImageBundle, type MoveDescriptor } from "@machinen/runtime";
+import { describe, expect, it } from "vitest";
+
+import {
+  attachNativeContinuation,
+  moveActiveSyscallPlan,
+  writeNativeProcessImageScaffold,
+} from "../move-native-bundle.ts";
+
+const descriptor: MoveDescriptor = {
+  formatVersion: 1,
+  kind: "machinen.move.descriptor",
+  rootPid: 71,
+  scannedAt: "2026-06-08T00:00:00.000Z",
+  nodes: [
+    {
+      pid: 71,
+      ppid: 70,
+      command: "ping",
+      argv: ["ping", "google.com"],
+      cwd: "/root",
+      exe: "/usr/bin/ping",
+    },
+  ],
+  edges: [],
+  translatedStateClasses: ["process-identity", "argv-env-cwd"],
+  refusedStateClasses: [],
+  target: "cross-isa-target-native-pid-translation",
+  productSurface: "machinen move",
+  resourcePlan: {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    sourceArch: "arm64",
+    resources: [],
+    fdTableEntries: [],
+    targetGuestResources: [],
+    refusals: [],
+    acceptedSubsets: [],
+  },
+};
+
+describe("move native bundle scaffold", () => {
+  it("writes a canonical native process-image bundle with move continuation refusals", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-move-native-bundle-"));
+    try {
+      const withContinuation = attachNativeContinuation(descriptor);
+      writeNativeProcessImageScaffold(dir, withContinuation);
+
+      const bundle = validateNativeProcessImageBundle(dir);
+      expect(bundle.manifest.process.exe).toBe("/usr/bin/ping");
+      expect(bundle.manifest.capture.sourceArch).toBe("arm64");
+      expect(bundle.manifest.target.arch).toBe("amd64");
+      expect(bundle.translation.threads[0]).toMatchObject({ state: "refused" });
+      expect(moveActiveSyscallPlan(withContinuation)).toMatchObject({ state: "refused" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/__tests__/move-rendezvous.test.ts
+++ b/packages/cli/src/__tests__/move-rendezvous.test.ts
@@ -1,0 +1,98 @@
+import type { MoveDescriptor, VmHandle } from "@machinen/runtime";
+import { describe, expect, it } from "vitest";
+
+import { runMoveTargetDirectLoaderInVm } from "../move-rendezvous.ts";
+
+const descriptor: MoveDescriptor = {
+  formatVersion: 1,
+  kind: "machinen.move.descriptor",
+  rootPid: 71,
+  scannedAt: "2026-06-08T00:00:00.000Z",
+  nodes: [
+    {
+      pid: 71,
+      ppid: 1,
+      command: "ping",
+      argv: ["ping", "google.com"],
+      cwd: "/",
+      exe: "/usr/bin/ping",
+    },
+  ],
+  edges: [],
+  translatedStateClasses: ["process-identity", "argv-env-cwd"],
+  refusedStateClasses: [],
+  target: "cross-isa-target-native-pid-translation",
+  productSurface: "machinen move",
+  resourcePlan: {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    resources: [],
+    fdTableEntries: [],
+    targetGuestResources: [],
+    refusals: [],
+    acceptedSubsets: [],
+    capture: { pingState: { ntransmitted: 4, nreceived: 4, nerrors: 0, lastSequence: 4 } },
+  },
+};
+
+describe("move target direct loader", () => {
+  it("launches original target ping and accepts a frozen pre-send capture", async () => {
+    const commands: string[] = [];
+    const vm = mockVm(
+      commands,
+      [
+        "LOAD_PID\t321",
+        "LOAD_LOG\t/tmp/machinen-move-loader.log",
+        "UNAME\tx86_64",
+        "SAFE_BOUNDARY\tpre-send-icmp\tsendto",
+        "FREEZE\tptrace-attached\tstatus:4991",
+        "REG_AMD64\t0x1\t0x2\t0x3\t0x4\t0x5\t0x6\t0x7\t0x8\t0x9\t0xa\t0xb\t0xc\t0xd\t0xe\t0xf\t0x10\t0x11\t0x12\t0x13\t0x14",
+        "PATCH\tping-rts\t0x1000\t4\t4\t0",
+        "PATCH\tping-send-buffer\tready\t0x2000\t64\t5",
+      ].join("\n"),
+    );
+
+    const loader = await runMoveTargetDirectLoaderInVm(vm, descriptor);
+
+    expect(commands[0]).toContain("--load-ping-state 4 4 0");
+    expect(commands[0]).toContain("/usr/bin/ping");
+    expect(commands[0]).toContain("google.com");
+    expect(loader).toMatchObject({
+      state: "ready",
+      strategy: "target-original-ping-direct-loader",
+      targetPid: 321,
+      refusals: [],
+    });
+  });
+
+  it("refuses when target ping does not reach the direct-loader boundary", async () => {
+    const vm = mockVm([], "LOAD_PID\t321\nSAFE_BOUNDARY\trefused\ttimeout\n");
+
+    const loader = await runMoveTargetDirectLoaderInVm(vm, descriptor);
+
+    expect(loader.refusals).toContainEqual(expect.objectContaining({ code: "active-syscall" }));
+  });
+});
+
+function mockVm(commands: string[], stdout: string): VmHandle {
+  return {
+    pid: 200,
+    stdin: undefined,
+    stdout: undefined,
+    stderr: undefined,
+    wait: undefined,
+    kill: undefined,
+    detach: undefined,
+    output: undefined,
+    errorOutput: undefined,
+    exec: undefined,
+    execRaw: async (cmd: string) => {
+      commands.push(cmd);
+      return { exitCode: 0, stdout, stderr: "" };
+    },
+    execPty: undefined,
+    writeFile: undefined,
+    snapshot: undefined,
+    memory: undefined,
+  } as unknown as VmHandle;
+}

--- a/packages/cli/src/__tests__/move-resource-plan.test.ts
+++ b/packages/cli/src/__tests__/move-resource-plan.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMoveResourcePlan, parseGuestMoveResourceScan } from "../move-resource-plan.ts";
+
+const pingNode = {
+  pid: 71,
+  ppid: 70,
+  command: "ping",
+  argv: ["ping", "127.0.0.1"],
+  cwd: "/root",
+};
+
+describe("move resource plan", () => {
+  it("captures ping socket procfs evidence before refusing missing sequence state", () => {
+    const scan = parseGuestMoveResourceScan(
+      [
+        "AGENT\tmachinen-move-capture-v1",
+        "STATUS\t1000\t1000",
+        "PING_RANGE\t0\t2147483647",
+        "FD\t59\tsocket:[12345]",
+        "FDINFO\t59\tflags:\t02",
+        "NET_ICMP\t0: 0100007F:4D50 0100007F:0000 07 00000000:00000000 00:00000000 00000000 1000 0 12345",
+      ].join("\n"),
+    );
+
+    const plan = buildMoveResourcePlan(pingNode, scan);
+
+    expect(plan.resources).toContainEqual(
+      expect.objectContaining({
+        kind: "socket",
+        recipe: expect.objectContaining({
+          pingSocketModel: "loopback-echo-v1",
+          destination: "127.0.0.1",
+          identifier: 0x4d50,
+          uid: 1000,
+          gid: 1000,
+        }),
+      }),
+    );
+    expect(plan.refusals).toContainEqual(
+      expect.objectContaining({ code: "target-socket-syscall-state-unsupported" }),
+    );
+    expect(plan.acceptedSubsets).toEqual([]);
+  });
+
+  it("captures external ping sockets but refuses until sequence state is translated", () => {
+    const scan = parseGuestMoveResourceScan(
+      [
+        "STATUS\t0\t0",
+        "PING_RANGE\t0\t2147483647",
+        "FD\t3\tsocket:[99]",
+        "FDINFO\t3\tflags:\t02",
+        "NET_ICMP\t0: 0A00020F:4D50 08080808:0000 07 00000000:00000000 00:00000000 00000000 0 0 99",
+      ].join("\n"),
+    );
+
+    const plan = buildMoveResourcePlan({ ...pingNode, argv: ["ping", "google.com"] }, scan);
+
+    expect(plan.resources).toContainEqual(
+      expect.objectContaining({
+        kind: "socket",
+        recipe: expect.objectContaining({
+          pingSocketModel: "external-target-egress-v1",
+          destination: "8.8.8.8",
+          networkNamespace: "target-network",
+          route: "target-egress",
+        }),
+      }),
+    );
+    expect(plan.refusals).toContainEqual(
+      expect.objectContaining({
+        code: "non-stdio-kernel-state-unsupported",
+        detail: expect.objectContaining({ kind: "socket", fd: 3 }),
+      }),
+    );
+  });
+});

--- a/packages/cli/src/commands/move.ts
+++ b/packages/cli/src/commands/move.ts
@@ -1,9 +1,38 @@
-import { loadMoveDescriptor, saveMoveDescriptor, scanMovePidGraph } from "@machinen/runtime";
+import {
+  attach,
+  loadMoveDescriptor,
+  MOVE_DESCRIPTOR_FORMAT_VERSION,
+  MOVE_REFUSAL_CODE,
+  validateNativeProcessImageBundle,
+  type MoveDescriptor,
+  type MovePidGraph,
+  type MovePidGraphNode,
+  type MoveRefusalEvidence,
+  type NativeProcessImageRefusal,
+  type VmHandle,
+} from "@machinen/runtime";
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
 
 import { consumeJsonFlag } from "../args.ts";
-import { die } from "../errors.ts";
+import {
+  readMoveExecutableIdentityInVm,
+  validateMoveLoadTargetInVm,
+  type MoveLoadTargetValidation,
+} from "../move-executable-identity.ts";
+import {
+  attachNativeContinuation,
+  moveActiveSyscallPlan,
+  writeNativeProcessImageScaffold,
+} from "../move-native-bundle.ts";
+import { buildMoveResourcePlan, parseGuestMoveResourceScan } from "../move-resource-plan.ts";
+import { runMoveTargetDirectLoaderInVm, type MoveLoadDirectLoader } from "../move-rendezvous.ts";
+import { die, handleError } from "../errors.ts";
+import type { Target } from "../parse-target.ts";
+import { parseTargetFlags, resolveTarget } from "./target.ts";
 
-type MoveHandler = (args: string[], json: boolean) => number;
+type MoveHandler = (args: string[], json: boolean) => Promise<number> | number;
+type MoveResourcePlan = NonNullable<MoveDescriptor["resourcePlan"]>;
 
 const MOVE_HANDLERS = new Map<string, MoveHandler>([
   ["scan", cmdMoveScan],
@@ -11,7 +40,7 @@ const MOVE_HANDLERS = new Map<string, MoveHandler>([
   ["load", cmdMoveLoad],
 ]);
 
-export function cmdMove(args: string[]): number {
+export function cmdMove(args: string[]): Promise<number> | number {
   const { json, rest } = consumeJsonFlag(args);
   const handler = MOVE_HANDLERS.get(rest[0] ?? "");
   if (!handler) {
@@ -20,51 +49,159 @@ export function cmdMove(args: string[]): number {
   return handler(rest.slice(1), json);
 }
 
-function cmdMoveScan(_args: string[], json: boolean): number {
-  const graph = scanMovePidGraph();
-  if (json) {
-    emitJson({ schema_version: 1, ...graph });
-  } else {
-    process.stdout.write(
-      `move scan: ${graph.nodes.length} processes; refused=${graph.refusedStateClasses.length}\n`,
-    );
-  }
-  return graph.refusedStateClasses.length === 0 ? 0 : 1;
+async function cmdMoveScan(args: string[], json: boolean): Promise<number> {
+  const target = parseTargetFlags(args, "move scan");
+  return withMoveVm(target, async (vm) => {
+    const graph = await scanMovePidGraphInVm(vm);
+    if (json) {
+      emitJson({ schema_version: 1, ...graph });
+    } else {
+      process.stdout.write(
+        `move scan: ${graph.nodes.length} in-VM processes; refused=${graph.refusedStateClasses.length}\n`,
+      );
+    }
+    return graph.refusedStateClasses.length === 0 ? 0 : 1;
+  });
 }
 
-function cmdMoveSave(args: string[], json: boolean): number {
+async function cmdMoveSave(args: string[], json: boolean): Promise<number> {
   const options = parseMoveSaveArgs(args);
-  const result = saveMoveDescriptor(options);
-  reportMoveSaveResult(result, json);
-  return result.accepted ? 0 : 1;
+  return withMoveVm(options.target, async (vm) => {
+    const descriptor = await createMoveDescriptorInVm(vm, options.pid);
+    const result = writeMoveDescriptorResult(descriptor, options);
+    reportMoveSaveResult(result, json);
+    return moveAcceptedExitCode(result.accepted);
+  });
 }
 
-type MoveSaveOptions = Parameters<typeof saveMoveDescriptor>[0];
-type MoveSaveResult = ReturnType<typeof saveMoveDescriptor>;
+type MoveSaveOptions = {
+  target: Target;
+  pid: number;
+  outPath: string;
+  issue: boolean;
+  issueRepo?: string;
+};
+
+type MoveSaveResult = {
+  accepted: boolean;
+  descriptorPath: string;
+  descriptor: MoveDescriptor;
+  refusalCode?: typeof MOVE_REFUSAL_CODE;
+  issueReport?: MoveIssueReport;
+};
+
+type MoveIssueReport = {
+  title: string;
+  body: string;
+  repository: string;
+};
 
 function parseMoveSaveArgs(args: string[]): MoveSaveOptions {
-  if (args.length < 2) {
+  const { target, rest } = resolveTarget(args, "move save");
+  if (rest.length < 2) {
     die(moveUsage());
   }
-  const issueRepo = parseIssueRepo(args);
+  const { issue, issueRepo } = parseMoveSaveFlags(rest.slice(2));
   return {
-    pid: parsePositiveInteger(args[0]!, "pid"),
-    outPath: args[1]!,
-    issue: args.includes("--issue"),
+    target,
+    pid: parsePositiveInteger(rest[0]!, "pid"),
+    outPath: rest[1]!,
+    issue,
     issueRepo,
   };
 }
 
-function parseIssueRepo(args: string[]): string | undefined {
-  const issueRepoIndex = args.indexOf("--issue-repo");
-  if (issueRepoIndex === -1) {
-    return undefined;
+function parseMoveSaveFlags(args: string[]): { issue: boolean; issueRepo?: string } {
+  let flags = newMoveSaveFlags();
+  for (let index = 0; index < args.length; index += 1) {
+    const parsed = parseMoveSaveFlag(args, index, flags);
+    flags = parsed.flags;
+    index = parsed.index;
   }
-  const issueRepo = args[issueRepoIndex + 1];
+  return flags;
+}
+
+function newMoveSaveFlags(): { issue: boolean; issueRepo?: string } {
+  return { issue: false };
+}
+
+function parseMoveSaveFlag(
+  args: string[],
+  index: number,
+  flags: { issue: boolean; issueRepo?: string },
+): { index: number; flags: { issue: boolean; issueRepo?: string } } {
+  const arg = args[index]!;
+  if (arg === "--issue") {
+    return { index, flags: { ...flags, issue: true } };
+  }
+  if (arg !== "--issue-repo") {
+    die(`unknown argument: ${arg}`);
+  }
+  return parseMoveSaveIssueRepoFlag(args, index, flags);
+}
+
+function parseMoveSaveIssueRepoFlag(
+  args: string[],
+  index: number,
+  flags: { issue: boolean; issueRepo?: string },
+): { index: number; flags: { issue: boolean; issueRepo?: string } } {
+  const issueRepo = args[index + 1];
   if (!issueRepo) {
     die("move save --issue-repo requires <owner/repo>");
   }
-  return issueRepo;
+  return { index: index + 1, flags: { ...flags, issueRepo } };
+}
+
+function writeMoveDescriptorResult(
+  descriptor: MoveDescriptor,
+  options: MoveSaveOptions,
+): MoveSaveResult {
+  const bundlePath = prepareMoveBundleDir(options.outPath);
+  const bundleDescriptor = attachNativeContinuation(descriptor);
+  writeNativeProcessImageScaffold(bundlePath, bundleDescriptor);
+  const descriptorPath = join(bundlePath, "move.json");
+  writeFileSync(descriptorPath, `${JSON.stringify(bundleDescriptor, null, 2)}\n`);
+  writeFileSync(
+    join(bundlePath, "active-syscall-plan.json"),
+    `${JSON.stringify(moveActiveSyscallPlan(bundleDescriptor), null, 2)}\n`,
+  );
+  const accepted =
+    descriptor.refusedStateClasses.length === 0 &&
+    bundleDescriptor.nativeContinuation?.state !== "refused";
+  return {
+    accepted,
+    descriptorPath: bundlePath,
+    descriptor: bundleDescriptor,
+    refusalCode: moveRefusalCode(accepted),
+    issueReport: moveIssueReport(descriptor, options),
+  };
+}
+
+function prepareMoveBundleDir(outPath: string): string {
+  const bundlePath = resolve(outPath);
+  if (existsSync(bundlePath) && !statSync(bundlePath).isDirectory()) {
+    die("move save output must be a directory");
+  }
+  mkdirSync(bundlePath, { recursive: true });
+  return bundlePath;
+}
+
+function moveRefusalCode(accepted: boolean): typeof MOVE_REFUSAL_CODE | undefined {
+  return accepted ? undefined : MOVE_REFUSAL_CODE;
+}
+
+function moveIssueReport(
+  descriptor: MoveDescriptor,
+  options: MoveSaveOptions,
+): MoveIssueReport | undefined {
+  if (!options.issue) {
+    return undefined;
+  }
+  return buildMoveIssueReport(descriptor, options.issueRepo ?? "redwoodjs/machinen");
+}
+
+function moveAcceptedExitCode(accepted: boolean): 0 | 1 {
+  return accepted ? 0 : 1;
 }
 
 function reportMoveSaveResult(result: MoveSaveResult, json: boolean): void {
@@ -87,29 +224,116 @@ function printIssueReport(result: MoveSaveResult): void {
   );
 }
 
-function cmdMoveLoad(args: string[], json: boolean): number {
-  if (args.length !== 1) {
+async function cmdMoveLoad(args: string[], json: boolean): Promise<number> {
+  const { target, rest } = resolveTarget(args, "move load");
+  if (rest.length !== 1) {
     die(moveUsage());
   }
-  const descriptor = loadMoveDescriptor(args[0]!);
-  const accepted = descriptor.refusedStateClasses.length === 0;
-  reportMoveLoadResult(descriptor, accepted, json);
-  return accepted ? 0 : 1;
+  return withMoveVm(target, async (vm) => {
+    const bundlePath = resolve(rest[0]!);
+    const descriptor = loadMoveDescriptor(moveLoadDescriptorPath(bundlePath));
+    const targetValidation = await validateMoveLoadTargetInVm(
+      vm,
+      descriptor,
+      moveLoadExecutablePath(descriptor),
+    );
+    const loader =
+      targetValidation.state === "ready"
+        ? await runMoveTargetDirectLoaderInVm(vm, descriptor)
+        : undefined;
+    const accepted = moveLoadAccepted(descriptor, bundlePath, targetValidation, loader);
+    reportMoveLoadResult(descriptor, accepted, json, targetValidation, loader);
+    return accepted ? 0 : 1;
+  });
 }
 
-type MoveDescriptor = ReturnType<typeof loadMoveDescriptor>;
+function moveLoadDescriptorPath(bundlePath: string): string {
+  if (existsSync(bundlePath) && statSync(bundlePath).isDirectory()) {
+    return join(bundlePath, "move.json");
+  }
+  return bundlePath;
+}
 
-function reportMoveLoadResult(descriptor: MoveDescriptor, accepted: boolean, json: boolean): void {
+function moveLoadAccepted(
+  descriptor: MoveDescriptor,
+  bundlePath: string,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): boolean {
+  return moveLoadGates(descriptor, bundlePath, targetValidation, loader).every(Boolean);
+}
+
+function moveLoadGates(
+  descriptor: MoveDescriptor,
+  bundlePath: string,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): boolean[] {
+  return [
+    moveBundleValid(bundlePath),
+    moveDescriptorContinuationPlanned(descriptor),
+    targetValidation.state === "ready",
+    loader?.state === "ready" || false,
+  ];
+}
+
+function moveLoadExecutablePath(descriptor: MoveDescriptor): string {
+  return savedExecutablePath(descriptor) ?? descriptorExecutablePath(descriptor) ?? "/usr/bin/ping";
+}
+
+function savedExecutablePath(descriptor: MoveDescriptor): string | undefined {
+  return descriptor.resourcePlan?.capture?.executablePackage?.path;
+}
+
+function descriptorExecutablePath(descriptor: MoveDescriptor): string | undefined {
+  return descriptor.nodes[0]?.exe;
+}
+
+function moveBundleValid(bundlePath: string): boolean {
+  if (!existsSync(bundlePath)) {
+    return false;
+  }
+  if (!statSync(bundlePath).isDirectory()) {
+    return false;
+  }
+  validateNativeProcessImageBundle(bundlePath);
+  return true;
+}
+
+function moveDescriptorContinuationPlanned(descriptor: MoveDescriptor): boolean {
+  if (descriptor.refusedStateClasses.every((refusal) => refusal.stateClass === "sockets")) {
+    return true;
+  }
+  if (descriptor.refusedStateClasses.length !== 0) {
+    return false;
+  }
+  return descriptor.nativeContinuation?.state !== "refused";
+}
+
+function reportMoveLoadResult(
+  descriptor: MoveDescriptor,
+  accepted: boolean,
+  json: boolean,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): void {
   if (json) {
-    emitJson({ schema_version: 1, accepted, descriptor });
+    emitJson({
+      schema_version: 1,
+      accepted,
+      descriptor,
+      targetValidation,
+      loader,
+      rendezvous: loader,
+    });
     return;
   }
   if (accepted) {
-    process.stdout.write(`move load accepted descriptor for PID ${descriptor.rootPid}\n`);
+    process.stdout.write(`move load accepted descriptor for in-VM PID ${descriptor.rootPid}\n`);
     return;
   }
   process.stderr.write(
-    `move load refused descriptor for PID ${descriptor.rootPid}: ${refusedStateClasses(descriptor)}\n`,
+    `move load refused descriptor for in-VM PID ${descriptor.rootPid}: ${refusedStateClasses(descriptor)}\n`,
   );
 }
 
@@ -117,8 +341,425 @@ function refusedStateClasses(descriptor: MoveDescriptor): string {
   return descriptor.refusedStateClasses.map((item) => item.stateClass).join(", ");
 }
 
+async function withMoveVm<T>(target: Target, run: (vm: VmHandle) => Promise<T> | T): Promise<T> {
+  const vm = await attach(target).catch(handleError);
+  try {
+    return await run(vm);
+  } finally {
+    await vm.detach();
+  }
+}
+
+async function createMoveDescriptorInVm(vm: VmHandle, pid: number): Promise<MoveDescriptor> {
+  const nodes = await readMoveProcNodesInVm(vm, pid);
+  const resourcePlan = await scanMoveResourcePlanInVm(vm, nodes[0]!);
+  await attachMoveSourceIdentity(vm, nodes[0]!, resourcePlan);
+  const graph = buildMovePidGraph(pid, nodes, resourcePlan);
+  return {
+    ...graph,
+    kind: "machinen.move.descriptor",
+    target: "cross-isa-target-native-pid-translation",
+    productSurface: "machinen move",
+    resourcePlan,
+  };
+}
+
+async function attachMoveSourceIdentity(
+  vm: VmHandle,
+  node: MovePidGraphNode,
+  resourcePlan: MoveResourcePlan,
+): Promise<void> {
+  resourcePlan.capture = {
+    ...resourcePlan.capture,
+    sourceVm: { pid: vm.pid, name: vm.name },
+    executablePackage: await readMoveExecutableIdentityInVm(vm, node.exe ?? moveProcessPath(node)),
+    pingState: await readMovePingStateInVm(vm, resourcePlan),
+  };
+}
+
+async function readMovePingStateInVm(
+  vm: VmHandle,
+  resourcePlan: MoveResourcePlan,
+): Promise<NonNullable<MoveResourcePlan["capture"]>["pingState"]> {
+  const path = moveStdoutFilePath(resourcePlan);
+  if (!path) {
+    return undefined;
+  }
+  const result = await vm.execRaw(`tail -n 500 ${shellQuote(path)} 2>/dev/null || true`, {
+    execTimeoutMs: 10_000,
+  });
+  return parsePingStateFromOutput(result.stdout);
+}
+
+function moveStdoutFilePath(resourcePlan: MoveResourcePlan): string | undefined {
+  const stdout = resourcePlan.resources.find((resource) => resource.fd === 1);
+  return stdout?.kind === "file" && typeof stdout.path === "string" ? stdout.path : undefined;
+}
+
+function parsePingStateFromOutput(
+  stdout: string,
+): NonNullable<MoveResourcePlan["capture"]>["pingState"] {
+  const sequences = Array.from(stdout.matchAll(/icmp_seq=(\d+)/g), (match) => Number(match[1]));
+  const replies = stdout.split("\n").filter((line) => /bytes from .*icmp_seq=\d+/.test(line));
+  const errors = stdout.split("\n").filter((line) => /^From .*icmp_seq=\d+/.test(line));
+  const lastSequence = sequences.at(-1);
+  if (!lastSequence) {
+    return undefined;
+  }
+  return {
+    ntransmitted: lastSequence,
+    nreceived: replies.length,
+    nerrors: errors.length,
+    lastSequence,
+  };
+}
+
+function moveProcessPath(node: MovePidGraphNode): string {
+  return node.argv[0]?.startsWith("/") ? node.argv[0]! : `/usr/bin/${node.command}`;
+}
+
+async function scanMovePidGraphInVm(vm: VmHandle, rootPid?: number): Promise<MovePidGraph> {
+  const nodes = await readMoveProcNodesInVm(vm, rootPid);
+  return buildMovePidGraph(rootPid, nodes);
+}
+
+function buildMovePidGraph(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+  resourcePlan?: MoveResourcePlan,
+): MovePidGraph {
+  const pidSet = new Set(nodes.map((node) => node.pid));
+  const edges = nodes
+    .filter((node) => node.ppid !== undefined && pidSet.has(node.ppid))
+    .map((node) => ({ fromPid: node.ppid!, toPid: node.pid, kind: "parent-child" as const }));
+  return {
+    formatVersion: MOVE_DESCRIPTOR_FORMAT_VERSION,
+    kind: "machinen.move.pid-graph",
+    rootPid,
+    scannedAt: new Date().toISOString(),
+    nodes,
+    edges,
+    translatedStateClasses: translatedStateClasses(resourcePlan),
+    refusedStateClasses: buildRefusals(rootPid, nodes, resourcePlan),
+  };
+}
+
+async function readMoveProcNodesInVm(vm: VmHandle, rootPid?: number): Promise<MovePidGraphNode[]> {
+  const result = await vm.execRaw(guestProcScanCommand(rootPid), { execTimeoutMs: 30_000 });
+  if (result.exitCode !== 0) {
+    die(`move proc scan failed inside VM: ${moveProcScanError(result)}`);
+  }
+  return parseGuestProcRows(result.stdout, rootPid);
+}
+
+function moveProcScanError(result: { stderr: string; stdout: string; exitCode: number }): string {
+  return result.stderr || result.stdout || String(result.exitCode);
+}
+
+async function scanMoveResourcePlanInVm(
+  vm: VmHandle,
+  node: MovePidGraphNode,
+): Promise<MoveResourcePlan> {
+  const result = await vm.execRaw(guestMoveResourceScanCommand(node.pid), {
+    execTimeoutMs: 30_000,
+  });
+  if (result.exitCode !== 0) {
+    die(`move resource scan failed inside VM: ${moveProcScanError(result)}`);
+  }
+  return buildMoveResourcePlan(node, parseGuestMoveResourceScan(result.stdout));
+}
+
+function guestMoveResourceScanCommand(pid: number): string {
+  return `pid=${pid}
+if [ -x /sbin/machinen-move-capture ]; then
+  exec /sbin/machinen-move-capture "$pid" --timeout-ms 10000
+fi
+printf 'UNAME\t%s\n' "$(uname -m 2>/dev/null || true)"
+status="/proc/$pid/status"
+uid=""
+gid=""
+if [ -r "$status" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      Uid:*) set -- $line; uid="$2" ;;
+      Gid:*) set -- $line; gid="$2" ;;
+    esac
+  done < "$status"
+fi
+printf 'STATUS\t%s\t%s\n' "$uid" "$gid"
+if [ -r /proc/sys/net/ipv4/ping_group_range ]; then
+  set -- $(cat /proc/sys/net/ipv4/ping_group_range 2>/dev/null || true)
+  printf 'PING_RANGE\t%s\t%s\n' "$1" "$2"
+fi
+for f in /proc/$pid/fd/*; do
+  [ -e "$f" ] || continue
+  fd="\${f##*/}"
+  target=$(readlink "$f" 2>/dev/null || true)
+  printf 'FD\t%s\t%s\n' "$fd" "$target"
+  if [ -r "/proc/$pid/fdinfo/$fd" ]; then
+    while IFS= read -r line; do
+      case "$line" in
+        pos:*|flags:*) printf 'FDINFO\t%s\t%s\n' "$fd" "$line" ;;
+      esac
+    done < "/proc/$pid/fdinfo/$fd"
+  fi
+done
+if [ -r /proc/net/icmp ]; then
+  while IFS= read -r line; do printf 'NET_ICMP\t%s\n' "$line"; done < /proc/net/icmp
+fi
+if [ -r /proc/net/raw ]; then
+  while IFS= read -r line; do printf 'NET_RAW\t%s\n' "$line"; done < /proc/net/raw
+fi`;
+}
+
+function guestProcScanCommand(rootPid?: number): string {
+  const pidSelector =
+    rootPid === undefined
+      ? 'for d in /proc/[0-9]*; do scan_pid "${d##*/}"; done'
+      : `scan_pid ${rootPid}`;
+  return `scan_pid() {
+  pid="$1"
+  d="/proc/$pid"
+  [ -d "$d" ] || return 0
+  stat=$(cat "$d/stat" 2>/dev/null || true)
+  cmd=$(tr '\\000' '\\037' <"$d/cmdline" 2>/dev/null || true)
+  cwd=$(readlink "$d/cwd" 2>/dev/null || true)
+  exe=$(readlink "$d/exe" 2>/dev/null || true)
+  printf '%s	%s	%s	%s	%s\n' "$pid" "$stat" "$cmd" "$cwd" "$exe"
+}
+${pidSelector}`;
+}
+
+function parseGuestProcRows(stdout: string, rootPid?: number): MovePidGraphNode[] {
+  const nodes = stdout
+    .split("\n")
+    .filter(Boolean)
+    .slice(0, rootPid === undefined ? 250 : 1)
+    .map(parseGuestProcRow)
+    .filter((node): node is MovePidGraphNode => node !== undefined)
+    .sort((left, right) => left.pid - right.pid);
+  if (rootPid !== undefined && nodes.length === 0) {
+    die(`in-VM pid ${rootPid} was not found`);
+  }
+  return nodes;
+}
+
+function parseGuestProcRow(row: string): MovePidGraphNode | undefined {
+  const [pidText, stat = "", cmdline = "", cwd = "", exe = ""] = row.split("\t");
+  const pid = parseOptionalPositiveInteger(pidText ?? "");
+  if (pid === undefined) {
+    return undefined;
+  }
+  const argv = cmdline.split("\x1f").filter(Boolean);
+  const command = moveProcCommand(argv, stat, pid);
+  return {
+    pid,
+    ppid: parsePpid(stat),
+    command,
+    argv,
+    cwd: emptyToUndefined(cwd),
+    exe: emptyToUndefined(exe),
+  };
+}
+
+function moveProcCommand(argv: string[], stat: string, pid: number): string {
+  if (argv[0]) {
+    return basename(argv[0]);
+  }
+  return parseStatCommand(stat) ?? `pid-${pid}`;
+}
+
+function emptyToUndefined(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}
+
+function translatedStateClasses(
+  resourcePlan?: MoveResourcePlan,
+): MovePidGraph["translatedStateClasses"] {
+  const base: MovePidGraph["translatedStateClasses"] = ["process-identity", "argv-env-cwd"];
+  if (resourcePlan && resourcePlan.refusals.length === 0) {
+    return [...base, "open-files", "sockets"];
+  }
+  return base;
+}
+
+function buildRefusals(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+  resourcePlan?: MoveResourcePlan,
+): MoveRefusalEvidence[] {
+  if (rootPid === undefined || !resourcePlan) {
+    return genericMoveRefusals(rootPid, nodes);
+  }
+  return resourcePlanRefusals(rootPid, resourcePlan);
+}
+
+function genericMoveRefusals(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+): MoveRefusalEvidence[] {
+  return [
+    {
+      stateClass: "open-files",
+      reason: "open file descriptor identity is not translated by this descriptor yet",
+      evidence:
+        rootPid === undefined ? "scan-only-no-root-pid" : `pid:${rootPid}:fd-audit-required`,
+      nextAction: "add a move-owned fd detector and target-native file/socket reconstruction proof",
+    },
+    {
+      stateClass: "sockets",
+      reason:
+        "kernel socket identity is not preserved across ISA and must be reconstructed or refused",
+      evidence: `nodes:${nodes.length}:socket-audit-required`,
+      nextAction: "attach socket-family evidence and a target-native reconstruction verifier",
+    },
+  ];
+}
+
+function resourcePlanRefusals(
+  rootPid: number,
+  resourcePlan: MoveResourcePlan,
+): MoveRefusalEvidence[] {
+  const refusals = [
+    openFileResourceRefusal(resourcePlan),
+    socketResourceRefusal(resourcePlan),
+    threadResourceRefusal(resourcePlan),
+  ].filter((refusal): refusal is MoveRefusalEvidence => refusal !== undefined);
+  if (resourcePlan.refusals.length > 0 && refusals.length === 0) {
+    return genericMoveRefusals(rootPid, []);
+  }
+  return refusals;
+}
+
+function openFileResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isOpenFileMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "open-files",
+    reason: "one or more open file descriptors still lack a target-native recipe",
+    evidence: JSON.stringify(moveRefusalEvidenceSummary(resourcePlan, "open-files")),
+    nextAction:
+      "model or broker every inherited fd, including stdin/PTY state, before target execution",
+  };
+}
+
+function socketResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isSocketMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "sockets",
+    reason: "one or more socket descriptors still lack proven target-native reconstruction",
+    evidence: JSON.stringify(moveRefusalEvidenceSummary(resourcePlan, "sockets")),
+    nextAction:
+      "graduate the captured socket into a supported ping/raw-ICMP loopback descriptor or keep it refused",
+  };
+}
+
+function threadResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isThreadMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "threads",
+    reason: "the process was not captured at the supported single-thread sleep/timer boundary",
+    evidence: JSON.stringify({ capture: resourcePlan.capture }),
+    nextAction:
+      "wait for the ping sleep/timer boundary and freeze the single thread before translation",
+  };
+}
+
+function isOpenFileMoveRefusal(refusal: NativeProcessImageRefusal): boolean {
+  return !isSocketMoveRefusal(refusal) && !isThreadMoveRefusal(refusal);
+}
+
+function isSocketMoveRefusal(refusal: NativeProcessImageRefusal): boolean {
+  const kind = refusal.detail?.kind;
+  return kind === "socket" || kind === "raw-socket";
+}
+
+function isThreadMoveRefusal(refusal: NativeProcessImageRefusal): boolean {
+  return refusal.detail?.kind === "thread";
+}
+
+function moveRefusalEvidenceSummary(
+  resourcePlan: MoveResourcePlan,
+  stateClass: "open-files" | "sockets",
+): Record<string, unknown> {
+  const predicate = stateClass === "sockets" ? isSocketMoveRefusal : isOpenFileMoveRefusal;
+  const refusals = resourcePlan.refusals.filter(predicate);
+  return {
+    resourceRefusals: refusals.map((refusal) => ({
+      code: refusal.code,
+      fd: refusal.detail?.fd,
+      kind: refusal.detail?.kind,
+      requiredModel: refusal.detail?.requiredModel,
+    })),
+    acceptedSubsets: resourcePlan.acceptedSubsets,
+  };
+}
+
+function buildMoveIssueReport(
+  descriptor: MoveDescriptor,
+  repository = "redwoodjs/machinen",
+): MoveIssueReport {
+  const stateClasses = descriptor.refusedStateClasses.map((item) => item.stateClass).join(", ");
+  const rootPid = moveDescriptorRootPidLabel(descriptor);
+  return {
+    repository,
+    title: `move refused in-VM PID ${rootPid}: ${moveStateClassLabel(stateClasses, "no refusals")}`,
+    body: [
+      "## Problem",
+      "`machinen move` refused this in-VM PID graph because some state classes are not proven yet.",
+      "",
+      "## Redacted evidence",
+      `- root pid: ${rootPid}`,
+      `- process count: ${descriptor.nodes.length}`,
+      `- refused classes: ${moveStateClassLabel(stateClasses, "none")}`,
+      "",
+      "## Next action",
+      ...descriptor.refusedStateClasses.map((item) => `- ${item.stateClass}: ${item.nextAction}`),
+    ].join("\n"),
+  };
+}
+
+function moveDescriptorRootPidLabel(descriptor: MoveDescriptor): string {
+  return descriptor.rootPid === undefined ? "unknown" : String(descriptor.rootPid);
+}
+
+function moveStateClassLabel(value: string, fallback: string): string {
+  return value === "" ? fallback : value;
+}
+
+function parseStatCommand(stat: string): string | undefined {
+  const match = stat.match(/^\d+\s+\((.*)\)\s+\S+/);
+  return match?.[1];
+}
+
+function parsePpid(stat: string): number | undefined {
+  const match = stat.match(/^\d+\s+\(.*\)\s+\S+\s+(\d+)/);
+  if (!match) {
+    return undefined;
+  }
+  const parsed = Number(match[1]);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
 function moveUsage(): string {
-  return "usage: machinen move scan [--json] | machinen move save <pid> <out> [--issue] [--issue-repo <owner/repo>] [--json] | machinen move load <descriptor> [--json]";
+  return "usage: machinen move scan <vm> [--json] | machinen move save <vm> <pid> <out-dir> [--issue] [--issue-repo <owner/repo>] [--json] | machinen move load <vm> <bundle-dir> [--json]";
+}
+
+function parseOptionalPositiveInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function parsePositiveInteger(value: string, flag: string): number {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -24,9 +24,11 @@ export function printHelp(): void {
       `                                                 when the host supports it.\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +
-      `  machinen move scan [--json]                  Scan host PID graph state classes.\n` +
-      `  machinen move save <pid> <out> [--issue]     Write a move descriptor or refusal evidence.\n` +
-      `  machinen move load <descriptor> [--json]     Validate a move descriptor fail-closed.\n` +
+      `  machinen move scan <vm> [--json]             Scan a VM's PID graph state classes.\n` +
+      `  machinen move save <vm> <pid> <out-dir> [--issue]\n` +
+      `                                                 Write a VM move descriptor or refusal evidence.\n` +
+      `  machinen move load <vm> <bundle-dir> [--json]\n` +
+      `                                                 Validate a move descriptor against a VM.\n` +
       `\n` +
       `  machinen restore <snap-dir> [--image <tar.gz>] [--name <name>] [-p ...]\n` +
       `                              [--mount-live <host>:<guest>[:<mode>]]\n` +
@@ -130,9 +132,9 @@ export function printHelp(): void {
       `  machinen exec worker --tty -- vim /etc/passwd        # full-screen TUI in a PTY\n` +
       `  machinen snapshot worker ./warm                      # CRIU snapshot bundle\n` +
       `  machinen restore ./warm\n` +
-      `  machinen move scan --json\n` +
-      `  machinen move save 1234 ./move.json --issue\n` +
-      `  machinen move load ./move.json --json\n` +
+      `  machinen move scan worker --json\n` +
+      `  machinen move save worker 1234 ./move.json --issue\n` +
+      `  machinen move load worker ./move.json --json\n` +
       `\n` +
       `Environment:\n` +
       `  MACHINEN_VMM                             Override the VMM binary path (dev)\n` +

--- a/packages/cli/src/move-executable-identity.ts
+++ b/packages/cli/src/move-executable-identity.ts
@@ -1,0 +1,135 @@
+import type { MoveDescriptor, NativeProcessImageRefusal, VmHandle } from "@machinen/runtime";
+
+type MoveExecutablePackageIdentity = NonNullable<
+  NonNullable<MoveDescriptor["resourcePlan"]>["capture"]
+>["executablePackage"] extends infer Identity
+  ? NonNullable<Identity>
+  : never;
+
+export interface MoveLoadTargetValidation {
+  state: "ready" | "refused";
+  source?: MoveExecutablePackageIdentity;
+  target?: MoveExecutablePackageIdentity;
+  refusals: NativeProcessImageRefusal[];
+}
+
+export async function readMoveExecutableIdentityInVm(
+  vm: VmHandle,
+  path: string,
+): Promise<MoveExecutablePackageIdentity> {
+  const result = await vm.execRaw(moveExecutableIdentityCommand(path), { execTimeoutMs: 10_000 });
+  if (result.exitCode !== 0) {
+    return { path };
+  }
+  return parseMoveExecutableIdentity(result.stdout, path);
+}
+
+export async function validateMoveLoadTargetInVm(
+  vm: VmHandle,
+  descriptor: MoveDescriptor,
+  exePath: string,
+): Promise<MoveLoadTargetValidation> {
+  const source = descriptor.resourcePlan?.capture?.executablePackage;
+  const target = await readMoveExecutableIdentityInVm(vm, exePath);
+  const refusals = [
+    sameVmRefusal(vm, descriptor),
+    ...moveExecutableIdentityRefusals(source, target),
+  ].filter((refusal): refusal is NativeProcessImageRefusal => refusal !== undefined);
+  return { state: refusals.length === 0 ? "ready" : "refused", source, target, refusals };
+}
+
+function moveExecutableIdentityCommand(path: string): string {
+  const quoted = shellQuote(path);
+  return `set -eu
+path=${quoted}
+real=$(readlink -f "$path" 2>/dev/null || printf %s "$path")
+pkg=""
+for candidate in "$path" "$real" "/bin/\${path##*/}" "/usr/bin/\${path##*/}"; do
+  [ -n "$pkg" ] && break
+  pkg=$(dpkg-query -S "$candidate" 2>/dev/null | head -n1 | cut -d: -f1 || true)
+done
+if [ -n "$pkg" ]; then
+  dpkg-query -W -f 'PKG\t\${Package}\t\${Version}\t\${Architecture}\n' "$pkg" 2>/dev/null || true
+fi
+printf 'EXE\t%s\t%s\n' "$path" "$real"`;
+}
+
+function parseMoveExecutableIdentity(
+  stdout: string,
+  fallbackPath: string,
+): MoveExecutablePackageIdentity {
+  const identity: MoveExecutablePackageIdentity = { path: fallbackPath };
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    const parts = row.split("\t");
+    if (parts[0] === "PKG") {
+      identity.packageName = emptyToUndefined(parts[1] ?? "");
+      identity.version = emptyToUndefined(parts[2] ?? "");
+      identity.architecture = emptyToUndefined(parts[3] ?? "");
+    }
+    if (parts[0] === "EXE") {
+      identity.path = parts[1] || fallbackPath;
+      identity.realPath = emptyToUndefined(parts[2] ?? "");
+    }
+  }
+  return identity;
+}
+
+function sameVmRefusal(
+  vm: VmHandle,
+  descriptor: MoveDescriptor,
+): NativeProcessImageRefusal | undefined {
+  if (descriptor.resourcePlan?.capture?.sourceVm?.pid !== vm.pid) {
+    return undefined;
+  }
+  return {
+    code: "target-process-context-unsupported",
+    message: "move load target is the same local VM that produced the save bundle",
+    detail: { sourceVmPid: vm.pid, boundary: "same-local-vm-load" },
+  };
+}
+
+function moveExecutableIdentityRefusals(
+  source: MoveExecutablePackageIdentity | undefined,
+  target: MoveExecutablePackageIdentity,
+): NativeProcessImageRefusal[] {
+  if (!source?.packageName || !source.version) {
+    return [
+      {
+        code: "target-build-mismatch",
+        message: "source executable package identity was not captured",
+        detail: { source, target, boundary: "executable-package-identity" },
+      },
+    ];
+  }
+  const failures = executableIdentityFailures(source, target);
+  return failures.map((failure) => ({
+    code: "target-build-mismatch",
+    message: `target executable ${failure} does not match source`,
+    detail: { source, target, boundary: "executable-package-identity", failure },
+  }));
+}
+
+function executableIdentityFailures(
+  source: MoveExecutablePackageIdentity,
+  target: MoveExecutablePackageIdentity,
+): string[] {
+  const failures: string[] = [];
+  if (target.path !== source.path) {
+    failures.push("path");
+  }
+  if (target.packageName !== source.packageName) {
+    failures.push("package");
+  }
+  if (target.version !== source.version) {
+    failures.push("version");
+  }
+  return failures;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function emptyToUndefined(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}

--- a/packages/cli/src/move-native-bundle.ts
+++ b/packages/cli/src/move-native-bundle.ts
@@ -1,0 +1,302 @@
+import type {
+  MoveDescriptor,
+  MovePidGraphNode,
+  NativeProcessImageArchitecture,
+  NativeProcessImageRefusal,
+} from "@machinen/runtime";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function attachNativeContinuation(descriptor: MoveDescriptor): MoveDescriptor {
+  const refusals = nativeContinuationRefusals(descriptor);
+  return {
+    ...descriptor,
+    nativeContinuation: {
+      kind: "machinen.move.native-continuation",
+      bundlePath: ".",
+      activeSyscallPlan: "active-syscall-plan.json",
+      state: refusals.length === 0 ? "planned" : "refused",
+      refusals,
+    },
+  };
+}
+
+export function moveActiveSyscallPlan(descriptor: MoveDescriptor): Record<string, unknown> {
+  return {
+    formatVersion: 1,
+    kind: "machinen.move.active-syscall-plan",
+    state: descriptor.nativeContinuation?.state ?? "refused",
+    refusals: descriptor.nativeContinuation?.refusals ?? nativeContinuationRefusals(descriptor),
+  };
+}
+
+export function writeNativeProcessImageScaffold(
+  bundlePath: string,
+  descriptor: MoveDescriptor,
+): void {
+  const node = descriptor.nodes[0];
+  const sourceArch = moveSourceArch(descriptor);
+  const targetArch = oppositeNativeArch(sourceArch);
+  const refusal = nativeMoveRefusal(
+    "target-semantic-continuation-missing",
+    "move save has not translated the native continuation yet",
+  );
+  writeJsonFile(bundlePath, "native-process.json", {
+    formatVersion: 1,
+    kind: "machinen.native-process-image",
+    capture: {
+      method: "external-ptrace-procfs",
+      sourceArch,
+      pid: descriptor.rootPid,
+      capturedAt: descriptor.scannedAt,
+    },
+    target: { mode: "native-cross-isa", arch: targetArch, abi: "linux-user" },
+    process: {
+      exe: moveProcessExe(node),
+      argv: node?.argv.length ? node.argv : [moveProcessExe(node)],
+      env: {},
+      cwd: node?.cwd ?? "/",
+    },
+    refusals: nativeMoveRefusals([refusal]),
+  });
+  const mappings = nativeMoveMappings(descriptor, refusal);
+  writeJsonFile(bundlePath, "native-mappings.json", mappings);
+  writeJsonFile(
+    bundlePath,
+    "native-threads.json",
+    nativeMoveThreads(descriptor, sourceArch, nativeMoveStackMappingId(mappings), refusal),
+  );
+  writeJsonFile(bundlePath, "native-resources.json", {
+    formatVersion: 1,
+    resources: descriptor.resourcePlan?.resources ?? [],
+    refusals: nativeMoveRefusals(descriptor.resourcePlan?.refusals ?? [refusal]),
+  });
+  writeJsonFile(
+    bundlePath,
+    "native-translation.json",
+    nativeMoveTranslation(sourceArch, targetArch, refusal),
+  );
+  writeFileSync(join(bundlePath, "native-memory.bin"), Buffer.alloc(0));
+}
+
+function nativeContinuationRefusals(descriptor: MoveDescriptor): NativeProcessImageRefusal[] {
+  return descriptor.resourcePlan?.refusals.length
+    ? descriptor.resourcePlan.refusals
+    : [
+        nativeMoveRefusal(
+          "target-semantic-continuation-missing",
+          "native move continuation is not translated yet",
+        ),
+      ];
+}
+
+function writeJsonFile(bundlePath: string, name: string, value: unknown): void {
+  writeFileSync(join(bundlePath, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function nativeMoveMappings(
+  descriptor: MoveDescriptor,
+  refusal: NativeProcessImageRefusal,
+): { formatVersion: 1; mappings: Record<string, unknown>[]; refusals: Record<string, unknown> } {
+  const mappings = (descriptor.resourcePlan?.capture?.maps ?? [])
+    .map((line, index) => nativeMoveMappingFromProcMap(line, index, refusal))
+    .filter((mapping): mapping is Record<string, unknown> => mapping !== undefined);
+  return {
+    formatVersion: 1,
+    mappings: mappings.length > 0 ? mappings : [nativePlaceholderStackMapping(refusal)],
+    refusals: nativeMoveRefusals([refusal]),
+  };
+}
+
+function nativeMoveStackMappingId(mappings: { mappings: Record<string, unknown>[] }): string {
+  const stack = mappings.mappings.find((mapping) => mapping.kind === "stack");
+  return typeof stack?.id === "string" ? stack.id : "mapping:move-placeholder-stack";
+}
+
+function nativePlaceholderStackMapping(
+  refusal: NativeProcessImageRefusal,
+): Record<string, unknown> {
+  return {
+    id: "mapping:move-placeholder-stack",
+    kind: "stack",
+    sourceStart: "0x0",
+    sourceEnd: "0x1000",
+    sizeBytes: 4096,
+    permissions: { read: true, write: true, execute: false, private: true, shared: false },
+    target: { materialization: "refuse", reason: "move native mapping capture pending" },
+    refusal,
+  };
+}
+
+function nativeMoveMappingFromProcMap(
+  line: string,
+  index: number,
+  refusal: NativeProcessImageRefusal,
+): Record<string, unknown> | undefined {
+  const match =
+    /^(?<start>[0-9a-f]+)-(?<end>[0-9a-f]+)\s+(?<perms>\S+)\s+(?<offset>[0-9a-f]+)\s+\S+\s+\S+\s*(?<path>.*)$/.exec(
+      line,
+    );
+  if (!match?.groups) {
+    return undefined;
+  }
+  const start = BigInt(`0x${match.groups.start}`);
+  const end = BigInt(`0x${match.groups.end}`);
+  const path = match.groups.path.trim();
+  const perms = match.groups.perms;
+  return {
+    id: `mapping:move-${index}`,
+    kind: nativeMoveMappingKind(path, perms),
+    sourceStart: `0x${start.toString(16)}`,
+    sourceEnd: `0x${end.toString(16)}`,
+    sizeBytes: Number(end - start),
+    permissions: {
+      read: perms[0] === "r",
+      write: perms[1] === "w",
+      execute: perms[2] === "x",
+      private: perms[3] === "p",
+      shared: perms[3] === "s",
+    },
+    ...(path.startsWith("/")
+      ? { file: { path, offset: Number.parseInt(match.groups.offset, 16) } }
+      : {}),
+    target: { materialization: "refuse", reason: "move native mapping translation pending" },
+    refusal,
+  };
+}
+
+function nativeMoveMappingKind(path: string, perms: string): string {
+  if (path === "[heap]") {
+    return "heap";
+  }
+  if (path === "[stack]") {
+    return "stack";
+  }
+  if (path === "[vdso]") {
+    return "vdso";
+  }
+  if (path === "[vvar]") {
+    return "vvar";
+  }
+  if (path.startsWith("/")) {
+    return perms[2] === "x" ? "text" : "file";
+  }
+  if (path.startsWith("[")) {
+    return "special";
+  }
+  return "anonymous";
+}
+
+function nativeMoveThreads(
+  descriptor: MoveDescriptor,
+  sourceArch: NativeProcessImageArchitecture,
+  stackMapping: string,
+  refusal: NativeProcessImageRefusal,
+): Record<string, unknown> {
+  return {
+    formatVersion: 1,
+    threads: [nativeMoveThread(descriptor, sourceArch, stackMapping, refusal)],
+    refusals: nativeMoveRefusals([refusal]),
+  };
+}
+
+function nativeMoveThread(
+  descriptor: MoveDescriptor,
+  sourceArch: NativeProcessImageArchitecture,
+  stackMapping: string,
+  refusal: NativeProcessImageRefusal,
+): Record<string, unknown> {
+  return {
+    id: "thread:main",
+    state: "stopped",
+    stopReason:
+      descriptor.resourcePlan?.capture?.freeze?.state === "ptrace-attached"
+        ? "ptrace-stop"
+        : "group-stop",
+    stackMapping,
+    sourceRegisters: descriptor.resourcePlan?.capture?.registers ?? nativeMoveRegisters(sourceArch),
+    syscall: { state: "outside-syscall" },
+    signal: { blocked: [], pending: [], activeFrame: false, altStack: { state: "disabled" } },
+    tls: { threadPointer: "0x0", rseq: { state: "absent" } },
+    simdFpu: { state: "not-captured", reason: "move native capture pending" },
+    refusal,
+  };
+}
+
+function nativeMoveRegisters(sourceArch: NativeProcessImageArchitecture): Record<string, unknown> {
+  if (sourceArch === "arm64") {
+    return { arch: "arm64", pc: "0x0", sp: "0x0", pstate: "0x0", x: Array(31).fill("0x0") };
+  }
+  return {
+    arch: "amd64",
+    rip: "0x0",
+    rsp: "0x0",
+    rbp: "0x0",
+    rax: "0x0",
+    rbx: "0x0",
+    rcx: "0x0",
+    rdx: "0x0",
+    rsi: "0x0",
+    rdi: "0x0",
+    r8: "0x0",
+    r9: "0x0",
+    r10: "0x0",
+    r11: "0x0",
+    r12: "0x0",
+    r13: "0x0",
+    r14: "0x0",
+    r15: "0x0",
+    rflags: "0x0",
+    fsBase: "0x0",
+    gsBase: "0x0",
+  };
+}
+
+function nativeMoveTranslation(
+  sourceArch: NativeProcessImageArchitecture,
+  targetArch: NativeProcessImageArchitecture,
+  refusal: NativeProcessImageRefusal,
+): Record<string, unknown> {
+  return {
+    formatVersion: 1,
+    mode: "native-cross-isa",
+    sourceArch,
+    targetArch,
+    codeLocations: [],
+    threads: [{ sourceThreadId: "thread:main", state: "refused", refusal }],
+    memoryRelocations: [],
+    refusals: nativeMoveRefusals([refusal]),
+  };
+}
+
+function nativeMoveRefusals(refusals: NativeProcessImageRefusal[]): Record<string, unknown> {
+  return { vocabularyVersion: 1, refusals };
+}
+
+function nativeMoveRefusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+): NativeProcessImageRefusal {
+  return { code, message, detail: { boundary: "machinen-move-native-continuation" } };
+}
+
+function moveSourceArch(descriptor: MoveDescriptor): NativeProcessImageArchitecture {
+  return descriptor.resourcePlan?.sourceArch ?? "arm64";
+}
+
+function oppositeNativeArch(
+  sourceArch: NativeProcessImageArchitecture,
+): NativeProcessImageArchitecture {
+  return sourceArch === "arm64" ? "amd64" : "arm64";
+}
+
+function moveProcessExe(node: MovePidGraphNode | undefined): string {
+  if (node?.exe?.startsWith("/")) {
+    return node.exe;
+  }
+  const argv0 = node?.argv[0];
+  if (argv0?.startsWith("/")) {
+    return argv0;
+  }
+  return `/usr/bin/${node?.command ?? "unknown"}`;
+}

--- a/packages/cli/src/move-rendezvous.ts
+++ b/packages/cli/src/move-rendezvous.ts
@@ -1,0 +1,237 @@
+import type { MoveDescriptor, NativeProcessImageRefusal, VmHandle } from "@machinen/runtime";
+
+import { parseGuestMoveResourceScan } from "./move-resource-plan.ts";
+
+export interface MoveLoadDirectLoader {
+  state: "ready" | "refused";
+  strategy: "target-original-ping-direct-loader";
+  executable: string;
+  argv: string[];
+  targetPid?: number;
+  logPath?: string;
+  capture?: unknown;
+  patch?: { state: "ready" | "refused"; stdout: string; stderr: string; exitCode: number };
+  refusals: NativeProcessImageRefusal[];
+}
+
+export type MoveLoadRendezvous = MoveLoadDirectLoader;
+
+export async function runMoveTargetDirectLoaderInVm(
+  vm: VmHandle,
+  descriptor: MoveDescriptor,
+): Promise<MoveLoadRendezvous> {
+  const executable = moveRendezvousExecutable(descriptor);
+  const argv = moveRendezvousArgv(descriptor, executable);
+  const command = moveRendezvousCommand(executable, argv.slice(1), descriptor);
+  const result = await vm.execRaw(command, { execTimeoutMs: 30_000 });
+  const parsed = parseRendezvousOutput(result.stdout);
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    return loaderRefused(executable, argv, parsed, {
+      code: "target-process-context-unsupported",
+      message: "target ping direct loader failed before a capture was produced",
+      detail: { exitCode: result.exitCode, stderr: result.stderr, stdout: result.stdout },
+    });
+  }
+  const capture = parseGuestMoveResourceScan(parsed.captureRows.join("\n"));
+  const patch = moveRendezvousPatchFromOutput(result);
+  const refusals = [...moveRendezvousRefusals(capture), ...movePatchRefusals(patch)];
+  if (refusals.length > 0 && parsed.pid) {
+    await vm.execRaw(`kill -TERM ${parsed.pid} 2>/dev/null || true`, { execTimeoutMs: 5_000 });
+  }
+  return {
+    state: refusals.length === 0 ? "ready" : "refused",
+    strategy: "target-original-ping-direct-loader",
+    executable,
+    argv,
+    targetPid: parsed.pid,
+    logPath: parsed.logPath,
+    capture,
+    patch,
+    refusals,
+  };
+}
+
+function moveRendezvousExecutable(descriptor: MoveDescriptor): string {
+  return (
+    descriptor.resourcePlan?.capture?.executablePackage?.path ??
+    descriptor.nodes[0]?.exe ??
+    "/usr/bin/ping"
+  );
+}
+
+function moveRendezvousArgv(descriptor: MoveDescriptor, executable: string): string[] {
+  const argv = descriptor.nodes[0]?.argv ?? [];
+  if (argv.length === 0) {
+    return [executable];
+  }
+  return [executable, ...argv.slice(1)];
+}
+
+function moveRendezvousCommand(
+  executable: string,
+  args: string[],
+  descriptor: MoveDescriptor,
+): string {
+  const pingState = descriptor.resourcePlan?.capture?.pingState;
+  if (!pingState) {
+    return "printf 'SAFE_BOUNDARY\\trefused\\tsource-ping-state-missing\\n'; exit 2";
+  }
+  const quotedExecutable = shellQuote(executable);
+  const quotedArgs = args.map(shellQuote).join(" ");
+  return `set -eu
+log="/tmp/machinen-move-loader-$$.log"
+if [ -x /sbin/machinen-move-capture ]; then
+  /sbin/machinen-move-capture --load-ping-state ${pingState.ntransmitted} ${pingState.nreceived} ${pingState.nerrors} --log "$log" -- ${quotedExecutable}${quotedArgs ? ` ${quotedArgs}` : ""}
+else
+  printf 'SAFE_BOUNDARY\trefused\tmissing-move-capture-agent\n'
+fi`;
+}
+
+function parseRendezvousOutput(stdout: string): {
+  pid?: number;
+  logPath?: string;
+  captureRows: string[];
+} {
+  const captureRows: string[] = [];
+  let pid: number | undefined;
+  let logPath: string | undefined;
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    const parts = row.split("\t");
+    if (parts[0] === "RENDEZVOUS_PID" || parts[0] === "LOAD_PID") {
+      pid = parsePositiveInteger(parts[1] ?? "");
+    } else if (parts[0] === "RENDEZVOUS_LOG" || parts[0] === "LOAD_LOG") {
+      logPath = parts[1];
+    } else {
+      captureRows.push(row);
+    }
+  }
+  return { pid, logPath, captureRows };
+}
+
+function moveRendezvousPatchFromOutput(result: {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}): MoveLoadRendezvous["patch"] {
+  const state =
+    result.exitCode === 0 &&
+    result.stdout.includes("PATCH\tping-rts") &&
+    result.stdout.includes("PATCH\tping-send-buffer\tready")
+      ? "ready"
+      : "refused";
+  return {
+    state,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+  };
+}
+
+function movePatchRefusals(
+  patch: MoveLoadRendezvous["patch"] | undefined,
+): NativeProcessImageRefusal[] {
+  if (patch?.state === "ready") {
+    return [];
+  }
+  return [
+    loaderRefusal("target-frame-register-value-unavailable", "target ping state patch failed", {
+      patch,
+    }),
+  ];
+}
+
+function moveRendezvousRefusals(capture: {
+  safeBoundary?: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string };
+  freeze?: { state: "ptrace-attached" | "refused"; detail: string };
+  registers?: Record<string, unknown>;
+}): NativeProcessImageRefusal[] {
+  const refusals: NativeProcessImageRefusal[] = [];
+  pushBoundaryRefusal(refusals, capture.safeBoundary);
+  pushFreezeRefusal(refusals, capture.freeze);
+  pushRegisterRefusal(refusals, capture.registers);
+  return refusals;
+}
+
+function pushBoundaryRefusal(
+  refusals: NativeProcessImageRefusal[],
+  safeBoundary: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string } | undefined,
+): void {
+  if (safeBoundary?.state === "sleep-timer" || safeBoundary?.state === "pre-send-icmp") {
+    return;
+  }
+  refusals.push(
+    loaderRefusal(
+      "active-syscall",
+      "target ping direct loader did not reach the pre-send boundary",
+      {
+        boundary: safeBoundary?.detail ?? "missing",
+      },
+    ),
+  );
+}
+
+function pushFreezeRefusal(
+  refusals: NativeProcessImageRefusal[],
+  freeze: { state: "ptrace-attached" | "refused"; detail: string } | undefined,
+): void {
+  if (freeze?.state === "ptrace-attached") {
+    return;
+  }
+  refusals.push(
+    loaderRefusal("thread-state-unsupported", "target ping was not frozen by direct loader", {
+      freeze: freeze?.detail ?? "missing",
+    }),
+  );
+}
+
+function pushRegisterRefusal(
+  refusals: NativeProcessImageRefusal[],
+  registers: Record<string, unknown> | undefined,
+): void {
+  if (registers) {
+    return;
+  }
+  refusals.push(
+    loaderRefusal(
+      "target-frame-register-value-unavailable",
+      "target register state was not captured by direct loader",
+      {},
+    ),
+  );
+}
+
+function loaderRefused(
+  executable: string,
+  argv: string[],
+  parsed: { pid?: number; logPath?: string; captureRows: string[] },
+  refusal: NativeProcessImageRefusal,
+): MoveLoadRendezvous {
+  return {
+    state: "refused",
+    strategy: "target-original-ping-direct-loader",
+    executable,
+    argv,
+    targetPid: parsed.pid,
+    logPath: parsed.logPath,
+    refusals: [refusal],
+  };
+}
+
+function loaderRefusal(
+  code: NativeProcessImageRefusal["code"],
+  message: string,
+  detail: Record<string, unknown>,
+): NativeProcessImageRefusal {
+  return { code, message, detail: { ...detail, boundary: "target-original-ping-direct-loader" } };
+}
+
+export const runMoveTargetRendezvousInVm = runMoveTargetDirectLoaderInVm;
+
+function parsePositiveInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/packages/cli/src/move-resource-plan.ts
+++ b/packages/cli/src/move-resource-plan.ts
@@ -1,0 +1,534 @@
+import {
+  planNativeTargetFdTable,
+  type MoveDescriptor,
+  type MovePidGraphNode,
+  type NativeProcessImageArchitecture,
+  type NativeProcessImageRefusal,
+  type NativeProcessResource,
+} from "@machinen/runtime";
+import { basename } from "node:path";
+
+type MoveResourcePlan = NonNullable<MoveDescriptor["resourcePlan"]>;
+
+type GuestMoveFd = {
+  fd: number;
+  target: string;
+  flags?: string[];
+  offset?: number;
+};
+
+type GuestMoveNetSocket = {
+  inode: string;
+  localAddress?: string;
+  remoteAddress?: string;
+  txQueue?: number;
+  rxQueue?: number;
+};
+
+type GuestMoveResourceScan = {
+  uid?: number;
+  gid?: number;
+  sourceArch?: NativeProcessImageArchitecture;
+  pingGroupRangeStart?: number;
+  pingGroupRangeEnd?: number;
+  safeBoundary?: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string };
+  freeze?: { state: "ptrace-attached" | "refused"; detail: string };
+  tasks?: number;
+  wchan?: string;
+  syscall?: string;
+  maps: string[];
+  registers?: Record<string, unknown>;
+  fds: GuestMoveFd[];
+  icmpSockets: GuestMoveNetSocket[];
+  rawSockets: GuestMoveNetSocket[];
+};
+
+export function parseGuestMoveResourceScan(stdout: string): GuestMoveResourceScan {
+  const scan: GuestMoveResourceScan = { maps: [], fds: [], icmpSockets: [], rawSockets: [] };
+  const fdMap = new Map<number, GuestMoveFd>();
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    parseGuestMoveResourceRow(row, scan, fdMap);
+  }
+  scan.fds = Array.from(fdMap.values()).sort((left, right) => left.fd - right.fd);
+  return scan;
+}
+
+type GuestMoveResourceRowParser = (
+  parts: string[],
+  scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+) => void;
+
+const GUEST_MOVE_RESOURCE_ROW_PARSERS: Record<string, GuestMoveResourceRowParser> = {
+  STATUS: parseGuestStatusRow,
+  UNAME: parseGuestUnameRow,
+  PING_RANGE: parseGuestPingRangeRow,
+  FD: parseGuestFdRow,
+  FDINFO: parseGuestFdInfoRow,
+  MAP: parseGuestMapRow,
+  TASKS: parseGuestTasksRow,
+  WCHAN: parseGuestWchanRow,
+  SYSCALL: parseGuestSyscallRow,
+  SAFE_BOUNDARY: parseGuestSafeBoundaryRow,
+  FREEZE: parseGuestFreezeRow,
+  REG_ARM64: parseGuestArm64RegistersRow,
+  REG_AMD64: parseGuestAmd64RegistersRow,
+  NET_ICMP: parseGuestIcmpSocketRow,
+  NET_RAW: parseGuestRawSocketRow,
+};
+
+function parseGuestMoveResourceRow(
+  row: string,
+  scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  const parts = row.split("\t");
+  GUEST_MOVE_RESOURCE_ROW_PARSERS[parts[0] ?? ""]?.(parts, scan, fdMap);
+}
+
+function parseGuestStatusRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.uid = parseOptionalNonNegativeInteger(parts[1] ?? "");
+  scan.gid = parseOptionalNonNegativeInteger(parts[2] ?? "");
+}
+
+function parseGuestUnameRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.sourceArch = nativeArchFromUname(parts[1] ?? "");
+}
+
+function parseGuestPingRangeRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.pingGroupRangeStart = parseOptionalNonNegativeInteger(parts[1] ?? "");
+  scan.pingGroupRangeEnd = parseOptionalNonNegativeInteger(parts[2] ?? "");
+}
+
+function parseGuestFdRow(
+  parts: string[],
+  _scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  upsertGuestFd(fdMap, parts[1] ?? "", parts[2] ?? "");
+}
+
+function parseGuestFdInfoRow(
+  parts: string[],
+  _scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  updateGuestFdInfo(fdMap, parts[1] ?? "", parts.slice(2).join("\t"));
+}
+
+function parseGuestMapRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.maps.push(parts.slice(1).join("\t"));
+}
+
+function parseGuestTasksRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.tasks = parseOptionalNonNegativeInteger(parts[1] ?? "");
+}
+
+function parseGuestWchanRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.wchan = parts.slice(1).join("\t");
+}
+
+function parseGuestSyscallRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.syscall = parts.slice(1).join("\t");
+}
+
+function parseGuestSafeBoundaryRow(parts: string[], scan: GuestMoveResourceScan): void {
+  const state = parts[1] === "sleep-timer" || parts[1] === "pre-send-icmp" ? parts[1] : "refused";
+  scan.safeBoundary = { state, detail: parts.slice(2).join("\t") };
+}
+
+function parseGuestFreezeRow(parts: string[], scan: GuestMoveResourceScan): void {
+  const state = parts[1] === "ptrace-attached" ? "ptrace-attached" : "refused";
+  scan.freeze = { state, detail: parts.slice(2).join("\t") };
+}
+
+function parseGuestArm64RegistersRow(parts: string[], scan: GuestMoveResourceScan): void {
+  if (parts[1] === "refused") {
+    return;
+  }
+  scan.registers = {
+    arch: "arm64",
+    pc: parts[1] ?? "0x0",
+    sp: parts[2] ?? "0x0",
+    pstate: parts[3] ?? "0x0",
+    x: parts.slice(4, 35),
+  };
+}
+
+function parseGuestAmd64RegistersRow(parts: string[], scan: GuestMoveResourceScan): void {
+  if (parts[1] === "refused") {
+    return;
+  }
+  const names = [
+    "rip",
+    "rsp",
+    "rflags",
+    "rax",
+    "rbx",
+    "rcx",
+    "rdx",
+    "rsi",
+    "rdi",
+    "rbp",
+    "r8",
+    "r9",
+    "r10",
+    "r11",
+    "r12",
+    "r13",
+    "r14",
+    "r15",
+    "fsBase",
+    "gsBase",
+  ];
+  scan.registers = { arch: "amd64" };
+  for (const [index, name] of names.entries()) {
+    scan.registers[name] = parts[index + 1] ?? "0x0";
+  }
+}
+
+function parseGuestIcmpSocketRow(parts: string[], scan: GuestMoveResourceScan): void {
+  pushGuestNetSocket(scan.icmpSockets, parts[1] ?? "");
+}
+
+function parseGuestRawSocketRow(parts: string[], scan: GuestMoveResourceScan): void {
+  pushGuestNetSocket(scan.rawSockets, parts[1] ?? "");
+}
+
+function pushGuestNetSocket(sockets: GuestMoveNetSocket[], line: string): void {
+  const socket = parseGuestNetSocket(line);
+  if (socket) {
+    sockets.push(socket);
+  }
+}
+
+function upsertGuestFd(fdMap: Map<number, GuestMoveFd>, fdText: string, target: string): void {
+  const fd = parseOptionalNonNegativeInteger(fdText);
+  if (fd === undefined) {
+    return;
+  }
+  fdMap.set(fd, { ...fdMap.get(fd), fd, target });
+}
+
+function updateGuestFdInfo(fdMap: Map<number, GuestMoveFd>, fdText: string, line: string): void {
+  const fd = parseOptionalNonNegativeInteger(fdText);
+  if (fd === undefined) {
+    return;
+  }
+  const current = fdMap.get(fd) ?? { fd, target: "" };
+  const [, key = "", value = ""] = line.match(/^(pos|flags):\s*(\S+)/) ?? [];
+  if (key === "pos") {
+    fdMap.set(fd, { ...current, offset: parseOptionalNonNegativeInteger(value) });
+  }
+  if (key === "flags") {
+    fdMap.set(fd, { ...current, flags: [`octal:${value}`] });
+  }
+}
+
+function parseGuestNetSocket(line: string): GuestMoveNetSocket | undefined {
+  const fields = line.trim().split(/\s+/);
+  if (fields[0] === "sl" || fields.length < 10) {
+    return undefined;
+  }
+  const [txQueue, rxQueue] = parseQueuePair(fields[4]);
+  return {
+    inode: fields[9]!,
+    localAddress: fields[1],
+    remoteAddress: fields[2],
+    txQueue,
+    rxQueue,
+  };
+}
+
+function parseQueuePair(value: string | undefined): [number | undefined, number | undefined] {
+  const [tx, rx] = (value ?? "").split(":");
+  return [parseOptionalHexInteger(tx ?? ""), parseOptionalHexInteger(rx ?? "")];
+}
+
+export function buildMoveResourcePlan(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+): MoveResourcePlan {
+  const resources = buildMoveResources(node, scan);
+  const plan = planNativeTargetFdTable({
+    resources,
+    expectedFds: scan.fds.map((fd) => fd.fd),
+    inheritedStdio: { mode: "inherit-output" },
+  });
+  return {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    sourceArch: scan.sourceArch,
+    resources: plan.resources,
+    fdTableEntries: plan.entries,
+    targetGuestResources: plan.targetGuestResources,
+    refusals: [...plan.refusals, ...nativeCaptureRefusals(scan)],
+    acceptedSubsets: acceptedMoveResourceSubsets(plan.entries),
+    capture: moveNativeCapture(scan),
+  };
+}
+
+function nativeCaptureRefusals(scan: GuestMoveResourceScan): NativeProcessImageRefusal[] {
+  const refusals: NativeProcessImageRefusal[] = [];
+  if (scan.safeBoundary?.state !== "sleep-timer") {
+    refusals.push({
+      code: "active-syscall",
+      message: "move capture did not reach the ping sleep/timer safe boundary",
+      detail: { kind: "thread", boundary: scan.safeBoundary?.detail ?? "missing" },
+    });
+  }
+  if (scan.freeze?.state !== "ptrace-attached") {
+    refusals.push({
+      code: "thread-state-unsupported",
+      message: "move capture did not freeze the process with ptrace",
+      detail: { kind: "thread", freeze: scan.freeze?.detail ?? "missing" },
+    });
+  }
+  return refusals;
+}
+
+function moveNativeCapture(scan: GuestMoveResourceScan): MoveResourcePlan["capture"] {
+  return {
+    safeBoundary: scan.safeBoundary,
+    freeze: scan.freeze,
+    tasks: scan.tasks,
+    wchan: scan.wchan,
+    syscall: scan.syscall,
+    maps: scan.maps,
+    registers: scan.registers,
+  };
+}
+
+function buildMoveResources(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+): NativeProcessResource[] {
+  return [
+    { id: `pid:${node.pid}:argv`, kind: "argv", state: "captured", recipe: { argv: node.argv } },
+    ...(node.cwd
+      ? [
+          {
+            id: `pid:${node.pid}:cwd`,
+            kind: "cwd" as const,
+            state: "captured" as const,
+            path: node.cwd,
+            recipe: { cwd: node.cwd },
+          },
+        ]
+      : []),
+    ...scan.fds.map((fd) => moveResourceFromGuestFd(node, scan, fd)),
+  ];
+}
+
+function moveResourceFromGuestFd(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  fd: GuestMoveFd,
+): NativeProcessResource {
+  const socketInode = socketInodeFromFdTarget(fd.target);
+  if (socketInode) {
+    return socketMoveResource(node, scan, fd, socketInode);
+  }
+  return nonSocketMoveResource(node.pid, fd);
+}
+
+function nonSocketMoveResource(pid: number, fd: GuestMoveFd): NativeProcessResource {
+  const base = nativeResourceBase(pid, fd);
+  if (fd.target.startsWith("pipe:[")) {
+    return { ...base, kind: "pipe", path: fd.target };
+  }
+  if (/^\/dev\/(pts|tty)/.test(fd.target)) {
+    return { ...base, kind: "pty", path: fd.target };
+  }
+  if (fd.target.startsWith("/")) {
+    return { ...base, kind: "file", path: fd.target, offset: fd.offset };
+  }
+  return { ...base, kind: "unknown", path: fd.target };
+}
+
+function socketMoveResource(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  fd: GuestMoveFd,
+  inode: string,
+): NativeProcessResource {
+  const icmpSocket = scan.icmpSockets.find((socket) => socket.inode === inode);
+  if (icmpSocket) {
+    return {
+      ...nativeResourceBase(node.pid, fd, `socket:${inode}:icmp`),
+      kind: "socket",
+      path: fd.target,
+      recipe: pingSocketRecipe(node, scan, icmpSocket),
+    };
+  }
+  const rawSocket = scan.rawSockets.find((socket) => socket.inode === inode);
+  if (rawSocket) {
+    return {
+      ...nativeResourceBase(node.pid, fd, `socket:${inode}:raw-icmp`),
+      kind: "raw-socket",
+      path: fd.target,
+      recipe: rawIcmpRecipe(node, rawSocket),
+    };
+  }
+  return {
+    ...nativeResourceBase(node.pid, fd, `socket:${inode}`),
+    kind: "socket",
+    path: fd.target,
+  };
+}
+
+function nativeResourceBase(
+  pid: number,
+  fd: GuestMoveFd,
+  idSuffix = `fd:${fd.fd}`,
+): Pick<NativeProcessResource, "id" | "state" | "fd" | "flags"> {
+  return { id: `pid:${pid}:${idSuffix}`, state: "captured", fd: fd.fd, flags: fd.flags };
+}
+
+function pingSocketRecipe(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  socket: GuestMoveNetSocket,
+): Record<string, unknown> | undefined {
+  const identifier = parseProcNetPort(socket.localAddress);
+  const destination = moveIcmpDestination(node, socket);
+  if (!destination || !socketQueuesEmpty(socket) || identifier === undefined) {
+    return undefined;
+  }
+  return {
+    pingSocketModel: destination === "127.0.0.1" ? "loopback-echo-v1" : "external-target-egress-v1",
+    family: "inet4",
+    socketType: "dgram",
+    protocol: "icmp",
+    destination,
+    credentialPolicy: "target-ping-group-range",
+    uid: scan.uid,
+    gid: scan.gid,
+    pingGroupRangeStart: scan.pingGroupRangeStart,
+    pingGroupRangeEnd: scan.pingGroupRangeEnd,
+    networkNamespace: destination === "127.0.0.1" ? "target-loopback" : "target-network",
+    route: destination === "127.0.0.1" ? "loopback" : "target-egress",
+    identifier,
+    inFlightPackets: "none",
+    receiveQueue: "empty",
+  };
+}
+
+function rawIcmpRecipe(
+  node: MovePidGraphNode,
+  socket: GuestMoveNetSocket,
+): Record<string, unknown> | undefined {
+  const identifier = parseProcNetPort(socket.localAddress);
+  const destination = moveIcmpDestination(node, socket);
+  if (!destination || !socketQueuesEmpty(socket) || identifier === undefined) {
+    return undefined;
+  }
+  return {
+    rawIcmpModel: destination === "127.0.0.1" ? "loopback-echo-v1" : "external-target-egress-v1",
+    family: "inet4",
+    socketType: "raw",
+    protocol: "icmp",
+    destination,
+    capability: "cap-net-raw",
+    networkNamespace: destination === "127.0.0.1" ? "target-loopback" : "target-network",
+    route: destination === "127.0.0.1" ? "loopback" : "target-egress",
+    identifier,
+    inFlightPackets: "none",
+    receiveQueue: "empty",
+  };
+}
+
+function moveIcmpDestination(
+  node: MovePidGraphNode,
+  socket: GuestMoveNetSocket,
+): string | undefined {
+  const remote = procNetAddressHost(socket.remoteAddress);
+  const argvDestination = movePingDestination(node.argv);
+  if (remote === "127.0.0.1") {
+    return argvDestination === "127.0.0.1" ? remote : undefined;
+  }
+  return remote;
+}
+
+function movePingDestination(argv: string[]): string | undefined {
+  let destination: string | undefined;
+  for (const arg of argv) {
+    if (!arg.startsWith("-") && basename(arg) !== "ping") {
+      destination = arg;
+    }
+  }
+  return destination === "localhost" ? "127.0.0.1" : destination;
+}
+
+function socketQueuesEmpty(socket: GuestMoveNetSocket): boolean {
+  return socket.txQueue === 0 && socket.rxQueue === 0;
+}
+
+function socketInodeFromFdTarget(target: string): string | undefined {
+  return target.match(/^socket:\[(\d+)\]$/)?.[1];
+}
+
+function parseProcNetPort(value: string | undefined): number | undefined {
+  const port = value?.split(":")[1];
+  return port ? parseOptionalHexInteger(port) : undefined;
+}
+
+function procNetAddressHost(value: string | undefined): string | undefined {
+  const address = value?.split(":")[0];
+  if (!address || address.length !== 8) {
+    return undefined;
+  }
+  const bytes = address
+    .match(/../g)
+    ?.reverse()
+    .map((byte) => Number.parseInt(byte, 16));
+  return bytes?.every((byte) => Number.isInteger(byte)) ? bytes.join(".") : undefined;
+}
+
+function acceptedMoveResourceSubsets(
+  entries: ReturnType<typeof planNativeTargetFdTable>["entries"],
+): string[] {
+  return entries.flatMap((entry) => {
+    if (entry.kind === "synthetic-ping-socket") {
+      return [
+        entry.recipe?.pingSocketModel === "external-target-egress-v1"
+          ? "external-ping-socket-v1:no-inflight-target-egress"
+          : "ping-socket-v1:loopback-echo-no-inflight",
+      ];
+    }
+    if (entry.kind === "synthetic-raw-icmp") {
+      return [
+        entry.recipe?.rawIcmpModel === "external-target-egress-v1"
+          ? "external-raw-icmp-v1:no-inflight-target-egress"
+          : "raw-icmp-v1:loopback-echo-no-inflight",
+      ];
+    }
+    return [];
+  });
+}
+
+function nativeArchFromUname(value: string): NativeProcessImageArchitecture | undefined {
+  if (value === "aarch64" || value === "arm64") {
+    return "arm64";
+  }
+  if (value === "x86_64" || value === "amd64") {
+    return "amd64";
+  }
+  return undefined;
+}
+
+function parseOptionalNonNegativeInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function parseOptionalHexInteger(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 16);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -78,6 +78,7 @@ const DT_LNK: u8 = 10;
 
 const O_RDONLY: c_int = 0;
 const O_RDWR: c_int = 2;
+const O_NONBLOCK: c_int = 0o4000;
 const SEEK_END: c_int = 2;
 const SEEK_SET: c_int = 0;
 const F_OK: c_int = 0;
@@ -273,12 +274,12 @@ fn bring_up_network() void {
 fn wait_for_console() c_int {
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
-        const fd_ttyS0 = open("/dev/ttyS0", O_RDWR);
+        const fd_console = open("/dev/console", O_RDWR);
+        if (fd_console >= 0) return fd_console;
+        const fd_ttyS0 = open("/dev/ttyS0", O_RDWR | O_NONBLOCK);
         if (fd_ttyS0 >= 0) return fd_ttyS0;
-        const fd = open("/dev/ttyAMA0", O_RDWR);
-        if (fd >= 0) return fd;
-        const fd2 = open("/dev/console", O_RDWR);
-        if (fd2 >= 0) return fd2;
+        const fd_ttyAMA0 = open("/dev/ttyAMA0", O_RDWR | O_NONBLOCK);
+        if (fd_ttyAMA0 >= 0) return fd_ttyAMA0;
         sleep_ms(50);
     }
     return -1;

--- a/packages/microvm/assets/move-capture.c
+++ b/packages/microvm/assets/move-capture.c
@@ -1,0 +1,674 @@
+// Guest-side capture scaffold for `machinen move`.
+//
+// This intentionally emits a stable, line-oriented evidence stream rather than
+// making product decisions itself. The host-side move command turns these rows
+// into the canonical move/native resource plan and remains responsible for
+// DWARF/state translation and target-native load decisions.
+//
+// Usage:
+//   /sbin/machinen-move-capture <pid>
+//
+// Output rows are tab-separated:
+//   AGENT\tmachinen-move-capture-v1
+//   STATUS\t<uid>\t<gid>
+//   PING_RANGE\t<start>\t<end>
+//   FD\t<fd>\t<readlink-target>
+//   FDINFO\t<fd>\t<pos|flags line>
+//   MAP\t<raw /proc/<pid>/maps row>
+//   TASKS\t<count>
+//   WCHAN\t<kernel wait-channel>
+//   SYSCALL\t<raw /proc/<pid>/syscall row>
+//   SAFE_BOUNDARY\t<sleep-timer|refused>\t<detail>
+//   FREEZE\t<ptrace-attached|refused>\t<detail>
+//   REG_ARM64\t<pc>\t<sp>\t<pstate>\t<x0>...<x30>
+//   REG_AMD64\t<rip>\t<rsp>\t<rflags>\t<rax>...<r15>\t<fs_base>\t<gs_base>
+//   NET_ICMP\t<raw /proc/net/icmp row>
+//   NET_RAW\t<raw /proc/net/raw row>
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/ptrace.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+#ifdef __aarch64__
+#include <asm/ptrace.h>
+#include <elf.h>
+#endif
+#ifdef __x86_64__
+#include <sys/user.h>
+#endif
+
+static int starts_with(const char *s, const char *prefix) {
+  return strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
+static int numeric_name(const char *s) {
+  if (!s || !*s) return 0;
+  for (const char *p = s; *p; p++) {
+    if (*p < '0' || *p > '9') return 0;
+  }
+  return 1;
+}
+
+static void chomp(char *s) {
+  size_t n = strlen(s);
+  while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r')) {
+    s[--n] = '\0';
+  }
+}
+
+static void emit_uname(void) {
+  struct utsname uts;
+  if (uname(&uts) == 0) {
+    printf("UNAME\t%s\n", uts.machine);
+  }
+}
+
+static void emit_status(const char *pid) {
+  char path[128];
+  snprintf(path, sizeof(path), "/proc/%s/status", pid);
+  FILE *f = fopen(path, "r");
+  char uid[32] = "";
+  char gid[32] = "";
+  if (f) {
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+      if (starts_with(line, "Uid:")) sscanf(line, "Uid:%31s", uid);
+      if (starts_with(line, "Gid:")) sscanf(line, "Gid:%31s", gid);
+    }
+    fclose(f);
+  }
+  printf("STATUS\t%s\t%s\n", uid, gid);
+}
+
+static void emit_ping_range(void) {
+  FILE *f = fopen("/proc/sys/net/ipv4/ping_group_range", "r");
+  if (!f) return;
+  char start[32] = "";
+  char end[32] = "";
+  if (fscanf(f, "%31s %31s", start, end) == 2) {
+    printf("PING_RANGE\t%s\t%s\n", start, end);
+  }
+  fclose(f);
+}
+
+static void emit_fdinfo_line(const char *fd, const char *line) {
+  if (!starts_with(line, "pos:") && !starts_with(line, "flags:")) return;
+  char copy[512];
+  snprintf(copy, sizeof(copy), "%s", line);
+  chomp(copy);
+  printf("FDINFO\t%s\t%s\n", fd, copy);
+}
+
+static void emit_fdinfo(const char *pid, const char *fd) {
+  char path[256];
+  snprintf(path, sizeof(path), "/proc/%s/fdinfo/%s", pid, fd);
+  FILE *f = fopen(path, "r");
+  if (!f) return;
+  char line[512];
+  while (fgets(line, sizeof(line), f)) {
+    emit_fdinfo_line(fd, line);
+  }
+  fclose(f);
+}
+
+static void emit_fds(const char *pid) {
+  char dirpath[128];
+  snprintf(dirpath, sizeof(dirpath), "/proc/%s/fd", pid);
+  DIR *dir = opendir(dirpath);
+  if (!dir) return;
+  struct dirent *ent;
+  while ((ent = readdir(dir))) {
+    if (!numeric_name(ent->d_name)) continue;
+    char linkpath[256];
+    snprintf(linkpath, sizeof(linkpath), "%s/%s", dirpath, ent->d_name);
+    char target[1024];
+    ssize_t n = readlink(linkpath, target, sizeof(target) - 1);
+    if (n < 0) target[0] = '\0';
+    else target[n] = '\0';
+    printf("FD\t%s\t%s\n", ent->d_name, target);
+    emit_fdinfo(pid, ent->d_name);
+  }
+  closedir(dir);
+}
+
+static void emit_proc_net(const char *path, const char *tag) {
+  FILE *f = fopen(path, "r");
+  if (!f) return;
+  char line[1024];
+  while (fgets(line, sizeof(line), f)) {
+    chomp(line);
+    printf("%s\t%s\n", tag, line);
+  }
+  fclose(f);
+}
+
+static void emit_proc_file(const char *pid, const char *name, const char *tag) {
+  char path[256];
+  snprintf(path, sizeof(path), "/proc/%s/%s", pid, name);
+  FILE *f = fopen(path, "r");
+  if (!f) return;
+  char line[2048];
+  while (fgets(line, sizeof(line), f)) {
+    chomp(line);
+    printf("%s\t%s\n", tag, line);
+  }
+  fclose(f);
+}
+
+static int count_tasks(const char *pid) {
+  char path[128];
+  snprintf(path, sizeof(path), "/proc/%s/task", pid);
+  DIR *dir = opendir(path);
+  if (!dir) return -1;
+  int count = 0;
+  struct dirent *ent;
+  while ((ent = readdir(dir))) {
+    if (numeric_name(ent->d_name)) count++;
+  }
+  closedir(dir);
+  return count;
+}
+
+static int read_proc_first_line(const char *pid, const char *name, char *out, size_t out_size) {
+  char path[256];
+  snprintf(path, sizeof(path), "/proc/%s/%s", pid, name);
+  FILE *f = fopen(path, "r");
+  if (!f) return -1;
+  if (!fgets(out, out_size, f)) {
+    fclose(f);
+    return -1;
+  }
+  fclose(f);
+  chomp(out);
+  return 0;
+}
+
+static long monotonic_ms(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000L + ts.tv_nsec / 1000000L;
+}
+
+static int looks_like_sleep_timer_boundary(const char *wchan, const char *syscall) {
+  if (strstr(wchan, "hrtimer") || strstr(wchan, "nanosleep") || strstr(wchan, "schedule_timeout")) return 1;
+  if (strstr(wchan, "__skb_wait_for_more_packets")) return 1;
+  if (starts_with(syscall, "35 ") || starts_with(syscall, "230 ") || starts_with(syscall, "271 ")) return 1;
+  if (starts_with(syscall, "23 ") || starts_with(syscall, "270 ") || starts_with(syscall, "73 ")) return 1;
+  return 0;
+}
+
+static int wait_safe_boundary(const char *pid, long timeout_ms) {
+  long deadline = monotonic_ms() + timeout_ms;
+  char wchan[256] = "";
+  char syscall[512] = "";
+  while (monotonic_ms() <= deadline) {
+    int tasks = count_tasks(pid);
+    printf("TASKS\t%d\n", tasks);
+    if (tasks != 1) {
+      printf("SAFE_BOUNDARY\trefused\tmultiple-tasks\n");
+      return 0;
+    }
+    if (read_proc_first_line(pid, "wchan", wchan, sizeof(wchan)) != 0) wchan[0] = '\0';
+    if (read_proc_first_line(pid, "syscall", syscall, sizeof(syscall)) != 0) syscall[0] = '\0';
+    printf("WCHAN\t%s\n", wchan);
+    printf("SYSCALL\t%s\n", syscall);
+    if (looks_like_sleep_timer_boundary(wchan, syscall)) {
+      printf("SAFE_BOUNDARY\tsleep-timer\t%s\n", wchan[0] ? wchan : syscall);
+      return 1;
+    }
+    usleep(50000);
+  }
+  printf("SAFE_BOUNDARY\trefused\ttimeout\n");
+  return 0;
+}
+
+static int freeze_pid(const char *pid_text) {
+  pid_t pid = (pid_t)strtol(pid_text, NULL, 10);
+  if (ptrace(PTRACE_ATTACH, pid, NULL, NULL) != 0) {
+    printf("FREEZE\trefused\tptrace-attach:%d\n", errno);
+    return 0;
+  }
+  int status = 0;
+  if (waitpid(pid, &status, 0) < 0) {
+    printf("FREEZE\trefused\twaitpid:%d\n", errno);
+    return 0;
+  }
+  printf("FREEZE\tptrace-attached\tstatus:%d\n", status);
+  return 1;
+}
+
+static void detach_pid(const char *pid_text) {
+  pid_t pid = (pid_t)strtol(pid_text, NULL, 10);
+  ptrace(PTRACE_DETACH, pid, NULL, NULL);
+}
+
+typedef struct PingStateLayout {
+  unsigned long symbol_vaddr;
+  unsigned long npackets;
+  unsigned long nreceived;
+  unsigned long ntransmitted;
+  unsigned long nerrors;
+  unsigned long interval;
+  unsigned long pipesize;
+  unsigned long min_size;
+} PingStateLayout;
+
+static PingStateLayout ping_layout;
+
+static int parse_layout_value(const char *line, const char *key, unsigned long *out) {
+  size_t key_len = strlen(key);
+  if (strncmp(line, key, key_len) != 0 || line[key_len] != '=') return 0;
+  *out = strtoul(line + key_len + 1, NULL, 0);
+  return 1;
+}
+
+static int load_ping_state_layout(void) {
+  FILE *f = fopen("/usr/share/machinen/move/iputils-ping.state", "r");
+  if (!f) {
+    printf("PATCH\trefused\tping-layout-missing\n");
+    return 0;
+  }
+  memset(&ping_layout, 0, sizeof(ping_layout));
+  char line[256];
+  while (fgets(line, sizeof(line), f)) {
+    chomp(line);
+    parse_layout_value(line, "symbol_vaddr", &ping_layout.symbol_vaddr) ||
+      parse_layout_value(line, "npackets", &ping_layout.npackets) ||
+      parse_layout_value(line, "nreceived", &ping_layout.nreceived) ||
+      parse_layout_value(line, "ntransmitted", &ping_layout.ntransmitted) ||
+      parse_layout_value(line, "nerrors", &ping_layout.nerrors) ||
+      parse_layout_value(line, "interval", &ping_layout.interval) ||
+      parse_layout_value(line, "pipesize", &ping_layout.pipesize) ||
+      parse_layout_value(line, "min_size", &ping_layout.min_size);
+  }
+  fclose(f);
+  if (ping_layout.symbol_vaddr == 0 || ping_layout.min_size == 0 || ping_layout.ntransmitted == 0 || ping_layout.nreceived == 0 || ping_layout.interval == 0 || ping_layout.pipesize == 0) {
+    printf("PATCH\trefused\tping-layout-incomplete\n");
+    return 0;
+  }
+  printf("PATCH\tping-layout\tready\t0x%lx\t%lu\n", ping_layout.symbol_vaddr, ping_layout.min_size);
+  return 1;
+}
+
+static int patch_long_fd(int memfd, unsigned long base, unsigned long offset, long value) {
+  return pwrite(memfd, &value, sizeof(value), (off_t)(base + offset)) == (ssize_t)sizeof(value);
+}
+
+static unsigned long find_ping_rts_symbol_addr(FILE *maps) {
+  char line[2048];
+  rewind(maps);
+  while (fgets(line, sizeof(line), maps)) {
+    unsigned long start = 0, end = 0, offset = 0;
+    char perms[8] = "";
+    char path[1024] = "";
+    if (sscanf(line, "%lx-%lx %7s %lx %*s %*s %1023[^\n]", &start, &end, perms, &offset, path) < 4) continue;
+    (void)end;
+    (void)perms;
+    if (offset == 0 && strstr(path, "/usr/bin/ping")) return start + ping_layout.symbol_vaddr;
+  }
+  return 0;
+}
+
+static void patch_ping_rts_fields(int memfd, unsigned long base, long ntransmitted, long nreceived, long nerrors) {
+  patch_long_fd(memfd, base, ping_layout.ntransmitted, ntransmitted);
+  patch_long_fd(memfd, base, ping_layout.nreceived, nreceived);
+  patch_long_fd(memfd, base, ping_layout.nerrors, nerrors);
+}
+
+static int plausible_ping_rts(int memfd, unsigned long base) {
+  long npackets = -1;
+  long ntransmitted = -1;
+  int interval = -1;
+  int pipesize = 0;
+  if (pread(memfd, &npackets, sizeof(npackets), (off_t)(base + ping_layout.npackets)) != (ssize_t)sizeof(npackets)) return 0;
+  if (pread(memfd, &ntransmitted, sizeof(ntransmitted), (off_t)(base + ping_layout.ntransmitted)) != (ssize_t)sizeof(ntransmitted)) return 0;
+  if (pread(memfd, &interval, sizeof(interval), (off_t)(base + ping_layout.interval)) != (ssize_t)sizeof(interval)) return 0;
+  if (pread(memfd, &pipesize, sizeof(pipesize), (off_t)(base + ping_layout.pipesize)) != (ssize_t)sizeof(pipesize)) return 0;
+  return npackets == 0 && ntransmitted >= 0 && ntransmitted < 1000000 && interval > 0 && interval <= 10000 && pipesize >= -1 && pipesize < 100000;
+}
+
+static int patch_ping_state(const char *pid_text, long ntransmitted, long nreceived, long nerrors) {
+  if (!load_ping_state_layout()) return 2;
+  if (!freeze_pid(pid_text)) return 2;
+  char maps_path[128];
+  char mem_path[128];
+  snprintf(maps_path, sizeof(maps_path), "/proc/%s/maps", pid_text);
+  snprintf(mem_path, sizeof(mem_path), "/proc/%s/mem", pid_text);
+  FILE *maps = fopen(maps_path, "r");
+  int memfd = open(mem_path, O_RDWR);
+  if (!maps || memfd < 0) {
+    printf("PATCH\trefused\topen-proc:%d\n", errno);
+    if (maps) fclose(maps);
+    if (memfd >= 0) close(memfd);
+    detach_pid(pid_text);
+    return 2;
+  }
+  unsigned long symbol_addr = find_ping_rts_symbol_addr(maps);
+  if (symbol_addr == 0) {
+    printf("PATCH\trefused\tping-load-bias-not-found\n");
+    fclose(maps);
+    close(memfd);
+    detach_pid(pid_text);
+    return 2;
+  }
+  if (!plausible_ping_rts(memfd, symbol_addr)) {
+    printf("PATCH\trefused\tping-rts-symbol-not-plausible\t0x%lx\n", symbol_addr);
+    fclose(maps);
+    close(memfd);
+    detach_pid(pid_text);
+    return 2;
+  }
+  patch_ping_rts_fields(memfd, symbol_addr, ntransmitted, nreceived, nerrors);
+  printf("PATCH\tping-rts\t0x%lx\t%ld\t%ld\t%ld\n", symbol_addr, ntransmitted, nreceived, nerrors);
+  fclose(maps);
+  close(memfd);
+  detach_pid(pid_text);
+  return 0;
+}
+
+static void emit_registers(const char *pid_text) {
+  pid_t pid = (pid_t)strtol(pid_text, NULL, 10);
+#ifdef __aarch64__
+  struct user_pt_regs regs;
+  struct iovec iov;
+  memset(&regs, 0, sizeof(regs));
+  iov.iov_base = &regs;
+  iov.iov_len = sizeof(regs);
+  if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_PRSTATUS, &iov) != 0) {
+    printf("REG_ARM64\trefused\tgetregset:%d\n", errno);
+    return;
+  }
+  printf("REG_ARM64\t0x%llx\t0x%llx\t0x%llx", (unsigned long long)regs.pc, (unsigned long long)regs.sp, (unsigned long long)regs.pstate);
+  for (int i = 0; i < 31; i++) printf("\t0x%llx", (unsigned long long)regs.regs[i]);
+  printf("\n");
+#elif defined(__x86_64__)
+  struct user_regs_struct regs;
+  memset(&regs, 0, sizeof(regs));
+  if (ptrace(PTRACE_GETREGS, pid, NULL, &regs) != 0) {
+    printf("REG_AMD64\trefused\tgetregs:%d\n", errno);
+    return;
+  }
+  printf("REG_AMD64\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\t0x%llx\n",
+         (unsigned long long)regs.rip, (unsigned long long)regs.rsp, (unsigned long long)regs.eflags,
+         (unsigned long long)regs.rax, (unsigned long long)regs.rbx, (unsigned long long)regs.rcx,
+         (unsigned long long)regs.rdx, (unsigned long long)regs.rsi, (unsigned long long)regs.rdi,
+         (unsigned long long)regs.rbp, (unsigned long long)regs.r8, (unsigned long long)regs.r9,
+         (unsigned long long)regs.r10, (unsigned long long)regs.r11, (unsigned long long)regs.r12,
+         (unsigned long long)regs.r13, (unsigned long long)regs.r14, (unsigned long long)regs.r15,
+         (unsigned long long)regs.fs_base, (unsigned long long)regs.gs_base);
+#else
+  printf("REG_UNKNOWN\trefused\tunsupported-arch\n");
+#endif
+}
+
+typedef struct SyscallEntry {
+  long nr;
+  unsigned long args[6];
+  int ok;
+} SyscallEntry;
+
+static SyscallEntry current_syscall_entry(pid_t pid) {
+  SyscallEntry out;
+  memset(&out, 0, sizeof(out));
+  out.nr = -1;
+#ifdef __x86_64__
+  struct user_regs_struct regs;
+  memset(&regs, 0, sizeof(regs));
+  if (ptrace(PTRACE_GETREGS, pid, NULL, &regs) != 0) return out;
+  out.nr = (long)regs.orig_rax;
+  out.args[0] = (unsigned long)regs.rdi;
+  out.args[1] = (unsigned long)regs.rsi;
+  out.args[2] = (unsigned long)regs.rdx;
+  out.args[3] = (unsigned long)regs.r10;
+  out.args[4] = (unsigned long)regs.r8;
+  out.args[5] = (unsigned long)regs.r9;
+  out.ok = 1;
+#elif defined(__aarch64__)
+  struct user_pt_regs regs;
+  struct iovec iov;
+  memset(&regs, 0, sizeof(regs));
+  iov.iov_base = &regs;
+  iov.iov_len = sizeof(regs);
+  if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_PRSTATUS, &iov) != 0) return out;
+  out.nr = (long)regs.regs[8];
+  for (int i = 0; i < 6; i++) out.args[i] = (unsigned long)regs.regs[i];
+  out.ok = 1;
+#endif
+  return out;
+}
+
+static int is_sendto_entry(SyscallEntry sc) {
+#ifdef __NR_sendto
+  return sc.ok && sc.nr == __NR_sendto && sc.args[1] != 0 && sc.args[2] >= 8 && sc.args[2] <= 65535;
+#else
+  (void)sc;
+  return 0;
+#endif
+}
+
+static uint16_t icmp_checksum(const unsigned char *buf, size_t len) {
+  uint32_t sum = 0;
+  size_t i = 0;
+  while (i + 1 < len) {
+    sum += ((uint16_t)buf[i] << 8) | buf[i + 1];
+    i += 2;
+  }
+  if (i < len) sum += ((uint16_t)buf[i] << 8);
+  while (sum >> 16) sum = (sum & 0xffffU) + (sum >> 16);
+  return (uint16_t)(~sum & 0xffffU);
+}
+
+static int patch_icmp_send_buffer(int memfd, unsigned long packet_addr, unsigned long packet_len, long ntransmitted) {
+  if (packet_len < 8 || packet_len > 65535) return 0;
+  unsigned char *packet = (unsigned char *)malloc(packet_len);
+  if (!packet) return 0;
+  int ok = 0;
+  if (pread(memfd, packet, packet_len, (off_t)packet_addr) == (ssize_t)packet_len) {
+    if (packet[0] == 8 || packet[0] == 128) {
+      unsigned long next = (unsigned long)(ntransmitted + 1);
+      packet[2] = 0;
+      packet[3] = 0;
+      packet[6] = (unsigned char)((next >> 8) & 0xff);
+      packet[7] = (unsigned char)(next & 0xff);
+      uint16_t sum = icmp_checksum(packet, packet_len);
+      packet[2] = (unsigned char)((sum >> 8) & 0xff);
+      packet[3] = (unsigned char)(sum & 0xff);
+      ok = pwrite(memfd, packet, packet_len, (off_t)packet_addr) == (ssize_t)packet_len;
+    }
+  }
+  free(packet);
+  return ok;
+}
+
+static int patch_ping_presend(pid_t pid, unsigned long packet_addr, unsigned long packet_len, long ntransmitted, long nreceived, long nerrors) {
+  char pid_text[32];
+  char maps_path[128];
+  char mem_path[128];
+  snprintf(pid_text, sizeof(pid_text), "%ld", (long)pid);
+  snprintf(maps_path, sizeof(maps_path), "/proc/%s/maps", pid_text);
+  snprintf(mem_path, sizeof(mem_path), "/proc/%s/mem", pid_text);
+  FILE *maps = fopen(maps_path, "r");
+  int memfd = open(mem_path, O_RDWR);
+  if (!maps || memfd < 0) {
+    printf("PATCH\trefused\topen-proc:%d\n", errno);
+    if (maps) fclose(maps);
+    if (memfd >= 0) close(memfd);
+    return 0;
+  }
+  unsigned long symbol_addr = find_ping_rts_symbol_addr(maps);
+  if (symbol_addr == 0 || !plausible_ping_rts(memfd, symbol_addr)) {
+    printf("PATCH\trefused\tping-rts-symbol-not-plausible\t0x%lx\n", symbol_addr);
+    fclose(maps);
+    close(memfd);
+    return 0;
+  }
+  patch_ping_rts_fields(memfd, symbol_addr, ntransmitted, nreceived, nerrors);
+  printf("PATCH\tping-rts\t0x%lx\t%ld\t%ld\t%ld\n", symbol_addr, ntransmitted, nreceived, nerrors);
+  int packet_ok = patch_icmp_send_buffer(memfd, packet_addr, packet_len, ntransmitted);
+  printf("PATCH\tping-send-buffer\t%s\t0x%lx\t%lu\t%lu\n", packet_ok ? "ready" : "refused", packet_addr, packet_len, (unsigned long)(ntransmitted + 1));
+  fclose(maps);
+  close(memfd);
+  return packet_ok;
+}
+
+static void append_resume_marker(const char *log_path) {
+  int fd = open(log_path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fd < 0) return;
+  const char marker[] = "\nMACHINEN_MOVE_RESUME\n";
+  (void)write(fd, marker, sizeof(marker) - 1);
+  close(fd);
+}
+
+static int run_load_ping_state(int argc, char **argv) {
+  if (!load_ping_state_layout()) return 2;
+  if (argc < 9 || strcmp(argv[5], "--log") != 0 || strcmp(argv[7], "--") != 0) {
+    fprintf(stderr, "usage: machinen-move-capture --load-ping-state <ntransmitted> <nreceived> <nerrors> --log <path> -- <executable> [args...]\n");
+    return 64;
+  }
+  long ntransmitted = strtol(argv[2], NULL, 10);
+  long nreceived = strtol(argv[3], NULL, 10);
+  long nerrors = strtol(argv[4], NULL, 10);
+  const char *log_path = argv[6];
+  char **child_argv = &argv[8];
+  pid_t pid = fork();
+  if (pid < 0) {
+    printf("RENDEZVOUS\trefused\tfork:%d\n", errno);
+    return 2;
+  }
+  if (pid == 0) {
+    int nullfd = open("/dev/null", O_RDONLY);
+    if (nullfd >= 0) {
+      dup2(nullfd, 0);
+      if (nullfd > 2) close(nullfd);
+    }
+    int logfd = open(log_path, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND, 0644);
+    if (logfd >= 0) {
+      dup2(logfd, 1);
+      dup2(logfd, 2);
+      if (logfd > 2) close(logfd);
+    }
+    ptrace(PTRACE_TRACEME, 0, NULL, NULL);
+    raise(SIGSTOP);
+    execvp(child_argv[0], child_argv);
+    _exit(127);
+  }
+
+  printf("LOAD_PID\t%ld\n", (long)pid);
+  printf("LOAD_LOG\t%s\n", log_path);
+  int status = 0;
+  if (waitpid(pid, &status, 0) < 0 || !WIFSTOPPED(status)) {
+    printf("FREEZE\trefused\tinitial-wait:%d\n", errno);
+    return 2;
+  }
+  if (ptrace(PTRACE_SETOPTIONS, pid, NULL, (void *)(unsigned long)PTRACE_O_TRACESYSGOOD) != 0) {
+    printf("FREEZE\trefused\tsetoptions:%d\n", errno);
+    kill(pid, SIGKILL);
+    return 2;
+  }
+
+  int in_syscall = 0;
+  long deadline = monotonic_ms() + 10000;
+  while (monotonic_ms() <= deadline) {
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+      printf("FREEZE\trefused\tptrace-syscall:%d\n", errno);
+      kill(pid, SIGKILL);
+      return 2;
+    }
+    if (waitpid(pid, &status, 0) < 0) {
+      printf("FREEZE\trefused\twait-syscall:%d\n", errno);
+      kill(pid, SIGKILL);
+      return 2;
+    }
+    if (WIFEXITED(status) || WIFSIGNALED(status)) {
+      printf("SAFE_BOUNDARY\trefused\tprocess-exited-before-send\n");
+      return 2;
+    }
+    if (!WIFSTOPPED(status)) continue;
+    int sig = WSTOPSIG(status);
+    if (sig != (SIGTRAP | 0x80)) continue;
+    in_syscall = !in_syscall;
+    if (!in_syscall) continue;
+    SyscallEntry sc = current_syscall_entry(pid);
+    if (!is_sendto_entry(sc)) continue;
+    char pid_text[32];
+    snprintf(pid_text, sizeof(pid_text), "%ld", (long)pid);
+    printf("AGENT\tmachinen-move-capture-v3\n");
+    emit_uname();
+    emit_status(pid_text);
+    emit_ping_range();
+    emit_fds(pid_text);
+    emit_proc_file(pid_text, "maps", "MAP");
+    printf("TASKS\t%d\n", count_tasks(pid_text));
+    printf("SAFE_BOUNDARY\tpre-send-icmp\tsendto\n");
+    printf("FREEZE\tptrace-attached\tstatus:%d\n", status);
+    emit_registers(pid_text);
+    int ok = patch_ping_presend(pid, sc.args[1], sc.args[2], ntransmitted, nreceived, nerrors);
+    emit_proc_net("/proc/net/icmp", "NET_ICMP");
+    emit_proc_net("/proc/net/raw", "NET_RAW");
+    if (!ok) {
+      kill(pid, SIGKILL);
+      return 2;
+    }
+    append_resume_marker(log_path);
+    ptrace(PTRACE_DETACH, pid, NULL, NULL);
+    return 0;
+  }
+  printf("SAFE_BOUNDARY\trefused\ttimeout-before-send\n");
+  kill(pid, SIGKILL);
+  return 2;
+}
+
+int main(int argc, char **argv) {
+  if (argc >= 2 && (strcmp(argv[1], "--load-ping-state") == 0 || strcmp(argv[1], "--rendezvous-ping-state") == 0)) {
+    return run_load_ping_state(argc, argv);
+  }
+  if (argc == 6 && strcmp(argv[1], "--patch-ping-state") == 0 && numeric_name(argv[2])) {
+    return patch_ping_state(argv[2], strtol(argv[3], NULL, 10), strtol(argv[4], NULL, 10), strtol(argv[5], NULL, 10));
+  }
+  if ((argc != 2 && argc != 4) || !numeric_name(argv[1])) {
+    fprintf(stderr, "usage: machinen-move-capture <pid> [--timeout-ms <ms>]\n       machinen-move-capture --patch-ping-state <pid> <ntransmitted> <nreceived> <nerrors>\n       machinen-move-capture --load-ping-state <ntransmitted> <nreceived> <nerrors> --log <path> -- <executable> [args...]\n");
+    return 64;
+  }
+  long timeout_ms = 10000;
+  if (argc == 4) {
+    if (strcmp(argv[2], "--timeout-ms") != 0 || !numeric_name(argv[3])) {
+      fprintf(stderr, "usage: machinen-move-capture <pid> [--timeout-ms <ms>]\n");
+      return 64;
+    }
+    timeout_ms = strtol(argv[3], NULL, 10);
+  }
+  char procpath[128];
+  snprintf(procpath, sizeof(procpath), "/proc/%s", argv[1]);
+  if (access(procpath, F_OK) != 0) {
+    fprintf(stderr, "machinen-move-capture: pid %s not found\n", argv[1]);
+    return 1;
+  }
+
+  printf("AGENT\tmachinen-move-capture-v2\n");
+  emit_uname();
+  emit_status(argv[1]);
+  emit_ping_range();
+  emit_fds(argv[1]);
+  emit_proc_file(argv[1], "maps", "MAP");
+  int safe = wait_safe_boundary(argv[1], timeout_ms);
+  int frozen = safe ? freeze_pid(argv[1]) : 0;
+  if (frozen) {
+    emit_registers(argv[1]);
+    detach_pid(argv[1]);
+  }
+  emit_proc_net("/proc/net/icmp", "NET_ICMP");
+  emit_proc_net("/proc/net/raw", "NET_RAW");
+  return 0;
+}

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -4638,6 +4638,10 @@ Size in bytes the file was allocated at.
 
 > **cwd**: `string`
 
+##### exe?
+
+> `optional` **exe?**: `string`
+
 ***
 
 ### MovePidGraphEdge
@@ -4793,6 +4797,170 @@ Size in bytes the file was allocated at.
 ##### productSurface
 
 > **productSurface**: `"machinen move"`
+
+##### resourcePlan?
+
+> `optional` **resourcePlan?**: `object`
+
+###### kind
+
+> **kind**: `"machinen.move.resource-plan"`
+
+###### source
+
+> **source**: `"guest-procfs"` \| `"host-procfs"`
+
+###### sourceArch?
+
+> `optional` **sourceArch?**: `"amd64"` \| `"arm64"`
+
+###### resources
+
+> **resources**: [`NativeProcessResource`](#nativeprocessresource)[]
+
+###### fdTableEntries
+
+> **fdTableEntries**: [`NativeTargetFdTableEntry`](#nativetargetfdtableentry)[]
+
+###### targetGuestResources
+
+> **targetGuestResources**: [`TargetGuestRestoreResourceRecipe`](#targetguestrestoreresourcerecipe)[]
+
+###### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
+
+###### acceptedSubsets
+
+> **acceptedSubsets**: `string`[]
+
+###### capture?
+
+> `optional` **capture?**: `object`
+
+###### capture.sourceVm?
+
+> `optional` **sourceVm?**: `object`
+
+###### capture.sourceVm.pid
+
+> **pid**: `number`
+
+###### capture.sourceVm.name?
+
+> `optional` **name?**: `string`
+
+###### capture.executablePackage?
+
+> `optional` **executablePackage?**: `object`
+
+###### capture.executablePackage.path
+
+> **path**: `string`
+
+###### capture.executablePackage.realPath?
+
+> `optional` **realPath?**: `string`
+
+###### capture.executablePackage.packageName?
+
+> `optional` **packageName?**: `string`
+
+###### capture.executablePackage.version?
+
+> `optional` **version?**: `string`
+
+###### capture.executablePackage.architecture?
+
+> `optional` **architecture?**: `string`
+
+###### capture.pingState?
+
+> `optional` **pingState?**: `object`
+
+###### capture.pingState.ntransmitted
+
+> **ntransmitted**: `number`
+
+###### capture.pingState.nreceived
+
+> **nreceived**: `number`
+
+###### capture.pingState.nerrors
+
+> **nerrors**: `number`
+
+###### capture.pingState.lastSequence?
+
+> `optional` **lastSequence?**: `number`
+
+###### capture.safeBoundary?
+
+> `optional` **safeBoundary?**: `object`
+
+###### capture.safeBoundary.state
+
+> **state**: `"refused"` \| `"sleep-timer"` \| `"pre-send-icmp"`
+
+###### capture.safeBoundary.detail
+
+> **detail**: `string`
+
+###### capture.freeze?
+
+> `optional` **freeze?**: `object`
+
+###### capture.freeze.state
+
+> **state**: `"refused"` \| `"ptrace-attached"`
+
+###### capture.freeze.detail
+
+> **detail**: `string`
+
+###### capture.tasks?
+
+> `optional` **tasks?**: `number`
+
+###### capture.wchan?
+
+> `optional` **wchan?**: `string`
+
+###### capture.syscall?
+
+> `optional` **syscall?**: `string`
+
+###### capture.maps?
+
+> `optional` **maps?**: `string`[]
+
+###### capture.registers?
+
+> `optional` **registers?**: `Record`\<`string`, `unknown`\>
+
+##### nativeContinuation?
+
+> `optional` **nativeContinuation?**: `object`
+
+###### kind
+
+> **kind**: `"machinen.move.native-continuation"`
+
+###### bundlePath
+
+> **bundlePath**: `"."`
+
+###### activeSyscallPlan
+
+> **activeSyscallPlan**: `"active-syscall-plan.json"`
+
+###### state
+
+> **state**: `"refused"` \| `"planned"`
+
+###### refusals
+
+> **refusals**: [`NativeProcessImageRefusal`](#nativeprocessimagerefusal)[]
 
 ***
 

--- a/packages/runtime/src/move-pid-graph.ts
+++ b/packages/runtime/src/move-pid-graph.ts
@@ -1,5 +1,13 @@
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, readlinkSync, writeFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
+
+import type {
+  NativeProcessImageArchitecture,
+  NativeProcessImageRefusal,
+  NativeProcessResource,
+} from "./native-process-image.ts";
+import type { NativeTargetFdTableEntry } from "./native-resource-translation.ts";
+import type { TargetGuestRestoreResourceRecipe } from "./target-guest-restore-loader.ts";
 
 export const MOVE_DESCRIPTOR_FORMAT_VERSION = 1 as const;
 export const MOVE_REFUSAL_CODE = "move-unproven-state-class" as const;
@@ -18,6 +26,7 @@ export interface MovePidGraphNode {
   command: string;
   argv: string[];
   cwd: string | undefined;
+  exe?: string;
 }
 
 export interface MovePidGraphEdge {
@@ -48,6 +57,46 @@ export interface MoveDescriptor extends Omit<MovePidGraph, "kind"> {
   kind: "machinen.move.descriptor";
   target: "cross-isa-target-native-pid-translation";
   productSurface: "machinen move";
+  resourcePlan?: {
+    kind: "machinen.move.resource-plan";
+    source: "guest-procfs" | "host-procfs";
+    sourceArch?: NativeProcessImageArchitecture;
+    resources: NativeProcessResource[];
+    fdTableEntries: NativeTargetFdTableEntry[];
+    targetGuestResources: TargetGuestRestoreResourceRecipe[];
+    refusals: NativeProcessImageRefusal[];
+    acceptedSubsets: string[];
+    capture?: {
+      sourceVm?: { pid: number; name?: string };
+      executablePackage?: {
+        path: string;
+        realPath?: string;
+        packageName?: string;
+        version?: string;
+        architecture?: string;
+      };
+      pingState?: {
+        ntransmitted: number;
+        nreceived: number;
+        nerrors: number;
+        lastSequence?: number;
+      };
+      safeBoundary?: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string };
+      freeze?: { state: "ptrace-attached" | "refused"; detail: string };
+      tasks?: number;
+      wchan?: string;
+      syscall?: string;
+      maps?: string[];
+      registers?: Record<string, unknown>;
+    };
+  };
+  nativeContinuation?: {
+    kind: "machinen.move.native-continuation";
+    bundlePath: ".";
+    activeSyscallPlan: "active-syscall-plan.json";
+    state: "planned" | "refused";
+    refusals: NativeProcessImageRefusal[];
+  };
 }
 
 export interface MoveSaveResult {
@@ -180,7 +229,16 @@ function readProcNode(pid: number): MovePidGraphNode {
     command: basename(command),
     argv,
     cwd: undefined,
+    exe: readlinkProcExe(pid),
   };
+}
+
+function readlinkProcExe(pid: number): string | undefined {
+  try {
+    return readlinkSync(`/proc/${pid}/exe`);
+  } catch {
+    return undefined;
+  }
 }
 
 function fallbackNode(pid: number): MovePidGraphNode {
@@ -190,6 +248,7 @@ function fallbackNode(pid: number): MovePidGraphNode {
     command: pid === process.pid ? basename(process.argv[0] ?? "node") : `pid-${pid}`,
     argv: pid === process.pid ? process.argv : [],
     cwd: pid === process.pid ? process.cwd() : undefined,
+    exe: pid === process.pid ? process.execPath : undefined,
   };
 }
 

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -178,7 +178,7 @@ fi
 #    (all statically linked against musl)
 # ------------------------------------------------------------
 
-echo "==> Building guest binaries (init, exec-agent, winsize-agent, CRIU helpers, poweroff, net-bench-probe) for ${ZIG_GUEST_TARGET}"
+echo "==> Building guest binaries (init, exec-agent, winsize-agent, CRIU helpers, poweroff, net-bench-probe, move-capture) for ${ZIG_GUEST_TARGET}"
 # STAGE has to live inside ROOT, not /tmp, because the mmdebstrap step
 # below runs docker with `-v "$STAGE":/stage:ro`. When build-base-assets
 # itself runs inside a container (agent-ci's local runner, dev shell
@@ -218,6 +218,12 @@ zig cc "${ASSETS}/machinen-netup.c" \
   -static \
   -Os \
   -o "${STAGE}/machinen-netup"
+
+zig cc "${ASSETS}/move-capture.c" \
+  -target "${ZIG_GUEST_TARGET}" \
+  -static \
+  -Os \
+  -o "${STAGE}/move-capture"
 
 zig cc "${ASSETS}/vmstate-reseed.c" \
   -target aarch64-linux-musl \
@@ -443,6 +449,64 @@ install -m 0755 /tmp/criu-build/criu/criu /work/rootfs/usr/sbin/criu
 chroot /work/rootfs /usr/sbin/criu --version | tee /dev/stderr | grep -qE "Version: ${CRIU_TAG#v}" \
   || { echo "criu overlay version mismatch — expected ${CRIU_TAG#v}"; exit 1; }
 
+# Generate the move ping-state layout from Debian's source/debug
+# artifacts instead of baking iputils offsets into machinen-move-capture.
+# The guest patcher reads this compact metadata file at load time and
+# refuses if it is absent/incomplete.
+echo "==> Generating iputils-ping move layout metadata"
+cat > /etc/apt/sources.list.d/machinen-iputils-debug.list <<'EOF'
+deb http://deb.debian.org/debian-debug bookworm-debug main
+deb-src http://ftp.debian.org/debian bookworm main contrib
+deb-src http://ftp.debian.org/debian bookworm-updates main contrib
+deb-src http://security.debian.org bookworm-security main contrib
+EOF
+apt-get update -qq > /dev/null
+PING_VERSION=$(chroot /work/rootfs dpkg-query -W -f='${Version}' iputils-ping)
+PING_BUILD_ID=$(readelf -n /work/rootfs/usr/bin/ping | awk '/Build ID:/ {print $3; exit}')
+rm -rf /tmp/iputils-dbgsym /tmp/iputils-source
+mkdir -p /tmp/iputils-dbgsym /tmp/iputils-source
+(
+  cd /tmp/iputils-dbgsym
+  apt-get download -qq "iputils-ping-dbgsym=${PING_VERSION}"
+  dpkg-deb -x iputils-ping-dbgsym_*.deb .
+)
+PING_DEBUG="/tmp/iputils-dbgsym/usr/lib/debug/.build-id/${PING_BUILD_ID:0:2}/${PING_BUILD_ID:2}.debug"
+PING_RTS_SYMBOL=$(nm -an "$PING_DEBUG" | awk '/ [bB] rts\./ {print "0x" $1; exit}')
+if [ -z "$PING_RTS_SYMBOL" ]; then
+  echo "could not resolve iputils ping_rts symbol from $PING_DEBUG" >&2
+  exit 1
+fi
+(
+  cd /tmp/iputils-source
+  apt-get source -qq "iputils-ping=${PING_VERSION}"
+)
+PING_SRC=$(find /tmp/iputils-source -mindepth 1 -maxdepth 1 -type d -name 'iputils-*' | head -1)
+cat > /tmp/ping-offsets.c <<'EOF'
+#include <stddef.h>
+#include <stdio.h>
+#define HAVE_LIBCAP 1
+#include "ping/ping.h"
+int main(void) {
+  printf("npackets=%zu\n", offsetof(struct ping_rts, npackets));
+  printf("nreceived=%zu\n", offsetof(struct ping_rts, nreceived));
+  printf("ntransmitted=%zu\n", offsetof(struct ping_rts, ntransmitted));
+  printf("nerrors=%zu\n", offsetof(struct ping_rts, nerrors));
+  printf("interval=%zu\n", offsetof(struct ping_rts, interval));
+  printf("pipesize=%zu\n", offsetof(struct ping_rts, pipesize));
+  printf("min_size=%zu\n", sizeof(struct ping_rts));
+  return 0;
+}
+EOF
+gcc -I"$PING_SRC" -I"$PING_SRC/ping" /tmp/ping-offsets.c -o /tmp/ping-offsets
+install -m 0755 -d /work/rootfs/usr/share/machinen/move
+{
+  echo "package=iputils-ping"
+  echo "version=${PING_VERSION}"
+  echo "build_id=${PING_BUILD_ID}"
+  echo "symbol_vaddr=${PING_RTS_SYMBOL}"
+  /tmp/ping-offsets
+} > /work/rootfs/usr/share/machinen/move/iputils-ping.state
+
 # Belt-and-braces cleanup for things path-exclude doesn't cover.
 # Also drop the second copy of the kernel image and initrd hooks we
 # don't use (we boot Image-arm64 from release-assets, not from
@@ -500,6 +564,7 @@ install -m 1777 -d /work/rootfs/tmp
 install -m 0755 /stage/init       /work/rootfs/init
 install -m 0755 /stage/exec-agent /work/rootfs/exec-agent
 install -m 0755 -D /stage/machinen-netup    /work/rootfs/sbin/machinen-netup
+install -m 0755 -D /stage/move-capture      /work/rootfs/sbin/machinen-move-capture
 install -m 0755 -D /stage/vmstate-reseed    /work/rootfs/sbin/machinen-vmstate-reseed
 install -m 0755 -D /stage/lo-up             /work/rootfs/sbin/machinen-lo-up
 install -m 0755 -D /stage/no-iou            /work/rootfs/sbin/machinen-no-iou

--- a/scripts/check-asset-freshness.sh
+++ b/scripts/check-asset-freshness.sh
@@ -91,6 +91,7 @@ rootfs_input_files() {
     "${ASSETS}/machinen-dump.sh" \
     "${ASSETS}/machinen-netup.c" \
     "${ASSETS}/machinen-restore.sh" \
+    "${ASSETS}/move-capture.c" \
     "${ASSETS}/machinen-supervisor.sh" \
     "${ASSETS}/memdirty.zig" \
     "${ASSETS}/net-bench-probe.zig" \

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -208,6 +208,11 @@ if ! grep -q "sbin/machinen-memdirty" <<<"$ROOTFS_ENTRIES"; then
   echo "smoke: WARN rootfs lacks /sbin/machinen-memdirty — S5 (headline RSS) will be skipped"
   ROOTFS_SUPPORTS_MEMDIRTY=0
 fi
+ROOTFS_SUPPORTS_MOVE_CAPTURE=1
+if ! grep -q "sbin/machinen-move-capture" <<<"$ROOTFS_ENTRIES"; then
+  echo "smoke: WARN rootfs lacks /sbin/machinen-move-capture — move-capture helpers unavailable"
+  ROOTFS_SUPPORTS_MOVE_CAPTURE=0
+fi
 
 # ----------------------------------------------------------------
 # Tests

--- a/scripts/smoke/manifest.json
+++ b/scripts/smoke/manifest.json
@@ -68,6 +68,13 @@
       "requires": ["local-node"]
     },
     {
+      "path": "scripts/smoke/move-ping-cross-arch.sh",
+      "classification": "proof-audit",
+      "packageScripts": ["proof-move-ping-cross-arch"],
+      "reason": "arm64 to amd64 machinen move proof for distro /usr/bin/ping direct-loader continuation",
+      "requires": ["local-arm64-vm", "remote-amd64-vm", "release-assets"]
+    },
+    {
       "path": "scripts/smoke/nested-virtualization-stretch-proof.sh",
       "classification": "proof-audit",
       "packageScripts": ["proof-nested-virtualization-stretch"],

--- a/scripts/smoke/move-ping-cross-arch.sh
+++ b/scripts/smoke/move-ping-cross-arch.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Cross-arch proof harness for `machinen move` ping continuation.
+#
+# This is intentionally a proof/audit script, not part of the default product
+# smoke suite: it needs a native x86_64 host reachable over ssh for the amd64
+# target VM. Default values match the maintainer lab host used during the move
+# implementation work.
+#
+# Required/overridable env:
+#   MACHINEN_MOVE_PROOF_REMOTE=root@192.168.0.8
+#   MACHINEN_MOVE_PROOF_REMOTE_REPO=/mnt/shared-500G/machinen-move-proof
+#   MACHINEN_MOVE_PROOF_REMOTE_ASSETS_DIR=$REMOTE_REPO/release-assets
+#
+# Optional:
+#   MACHINEN_MOVE_PROOF_JSON=1 or --json
+#   MACHINEN_MOVE_PROOF_BUILD_REMOTE=1   # rebuild remote CLI/VMM/assets first
+#   MACHINEN_MOVE_PROOF_KEEP=1           # keep VMs/temp dirs for debugging
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+REMOTE=${MACHINEN_MOVE_PROOF_REMOTE:-root@192.168.0.8}
+REMOTE_REPO=${MACHINEN_MOVE_PROOF_REMOTE_REPO:-/mnt/shared-500G/machinen-move-proof}
+REMOTE_ASSETS_DIR=${MACHINEN_MOVE_PROOF_REMOTE_ASSETS_DIR:-${REMOTE_REPO}/release-assets}
+JSON=0
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON=1 ;;
+    --) ;;
+    "") ;;
+    *) echo "usage: $0 [--json]" >&2; exit 64 ;;
+  esac
+done
+if [ "${MACHINEN_MOVE_PROOF_JSON:-}" = "1" ]; then
+  JSON=1
+fi
+RUN_ID="move-ping-cross-arch-$$-$(date +%s)"
+SRC_VM="${MACHINEN_MOVE_PROOF_SOURCE_VM:-${RUN_ID}-src}"
+TGT_VM="${MACHINEN_MOVE_PROOF_TARGET_VM:-${RUN_ID}-tgt}"
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/machinen-move-ping-cross-arch.XXXXXX")
+BUNDLE="$WORKDIR/bundle"
+SAVE_JSON="$WORKDIR/save.json"
+REMOTE_WORKDIR="/mnt/shared-500G/${RUN_ID}"
+REMOTE_BUNDLE="${REMOTE_WORKDIR}/bundle"
+REMOTE_LOAD_JSON="${REMOTE_WORKDIR}/load.json"
+REMOTE_LOG_TXT="${REMOTE_WORKDIR}/target.log"
+
+q() { printf '%q' "$1"; }
+
+info() {
+  if [ "$JSON" != "1" ]; then
+    echo "$*" >&2
+  fi
+}
+
+remote_bash() {
+  local body="$1"
+  local script="set -euo pipefail; cd $(q "$REMOTE_REPO"); export TMPDIR=/mnt/shared-500G/tmp XDG_CACHE_HOME=/mnt/shared-500G/cache PNPM_HOME=/mnt/shared-500G/pnpm-home MACHINEN_GUEST_ARCH=amd64 MACHINEN_ASSETS_DIR=$(q "$REMOTE_ASSETS_DIR"); ${body}"
+  ssh "$REMOTE" "bash -lc $(q "$script")"
+}
+
+local_cli() {
+  (cd "$ROOT" && MACHINEN_GUEST_ARCH=arm64 MACHINEN_ASSETS_DIR="$ROOT/release-assets" node packages/cli/dist/cli.js "$@")
+}
+
+cleanup() {
+  if [ "${MACHINEN_MOVE_PROOF_KEEP:-}" = "1" ]; then
+    info "keep requested: source=$SRC_VM target=$TGT_VM workdir=$WORKDIR remote_workdir=$REMOTE_WORKDIR"
+    return
+  fi
+  (cd "$ROOT" && MACHINEN_GUEST_ARCH=arm64 MACHINEN_ASSETS_DIR="$ROOT/release-assets" node packages/cli/dist/cli.js stop "$SRC_VM" >/dev/null 2>&1 || true)
+  remote_bash "node packages/cli/dist/cli.js stop $(q "$TGT_VM") >/dev/null 2>&1 || true; rm -rf $(q "$REMOTE_WORKDIR")" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+info "==> building local runtime/cli"
+(cd "$ROOT" && pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null)
+
+if [ "${MACHINEN_MOVE_PROOF_BUILD_REMOTE:-}" = "1" ]; then
+  info "==> building remote runtime/cli/VMM/assets on $REMOTE"
+  remote_bash "pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null; bash scripts/build-vmm.sh >/dev/null; MACHINEN_GUEST_ARCH=amd64 bash scripts/build-base-assets.sh >/dev/null"
+fi
+
+info "==> booting source arm64 VM: $SRC_VM"
+local_cli boot --name "$SRC_VM" --detach --json -- sleep infinity >/dev/null
+info "==> booting target amd64 VM on $REMOTE: $TGT_VM"
+remote_bash "mkdir -p $(q "$REMOTE_WORKDIR"); node packages/cli/dist/cli.js boot --name $(q "$TGT_VM") --detach --json -- sleep infinity > $(q "$REMOTE_WORKDIR/target.boot.json")"
+
+info "==> starting source distro ping"
+SOURCE_PID=$(local_cli exec "$SRC_VM" -- "ping google.com > /tmp/ping.log 2>&1 & echo \$!" | tail -1 | tr -d '\r')
+if ! [[ "$SOURCE_PID" =~ ^[0-9]+$ ]]; then
+  echo "move-ping-cross-arch: failed to parse source ping pid: $SOURCE_PID" >&2
+  exit 1
+fi
+sleep 5
+
+info "==> saving source ping pid=$SOURCE_PID"
+mkdir -p "$BUNDLE"
+set +e
+local_cli move save "$SRC_VM" "$SOURCE_PID" "$BUNDLE" --json > "$SAVE_JSON"
+SAVE_RC=$?
+set -e
+if [ ! -f "$BUNDLE/move.json" ]; then
+  echo "move-ping-cross-arch: move save did not write $BUNDLE/move.json (rc=$SAVE_RC)" >&2
+  exit 1
+fi
+
+SOURCE_STATE_JSON=$(node -e 'const d=require(process.argv[1]); console.log(JSON.stringify(d.resourcePlan.capture.pingState));' "$BUNDLE/move.json")
+SOURCE_N=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.ntransmitted);' "$SOURCE_STATE_JSON")
+EXPECTED_NEXT=$(( SOURCE_N + 1 ))
+info "==> source ping state: $SOURCE_STATE_JSON (expect target first seq $EXPECTED_NEXT)"
+
+info "==> copying bundle to target host"
+ssh "$REMOTE" "mkdir -p $(q "$REMOTE_BUNDLE")"
+rsync -az --delete "$BUNDLE/" "$REMOTE:${REMOTE_BUNDLE}/"
+
+info "==> loading into amd64 target"
+remote_bash "node packages/cli/dist/cli.js move load $(q "$TGT_VM") $(q "$REMOTE_BUNDLE") --json > $(q "$REMOTE_LOAD_JSON")"
+
+LOAD_SUMMARY=$(remote_bash "node - <<'NODE'
+const fs = require('fs');
+const j = JSON.parse(fs.readFileSync(process.env.REMOTE_LOAD_JSON || '$REMOTE_LOAD_JSON', 'utf8'));
+const loader = j.loader || j.rendezvous;
+console.log(JSON.stringify({
+  accepted: j.accepted,
+  strategy: loader?.strategy,
+  targetPid: loader?.targetPid,
+  logPath: loader?.logPath,
+  patchState: loader?.patch?.state,
+  sourceArch: j.targetValidation?.source?.architecture,
+  targetArch: j.targetValidation?.target?.architecture,
+  patchRows: String(loader?.patch?.stdout || '').split('\n').filter((row) => row.startsWith('PATCH\t') || row.startsWith('SAFE_BOUNDARY\t')),
+}));
+NODE")
+
+ACCEPTED=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.accepted ? "1" : "0");' "$LOAD_SUMMARY")
+TARGET_PID=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.targetPid || "");' "$LOAD_SUMMARY")
+TARGET_LOG=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.logPath || "");' "$LOAD_SUMMARY")
+STRATEGY=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.strategy || "");' "$LOAD_SUMMARY")
+PATCH_STATE=$(node -e 'const s=JSON.parse(process.argv[1]); console.log(s.patchState || "");' "$LOAD_SUMMARY")
+
+if [ "$ACCEPTED" != "1" ] || [ "$STRATEGY" != "target-original-ping-direct-loader" ] || [ "$PATCH_STATE" != "ready" ]; then
+  echo "move-ping-cross-arch: load did not reach ready direct-loader state: $LOAD_SUMMARY" >&2
+  exit 1
+fi
+if ! [[ "$TARGET_PID" =~ ^[0-9]+$ ]] || [ -z "$TARGET_LOG" ]; then
+  echo "move-ping-cross-arch: load summary missing target pid/log: $LOAD_SUMMARY" >&2
+  exit 1
+fi
+
+info "==> collecting target continuation log"
+sleep 5
+remote_bash "node packages/cli/dist/cli.js exec $(q "$TGT_VM") -- $(q "kill -INT $TARGET_PID; sleep 1; cat $TARGET_LOG") > $(q "$REMOTE_LOG_TXT")"
+TARGET_OUTPUT=$(ssh "$REMOTE" "cat $(q "$REMOTE_LOG_TXT")")
+
+VERIFY_JSON=$(printf '%s' "$TARGET_OUTPUT" | node -e '
+const fs = require("fs");
+const input = fs.readFileSync(0, "utf8");
+const expected = Number(process.argv[1]);
+const seqs = [...input.matchAll(/icmp_seq=(\d+)/g)].map((m) => Number(m[1]));
+const summary = input.match(/(\d+) packets transmitted, (\d+) received/);
+const markerIndex = input.indexOf("MACHINEN_MOVE_RESUME");
+const firstSeq = seqs[0];
+const ok = markerIndex >= 0 && firstSeq === expected && !seqs.includes(1) && summary && Number(summary[1]) >= expected && Number(summary[2]) >= expected;
+console.log(JSON.stringify({ ok, marker: markerIndex >= 0, firstSeq, expectedFirstSeq: expected, seqs: seqs.slice(0, 8), transmitted: summary ? Number(summary[1]) : null, received: summary ? Number(summary[2]) : null }));
+process.exit(ok ? 0 : 1);
+' "$EXPECTED_NEXT")
+
+if [ "$JSON" = "1" ]; then
+  node - <<NODE
+const summary = $LOAD_SUMMARY;
+const verify = $VERIFY_JSON;
+const sourceState = $SOURCE_STATE_JSON;
+console.log(JSON.stringify({
+  kind: 'machinen.move-ping-cross-arch-proof',
+  state: 'passed',
+  source: { arch: 'arm64', vm: '$SRC_VM', pid: Number('$SOURCE_PID'), pingState: sourceState },
+  target: { arch: 'amd64', remote: '$REMOTE', vm: '$TGT_VM', pid: summary.targetPid, logPath: summary.logPath },
+  loader: summary,
+  continuation: verify,
+}, null, 2));
+NODE
+else
+  echo "pass: move ping arm64→amd64 direct-loader continuation"
+  echo "  source: pid=$SOURCE_PID state=$SOURCE_STATE_JSON"
+  echo "  loader: $LOAD_SUMMARY"
+  echo "  continuation: $VERIFY_JSON"
+fi


### PR DESCRIPTION
## Problem

Snapshot and restore were carrying two different stories. Some old Node "Level 5" and clean-service paths made it look like app-specific restore was still a product path, even though snapshot and restore are supposed to stay whole-VM only.

At the same time, `machinen move` could save a process shape, but it did not give a real cross-arch continuation for distro `/usr/bin/ping`.

## Solution

This PR removes the old Node/product snapshot surfaces and keeps snapshot and restore focused on whole VMs. It also makes `machinen move` save a bundle and load distro `/usr/bin/ping` into another VM with target-native state patching.

For ping, the target runs its own original `/usr/bin/ping`. The loader stops it before the first packet leaves, patches the saved counters, then resumes it so the next visible packet continues the source sequence.

## Technical Summary

- Treat snapshot/restore and move as separate product surfaces: snapshot/restore stay VM-only, while `machinen move` is the cross-ISA process movement path.
- Write move saves as bundle directories with `move.json`, native process scaffolding, active syscall plan, resource plan, and capture evidence.
- Validate target executable identity by path/package/version before load. Source and target package architectures may differ.
- Use a guest move-capture helper for safe process capture and target load. The target loader launches original distro ping, traces it to the first ICMP `sendto`, patches `ping_rts` and the outbound packet buffer, then resumes it.
- Generate ping layout metadata from Debian source/debug artifacts during rootfs build, instead of baking struct offsets into C.
- Add a repeatable proof harness for arm64 source to amd64 target ping continuation: `pnpm proof-move-ping-cross-arch`.
