### PR TITLE
Fix x64 fifth live mount and surface boot panics

### DIFF
--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -435,7 +435,10 @@ fn default_cmdline() []const u8 {
         "virtio_mmio.device=512@0x0a001000:13 " ++
         "virtio_mmio.device=512@0x0a001200:14 " ++
         "virtio_mmio.device=512@0x0a001400:15 " ++
-        "virtio_mmio.device=512@0x0a001600:16";
+        // x86 runs with `noapic`, so IRQ 16 is not routable via the
+        // legacy PIC. Use the otherwise-free COM2 line for the fifth
+        // virtio-fs slot instead of advertising an invalid GSI (#943).
+        "virtio_mmio.device=512@0x0a001600:3";
 }
 
 fn write_gdt(ram: []u8) void {
@@ -1276,7 +1279,7 @@ const IrqMap = struct {
             .balloon = 9,
             .blk3 = 10,
             .blk4 = 11,
-            .virtiofs = .{ 12, 13, 14, 15, 16 },
+            .virtiofs = .{ 12, 13, 14, 15, 3 },
         };
     }
 };
@@ -1623,4 +1626,16 @@ test "x86 cmdline advertises ttyS0, noapic, and virtio-mmio" {
     try std.testing.expect(std.mem.indexOf(u8, cmd, "console=ttyS0") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "noapic") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a000200:6") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a001600:3") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a001600:16") == null,
+    );
+}
+
+test "x86 fifth virtio-fs slot uses a legacy noapic IRQ" {
+    const irqs = IrqMap.init();
+    try std.testing.expectEqual(@as(u32, 3), irqs.virtiofs[4]);
+    for (irqs.virtiofs) |irq| {
+        try std.testing.expect(irq < 16);
+    }
 }

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -8,6 +8,7 @@
 
 import { execSync, spawn } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -32,6 +33,17 @@ import { performSnapshot } from "../vm/snapshot.ts";
 import { buildGuestHostname } from "../vm/helpers.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
+
+function writePanicVmm(path: string): void {
+  writeFileSync(
+    path,
+    "#!/bin/sh\n" +
+      "echo 'Linux version fake-test' >&2\n" +
+      "echo 'Kernel panic - not syncing: fake panic before exec-agent' >&2\n" +
+      "exit 0\n",
+  );
+  chmodSync(path, 0o755);
+}
 
 function findBootTestBinary(): string | undefined {
   const cacheDir = resolve(microvmRoot, ".zig-cache/o");
@@ -98,6 +110,38 @@ function requireFixturesOrSkip(extraPaths: string[] = []): {
 describe("boot", () => {
   it("throws BootError when the binary path does not exist", async () => {
     await expect(boot({ binary: "/nope/does/not/exist" })).rejects.toThrow(BootError);
+  });
+
+  it("surfaces early guest panic stderr during detached readiness", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-panic-vmm-"));
+    const bin = join(dir, "panic-vmm.sh");
+    try {
+      writePanicVmm(bin);
+      const err = await boot({ binary: bin, detached: true, timeoutMs: 1_000 }).catch((e) => e);
+      expect(err).toBeInstanceOf(BootError);
+      expect(err.code).toBe("BOOT_DETACHED_READINESS_FAILED");
+      expect(err.message).toContain("guest kernel panic/oops before exec-agent readiness");
+      expect(err.message).toContain("--- VMM stderr tail ---");
+      expect(err.message).toContain("Kernel panic - not syncing: fake panic before exec-agent");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds early guest panic stderr to exec-agent failures after VMM exit", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-panic-vmm-"));
+    const bin = join(dir, "panic-vmm.sh");
+    try {
+      writePanicVmm(bin);
+      const vm = await boot({ binary: bin, timeoutMs: 1_000 });
+      await expect(
+        vm.execRaw("true", { connectTimeoutMs: 500, execTimeoutMs: 500 }),
+      ).rejects.toThrow(
+        /guest kernel panic\/oops before exec-agent readiness.*Kernel panic - not syncing/s,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   // #200: the VMM was spawned without parent-death wiring, so a

--- a/packages/runtime/src/vm/boot-diagnostics.ts
+++ b/packages/runtime/src/vm/boot-diagnostics.ts
@@ -1,0 +1,95 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { ExecError } from "../errors.ts";
+import type { VmHandle } from "../vm-handle.ts";
+import { CONSOLE_TAIL_BYTES } from "./helpers.ts";
+
+type DetachedReadinessOutcome =
+  | { kind: "ready" }
+  | { kind: "exit"; lastError?: unknown }
+  | { kind: "timeout"; lastError?: unknown };
+
+export async function runVsockWithBootDiagnostics<T>(
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    if (err instanceof ExecError && (child.exitCode !== null || child.signalCode !== null)) {
+      const stderrTail = (await errorCollector).slice(-CONSOLE_TAIL_BYTES);
+      if (stderrTail) {
+        throw new ExecError(err.code, `${err.message}\n${bootStderrDiagnostic(stderrTail)}`, {
+          cause: err,
+          retryable: err.retryable,
+        });
+      }
+    }
+    throw err;
+  }
+}
+
+export async function waitForDetachedExecAgent(
+  args: {
+    child: ChildProcessWithoutNullStreams;
+    handle: VmHandle;
+  },
+  timeoutMs: number,
+): Promise<DetachedReadinessOutcome> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (args.child.exitCode !== null || args.child.signalCode !== null) {
+      return { kind: "exit", lastError };
+    }
+    const remaining = Math.max(1, deadline - Date.now());
+    try {
+      await args.handle.execRaw("true", {
+        connectTimeoutMs: Math.min(remaining, 250),
+        execTimeoutMs: Math.min(remaining, 1_000),
+      });
+      return { kind: "ready" };
+    } catch (err) {
+      lastError = err;
+      if (args.child.exitCode !== null || args.child.signalCode !== null) {
+        return { kind: "exit", lastError };
+      }
+      await delay(Math.min(Math.max(1, deadline - Date.now()), 50));
+    }
+  }
+  return { kind: "timeout", lastError };
+}
+
+export function bootStderrTail(chunks: Buffer[]): string {
+  return Buffer.concat(chunks).slice(-CONSOLE_TAIL_BYTES).toString("utf8");
+}
+
+export function bootReadinessFailureMessage(
+  prefix: string,
+  bootLogPath: string,
+  stderrTail: string,
+): string {
+  return (
+    `${prefix} ${classifyBootStderr(stderrTail)}. Boot console snapshot at ${bootLogPath}.` +
+    (stderrTail ? `\n${bootStderrDiagnostic(stderrTail)}` : "")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
+}
+
+function bootStderrDiagnostic(stderrTail: string): string {
+  return `${classifyBootStderr(stderrTail)}.\n--- VMM stderr tail ---\n${stderrTail}`;
+}
+
+function classifyBootStderr(stderrTail: string): string {
+  if (/Kernel panic - not syncing|Oops:|general protection fault/i.test(stderrTail)) {
+    return "guest kernel panic/oops before exec-agent readiness";
+  }
+  return "guest did not reach exec-agent readiness";
+}

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -21,6 +21,12 @@ import { join, resolve } from "node:path";
 import debugLib from "debug";
 
 import { readBalloonStats } from "../balloon-stats.ts";
+import {
+  bootReadinessFailureMessage,
+  bootStderrTail,
+  runVsockWithBootDiagnostics,
+  waitForDetachedExecAgent,
+} from "./boot-diagnostics.ts";
 import { bootSnapshotPath, writeBootSnapshot } from "../detached-log.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "../errors.ts";
 import { VsockExec } from "../exec.ts";
@@ -1895,8 +1901,8 @@ function createBootVmHandle(args: BootHandleArgs): VmHandle {
     detach: makeDetach(args.child),
     output: () => args.outputCollector,
     errorOutput: () => args.errorCollector,
-    exec: makeExec(args.vsockUdsPath, args.onLog),
-    execRaw: makeExecRaw(args.vsockUdsPath, args.onLog),
+    exec: makeExec(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
+    execRaw: makeExecRaw(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
     execPty: makeExecPty(args.vsockUdsPath),
     writeFile: makeWriteFile(() => handle),
     memoryStats: makeMemoryStats(args.childPid, args.statsFilePath, args.memoryCeilingMib),
@@ -1913,10 +1919,17 @@ function makeDetach(child: ChildProcessWithoutNullStreams): VmHandle["detach"] {
   };
 }
 
-function makeExec(vsockUdsPath: string | undefined, onLog: OnLog | undefined): VmHandle["exec"] {
+function makeExec(
+  vsockUdsPath: string | undefined,
+  onLog: OnLog | undefined,
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+): VmHandle["exec"] {
   return async (cmd, execOpts) => {
     const udsPath = requireVsockPath(vsockUdsPath, "exec");
-    const res = await VsockExec.run(udsPath, cmd, teeOnLog(cmd, execOpts, onLog));
+    const res = await runVsockWithBootDiagnostics(child, errorCollector, () =>
+      VsockExec.run(udsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
+    );
     if (res.exitCode !== 0) {
       throw new ExecError(
         "EXEC_NONZERO_EXIT",
@@ -1930,12 +1943,16 @@ function makeExec(vsockUdsPath: string | undefined, onLog: OnLog | undefined): V
 function makeExecRaw(
   vsockUdsPath: string | undefined,
   onLog: OnLog | undefined,
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
 ): VmHandle["execRaw"] {
   return (cmd, execOpts) => {
     if (!vsockUdsPath) {
       return Promise.reject(missingVsockError("execRaw"));
     }
-    return VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog));
+    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+      VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
+    );
   };
 }
 
@@ -2145,19 +2162,8 @@ function updateVmstateChainState(
   }
 }
 
-// #150 phase 2: detached mode blocks until the guest produces its
-// first console byte (readiness), then dumps the boot snapshot,
-// unrefs the child, and resolves. Two failure shapes to gate on:
-//
-//   - VMM dies in the readiness window. The exit hook above will
-//     have torn down per-boot disks / vsock dirs / gvproxy / cache /
-//     live mounts already; we still need to surface the failure to
-//     the caller instead of silently resolving. Snapshot whatever
-//     stderr we captured before death so a post-mortem has bytes
-//     to work with.
-//   - Readiness never arrives. Cap at `timeoutMs` (caller default
-//     60s, CLI passes null for interactive boots — but `--detached`
-//     forces a finite wait so the CLI can exit cleanly).
+// #150/#944: detached mode waits for exec-agent readiness, not just
+// the first console byte, so early guest panics become BootErrors.
 async function gateOnDetachedReadiness(args: {
   child: ChildProcessWithoutNullStreams;
   timeoutMs: number | null;
@@ -2166,47 +2172,32 @@ async function gateOnDetachedReadiness(args: {
   handle: VmHandle;
 }): Promise<void> {
   const readinessTimeoutMs = args.timeoutMs ?? 60_000;
-  let onByte: (() => void) | null = null;
-  let onExit: (() => void) | null = null;
-  const readiness = new Promise<"ready" | "exit">((resolve) => {
-    onByte = () => resolve("ready");
-    onExit = () => resolve("exit");
-    args.child.stderr.once("data", onByte);
-    args.child.once("exit", onExit);
-  });
-  const timeoutP = new Promise<"timeout">((resolve) => {
-    setTimeout(() => resolve("timeout"), readinessTimeoutMs).unref();
-  });
-  const outcome = await Promise.race([readiness, timeoutP]);
-  // Cleanup whichever listeners didn't fire so a throw below doesn't
-  // leave orphaned handlers holding the event loop.
-  if (onByte) {
-    args.child.stderr.removeListener("data", onByte);
-  }
-  if (onExit) {
-    args.child.removeListener("exit", onExit);
-  }
-  // Always dump whatever stderr we have so far — failure paths
-  // benefit from the snapshot more than success paths do.
-  writeBootSnapshot(args.bootLogPath, Buffer.concat(args.detachedBootChunks).toString("utf8"));
-  if (outcome === "exit") {
+  const outcome = await waitForDetachedExecAgent(args, readinessTimeoutMs);
+  const stderrTail = bootStderrTail(args.detachedBootChunks);
+  writeBootSnapshot(args.bootLogPath, stderrTail);
+  if (outcome.kind === "exit") {
     throw new BootError(
       "BOOT_DETACHED_READINESS_FAILED",
-      `boot --detached: VMM exited before readiness (code=${args.child.exitCode} signal=${args.child.signalCode}). ` +
-        `Boot console snapshot at ${args.bootLogPath}`,
+      bootReadinessFailureMessage(
+        `boot --detached: VMM exited before exec-agent readiness (code=${args.child.exitCode} signal=${args.child.signalCode}).`,
+        args.bootLogPath,
+        stderrTail,
+      ),
+      { cause: outcome.lastError },
     );
   }
-  if (outcome === "timeout") {
-    // The VMM is still alive but never wrote a console byte. Kill
-    // it (parent still holds the pdeathsig-less child handle) so
-    // we don't leave an orphan after throwing.
+  if (outcome.kind === "timeout") {
     try {
       args.child.kill("SIGTERM");
     } catch {}
     throw new BootError(
       "BOOT_DETACHED_READINESS_FAILED",
-      `boot --detached: VMM did not signal readiness within ${readinessTimeoutMs}ms. ` +
-        `Boot console snapshot at ${args.bootLogPath}`,
+      bootReadinessFailureMessage(
+        `boot --detached: exec-agent did not become reachable within ${readinessTimeoutMs}ms.`,
+        args.bootLogPath,
+        stderrTail,
+      ),
+      { cause: outcome.lastError },
     );
   }
   // Ready. Stop accumulating stderr — the snapshot is already on

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -226,7 +226,7 @@ zig cc "${ASSETS}/move-capture.c" \
   -o "${STAGE}/move-capture"
 
 zig cc "${ASSETS}/vmstate-reseed.c" \
-  -target aarch64-linux-musl \
+  -target "${ZIG_GUEST_TARGET}" \
   -static \
   -Os \
   -o "${STAGE}/vmstate-reseed"


### PR DESCRIPTION
## Problem

On x64 Linux, a Machinen VM could boot with four live mounts but panic when a fifth live mount was added. The useful kernel panic was also hidden in normal output, so users saw vague errors like the exec agent never became ready.

A full smoke run also found that the amd64 base image had an arm64 `machinen-vmstate-reseed` helper. That made restore-time entropy reseeding fail with an exec format error.

## Solution

The fifth x64 live mount now uses an IRQ that works with the `noapic` boot mode. Early guest panics now produce a clear boot error with the last VMM stderr lines attached, even without `DEBUG=machinen:*`.

The base asset build now compiles `machinen-vmstate-reseed` for the selected guest target, instead of always building it for arm64.

Fixes #943.
Fixes #944.

## Technical Summary

- Keep x64 KVM on legacy-PIC-safe IRQs while `noapic` is enabled. The fifth virtio-fs slot moves from IRQ 16 to IRQ 3, and tests guard that virtio-fs IRQs stay below 16.
- Treat exec-agent readiness as the real detached boot readiness signal. A first byte on stderr is not enough, because that can be an early panic.
- Put boot panic classification and stderr-tail formatting in a small helper module. This keeps `boot.ts` focused on boot flow while preserving clear user-facing errors.
- Add diagnostics to early exec-agent failures after the VMM exits, so users get the kernel panic text instead of only a vsock or exec-agent error.
- Build `vmstate-reseed` with `${ZIG_GUEST_TARGET}` so amd64 and arm64 base images each get a runnable guest helper.