### PR TITLE
Add changeset for x64 live mount fix

### DIFF
--- a/.changeset/fix-x64-live-mounts-boot-panics.md
+++ b/.changeset/fix-x64-live-mounts-boot-panics.md
@@ -1,0 +1,11 @@
+---
+"@machinen/runtime": patch
+"@machinen/microvm": patch
+"@machinen/native-x64-linux": patch
+---
+
+Fix x64 Linux VMs booting with a fifth live mount by keeping virtio-fs IRQs valid under `noapic`.
+
+Surface early guest kernel panics in boot errors by including a bounded VMM stderr tail and panic/oops classification.
+
+Build the vmstate entropy reseed helper for the selected guest target so amd64 base assets do not receive an arm64 helper.


### PR DESCRIPTION
## Problem

PR #945 fixed real user-facing bugs, but it merged without a changeset. That means the next release would not clearly tell users what changed.

## Solution

This PR adds a changeset for the x64 live mount fix, the early boot panic diagnostics, and the vmstate reseed helper build fix. The next release will include those notes in the package changelog.

## Technical Summary

- Mark `@machinen/runtime`, `@machinen/microvm`, and `@machinen/native-x64-linux` for a patch release because the merged fix changes runtime behavior and the x64 VMM package.
- Keep this PR to metadata only. It does not change the code that already landed in #945.
- Mention the amd64 `vmstate-reseed` target fix because it affects generated base assets and was required for full smoke to pass.
