### PR TITLE
Add goal-driven memory resources

### DIFF
--- a/.changeset/elastic-memory-guide.md
+++ b/.changeset/elastic-memory-guide.md
@@ -1,0 +1,7 @@
+---
+"@machinen/runtime": minor
+---
+
+Add goal-driven VM memory resources via `boot({ resources: { memory: { maxMib, reclaim: "auto" } } })`, keep `memory` as a compatibility alias, and expose `memoryStats().balloonReclaimedBytes` as the clearer free-page-reporting reclaim counter.
+
+Document the user-facing memory model with a simple guide covering ceiling versus host footprint, lazy grow-on-touch allocation, balloon reclaim, and the macOS `phys_footprint` caveat.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Then dive deeper:
 - [Hand off a running VM](./guides/handoff.md) — snapshot → transfer → restore
 - [Snapshot, restore, and fork](./guides/snapshot-restore-fork.md) — clone a running process, including vmstate timer, entropy, and socket contracts
 - [Mount files into a VM](./guides/mount-files.md) — `--mount`, `--mount-live`, `vm.writeFile`
+- [Memory in machinen](./guides/memory.md) — ceiling vs host footprint, grow-on-touch, and reclaim
 - [Networking](./guides/networking.md) — port forwards and outbound traffic via gvproxy
 - [Nested virtualization](./guides/nested-virtualization.md) — opt-in `/dev/kvm` inside a VM
 - [Run Firecracker inside machinen](./guides/firecracker.md) — boot an aarch64 L2 microVM with nested KVM

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -1,0 +1,178 @@
+# Memory in machinen
+
+Machinen memory has two different numbers that are easy to mix up:
+
+1. **Capacity ceiling** — how much RAM the guest is allowed to use.
+2. **Host footprint** — how much memory the VM is actually costing the host right now.
+
+The important model is:
+
+> Give the guest room to grow, but only pay host memory for pages the guest really touches and still needs.
+
+## The API
+
+For new code, describe memory as a resource goal:
+
+```ts
+import { boot } from "@machinen/runtime";
+
+const vm = await boot({
+  resources: {
+    memory: {
+      maxMib: 4096,
+      reclaim: "auto",
+    },
+  },
+});
+```
+
+- `maxMib` is the guest-visible RAM ceiling.
+- `reclaim: "auto"` lets the guest report free pages so machinen can return them to the host.
+
+The older shorthand still works:
+
+```ts
+await boot({ memory: 4096 });
+```
+
+Treat `memory` as a compatibility/debug alias for `resources.memory.maxMib`.
+
+## Ceiling is not reservation
+
+If you boot with `maxMib: 4096`, the guest sees roughly a 4 GiB machine.
+That does **not** mean the host immediately loses 4 GiB of RAM.
+
+Machinen maps guest RAM lazily. At boot, the host creates a large address range, but physical host pages are committed only when the guest writes to them.
+
+So a VM can have:
+
+```txt
+ceiling:       4096 MiB
+host footprint: ~150 MiB after boot
+```
+
+Those numbers are normal together. The first number is capacity. The second number is current cost.
+
+## Why the boot footprint is not tiny
+
+A fresh VM is not empty. Even before your app runs, memory is used by:
+
+- the guest Linux kernel,
+- kernel metadata for the configured RAM ceiling,
+- page tables,
+- virtio devices,
+- early userspace and the exec agent,
+- root filesystem setup and caches,
+- the host VMM process itself.
+
+In recent local measurements, a 4 GiB-ceiling Linux VM started around **150 MiB** of host footprint after boot/reclaim. That is much smaller than 4 GiB, but it is not single-digit MiB.
+
+## Grow on touch
+
+Host footprint grows when the guest touches memory.
+
+Example shape:
+
+```txt
+boot:             ~153 MiB host footprint
+write 1 GiB file: ~1200 MiB host footprint
+```
+
+The guest wrote pages, so the host had to back them with real memory.
+
+## Shrink through balloon reporting
+
+The host cannot automatically know which guest pages are free. The guest kernel has to tell machinen.
+
+Machinen uses virtio-balloon free-page reporting:
+
+1. Your workload frees memory or deletes files.
+2. The guest kernel marks pages free.
+3. The balloon driver reports free page ranges to the VMM.
+4. The VMM calls `madvise` so the host can drop those pages.
+
+Example shape:
+
+```txt
+boot:               ~153 MiB
+post allocation:   ~1200 MiB
+post free/reclaim:  ~164 MiB
+```
+
+Temporary spikes should not become the long-term footprint once the guest frees the memory and reporting runs.
+
+## Reading memory stats
+
+Use `vm.memoryStats()`:
+
+```ts
+const stats = await vm.memoryStats();
+
+console.log({
+  ceilingMib: stats.ceilingMib,
+  hostMib: stats.hostRssBytes == null ? null : stats.hostRssBytes / 1024 / 1024,
+  reclaimedMib: stats.balloonReclaimedBytes / 1024 / 1024,
+});
+```
+
+Fields to care about:
+
+- `ceilingMib` — configured guest capacity.
+- `hostRssBytes` — current host footprint.
+- `balloonReclaimedBytes` — bytes returned through balloon reporting.
+
+`balloonInflatedBytes` is still present as an older alias for `balloonReclaimedBytes`.
+
+You can also inspect running VMs with:
+
+```sh
+machinen ls --json
+```
+
+## Choosing a memory value
+
+Use a ceiling that is comfortably above your workload's expected peak.
+
+For example:
+
+```ts
+await boot({
+  resources: {
+    memory: {
+      maxMib: 4096,
+      reclaim: "auto",
+    },
+  },
+});
+```
+
+This means:
+
+- the guest can grow up to about 4 GiB,
+- the host does not reserve 4 GiB up front,
+- memory touched during a spike can be reclaimed after the guest frees it.
+
+Do not set the ceiling infinitely high. Larger ceilings still add some guest kernel metadata and increase the possible high-water mark.
+
+## Platform caveat: macOS RSS
+
+On Linux, host footprint is read from `/proc/<pid>/status:VmRSS`.
+
+On macOS, `ps rss` can stay high after reclaim because `MADV_FREE_REUSABLE` pages remain in the resident-size accounting until the kernel is under pressure. Machinen therefore prefers the VMM's sampled `phys_footprint`, which drops when pages become reusable.
+
+So for machinen, trust `vm.memoryStats().hostRssBytes` over raw `ps` output on macOS.
+
+## Mental model
+
+Think of machinen memory like a sparse file:
+
+- The file can have a large maximum size.
+- Empty regions cost almost nothing.
+- Written regions cost real storage.
+- Deleted/free regions can be punched out and returned.
+
+For VMs:
+
+- `maxMib` is the maximum size.
+- touched guest pages are the written regions.
+- balloon-reported pages are the punched-out regions.

--- a/packages/microvm/docs/memory.md
+++ b/packages/microvm/docs/memory.md
@@ -1,8 +1,48 @@
 # microvm memory — host RSS and the guest RAM ceiling
 
-How guest RAM is allocated, what the configured `ram_size` actually
-costs the host, and what it would take to make the host footprint
-shrink as well as grow.
+How guest RAM is allocated, what the configured ceiling actually
+costs the host, and how the host footprint shrinks as well as grows.
+
+## User model: capacity without up-front reservation
+
+Use `resources.memory` when you want to state memory as a resource goal:
+
+```ts
+await boot({
+  resources: {
+    memory: {
+      maxMib: 4096,
+      reclaim: "auto",
+    },
+  },
+});
+```
+
+- `maxMib` is the guest-visible RAM ceiling. The guest can grow into
+  this capacity, but the host does not reserve the full ceiling as RSS
+  at boot.
+- `reclaim: "auto"` uses Machinen's always-on virtio-balloon
+  free-page-reporting path. When the guest frees pages and Linux
+  reports those free runs, the VMM calls `madvise` so the host can stop
+  charging those pages to the VM footprint.
+- `memory: 4096` remains a compatibility/debug alias for
+  `resources.memory.maxMib`; prefer the resource shape in user-facing
+  code and docs.
+
+`vm.memoryStats()` reports the pieces users should compare:
+
+- `ceilingMib` — the configured capacity ceiling.
+- `hostRssBytes` — the host footprint currently charged to the VMM
+  (`phys_footprint` on Darwin when available, VmRSS on Linux).
+- `balloonReclaimedBytes` — bytes returned through balloon
+  free-page-reporting. `balloonInflatedBytes` is kept as an old-name
+  alias for the same counter.
+
+The product promise is not "idle VMs always reach single-digit MiB".
+Kernel metadata, page tables, device buffers, and the guest's active
+working set still cost memory. The promise is: a large ceiling provides
+room to grow without reserving that ceiling up front, and temporary
+spikes can be reclaimed after the guest frees pages and reports them.
 
 ## What `ram_size` is
 
@@ -212,9 +252,11 @@ removing it would re-introduce the trap.
 - The ceiling is approximately free until touched, on both backends.
   Setting it too low caps real workloads; setting it too high costs
   only some address-space VSZ and a bit of kernel-side bookkeeping.
-- Be wary of the high-water mark: long-lived VMs that briefly spike
-  to N MiB will hold N MiB of RSS until they exit. Without a
-  balloon, sizing for the spike means paying for the spike forever.
+- Be aware of the high-water mark: long-lived VMs that briefly spike
+  to N MiB will hold that RSS until the guest frees those pages and
+  the balloon reports them. With `reclaim: "auto"`, the VMM can return
+  reported free pages to the host; without guest cooperation, the spike
+  remains charged until exit.
 - 16 KiB page granularity on Apple Silicon means RSS moves in 16 KiB
   steps; small allocations round up.
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -345,6 +345,8 @@
 
 - [`boot`](#boot)
 - [`BootOptions`](#bootoptions)
+- [`BootResourcesOptions`](#bootresourcesoptions)
+- [`BootMemoryResourceOptions`](#bootmemoryresourceoptions)
 - [`attach`](#attach)
 - [`AttachOptions`](#attachoptions)
 - [`bootPty`](#bootpty)
@@ -16865,8 +16867,9 @@ Supported on both boot-owned and attach handles.
 
 Read the host's view of this VM's memory: the ceiling the VMM was
 sized at, the host RSS the VMM is currently holding, the bytes
-the virtio-balloon device has reported back to the host, and the
-count of lazy-restore pages the guest hasn't faulted in yet (#274).
+the virtio-balloon device has reclaimed through free-page reporting,
+and the count of lazy-restore pages the guest hasn't faulted in yet
+(#274).
 
 Pure read, no side effects. The numbers come from:
   - `ceiling`           — captured at boot from the resolved
@@ -16875,12 +16878,12 @@ Pure read, no side effects. The numbers come from:
   - `hostRss`           — `/proc/<vmm>/status:VmRSS` on Linux,
                            `ps -o rss=` on Darwin. May be `null`
                            if the VMM exited between calls.
-  - `balloonInflated`   — running total of bytes the balloon
+  - `balloonReclaimed`  — running total of bytes the balloon
                            device has reclaimed via free-page
-                           reporting (`mmap MAP_FIXED` on the
-                           reported runs). Read out of the shared
-                           stats file the VMM mmaps at startup.
-                           `0` when the VMM was launched without
+                           reporting (`madvise` on the reported
+                           runs). Read out of the shared stats file
+                           the VMM mmaps at startup. `0` when the
+                           VMM was launched without
                            `MACHINEN_STATS_FILE`.
   - `lazyPagesPending`  — for forks restored lazily (#266), the
                            count of pages the rewriter marked
@@ -16955,9 +16958,9 @@ Resident bytes the host kernel sees the VMM holding. `null`
 when the VMM has exited or `/proc/<pid>/status` / `ps` couldn't
 be read.
 
-##### balloonInflatedBytes
+##### balloonReclaimedBytes
 
-> **balloonInflatedBytes**: `number`
+> **balloonReclaimedBytes**: `number`
 
 Bytes the virtio-balloon device has reclaimed via free-page
 reporting since the VMM started. Strictly increases over the
@@ -16965,6 +16968,14 @@ VMM's lifetime; if `hostRssBytes` is well below ceiling, balloon
 reclaim is the reason. Read out of the shared stats file the VMM
 writes via `MACHINEN_STATS_FILE`. `0` when the VMM was launched
 without that env var.
+
+##### balloonInflatedBytes
+
+> **balloonInflatedBytes**: `number`
+
+Compatibility alias for `balloonReclaimedBytes`. The old name came
+from classic inflate/deflate balloon terminology, but Machinen uses
+free-page reporting for reclaim.
 
 ##### lazyPagesPending
 
@@ -17758,21 +17769,23 @@ authoritative.
 
 [`BootOptions`](#bootoptions).[`nested`](#nested-2)
 
+##### resources?
+
+> `optional` **resources?**: [`BootResourcesOptions`](#bootresourcesoptions)
+
+Explicit resource goals for the VM. Prefer this for user-facing memory policy.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`resources`](#resources-13)
+
 ##### memory?
 
 > `optional` **memory?**: `number`
 
-Guest RAM ceiling, in MiB (decimal integer; no unit suffixes). The
-VMM reads this as `MACHINEN_MEMORY` (#263 phase A). This is the
-guest's memory layout limit, not the host memory used right now.
-Defaults to `min(host_ram_mib / 2, 4096)` with a floor of 512 — a
-modest ceiling for typical dev workloads. The ceiling is
-approximately free until the guest touches a page (see
-`packages/microvm/docs/memory.md`), but a bigger ceiling still
-increases guest metadata and the possible high-water mark.
-
-This is documented as a debug knob — most workloads should never
-need to set it.
+Compatibility alias for `resources.memory.maxMib`, in MiB. This is
+a guest-visible ceiling, not current host RSS; prefer
+`resources.memory` for user-facing policy.
 
 ###### Inherited from
 
@@ -18182,21 +18195,19 @@ When set, the runtime does a best-effort host preflight and passes
 `MACHINEN_NESTED=1` to the VMM. The VMM's backend probe is still
 authoritative.
 
+##### resources?
+
+> `optional` **resources?**: [`BootResourcesOptions`](#bootresourcesoptions)
+
+Explicit resource goals for the VM. Prefer this for user-facing memory policy.
+
 ##### memory?
 
 > `optional` **memory?**: `number`
 
-Guest RAM ceiling, in MiB (decimal integer; no unit suffixes). The
-VMM reads this as `MACHINEN_MEMORY` (#263 phase A). This is the
-guest's memory layout limit, not the host memory used right now.
-Defaults to `min(host_ram_mib / 2, 4096)` with a floor of 512 — a
-modest ceiling for typical dev workloads. The ceiling is
-approximately free until the guest touches a page (see
-`packages/microvm/docs/memory.md`), but a bigger ceiling still
-increases guest metadata and the possible high-water mark.
-
-This is documented as a debug knob — most workloads should never
-need to set it.
+Compatibility alias for `resources.memory.maxMib`, in MiB. This is
+a guest-visible ceiling, not current host RSS; prefer
+`resources.memory` for user-facing policy.
 
 ##### pdeathsig?
 
@@ -18260,6 +18271,39 @@ hook. After detach the parent is gone, so those leak until
 
 Reattach with `attach({ name | pid })` from another process —
 the registry entry stays live, the vsock UDS is still listening.
+
+***
+
+### BootResourcesOptions
+
+#### Properties
+
+##### memory?
+
+> `optional` **memory?**: [`BootMemoryResourceOptions`](#bootmemoryresourceoptions)
+
+Goal-driven memory policy: a fixed guest-visible ceiling whose host
+footprint grows on touched pages and shrinks through balloon free-
+page reporting.
+
+***
+
+### BootMemoryResourceOptions
+
+#### Properties
+
+##### maxMib
+
+> **maxMib**: `number`
+
+Guest-visible RAM ceiling in MiB.
+
+##### reclaim?
+
+> `optional` **reclaim?**: `"auto"`
+
+Reclaim policy for guest-free pages. `auto` uses the always-present
+virtio-balloon free-page-reporting path.
 
 ***
 
@@ -18576,21 +18620,23 @@ authoritative.
 
 [`BootOptions`](#bootoptions).[`nested`](#nested-2)
 
+##### resources?
+
+> `optional` **resources?**: [`BootResourcesOptions`](#bootresourcesoptions)
+
+Explicit resource goals for the VM. Prefer this for user-facing memory policy.
+
+###### Inherited from
+
+[`BootOptions`](#bootoptions).[`resources`](#resources-13)
+
 ##### memory?
 
 > `optional` **memory?**: `number`
 
-Guest RAM ceiling, in MiB (decimal integer; no unit suffixes). The
-VMM reads this as `MACHINEN_MEMORY` (#263 phase A). This is the
-guest's memory layout limit, not the host memory used right now.
-Defaults to `min(host_ram_mib / 2, 4096)` with a floor of 512 — a
-modest ceiling for typical dev workloads. The ceiling is
-approximately free until the guest touches a page (see
-`packages/microvm/docs/memory.md`), but a bigger ceiling still
-increases guest metadata and the possible high-water mark.
-
-This is documented as a debug knob — most workloads should never
-need to set it.
+Compatibility alias for `resources.memory.maxMib`, in MiB. This is
+a guest-visible ceiling, not current host RSS; prefer
+`resources.memory` for user-facing policy.
 
 ###### Inherited from
 
@@ -25977,6 +26023,30 @@ the guest agent skips entries that don't match.
 ###### mib
 
 `number`
+
+###### Returns
+
+`number`
+
+##### resolveMemoryCeilingMib
+
+> **resolveMemoryCeilingMib**: (`opts`, `autoSize`) => `number` = `_resolveMemoryCeilingMib`
+
+###### Parameters
+
+###### opts
+
+###### memory?
+
+`number`
+
+###### resources?
+
+[`BootResourcesOptions`](#bootresourcesoptions)
+
+###### autoSize?
+
+() => `number`
 
 ###### Returns
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -3,10 +3,20 @@
 // the guest actually see N MiB?" check lives in the smoke suite —
 // this file just covers the policy + validation logic.
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { _internal, autoSizeMemoryMib, BootError } from "../index.ts";
+import {
+  _internal,
+  attach,
+  autoSizeMemoryMib,
+  boot,
+  BootError,
+  STATS_FILE_SIZE,
+} from "../index.ts";
 
-const { validateMemoryMib } = _internal;
+const { resolveMemoryCeilingMib, validateMemoryMib } = _internal;
 
 describe("autoSizeMemoryMib", () => {
   it("uses a modest 4 GiB ceiling for normal desktops", () => {
@@ -34,6 +44,94 @@ describe("autoSizeMemoryMib", () => {
     expect(autoSizeMemoryMib(512 * 1024 * 1024)).toBe(512);
     expect(autoSizeMemoryMib(256 * 1024 * 1024)).toBe(512);
     expect(autoSizeMemoryMib(0)).toBe(512);
+  });
+});
+
+describe("resolveMemoryCeilingMib", () => {
+  it("uses resources.memory.maxMib as the canonical ceiling", () => {
+    expect(
+      resolveMemoryCeilingMib(
+        { resources: { memory: { maxMib: 4096, reclaim: "auto" } } },
+        () => 1024,
+      ),
+    ).toBe(4096);
+  });
+
+  it("keeps boot({ memory }) as a compatibility alias", () => {
+    expect(resolveMemoryCeilingMib({ memory: 2048 }, () => 1024)).toBe(2048);
+  });
+
+  it("allows matching memory and resources.memory.maxMib values", () => {
+    expect(
+      resolveMemoryCeilingMib(
+        { memory: 2048, resources: { memory: { maxMib: 2048, reclaim: "auto" } } },
+        () => 1024,
+      ),
+    ).toBe(2048);
+  });
+
+  it("rejects conflicting memory aliases", () => {
+    expect(() =>
+      resolveMemoryCeilingMib(
+        { memory: 1024, resources: { memory: { maxMib: 2048, reclaim: "auto" } } },
+        () => 1024,
+      ),
+    ).toThrow(/conflicts/);
+  });
+
+  it("rejects unsupported reclaim policies", () => {
+    expect(() =>
+      resolveMemoryCeilingMib(
+        { resources: { memory: { maxMib: 2048, reclaim: "manual" as "auto" } } },
+        () => 1024,
+      ),
+    ).toThrow(/resources\.memory\.reclaim must be "auto"/);
+  });
+
+  it("falls back to auto sizing when no explicit ceiling is set", () => {
+    expect(resolveMemoryCeilingMib({}, () => 1536)).toBe(1536);
+  });
+});
+
+describe("memoryStats", () => {
+  it("reports the reclaimed-by-balloon counter on boot and attach handles", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-memory-stats-test-"));
+    const priorRegistryDir = process.env.MACHINEN_REGISTRY_DIR;
+    process.env.MACHINEN_REGISTRY_DIR = join(dir, "registry");
+    const statsPath = join(dir, "stats.bin");
+    const stats = Buffer.alloc(STATS_FILE_SIZE);
+    stats.writeBigUInt64LE(123_456n, 0);
+    writeFileSync(statsPath, stats);
+
+    const vm = await boot({
+      binary: "/bin/sleep",
+      args: ["10"],
+      resources: { memory: { maxMib: 1024, reclaim: "auto" } },
+      vmmEnv: { MACHINEN_STATS_FILE: statsPath },
+      timeoutMs: 5_000,
+    });
+    try {
+      const bootStats = await vm.memoryStats();
+      expect(bootStats.ceilingMib).toBe(1024);
+      expect(bootStats.hostRssBytes).toBeGreaterThan(0);
+      expect(bootStats.balloonReclaimedBytes).toBe(123_456);
+      expect(bootStats.balloonInflatedBytes).toBe(123_456);
+
+      const attached = await attach({ pid: vm.pid });
+      const attachStats = await attached.memoryStats();
+      expect(attachStats.ceilingMib).toBe(1024);
+      expect(attachStats.hostRssBytes).toBeGreaterThan(0);
+      expect(attachStats.balloonReclaimedBytes).toBe(123_456);
+      expect(attachStats.balloonInflatedBytes).toBe(123_456);
+    } finally {
+      await vm.kill();
+      if (priorRegistryDir === undefined) {
+        delete process.env.MACHINEN_REGISTRY_DIR;
+      } else {
+        process.env.MACHINEN_REGISTRY_DIR = priorRegistryDir;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1226,7 +1226,14 @@ export {
   restore,
 } from "./vm/index.ts";
 export { warmImageConfigCache } from "./vm/index.ts";
-export type { AttachOptions, BootOptions, ImageConfig, RestoreOptions } from "./vm/index.ts";
+export type {
+  AttachOptions,
+  BootMemoryResourceOptions,
+  BootOptions,
+  BootResourcesOptions,
+  ImageConfig,
+  RestoreOptions,
+} from "./vm/index.ts";
 export {
   checkForkBackpressure,
   DEFAULT_FREE_MEMORY_THRESHOLD,

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -142,8 +142,9 @@ export interface VmHandle {
   /**
    * Read the host's view of this VM's memory: the ceiling the VMM was
    * sized at, the host RSS the VMM is currently holding, the bytes
-   * the virtio-balloon device has reported back to the host, and the
-   * count of lazy-restore pages the guest hasn't faulted in yet (#274).
+   * the virtio-balloon device has reclaimed through free-page reporting,
+   * and the count of lazy-restore pages the guest hasn't faulted in yet
+   * (#274).
    *
    * Pure read, no side effects. The numbers come from:
    *   - `ceiling`           — captured at boot from the resolved
@@ -152,12 +153,12 @@ export interface VmHandle {
    *   - `hostRss`           — `/proc/<vmm>/status:VmRSS` on Linux,
    *                            `ps -o rss=` on Darwin. May be `null`
    *                            if the VMM exited between calls.
-   *   - `balloonInflated`   — running total of bytes the balloon
+   *   - `balloonReclaimed`  — running total of bytes the balloon
    *                            device has reclaimed via free-page
-   *                            reporting (`mmap MAP_FIXED` on the
-   *                            reported runs). Read out of the shared
-   *                            stats file the VMM mmaps at startup.
-   *                            `0` when the VMM was launched without
+   *                            reporting (`madvise` on the reported
+   *                            runs). Read out of the shared stats file
+   *                            the VMM mmaps at startup. `0` when the
+   *                            VMM was launched without
    *                            `MACHINEN_STATS_FILE`.
    *   - `lazyPagesPending`  — for forks restored lazily (#266), the
    *                            count of pages the rewriter marked
@@ -219,6 +220,12 @@ export interface MemoryStats {
    * reclaim is the reason. Read out of the shared stats file the VMM
    * writes via `MACHINEN_STATS_FILE`. `0` when the VMM was launched
    * without that env var.
+   */
+  balloonReclaimedBytes: number;
+  /**
+   * Compatibility alias for `balloonReclaimedBytes`. The old name came
+   * from classic inflate/deflate balloon terminology, but Machinen uses
+   * free-page reporting for reclaim.
    */
   balloonInflatedBytes: number;
   /**

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -151,10 +151,12 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
 
     async memoryStats(): Promise<MemoryStats> {
       const balloon = entry.statsPath ? readBalloonStats(entry.statsPath) : null;
+      const balloonReclaimedBytes = balloon?.bytesReported ?? 0;
       return {
         ceilingMib: entry.memoryCeilingMib ?? null,
         hostRssBytes: readHostRssBytes(entry.pid, entry.statsPath),
-        balloonInflatedBytes: balloon?.bytesReported ?? 0,
+        balloonReclaimedBytes,
+        balloonInflatedBytes: balloonReclaimedBytes,
         lazyPagesPending: 0,
       };
     },

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { claimName, findEntry, removeEntry, writeEntry } from "../registry.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
 import { resolveLiveMounts, type ResolvedLiveMount, synthesizeAndPackBundle } from "./bundle.ts";
 import { performForkWithRestore } from "./fork-core.ts";
+import { resolveExplicitMemoryCeilingMib, type BootResourcesOptions } from "./memory-resources.ts";
 import type { VmHandle } from "../vm-handle.ts";
 import {
   allocateSparseFile,
@@ -67,7 +68,6 @@ import {
   setGuestHostname,
   SNAP_SCRATCH_BYTES,
   teeOnLog,
-  validateMemoryMib,
 } from "./helpers.ts";
 import { performSnapshot, type SnapshotContext } from "./snapshot.ts";
 import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
@@ -339,18 +339,12 @@ export interface BootOptions {
    * authoritative.
    */
   nested?: boolean;
+  /** Explicit resource goals for the VM. Prefer this for user-facing memory policy. */
+  resources?: BootResourcesOptions;
   /**
-   * Guest RAM ceiling, in MiB (decimal integer; no unit suffixes). The
-   * VMM reads this as `MACHINEN_MEMORY` (#263 phase A). This is the
-   * guest's memory layout limit, not the host memory used right now.
-   * Defaults to `min(host_ram_mib / 2, 4096)` with a floor of 512 — a
-   * modest ceiling for typical dev workloads. The ceiling is
-   * approximately free until the guest touches a page (see
-   * `packages/microvm/docs/memory.md`), but a bigger ceiling still
-   * increases guest metadata and the possible high-water mark.
-   *
-   * This is documented as a debug knob — most workloads should never
-   * need to set it.
+   * Compatibility alias for `resources.memory.maxMib`, in MiB. This is
+   * a guest-visible ceiling, not current host RSS; prefer
+   * `resources.memory` for user-facing policy.
    */
   memory?: number;
   /**
@@ -1224,10 +1218,12 @@ function runtimeEntryImportPath(): string {
 }
 
 function setMemoryCeiling(opts: BootOptions, env: Record<string, string>): number | undefined {
+  // Validate public API input even when lower-level vmmEnv wins.
+  const explicitCeiling = resolveExplicitMemoryCeilingMib(opts);
   if (env.MACHINEN_MEMORY !== undefined) {
     return undefined;
   }
-  const ceiling = opts.memory !== undefined ? validateMemoryMib(opts.memory) : autoSizeMemoryMib();
+  const ceiling = explicitCeiling ?? autoSizeMemoryMib();
   env.MACHINEN_MEMORY = String(ceiling);
   return ceiling;
 }
@@ -2004,10 +2000,12 @@ function makeMemoryStats(
   return async () => {
     const balloon = statsFilePath ? readBalloonStats(statsFilePath) : null;
     const lazyTotal = findEntry({ pid: childPid })?.lazyPagesTotal ?? 0;
+    const balloonReclaimedBytes = balloon?.bytesReported ?? 0;
     return {
       ceilingMib: memoryCeilingMib ?? null,
       hostRssBytes: readHostRssBytes(childPid, statsFilePath),
-      balloonInflatedBytes: balloon?.bytesReported ?? 0,
+      balloonReclaimedBytes,
+      balloonInflatedBytes: balloonReclaimedBytes,
       lazyPagesPending: lazyTotal,
     };
   };

--- a/packages/runtime/src/vm/index.ts
+++ b/packages/runtime/src/vm/index.ts
@@ -32,6 +32,7 @@
 
 export { attach, type AttachOptions } from "./attach.ts";
 export { boot, type BootOptions } from "./boot.ts";
+export type { BootMemoryResourceOptions, BootResourcesOptions } from "./memory-resources.ts";
 export { buildMachinenConfig, resolveRestoreLiveMounts } from "./bundle.ts";
 export { measureFirstByte } from "./fork.ts";
 export {
@@ -48,10 +49,12 @@ import {
   CONSOLE_TAIL_BYTES as _CONSOLE_TAIL_BYTES,
   validateMemoryMib as _validateMemoryMib,
 } from "./helpers.ts";
+import { resolveMemoryCeilingMib as _resolveMemoryCeilingMib } from "./memory-resources.ts";
 
 // Visible to tests that exercise the ring-buffer logic without booting a VM.
 export const _internal = {
   collect: _collect,
   CONSOLE_TAIL_BYTES: _CONSOLE_TAIL_BYTES,
   validateMemoryMib: _validateMemoryMib,
+  resolveMemoryCeilingMib: _resolveMemoryCeilingMib,
 };

--- a/packages/runtime/src/vm/memory-resources.ts
+++ b/packages/runtime/src/vm/memory-resources.ts
@@ -1,0 +1,69 @@
+import { BootError } from "../errors.ts";
+import { autoSizeMemoryMib, validateMemoryMib } from "./helpers.ts";
+
+export interface BootResourcesOptions {
+  /**
+   * Goal-driven memory policy: a fixed guest-visible ceiling whose host
+   * footprint grows on touched pages and shrinks through balloon free-
+   * page reporting.
+   */
+  memory?: BootMemoryResourceOptions;
+}
+
+export interface BootMemoryResourceOptions {
+  /** Guest-visible RAM ceiling in MiB. */
+  maxMib: number;
+  /**
+   * Reclaim policy for guest-free pages. `auto` uses the always-present
+   * virtio-balloon free-page-reporting path.
+   */
+  reclaim?: "auto";
+}
+
+type MemoryCeilingInput = {
+  memory?: number;
+  resources?: BootResourcesOptions;
+};
+
+export function resolveMemoryCeilingMib(
+  opts: { memory?: number; resources?: BootResourcesOptions },
+  autoSize: () => number = autoSizeMemoryMib,
+): number {
+  return resolveExplicitMemoryCeilingMib(opts) ?? autoSize();
+}
+
+export function resolveExplicitMemoryCeilingMib(opts: MemoryCeilingInput): number | undefined {
+  const aliasCeiling = opts.memory !== undefined ? validateMemoryMib(opts.memory) : undefined;
+  const resourceCeiling = resolveResourceMemoryCeiling(opts.resources?.memory);
+  if (
+    aliasCeiling !== undefined &&
+    resourceCeiling !== undefined &&
+    aliasCeiling !== resourceCeiling
+  ) {
+    throw new BootError(
+      "BOOT_MEMORY_INVALID",
+      `boot: memory (${aliasCeiling} MiB) conflicts with resources.memory.maxMib (${resourceCeiling} MiB). Use one value.`,
+    );
+  }
+  return resourceCeiling ?? aliasCeiling;
+}
+
+function resolveResourceMemoryCeiling(
+  memory: BootMemoryResourceOptions | undefined,
+): number | undefined {
+  if (memory === undefined) {
+    return undefined;
+  }
+  validateMemoryReclaim(memory.reclaim);
+  return validateMemoryMib(memory.maxMib);
+}
+
+function validateMemoryReclaim(reclaim: BootMemoryResourceOptions["reclaim"] | undefined): void {
+  if (reclaim === undefined || reclaim === "auto") {
+    return;
+  }
+  throw new BootError(
+    "BOOT_MEMORY_INVALID",
+    `boot: resources.memory.reclaim must be "auto" when set (got ${JSON.stringify(reclaim)}).`,
+  );
+}

--- a/scripts/build-api-toc.mjs
+++ b/scripts/build-api-toc.mjs
@@ -7,15 +7,9 @@
 // TOC that buckets symbols by "what is the reader trying to do?".
 //
 // The mapping below is the single source of truth for those buckets.
-// When you add a new public export to packages/runtime/src/index.ts,
-// add the symbol here too (or it lands in "Other"). Run is:
-//
-//   pnpm build:docs   (typedoc → this script)
-//
-// The script validates that every symbol it references is a real H3
-// in the generated API.md and that no H3 is left uncategorised, so
-// drift between source exports and the TOC fails the build instead
-// of silently producing broken anchors.
+// When adding a public export to packages/runtime/src/index.ts, add it
+// here too. The script validates every referenced/generated H3 so drift
+// fails the build instead of silently producing broken anchors.
 
 import { readFileSync, writeFileSync } from "node:fs";
 
@@ -365,6 +359,8 @@ const TOC = {
   "Boot a VM": [
     "boot",
     "BootOptions",
+    "BootResourcesOptions",
+    "BootMemoryResourceOptions",
     "attach",
     "AttachOptions",
     "bootPty",


### PR DESCRIPTION
## Problem

Machinen already had the low-level memory pieces for elastic VM memory. But the public model still looked like a fixed box: pick a memory size and hope it is right. That made it hard to explain that a VM can have a large ceiling without reserving that much host memory up front.

## Solution

This PR adds a clearer memory resource shape for `boot()`: `resources.memory.maxMib` with `reclaim: "auto"`. It keeps the old `memory` option as a compatibility alias. It also adds a simple memory guide so users can understand ceiling, host footprint, grow-on-touch behavior, and balloon reclaim.

## Technical Summary

- Treat `resources.memory.maxMib` as the canonical user-facing API, while keeping `memory` as a safe alias for existing callers.
- Reject conflicting `memory` and `resources.memory.maxMib` values, so callers do not accidentally ask for two different ceilings.
- Keep reclaim simple: only `reclaim: "auto"` is accepted, because Machinen's current product path is the existing virtio-balloon free-page-reporting path.
- Add `memoryStats().balloonReclaimedBytes` as the clearer name for pages returned by free-page reporting. Keep `balloonInflatedBytes` as an old-name alias.
- Document the memory model from a user's point of view, including why a 4 GiB ceiling can start with a much smaller host footprint and why macOS should use `phys_footprint` instead of raw `ps rss`.
