### PR TITLE
Add guest-visible multi-vCPU support

### DIFF
--- a/docs/guides/cpu.md
+++ b/docs/guides/cpu.md
@@ -7,7 +7,7 @@ await boot({
   image: "./image.ext4",
   resources: {
     cpu: {
-      maxVcpus: 1,
+      maxVcpus: 2,
       quotaCpus: 0.5,
       weight: 200,
     },
@@ -18,15 +18,16 @@ await boot({
 CLI flags use the same shape:
 
 ```sh
-machinen boot ./bundle --cpu-quota 0.5 --cpu-weight 200 --vcpus 1
+machinen boot ./bundle --cpu-quota 0.5 --cpu-weight 200 --vcpus 2
 machinen fork --name app --cpu-quota 0.25 --cpu-weight 50
 ```
 
 ## vCPUs vs quota
 
-`maxVcpus` is the guest-visible CPU count. Phase 1 intentionally supports only
-`maxVcpus: 1`; values above 1 are rejected instead of pretending that quota is a
-multi-vCPU feature.
+`maxVcpus` is the guest-visible CPU count. On linux/x64 KVM hosts, values above
+`1` create real guest vCPUs, so commands such as `nproc` see the requested CPU
+count. Other host backends still reject values above `1` instead of pretending
+that quota is a multi-vCPU feature.
 
 `quotaCpus` is host scheduler budget. A quota of `0.5` means the VMM may consume
 about half of one host CPU over the cgroup scheduling period. It does not add
@@ -43,6 +44,8 @@ On Linux, Machinen uses cgroup v2 CPU controls for quota and fairness:
 - `quotaCpus` writes `cpu.max` using a `100000` microsecond period.
 - `weight` writes `cpu.weight`.
 - The spawned VMM process is moved into a per-VM cgroup.
+- The quota applies to the whole VMM process, so it caps total host CPU budget
+  across all vCPU threads rather than changing the guest-visible CPU count.
 - The cgroup path is registered for cleanup when the VM exits or `machinen gc`
   reaps a dead detached VM.
 
@@ -53,8 +56,8 @@ non-default weight fails during boot with a CPU unsupported error.
 
 macOS does not provide a cgroup v2 equivalent for hard per-process CPU quota.
 Machinen still validates the `resources.cpu` shape so configuration files can be
-shared, but hard quota and weight enforcement are documented as unsupported on
-macOS in this phase. `maxVcpus` remains limited to `1`.
+shared, but hard quota, weight enforcement, and multi-vCPU guests are documented
+as unsupported on macOS in this phase. `maxVcpus` remains limited to `1` there.
 
 ## Observability
 
@@ -63,7 +66,7 @@ macOS in this phase. `maxVcpus` remains limited to `1`.
 ```json
 {
   "cpu": {
-    "max_vcpus": 1,
+    "max_vcpus": 2,
     "quota_cpus": 0.5,
     "weight": 200,
     "enforcement": { "status": "linux-cgroup-v2" }

--- a/docs/guides/cpu.md
+++ b/docs/guides/cpu.md
@@ -24,10 +24,10 @@ machinen fork --name app --cpu-quota 0.25 --cpu-weight 50
 
 ## vCPUs vs quota
 
-`maxVcpus` is the guest-visible CPU count. On linux/x64 KVM hosts, values above
-`1` create real guest vCPUs, so commands such as `nproc` see the requested CPU
-count. Other host backends still reject values above `1` instead of pretending
-that quota is a multi-vCPU feature.
+`maxVcpus` is the guest-visible CPU count. On linux/x64 KVM and macOS arm64 HVF
+hosts, values above `1` create real guest vCPUs, so commands such as `nproc` see
+the requested CPU count. Other host backends still reject values above `1`
+instead of pretending that quota is a multi-vCPU feature.
 
 `quotaCpus` is host scheduler budget. A quota of `0.5` means the VMM may consume
 about half of one host CPU over the cgroup scheduling period. It does not add
@@ -56,8 +56,11 @@ non-default weight fails during boot with a CPU unsupported error.
 
 macOS does not provide a cgroup v2 equivalent for hard per-process CPU quota.
 Machinen still validates the `resources.cpu` shape so configuration files can be
-shared, but hard quota, weight enforcement, and multi-vCPU guests are documented
-as unsupported on macOS in this phase. `maxVcpus` remains limited to `1` there.
+shared, but hard quota and weight enforcement remain unsupported on macOS.
+
+On macOS arm64 HVF hosts, `maxVcpus` creates real guest-visible vCPUs. Unsupported
+macOS architectures still reject `maxVcpus > 1` rather than booting a one-vCPU
+guest silently.
 
 ## Observability
 

--- a/packages/microvm/assets/virt.dts
+++ b/packages/microvm/assets/virt.dts
@@ -192,17 +192,711 @@
 			socket0 {
 				cluster0 {
 					core0 {
-						cpu = <0x8001>;
+						cpu = <0x8100>;
+					};
+					core1 {
+						cpu = <0x8101>;
+					};
+					core2 {
+						cpu = <0x8102>;
+					};
+					core3 {
+						cpu = <0x8103>;
+					};
+					core4 {
+						cpu = <0x8104>;
+					};
+					core5 {
+						cpu = <0x8105>;
+					};
+					core6 {
+						cpu = <0x8106>;
+					};
+					core7 {
+						cpu = <0x8107>;
+					};
+					core8 {
+						cpu = <0x8108>;
+					};
+					core9 {
+						cpu = <0x8109>;
+					};
+					core10 {
+						cpu = <0x810a>;
+					};
+					core11 {
+						cpu = <0x810b>;
+					};
+					core12 {
+						cpu = <0x810c>;
+					};
+					core13 {
+						cpu = <0x810d>;
+					};
+					core14 {
+						cpu = <0x810e>;
+					};
+					core15 {
+						cpu = <0x810f>;
+					};
+					core16 {
+						cpu = <0x8110>;
+					};
+					core17 {
+						cpu = <0x8111>;
+					};
+					core18 {
+						cpu = <0x8112>;
+					};
+					core19 {
+						cpu = <0x8113>;
+					};
+					core20 {
+						cpu = <0x8114>;
+					};
+					core21 {
+						cpu = <0x8115>;
+					};
+					core22 {
+						cpu = <0x8116>;
+					};
+					core23 {
+						cpu = <0x8117>;
+					};
+					core24 {
+						cpu = <0x8118>;
+					};
+					core25 {
+						cpu = <0x8119>;
+					};
+					core26 {
+						cpu = <0x811a>;
+					};
+					core27 {
+						cpu = <0x811b>;
+					};
+					core28 {
+						cpu = <0x811c>;
+					};
+					core29 {
+						cpu = <0x811d>;
+					};
+					core30 {
+						cpu = <0x811e>;
+					};
+					core31 {
+						cpu = <0x811f>;
+					};
+					core32 {
+						cpu = <0x8120>;
+					};
+					core33 {
+						cpu = <0x8121>;
+					};
+					core34 {
+						cpu = <0x8122>;
+					};
+					core35 {
+						cpu = <0x8123>;
+					};
+					core36 {
+						cpu = <0x8124>;
+					};
+					core37 {
+						cpu = <0x8125>;
+					};
+					core38 {
+						cpu = <0x8126>;
+					};
+					core39 {
+						cpu = <0x8127>;
+					};
+					core40 {
+						cpu = <0x8128>;
+					};
+					core41 {
+						cpu = <0x8129>;
+					};
+					core42 {
+						cpu = <0x812a>;
+					};
+					core43 {
+						cpu = <0x812b>;
+					};
+					core44 {
+						cpu = <0x812c>;
+					};
+					core45 {
+						cpu = <0x812d>;
+					};
+					core46 {
+						cpu = <0x812e>;
+					};
+					core47 {
+						cpu = <0x812f>;
+					};
+					core48 {
+						cpu = <0x8130>;
+					};
+					core49 {
+						cpu = <0x8131>;
+					};
+					core50 {
+						cpu = <0x8132>;
+					};
+					core51 {
+						cpu = <0x8133>;
+					};
+					core52 {
+						cpu = <0x8134>;
+					};
+					core53 {
+						cpu = <0x8135>;
+					};
+					core54 {
+						cpu = <0x8136>;
+					};
+					core55 {
+						cpu = <0x8137>;
+					};
+					core56 {
+						cpu = <0x8138>;
+					};
+					core57 {
+						cpu = <0x8139>;
+					};
+					core58 {
+						cpu = <0x813a>;
+					};
+					core59 {
+						cpu = <0x813b>;
+					};
+					core60 {
+						cpu = <0x813c>;
+					};
+					core61 {
+						cpu = <0x813d>;
+					};
+					core62 {
+						cpu = <0x813e>;
+					};
+					core63 {
+						cpu = <0x813f>;
 					};
 				};
 			};
 		};
 
 		cpu@0 {
-			phandle = <0x8001>;
-			reg = <0x00>;
+			phandle = <0x8100>;
+			reg = <0x0>;
 			compatible = "arm,cortex-a72";
 			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1 {
+			phandle = <0x8101>;
+			reg = <0x1>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2 {
+			phandle = <0x8102>;
+			reg = <0x2>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3 {
+			phandle = <0x8103>;
+			reg = <0x3>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@4 {
+			phandle = <0x8104>;
+			reg = <0x4>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@5 {
+			phandle = <0x8105>;
+			reg = <0x5>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@6 {
+			phandle = <0x8106>;
+			reg = <0x6>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@7 {
+			phandle = <0x8107>;
+			reg = <0x7>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@8 {
+			phandle = <0x8108>;
+			reg = <0x8>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@9 {
+			phandle = <0x8109>;
+			reg = <0x9>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@a {
+			phandle = <0x810a>;
+			reg = <0xa>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@b {
+			phandle = <0x810b>;
+			reg = <0xb>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@c {
+			phandle = <0x810c>;
+			reg = <0xc>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@d {
+			phandle = <0x810d>;
+			reg = <0xd>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@e {
+			phandle = <0x810e>;
+			reg = <0xe>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@f {
+			phandle = <0x810f>;
+			reg = <0xf>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@10 {
+			phandle = <0x8110>;
+			reg = <0x10>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@11 {
+			phandle = <0x8111>;
+			reg = <0x11>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@12 {
+			phandle = <0x8112>;
+			reg = <0x12>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@13 {
+			phandle = <0x8113>;
+			reg = <0x13>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@14 {
+			phandle = <0x8114>;
+			reg = <0x14>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@15 {
+			phandle = <0x8115>;
+			reg = <0x15>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@16 {
+			phandle = <0x8116>;
+			reg = <0x16>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@17 {
+			phandle = <0x8117>;
+			reg = <0x17>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@18 {
+			phandle = <0x8118>;
+			reg = <0x18>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@19 {
+			phandle = <0x8119>;
+			reg = <0x19>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1a {
+			phandle = <0x811a>;
+			reg = <0x1a>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1b {
+			phandle = <0x811b>;
+			reg = <0x1b>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1c {
+			phandle = <0x811c>;
+			reg = <0x1c>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1d {
+			phandle = <0x811d>;
+			reg = <0x1d>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1e {
+			phandle = <0x811e>;
+			reg = <0x1e>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@1f {
+			phandle = <0x811f>;
+			reg = <0x1f>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@20 {
+			phandle = <0x8120>;
+			reg = <0x20>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@21 {
+			phandle = <0x8121>;
+			reg = <0x21>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@22 {
+			phandle = <0x8122>;
+			reg = <0x22>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@23 {
+			phandle = <0x8123>;
+			reg = <0x23>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@24 {
+			phandle = <0x8124>;
+			reg = <0x24>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@25 {
+			phandle = <0x8125>;
+			reg = <0x25>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@26 {
+			phandle = <0x8126>;
+			reg = <0x26>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@27 {
+			phandle = <0x8127>;
+			reg = <0x27>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@28 {
+			phandle = <0x8128>;
+			reg = <0x28>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@29 {
+			phandle = <0x8129>;
+			reg = <0x29>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2a {
+			phandle = <0x812a>;
+			reg = <0x2a>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2b {
+			phandle = <0x812b>;
+			reg = <0x2b>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2c {
+			phandle = <0x812c>;
+			reg = <0x2c>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2d {
+			phandle = <0x812d>;
+			reg = <0x2d>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2e {
+			phandle = <0x812e>;
+			reg = <0x2e>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@2f {
+			phandle = <0x812f>;
+			reg = <0x2f>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@30 {
+			phandle = <0x8130>;
+			reg = <0x30>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@31 {
+			phandle = <0x8131>;
+			reg = <0x31>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@32 {
+			phandle = <0x8132>;
+			reg = <0x32>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@33 {
+			phandle = <0x8133>;
+			reg = <0x33>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@34 {
+			phandle = <0x8134>;
+			reg = <0x34>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@35 {
+			phandle = <0x8135>;
+			reg = <0x35>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@36 {
+			phandle = <0x8136>;
+			reg = <0x36>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@37 {
+			phandle = <0x8137>;
+			reg = <0x37>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@38 {
+			phandle = <0x8138>;
+			reg = <0x38>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@39 {
+			phandle = <0x8139>;
+			reg = <0x39>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3a {
+			phandle = <0x813a>;
+			reg = <0x3a>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3b {
+			phandle = <0x813b>;
+			reg = <0x3b>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3c {
+			phandle = <0x813c>;
+			reg = <0x3c>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3d {
+			phandle = <0x813d>;
+			reg = <0x3d>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3e {
+			phandle = <0x813e>;
+			reg = <0x3e>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
+		};
+
+		cpu@3f {
+			phandle = <0x813f>;
+			reg = <0x3f>;
+			compatible = "arm,cortex-a72";
+			device_type = "cpu";
+			enable-method = "psci";
 		};
 	};
 

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -77,6 +77,7 @@ const virtio_virtiofs_size: u64 = 0x200;
 // consumed internally by a lazy restore). Slots 7..11, contiguous
 // after blk4. The runtime caps `liveMounts` to this many.
 const MAX_VIRTIOFS_SLOTS: usize = 5;
+const MAX_VCPUS: u32 = 64;
 const virtio_virtiofs_bases: [MAX_VIRTIOFS_SLOTS]u64 = .{
     0x0A00_0E00,
     0x0A00_1000,
@@ -116,6 +117,8 @@ pub const Error = error{
     GuestCrashed,
     RanTooLong,
     NestedVirtUnsupported,
+    SecondaryVcpuInitFailed,
+    MultiVcpuVmstateUnsupported,
 };
 
 pub const Config = struct {
@@ -146,6 +149,9 @@ pub const Config = struct {
     mountdisk_upper_fd: ?c_int = null,
     ram_base: u64 = 0x4000_0000,
     ram_size: usize = 4 * 1024 * 1024 * 1024, // 4 GB — room for Debian+Node+CRIU+Claude Code in the initramfs tmpfs
+    /// Guest-visible vCPU count. The DTB CPU topology is trimmed to this
+    /// count before boot so Linux only sees CPUs Machinen really created.
+    max_vcpus: u32 = 1,
     // DTB sits well past the kernel so the kernel doesn't clobber it.
     dtb_offset: u64 = 0x0300_0000, // 48 MB into RAM
     // Where the initramfs goes in guest RAM. Must match the
@@ -224,6 +230,8 @@ fn validate_config(cfg: *const Config) void {
     assert(cfg.dtb_offset < cfg.ram_size);
     assert(cfg.initrd_offset < cfg.ram_size);
     assert(cfg.max_exits > 0);
+    assert(cfg.max_vcpus >= 1);
+    assert(cfg.max_vcpus <= MAX_VCPUS);
 }
 
 /// Turn on HVF's in-kernel GIC v3 at the addresses the device tree
@@ -249,6 +257,10 @@ fn enable_gic() !void {
 
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     validate_config(&cfg);
+    if (cfg.max_vcpus > 1 and (cfg.restore_path != null or cfg.snapshot_path != null)) {
+        std.debug.print("hvf boot: refusing vmstate snapshot/restore for multi-vCPU guest\n", .{});
+        return error.MultiVcpuVmstateUnsupported;
+    }
 
     // Install the SIGUSR1 snapshot handler FIRST — before the
     // multi-second fixture load + device bring-up. Until the handler
@@ -297,8 +309,15 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         log_best_effort("hvf: unmap failed", err);
     };
 
-    const vcpu = try init_vcpu(fx.img, &cfg);
+    const vcpu = try init_boot_vcpu(fx.img, &cfg);
     defer vcpu.destroy();
+
+    var secondary_storage: [MAX_VCPUS - 1]SecondaryVcpu = undefined;
+    var secondary_thread_storage: [MAX_VCPUS - 1]std.Thread = undefined;
+    var secondary_args_storage: [MAX_VCPUS - 1]SecondaryRunArgs = undefined;
+    const secondary_vcpus = secondary_storage[0..@intCast(cfg.max_vcpus - 1)];
+    const secondary_threads = secondary_thread_storage[0..secondary_vcpus.len];
+    const secondary_args = secondary_args_storage[0..secondary_vcpus.len];
 
     // --- run loop -------------------------------------------------
     var uart: hvf.Pl011 = .init;
@@ -522,7 +541,34 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
         start_snapshot_watcher(vcpu.handle);
     }
 
-    return try run_loop(gpa, &cfg, vm, vcpu, &devs, irqs, ram);
+    var psci_cpus = PsciCpuTable.init(cfg.max_vcpus);
+    var run_shared = HvfRunShared{};
+    const secondary_started = try start_secondary_vcpus(
+        secondary_vcpus,
+        secondary_threads,
+        secondary_args,
+        &cfg,
+        &devs,
+        irqs,
+        &run_shared,
+        &psci_cpus,
+    );
+    const started_threads = secondary_threads[0..@intCast(secondary_started)];
+    errdefer stop_secondary_vcpus(secondary_vcpus, started_threads, &run_shared);
+    defer stop_secondary_vcpus(secondary_vcpus, started_threads, &run_shared);
+
+    return try run_loop(
+        gpa,
+        &cfg,
+        vm,
+        vcpu,
+        secondary_vcpus,
+        &devs,
+        irqs,
+        ram,
+        &psci_cpus,
+        &run_shared,
+    );
 }
 
 // SIGUSR1 atomic + watcher-thread plumbing. macOS HVF doesn't return
@@ -990,15 +1036,20 @@ fn run_loop(
     cfg: *const Config,
     vm: hvf.Vm,
     vcpu: hvf.Vcpu,
+    secondaries: []SecondaryVcpu,
     devs: *const Devices,
     irqs: IrqMap,
     ram: []u8,
+    psci_cpus: *PsciCpuTable,
+    shared: *HvfRunShared,
 ) !Result {
     assert(cfg.max_exits > 0);
     assert(ram.len == cfg.ram_size);
 
-    var exits: usize = 0;
-    var saw_off = false;
+    shared.stop.store(false, .seq_cst);
+    shared.saw_off.store(false, .seq_cst);
+    shared.crashed.store(false, .seq_cst);
+    shared.exits.store(0, .seq_cst);
     var snapshotted = false;
     var checkpoint_delta_mode = cfg.restore_path != null;
     var ram_dirty = try RamDirtyTracker.init(gpa, vm, cfg);
@@ -1008,8 +1059,10 @@ fn run_loop(
     }
     var snapshot_writer_state: vmstate_writer.Writer = .{};
     defer snapshot_writer_state.wait();
-    while (exits < cfg.max_exits) : (exits += 1) {
+    while (!shared.stop.load(.seq_cst) and shared.exits.load(.seq_cst) < cfg.max_exits) {
         try vcpu.run();
+        const previous_exits = shared.exits.fetchAdd(1, .seq_cst);
+        assert(previous_exits < cfg.max_exits);
 
         // Async exit from hv_vcpus_exit (watcher thread, snapshot
         // trigger). Don't treat as a guest fault; check the flag and
@@ -1062,12 +1115,20 @@ fn run_loop(
                 try handle_wait_trap(vcpu);
             },
             .hvc_aarch64, .smc_aarch64 => {
-                switch (try handle_psci(vcpu)) {
+                shared.mutex.lock();
+                const outcome = handle_psci(vcpu, psci_cpus, secondaries) catch |err| {
+                    shared.mutex.unlock();
+                    return err;
+                };
+                shared.mutex.unlock();
+                switch (outcome) {
                     .shutdown => {
-                        saw_off = true;
+                        shared.saw_off.store(true, .seq_cst);
+                        shared.stop.store(true, .seq_cst);
+                        kick_secondary_vcpus(secondaries);
                         break;
                     },
-                    .handled => {},
+                    .cpu_off, .handled => {},
                 }
             },
             .system_register => {
@@ -1079,6 +1140,8 @@ fn run_loop(
             .data_abort_lower_el => {
                 const info = hvf.DataAbort.decode(vcpu.exit.exception);
                 if (!try ram_dirty.handle_write_fault(info)) {
+                    shared.mutex.lock();
+                    defer shared.mutex.unlock();
                     try route_data_abort(vcpu, devs, irqs, info);
                 }
             },
@@ -1089,7 +1152,9 @@ fn run_loop(
         }
 
         if (devs.nested_poweroff.seen) {
-            saw_off = true;
+            shared.saw_off.store(true, .seq_cst);
+            shared.stop.store(true, .seq_cst);
+            kick_secondary_vcpus(secondaries);
             break;
         }
 
@@ -1097,7 +1162,11 @@ fn run_loop(
         // be confident the kernel booted far enough to prove our point.
         // Production boots set `unbounded_serial` so the loop ends only
         // on PSCI SYSTEM_OFF (or max_exits).
-        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
+        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) {
+            shared.stop.store(true, .seq_cst);
+            kick_secondary_vcpus(secondaries);
+            break;
+        }
 
         // Snapshot trigger fallback — for the rare case the watcher's
         // hv_vcpus_exit() landed as a plain exception exit rather than
@@ -1122,13 +1191,15 @@ fn run_loop(
         }
     }
 
+    const exits = shared.exits.load(.seq_cst);
+    if (shared.crashed.load(.seq_cst)) return error.GuestCrashed;
     if (exits >= cfg.max_exits) return error.RanTooLong;
 
     const serial = try gpa.dupe(u8, devs.uart.captured_bytes());
     return .{
         .serial = serial,
-        .saw_psci_shutdown = saw_off,
-        .exits = exits,
+        .saw_psci_shutdown = shared.saw_off.load(.seq_cst),
+        .exits = @intCast(exits),
         .snapshotted = snapshotted,
     };
 }
@@ -1483,10 +1554,18 @@ fn allocate_and_populate_ram(
     // from virt.dts); without this patch any other ceiling silently
     // becomes 4 GiB to the kernel. Failures here would silently cap
     // the guest, so log loudly even outside debug mode.
-    dtb_patch.patch_memory_size(ram[cfg.dtb_offset..][0..fx.dtb.len], cfg.ram_size) catch |err| {
+    const guest_dtb = ram[cfg.dtb_offset..][0..fx.dtb.len];
+    dtb_patch.patch_memory_size(guest_dtb, cfg.ram_size) catch |err| {
         std.debug.print(
-            "warn: patchMemorySize failed ({s}); guest will see the DTB-declared ceiling, not cfg.ram_size={d}\n",
+            "warn: patchMemorySize failed ({s}); guest will see DTB RAM, not cfg.ram_size={d}\n",
             .{ @errorName(err), cfg.ram_size },
+        );
+    };
+    dtb_patch.patch_cpu_topology(guest_dtb, cfg.max_vcpus) catch |err| {
+        if (cfg.max_vcpus > 1) return err;
+        if (debug_enabled()) std.debug.print(
+            "warn: patchCpuTopology failed ({s}); single-vCPU guest keeps DTB topology\n",
+            .{@errorName(err)},
         );
     };
 
@@ -1504,9 +1583,9 @@ fn allocate_and_populate_ram(
         // compressed archives — at ~1 GB/s of wall clock. Leaving 1 GB
         // of dead tail in that window costs ~1 s of early boot.
         const initrd_end_abs: u32 = @intCast(cfg.ram_base + cfg.initrd_offset + initrd.len);
-        dtb_patch.patch_initrd_end(ram[cfg.dtb_offset..][0..fx.dtb.len], initrd_end_abs) catch |err| {
+        dtb_patch.patch_initrd_end(guest_dtb, initrd_end_abs) catch |err| {
             if (debug_enabled()) std.debug.print(
-                "warn: patchInitrdEnd failed ({s}); kernel will scan the full DTB-declared initrd window\n",
+                "warn: patchInitrdEnd failed ({s}); kernel will scan the full initrd window\n",
                 .{@errorName(err)},
             );
         };
@@ -1514,34 +1593,355 @@ fn allocate_and_populate_ram(
     return ram;
 }
 
-/// Bring up the vCPU: register MPIDR/timer/EL1 state, then point
-/// X0 at the DTB and PC at the kernel entry per the arm64 Linux boot
-/// protocol. Caller owns the destroy.
-fn init_vcpu(img: hvf.KernelImage, cfg: *const Config) !hvf.Vcpu {
-    const vcpu = try hvf.Vcpu.create();
-    errdefer vcpu.destroy();
+const SecondaryVcpuState = enum(u32) {
+    init = 0,
+    parked = 1,
+    running = 2,
+    failed = 3,
+};
 
+const HvfRunShared = struct {
+    mutex: hvf.PthreadMutex = .{},
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    saw_off: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    crashed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    exits: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+};
+
+const SecondaryVcpu = struct {
+    index: u32 = 0,
+    state: std.atomic.Value(u32) = std.atomic.Value(u32).init(
+        @intFromEnum(SecondaryVcpuState.init),
+    ),
+    handle: std.atomic.Value(u64) = std.atomic.Value(u64).init(std.math.maxInt(u64)),
+    mpidr: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    run_entries: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    start_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    entry: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    context: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+};
+
+const SecondaryRunArgs = struct {
+    slot: *SecondaryVcpu,
+    cfg: *const Config,
+    devs: *const Devices,
+    irqs: IrqMap,
+    shared: *HvfRunShared,
+    psci_cpus: *PsciCpuTable,
+    secondaries: []SecondaryVcpu,
+};
+
+fn init_secondary_vcpu_slot(slot: *SecondaryVcpu, index: u32) void {
+    assert(index > 0);
+    slot.* = .{ .index = index };
+}
+
+fn start_secondary_vcpus(
+    slots: []SecondaryVcpu,
+    threads: []std.Thread,
+    args: []SecondaryRunArgs,
+    cfg: *const Config,
+    devs: *const Devices,
+    irqs: IrqMap,
+    shared: *HvfRunShared,
+    psci_cpus: *PsciCpuTable,
+) !u32 {
+    assert(threads.len == slots.len);
+    assert(args.len == slots.len);
+    var started: u32 = 0;
+    errdefer stop_secondary_vcpus(slots, threads[0..@intCast(started)], shared);
+    for (slots, 0..) |*slot, idx| {
+        init_secondary_vcpu_slot(slot, @intCast(idx + 1));
+        args[idx] = .{
+            .slot = slot,
+            .cfg = cfg,
+            .devs = devs,
+            .irqs = irqs,
+            .shared = shared,
+            .psci_cpus = psci_cpus,
+            .secondaries = slots,
+        };
+        threads[idx] = try std.Thread.spawn(
+            thread_spawn_config,
+            secondary_vcpu_thread_main,
+            .{&args[idx]},
+        );
+        started += 1;
+    }
+
+    const poll_us: c_uint = 1_000;
+    const max_polls: u32 = 5_000;
+    var polls: u32 = 0;
+    while (polls < max_polls) : (polls += 1) {
+        var parked: u32 = 0;
+        for (slots) |*slot| {
+            const state: SecondaryVcpuState = @enumFromInt(slot.state.load(.seq_cst));
+            switch (state) {
+                .parked => parked += 1,
+                .failed => return error.SecondaryVcpuInitFailed,
+                .init, .running => {},
+            }
+        }
+        if (parked == slots.len) return started;
+        sleep_micros(poll_us);
+    }
+    return error.SecondaryVcpuInitFailed;
+}
+
+fn stop_secondary_vcpus(slots: []SecondaryVcpu, threads: []std.Thread, shared: *HvfRunShared) void {
+    assert(threads.len <= slots.len);
+    shared.stop.store(true, .seq_cst);
+    kick_secondary_vcpus(slots);
+    for (threads) |thread| thread.join();
+}
+
+fn kick_secondary_vcpus(slots: []SecondaryVcpu) void {
+    assert(slots.len <= MAX_VCPUS - 1);
+    var handles: [MAX_VCPUS - 1]u64 = undefined;
+    var count: u32 = 0;
+    for (slots) |*slot| {
+        const handle = slot.handle.load(.seq_cst);
+        if (handle != std.math.maxInt(u64)) {
+            handles[count] = handle;
+            count += 1;
+        }
+    }
+    if (count > 0) {
+        const rc = hv_vcpus_exit(&handles[0], count);
+        if (rc != 0) std.debug.print("hvf: hv_vcpus_exit secondaries rc={d}\n", .{rc});
+    }
+}
+
+fn request_secondary_start(
+    secondaries: []SecondaryVcpu,
+    index: u32,
+    entry: u64,
+    context: u64,
+) void {
+    assert(index > 0);
+    const slot = &secondaries[index - 1];
+    slot.entry.store(entry, .seq_cst);
+    slot.context.store(context, .seq_cst);
+    slot.start_requested.store(true, .seq_cst);
+    kick_secondary_vcpus(secondaries);
+}
+
+fn secondary_vcpu_thread_main(args: *SecondaryRunArgs) void {
+    assert(args.slot.index > 0);
+    const slot = args.slot;
+    const create_vcpu = hvf.Vcpu.create;
+    const vcpu = create_vcpu() catch {
+        slot.state.store(@intFromEnum(SecondaryVcpuState.failed), .seq_cst);
+        return;
+    };
+    defer vcpu.destroy();
+    defer slot.handle.store(std.math.maxInt(u64), .seq_cst);
+
+    init_vcpu_common(vcpu, slot.index, true) catch {
+        slot.state.store(@intFromEnum(SecondaryVcpuState.failed), .seq_cst);
+        return;
+    };
+    init_vcpu_el_state(vcpu, args.cfg) catch {
+        slot.state.store(@intFromEnum(SecondaryVcpuState.failed), .seq_cst);
+        return;
+    };
+    const mpidr = vcpu.get_sys_reg(.mpidr_el1) catch {
+        slot.state.store(@intFromEnum(SecondaryVcpuState.failed), .seq_cst);
+        return;
+    };
+    slot.mpidr.store(mpidr, .seq_cst);
+    slot.handle.store(vcpu.handle, .seq_cst);
+    slot.state.store(@intFromEnum(SecondaryVcpuState.parked), .seq_cst);
+
+    while (!args.shared.stop.load(.seq_cst)) {
+        if (!slot.start_requested.swap(false, .seq_cst)) {
+            sleep_micros(1_000);
+            continue;
+        }
+        const entry = slot.entry.load(.seq_cst);
+        const context = slot.context.load(.seq_cst);
+        vcpu.set_reg(.x0, context) catch {
+            args.shared.crashed.store(true, .seq_cst);
+            args.shared.stop.store(true, .seq_cst);
+            return;
+        };
+        vcpu.set_reg(.x1, 0) catch |err| log_best_effort("hvf: secondary x1 clear failed", err);
+        vcpu.set_reg(.x2, 0) catch |err| log_best_effort("hvf: secondary x2 clear failed", err);
+        vcpu.set_reg(.x3, 0) catch |err| log_best_effort("hvf: secondary x3 clear failed", err);
+        vcpu.set_reg(.pc, entry) catch {
+            args.shared.crashed.store(true, .seq_cst);
+            args.shared.stop.store(true, .seq_cst);
+            return;
+        };
+        vcpu.set_vtimer_mask(false) catch |err| log_best_effort("hvf: secondary timer unmask failed", err);
+        args.shared.mutex.lock();
+        const marked = args.psci_cpus.mark_on(mpidr);
+        assert(marked == .success);
+        args.shared.mutex.unlock();
+        slot.state.store(@intFromEnum(SecondaryVcpuState.running), .seq_cst);
+        run_secondary_vcpu(vcpu, args);
+        vcpu.set_vtimer_mask(true) catch |err| log_best_effort("hvf: secondary timer park failed", err);
+        if (!args.shared.stop.load(.seq_cst)) {
+            slot.state.store(@intFromEnum(SecondaryVcpuState.parked), .seq_cst);
+        }
+    }
+}
+
+const SecondaryStep = enum { keep_running, park, stop };
+
+fn run_secondary_vcpu(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) void {
+    assert(args.slot.index > 0);
+    while (!args.shared.stop.load(.seq_cst) and
+        args.shared.exits.load(.seq_cst) < args.cfg.max_exits)
+    {
+        if (!run_secondary_once(vcpu, args)) return;
+    }
+}
+
+fn run_secondary_once(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) bool {
+    assert(args.slot.index > 0);
+    vcpu.run() catch |err| {
+        std.debug.print("hvf: secondary vCPU {d} run failed: {s}\n", .{
+            args.slot.index,
+            @errorName(err),
+        });
+        fail_secondary(args);
+        return false;
+    };
+    const previous_runs = args.slot.run_entries.fetchAdd(1, .seq_cst);
+    assert(previous_runs < args.cfg.max_exits);
+    const previous_exits = args.shared.exits.fetchAdd(1, .seq_cst);
+    assert(previous_exits < args.cfg.max_exits);
+    return switch (classify_secondary_exit(vcpu, args)) {
+        .keep_running => true,
+        .park, .stop => false,
+    };
+}
+
+fn classify_secondary_exit(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) SecondaryStep {
+    assert(args.slot.index > 0);
+    if (vcpu.exit.reason == .canceled) return .keep_running;
+    if (vcpu.exit.reason == .vtimer_activated) {
+        vcpu.set_vtimer_mask(true) catch |err| log_best_effort("hvf: secondary timer remask failed", err);
+        vcpu.set_vtimer_mask(false) catch |err| log_best_effort("hvf: secondary timer rearm failed", err);
+        return .keep_running;
+    }
+    if (vcpu.exit.reason != .exception) {
+        log_unhandled_exit(vcpu, "secondary non-exception exit");
+        fail_secondary(args);
+        return .stop;
+    }
+    const ec = hvf.ExceptionClass.from_syndrome(vcpu.exit.exception.syndrome);
+    return handle_secondary_exception(vcpu, args, ec);
+}
+
+fn handle_secondary_exception(
+    vcpu: hvf.Vcpu,
+    args: *SecondaryRunArgs,
+    ec: hvf.ExceptionClass,
+) SecondaryStep {
+    assert(args.slot.index > 0);
+    switch (ec) {
+        .trapped_wfx => return handle_secondary_wait(vcpu, args),
+        .hvc_aarch64, .smc_aarch64 => return handle_secondary_psci(vcpu, args),
+        .system_register => return handle_secondary_sysreg(vcpu, args, ec),
+        .data_abort_lower_el => return handle_secondary_data_abort(vcpu, args),
+        else => {
+            log_unhandled_exception(vcpu, ec, "secondary unhandled exception class");
+            fail_secondary(args);
+            return .stop;
+        },
+    }
+}
+
+fn handle_secondary_wait(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) SecondaryStep {
+    assert(args.slot.index > 0);
+    handle_wait_trap(vcpu) catch |err| {
+        std.debug.print("hvf: secondary wait trap failed: {s}\n", .{@errorName(err)});
+        fail_secondary(args);
+        return .stop;
+    };
+    return .keep_running;
+}
+
+fn handle_secondary_psci(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) SecondaryStep {
+    assert(args.slot.index > 0);
+    args.shared.mutex.lock();
+    const outcome = handle_psci(vcpu, args.psci_cpus, args.secondaries) catch |err| {
+        args.shared.mutex.unlock();
+        std.debug.print("hvf: secondary PSCI failed: {s}\n", .{@errorName(err)});
+        fail_secondary(args);
+        return .stop;
+    };
+    args.shared.mutex.unlock();
+    switch (outcome) {
+        .shutdown => {
+            args.shared.saw_off.store(true, .seq_cst);
+            args.shared.stop.store(true, .seq_cst);
+            kick_secondary_vcpus(args.secondaries);
+            return .stop;
+        },
+        .cpu_off => return .park,
+        .handled => return .keep_running,
+    }
+}
+
+fn handle_secondary_sysreg(
+    vcpu: hvf.Vcpu,
+    args: *SecondaryRunArgs,
+    ec: hvf.ExceptionClass,
+) SecondaryStep {
+    assert(args.slot.index > 0);
+    args.shared.mutex.lock();
+    const handled = handle_system_register_trap(vcpu) catch |err| {
+        args.shared.mutex.unlock();
+        std.debug.print("hvf: secondary system-register trap failed: {s}\n", .{@errorName(err)});
+        fail_secondary(args);
+        return .stop;
+    };
+    args.shared.mutex.unlock();
+    if (!handled) {
+        log_unhandled_exception(vcpu, ec, "secondary unsupported system-register trap");
+        fail_secondary(args);
+        return .stop;
+    }
+    return .keep_running;
+}
+
+fn handle_secondary_data_abort(vcpu: hvf.Vcpu, args: *SecondaryRunArgs) SecondaryStep {
+    assert(args.slot.index > 0);
+    const info = hvf.DataAbort.decode(vcpu.exit.exception);
+    args.shared.mutex.lock();
+    route_data_abort(vcpu, args.devs, args.irqs, info) catch |err| {
+        args.shared.mutex.unlock();
+        std.debug.print("hvf: secondary data-abort route failed: {s}\n", .{@errorName(err)});
+        fail_secondary(args);
+        return .stop;
+    };
+    args.shared.mutex.unlock();
+    return .keep_running;
+}
+
+fn fail_secondary(args: *SecondaryRunArgs) void {
+    assert(args.slot.index > 0);
+    args.shared.crashed.store(true, .seq_cst);
+    args.shared.stop.store(true, .seq_cst);
+    kick_secondary_vcpus(args.secondaries);
+}
+
+fn init_vcpu_common(vcpu: hvf.Vcpu, index: u32, parked: bool) !void {
     // Set the vCPU's multiprocessor affinity. Without this, Apple's
     // GIC won't associate this vCPU with a redistributor frame and
     // any `hv_gic_*_redistributor_reg` call returns HV_DENIED. Value
     // layout: bit 31 reserved-as-1, bits 23:16/15:8/7:0 = Aff2/Aff1/Aff0.
-    // For our single-CPU guest, all affinity fields = 0.
-    try vcpu.set_sys_reg(.mpidr_el1, 1 << 31);
+    try vcpu.set_sys_reg(.mpidr_el1, hvf.mpidr_for_vcpu_index(index));
 
-    // Let the virtual timer wake the vCPU so we can deliver ticks.
-    try vcpu.set_vtimer_mask(false);
+    // Let the boot CPU's virtual timer wake it; keep parked secondaries
+    // masked until PSCI starts them.
+    try vcpu.set_vtimer_mask(parked);
+}
 
-    // Diagnostic: query where HVF actually placed this vCPU's
-    // redistributor. If this differs from what we told the kernel via
-    // the DTB, the kernel will report "No redistributor present."
-    if (debug_enabled()) {
-        if (hvf.Gic.redistributor_base(vcpu)) |rdist| {
-            std.debug.print("GIC redistributor for vcpu 0: 0x{x}\n", .{rdist});
-        } else |err| {
-            std.debug.print("GIC redistributor query failed: {s}\n", .{@errorName(err)});
-        }
-    }
-
+fn init_vcpu_el_state(vcpu: hvf.Vcpu, cfg: *const Config) !void {
     if (cfg.nested) {
         // EL2h, all interrupts masked. When EL2 is exposed, Linux must
         // enter at EL2 so it can own the guest hypervisor state and
@@ -1559,6 +1959,29 @@ fn init_vcpu(img: hvf.KernelImage, cfg: *const Config) !hvf.Vcpu {
         // MMU off (kernel turns it on itself); I-bit for executable fetches.
         try vcpu.set_sys_reg(.sctlr_el1, 1 << 12);
     }
+}
+
+/// Bring up the boot vCPU: register MPIDR/timer/EL1 state, then point
+/// X0 at the DTB and PC at the kernel entry per the arm64 Linux boot
+/// protocol. Caller owns the destroy.
+fn init_boot_vcpu(img: hvf.KernelImage, cfg: *const Config) !hvf.Vcpu {
+    const vcpu = try hvf.Vcpu.create();
+    errdefer vcpu.destroy();
+
+    try init_vcpu_common(vcpu, 0, false);
+
+    // Diagnostic: query where HVF actually placed this vCPU's
+    // redistributor. If this differs from what we told the kernel via
+    // the DTB, the kernel will report "No redistributor present."
+    if (debug_enabled()) {
+        if (hvf.Gic.redistributor_base(vcpu)) |rdist| {
+            std.debug.print("GIC redistributor for vcpu 0: 0x{x}\n", .{rdist});
+        } else |err| {
+            std.debug.print("GIC redistributor query failed: {s}\n", .{@errorName(err)});
+        }
+    }
+
+    try init_vcpu_el_state(vcpu, cfg);
 
     // arm64 Linux boot protocol: X0 = physical address of DTB.
     const dtb_phys = cfg.ram_base + cfg.dtb_offset;
@@ -1921,13 +2344,110 @@ fn start_vsock_bridge(
     return bridge;
 }
 
+const PsciReturn = enum(i64) {
+    success = 0,
+    not_supported = -1,
+    invalid_parameters = -2,
+    denied = -3,
+    already_on = -4,
+    on_pending = -5,
+};
+
+const PsciAffinity = enum(u64) {
+    on = 0,
+    off = 1,
+    on_pending = 2,
+};
+
+const PsciPowerState = enum(u8) { off, on_pending, on };
+
+const PsciCpuTable = struct {
+    count: u32,
+    states: [MAX_VCPUS]PsciPowerState,
+    entries: [MAX_VCPUS]u64,
+    contexts: [MAX_VCPUS]u64,
+
+    fn init(count: u32) PsciCpuTable {
+        assert(count >= 1);
+        assert(count <= MAX_VCPUS);
+        var table = PsciCpuTable{
+            .count = count,
+            .states = [_]PsciPowerState{.off} ** MAX_VCPUS,
+            .entries = [_]u64{0} ** MAX_VCPUS,
+            .contexts = [_]u64{0} ** MAX_VCPUS,
+        };
+        table.states[0] = .on;
+        return table;
+    }
+
+    fn index_for_mpidr(self: *const PsciCpuTable, mpidr: u64) ?u32 {
+        assert(self.count >= 1);
+        // Linux passes the PSCI target_cpu using the affinity value from the
+        // DTB `cpu@N.reg` cells (Aff0=N for Machinen's flat topology). HVF's
+        // MPIDR_EL1 value also carries bit31 RES1, so accept either spelling
+        // and key the vCPU by Aff0.
+        if ((mpidr & ~(@as(u64, 1) << 31) & ~@as(u64, 0xff)) != 0) return null;
+        const index: u32 = @intCast(mpidr & 0xff);
+        if (index >= self.count) return null;
+        return index;
+    }
+
+    fn cpu_on(self: *PsciCpuTable, target_mpidr: u64, entry: u64, context: u64) PsciReturn {
+        assert(self.count >= 1);
+        const index = self.index_for_mpidr(target_mpidr) orelse return .invalid_parameters;
+        return switch (self.states[index]) {
+            .on => .already_on,
+            .on_pending => .on_pending,
+            .off => blk: {
+                self.entries[index] = entry;
+                self.contexts[index] = context;
+                self.states[index] = .on_pending;
+                break :blk .success;
+            },
+        };
+    }
+
+    fn mark_on(self: *PsciCpuTable, mpidr: u64) PsciReturn {
+        assert(self.count >= 1);
+        const index = self.index_for_mpidr(mpidr) orelse return .invalid_parameters;
+        self.states[index] = .on;
+        return .success;
+    }
+
+    fn cpu_off(self: *PsciCpuTable, mpidr: u64) PsciReturn {
+        assert(self.count >= 1);
+        const index = self.index_for_mpidr(mpidr) orelse return .invalid_parameters;
+        if (index == 0) return .denied;
+        self.states[index] = .off;
+        self.entries[index] = 0;
+        self.contexts[index] = 0;
+        return .success;
+    }
+
+    fn affinity_info(self: *const PsciCpuTable, target_mpidr: u64) ?PsciAffinity {
+        assert(self.count >= 1);
+        const index = self.index_for_mpidr(target_mpidr) orelse return null;
+        return switch (self.states[index]) {
+            .on => .on,
+            .off => .off,
+            .on_pending => .on_pending,
+        };
+    }
+};
+
+fn psci_return_value(value: PsciReturn) u64 {
+    assert(@intFromEnum(PsciReturn.success) == 0);
+    return @bitCast(@intFromEnum(value));
+}
+
 /// What `handlePsci` decided. Most PSCI calls just return a value to
 /// the guest; SYSTEM_OFF / SYSTEM_RESET ask the run loop to stop.
-const PsciOutcome = enum { handled, shutdown };
+const PsciOutcome = enum { handled, shutdown, cpu_off };
 
 /// Decode and respond to a PSCI HVC/SMC. Returns `.shutdown` only on
 /// SYSTEM_OFF / SYSTEM_RESET; all other cases are answered in-place.
-fn handle_psci(vcpu: hvf.Vcpu) !PsciOutcome {
+fn handle_psci(vcpu: hvf.Vcpu, cpus: *PsciCpuTable, secondaries: []SecondaryVcpu) !PsciOutcome {
+    assert(cpus.count >= 1);
     const f = try hvf.Psci.decode(vcpu) orelse return .handled;
     switch (f) {
         .system_off, .system_reset => return .shutdown,
@@ -1940,17 +2460,38 @@ fn handle_psci(vcpu: hvf.Vcpu) !PsciOutcome {
             try vcpu.set_reg(.x0, 2);
         },
         .affinity_info_64 => {
-            // CPU 0 is "ON." The kernel queries this as part of setup;
-            // anything else gets NOT_SUPPORTED.
-            const x1 = try vcpu.get_reg(.x1);
-            try vcpu.set_reg(.x0, if (x1 == 0) 0 else @bitCast(@as(i64, -1)));
+            const target_mpidr = try vcpu.get_reg(.x1);
+            if (cpus.affinity_info(target_mpidr)) |state| {
+                try vcpu.set_reg(.x0, @intFromEnum(state));
+            } else {
+                try vcpu.set_reg(.x0, psci_return_value(.invalid_parameters));
+            }
         },
-        .cpu_off, .cpu_on_64, .features => {
-            // We only support one CPU and no optional features.
-            try vcpu.set_reg(.x0, @bitCast(@as(i64, -1)));
+        .cpu_on_64 => {
+            const target_mpidr = try vcpu.get_reg(.x1);
+            const entry = try vcpu.get_reg(.x2);
+            const context = try vcpu.get_reg(.x3);
+            const target_index = cpus.index_for_mpidr(target_mpidr);
+            const result = cpus.cpu_on(target_mpidr, entry, context);
+            if (result == .success) {
+                if (target_index) |idx| {
+                    if (idx > 0) request_secondary_start(secondaries, idx, entry, context);
+                }
+            }
+            try vcpu.set_reg(.x0, psci_return_value(result));
+        },
+        .cpu_off => {
+            const current_mpidr = try vcpu.get_sys_reg(.mpidr_el1);
+            const result = cpus.cpu_off(current_mpidr);
+            try vcpu.set_reg(.x0, psci_return_value(result));
+            if (result == .success) return .cpu_off;
+        },
+        .features => {
+            // No optional PSCI features beyond the calls decoded above.
+            try vcpu.set_reg(.x0, psci_return_value(.not_supported));
         },
         _ => {
-            try vcpu.set_reg(.x0, @bitCast(@as(i64, -1)));
+            try vcpu.set_reg(.x0, psci_return_value(.not_supported));
         },
     }
     return .handled;
@@ -2305,6 +2846,212 @@ fn fixtures_present() bool {
         if (access(path_z, F_OK) != 0) return false;
     }
     return true;
+}
+
+test "HVF multi-vCPU vmstate paths are refused before fixture load" {
+    const cfg = Config{
+        .kernel_path = "missing-kernel",
+        .dtb_path = "missing-dtb",
+        .max_vcpus = 2,
+        .snapshot_path = "out.vmstate",
+    };
+    try std.testing.expectError(
+        error.MultiVcpuVmstateUnsupported,
+        boot(std.testing.allocator, cfg),
+    );
+}
+
+test "PSCI CPU lifecycle state transitions" {
+    var cpus = PsciCpuTable.init(2);
+    const boot_mpidr = hvf.mpidr_for_vcpu_index(0);
+    const secondary_mpidr = hvf.mpidr_for_vcpu_index(1);
+
+    try std.testing.expectEqual(PsciAffinity.on, cpus.affinity_info(boot_mpidr).?);
+    try std.testing.expectEqual(PsciAffinity.off, cpus.affinity_info(secondary_mpidr).?);
+    try std.testing.expectEqual(
+        PsciReturn.invalid_parameters,
+        cpus.cpu_on(hvf.mpidr_for_vcpu_index(3), 0x80000, 0),
+    );
+    try std.testing.expectEqual(PsciReturn.already_on, cpus.cpu_on(boot_mpidr, 0x80000, 0));
+
+    try std.testing.expectEqual(
+        PsciReturn.success,
+        cpus.cpu_on(secondary_mpidr, 0x4010_0000, 0x55aa),
+    );
+    try std.testing.expectEqual(PsciAffinity.on_pending, cpus.affinity_info(secondary_mpidr).?);
+    try std.testing.expectEqual(@as(u64, 0x4010_0000), cpus.entries[1]);
+    try std.testing.expectEqual(@as(u64, 0x55aa), cpus.contexts[1]);
+    try std.testing.expectEqual(
+        PsciReturn.on_pending,
+        cpus.cpu_on(secondary_mpidr, 0x4020_0000, 0),
+    );
+
+    try std.testing.expectEqual(PsciReturn.success, cpus.mark_on(secondary_mpidr));
+    try std.testing.expectEqual(PsciAffinity.on, cpus.affinity_info(secondary_mpidr).?);
+    try std.testing.expectEqual(
+        PsciReturn.already_on,
+        cpus.cpu_on(secondary_mpidr, 0x4020_0000, 0),
+    );
+
+    try std.testing.expectEqual(PsciReturn.denied, cpus.cpu_off(boot_mpidr));
+    try std.testing.expectEqual(PsciReturn.success, cpus.cpu_off(secondary_mpidr));
+    try std.testing.expectEqual(PsciAffinity.off, cpus.affinity_info(secondary_mpidr).?);
+    try std.testing.expectEqual(@as(u64, 0), cpus.entries[1]);
+    try std.testing.expectEqual(@as(u64, 0), cpus.contexts[1]);
+}
+
+test "initialize HVF secondary vCPUs parked before PSCI" {
+    const create_vm = hvf.Vm.create;
+    const vm = create_vm() catch |err| switch (err) {
+        error.Denied => {
+            std.debug.print("skip: HV_DENIED\n", .{});
+            return;
+        },
+        else => return err,
+    };
+    defer vm.destroy();
+    try enable_gic();
+
+    const img: hvf.KernelImage = .{
+        .text_offset = 0,
+        .image_size = 0,
+        .bytes = &.{},
+    };
+    const cfg = Config{
+        .kernel_path = "unused",
+        .dtb_path = "unused",
+        .max_vcpus = 2,
+    };
+    const boot_vcpu = try init_boot_vcpu(img, &cfg);
+    defer boot_vcpu.destroy();
+
+    var secondary_storage: [MAX_VCPUS - 1]SecondaryVcpu = undefined;
+    var secondary_thread_storage: [MAX_VCPUS - 1]std.Thread = undefined;
+    var secondary_args_storage: [MAX_VCPUS - 1]SecondaryRunArgs = undefined;
+    const secondary_vcpus = secondary_storage[0..1];
+    const secondary_threads = secondary_thread_storage[0..1];
+    const secondary_args = secondary_args_storage[0..1];
+    var run_shared = HvfRunShared{};
+    var psci_cpus = PsciCpuTable.init(2);
+    var devs: Devices = undefined;
+    const irqs: IrqMap = undefined;
+    const started = try start_secondary_vcpus(
+        secondary_vcpus,
+        secondary_threads,
+        secondary_args,
+        &cfg,
+        &devs,
+        irqs,
+        &run_shared,
+        &psci_cpus,
+    );
+    defer stop_secondary_vcpus(
+        secondary_vcpus,
+        secondary_threads[0..@intCast(started)],
+        &run_shared,
+    );
+
+    try std.testing.expectEqual(hvf.mpidr_for_vcpu_index(0), try boot_vcpu.get_sys_reg(.mpidr_el1));
+    try std.testing.expectEqual(
+        hvf.mpidr_for_vcpu_index(1),
+        secondary_vcpus[0].mpidr.load(.seq_cst),
+    );
+    try std.testing.expect(secondary_vcpus[0].handle.load(.seq_cst) != std.math.maxInt(u64));
+    try std.testing.expect(secondary_vcpus[0].handle.load(.seq_cst) != boot_vcpu.handle);
+    try std.testing.expectEqual(@as(u64, 0), secondary_vcpus[0].run_entries.load(.seq_cst));
+}
+
+test "HVF secondary vCPU wakes on PSCI CPU_ON and parks on CPU_OFF" {
+    const create_vm = hvf.Vm.create;
+    const vm = create_vm() catch |err| switch (err) {
+        error.Denied => {
+            std.debug.print("skip: HV_DENIED\n", .{});
+            return;
+        },
+        else => return err,
+    };
+    defer vm.destroy();
+    try enable_gic();
+
+    const host_mem = try std.posix.mmap(
+        null,
+        hvf.page_size,
+        .{ .READ = true, .WRITE = true },
+        .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
+        -1,
+        0,
+    );
+    defer std.posix.munmap(host_mem);
+    const hvc0_instr: u32 = 0xD4000002;
+    @as(*align(4) u32, @ptrCast(@alignCast(host_mem.ptr))).* = hvc0_instr;
+    const guest_base: u64 = 0x40000000;
+    try vm.map(host_mem, guest_base, hvf.MapFlags.rx);
+    defer vm.unmap(guest_base, hvf.page_size) catch |err| {
+        std.debug.print("hvf secondary test: unmap failed: {s}\n", .{@errorName(err)});
+    };
+
+    const cfg = Config{
+        .kernel_path = "unused",
+        .dtb_path = "unused",
+        .max_vcpus = 2,
+    };
+    var secondary_storage: [MAX_VCPUS - 1]SecondaryVcpu = undefined;
+    var secondary_thread_storage: [MAX_VCPUS - 1]std.Thread = undefined;
+    var secondary_args_storage: [MAX_VCPUS - 1]SecondaryRunArgs = undefined;
+    const secondary_vcpus = secondary_storage[0..1];
+    const secondary_threads = secondary_thread_storage[0..1];
+    const secondary_args = secondary_args_storage[0..1];
+    var run_shared = HvfRunShared{};
+    var psci_cpus = PsciCpuTable.init(2);
+    var devs: Devices = undefined;
+    const irqs: IrqMap = undefined;
+    const started = try start_secondary_vcpus(
+        secondary_vcpus,
+        secondary_threads,
+        secondary_args,
+        &cfg,
+        &devs,
+        irqs,
+        &run_shared,
+        &psci_cpus,
+    );
+    defer stop_secondary_vcpus(
+        secondary_vcpus,
+        secondary_threads[0..@intCast(started)],
+        &run_shared,
+    );
+
+    const secondary_mpidr = hvf.mpidr_for_vcpu_index(1);
+    const cpu_off_id = @intFromEnum(hvf.Psci.Function.cpu_off);
+    try std.testing.expectEqual(
+        PsciReturn.success,
+        psci_cpus.cpu_on(secondary_mpidr, guest_base, cpu_off_id),
+    );
+    request_secondary_start(secondary_vcpus, 1, guest_base, cpu_off_id);
+
+    const max_polls: u32 = 5_000;
+    var polls: u32 = 0;
+    while (polls < max_polls and
+        secondary_vcpus[0].run_entries.load(.seq_cst) == 0 and
+        !run_shared.crashed.load(.seq_cst)) : (polls += 1)
+    {
+        sleep_micros(1_000);
+    }
+    try std.testing.expect(!run_shared.crashed.load(.seq_cst));
+    try std.testing.expect(secondary_vcpus[0].run_entries.load(.seq_cst) > 0);
+
+    polls = 0;
+    const parked_state = @intFromEnum(SecondaryVcpuState.parked);
+    while (polls < max_polls and
+        secondary_vcpus[0].state.load(.seq_cst) != parked_state) : (polls += 1)
+    {
+        sleep_micros(1_000);
+    }
+    try std.testing.expectEqual(parked_state, secondary_vcpus[0].state.load(.seq_cst));
+    run_shared.mutex.lock();
+    const affinity = psci_cpus.affinity_info(secondary_mpidr).?;
+    run_shared.mutex.unlock();
+    try std.testing.expectEqual(PsciAffinity.off, affinity);
 }
 
 test "boot a real arm64 Linux kernel" {

--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -19,6 +19,7 @@ comptime {
 
 const kvm = @import("kvm.zig");
 const uart8250_mod = @import("uart8250.zig");
+const pl011_mod = @import("pl011.zig");
 const virtio = @import("virtio.zig");
 const blk_mod = @import("blk.zig");
 const vsock_mod = @import("vsock.zig");
@@ -47,6 +48,7 @@ const virtio_mmio_hole_base: u64 = virtio_net_base;
 const virtio_mmio_hole_size: u64 = 0x1_0000;
 const virtio_mmio_hole_end: u64 = virtio_mmio_hole_base + virtio_mmio_hole_size;
 
+const MAX_VCPUS = 64;
 const MAX_VIRTIOFS_SLOTS: usize = 5;
 const virtio_virtiofs_bases: [MAX_VIRTIOFS_SLOTS]u64 = .{
     0x0A00_0E00,
@@ -64,6 +66,10 @@ const boot_stack_addr: u64 = 0x0009_0000;
 const cmdline_addr: u64 = 0x0002_0000;
 const kernel_load_addr: u64 = 0x0100_0000;
 const acpi_base: u64 = 0x000F_0000;
+const ioapic_base: u64 = 0xFEC0_0000;
+const ioapic_size: u64 = 0x1000;
+const lapic_base: u64 = 0xFEE0_0000;
+const lapic_size: u64 = 0x1000;
 const pm1a_evt_port: u16 = 0x0600;
 const pm1a_cnt_port: u16 = 0x0604;
 const reset_port: u16 = 0x0CF9;
@@ -107,6 +113,7 @@ pub const Config = struct {
     restore_path: ?[]const u8 = null,
     snapshot_path: ?[]const u8 = null,
     cmdline: ?[]const u8 = null,
+    max_vcpus: u32 = 1,
 };
 
 pub const Result = struct {
@@ -124,6 +131,8 @@ fn validate_config(cfg: *const Config) void {
     assert(cfg.initrd_offset % 4096 == 0);
     assert(cfg.initrd_offset < cfg.ram_size);
     assert(cfg.max_exits > 0);
+    assert(cfg.max_vcpus >= 1);
+    assert(cfg.max_vcpus <= MAX_VCPUS);
 }
 
 fn set_irq_best_effort(vm: *kvm.Vm, irq: u32, level: u32) void {
@@ -136,6 +145,7 @@ fn set_irq_best_effort(vm: *kvm.Vm, irq: u32, level: u32) void {
 pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     validate_config(&cfg);
     if (cfg.snapshot_path != null) install_snapshot_signal();
+    if (cfg.max_vcpus > 1) install_ap_kick_signal();
 
     var fx = try load_fixtures(gpa, &cfg);
     defer fx.deinit(gpa);
@@ -151,17 +161,21 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     defer vm.destroy();
 
     try vm.set_tss_addr(0xFFFBD000);
+    try vm.set_identity_map_addr(0xFFE0_0000);
     try vm.create_irqchip();
     try vm.create_pit2();
     try map_guest_ram(&vm, &cfg, ram);
 
-    var vcpu = try init_vcpu(&vm, ram, &cfg);
-    defer vcpu.destroy();
+    var vcpu_storage: [MAX_VCPUS]kvm.Vcpu = undefined;
+    const vcpu_count = @as(@TypeOf(vcpu_storage.len), @intCast(cfg.max_vcpus));
+    var vcpus = vcpu_storage[0..vcpu_count];
+    try init_vcpus(&vm, ram, &cfg, vcpus);
+    defer for (vcpus) |*vcpu| vcpu.destroy();
 
     var uart = uart8250_mod.Uart8250.with_base(uart_base);
     uart.capture_enabled = !cfg.unbounded_serial;
 
-    const irqs = IrqMap.init();
+    const irqs = IrqMap.init(cfg.max_vcpus);
 
     const slot1_path: ?[]const u8 = cfg.rootdisk_path orelse cfg.disk_path;
     const slot3_path: ?[]const u8 = if (cfg.rootdisk_path != null) cfg.disk_path else null;
@@ -265,14 +279,14 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     };
 
     if (cfg.restore_path) |path| {
-        apply_restore_file(gpa, path, &vm, &vcpu, ram, &cfg, &devs) catch |err| {
+        apply_restore_file(gpa, path, &vm, &vcpus[0], ram, &cfg, &devs) catch |err| {
             std.debug.print("kvm-x86_64 boot: restore from {s} failed: {s}\n", .{ path, @errorName(err) });
             return err;
         };
         std.debug.print("kvm-x86_64 boot: restored from {s}\n", .{path});
     }
 
-    return try run_loop(gpa, &cfg, &vm, &vcpu, &devs, irqs, ram);
+    return try run_loop(gpa, &cfg, &vm, vcpus, &devs, irqs, ram);
 }
 
 const LoadedFixtures = struct {
@@ -348,7 +362,7 @@ fn allocate_and_populate_ram(
     @memcpy(bp[0..setup_copy], fx.kernel[0..setup_copy]);
     populate_boot_params(bp, cfg, fx.img);
 
-    const cmdline = cfg.cmdline orelse default_cmdline();
+    const cmdline = cfg.cmdline orelse default_cmdline(cfg.max_vcpus);
     if (cmdline.len + 1 > 4096) return error.BootParamsTooLarge;
     const cmd = guest_slice(ram, cmdline_addr, cmdline.len + 1);
     @memcpy(cmd[0..cmdline.len], cmdline);
@@ -367,7 +381,7 @@ fn allocate_and_populate_ram(
     }
 
     write_gdt(ram);
-    write_acpi_tables(ram);
+    write_acpi_tables(ram, cfg.max_vcpus);
     return ram;
 }
 
@@ -382,10 +396,32 @@ fn map_guest_ram(vm: *kvm.Vm, cfg: *const Config, ram: []u8) !void {
     assert(cfg.ram_base == 0);
     assert(cfg.ram_size == ram.len);
     assert(cfg.ram_size > virtio_mmio_hole_end);
-    const low_len: usize = @intCast(virtio_mmio_hole_base);
-    const high_off: usize = @intCast(virtio_mmio_hole_end);
-    try vm.map_memory(0, 0, ram[0..low_len]);
-    try vm.map_memory(1, virtio_mmio_hole_end, ram[high_off..]);
+    var slot: u32 = 0;
+    try map_ram_range(vm, ram, &slot, 0, virtio_mmio_hole_base);
+    try map_ram_range(
+        vm,
+        ram,
+        &slot,
+        virtio_mmio_hole_end,
+        @min(ioapic_base, cfg.ram_size),
+    );
+    try map_ram_range(
+        vm,
+        ram,
+        &slot,
+        ioapic_base + ioapic_size,
+        @min(lapic_base, cfg.ram_size),
+    );
+    try map_ram_range(vm, ram, &slot, lapic_base + lapic_size, cfg.ram_size);
+}
+
+fn map_ram_range(vm: *kvm.Vm, ram: []u8, slot: *u32, start: u64, end: u64) !void {
+    if (end <= start) return;
+    assert(end <= ram.len);
+    const start_idx = @as(@TypeOf(ram.len), @intCast(start));
+    const end_idx = @as(@TypeOf(ram.len), @intCast(end));
+    try vm.map_memory(slot.*, start, ram[start_idx..end_idx]);
+    slot.* += 1;
 }
 
 fn write_int(buf: []u8, off: usize, comptime T: type, value: T) void {
@@ -401,29 +437,73 @@ fn populate_boot_params(bp: []u8, cfg: *const Config, img: BzImage) void {
     write_int(bp, 0x224, u16, 0xFE00); // heap_end_ptr
     write_int(bp, 0x228, u32, @intCast(cmdline_addr));
     write_int(bp, 0x238, u32, 4096); // cmdline_size
-    write_int(bp, 0x1E8, u8, 6); // e820_entries
+    var e820_entries: u8 = 0;
 
     // Keep the arm64 virtio-mmio layout (0x0a00_0000...), but on x86
-    // guest RAM starts at GPA 0. Carve a page-aligned hole out of both
-    // KVM's RAM slots (see mapGuestRam) and Linux's e820 map so the
-    // virtio-mmio resources are neither System RAM nor backed by RAM.
-    write_e820(bp, 0, 0x0000_0000, 0x0009_FC00, 1);
-    write_e820(bp, 1, 0x0009_FC00, 0x0005_0400, 2);
-    write_e820(bp, 2, acpi_base, 0x0001_0000, 3);
-    write_e820(bp, 3, 0x0010_0000, virtio_mmio_hole_base - 0x0010_0000, 1);
-    write_e820(bp, 4, virtio_mmio_hole_base, virtio_mmio_hole_size, 2);
-    write_e820(bp, 5, virtio_mmio_hole_end, cfg.ram_size - virtio_mmio_hole_end, 1);
+    // guest RAM starts at GPA 0. Carve page-aligned holes out of both
+    // KVM's RAM slots (see mapGuestRam) and Linux's e820 map so MMIO
+    // resources are neither System RAM nor backed by RAM. The APIC
+    // holes are essential for SMP: if LAPIC MMIO is backed by RAM,
+    // Linux's startup IPIs never reach KVM's in-kernel local APIC.
+    append_e820(bp, &e820_entries, 0x0000_0000, 0x0009_FC00, 1);
+    append_e820(bp, &e820_entries, 0x0009_FC00, 0x0005_0400, 2);
+    append_e820(bp, &e820_entries, acpi_base, 0x0001_0000, 3);
+    append_e820(bp, &e820_entries, 0x0010_0000, virtio_mmio_hole_base - 0x0010_0000, 1);
+    append_e820(bp, &e820_entries, virtio_mmio_hole_base, virtio_mmio_hole_size, 2);
+    append_e820(
+        bp,
+        &e820_entries,
+        virtio_mmio_hole_end,
+        @min(ioapic_base, cfg.ram_size) - virtio_mmio_hole_end,
+        1,
+    );
+    if (cfg.ram_size > ioapic_base) {
+        const ioapic_end = @min(ioapic_base + ioapic_size, cfg.ram_size);
+        append_e820(bp, &e820_entries, ioapic_base, ioapic_end - ioapic_base, 2);
+        append_e820(bp, &e820_entries, ioapic_end, @min(lapic_base, cfg.ram_size) - ioapic_end, 1);
+    }
+    if (cfg.ram_size > lapic_base) {
+        const lapic_end = @min(lapic_base + lapic_size, cfg.ram_size);
+        append_e820(bp, &e820_entries, lapic_base, lapic_end - lapic_base, 2);
+        append_e820(bp, &e820_entries, lapic_end, cfg.ram_size - lapic_end, 1);
+    }
+    write_int(bp, 0x1E8, u8, e820_entries); // e820_entries
 }
 
-fn write_e820(bp: []u8, idx: usize, addr: u64, size: u64, typ: u32) void {
-    const off = 0x2D0 + idx * 20;
+fn append_e820(bp: []u8, entries: *u8, addr: u64, size: u64, typ: u32) void {
+    assert(bp.len >= 4096);
+    if (size == 0) return;
+    const idx = entries.*;
+    const off = 0x2D0 + @as(u16, idx) * 20;
     write_int(bp, off + 0, u64, addr);
     write_int(bp, off + 8, u64, size);
     write_int(bp, off + 16, u32, typ);
+    entries.* += 1;
 }
 
-fn default_cmdline() []const u8 {
-    return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 panic=1 loglevel=3 quiet reboot=k noapic acpi=force pci=off " ++
+fn default_cmdline(max_vcpus: u32) []const u8 {
+    assert(max_vcpus >= 1);
+    if (max_vcpus == 1) {
+        return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 " ++
+            "panic=1 loglevel=3 quiet reboot=k noapic acpi=force pci=off " ++
+            "virtio_mmio.device=512@0x0a000000:5 " ++
+            "virtio_mmio.device=512@0x0a000200:6 " ++
+            "virtio_mmio.device=512@0x0a000400:7 " ++
+            "virtio_mmio.device=512@0x0a000600:8 " ++
+            "virtio_mmio.device=512@0x0a000800:9 " ++
+            "virtio_mmio.device=512@0x0a000a00:10 " ++
+            "virtio_mmio.device=512@0x0a000c00:11 " ++
+            "virtio_mmio.device=512@0x0a000e00:12 " ++
+            "virtio_mmio.device=512@0x0a001000:13 " ++
+            "virtio_mmio.device=512@0x0a001200:14 " ++
+            "virtio_mmio.device=512@0x0a001400:15 " ++
+            // x86 runs with `noapic`, so IRQ 16 is not routable via the
+            // legacy PIC. Use the otherwise-free COM2 line for the fifth
+            // virtio-fs slot instead of advertising an invalid GSI (#943).
+            "virtio_mmio.device=512@0x0a001600:3";
+    }
+    return "earlycon=uart8250,io,0x3f8,115200n8 console=ttyS0 " ++
+        "panic=1 loglevel=3 quiet reboot=k noapic acpi=force pci=off " ++
         "virtio_mmio.device=512@0x0a000000:5 " ++
         "virtio_mmio.device=512@0x0a000200:6 " ++
         "virtio_mmio.device=512@0x0a000400:7 " ++
@@ -435,9 +515,6 @@ fn default_cmdline() []const u8 {
         "virtio_mmio.device=512@0x0a001000:13 " ++
         "virtio_mmio.device=512@0x0a001200:14 " ++
         "virtio_mmio.device=512@0x0a001400:15 " ++
-        // x86 runs with `noapic`, so IRQ 16 is not routable via the
-        // legacy PIC. Use the otherwise-free COM2 line for the fifth
-        // virtio-fs slot instead of advertising an invalid GSI (#943).
         "virtio_mmio.device=512@0x0a001600:3";
 }
 
@@ -449,14 +526,56 @@ fn write_gdt(ram: []u8) void {
     write_int(gdt, 24, u64, 0x00CF_9300_0000_FFFF);
 }
 
-fn init_vcpu(vm: *kvm.Vm, ram: []u8, cfg: *const Config) !kvm.Vcpu {
+fn init_vcpus(vm: *kvm.Vm, ram: []u8, cfg: *const Config, vcpus: []kvm.Vcpu) !void {
+    assert(vcpus.len == @as(@TypeOf(vcpus.len), @intCast(cfg.max_vcpus)));
+    var initialized: usize = 0;
+    errdefer for (vcpus[0..initialized]) |*vcpu| vcpu.destroy();
+
+    const supported_cpuid = try vm.parent.supported_cpuid();
+    for (vcpus, 0..) |*slot, id| {
+        var cpuid = supported_cpuid;
+        configure_vcpu_cpuid(&cpuid, @intCast(id), cfg.max_vcpus);
+        slot.* = try init_vcpu(vm, ram, cfg, @intCast(id), &cpuid);
+        initialized += 1;
+    }
+}
+
+fn configure_vcpu_cpuid(cpuid: *kvm.Cpuid2, id: u32, max_vcpus: u32) void {
+    assert(max_vcpus >= 1);
+    assert(id < max_vcpus);
+    const logical = @min(max_vcpus, 255);
+    for (cpuid.entries[0..cpuid.nent]) |*entry| {
+        switch (entry.function) {
+            0x1 => {
+                entry.ebx = (entry.ebx & 0x0000_FFFF) |
+                    (@as(u32, logical) << @as(u5, 16)) |
+                    (@as(u32, id) << @as(u5, 24));
+                // Keep the host-supported APIC mode bits; KVM handles
+                // xAPIC MMIO and x2APIC MSRs for the in-kernel irqchip.
+            },
+            else => {},
+        }
+    }
+}
+
+fn init_vcpu(
+    vm: *kvm.Vm,
+    ram: []u8,
+    cfg: *const Config,
+    id: u32,
+    cpuid: *const kvm.Cpuid2,
+) !kvm.Vcpu {
     _ = ram;
-    _ = cfg;
-    var vcpu = try vm.create_vcpu(0);
+    assert(id < cfg.max_vcpus);
+    var vcpu = try vm.create_vcpu(id);
     errdefer vcpu.destroy();
 
-    const cpuid = try vm.parent.supported_cpuid();
-    try vcpu.set_cpuid2(&cpuid);
+    try vcpu.set_cpuid2(cpuid);
+    try set_lapic_id(&vcpu, id);
+    if (id != 0) {
+        try vcpu.set_mp_state(kvm.KVM_MP_STATE_UNINITIALIZED);
+        return vcpu;
+    }
 
     var sregs = try vcpu.get_sregs_x86();
     sregs.gdt.base = gdt_addr;
@@ -480,6 +599,16 @@ fn init_vcpu(vm: *kvm.Vm, ram: []u8, cfg: *const Config) !kvm.Vcpu {
     return vcpu;
 }
 
+fn set_lapic_id(vcpu: *kvm.Vcpu, id: u32) !void {
+    assert(id < MAX_VCPUS);
+    var lapic = try vcpu.get_lapic();
+    lapic.regs[0x20 + 0] = 0;
+    lapic.regs[0x20 + 1] = 0;
+    lapic.regs[0x20 + 2] = 0;
+    lapic.regs[0x20 + 3] = @truncate(id);
+    try vcpu.set_lapic(lapic);
+}
+
 fn flat_segment(index: u16, code: bool) kvm.X86Segment {
     return .{
         .base = 0,
@@ -498,15 +627,17 @@ fn flat_segment(index: u16, code: bool) kvm.X86Segment {
     };
 }
 
-fn write_acpi_tables(ram: []u8) void {
+fn write_acpi_tables(ram: []u8, max_vcpus: u32) void {
     const rsdp_addr = acpi_base;
     const rsdt_addr = acpi_base + 0x0100;
     const xsdt_addr = acpi_base + 0x0180;
     const madt_addr = acpi_base + 0x0200;
     const fadt_addr = acpi_base + 0x0300;
     const dsdt_addr = acpi_base + 0x0500;
+    assert(max_vcpus >= 1);
+    const madt_len = 44 + @as(@TypeOf(ram.len), @intCast(max_vcpus)) * 8 + 12 + 10;
 
-    write_madt(guest_slice(ram, madt_addr, 74));
+    write_madt(guest_slice(ram, madt_addr, madt_len), max_vcpus);
     write_dsdt(guest_slice(ram, dsdt_addr, 128));
     write_fadt(guest_slice(ram, fadt_addr, 244), dsdt_addr);
     write_rsdt(guest_slice(ram, rsdt_addr, 44), madt_addr, fadt_addr);
@@ -561,18 +692,21 @@ fn write_xsdt(xsdt: []u8, madt_addr: u64, fadt_addr: u64) void {
     finish_checksum(xsdt, 9);
 }
 
-fn write_madt(madt: []u8) void {
+fn write_madt(madt: []u8, max_vcpus: u32) void {
     @memset(madt, 0);
     write_acpi_header(madt, "APIC", 1, "MACHAPIC");
     write_int(madt, 36, u32, 0xFEE0_0000);
     write_int(madt, 40, u32, 1); // PC/AT dual-8259 present
-    var off: usize = 44;
-    madt[off + 0] = 0; // processor local APIC
-    madt[off + 1] = 8;
-    madt[off + 2] = 0;
-    madt[off + 3] = 0;
-    write_int(madt, off + 4, u32, 1);
-    off += 8;
+    assert(max_vcpus >= 1);
+    var off = @as(@TypeOf(madt.len), 44);
+    for (0..@intCast(max_vcpus)) |id| {
+        madt[off + 0] = 0; // processor local APIC
+        madt[off + 1] = 8;
+        madt[off + 2] = @intCast(id); // ACPI processor UID
+        madt[off + 3] = @intCast(id); // APIC ID, matching KVM vCPU id
+        write_int(madt, off + 4, u32, 1); // enabled
+        off += 8;
+    }
     madt[off + 0] = 1; // IOAPIC
     madt[off + 1] = 12;
     madt[off + 2] = 0;
@@ -635,62 +769,129 @@ fn write_dsdt(dsdt_buf: []u8) void {
     @memcpy(dsdt_buf[0..dsdt.len], &dsdt);
 }
 
+const RunShared = struct {
+    mutex: pl011_mod.PthreadMutex = .{},
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    saw_off: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    crashed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    exits: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+};
+
+const ApRunArgs = struct {
+    cfg: *const Config,
+    vm: *kvm.Vm,
+    vcpu: *kvm.Vcpu,
+    devs: *const Devices,
+    irqs: IrqMap,
+    shared: *RunShared,
+};
+
 fn run_loop(
     gpa: std.mem.Allocator,
     cfg: *const Config,
     vm: *kvm.Vm,
-    vcpu: *kvm.Vcpu,
+    vcpus: []kvm.Vcpu,
     devs: *const Devices,
     irqs: IrqMap,
     ram: []u8,
 ) !Result {
     assert(cfg.max_exits > 0);
     assert(ram.len == cfg.ram_size);
+    assert(vcpus.len >= 1);
 
-    var exits: usize = 0;
-    var saw_off = false;
+    var shared = RunShared{};
+    var ap_args_storage: [MAX_VCPUS - 1]ApRunArgs = undefined;
+    var thread_storage: [MAX_VCPUS - 1]std.Thread = undefined;
+    var ap_args = ap_args_storage[0 .. vcpus.len - 1];
+    var threads = thread_storage[0 .. vcpus.len - 1];
+    var started = @as(@TypeOf(vcpus.len), 0);
+    defer {
+        shared.stop.store(true, .seq_cst);
+        kick_ap_threads(vcpus[1..], threads[0..started]);
+        for (threads[0..started]) |thread| thread.join();
+    }
+
+    for (vcpus[1..], 0..) |*ap_vcpu, idx| {
+        ap_args[idx] = .{
+            .cfg = cfg,
+            .vm = vm,
+            .vcpu = ap_vcpu,
+            .devs = devs,
+            .irqs = irqs,
+            .shared = &shared,
+        };
+        threads[idx] = try std.Thread.spawn(
+            .{ .stack_size = std.Thread.SpawnConfig.default_stack_size },
+            ap_run_loop,
+            .{&ap_args[idx]},
+        );
+        started += 1;
+    }
+
     var snapshotted = false;
     var snapshot_writer_state: vmstate_writer.Writer = .{};
     defer snapshot_writer_state.wait();
-    while (exits < cfg.max_exits) : (exits += 1) {
-        const reason = try vcpu.run();
+    while (!shared.stop.load(.seq_cst) and shared.exits.load(.seq_cst) < cfg.max_exits) {
+        const reason = try vcpus[0].run();
+        _ = shared.exits.fetchAdd(1, .seq_cst);
         switch (reason) {
             .mmio => {
-                const ev = vcpu.mmio_exit();
-                try route_mmio(vm, vcpu, devs, irqs, ev);
+                const ev = vcpus[0].mmio_exit();
+                shared.mutex.lock();
+                defer shared.mutex.unlock();
+                try route_mmio(vm, &vcpus[0], devs, irqs, ev);
             },
             .io => {
-                const ev = vcpu.io_exit();
-                if (route_io(vcpu, devs, ev)) {
-                    saw_off = true;
+                const ev = vcpus[0].io_exit();
+                shared.mutex.lock();
+                defer shared.mutex.unlock();
+                if (route_io(&vcpus[0], devs, ev)) {
+                    shared.saw_off.store(true, .seq_cst);
+                    shared.stop.store(true, .seq_cst);
+                    kick_ap_threads(vcpus[1..], threads[0..started]);
                     break;
                 }
             },
-            .shutdown => {
-                saw_off = true;
-                break;
-            },
-            .system_event => {
-                saw_off = true;
+            .shutdown, .system_event => {
+                shared.saw_off.store(true, .seq_cst);
+                shared.stop.store(true, .seq_cst);
+                kick_ap_threads(vcpus[1..], threads[0..started]);
                 break;
             },
             .hlt, .intr, .debug => {},
             else => {
-                std.debug.print("kvm-x86_64: unhandled exit reason {d}\n", .{@intFromEnum(reason)});
+                std.debug.print("kvm-x86_64: unhandled BSP exit reason {d}\n", .{@intFromEnum(reason)});
+                shared.crashed.store(true, .seq_cst);
+                shared.stop.store(true, .seq_cst);
+                kick_ap_threads(vcpus[1..], threads[0..started]);
                 return error.GuestCrashed;
             },
         }
-        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) break;
+        if (!cfg.unbounded_serial and devs.uart.captured_len >= cfg.capture_bytes) {
+            shared.stop.store(true, .seq_cst);
+            break;
+        }
         if (snapshot_requested.load(.seq_cst)) {
-            if (cfg.snapshot_path) |path| {
-                if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vm, vcpu, ram, cfg, devs)) {
-                    snapshotted = true;
-                }
+            if (cfg.max_vcpus > 1) {
+                std.debug.print("kvm-x86_64: refusing vmstate snapshot for multi-vCPU guest\n", .{});
                 snapshot_requested.store(false, .seq_cst);
+            } else {
+                if (cfg.snapshot_path) |path| {
+                    shared.mutex.lock();
+                    defer shared.mutex.unlock();
+                    if (queue_snapshot_write(&snapshot_writer_state, gpa, path, vm, &vcpus[0], ram, cfg, devs)) {
+                        snapshotted = true;
+                    }
+                    snapshot_requested.store(false, .seq_cst);
+                }
             }
         }
     }
 
+    shared.stop.store(true, .seq_cst);
+    kick_ap_threads(vcpus[1..], threads[0..started]);
+    if (shared.crashed.load(.seq_cst)) return error.GuestCrashed;
+    const exits = shared.exits.load(.seq_cst);
     if (exits >= cfg.max_exits) {
         std.debug.print(
             "kvm-x86_64 boot: RanTooLong after {d} exits. Captured serial ({d} bytes):\n{s}\n",
@@ -700,7 +901,74 @@ fn run_loop(
     }
 
     const serial = try gpa.dupe(u8, devs.uart.captured_bytes());
-    return .{ .serial = serial, .saw_psci_shutdown = saw_off, .exits = exits, .snapshotted = snapshotted };
+    return .{
+        .serial = serial,
+        .saw_psci_shutdown = shared.saw_off.load(.seq_cst),
+        .exits = @intCast(exits),
+        .snapshotted = snapshotted,
+    };
+}
+
+fn kick_ap_threads(vcpus: []kvm.Vcpu, threads: []std.Thread) void {
+    assert(vcpus.len >= threads.len);
+    for (vcpus) |*vcpu| vcpu.request_immediate_exit();
+    for (threads) |thread| _ = std.c.pthread_kill(thread.getHandle(), .USR2);
+}
+
+fn ap_run_loop(args: *ApRunArgs) void {
+    assert(args.cfg.max_vcpus > 1);
+    while (!args.shared.stop.load(.seq_cst)) {
+        const state = args.vcpu.get_mp_state() catch kvm.KVM_MP_STATE_RUNNABLE;
+        if (state != kvm.KVM_MP_STATE_UNINITIALIZED) break;
+        _ = std.os.linux.sched_yield();
+    }
+
+    while (!args.shared.stop.load(.seq_cst) and
+        args.shared.exits.load(.seq_cst) < args.cfg.max_exits)
+    {
+        const reason = args.vcpu.run() catch |err| {
+            std.debug.print("kvm-x86_64: AP vCPU run failed: {s}\n", .{@errorName(err)});
+            args.shared.crashed.store(true, .seq_cst);
+            args.shared.stop.store(true, .seq_cst);
+            return;
+        };
+        _ = args.shared.exits.fetchAdd(1, .seq_cst);
+        switch (reason) {
+            .mmio => {
+                const ev = args.vcpu.mmio_exit();
+                args.shared.mutex.lock();
+                route_mmio(args.vm, args.vcpu, args.devs, args.irqs, ev) catch |err| {
+                    std.debug.print("kvm-x86_64: AP MMIO route failed: {s}\n", .{@errorName(err)});
+                    args.shared.crashed.store(true, .seq_cst);
+                    args.shared.stop.store(true, .seq_cst);
+                };
+                args.shared.mutex.unlock();
+            },
+            .io => {
+                const ev = args.vcpu.io_exit();
+                args.shared.mutex.lock();
+                const poweroff = route_io(args.vcpu, args.devs, ev);
+                args.shared.mutex.unlock();
+                if (poweroff) {
+                    args.shared.saw_off.store(true, .seq_cst);
+                    args.shared.stop.store(true, .seq_cst);
+                    return;
+                }
+            },
+            .shutdown, .system_event => {
+                args.shared.saw_off.store(true, .seq_cst);
+                args.shared.stop.store(true, .seq_cst);
+                return;
+            },
+            .hlt, .intr, .debug => {},
+            else => {
+                std.debug.print("kvm-x86_64: unhandled AP exit reason {d}\n", .{@intFromEnum(reason)});
+                args.shared.crashed.store(true, .seq_cst);
+                args.shared.stop.store(true, .seq_cst);
+                return;
+            },
+        }
+    }
 }
 
 fn queue_snapshot_write(
@@ -1254,6 +1522,18 @@ fn install_snapshot_signal() void {
     _ = c.signal(SIGUSR1, @intFromPtr(&sigusr1_handler));
 }
 
+fn ap_kick_handler(sig: c_int) callconv(.c) void {
+    _ = sig;
+}
+
+fn install_ap_kick_signal() void {
+    const c = struct {
+        extern "c" fn signal(sig: c_int, handler: usize) usize;
+    };
+    const SIGUSR2: c_int = 12;
+    _ = c.signal(SIGUSR2, @intFromPtr(&ap_kick_handler));
+}
+
 /// Drive the vCPU until PSCI SYSTEM_OFF, an unhandled exit, the
 /// configured serial-capture threshold, `max_exits`, or a
 /// Raw x86 GSI numbers used with KVM_IRQ_LINE. Linux learns these from
@@ -1269,7 +1549,7 @@ const IrqMap = struct {
     blk4: u32,
     virtiofs: [MAX_VIRTIOFS_SLOTS]u32,
 
-    fn init() IrqMap {
+    fn init(_: u32) IrqMap {
         return .{
             .uart = 4,
             .net = 5,
@@ -1621,8 +1901,8 @@ test "x86 bzImage parser rejects non-bzImage" {
     try std.testing.expectError(error.TruncatedSetup, BzImage.parse(bytes[0..1024]));
 }
 
-test "x86 cmdline advertises ttyS0, noapic, and virtio-mmio" {
-    const cmd = default_cmdline();
+test "x86 cmdline advertises ttyS0, noapic, and virtio-mmio for one vCPU" {
+    const cmd = default_cmdline(1);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "console=ttyS0") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "noapic") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a000200:6") != null);
@@ -1632,10 +1912,20 @@ test "x86 cmdline advertises ttyS0, noapic, and virtio-mmio" {
     );
 }
 
-test "x86 fifth virtio-fs slot uses a legacy noapic IRQ" {
-    const irqs = IrqMap.init();
-    try std.testing.expectEqual(@as(u32, 3), irqs.virtiofs[4]);
-    for (irqs.virtiofs) |irq| {
+test "x86 multi-vCPU cmdline keeps legacy IRQ routing" {
+    const cmd = default_cmdline(4);
+    try std.testing.expect(std.mem.indexOf(u8, cmd, "console=ttyS0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cmd, "noapic") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cmd, "virtio_mmio.device=512@0x0a001600:3") != null);
+}
+
+test "x86 fifth virtio-fs slot uses legacy IRQ routing" {
+    const single = IrqMap.init(1);
+    try std.testing.expectEqual(@as(u32, 3), single.virtiofs[4]);
+    for (single.virtiofs) |irq| {
         try std.testing.expect(irq < 16);
     }
+
+    const multi = IrqMap.init(4);
+    try std.testing.expectEqual(@as(u32, 3), multi.virtiofs[4]);
 }

--- a/packages/microvm/src/dtb_patch.zig
+++ b/packages/microvm/src/dtb_patch.zig
@@ -115,9 +115,9 @@ pub fn patch_initrd_end(dtb: []u8, new_end: u32) !void {
     // Each loop iteration consumes at least 4 bytes (one token), so
     // dtb.len/4 is a hard upper bound on iterations. +1 covers the
     // trailing exit check. Tigerstyle: every loop bounded.
-    const max_iters: usize = @divFloor(dtb.len, 4) + 1;
-    var iters: usize = 0;
-    var i: usize = h.off_struct;
+    const max_iters = @divFloor(dtb.len, 4) + 1;
+    var iters: @TypeOf(max_iters) = 0;
+    var i: @TypeOf(dtb.len) = h.off_struct;
     while (i + 4 <= dtb.len) : (iters += 1) {
         if (iters >= max_iters) return error.DtbTruncated;
         assert(i + 4 <= dtb.len);
@@ -137,9 +137,10 @@ pub fn patch_initrd_end(dtb: []u8, new_end: u32) !void {
                     std.mem.writeInt(u32, dtb[i..][0..4], new_end, .big);
                     return;
                 }
-                if (@as(usize, plen) > dtb.len - i) return error.DtbTruncated;
-                i += plen;
-                i = std.mem.alignForward(usize, i, 4);
+                const prop_len: @TypeOf(i) = plen;
+                if (prop_len > dtb.len - i) return error.DtbTruncated;
+                i += prop_len;
+                i = std.mem.alignForward(@TypeOf(i), i, 4);
                 if (i > dtb.len) return error.DtbTruncated;
                 assert(i <= dtb.len);
             },
@@ -172,9 +173,9 @@ pub fn patch_memory_size(dtb: []u8, size_bytes: u64) !void {
     // Walk the struct block. `depth` counts open BEGIN_NODE tokens;
     // root sits at depth 1, its children at depth 2.
     const ROOT_CHILD_DEPTH: i32 = 2;
-    const max_iters: usize = @divFloor(dtb.len, 4) + 1;
-    var iters: usize = 0;
-    var i: usize = h.off_struct;
+    const max_iters = @divFloor(dtb.len, 4) + 1;
+    var iters: @TypeOf(max_iters) = 0;
+    var i: @TypeOf(dtb.len) = h.off_struct;
     var depth: i32 = 0;
     var in_memory_node: bool = false;
     while (i + 4 <= dtb.len) : (iters += 1) {
@@ -220,9 +221,10 @@ pub fn patch_memory_size(dtb: []u8, size_bytes: u64) !void {
                     std.mem.writeInt(u64, dtb[i + 8 ..][0..8], size_bytes, .big);
                     return;
                 }
-                if (@as(usize, plen) > dtb.len - i) return error.DtbTruncated;
-                i += plen;
-                i = std.mem.alignForward(usize, i, 4);
+                const prop_len: @TypeOf(i) = plen;
+                if (prop_len > dtb.len - i) return error.DtbTruncated;
+                i += prop_len;
+                i = std.mem.alignForward(@TypeOf(i), i, 4);
                 if (i > dtb.len) return error.DtbTruncated;
                 assert(i <= dtb.len);
             },
@@ -233,6 +235,183 @@ pub fn patch_memory_size(dtb: []u8, size_bytes: u64) !void {
     assert(iters <= max_iters);
     assert(depth >= 0);
     return error.DtbTruncated;
+}
+
+/// Keep exactly `max_vcpus` arm64 CPU topology entries in the static DTB.
+///
+/// `assets/virt.dts` is compiled with a ceiling of CPU nodes so the runtime
+/// only has to delete entries, never grow the FDT. Deletion is represented as
+/// FDT_NOP tokens across the whole `cpu@N` node and matching `cpu-map/coreN`
+/// node. That keeps the DTB byte length stable while making Linux see only the
+/// CPUs Machinen is about to create and start through PSCI.
+pub fn patch_cpu_topology(dtb: []u8, max_vcpus: u32) !void {
+    assert(dtb.len > 0);
+    if (max_vcpus == 0) return error.CpuCountZero;
+    const h = try Header.read(dtb);
+
+    const max_iters = @divFloor(dtb.len, 4) + 1;
+    var iters: @TypeOf(max_iters) = 0;
+    var i: @TypeOf(dtb.len) = h.off_struct;
+    var depth: i32 = 0;
+    while (i + 4 <= dtb.len) : (iters += 1) {
+        if (iters >= max_iters) return error.DtbTruncated;
+        assert(depth >= 0);
+        assert(depth < MAX_FDT_DEPTH);
+        const token_start = i;
+        const tok = std.mem.readInt(u32, dtb[i..][0..4], .big);
+        i += 4;
+        switch (tok) {
+            FDT_BEGIN_NODE => {
+                if (depth >= MAX_FDT_DEPTH) return error.DtbTooDeep;
+                const name_start = i;
+                i = try skip_name(dtb, i);
+                depth += 1;
+                const name = name_slice(dtb, name_start);
+                const cpu_idx = cpu_node_index(name);
+                const core_idx = core_node_index(name);
+                var should_remove = false;
+                if (cpu_idx) |idx| {
+                    should_remove = idx >= max_vcpus;
+                } else {
+                    if (core_idx) |idx| should_remove = idx >= max_vcpus;
+                }
+                if (should_remove) {
+                    const end = try subtree_end(dtb, token_start);
+                    nop_range(dtb, token_start, end);
+                    i = end;
+                    depth -= 1;
+                }
+            },
+            FDT_END_NODE => {
+                if (depth == 0) return error.DtbBadToken;
+                depth -= 1;
+            },
+            FDT_NOP => {},
+            FDT_PROP => {
+                if (i + 8 > dtb.len) return error.DtbTruncated;
+                const plen = std.mem.readInt(u32, dtb[i..][0..4], .big);
+                i += 8;
+                const prop_len: @TypeOf(i) = plen;
+                if (prop_len > dtb.len - i) return error.DtbTruncated;
+                i += prop_len;
+                i = std.mem.alignForward(@TypeOf(i), i, 4);
+                if (i > dtb.len) return error.DtbTruncated;
+            },
+            FDT_END => break,
+            else => return error.DtbBadToken,
+        }
+    }
+
+    const counts = try count_cpu_topology_nodes(dtb);
+    if (counts.cpus != max_vcpus) return error.CpuTopologyTooSmall;
+    if (counts.cores != max_vcpus) return error.CpuMapTooSmall;
+}
+
+const CpuTopologyCounts = struct { cpus: u32 = 0, cores: u32 = 0 };
+
+fn count_cpu_topology_nodes(dtb: []const u8) !CpuTopologyCounts {
+    assert(dtb.len > 0);
+    const h = try Header.read(dtb);
+    const max_iters = @divFloor(dtb.len, 4) + 1;
+    var iters: @TypeOf(max_iters) = 0;
+    var i: @TypeOf(dtb.len) = h.off_struct;
+    var depth: i32 = 0;
+    var counts: CpuTopologyCounts = .{};
+    while (i + 4 <= dtb.len) : (iters += 1) {
+        if (iters >= max_iters) return error.DtbTruncated;
+        const tok = std.mem.readInt(u32, dtb[i..][0..4], .big);
+        i += 4;
+        switch (tok) {
+            FDT_BEGIN_NODE => {
+                if (depth >= MAX_FDT_DEPTH) return error.DtbTooDeep;
+                const name_start = i;
+                i = try skip_name(dtb, i);
+                depth += 1;
+                const name = name_slice(dtb, name_start);
+                if (cpu_node_index(name) != null) counts.cpus += 1;
+                if (core_node_index(name) != null) counts.cores += 1;
+            },
+            FDT_END_NODE => {
+                if (depth == 0) return error.DtbBadToken;
+                depth -= 1;
+            },
+            FDT_NOP => {},
+            FDT_PROP => {
+                if (i + 8 > dtb.len) return error.DtbTruncated;
+                const plen = std.mem.readInt(u32, dtb[i..][0..4], .big);
+                i += 8;
+                const prop_len: @TypeOf(i) = plen;
+                if (prop_len > dtb.len - i) return error.DtbTruncated;
+                i += prop_len;
+                i = std.mem.alignForward(@TypeOf(i), i, 4);
+                if (i > dtb.len) return error.DtbTruncated;
+            },
+            FDT_END => return counts,
+            else => return error.DtbBadToken,
+        }
+    }
+    return error.DtbTruncated;
+}
+
+fn subtree_end(dtb: []const u8, start: usize) !usize {
+    assert(start + 4 <= dtb.len);
+    const max_iters = @divFloor(dtb.len - start, 4) + 1;
+    var iters: @TypeOf(max_iters) = 0;
+    var i: @TypeOf(start) = start;
+    var depth: i32 = 0;
+    while (i + 4 <= dtb.len) : (iters += 1) {
+        if (iters >= max_iters) return error.DtbTruncated;
+        const tok = std.mem.readInt(u32, dtb[i..][0..4], .big);
+        i += 4;
+        switch (tok) {
+            FDT_BEGIN_NODE => {
+                if (depth >= MAX_FDT_DEPTH) return error.DtbTooDeep;
+                i = try skip_name(dtb, i);
+                depth += 1;
+            },
+            FDT_END_NODE => {
+                if (depth == 0) return error.DtbBadToken;
+                depth -= 1;
+                if (depth == 0) return i;
+            },
+            FDT_NOP => {},
+            FDT_PROP => {
+                if (i + 8 > dtb.len) return error.DtbTruncated;
+                const plen = std.mem.readInt(u32, dtb[i..][0..4], .big);
+                i += 8;
+                const prop_len: @TypeOf(i) = plen;
+                if (prop_len > dtb.len - i) return error.DtbTruncated;
+                i += prop_len;
+                i = std.mem.alignForward(@TypeOf(i), i, 4);
+                if (i > dtb.len) return error.DtbTruncated;
+            },
+            FDT_END => return error.DtbTruncated,
+            else => return error.DtbBadToken,
+        }
+    }
+    return error.DtbTruncated;
+}
+
+fn nop_range(dtb: []u8, start: usize, end: usize) void {
+    assert(start <= end);
+    assert(end <= dtb.len);
+    assert((end - start) % 4 == 0);
+    var i = start;
+    while (i < end) : (i += 4) {
+        std.mem.writeInt(u32, dtb[i..][0..4], FDT_NOP, .big);
+    }
+}
+
+fn cpu_node_index(name: []const u8) ?u32 {
+    assert(name.len <= MAX_NAME_BYTES);
+    if (!std.mem.startsWith(u8, name, "cpu@")) return null;
+    return std.fmt.parseUnsigned(u32, name[4..], 16) catch null;
+}
+
+fn core_node_index(name: []const u8) ?u32 {
+    assert(name.len <= MAX_NAME_BYTES);
+    if (!std.mem.startsWith(u8, name, "core")) return null;
+    return std.fmt.parseUnsigned(u32, name[4..], 10) catch null;
 }
 
 fn skip_name(dtb: []const u8, start: usize) !usize {
@@ -338,6 +517,27 @@ test "patchMemorySize ignores a depth>1 memory node (e.g. reserved-memory)" {
     try std.testing.expectError(error.MemoryRegNotFound, patch_memory_size(buf.bytes(), 0x1000));
 }
 
+test "patchCpuTopology keeps requested CPU nodes and matching cpu-map cores" {
+    var buf = minimal_cpu_topology_dtb(4);
+    try std.testing.expectEqual(
+        CpuTopologyCounts{ .cpus = 4, .cores = 4 },
+        try count_cpu_topology_nodes(buf.bytes()),
+    );
+
+    try patch_cpu_topology(buf.bytes(), 2);
+    try std.testing.expectEqual(
+        CpuTopologyCounts{ .cpus = 2, .cores = 2 },
+        try count_cpu_topology_nodes(buf.bytes()),
+    );
+
+    var too_small = minimal_cpu_topology_dtb(1);
+    try std.testing.expectError(
+        error.CpuTopologyTooSmall,
+        patch_cpu_topology(too_small.bytes(), 2),
+    );
+    try std.testing.expectError(error.CpuCountZero, patch_cpu_topology(too_small.bytes(), 0));
+}
+
 // Real-fixture coverage (DTB shape match against `assets/virt.dtb`)
 // is exercised end-to-end by the boot_hvf / boot_kvm smoke tests in
 // `pnpm smoke-tests`, where a DTS-shape regression surfaces as a
@@ -347,7 +547,7 @@ test "patchMemorySize ignores a depth>1 memory node (e.g. reserved-memory)" {
 // ---- test fixture builders ----
 
 const FixtureBuf = struct {
-    storage: [256]u8,
+    storage: [4096]u8,
     total_len: usize,
     struct_off: usize,
     reg_data_off: usize = 0,
@@ -366,7 +566,7 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
     assert(name_with_nul.len > 0);
 
     var fb: FixtureBuf = undefined;
-    fb.storage = [_]u8{0} ** 256;
+    fb.storage = [_]u8{0} ** 4096;
 
     // 0x00 header (40 bytes), 0x28 rsvmap terminator (16 bytes),
     // 0x38 struct block, 0x?? strings block. Struct breakdown:
@@ -375,7 +575,7 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
     //   value, padded to a 4-byte boundary             = padded
     //   END_NODE (4) + END (4)                         = 8
     const struct_off: u32 = 0x38;
-    const padded_value_len = std.mem.alignForward(usize, plen, 4);
+    const padded_value_len = std.mem.alignForward(@TypeOf(plen), plen, 4);
     const struct_size: u32 = @intCast(8 + 12 + padded_value_len + 4 + 4);
     const strings_off: u32 = struct_off + struct_size;
     const strings_size: u32 = @intCast(name_with_nul.len);
@@ -423,6 +623,92 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
     return fb;
 }
 
+fn minimal_cpu_topology_dtb(cpu_count: u32) FixtureBuf {
+    assert(cpu_count > 0);
+    assert(cpu_count <= 64);
+    var fb: FixtureBuf = undefined;
+    fb.storage = [_]u8{0} ** 4096;
+
+    const struct_off: u32 = 0x38;
+    var off: usize = struct_off;
+    write_begin_node(&fb.storage, &off, "");
+    write_begin_node(&fb.storage, &off, "cpus");
+    write_begin_node(&fb.storage, &off, "cpu-map");
+    write_begin_node(&fb.storage, &off, "socket0");
+    write_begin_node(&fb.storage, &off, "cluster0");
+    for (0..cpu_count) |idx| {
+        var name_buf: [16]u8 = undefined;
+        const name = std.fmt.bufPrint(&name_buf, "core{d}", .{idx}) catch unreachable;
+        write_begin_node(&fb.storage, &off, name);
+        write_end_node(&fb.storage, &off);
+    }
+    write_end_node(&fb.storage, &off); // cluster0
+    write_end_node(&fb.storage, &off); // socket0
+    write_end_node(&fb.storage, &off); // cpu-map
+    for (0..cpu_count) |idx| {
+        var name_buf: [16]u8 = undefined;
+        const name = std.fmt.bufPrint(&name_buf, "cpu@{x}", .{idx}) catch unreachable;
+        write_begin_node(&fb.storage, &off, name);
+        write_end_node(&fb.storage, &off);
+    }
+    write_end_node(&fb.storage, &off); // cpus
+    write_end_node(&fb.storage, &off); // root
+    std.mem.writeInt(u32, fb.storage[off..][0..4], FDT_END, .big);
+    off += 4;
+
+    const strings_off: u32 = @intCast(off);
+    fb.storage[off] = 0;
+    off += 1;
+    const total: u32 = @intCast(off);
+    const struct_size: u32 = strings_off - struct_off;
+    assert(total <= fb.storage.len);
+
+    write_header(&fb.storage, total, struct_off, strings_off, 1, struct_size);
+    fb.total_len = total;
+    fb.struct_off = struct_off;
+    return fb;
+}
+
+fn write_header(
+    storage: *[4096]u8,
+    total: u32,
+    struct_off: u32,
+    strings_off: u32,
+    strings_size: u32,
+    struct_size: u32,
+) void {
+    assert(total <= storage.len);
+    std.mem.writeInt(u32, storage[0..4], FDT_MAGIC, .big);
+    std.mem.writeInt(u32, storage[4..8], total, .big);
+    std.mem.writeInt(u32, storage[8..12], struct_off, .big);
+    std.mem.writeInt(u32, storage[12..16], strings_off, .big);
+    std.mem.writeInt(u32, storage[16..20], 0x28, .big);
+    std.mem.writeInt(u32, storage[20..24], 17, .big);
+    std.mem.writeInt(u32, storage[24..28], 16, .big);
+    std.mem.writeInt(u32, storage[28..32], 0, .big);
+    std.mem.writeInt(u32, storage[32..36], strings_size, .big);
+    std.mem.writeInt(u32, storage[36..40], struct_size, .big);
+}
+
+fn write_begin_node(storage: *[4096]u8, off: *usize, name: []const u8) void {
+    assert(off.* + name.len + 8 <= storage.len);
+    std.mem.writeInt(u32, storage[off.*..][0..4], FDT_BEGIN_NODE, .big);
+    off.* += 4;
+    @memcpy(storage[off.*..][0..name.len], name);
+    off.* += name.len;
+    storage[off.*] = 0;
+    off.* += 1;
+    const aligned = std.mem.alignForward(@TypeOf(off.*), off.*, 4);
+    @memset(storage[off.*..aligned], 0);
+    off.* = aligned;
+}
+
+fn write_end_node(storage: *[4096]u8, off: *usize) void {
+    assert(off.* + 4 <= storage.len);
+    std.mem.writeInt(u32, storage[off.*..][0..4], FDT_END_NODE, .big);
+    off.* += 4;
+}
+
 /// Build a DTB shaped like a real one: root "/" wrapping a single
 /// `memory@40000000` child with one `reg` property (16 bytes;
 /// address+size, 2 cells each). Matches the shape patchMemorySize
@@ -430,7 +716,7 @@ fn minimal_single_prop_dtb(name_with_nul: []const u8, plen: u32, value: []const 
 fn minimal_memory_node_dtb(addr: u64, size: u64) FixtureBuf {
     assert(size > 0);
     var fb: FixtureBuf = undefined;
-    fb.storage = [_]u8{0} ** 256;
+    fb.storage = [_]u8{0} ** 4096;
 
     const node_name = "memory@40000000\x00"; // 16 bytes incl. nul
     const reg_str = "reg\x00";
@@ -504,7 +790,7 @@ fn minimal_memory_node_dtb(addr: u64, size: u64) FixtureBuf {
 /// (depth 2) are valid candidates.
 fn nested_memory_node_dtb() FixtureBuf {
     var fb: FixtureBuf = undefined;
-    fb.storage = [_]u8{0} ** 256;
+    fb.storage = [_]u8{0} ** 4096;
 
     const wrap_name = "wrap\x00\x00\x00\x00"; // padded to 8
     const inner_name = "memory@40000000\x00"; // 16 bytes

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -459,6 +459,17 @@ pub const SysReg = enum(u32) {
     cntvoff_el2 = 0xE703,
 };
 
+/// Guest MPIDR_EL1 value for Machinen's flat arm64 topology.
+///
+/// Bit 31 is RES1 for MPIDR_EL1 on this HVF path, and Aff0 carries the
+/// vCPU index. The arm64 DTB `cpu@N` reg values and PSCI CPU_ON target
+/// MPIDRs must use this same mapping so Linux's logical CPUs line up with
+/// HVF's per-vCPU GIC redistributors.
+pub fn mpidr_for_vcpu_index(index: u32) u64 {
+    assert(index < 256);
+    return (@as(u64, 1) << 31) | index;
+}
+
 /// arm64 vCPU wrapper. Must be created from the thread that will run it.
 pub const Vcpu = struct {
     handle: u64,
@@ -776,6 +787,120 @@ test "hv_vm_create and destroy" {
     };
     defer vm.destroy();
     std.debug.print("hv_vm_create: HV_SUCCESS (entitled)\n", .{});
+}
+
+const MultiVcpuProbeResult = struct {
+    err: ?anyerror = null,
+    handle: u64 = 0,
+    mpidr: u64 = 0,
+    rdist: u64 = 0,
+};
+
+fn hvf_multi_vcpu_probe_worker(
+    index: u32,
+    ready: *std.atomic.Value(u32),
+    failed: *std.atomic.Value(bool),
+    result: *MultiVcpuProbeResult,
+) void {
+    assert(index < 2);
+    const create_vcpu = Vcpu.create;
+    const vcpu = create_vcpu() catch |err| {
+        result.err = err;
+        failed.store(true, .seq_cst);
+        return;
+    };
+    defer vcpu.destroy();
+
+    const mpidr = mpidr_for_vcpu_index(index);
+    vcpu.set_sys_reg(.mpidr_el1, mpidr) catch |err| {
+        result.err = err;
+        failed.store(true, .seq_cst);
+        return;
+    };
+
+    result.handle = vcpu.handle;
+    result.mpidr = vcpu.get_sys_reg(.mpidr_el1) catch |err| {
+        result.err = err;
+        failed.store(true, .seq_cst);
+        return;
+    };
+    const previous_ready = ready.fetchAdd(1, .seq_cst);
+    assert(previous_ready < 2);
+
+    // HVF vCPUs are thread-owned, so the multi-vCPU boot path must create
+    // each secondary from the host thread that will run it. Keep both vCPUs
+    // alive together before querying redistributors to prove this topology is
+    // not just sequential one-vCPU reuse.
+    while (ready.load(.seq_cst) < 2 and !failed.load(.seq_cst)) {
+        std.atomic.spinLoopHint();
+    }
+    if (failed.load(.seq_cst)) return;
+
+    result.rdist = Gic.redistributor_base(vcpu) catch |err| {
+        result.err = err;
+        failed.store(true, .seq_cst);
+        return;
+    };
+}
+
+test "HVF creates two vCPUs with unique MPIDR redistributors" {
+    const create_vm = Vm.create;
+    const vm = create_vm() catch |err| switch (err) {
+        error.Denied => {
+            std.debug.print("skip: HV_DENIED\n", .{});
+            return;
+        },
+        else => return err,
+    };
+    defer vm.destroy();
+
+    try Gic.enable(.{});
+    const rdist_region_base = (Gic.Config{}).redistributor_base;
+    const rdist_region_size = try Gic.redistributor_region_size();
+    try std.testing.expect(rdist_region_size > 0);
+
+    var ready = std.atomic.Value(u32).init(0);
+    var failed = std.atomic.Value(bool).init(false);
+    var results = [_]MultiVcpuProbeResult{ .{}, .{} };
+    const t0 = try std.Thread.spawn(
+        .{ .stack_size = std.Thread.SpawnConfig.default_stack_size },
+        hvf_multi_vcpu_probe_worker,
+        .{ 0, &ready, &failed, &results[0] },
+    );
+    const t1 = try std.Thread.spawn(
+        .{ .stack_size = std.Thread.SpawnConfig.default_stack_size },
+        hvf_multi_vcpu_probe_worker,
+        .{ 1, &ready, &failed, &results[1] },
+    );
+    t0.join();
+    t1.join();
+
+    if (results[0].err) |err| return err;
+    if (results[1].err) |err| return err;
+
+    try std.testing.expectEqual(mpidr_for_vcpu_index(0), results[0].mpidr);
+    try std.testing.expectEqual(mpidr_for_vcpu_index(1), results[1].mpidr);
+    try std.testing.expect(results[0].handle != results[1].handle);
+    try std.testing.expect(results[0].rdist != results[1].rdist);
+    try std.testing.expect(results[0].rdist >= rdist_region_base);
+    try std.testing.expect(results[1].rdist >= rdist_region_base);
+    try std.testing.expect(results[0].rdist < rdist_region_base + rdist_region_size);
+    try std.testing.expect(results[1].rdist < rdist_region_base + rdist_region_size);
+
+    std.debug.print(
+        "hvf multi-vcpu probe: vcpu0 handle={d} mpidr=0x{x} rdist=0x{x}; " ++
+            "vcpu1 handle={d} mpidr=0x{x} rdist=0x{x}; rdist_region=[0x{x},0x{x})\n",
+        .{
+            results[0].handle,
+            results[0].mpidr,
+            results[0].rdist,
+            results[1].handle,
+            results[1].mpidr,
+            results[1].rdist,
+            rdist_region_base,
+            rdist_region_base + rdist_region_size,
+        },
+    );
 }
 
 test "map a page, run hvc #0, observe exception exit" {

--- a/packages/microvm/src/kvm.zig
+++ b/packages/microvm/src/kvm.zig
@@ -62,6 +62,7 @@ pub const KVM_GET_SUPPORTED_CPUID = iowr(KVMIO, 0x05, @sizeOf(Cpuid2Header));
 // in-kernel irqchip on Intel hosts; KVM_CREATE_PIT2 gives Linux a legacy
 // PIT to calibrate timers against during early boot.
 pub const KVM_SET_TSS_ADDR = io_(KVMIO, 0x47);
+pub const KVM_SET_IDENTITY_MAP_ADDR = iow(KVMIO, 0x48, @sizeOf(u64));
 pub const KVM_CREATE_PIT2 = iow(KVMIO, 0x77, @sizeOf(PitConfig));
 pub const KVM_GET_PIT2 = ior(KVMIO, 0x9f, @sizeOf(PitState2));
 pub const KVM_SET_PIT2 = iow(KVMIO, 0xa0, @sizeOf(PitState2));
@@ -89,7 +90,11 @@ pub const KVM_GET_REGS = ior(KVMIO, 0x81, @sizeOf(X86Regs));
 pub const KVM_SET_REGS = iow(KVMIO, 0x82, @sizeOf(X86Regs));
 pub const KVM_GET_SREGS = ior(KVMIO, 0x83, @sizeOf(X86Sregs));
 pub const KVM_SET_SREGS = iow(KVMIO, 0x84, @sizeOf(X86Sregs));
+pub const KVM_GET_LAPIC = ior(KVMIO, 0x8E, @sizeOf(LapicState));
+pub const KVM_SET_LAPIC = iow(KVMIO, 0x8F, @sizeOf(LapicState));
 pub const KVM_SET_CPUID2 = iow(KVMIO, 0x90, @sizeOf(Cpuid2Header));
+pub const KVM_GET_MP_STATE = ior(KVMIO, 0x98, @sizeOf(MpState));
+pub const KVM_SET_MP_STATE = iow(KVMIO, 0x99, @sizeOf(MpState));
 
 // VM-scoped device creation (for vgic-v3, vsock, etc.) + per-device
 // attributes. `KVM_CREATE_DEVICE` returns a fd for the device; attr
@@ -322,6 +327,18 @@ pub const Cpuid2 = extern struct {
     padding: u32 = 0,
     entries: [max_cpuid_entries]CpuidEntry2 = @splat(std.mem.zeroes(CpuidEntry2)),
 };
+
+pub const MpState = extern struct {
+    mp_state: u32,
+};
+
+pub const LapicState = extern struct {
+    regs: [1024]u8,
+};
+
+pub const KVM_MP_STATE_RUNNABLE: u32 = 0;
+pub const KVM_MP_STATE_UNINITIALIZED: u32 = 1;
+pub const KVM_MP_STATE_HALTED: u32 = 3;
 
 pub const X86Sregs = extern struct {
     cs: X86Segment,
@@ -590,6 +607,7 @@ pub const KvmError = error{
     KvmCreateIrqchipFailed,
     KvmCreatePitFailed,
     KvmSetTssAddrFailed,
+    KvmSetIdentityMapFailed,
     KvmIrqLineFailed,
     KvmMmapRunFailed,
     KvmCheckExtensionFailed,
@@ -746,6 +764,17 @@ pub const Vm = struct {
         assert(addr % 4096 == 0);
         if (ioctl(self.fd, KVM_SET_TSS_ADDR, @as(c_ulong, @intCast(addr))) != 0) {
             return error.KvmSetTssAddrFailed;
+        }
+    }
+
+    /// x86 only: set the identity-map page KVM may need for real-mode transitions.
+    /// Must happen before createIrqchip() on Intel hosts.
+    pub fn set_identity_map_addr(self: *Vm, addr: u64) !void {
+        assert(self.fd >= 0);
+        assert(addr % 4096 == 0);
+        var v = addr;
+        if (ioctl(self.fd, KVM_SET_IDENTITY_MAP_ADDR, &v) != 0) {
+            return error.KvmSetIdentityMapFailed;
         }
     }
 
@@ -964,6 +993,13 @@ pub const Vcpu = struct {
         return v;
     }
 
+    pub fn request_immediate_exit(self: *Vcpu) void {
+        assert(self.fd >= 0);
+        assert(self.run_size >= 2);
+        const base: [*]u8 = @ptrCast(self.run_page);
+        base[1] = 1;
+    }
+
     pub fn run(self: *Vcpu) !ExitReason {
         assert(self.fd >= 0);
         // We at minimum need to read exit_reason (offset 8, 4 bytes)
@@ -1080,6 +1116,32 @@ pub const Vcpu = struct {
         if (ioctl(self.fd, KVM_SET_CPUID2, cpuid) != 0) return error.Unsupported;
     }
 
+    pub fn get_mp_state(self: *Vcpu) !u32 {
+        assert(self.fd >= 0);
+        var v: MpState = undefined;
+        if (ioctl(self.fd, KVM_GET_MP_STATE, &v) != 0) return error.Unsupported;
+        return v.mp_state;
+    }
+
+    pub fn set_mp_state(self: *Vcpu, state: u32) !void {
+        assert(self.fd >= 0);
+        var v = MpState{ .mp_state = state };
+        if (ioctl(self.fd, KVM_SET_MP_STATE, &v) != 0) return error.Unsupported;
+    }
+
+    pub fn get_lapic(self: *Vcpu) !LapicState {
+        assert(self.fd >= 0);
+        var v: LapicState = undefined;
+        if (ioctl(self.fd, KVM_GET_LAPIC, &v) != 0) return error.Unsupported;
+        return v;
+    }
+
+    pub fn set_lapic(self: *Vcpu, state: LapicState) !void {
+        assert(self.fd >= 0);
+        var v = state;
+        if (ioctl(self.fd, KVM_SET_LAPIC, &v) != 0) return error.Unsupported;
+    }
+
     pub fn get_regs_x86(self: *Vcpu) !X86Regs {
         assert(self.fd >= 0);
         var r: X86Regs = undefined;
@@ -1129,6 +1191,7 @@ test "KVMIO ioctl numbers match their documented kernel values" {
     try std.testing.expectEqual(@as(u32, 0xAE04), KVM_GET_VCPU_MMAP_SIZE);
     try std.testing.expectEqual(@as(u32, 0xC008AE05), KVM_GET_SUPPORTED_CPUID);
     try std.testing.expectEqual(@as(u32, 0xAE47), KVM_SET_TSS_ADDR);
+    try std.testing.expectEqual(@as(u32, 0x4008AE48), KVM_SET_IDENTITY_MAP_ADDR);
     try std.testing.expectEqual(@as(u32, 0x4040AE77), KVM_CREATE_PIT2);
     try std.testing.expectEqual(@as(u32, 0x8070AE9F), KVM_GET_PIT2);
     try std.testing.expectEqual(@as(u32, 0x4070AEA0), KVM_SET_PIT2);

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -53,6 +53,7 @@ pub fn main(init: std.process.Init) !void {
     // #271: explicit opt-in to expose EL2 / nested virtualization to
     // the guest. The runtime sets this from boot({ nested: true }).
     const nested = env_bool("MACHINEN_NESTED");
+    const max_vcpus = env_positive_u32("MACHINEN_MAX_VCPUS") orelse 1;
 
     // Guest console is live-echoed to stderr from inside the boot loop
     // (boot_hvf.zig's PL011 DR-write handler). The result.serial buffer is
@@ -78,6 +79,13 @@ pub fn main(init: std.process.Init) !void {
     const snapshot_path = env_optional("MACHINEN_SNAPSHOT_PATH");
 
     if (builtin.os.tag == .macos) {
+        if (max_vcpus != 1) {
+            std.debug.print(
+                "machinen-microvm: MACHINEN_MAX_VCPUS={d} unsupported on HVF arm64\n",
+                .{max_vcpus},
+            );
+            std.process.exit(2);
+        }
         const disk_path = env_optional("MACHINEN_DISK");
         const rootdisk_path = env_optional("MACHINEN_ROOTDISK");
         const hvf_dtb_path = dtb_path orelse env_required("MACHINEN_DTB");
@@ -120,12 +128,20 @@ pub fn main(init: std.process.Init) !void {
                 .max_exits = std.math.maxInt(usize),
                 .restore_path = restore_path,
                 .snapshot_path = snapshot_path,
+                .max_vcpus = max_vcpus,
             };
             if (ram_size_override) |bytes| cfg.ram_size = bytes;
             const result = try microvm.boot_kvm_x86_64.boot(gpa, cfg);
             gpa.free(result.serial);
             std.process.exit(if (result.saw_psci_shutdown or result.snapshotted) 0 else 1);
         } else {
+            if (max_vcpus != 1) {
+                std.debug.print(
+                    "machinen-microvm: MACHINEN_MAX_VCPUS={d} unsupported on KVM arm64\n",
+                    .{max_vcpus},
+                );
+                std.process.exit(2);
+            }
             const arm_dtb_path = dtb_path orelse env_required("MACHINEN_DTB");
             var cfg: microvm.boot_kvm.Config = .{
                 .kernel_path = kernel_path,
@@ -227,6 +243,28 @@ fn env_int(comptime name: [:0]const u8) ?c_int {
 /// value in bytes, or null if the var is unset / empty. Refuses
 /// anything we can't safely turn into a `usize` byte count: bad
 /// digits, zero, or values that would overflow.
+fn env_positive_u32(comptime name: [:0]const u8) ?u32 {
+    comptime assert(name.len > 0);
+    const raw = getenv(name.ptr) orelse return null;
+    const s = std.mem.span(raw);
+    if (s.len == 0) return null;
+    const parsed = std.fmt.parseInt(u32, s, 10) catch {
+        std.debug.print(
+            "machinen-microvm: {s}={s} is invalid: must be a positive integer.\n",
+            .{ name, s },
+        );
+        std.process.exit(2);
+    };
+    if (parsed == 0) {
+        std.debug.print(
+            "machinen-microvm: {s}=0 is invalid: must be a positive integer.\n",
+            .{name},
+        );
+        std.process.exit(2);
+    }
+    return parsed;
+}
+
 fn env_memory_mib() ?usize {
     const raw = getenv("MACHINEN_MEMORY") orelse return null;
     const s = std.mem.span(raw);

--- a/packages/microvm/src/main.zig
+++ b/packages/microvm/src/main.zig
@@ -79,13 +79,6 @@ pub fn main(init: std.process.Init) !void {
     const snapshot_path = env_optional("MACHINEN_SNAPSHOT_PATH");
 
     if (builtin.os.tag == .macos) {
-        if (max_vcpus != 1) {
-            std.debug.print(
-                "machinen-microvm: MACHINEN_MAX_VCPUS={d} unsupported on HVF arm64\n",
-                .{max_vcpus},
-            );
-            std.process.exit(2);
-        }
         const disk_path = env_optional("MACHINEN_DISK");
         const rootdisk_path = env_optional("MACHINEN_ROOTDISK");
         const hvf_dtb_path = dtb_path orelse env_required("MACHINEN_DTB");
@@ -102,6 +95,7 @@ pub fn main(init: std.process.Init) !void {
             .restore_path = restore_path,
             .snapshot_path = snapshot_path,
             .nested = nested,
+            .max_vcpus = max_vcpus,
         };
         if (ram_size_override) |bytes| cfg.ram_size = bytes;
         const result = try microvm.boot_hvf.boot(gpa, cfg);

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -4822,7 +4822,7 @@ Size in bytes the file was allocated at.
 
 ###### sourceArch?
 
-> `optional` **sourceArch?**: `"amd64"` \| `"arm64"`
+> `optional` **sourceArch?**: `"arm64"` \| `"amd64"`
 
 ###### resources
 
@@ -6154,7 +6154,7 @@ by default when `output` is a TTY.
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### targetRoot?
 
@@ -6203,7 +6203,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ##### kind
 
@@ -6839,7 +6839,7 @@ by default when `output` is a TTY.
 
 ###### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ###### pid?
 
@@ -6859,7 +6859,7 @@ by default when `output` is a TTY.
 
 ###### arch
 
-> **arch**: `"amd64"` \| `"arm64"`
+> **arch**: `"arm64"` \| `"amd64"`
 
 ###### abi
 
@@ -7439,11 +7439,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### codeLocations
 
@@ -7571,7 +7571,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ###### Inherited from
 
@@ -7679,7 +7679,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ###### Inherited from
 
@@ -7925,7 +7925,7 @@ by default when `output` is a TTY.
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### targetModules
 
@@ -8089,11 +8089,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### threads
 
@@ -8141,11 +8141,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### threads
 
@@ -11560,11 +11560,11 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### sourceThreadPointer?
 
@@ -11602,7 +11602,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### targetArch?
 
-> `optional` **targetArch?**: `"amd64"` \| `"arm64"`
+> `optional` **targetArch?**: `"arm64"` \| `"amd64"`
 
 ##### targetFsBase?
 
@@ -14397,7 +14397,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### guestArch
 
-> **guestArch**: `"amd64"` \| `"arm64"`
+> **guestArch**: `"arm64"` \| `"amd64"`
 
 ###### vmstate
 
@@ -14429,7 +14429,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### guestArch
 
-> **guestArch**: `"amd64"` \| `"arm64"`
+> **guestArch**: `"arm64"` \| `"amd64"`
 
 ###### mode
 
@@ -17191,7 +17191,7 @@ VMM backend that wrote `state.vmstate`.
 
 ##### guestArch?
 
-> `optional` **guestArch?**: `"amd64"` \| `"arm64"` \| `"unknown"`
+> `optional` **guestArch?**: `"arm64"` \| `"amd64"` \| `"unknown"`
 
 Guest CPU architecture captured in `state.vmstate`; restore must match.
 
@@ -17309,6 +17309,16 @@ this as the default rootfs, so the same-host quickstart works
 without callers having to repeat the image path. Cross-host
 restores need either the path to resolve on the new host, or an
 explicit `image` override.
+
+##### cpu?
+
+> `optional` **cpu?**: `object`
+
+Resolved CPU resource policy for the source VM, when known.
+
+###### maxVcpus
+
+> **maxVcpus**: `number`
 
 ##### snappedAt
 
@@ -18314,7 +18324,7 @@ the registry entry stays live, the vsock UDS is still listening.
 
 > `optional` **maxVcpus?**: `number`
 
-Maximum guest-visible vCPUs. Phase 1 supports only 1.
+Maximum guest-visible vCPUs.
 
 ##### quotaCpus?
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -26165,6 +26165,24 @@ the guest agent skips entries that don't match.
 
 [`ResolvedCpuResourcePolicy`](#resolvedcpuresourcepolicy)
 
+##### multiVcpuHostSupported
+
+> **multiVcpuHostSupported**: (`platform`, `arch`) => `boolean` = `_multiVcpuHostSupported`
+
+###### Parameters
+
+###### platform?
+
+`Platform` = `process.platform`
+
+###### arch?
+
+`Architecture` = `process.arch`
+
+###### Returns
+
+`boolean`
+
 ## Functions
 
 ### buildAdvancedLinuxFacilityProbeRow()

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -22,7 +22,14 @@ import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { BootError, ExecError, boot, buildMachinenConfig, measureFirstByte } from "../index.ts";
+import {
+  BootError,
+  ExecError,
+  boot,
+  buildMachinenConfig,
+  measureFirstByte,
+  restore,
+} from "../index.ts";
 import {
   applyNestedVirtualizationEnv,
   preflightNestedVirtualization,
@@ -30,6 +37,7 @@ import {
 } from "../nested-virt.ts";
 import { ensurePdeathsig } from "../pdeathsig.ts";
 import { performSnapshot } from "../vm/snapshot.ts";
+import { performForkWithRestore } from "../vm/fork-core.ts";
 import { buildGuestHostname } from "../vm/helpers.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
@@ -518,6 +526,52 @@ describe("measureFirstByte", () => {
   });
 });
 
+describe("multi-vCPU boot", () => {
+  it("boots a linux/x64 KVM guest that reports the requested vCPU count", async () => {
+    if (process.platform !== "linux" || process.arch !== "x64") {
+      return;
+    }
+    const binary = resolve(microvmRoot, "zig-out/bin/machinen-vm");
+    const kernel = resolve(import.meta.dirname, "../../../..", "release-assets/bzImage-x86_64");
+    const image = resolve(
+      import.meta.dirname,
+      "../../../..",
+      "release-assets/rootfs-debian-amd64.tar.gz",
+    );
+    const missing = [binary, kernel, image].filter((p) => !existsSync(p));
+    if (missing.length > 0) {
+      if (process.env.MACHINEN_REQUIRE_FIXTURES === "0") {
+        return;
+      }
+      throw new Error(`test requires multi-vCPU fixtures (missing: ${missing.join(", ")})`);
+    }
+
+    const vm = await boot({
+      binary,
+      kernel,
+      image,
+      cmd: [
+        "sh",
+        "-lc",
+        "echo nproc=$(nproc); echo processors=$(grep -c ^processor /proc/cpuinfo)",
+      ],
+      resources: { cpu: { maxVcpus: 2 } },
+      timeoutMs: 60_000,
+      snapshot: false,
+      pdeathsig: true,
+      rootDisk: true,
+    });
+    try {
+      await expect(vm.wait()).resolves.toEqual({ code: 0, signal: null });
+      const output = await vm.errorOutput();
+      expect(output).toContain("nproc=2");
+      expect(output).toContain("processors=2");
+    } finally {
+      await vm.kill().catch(() => {});
+    }
+  });
+});
+
 describe("image + cmd", () => {
   it("rejects cmd without image", async () => {
     await expect(boot({ binary: "/bin/sh", cmd: ["/bin/true"] })).rejects.toThrow(
@@ -912,6 +966,66 @@ describe("liveMounts option", () => {
 });
 
 describe("vm.snapshot", () => {
+  it("refuses provider-level snapshots of multi-vCPU VMs", async () => {
+    await expect(
+      performSnapshot(
+        {
+          pid: process.pid,
+          diskPath: "/tmp/unused-disk.img",
+          maxVcpus: 2,
+          execRaw: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+          wait: async () => ({ code: 0, signal: null }),
+          kill: async () => {},
+          teeGuestConsole: undefined,
+          errorOutput: async () => "",
+        },
+        { outDir: "/tmp/unused-multivcpu-snap" },
+      ),
+    ).rejects.toMatchObject({ code: "BOOT_VMSTATE_UNSUPPORTED" });
+  });
+
+  it("refuses restore of multi-vCPU snapshot metadata before boot", async () => {
+    const snapDir = mkdtempSync(join(tmpdir(), "machinen-multivcpu-restore-test-"));
+    try {
+      const imgDir = join(snapDir, "img");
+      const core = join(imgDir, "core-1.img");
+      rmSync(imgDir, { recursive: true, force: true });
+      writeFileSync(
+        join(snapDir, "meta.json"),
+        JSON.stringify({ snappedAt: 0, cpu: { maxVcpus: 2 } }),
+      );
+      execSync(`mkdir -p ${JSON.stringify(imgDir)}`);
+      writeFileSync(core, "fake");
+
+      await expect(restore({ snapDir })).rejects.toMatchObject({
+        code: "BOOT_VMSTATE_UNSUPPORTED",
+      });
+    } finally {
+      rmSync(snapDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses fork of multi-vCPU VMs before snapshot capture", async () => {
+    await expect(
+      performForkWithRestore(
+        {
+          pid: process.pid,
+          diskPath: "/tmp/unused-disk.img",
+          maxVcpus: 2,
+          execRaw: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+          wait: async () => ({ code: 0, signal: null }),
+          kill: async () => {},
+          teeGuestConsole: undefined,
+          errorOutput: async () => "",
+        },
+        {},
+        async () => {
+          throw new Error("restore should not run after multi-vCPU snapshot refusal");
+        },
+      ),
+    ).rejects.toMatchObject({ code: "BOOT_VMSTATE_UNSUPPORTED" });
+  });
+
   it("refuses provider-level snapshots of nested-enabled VMs", async () => {
     await expect(
       performSnapshot(

--- a/packages/runtime/src/__tests__/cpu-cgroup.test.ts
+++ b/packages/runtime/src/__tests__/cpu-cgroup.test.ts
@@ -22,14 +22,16 @@ describe("cpu cgroup controls", () => {
   it("does nothing when no policy or only no-op defaults are requested", () => {
     expect(applyCpuControls(123, undefined)).toEqual({ status: "none" });
     expect(applyCpuControls(123, { maxVcpus: 1, weight: 100 })).toEqual({ status: "none" });
+    expect(applyCpuControls(123, { maxVcpus: 2, weight: 100 })).toEqual({ status: "none" });
     expect(cpuPolicyNeedsCgroup({ maxVcpus: 1, weight: 100 })).toBe(false);
+    expect(cpuPolicyNeedsCgroup({ maxVcpus: 2, weight: 100 })).toBe(false);
   });
 
   it("writes cgroup v2 cpu.max, cpu.weight, and cgroup.procs", () => {
     const parentDir = tempCgroupParent();
     const result = applyCpuControls(
       4321,
-      { maxVcpus: 1, quotaCpus: 0.5, weight: 250 },
+      { maxVcpus: 4, quotaCpus: 0.5, weight: 250 },
       { parentDir, id: "unit" },
     );
 
@@ -45,7 +47,7 @@ describe("cpu cgroup controls", () => {
 
   it("enforces weight without a hard quota when weight differs from the default", () => {
     const parentDir = tempCgroupParent();
-    const result = applyCpuControls(4321, { maxVcpus: 1, weight: 50 }, { parentDir, id: "weight" });
+    const result = applyCpuControls(4321, { maxVcpus: 2, weight: 50 }, { parentDir, id: "weight" });
 
     expect(readFileSync(join(result.cgroupPath!, "cpu.weight"), "utf8")).toBe("50\n");
     expect(existsSync(join(result.cgroupPath!, "cpu.max"))).toBe(false);

--- a/packages/runtime/src/__tests__/cpu-resources.test.ts
+++ b/packages/runtime/src/__tests__/cpu-resources.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { _internal, BootError } from "../index.ts";
 
-const { resolveCpuResourcePolicy } = _internal;
+const { multiVcpuHostSupported, resolveCpuResourcePolicy } = _internal;
 
 describe("resolveCpuResourcePolicy", () => {
   it("returns undefined when CPU resources are omitted", () => {
@@ -20,8 +20,8 @@ describe("resolveCpuResourcePolicy", () => {
     });
   });
 
-  it("accepts multi-vCPU requests only on linux/x64 KVM hosts", () => {
-    if (process.platform === "linux" && process.arch === "x64") {
+  it("accepts multi-vCPU requests only on guest-visible multi-vCPU hosts", () => {
+    if (multiVcpuHostSupported()) {
       expect(resolveCpuResourcePolicy({ maxVcpus: 2, quotaCpus: 1.5, weight: 200 })).toEqual({
         maxVcpus: 2,
         quotaCpus: 1.5,
@@ -31,11 +31,21 @@ describe("resolveCpuResourcePolicy", () => {
     }
 
     expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(BootError);
-    expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(/linux\/x64 KVM/);
+    expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(
+      /linux\/x64 KVM and darwin\/arm64 HVF/,
+    );
+  });
+
+  it("documents the multi-vCPU host allow-list", () => {
+    expect(multiVcpuHostSupported("linux", "x64")).toBe(true);
+    expect(multiVcpuHostSupported("darwin", "arm64")).toBe(true);
+    expect(multiVcpuHostSupported("linux", "arm64")).toBe(false);
+    expect(multiVcpuHostSupported("darwin", "x64")).toBe(false);
+    expect(multiVcpuHostSupported("win32", "x64")).toBe(false);
   });
 
   it("keeps quota as host CPU budget instead of guest-visible vCPU count", () => {
-    if (process.platform === "linux" && process.arch === "x64") {
+    if (multiVcpuHostSupported()) {
       expect(resolveCpuResourcePolicy({ maxVcpus: 2, quotaCpus: 0.5 })).toEqual({
         maxVcpus: 2,
         quotaCpus: 0.5,

--- a/packages/runtime/src/__tests__/cpu-resources.test.ts
+++ b/packages/runtime/src/__tests__/cpu-resources.test.ts
@@ -8,7 +8,7 @@ describe("resolveCpuResourcePolicy", () => {
     expect(resolveCpuResourcePolicy(undefined)).toBeUndefined();
   });
 
-  it("uses Phase 1 defaults when resources.cpu is present", () => {
+  it("uses defaults when resources.cpu is present", () => {
     expect(resolveCpuResourcePolicy({})).toEqual({ maxVcpus: 1, weight: 100 });
   });
 
@@ -20,9 +20,28 @@ describe("resolveCpuResourcePolicy", () => {
     });
   });
 
-  it("rejects maxVcpus above Phase 1 support", () => {
+  it("accepts multi-vCPU requests only on linux/x64 KVM hosts", () => {
+    if (process.platform === "linux" && process.arch === "x64") {
+      expect(resolveCpuResourcePolicy({ maxVcpus: 2, quotaCpus: 1.5, weight: 200 })).toEqual({
+        maxVcpus: 2,
+        quotaCpus: 1.5,
+        weight: 200,
+      });
+      return;
+    }
+
     expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(BootError);
-    expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(/greater than 1/);
+    expect(() => resolveCpuResourcePolicy({ maxVcpus: 2 })).toThrow(/linux\/x64 KVM/);
+  });
+
+  it("keeps quota as host CPU budget instead of guest-visible vCPU count", () => {
+    if (process.platform === "linux" && process.arch === "x64") {
+      expect(resolveCpuResourcePolicy({ maxVcpus: 2, quotaCpus: 0.5 })).toEqual({
+        maxVcpus: 2,
+        quotaCpus: 0.5,
+        weight: 100,
+      });
+    }
   });
 
   it("rejects quota above guest-visible vCPU count", () => {
@@ -31,6 +50,7 @@ describe("resolveCpuResourcePolicy", () => {
 
   it("rejects malformed CPU values", () => {
     expect(() => resolveCpuResourcePolicy({ maxVcpus: 0 })).toThrow(/positive integer/);
+    expect(() => resolveCpuResourcePolicy({ maxVcpus: 65 })).toThrow(/<= 64/);
     expect(() => resolveCpuResourcePolicy({ quotaCpus: 0 })).toThrow(/must be > 0/);
     expect(() => resolveCpuResourcePolicy({ quotaCpus: Number.NaN })).toThrow(/must be > 0/);
     expect(() => resolveCpuResourcePolicy({ weight: 0 })).toThrow(/1..10000/);

--- a/packages/runtime/src/cpu-cgroup.ts
+++ b/packages/runtime/src/cpu-cgroup.ts
@@ -29,7 +29,7 @@ export function applyCpuControls(
   if (policy === undefined || !cpuPolicyNeedsCgroup(policy)) {
     return { status: "none" };
   }
-  if (osPlatform() !== "linux") {
+  if (osPlatform() !== "linux" && opts.parentDir === undefined) {
     return { status: "unsupported", reason: "hard CPU quota uses Linux cgroup v2" };
   }
   const parentDir = opts.parentDir ?? process.env.MACHINEN_CGROUP_PARENT ?? DEFAULT_CGROUP_PARENT;

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -395,6 +395,10 @@ export interface SnapshotMeta {
    * explicit `image` override.
    */
   sourceImage?: string;
+  /** Resolved CPU resource policy for the source VM, when known. */
+  cpu?: {
+    maxVcpus: number;
+  };
   /** ms epoch when `vm.snapshot()` returned. */
   snappedAt: number;
   /** Whole-VM `.vmstate` restore invariants. Present on new vmstate bundles. */

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -212,6 +212,7 @@ export async function attach(opts: AttachOptions): Promise<VmHandle> {
       // Vmstate engine: the VMM's whole-VM state-file path, persisted
       // at boot. performSnapshotVmstate SIGUSR1s the VMM and reads it.
       vmstatePath: entry.vmstatePath,
+      maxVcpus: entry.cpu?.maxVcpus,
       vmstateChain: entry.vmstatePath
         ? {
             chainId: entry.vmstateChainId ?? `attached-${entry.pid}`,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -1,9 +1,3 @@
-// `boot()` and its options surface. Owns the host-side VMM lifecycle:
-// asset resolution, port-forward validation, gvproxy bring-up, initramfs
-// pack, rootdisk materialization, VMM spawn + pdeathsig wrap, registry
-// write, live-mount helper spawn, the returned `VmHandle`, and the
-// `--detached` readiness gate.
-
 import { type ChildProcessWithoutNullStreams, spawn as nodeSpawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { once } from "node:events";
@@ -520,6 +514,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     memoryCeilingMib,
     diskAbs,
     vmstateStatePath: vmstate.statePath,
+    cpuPolicy: plan.cpuPolicy,
     snapshot: {
       child,
       childPid,
@@ -533,6 +528,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       mountDiskPaths,
       liveMountsResolved,
       nested: opts.nested,
+      cpuPolicy: plan.cpuPolicy,
       vmstate,
     },
   });
@@ -951,6 +947,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
   configureNestedVirtualization(opts, assets.binary, env);
   const memoryCeilingMib = setMemoryCeiling(opts, env);
   const cpuPolicy = resolveCpuResourcePolicy(opts.resources?.cpu);
+  setVcpuCount(cpuPolicy, env);
   const scratch = prepareBootScratchDisk(opts, env, phases);
   const wantsRootDisk = wantsRootDiskBoot(opts);
   validateRootDiskRequest(opts, wantsRootDisk);
@@ -1008,6 +1005,15 @@ function buildVmmEnv(opts: BootOptions): Record<string, string> {
     ...(process.env as Record<string, string>),
     ...opts.vmmEnv,
   };
+}
+
+function setVcpuCount(
+  cpuPolicy: ResolvedCpuResourcePolicy | undefined,
+  env: Record<string, string>,
+): void {
+  if (cpuPolicy) {
+    env.MACHINEN_MAX_VCPUS = String(cpuPolicy.maxVcpus);
+  }
 }
 
 function prepareBootScratchDisk(
@@ -1487,21 +1493,10 @@ function materializeRootdisk(
     env.MACHINEN_ROOTDISK = rootDiskAbs;
     return undefined;
   }
-  // #121: hand the VMM a per-boot reflink clone of the cached
-  // template, never the template itself. virtio-blk mounts the
-  // image read-write, so without the clone every boot from the
-  // same tarball would inherit the previous boot's writes
-  // (apt installs leaking, /var/log poisoning, two concurrent
-  // boots stomping each other's filesystem). COPYFILE_FICLONE →
-  // APFS clonefile / Linux FICLONE on reflink-capable fs (free,
-  // shared blocks until the guest writes); falls back to a
-  // regular copy elsewhere (one-time cost, sparse).
+  // Hand the VMM a per-boot reflink clone so guest writes do not leak across boots.
   const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
   const cachedImg = ensureRootfsImage(baseAbs, {
     sizeBytes: opts.rootDiskSizeBytes,
-    // #233 follow-up: surface the sub-steps of ensureRootfsImage
-    // (sha256, e2fsck, sparse-extend, …) as dot-separated
-    // children of `rootdisk-materialize` in the boot timeline.
     onPhase: (name, ms) => phases.mark(`rootdisk-materialize.${name}`, ms),
   });
   const perBoot = join(
@@ -1511,9 +1506,6 @@ function materializeRootdisk(
   const reflinkT0 = Date.now();
   reflinkCopy(cachedImg, perBoot);
   phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
-  // The cache file was only READ here — restore the
-  // clean-shutdown marker so the next boot finds a usable
-  // template instead of wiping and rematerializing (#170).
   markRootfsImageClean(cachedImg);
   env.MACHINEN_ROOTDISK = perBoot;
   return perBoot;
@@ -1841,6 +1833,7 @@ interface BootHandleArgs {
   memoryCeilingMib: number | undefined;
   diskAbs: string | undefined;
   vmstateStatePath: string | undefined;
+  cpuPolicy: ResolvedCpuResourcePolicy | undefined;
   snapshot: BootSnapshotContextArgs;
 }
 
@@ -1857,6 +1850,7 @@ interface BootSnapshotContextArgs {
   mountDiskPaths: MountDiskPaths | undefined;
   liveMountsResolved: ResolvedLiveMount[];
   nested: boolean | undefined;
+  cpuPolicy: ResolvedCpuResourcePolicy | undefined;
   vmstate: BootVmstateRuntime;
 }
 
@@ -2070,6 +2064,7 @@ function buildBootSnapshotContext(
     vmstatePath: args.vmstate.statePath,
     vmstateChain: snapshotVmstateChain(args.vmstate),
     updateVmstateChain: snapshotVmstateUpdater(args.vmstate, args.childPid),
+    maxVcpus: args.cpuPolicy?.maxVcpus,
     nested: args.nested,
     execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
     wait: () => handle.wait(),

--- a/packages/runtime/src/vm/cpu-resources.ts
+++ b/packages/runtime/src/vm/cpu-resources.ts
@@ -1,7 +1,7 @@
 import { BootError } from "../errors.ts";
 
 export interface BootCpuResourceOptions {
-  /** Maximum guest-visible vCPUs. Phase 1 supports only 1. */
+  /** Maximum guest-visible vCPUs. */
   maxVcpus?: number;
   /** Maximum host CPU budget. Fractional values are scheduling quota, not guest CPUs. */
   quotaCpus?: number;
@@ -16,6 +16,7 @@ export interface ResolvedCpuResourcePolicy {
 }
 
 const DEFAULT_CPU_MAX_VCPUS = 1;
+const MAX_CPU_MAX_VCPUS = 64;
 export const DEFAULT_CPU_WEIGHT = 100;
 const MIN_CPU_WEIGHT = 1;
 const MAX_CPU_WEIGHT = 10_000;
@@ -39,14 +40,24 @@ function validateMaxVcpus(value: number): number {
       `boot: resources.cpu.maxVcpus must be a positive integer (got ${String(value)}).`,
     );
   }
-  if (value !== DEFAULT_CPU_MAX_VCPUS) {
+  if (value > MAX_CPU_MAX_VCPUS) {
     throw new BootError(
       "BOOT_CPU_INVALID",
-      "boot: resources.cpu.maxVcpus greater than 1 is not supported yet. " +
+      `boot: resources.cpu.maxVcpus must be <= ${MAX_CPU_MAX_VCPUS} (got ${String(value)}).`,
+    );
+  }
+  if (value > DEFAULT_CPU_MAX_VCPUS && !multiVcpuHostSupported()) {
+    throw new BootError(
+      "BOOT_CPU_UNSUPPORTED",
+      "boot: resources.cpu.maxVcpus greater than 1 is currently supported only on linux/x64 KVM hosts. " +
         "CPU quota is scheduling budget, not extra guest-visible CPUs.",
     );
   }
   return value;
+}
+
+function multiVcpuHostSupported(): boolean {
+  return process.platform === "linux" && process.arch === "x64";
 }
 
 function validateQuotaCpus(value: number | undefined, maxVcpus: number): number | undefined {

--- a/packages/runtime/src/vm/cpu-resources.ts
+++ b/packages/runtime/src/vm/cpu-resources.ts
@@ -49,15 +49,18 @@ function validateMaxVcpus(value: number): number {
   if (value > DEFAULT_CPU_MAX_VCPUS && !multiVcpuHostSupported()) {
     throw new BootError(
       "BOOT_CPU_UNSUPPORTED",
-      "boot: resources.cpu.maxVcpus greater than 1 is currently supported only on linux/x64 KVM hosts. " +
+      "boot: resources.cpu.maxVcpus greater than 1 is currently supported only on linux/x64 KVM and darwin/arm64 HVF hosts. " +
         "CPU quota is scheduling budget, not extra guest-visible CPUs.",
     );
   }
   return value;
 }
 
-function multiVcpuHostSupported(): boolean {
-  return process.platform === "linux" && process.arch === "x64";
+export function multiVcpuHostSupported(
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): boolean {
+  return (platform === "linux" && arch === "x64") || (platform === "darwin" && arch === "arm64");
 }
 
 function validateQuotaCpus(value: number | undefined, maxVcpus: number): number | undefined {

--- a/packages/runtime/src/vm/index.ts
+++ b/packages/runtime/src/vm/index.ts
@@ -50,7 +50,10 @@ import {
   CONSOLE_TAIL_BYTES as _CONSOLE_TAIL_BYTES,
   validateMemoryMib as _validateMemoryMib,
 } from "./helpers.ts";
-import { resolveCpuResourcePolicy as _resolveCpuResourcePolicy } from "./cpu-resources.ts";
+import {
+  multiVcpuHostSupported as _multiVcpuHostSupported,
+  resolveCpuResourcePolicy as _resolveCpuResourcePolicy,
+} from "./cpu-resources.ts";
 import { resolveMemoryCeilingMib as _resolveMemoryCeilingMib } from "./memory-resources.ts";
 
 // Visible to tests that exercise the ring-buffer logic without booting a VM.
@@ -60,4 +63,5 @@ export const _internal = {
   validateMemoryMib: _validateMemoryMib,
   resolveMemoryCeilingMib: _resolveMemoryCeilingMib,
   resolveCpuResourcePolicy: _resolveCpuResourcePolicy,
+  multiVcpuHostSupported: _multiVcpuHostSupported,
 };

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -185,6 +185,7 @@ async function restoreCriu(opts: RestoreOptions, snapDir: string): Promise<VmHan
   const phases = new PhaseTimer();
   const imgDir = validateCriuSnapshotBundle(snapDir);
   const meta = readSnapshotMetaWithPhase(join(snapDir, "meta.json"), phases);
+  refuseMultiVcpuRestore(meta);
   const resolvedImage = resolveRestoreImage(opts, meta);
   const lazy = prepareLazyPages(opts, imgDir, phases);
   const effectiveLiveMounts = resolveRestoreLiveMounts(meta.liveMounts, opts.liveMounts);
@@ -237,6 +238,17 @@ function readSnapshotMeta(metaPath: string): SnapshotMeta {
     // anonymous source name. The fork still boots.
     return { snappedAt: 0 };
   }
+}
+
+function refuseMultiVcpuRestore(meta: SnapshotMeta): void {
+  if ((meta.cpu?.maxVcpus ?? 1) <= 1) {
+    return;
+  }
+  throw new BootError(
+    "BOOT_VMSTATE_UNSUPPORTED",
+    "restore: multi-vCPU snapshot bundles are not supported yet.\n" +
+      "  Machinen does not yet restore every vCPU, timer, and interrupt-controller state safely.",
+  );
 }
 
 function prepareLazyPages(
@@ -901,11 +913,13 @@ interface PreparedVmstateRestoreBundle {
 }
 
 function initialVmstateRestoreBundle(snapDir: string): PreparedVmstateRestoreBundle {
+  const meta = readSnapshotMeta(join(snapDir, "meta.json"));
+  refuseMultiVcpuRestore(meta);
   return {
     statePath: join(snapDir, VMSTATE_FILE),
     effectiveSnapDir: snapDir,
     materializedTempDir: undefined,
-    meta: readSnapshotMeta(join(snapDir, "meta.json")),
+    meta,
   };
 }
 

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -76,28 +76,13 @@ export interface SnapshotContext {
   kernelPath?: string;
   /** Explicit DTB path used by the source boot, when known. */
   dtbPath?: string;
-  /**
-   * #272: when the source VM was booted with `mount: { host, guest }`,
-   * the runtime materialized a squashfs lower + ext4 upper. We need
-   * to reflink both files into the snapshot bundle so a restore
-   * elsewhere can mount the same overlay without consulting the host
-   * source dir. Undefined when no mount was configured.
-   */
+  /** Overlay mount disk files to reflink into the snapshot bundle. */
   mountDisk?: {
     guest: string;
     lowerPath: string;
     upperPath: string;
   };
-  /**
-   * #273: live-share mounts the source VM has active. Threaded into
-   * the bundle's `meta.json` so `restore()` can re-establish the same
-   * window (or apply per-guest overrides on a different host). Both
-   * boot- and attach-handle ctxes populate this — boot from
-   * `liveMountsResolved`, attach from the registry. Undefined / empty
-   * for VMs booted without `liveMounts`. Since #332 each is served by
-   * an in-VMM virtio-fs device that the VMM carries across the CRIU
-   * dump, so there's nothing host-side to stop or respawn.
-   */
+  /** Live-share mounts to record for restore-time reattachment. */
   liveMounts?: ReadonlyArray<{
     host: string;
     guest: string;
@@ -121,6 +106,8 @@ export interface SnapshotContext {
   };
   /** Persist the next parent pointer after a successful vmstate checkpoint. */
   updateVmstateChain?: (next: { parentDir: string; sequence: number }) => void;
+  /** Guest-visible vCPU count for this source VM. */
+  maxVcpus?: number;
   /**
    * True when the source VM exposed EL2 to its guest. Provider-level
    * snapshots of this L1 are refused until nested KVM/HVF state capture
@@ -183,6 +170,14 @@ export async function performSnapshot(
   const engine = resolveSnapshotEngine();
   if (engine === "portable") {
     return performSnapshotPortable(ctx, opts);
+  }
+  if ((ctx.maxVcpus ?? 1) > 1) {
+    throw new SnapshotError(
+      "BOOT_VMSTATE_UNSUPPORTED",
+      "vm.snapshot: provider-level snapshots of multi-vCPU VMs are not supported yet.\n" +
+        "  Machinen does not yet capture and restore every vCPU, timer, and interrupt-controller state safely.\n" +
+        "  Re-boot with resources.cpu.maxVcpus: 1 before snapshot or fork.",
+    );
   }
   if (ctx.nested) {
     throw new SnapshotError(
@@ -638,13 +633,10 @@ function writeSnapshotMeta(
     engine,
     sourceName: ctx.sourceName,
     sourceImage: ctx.sourceImage,
+    cpu: ctx.maxVcpus === undefined ? undefined : { maxVcpus: ctx.maxVcpus },
     snappedAt: Date.now(),
     vmstate: vmstateMeta,
     mountDisk: mountDiskMeta,
-    // #273: bytes are NOT in the bundle — `host` is a path on the
-    // snapshotting host that the restoring host has to resolve (or
-    // remap via `restore({ liveMounts })`). Recorded only when ctx
-    // carried a resolved list (boot-handle path).
     liveMounts:
       ctx.liveMounts && ctx.liveMounts.length > 0
         ? ctx.liveMounts.map(({ guest, host, mode }) => ({


### PR DESCRIPTION
## Problem

`resources.cpu.maxVcpus` could only describe a limit on the host side. The guest still saw one CPU, so apps inside the VM could not split work across multiple CPUs.

This also made snapshot and fork risky. A VM with more than one CPU has more CPU and interrupt state to save, and Machinen did not have that full state path yet.

## Solution

This PR makes supported guests actually boot with the requested vCPU count:

- linux/x64 KVM guests now get real guest-visible vCPUs.
- macOS arm64 HVF guests now get real guest-visible vCPUs.

A VM started with `resources.cpu.maxVcpus: 2` now sees two CPUs from inside the guest on those backends.

Quota and weight still act like host scheduling controls. Snapshot, restore, and fork now fail clearly for multi-vCPU VMs until full multi-vCPU state restore is safe.

Closes #951.
Closes #953.

## Technical Summary

- Ships real multi-vCPU support for linux/x64 KVM and macOS arm64 HVF.
- For KVM, creates and runs the requested vCPUs and exposes them through ACPI MADT entries.
- For HVF, exposes a multi-CPU arm64 DTB topology, creates one HVF vCPU per host thread, implements PSCI `CPU_ON`/`AFFINITY_INFO`/`CPU_OFF`, and synchronizes per-vCPU run-loop/device access.
- Keeps unsupported backends honest. Runtime validation and direct VMM checks reject `maxVcpus > 1` where the guest would not actually get those CPUs.
- Fixes x86 AP startup by keeping APIC MMIO out of RAM/e820 and by waiting to run AP threads until KVM moves them out of the uninitialized state.
- Wakes AP/HVF secondary run threads during teardown so the VMM can shut down cleanly.
- Keeps `quotaCpus` and `weight` separate from guest-visible CPU count. They still control host scheduling through cgroups where supported.
- Records CPU metadata in snapshot bundles and refuses multi-vCPU snapshot, restore, and fork before unsafe work starts.

## Validation

- `pnpm -C packages/microvm test --summary all`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build:docs`
- `pnpm run typecheck`
- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run`
- `pnpm exec fallow audit --changed-since origin/main`
- macOS arm64 HVF guest proof: `maxVcpus: 2`, `nproc=2`, `/proc/cpuinfo` processors=2, two parallel CPU-bound jobs completed, clean poweroff.
- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests`
