### PR TITLE
Fix default persistent PTY sessions

### DIFF
--- a/.changeset/default-pty-sessions.md
+++ b/.changeset/default-pty-sessions.md
@@ -1,0 +1,7 @@
+---
+"@machinen/cli": minor
+"@machinen/runtime": minor
+"@machinen/microvm": minor
+---
+
+Default VM and persistent PTY session names to `default`, and fix persistent PTY list/reconnect/exit handling so `machinen attach` works as a tmux-like reconnectable shell by default.

--- a/docs/guides/create-a-vm.md
+++ b/docs/guides/create-a-vm.md
@@ -87,19 +87,19 @@ to completion, exit code propagates. `attach` is for when _you_ want a
 real terminal: tab completion, full-screen TUIs, Ctrl-C signalling the
 guest process and not the host CLI.
 
-If the interactive work itself should survive your host terminal going
-away, use a named persistent session:
+Interactive attach uses a persistent session by default, so the work
+survives your host terminal going away:
 
 ```bash
-npx machinen attach --session pi worker     # create or reattach the session
+npx machinen attach worker                  # create or reattach worker/default
+npx machinen attach --session pi worker     # use a second named session
 npx machinen sessions worker                # list live persistent sessions
-npx machinen session-kill worker pi         # reset/stop that session
+npx machinen session-kill worker            # reset/stop worker/default
 ```
 
 The shell or TUI runs under the guest exec-agent, so it stays alive when
 your SSH connection, laptop, or host CLI disconnects. Re-run the same
-`attach --session` command to reconnect. Plain `machinen attach worker`
-still opens a normal non-persistent shell.
+`attach` command to reconnect.
 
 When you're done:
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "vm": "node vm.ts",
     "vm-pick": "bash scripts/vm-pick.sh",
     "repro-192": "node scripts/repro-issue-192.ts",
+    "repro-954": "tsx scripts/repro-issue-954-persistent-pty.ts",
     "machinen-dev": "bash scripts/machinen-dev.sh",
     "smoke-tests": "bash scripts/smoke-tests.sh",
     "controlled-binary-corpus": "node scripts/controlled-binary-corpus.mjs verify",

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -12,17 +12,17 @@ machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bun
 machinen move     <scan|save|load> [opts]       Discover or validate cross-ISA move descriptors
 machinen support  [filters] [--json]            Show product support and refusal status
 machinen list     (alias: ls, ps)               List running VMs
-machinen exec     <target> [--tty] -- <cmd>     Run a command in a running VM
-machinen snapshot <target> <out-dir> [--keep-alive] [--dry-run]
+machinen exec     [<target>] [--tty] -- <cmd>   Run a command in a running VM
+machinen snapshot [<target>] <out-dir> [--keep-alive] [--dry-run]
                                                 Checkpoint a running VM
-machinen fork     <target> [opts]               Clone a running VM into a sibling
-machinen attach   <target> [--shell <c>] [--tail [N]] [--session <s>]
+machinen fork     [<target>] [opts]             Clone a running VM into a sibling
+machinen attach   [<target>] [--shell <c>] [--tail [N]] [--session <s>]
                                                 Interactive PTY shell into a VM
-machinen sessions <target>                       List persistent PTY sessions
-machinen session-kill <target> <session> [--dry-run]
+machinen sessions [<target>]                     List persistent PTY sessions
+machinen session-kill [<target>] [<session>] [--dry-run]
                                                 Kill a persistent PTY session
-machinen repl     <target>                       Per-line exec REPL (no persistent state)
-machinen stop     <target> [--force|-9] [--dry-run]
+machinen repl     [<target>]                     Per-line exec REPL (no persistent state)
+machinen stop     [<target>] [--force|-9] [--dry-run]
                                                 Stop a running VM
 machinen gc       [--dry-run|-n]                Drop dead registry entries + clean artifacts
 machinen install  [--version <tag>]             Pre-fetch base assets for a release
@@ -33,7 +33,8 @@ machinen --version | -h                          Print version / help
 ```
 
 `<target>` is the first positional after the subcommand. Pass a name
-(any non-digit string) or a host pid (digits-only).
+(any non-digit string) or a host pid (digits-only). If you omit it,
+Machinen uses the default VM name: `default`.
 
 ## Agent-friendly conventions
 
@@ -68,7 +69,7 @@ cache (populated by `machinen install`, or auto-fetched on first use).
 
 | Flag                                            | What it does                                                                                                                                                                                                        |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`)                                                                                                                                          |
+| `--name <name>`                                 | Register the VM under a human-friendly name (path-shaped allowed: `a/b/c`; default: `default`)                                                                                                                      |
 | `--mount <host-dir>:<guest-path>`               | Copy-once host directory into the guest (`/mnt/...`)                                                                                                                                                                |
 | `--mount-live <host-dir>:<guest-path>[:rw\|ro]` | Live-share via in-VMM virtio-fs — guest reads stream in on demand. `rw` (default) or `ro`                                                                                                                           |
 | `--env KEY=VALUE`                               | Set an env var inside the guest (repeatable)                                                                                                                                                                        |
@@ -124,7 +125,7 @@ none). `ps` is an alias.
 ## `machinen exec`
 
 ```
-machinen exec <target> [--tty|--pty] -- <cmd>
+machinen exec [<target>] [--tty|--pty] -- <cmd>
 ```
 
 Runs `<cmd>` inside a running VM via vsock. Without `--tty`, stdio is
@@ -140,7 +141,7 @@ machinen exec worker --tty -- bash -i
 ## `machinen snapshot`
 
 ```
-machinen snapshot <target> <out-dir> [--keep-alive]
+machinen snapshot [<target>] <out-dir> [--keep-alive]
 ```
 
 Checkpoints a running VM into `<out-dir>`. With the default vmstate
@@ -154,7 +155,7 @@ connection state.
 ## `machinen fork`
 
 ```
-machinen fork <target> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]
+machinen fork [<target>] [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]
               [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...
               [--cwd <abs>] [--memory <mib>]
 ```
@@ -187,27 +188,28 @@ source's rootdisk at dump time.
 ## `machinen attach`
 
 ```
-machinen attach <target> [--shell <cmd>] [--tail [N]] [--session <name>]
+machinen attach [<target>] [--shell <cmd>] [--tail [N]] [--session <name>]
 ```
 
-Drops into an interactive PTY shell in the running VM (default `bash
--i`, override with `--shell`). `cd`, env vars, history, job control,
-and full-screen TUIs all work. Exit the shell (Ctrl-D) to detach.
+Drops into an interactive PTY shell in the running VM (default VM:
+`default`; default session: `default`; default shell: `bash -i`,
+override with `--shell`). `cd`, env vars, history, job control, and
+full-screen TUIs all work.
 
-Pass `--session <name>` to create or reattach a named persistent PTY
+By default, attach creates or reattaches the `default` persistent PTY
 session. The guest keeps that shell or TUI running if the host terminal
-or SSH connection drops, so a later `machinen attach --session <name>
-<target>` reconnects to it without needing `tmux` or `screen` inside
-the VM. Plain `machinen attach <target>` remains non-persistent and
-keeps the old behavior.
+or SSH connection drops, so a later `machinen attach` reconnects to it
+without needing `tmux` or `screen` inside the VM. Pass `--session
+<name>` to use a different persistent session name.
 
 Session names must be 1-64 characters using only letters, digits, dot,
 underscore, or dash. Common examples:
 
 ```bash
+machinen attach
 machinen attach --session pi worker
 machinen sessions worker
-machinen session-kill worker pi
+machinen session-kill worker
 ```
 
 `--tail` dumps the boot-console snapshot before opening the shell.
@@ -218,7 +220,7 @@ With no value it prints the whole snapshot (capped at ~1 MiB);
 ## `machinen sessions`
 
 ```
-machinen sessions <target>
+machinen sessions [<target>]
 ```
 
 Lists named persistent PTY sessions currently held by the guest. Output
@@ -227,18 +229,19 @@ is tab-separated: session name, then guest pid.
 ## `machinen session-kill`
 
 ```
-machinen session-kill <target> <session> [--dry-run]
+machinen session-kill [<target>] [<session>] [--dry-run]
 ```
 
-Terminates a named persistent PTY session inside the guest. Use this to
-reset a stuck shell or stop a long-running TUI that was intentionally
-left alive after disconnect. `--dry-run` reports whether the session
-exists without killing it.
+Terminates a named persistent PTY session inside the guest. Omit the
+session to kill `default`; omit the target to use the default VM. Use
+this to reset a stuck shell or stop a long-running TUI that was
+intentionally left alive after disconnect. `--dry-run` reports whether
+the session exists without killing it.
 
 ## `machinen repl`
 
 ```
-machinen repl <target>
+machinen repl [<target>]
 ```
 
 Per-line exec REPL: every line is a fresh one-shot `exec`, so `cd`,
@@ -249,7 +252,7 @@ an actual interactive shell, use `machinen attach`.
 ## `machinen stop`
 
 ```
-machinen stop <target> [--force|-9]
+machinen stop [<target>] [--force|-9]
 ```
 
 SIGTERM the VMM, escalate to SIGKILL after 2s, then `gc` its entry.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -52,6 +52,11 @@ describe("parseRunArgs --env", () => {
     expect(parsed.positional).toEqual(["./my-bundle"]);
   });
 
+  it("defaults the VM name to default", () => {
+    expect(parseRunArgs([]).name).toBe("default");
+    expect(parseRunArgs(["--name", "worker"]).name).toBe("worker");
+  });
+
   it("rejects --env without a '=' separator", () => {
     expect(() => parseRunArgs(["--env", "FOO", "--", "/bin/true"])).toThrow(ParseError);
   });
@@ -854,8 +859,10 @@ describe("extractTarget", () => {
     expect(r.rest).toEqual(["./warm"]);
   });
 
-  it("rejects no target at all", () => {
-    expect(() => extractTarget([], "exec")).toThrow(/requires a target/);
+  it("defaults no target to the default VM name", () => {
+    const r = extractTarget([], "exec");
+    expect(r.target).toEqual({ name: "default" });
+    expect(r.rest).toEqual([]);
   });
 
   it("rejects unknown flags (legacy --name/--pid no longer recognized)", () => {
@@ -864,7 +871,7 @@ describe("extractTarget", () => {
     expect(() => extractTarget(["--bogus"], "exec")).toThrow(/unknown argument: --bogus/);
   });
 
-  it("throws ParseError so the CLI can format it", () => {
-    expect(() => extractTarget([], "exec")).toThrow(ParseError);
+  it("throws ParseError so the CLI can format unknown flags", () => {
+    expect(() => extractTarget(["--bogus"], "exec")).toThrow(ParseError);
   });
 });

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -54,7 +54,9 @@ interface CommandSpec {
 // a single positional, digits → pid, otherwise → name.
 const TARGET_POSITIONAL: PositionalSpec = {
   name: "target",
-  description: "The VM to act on. Pass a registered name or a host pid (digits-only).",
+  required: false,
+  description:
+    "The VM to act on. Pass a registered name or a host pid (digits-only). Defaults to name 'default'.",
 };
 
 /** The top-level commands of the CLI, keyed by canonical name. */
@@ -67,7 +69,7 @@ export const COMMANDS: CommandSpec[] = [
       {
         name: "--name",
         type: "string",
-        description: "Register the VM under a human-friendly name.",
+        description: "Register the VM under a human-friendly name (default: default).",
       },
       {
         name: "--snapshot",
@@ -311,7 +313,7 @@ export const COMMANDS: CommandSpec[] = [
       {
         name: "--session",
         type: "string",
-        description: "Create or reattach a named persistent PTY session.",
+        description: "Create or reattach a named persistent PTY session (default: default).",
       },
       {
         name: "--tail",
@@ -335,7 +337,11 @@ export const COMMANDS: CommandSpec[] = [
     mutating: true,
     positionals: [
       TARGET_POSITIONAL,
-      { name: "session", description: "The persistent session name." },
+      {
+        name: "session",
+        required: false,
+        description: "The persistent session name (default: default).",
+      },
     ],
     flags: [
       {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,7 +9,7 @@
 //   machinen exec <name|pid> -- <cmd>
 //   machinen snapshot <name|pid> <out-dir>
 //   machinen attach <name|pid> [--shell <cmd>]   # PTY shell
-//   machinen attach --session <session> <name|pid> # persistent PTY shell
+//   machinen attach [--session <session>] [name|pid] # persistent PTY shell
 //   machinen repl   <name|pid>                   # per-line exec
 //   machinen completion <bash|zsh|fish>
 //   machinen --version | -h | --help

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -1,6 +1,7 @@
 import { attach, type RegistryEntry, type VmHandle } from "@machinen/runtime";
 import { readFileSync } from "node:fs";
 
+import { DEFAULT_PTY_SESSION_NAME } from "../defaults.ts";
 import { die, handleError } from "../errors.ts";
 import type { Target } from "../parse-target.ts";
 import { tailLines } from "../tail-lines.ts";
@@ -27,7 +28,7 @@ interface AttachOptionsCli {
 function parseAttachOptions(args: string[]): AttachOptionsCli {
   const state = {
     shell: "/bin/bash -i",
-    sessionName: undefined as string | undefined,
+    sessionName: DEFAULT_PTY_SESSION_NAME,
     tail: undefined as number | "all" | undefined,
     rest: [] as string[],
   };
@@ -186,13 +187,10 @@ async function runAttachedPty(
     die("machinen attach: stdin is not a TTY (pipe scripts via `machinen repl` instead)");
   }
   const label = vm.name ?? `pid ${vm.pid}`;
-  if (sessionName) {
-    process.stderr.write(
-      `attached to ${label} session ${sessionName} — kill with machinen session-kill ${label} ${sessionName}.\n`,
-    );
-  } else {
-    process.stderr.write(`attached to ${label} — exit the shell to detach.\n`);
-  }
+  const targetArg = vm.name ?? String(vm.pid);
+  process.stderr.write(
+    `attached to ${label} session ${sessionName} — kill with machinen session-kill ${targetArg} ${sessionName}.\n`,
+  );
   try {
     return await runPtyExec(vm, shell, sessionName);
   } finally {
@@ -244,15 +242,15 @@ function parseSessionKillOptions(args: string[]): {
 } {
   const dryRun = args.includes("--dry-run");
   const positional = args.filter((arg) => arg !== "--dry-run");
-  const name = positional.at(-1);
-  if (!name) {
-    die("machinen session-kill: missing session name");
-  }
+  const name = positional.length >= 2 ? positional.at(-1)! : DEFAULT_PTY_SESSION_NAME;
   validateSessionName(name);
   return {
     dryRun,
     name,
-    target: parseTargetFlags(positional.slice(0, -1), "session-kill"),
+    target: parseTargetFlags(
+      positional.length >= 2 ? positional.slice(0, -1) : positional,
+      "session-kill",
+    ),
   };
 }
 

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -50,7 +50,7 @@ function consumeExecPtyFlag(args: string[]): { usePty: boolean; filtered: string
 async function runExecCommand(vm: VmHandle, parsed: ParsedExecArgs): Promise<number> {
   if (parsed.usePty) {
     assertExecPtyTty();
-    return runPtyExec(vm, parsed.cmd);
+    return runPtyExec(vm, parsed.cmd, false);
   }
   return runRawExec(vm, parsed.cmd);
 }

--- a/packages/cli/src/commands/pty.ts
+++ b/packages/cli/src/commands/pty.ts
@@ -1,6 +1,10 @@
 import type { VmHandle } from "@machinen/runtime";
 
-export async function runPtyExec(vm: VmHandle, cmd: string, sessionName?: string): Promise<number> {
+export async function runPtyExec(
+  vm: VmHandle,
+  cmd: string,
+  sessionName?: string | false,
+): Promise<number> {
   const tty = enterPtyRawMode();
   const handle = vm.execPty(cmd, {
     cols: tty.cols,

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -2,6 +2,7 @@ import { attach, type LogEvent, type RegistryEntry, type VmHandle } from "@machi
 import { resolve } from "node:path";
 
 import { consumeDryRunFlag, consumeJsonFlag, emitJson, emitJsonError } from "../args.ts";
+import { DEFAULT_VM_NAME } from "../defaults.ts";
 import { describeError, die, failQuiet, handleError } from "../errors.ts";
 import type { Target } from "../parse-target.ts";
 import { isQuiet, printHeadline, RingBuffer } from "../quiet.ts";
@@ -27,15 +28,15 @@ interface SnapshotOptionsCli {
 }
 
 function parseSnapshotOptions(args: string[]): SnapshotOptionsCli {
-  // Forms: `machinen snapshot <target> <out-dir>` and
-  // `machinen snapshot <target> --out <dir>`. We strip --json /
-  // --dry-run / --keep-alive first; the first positional left is the target.
+  // Forms: `machinen snapshot [<target>] <out-dir>` and
+  // `machinen snapshot [<target>] --out <dir>`. We strip --json /
+  // --dry-run / --keep-alive first, then default the target to `default`
+  // when only an out-dir remains.
   const { json, rest: afterJson } = consumeJsonFlag(args);
   const { dryRun, rest: afterDry } = consumeDryRunFlag(afterJson);
   const { keepAlive, rest: afterKeepAlive } = consumeKeepAliveFlag(afterDry);
   const { outDir: flaggedOutDir, rest } = consumeSnapshotOutFlag(afterKeepAlive);
-  const { target, rest: afterTarget } = resolveTarget(rest, "snapshot");
-  const outDir = parseSnapshotOutDir(afterTarget, flaggedOutDir);
+  const { target, outDir } = parseSnapshotTargetAndOutDir(rest, flaggedOutDir);
   return { json, dryRun, keepAlive, target, outDir, resolvedOutDir: resolve(outDir) };
 }
 
@@ -62,10 +63,19 @@ function consumeSnapshotOutFlag(args: string[]): { outDir: string | undefined; r
   return { outDir, rest };
 }
 
-function parseSnapshotOutDir(args: string[], flaggedOutDir?: string): string {
-  return flaggedOutDir
-    ? parseFlaggedSnapshotOutDir(args, flaggedOutDir)
-    : parsePositionalSnapshotOutDir(args);
+function parseSnapshotTargetAndOutDir(
+  args: string[],
+  flaggedOutDir?: string,
+): { target: Target; outDir: string } {
+  if (flaggedOutDir) {
+    const { target, rest } = resolveTarget(args, "snapshot");
+    return { target, outDir: parseFlaggedSnapshotOutDir(rest, flaggedOutDir) };
+  }
+  if (args.length === 1) {
+    return { target: { name: DEFAULT_VM_NAME }, outDir: args[0]! };
+  }
+  const { target, rest } = resolveTarget(args, "snapshot");
+  return { target, outDir: parsePositionalSnapshotOutDir(rest) };
 }
 
 function parseFlaggedSnapshotOutDir(args: string[], flaggedOutDir: string): string {
@@ -87,8 +97,8 @@ function parsePositionalSnapshotOutDir(args: string[]): string {
 
 function snapshotUsage(): string {
   return (
-    "usage: machinen snapshot <name|pid> <out-dir> [--keep-alive] [--dry-run] [--json]\n" +
-    "       machinen snapshot <name|pid> --out <dir> [--keep-alive] [--dry-run] [--json]"
+    "usage: machinen snapshot [<name|pid>] <out-dir> [--keep-alive] [--dry-run] [--json]\n" +
+    "       machinen snapshot [<name|pid>] --out <dir> [--keep-alive] [--dry-run] [--json]"
   );
 }
 

--- a/packages/cli/src/defaults.ts
+++ b/packages/cli/src/defaults.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_VM_NAME = "default";
+export const DEFAULT_PTY_SESSION_NAME = "default";

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -7,6 +7,7 @@ export function printHelp(): void {
       `Usage:\n` +
       `  machinen boot [opts] -- <cmd>                  Boot a microVM and run <cmd>\n` +
       `    --name <name>                                Register under a unique human name\n` +
+      `                                                 (default: default)\n` +
       `                                                 (path-shaped allowed: 'a/b/c').\n` +
       `    --snapshot <path>                            Attach <path> as /dev/vda — scratch\n` +
       `                                                 disk for a future vm.snapshot().\n` +
@@ -49,9 +50,10 @@ export function printHelp(): void {
       `\n` +
       `  Targeting a running VM:\n` +
       `    Pass the name or pid as the first positional arg.\n` +
+      `    Omit it to use the default VM name: default.\n` +
       `    Digits-only is interpreted as a pid; everything else as a name.\n` +
       `\n` +
-      `  machinen exec     <name|pid> [--tty] -- <cmd>\n` +
+      `  machinen exec     [<name|pid>] [--tty] -- <cmd>\n` +
       `                                                 Run a command in a running VM. Pass\n` +
       `                                                 --tty for a real PTY session — needed\n` +
       `                                                 for an interactive shell, vim, htop,\n` +
@@ -59,19 +61,19 @@ export function printHelp(): void {
       `                                                 Without --tty stdio is line-buffered\n` +
       `                                                 pipes (good for one-shot commands).\n` +
       `                                                 Example:\n` +
-      `                                                   machinen exec <name|pid> --tty -- bash -i\n` +
-      `  machinen attach   <name|pid> [--shell <c>]    Drop into an interactive PTY shell\n` +
-      `                                                 in the running VM (default \`bash -i\`).\n` +
+      `                                                   machinen exec [<name|pid>] --tty -- bash -i\n` +
+      `  machinen attach   [<name|pid>] [--shell <c>]  Drop into an interactive PTY shell\n` +
+      `                                                 in the running VM (default VM/session: default; shell: \`bash -i\`).\n` +
       `                                                 \`cd\`, env vars, history, job control\n` +
       `                                                 and full-screen TUIs all work. Exit\n` +
       `                                                 the shell (Ctrl-D) to detach.\n` +
-      `  machinen attach   --session <s> <name|pid>     Create or reattach a named persistent\n` +
+      `  machinen attach   --session <s> [<name|pid>]   Create or reattach a named persistent\n` +
       `                                                 PTY session that survives host\n` +
-      `                                                 disconnects.\n` +
-      `  machinen sessions <name|pid>                   List persistent PTY sessions.\n` +
-      `  machinen session-kill <name|pid> <session>     Kill a persistent PTY session.\n` +
-      `  machinen snapshot <name|pid> <out-dir> [--keep-alive]\n` +
-      `  machinen snapshot <name|pid> --out <dir> [--keep-alive]\n` +
+      `                                                 disconnects (default: default).\n` +
+      `  machinen sessions [<name|pid>]                 List persistent PTY sessions.\n` +
+      `  machinen session-kill [<name|pid>] [<session>] Kill a persistent PTY session.\n` +
+      `  machinen snapshot [<name|pid>] <out-dir> [--keep-alive]\n` +
+      `  machinen snapshot [<name|pid>] --out <dir> [--keep-alive]\n` +
       `                                                 Checkpoint a running VM into <d>.\n` +
       `                                                 Node workloads are detected inside the VM;\n` +
       `                                                 no Node-only snapshot selector is needed.\n` +
@@ -79,7 +81,7 @@ export function printHelp(): void {
       `                                                 and non-destructive. CRIU snapshots stay\n` +
       `                                                 non-incremental; --keep-alive leaves them\n` +
       `                                                 running and closes inherited TCP sockets.\n` +
-      `  machinen fork     <name|pid> [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
+      `  machinen fork     [<name|pid>] [--new-name <n>] [--out-dir <d>] [--tcp-keep] [--detach]\n` +
       `                    [-p ...] [--mount ...] [--mount-live ...] [--env KEY=VALUE]...\n` +
       `                    [--cwd <abs>] [--memory <mib>]\n` +
       `                                                 Snapshot the source live (it keeps\n` +
@@ -99,7 +101,7 @@ export function printHelp(): void {
       `                                                 --mount-live, --env, --cwd, --memory)\n` +
       `                                                 take effect on the forked sibling, not\n` +
       `                                                 the source.\n` +
-      `  machinen repl     <name|pid>                   Per-line exec REPL: each line is a\n` +
+      `  machinen repl     [<name|pid>]                 Per-line exec REPL: each line is a\n` +
       `                                                 fresh one-shot \`exec\`, no persistent\n` +
       `                                                 state. Useful for piping a script of\n` +
       `                                                 one-liners; for an interactive shell\n` +
@@ -133,10 +135,11 @@ export function printHelp(): void {
       `  machinen ls\n` +
       `  machinen exec worker -- ps aux                       # one-off command\n` +
       `  machinen exec worker --tty -- bash -i                # interactive shell w/ job control\n` +
-      `  machinen attach worker                              # interactive shell\n` +
-      `  machinen attach --session pi worker                  # reconnectable shell/session\n` +
+      `  machinen attach                                     # default VM + default session\n` +
+      `  machinen attach worker                              # worker VM + default session\n` +
+      `  machinen attach --session pi worker                  # worker VM + pi session\n` +
       `  machinen sessions worker\n` +
-      `  machinen session-kill worker pi\n` +
+      `  machinen session-kill worker                         # kill worker/default session\n` +
       `  machinen exec worker --tty -- vim /etc/passwd        # full-screen TUI in a PTY\n` +
       `  machinen snapshot worker ./warm                      # CRIU snapshot bundle\n` +
       `  machinen restore ./warm\n` +

--- a/packages/cli/src/parse-run-args.ts
+++ b/packages/cli/src/parse-run-args.ts
@@ -4,6 +4,8 @@
 
 import { ParseError } from "@machinen/runtime";
 
+import { DEFAULT_VM_NAME } from "./defaults.ts";
+
 export interface ParsedCpuResourceArgs {
   maxVcpus?: number;
   quotaCpus?: number;
@@ -33,7 +35,7 @@ interface ParsedRunArgs {
   snapshot?: string;
   /** Expose arm64 EL2 / `/dev/kvm` to the guest (`--nested`). */
   nested?: boolean;
-  /** Optional VM name registered for `attach` (`--name <name>`). */
+  /** VM name registered for `attach` (`--name <name>`, default `default`). */
   name?: string;
   /**
    * Working directory for the guest cmd (`--cwd <abs-path>`). Lands
@@ -207,7 +209,7 @@ function finishRunArgs(state: RunParseState, double_dash_args: string[]): Parsed
     portForward: state.portForward.length > 0 ? state.portForward : undefined,
     snapshot: state.snapshot,
     nested: state.nested || undefined,
-    name: state.name,
+    name: state.name ?? DEFAULT_VM_NAME,
     guestCwd: state.guestCwd,
     detached: state.detached || undefined,
     memory: state.memory,

--- a/packages/cli/src/parse-target.ts
+++ b/packages/cli/src/parse-target.ts
@@ -2,12 +2,14 @@
 // attach/repl/stop. Sibling of parse-run-args.ts / parse-fork-args.ts
 // — extracted so tests don't need to spawn the CLI.
 //
-// The target is a single positional. All-digits → pid; everything
-// else → name. Anything that isn't the target lands in `rest` so
-// callers with a second positional (snapshot's <out-dir>) can read
-// it without re-parsing.
+// The target is a single optional positional. Missing → default VM
+// name, all-digits → pid, everything else → name. Anything that isn't
+// the target lands in `rest` so callers with a second positional
+// (snapshot's <out-dir>) can read it without re-parsing.
 
 import { ParseError } from "@machinen/runtime";
+
+import { DEFAULT_VM_NAME } from "./defaults.ts";
 
 export type Target = { name: string } | { pid: number };
 
@@ -17,7 +19,7 @@ interface ExtractedTarget {
   rest: string[];
 }
 
-export function extractTarget(args: string[], cmd: string): ExtractedTarget {
+export function extractTarget(args: string[], _cmd: string): ExtractedTarget {
   let positional: string | undefined;
   const rest: string[] = [];
   for (const a of args) {
@@ -32,10 +34,7 @@ export function extractTarget(args: string[], cmd: string): ExtractedTarget {
     }
   }
   if (positional === undefined) {
-    throw new ParseError(
-      "PARSE_FLAG_MISSING_VALUE",
-      `machinen ${cmd}: requires a target name or pid (e.g. \`machinen ${cmd} <name|pid>\`)`,
-    );
+    return { target: { name: DEFAULT_VM_NAME }, rest };
   }
   // Edge case: a VM literally named "123" can't be targeted
   // positionally (resolves as pid). Rename the VM if you hit this —

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -452,9 +452,16 @@ fn reap_session(entry: *SessionEntry) void {
     if (!entry.used) return;
     var status: c_int = 0;
     const r = waitpid(entry.broker_pid, &status, WNOHANG);
-    if (r == entry.broker_pid) {
+    if (r == entry.broker_pid or r < 0) {
         entry.used = false;
     }
+}
+
+fn reap_child_zombies() void {
+    std.debug.assert(MAX_SESSIONS > 0);
+    for (&sessions) |*entry| reap_session(entry);
+    var status: c_int = 0;
+    while (waitpid(-1, &status, WNOHANG) > 0) {}
 }
 
 fn find_session(name: []const u8) ?u8 {
@@ -567,6 +574,22 @@ fn proxy_session(client_fd: c_int, broker_fd: c_int, cols: u16, rows: u16) void 
     }
 }
 
+fn proxy_session_child(client_fd: c_int, broker_fd: c_int, cols: u16, rows: u16) void {
+    std.debug.assert(client_fd >= 0);
+    std.debug.assert(broker_fd >= 0);
+    const pid = fork();
+    if (pid < 0) {
+        send_exit(client_fd, 1);
+        ignore_int(close(broker_fd));
+        return;
+    }
+    if (pid == 0) {
+        proxy_session(client_fd, broker_fd, cols, rows);
+        _exit(0);
+    }
+    ignore_int(close(broker_fd));
+}
+
 fn create_session(name: []const u8, cmd: []const u8, cols: u16, rows: u16) ?u8 {
     std.debug.assert(valid_session_name(name));
     const slot = alloc_session_slot() orelse return null;
@@ -652,7 +675,7 @@ fn handle_persistent_pty(
         send_exit(client_fd, 1);
         return;
     }
-    proxy_session(client_fd, broker_fd, cols, rows);
+    proxy_session_child(client_fd, broker_fd, cols, rows);
 }
 
 fn cmd_z_ptr(cmd: []const u8, out: *[MAX_EXEC2_CMD + 1]u8) [*:0]const u8 {
@@ -734,13 +757,21 @@ fn broker_event_loop(
         const nfds: c_uint = if (client_fd >= 0) 3 else 2;
         const n = poll(&fds, nfds, -1);
         if (n < 0) continue;
-        if (master_exited(fds[0].revents)) return wait_exit_status(child_pid);
+        if (master_exited(fds[0].revents)) return finish_broker_session(child_pid, client_fd);
         if ((fds[1].revents & POLLIN) != 0) accept_broker_client(listen_fd, &client_fd, master_fd);
         if (!drain_master_to_client(master_fd, &client_fd, fds[0].revents)) {
-            return wait_exit_status(child_pid);
+            return finish_broker_session(child_pid, client_fd);
         }
         if (client_fd >= 0) service_broker_client(&client_fd, master_fd, fds[2].revents);
     }
+}
+
+fn finish_broker_session(child_pid: pid_t, client_fd: c_int) c_int {
+    std.debug.assert(child_pid > 0);
+    std.debug.assert(client_fd >= -1);
+    const code = wait_exit_status(child_pid);
+    if (client_fd >= 0) send_exit(client_fd, code);
+    return code;
 }
 
 fn broker_pollfds(master_fd: c_int, listen_fd: c_int, client_fd: c_int) [3]pollfd {
@@ -1047,6 +1078,7 @@ pub fn main() !void {
     // Intentional daemon loop. `accept` blocks between connections;
     // the VMM tears the agent down with the guest.
     while (true) {
+        reap_child_zombies();
         const client = accept(srv, null, null);
         if (client < 0) {
             log_err("exec-agent: accept() failed; continuing");

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -3104,9 +3104,9 @@ Connect timeout (ms). Default 5000 — agent should already be up.
 
 ##### sessionName?
 
-> `optional` **sessionName?**: `string`
+> `optional` **sessionName?**: `string` \| `false`
 
-Named persistent PTY session to create or reattach.
+Named persistent PTY session to create or reattach. Defaults to `default`; pass `false` for a one-shot PTY.
 
 ***
 
@@ -17906,14 +17906,14 @@ release rootfs path here.
 > `optional` **pid?**: `number`
 
 Look up a VM by the host pid of its VMM process. Kernel-unique
-while alive; mutually exclusive with `name`. Exactly one of
-`pid` / `name` is required.
+while alive; mutually exclusive with `name`. If neither `pid` nor
+`name` is provided, attach uses the default VM name `default`.
 
 ##### name?
 
 > `optional` **name?**: `string`
 
-Look up a VM by the name passed to `boot({ name })`.
+Look up a VM by the name passed to `boot({ name })`. Defaults to `default`.
 
 ##### onLog?
 
@@ -30509,7 +30509,7 @@ resolve the binary through the same lookup chain.
 
 ### attach()
 
-> **attach**(`opts`): `Promise`\<[`VmHandle`](#vmhandle)\>
+> **attach**(`opts?`): `Promise`\<[`VmHandle`](#vmhandle)\>
 
 Reconnect to a running VM registered by an earlier `boot()` call
 (possibly from a different process). Returns a `VmHandle` that can
@@ -30523,9 +30523,9 @@ booter. `output()`/`errorOutput()` resolve with the empty string.
 
 #### Parameters
 
-##### opts
+##### opts?
 
-[`AttachOptions`](#attachoptions)
+[`AttachOptions`](#attachoptions) = `{}`
 
 #### Returns
 

--- a/packages/runtime/src/__tests__/exec-pty.test.ts
+++ b/packages/runtime/src/__tests__/exec-pty.test.ts
@@ -67,7 +67,7 @@ describe("VsockExec.startPty wire protocol", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("sends a PTY header with cols, rows, and length-prefixed cmd", async () => {
+  it("uses the default persistent PTY session when sessionName is omitted", async () => {
     // Agent: just send X 0 + close so the host resolves quickly. We
     // care about what the host wrote on the wire, not the response.
     const agent = startCapturingAgent(socketPath, (sock) => {
@@ -87,6 +87,34 @@ describe("VsockExec.startPty wire protocol", () => {
         stdin,
         stdout,
         connectTimeoutMs: 2_000,
+      });
+      const res = await handle.result;
+      expect(res.exitCode).toBe(0);
+      const sent = collectBytes(agent.received).toString("utf8");
+      expect(sent.startsWith("PTYSESSION 132 50 7 7\n")).toBe(true);
+      expect(sent.slice("PTYSESSION 132 50 7 7\n".length)).toContain("defaultbash -i");
+    } finally {
+      await agent.stop();
+    }
+  });
+
+  it("sends a one-shot PTY header when sessionName is false", async () => {
+    const agent = startCapturingAgent(socketPath, (sock) => {
+      setTimeout(() => {
+        sock.write("X 0\n");
+        sock.end();
+      }, 10);
+    });
+    try {
+      const stdin = new PassThrough();
+      const stdout = new CapturingWritable();
+      const handle = VsockExec.startPty(socketPath, "bash -i", {
+        cols: 132,
+        rows: 50,
+        stdin,
+        stdout,
+        connectTimeoutMs: 2_000,
+        sessionName: false,
       });
       const res = await handle.result;
       expect(res.exitCode).toBe(0);

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -217,8 +217,8 @@ export interface VsockExecPtyOptions {
   stdout: Writable;
   /** Connect timeout (ms). Default 5000 — agent should already be up. */
   connectTimeoutMs?: number;
-  /** Named persistent PTY session to create or reattach. */
-  sessionName?: string;
+  /** Named persistent PTY session to create or reattach. Defaults to `default`; pass `false` for a one-shot PTY. */
+  sessionName?: string | false;
 }
 
 export interface VsockExecPtyResult {
@@ -701,17 +701,20 @@ function validatePtySessionName(name: string): void {
   }
 }
 
+const DEFAULT_PTY_SESSION_NAME = "default";
+
 function writePtyStartFrame(socket: Socket, cmd: string, opts: VsockExecPtyOptions): void {
   const cmdBuf = Buffer.from(cmd, "utf8");
-  if (!opts.sessionName) {
+  if (opts.sessionName === false) {
     socket.write(`PTY ${opts.cols} ${opts.rows} ${cmdBuf.length}\n`);
     if (cmdBuf.length > 0) {
       socket.write(cmdBuf);
     }
     return;
   }
-  validatePtySessionName(opts.sessionName);
-  const nameBuf = Buffer.from(opts.sessionName, "utf8");
+  const sessionName = opts.sessionName ?? DEFAULT_PTY_SESSION_NAME;
+  validatePtySessionName(sessionName);
+  const nameBuf = Buffer.from(sessionName, "utf8");
   socket.write(`PTYSESSION ${opts.cols} ${opts.rows} ${nameBuf.length} ${cmdBuf.length}\n`);
   socket.write(nameBuf);
   if (cmdBuf.length > 0) {

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -19,11 +19,11 @@ const debugAttach = debugLib("machinen:attach");
 export interface AttachOptions {
   /**
    * Look up a VM by the host pid of its VMM process. Kernel-unique
-   * while alive; mutually exclusive with `name`. Exactly one of
-   * `pid` / `name` is required.
+   * while alive; mutually exclusive with `name`. If neither `pid` nor
+   * `name` is provided, attach uses the default VM name `default`.
    */
   pid?: number;
-  /** Look up a VM by the name passed to `boot({ name })`. */
+  /** Look up a VM by the name passed to `boot({ name })`. Defaults to `default`. */
   name?: string;
   /**
    * Streaming log callback — fires for every byte of output from execs
@@ -47,11 +47,13 @@ export interface AttachOptions {
  *
  * @throws {RegistryError} REGISTRY_VM_NOT_FOUND
  */
-export async function attach(opts: AttachOptions): Promise<VmHandle> {
-  debugAttach("attach lookup pid=%s name=%s", opts.pid ?? "<unset>", opts.name ?? "<unset>");
-  let entry = findEntry(opts);
+export async function attach(opts: AttachOptions = {}): Promise<VmHandle> {
+  const query =
+    opts.pid === undefined && opts.name === undefined ? { ...opts, name: "default" } : opts;
+  debugAttach("attach lookup pid=%s name=%s", query.pid ?? "<unset>", query.name ?? "<unset>");
+  let entry = findEntry(query);
   if (!entry) {
-    const q = opts.pid !== undefined ? `pid ${opts.pid}` : `name ${opts.name}`;
+    const q = query.pid !== undefined ? `pid ${query.pid}` : `name ${query.name}`;
     debugAttach("attach miss for %s", q);
     throw new RegistryError("REGISTRY_VM_NOT_FOUND", `attach: no running VM found for ${q}`);
   }

--- a/scripts/repro-issue-954-persistent-pty.ts
+++ b/scripts/repro-issue-954-persistent-pty.ts
@@ -1,0 +1,97 @@
+import { Writable, PassThrough } from "node:stream";
+import { attach } from "../packages/runtime/src/index.ts";
+
+const vmName = process.env.MACHINEN_VM_NAME ?? "default";
+const sessionName = process.env.MACHINEN_SESSION_NAME ?? "default";
+
+class Capture extends Writable {
+  chunks: Buffer[] = [];
+  _write(chunk: Buffer, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+    this.chunks.push(Buffer.from(chunk));
+    cb();
+  }
+  text() {
+    return Buffer.concat(this.chunks).toString("utf8");
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function eventually(label: string, fn: () => Promise<boolean>, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) {
+      return;
+    }
+    await sleep(100);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function log(step: string) {
+  process.stderr.write(`[issue-954] ${step}\n`);
+}
+
+const vm = await attach({ name: vmName });
+try {
+  log(`attached to vm=${vmName}; resetting session=${sessionName}`);
+  await vm.killSession?.(sessionName).catch(() => false);
+
+  const stdin1 = new PassThrough();
+  const stdout1 = new Capture();
+  const first = vm.execPty("/bin/bash -i", {
+    cols: 80,
+    rows: 24,
+    stdin: stdin1,
+    stdout: stdout1,
+    // Deliberately omitted: default session name should be "default".
+  });
+
+  log("started first PTY without sessionName; waiting for default session to appear");
+  await eventually("default session to appear", async () => {
+    const sessions = await vm.listSessions?.();
+    return sessions?.some((s) => s.name === sessionName) ?? false;
+  });
+
+  log("sending command through first attach");
+  stdin1.write("echo issue-954-first\n");
+  await eventually("first output", async () => stdout1.text().includes("issue-954-first"));
+
+  log("cancelling first attach to simulate host terminal/SSH disconnect");
+  first.cancel();
+  void first.result.catch(() => undefined);
+  await sleep(250);
+
+  const stdin2 = new PassThrough();
+  const stdout2 = new Capture();
+  const second = vm.execPty("/bin/bash -i", {
+    cols: 80,
+    rows: 24,
+    stdin: stdin2,
+    stdout: stdout2,
+    // Deliberately omitted again: should reattach to default.
+  });
+
+  log("reattached without sessionName; sending second command");
+  stdin2.write("echo issue-954-second\n");
+  await eventually("reattached output", async () => stdout2.text().includes("issue-954-second"));
+
+  log("exiting session and waiting for PTY result");
+  stdin2.write("exit\n");
+  const result = await second.result;
+  if (result.exitCode !== 0) {
+    throw new Error(`expected exitCode 0, got ${result.exitCode}`);
+  }
+
+  log("waiting for session to disappear from listSessions()");
+  await eventually("default session to disappear", async () => {
+    const sessions = await vm.listSessions?.();
+    return !(sessions?.some((s) => s.name === sessionName) ?? false);
+  });
+
+  console.log(`issue-954 repro passed for vm=${vmName} session=${sessionName}`);
+} finally {
+  await vm.detach();
+}


### PR DESCRIPTION
## Problem

Persistent VM shells were hard to use as a simple tmux-like session. A named session could fail to show up in `sessions`, reconnecting could be unreliable, and typing `exit` could leave the host waiting forever. Users also had to remember both a VM name and a session name for the common case.

## Solution

This PR makes the common path use `default`. A VM boots with the name `default` unless you pass `--name`, and `machinen attach` uses the persistent session `default` unless you pass `--session`. Persistent PTY sessions now list correctly, reconnect correctly, and resolve normally when the shell exits.

Fixes #954.

## Technical Summary

- Keep attach persistent by default, but preserve one-shot PTYs for `machinen exec --tty` with `sessionName: false`.
- Default missing CLI targets to the VM named `default`, with special handling so `snapshot <out-dir>` still treats the lone positional as the output directory.
- Move persistent PTY attach proxying into a child process inside `exec-agent`, so one attached session does not block the main agent from serving `listSessions`, `killSession`, or reconnects.
- Send the normal PTY exit frame when the broker sees the guest shell exit, so host-side `pty.result` resolves instead of hanging.
- Add a focused repro script that starts, lists, disconnects, reconnects, exits, and checks cleanup for the default session.
