### PR TITLE
Speed up rootdisk restore paths

### DIFF
--- a/packages/cli/src/base-assets.ts
+++ b/packages/cli/src/base-assets.ts
@@ -34,6 +34,8 @@ type BaseAssetSpec = {
   kernelAsset: string;
   dtbAsset?: string;
   rootfsAsset: string;
+  rootfsPrebakeGzAsset: string;
+  rootfsPrebakeZstAsset: string;
 };
 
 export interface CliBaseAssetPaths {
@@ -57,12 +59,16 @@ function baseAssetSpec(): BaseAssetSpec {
         cpu: "amd64",
         kernelAsset: "bzImage-x86_64",
         rootfsAsset: "rootfs-debian-amd64.tar.gz",
+        rootfsPrebakeGzAsset: "rootfs-debian-amd64.img.gz",
+        rootfsPrebakeZstAsset: "rootfs-debian-amd64.img.zst",
       }
     : {
         cpu: "arm64",
         kernelAsset: "Image-arm64",
         dtbAsset: "virt-arm64.dtb",
         rootfsAsset: "rootfs-debian-arm64.tar.gz",
+        rootfsPrebakeGzAsset: "rootfs-debian-arm64.img.gz",
+        rootfsPrebakeZstAsset: "rootfs-debian-arm64.img.zst",
       };
 }
 
@@ -73,11 +79,17 @@ function baseDirFor(tag: string, distro = "debian", cpu = guestCpu()): string {
 export function baseAssetsComplete(tag: string): boolean {
   const spec = baseAssetSpec();
   const base = baseDirFor(tag, "debian", spec.cpu);
-  return (
-    existsSync(join(base, "Image")) &&
-    (!spec.dtbAsset || existsSync(join(base, "virt.dtb"))) &&
-    existsSync(join(base, "rootfs.tar.gz"))
-  );
+  return cachedBaseAssetFiles(spec).every((file) => existsSync(join(base, file)));
+}
+
+function cachedBaseAssetFiles(spec: BaseAssetSpec): string[] {
+  return [
+    "Image",
+    ...(spec.dtbAsset ? ["virt.dtb"] : []),
+    "rootfs.tar.gz",
+    "rootfs.img.gz",
+    "rootfs.img.zst",
+  ];
 }
 
 function validateAssetsDir(dir: string): void {
@@ -110,13 +122,7 @@ export async function ensureBaseAssets(tag: string): Promise<string> {
 }
 
 function cachedBaseAssetsReady(base: string, spec: BaseAssetSpec): boolean {
-  if (!existsSync(join(base, "Image"))) {
-    return false;
-  }
-  if (spec.dtbAsset && !existsSync(join(base, "virt.dtb"))) {
-    return false;
-  }
-  return existsSync(join(base, "rootfs.tar.gz"));
+  return cachedBaseAssetFiles(spec).every((file) => existsSync(join(base, file)));
 }
 
 async function downloadBaseAssets(tag: string, base: string, spec: BaseAssetSpec): Promise<void> {
@@ -133,7 +139,11 @@ function baseAssetDownloads(
   if (spec.dtbAsset) {
     assets.push({ name: spec.dtbAsset, dest: join(base, "virt.dtb") });
   }
-  assets.push({ name: spec.rootfsAsset, dest: join(base, "rootfs.tar.gz") });
+  assets.push(
+    { name: spec.rootfsAsset, dest: join(base, "rootfs.tar.gz") },
+    { name: spec.rootfsPrebakeGzAsset, dest: join(base, "rootfs.img.gz") },
+    { name: spec.rootfsPrebakeZstAsset, dest: join(base, "rootfs.img.zst") },
+  );
   return assets;
 }
 

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -208,6 +208,8 @@ fn read_exact(fd: c_int, out: []u8) bool {
 // base64-encoded contents `vm.writeFile()` ships through; binary blobs
 // belong in the file/mount paths.
 const MAX_EXEC2_CMD: usize = 1 * 1024 * 1024;
+const MAX_RESEED_HEX: usize = 128;
+const VMSTATE_RESEED_HELPER = "/sbin/machinen-vmstate-reseed";
 
 // Cap on a single PTY `I <n>\n` input frame. Real keystroke bursts are
 // well under 1 KiB; this is a defensive ceiling so a malicious / buggy
@@ -224,6 +226,33 @@ const SessionEntry = struct {
 };
 
 var sessions: [MAX_SESSIONS]SessionEntry = [_]SessionEntry{.{}} ** MAX_SESSIONS;
+
+fn run_vmstate_reseed(client_fd: c_int, seed_hex: []const u8) void {
+    std.debug.assert(client_fd >= 0);
+    if (seed_hex.len == 0 or seed_hex.len > MAX_RESEED_HEX) {
+        return send_exit(client_fd, 2);
+    }
+    var seed_buf: [MAX_RESEED_HEX + 1]u8 = undefined;
+    @memcpy(seed_buf[0..seed_hex.len], seed_hex);
+    seed_buf[seed_hex.len] = 0;
+
+    const pid = fork();
+    if (pid < 0) return send_exit(client_fd, 1);
+    if (pid == 0) {
+        const argv = &[_:null]?[*:0]const u8{
+            VMSTATE_RESEED_HELPER,
+            @ptrCast(&seed_buf),
+            null,
+        };
+        const envp = &[_:null]?[*:0]const u8{
+            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            null,
+        };
+        _ = execve(VMSTATE_RESEED_HELPER, argv, envp);
+        _exit(127);
+    }
+    send_exit(client_fd, wait_exit_status(pid));
+}
 
 fn run_command(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !void {
     std.debug.assert(client_fd >= 0);
@@ -903,6 +932,7 @@ fn handle_connection(client_fd: c_int, alloc: std.mem.Allocator) void {
         return handle_ptysession(client_fd, line);
     }
     if (std.mem.startsWith(u8, line, "PTY ")) return handle_pty(client_fd, line, alloc);
+    if (std.mem.startsWith(u8, line, "RESEED ")) return handle_reseed(client_fd, line);
     if (std.mem.startsWith(u8, line, "EXEC2 ")) return handle_exec2(client_fd, line, alloc);
     if (line.len < 5 or !std.mem.startsWith(u8, line, "EXEC ")) {
         log_err("exec-agent: unknown op");
@@ -1010,6 +1040,24 @@ fn handle_pty(client_fd: c_int, line: []const u8, alloc: std.mem.Allocator) void
     run_pty_command(client_fd, cmd_buf, h.cols, h.rows, alloc) catch |err| {
         log_run_error("pty", err);
     };
+}
+
+fn handle_reseed(client_fd: c_int, line: []const u8) void {
+    std.debug.assert(client_fd >= 0);
+    const seed_len = std.fmt.parseInt(u32, line[7..], 10) catch {
+        log_err("exec-agent: RESEED bad length");
+        return send_exit(client_fd, 2);
+    };
+    if (seed_len == 0 or seed_len > MAX_RESEED_HEX) {
+        log_err("exec-agent: RESEED seed too large");
+        return send_exit(client_fd, 2);
+    }
+    var seed_buf: [MAX_RESEED_HEX]u8 = undefined;
+    if (!read_exact(client_fd, seed_buf[0..seed_len])) {
+        log_err("exec-agent: RESEED short read");
+        return send_exit(client_fd, 2);
+    }
+    run_vmstate_reseed(client_fd, seed_buf[0..seed_len]);
 }
 
 fn handle_exec2(client_fd: c_int, line: []const u8, alloc: std.mem.Allocator) void {

--- a/packages/microvm/assets/vmstate-reseed.c
+++ b/packages/microvm/assets/vmstate-reseed.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifndef RNDRESEEDCRNG
@@ -45,6 +47,20 @@ static size_t decode_hex(const char *hex, uint8_t *out, size_t out_cap) {
     out[i] = (uint8_t)((hi << 4) | lo);
   }
   return len / 2;
+}
+
+static void write_marker(void) {
+  if (mkdir("/run", 0755) != 0 && errno != EEXIST) return;
+  const int fd = open("/run/machinen-vmstate-reseed", O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+  if (fd < 0) return;
+  char buf[128];
+  const time_t now = time(NULL);
+  const int n = snprintf(buf, sizeof(buf), "vmstate reseeded %lld\n", (long long)now);
+  if (n > 0) {
+    (void)write(fd, buf, (size_t)n);
+  }
+  (void)fchmod(fd, 0600);
+  close(fd);
 }
 
 int main(int argc, char **argv) {
@@ -95,6 +111,7 @@ int main(int argc, char **argv) {
 
   free(info);
   close(fd);
+  write_marker();
   puts("machinen-vmstate-reseed: ok");
   return 0;
 }

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -16754,6 +16754,26 @@ Like `exec()` but returns non-zero exit codes instead of throwing.
 
 `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
 
+##### reseedVmstateEntropy()?
+
+> `optional` **reseedVmstateEntropy**(`seedHex`, `opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
+Internal fast path for vmstate restore entropy reseed; avoids shell startup.
+
+###### Parameters
+
+###### seedHex
+
+`string`
+
+###### opts?
+
+[`VsockExecOptions`](#vsockexecoptions)
+
+###### Returns
+
+`Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
 ##### execPty()
 
 > **execPty**(`cmd`, `opts`): [`VsockExecPtyHandle`](#vsockexecptyhandle)
@@ -24163,6 +24183,28 @@ tarball-producing tool can pre-populate the lookup cache.
 
 EXEC_AGENT_UNAVAILABLE (retryable) |
   EXEC_AGENT_TIMEOUT (retryable) | EXEC_PROTOCOL
+
+##### reseedVmstate()
+
+> `readonly` **reseedVmstate**(`udsPath`, `seedHex`, `opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
+###### Parameters
+
+###### udsPath
+
+`string`
+
+###### seedHex
+
+`string`
+
+###### opts?
+
+[`VsockExecOptions`](#vsockexecoptions) = `{}`
+
+###### Returns
+
+`Promise`\<[`VsockExecResult`](#vsockexecresult)\>
 
 ##### startPty()
 

--- a/packages/runtime/src/__tests__/exec-multiline.test.ts
+++ b/packages/runtime/src/__tests__/exec-multiline.test.ts
@@ -58,8 +58,8 @@ function startFakeAgent(socketPath: string): {
           }
           header = buf.subarray(0, nl).toString("utf8");
           buf = buf.subarray(nl + 1);
-          if (header.startsWith("EXEC2 ")) {
-            bodyLen = Number.parseInt(header.slice(6), 10);
+          if (header.startsWith("EXEC2 ") || header.startsWith("RESEED ")) {
+            bodyLen = Number.parseInt(header.slice(header.indexOf(" ") + 1), 10);
             phase = "body";
             continue;
           }
@@ -120,6 +120,16 @@ describe("VsockExec multi-line wire format", () => {
     expect(res.exitCode).toBe(0);
     expect(agent.requests).toHaveLength(1);
     expect(agent.requests[0]!.header).toBe("EXEC echo hello");
+  });
+
+  it("sends vmstate reseed over direct RESEED opcode", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startFakeAgent(uds);
+    const seed = "ab".repeat(64);
+    const res = await VsockExec.reseedVmstate(uds, seed);
+    expect(res.exitCode).toBe(0);
+    expect(agent.requests[0]!.header).toBe(`RESEED ${seed.length}`);
+    expect(agent.requests[0]!.body.toString("ascii")).toBe(seed);
   });
 
   it("switches to EXEC2 length-prefix opcode when cmd contains newlines", async () => {

--- a/packages/runtime/src/__tests__/rootfs-img.test.ts
+++ b/packages/runtime/src/__tests__/rootfs-img.test.ts
@@ -107,6 +107,51 @@ describe("ensureRootfsImage", () => {
     }
   });
 
+  it("zstd prebake returns false when zstd is absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "machinen-rootfs-no-zstd-"));
+    const zst = join(dir, "rootfs.img.zst");
+    const out = join(dir, "rootfs.img");
+    const savedPath = process.env.PATH;
+    writeFileSync(zst, "not used because zstd is unavailable");
+    process.env.PATH = dir;
+    try {
+      expect(_internal.zstdPrebakeToFile(zst, out)).toBe(false);
+    } finally {
+      if (savedPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = savedPath;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sparse prebake zstd preserves large zero ranges as holes when zstd is available", () => {
+    const zstd = _internal.whichFirst(["zstd"]);
+    if (!zstd) {
+      return;
+    }
+    const dir = mkdtempSync(join(tmpdir(), "machinen-rootfs-sparse-zstd-"));
+    const img = join(dir, "rootfs.img");
+    const zst = join(dir, "rootfs.img.zst");
+    const out = join(dir, "out.img");
+    const image = Buffer.alloc(8 * 1024 * 1024);
+    image[1080] = 0x53;
+    image[1081] = 0xef;
+    image.write("payload", 4 * 1024 * 1024);
+    writeFileSync(img, image);
+    execSync(`${zstd} -q -f -o ${zst} ${img}`);
+    try {
+      expect(_internal.zstdPrebakeToFile(zst, out)).toBe(true);
+      const st = statSync(out);
+      expect(st.size).toBe(image.length);
+      expect(_internal.looksLikeExt4(out)).toBe(true);
+      expect(st.blocks * 512).toBeLessThan(image.length / 4);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("sparse prebake gunzip preserves large zero ranges as holes", () => {
     const dir = mkdtempSync(join(tmpdir(), "machinen-rootfs-sparse-gunzip-"));
     const gz = join(dir, "rootfs.img.gz");
@@ -430,6 +475,98 @@ describe("ensureRootfsImage", () => {
     }
   }
 
+  it("uses a sha256 sidecar and immutable template metadata to skip tarball hashing and e2fsck", () => {
+    const tarPath = `/tmp/machinen-rootfs-sidecar-template-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-sidecar-template-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-sidecar-template-cache-"));
+    const sha = "a".repeat(64);
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    try {
+      writeFileSync(`${tarPath}.sha256`, `${sha}  ${tarPath.split("/").at(-1)}\n`);
+      const imgPath = join(cacheDir, `${sha}.img`);
+      writeFakeExt4Image(imgPath, 4096);
+      writeFileSync(_internal.okMarkerPath(imgPath), "");
+      writeFileSync(
+        _internal.templateMetaPath(imgPath),
+        `${JSON.stringify({
+          version: 1,
+          sha256: sha,
+          sizeBytes: 4096,
+          source: "prebake",
+          createdAt: new Date().toISOString(),
+        })}\n`,
+      );
+
+      const phases: string[] = [];
+      const result = ensureRootfsImage(tarPath, { cacheDir, onPhase: (name) => phases.push(name) });
+
+      expect(result).toBe(imgPath);
+      expect(phases).toContain("sha256.sidecar");
+      expect(phases).toContain("template-metadata");
+      expect(phases).not.toContain("sha256");
+      expect(phases).not.toContain("cache-mark-in-use");
+      expect(phases).not.toContain("e2fsck");
+      expect(existsSync(_internal.okMarkerPath(imgPath))).toBe(true);
+    } finally {
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(`${tarPath}.sha256`);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not trust immutable template metadata without the clean marker", () => {
+    const tarPath = `/tmp/machinen-rootfs-template-dirty-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-template-dirty-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-template-dirty-cache-"));
+    const sha = "b".repeat(64);
+    writeFileSync(join(tmpDir, "stub"), "x");
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      writeFileSync(`${tarPath}.sha256`, `${sha}  ${tarPath.split("/").at(-1)}\n`);
+      const imgPath = join(cacheDir, `${sha}.img`);
+      writeFakeExt4Image(imgPath, 4096);
+      writeFileSync(
+        _internal.templateMetaPath(imgPath),
+        `${JSON.stringify({
+          version: 1,
+          sha256: sha,
+          sizeBytes: 4096,
+          source: "prebake",
+          createdAt: new Date().toISOString(),
+        })}\n`,
+      );
+
+      expect(() => ensureRootfsImage(tarPath, { cacheDir })).toThrow(ProvisionError);
+      try {
+        ensureRootfsImage(tarPath, { cacheDir });
+      } catch (err) {
+        expect((err as ProvisionError).code).toBe("ROOTFS_IMG_TOOL_MISSING");
+      }
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(`${tarPath}.sha256`);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
   it("siblingPrebakePath strips .tar.gz / .tgz / .tar and points at .img.gz", () => {
     // Only the gzipped release-build sibling form is recognized;
     // provision() writes its prebake into the runtime cache directly.
@@ -440,7 +577,94 @@ describe("ensureRootfsImage", () => {
     // for them, so the runtime falls through to the materialize path.
     expect(_internal.siblingPrebakePath("/r/rootfs")).toBeUndefined();
     expect(_internal.siblingPrebakePath("/r/rootfs.zip")).toBeUndefined();
+    expect(_internal.siblingPrebakeCandidates("/r/rootfs.tar.gz")).toEqual([
+      { path: "/r/rootfs.img.zst", format: "zst", phaseName: "zstd-prebake" },
+      { path: "/r/rootfs.img.gz", format: "gz", phaseName: "gunzip-prebake" },
+    ]);
   });
+
+  it("uses a sibling .img.zst to populate the cache and skips mke2fs when zstd is available", () => {
+    const zstd = _internal.whichFirst(["zstd"]);
+    if (!zstd) {
+      return;
+    }
+    const tarPath = `/tmp/machinen-rootfs-prebake-zst-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-zst-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-zst-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-zst-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const fakeImg = join(tmpDir, "fake.img");
+    writeFakeExt4Image(fakeImg, 4096);
+    const sibling = tarPath.replace(/\.tar\.gz$/, ".img.zst");
+    execSync(`${zstd} -q -f -o ${sibling} ${fakeImg}`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      const phases: string[] = [];
+      const sha = execSync(`shasum -a 256 ${tarPath}`, { encoding: "utf8" })
+        .trim()
+        .split(/\s+/, 1)[0]!;
+      const result = ensureRootfsImage(tarPath, { cacheDir, onPhase: (name) => phases.push(name) });
+      expect(result).toBe(join(cacheDir, `${sha}.img`));
+      expect(_internal.looksLikeExt4(result)).toBe(true);
+      expect(phases).toContain("zstd-prebake");
+      expect(phases).not.toContain("gunzip-prebake");
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(sibling);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("falls back from an invalid .img.zst sibling to a valid .img.gz sibling", () => {
+    const tarPath = `/tmp/machinen-rootfs-prebake-zst-fallback-${process.pid}.tar.gz`;
+    const tmpDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-zst-fallback-tar-"));
+    const cacheDir = mkdtempSync(join(tmpdir(), "machinen-rootfs-prebake-zst-fallback-cache-"));
+    writeFileSync(join(tmpDir, "stub"), `prebake-zst-fallback-${process.pid}-${Date.now()}`);
+    execSync(`tar -czf ${tarPath} -C ${tmpDir} .`);
+    const fakeImg = join(tmpDir, "fake.img");
+    writeFakeExt4Image(fakeImg, 4096);
+    const zstSibling = tarPath.replace(/\.tar\.gz$/, ".img.zst");
+    const gzSibling = tarPath.replace(/\.tar\.gz$/, ".img.gz");
+    writeFileSync(zstSibling, "not zstd");
+    execSync(`gzip -n -c ${fakeImg} > ${gzSibling}`);
+    const saved = process.env.MACHINEN_MKE2FS;
+    process.env.MACHINEN_MKE2FS = "/definitely/not/here/mke2fs";
+    try {
+      const phases: string[] = [];
+      const result = ensureRootfsImage(tarPath, { cacheDir, onPhase: (name) => phases.push(name) });
+      expect(_internal.looksLikeExt4(result)).toBe(true);
+      expect(phases).toContain("zstd-prebake");
+      expect(phases).toContain("gunzip-prebake");
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MACHINEN_MKE2FS;
+      } else {
+        process.env.MACHINEN_MKE2FS = saved;
+      }
+      try {
+        unlinkSync(tarPath);
+      } catch {}
+      try {
+        unlinkSync(zstSibling);
+      } catch {}
+      try {
+        unlinkSync(gzSibling);
+      } catch {}
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  }, 20_000);
 
   it("uses a sibling .img.gz to populate the cache and skips mke2fs", () => {
     // Pair a tarball with a sibling prebake. Pointing MACHINEN_MKE2FS

--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -1,9 +1,16 @@
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { restore } from "../index.ts";
-import { currentVmstateBackend, readVmstateFacts } from "../vm/vmstate-metadata.ts";
+import {
+  currentVmstateBackend,
+  fileIdentity,
+  readVmstateFacts,
+  rememberTrustedFileIdentity,
+  trustedFileIdentity,
+} from "../vm/vmstate-metadata.ts";
 
 const MAGIC = Buffer.from("VMSTATE\0");
 const VERSION = 1;
@@ -62,6 +69,10 @@ function u64(v: bigint): Buffer {
   const b = Buffer.alloc(8);
   b.writeBigUInt64LE(v, 0);
   return b;
+}
+
+function sha256(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
 }
 
 function writeBundle(name: string, meta: unknown, sctlr: bigint): { dir: string; image: string } {
@@ -239,6 +250,49 @@ describe("vmstate portability metadata", () => {
     await expect(restore({ snapDir: dir, image, binary: "/bin/sh" })).rejects.toThrow(
       /missing rootdisk image/,
     );
+  });
+
+  it("reuses trusted file identity only while the file stamp is unchanged", () => {
+    const path = join(TMP, "trusted-rootdisk.img");
+    writeFileSync(path, "same-size-a");
+    const identity = fileIdentity(path);
+    rememberTrustedFileIdentity(identity);
+
+    expect(trustedFileIdentity(path)).toMatchObject(identity);
+
+    writeFileSync(path, "same-size-b");
+
+    expect(trustedFileIdentity(path)).toBeUndefined();
+  });
+
+  it("refuses an explicit caller-managed rootDisk whose bytes differ from metadata", async () => {
+    const target = currentVmstateBackend();
+    const { dir, image } = writeBundle(
+      "bad-explicit-rootdisk",
+      {
+        engine: "vmstate",
+        snappedAt: 1,
+        vmstate: {
+          sourceBackend: target,
+          topologyHash: TOPO.toString("hex"),
+          guestPauth: { active: false, sctlrEl1: "0x0" },
+          rootDisk: {
+            mode: "block",
+            file: "rootdisk.img",
+            sizeBytes: 4,
+            sha256: sha256("good"),
+          },
+        },
+      },
+      0n,
+    );
+    const explicitRootDisk = join(TMP, "explicit-rootdisk.img");
+    writeFileSync(join(dir, "rootdisk.img"), "good");
+    writeFileSync(explicitRootDisk, "evil");
+
+    await expect(
+      restore({ snapDir: dir, image, binary: "/bin/sh", rootDisk: explicitRootDisk }),
+    ).rejects.toThrow(/rootdisk identity mismatch/);
   });
 
   it("refuses a vmstate bundle whose rootdisk bytes differ from metadata", async () => {

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -89,54 +89,16 @@ export const VsockExec = {
    *   EXEC_AGENT_TIMEOUT (retryable) | EXEC_PROTOCOL
    */
   async run(udsPath: string, cmd: string, opts: VsockExecOptions = {}): Promise<VsockExecResult> {
-    const connectTimeout = opts.connectTimeoutMs ?? 30_000;
-    const retryMs = opts.retryMs ?? 250;
-    const deadline = Date.now() + connectTimeout;
-    debug("run uds=%s cmd=%j connectTimeoutMs=%d", udsPath, cmd, connectTimeout);
-    const t0 = Date.now();
-    let lastErr: Error | null = null;
-    let attempt = 0;
-    while (Date.now() < deadline) {
-      attempt++;
-      const socket = await connectWithRetry(udsPath, {
-        ...opts,
-        connectTimeoutMs: Math.max(0, deadline - Date.now()),
-      });
-      try {
-        const res = await runOnSocket(socket, cmd, opts);
-        debug(
-          "run done attempt=%d exit=%d stdout=%dB stderr=%dB elapsed=%dms",
-          attempt,
-          res.exitCode,
-          res.stdout.length,
-          res.stderr.length,
-          Date.now() - t0,
-        );
-        return res;
-      } catch (err) {
-        lastErr = err as Error;
-        // EPIPE on write / unexpected close-before-X — the agent
-        // probably wasn't listening yet. Retry the whole command.
-        if (!isTransientAgentError(lastErr)) {
-          debug("run failed (non-transient) attempt=%d err=%s", attempt, lastErr.message);
-          throw lastErr;
-        }
-        debug(
-          "run transient err attempt=%d code=%s msg=%s — retrying",
-          attempt,
-          (lastErr as Error & { code?: string }).code,
-          lastErr.message,
-        );
-      } finally {
-        await endSocket(socket);
-      }
-      await new Promise((r) => setTimeout(r, retryMs));
-    }
-    debug("run gave up after %dms attempts=%d", connectTimeout, attempt);
-    throw new ExecError(
-      "EXEC_AGENT_UNAVAILABLE",
-      `VsockExec.run: agent did not respond within ${connectTimeout}ms: ${lastErr?.message ?? "no error"}`,
-      { retryable: true, cause: lastErr ?? undefined },
+    return runWithRetry(udsPath, opts, "run", (socket) => runOnSocket(socket, cmd, opts));
+  },
+
+  async reseedVmstate(
+    udsPath: string,
+    seedHex: string,
+    opts: VsockExecOptions = {},
+  ): Promise<VsockExecResult> {
+    return runWithRetry(udsPath, opts, "reseedVmstate", (socket) =>
+      runReseedOnSocket(socket, seedHex, opts),
     );
   },
 
@@ -250,6 +212,63 @@ function isTransientAgentError(err: Error): boolean {
 // prefix, the trailing `\n`, and minor encoding overhead.
 const EXEC_LEGACY_MAX_BYTES = 3500;
 
+async function runWithRetry(
+  udsPath: string,
+  opts: VsockExecOptions,
+  label: string,
+  runSocket: (socket: Socket) => Promise<VsockExecResult>,
+): Promise<VsockExecResult> {
+  const connectTimeout = opts.connectTimeoutMs ?? 30_000;
+  const retryMs = opts.retryMs ?? 250;
+  const deadline = Date.now() + connectTimeout;
+  debug("%s uds=%s connectTimeoutMs=%d", label, udsPath, connectTimeout);
+  const t0 = Date.now();
+  let lastErr: Error | null = null;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    attempt++;
+    const socket = await connectWithRetry(udsPath, {
+      ...opts,
+      connectTimeoutMs: Math.max(0, deadline - Date.now()),
+    });
+    try {
+      const res = await runSocket(socket);
+      debug(
+        "%s done attempt=%d exit=%d stdout=%dB stderr=%dB elapsed=%dms",
+        label,
+        attempt,
+        res.exitCode,
+        res.stdout.length,
+        res.stderr.length,
+        Date.now() - t0,
+      );
+      return res;
+    } catch (err) {
+      lastErr = err as Error;
+      if (!isTransientAgentError(lastErr)) {
+        debug("%s failed (non-transient) attempt=%d err=%s", label, attempt, lastErr.message);
+        throw lastErr;
+      }
+      debug(
+        "%s transient err attempt=%d code=%s msg=%s — retrying",
+        label,
+        attempt,
+        (lastErr as Error & { code?: string }).code,
+        lastErr.message,
+      );
+    } finally {
+      await endSocket(socket);
+    }
+    await new Promise((r) => setTimeout(r, retryMs));
+  }
+  debug("%s gave up after %dms attempts=%d", label, connectTimeout, attempt);
+  throw new ExecError(
+    "EXEC_AGENT_UNAVAILABLE",
+    `VsockExec.${label}: agent did not respond within ${connectTimeout}ms: ${lastErr?.message ?? "no error"}`,
+    { retryable: true, cause: lastErr ?? undefined },
+  );
+}
+
 async function runOnSocket(
   socket: Socket,
   cmd: string,
@@ -275,6 +294,22 @@ async function runOnSocket(
     socket,
     () => {
       socket.write(`EXEC ${cmd}\n`);
+    },
+    opts,
+  );
+}
+
+function runReseedOnSocket(
+  socket: Socket,
+  seedHex: string,
+  opts: VsockExecOptions,
+): Promise<VsockExecResult> {
+  const buf = Buffer.from(seedHex, "ascii");
+  return runFramedRequestOnSocket(
+    socket,
+    () => {
+      socket.write(`RESEED ${buf.length}\n`);
+      socket.write(buf);
     },
     opts,
   );

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -57,7 +57,6 @@
 // to the caller.
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -78,16 +77,21 @@ import { arch, homedir, platform } from "node:os";
 import { join, resolve } from "node:path";
 import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
+import { SPARSE_GUNZIP_WORKER, SPARSE_ZSTD_WORKER } from "./rootfs-sparse-workers.ts";
+import {
+  okMarkerPath,
+  readSha256Sidecar,
+  readVerifiedTemplateMetadata,
+  sha256OfFile,
+  templateMetaPath,
+  writeTemplateMetadata,
+} from "./rootfs-template-metadata.ts";
 
 const debug = debugLib("machinen:rootfs-img");
 
 /** Default cache root: `~/.cache/machinen/rootfs`. */
 export function rootfsImgCacheDir(): string {
   return join(homedir(), ".cache", "machinen", "rootfs");
-}
-
-function okMarkerPath(imgPath: string): string {
-  return `${imgPath}.ok`;
 }
 
 /**
@@ -184,6 +188,7 @@ interface RootfsCachePaths {
   sha: string;
   imgPath: string;
   okPath: string;
+  metaPath: string;
 }
 
 interface RootfsStagingPaths {
@@ -240,11 +245,29 @@ function resolveRootfsCachePaths(
   mkdirSync(cacheDir, { recursive: true });
   opts.onPhase?.("cache-dir", Date.now() - cacheDirT0);
 
+  const sha = resolveTarballSha(tarAbs, opts);
+  const imgPath = join(cacheDir, `${sha}.img`);
+  return {
+    tarAbs,
+    cacheDir,
+    sha,
+    imgPath,
+    okPath: okMarkerPath(imgPath),
+    metaPath: templateMetaPath(imgPath),
+  };
+}
+
+function resolveTarballSha(tarAbs: string, opts: EnsureRootfsImageOptions): string {
+  const sidecarT0 = Date.now();
+  const sidecarSha = readSha256Sidecar(tarAbs);
+  if (sidecarSha) {
+    opts.onPhase?.("sha256.sidecar", Date.now() - sidecarT0);
+    return sidecarSha;
+  }
   const shaT0 = Date.now();
   const sha = sha256OfFile(tarAbs);
   opts.onPhase?.("sha256", Date.now() - shaT0);
-  const imgPath = join(cacheDir, `${sha}.img`);
-  return { tarAbs, cacheDir, sha, imgPath, okPath: okMarkerPath(imgPath) };
+  return sha;
 }
 
 function tryReusableCachedRootfs(
@@ -261,6 +284,10 @@ function tryReusableCachedRootfs(
   if (!cachedImageHasCleanMarker(paths, opts)) {
     return undefined;
   }
+  if (cachedImageHasVerifiedTemplateMetadata(paths, opts)) {
+    growCachedRootfsIfRequested(paths.imgPath, opts);
+    return paths.imgPath;
+  }
   const markInUseT0 = Date.now();
   markCachedImageInUse(paths.okPath);
   opts.onPhase?.("cache-mark-in-use", Date.now() - markInUseT0);
@@ -269,6 +296,7 @@ function tryReusableCachedRootfs(
     return undefined;
   }
   growCachedRootfsIfRequested(paths.imgPath, opts);
+  writeTemplateMetadata(paths, "legacy-fsck");
   return paths.imgPath;
 }
 
@@ -284,6 +312,20 @@ function cachedImageHasCleanMarker(
   }
   debug("cache hit but no clean marker, will rematerialize img=%s", paths.imgPath);
   return false;
+}
+
+function cachedImageHasVerifiedTemplateMetadata(
+  paths: RootfsCachePaths,
+  opts: EnsureRootfsImageOptions,
+): boolean {
+  const metaT0 = Date.now();
+  const meta = readVerifiedTemplateMetadata(paths);
+  opts.onPhase?.("template-metadata", Date.now() - metaT0);
+  if (!meta) {
+    return false;
+  }
+  debug("cache hit immutable template sha=%s img=%s", paths.sha.slice(0, 12), paths.imgPath);
+  return true;
 }
 
 function markCachedImageInUse(okPath: string): void {
@@ -326,22 +368,25 @@ function tryPrebakedRootfs(
     return undefined;
   }
   const siblingProbeT0 = Date.now();
-  const sibling = siblingPrebakePath(paths.tarAbs);
-  const siblingExists = Boolean(sibling && existsSync(sibling));
+  const siblings = siblingPrebakeCandidates(paths.tarAbs).filter((sibling) =>
+    existsSync(sibling.path),
+  );
   opts.onPhase?.("prebake-probe", Date.now() - siblingProbeT0);
-  if (!sibling || !siblingExists) {
-    return undefined;
+  for (const sibling of siblings) {
+    const prebakeT0 = Date.now();
+    const fast = tryPrebakeFromSibling({
+      sibling,
+      cacheDir: paths.cacheDir,
+      sha: paths.sha,
+      imgPath: paths.imgPath,
+      sizeBytes: opts.sizeBytes,
+    });
+    opts.onPhase?.(sibling.phaseName, Date.now() - prebakeT0);
+    if (fast) {
+      return fast;
+    }
   }
-  const prebakeT0 = Date.now();
-  const fast = tryPrebakeFromSibling({
-    sibling,
-    cacheDir: paths.cacheDir,
-    sha: paths.sha,
-    imgPath: paths.imgPath,
-    sizeBytes: opts.sizeBytes,
-  });
-  opts.onPhase?.("gunzip-prebake", Date.now() - prebakeT0);
-  return fast;
+  return undefined;
 }
 
 function resolveMke2fsOrThrow(): string {
@@ -384,6 +429,8 @@ function materializeRootfsFromTar(
     const renameT0 = Date.now();
     renameSync(staging.stagingImg, paths.imgPath);
     opts.onPhase?.("rename", Date.now() - renameT0);
+    markRootfsImageClean(paths.imgPath);
+    writeTemplateMetadata(paths, "materialize");
     debug(
       "materialize done sha=%s img=%s sizeBytes=%d",
       paths.sha.slice(0, 12),
@@ -529,26 +576,6 @@ function looksLikeExt4(path: string): boolean {
   }
 }
 
-function sha256OfFile(path: string): string {
-  // Streaming hash — these tarballs are big (hundreds of MB) and we
-  // call this on every boot in the cache-hit path.
-  const h = createHash("sha256");
-  const fd = openSync(path, "r");
-  try {
-    const buf = Buffer.alloc(64 * 1024);
-    while (true) {
-      const nread = readSync(fd, buf, 0, buf.length, null);
-      if (nread <= 0) {
-        break;
-      }
-      h.update(buf.subarray(0, nread));
-    }
-  } finally {
-    closeSync(fd);
-  }
-  return h.digest("hex");
-}
-
 function whichFirst(names: string[]): string | undefined {
   for (const name of names) {
     try {
@@ -643,21 +670,33 @@ function duBytes(path: string): number {
   return statSync(path).size || 0;
 }
 
-// Resolve the prebake sibling next to a tarball. Only one form is
-// supported: `<basename>.img.gz` — gzipped ext4 image, shipped by
-// build-base-assets.sh for release tarballs where download size
-// matters more than decompress speed. Returns undefined when the
-// input path doesn't end in a recognized tarball suffix.
-//
-// `provision()` no longer emits an uncompressed sibling; it writes
-// the prebake straight into the runtime cache via
-// `prebakeRootfsImageFromTree()` instead.
+interface PrebakeSibling {
+  path: string;
+  format: "zst" | "gz";
+  phaseName: "zstd-prebake" | "gunzip-prebake";
+}
+
+// Resolve the legacy gzip prebake sibling next to a tarball.
 function siblingPrebakePath(tarAbs: string): string | undefined {
-  const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(tarAbs);
-  if (!m) {
-    return undefined;
+  return siblingPrebakeBase(tarAbs)?.concat(".img.gz");
+}
+
+// Prefer a zstd-compressed prebake when present. Keep gzip as the
+// compatibility fallback for existing release assets and hosts without zstd.
+function siblingPrebakeCandidates(tarAbs: string): PrebakeSibling[] {
+  const base = siblingPrebakeBase(tarAbs);
+  if (!base) {
+    return [];
   }
-  return `${m[1]}.img.gz`;
+  return [
+    { path: `${base}.img.zst`, format: "zst", phaseName: "zstd-prebake" },
+    { path: `${base}.img.gz`, format: "gz", phaseName: "gunzip-prebake" },
+  ];
+}
+
+function siblingPrebakeBase(tarAbs: string): string | undefined {
+  const m = /^(.*)(\.tar\.gz|\.tgz|\.tar)$/i.exec(tarAbs);
+  return m?.[1];
 }
 
 // Populate the cache from a release-built `<base>.img.gz` sibling.
@@ -666,7 +705,7 @@ function siblingPrebakePath(tarAbs: string): string | undefined {
 // renames into place. Any failure returns undefined and the caller
 // falls through to the slow materialize path.
 function tryPrebakeFromSibling(args: {
-  sibling: string;
+  sibling: PrebakeSibling;
   cacheDir: string;
   sha: string;
   imgPath: string;
@@ -676,8 +715,8 @@ function tryPrebakeFromSibling(args: {
   const stagingDir = mkdtempSync(join(cacheDir, `${sha.slice(0, 12)}-prebake-`));
   const stagingImg = join(stagingDir, "rootfs.img");
   try {
-    debug("prebake try sibling=%s sha=%s", sibling, sha.slice(0, 12));
-    if (!gunzipPrebakeToFile(sibling, stagingImg)) {
+    debug("prebake try sibling=%s sha=%s", sibling.path, sha.slice(0, 12));
+    if (!decompressPrebakeToFile(sibling, stagingImg)) {
       return undefined;
     }
     // Sniff ext4 magic so a corrupted / wrong-content sibling can't
@@ -698,16 +737,49 @@ function tryPrebakeFromSibling(args: {
       }
     }
     renameSync(stagingImg, imgPath);
+    markRootfsImageClean(imgPath);
+    writeTemplateMetadata({ sha, imgPath, metaPath: templateMetaPath(imgPath) }, "prebake");
     debug("prebake done sha=%s img=%s", sha.slice(0, 12), imgPath);
     return imgPath;
   } catch (err) {
-    debug("prebake error sibling=%s err=%s", sibling, (err as Error).message);
+    debug("prebake error sibling=%s err=%s", sibling.path, (err as Error).message);
     return undefined;
   } finally {
     try {
       rmSync(stagingDir, { recursive: true, force: true });
     } catch {}
   }
+}
+
+function decompressPrebakeToFile(sibling: PrebakeSibling, dst: string): boolean {
+  return sibling.format === "zst"
+    ? zstdPrebakeToFile(sibling.path, dst)
+    : gunzipPrebakeToFile(sibling.path, dst);
+}
+
+function zstdPrebakeToFile(sibling: string, dst: string): boolean {
+  const zstd = whichFirst(["zstd"]);
+  if (!zstd) {
+    debug("prebake zstd missing; falling back sibling=%s", sibling);
+    return false;
+  }
+  const r = spawnSync(
+    process.execPath,
+    ["--input-type=module", "-e", SPARSE_ZSTD_WORKER, zstd, sibling, dst],
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  if (r.status === 0) {
+    return true;
+  }
+  debug(
+    "prebake sparse zstd failed sibling=%s status=%s stderr=%s",
+    sibling,
+    r.status,
+    r.stderr?.toString().slice(0, 200) ?? "",
+  );
+  return false;
 }
 
 function gunzipPrebakeToFile(sibling: string, dst: string): boolean {
@@ -759,39 +831,6 @@ function sparseGunzipPrebakeToFile(sibling: string, dst: string): boolean {
   );
   return false;
 }
-
-const SPARSE_GUNZIP_WORKER = String.raw`
-import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
-import { createReadStream } from "node:fs";
-import { createGunzip } from "node:zlib";
-
-const [sibling, dst] = process.argv.slice(1);
-const fd = openSync(dst, "w");
-let offset = 0;
-
-function isAllZero(buf) {
-  for (let i = 0; i < buf.length; i++) {
-    if (buf[i] !== 0) return false;
-  }
-  return true;
-}
-
-try {
-  const gunzip = createReadStream(sibling).pipe(createGunzip());
-  for await (const chunk of gunzip) {
-    if (!isAllZero(chunk)) {
-      writeSync(fd, chunk, 0, chunk.length, offset);
-    }
-    offset += chunk.length;
-  }
-  ftruncateSync(fd, offset);
-  closeSync(fd);
-} catch (err) {
-  try { closeSync(fd); } catch {}
-  console.error(err instanceof Error ? err.stack || err.message : String(err));
-  process.exit(1);
-}
-`;
 
 // Extract `tarPath` into `dest` with mode-bit fidelity.
 //
@@ -918,6 +957,7 @@ export function prebakeRootfsImageFromTree(args: {
 
       renameSync(stagingImg, imgPath);
       markRootfsImageClean(imgPath);
+      writeTemplateMetadata({ sha, imgPath, metaPath: templateMetaPath(imgPath) }, "prebake-tree");
       debug("prebake emitted cache=%s sizeBytes=%d", imgPath, sizeBytes);
     } finally {
       try {
@@ -940,7 +980,12 @@ export const _rootfsImgInternal = {
   findBundledMke2fs,
   resolveMke2fsEnvOverride,
   okMarkerPath,
+  templateMetaPath,
+  readSha256Sidecar,
+  readVerifiedTemplateMetadata,
   siblingPrebakePath,
+  siblingPrebakeCandidates,
   extractTarball,
   gunzipPrebakeToFile,
+  zstdPrebakeToFile,
 };

--- a/packages/runtime/src/rootfs-sparse-workers.ts
+++ b/packages/runtime/src/rootfs-sparse-workers.ts
@@ -1,0 +1,70 @@
+export const SPARSE_GUNZIP_WORKER = String.raw`
+import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
+import { createReadStream } from "node:fs";
+import { createGunzip } from "node:zlib";
+
+const [sibling, dst] = process.argv.slice(1);
+const fd = openSync(dst, "w");
+let offset = 0;
+
+function isAllZero(buf) {
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] !== 0) return false;
+  }
+  return true;
+}
+
+try {
+  const gunzip = createReadStream(sibling).pipe(createGunzip());
+  for await (const chunk of gunzip) {
+    if (!isAllZero(chunk)) {
+      writeSync(fd, chunk, 0, chunk.length, offset);
+    }
+    offset += chunk.length;
+  }
+  ftruncateSync(fd, offset);
+  closeSync(fd);
+} catch (err) {
+  try { closeSync(fd); } catch {}
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+}
+`;
+
+export const SPARSE_ZSTD_WORKER = String.raw`
+import { spawn } from "node:child_process";
+import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
+
+const [zstd, sibling, dst] = process.argv.slice(1);
+const fd = openSync(dst, "w");
+let offset = 0;
+let stderr = "";
+
+function isAllZero(buf) {
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] !== 0) return false;
+  }
+  return true;
+}
+
+try {
+  const child = spawn(zstd, ["-dc", sibling], { stdio: ["ignore", "pipe", "pipe"] });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  for await (const chunk of child.stdout) {
+    if (!isAllZero(chunk)) {
+      writeSync(fd, chunk, 0, chunk.length, offset);
+    }
+    offset += chunk.length;
+  }
+  const status = await new Promise((resolve) => child.on("close", resolve));
+  if (status !== 0) {
+    throw new Error("zstd exited " + status + ": " + stderr.slice(0, 200));
+  }
+  ftruncateSync(fd, offset);
+  closeSync(fd);
+} catch (err) {
+  try { closeSync(fd); } catch {}
+  console.error(err instanceof Error ? err.stack || err.message : String(err));
+  process.exit(1);
+}
+`;

--- a/packages/runtime/src/rootfs-template-metadata.ts
+++ b/packages/runtime/src/rootfs-template-metadata.ts
@@ -1,0 +1,104 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:rootfs-img");
+
+export function okMarkerPath(imgPath: string): string {
+  return `${imgPath}.ok`;
+}
+
+export function templateMetaPath(imgPath: string): string {
+  return `${imgPath}.meta.json`;
+}
+
+export type RootfsTemplateSource = "materialize" | "prebake" | "prebake-tree" | "legacy-fsck";
+
+export interface RootfsTemplateMetadata {
+  version: 1;
+  sha256: string;
+  sizeBytes: number;
+  source: RootfsTemplateSource;
+  createdAt: string;
+}
+
+export function readSha256Sidecar(tarAbs: string): string | undefined {
+  const sidecar = `${tarAbs}.sha256`;
+  if (!existsSync(sidecar)) {
+    return undefined;
+  }
+  try {
+    const first = readFileSync(sidecar, "utf8").trim().split(/\s+/, 1)[0]?.toLowerCase();
+    return first && /^[0-9a-f]{64}$/.test(first) ? first : undefined;
+  } catch (err) {
+    debug("sha256 sidecar unreadable sidecar=%s err=%s", sidecar, (err as Error).message);
+    return undefined;
+  }
+}
+
+export function sha256OfFile(path: string): string {
+  const h = createHash("sha256");
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(64 * 1024);
+    while (true) {
+      const nread = readSync(fd, buf, 0, buf.length, null);
+      if (nread <= 0) {
+        break;
+      }
+      h.update(buf.subarray(0, nread));
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return h.digest("hex");
+}
+
+export function readVerifiedTemplateMetadata(paths: {
+  metaPath: string;
+  imgPath: string;
+  sha: string;
+}): RootfsTemplateMetadata | undefined {
+  if (!existsSync(paths.metaPath)) {
+    return undefined;
+  }
+  try {
+    const meta = JSON.parse(
+      readFileSync(paths.metaPath, "utf8"),
+    ) as Partial<RootfsTemplateMetadata>;
+    if (meta.version !== 1 || meta.sha256 !== paths.sha || typeof meta.sizeBytes !== "number") {
+      return undefined;
+    }
+    const currentSize = statSync(paths.imgPath).size;
+    return currentSize >= meta.sizeBytes ? (meta as RootfsTemplateMetadata) : undefined;
+  } catch (err) {
+    debug("template metadata invalid meta=%s err=%s", paths.metaPath, (err as Error).message);
+    return undefined;
+  }
+}
+
+export function writeTemplateMetadata(
+  paths: { sha: string; imgPath: string; metaPath: string },
+  source: RootfsTemplateSource,
+): void {
+  try {
+    const meta: RootfsTemplateMetadata = {
+      version: 1,
+      sha256: paths.sha,
+      sizeBytes: statSync(paths.imgPath).size,
+      source,
+      createdAt: new Date().toISOString(),
+    };
+    writeFileSync(paths.metaPath, `${JSON.stringify(meta)}\n`);
+  } catch (err) {
+    debug("template metadata write failed img=%s err=%s", paths.imgPath, (err as Error).message);
+  }
+}

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -67,6 +67,9 @@ export interface VmHandle {
   /** Like `exec()` but returns non-zero exit codes instead of throwing. */
   execRaw(cmd: string, opts?: VsockExecOptions): Promise<VsockExecResult>;
 
+  /** Internal fast path for vmstate restore entropy reseed; avoids shell startup. */
+  reseedVmstateEntropy?(seedHex: string, opts?: VsockExecOptions): Promise<VsockExecResult>;
+
   /**
    * Run a shell command inside a pseudoterminal. Bidirectional bytes
    * flow between `opts.stdin` and `opts.stdout`; the returned handle's

--- a/packages/runtime/src/vm/boot-rootdisk.ts
+++ b/packages/runtime/src/vm/boot-rootdisk.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { BootError } from "../errors.ts";
+import type { PhaseTimer } from "../phase-timer.ts";
+import { reflinkCopy } from "../reflink.ts";
+import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
+import type { BootOptions } from "./boot.ts";
+
+// Materialize the rootdisk image and reflink it into a per-boot path
+// so guest writes don't leak across boots. Returns the per-boot
+// reflink path so the exit hook can unlink it; undefined when the
+// caller passed a pre-built image (`rootDisk: '<path>'`) — that
+// file's lifecycle is the caller's.
+export function materializeRootdisk(
+  opts: BootOptions,
+  env: Record<string, string>,
+  phases: PhaseTimer,
+): string | undefined {
+  if (opts._rootDiskRestorePath) {
+    return materializeRestoredRootdisk(opts, env, phases);
+  }
+  if (typeof opts.rootDisk === "string") {
+    const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
+    if (!existsSync(rootDiskAbs)) {
+      throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
+    }
+    env.MACHINEN_ROOTDISK = rootDiskAbs;
+    return undefined;
+  }
+  return materializeCachedRootdisk(opts, env, phases);
+}
+
+function materializeRestoredRootdisk(
+  opts: BootOptions,
+  env: Record<string, string>,
+  phases: PhaseTimer,
+): string {
+  const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts._rootDiskRestorePath!);
+  if (!existsSync(rootDiskAbs)) {
+    throw new BootError(
+      "BOOT_SNAPSHOT_NOT_FOUND",
+      `restore: vmstate rootdisk image not found: ${rootDiskAbs}`,
+    );
+  }
+  const perBoot = join(
+    tmpdir(),
+    `machinen-rootdisk-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  const reflinkT0 = Date.now();
+  reflinkCopy(rootDiskAbs, perBoot);
+  phases.mark("rootdisk-materialize.restore-reflink", Date.now() - reflinkT0);
+  env.MACHINEN_ROOTDISK = perBoot;
+  return perBoot;
+}
+
+function materializeCachedRootdisk(
+  opts: BootOptions,
+  env: Record<string, string>,
+  phases: PhaseTimer,
+): string {
+  // #121: hand the VMM a per-boot reflink clone of the cached
+  // template, never the template itself. virtio-blk mounts the
+  // image read-write, so without the clone every boot from the
+  // same tarball would inherit the previous boot's writes.
+  const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
+  const cachedImg = ensureRootfsImage(baseAbs, {
+    sizeBytes: opts.rootDiskSizeBytes,
+    onPhase: (name, ms) => phases.mark(`rootdisk-materialize.${name}`, ms),
+  });
+  const perBoot = join(
+    tmpdir(),
+    `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+  );
+  const reflinkT0 = Date.now();
+  reflinkCopy(cachedImg, perBoot);
+  phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
+  // The cache file was only READ here — restore the clean-shutdown
+  // marker so the next boot finds a usable template instead of wiping
+  // and rematerializing (#170).
+  markRootfsImageClean(cachedImg);
+  env.MACHINEN_ROOTDISK = perBoot;
+  return perBoot;
+}

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -52,8 +52,8 @@ import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
+import { materializeRootdisk } from "./boot-rootdisk.ts";
 import { resolveCpuResourcePolicy, type ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
-import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
 import { resolveLiveMounts, type ResolvedLiveMount, synthesizeAndPackBundle } from "./bundle.ts";
 import { installVmExitCleanup } from "./exit-cleanup.ts";
 import { performForkWithRestore } from "./fork-core.ts";
@@ -1451,74 +1451,6 @@ async function bringUpGvproxy(
   };
 }
 
-// Materialize the rootdisk image and reflink it into a per-boot path
-// so guest writes don't leak across boots. Returns the per-boot
-// reflink path so the exit hook can unlink it; undefined when the
-// caller passed a pre-built image (`rootDisk: '<path>'`) — that
-// file's lifecycle is the caller's.
-function materializeRootdisk(
-  opts: BootOptions,
-  env: Record<string, string>,
-  phases: PhaseTimer,
-): string | undefined {
-  if (opts._rootDiskRestorePath) {
-    const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts._rootDiskRestorePath);
-    if (!existsSync(rootDiskAbs)) {
-      throw new BootError(
-        "BOOT_SNAPSHOT_NOT_FOUND",
-        `restore: vmstate rootdisk image not found: ${rootDiskAbs}`,
-      );
-    }
-    const perBoot = join(
-      tmpdir(),
-      `machinen-rootdisk-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-    );
-    const reflinkT0 = Date.now();
-    reflinkCopy(rootDiskAbs, perBoot);
-    phases.mark("rootdisk-materialize.restore-reflink", Date.now() - reflinkT0);
-    env.MACHINEN_ROOTDISK = perBoot;
-    return perBoot;
-  }
-  if (typeof opts.rootDisk === "string") {
-    const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
-    if (!existsSync(rootDiskAbs)) {
-      throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
-    }
-    env.MACHINEN_ROOTDISK = rootDiskAbs;
-    return undefined;
-  }
-  // #121: hand the VMM a per-boot reflink clone of the cached
-  // template, never the template itself. virtio-blk mounts the
-  // image read-write, so without the clone every boot from the
-  // same tarball would inherit the previous boot's writes
-  // (apt installs leaking, /var/log poisoning, two concurrent
-  // boots stomping each other's filesystem). COPYFILE_FICLONE →
-  // APFS clonefile / Linux FICLONE on reflink-capable fs (free,
-  // shared blocks until the guest writes); falls back to a
-  // regular copy elsewhere (one-time cost, sparse).
-  const baseAbs = resolve(opts.cwd ?? process.cwd(), opts.image!);
-  const cachedImg = ensureRootfsImage(baseAbs, {
-    sizeBytes: opts.rootDiskSizeBytes,
-    // #233 follow-up: surface the sub-steps of ensureRootfsImage
-    // (sha256, e2fsck, sparse-extend, …) as dot-separated
-    // children of `rootdisk-materialize` in the boot timeline.
-    onPhase: (name, ms) => phases.mark(`rootdisk-materialize.${name}`, ms),
-  });
-  const perBoot = join(
-    tmpdir(),
-    `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-  );
-  const reflinkT0 = Date.now();
-  reflinkCopy(cachedImg, perBoot);
-  phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
-  // The cache file was only READ here — restore the
-  // clean-shutdown marker so the next boot finds a usable
-  // template instead of wiping and rematerializing (#170).
-  markRootfsImageClean(cachedImg);
-  env.MACHINEN_ROOTDISK = perBoot;
-  return perBoot;
-}
-
 // Roll back gvproxy + per-boot disks/dirs after a pre-spawn failure.
 // Live mounts are in-VMM virtio-fs devices configured through env, so
 // there are no separate live-mount helper processes to roll back.
@@ -1882,6 +1814,11 @@ function createBootVmHandle(args: BootHandleArgs): VmHandle {
     errorOutput: () => args.errorCollector,
     exec: makeExec(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
     execRaw: makeExecRaw(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
+    reseedVmstateEntropy: makeReseedVmstateEntropy(
+      args.vsockUdsPath,
+      args.child,
+      args.errorCollector,
+    ),
     execPty: makeExecPty(args.vsockUdsPath),
     writeFile: makeWriteFile(() => handle),
     memoryStats: makeMemoryStats(args.childPid, args.statsFilePath, args.memoryCeilingMib),
@@ -1931,6 +1868,21 @@ function makeExecRaw(
     }
     return runVsockWithBootDiagnostics(child, errorCollector, () =>
       VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
+    );
+  };
+}
+
+function makeReseedVmstateEntropy(
+  vsockUdsPath: string | undefined,
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+): NonNullable<VmHandle["reseedVmstateEntropy"]> {
+  return (seedHex, execOpts) => {
+    if (!vsockUdsPath) {
+      return Promise.reject(missingVsockError("reseedVmstateEntropy"));
+    }
+    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+      VsockExec.reseedVmstate(vsockUdsPath, seedHex, execOpts),
     );
   };
 }

--- a/packages/runtime/src/vm/restore-reseed.ts
+++ b/packages/runtime/src/vm/restore-reseed.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from "node:crypto";
+import debugLib from "debug";
+
+import { BootError } from "../errors.ts";
+import type { VsockExecResult } from "../exec.ts";
+import type { VmHandle } from "../vm-handle.ts";
+
+const debugRestore = debugLib("machinen:restore");
+const VMSTATE_RESEED_MARKER = "/run/machinen-vmstate-reseed";
+
+/**
+ * Whole-VM snapshots include the guest kernel's CSPRNG state. Without a
+ * restore-time mix-in, two restores from the same bundle can hand out the same
+ * post-restore secrets. Mix host entropy into the guest's input pool before
+ * returning the restored handle, and leave a non-secret marker for smoke tests
+ * and operators to confirm the reseed path ran.
+ */
+export async function reseedVmstateGuestEntropy(vm: VmHandle): Promise<"direct" | "shell"> {
+  const seedHex = randomBytes(64).toString("hex");
+  let mode: "direct" | "shell" = "direct";
+  const res = await reseedVmstateGuestEntropyDirect(vm, seedHex).catch((err: unknown) => {
+    mode = "shell";
+    debugRestore(
+      "direct vmstate reseed unavailable, falling back to shell helper: %s",
+      err instanceof Error ? err.message : String(err),
+    );
+    return reseedVmstateGuestEntropyShell(vm, seedHex);
+  });
+  if (res.exitCode !== 0) {
+    throw new BootError(
+      "BOOT_VMSTATE_RESEED_FAILED",
+      `restore: vmstate entropy reseed command failed (exit ${res.exitCode}).\n` +
+        `stderr:\n${res.stderr}`,
+    );
+  }
+  debugRestore("vmstate restore entropy reseeded marker=%s mode=%s", VMSTATE_RESEED_MARKER, mode);
+  return mode;
+}
+
+async function reseedVmstateGuestEntropyDirect(
+  vm: VmHandle,
+  seedHex: string,
+): Promise<VsockExecResult> {
+  if (!vm.reseedVmstateEntropy) {
+    throw new Error("current VM handle does not expose direct vmstate entropy reseed");
+  }
+  return vm.reseedVmstateEntropy(seedHex, {
+    connectTimeoutMs: 1_000,
+    retryMs: 25,
+    execTimeoutMs: 10_000,
+  });
+}
+
+async function reseedVmstateGuestEntropyShell(
+  vm: VmHandle,
+  seedHex: string,
+): Promise<VsockExecResult> {
+  const marker = `vmstate reseeded ${new Date().toISOString()}\n`;
+  const cmd = [
+    "mkdir -p /run",
+    "test -x /sbin/machinen-vmstate-reseed",
+    `/sbin/machinen-vmstate-reseed ${shellQuote(seedHex)}`,
+    `printf %s ${shellQuote(marker)} > ${shellQuote(VMSTATE_RESEED_MARKER)}`,
+    `chmod 0600 ${shellQuote(VMSTATE_RESEED_MARKER)}`,
+  ].join(" && ");
+  return vm
+    .execRaw(cmd, { connectTimeoutMs: 30_000, execTimeoutMs: 10_000 })
+    .catch((err: unknown) => {
+      throw new BootError(
+        "BOOT_VMSTATE_RESEED_FAILED",
+        `restore: failed to inject vmstate restore entropy before handing the VM to the caller.\n` +
+          `  The restored guest may otherwise reuse CSPRNG state from the snapshot.`,
+        { cause: err },
+      );
+    });
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -33,6 +33,7 @@ import {
   PortableSnapshotValidationError,
   validatePortableSnapshotBundle,
 } from "./portable-snapshot.ts";
+import { reseedVmstateGuestEntropy } from "./restore-reseed.ts";
 import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
 import { materializeVmstateChain } from "./vmstate-chain.ts";
 import type {
@@ -46,6 +47,7 @@ import {
   currentVmstateGuestArch,
   fileIdentity,
   readVmstateFacts,
+  trustedFileIdentity,
   type VmstateFacts,
 } from "./vmstate-metadata.ts";
 import {
@@ -57,8 +59,6 @@ import {
 
 const debug = debugLib("machinen:boot");
 const debugRestore = debugLib("machinen:restore");
-
-const VMSTATE_RESEED_MARKER = "/run/machinen-vmstate-reseed";
 
 export interface RestoreOptions extends Omit<BootOptions, "snapshot" | "image" | "cmd" | "name"> {
   /**
@@ -501,8 +501,11 @@ function planVmstateRestore(
   meta: SnapshotMeta,
   snapDir: string,
   statePath: string,
+  phases?: PhaseTimer,
 ): VmstateRestorePlan {
+  phases?.start("plan.read-vmstate-facts");
   const facts = readVmstateFactsOrBootError(statePath);
+  phases?.end("plan.read-vmstate-facts");
   const vmstate = meta.vmstate;
   if (!vmstate) {
     throw new BootError(
@@ -513,13 +516,23 @@ function planVmstateRestore(
         "  Recreate the snapshot with a current machinen build.",
     );
   }
+  phases?.start("plan.validate-invariants");
   validateVmstateTopology(vmstate, facts);
   validateVmstateGuestArch(vmstate, facts);
   validateVmstateBackendAndPauth(vmstate, facts);
+  phases?.end("plan.validate-invariants");
+  phases?.start("plan.validate-artifacts");
   validateVmstateArtifacts(opts, vmstate);
+  phases?.end("plan.validate-artifacts");
+  phases?.start("plan.resolve-memory");
+  const memoryCeiling = resolveVmstateMemoryCeiling(opts, vmstate);
+  phases?.end("plan.resolve-memory");
+  phases?.start("plan.resolve-rootdisk");
+  const rootDisk = resolveVmstateRootDisk(opts, vmstate, snapDir, phases);
+  phases?.end("plan.resolve-rootdisk");
   return {
-    memoryCeiling: resolveVmstateMemoryCeiling(opts, vmstate),
-    ...resolveVmstateRootDisk(opts, vmstate, snapDir),
+    memoryCeiling,
+    ...rootDisk,
   };
 }
 
@@ -644,10 +657,22 @@ function pauthSctlrLabel(vmstate: VmstateSnapshotMeta, facts: VmstateFacts): str
 
 function validateVmstateArtifacts(opts: RestoreOptions, vmstate: VmstateSnapshotMeta): void {
   if (opts.kernel && vmstate.kernel) {
-    validateIdentity("kernel", resolve(opts.cwd ?? process.cwd(), opts.kernel), vmstate.kernel);
+    validateIdentity(
+      "kernel",
+      resolve(opts.cwd ?? process.cwd(), opts.kernel),
+      vmstate.kernel,
+      undefined,
+      "external",
+    );
   }
   if (opts.dtb && vmstate.dtb) {
-    validateIdentity("dtb", resolve(opts.cwd ?? process.cwd(), opts.dtb), vmstate.dtb);
+    validateIdentity(
+      "dtb",
+      resolve(opts.cwd ?? process.cwd(), opts.dtb),
+      vmstate.dtb,
+      undefined,
+      "external",
+    );
   }
 }
 
@@ -728,6 +753,7 @@ function resolveVmstateRootDisk(
   opts: RestoreOptions,
   vmstate: VmstateSnapshotMeta,
   snapDir: string,
+  phases?: PhaseTimer,
 ): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
   const recorded = vmstate.rootDisk;
   if (!recorded) {
@@ -742,7 +768,7 @@ function resolveVmstateRootDisk(
   if (recorded.mode === "none") {
     return resolveNoneVmstateRootDisk(opts);
   }
-  return resolveFileVmstateRootDisk(opts, snapDir, recorded);
+  return resolveFileVmstateRootDisk(opts, snapDir, recorded, phases);
 }
 
 function resolveMissingVmstateRootDisk(
@@ -782,6 +808,7 @@ function resolveFileVmstateRootDisk(
   opts: RestoreOptions,
   snapDir: string,
   recorded: VmstateRootDiskBlock,
+  phases?: PhaseTimer,
 ): Pick<VmstateRestorePlan, "rootDisk" | "rootDiskRestorePath"> {
   if (opts.rootDisk === false) {
     throw new BootError(
@@ -791,7 +818,7 @@ function resolveFileVmstateRootDisk(
   }
   if (typeof opts.rootDisk === "string") {
     const explicit = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
-    validateIdentity("rootdisk", explicit, recorded);
+    validateIdentity("rootdisk", explicit, recorded, phases, "external");
     return { rootDisk: explicit };
   }
 
@@ -802,15 +829,24 @@ function resolveFileVmstateRootDisk(
       `restore: vmstate bundle is missing rootdisk image: ${bundled}`,
     );
   }
-  validateIdentity("rootdisk", bundled, recorded);
+  validateIdentity("rootdisk", bundled, recorded, phases, "bundled");
   return { rootDiskRestorePath: bundled };
 }
 
-function validateIdentity(label: string, path: string, expected: SnapshotFileIdentity): void {
+function validateIdentity(
+  label: string,
+  path: string,
+  expected: SnapshotFileIdentity,
+  phases: PhaseTimer | undefined,
+  source: "bundled" | "external",
+): void {
   if (!existsSync(path)) {
     throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${label} not found: ${path}`);
   }
-  const actual = fileIdentity(path);
+  const cached = source === "bundled" ? trustedFileIdentity(path) : undefined;
+  phases?.start(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
+  const actual = cached ?? fileIdentity(path);
+  phases?.end(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
   if (actual.sizeBytes !== expected.sizeBytes || actual.sha256 !== expected.sha256) {
     throw new BootError(
       "BOOT_VMSTATE_UNSUPPORTED",
@@ -820,47 +856,6 @@ function validateIdentity(label: string, path: string, expected: SnapshotFileIde
         "  vmstate restore requires byte-identical artifacts.",
     );
   }
-}
-
-/**
- * Whole-VM snapshots include the guest kernel's CSPRNG state. Without a
- * restore-time mix-in, two restores from the same bundle can hand out the same
- * post-restore secrets. Mix host entropy into the guest's input pool before
- * returning the restored handle, and leave a non-secret marker for smoke tests
- * and operators to confirm the reseed path ran.
- */
-async function reseedVmstateGuestEntropy(vm: VmHandle): Promise<void> {
-  const seedHex = randomBytes(64).toString("hex");
-  const marker = `vmstate reseeded ${new Date().toISOString()}\n`;
-  const cmd = [
-    "mkdir -p /run",
-    "test -x /sbin/machinen-vmstate-reseed",
-    `/sbin/machinen-vmstate-reseed ${shellQuote(seedHex)}`,
-    `printf %s ${shellQuote(marker)} > ${shellQuote(VMSTATE_RESEED_MARKER)}`,
-    `chmod 0600 ${shellQuote(VMSTATE_RESEED_MARKER)}`,
-  ].join(" && ");
-  const res = await vm
-    .execRaw(cmd, { connectTimeoutMs: 30_000, execTimeoutMs: 10_000 })
-    .catch((err: unknown) => {
-      throw new BootError(
-        "BOOT_VMSTATE_RESEED_FAILED",
-        `restore: failed to inject vmstate restore entropy before handing the VM to the caller.\n` +
-          `  The restored guest may otherwise reuse CSPRNG state from the snapshot.`,
-        { cause: err },
-      );
-    });
-  if (res.exitCode !== 0) {
-    throw new BootError(
-      "BOOT_VMSTATE_RESEED_FAILED",
-      `restore: vmstate entropy reseed command failed (exit ${res.exitCode}).\n` +
-        `stderr:\n${res.stderr}`,
-    );
-  }
-  debugRestore("vmstate restore entropy reseeded marker=%s", VMSTATE_RESEED_MARKER);
-}
-
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 /**
@@ -879,21 +874,37 @@ function shellQuote(s: string): string {
  */
 async function restoreVmstate(opts: RestoreOptions, snapDir: string): Promise<VmHandle> {
   const phases = new PhaseTimer();
-  let prepared = initialVmstateRestoreBundle(snapDir);
+  let prepared: PreparedVmstateRestoreBundle | undefined;
   let vm: VmHandle;
   try {
+    phases.start("read-meta");
+    prepared = initialVmstateRestoreBundle(snapDir);
+    phases.end("read-meta");
     phases.start("materialize-chain");
     prepared = materializeVmstateRestoreChainIfNeeded(snapDir, prepared);
     phases.end("materialize-chain");
+    phases.start("resolve-image");
+    const resolvedImage = resolveRestoreImage(opts, prepared.meta);
+    phases.end("resolve-image");
+    phases.start("plan");
+    const vmstatePlan = planVmstateRestore(
+      opts,
+      prepared.meta,
+      prepared.effectiveSnapDir,
+      prepared.statePath,
+      phases,
+    );
+    phases.end("plan");
     phases.start("boot");
-    vm = await bootVmstateRestore(opts, snapDir, prepared);
+    vm = await bootVmstateRestore(opts, snapDir, prepared, resolvedImage, vmstatePlan);
     phases.end("boot");
     phases.start("entropy-reseed");
-    await reseedVmstateGuestEntropy(vm);
-    phases.end("entropy-reseed");
+    const reseedMode = await reseedVmstateGuestEntropy(vm);
+    const reseedMs = phases.end("entropy-reseed");
+    phases.mark(`entropy-reseed.${reseedMode}`, reseedMs);
   } finally {
     phases.start("cleanup-materialized-chain");
-    cleanupMaterializedVmstate(prepared.materializedTempDir);
+    cleanupMaterializedVmstate(prepared?.materializedTempDir);
     phases.end("cleanup-materialized-chain");
   }
 
@@ -943,14 +954,9 @@ async function bootVmstateRestore(
   opts: RestoreOptions,
   snapDir: string,
   prepared: PreparedVmstateRestoreBundle,
+  resolvedImage: string,
+  vmstatePlan: VmstateRestorePlan,
 ): Promise<VmHandle> {
-  const resolvedImage = resolveRestoreImage(opts, prepared.meta);
-  const vmstatePlan = planVmstateRestore(
-    opts,
-    prepared.meta,
-    prepared.effectiveSnapDir,
-    prepared.statePath,
-  );
   debugRestore(
     "vmstate restore snapDir=%s state=%s image=%s",
     snapDir,

--- a/packages/runtime/src/vm/snapshot-rootdisk.ts
+++ b/packages/runtime/src/vm/snapshot-rootdisk.ts
@@ -1,0 +1,69 @@
+import { join } from "node:path";
+
+import { SnapshotError } from "../errors.ts";
+import { reflinkCopy } from "../reflink.ts";
+import type { VmstateSnapshotMeta } from "../vm-handle.ts";
+import type { SnapshotContext } from "./snapshot.ts";
+import { VMSTATE_ROOTDISK_FILE } from "./snapshot-engine.ts";
+import { fileIdentity, rememberTrustedFileIdentity } from "./vmstate-metadata.ts";
+
+export type PendingVmstateRootDisk =
+  | { mode: "block"; file: string; path: string; bundlePath: string }
+  | { mode: "delta" }
+  | { mode: "none" };
+
+export function copyVmstateRootDisk(
+  ctx: SnapshotContext,
+  snapDir: string,
+  deltaOnly: boolean,
+): PendingVmstateRootDisk {
+  if (ctx.rootDiskMode === "none") {
+    return { mode: "none" };
+  }
+  if (!ctx.rootDiskPath) {
+    throw new SnapshotError(
+      "SNAPSHOT_DUMP_FAILED",
+      "vm.snapshot: cannot record vmstate rootdisk identity for this VM.\n" +
+        "  Reboot it with the current runtime so the registry records /dev/vda,\n" +
+        "  or boot with rootDisk:false if the guest intentionally has no root block device.",
+    );
+  }
+  if (deltaOnly) {
+    return { mode: "delta" };
+  }
+  const dest = join(snapDir, VMSTATE_ROOTDISK_FILE);
+  try {
+    reflinkCopy(ctx.rootDiskPath, dest);
+  } catch (err) {
+    throw new SnapshotError(
+      "SNAPSHOT_DUMP_FAILED",
+      `vm.snapshot: failed to copy rootdisk into vmstate bundle: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err },
+    );
+  }
+  return {
+    mode: "block",
+    file: VMSTATE_ROOTDISK_FILE,
+    path: ctx.rootDiskPath,
+    bundlePath: dest,
+  };
+}
+
+export function finalizeVmstateRootDisk(
+  rootDisk: PendingVmstateRootDisk,
+): VmstateSnapshotMeta["rootDisk"] {
+  if (rootDisk.mode !== "block") {
+    return rootDisk;
+  }
+  const identity = fileIdentity(rootDisk.bundlePath);
+  rememberTrustedFileIdentity(identity);
+  return {
+    mode: "block",
+    file: rootDisk.file,
+    path: rootDisk.path,
+    sizeBytes: identity.sizeBytes,
+    sha256: identity.sha256,
+  };
+}

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -22,8 +22,9 @@ import type {
   SnapshotResult,
   VmstateSnapshotMeta,
 } from "../vm-handle.ts";
-import { resolveSnapshotEngine, VMSTATE_FILE, VMSTATE_ROOTDISK_FILE } from "./snapshot-engine.ts";
+import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
 import { relativeCheckpointParent, VMSTATE_SECTION, vmstateSectionTags } from "./vmstate-chain.ts";
+import { copyVmstateRootDisk, finalizeVmstateRootDisk } from "./snapshot-rootdisk.ts";
 import {
   currentVmstateBackend,
   currentVmstateGuestArch,
@@ -739,7 +740,7 @@ async function captureVmstateSnapshotBundle(
   phases: PhaseTimer,
 ): Promise<SnapshotResult> {
   phases.start("pause-critical-section");
-  const result = await withPausedVmstateSource(ctx, async () => {
+  const bundle = await withPausedVmstateSource(ctx, async () => {
     phases.start("wait-state-file");
     await waitForVmstateFile(ctx.vmstatePath!, deadlineMs);
     phases.end("wait-state-file");
@@ -747,26 +748,39 @@ async function captureVmstateSnapshotBundle(
     const bundleStatePath = copyVmstateStateIntoBundle(ctx.vmstatePath!, snapDir);
     phases.end("copy-state-file");
     const nextSequence = (ctx.vmstateChain?.sequence ?? 0) + 1;
-    phases.start("build-metadata-and-rootdisk");
-    const vmstateMeta = buildVmstateMeta(
+    const flags = readVmstateSectionFlags(bundleStatePath);
+    phases.start("rootdisk-reflink");
+    const rootDisk = copyVmstateRootDisk(
       ctx,
-      bundleStatePath,
       snapDir,
-      ctx.vmstateChain?.parentDir,
-      nextSequence,
+      shouldCopyRootdiskDeltaOnly(ctx.vmstateChain?.parentDir, flags),
     );
-    phases.end("build-metadata-and-rootdisk");
+    phases.end("rootdisk-reflink");
     phases.start("mount-overlay-reflink");
     const mountDiskMeta = await reflinkMountOverlay(ctx, snapDir, deadlineMs);
     phases.end("mount-overlay-reflink");
-    phases.start("write-meta");
-    writeSnapshotMeta(ctx, snapDir, mountDiskMeta, "vmstate", vmstateMeta);
-    ctx.updateVmstateChain?.({ parentDir: snapDir, sequence: nextSequence });
-    phases.end("write-meta");
-    return vmstateSnapshotResult(snapDir, bundleStatePath, t0);
+    return { bundleStatePath, flags, mountDiskMeta, nextSequence, rootDisk };
   });
   phases.end("pause-critical-section");
-  return result;
+  phases.start("rootdisk-identity");
+  const rootDisk = finalizeVmstateRootDisk(bundle.rootDisk);
+  phases.end("rootdisk-identity");
+  phases.start("build-metadata");
+  const vmstateMeta = buildVmstateMeta(
+    ctx,
+    bundle.bundleStatePath,
+    snapDir,
+    ctx.vmstateChain?.parentDir,
+    bundle.nextSequence,
+    bundle.flags,
+    rootDisk,
+  );
+  phases.end("build-metadata");
+  phases.start("write-meta");
+  writeSnapshotMeta(ctx, snapDir, bundle.mountDiskMeta, "vmstate", vmstateMeta);
+  ctx.updateVmstateChain?.({ parentDir: snapDir, sequence: bundle.nextSequence });
+  phases.end("write-meta");
+  return vmstateSnapshotResult(snapDir, bundle.bundleStatePath, t0);
 }
 
 async function withPausedVmstateSource<T>(
@@ -858,16 +872,17 @@ function buildVmstateMeta(
   snapDir: string,
   parentDir: string | undefined,
   sequence: number,
+  flags: VmstateSectionFlags,
+  rootDisk: VmstateSnapshotMeta["rootDisk"],
 ): VmstateSnapshotMeta {
   const facts = readVmstateFacts(statePath);
-  const flags = readVmstateSectionFlags(statePath);
   return {
     sourceBackend: currentVmstateBackend(),
     guestArch: vmstateGuestArch(facts),
     topologyHash: facts.topologyHash,
     memoryCeilingMib: ctx.memoryCeilingMib,
     guestPauth: vmstateGuestPauth(facts),
-    rootDisk: copyVmstateRootDisk(ctx, snapDir, shouldCopyRootdiskDeltaOnly(parentDir, flags)),
+    rootDisk,
     kernel: optionalFileIdentity(ctx.kernelPath),
     dtb: optionalFileIdentity(ctx.dtbPath),
     checkpoint: buildVmstateCheckpoint(ctx, snapDir, parentDir, sequence, flags),
@@ -934,47 +949,6 @@ function checkpointRootDiskMode(
     return "none";
   }
   return flags.hasRootdiskDelta ? "delta" : "full";
-}
-
-function copyVmstateRootDisk(
-  ctx: SnapshotContext,
-  snapDir: string,
-  deltaOnly: boolean,
-): VmstateSnapshotMeta["rootDisk"] {
-  if (ctx.rootDiskMode === "none") {
-    return { mode: "none" };
-  }
-  if (!ctx.rootDiskPath) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      "vm.snapshot: cannot record vmstate rootdisk identity for this VM.\n" +
-        "  Reboot it with the current runtime so the registry records /dev/vda,\n" +
-        "  or boot with rootDisk:false if the guest intentionally has no root block device.",
-    );
-  }
-  if (deltaOnly) {
-    return { mode: "delta" };
-  }
-  const dest = join(snapDir, VMSTATE_ROOTDISK_FILE);
-  try {
-    reflinkCopy(ctx.rootDiskPath, dest);
-  } catch (err) {
-    throw new SnapshotError(
-      "SNAPSHOT_DUMP_FAILED",
-      `vm.snapshot: failed to copy rootdisk into vmstate bundle: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { cause: err },
-    );
-  }
-  const identity = fileIdentity(dest);
-  return {
-    mode: "block",
-    file: VMSTATE_ROOTDISK_FILE,
-    path: ctx.rootDiskPath,
-    sizeBytes: identity.sizeBytes,
-    sha256: identity.sha256,
-  };
 }
 
 // Poll for the VMM's atomically-written `.vmstate` to (re)appear. The

--- a/packages/runtime/src/vm/vmstate-metadata.ts
+++ b/packages/runtime/src/vm/vmstate-metadata.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { openSync, readFileSync, readSync, statSync, closeSync } from "node:fs";
+import { closeSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { gunzipSync } from "node:zlib";
 import type { SnapshotFileIdentity as FileIdentity, VmstateBackend } from "../vm-handle.ts";
 
@@ -115,12 +115,100 @@ export function readVmstateFacts(path: string): VmstateFacts {
   return { arch, topologyHash, sectionCount, guestPauthActive, sctlrEl1 };
 }
 
+interface FileIdentityStamp {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+  sampleSha256: string;
+}
+
+interface CachedFileIdentity {
+  identity: FileIdentity;
+  stamp: FileIdentityStamp;
+}
+
+const trustedFileIdentities = new Map<string, CachedFileIdentity>();
+
 export function fileIdentity(path: string): FileIdentity {
   return {
     path,
     sizeBytes: statSync(path).size,
     sha256: sha256File(path),
   };
+}
+
+export function rememberTrustedFileIdentity(identity: FileIdentity): void {
+  if (!identity.path) {
+    return;
+  }
+  const stamp = fileIdentityStamp(identity.path);
+  if (stamp.size !== BigInt(identity.sizeBytes)) {
+    return;
+  }
+  trustedFileIdentities.set(identity.path, { identity, stamp });
+}
+
+export function trustedFileIdentity(path: string): FileIdentity | undefined {
+  const cached = trustedFileIdentities.get(path);
+  if (!cached) {
+    return undefined;
+  }
+  if (!sameFileIdentityStamp(cached.stamp, fileIdentityStamp(path))) {
+    trustedFileIdentities.delete(path);
+    return undefined;
+  }
+  return cached.identity;
+}
+
+function fileIdentityStamp(path: string): FileIdentityStamp {
+  const st = statSync(path, { bigint: true });
+  return {
+    dev: st.dev,
+    ino: st.ino,
+    size: st.size,
+    mtimeNs: st.mtimeNs,
+    ctimeNs: st.ctimeNs,
+    sampleSha256: sampleSha256(path, st.size),
+  };
+}
+
+function sameFileIdentityStamp(a: FileIdentityStamp, b: FileIdentityStamp): boolean {
+  return (
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.size === b.size &&
+    a.mtimeNs === b.mtimeNs &&
+    a.ctimeNs === b.ctimeNs &&
+    a.sampleSha256 === b.sampleSha256
+  );
+}
+
+function sampleSha256(path: string, size: bigint): string {
+  const h = createHash("sha256");
+  const fd = openSync(path, "r");
+  try {
+    const offsets = sampleOffsets(size);
+    const buf = Buffer.allocUnsafe(4096);
+    for (const offset of offsets) {
+      const nread = readSync(fd, buf, 0, buf.length, Number(offset));
+      if (nread > 0) {
+        h.update(buf.subarray(0, nread));
+      }
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return h.digest("hex");
+}
+
+function sampleOffsets(size: bigint): bigint[] {
+  if (size <= 0n) {
+    return [];
+  }
+  const last = size > 4096n ? size - 4096n : 0n;
+  return [...new Set([0n, size / 2n, last])];
 }
 
 function sha256File(path: string): string {

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -11,10 +11,10 @@
 #   virt-arm64.dtb                 ← compiled device tree
 #   rootfs-debian-arm64.tar.gz     ← debian minbase + /init + /exec-agent
 #   rootfs-debian-arm64.img.gz     ← prebaked ext4 image of the same
-#                                    rootfs; lets cold boots skip
+#   rootfs-debian-arm64.img.zst       rootfs; lets cold boots skip
 #                                    tar -xf + mke2fs (#223). Sparse
-#                                    inside the gzip — wire size is
-#                                    close to the tarball.
+#                                    inside the compressed stream — wire
+#                                    size is close to the tarball.
 #
 # For amd64 guests (`MACHINEN_GUEST_ARCH=amd64`), the same flow emits
 # `bzImage-x86_64`, `rootfs-debian-amd64.tar.gz`, and
@@ -74,6 +74,7 @@ case "$GUEST_ARCH" in
     DTB_ASSET="virt-arm64.dtb"
     ROOTFS_TAR="rootfs-debian-arm64.tar.gz"
     ROOTFS_IMG="rootfs-debian-arm64.img.gz"
+    ROOTFS_IMG_ZST="rootfs-debian-arm64.img.zst"
     ZIG_GUEST_TARGET="aarch64-linux-musl"
     DOCKER_PLATFORM="linux/arm64"
     DEBIAN_ARCH="arm64"
@@ -85,6 +86,7 @@ case "$GUEST_ARCH" in
     DTB_ASSET=""
     ROOTFS_TAR="rootfs-debian-amd64.tar.gz"
     ROOTFS_IMG="rootfs-debian-amd64.img.gz"
+    ROOTFS_IMG_ZST="rootfs-debian-amd64.img.zst"
     ZIG_GUEST_TARGET="x86_64-linux-musl"
     DOCKER_PLATFORM="linux/amd64"
     DEBIAN_ARCH="amd64"
@@ -308,6 +310,7 @@ docker run --rm -i --privileged --platform "${DOCKER_PLATFORM}" \
   -e DEBIAN_ARCH="${DEBIAN_ARCH}" \
   -e ROOTFS_TAR="${ROOTFS_TAR}" \
   -e ROOTFS_IMG="${ROOTFS_IMG}" \
+  -e ROOTFS_IMG_ZST="${ROOTFS_IMG_ZST}" \
   -v "${STAGE}":/stage:ro \
   -v "$OUT":/out \
   debian:bookworm-slim bash -s <<'CONTAINER_SCRIPT'
@@ -315,10 +318,11 @@ set -euo pipefail
 
 apt-get update -qq > /dev/null
 # e2fsprogs is the host-side tool that builds the prebake `.img` from
-# the staged rootfs tree (#223). gzip ships with debian:bookworm-slim
-# already; listed here for clarity.
+# the staged rootfs tree (#223). gzip ships with debian:bookworm-slim;
+# zstd is installed so release builds also emit the faster .img.zst
+# sibling that runtime cold boots prefer when available.
 apt-get install -y --no-install-recommends \
-  mmdebstrap gpg debian-archive-keyring e2fsprogs gzip > /dev/null
+  mmdebstrap gpg debian-archive-keyring e2fsprogs gzip zstd > /dev/null
 
 mkdir -p /work
 
@@ -613,6 +617,7 @@ echo "==> Prebaking rootfs ext4 image: ${SIZE_BYTES} bytes (${BLOCKS} x 4 KiB bl
 truncate -s "$SIZE_BYTES" /tmp/rootfs.img
 mke2fs -d /work/rootfs -t ext4 -F -q -b 4096 /tmp/rootfs.img "$BLOCKS"
 gzip -n -c /tmp/rootfs.img > "/out/${ROOTFS_IMG}"
+zstd -q -T0 --no-check -19 -f -o "/out/${ROOTFS_IMG_ZST}" /tmp/rootfs.img
 rm -f /tmp/rootfs.img
 CONTAINER_SCRIPT
 
@@ -622,7 +627,7 @@ CONTAINER_SCRIPT
 
 echo "==> Writing sha256 sidecars"
 cd "$OUT"
-for f in "$KERNEL_ASSET" ${DTB_ASSET:+"$DTB_ASSET"} "$ROOTFS_TAR" "$ROOTFS_IMG"; do
+for f in "$KERNEL_ASSET" ${DTB_ASSET:+"$DTB_ASSET"} "$ROOTFS_TAR" "$ROOTFS_IMG" "$ROOTFS_IMG_ZST"; do
   shasum -a 256 "$f" > "${f}.sha256"
 done
 
@@ -654,6 +659,7 @@ CACHE_DIR="${HOME}/.machinen/runtime-v${RUNTIME_VERSION}/bases/debian-${GUEST_AR
 mkdir -p "$CACHE_DIR"
 cp "${OUT}/${ROOTFS_TAR}" "${CACHE_DIR}/rootfs.tar.gz"
 cp "${OUT}/${ROOTFS_IMG}" "${CACHE_DIR}/rootfs.img.gz"
+cp "${OUT}/${ROOTFS_IMG_ZST}" "${CACHE_DIR}/rootfs.img.zst"
 cp "${OUT}/${KERNEL_ASSET}" "${CACHE_DIR}/Image"
 if [ -n "$DTB_ASSET" ]; then
   cp "${OUT}/${DTB_ASSET}" "${CACHE_DIR}/virt.dtb"

--- a/scripts/release-base-assets.mjs
+++ b/scripts/release-base-assets.mjs
@@ -27,9 +27,11 @@ const PAYLOAD_ASSETS = [
   "virt-arm64.dtb",
   "rootfs-debian-arm64.tar.gz",
   "rootfs-debian-arm64.img.gz",
+  "rootfs-debian-arm64.img.zst",
   "bzImage-x86_64",
   "rootfs-debian-amd64.tar.gz",
   "rootfs-debian-amd64.img.gz",
+  "rootfs-debian-amd64.img.zst",
 ];
 const OPTIONAL_UPLOAD_ASSETS = [
   "Image-arm64.inputs-sha256",


### PR DESCRIPTION
## Problem

Boot and restore had a few fixed costs that made small VMs feel slower than they should. The runtime often rechecked large root disks, decompressed rootfs images with a slower format, and reseeded restored guests through a shell command. These steps were safe, but they were doing more work than the common path needed.

## Solution

This PR keeps the safety checks for caller-managed files, but avoids repeated work for files Machinen just created or verified. Rootfs prebakes can now use zstd, restored guests use a direct reseed command, and clean cached rootfs templates can skip full hashing and fsck. The result is faster warm boots and faster vmstate restores without weakening mismatch checks.

## Technical Summary

- Keep strict byte checks for explicit `rootDisk` inputs. The faster trusted identity path is only used for snapshot-controlled bundled rootdisks.
- Move snapshot rootdisk identity work out of the pause-critical section, so the guest spends less time stopped.
- Prefer `.img.zst` prebake assets when available, while keeping `.img.gz` and tar materialization as fallback paths.
- Add a direct exec-agent `RESEED` operation. Restore tries it first and only falls back to the shell helper for old guest agents.
- Mark verified rootfs cache templates with metadata. A clean immutable template can be cloned for a boot without rerunning tarball hashing or `e2fsck`.
- Split helper modules out of the large boot, restore, snapshot, and rootfs files so the latency changes do not add more large-file health debt.
