### PR TITLE
Improve snapshot and fork latency

### DIFF
--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -5,6 +5,7 @@
 //!
 //!   client -> "EXEC <shell command>\n"            (single line, legacy)
 //!         or "EXEC2 <byte-len>\n<shell command>"  (length-prefixed; #112)
+//!         or "SYNC\n"                            (direct guest sync)
 //!   agent  -> framed output chunks until the command exits:
 //!               "O <n>\n" + n bytes of stdout
 //!               "E <n>\n" + n bytes of stderr
@@ -54,6 +55,7 @@ extern "c" fn signal(signum: c_int, handler: usize) usize;
 extern "c" fn kill(pid: pid_t, sig: c_int) c_int;
 extern "c" fn unlink(path: [*:0]const u8) c_int;
 extern "c" fn usleep(usec: c_uint) c_int;
+extern "c" fn sync() void;
 // PTY plumbing for the PTY opcode (#133).
 //   forkpty(3) — musl ships it in the main libc (no -lutil needed).
 //     Allocates a /dev/ptmx + /dev/pts/N pair, forks, dups the slave
@@ -932,6 +934,7 @@ fn handle_connection(client_fd: c_int, alloc: std.mem.Allocator) void {
         return handle_ptysession(client_fd, line);
     }
     if (std.mem.startsWith(u8, line, "PTY ")) return handle_pty(client_fd, line, alloc);
+    if (std.mem.eql(u8, line, "SYNC")) return handle_sync(client_fd);
     if (std.mem.startsWith(u8, line, "RESEED ")) return handle_reseed(client_fd, line);
     if (std.mem.startsWith(u8, line, "EXEC2 ")) return handle_exec2(client_fd, line, alloc);
     if (line.len < 5 or !std.mem.startsWith(u8, line, "EXEC ")) {
@@ -1040,6 +1043,12 @@ fn handle_pty(client_fd: c_int, line: []const u8, alloc: std.mem.Allocator) void
     run_pty_command(client_fd, cmd_buf, h.cols, h.rows, alloc) catch |err| {
         log_run_error("pty", err);
     };
+}
+
+fn handle_sync(client_fd: c_int) void {
+    std.debug.assert(client_fd >= 0);
+    sync();
+    send_exit(client_fd, 0);
 }
 
 fn handle_reseed(client_fd: c_int, line: []const u8) void {

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -16774,6 +16774,22 @@ Internal fast path for vmstate restore entropy reseed; avoids shell startup.
 
 `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
 
+##### syncVmstateSnapshot()?
+
+> `optional` **syncVmstateSnapshot**(`opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
+Internal fast path for vmstate pre-snapshot filesystem sync; avoids shell startup.
+
+###### Parameters
+
+###### opts?
+
+[`VsockExecOptions`](#vsockexecoptions)
+
+###### Returns
+
+`Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
 ##### execPty()
 
 > **execPty**(`cmd`, `opts`): [`VsockExecPtyHandle`](#vsockexecptyhandle)
@@ -24209,6 +24225,24 @@ EXEC_AGENT_UNAVAILABLE (retryable) |
 `string`
 
 ###### seedHex
+
+`string`
+
+###### opts?
+
+[`VsockExecOptions`](#vsockexecoptions) = `{}`
+
+###### Returns
+
+`Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
+##### syncVmstate()
+
+> `readonly` **syncVmstate**(`udsPath`, `opts?`): `Promise`\<[`VsockExecResult`](#vsockexecresult)\>
+
+###### Parameters
+
+###### udsPath
 
 `string`
 

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -17197,6 +17197,20 @@ Logical file size in bytes.
 
 SHA-256 over the logical file bytes.
 
+##### trustedContentSample?
+
+> `optional` **trustedContentSample?**: `object`
+
+Cheap bundled-artifact proof for Machinen-managed rootdisk clones.
+
+###### algorithm
+
+> **algorithm**: `"machinen-rootdisk-sample-v1"`
+
+###### sha256
+
+> **sha256**: `string`
+
 ***
 
 ### VmstateSnapshotMeta

--- a/packages/runtime/src/__tests__/exec-multiline.test.ts
+++ b/packages/runtime/src/__tests__/exec-multiline.test.ts
@@ -132,6 +132,14 @@ describe("VsockExec multi-line wire format", () => {
     expect(agent.requests[0]!.body.toString("ascii")).toBe(seed);
   });
 
+  it("sends vmstate snapshot sync over direct SYNC opcode", async () => {
+    const uds = join(workDir, "exec.sock");
+    agent = startFakeAgent(uds);
+    const res = await VsockExec.syncVmstate(uds);
+    expect(res.exitCode).toBe(0);
+    expect(agent.requests[0]!.header).toBe("SYNC");
+  });
+
   it("switches to EXEC2 length-prefix opcode when cmd contains newlines", async () => {
     const uds = join(workDir, "exec.sock");
     agent = startFakeAgent(uds);

--- a/packages/runtime/src/__tests__/rootdisk-dirty-range-proof.test.ts
+++ b/packages/runtime/src/__tests__/rootdisk-dirty-range-proof.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDirtyRangeProof,
+  buildDirtyRangeProof,
+  type DirtyRangeProofBundle,
+} from "../vm/rootdisk-dirty-range-proof.ts";
+
+function baseImage(): Buffer {
+  const buf = Buffer.alloc(16 * 1024);
+  for (let i = 0; i < buf.length; i++) {
+    buf[i] = i % 251;
+  }
+  return buf;
+}
+
+function cloneProof(proof: DirtyRangeProofBundle): DirtyRangeProofBundle {
+  return JSON.parse(JSON.stringify(proof)) as DirtyRangeProofBundle;
+}
+
+describe("dirty-range rootdisk proof harness", () => {
+  it("reconstructs exact target bytes from changed ranges", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target.fill(0xaa, 100, 180);
+    target.fill(0xbb, 8000, 9000);
+
+    const proof = buildDirtyRangeProof(base, target, 4096);
+    const restored = applyDirtyRangeProof(base, proof);
+
+    expect(restored.equals(target)).toBe(true);
+    expect(proof.ranges).toHaveLength(3);
+  });
+
+  it("round-trips an unchanged image as an empty delta", () => {
+    const base = baseImage();
+    const proof = buildDirtyRangeProof(base, base, 4096);
+
+    expect(proof.ranges).toHaveLength(0);
+    expect(applyDirtyRangeProof(base, proof).equals(base)).toBe(true);
+  });
+
+  it("refuses a mismatched base image", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target[1] = 99;
+    const proof = buildDirtyRangeProof(base, target, 4096);
+    const wrongBase = Buffer.from(base);
+    wrongBase[0] = 42;
+
+    expect(() => applyDirtyRangeProof(wrongBase, proof)).toThrow(/base sha256 mismatch/);
+  });
+
+  it("refuses missing dirty ranges instead of reporting metadata-only success", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target.fill(0xcc, 4096, 4200);
+    const proof = cloneProof(buildDirtyRangeProof(base, target, 4096));
+    proof.ranges = [];
+
+    expect(() => applyDirtyRangeProof(base, proof)).toThrow(/target sha256 mismatch/);
+  });
+
+  it("refuses corrupted dirty range payloads", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target[8192] = 12;
+    const proof = cloneProof(buildDirtyRangeProof(base, target, 4096));
+    proof.ranges[0]!.dataBase64 = Buffer.alloc(proof.ranges[0]!.length, 0xff).toString("base64");
+
+    expect(() => applyDirtyRangeProof(base, proof)).toThrow(/data sha256 mismatch/);
+  });
+
+  it("refuses overlapping dirty ranges", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target.fill(0xdd, 4096, 8200);
+    const proof = cloneProof(buildDirtyRangeProof(base, target, 4096));
+    proof.ranges[1]!.offset = proof.ranges[0]!.offset + 1;
+
+    expect(() => applyDirtyRangeProof(base, proof)).toThrow(/sorted and non-overlapping/);
+  });
+
+  it("refuses out-of-bounds dirty ranges", () => {
+    const base = baseImage();
+    const target = Buffer.from(base);
+    target[base.length - 1] = 77;
+    const proof = cloneProof(buildDirtyRangeProof(base, target, 4096));
+    proof.ranges[0]!.offset = base.length;
+
+    expect(() => applyDirtyRangeProof(base, proof)).toThrow(/exceeds image bounds/);
+  });
+});

--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -7,6 +7,8 @@ import { restore } from "../index.ts";
 import {
   currentVmstateBackend,
   fileIdentity,
+  fileSampleSha256,
+  managedRootDiskSyntheticSha256,
   readVmstateFacts,
   rememberTrustedFileIdentity,
   trustedFileIdentity,
@@ -293,6 +295,83 @@ describe("vmstate portability metadata", () => {
     await expect(
       restore({ snapDir: dir, image, binary: "/bin/sh", rootDisk: explicitRootDisk }),
     ).rejects.toThrow(/rootdisk identity mismatch/);
+  });
+
+  it("still refuses explicit caller-managed rootDisk for managed bundled samples", async () => {
+    const target = currentVmstateBackend();
+    const { dir, image } = writeBundle(
+      "sample-explicit-rootdisk",
+      { engine: "vmstate", snappedAt: 1, vmstate: { sourceBackend: target } },
+      0n,
+    );
+    const bundled = join(dir, "rootdisk.img");
+    writeFileSync(bundled, "good");
+    const sampleSha256 = fileSampleSha256(bundled);
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({
+        engine: "vmstate",
+        snappedAt: 1,
+        vmstate: {
+          sourceBackend: target,
+          topologyHash: TOPO.toString("hex"),
+          guestPauth: { active: false, sctlrEl1: "0x0" },
+          rootDisk: {
+            mode: "block",
+            file: "rootdisk.img",
+            sizeBytes: 4,
+            sha256: managedRootDiskSyntheticSha256(4, sampleSha256),
+            trustedContentSample: {
+              algorithm: "machinen-rootdisk-sample-v1",
+              sha256: sampleSha256,
+            },
+          },
+        },
+      }),
+    );
+    const explicitRootDisk = join(TMP, "sample-explicit-rootdisk.img");
+    writeFileSync(explicitRootDisk, "good");
+
+    await expect(
+      restore({ snapDir: dir, image, binary: "/bin/sh", rootDisk: explicitRootDisk }),
+    ).rejects.toThrow(/rootdisk identity mismatch/);
+  });
+
+  it("refuses a managed-sample vmstate bundle whose rootdisk sample differs", async () => {
+    const target = currentVmstateBackend();
+    const { dir, image } = writeBundle(
+      "bad-sample-rootdisk",
+      { engine: "vmstate", snappedAt: 1, vmstate: { sourceBackend: target } },
+      0n,
+    );
+    const expectedSample = sha256("not-the-file-sample");
+    writeFileSync(join(dir, "rootdisk.img"), "changed");
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({
+        engine: "vmstate",
+        snappedAt: 1,
+        vmstate: {
+          sourceBackend: target,
+          topologyHash: TOPO.toString("hex"),
+          guestPauth: { active: false, sctlrEl1: "0x0" },
+          rootDisk: {
+            mode: "block",
+            file: "rootdisk.img",
+            sizeBytes: 7,
+            sha256: managedRootDiskSyntheticSha256(7, expectedSample),
+            trustedContentSample: {
+              algorithm: "machinen-rootdisk-sample-v1",
+              sha256: expectedSample,
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(restore({ snapDir: dir, image, binary: "/bin/sh" })).rejects.toThrow(
+      /rootdisk identity mismatch/,
+    );
   });
 
   it("refuses a vmstate bundle whose rootdisk bytes differ from metadata", async () => {

--- a/packages/runtime/src/__tests__/vmstate-wait.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-wait.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { waitForVmstateFile } from "../vm/vmstate-wait.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "vmstate-wait-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("waitForVmstateFile", () => {
+  it("returns wait stats once the state file appears", async () => {
+    const path = join(dir, "state.vmstate");
+    const wait = waitForVmstateFile(path, 1_000);
+    setTimeout(() => writeFileSync(path, "state"), 25);
+
+    const stats = await wait;
+
+    expect(stats.pollSleepMs).toBeGreaterThanOrEqual(10);
+    expect(stats.detectLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("times out when the state file never appears", async () => {
+    await expect(waitForVmstateFile(join(dir, "missing.vmstate"), 20)).rejects.toThrow(
+      /did not write its \.vmstate/,
+    );
+  });
+});

--- a/packages/runtime/src/exec.ts
+++ b/packages/runtime/src/exec.ts
@@ -4,7 +4,7 @@
 // the framed output stream until an `X <code>\n` terminator, returns
 // stdout/stderr + the exit code.
 //
-// Two on-the-wire opcodes:
+// Guest exec-agent wire opcodes:
 //   `EXEC <cmd>\n`            — legacy single-line cmd (no \r or \n).
 //                                Compatible with all agents.
 //   `EXEC2 <byte-len>\n<cmd>` — length-prefixed cmd; supports any byte
@@ -100,6 +100,10 @@ export const VsockExec = {
     return runWithRetry(udsPath, opts, "reseedVmstate", (socket) =>
       runReseedOnSocket(socket, seedHex, opts),
     );
+  },
+
+  async syncVmstate(udsPath: string, opts: VsockExecOptions = {}): Promise<VsockExecResult> {
+    return runWithRetry(udsPath, opts, "syncVmstate", (socket) => runSyncOnSocket(socket, opts));
   },
 
   /**
@@ -310,6 +314,16 @@ function runReseedOnSocket(
     () => {
       socket.write(`RESEED ${buf.length}\n`);
       socket.write(buf);
+    },
+    opts,
+  );
+}
+
+function runSyncOnSocket(socket: Socket, opts: VsockExecOptions): Promise<VsockExecResult> {
+  return runFramedRequestOnSocket(
+    socket,
+    () => {
+      socket.write("SYNC\n");
     },
     opts,
   );

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -699,11 +699,8 @@ function siblingPrebakeBase(tarAbs: string): string | undefined {
   return m?.[1];
 }
 
-// Populate the cache from a release-built `<base>.img.gz` sibling.
-// Decompresses into a staging file with `gunzip -c`, sniffs ext4
-// magic so a corrupt sibling can't poison the cache, then atomically
-// renames into place. Any failure returns undefined and the caller
-// falls through to the slow materialize path.
+// Populate the cache from a release-built prebake sibling. Sniff ext4
+// magic before the atomic rename so corrupt siblings never poison cache.
 function tryPrebakeFromSibling(args: {
   sibling: PrebakeSibling;
   cacheDir: string;
@@ -716,14 +713,11 @@ function tryPrebakeFromSibling(args: {
   const stagingImg = join(stagingDir, "rootfs.img");
   try {
     debug("prebake try sibling=%s sha=%s", sibling.path, sha.slice(0, 12));
-    if (!decompressPrebakeToFile(sibling, stagingImg)) {
+    const prebake = decompressPrebakeToFile(sibling, stagingImg);
+    if (!prebake.ok) {
       return undefined;
     }
-    // Sniff ext4 magic so a corrupted / wrong-content sibling can't
-    // pollute the cache. We don't run e2fsck here — the build
-    // pipeline already produced a clean fs, and a host crash this
-    // soon after rename is rare enough that the .ok marker handles
-    // it on the next boot.
+    // Build already fscked prebakes; ext4 magic plus .ok handles bad payloads/crashes.
     if (!looksLikeExt4(stagingImg)) {
       debug("prebake sibling did not yield an ext4 image — falling back");
       return undefined;
@@ -738,7 +732,9 @@ function tryPrebakeFromSibling(args: {
     }
     renameSync(stagingImg, imgPath);
     markRootfsImageClean(imgPath);
-    writeTemplateMetadata({ sha, imgPath, metaPath: templateMetaPath(imgPath) }, "prebake");
+    writeTemplateMetadata({ sha, imgPath, metaPath: templateMetaPath(imgPath) }, "prebake", {
+      imageSha256: prebake.sha256,
+    });
     debug("prebake done sha=%s img=%s", sha.slice(0, 12), imgPath);
     return imgPath;
   } catch (err) {
@@ -751,27 +747,37 @@ function tryPrebakeFromSibling(args: {
   }
 }
 
-function decompressPrebakeToFile(sibling: PrebakeSibling, dst: string): boolean {
+interface PrebakeDecompressResult {
+  ok: boolean;
+  sha256?: string;
+}
+
+function decompressPrebakeToFile(sibling: PrebakeSibling, dst: string): PrebakeDecompressResult {
   return sibling.format === "zst"
-    ? zstdPrebakeToFile(sibling.path, dst)
-    : gunzipPrebakeToFile(sibling.path, dst);
+    ? zstdPrebakeToFileWithSha(sibling.path, dst)
+    : gunzipPrebakeToFileWithSha(sibling.path, dst);
 }
 
 function zstdPrebakeToFile(sibling: string, dst: string): boolean {
+  return zstdPrebakeToFileWithSha(sibling, dst).ok;
+}
+
+function zstdPrebakeToFileWithSha(sibling: string, dst: string): PrebakeDecompressResult {
   const zstd = whichFirst(["zstd"]);
   if (!zstd) {
     debug("prebake zstd missing; falling back sibling=%s", sibling);
-    return false;
+    return { ok: false };
   }
   const r = spawnSync(
     process.execPath,
     ["--input-type=module", "-e", SPARSE_ZSTD_WORKER, zstd, sibling, dst],
     {
-      stdio: ["ignore", "ignore", "pipe"],
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
     },
   );
   if (r.status === 0) {
-    return true;
+    return { ok: true, sha256: parseWorkerSha256(r.stdout) };
   }
   debug(
     "prebake sparse zstd failed sibling=%s status=%s stderr=%s",
@@ -779,26 +785,30 @@ function zstdPrebakeToFile(sibling: string, dst: string): boolean {
     r.status,
     r.stderr?.toString().slice(0, 200) ?? "",
   );
-  return false;
+  return { ok: false };
 }
 
 function gunzipPrebakeToFile(sibling: string, dst: string): boolean {
-  const sparse = sparseGunzipPrebakeToFile(sibling, dst);
-  if (sparse) {
-    return true;
-  }
-  debug("prebake sparse gunzip failed; falling back to full gunzip sibling=%s", sibling);
-  return fullGunzipPrebakeToFile(sibling, dst);
+  return gunzipPrebakeToFileWithSha(sibling, dst).ok;
 }
 
-function fullGunzipPrebakeToFile(sibling: string, dst: string): boolean {
+function gunzipPrebakeToFileWithSha(sibling: string, dst: string): PrebakeDecompressResult {
+  const sparse = sparseGunzipPrebakeToFileWithSha(sibling, dst);
+  if (sparse.ok) {
+    return sparse;
+  }
+  debug("prebake sparse gunzip failed; falling back to full gunzip sibling=%s", sibling);
+  return fullGunzipPrebakeToFileWithSha(sibling, dst);
+}
+
+function fullGunzipPrebakeToFileWithSha(sibling: string, dst: string): PrebakeDecompressResult {
   const dstFd = openSync(dst, "w");
   try {
     const r = spawnSync("gunzip", ["-c", sibling], {
       stdio: ["ignore", dstFd, "pipe"],
     });
     if (r.status === 0) {
-      return true;
+      return { ok: true, sha256: sha256OfFile(dst) };
     }
     debug(
       "prebake gunzip failed sibling=%s status=%s stderr=%s",
@@ -806,22 +816,23 @@ function fullGunzipPrebakeToFile(sibling: string, dst: string): boolean {
       r.status,
       r.stderr?.toString().slice(0, 200) ?? "",
     );
-    return false;
+    return { ok: false };
   } finally {
     closeSync(dstFd);
   }
 }
 
-function sparseGunzipPrebakeToFile(sibling: string, dst: string): boolean {
+function sparseGunzipPrebakeToFileWithSha(sibling: string, dst: string): PrebakeDecompressResult {
   const r = spawnSync(
     process.execPath,
     ["--input-type=module", "-e", SPARSE_GUNZIP_WORKER, sibling, dst],
     {
-      stdio: ["ignore", "ignore", "pipe"],
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
     },
   );
   if (r.status === 0) {
-    return true;
+    return { ok: true, sha256: parseWorkerSha256(r.stdout) };
   }
   debug(
     "prebake sparse gunzip failed sibling=%s status=%s stderr=%s",
@@ -829,20 +840,17 @@ function sparseGunzipPrebakeToFile(sibling: string, dst: string): boolean {
     r.status,
     r.stderr?.toString().slice(0, 200) ?? "",
   );
-  return false;
+  return { ok: false };
 }
 
-// Extract `tarPath` into `dest` with mode-bit fidelity.
-//
-// `-p` (--preserve-permissions) matters: BSD tar (the macOS default)
-// applies the host umask when extracting as non-root, which silently
-// drops the sticky bit and other "extra" mode bits declared in the
-// archive. /tmp ships at 1777 in our base rootfs but extracts as 0755
-// without -p, which bakes into the ext4 image and breaks `apt-get`
-// in the booted guest — apt drops to the `_apt` user for fetches and
-// can't write to /tmp, so apt-key fails and Release files look
-// unsigned (#262). GNU tar treats -p as a no-op for non-root (umask
-// is already not applied there), so adding it is safe on every host.
+function parseWorkerSha256(stdout: string | Buffer | null | undefined): string | undefined {
+  const first = stdout?.toString().trim().split(/\s+/, 1)[0]?.toLowerCase();
+  return first && /^[0-9a-f]{64}$/.test(first) ? first : undefined;
+}
+
+// Extract with mode-bit fidelity. BSD tar otherwise applies umask for
+// non-root users and drops bits like /tmp's sticky bit, breaking apt in
+// the guest (#262). GNU tar accepts -p safely for this path too.
 function extractTarball(tarPath: string, dest: string): void {
   const r = spawnSync("tar", ["-xpf", tarPath, "-C", dest], {
     stdio: ["ignore", "ignore", "pipe"],

--- a/packages/runtime/src/rootfs-sparse-workers.ts
+++ b/packages/runtime/src/rootfs-sparse-workers.ts
@@ -1,10 +1,12 @@
 export const SPARSE_GUNZIP_WORKER = String.raw`
+import { createHash } from "node:crypto";
 import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
 import { createReadStream } from "node:fs";
 import { createGunzip } from "node:zlib";
 
 const [sibling, dst] = process.argv.slice(1);
 const fd = openSync(dst, "w");
+const hash = createHash("sha256");
 let offset = 0;
 
 function isAllZero(buf) {
@@ -17,6 +19,7 @@ function isAllZero(buf) {
 try {
   const gunzip = createReadStream(sibling).pipe(createGunzip());
   for await (const chunk of gunzip) {
+    hash.update(chunk);
     if (!isAllZero(chunk)) {
       writeSync(fd, chunk, 0, chunk.length, offset);
     }
@@ -24,6 +27,7 @@ try {
   }
   ftruncateSync(fd, offset);
   closeSync(fd);
+  console.log(hash.digest("hex"));
 } catch (err) {
   try { closeSync(fd); } catch {}
   console.error(err instanceof Error ? err.stack || err.message : String(err));
@@ -33,10 +37,12 @@ try {
 
 export const SPARSE_ZSTD_WORKER = String.raw`
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { closeSync, ftruncateSync, openSync, writeSync } from "node:fs";
 
 const [zstd, sibling, dst] = process.argv.slice(1);
 const fd = openSync(dst, "w");
+const hash = createHash("sha256");
 let offset = 0;
 let stderr = "";
 
@@ -51,6 +57,7 @@ try {
   const child = spawn(zstd, ["-dc", sibling], { stdio: ["ignore", "pipe", "pipe"] });
   child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
   for await (const chunk of child.stdout) {
+    hash.update(chunk);
     if (!isAllZero(chunk)) {
       writeSync(fd, chunk, 0, chunk.length, offset);
     }
@@ -62,6 +69,7 @@ try {
   }
   ftruncateSync(fd, offset);
   closeSync(fd);
+  console.log(hash.digest("hex"));
 } catch (err) {
   try { closeSync(fd); } catch {}
   console.error(err instanceof Error ? err.stack || err.message : String(err));

--- a/packages/runtime/src/rootfs-template-metadata.ts
+++ b/packages/runtime/src/rootfs-template-metadata.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import debugLib from "debug";
+import type { SnapshotFileIdentity } from "./vm-handle.ts";
 
 const debug = debugLib("machinen:rootfs-img");
 
@@ -20,14 +21,15 @@ export function templateMetaPath(imgPath: string): string {
   return `${imgPath}.meta.json`;
 }
 
-export type RootfsTemplateSource = "materialize" | "prebake" | "prebake-tree" | "legacy-fsck";
+type RootfsTemplateSource = "materialize" | "prebake" | "prebake-tree" | "legacy-fsck";
 
-export interface RootfsTemplateMetadata {
+interface RootfsTemplateMetadata {
   version: 1;
   sha256: string;
   sizeBytes: number;
   source: RootfsTemplateSource;
   createdAt: string;
+  imageSha256?: string;
 }
 
 export function readSha256Sidecar(tarAbs: string): string | undefined {
@@ -85,9 +87,28 @@ export function readVerifiedTemplateMetadata(paths: {
   }
 }
 
+export function trustedRootfsTemplateIdentity(imgPath: string): SnapshotFileIdentity | undefined {
+  const metaPath = templateMetaPath(imgPath);
+  if (!existsSync(metaPath)) {
+    return undefined;
+  }
+  try {
+    const meta = JSON.parse(readFileSync(metaPath, "utf8")) as Partial<RootfsTemplateMetadata>;
+    const st = statSync(imgPath);
+    if (!validImageSha256(meta.imageSha256) || meta.sizeBytes !== st.size) {
+      return undefined;
+    }
+    return { path: imgPath, sizeBytes: st.size, sha256: meta.imageSha256 };
+  } catch (err) {
+    debug("template identity invalid meta=%s err=%s", metaPath, (err as Error).message);
+    return undefined;
+  }
+}
+
 export function writeTemplateMetadata(
   paths: { sha: string; imgPath: string; metaPath: string },
   source: RootfsTemplateSource,
+  opts: { imageSha256?: string } = {},
 ): void {
   try {
     const meta: RootfsTemplateMetadata = {
@@ -96,9 +117,14 @@ export function writeTemplateMetadata(
       sizeBytes: statSync(paths.imgPath).size,
       source,
       createdAt: new Date().toISOString(),
+      ...(validImageSha256(opts.imageSha256) ? { imageSha256: opts.imageSha256 } : {}),
     };
     writeFileSync(paths.metaPath, `${JSON.stringify(meta)}\n`);
   } catch (err) {
     debug("template metadata write failed img=%s err=%s", paths.imgPath, (err as Error).message);
   }
+}
+
+function validImageSha256(value: string | undefined): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
 }

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -336,6 +336,11 @@ export interface SnapshotFileIdentity {
   sizeBytes: number;
   /** SHA-256 over the logical file bytes. */
   sha256: string;
+  /** Cheap bundled-artifact proof for Machinen-managed rootdisk clones. */
+  trustedContentSample?: {
+    algorithm: "machinen-rootdisk-sample-v1";
+    sha256: string;
+  };
 }
 
 export interface VmstateSnapshotMeta {

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -70,6 +70,9 @@ export interface VmHandle {
   /** Internal fast path for vmstate restore entropy reseed; avoids shell startup. */
   reseedVmstateEntropy?(seedHex: string, opts?: VsockExecOptions): Promise<VsockExecResult>;
 
+  /** Internal fast path for vmstate pre-snapshot filesystem sync; avoids shell startup. */
+  syncVmstateSnapshot?(opts?: VsockExecOptions): Promise<VsockExecResult>;
+
   /**
    * Run a shell command inside a pseudoterminal. Bidirectional bytes
    * flow between `opts.stdin` and `opts.stdout`; the returned handle's

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -133,6 +133,10 @@ export async function attach(opts: AttachOptions = {}): Promise<VmHandle> {
       return VsockExec.run(entry.socketPath, cmd, teeOnLog(cmd, execOpts, opts.onLog));
     },
 
+    syncVmstateSnapshot(execOpts) {
+      return VsockExec.syncVmstate(entry.socketPath, execOpts);
+    },
+
     execPty(cmd, ptyOpts) {
       return VsockExec.startPty(entry.socketPath, cmd, ptyOpts);
     },
@@ -234,6 +238,7 @@ export async function attach(opts: AttachOptions = {}): Promise<VmHandle> {
         : undefined,
       nested: entry.nested,
       execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
+      syncVmstateSnapshot: (execOpts) => handle.syncVmstateSnapshot?.(execOpts),
       wait: () => handle.wait(),
       kill: () => handle.kill(),
       // Attach handles don't own the VMM child, so there's no guest

--- a/packages/runtime/src/vm/boot-rootdisk.ts
+++ b/packages/runtime/src/vm/boot-rootdisk.ts
@@ -7,6 +7,8 @@ import { BootError } from "../errors.ts";
 import type { PhaseTimer } from "../phase-timer.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
+import { trustedRootfsTemplateIdentity } from "../rootfs-template-metadata.ts";
+import { rememberManagedRootDisk, rememberTrustedFileIdentity } from "./vmstate-metadata.ts";
 import type { BootOptions } from "./boot.ts";
 
 // Materialize the rootdisk image and reflink it into a per-boot path
@@ -74,9 +76,14 @@ function materializeCachedRootdisk(
     tmpdir(),
     `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
   );
+  const trustedTemplateIdentity = trustedRootfsTemplateIdentity(cachedImg);
   const reflinkT0 = Date.now();
   reflinkCopy(cachedImg, perBoot);
   phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
+  if (trustedTemplateIdentity) {
+    rememberTrustedFileIdentity({ ...trustedTemplateIdentity, path: perBoot });
+    rememberManagedRootDisk(perBoot);
+  }
   // The cache file was only READ here — restore the clean-shutdown
   // marker so the next boot finds a usable template instead of wiping
   // and rematerializing (#170).

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -27,6 +27,7 @@ import {
   runVsockWithBootDiagnostics,
   waitForDetachedExecAgent,
 } from "./boot-diagnostics.ts";
+import { makeReseedVmstateEntropy, makeSyncVmstateSnapshot } from "./vsock-handle-ops.ts";
 import { bootSnapshotPath, writeBootSnapshot } from "../detached-log.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "../errors.ts";
 import { VsockExec } from "../exec.ts";
@@ -1819,6 +1820,11 @@ function createBootVmHandle(args: BootHandleArgs): VmHandle {
       args.child,
       args.errorCollector,
     ),
+    syncVmstateSnapshot: makeSyncVmstateSnapshot(
+      args.vsockUdsPath,
+      args.child,
+      args.errorCollector,
+    ),
     execPty: makeExecPty(args.vsockUdsPath),
     writeFile: makeWriteFile(() => handle),
     memoryStats: makeMemoryStats(args.childPid, args.statsFilePath, args.memoryCeilingMib),
@@ -1868,21 +1874,6 @@ function makeExecRaw(
     }
     return runVsockWithBootDiagnostics(child, errorCollector, () =>
       VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
-    );
-  };
-}
-
-function makeReseedVmstateEntropy(
-  vsockUdsPath: string | undefined,
-  child: ChildProcessWithoutNullStreams,
-  errorCollector: Promise<string>,
-): NonNullable<VmHandle["reseedVmstateEntropy"]> {
-  return (seedHex, execOpts) => {
-    if (!vsockUdsPath) {
-      return Promise.reject(missingVsockError("reseedVmstateEntropy"));
-    }
-    return runVsockWithBootDiagnostics(child, errorCollector, () =>
-      VsockExec.reseedVmstate(vsockUdsPath, seedHex, execOpts),
     );
   };
 }
@@ -2024,6 +2015,7 @@ function buildBootSnapshotContext(
     updateVmstateChain: snapshotVmstateUpdater(args.vmstate, args.childPid),
     nested: args.nested,
     execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
+    syncVmstateSnapshot: (execOpts) => handle.syncVmstateSnapshot?.(execOpts),
     wait: () => handle.wait(),
     kill: () => handle.kill(),
     teeGuestConsole: (onChunk) => {

--- a/packages/runtime/src/vm/restore-identity.ts
+++ b/packages/runtime/src/vm/restore-identity.ts
@@ -1,0 +1,72 @@
+import { existsSync, statSync } from "node:fs";
+
+import { BootError } from "../errors.ts";
+import type { PhaseTimer } from "../phase-timer.ts";
+import type { SnapshotFileIdentity } from "../vm-handle.ts";
+import {
+  fileIdentity,
+  fileSampleSha256,
+  managedRootDiskSyntheticSha256,
+  trustedFileIdentity,
+} from "./vmstate-metadata.ts";
+
+export function validateIdentity(
+  label: string,
+  path: string,
+  expected: SnapshotFileIdentity,
+  phases: PhaseTimer | undefined,
+  source: "bundled" | "external",
+): void {
+  if (!existsSync(path)) {
+    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${label} not found: ${path}`);
+  }
+  if (source === "bundled" && validateTrustedContentSample(label, path, expected, phases)) {
+    return;
+  }
+
+  const cached = source === "bundled" ? trustedFileIdentity(path) : undefined;
+  phases?.start(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
+  const actual = cached ?? fileIdentity(path);
+  phases?.end(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
+  if (actual.sizeBytes !== expected.sizeBytes || actual.sha256 !== expected.sha256) {
+    throwIdentityMismatch(label, expected, actual);
+  }
+}
+
+function validateTrustedContentSample(
+  label: string,
+  path: string,
+  expected: SnapshotFileIdentity,
+  phases: PhaseTimer | undefined,
+): boolean {
+  const sample = expected.trustedContentSample;
+  if (sample?.algorithm !== "machinen-rootdisk-sample-v1") {
+    return false;
+  }
+  phases?.start(`${label}-identity.trusted-sample`);
+  const sizeBytes = statSync(path).size;
+  const sampleSha256 = fileSampleSha256(path);
+  const actual = {
+    sizeBytes,
+    sha256: managedRootDiskSyntheticSha256(sizeBytes, sampleSha256),
+  };
+  phases?.end(`${label}-identity.trusted-sample`);
+  if (actual.sizeBytes !== expected.sizeBytes || sampleSha256 !== sample.sha256) {
+    throwIdentityMismatch(label, expected, actual);
+  }
+  return true;
+}
+
+function throwIdentityMismatch(
+  label: string,
+  expected: SnapshotFileIdentity,
+  actual: SnapshotFileIdentity,
+): never {
+  throw new BootError(
+    "BOOT_VMSTATE_UNSUPPORTED",
+    `restore: ${label} identity mismatch.\n` +
+      `  expected: size=${expected.sizeBytes} sha256=${expected.sha256}\n` +
+      `  actual:   size=${actual.sizeBytes} sha256=${actual.sha256}\n` +
+      "  vmstate restore requires byte-identical artifacts.",
+  );
+}

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -33,21 +33,15 @@ import {
   PortableSnapshotValidationError,
   validatePortableSnapshotBundle,
 } from "./portable-snapshot.ts";
+import { validateIdentity } from "./restore-identity.ts";
 import { reseedVmstateGuestEntropy } from "./restore-reseed.ts";
 import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
 import { materializeVmstateChain } from "./vmstate-chain.ts";
-import type {
-  SnapshotFileIdentity,
-  SnapshotMeta,
-  VmHandle,
-  VmstateSnapshotMeta,
-} from "../vm-handle.ts";
+import type { SnapshotMeta, VmHandle, VmstateSnapshotMeta } from "../vm-handle.ts";
 import {
   currentVmstateBackend,
   currentVmstateGuestArch,
-  fileIdentity,
   readVmstateFacts,
-  trustedFileIdentity,
   type VmstateFacts,
 } from "./vmstate-metadata.ts";
 import {
@@ -831,31 +825,6 @@ function resolveFileVmstateRootDisk(
   }
   validateIdentity("rootdisk", bundled, recorded, phases, "bundled");
   return { rootDiskRestorePath: bundled };
-}
-
-function validateIdentity(
-  label: string,
-  path: string,
-  expected: SnapshotFileIdentity,
-  phases: PhaseTimer | undefined,
-  source: "bundled" | "external",
-): void {
-  if (!existsSync(path)) {
-    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `restore: ${label} not found: ${path}`);
-  }
-  const cached = source === "bundled" ? trustedFileIdentity(path) : undefined;
-  phases?.start(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
-  const actual = cached ?? fileIdentity(path);
-  phases?.end(cached ? `${label}-identity.cache-hit` : `${label}-identity.sha256`);
-  if (actual.sizeBytes !== expected.sizeBytes || actual.sha256 !== expected.sha256) {
-    throw new BootError(
-      "BOOT_VMSTATE_UNSUPPORTED",
-      `restore: ${label} identity mismatch.\n` +
-        `  expected: size=${expected.sizeBytes} sha256=${expected.sha256}\n` +
-        `  actual:   size=${actual.sizeBytes} sha256=${actual.sha256}\n` +
-        "  vmstate restore requires byte-identical artifacts.",
-    );
-  }
 }
 
 /**

--- a/packages/runtime/src/vm/rootdisk-dirty-range-proof.ts
+++ b/packages/runtime/src/vm/rootdisk-dirty-range-proof.ts
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Non-product proof harness for #970. It models dirty-range rootdisk
+ * snapshots against an already-verified base image and refuses to
+ * reconstruct unless every byte-level invariant checks out.
+ */
+export interface DirtyRangeProofBundle {
+  version: 1;
+  baseSizeBytes: number;
+  baseSha256: string;
+  targetSha256: string;
+  chunkSize: number;
+  ranges: DirtyRangeProof[];
+}
+
+interface DirtyRangeProof {
+  offset: number;
+  length: number;
+  sha256: string;
+  dataBase64: string;
+}
+
+class DirtyRangeProofError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DirtyRangeProofError";
+  }
+}
+
+export function buildDirtyRangeProof(
+  base: Buffer,
+  target: Buffer,
+  chunkSize = 4096,
+): DirtyRangeProofBundle {
+  if (base.length !== target.length) {
+    throw new DirtyRangeProofError("dirty range proof requires equal-size images");
+  }
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new DirtyRangeProofError("dirty range proof chunk size must be positive");
+  }
+  const ranges: DirtyRangeProof[] = [];
+  for (let offset = 0; offset < target.length; offset += chunkSize) {
+    const end = Math.min(offset + chunkSize, target.length);
+    const baseChunk = base.subarray(offset, end);
+    const targetChunk = target.subarray(offset, end);
+    if (baseChunk.equals(targetChunk)) {
+      continue;
+    }
+    ranges.push({
+      offset,
+      length: targetChunk.length,
+      sha256: sha256(targetChunk),
+      dataBase64: targetChunk.toString("base64"),
+    });
+  }
+  return {
+    version: 1,
+    baseSizeBytes: base.length,
+    baseSha256: sha256(base),
+    targetSha256: sha256(target),
+    chunkSize,
+    ranges,
+  };
+}
+
+export function applyDirtyRangeProof(base: Buffer, proof: DirtyRangeProofBundle): Buffer {
+  validateProofHeader(base, proof);
+  const target = Buffer.from(base);
+  let nextOffset = 0;
+  for (const range of proof.ranges) {
+    const data = validateRange(range, proof.baseSizeBytes, nextOffset);
+    data.copy(target, range.offset);
+    nextOffset = range.offset + range.length;
+  }
+  const actualTargetSha256 = sha256(target);
+  if (actualTargetSha256 !== proof.targetSha256) {
+    throw new DirtyRangeProofError(
+      `dirty range target sha256 mismatch: expected ${proof.targetSha256}, got ${actualTargetSha256}`,
+    );
+  }
+  return target;
+}
+
+function validateProofHeader(base: Buffer, proof: DirtyRangeProofBundle): void {
+  if (proof.version !== 1) {
+    throw new DirtyRangeProofError(`unsupported dirty range proof version ${proof.version}`);
+  }
+  if (proof.baseSizeBytes !== base.length) {
+    throw new DirtyRangeProofError("dirty range base size mismatch");
+  }
+  if (proof.baseSha256 !== sha256(base)) {
+    throw new DirtyRangeProofError("dirty range base sha256 mismatch");
+  }
+  if (!Number.isInteger(proof.chunkSize) || proof.chunkSize <= 0) {
+    throw new DirtyRangeProofError("dirty range proof chunk size must be positive");
+  }
+}
+
+function validateRange(range: DirtyRangeProof, imageSize: number, minOffset: number): Buffer {
+  if (!Number.isInteger(range.offset) || !Number.isInteger(range.length) || range.length <= 0) {
+    throw new DirtyRangeProofError("dirty range has invalid offset or length");
+  }
+  if (range.offset < minOffset) {
+    throw new DirtyRangeProofError("dirty ranges must be sorted and non-overlapping");
+  }
+  if (range.offset + range.length > imageSize) {
+    throw new DirtyRangeProofError("dirty range exceeds image bounds");
+  }
+  const data = Buffer.from(range.dataBase64, "base64");
+  if (data.length !== range.length) {
+    throw new DirtyRangeProofError("dirty range data length mismatch");
+  }
+  const actualSha256 = sha256(data);
+  if (actualSha256 !== range.sha256) {
+    throw new DirtyRangeProofError(
+      `dirty range data sha256 mismatch: expected ${range.sha256}, got ${actualSha256}`,
+    );
+  }
+  return data;
+}
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}

--- a/packages/runtime/src/vm/snapshot-rootdisk.ts
+++ b/packages/runtime/src/vm/snapshot-rootdisk.ts
@@ -1,13 +1,21 @@
+import { statSync } from "node:fs";
 import { join } from "node:path";
 
 import { SnapshotError } from "../errors.ts";
 import { reflinkCopy } from "../reflink.ts";
-import type { VmstateSnapshotMeta } from "../vm-handle.ts";
+import type { SnapshotFileIdentity, VmstateSnapshotMeta } from "../vm-handle.ts";
 import type { SnapshotContext } from "./snapshot.ts";
 import { VMSTATE_ROOTDISK_FILE } from "./snapshot-engine.ts";
-import { fileIdentity, rememberTrustedFileIdentity } from "./vmstate-metadata.ts";
+import {
+  fileIdentity,
+  fileSampleSha256,
+  managedRootDiskSyntheticSha256,
+  rememberTrustedFileIdentity,
+  trustedFileIdentity,
+  trustedManagedRootDisk,
+} from "./vmstate-metadata.ts";
 
-export type PendingVmstateRootDisk =
+type PendingVmstateRootDisk =
   | { mode: "block"; file: string; path: string; bundlePath: string }
   | { mode: "delta" }
   | { mode: "none" };
@@ -57,7 +65,10 @@ export function finalizeVmstateRootDisk(
   if (rootDisk.mode !== "block") {
     return rootDisk;
   }
-  const identity = fileIdentity(rootDisk.bundlePath);
+  const identity =
+    managedSnapshotRootDiskIdentity(rootDisk) ??
+    trustedSnapshotRootDiskIdentity(rootDisk) ??
+    fileIdentity(rootDisk.bundlePath);
   rememberTrustedFileIdentity(identity);
   return {
     mode: "block",
@@ -65,5 +76,35 @@ export function finalizeVmstateRootDisk(
     path: rootDisk.path,
     sizeBytes: identity.sizeBytes,
     sha256: identity.sha256,
+    trustedContentSample: identity.trustedContentSample,
   };
+}
+
+function managedSnapshotRootDiskIdentity(
+  rootDisk: Extract<PendingVmstateRootDisk, { mode: "block" }>,
+): SnapshotFileIdentity | undefined {
+  const managed = trustedManagedRootDisk(rootDisk.path);
+  if (!managed || statSync(rootDisk.bundlePath).size !== managed.sizeBytes) {
+    return undefined;
+  }
+  const sampleSha256 = fileSampleSha256(rootDisk.bundlePath);
+  return {
+    path: rootDisk.bundlePath,
+    sizeBytes: managed.sizeBytes,
+    sha256: managedRootDiskSyntheticSha256(managed.sizeBytes, sampleSha256),
+    trustedContentSample: {
+      algorithm: "machinen-rootdisk-sample-v1",
+      sha256: sampleSha256,
+    },
+  };
+}
+
+function trustedSnapshotRootDiskIdentity(
+  rootDisk: Extract<PendingVmstateRootDisk, { mode: "block" }>,
+): ReturnType<typeof fileIdentity> | undefined {
+  const trusted = trustedFileIdentity(rootDisk.path);
+  if (!trusted || statSync(rootDisk.bundlePath).size !== trusted.sizeBytes) {
+    return undefined;
+  }
+  return { ...trusted, path: rootDisk.bundlePath };
 }

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -119,6 +119,7 @@ export interface SnapshotContext {
    */
   nested?: boolean;
   execRaw: (cmd: string, opts?: VsockExecOptions) => Promise<VsockExecResult>;
+  syncVmstateSnapshot?: (opts?: VsockExecOptions) => Promise<VsockExecResult> | undefined;
   wait: () => Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
   kill: () => Promise<void>;
   teeGuestConsole: ((onChunk: (chunk: Buffer) => void) => void) | undefined;
@@ -676,8 +677,9 @@ async function performSnapshotVmstate(
   clearVmstateStateFile(ctx.vmstatePath!);
   phases.end("prepare");
   phases.start("guest-sync");
-  await syncGuestForVmstateSnapshot(ctx, deadlineMs);
-  phases.end("guest-sync");
+  const syncMode = await syncGuestForVmstateSnapshot(ctx, deadlineMs);
+  const syncMs = phases.end("guest-sync");
+  phases.mark(`guest-sync.${syncMode}`, syncMs);
   const result = await captureVmstateSnapshotBundle(ctx, snapDir, deadlineMs, t0, phases);
   phases.flush(debugVmstate, "snapshot", result.elapsedMs);
   return result;
@@ -715,18 +717,51 @@ function clearVmstateStateFile(vmstatePath: string): void {
 async function syncGuestForVmstateSnapshot(
   ctx: SnapshotContext,
   deadlineMs: number,
-): Promise<void> {
+): Promise<"direct" | "shell" | "failed"> {
   try {
-    await ctx.execRaw(VMSTATE_PRE_SNAPSHOT_SYNC, {
-      connectTimeoutMs: Math.min(deadlineMs, 5_000),
-      execTimeoutMs: 10_000,
-    });
+    const direct = await tryDirectVmstateSync(ctx, deadlineMs);
+    if (direct) {
+      return "direct";
+    }
+    await shellVmstateSync(ctx, deadlineMs);
+    return "shell";
   } catch (err) {
     debugVmstate(
       "pre-snapshot sync failed (continuing): %s",
       err instanceof Error ? err.message : String(err),
     );
+    return "failed";
   }
+}
+
+async function tryDirectVmstateSync(ctx: SnapshotContext, deadlineMs: number): Promise<boolean> {
+  if (!ctx.syncVmstateSnapshot) {
+    return false;
+  }
+  try {
+    const res = await ctx.syncVmstateSnapshot({
+      connectTimeoutMs: Math.min(deadlineMs, 5_000),
+      execTimeoutMs: 10_000,
+    });
+    if (res.exitCode === 0) {
+      debugVmstate("pre-snapshot sync mode=direct");
+      return true;
+    }
+    debugVmstate("pre-snapshot direct sync exit=%d; falling back", res.exitCode);
+  } catch (err) {
+    debugVmstate(
+      "pre-snapshot direct sync unavailable; falling back: %s",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return false;
+}
+
+async function shellVmstateSync(ctx: SnapshotContext, deadlineMs: number): Promise<void> {
+  await ctx.execRaw(VMSTATE_PRE_SNAPSHOT_SYNC, {
+    connectTimeoutMs: Math.min(deadlineMs, 5_000),
+    execTimeoutMs: 10_000,
+  });
 }
 
 const VMSTATE_PRE_SNAPSHOT_SYNC =

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -25,6 +25,7 @@ import type {
 import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
 import { relativeCheckpointParent, VMSTATE_SECTION, vmstateSectionTags } from "./vmstate-chain.ts";
 import { copyVmstateRootDisk, finalizeVmstateRootDisk } from "./snapshot-rootdisk.ts";
+import { waitForVmstateFile } from "./vmstate-wait.ts";
 import {
   currentVmstateBackend,
   currentVmstateGuestArch,
@@ -742,8 +743,10 @@ async function captureVmstateSnapshotBundle(
   phases.start("pause-critical-section");
   const bundle = await withPausedVmstateSource(ctx, async () => {
     phases.start("wait-state-file");
-    await waitForVmstateFile(ctx.vmstatePath!, deadlineMs);
+    const waitStats = await waitForVmstateFile(ctx.vmstatePath!, deadlineMs);
     phases.end("wait-state-file");
+    phases.mark("wait-state-file.poll-sleep", waitStats.pollSleepMs);
+    phases.mark("wait-state-file.detect-latency", waitStats.detectLatencyMs);
     phases.start("copy-state-file");
     const bundleStatePath = copyVmstateStateIntoBundle(ctx.vmstatePath!, snapDir);
     phases.end("copy-state-file");
@@ -949,26 +952,4 @@ function checkpointRootDiskMode(
     return "none";
   }
   return flags.hasRootdiskDelta ? "delta" : "full";
-}
-
-// Poll for the VMM's atomically-written `.vmstate` to (re)appear. The
-// VMM writes `<path>.tmp` then rename()s it onto `<path>`, so the file
-// existing with a non-zero size means the dump is complete.
-async function waitForVmstateFile(path: string, deadlineMs: number): Promise<void> {
-  const deadline = Date.now() + deadlineMs;
-  while (Date.now() < deadline) {
-    try {
-      if (statSync(path).size > 0) {
-        return;
-      }
-    } catch {
-      // ENOENT — not written yet.
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new SnapshotError(
-    "SNAPSHOT_TIMEOUT",
-    `vm.snapshot: the VMM did not write its .vmstate within ${deadlineMs}ms (${path}).\n` +
-      `  The VM may not have been booted with MACHINEN_SNAPSHOT_ENGINE=vmstate.`,
-  );
 }

--- a/packages/runtime/src/vm/vmstate-metadata.ts
+++ b/packages/runtime/src/vm/vmstate-metadata.ts
@@ -129,7 +129,14 @@ interface CachedFileIdentity {
   stamp: FileIdentityStamp;
 }
 
+interface ManagedRootDiskStamp {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+}
+
 const trustedFileIdentities = new Map<string, CachedFileIdentity>();
+const managedRootDisks = new Map<string, ManagedRootDiskStamp>();
 
 export function fileIdentity(path: string): FileIdentity {
   return {
@@ -160,6 +167,38 @@ export function trustedFileIdentity(path: string): FileIdentity | undefined {
     return undefined;
   }
   return cached.identity;
+}
+
+export function rememberManagedRootDisk(path: string): void {
+  const st = statSync(path, { bigint: true });
+  managedRootDisks.set(path, { dev: st.dev, ino: st.ino, size: st.size });
+}
+
+export function trustedManagedRootDisk(path: string): { sizeBytes: number } | undefined {
+  const stamp = managedRootDisks.get(path);
+  if (!stamp) {
+    return undefined;
+  }
+  const st = statSync(path, { bigint: true });
+  if (stamp.dev !== st.dev || stamp.ino !== st.ino || stamp.size !== st.size) {
+    managedRootDisks.delete(path);
+    return undefined;
+  }
+  return { sizeBytes: Number(st.size) };
+}
+
+export function fileSampleSha256(path: string): string {
+  const st = statSync(path, { bigint: true });
+  return sampleSha256(path, st.size);
+}
+
+export function managedRootDiskSyntheticSha256(sizeBytes: number, sampleSha256: string): string {
+  return createHash("sha256")
+    .update("machinen-managed-rootdisk-v1\0")
+    .update(String(sizeBytes))
+    .update("\0")
+    .update(sampleSha256)
+    .digest("hex");
 }
 
 function fileIdentityStamp(path: string): FileIdentityStamp {

--- a/packages/runtime/src/vm/vmstate-wait.ts
+++ b/packages/runtime/src/vm/vmstate-wait.ts
@@ -1,0 +1,44 @@
+import { statSync } from "node:fs";
+
+import { SnapshotError } from "../errors.ts";
+
+const VMSTATE_FILE_POLL_MS = 10;
+
+export interface VmstateFileWaitStats {
+  pollSleepMs: number;
+  detectLatencyMs: number;
+}
+
+// Poll for the VMM's atomically-written `.vmstate` to (re)appear. The
+// VMM writes `<path>.tmp` then rename()s it onto `<path>`, so the file
+// existing with a non-zero size means the dump is complete.
+export async function waitForVmstateFile(
+  path: string,
+  deadlineMs: number,
+): Promise<VmstateFileWaitStats> {
+  const deadline = Date.now() + deadlineMs;
+  let pollSleepMs = 0;
+  while (Date.now() < deadline) {
+    try {
+      const st = statSync(path);
+      if (st.size > 0) {
+        return {
+          pollSleepMs,
+          detectLatencyMs: Math.max(0, Date.now() - st.mtimeMs),
+        };
+      }
+    } catch {
+      // ENOENT — not written yet.
+    }
+    const sleepMs = Math.min(VMSTATE_FILE_POLL_MS, Math.max(0, deadline - Date.now()));
+    if (sleepMs > 0) {
+      await new Promise((r) => setTimeout(r, sleepMs));
+      pollSleepMs += sleepMs;
+    }
+  }
+  throw new SnapshotError(
+    "SNAPSHOT_TIMEOUT",
+    `vm.snapshot: the VMM did not write its .vmstate within ${deadlineMs}ms (${path}).\n` +
+      `  The VM may not have been booted with MACHINEN_SNAPSHOT_ENGINE=vmstate.`,
+  );
+}

--- a/packages/runtime/src/vm/vmstate-wait.ts
+++ b/packages/runtime/src/vm/vmstate-wait.ts
@@ -4,7 +4,7 @@ import { SnapshotError } from "../errors.ts";
 
 const VMSTATE_FILE_POLL_MS = 10;
 
-export interface VmstateFileWaitStats {
+interface VmstateFileWaitStats {
   pollSleepMs: number;
   detectLatencyMs: number;
 }

--- a/packages/runtime/src/vm/vsock-handle-ops.ts
+++ b/packages/runtime/src/vm/vsock-handle-ops.ts
@@ -1,0 +1,44 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { ExecError } from "../errors.ts";
+import { VsockExec } from "../exec.ts";
+import type { VmHandle } from "../vm-handle.ts";
+import { runVsockWithBootDiagnostics } from "./boot-diagnostics.ts";
+
+export function makeReseedVmstateEntropy(
+  vsockUdsPath: string | undefined,
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+): NonNullable<VmHandle["reseedVmstateEntropy"]> {
+  return (seedHex, execOpts) => {
+    if (!vsockUdsPath) {
+      return Promise.reject(missingVsockError("reseedVmstateEntropy"));
+    }
+    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+      VsockExec.reseedVmstate(vsockUdsPath, seedHex, execOpts),
+    );
+  };
+}
+
+export function makeSyncVmstateSnapshot(
+  vsockUdsPath: string | undefined,
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+): NonNullable<VmHandle["syncVmstateSnapshot"]> {
+  return (execOpts) => {
+    if (!vsockUdsPath) {
+      return Promise.reject(missingVsockError("syncVmstateSnapshot"));
+    }
+    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+      VsockExec.syncVmstate(vsockUdsPath, execOpts),
+    );
+  };
+}
+
+function missingVsockError(method: string): ExecError {
+  return new ExecError(
+    "EXEC_VSOCK_UNAVAILABLE",
+    `vm.${method}: no vsock UDS available — MACHINEN_VSOCK was set to an ` +
+      "unrecognized spec. Expected `in:<port>:<uds-path>`.",
+  );
+}

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -1,22 +1,10 @@
-// Raw benchmark capture for #935.
-//
-// Captures one JSON document per run with:
-//   - cold/warm boot phase timing
-//   - cold/warm vmstate restore phase timing
-//   - snapshot wall time and bundle size for the restore source
-//   - raw CPU hash throughput: host native, guest, guest with quota
-//   - host RSS after touching guest tmpfs memory at selected sizes
-//   - optional live-mount and gvproxy network suites
-// Usage:
-//   pnpm bench --json-dir bench-results  # defaults to --n 5 --suite all
-//   pnpm bench --suite core --guest-arch amd64 --n 1 --json /tmp/machinen-bench.json
-
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { arch as hostArch, homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runMountBenchSuite, runNetBenchSuite } from "./bench/external-suites.ts";
+import { runOneFork } from "./bench/fork.ts";
 import {
   assetMetadata,
   filesystemMetadata,
@@ -36,7 +24,7 @@ async function loadRuntime(): Promise<RuntimeMod> {
   if (!runtime) {
     process.env.DEBUG =
       (process.env.DEBUG ?? "") +
-      ",machinen:boot,machinen:restore,machinen:snapshot,machinen:vmstate,machinen:reflink";
+      ",machinen:boot,machinen:restore,machinen:snapshot,machinen:vmstate,machinen:fork,machinen:reflink";
     runtime = await import("@machinen/runtime");
   }
   return runtime;
@@ -99,8 +87,6 @@ interface SnapshotSample {
   bundleApparentBytes: number;
   bundleAllocatedBytes: number;
   phases: Map<string, number>;
-  sourcePauseMs: number | null;
-  sourcePauseNote: string;
 }
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
@@ -605,9 +591,6 @@ async function takeSnapshot(
         bundleApparentBytes: size.apparentBytes,
         bundleAllocatedBytes: size.allocatedBytes,
         phases: snapshotPhases?.phases ?? new Map<string, number>(),
-        sourcePauseMs: null,
-        sourcePauseNote:
-          "not separately exposed by runtime yet; vmstate source is paused during the SIGUSR1/SIGUSR2 snapshot critical section",
       },
     };
   } catch (err) {
@@ -636,6 +619,7 @@ async function runLatencyBench(args: Args, assets: AssetPaths): Promise<JsonValu
   const snapshots: SnapshotSample[] = [];
   const restoreCold: PhaseLine[] = [];
   const restoreWarm: PhaseLine[] = [];
+  const forks: PhaseLine[] = [];
   try {
     for (let i = 0; i < args.n; i++) {
       const snapshot = await takeSnapshot(assets, i + 1);
@@ -664,6 +648,17 @@ async function runLatencyBench(args: Args, assets: AssetPaths): Promise<JsonValu
         await runOneRestore(assets, restoreSnapDir, `restore-warm-${i + 1}`),
       );
     }
+    for (let i = 0; i < args.n; i++) {
+      forks.push(
+        await runOneFork(assets, `fork-${i + 1}`, {
+          loadRuntime,
+          captureStderr,
+          phaseLinesForKinds,
+          elapsedSinceMs,
+          delay,
+        }),
+      );
+    }
   } finally {
     for (const snapDir of snapDirs) {
       cleanupSnapshotDir(snapDir);
@@ -675,6 +670,7 @@ async function runLatencyBench(args: Args, assets: AssetPaths): Promise<JsonValu
   printSnapshotSummary(snapshots);
   printAggregate("RESTORE (cold)", restoreCold);
   printAggregate("RESTORE (warm)", restoreWarm);
+  printAggregate("FORK", forks);
 
   return {
     boot_cold: suiteJson(bootCold),
@@ -682,6 +678,7 @@ async function runLatencyBench(args: Args, assets: AssetPaths): Promise<JsonValu
     snapshot: snapshotSuiteJson(snapshots),
     restore_cold: suiteJson(restoreCold),
     restore_warm: suiteJson(restoreWarm),
+    fork: suiteJson(forks),
   };
 }
 
@@ -735,8 +732,7 @@ function snapshotSuiteJson(samples: SnapshotSample[]): JsonValue {
     },
     phases: aggregateJson(snapshotPhaseLines(samples)),
     source_pause_ms: null,
-    source_pause_note:
-      "not separately exposed by runtime yet; vmstate source is paused during the SIGUSR1/SIGUSR2 snapshot critical section",
+    source_pause_note: "not separately exposed by runtime yet; source is paused during snapshot",
   };
 }
 

--- a/scripts/bench/fork.ts
+++ b/scripts/bench/fork.ts
@@ -1,0 +1,152 @@
+import type { RootdiskCopyEvent } from "./metadata.ts";
+import { parseRootdiskCopyEvents } from "./metadata.ts";
+
+type RuntimeMod = typeof import("@machinen/runtime");
+
+export interface ForkBenchAssets {
+  kernel: string;
+  dtb?: string;
+  image: string;
+}
+
+export interface ForkBenchPhaseLine {
+  kind: string;
+  total: number;
+  phases: Map<string, number>;
+  rootdiskCopies?: RootdiskCopyEvent[];
+}
+
+export interface ForkBenchTools {
+  loadRuntime(): Promise<RuntimeMod>;
+  captureStderr<T>(fn: () => Promise<T>): Promise<{ result: T; captured: string }>;
+  phaseLinesForKinds(captured: string, kinds: Set<string>): ForkBenchPhaseLine[];
+  elapsedSinceMs(start: bigint): number;
+  delay(ms: number): Promise<void>;
+}
+
+export async function runOneFork(
+  assets: ForkBenchAssets,
+  label: string,
+  tools: ForkBenchTools,
+): Promise<ForkBenchPhaseLine> {
+  const timing = newForkTiming();
+  const { captured } = await tools.captureStderr(async () => {
+    process.stderr.write(`[${label}] booting source + forking...\n`);
+    const { boot } = await tools.loadRuntime();
+    const source = await boot({
+      image: assets.image,
+      kernel: assets.kernel,
+      dtb: assets.dtb,
+      cmd: ["/bin/sh", "-c", "while :; do sleep 1; done"],
+      timeoutMs: 60_000,
+    });
+    let forked: Awaited<ReturnType<typeof source.fork>> | undefined;
+    try {
+      await tools.delay(1500);
+      const forkStart = process.hrtime.bigint();
+      forked = await source.fork({
+        image: assets.image,
+        kernel: assets.kernel,
+        dtb: assets.dtb,
+        timeoutMs: 60_000,
+      });
+      timing.handleMs = tools.elapsedSinceMs(forkStart);
+      const execStart = process.hrtime.bigint();
+      const execResult = await forked.execRaw("/bin/true", {
+        connectTimeoutMs: 5_000,
+        execTimeoutMs: 5_000,
+      });
+      timing.execAfterHandleMs = tools.elapsedSinceMs(execStart);
+      timing.execReadyMs = tools.elapsedSinceMs(forkStart);
+      if (execResult.exitCode !== 0) {
+        throw new Error(`bench: ${label} fork readiness exec failed exit=${execResult.exitCode}`);
+      }
+      await tools.delay(250);
+    } finally {
+      await forked?.kill().catch(() => {});
+      await forked?.wait().catch(() => undefined);
+      await source.kill().catch(() => {});
+      await source.wait().catch(() => undefined);
+    }
+  });
+  return buildForkPhaseLine(captured, timing, tools);
+}
+
+function newForkTiming(): { handleMs: number; execAfterHandleMs: number; execReadyMs: number } {
+  return { handleMs: 0, execAfterHandleMs: 0, execReadyMs: 0 };
+}
+
+function buildForkPhaseLine(
+  captured: string,
+  timing: { handleMs: number; execAfterHandleMs: number; execReadyMs: number },
+  tools: Pick<ForkBenchTools, "phaseLinesForKinds">,
+): ForkBenchPhaseLine {
+  const phases = new Map<string, number>();
+  phases.set("handle", Math.round(timing.handleMs));
+  phases.set("exec-after-handle", Math.round(timing.execAfterHandleMs));
+  phases.set("exec-ready", Math.round(timing.execReadyMs));
+  copyPrefixedPhases(phases, "snapshot", lastPhase(captured, "snapshot", tools));
+  copyPrefixedPhases(phases, "restore", forkRestoreLine(captured, tools));
+  return {
+    kind: "fork",
+    total: Math.round(timing.handleMs),
+    phases,
+    rootdiskCopies: parseRootdiskCopyEvents(captured),
+  };
+}
+
+function forkRestoreLine(
+  captured: string,
+  tools: Pick<ForkBenchTools, "phaseLinesForKinds">,
+): ForkBenchPhaseLine | undefined {
+  const restore = lastPhase(captured, "restore", tools);
+  if (!restore) {
+    return undefined;
+  }
+  const phases = new Map<string, number>(restore.phases);
+  const boot = lastPhase(captured, "boot", tools);
+  if (boot) {
+    phases.set("boot-to-first-guest-byte", boot.total);
+    phases.set("boot.total", boot.total);
+    for (const [key, value] of boot.phases) {
+      phases.set(`boot.${key}`, value);
+    }
+  }
+  const vmstateApply = parseVmstateRestoreTotal(captured);
+  if (vmstateApply !== undefined) {
+    phases.set("vmstate-apply", vmstateApply);
+  }
+  return { kind: "restore", total: restore.total, phases };
+}
+
+function lastPhase(
+  captured: string,
+  kind: string,
+  tools: Pick<ForkBenchTools, "phaseLinesForKinds">,
+): ForkBenchPhaseLine | undefined {
+  return tools.phaseLinesForKinds(captured, new Set([kind])).at(-1);
+}
+
+function copyPrefixedPhases(
+  target: Map<string, number>,
+  prefix: string,
+  source: ForkBenchPhaseLine | undefined,
+): void {
+  if (!source) {
+    return;
+  }
+  target.set(`${prefix}.total`, source.total);
+  for (const [key, value] of source.phases) {
+    target.set(`${prefix}.${key}`, value);
+  }
+}
+
+function parseVmstateRestoreTotal(captured: string): number | undefined {
+  for (const line of captured.split("\n").reverse()) {
+    const match = /vmstate restore timing .*event=done total_ms=(\d+)/.exec(line);
+    if (match?.[1]) {
+      return Number.parseInt(match[1], 10);
+    }
+  }
+  return undefined;
+}

--- a/scripts/bench/fork.ts
+++ b/scripts/bench/fork.ts
@@ -104,19 +104,32 @@ function forkRestoreLine(
     return undefined;
   }
   const phases = new Map<string, number>(restore.phases);
+  appendBootRestorePhases(phases, captured, tools);
+  appendVmstateApplyPhase(phases, captured);
+  return { kind: "restore", total: restore.total, phases };
+}
+
+function appendBootRestorePhases(
+  phases: Map<string, number>,
+  captured: string,
+  tools: Pick<ForkBenchTools, "phaseLinesForKinds">,
+): void {
   const boot = lastPhase(captured, "boot", tools);
-  if (boot) {
-    phases.set("boot-to-first-guest-byte", boot.total);
-    phases.set("boot.total", boot.total);
-    for (const [key, value] of boot.phases) {
-      phases.set(`boot.${key}`, value);
-    }
+  if (!boot) {
+    return;
   }
+  phases.set("boot-to-first-guest-byte", boot.total);
+  phases.set("boot.total", boot.total);
+  for (const [key, value] of boot.phases) {
+    phases.set(`boot.${key}`, value);
+  }
+}
+
+function appendVmstateApplyPhase(phases: Map<string, number>, captured: string): void {
   const vmstateApply = parseVmstateRestoreTotal(captured);
   if (vmstateApply !== undefined) {
     phases.set("vmstate-apply", vmstateApply);
   }
-  return { kind: "restore", total: restore.total, phases };
 }
 
 function lastPhase(


### PR DESCRIPTION
## Problem

Snapshot and fork paths were still slower than they should be. The benchmark also did not show fork as its own user-facing action, so it was hard to see what a fork really cost.

## Solution

This PR adds a fork benchmark and removes the biggest avoidable snapshot cost. Trusted Machinen-managed rootdisks no longer need a full hash during snapshot, while caller-managed root disks still get strict byte checks. It also adds more timing around vmstate capture and keeps dirty-range rootdisk work as a safe proof harness instead of enabling it in product code.

## Technical Summary

- Treat Machinen-managed rootdisks differently from caller-managed root disks. Managed rootdisks can use trusted provenance and cheap samples. Caller-managed root disks still require full identity checks and still refuse mismatches.
- Add fork timing to the core benchmark so reviewers can see handle time, exec-ready time, snapshot phases, and restore phases in one run.
- Split vmstate wait timing into smaller parts. This showed most remaining paused time is the VMM producing the state file, not host polling.
- Add a direct guest-agent sync command, but keep the old shell sync path as a fallback for older guests. The benchmark showed sync itself still costs about the same.
- Keep dirty-range rootdisk snapshots as a harness only. The harness proves exact byte reconstruction and refusal of bad deltas, but product restore behavior does not use it yet.
