### PR TITLE
Move mount manifest hashing to Zig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           version: 0.16.0
       - run: pnpm install --frozen-lockfile
 
-      # Stage VMM binaries into the consolidated native packages so
+      # Stage host binaries into the consolidated native packages so
       # `changeset publish` picks them up. Each package's `files`
       # field includes `vmm/`.
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -216,10 +216,31 @@ jobs:
         with:
           name: vmm-x64-linux
           path: packages/native-x64-linux/vmm/bin/
-      # chmod machinen-vm so the working copy stays usable locally; the
+      - name: Build and stage machinen-runtime-helper
+        run: |
+          set -euo pipefail
+          rm -rf "${RUNNER_TEMP}/machinen-runtime-helper"
+          mkdir -p "${RUNNER_TEMP}/machinen-runtime-helper"
+          cd packages/runtime/native
+          zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-macos --prefix "${RUNNER_TEMP}/machinen-runtime-helper/arm64-darwin"
+          zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux --prefix "${RUNNER_TEMP}/machinen-runtime-helper/arm64-linux"
+          zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux --prefix "${RUNNER_TEMP}/machinen-runtime-helper/x64-linux"
+          cd ../../..
+          cp "${RUNNER_TEMP}/machinen-runtime-helper/arm64-darwin/bin/machinen-runtime-helper" packages/native-arm64-darwin/vmm/bin/machinen-runtime-helper
+          cp "${RUNNER_TEMP}/machinen-runtime-helper/arm64-linux/bin/machinen-runtime-helper" packages/native-arm64-linux/vmm/bin/machinen-runtime-helper
+          cp "${RUNNER_TEMP}/machinen-runtime-helper/x64-linux/bin/machinen-runtime-helper" packages/native-x64-linux/vmm/bin/machinen-runtime-helper
+
+      # chmod host tools so the working copy stays usable locally; the
       # `bin` field in each package's package.json is what makes pnpm
       # pack preserve the +x bit in the published tarball (issue #309).
-      - run: chmod +x packages/native-{arm64-darwin,arm64-linux,x64-linux}/vmm/bin/machinen-vm
+      - run: |
+          chmod +x \
+            packages/native-arm64-darwin/vmm/bin/machinen-vm \
+            packages/native-arm64-darwin/vmm/bin/machinen-runtime-helper \
+            packages/native-arm64-linux/vmm/bin/machinen-vm \
+            packages/native-arm64-linux/vmm/bin/machinen-runtime-helper \
+            packages/native-x64-linux/vmm/bin/machinen-vm \
+            packages/native-x64-linux/vmm/bin/machinen-runtime-helper
 
       # gvproxy (containers/gvisor-tap-vsock) — bundled next to the VMM
       # so `@machinen/runtime` can auto-spawn it for virtio-net without

--- a/packages/microvm/src/hvf.zig
+++ b/packages/microvm/src/hvf.zig
@@ -20,15 +20,41 @@ comptime {
 pub const Pl011 = pl011_mod.Pl011;
 pub const PthreadMutex = pl011_mod.PthreadMutex;
 
-// Cherry-pick headers — the umbrella Hypervisor.h pulls in
-// hv_vcpu_config.h, which has a `uint64_t values[_Nonnull 8]`
-// declaration that Zig's translate-c can't parse. We pull what cImport
-// handles cleanly (VM lifecycle + memory map + error codes) and declare
-// the vCPU surface manually below.
-pub const c = @cImport({
-    @cInclude("Hypervisor/hv_error.h");
-    @cInclude("Hypervisor/hv_vm.h");
-});
+// Do not @cImport Hypervisor or Mach headers here. macOS 26 SDK
+// mach/message.h defines mach_msg_* descriptor structs with bitfields;
+// Zig 0.16 translate-c marks them opaque but still emits @sizeOf
+// assertions, which breaks fresh HVF builds. Keep this to the tiny
+// Hypervisor.framework ABI surface Machinen actually uses and declare
+// the vCPU/GIC surface manually below as before.
+pub const c = struct {
+    pub const hv_return_t = c_int;
+    pub const hv_vm_config_t = ?*opaque {};
+    pub const hv_memory_flags_t = u64;
+
+    pub const HV_SUCCESS: hv_return_t = 0;
+    pub const HV_ERROR: hv_return_t = hv_error_code(0x01);
+    pub const HV_BUSY: hv_return_t = hv_error_code(0x02);
+    pub const HV_BAD_ARGUMENT: hv_return_t = hv_error_code(0x03);
+    pub const HV_ILLEGAL_GUEST_STATE: hv_return_t = hv_error_code(0x04);
+    pub const HV_NO_RESOURCES: hv_return_t = hv_error_code(0x05);
+    pub const HV_NO_DEVICE: hv_return_t = hv_error_code(0x06);
+    pub const HV_DENIED: hv_return_t = hv_error_code(0x07);
+    pub const HV_UNSUPPORTED: hv_return_t = hv_error_code(0x0f);
+
+    pub const HV_MEMORY_READ: hv_memory_flags_t = 1 << 0;
+    pub const HV_MEMORY_WRITE: hv_memory_flags_t = 1 << 1;
+    pub const HV_MEMORY_EXEC: hv_memory_flags_t = 1 << 2;
+};
+
+fn hv_error_code(comptime code: u32) c.hv_return_t {
+    return @bitCast(@as(u32, 0xfae94000 | code));
+}
+
+extern "c" fn hv_vm_create(config: c.hv_vm_config_t) c.hv_return_t;
+extern "c" fn hv_vm_destroy() c.hv_return_t;
+extern "c" fn hv_vm_map(addr: *anyopaque, ipa: u64, size: usize, flags: c.hv_memory_flags_t) c.hv_return_t;
+extern "c" fn hv_vm_unmap(ipa: u64, size: usize) c.hv_return_t;
+extern "c" fn hv_vm_protect(ipa: u64, size: usize, flags: c.hv_memory_flags_t) c.hv_return_t;
 
 pub const Error = error{
     Denied, // missing com.apple.security.hypervisor entitlement
@@ -94,7 +120,7 @@ pub fn nested_supported() bool {
 /// Process-wide VM context. HVF currently supports one VM per process.
 pub const Vm = struct {
     pub fn create() Error!Vm {
-        try check(c.hv_vm_create(null));
+        try check(hv_vm_create(null));
         return .{};
     }
 
@@ -108,12 +134,12 @@ pub const Vm = struct {
         try check(get_el2(&supported));
         if (!supported) return error.Unsupported;
         try check(set_el2(config, true));
-        try check(c.hv_vm_create(config));
+        try check(hv_vm_create(config));
         return .{};
     }
 
     pub fn destroy(_: Vm) void {
-        _ = c.hv_vm_destroy();
+        _ = hv_vm_destroy();
     }
 
     /// Map host memory into the guest's physical address space.
@@ -127,14 +153,14 @@ pub const Vm = struct {
         // Mapping an unreadable page is a programmer bug — the guest
         // would trap on the first fetch with no useful diagnostic.
         assert(flags.read or flags.write or flags.exec);
-        try check(c.hv_vm_map(host_mem.ptr, guest_phys, host_mem.len, flags.bits()));
+        try check(hv_vm_map(host_mem.ptr, guest_phys, host_mem.len, flags.bits()));
     }
 
     pub fn unmap(_: Vm, guest_phys: u64, size: usize) Error!void {
         assert(size > 0);
         assert(size % page_size == 0);
         assert(guest_phys % page_size == 0);
-        try check(c.hv_vm_unmap(guest_phys, size));
+        try check(hv_vm_unmap(guest_phys, size));
     }
 
     pub fn protect(_: Vm, guest_phys: u64, size: usize, flags: MapFlags) Error!void {
@@ -142,7 +168,7 @@ pub const Vm = struct {
         assert(size % page_size == 0);
         assert(guest_phys % page_size == 0);
         assert(flags.read or flags.write or flags.exec);
-        try check(c.hv_vm_protect(guest_phys, size, flags.bits()));
+        try check(hv_vm_protect(guest_phys, size, flags.bits()));
     }
 };
 

--- a/packages/native-arm64-darwin/index.mjs
+++ b/packages/native-arm64-darwin/index.mjs
@@ -17,6 +17,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 /** The microVM hypervisor binary the runtime spawns per guest. */
 export const binary = join(here, "vmm", "bin", "machinen-vm");
+/** Host-side Zig helper for runtime-owned native operations. */
+export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-darwin/package.json
+++ b/packages/native-arm64-darwin/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },
   "files": [

--- a/packages/native-arm64-linux/index.mjs
+++ b/packages/native-arm64-linux/index.mjs
@@ -17,6 +17,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 /** The microVM hypervisor binary the runtime spawns per guest. */
 export const binary = join(here, "vmm", "bin", "machinen-vm");
+/** Host-side Zig helper for runtime-owned native operations. */
+export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-linux/package.json
+++ b/packages/native-arm64-linux/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },
   "files": [

--- a/packages/native-x64-linux/index.mjs
+++ b/packages/native-x64-linux/index.mjs
@@ -17,6 +17,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 /** The microVM hypervisor binary the runtime spawns per guest. */
 export const binary = join(here, "vmm", "bin", "machinen-vm");
+/** Host-side Zig helper for runtime-owned native operations. */
+export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-x64-linux/package.json
+++ b/packages/native-x64-linux/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },
   "files": [

--- a/packages/runtime/native/build.zig
+++ b/packages/runtime/native/build.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const mod = b.addModule("runtime_helper", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "machinen-runtime-helper",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "runtime_helper", .module = mod },
+            },
+        }),
+    });
+    b.installArtifact(exe);
+
+    const run_step = b.step("run", "Run machinen-runtime-helper");
+    const run_cmd = b.addRunArtifact(exe);
+    run_step.dependOn(&run_cmd.step);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const mod_tests = b.addTest(.{
+        .root_module = mod,
+    });
+    const run_mod_tests = b.addRunArtifact(mod_tests);
+    run_mod_tests.setCwd(b.path("."));
+
+    const exe_tests = b.addTest(.{
+        .root_module = exe.root_module,
+    });
+    const run_exe_tests = b.addRunArtifact(exe_tests);
+    run_exe_tests.setCwd(b.path("."));
+
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_mod_tests.step);
+    test_step.dependOn(&run_exe_tests.step);
+}

--- a/packages/runtime/native/build.zig.zon
+++ b/packages/runtime/native/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .runtime_native,
+    .version = "0.0.0",
+    .fingerprint = 0x4efb9d0355629263, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/packages/runtime/native/src/commands/tree_manifest_hash.zig
+++ b/packages/runtime/native/src/commands/tree_manifest_hash.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "tree-manifest-hash";
+
+const Request = struct {
+    root: []const u8,
+};
+
+const RequestError = error{
+    MissingRoot,
+    InvalidRoot,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        switch (err) {
+            error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+            error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+            error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+            error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+            error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+            error.MissingRoot => try protocol.writeError(io, "INVALID_REQUEST", "tree-manifest-hash request data must include a string root field"),
+            error.InvalidRoot => try protocol.writeError(io, "INVALID_REQUEST", "tree-manifest-hash root field must be a string"),
+            error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+            error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+            else => try protocol.writeError(io, "REQUEST_READ_FAILED", @errorName(err)),
+        }
+        return .fail;
+    };
+
+    const hash = runtime_helper.manifest.treeManifestHash(allocator, io, request.root) catch |err| {
+        switch (err) {
+            error.PathNotFound => try protocol.writeError(io, "PATH_NOT_FOUND", "root path does not exist"),
+            error.PathNotDirectory => try protocol.writeError(io, "PATH_NOT_DIRECTORY", "root path is not a directory"),
+            else => try protocol.writeError(io, "TREE_MANIFEST_HASH_FAILED", @errorName(err)),
+        }
+        return .fail;
+    };
+
+    const out = try std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"tree-manifest-hash\",\"data\":{{\"hash\":\"{s}\"}}}}\n",
+        .{&hash},
+    );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const request = request_value.object;
+    try protocol.rejectUnknownFields(request, &.{ "protocolVersion", "data" });
+
+    const protocol_version = request.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+
+    const data_value = request.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    try protocol.rejectUnknownFields(data_value.object, &.{"root"});
+    const root_field = data_value.object.get("root") orelse return error.MissingRoot;
+    if (root_field != .string) return error.InvalidRoot;
+    return .{ .root = root_field.string };
+}

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const protocol = @import("protocol.zig");
+const tree_manifest_hash = @import("commands/tree_manifest_hash.zig");
+
+var g_io: std.Io = undefined;
+
+pub fn main(init: std.process.Init) !u8 {
+    g_io = init.io;
+    var it = init.minimal.args.iterate();
+    _ = it.next(); // argv[0]
+
+    const command = it.next() orelse {
+        try protocol.writeError(g_io, "USAGE", "missing command");
+        return @intFromEnum(protocol.Exit.usage);
+    };
+
+    if (std.mem.eql(u8, command, tree_manifest_hash.name)) {
+        if (it.next() != null) {
+            try protocol.writeError(g_io, "USAGE", "tree-manifest-hash reads its JSON request from stdin and accepts no positional arguments");
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try tree_manifest_hash.run(init.gpa, g_io));
+    }
+
+    if (std.mem.eql(u8, command, "--help") or std.mem.eql(u8, command, "-h") or std.mem.eql(u8, command, "help")) {
+        try protocol.stdout(g_io, "{\"ok\":true,\"protocolVersion\":1,\"commands\":[\"tree-manifest-hash\"]}\n");
+        return @intFromEnum(protocol.Exit.ok);
+    }
+
+    try protocol.writeError(g_io, "UNKNOWN_COMMAND", "unknown command");
+    return @intFromEnum(protocol.Exit.usage);
+}

--- a/packages/runtime/native/src/manifest.zig
+++ b/packages/runtime/native/src/manifest.zig
@@ -1,0 +1,291 @@
+const std = @import("std");
+
+pub const Error = error{
+    PathNotFound,
+    PathNotDirectory,
+    UnsupportedPath,
+} || std.mem.Allocator.Error || std.Io.Dir.OpenError || std.Io.Dir.Iterator.Error || std.Io.Dir.StatFileError || std.Io.Dir.ReadLinkError || std.Io.File.OpenError || std.Io.File.ReadStreamingError || std.Io.File.SetTimestampsError || std.Io.Dir.SetFilePermissionsError || std.Io.Dir.CreateDirError || std.Io.Dir.WriteFileError || std.Io.Dir.SymLinkError;
+
+pub fn treeManifestHash(allocator: std.mem.Allocator, io: std.Io, root: []const u8) Error![64]u8 {
+    const root_stat = std.Io.Dir.cwd().statFile(io, root, .{ .follow_symlinks = false }) catch |err| switch (err) {
+        error.FileNotFound => return error.PathNotFound,
+        else => |e| return e,
+    };
+    if (root_stat.kind != .directory) return error.PathNotDirectory;
+
+    var lines: std.ArrayList([]u8) = .empty;
+    defer {
+        for (lines.items) |line| allocator.free(line);
+        lines.deinit(allocator);
+    }
+
+    try walk(allocator, io, root, "", &lines);
+    std.mem.sort([]u8, lines.items, {}, lineLessThan);
+
+    var sha = std.crypto.hash.sha2.Sha256.init(.{});
+    for (lines.items) |line| {
+        sha.update(line);
+        sha.update("\n");
+    }
+    var digest: [32]u8 = undefined;
+    sha.final(&digest);
+    return hexDigest(digest);
+}
+
+fn walk(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    root: []const u8,
+    rel: []const u8,
+    lines: *std.ArrayList([]u8),
+) Error!void {
+    const here = if (rel.len == 0) try allocator.dupe(u8, root) else try std.fs.path.join(allocator, &.{ root, rel });
+    defer allocator.free(here);
+
+    var dir = std.Io.Dir.cwd().openDir(io, here, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => |e| return e,
+    };
+    defer dir.close(io);
+
+    var names: std.ArrayList([]u8) = .empty;
+    defer {
+        for (names.items) |name| allocator.free(name);
+        names.deinit(allocator);
+    }
+
+    var it = dir.iterateAssumeFirstIteration();
+    while (try it.next(io)) |entry| {
+        try names.append(allocator, try allocator.dupe(u8, entry.name));
+    }
+    std.mem.sort([]u8, names.items, {}, lineLessThan);
+
+    for (names.items) |name| {
+        try appendChild(allocator, io, root, rel, here, name, lines);
+    }
+}
+
+fn appendChild(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    root: []const u8,
+    rel: []const u8,
+    parent_abs: []const u8,
+    name: []const u8,
+    lines: *std.ArrayList([]u8),
+) Error!void {
+    const child_rel = if (rel.len == 0) try allocator.dupe(u8, name) else try std.fmt.allocPrint(allocator, "{s}/{s}", .{ rel, name });
+    defer allocator.free(child_rel);
+    const child_abs = try std.fs.path.join(allocator, &.{ parent_abs, name });
+    defer allocator.free(child_abs);
+
+    const st = std.Io.Dir.cwd().statFile(io, child_abs, .{ .follow_symlinks = false }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => |e| return e,
+    };
+    const line = try manifestLineForStat(allocator, io, child_rel, child_abs, st);
+    errdefer allocator.free(line);
+    try lines.append(allocator, line);
+
+    if (st.kind == .directory) {
+        try walk(allocator, io, root, child_rel, lines);
+    }
+}
+
+fn manifestLineForStat(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    child_rel: []const u8,
+    child_abs: []const u8,
+    st: std.Io.File.Stat,
+) Error![]u8 {
+    const mode = modeBits(st);
+    const mtime_ns = manifestMtimeNs(st);
+    return switch (st.kind) {
+        .sym_link => symlinkManifestLine(allocator, io, child_rel, child_abs, mode, mtime_ns),
+        .directory => std.fmt.allocPrint(allocator, "{s}\x00D\x00{o}\x00\x00{d}\x00", .{ child_rel, mode, mtime_ns }),
+        .file => fileManifestLine(allocator, io, child_rel, child_abs, mode, st.size, mtime_ns),
+        else => std.fmt.allocPrint(allocator, "{s}\x00?\x00{o}\x00\x00{d}\x00", .{ child_rel, mode, mtime_ns }),
+    };
+}
+
+fn symlinkManifestLine(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    child_rel: []const u8,
+    child_abs: []const u8,
+    mode: u64,
+    mtime_ns: i96,
+) Error![]u8 {
+    var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, child_abs, &buf);
+    const target = buf[0..n];
+    return std.fmt.allocPrint(allocator, "{s}\x00L\x00{o}\x00{d}\x00{d}\x00{s}", .{
+        child_rel,
+        mode,
+        utf16CodeUnitCount(target),
+        mtime_ns,
+        target,
+    });
+}
+
+fn fileManifestLine(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    child_rel: []const u8,
+    child_abs: []const u8,
+    mode: u64,
+    size: u64,
+    mtime_ns: i96,
+) Error![]u8 {
+    const file_hash = try sha256FileHex(io, child_abs);
+    return std.fmt.allocPrint(allocator, "{s}\x00F\x00{o}\x00{d}\x00{d}\x00{s}", .{
+        child_rel,
+        mode,
+        size,
+        mtime_ns,
+        &file_hash,
+    });
+}
+
+fn sha256FileHex(io: std.Io, path: []const u8) Error![64]u8 {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false });
+    defer file.close(io);
+
+    var sha = std.crypto.hash.sha2.Sha256.init(.{});
+    var buf: [64 * 1024]u8 = undefined;
+    while (true) {
+        const n = file.readStreaming(io, &.{buf[0..]}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+        if (n == 0) break;
+        sha.update(buf[0..n]);
+    }
+    var digest: [32]u8 = undefined;
+    sha.final(&digest);
+    return hexDigest(digest);
+}
+
+fn modeBits(st: std.Io.File.Stat) u64 {
+    return @as(u64, @intCast(st.permissions.toMode() & 0o7777));
+}
+
+fn manifestMtimeNs(st: std.Io.File.Stat) i96 {
+    return @divFloor(st.mtime.nanoseconds, 1_000_000) * 1_000_000;
+}
+
+fn utf16CodeUnitCount(bytes: []const u8) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    while (i < bytes.len) {
+        const first = bytes[i];
+        const len: usize = if (first < 0x80) 1 else if ((first & 0xe0) == 0xc0) 2 else if ((first & 0xf0) == 0xe0) 3 else if ((first & 0xf8) == 0xf0) 4 else 1;
+        if (i + len > bytes.len) {
+            count += 1;
+            break;
+        }
+        if (len == 4) {
+            count += 2;
+        } else {
+            count += 1;
+        }
+        i += len;
+    }
+    return count;
+}
+
+fn hexDigest(digest: [32]u8) [64]u8 {
+    var out: [64]u8 = undefined;
+    const digits = "0123456789abcdef";
+    for (digest, 0..) |byte, i| {
+        out[i * 2] = digits[(byte >> 4) & 0xf];
+        out[i * 2 + 1] = digits[byte & 0xf];
+    }
+    return out;
+}
+
+fn lineLessThan(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+    const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
+    defer allocator.free(cwd);
+    return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
+}
+
+fn setFileMtime(dir: std.Io.Dir, sub_path: []const u8, ns: i96) !void {
+    var file = try dir.openFile(std.testing.io, sub_path, .{ .allow_directory = true });
+    defer file.close(std.testing.io);
+    const ts = std.Io.Timestamp.fromNanoseconds(ns);
+    try file.setTimestamps(std.testing.io, .{ .access_timestamp = .{ .new = ts }, .modify_timestamp = .{ .new = ts } });
+}
+
+test "treeManifestHash matches legacy deterministic regular-file hash" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "root", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "root/sub", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "root/alpha.txt", .data = "alpha" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "root/sub/beta.sh", .data = "beta" });
+    try tmp.dir.setFilePermissions(std.testing.io, "root/sub/beta.sh", .fromMode(0o755), .{});
+    try setFileMtime(tmp.dir, "root/alpha.txt", 1_000_000_000_000);
+    try setFileMtime(tmp.dir, "root/sub/beta.sh", 1_000_000_000_000);
+    try setFileMtime(tmp.dir, "root/sub", 1_000_000_000_000);
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const target = try std.fs.path.join(allocator, &.{ root, "root" });
+    defer allocator.free(target);
+
+    const hash = try treeManifestHash(allocator, std.testing.io, target);
+    try std.testing.expectEqualStrings("c1f475b2e3e6ad2d70b50312c2e898c26a2a4236ee0f0f0983b62fb848db19cd", &hash);
+}
+
+test "treeManifestHash changes for content, symlink target, and mode" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "root", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "root/file.txt", .data = "one" });
+    try tmp.dir.symLink(std.testing.io, "target-a", "root/link", .{});
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const target = try std.fs.path.join(allocator, &.{ root, "root" });
+    defer allocator.free(target);
+
+    const a = try treeManifestHash(allocator, std.testing.io, target);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "root/file.txt", .data = "two" });
+    const b = try treeManifestHash(allocator, std.testing.io, target);
+    try std.testing.expect(!std.mem.eql(u8, &a, &b));
+
+    try tmp.dir.deleteFile(std.testing.io, "root/link");
+    try tmp.dir.symLink(std.testing.io, "target-b", "root/link", .{});
+    const c = try treeManifestHash(allocator, std.testing.io, target);
+    try std.testing.expect(!std.mem.eql(u8, &b, &c));
+
+    try tmp.dir.setFilePermissions(std.testing.io, "root/file.txt", .fromMode(0o755), .{});
+    const d = try treeManifestHash(allocator, std.testing.io, target);
+    try std.testing.expect(!std.mem.eql(u8, &c, &d));
+}
+
+test "treeManifestHash refuses missing and non-directory roots" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "file.txt", .data = "data" });
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const missing = try std.fs.path.join(allocator, &.{ root, "missing" });
+    defer allocator.free(missing);
+    const file = try std.fs.path.join(allocator, &.{ root, "file.txt" });
+    defer allocator.free(file);
+
+    try std.testing.expectError(error.PathNotFound, treeManifestHash(allocator, std.testing.io, missing));
+    try std.testing.expectError(error.PathNotDirectory, treeManifestHash(allocator, std.testing.io, file));
+}

--- a/packages/runtime/native/src/protocol.zig
+++ b/packages/runtime/native/src/protocol.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+pub const version = 1;
+pub const max_request_bytes = 1024 * 1024;
+
+pub const Exit = enum(u8) { ok = 0, fail = 1, usage = 2 };
+
+pub const RequestError = error{
+    RequestTooLarge,
+    InvalidJson,
+    InvalidShape,
+    UnknownField,
+    UnsupportedProtocolVersion,
+    MissingData,
+    InvalidData,
+} || std.mem.Allocator.Error || std.Io.File.ReadStreamingError;
+
+pub fn readStdinAll(allocator: std.mem.Allocator, io: std.Io, max_bytes: usize) RequestError![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.Io.File.stdin().readStreaming(io, &.{buf[0..]}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+        if (n == 0) break;
+        if (out.items.len + n > max_bytes) return error.RequestTooLarge;
+        try out.appendSlice(allocator, buf[0..n]);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn rejectUnknownFields(object: std.json.ObjectMap, allowed: []const []const u8) RequestError!void {
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        for (allowed) |field| {
+            if (std.mem.eql(u8, entry.key_ptr.*, field)) break;
+        } else {
+            return error.UnknownField;
+        }
+    }
+}
+
+pub fn writeError(io: std.Io, code: []const u8, message: []const u8) !void {
+    var buf: [1024]u8 = undefined;
+    const payload = try std.fmt.bufPrint(
+        &buf,
+        "{{\"ok\":false,\"protocolVersion\":1,\"error\":{{\"code\":\"{s}\",\"message\":\"{s}\"}}}}\n",
+        .{ code, message },
+    );
+    try stdout(io, payload);
+}
+
+pub fn stdout(io: std.Io, s: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(io, s);
+}

--- a/packages/runtime/native/src/root.zig
+++ b/packages/runtime/native/src/root.zig
@@ -1,0 +1,1 @@
+pub const manifest = @import("manifest.zig");

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,6 +20,8 @@
   },
   "scripts": {
     "build": "tsup",
+    "native:build": "cd native && zig build",
+    "native:test": "cd native && zig build test",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "prepublishOnly": "pnpm build"

--- a/packages/runtime/src/__tests__/mountdisk-img.test.ts
+++ b/packages/runtime/src/__tests__/mountdisk-img.test.ts
@@ -9,6 +9,7 @@
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -18,7 +19,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   _mountdiskImgInternal,
   ensureMountDiskImage,
@@ -27,6 +28,30 @@ import {
   resolveMksquashfs,
   treeManifestHash,
 } from "../mountdisk-img.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("treeManifestHash", () => {
   let tmp: string;
@@ -85,6 +110,70 @@ describe("treeManifestHash", () => {
     utimesSync(join(a, "sub", "f.txt"), 1000, 1000);
     utimesSync(join(b, "sub", "f.txt"), 1000, 1000);
     expect(treeManifestHash(a)).not.toBe(treeManifestHash(b));
+  });
+
+  it("matches the exact legacy manifest hash for a deterministic regular-file tree", () => {
+    const root = join(tmp, "root");
+    mkdirSync(join(root, "sub"), { recursive: true });
+    writeFileSync(join(root, "alpha.txt"), "alpha");
+    writeFileSync(join(root, "sub", "beta.sh"), "beta");
+    chmodSync(join(root, "sub", "beta.sh"), 0o755);
+    utimesSync(join(root, "alpha.txt"), 1000, 1000);
+    utimesSync(join(root, "sub", "beta.sh"), 1000, 1000);
+    utimesSync(join(root, "sub"), 1000, 1000);
+
+    expect(treeManifestHash(root)).toBe(
+      "c1f475b2e3e6ad2d70b50312c2e898c26a2a4236ee0f0f0983b62fb848db19cd",
+    );
+  });
+
+  it("changes when a file's executable mode changes", () => {
+    const dir = join(tmp, "d");
+    mkdirSync(dir, { recursive: true });
+    const script = join(dir, "run.sh");
+    writeFileSync(script, "echo hi\n");
+    utimesSync(script, 1000, 1000);
+    chmodSync(script, 0o644);
+    const k1 = treeManifestHash(dir);
+    chmodSync(script, 0o755);
+    utimesSync(script, 1000, 1000);
+    const k2 = treeManifestHash(dir);
+    expect(k1).not.toBe(k2);
+  });
+
+  it("reports a useful error when MACHINEN_RUNTIME_HELPER points at nothing", () => {
+    const dir = join(tmp, "d");
+    mkdirSync(dir, { recursive: true });
+    const realHelper = process.env.MACHINEN_RUNTIME_HELPER;
+    process.env.MACHINEN_RUNTIME_HELPER = join(tmp, "missing-machinen-runtime-helper");
+    try {
+      expect(() => treeManifestHash(dir)).toThrow(/MACHINEN_RUNTIME_HELPER=.*does not exist/);
+    } finally {
+      if (realHelper === undefined) {
+        delete process.env.MACHINEN_RUNTIME_HELPER;
+      } else {
+        process.env.MACHINEN_RUNTIME_HELPER = realHelper;
+      }
+    }
+  });
+
+  it("reports a useful error when machinen-runtime-helper returns invalid JSON", () => {
+    const dir = join(tmp, "d");
+    mkdirSync(dir, { recursive: true });
+    const fake = join(tmp, "fake-machinen-runtime-helper");
+    writeFileSync(fake, "#!/bin/sh\nprintf 'not-json'\n");
+    chmodSync(fake, 0o755);
+    const realHelper = process.env.MACHINEN_RUNTIME_HELPER;
+    process.env.MACHINEN_RUNTIME_HELPER = fake;
+    try {
+      expect(() => treeManifestHash(dir)).toThrow(/invalid JSON/);
+    } finally {
+      if (realHelper === undefined) {
+        delete process.env.MACHINEN_RUNTIME_HELPER;
+      } else {
+        process.env.MACHINEN_RUNTIME_HELPER = realHelper;
+      }
+    }
   });
 
   it("is order-insensitive across readdir orderings", () => {

--- a/packages/runtime/src/mountdisk-img.ts
+++ b/packages/runtime/src/mountdisk-img.ts
@@ -46,7 +46,6 @@
 // caller's PATH, or the env override.
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -54,22 +53,19 @@ import {
   mkdirSync,
   mkdtempSync,
   openSync,
-  readSync,
-  readdirSync,
-  readlinkSync,
   renameSync,
   rmSync,
   statSync,
   truncateSync,
   unlinkSync,
   writeSync,
-  lstatSync,
 } from "node:fs";
 import { createRequire } from "node:module";
 import { arch, homedir, platform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import debugLib from "debug";
 import { BootError, ProvisionError } from "./errors.ts";
+import { treeManifestHashNative } from "./native/tree-manifest-hash.ts";
 import { resolveMke2fs } from "./rootfs-img.ts";
 
 const debug = debugLib("machinen:mountdisk-img");
@@ -430,147 +426,13 @@ function whichFirst(names: string[]): string | undefined {
 }
 
 /**
- * Compute a sha256 over a sorted manifest of every entry under
- * `root`. Each line is `<relpath>\0<mode>\0<size>\0<mtime_ns>\0<extra>\n`,
- * where `<extra>` is the symlink target for symlinks or the file
- * sha256 for regular files.
- *
- * Trade-off: file-content sha makes the cache key bulletproof
- * (mtime alone could be wrong-but-same after a rebuild) but reads
- * every byte. Acceptable because the materialise path needs the
- * bytes anyway, and on cache *hits* the manifest still pays for one
- * walk + read of every file. If profiling demands, we can drop to
- * `(relpath, mode, size, mtime_ns)` later.
+ * Compute the mountdisk cache-key manifest hash in Zig. The manifest
+ * contract is intentionally still documented and tested here, but the
+ * filesystem walk, metadata normalization, and file hashing live in
+ * `machinen-runtime-helper tree-manifest-hash`.
  */
 export function treeManifestHash(root: string): string {
-  const lines: string[] = [];
-  walkForManifest(root, "", lines);
-  lines.sort();
-  const h = createHash("sha256");
-  for (const line of lines) {
-    h.update(line);
-    h.update("\n");
-  }
-  return h.digest("hex");
-}
-
-type ManifestStats = import("node:fs").Stats & { mtimeNs?: bigint };
-
-function walkForManifest(root: string, rel: string, out: string[]): void {
-  const here = rel ? join(root, rel) : root;
-  const entries = readManifestDir(here);
-  if (!entries) {
-    return;
-  }
-  for (const name of entries) {
-    appendManifestChild(root, rel, here, name, out);
-  }
-}
-
-function appendManifestChild(
-  root: string,
-  rel: string,
-  parentAbs: string,
-  name: string,
-  out: string[],
-): void {
-  const childRel = rel ? `${rel}/${name}` : name;
-  const childAbs = join(parentAbs, name);
-  const st = tryManifestLstat(childAbs);
-  if (!st) {
-    return;
-  }
-  out.push(manifestLineForStats(childRel, childAbs, st));
-  walkManifestDirectoryIfNeeded(root, childRel, st, out);
-}
-
-function manifestLineForStats(childRel: string, childAbs: string, st: ManifestStats): string {
-  const mode = (st.mode & 0o7777).toString(8);
-  const mtimeNs = manifestMtimeNs(st);
-  if (st.isSymbolicLink()) {
-    return symlinkManifestLine(childRel, childAbs, mode, mtimeNs);
-  }
-  if (st.isDirectory()) {
-    return `${childRel}\0D\0${mode}\0\0${mtimeNs}\0`;
-  }
-  if (st.isFile()) {
-    return `${childRel}\0F\0${mode}\0${st.size}\0${mtimeNs}\0${sha256OfFile(childAbs)}`;
-  }
-  // sockets, pipes, device nodes — squashfs would refuse those on a
-  // regular host fs anyway. Hash a placeholder so the key changes when
-  // they appear/disappear.
-  return `${childRel}\0?\0${mode}\0\0${mtimeNs}\0`;
-}
-
-function symlinkManifestLine(
-  childRel: string,
-  childAbs: string,
-  mode: string,
-  mtimeNs: string,
-): string {
-  const target = tryReadlink(childAbs);
-  return `${childRel}\0L\0${mode}\0${target.length}\0${mtimeNs}\0${target}`;
-}
-
-function manifestMtimeNs(st: ManifestStats): string {
-  // mtimeMs is a non-integer float on some platforms; mtimeNs is a
-  // bigint when bigint=true and unset otherwise. Either way, we need a
-  // stable string. Floor to ms when nanoseconds aren't available — same
-  // precision Node 18+ exposes anyway.
-  return String(st.mtimeNs ?? BigInt(Math.floor(st.mtimeMs)) * BigInt(1_000_000));
-}
-
-function walkManifestDirectoryIfNeeded(
-  root: string,
-  childRel: string,
-  st: ManifestStats,
-  out: string[],
-): void {
-  if (st.isDirectory()) {
-    walkForManifest(root, childRel, out);
-  }
-}
-
-function readManifestDir(here: string): string[] | undefined {
-  try {
-    return readdirSync(here).sort();
-  } catch {
-    return undefined;
-  }
-}
-
-function tryManifestLstat(childAbs: string): ManifestStats | undefined {
-  try {
-    return lstatSync(childAbs);
-  } catch {
-    return undefined;
-  }
-}
-
-function tryReadlink(childAbs: string): string {
-  try {
-    return readlinkSync(childAbs);
-  } catch {
-    return "";
-  }
-}
-
-function sha256OfFile(path: string): string {
-  const h = createHash("sha256");
-  const fd = openSync(path, "r");
-  try {
-    const buf = Buffer.alloc(64 * 1024);
-    while (true) {
-      const nread = readSync(fd, buf, 0, buf.length, null);
-      if (nread <= 0) {
-        break;
-      }
-      h.update(buf.subarray(0, nread));
-    }
-  } finally {
-    closeSync(fd);
-  }
-  return h.digest("hex");
+  return treeManifestHashNative(root);
 }
 
 function allocateSparseFile(path: string, sizeBytes: number): void {

--- a/packages/runtime/src/native-helper.ts
+++ b/packages/runtime/src/native-helper.ts
@@ -1,0 +1,176 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { arch, platform } from "node:os";
+import { BootError, type ErrorCode } from "./errors.ts";
+
+const PROTOCOL_VERSION = 1;
+const HELPER_NAME = "machinen-runtime-helper";
+const require_ = createRequire(import.meta.url);
+
+interface RuntimeHelperCallOptions<TData> {
+  command: string;
+  data: unknown;
+  isData: (value: unknown) => value is TData;
+  errorCode?: ErrorCode;
+}
+
+interface RuntimeHelperSuccess<TData> {
+  ok: true;
+  protocolVersion: number;
+  command: string;
+  data: TData;
+}
+
+interface RuntimeHelperFailure {
+  ok: false;
+  protocolVersion: number;
+  error: RuntimeHelperErrorDetail;
+}
+
+interface RuntimeHelperErrorDetail {
+  code: string;
+  message: string;
+}
+
+export function callRuntimeHelper<TData>(opts: RuntimeHelperCallOptions<TData>): TData {
+  const errorCode = opts.errorCode ?? "BOOT_MOUNTDISK_TOOL_MISSING";
+  const helper = resolveRuntimeHelper(errorCode);
+  const result = spawnSync(helper, [opts.command], {
+    input: `${JSON.stringify({ protocolVersion: PROTOCOL_VERSION, data: opts.data })}\n`,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} failed to start at ${helper}: ${result.error.message}`,
+      {
+        cause: result.error,
+      },
+    );
+  }
+
+  const response = parseRuntimeHelperResponse<TData>(result.stdout, opts, helper, errorCode);
+  if (response.ok === false) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} ${opts.command} failed (${response.error.code}): ${response.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} ${opts.command} exited ${result.status} after returning ok:true.`,
+    );
+  }
+  return response.data;
+}
+
+function parseRuntimeHelperResponse<TData>(
+  stdout: string,
+  opts: RuntimeHelperCallOptions<TData>,
+  helper: string,
+  errorCode: ErrorCode,
+): RuntimeHelperSuccess<TData> | RuntimeHelperFailure {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} at ${helper} returned invalid JSON for ${opts.command}.`,
+      {
+        cause: err,
+      },
+    );
+  }
+  if (isRuntimeHelperFailure(parsed)) {
+    return parsed;
+  }
+  if (!isRuntimeHelperSuccessEnvelope(parsed, opts.command)) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} at ${helper} returned an invalid ${opts.command} response shape.`,
+    );
+  }
+  if (!opts.isData(parsed.data)) {
+    throw new BootError(
+      errorCode,
+      `${HELPER_NAME} at ${helper} returned invalid ${opts.command} response data.`,
+    );
+  }
+  return { ...parsed, data: parsed.data };
+}
+
+function isRuntimeHelperSuccessEnvelope(
+  value: unknown,
+  command: string,
+): value is Omit<RuntimeHelperSuccess<unknown>, "data"> & { data: unknown } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const response = value as Partial<RuntimeHelperSuccess<unknown>>;
+  return (
+    response.ok === true &&
+    response.protocolVersion === PROTOCOL_VERSION &&
+    response.command === command
+  );
+}
+
+function isRuntimeHelperFailure(value: unknown): value is RuntimeHelperFailure {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const response = value as Partial<RuntimeHelperFailure>;
+  return (
+    response.ok === false &&
+    response.protocolVersion === PROTOCOL_VERSION &&
+    !!response.error &&
+    typeof response.error.code === "string" &&
+    typeof response.error.message === "string"
+  );
+}
+
+function resolveRuntimeHelper(errorCode: ErrorCode): string {
+  return (
+    resolveRuntimeHelperEnvOverride(errorCode) ??
+    findBundledRuntimeHelper() ??
+    missingRuntimeHelper(errorCode)
+  );
+}
+
+function resolveRuntimeHelperEnvOverride(errorCode: ErrorCode): string | undefined {
+  const envOverride = process.env.MACHINEN_RUNTIME_HELPER;
+  if (!envOverride) {
+    return undefined;
+  }
+  if (existsSync(envOverride)) {
+    return envOverride;
+  }
+  throw new BootError(
+    errorCode,
+    `MACHINEN_RUNTIME_HELPER=${envOverride} is set but that file does not exist.`,
+  );
+}
+
+function findBundledRuntimeHelper(): string | undefined {
+  const pkg = `@machinen/native-${arch()}-${platform()}`;
+  try {
+    const mod = require_(pkg) as { runtimeHelper?: string };
+    if (mod.runtimeHelper && existsSync(mod.runtimeHelper)) {
+      return mod.runtimeHelper;
+    }
+  } catch {
+    // Optional dep not installed for this arch+os.
+  }
+  return undefined;
+}
+
+function missingRuntimeHelper(errorCode: ErrorCode): never {
+  throw new BootError(
+    errorCode,
+    `${HELPER_NAME} was not found. Build it with scripts/build-runtime-helper.sh, install the matching @machinen/native-* package, or set MACHINEN_RUNTIME_HELPER=/abs/path/to/${HELPER_NAME}.`,
+  );
+}

--- a/packages/runtime/src/native/tree-manifest-hash.ts
+++ b/packages/runtime/src/native/tree-manifest-hash.ts
@@ -1,0 +1,22 @@
+import { callRuntimeHelper } from "../native-helper.ts";
+
+interface TreeManifestHashData {
+  hash: string;
+}
+
+export function treeManifestHashNative(root: string): string {
+  return callRuntimeHelper({
+    command: "tree-manifest-hash",
+    data: { root },
+    errorCode: "BOOT_MOUNTDISK_TOOL_MISSING",
+    isData: isTreeManifestHashData,
+  }).hash;
+}
+
+function isTreeManifestHashData(value: unknown): value is TreeManifestHashData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<TreeManifestHashData>;
+  return typeof data.hash === "string" && /^[0-9a-f]{64}$/.test(data.hash);
+}

--- a/scripts/build-runtime-helper.sh
+++ b/scripts/build-runtime-helper.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the host-side machinen-runtime-helper helper and stage it next to the
+# other native host tools. The TypeScript runtime resolves this binary
+# from @machinen/native-<arch>-<os> and uses it for Zig-owned helper
+# operations such as mountdisk tree-manifest hashing.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PKG="$ROOT/packages/runtime/native"
+OS=$(uname -s)
+ARCH=$(uname -m)
+case "$OS:$ARCH" in
+  Darwin:arm64) PKG_ARCH="arm64"; PKG_OS="darwin" ;;
+  Linux:aarch64|Linux:arm64) PKG_ARCH="arm64"; PKG_OS="linux" ;;
+  Linux:x86_64|Linux:amd64) PKG_ARCH="x64"; PKG_OS="linux" ;;
+  *)
+    echo "unsupported host for runtime helper staging: $OS/$ARCH" >&2
+    exit 1
+    ;;
+esac
+
+DEST_DIR="$ROOT/packages/native-${PKG_ARCH}-${PKG_OS}/vmm/bin"
+DEST="$DEST_DIR/machinen-runtime-helper"
+
+echo "==> building machinen-runtime-helper (zig ReleaseSafe)"
+( cd "$PKG" && zig build -Doptimize=ReleaseSafe )
+
+echo "==> staging into $DEST"
+mkdir -p "$DEST_DIR"
+cp "$PKG/zig-out/bin/machinen-runtime-helper" "$DEST"
+
+if [[ "$OS" == "Darwin" ]]; then
+  # machinen-runtime-helper does not need entitlements, but clearing provenance
+  # keeps the staged host tool consistent with the VMM staging flow.
+  xattr -c "$DEST" || true
+fi
+
+echo "==> Done."

--- a/scripts/machinen-dev.sh
+++ b/scripts/machinen-dev.sh
@@ -6,6 +6,7 @@
 #
 # Producers (called automatically when missing or stale):
 #   - VMM:    bash scripts/build-vmm.sh
+#   - runtime helper: bash scripts/build-runtime-helper.sh
 #   - assets: bash scripts/build-base-assets.sh
 #
 # Usage:
@@ -34,6 +35,12 @@ if [[ ! -x "$VMM" ]] \
   bash "$ROOT/scripts/build-vmm.sh"
 fi
 
+RUNTIME_HELPER="$ROOT/packages/native-arm64-darwin/vmm/bin/machinen-runtime-helper"
+if [[ ! -x "$RUNTIME_HELPER" ]]; then
+  step "machinen-runtime-helper missing — rebuilding"
+  bash "$ROOT/scripts/build-runtime-helper.sh"
+fi
+
 # Stale-source check covers rootfs, kernel, and VMM. Dispatch on
 # `--what-stale` so balloon.zig edits don't trigger the slow rootfs
 # rebuild and vice versa.
@@ -52,5 +59,6 @@ if (( $# > 0 )); then
   step "running: machinen $*"
   cd "$USER_CWD"
   exec env MACHINEN_ASSETS_DIR="$ROOT/release-assets" \
+    MACHINEN_RUNTIME_HELPER="$RUNTIME_HELPER" \
     node "$ROOT/packages/cli/dist/cli.js" "$@"
 fi

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -9,6 +9,7 @@
 # isn't already built, then runs the tests.
 #   - @machinen/runtime + @machinen/cli  (fast)
 #   - packages/microvm/zig-out/bin/machinen-vm  (~30s on first run)
+#   - packages/runtime/native/zig-out/bin/machinen-runtime-helper  (fast)
 #   - release-assets/ (kernel, optional dtb, rootfs tarball)  (~5 min, needs Docker)
 #
 # Tests:
@@ -51,6 +52,7 @@ case "$OS:$HOST_ARCH" in
   *) echo "smoke: unsupported host: $OS/$HOST_ARCH" >&2; exit 1 ;;
 esac
 VMM="$ROOT/packages/$HOST_NATIVE_PKG/vmm/bin/machinen-vm"
+RUNTIME_HELPER="$ROOT/packages/$HOST_NATIVE_PKG/vmm/bin/machinen-runtime-helper"
 
 GUEST_ARCH="${MACHINEN_GUEST_ARCH:-}"
 if [[ -z "$GUEST_ARCH" ]]; then
@@ -133,6 +135,9 @@ fi
 echo "=== building VMM ==="
 bash "$ROOT/scripts/build-vmm.sh"
 
+echo "=== building machinen-runtime-helper ==="
+bash "$ROOT/scripts/build-runtime-helper.sh"
+
 if ! assets_complete; then
   echo "=== building $GUEST_ARCH base assets (~5 min on first run, cached after) ==="
   MACHINEN_GUEST_ARCH="$GUEST_ARCH" "$ROOT/scripts/build-base-assets.sh"
@@ -163,11 +168,13 @@ pnpm -F @machinen/runtime -F @machinen/cli build >/dev/null
 "$ROOT/scripts/install-gvproxy.sh" --dest "$(dirname "$VMM")"
 
 export MACHINEN_VMM="$VMM"
+export MACHINEN_RUNTIME_HELPER="$RUNTIME_HELPER"
 export MACHINEN_ASSETS_DIR="$ASSETS"
 export MACHINEN_GUEST_ARCH="$GUEST_ARCH"
 
 echo
 echo "smoke: VMM=$MACHINEN_VMM"
+echo "smoke: RUNTIME_HELPER=$MACHINEN_RUNTIME_HELPER"
 echo "smoke: ASSETS=$MACHINEN_ASSETS_DIR"
 echo "smoke: GUEST_ARCH=$MACHINEN_GUEST_ARCH"
 echo

--- a/scripts/verify-bin-packages.sh
+++ b/scripts/verify-bin-packages.sh
@@ -7,9 +7,10 @@
 #     mke2fs, and mksquashfs, all under per-tool subdirs.
 #
 # What this catches:
-#   1. Host-side binaries (the things node spawns: machinen-vm, gvproxy,
-#      mke2fs, mksquashfs) lacking the +x bit in the tarball — pnpm pack
-#      normalizes file modes to 0644 unless the file is declared in the
+#   1. Host-side binaries (the things node spawns: machinen-vm,
+#      machinen-runtime-helper, gvproxy, mke2fs, mksquashfs) lacking the +x bit
+#      in the tarball — pnpm pack normalizes file modes to 0644 unless
+#      the file is declared in the
 #      `bin` field of package.json. Without +x the runtime exits at
 #      spawn (code=127).
 #   2. Files we expect to ship missing entirely — e.g. the vmm packages'
@@ -99,13 +100,14 @@ check_pkg() {
 
 # --- native-* ------------------------------------------------------------
 # One consolidated package per host arch. Per-tool subdirs:
-#   vmm/bin/{machinen-vm,gvproxy}   host binaries node spawns.
+#   vmm/bin/{machinen-vm,machinen-runtime-helper,gvproxy}   host binaries node spawns.
 #   vmm/guest/{init,exec-agent}  guest-arch Linux ELFs the runtime
 #       reads as data to pack into the initramfs cpio (mode irrelevant).
 #   e2fsprogs/bin/mke2fs, squashfs/bin/mksquashfs  host binaries node spawns.
 for pkg in native-arm64-darwin native-arm64-linux native-x64-linux; do
   check_pkg "$pkg" \
     vmm/bin/machinen-vm \
+    vmm/bin/machinen-runtime-helper \
     vmm/bin/gvproxy \
     e2fsprogs/bin/mke2fs \
     squashfs/bin/mksquashfs \


### PR DESCRIPTION
## Problem

Mount disk cache keys were still built in TypeScript. That meant the runtime was doing low-level filesystem walking and file hashing in JavaScript, even though this kind of systems work belongs in native runtime code.

Fresh macOS builds also hit a Zig 0.16 problem when translating Apple Hypervisor headers. That blocked typecheck and smoke tests before this mount change could be fully proved.

## Solution

This PR adds a Zig `machinen-runtime-helper tree-manifest-hash` helper under `packages/runtime/native` and makes the runtime call it for mount disk manifest hashes. The public TypeScript `treeManifestHash()` API stays the same, but the real filesystem work now lives in Zig next to the runtime.

It also replaces the fragile Hypervisor `@cImport` path with a small hand-written HVF ABI shim, so macOS builds no longer trip over the SDK headers.

## Technical Summary

- Keep ownership with `@machinen/runtime`: the Zig source lives in `packages/runtime/native`, not in a separate broad “engine” package.
- Use one strict helper protocol: argv selects the command, stdin is `{ protocolVersion, data }`, and stdout is the only protocol response stream.
- Split the Zig helper so `main.zig` dispatches only, `protocol.zig` owns shared JSON protocol helpers, and `src/commands/tree_manifest_hash.zig` owns command request parsing and execution.
- Centralize the generic TypeScript side in `packages/runtime/src/native-helper.ts`, which owns helper lookup, env override handling, subprocess spawning, request envelopes, and response parsing.
- Put command-specific TypeScript wrappers under `packages/runtime/src/native/`; `tree-manifest-hash.ts` sends `{ root }` and validates `data.hash`.
- Keep cache behavior stable: the Zig tests pin the legacy hash shape, including file content, symlink targets, modes, and refusal of bad roots.
- Ship the helper like the other native host tools: native packages export `runtimeHelper`, expose a `machinen-runtime-helper` bin, and release staging builds it for each host package.
- Avoid a TypeScript fallback on purpose. If the helper is missing or returns bad data, the runtime gives a clear mount tool error instead of silently using old logic.
- Avoid broad macOS header translation in `hvf.zig`. The code declares only the HVF types, constants, and functions Machinen already uses.
