### PR TITLE
Move host probes to Zig

### DIFF
--- a/packages/runtime/native/src/commands/cpu_cgroup_apply.zig
+++ b/packages/runtime/native/src/commands/cpu_cgroup_apply.zig
@@ -1,0 +1,134 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "cpu-cgroup-apply";
+
+const Request = struct {
+    pid: u32,
+    weight: u32,
+    quota_cpus: ?f64,
+    parent_dir: []const u8,
+    id: []const u8,
+};
+
+const RequestError = error{
+    MissingPid,
+    InvalidPid,
+    MissingWeight,
+    InvalidWeight,
+    InvalidQuotaCpus,
+    MissingParentDir,
+    InvalidParentDir,
+    MissingId,
+    InvalidId,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const result = runtime_helper.host.applyCpuCgroup(allocator, io, .{
+        .pid = request.pid,
+        .weight = request.weight,
+        .quota_cpus = request.quota_cpus,
+        .parent_dir = request.parent_dir,
+        .id = request.id,
+    }) catch |err| {
+        switch (err) {
+            error.CgroupUnsupported => try protocol.writeError(io, "BOOT_CPU_UNSUPPORTED", "boot: resources.cpu requires Linux cgroup v2 CPU controls, but the cgroup parent is not usable."),
+            else => try protocol.writeError(io, "BOOT_CPU_UNSUPPORTED", @errorName(err)),
+        }
+        return .fail;
+    };
+    defer if (result.cgroup_path) |path| allocator.free(path);
+
+    const out = try formatResponse(allocator, result);
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn formatResponse(allocator: std.mem.Allocator, result: runtime_helper.host.CpuCgroupResult) ![]u8 {
+    switch (result.status) {
+        .unsupported => return std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-apply\",\"data\":{{\"status\":\"unsupported\",\"reason\":\"{s}\"}}}}\n",
+            .{result.reason orelse "unsupported"},
+        ),
+        .linux_cgroup_v2 => return std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-apply\",\"data\":{{\"status\":\"linux-cgroup-v2\",\"cgroupPath\":\"{s}\"}}}}\n",
+            .{result.cgroup_path.?},
+        ),
+    }
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{ "pid", "weight", "quotaCpus", "parentDir", "id" });
+    return .{
+        .pid = try requiredU32(object, "pid", error.MissingPid, error.InvalidPid),
+        .weight = try requiredU32(object, "weight", error.MissingWeight, error.InvalidWeight),
+        .quota_cpus = try optionalFloat(object, "quotaCpus", error.InvalidQuotaCpus),
+        .parent_dir = try requiredString(object, "parentDir", error.MissingParentDir, error.InvalidParentDir),
+        .id = try requiredString(object, "id", error.MissingId, error.InvalidId),
+    };
+}
+
+fn requiredString(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError![]const u8 {
+    const value = object.get(field) orelse return missing;
+    if (value != .string) return invalid;
+    return value.string;
+}
+
+fn requiredU32(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!u32 {
+    const value = object.get(field) orelse return missing;
+    if (value != .integer or value.integer <= 0 or value.integer > std.math.maxInt(u32)) return invalid;
+    return @intCast(value.integer);
+}
+
+fn optionalFloat(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!?f64 {
+    const value = object.get(field) orelse return null;
+    if (value == .null) return null;
+    return switch (value) {
+        .float => |f| f,
+        .integer => |i| @floatFromInt(i),
+        else => invalid,
+    };
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/cpu_cgroup_apply.zig
+++ b/packages/runtime/native/src/commands/cpu_cgroup_apply.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "cpu-cgroup-apply";
 
 const Request = struct {
@@ -25,6 +27,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -42,35 +46,54 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .id = request.id,
     }) catch |err| {
         switch (err) {
-            error.CgroupUnsupported => try protocol.writeError(io, "BOOT_CPU_UNSUPPORTED", "boot: resources.cpu requires Linux cgroup v2 CPU controls, but the cgroup parent is not usable."),
+            error.CgroupUnsupported => try protocol.writeError(
+                io,
+                "BOOT_CPU_UNSUPPORTED",
+                "boot: resources.cpu requires Linux cgroup v2 CPU controls, " ++
+                    "but the cgroup parent is not usable.",
+            ),
             else => try protocol.writeError(io, "BOOT_CPU_UNSUPPORTED", @errorName(err)),
         }
         return .fail;
     };
     defer if (result.cgroup_path) |path| allocator.free(path);
 
-    const out = try formatResponse(allocator, result);
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writeResponse(allocator, io, result);
     return .ok;
 }
 
-fn formatResponse(allocator: std.mem.Allocator, result: runtime_helper.host.CpuCgroupResult) ![]u8 {
+fn writeResponse(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    result: runtime_helper.host.CpuCgroupResult,
+) !void {
+    assert(name.len > 0);
+
     switch (result.status) {
-        .unsupported => return std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-apply\",\"data\":{{\"status\":\"unsupported\",\"reason\":\"{s}\"}}}}\n",
-            .{result.reason orelse "unsupported"},
-        ),
-        .linux_cgroup_v2 => return std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-apply\",\"data\":{{\"status\":\"linux-cgroup-v2\",\"cgroupPath\":\"{s}\"}}}}\n",
-            .{result.cgroup_path.?},
-        ),
+        .unsupported => try protocol.writeJson(allocator, io, .{
+            .ok = true,
+            .protocolVersion = @as(u8, protocol.version),
+            .command = name,
+            .data = .{
+                .status = "unsupported",
+                .reason = result.reason orelse "unsupported",
+            },
+        }),
+        .linux_cgroup_v2 => try protocol.writeJson(allocator, io, .{
+            .ok = true,
+            .protocolVersion = @as(u8, protocol.version),
+            .command = name,
+            .data = .{
+                .status = "linux-cgroup-v2",
+                .cgroupPath = result.cgroup_path.?,
+            },
+        }),
     }
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -83,34 +106,58 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "pid", "weight", "quotaCpus", "parentDir", "id" });
+    try protocol.rejectUnknownFields(
+        object,
+        &.{ "pid", "weight", "quotaCpus", "parentDir", "id" },
+    );
     return .{
         .pid = try requiredU32(object, "pid", error.MissingPid, error.InvalidPid),
         .weight = try requiredU32(object, "weight", error.MissingWeight, error.InvalidWeight),
         .quota_cpus = try optionalFloat(object, "quotaCpus", error.InvalidQuotaCpus),
-        .parent_dir = try requiredString(object, "parentDir", error.MissingParentDir, error.InvalidParentDir),
+        .parent_dir = try requiredString(
+            object,
+            "parentDir",
+            error.MissingParentDir,
+            error.InvalidParentDir,
+        ),
         .id = try requiredString(object, "id", error.MissingId, error.InvalidId),
     };
 }
 
-fn requiredString(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError![]const u8 {
+fn requiredString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError![]const u8 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return missing;
     if (value != .string) return invalid;
     return value.string;
 }
 
-fn requiredU32(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!u32 {
+fn requiredU32(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError!u32 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return missing;
-    if (value != .integer or value.integer <= 0 or value.integer > std.math.maxInt(u32)) return invalid;
+    if (value != .integer or value.integer <= 0) return invalid;
+    if (value.integer > std.math.maxInt(u32)) return invalid;
     return @intCast(value.integer);
 }
 
 fn optionalFloat(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!?f64 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return null;
     if (value == .null) return null;
     return switch (value) {
@@ -121,14 +168,7 @@ fn optionalFloat(object: std.json.ObjectMap, field: []const u8, invalid: Request
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/cpu_cgroup_remove.zig
+++ b/packages/runtime/native/src/commands/cpu_cgroup_remove.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "cpu-cgroup-remove";
+
+const Request = struct {
+    cgroup_path: []const u8,
+};
+
+const RequestError = error{
+    MissingCgroupPath,
+    InvalidCgroupPath,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    runtime_helper.host.removeCpuCgroup(io, request.cgroup_path);
+    try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-remove\",\"data\":{\"ok\":true}}\n");
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{"cgroupPath"});
+    const cgroup_path = object.get("cgroupPath") orelse return error.MissingCgroupPath;
+    if (cgroup_path != .string) return error.InvalidCgroupPath;
+    return .{ .cgroup_path = cgroup_path.string };
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/cpu_cgroup_remove.zig
+++ b/packages/runtime/native/src/commands/cpu_cgroup_remove.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "cpu-cgroup-remove";
 
 const Request = struct {
@@ -14,6 +16,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -24,11 +28,18 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
     };
 
     runtime_helper.host.removeCpuCgroup(io, request.cgroup_path);
-    try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"cpu-cgroup-remove\",\"data\":{\"ok\":true}}\n");
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .ok = true },
+    });
     return .ok;
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -41,8 +52,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
@@ -53,14 +63,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/host_memory.zig
+++ b/packages/runtime/native/src/commands/host_memory.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "host-memory";
+
+const RequestError = protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const memory = runtime_helper.host.readHostMemory(allocator, io) catch |err| {
+        switch (err) {
+            error.UnsupportedHostMemory => try protocol.writeError(io, "FORK_MEMORY_BACKPRESSURE", "host memory probing is unsupported on this platform"),
+            else => try protocol.writeError(io, "FORK_MEMORY_BACKPRESSURE", @errorName(err)),
+        }
+        return .fail;
+    };
+
+    const out = try std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"host-memory\",\"data\":{{\"freeBytes\":{d},\"totalBytes\":{d}}}}}\n",
+        .{ memory.free_bytes, memory.total_bytes },
+    );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!void {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    try protocol.rejectUnknownFields(data_value.object, &.{});
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/host_memory.zig
+++ b/packages/runtime/native/src/commands/host_memory.zig
@@ -2,11 +2,15 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "host-memory";
 
 const RequestError = protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -18,23 +22,31 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
 
     const memory = runtime_helper.host.readHostMemory(allocator, io) catch |err| {
         switch (err) {
-            error.UnsupportedHostMemory => try protocol.writeError(io, "FORK_MEMORY_BACKPRESSURE", "host memory probing is unsupported on this platform"),
+            error.UnsupportedHostMemory => try protocol.writeError(
+                io,
+                "FORK_MEMORY_BACKPRESSURE",
+                "host memory probing is unsupported on this platform",
+            ),
             else => try protocol.writeError(io, "FORK_MEMORY_BACKPRESSURE", @errorName(err)),
         }
         return .fail;
     };
 
-    const out = try std.fmt.allocPrint(
-        allocator,
-        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"host-memory\",\"data\":{{\"freeBytes\":{d},\"totalBytes\":{d}}}}}\n",
-        .{ memory.free_bytes, memory.total_bytes },
-    );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{
+            .freeBytes = memory.free_bytes,
+            .totalBytes = memory.total_bytes,
+        },
+    });
     return .ok;
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!void {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -47,22 +59,14 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!void {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     try protocol.rejectUnknownFields(data_value.object, &.{});
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/host_rss.zig
+++ b/packages/runtime/native/src/commands/host_rss.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "host-rss";
 
 const Request = struct {
@@ -18,6 +20,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -27,33 +31,37 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         return .fail;
     };
 
-    const readings = runtime_helper.host.readHostRss(allocator, io, request.targets) catch |err| {
+    const readings = runtime_helper.host.readHostRss(
+        allocator,
+        io,
+        request.targets,
+    ) catch |err| {
         try protocol.writeError(io, "BOOT_PACK_FAILED", @errorName(err));
         return .fail;
     };
     defer allocator.free(readings);
 
-    const out = try formatResponse(allocator, readings);
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writeResponse(allocator, io, readings);
     return .ok;
 }
 
-fn formatResponse(allocator: std.mem.Allocator, readings: []const runtime_helper.host.RssReading) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    try out.appendSlice(allocator, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"host-rss\",\"data\":{\"readings\":[");
-    for (readings, 0..) |reading, i| {
-        if (i != 0) try out.append(allocator, ',');
-        const item = try std.fmt.allocPrint(allocator, "{{\"pid\":{d},\"rssBytes\":{d}}}", .{ reading.pid, reading.rss_bytes });
-        defer allocator.free(item);
-        try out.appendSlice(allocator, item);
-    }
-    try out.appendSlice(allocator, "]}}\n");
-    return out.toOwnedSlice(allocator);
+fn writeResponse(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    readings: []const runtime_helper.host.RssReading,
+) !void {
+    assert(name.len > 0);
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .readings = readings },
+    });
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -66,27 +74,29 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
     try protocol.rejectUnknownFields(object, &.{"targets"});
     const targets_value = object.get("targets") orelse return error.MissingTargets;
     if (targets_value != .array) return error.InvalidTargets;
-    const targets = try allocator.alloc(runtime_helper.host.RssTarget, targets_value.array.items.len);
-    for (targets_value.array.items, 0..) |target_value, i| {
-        targets[i] = try parseTarget(target_value);
+    var targets: std.array_list.Aligned(runtime_helper.host.RssTarget, null) = .empty;
+    for (targets_value.array.items) |target_value| {
+        try targets.append(allocator, try parseTarget(target_value));
     }
-    return .{ .targets = targets };
+    return .{ .targets = try targets.toOwnedSlice(allocator) };
 }
 
 fn parseTarget(value: std.json.Value) RequestError!runtime_helper.host.RssTarget {
+    assert(@sizeOf(runtime_helper.host.RssTarget) > 0);
+
     if (value != .object) return error.InvalidTarget;
     const object = value.object;
     try protocol.rejectUnknownFields(object, &.{ "pid", "statsPath" });
     const pid_value = object.get("pid") orelse return error.MissingPid;
-    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    if (pid_value != .integer or pid_value.integer <= 0) return error.InvalidPid;
+    if (pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
     const stats_path_value = object.get("statsPath");
     const stats_path = if (stats_path_value) |stats_path| blk: {
         if (stats_path == .null) break :blk null;
@@ -97,14 +107,7 @@ fn parseTarget(value: std.json.Value) RequestError!runtime_helper.host.RssTarget
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/host_rss.zig
+++ b/packages/runtime/native/src/commands/host_rss.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "host-rss";
+
+const Request = struct {
+    targets: []runtime_helper.host.RssTarget,
+};
+
+const RequestError = error{
+    MissingTargets,
+    InvalidTargets,
+    InvalidTarget,
+    MissingPid,
+    InvalidPid,
+    InvalidStatsPath,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const readings = runtime_helper.host.readHostRss(allocator, io, request.targets) catch |err| {
+        try protocol.writeError(io, "BOOT_PACK_FAILED", @errorName(err));
+        return .fail;
+    };
+    defer allocator.free(readings);
+
+    const out = try formatResponse(allocator, readings);
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn formatResponse(allocator: std.mem.Allocator, readings: []const runtime_helper.host.RssReading) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"host-rss\",\"data\":{\"readings\":[");
+    for (readings, 0..) |reading, i| {
+        if (i != 0) try out.append(allocator, ',');
+        const item = try std.fmt.allocPrint(allocator, "{{\"pid\":{d},\"rssBytes\":{d}}}", .{ reading.pid, reading.rss_bytes });
+        defer allocator.free(item);
+        try out.appendSlice(allocator, item);
+    }
+    try out.appendSlice(allocator, "]}}\n");
+    return out.toOwnedSlice(allocator);
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{"targets"});
+    const targets_value = object.get("targets") orelse return error.MissingTargets;
+    if (targets_value != .array) return error.InvalidTargets;
+    const targets = try allocator.alloc(runtime_helper.host.RssTarget, targets_value.array.items.len);
+    for (targets_value.array.items, 0..) |target_value, i| {
+        targets[i] = try parseTarget(target_value);
+    }
+    return .{ .targets = targets };
+}
+
+fn parseTarget(value: std.json.Value) RequestError!runtime_helper.host.RssTarget {
+    if (value != .object) return error.InvalidTarget;
+    const object = value.object;
+    try protocol.rejectUnknownFields(object, &.{ "pid", "statsPath" });
+    const pid_value = object.get("pid") orelse return error.MissingPid;
+    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    const stats_path_value = object.get("statsPath");
+    const stats_path = if (stats_path_value) |stats_path| blk: {
+        if (stats_path == .null) break :blk null;
+        if (stats_path != .string) return error.InvalidStatsPath;
+        break :blk stats_path.string;
+    } else null;
+    return .{ .pid = @intCast(pid_value.integer), .stats_path = stats_path };
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/pid_validate.zig
+++ b/packages/runtime/native/src/commands/pid_validate.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "pid-validate";
 
 const Request = struct {
@@ -19,6 +21,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -41,17 +45,18 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .dead => "dead",
         .recycled => "recycled",
     };
-    const out = try std.fmt.allocPrint(
-        allocator,
-        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"pid-validate\",\"data\":{{\"status\":\"{s}\"}}}}\n",
-        .{status_text},
-    );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .status = status_text },
+    });
     return .ok;
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -64,14 +69,14 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
     try protocol.rejectUnknownFields(object, &.{ "pid", "expected" });
     const pid_value = object.get("pid") orelse return error.MissingPid;
-    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    if (pid_value != .integer or pid_value.integer <= 0) return error.InvalidPid;
+    if (pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
     var request: Request = .{ .pid = @intCast(pid_value.integer) };
     if (object.get("expected")) |expected_value| {
         if (expected_value != .object) return error.InvalidExpected;
@@ -90,14 +95,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/pid_validate.zig
+++ b/packages/runtime/native/src/commands/pid_validate.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "pid-validate";
+
+const Request = struct {
+    pid: u32,
+    vmm_exe: ?[]const u8 = null,
+    started_at_ms: ?i64 = null,
+};
+
+const RequestError = error{
+    MissingPid,
+    InvalidPid,
+    InvalidExpected,
+    InvalidVmmExe,
+    InvalidStartedAt,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const status = runtime_helper.host.validatePid(allocator, io, request.pid, .{
+        .vmm_exe = request.vmm_exe,
+        .started_at_ms = request.started_at_ms,
+    }) catch |err| {
+        try protocol.writeError(io, "REGISTRY_VM_NOT_FOUND", @errorName(err));
+        return .fail;
+    };
+
+    const status_text = switch (status) {
+        .alive => "alive",
+        .dead => "dead",
+        .recycled => "recycled",
+    };
+    const out = try std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"pid-validate\",\"data\":{{\"status\":\"{s}\"}}}}\n",
+        .{status_text},
+    );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{ "pid", "expected" });
+    const pid_value = object.get("pid") orelse return error.MissingPid;
+    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    var request: Request = .{ .pid = @intCast(pid_value.integer) };
+    if (object.get("expected")) |expected_value| {
+        if (expected_value != .object) return error.InvalidExpected;
+        const expected = expected_value.object;
+        try protocol.rejectUnknownFields(expected, &.{ "vmmExe", "startedAt" });
+        if (expected.get("vmmExe")) |vmm_exe| {
+            if (vmm_exe != .string) return error.InvalidVmmExe;
+            request.vmm_exe = vmm_exe.string;
+        }
+        if (expected.get("startedAt")) |started_at| {
+            if (started_at != .integer) return error.InvalidStartedAt;
+            request.started_at_ms = @intCast(started_at.integer);
+        }
+    }
+    return request;
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/process_identity.zig
+++ b/packages/runtime/native/src/commands/process_identity.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "process-identity";
+
+const Request = struct {
+    pid: u32,
+};
+
+const RequestError = error{
+    MissingPid,
+    InvalidPid,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const identity = runtime_helper.host.readProcessIdentity(allocator, io, request.pid) catch |err| {
+        try protocol.writeError(io, "REGISTRY_VM_NOT_FOUND", @errorName(err));
+        return .fail;
+    };
+    defer if (identity) |observed| observed.deinit(allocator);
+
+    const out = try formatResponse(allocator, identity);
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn formatResponse(allocator: std.mem.Allocator, identity: ?runtime_helper.host.ProcessIdentity) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"process-identity\",\"data\":{");
+    if (identity) |observed| {
+        try out.appendSlice(allocator, "\"identity\":{\"exeBase\":");
+        try appendJsonString(allocator, &out, observed.exe_base);
+        if (observed.started_at_ms) |started_at_ms| {
+            const part = try std.fmt.allocPrint(allocator, ",\"startedAtMs\":{d}", .{started_at_ms});
+            defer allocator.free(part);
+            try out.appendSlice(allocator, part);
+        }
+        try out.append(allocator, '}');
+    } else {
+        try out.appendSlice(allocator, "\"identity\":null");
+    }
+    try out.appendSlice(allocator, "}}\n");
+    return out.toOwnedSlice(allocator);
+}
+
+fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), value: []const u8) !void {
+    try out.append(allocator, '"');
+    for (value) |c| {
+        switch (c) {
+            '"' => try out.appendSlice(allocator, "\\\""),
+            '\\' => try out.appendSlice(allocator, "\\\\"),
+            '\n' => try out.appendSlice(allocator, "\\n"),
+            '\r' => try out.appendSlice(allocator, "\\r"),
+            '\t' => try out.appendSlice(allocator, "\\t"),
+            else => if (c < 0x20) {
+                const escaped = try std.fmt.allocPrint(allocator, "\\u{x:0>4}", .{c});
+                defer allocator.free(escaped);
+                try out.appendSlice(allocator, escaped);
+            } else {
+                try out.append(allocator, c);
+            },
+        }
+    }
+    try out.append(allocator, '"');
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{"pid"});
+    const pid_value = object.get("pid") orelse return error.MissingPid;
+    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    return .{ .pid = @intCast(pid_value.integer) };
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/process_identity.zig
+++ b/packages/runtime/native/src/commands/process_identity.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "process-identity";
 
 const Request = struct {
@@ -14,6 +16,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -23,60 +27,47 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         return .fail;
     };
 
-    const identity = runtime_helper.host.readProcessIdentity(allocator, io, request.pid) catch |err| {
+    const identity = runtime_helper.host.readProcessIdentity(
+        allocator,
+        io,
+        request.pid,
+    ) catch |err| {
         try protocol.writeError(io, "REGISTRY_VM_NOT_FOUND", @errorName(err));
         return .fail;
     };
     defer if (identity) |observed| observed.deinit(allocator);
 
-    const out = try formatResponse(allocator, identity);
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writeResponse(allocator, io, identity);
     return .ok;
 }
 
-fn formatResponse(allocator: std.mem.Allocator, identity: ?runtime_helper.host.ProcessIdentity) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    try out.appendSlice(allocator, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"process-identity\",\"data\":{");
-    if (identity) |observed| {
-        try out.appendSlice(allocator, "\"identity\":{\"exeBase\":");
-        try appendJsonString(allocator, &out, observed.exe_base);
-        if (observed.started_at_ms) |started_at_ms| {
-            const part = try std.fmt.allocPrint(allocator, ",\"startedAtMs\":{d}", .{started_at_ms});
-            defer allocator.free(part);
-            try out.appendSlice(allocator, part);
-        }
-        try out.append(allocator, '}');
-    } else {
-        try out.appendSlice(allocator, "\"identity\":null");
-    }
-    try out.appendSlice(allocator, "}}\n");
-    return out.toOwnedSlice(allocator);
-}
+const ResponseIdentity = struct {
+    exeBase: []const u8,
+    startedAtMs: ?i64 = null,
+};
 
-fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), value: []const u8) !void {
-    try out.append(allocator, '"');
-    for (value) |c| {
-        switch (c) {
-            '"' => try out.appendSlice(allocator, "\\\""),
-            '\\' => try out.appendSlice(allocator, "\\\\"),
-            '\n' => try out.appendSlice(allocator, "\\n"),
-            '\r' => try out.appendSlice(allocator, "\\r"),
-            '\t' => try out.appendSlice(allocator, "\\t"),
-            else => if (c < 0x20) {
-                const escaped = try std.fmt.allocPrint(allocator, "\\u{x:0>4}", .{c});
-                defer allocator.free(escaped);
-                try out.appendSlice(allocator, escaped);
-            } else {
-                try out.append(allocator, c);
-            },
-        }
-    }
-    try out.append(allocator, '"');
+fn writeResponse(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    identity: ?runtime_helper.host.ProcessIdentity,
+) !void {
+    assert(name.len > 0);
+
+    const response_identity: ?ResponseIdentity = if (identity) |observed| .{
+        .exeBase = observed.exe_base,
+        .startedAtMs = observed.started_at_ms,
+    } else null;
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .identity = response_identity },
+    });
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -89,26 +80,19 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
     try protocol.rejectUnknownFields(object, &.{"pid"});
     const pid_value = object.get("pid") orelse return error.MissingPid;
-    if (pid_value != .integer or pid_value.integer <= 0 or pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
+    if (pid_value != .integer or pid_value.integer <= 0) return error.InvalidPid;
+    if (pid_value.integer > std.math.maxInt(u32)) return error.InvalidPid;
     return .{ .pid = @intCast(pid_value.integer) };
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -13,6 +13,76 @@ pub const RssReading = struct {
     rss_bytes: u64,
 };
 
+pub const CpuCgroupOptions = struct {
+    pid: u32,
+    weight: u32,
+    quota_cpus: ?f64 = null,
+    parent_dir: []const u8,
+    id: []const u8,
+};
+
+pub const CpuCgroupStatus = enum {
+    linux_cgroup_v2,
+    unsupported,
+};
+
+pub const CpuCgroupResult = struct {
+    status: CpuCgroupStatus,
+    cgroup_path: ?[]u8 = null,
+    reason: ?[]const u8 = null,
+};
+
+const CPU_PERIOD_US = 100_000;
+const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
+
+pub fn applyCpuCgroup(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
+    if (builtin.os.tag != .linux) {
+        return .{ .status = .unsupported, .reason = "hard CPU quota uses Linux cgroup v2" };
+    }
+    return applyCpuCgroupLinux(allocator, io, opts);
+}
+
+fn applyCpuCgroupLinux(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
+    if (!looksLikeCgroupV2(io, opts.parent_dir)) return error.CgroupUnsupported;
+    try std.Io.Dir.cwd().createDirPath(io, opts.parent_dir);
+    const safe_id = try sanitizeCgroupId(allocator, opts.id);
+    defer allocator.free(safe_id);
+    const suffix = randomHexSuffix();
+    const cgroup_path = try std.fmt.allocPrint(allocator, "{s}/machinen-vm-{s}-{s}", .{ opts.parent_dir, safe_id, &suffix });
+    errdefer allocator.free(cgroup_path);
+    try std.Io.Dir.cwd().createDir(io, cgroup_path, .default_dir);
+    errdefer removeCpuCgroup(io, cgroup_path);
+
+    if (opts.quota_cpus) |quota_cpus| {
+        const quota_us: u64 = @max(1, @as(u64, @intFromFloat(@round(quota_cpus * CPU_PERIOD_US))));
+        const cpu_max = try std.fmt.allocPrint(allocator, "{d} {d}\n", .{ quota_us, CPU_PERIOD_US });
+        defer allocator.free(cpu_max);
+        const cpu_max_path = try joinCgroupFile(allocator, cgroup_path, "cpu.max");
+        defer allocator.free(cpu_max_path);
+        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = cpu_max_path, .data = cpu_max });
+    }
+    const weight = try std.fmt.allocPrint(allocator, "{d}\n", .{opts.weight});
+    defer allocator.free(weight);
+    const weight_path = try joinCgroupFile(allocator, cgroup_path, "cpu.weight");
+    defer allocator.free(weight_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = weight_path, .data = weight });
+    const procs = try std.fmt.allocPrint(allocator, "{d}\n", .{opts.pid});
+    defer allocator.free(procs);
+    const procs_path = try joinCgroupFile(allocator, cgroup_path, "cgroup.procs");
+    defer allocator.free(procs_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = procs_path, .data = procs });
+
+    return .{ .status = .linux_cgroup_v2, .cgroup_path = cgroup_path };
+}
+
+pub fn removeCpuCgroup(io: std.Io, cgroup_path: []const u8) void {
+    std.Io.Dir.cwd().deleteDir(io, cgroup_path) catch {
+        if (!std.mem.startsWith(u8, cgroup_path, DEFAULT_CGROUP_PARENT ++ "/")) {
+            std.Io.Dir.cwd().deleteTree(io, cgroup_path) catch {};
+        }
+    };
+}
+
 pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const RssTarget) Error![]RssReading {
     var readings: std.ArrayList(RssReading) = .empty;
     errdefer readings.deinit(allocator);
@@ -40,6 +110,47 @@ pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const Rs
     }
 
     return readings.toOwnedSlice(allocator);
+}
+
+fn looksLikeCgroupV2(io: std.Io, parent_dir: []const u8) bool {
+    if (std.mem.eql(u8, parent_dir, DEFAULT_CGROUP_PARENT)) {
+        return existsFile(io, DEFAULT_CGROUP_PARENT ++ "/cgroup.controllers");
+    }
+    return existsPath(io, parent_dir);
+}
+
+fn existsPath(io: std.Io, path: []const u8) bool {
+    _ = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    return true;
+}
+
+fn existsFile(io: std.Io, path: []const u8) bool {
+    const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    return st.kind == .file;
+}
+
+fn sanitizeCgroupId(allocator: std.mem.Allocator, id: []const u8) Error![]u8 {
+    const out = try allocator.alloc(u8, id.len);
+    for (id, 0..) |c, i| {
+        out[i] = if (std.ascii.isAlphanumeric(c) or c == '_' or c == '.' or c == '-') c else '-';
+    }
+    return out;
+}
+
+fn randomHexSuffix() [8]u8 {
+    var bytes: [4]u8 = undefined;
+    std.crypto.random.bytes(&bytes);
+    const digits = "0123456789abcdef";
+    var out: [8]u8 = undefined;
+    for (bytes, 0..) |byte, i| {
+        out[i * 2] = digits[(byte >> 4) & 0xf];
+        out[i * 2 + 1] = digits[byte & 0xf];
+    }
+    return out;
+}
+
+fn joinCgroupFile(allocator: std.mem.Allocator, cgroup_path: []const u8, name: []const u8) Error![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ cgroup_path, name });
 }
 
 fn readVmRssLinux(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64 {
@@ -113,6 +224,69 @@ fn readFileAlloc(allocator: std.mem.Allocator, io: std.Io, path: []const u8) Err
         try out.appendSlice(allocator, buf[0..n]);
     }
     return out.toOwnedSlice(allocator);
+}
+
+fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+    const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
+    defer allocator.free(cwd);
+    return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
+}
+
+test "applyCpuCgroup returns explicit unsupported outside Linux" {
+    if (builtin.os.tag == .linux) return;
+    const result = try applyCpuCgroup(std.testing.allocator, std.testing.io, .{
+        .pid = 4321,
+        .weight = 250,
+        .quota_cpus = 0.5,
+        .parent_dir = "/tmp/machinen-cgroup-test",
+        .id = "unit",
+    });
+    try std.testing.expectEqual(.unsupported, result.status);
+    try std.testing.expect(result.reason != null);
+}
+
+test "applyCpuCgroupLinux writes cgroup v2 files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "parent", .default_dir);
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const parent = try std.fs.path.join(allocator, &.{ root, "parent" });
+    defer allocator.free(parent);
+
+    const result = try applyCpuCgroupLinux(allocator, std.testing.io, .{
+        .pid = 4321,
+        .weight = 250,
+        .quota_cpus = 0.5,
+        .parent_dir = parent,
+        .id = "unit/unsafe",
+    });
+    defer if (result.cgroup_path) |path| allocator.free(path);
+    try std.testing.expectEqual(.linux_cgroup_v2, result.status);
+    try std.testing.expect(result.cgroup_path != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.cgroup_path.?, "machinen-vm-unit-unsafe-") != null);
+
+    const cpu_max_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cpu.max");
+    defer allocator.free(cpu_max_path);
+    const cpu_max = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, cpu_max_path, 1024);
+    defer allocator.free(cpu_max);
+    try std.testing.expectEqualStrings("50000 100000\n", cpu_max);
+
+    const weight_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cpu.weight");
+    defer allocator.free(weight_path);
+    const weight = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, weight_path, 1024);
+    defer allocator.free(weight);
+    try std.testing.expectEqualStrings("250\n", weight);
+
+    const procs_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cgroup.procs");
+    defer allocator.free(procs_path);
+    const procs = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, procs_path, 1024);
+    defer allocator.free(procs);
+    try std.testing.expectEqualStrings("4321\n", procs);
+
+    removeCpuCgroup(std.testing.io, result.cgroup_path.?);
+    try std.testing.expect(!existsPath(std.testing.io, result.cgroup_path.?));
 }
 
 test "parseVmRssStatus reads VmRSS in bytes" {

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -1,5 +1,14 @@
+// Host-side probes and controls used by the TypeScript runtime.
+//
+// This file keeps OS-specific, synchronous host operations in the native
+// helper: memory/RSS reads, pid identity checks, and Linux cgroup CPU setup.
+// The command files translate JSON protocol requests into these functions;
+// this module owns the actual platform behavior so the TS layer stays small.
+
 const std = @import("std");
 const builtin = @import("builtin");
+
+const assert = std.debug.assert;
 
 pub const Error = anyerror;
 
@@ -10,7 +19,7 @@ pub const RssTarget = struct {
 
 pub const RssReading = struct {
     pid: u32,
-    rss_bytes: u64,
+    rssBytes: u64,
 };
 
 pub const PidStatus = enum {
@@ -24,6 +33,7 @@ pub const ProcessIdentity = struct {
     started_at_ms: ?i64 = null,
 
     pub fn deinit(self: ProcessIdentity, allocator: std.mem.Allocator) void {
+        assert(self.exe_base.len > 0);
         allocator.free(self.exe_base);
     }
 };
@@ -61,7 +71,13 @@ const CPU_PERIOD_US = 100_000;
 const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
 const STARTTIME_SKEW_MS = 5_000;
 
-pub fn readProcessIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
+pub fn readProcessIdentity(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    pid: u32,
+) Error!?ProcessIdentity {
+    assert(pid > 0);
+
     return switch (builtin.os.tag) {
         .linux => readLinuxIdentity(allocator, io, pid),
         .macos => readPsIdentity(allocator, io, pid),
@@ -69,7 +85,14 @@ pub fn readProcessIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) E
     };
 }
 
-pub fn validatePid(allocator: std.mem.Allocator, io: std.Io, pid: u32, expected: PidExpected) Error!PidStatus {
+pub fn validatePid(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    pid: u32,
+    expected: PidExpected,
+) Error!PidStatus {
+    assert(STARTTIME_SKEW_MS > 0);
+
     if (pid == 0) return .dead;
     if (!pidAlive(pid)) return .dead;
     if (expected.vmm_exe == null and expected.started_at_ms == null) return .alive;
@@ -79,9 +102,10 @@ pub fn validatePid(allocator: std.mem.Allocator, io: std.Io, pid: u32, expected:
     if (expected.vmm_exe) |vmm_exe| {
         const expected_base = std.fs.path.basename(vmm_exe);
         if (!std.mem.eql(u8, observed.exe_base, expected_base)) {
-            if (builtin.os.tag != .linux or !std.mem.eql(u8, observed.exe_base, "pdeathsig") or !startTimesMatch(expected.started_at_ms, observed.started_at_ms)) {
-                return .recycled;
-            }
+            const wrapper_match = builtin.os.tag == .linux and
+                std.mem.eql(u8, observed.exe_base, "pdeathsig") and
+                startTimesMatch(expected.started_at_ms, observed.started_at_ms);
+            if (!wrapper_match) return .recycled;
         }
     }
     if (!startTimesMatch(expected.started_at_ms, observed.started_at_ms)) return .recycled;
@@ -89,6 +113,8 @@ pub fn validatePid(allocator: std.mem.Allocator, io: std.Io, pid: u32, expected:
 }
 
 pub fn readHostMemory(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    assert(@sizeOf(HostMemory) > 0);
+
     return switch (builtin.os.tag) {
         .linux => readHostMemoryLinux(allocator, io),
         .macos => readHostMemoryDarwin(allocator, io),
@@ -96,74 +122,105 @@ pub fn readHostMemory(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory
     };
 }
 
-pub fn applyCpuCgroup(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
+pub fn applyCpuCgroup(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: CpuCgroupOptions,
+) Error!CpuCgroupResult {
+    assert(opts.pid > 0);
+    assert(opts.weight > 0);
+    assert(opts.parent_dir.len > 0);
+    assert(opts.id.len > 0);
+
     if (builtin.os.tag != .linux) {
         return .{ .status = .unsupported, .reason = "hard CPU quota uses Linux cgroup v2" };
     }
     return applyCpuCgroupLinux(allocator, io, opts);
 }
 
-fn applyCpuCgroupLinux(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
+fn applyCpuCgroupLinux(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: CpuCgroupOptions,
+) Error!CpuCgroupResult {
+    assert(opts.pid > 0);
+    assert(opts.weight > 0);
+    assert(opts.parent_dir.len > 0);
+    assert(opts.id.len > 0);
+
     if (!looksLikeCgroupV2(io, opts.parent_dir)) return error.CgroupUnsupported;
     try std.Io.Dir.cwd().createDirPath(io, opts.parent_dir);
     const safe_id = try sanitizeCgroupId(allocator, opts.id);
     defer allocator.free(safe_id);
     const suffix = randomHexSuffix();
-    const cgroup_path = try std.fmt.allocPrint(allocator, "{s}/machinen-vm-{s}-{s}", .{ opts.parent_dir, safe_id, &suffix });
+    const leaf = try std.mem.concat(allocator, u8, &.{
+        "machinen-vm-",
+        safe_id,
+        "-",
+        suffix[0..],
+    });
+    defer allocator.free(leaf);
+    const cgroup_path = try std.fs.path.join(allocator, &.{ opts.parent_dir, leaf });
     errdefer allocator.free(cgroup_path);
     try std.Io.Dir.cwd().createDir(io, cgroup_path, .default_dir);
     errdefer removeCpuCgroup(io, cgroup_path);
 
     if (opts.quota_cpus) |quota_cpus| {
-        const quota_us: u64 = @max(1, @as(u64, @intFromFloat(@round(quota_cpus * CPU_PERIOD_US))));
-        const cpu_max = try std.fmt.allocPrint(allocator, "{d} {d}\n", .{ quota_us, CPU_PERIOD_US });
-        defer allocator.free(cpu_max);
-        const cpu_max_path = try joinCgroupFile(allocator, cgroup_path, "cpu.max");
-        defer allocator.free(cpu_max_path);
-        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = cpu_max_path, .data = cpu_max });
+        const quota_us = quotaMicros(quota_cpus);
+        var cpu_max_buf: [64]u8 = undefined;
+        const cpu_max = try std.fmt.bufPrint(
+            &cpu_max_buf,
+            "{d} {d}\n",
+            .{ quota_us, CPU_PERIOD_US },
+        );
+        try writeCgroupFile(allocator, io, cgroup_path, "cpu.max", cpu_max);
     }
-    const weight = try std.fmt.allocPrint(allocator, "{d}\n", .{opts.weight});
-    defer allocator.free(weight);
-    const weight_path = try joinCgroupFile(allocator, cgroup_path, "cpu.weight");
-    defer allocator.free(weight_path);
-    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = weight_path, .data = weight });
-    const procs = try std.fmt.allocPrint(allocator, "{d}\n", .{opts.pid});
-    defer allocator.free(procs);
-    const procs_path = try joinCgroupFile(allocator, cgroup_path, "cgroup.procs");
-    defer allocator.free(procs_path);
-    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = procs_path, .data = procs });
+    var weight_buf: [32]u8 = undefined;
+    const weight = try std.fmt.bufPrint(&weight_buf, "{d}\n", .{opts.weight});
+    try writeCgroupFile(allocator, io, cgroup_path, "cpu.weight", weight);
+    var procs_buf: [32]u8 = undefined;
+    const procs = try std.fmt.bufPrint(&procs_buf, "{d}\n", .{opts.pid});
+    try writeCgroupFile(allocator, io, cgroup_path, "cgroup.procs", procs);
 
     return .{ .status = .linux_cgroup_v2, .cgroup_path = cgroup_path };
 }
 
 pub fn removeCpuCgroup(io: std.Io, cgroup_path: []const u8) void {
+    assert(cgroup_path.len > 0);
+
     std.Io.Dir.cwd().deleteDir(io, cgroup_path) catch {
         if (!std.mem.startsWith(u8, cgroup_path, DEFAULT_CGROUP_PARENT ++ "/")) {
-            std.Io.Dir.cwd().deleteTree(io, cgroup_path) catch {};
+            std.Io.Dir.cwd().deleteTree(io, cgroup_path) catch return;
         }
     };
 }
 
-pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const RssTarget) Error![]RssReading {
-    var readings: std.ArrayList(RssReading) = .empty;
+pub fn readHostRss(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    targets: []const RssTarget,
+) Error![]RssReading {
+    assert(targets.len <= 16 * 1024);
+
+    var readings: std.array_list.Aligned(RssReading, null) = .empty;
     errdefer readings.deinit(allocator);
 
     switch (builtin.os.tag) {
         .linux => {
             for (targets) |target| {
                 if (try readVmRssLinux(allocator, io, target.pid)) |rss| {
-                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                    try readings.append(allocator, .{ .pid = target.pid, .rssBytes = rss });
                 }
             }
         },
         .macos => {
             for (targets) |target| {
                 if (readPhysFootprintFromStats(io, target.stats_path)) |rss| {
-                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                    try readings.append(allocator, .{ .pid = target.pid, .rssBytes = rss });
                     continue;
                 }
                 if (try readPsRssDarwin(allocator, io, target.pid)) |rss| {
-                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                    try readings.append(allocator, .{ .pid = target.pid, .rssBytes = rss });
                 }
             }
         },
@@ -174,14 +231,20 @@ pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const Rs
 }
 
 fn readHostMemoryLinux(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    assert(builtin.os.tag == .linux);
+
     const data = try readFileAlloc(allocator, io, "/proc/meminfo");
     defer allocator.free(data);
     const total = parseMeminfoKb(data, "MemTotal") orelse return error.InvalidHostMemory;
-    const free = parseMeminfoKb(data, "MemAvailable") orelse parseMeminfoKb(data, "MemFree") orelse return error.InvalidHostMemory;
+    const free = parseMeminfoKb(data, "MemAvailable") orelse
+        parseMeminfoKb(data, "MemFree") orelse
+        return error.InvalidHostMemory;
     return .{ .free_bytes = free * 1024, .total_bytes = total * 1024 };
 }
 
 fn readHostMemoryDarwin(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    assert(builtin.os.tag == .macos);
+
     const total = try readDarwinTotalMemory(allocator, io);
     const vm_stat = std.process.run(allocator, io, .{
         .argv = &.{"/usr/bin/vm_stat"},
@@ -199,6 +262,8 @@ fn readHostMemoryDarwin(allocator: std.mem.Allocator, io: std.Io) Error!HostMemo
 }
 
 fn readDarwinTotalMemory(allocator: std.mem.Allocator, io: std.Io) Error!u64 {
+    assert(builtin.os.tag == .macos);
+
     const result = std.process.run(allocator, io, .{
         .argv = &.{ "/usr/sbin/sysctl", "-n", "hw.memsize" },
         .stdout_limit = .limited(16 * 1024),
@@ -215,9 +280,12 @@ fn readDarwinTotalMemory(allocator: std.mem.Allocator, io: std.Io) Error!u64 {
 }
 
 pub fn parseMeminfoKb(meminfo: []const u8, field: []const u8) ?u64 {
+    assert(field.len > 0);
+
     var lines = std.mem.splitScalar(u8, meminfo, '\n');
     while (lines.next()) |line| {
-        if (!std.mem.startsWith(u8, line, field) or line.len <= field.len or line[field.len] != ':') continue;
+        if (!std.mem.startsWith(u8, line, field)) continue;
+        if (line.len <= field.len or line[field.len] != ':') continue;
         var it = std.mem.tokenizeAny(u8, line[field.len + 1 ..], " \t");
         const number_text = it.next() orelse return null;
         const unit_text = it.next() orelse return null;
@@ -228,6 +296,8 @@ pub fn parseMeminfoKb(meminfo: []const u8, field: []const u8) ?u64 {
 }
 
 pub fn parseVmStatAvailableBytes(vm_stat: []const u8) ?u64 {
+    assert(vm_stat.len > 0);
+
     const page_size = parseVmStatPageSize(vm_stat) orelse 4096;
     const free = parseVmStatPages(vm_stat, "Pages free") orelse 0;
     const speculative = parseVmStatPages(vm_stat, "Pages speculative") orelse 0;
@@ -236,6 +306,8 @@ pub fn parseVmStatAvailableBytes(vm_stat: []const u8) ?u64 {
 }
 
 fn parseVmStatPageSize(vm_stat: []const u8) ?u64 {
+    assert(vm_stat.len > 0);
+
     const marker = "page size of ";
     const start = std.mem.indexOf(u8, vm_stat, marker) orelse return null;
     const after = vm_stat[start + marker.len ..];
@@ -245,10 +317,13 @@ fn parseVmStatPageSize(vm_stat: []const u8) ?u64 {
 }
 
 fn parseVmStatPages(vm_stat: []const u8, label: []const u8) ?u64 {
+    assert(label.len > 0);
+
     var lines = std.mem.splitScalar(u8, vm_stat, '\n');
     while (lines.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (!std.mem.startsWith(u8, trimmed, label) or trimmed.len <= label.len or trimmed[label.len] != ':') continue;
+        if (!std.mem.startsWith(u8, trimmed, label)) continue;
+        if (trimmed.len <= label.len or trimmed[label.len] != ':') continue;
         const rest = std.mem.trim(u8, trimmed[label.len + 1 ..], " \t.");
         return std.fmt.parseUnsigned(u64, rest, 10) catch null;
     }
@@ -256,27 +331,52 @@ fn parseVmStatPages(vm_stat: []const u8, label: []const u8) ?u64 {
 }
 
 fn pidAlive(pid: u32) bool {
+    assert(pid > 0);
+
     std.posix.kill(@intCast(pid), @enumFromInt(0)) catch return false;
     return true;
 }
 
 fn startTimesMatch(expected: ?i64, observed: ?i64) bool {
+    assert(STARTTIME_SKEW_MS > 0);
+
     const e = expected orelse return true;
     const o = observed orelse return true;
     return @abs(e - o) <= STARTTIME_SKEW_MS;
 }
 
+fn formatProcPidPath(buf: []u8, pid: u32, leaf: []const u8) ![]u8 {
+    assert(buf.len > 0);
+    assert(pid > 0);
+    assert(leaf.len > 0);
+
+    return std.fmt.bufPrint(buf, "/proc/{d}/{s}", .{ pid, leaf });
+}
+
+fn formatPid(buf: []u8, pid: u32) ![]u8 {
+    assert(buf.len > 0);
+    assert(pid > 0);
+
+    return std.fmt.bufPrint(buf, "{d}", .{pid});
+}
+
 fn readLinuxIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
+    assert(pid > 0);
+
     var link_buf: [4096]u8 = undefined;
-    const exe_path = try std.fmt.allocPrint(allocator, "/proc/{d}/exe", .{pid});
-    defer allocator.free(exe_path);
+    var exe_path_buf: [64]u8 = undefined;
+    const exe_path = try formatProcPidPath(&exe_path_buf, pid, "exe");
     const link_len = std.Io.Dir.readLinkAbsolute(io, exe_path, &link_buf) catch return null;
-    const exe_base = try allocator.dupe(u8, std.fs.path.basename(link_buf[0..link_len]));
+    const exe_base = try std.mem.concat(
+        allocator,
+        u8,
+        &.{std.fs.path.basename(link_buf[0..link_len])},
+    );
     errdefer allocator.free(exe_base);
 
     var started_at_ms: ?i64 = null;
-    const stat_path = try std.fmt.allocPrint(allocator, "/proc/{d}/stat", .{pid});
-    defer allocator.free(stat_path);
+    var stat_path_buf: [64]u8 = undefined;
+    const stat_path = try formatProcPidPath(&stat_path_buf, pid, "stat");
     if (readFileAlloc(allocator, io, stat_path) catch null) |stat_data| {
         defer allocator.free(stat_data);
         if (try readBootTimeSeconds(allocator, io)) |boot_time_seconds| {
@@ -288,12 +388,16 @@ fn readLinuxIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?
 }
 
 fn readBootTimeSeconds(allocator: std.mem.Allocator, io: std.Io) Error!?i64 {
+    assert(builtin.os.tag == .linux);
+
     const data = readFileAlloc(allocator, io, "/proc/stat") catch return null;
     defer allocator.free(data);
     return parseBootTimeSeconds(data);
 }
 
 pub fn parseBootTimeSeconds(proc_stat: []const u8) ?i64 {
+    assert(proc_stat.len > 0);
+
     var lines = std.mem.splitScalar(u8, proc_stat, '\n');
     while (lines.next()) |line| {
         if (!std.mem.startsWith(u8, line, "btime ")) continue;
@@ -304,10 +408,13 @@ pub fn parseBootTimeSeconds(proc_stat: []const u8) ?i64 {
 }
 
 pub fn parseLinuxStartTimeMs(proc_pid_stat: []const u8, boot_time_seconds: i64) ?i64 {
+    assert(proc_pid_stat.len > 0);
+    assert(boot_time_seconds > 0);
+
     const last_paren = std.mem.lastIndexOfScalar(u8, proc_pid_stat, ')') orelse return null;
     if (last_paren + 2 > proc_pid_stat.len) return null;
     var fields = std.mem.tokenizeScalar(u8, proc_pid_stat[last_paren + 2 ..], ' ');
-    var index: usize = 0;
+    var index: u8 = 0;
     while (fields.next()) |field| : (index += 1) {
         if (index != 19) continue;
         const ticks = std.fmt.parseInt(i64, field, 10) catch return null;
@@ -317,8 +424,10 @@ pub fn parseLinuxStartTimeMs(proc_pid_stat: []const u8, boot_time_seconds: i64) 
 }
 
 fn readPsIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
-    const pid_text = try std.fmt.allocPrint(allocator, "{d}", .{pid});
-    defer allocator.free(pid_text);
+    assert(pid > 0);
+
+    var pid_buf: [16]u8 = undefined;
+    const pid_text = try formatPid(&pid_buf, pid);
     const result = std.process.run(allocator, io, .{
         .argv = &.{ "/bin/ps", "-o", "lstart=,command=", "-p", pid_text },
         .stdout_limit = .limited(16 * 1024),
@@ -330,39 +439,45 @@ fn readPsIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?Pro
         .exited => |code| if (code != 0) return null,
         else => return null,
     }
-    const parsed = try parsePsLstartLine(allocator, result.stdout);
+    const parsed = parsePsLstartLine(result.stdout);
     const parts = parsed orelse return null;
-    defer allocator.free(parts.lstart);
-    defer allocator.free(parts.command);
-    return try identityFromPsParts(allocator, parts.command, try parseDarwinLstartMs(allocator, io, parts.lstart));
+    const started_at_ms = try parseDarwinLstartMs(allocator, io, parts.lstart);
+    return try identityFromPsParts(allocator, parts.command, started_at_ms);
 }
 
 const PsLstartParts = struct {
-    lstart: []u8,
-    command: []u8,
+    lstart: []const u8,
+    command: []const u8,
 };
 
-pub fn parsePsLstartLine(allocator: std.mem.Allocator, output: []const u8) Error!?PsLstartParts {
+pub fn parsePsLstartLine(output: []const u8) ?PsLstartParts {
+    assert(output.len > 0);
+
     const trimmed = std.mem.trim(u8, output, " \t\r\n");
     if (trimmed.len < 24) return null;
     const lstart = std.mem.trim(u8, trimmed[0..24], " \t");
     const rest = std.mem.trim(u8, trimmed[24..], " \t");
     var command_it = std.mem.tokenizeAny(u8, rest, " \t\r\n");
     const command = command_it.next() orelse return null;
-    return .{
-        .lstart = try allocator.dupe(u8, lstart),
-        .command = try allocator.dupe(u8, command),
-    };
+    return .{ .lstart = lstart, .command = command };
 }
 
-fn identityFromPsParts(allocator: std.mem.Allocator, command: []const u8, started_at_ms: ?i64) Error!ProcessIdentity {
+fn identityFromPsParts(
+    allocator: std.mem.Allocator,
+    command: []const u8,
+    started_at_ms: ?i64,
+) Error!ProcessIdentity {
+    assert(command.len > 0);
+
     return .{
-        .exe_base = try allocator.dupe(u8, std.fs.path.basename(command)),
+        .exe_base = try std.mem.concat(allocator, u8, &.{std.fs.path.basename(command)}),
         .started_at_ms = started_at_ms,
     };
 }
 
 fn parseDarwinLstartMs(allocator: std.mem.Allocator, io: std.Io, lstart: []const u8) Error!?i64 {
+    assert(lstart.len > 0);
+
     const result = std.process.run(allocator, io, .{
         .argv = &.{ "/bin/date", "-j", "-f", "%a %e %b %T %Y", lstart, "+%s" },
         .stdout_limit = .limited(16 * 1024),
@@ -380,6 +495,8 @@ fn parseDarwinLstartMs(allocator: std.mem.Allocator, io: std.Io, lstart: []const
 }
 
 fn looksLikeCgroupV2(io: std.Io, parent_dir: []const u8) bool {
+    assert(parent_dir.len > 0);
+
     if (std.mem.eql(u8, parent_dir, DEFAULT_CGROUP_PARENT)) {
         return existsFile(io, DEFAULT_CGROUP_PARENT ++ "/cgroup.controllers");
     }
@@ -387,24 +504,35 @@ fn looksLikeCgroupV2(io: std.Io, parent_dir: []const u8) bool {
 }
 
 fn existsPath(io: std.Io, path: []const u8) bool {
-    _ = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
-    return true;
+    assert(path.len > 0);
+
+    const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    return st.kind != .unknown;
 }
 
 fn existsFile(io: std.Io, path: []const u8) bool {
+    assert(path.len > 0);
+
     const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
     return st.kind == .file;
 }
 
 fn sanitizeCgroupId(allocator: std.mem.Allocator, id: []const u8) Error![]u8 {
-    const out = try allocator.alloc(u8, id.len);
-    for (id, 0..) |c, i| {
-        out[i] = if (std.ascii.isAlphanumeric(c) or c == '_' or c == '.' or c == '-') c else '-';
+    assert(id.len > 0);
+
+    const out = try std.mem.concat(allocator, u8, &.{id});
+    for (out) |*c| {
+        c.* = if (std.ascii.isAlphanumeric(c.*) or c.* == '_' or c.* == '.' or c.* == '-')
+            c.*
+        else
+            '-';
     }
     return out;
 }
 
 fn randomHexSuffix() [8]u8 {
+    assert(@sizeOf([8]u8) == 8);
+
     var bytes: [4]u8 = undefined;
     std.crypto.random.bytes(&bytes);
     const digits = "0123456789abcdef";
@@ -416,13 +544,41 @@ fn randomHexSuffix() [8]u8 {
     return out;
 }
 
+fn quotaMicros(quota_cpus: f64) u64 {
+    assert(quota_cpus == quota_cpus);
+
+    const rounded_quota_us = @round(quota_cpus * CPU_PERIOD_US);
+    return if (rounded_quota_us <= 1) 1 else @intFromFloat(rounded_quota_us);
+}
+
+fn writeCgroupFile(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    cgroup_path: []const u8,
+    name: []const u8,
+    data: []const u8,
+) Error!void {
+    assert(cgroup_path.len > 0);
+    assert(name.len > 0);
+    assert(data.len > 0);
+
+    const path = try joinCgroupFile(allocator, cgroup_path, name);
+    defer allocator.free(path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = data });
+}
+
 fn joinCgroupFile(allocator: std.mem.Allocator, cgroup_path: []const u8, name: []const u8) Error![]u8 {
-    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ cgroup_path, name });
+    assert(cgroup_path.len > 0);
+    assert(name.len > 0);
+
+    return std.fs.path.join(allocator, &.{ cgroup_path, name });
 }
 
 fn readVmRssLinux(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64 {
-    const path = try std.fmt.allocPrint(allocator, "/proc/{d}/status", .{pid});
-    defer allocator.free(path);
+    assert(pid > 0);
+
+    var path_buf: [64]u8 = undefined;
+    const path = try formatProcPidPath(&path_buf, pid, "status");
     const data = readFileAlloc(allocator, io, path) catch |err| switch (err) {
         error.FileNotFound => return null,
         else => return null,
@@ -432,6 +588,8 @@ fn readVmRssLinux(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64
 }
 
 pub fn parseVmRssStatus(status: []const u8) ?u64 {
+    assert(status.len > 0);
+
     var lines = std.mem.splitScalar(u8, status, '\n');
     while (lines.next()) |line| {
         if (!std.mem.startsWith(u8, line, "VmRSS:")) continue;
@@ -446,6 +604,8 @@ pub fn parseVmRssStatus(status: []const u8) ?u64 {
 }
 
 fn readPhysFootprintFromStats(io: std.Io, stats_path: ?[]const u8) ?u64 {
+    assert(@sizeOf(u64) == 8);
+
     const path = stats_path orelse return null;
     var file = std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false }) catch return null;
     defer file.close(io);
@@ -457,8 +617,10 @@ fn readPhysFootprintFromStats(io: std.Io, stats_path: ?[]const u8) ?u64 {
 }
 
 fn readPsRssDarwin(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64 {
-    const pid_text = try std.fmt.allocPrint(allocator, "{d}", .{pid});
-    defer allocator.free(pid_text);
+    assert(pid > 0);
+
+    var pid_buf: [16]u8 = undefined;
+    const pid_text = try formatPid(&pid_buf, pid);
     const result = std.process.run(allocator, io, .{
         .argv = &.{ "/bin/ps", "-o", "rss=", "-p", pid_text },
         .stdout_limit = .limited(16 * 1024),
@@ -477,23 +639,14 @@ fn readPsRssDarwin(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u6
 }
 
 fn readFileAlloc(allocator: std.mem.Allocator, io: std.Io, path: []const u8) Error![]u8 {
-    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false });
-    defer file.close(io);
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    var buf: [4096]u8 = undefined;
-    while (true) {
-        const n = file.readStreaming(io, &.{buf[0..]}) catch |err| switch (err) {
-            error.EndOfStream => break,
-            else => |e| return e,
-        };
-        if (n == 0) break;
-        try out.appendSlice(allocator, buf[0..n]);
-    }
-    return out.toOwnedSlice(allocator);
+    assert(path.len > 0);
+
+    return std.Io.Dir.cwd().readFileAlloc(io, allocator, path, 16 * 1024 * 1024);
 }
 
 fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+    assert(tmp.sub_path.len > 0);
+
     const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
     defer allocator.free(cwd);
     return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
@@ -532,7 +685,9 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
     defer if (result.cgroup_path) |path| allocator.free(path);
     try std.testing.expectEqual(.linux_cgroup_v2, result.status);
     try std.testing.expect(result.cgroup_path != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.cgroup_path.?, "machinen-vm-unit-unsafe-") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, result.cgroup_path.?, "machinen-vm-unit-unsafe-") != null,
+    );
 
     const cpu_max_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cpu.max");
     defer allocator.free(cpu_max_path);
@@ -557,7 +712,10 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
 }
 
 test "parseMeminfoKb reads Linux memory fields" {
-    const meminfo = "MemTotal:       8388608 kB\nMemFree:        1000000 kB\nMemAvailable:   2000000 kB\n";
+    const meminfo =
+        "MemTotal:       8388608 kB\n" ++
+        "MemFree:        1000000 kB\n" ++
+        "MemAvailable:   2000000 kB\n";
     try std.testing.expectEqual(@as(?u64, 8_388_608), parseMeminfoKb(meminfo, "MemTotal"));
     try std.testing.expectEqual(@as(?u64, 2_000_000), parseMeminfoKb(meminfo, "MemAvailable"));
     try std.testing.expectEqual(@as(?u64, null), parseMeminfoKb(meminfo, "SwapTotal"));
@@ -582,21 +740,31 @@ test "readHostMemory returns positive values on supported platforms" {
 }
 
 test "parseBootTimeSeconds reads Linux btime" {
-    try std.testing.expectEqual(@as(?i64, 1_700_000_000), parseBootTimeSeconds("cpu 0 0 0\nbtime 1700000000\n"));
+    try std.testing.expectEqual(
+        @as(?i64, 1_700_000_000),
+        parseBootTimeSeconds("cpu 0 0 0\nbtime 1700000000\n"),
+    );
     try std.testing.expectEqual(@as(?i64, null), parseBootTimeSeconds("cpu 0 0 0\n"));
 }
 
 test "parseLinuxStartTimeMs reads field 22 after process name" {
     const stat = "1234 (name with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 250 21";
-    try std.testing.expectEqual(@as(?i64, 1_700_000_002_500), parseLinuxStartTimeMs(stat, 1_700_000_000));
+    try std.testing.expectEqual(
+        @as(?i64, 1_700_000_002_500),
+        parseLinuxStartTimeMs(stat, 1_700_000_000),
+    );
 }
 
 test "parsePsLstartLine reads lstart and command basename" {
-    const parts = (try parsePsLstartLine(std.testing.allocator, "Sat 20 Jun 16:59:31 2026     /tmp/machinen-vm --flag\n")).?;
-    defer std.testing.allocator.free(parts.lstart);
-    defer std.testing.allocator.free(parts.command);
+    const parts = parsePsLstartLine(
+        "Sat 20 Jun 16:59:31 2026     /tmp/machinen-vm --flag\n",
+    ).?;
     try std.testing.expectEqualStrings("Sat 20 Jun 16:59:31 2026", parts.lstart);
-    const identity = try identityFromPsParts(std.testing.allocator, parts.command, 1_700_000_058_000);
+    const identity = try identityFromPsParts(
+        std.testing.allocator,
+        parts.command,
+        1_700_000_058_000,
+    );
     defer identity.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("machinen-vm", identity.exe_base);
     try std.testing.expectEqual(@as(?i64, 1_700_000_058_000), identity.started_at_ms);
@@ -604,11 +772,17 @@ test "parsePsLstartLine reads lstart and command basename" {
 
 test "validatePid returns alive for this process without expectations" {
     const pid: u32 = @intCast(std.c.getpid());
-    try std.testing.expectEqual(.alive, try validatePid(std.testing.allocator, std.testing.io, pid, .{}));
+    try std.testing.expectEqual(
+        .alive,
+        try validatePid(std.testing.allocator, std.testing.io, pid, .{}),
+    );
 }
 
 test "validatePid returns dead for an invalid pid" {
-    try std.testing.expectEqual(.dead, try validatePid(std.testing.allocator, std.testing.io, 0, .{}));
+    try std.testing.expectEqual(
+        .dead,
+        try validatePid(std.testing.allocator, std.testing.io, 0, .{}),
+    );
 }
 
 test "parseVmRssStatus reads VmRSS in bytes" {
@@ -629,10 +803,14 @@ test "readHostRss reports current process on supported platforms" {
     switch (builtin.os.tag) {
         .linux, .macos => {
             const pid: u32 = @intCast(std.c.getpid());
-            const readings = try readHostRss(std.testing.allocator, std.testing.io, &.{.{ .pid = pid }});
+            const readings = try readHostRss(
+                std.testing.allocator,
+                std.testing.io,
+                &.{.{ .pid = pid }},
+            );
             defer std.testing.allocator.free(readings);
             try std.testing.expect(readings.len == 1);
-            try std.testing.expect(readings[0].rss_bytes > 0);
+            try std.testing.expect(readings[0].rssBytes > 0);
         },
         else => {},
     }

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Error = anyerror;
+
+pub const RssTarget = struct {
+    pid: u32,
+    stats_path: ?[]const u8 = null,
+};
+
+pub const RssReading = struct {
+    pid: u32,
+    rss_bytes: u64,
+};
+
+pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const RssTarget) Error![]RssReading {
+    var readings: std.ArrayList(RssReading) = .empty;
+    errdefer readings.deinit(allocator);
+
+    switch (builtin.os.tag) {
+        .linux => {
+            for (targets) |target| {
+                if (try readVmRssLinux(allocator, io, target.pid)) |rss| {
+                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                }
+            }
+        },
+        .macos => {
+            for (targets) |target| {
+                if (readPhysFootprintFromStats(io, target.stats_path)) |rss| {
+                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                    continue;
+                }
+                if (try readPsRssDarwin(allocator, io, target.pid)) |rss| {
+                    try readings.append(allocator, .{ .pid = target.pid, .rss_bytes = rss });
+                }
+            }
+        },
+        else => {},
+    }
+
+    return readings.toOwnedSlice(allocator);
+}
+
+fn readVmRssLinux(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64 {
+    const path = try std.fmt.allocPrint(allocator, "/proc/{d}/status", .{pid});
+    defer allocator.free(path);
+    const data = readFileAlloc(allocator, io, path) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return null,
+    };
+    defer allocator.free(data);
+    return parseVmRssStatus(data);
+}
+
+pub fn parseVmRssStatus(status: []const u8) ?u64 {
+    var lines = std.mem.splitScalar(u8, status, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "VmRSS:")) continue;
+        var it = std.mem.tokenizeAny(u8, line[6..], " \t");
+        const number_text = it.next() orelse return null;
+        const unit_text = it.next() orelse return null;
+        if (!std.mem.eql(u8, unit_text, "kB")) return null;
+        const kib = std.fmt.parseUnsigned(u64, number_text, 10) catch return null;
+        return kib * 1024;
+    }
+    return null;
+}
+
+fn readPhysFootprintFromStats(io: std.Io, stats_path: ?[]const u8) ?u64 {
+    const path = stats_path orelse return null;
+    var file = std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false }) catch return null;
+    defer file.close(io);
+    var buf: [24]u8 = undefined;
+    const n = file.readStreaming(io, &.{buf[0..]}) catch return null;
+    if (n < 24) return null;
+    const value = std.mem.readInt(u64, buf[16..24], .little);
+    return if (value == 0) null else value;
+}
+
+fn readPsRssDarwin(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u64 {
+    const pid_text = try std.fmt.allocPrint(allocator, "{d}", .{pid});
+    defer allocator.free(pid_text);
+    const result = std.process.run(allocator, io, .{
+        .argv = &.{ "/bin/ps", "-o", "rss=", "-p", pid_text },
+        .stdout_limit = .limited(16 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+    const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const rss_kib = std.fmt.parseUnsigned(u64, trimmed, 10) catch return null;
+    return if (rss_kib == 0) null else rss_kib * 1024;
+}
+
+fn readFileAlloc(allocator: std.mem.Allocator, io: std.Io, path: []const u8) Error![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{ .allow_directory = false });
+    defer file.close(io);
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = file.readStreaming(io, &.{buf[0..]}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
+        if (n == 0) break;
+        try out.appendSlice(allocator, buf[0..n]);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+test "parseVmRssStatus reads VmRSS in bytes" {
+    try std.testing.expectEqual(@as(?u64, 12_345 * 1024), parseVmRssStatus(
+        \\Name:\tnode
+        \\VmSize:\t1 kB
+        \\VmRSS:\t   12345 kB
+        \\Threads:\t1
+        \\
+    ));
+}
+
+test "parseVmRssStatus returns null when VmRSS is absent" {
+    try std.testing.expectEqual(@as(?u64, null), parseVmRssStatus("Name:\tnode\n"));
+}
+
+test "readHostRss reports current process on supported platforms" {
+    switch (builtin.os.tag) {
+        .linux, .macos => {
+            const pid: u32 = @intCast(std.c.getpid());
+            const readings = try readHostRss(std.testing.allocator, std.testing.io, &.{.{ .pid = pid }});
+            defer std.testing.allocator.free(readings);
+            try std.testing.expect(readings.len == 1);
+            try std.testing.expect(readings[0].rss_bytes > 0);
+        },
+        else => {},
+    }
+}

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -33,6 +33,11 @@ pub const PidExpected = struct {
     started_at_ms: ?i64 = null,
 };
 
+pub const HostMemory = struct {
+    free_bytes: u64,
+    total_bytes: u64,
+};
+
 pub const CpuCgroupOptions = struct {
     pid: u32,
     weight: u32,
@@ -81,6 +86,14 @@ pub fn validatePid(allocator: std.mem.Allocator, io: std.Io, pid: u32, expected:
     }
     if (!startTimesMatch(expected.started_at_ms, observed.started_at_ms)) return .recycled;
     return .alive;
+}
+
+pub fn readHostMemory(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    return switch (builtin.os.tag) {
+        .linux => readHostMemoryLinux(allocator, io),
+        .macos => readHostMemoryDarwin(allocator, io),
+        else => error.UnsupportedHostMemory,
+    };
 }
 
 pub fn applyCpuCgroup(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
@@ -158,6 +171,88 @@ pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const Rs
     }
 
     return readings.toOwnedSlice(allocator);
+}
+
+fn readHostMemoryLinux(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    const data = try readFileAlloc(allocator, io, "/proc/meminfo");
+    defer allocator.free(data);
+    const total = parseMeminfoKb(data, "MemTotal") orelse return error.InvalidHostMemory;
+    const free = parseMeminfoKb(data, "MemAvailable") orelse parseMeminfoKb(data, "MemFree") orelse return error.InvalidHostMemory;
+    return .{ .free_bytes = free * 1024, .total_bytes = total * 1024 };
+}
+
+fn readHostMemoryDarwin(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory {
+    const total = try readDarwinTotalMemory(allocator, io);
+    const vm_stat = std.process.run(allocator, io, .{
+        .argv = &.{"/usr/bin/vm_stat"},
+        .stdout_limit = .limited(64 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return error.InvalidHostMemory;
+    defer allocator.free(vm_stat.stdout);
+    defer allocator.free(vm_stat.stderr);
+    switch (vm_stat.term) {
+        .exited => |code| if (code != 0) return error.InvalidHostMemory,
+        else => return error.InvalidHostMemory,
+    }
+    const free = parseVmStatAvailableBytes(vm_stat.stdout) orelse return error.InvalidHostMemory;
+    return .{ .free_bytes = free, .total_bytes = total };
+}
+
+fn readDarwinTotalMemory(allocator: std.mem.Allocator, io: std.Io) Error!u64 {
+    const result = std.process.run(allocator, io, .{
+        .argv = &.{ "/usr/sbin/sysctl", "-n", "hw.memsize" },
+        .stdout_limit = .limited(16 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return error.InvalidHostMemory;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) return error.InvalidHostMemory,
+        else => return error.InvalidHostMemory,
+    }
+    const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+    return std.fmt.parseUnsigned(u64, trimmed, 10) catch error.InvalidHostMemory;
+}
+
+pub fn parseMeminfoKb(meminfo: []const u8, field: []const u8) ?u64 {
+    var lines = std.mem.splitScalar(u8, meminfo, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, field) or line.len <= field.len or line[field.len] != ':') continue;
+        var it = std.mem.tokenizeAny(u8, line[field.len + 1 ..], " \t");
+        const number_text = it.next() orelse return null;
+        const unit_text = it.next() orelse return null;
+        if (!std.mem.eql(u8, unit_text, "kB")) return null;
+        return std.fmt.parseUnsigned(u64, number_text, 10) catch null;
+    }
+    return null;
+}
+
+pub fn parseVmStatAvailableBytes(vm_stat: []const u8) ?u64 {
+    const page_size = parseVmStatPageSize(vm_stat) orelse 4096;
+    const free = parseVmStatPages(vm_stat, "Pages free") orelse 0;
+    const speculative = parseVmStatPages(vm_stat, "Pages speculative") orelse 0;
+    const purgeable = parseVmStatPages(vm_stat, "Pages purgeable") orelse 0;
+    return (free + speculative + purgeable) * page_size;
+}
+
+fn parseVmStatPageSize(vm_stat: []const u8) ?u64 {
+    const marker = "page size of ";
+    const start = std.mem.indexOf(u8, vm_stat, marker) orelse return null;
+    const after = vm_stat[start + marker.len ..];
+    var it = std.mem.tokenizeAny(u8, after, " \t\r\n");
+    const raw = it.next() orelse return null;
+    return std.fmt.parseUnsigned(u64, raw, 10) catch null;
+}
+
+fn parseVmStatPages(vm_stat: []const u8, label: []const u8) ?u64 {
+    var lines = std.mem.splitScalar(u8, vm_stat, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (!std.mem.startsWith(u8, trimmed, label) or trimmed.len <= label.len or trimmed[label.len] != ':') continue;
+        const rest = std.mem.trim(u8, trimmed[label.len + 1 ..], " \t.");
+        return std.fmt.parseUnsigned(u64, rest, 10) catch null;
+    }
+    return null;
 }
 
 fn pidAlive(pid: u32) bool {
@@ -459,6 +554,31 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
 
     removeCpuCgroup(std.testing.io, result.cgroup_path.?);
     try std.testing.expect(!existsPath(std.testing.io, result.cgroup_path.?));
+}
+
+test "parseMeminfoKb reads Linux memory fields" {
+    const meminfo = "MemTotal:       8388608 kB\nMemFree:        1000000 kB\nMemAvailable:   2000000 kB\n";
+    try std.testing.expectEqual(@as(?u64, 8_388_608), parseMeminfoKb(meminfo, "MemTotal"));
+    try std.testing.expectEqual(@as(?u64, 2_000_000), parseMeminfoKb(meminfo, "MemAvailable"));
+    try std.testing.expectEqual(@as(?u64, null), parseMeminfoKb(meminfo, "SwapTotal"));
+}
+
+test "parseVmStatAvailableBytes sums Darwin free speculative purgeable pages" {
+    const vm_stat =
+        \\Mach Virtual Memory Statistics: (page size of 16384 bytes)
+        \\Pages free:                               10.
+        \\Pages active:                             99.
+        \\Pages speculative:                         5.
+        \\Pages purgeable:                           2.
+    ;
+    try std.testing.expectEqual(@as(?u64, 17 * 16_384), parseVmStatAvailableBytes(vm_stat));
+}
+
+test "readHostMemory returns positive values on supported platforms" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return;
+    const memory = try readHostMemory(std.testing.allocator, std.testing.io);
+    try std.testing.expect(memory.free_bytes > 0);
+    try std.testing.expect(memory.total_bytes >= memory.free_bytes);
 }
 
 test "parseBootTimeSeconds reads Linux btime" {

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -13,6 +13,26 @@ pub const RssReading = struct {
     rss_bytes: u64,
 };
 
+pub const PidStatus = enum {
+    alive,
+    dead,
+    recycled,
+};
+
+pub const ProcessIdentity = struct {
+    exe_base: []u8,
+    started_at_ms: ?i64 = null,
+
+    pub fn deinit(self: ProcessIdentity, allocator: std.mem.Allocator) void {
+        allocator.free(self.exe_base);
+    }
+};
+
+pub const PidExpected = struct {
+    vmm_exe: ?[]const u8 = null,
+    started_at_ms: ?i64 = null,
+};
+
 pub const CpuCgroupOptions = struct {
     pid: u32,
     weight: u32,
@@ -34,6 +54,34 @@ pub const CpuCgroupResult = struct {
 
 const CPU_PERIOD_US = 100_000;
 const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
+const STARTTIME_SKEW_MS = 5_000;
+
+pub fn readProcessIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
+    return switch (builtin.os.tag) {
+        .linux => readLinuxIdentity(allocator, io, pid),
+        .macos => readPsIdentity(allocator, io, pid),
+        else => readPsIdentity(allocator, io, pid),
+    };
+}
+
+pub fn validatePid(allocator: std.mem.Allocator, io: std.Io, pid: u32, expected: PidExpected) Error!PidStatus {
+    if (pid == 0) return .dead;
+    if (!pidAlive(pid)) return .dead;
+    if (expected.vmm_exe == null and expected.started_at_ms == null) return .alive;
+    const observed = (try readProcessIdentity(allocator, io, pid)) orelse return .alive;
+    defer observed.deinit(allocator);
+
+    if (expected.vmm_exe) |vmm_exe| {
+        const expected_base = std.fs.path.basename(vmm_exe);
+        if (!std.mem.eql(u8, observed.exe_base, expected_base)) {
+            if (builtin.os.tag != .linux or !std.mem.eql(u8, observed.exe_base, "pdeathsig") or !startTimesMatch(expected.started_at_ms, observed.started_at_ms)) {
+                return .recycled;
+            }
+        }
+    }
+    if (!startTimesMatch(expected.started_at_ms, observed.started_at_ms)) return .recycled;
+    return .alive;
+}
 
 pub fn applyCpuCgroup(allocator: std.mem.Allocator, io: std.Io, opts: CpuCgroupOptions) Error!CpuCgroupResult {
     if (builtin.os.tag != .linux) {
@@ -110,6 +158,130 @@ pub fn readHostRss(allocator: std.mem.Allocator, io: std.Io, targets: []const Rs
     }
 
     return readings.toOwnedSlice(allocator);
+}
+
+fn pidAlive(pid: u32) bool {
+    std.posix.kill(@intCast(pid), @enumFromInt(0)) catch return false;
+    return true;
+}
+
+fn startTimesMatch(expected: ?i64, observed: ?i64) bool {
+    const e = expected orelse return true;
+    const o = observed orelse return true;
+    return @abs(e - o) <= STARTTIME_SKEW_MS;
+}
+
+fn readLinuxIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
+    var link_buf: [4096]u8 = undefined;
+    const exe_path = try std.fmt.allocPrint(allocator, "/proc/{d}/exe", .{pid});
+    defer allocator.free(exe_path);
+    const link_len = std.Io.Dir.readLinkAbsolute(io, exe_path, &link_buf) catch return null;
+    const exe_base = try allocator.dupe(u8, std.fs.path.basename(link_buf[0..link_len]));
+    errdefer allocator.free(exe_base);
+
+    var started_at_ms: ?i64 = null;
+    const stat_path = try std.fmt.allocPrint(allocator, "/proc/{d}/stat", .{pid});
+    defer allocator.free(stat_path);
+    if (readFileAlloc(allocator, io, stat_path) catch null) |stat_data| {
+        defer allocator.free(stat_data);
+        if (try readBootTimeSeconds(allocator, io)) |boot_time_seconds| {
+            started_at_ms = parseLinuxStartTimeMs(stat_data, boot_time_seconds);
+        }
+    }
+
+    return .{ .exe_base = exe_base, .started_at_ms = started_at_ms };
+}
+
+fn readBootTimeSeconds(allocator: std.mem.Allocator, io: std.Io) Error!?i64 {
+    const data = readFileAlloc(allocator, io, "/proc/stat") catch return null;
+    defer allocator.free(data);
+    return parseBootTimeSeconds(data);
+}
+
+pub fn parseBootTimeSeconds(proc_stat: []const u8) ?i64 {
+    var lines = std.mem.splitScalar(u8, proc_stat, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "btime ")) continue;
+        const raw = std.mem.trim(u8, line[6..], " \t");
+        return std.fmt.parseInt(i64, raw, 10) catch null;
+    }
+    return null;
+}
+
+pub fn parseLinuxStartTimeMs(proc_pid_stat: []const u8, boot_time_seconds: i64) ?i64 {
+    const last_paren = std.mem.lastIndexOfScalar(u8, proc_pid_stat, ')') orelse return null;
+    if (last_paren + 2 > proc_pid_stat.len) return null;
+    var fields = std.mem.tokenizeScalar(u8, proc_pid_stat[last_paren + 2 ..], ' ');
+    var index: usize = 0;
+    while (fields.next()) |field| : (index += 1) {
+        if (index != 19) continue;
+        const ticks = std.fmt.parseInt(i64, field, 10) catch return null;
+        return boot_time_seconds * 1000 + ticks * 10;
+    }
+    return null;
+}
+
+fn readPsIdentity(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?ProcessIdentity {
+    const pid_text = try std.fmt.allocPrint(allocator, "{d}", .{pid});
+    defer allocator.free(pid_text);
+    const result = std.process.run(allocator, io, .{
+        .argv = &.{ "/bin/ps", "-o", "lstart=,command=", "-p", pid_text },
+        .stdout_limit = .limited(16 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+    const parsed = try parsePsLstartLine(allocator, result.stdout);
+    const parts = parsed orelse return null;
+    defer allocator.free(parts.lstart);
+    defer allocator.free(parts.command);
+    return try identityFromPsParts(allocator, parts.command, try parseDarwinLstartMs(allocator, io, parts.lstart));
+}
+
+const PsLstartParts = struct {
+    lstart: []u8,
+    command: []u8,
+};
+
+pub fn parsePsLstartLine(allocator: std.mem.Allocator, output: []const u8) Error!?PsLstartParts {
+    const trimmed = std.mem.trim(u8, output, " \t\r\n");
+    if (trimmed.len < 24) return null;
+    const lstart = std.mem.trim(u8, trimmed[0..24], " \t");
+    const rest = std.mem.trim(u8, trimmed[24..], " \t");
+    var command_it = std.mem.tokenizeAny(u8, rest, " \t\r\n");
+    const command = command_it.next() orelse return null;
+    return .{
+        .lstart = try allocator.dupe(u8, lstart),
+        .command = try allocator.dupe(u8, command),
+    };
+}
+
+fn identityFromPsParts(allocator: std.mem.Allocator, command: []const u8, started_at_ms: ?i64) Error!ProcessIdentity {
+    return .{
+        .exe_base = try allocator.dupe(u8, std.fs.path.basename(command)),
+        .started_at_ms = started_at_ms,
+    };
+}
+
+fn parseDarwinLstartMs(allocator: std.mem.Allocator, io: std.Io, lstart: []const u8) Error!?i64 {
+    const result = std.process.run(allocator, io, .{
+        .argv = &.{ "/bin/date", "-j", "-f", "%a %e %b %T %Y", lstart, "+%s" },
+        .stdout_limit = .limited(16 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+    const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+    const seconds = std.fmt.parseInt(i64, trimmed, 10) catch return null;
+    return seconds * 1000;
 }
 
 fn looksLikeCgroupV2(io: std.Io, parent_dir: []const u8) bool {
@@ -287,6 +459,36 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
 
     removeCpuCgroup(std.testing.io, result.cgroup_path.?);
     try std.testing.expect(!existsPath(std.testing.io, result.cgroup_path.?));
+}
+
+test "parseBootTimeSeconds reads Linux btime" {
+    try std.testing.expectEqual(@as(?i64, 1_700_000_000), parseBootTimeSeconds("cpu 0 0 0\nbtime 1700000000\n"));
+    try std.testing.expectEqual(@as(?i64, null), parseBootTimeSeconds("cpu 0 0 0\n"));
+}
+
+test "parseLinuxStartTimeMs reads field 22 after process name" {
+    const stat = "1234 (name with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 250 21";
+    try std.testing.expectEqual(@as(?i64, 1_700_000_002_500), parseLinuxStartTimeMs(stat, 1_700_000_000));
+}
+
+test "parsePsLstartLine reads lstart and command basename" {
+    const parts = (try parsePsLstartLine(std.testing.allocator, "Sat 20 Jun 16:59:31 2026     /tmp/machinen-vm --flag\n")).?;
+    defer std.testing.allocator.free(parts.lstart);
+    defer std.testing.allocator.free(parts.command);
+    try std.testing.expectEqualStrings("Sat 20 Jun 16:59:31 2026", parts.lstart);
+    const identity = try identityFromPsParts(std.testing.allocator, parts.command, 1_700_000_058_000);
+    defer identity.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("machinen-vm", identity.exe_base);
+    try std.testing.expectEqual(@as(?i64, 1_700_000_058_000), identity.started_at_ms);
+}
+
+test "validatePid returns alive for this process without expectations" {
+    const pid: u32 = @intCast(std.c.getpid());
+    try std.testing.expectEqual(.alive, try validatePid(std.testing.allocator, std.testing.io, pid, .{}));
+}
+
+test "validatePid returns dead for an invalid pid" {
+    try std.testing.expectEqual(.dead, try validatePid(std.testing.allocator, std.testing.io, 0, .{}));
 }
 
 test "parseVmRssStatus reads VmRSS in bytes" {

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -61,6 +61,18 @@ fn runKnownCommand(
 ) !?u8 {
     assert(command.len > 0);
 
+    if (try runHostCommand(allocator, it, command)) |exit| return exit;
+    if (try runFilesystemCommand(allocator, it, command)) |exit| return exit;
+    return null;
+}
+
+fn runHostCommand(
+    allocator: std.mem.Allocator,
+    it: anytype,
+    command: []const u8,
+) !?u8 {
+    assert(command.len > 0);
+
     if (std.mem.eql(u8, command, cpu_cgroup_apply.name)) {
         if (try rejectExtraArgs(it, cpu_cgroup_apply.name)) {
             return @intFromEnum(protocol.Exit.usage);
@@ -80,11 +92,37 @@ fn runKnownCommand(
         return @intFromEnum(try host_memory.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, host_rss.name)) {
-        if (try rejectExtraArgs(it, host_rss.name)) return @intFromEnum(protocol.Exit.usage);
+        if (try rejectExtraArgs(it, host_rss.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
         return @intFromEnum(try host_rss.run(allocator, g_io));
     }
+    if (std.mem.eql(u8, command, pid_validate.name)) {
+        if (try rejectExtraArgs(it, pid_validate.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try pid_validate.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, process_identity.name)) {
+        if (try rejectExtraArgs(it, process_identity.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try process_identity.run(allocator, g_io));
+    }
+    return null;
+}
+
+fn runFilesystemCommand(
+    allocator: std.mem.Allocator,
+    it: anytype,
+    command: []const u8,
+) !?u8 {
+    assert(command.len > 0);
+
     if (std.mem.eql(u8, command, mkinitramfs.name)) {
-        if (try rejectExtraArgs(it, mkinitramfs.name)) return @intFromEnum(protocol.Exit.usage);
+        if (try rejectExtraArgs(it, mkinitramfs.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
         return @intFromEnum(try mkinitramfs.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, mountdisk_image.name)) {
@@ -98,18 +136,6 @@ fn runKnownCommand(
             return @intFromEnum(protocol.Exit.usage);
         }
         return @intFromEnum(try mountdisk_upper.run(allocator, g_io));
-    }
-    if (std.mem.eql(u8, command, pid_validate.name)) {
-        if (try rejectExtraArgs(it, pid_validate.name)) {
-            return @intFromEnum(protocol.Exit.usage);
-        }
-        return @intFromEnum(try pid_validate.run(allocator, g_io));
-    }
-    if (std.mem.eql(u8, command, process_identity.name)) {
-        if (try rejectExtraArgs(it, process_identity.name)) {
-            return @intFromEnum(protocol.Exit.usage);
-        }
-        return @intFromEnum(try process_identity.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, reflink_copy.name)) {
         if (try rejectExtraArgs(it, reflink_copy.name)) {

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -6,6 +6,8 @@ const host_rss = @import("commands/host_rss.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
 const mountdisk_image = @import("commands/mountdisk_image.zig");
 const mountdisk_upper = @import("commands/mountdisk_upper.zig");
+const pid_validate = @import("commands/pid_validate.zig");
+const process_identity = @import("commands/process_identity.zig");
 const reflink_copy = @import("commands/reflink_copy.zig");
 const rootfs_cache_key = @import("commands/rootfs_cache_key.zig");
 const rootfs_materialize = @import("commands/rootfs_materialize.zig");
@@ -24,6 +26,8 @@ pub fn main(init: std.process.Init) !u8 {
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
+    assert(pid_validate.name.len > 0);
+    assert(process_identity.name.len > 0);
     assert(reflink_copy.name.len > 0);
     assert(rootfs_cache_key.name.len > 0);
     assert(rootfs_materialize.name.len > 0);
@@ -86,6 +90,18 @@ fn runKnownCommand(
             return @intFromEnum(protocol.Exit.usage);
         }
         return @intFromEnum(try mountdisk_upper.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, pid_validate.name)) {
+        if (try rejectExtraArgs(it, pid_validate.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try pid_validate.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, process_identity.name)) {
+        if (try rejectExtraArgs(it, process_identity.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try process_identity.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, reflink_copy.name)) {
         if (try rejectExtraArgs(it, reflink_copy.name)) {
@@ -155,6 +171,8 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
+    assert(pid_validate.name.len > 0);
+    assert(process_identity.name.len > 0);
     assert(reflink_copy.name.len > 0);
     assert(rootfs_cache_key.name.len > 0);
     assert(rootfs_materialize.name.len > 0);
@@ -172,6 +190,8 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
             mkinitramfs.name,
             mountdisk_image.name,
             mountdisk_upper.name,
+            pid_validate.name,
+            process_identity.name,
             reflink_copy.name,
             rootfs_cache_key.name,
             rootfs_materialize.name,

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
+const host_rss = @import("commands/host_rss.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
 const mountdisk_image = @import("commands/mountdisk_image.zig");
 const mountdisk_upper = @import("commands/mountdisk_upper.zig");
@@ -15,6 +16,7 @@ const assert = std.debug.assert;
 var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
+    assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
@@ -49,6 +51,10 @@ fn runKnownCommand(
 ) !?u8 {
     assert(command.len > 0);
 
+    if (std.mem.eql(u8, command, host_rss.name)) {
+        if (try rejectExtraArgs(it, host_rss.name)) return @intFromEnum(protocol.Exit.usage);
+        return @intFromEnum(try host_rss.run(allocator, g_io));
+    }
     if (std.mem.eql(u8, command, mkinitramfs.name)) {
         if (try rejectExtraArgs(it, mkinitramfs.name)) return @intFromEnum(protocol.Exit.usage);
         return @intFromEnum(try mkinitramfs.run(allocator, g_io));
@@ -127,6 +133,7 @@ fn isHelp(command: []const u8) bool {
 }
 
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
+    assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
@@ -141,6 +148,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .ok = true,
         .protocolVersion = @as(u8, protocol.version),
         .commands = .{
+            host_rss.name,
             mkinitramfs.name,
             mountdisk_image.name,
             mountdisk_upper.name,

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
+const cpu_cgroup_apply = @import("commands/cpu_cgroup_apply.zig");
+const cpu_cgroup_remove = @import("commands/cpu_cgroup_remove.zig");
 const host_rss = @import("commands/host_rss.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
 const mountdisk_image = @import("commands/mountdisk_image.zig");
@@ -16,6 +18,8 @@ const assert = std.debug.assert;
 var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
+    assert(cpu_cgroup_apply.name.len > 0);
+    assert(cpu_cgroup_remove.name.len > 0);
     assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
@@ -51,6 +55,18 @@ fn runKnownCommand(
 ) !?u8 {
     assert(command.len > 0);
 
+    if (std.mem.eql(u8, command, cpu_cgroup_apply.name)) {
+        if (try rejectExtraArgs(it, cpu_cgroup_apply.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try cpu_cgroup_apply.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, cpu_cgroup_remove.name)) {
+        if (try rejectExtraArgs(it, cpu_cgroup_remove.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try cpu_cgroup_remove.run(allocator, g_io));
+    }
     if (std.mem.eql(u8, command, host_rss.name)) {
         if (try rejectExtraArgs(it, host_rss.name)) return @intFromEnum(protocol.Exit.usage);
         return @intFromEnum(try host_rss.run(allocator, g_io));
@@ -133,6 +149,8 @@ fn isHelp(command: []const u8) bool {
 }
 
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
+    assert(cpu_cgroup_apply.name.len > 0);
+    assert(cpu_cgroup_remove.name.len > 0);
     assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
@@ -148,6 +166,8 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .ok = true,
         .protocolVersion = @as(u8, protocol.version),
         .commands = .{
+            cpu_cgroup_apply.name,
+            cpu_cgroup_remove.name,
             host_rss.name,
             mkinitramfs.name,
             mountdisk_image.name,

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const protocol = @import("protocol.zig");
 const cpu_cgroup_apply = @import("commands/cpu_cgroup_apply.zig");
 const cpu_cgroup_remove = @import("commands/cpu_cgroup_remove.zig");
+const host_memory = @import("commands/host_memory.zig");
 const host_rss = @import("commands/host_rss.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
 const mountdisk_image = @import("commands/mountdisk_image.zig");
@@ -22,6 +23,7 @@ var g_io: std.Io = undefined;
 pub fn main(init: std.process.Init) !u8 {
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
+    assert(host_memory.name.len > 0);
     assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
@@ -70,6 +72,12 @@ fn runKnownCommand(
             return @intFromEnum(protocol.Exit.usage);
         }
         return @intFromEnum(try cpu_cgroup_remove.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, host_memory.name)) {
+        if (try rejectExtraArgs(it, host_memory.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try host_memory.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, host_rss.name)) {
         if (try rejectExtraArgs(it, host_rss.name)) return @intFromEnum(protocol.Exit.usage);
@@ -167,6 +175,7 @@ fn isHelp(command: []const u8) bool {
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
+    assert(host_memory.name.len > 0);
     assert(host_rss.name.len > 0);
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
@@ -186,6 +195,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .commands = .{
             cpu_cgroup_apply.name,
             cpu_cgroup_remove.name,
+            host_memory.name,
             host_rss.name,
             mkinitramfs.name,
             mountdisk_image.name,

--- a/packages/runtime/native/src/protocol.zig
+++ b/packages/runtime/native/src/protocol.zig
@@ -67,7 +67,7 @@ pub fn rejectUnknownFields(
     object: std.json.ObjectMap,
     allowed: []const []const u8,
 ) RequestError!void {
-    assert(allowed.len > 0);
+    assert(version == 1);
 
     var it = object.iterator();
     while (it.next()) |entry| {
@@ -77,6 +77,59 @@ pub fn rejectUnknownFields(
             return error.UnknownField;
         }
     }
+}
+
+pub fn requireProtocolVersion(envelope: std.json.ObjectMap) RequestError!void {
+    assert(version == 1);
+
+    const protocol_version = envelope.get("protocolVersion") orelse
+        return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer) return error.UnsupportedProtocolVersion;
+    if (protocol_version.integer != version) return error.UnsupportedProtocolVersion;
+}
+
+pub fn writeCommonRequestError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.RequestTooLarge => try writeError(
+            io,
+            "REQUEST_TOO_LARGE",
+            "request JSON exceeds the maximum size",
+        ),
+        error.UnknownField => try writeError(
+            io,
+            "UNKNOWN_FIELD",
+            "request contains an unknown field",
+        ),
+        error.UnsupportedProtocolVersion => try writeError(
+            io,
+            "UNSUPPORTED_PROTOCOL_VERSION",
+            "request protocolVersion must be 1",
+        ),
+        error.MissingData => try writeError(
+            io,
+            "INVALID_REQUEST",
+            "request must include a data object",
+        ),
+        error.InvalidData => try writeError(
+            io,
+            "INVALID_REQUEST",
+            "request data field must be an object",
+        ),
+        error.InvalidJson => try writeError(
+            io,
+            "INVALID_JSON",
+            "request body is not valid JSON",
+        ),
+        error.InvalidShape => try writeError(
+            io,
+            "INVALID_REQUEST",
+            "request body must be a JSON object",
+        ),
+        else => return false,
+    }
+    return true;
 }
 
 pub fn writeError(io: std.Io, code: []const u8, message: []const u8) !void {

--- a/packages/runtime/native/src/root.zig
+++ b/packages/runtime/native/src/root.zig
@@ -1,3 +1,4 @@
+pub const host = @import("host.zig");
 pub const manifest = @import("manifest.zig");
 pub const mkinitramfs = @import("mkinitramfs.zig");
 pub const mountdisk = @import("mountdisk.zig");

--- a/packages/runtime/src/__tests__/cpu-cgroup.test.ts
+++ b/packages/runtime/src/__tests__/cpu-cgroup.test.ts
@@ -1,10 +1,34 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { applyCpuControls, cpuPolicyNeedsCgroup, removeCpuCgroup } from "../cpu-cgroup.ts";
 
 const tempDirs: string[] = [];
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 function tempCgroupParent(): string {
   const dir = mkdtempSync(join(tmpdir(), "machinen-cpu-cgroup-"));
@@ -25,7 +49,24 @@ describe("cpu cgroup controls", () => {
     expect(cpuPolicyNeedsCgroup({ maxVcpus: 1, weight: 100 })).toBe(false);
   });
 
+  it("reports unsupported for cgroup writes outside Linux", () => {
+    if (platform() === "linux") {
+      return;
+    }
+    const parentDir = tempCgroupParent();
+    const result = applyCpuControls(
+      4321,
+      { maxVcpus: 1, quotaCpus: 0.5, weight: 250 },
+      { parentDir, id: "unit" },
+    );
+    expect(result.status).toBe("unsupported");
+    expect(result.reason).toContain("Linux cgroup v2");
+  });
+
   it("writes cgroup v2 cpu.max, cpu.weight, and cgroup.procs", () => {
+    if (platform() !== "linux") {
+      return;
+    }
     const parentDir = tempCgroupParent();
     const result = applyCpuControls(
       4321,
@@ -44,6 +85,9 @@ describe("cpu cgroup controls", () => {
   });
 
   it("enforces weight without a hard quota when weight differs from the default", () => {
+    if (platform() !== "linux") {
+      return;
+    }
     const parentDir = tempCgroupParent();
     const result = applyCpuControls(4321, { maxVcpus: 1, weight: 50 }, { parentDir, id: "weight" });
 

--- a/packages/runtime/src/__tests__/gc.test.ts
+++ b/packages/runtime/src/__tests__/gc.test.ts
@@ -8,9 +8,33 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { runGc, validatePid } from "../index.ts";
 import { listAll, type RegistryEntry } from "../registry.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 function makeEntry(root: string, e: RegistryEntry): void {
   const dir = join(root, String(e.pid));

--- a/packages/runtime/src/__tests__/host-mem.test.ts
+++ b/packages/runtime/src/__tests__/host-mem.test.ts
@@ -6,7 +6,11 @@
 // `checkForkBackpressure`'s threshold logic, which is the part fork
 // orchestration depends on.
 
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { BootError } from "../errors.ts";
 import {
   checkForkBackpressure,
@@ -14,6 +18,30 @@ import {
   readHostFreeBytes,
   readHostTotalBytes,
 } from "../host-mem.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("readHostFreeBytes", () => {
   it("returns a positive number on the running platform", async () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -3,10 +3,11 @@
 // the guest actually see N MiB?" check lives in the smoke suite —
 // this file just covers the policy + validation logic.
 
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   _internal,
   attach,
@@ -17,6 +18,30 @@ import {
 } from "../index.ts";
 
 const { resolveMemoryCeilingMib, validateMemoryMib } = _internal;
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("autoSizeMemoryMib", () => {
   it("uses a modest 4 GiB ceiling for normal desktops", () => {

--- a/packages/runtime/src/__tests__/proc-rss.test.ts
+++ b/packages/runtime/src/__tests__/proc-rss.test.ts
@@ -6,12 +6,37 @@
 // positive number. The statsPath-aware tests pretend to be the VMM
 // sampler thread by writing the same wire format into a tmpfile.
 
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { STATS_FILE_SIZE } from "../balloon-stats.ts";
 import { readHostRssBytes, readHostRssBytesMulti } from "../proc-rss.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("readHostRssBytes", () => {
   it("returns a positive number for the running process", () => {

--- a/packages/runtime/src/__tests__/proc-rss.test.ts
+++ b/packages/runtime/src/__tests__/proc-rss.test.ts
@@ -49,13 +49,20 @@ describe("readHostRssBytes", () => {
     // 0x7fff_ffff — outside the kernel's pid_max on every Unix.
     expect(readHostRssBytes(0x7fff_ffff)).toBeNull();
   });
+
+  it("returns null for invalid pid inputs", () => {
+    expect(readHostRssBytes(0)).toBeNull();
+    expect(readHostRssBytes(-1)).toBeNull();
+  });
 });
 
 describe("readHostRssBytesMulti", () => {
   it("returns a map keyed by pid for the live processes it could read", () => {
-    const map = readHostRssBytesMulti([process.pid, 0x7fff_ffff]);
+    const map = readHostRssBytesMulti([process.pid, 0x7fff_ffff, 0, -1]);
     expect(map.get(process.pid)).toBeGreaterThan(0);
     expect(map.has(0x7fff_ffff)).toBe(false);
+    expect(map.has(0)).toBe(false);
+    expect(map.has(-1)).toBe(false);
   });
 
   it("accepts the {pid, statsPath} target shape too", () => {

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -5,11 +5,12 @@
 // boot()→list()→attach() against a long-running /usr/bin/yes "VMM" so
 // we don't need real HVF.
 
+import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { RegistryError, attach, boot, list, type RegistryEntry } from "../index.ts";
 import {
   claimName,
@@ -29,6 +30,30 @@ import { readProcessIdentity } from "../pid-validate.ts";
  * exe basename so the snapshot in the entry matches what
  * `validatePid` re-reads from `ps` / `/proc`.
  */
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
+
 function entryForSelf(name: string): RegistryEntry {
   const observed = readProcessIdentity(process.pid);
   return {

--- a/packages/runtime/src/cpu-cgroup.ts
+++ b/packages/runtime/src/cpu-cgroup.ts
@@ -1,12 +1,7 @@
-import { existsSync, mkdirSync, rmdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { platform as osPlatform } from "node:os";
-import { randomBytes } from "node:crypto";
-import { BootError } from "./errors.ts";
 import { DEFAULT_CPU_WEIGHT, type ResolvedCpuResourcePolicy } from "./vm/cpu-resources.ts";
+import { applyCpuCgroupNative, removeCpuCgroupNative } from "./native/cpu-cgroup.ts";
 
 const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
-const CPU_PERIOD_US = 100_000;
 
 type CpuControlStatus = "none" | "linux-cgroup-v2" | "unsupported";
 
@@ -29,30 +24,13 @@ export function applyCpuControls(
   if (policy === undefined || !cpuPolicyNeedsCgroup(policy)) {
     return { status: "none" };
   }
-  if (osPlatform() !== "linux") {
-    return { status: "unsupported", reason: "hard CPU quota uses Linux cgroup v2" };
-  }
-  const parentDir = opts.parentDir ?? process.env.MACHINEN_CGROUP_PARENT ?? DEFAULT_CGROUP_PARENT;
-  if (!looksLikeCgroupV2(parentDir)) {
-    throw new BootError(
-      "BOOT_CPU_UNSUPPORTED",
-      `boot: resources.cpu requires Linux cgroup v2 CPU controls, but ${parentDir} is not usable.`,
-    );
-  }
-  const cgroupPath = createCpuCgroup(parentDir, opts.id ?? String(pid));
-  try {
-    writeCpuQuota(cgroupPath, policy.quotaCpus);
-    writeCpuWeight(cgroupPath, policy.weight);
-    writeFileSync(join(cgroupPath, "cgroup.procs"), `${pid}\n`);
-    return { status: "linux-cgroup-v2", cgroupPath };
-  } catch (err) {
-    removeCpuCgroup(cgroupPath);
-    throw new BootError(
-      "BOOT_CPU_UNSUPPORTED",
-      `boot: failed to apply resources.cpu cgroup controls: ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
-  }
+  return applyCpuCgroupNative({
+    pid,
+    weight: policy.weight,
+    quotaCpus: policy.quotaCpus,
+    parentDir: opts.parentDir ?? process.env.MACHINEN_CGROUP_PARENT ?? DEFAULT_CGROUP_PARENT,
+    id: opts.id ?? String(pid),
+  });
 }
 
 export function cpuPolicyNeedsCgroup(policy: ResolvedCpuResourcePolicy): boolean {
@@ -60,43 +38,8 @@ export function cpuPolicyNeedsCgroup(policy: ResolvedCpuResourcePolicy): boolean
 }
 
 export function removeCpuCgroup(cgroupPath: string | undefined): void {
-  if (!cgroupPath || !existsSync(cgroupPath)) {
+  if (!cgroupPath) {
     return;
   }
-  try {
-    rmdirSync(cgroupPath);
-  } catch {
-    if (!cgroupPath.startsWith("/sys/fs/cgroup/")) {
-      try {
-        rmSync(cgroupPath, { recursive: true, force: true });
-      } catch {}
-    }
-  }
-}
-
-function looksLikeCgroupV2(parentDir: string): boolean {
-  if (parentDir === DEFAULT_CGROUP_PARENT && !existsSync(join(parentDir, "cgroup.controllers"))) {
-    return false;
-  }
-  return existsSync(parentDir);
-}
-
-function createCpuCgroup(parentDir: string, id: string): string {
-  mkdirSync(parentDir, { recursive: true });
-  const safeId = id.replace(/[^a-zA-Z0-9_.-]/g, "-");
-  const cgroupPath = join(parentDir, `machinen-vm-${safeId}-${randomBytes(4).toString("hex")}`);
-  mkdirSync(cgroupPath);
-  return cgroupPath;
-}
-
-function writeCpuQuota(cgroupPath: string, quotaCpus: number | undefined): void {
-  if (quotaCpus === undefined) {
-    return;
-  }
-  const quotaUs = Math.max(1, Math.round(quotaCpus * CPU_PERIOD_US));
-  writeFileSync(join(cgroupPath, "cpu.max"), `${quotaUs} ${CPU_PERIOD_US}\n`);
-}
-
-function writeCpuWeight(cgroupPath: string, weight: number): void {
-  writeFileSync(join(cgroupPath, "cpu.weight"), `${weight}\n`);
+  removeCpuCgroupNative(cgroupPath);
 }

--- a/packages/runtime/src/cpu-cgroup.ts
+++ b/packages/runtime/src/cpu-cgroup.ts
@@ -1,3 +1,14 @@
+// Linux CPU controls for Machinen VMM processes.
+//
+// `resources.cpu` is enforced by placing the VMM process into a cgroup v2
+// CPU group. This module is the TypeScript policy layer: it decides whether a
+// CPU policy needs native cgroup setup, calls the runtime helper to create/apply
+// the group, and removes that group when the VM stops.
+//
+// `quotaCpus` becomes a hard scheduling cap via `cpu.max`; `weight` becomes a
+// relative share via `cpu.weight`. These controls affect host scheduling of the
+// VMM process, not guest-visible vCPU count. Non-Linux hosts report unsupported.
+
 import { DEFAULT_CPU_WEIGHT, type ResolvedCpuResourcePolicy } from "./vm/cpu-resources.ts";
 import { applyCpuCgroupNative, removeCpuCgroupNative } from "./native/cpu-cgroup.ts";
 

--- a/packages/runtime/src/host-mem.ts
+++ b/packages/runtime/src/host-mem.ts
@@ -1,15 +1,13 @@
-// Host-memory observation for `vm.fork()` backpressure (#274).
+// Host memory probes for VM fork backpressure and memory auto-sizing.
 //
-// A runaway script that calls `vm.fork()` faster than memory frees
-// will eventually push the host past its OOM threshold and the
-// kernel picks an arbitrary VMM (or any other host process) to
-// kill. Throwing a clear backpressure error before that happens —
-// the same retry/error idiom #267's port-conflict gate uses — lets
-// the caller back off or surface the pressure to its own user.
+// Machinen needs a fresh view of host memory before starting/forking VMs so a
+// runaway workload does not push the host into OOM. This module asks the native
+// runtime helper for available and total physical memory, then applies the
+// runtime's backpressure policy.
 //
-// The native runtime helper reads `/proc/meminfo` on Linux and
-// `vm_stat`/`sysctl` on Darwin. It is zero-state — no daemon, no probe
-// socket, no caching. The check fires once per `vm.fork()`.
+// The native helper owns platform details: Linux reads `/proc/meminfo`; Darwin
+// reads `vm_stat`/`sysctl`. Callers should treat these as point-in-time probes,
+// not cached capacity guarantees.
 
 import { BootError } from "./errors.ts";
 import { readHostMemoryNative } from "./native/host-memory.ts";

--- a/packages/runtime/src/host-mem.ts
+++ b/packages/runtime/src/host-mem.ts
@@ -7,15 +7,12 @@
 // the same retry/error idiom #267's port-conflict gate uses — lets
 // the caller back off or surface the pressure to its own user.
 //
-// The reader is pure-stdlib: `/proc/meminfo` on Linux, `vm_stat` on
-// Darwin. Both are zero-state — no daemon, no probe socket, no
-// caching. The check fires once per `vm.fork()`; the cost is one
-// syscall (Linux) or one short-lived subprocess (Darwin).
+// The native runtime helper reads `/proc/meminfo` on Linux and
+// `vm_stat`/`sysctl` on Darwin. It is zero-state — no daemon, no probe
+// socket, no caching. The check fires once per `vm.fork()`.
 
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { platform as osPlatform, totalmem } from "node:os";
 import { BootError } from "./errors.ts";
+import { readHostMemoryNative } from "./native/host-memory.ts";
 
 /**
  * Bytes of memory the OS reports as available right now. "Available"
@@ -28,59 +25,15 @@ import { BootError } from "./errors.ts";
  *   - Darwin → vm_stat free + speculative + purgeable. Inactive is
  *              excluded because it's dirty and needs a pageout, which
  *              wouldn't help a fork that needs RAM right now.
- *   - other  → totalmem(). Soft-fail rather than block fork on a
- *              platform we can't measure.
+ *   - other  → explicit helper error on platforms we do not support.
  */
 export async function readHostFreeBytes(): Promise<number> {
-  if (osPlatform() === "linux") {
-    return readMemAvailableLinux();
-  }
-  if (osPlatform() === "darwin") {
-    return readVmStatFreeDarwin();
-  }
-  return totalmem();
+  return readHostMemoryNative().freeBytes;
 }
 
-/**
- * Total physical memory in bytes. Thin wrapper over `os.totalmem()`
- * exported alongside the free reader so tests and the backpressure
- * check pull both numbers from the same module.
- */
+/** Total physical memory in bytes, read by the native runtime helper. */
 export function readHostTotalBytes(): number {
-  return totalmem();
-}
-
-function readMemAvailableLinux(): number {
-  const text = readFileSync("/proc/meminfo", "utf8");
-  const avail = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(text);
-  if (avail) {
-    return Number(avail[1]) * 1024;
-  }
-  // Fallback for ancient kernels (pre-3.14, 2014). MemFree alone
-  // undercounts by the page-cache size, which is conservative — the
-  // gate trips earlier than ideal but never lets a fork through that
-  // a real check would have caught.
-  const free = /^MemFree:\s+(\d+)\s+kB$/m.exec(text);
-  if (free) {
-    return Number(free[1]) * 1024;
-  }
-  throw new Error("host-mem: /proc/meminfo missing MemAvailable + MemFree");
-}
-
-function readVmStatFreeDarwin(): number {
-  const stdout = execFileSync("/usr/bin/vm_stat", { encoding: "utf8", timeout: 1_000 });
-  const pageSizeMatch = /page size of (\d+) bytes/.exec(stdout);
-  const pageSize = pageSizeMatch ? Number(pageSizeMatch[1]) : 4096;
-  const free = parseVmStatPages(stdout, "Pages free");
-  const speculative = parseVmStatPages(stdout, "Pages speculative");
-  const purgeable = parseVmStatPages(stdout, "Pages purgeable");
-  return (free + speculative + purgeable) * pageSize;
-}
-
-function parseVmStatPages(text: string, label: string): number {
-  const re = new RegExp(`^${label.replace(/ /g, "\\s+")}:\\s+(\\d+)\\.?$`, "m");
-  const m = re.exec(text);
-  return m ? Number(m[1]) : 0;
+  return readHostMemoryNative().totalBytes;
 }
 
 /**

--- a/packages/runtime/src/native/cpu-cgroup.ts
+++ b/packages/runtime/src/native/cpu-cgroup.ts
@@ -1,0 +1,69 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+export type NativeCpuControlStatus = "linux-cgroup-v2" | "unsupported";
+
+export interface NativeCpuControlResult {
+  status: NativeCpuControlStatus;
+  cgroupPath?: string;
+  reason?: string;
+}
+
+interface CpuCgroupApplyRequest {
+  pid: number;
+  weight: number;
+  quotaCpus?: number;
+  parentDir: string;
+  id: string;
+}
+
+interface CpuCgroupRemoveData {
+  ok: true;
+}
+
+export function applyCpuCgroupNative(request: CpuCgroupApplyRequest): NativeCpuControlResult {
+  return callRuntimeHelper({
+    command: "cpu-cgroup-apply",
+    data: request,
+    errorCode: "BOOT_CPU_UNSUPPORTED",
+    makeError: cpuCgroupError,
+    isData: isNativeCpuControlResult,
+  });
+}
+
+export function removeCpuCgroupNative(cgroupPath: string): void {
+  callRuntimeHelper({
+    command: "cpu-cgroup-remove",
+    data: { cgroupPath },
+    errorCode: "BOOT_CPU_UNSUPPORTED",
+    makeError: cpuCgroupError,
+    isData: isCpuCgroupRemoveData,
+  });
+}
+
+function cpuCgroupError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function isNativeCpuControlResult(value: unknown): value is NativeCpuControlResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<NativeCpuControlResult>;
+  return (
+    (data.status === "linux-cgroup-v2" || data.status === "unsupported") &&
+    optionalString(data.cgroupPath) &&
+    optionalString(data.reason)
+  );
+}
+
+function isCpuCgroupRemoveData(value: unknown): value is CpuCgroupRemoveData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return (value as Partial<CpuCgroupRemoveData>).ok === true;
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}

--- a/packages/runtime/src/native/cpu-cgroup.ts
+++ b/packages/runtime/src/native/cpu-cgroup.ts
@@ -1,9 +1,9 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
 
-export type NativeCpuControlStatus = "linux-cgroup-v2" | "unsupported";
+type NativeCpuControlStatus = "linux-cgroup-v2" | "unsupported";
 
-export interface NativeCpuControlResult {
+interface NativeCpuControlResult {
   status: NativeCpuControlStatus;
   cgroupPath?: string;
   reason?: string;

--- a/packages/runtime/src/native/host-memory.ts
+++ b/packages/runtime/src/native/host-memory.ts
@@ -1,0 +1,33 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+interface HostMemoryReading {
+  freeBytes: number;
+  totalBytes: number;
+}
+
+export function readHostMemoryNative(): HostMemoryReading {
+  return callRuntimeHelper({
+    command: "host-memory",
+    data: {},
+    errorCode: "FORK_MEMORY_BACKPRESSURE",
+    makeError: hostMemoryError,
+    isData: isHostMemoryReading,
+  });
+}
+
+function hostMemoryError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function isHostMemoryReading(value: unknown): value is HostMemoryReading {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<HostMemoryReading>;
+  return positiveNumber(data.freeBytes) && positiveNumber(data.totalBytes);
+}
+
+function positiveNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}

--- a/packages/runtime/src/native/host-rss.ts
+++ b/packages/runtime/src/native/host-rss.ts
@@ -1,12 +1,12 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
 
-export interface HostRssTarget {
+interface HostRssTarget {
   pid: number;
   statsPath?: string;
 }
 
-export interface HostRssReading {
+interface HostRssReading {
   pid: number;
   rssBytes: number;
 }

--- a/packages/runtime/src/native/host-rss.ts
+++ b/packages/runtime/src/native/host-rss.ts
@@ -1,0 +1,50 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+export interface HostRssTarget {
+  pid: number;
+  statsPath?: string;
+}
+
+export interface HostRssReading {
+  pid: number;
+  rssBytes: number;
+}
+
+interface HostRssData {
+  readings: HostRssReading[];
+}
+
+export function hostRssNative(targets: readonly HostRssTarget[]): HostRssReading[] {
+  return callRuntimeHelper({
+    command: "host-rss",
+    data: { targets },
+    errorCode: "BOOT_PACK_FAILED",
+    makeError: hostRssError,
+    isData: isHostRssData,
+  }).readings;
+}
+
+function hostRssError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function isHostRssData(value: unknown): value is HostRssData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<HostRssData>;
+  return Array.isArray(data.readings) && data.readings.every(isHostRssReading);
+}
+
+function isHostRssReading(value: unknown): value is HostRssReading {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const reading = value as Partial<HostRssReading>;
+  return isPositiveInteger(reading.pid) && isPositiveInteger(reading.rssBytes);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}

--- a/packages/runtime/src/native/pid.ts
+++ b/packages/runtime/src/native/pid.ts
@@ -1,0 +1,73 @@
+import { RegistryError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+type NativePidStatus = "alive" | "dead" | "recycled";
+
+interface NativeProcessIdentity {
+  exeBase: string;
+  startedAtMs?: number;
+}
+
+interface PidValidateResponse {
+  status: NativePidStatus;
+}
+
+interface ProcessIdentityResponse {
+  identity: NativeProcessIdentity | null;
+}
+
+export function validatePidNative(request: {
+  pid: number;
+  expected: { vmmExe?: string; startedAt?: number };
+}): NativePidStatus {
+  return callRuntimeHelper({
+    command: "pid-validate",
+    data: request,
+    errorCode: "REGISTRY_VM_NOT_FOUND",
+    makeError: registryError,
+    isData: isPidValidateResponse,
+  }).status;
+}
+
+export function readProcessIdentityNative(pid: number): NativeProcessIdentity | undefined {
+  const response = callRuntimeHelper({
+    command: "process-identity",
+    data: { pid },
+    errorCode: "REGISTRY_VM_NOT_FOUND",
+    makeError: registryError,
+    isData: isProcessIdentityResponse,
+  });
+  return response.identity ?? undefined;
+}
+
+function registryError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new RegistryError(code, message, opts);
+}
+
+function isPidValidateResponse(value: unknown): value is PidValidateResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const status = (value as Partial<PidValidateResponse>).status;
+  return status === "alive" || status === "dead" || status === "recycled";
+}
+
+function isProcessIdentityResponse(value: unknown): value is ProcessIdentityResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const identity = (value as Partial<ProcessIdentityResponse>).identity;
+  return identity === null || isNativeProcessIdentity(identity);
+}
+
+function isNativeProcessIdentity(value: unknown): value is NativeProcessIdentity {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<NativeProcessIdentity>;
+  return typeof data.exeBase === "string" && optionalNumber(data.startedAtMs);
+}
+
+function optionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "number";
+}

--- a/packages/runtime/src/pid-validate.ts
+++ b/packages/runtime/src/pid-validate.ts
@@ -2,60 +2,30 @@
 //
 // `kill(pid, 0)` only tells us "some process with this pid exists" —
 // the kernel happily recycles pids, so a long-dead VMM's pid can land
-// on an unrelated process. If gc trusts kill(0) alone, two things go
-// wrong: it leaves cleanupPaths around for the recycled-pid entry,
-// and `machinen stop <name>` ends up SIGTERM-ing whatever happened to
-// inherit that pid.
-//
-// The fix is to also confirm the process *is the original VMM*:
-//   - exe path matches the recorded `entry.vmmExe`, and
-//   - process start time is within a small skew of `entry.startedAt`.
-//
-// Linux: `/proc/<pid>/exe` is a symlink to the on-disk exe; readlink
-// is rock-solid. `/proc/<pid>/stat` field 22 (starttime in clock
-// ticks since boot) gives the start time we cross-check.
-//
-// macOS: no /proc. `ps -o command=,lstart= -p <pid>` is the portable
-// answer; argv[0] gives the executable path, lstart is a wall-clock
-// human-readable timestamp. (We avoid `comm=` because the kernel
-// truncates it to MAXCOMLEN ≈ 16 chars, which false-positives
-// "recycled" whenever the absolute exe path is longer — common for
-// dev binaries under $HOME.) Comparing basenames means we miss
-// exe-replacement attacks, but the threat model here is pid
-// recycling on a development laptop — basename + lstart-within-skew
-// is enough.
+// on an unrelated process. The native runtime helper verifies the pid
+// against OS process identity instead: exe basename plus start time
+// when the platform can report it.
 
-import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readlinkSync } from "node:fs";
-import { platform } from "node:os";
-import { basename } from "node:path";
-
-/**
- * Skew tolerance for start-time comparison. macOS `ps` only gives us
- * second-level resolution and the registry records ms; allow a few
- * seconds either way to absorb both. Smaller would be tighter but
- * would false-positive on slow boots where Date.now() (in JS, after
- * spawn) and ps's start time (in the kernel, before exec) differ by
- * a noticeable amount.
- */
-const STARTTIME_SKEW_MS = 5_000;
+import { readProcessIdentityNative, validatePidNative } from "./native/pid.ts";
 
 /** Result of `validatePid` — easy to switch on at the call site. */
 export type PidStatus = "alive" | "dead" | "recycled";
+
+interface ProcessIdentity {
+  exeBase: string;
+  startedAtMs?: number;
+}
 
 /**
  * Return whether the running process at `pid` is still our VMM.
  *
  * - `alive`     — pid is alive AND the exe + start-time match.
- * - `dead`      — kill(pid, 0) failed (gone or permission-denied,
- *                 either way unreachable).
- * - `recycled`  — pid is alive but the process isn't ours (different
- *                 exe, or start time outside skew).
+ * - `dead`      — pid is gone or unreachable.
+ * - `recycled`  — pid is alive but the process is not ours.
  *
  * Falls back to `alive` when the recorded entry lacks `vmmExe` /
  * `startedAt` (older entries from before PR2). Conservative on
- * purpose: the gc decision then leans on `kill(pid, 0)` alone, same
- * behaviour we had before.
+ * purpose: the gc decision then leans on process liveness alone.
  */
 export function validatePid(
   pid: number,
@@ -64,151 +34,28 @@ export function validatePid(
   if (!Number.isInteger(pid) || pid <= 0) {
     return "dead";
   }
-  try {
-    process.kill(pid, 0);
-  } catch {
-    return "dead";
-  }
-  // No way to distinguish — be conservative.
-  if (!expected.vmmExe && expected.startedAt === undefined) {
-    return "alive";
-  }
-  const observed = readProcessIdentity(pid);
-  if (!observed) {
-    // Couldn't read /proc or ps; don't lie that it's recycled — fall
-    // back to the kill(0) result.
-    return "alive";
-  }
-  if (expected.vmmExe) {
-    const expectedBase = basename(expected.vmmExe);
-    if (observed.exeBase !== expectedBase) {
-      // Linux pdeathsig execs the target in-place, but a registry read
-      // immediately after spawn can observe the tiny wrapper in the
-      // pre-exec window. Treat that as alive when the start time still
-      // matches; a later read will see the real target basename.
-      if (
-        platform() !== "linux" ||
-        observed.exeBase !== "pdeathsig" ||
-        !startTimesMatch(expected.startedAt, observed.startedAtMs)
-      ) {
-        return "recycled";
-      }
-    }
-  }
-  if (!startTimesMatch(expected.startedAt, observed.startedAtMs)) {
-    return "recycled";
-  }
-  return "alive";
-}
-
-interface ProcessIdentity {
-  exeBase: string;
-  startedAtMs?: number;
+  return validatePidNative({ pid, expected });
 }
 
 /**
  * Read the OS's view of `pid`'s exe basename and start time. Exposed
  * so `boot()` can snapshot the values at spawn time and persist them
  * into the registry entry — that way `validatePid` later compares
- * apples-to-apples instead of comparing what we *asked* spawn to run
- * (which on macOS is the pdeathsig fork-wrapper, not the target the
- * caller named).
+ * apples-to-apples.
  */
 export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
-  if (platform() === "linux") {
-    return readLinuxIdentity(pid);
-  }
-  return readPsIdentity(pid);
-}
-
-function startTimesMatch(expected: number | undefined, observed: number | undefined): boolean {
-  if (expected === undefined || observed === undefined) {
-    return true;
-  }
-  return Math.abs(observed - expected) <= STARTTIME_SKEW_MS;
-}
-
-function readLinuxIdentity(pid: number): ProcessIdentity | undefined {
-  let exeBase: string;
-  try {
-    exeBase = basename(readlinkSync(`/proc/${pid}/exe`));
-  } catch {
+  if (!Number.isInteger(pid) || pid <= 0) {
     return undefined;
   }
-  // /proc/<pid>/stat layout: pid (comm) state … starttime[22] (in
-  // clock ticks since boot). The comm field is parens-wrapped and
-  // can contain spaces, so split on the *last* `)` to skip it.
-  let startedAtMs: number | undefined;
-  try {
-    if (existsSync(`/proc/${pid}/stat`)) {
-      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-      const lastParen = stat.lastIndexOf(")");
-      if (lastParen !== -1) {
-        const fields = stat.slice(lastParen + 2).split(" ");
-        // After the comm field, indices restart from 0 (state).
-        // starttime is the original field 22 → index 22 - 3 = 19.
-        const ticksRaw = fields[19];
-        const ticks = Number(ticksRaw);
-        const btime = readBootTimeSeconds();
-        if (Number.isFinite(ticks) && btime !== undefined) {
-          // SC_CLK_TCK is 100 on every Linux the runtime targets;
-          // not exposed by Node, hard-coded with this assumption.
-          startedAtMs = (btime + ticks / 100) * 1000;
-        }
-      }
-    }
-  } catch {
-    // start-time is best-effort — exe match alone is plenty signal.
-  }
-  return { exeBase, startedAtMs };
+  return fromNativeIdentity(readProcessIdentityNative(pid));
 }
 
-function readBootTimeSeconds(): number | undefined {
-  try {
-    const stat = readFileSync("/proc/stat", "utf8");
-    for (const line of stat.split("\n")) {
-      if (line.startsWith("btime ")) {
-        const v = Number(line.slice(6).trim());
-        return Number.isFinite(v) ? v : undefined;
-      }
-    }
-  } catch {}
-  return undefined;
-}
-
-function readPsIdentity(pid: number): ProcessIdentity | undefined {
-  let out: string;
-  try {
-    // Order matters: when `command=` appears before another column,
-    // BSD ps truncates *all* preceding columns to keep the layout
-    // tabular (and `command` shares the truncation, capping argv at
-    // ~16 chars). Putting `lstart=` first sidesteps that — lstart is
-    // a fixed-width 24-char ctime-ish string ("Sun  3 May 09:37:27
-    // 2026") and command runs to end-of-line untruncated.
-    out = execFileSync("ps", ["-o", "lstart=,command=", "-p", String(pid)], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
+function fromNativeIdentity(identity: ProcessIdentity | undefined): ProcessIdentity | undefined {
+  if (!identity) {
     return undefined;
   }
-  const trimmed = out.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  // lstart format from `man ps`: "%a %e %b %T %Y" = "Sun  3 May
-  // 09:37:27 2026". Date.parse reads it directly. argv[0] is the
-  // first whitespace-delimited token after lstart; basename of it is
-  // what we compare against (best-effort — our binary paths don't
-  // contain spaces).
-  const m = trimmed.match(/^(\S{3}\s+\d{1,2}\s+\S{3}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(\S+)/);
-  if (!m) {
-    return undefined;
-  }
-  const lstartMs = Date.parse(m[1]!);
-  const exeBase = basename(m[2]!);
   return {
-    exeBase,
-    startedAtMs: Number.isFinite(lstartMs) ? lstartMs : undefined,
+    exeBase: identity.exeBase,
+    startedAtMs: identity.startedAtMs,
   };
 }

--- a/packages/runtime/src/pid-validate.ts
+++ b/packages/runtime/src/pid-validate.ts
@@ -1,10 +1,12 @@
-// Anti-recycling check for `machinen gc` / `machinen stop`.
+// PID liveness and recycling checks for registry operations.
 //
-// `kill(pid, 0)` only tells us "some process with this pid exists" —
-// the kernel happily recycles pids, so a long-dead VMM's pid can land
-// on an unrelated process. The native runtime helper verifies the pid
-// against OS process identity instead: exe basename plus start time
-// when the platform can report it.
+// A pid being alive does not prove it is still our VMM: operating systems reuse
+// pids. This module asks the native runtime helper for process identity and
+// validates the registry's recorded exe/start-time against the current process.
+//
+// Used by `machinen gc`, `stop`, `attach`, and registry listing so stale entries
+// are cleaned up without accidentally treating an unrelated recycled pid as a
+// Machinen VM.
 
 import { readProcessIdentityNative, validatePidNative } from "./native/pid.ts";
 

--- a/packages/runtime/src/proc-rss.ts
+++ b/packages/runtime/src/proc-rss.ts
@@ -1,21 +1,9 @@
 // Read the resident-set size of a host pid, in bytes (#274).
 //
-// Linux  → /proc/<pid>/status:VmRSS (kB; multiply by 1024).
-// Darwin → the VMM's own `phys_footprint` sample, written into the
-//          MACHINEN_STATS_FILE every ~500 ms by a sampler thread
-//          (see `packages/microvm/src/stats.zig`). Falls back to
-//          `ps -o rss=` when no statsPath is supplied (e.g. for an
-//          arbitrary host pid that isn't a machinen VMM) or when the
-//          stats file is missing / hasn't been initialised yet.
-// other  → null (we don't measure on platforms machinen doesn't ship for).
-//
-// Why prefer phys_footprint on Darwin: after balloon reclaim the VMM
-// calls `madvise(MADV_FREE_REUSABLE)`. Reusable pages stay counted
-// in `task_basic_info.resident_size` (what `ps -o rss=` reads) until
-// the kernel actually reclaims them under memory pressure, but they
-// are excluded from `phys_footprint` immediately. So `ps rss` makes
-// reclaim look broken even when it's working; `phys_footprint`
-// (Activity Monitor's "Memory" column) shows the truth.
+// Linux  → machinen-runtime-helper reads /proc/<pid>/status:VmRSS.
+// Darwin → machinen-runtime-helper prefers the VMM stats file's
+//          phys_footprint sample, then falls back to `ps -o rss=`.
+// other  → null / absent map entries (unsupported by the native helper).
 //
 // Synchronous because callers — `machinen ls` and `vm.memoryStats()` —
 // fetch the number once, at the moment they need it. There's no
@@ -26,43 +14,29 @@
 // "VMM is gone / unreadable" apart from "VMM is alive but using zero
 // pages" (which never happens in practice but is the natural floor).
 
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { platform as osPlatform } from "node:os";
-import { readBalloonStats } from "./balloon-stats.ts";
+import { hostRssNative } from "./native/host-rss.ts";
 
 /** A pid plus the absolute path to its stats file (when available). */
 export interface RssTarget {
   pid: number;
   /**
    * MACHINEN_STATS_FILE path for this VMM (registry entry's
-   * `statsPath`). On Darwin we read `phys_footprint` from this file
-   * in preference to `ps -o rss=`. Optional / undefined for arbitrary
-   * pids that aren't machinen-managed; those fall back to ps.
+   * `statsPath`). On Darwin the native helper reads `phys_footprint`
+   * from this file in preference to `ps -o rss=`. Optional / undefined
+   * for arbitrary pids that aren't machinen-managed; those fall back to ps.
    */
   statsPath?: string;
 }
 
 /** RSS bytes for one pid, or null if not readable. */
 export function readHostRssBytes(pid: number, statsPath?: string): number | null {
-  if (osPlatform() === "linux") {
-    return readVmRssLinux(pid);
-  }
-  if (osPlatform() === "darwin") {
-    const fromStats = readPhysFootprintFromStats(statsPath);
-    if (fromStats !== null) {
-      return fromStats;
-    }
-    return readPsRssDarwin([pid]).get(pid) ?? null;
-  }
-  return null;
+  return readHostRssBytesMulti([{ pid, statsPath }]).get(pid) ?? null;
 }
 
 /**
- * Bulk variant for `machinen ls`: one syscall (Linux) or one
- * subprocess (Darwin) for every live VM, instead of N. Pids that
- * can't be read are simply absent from the result map — caller
- * decides whether to render "?" or skip the row.
+ * Bulk variant for `machinen ls`. Pids that can't be read are simply
+ * absent from the result map — caller decides whether to render "?" or
+ * skip the row.
  */
 export function readHostRssBytesMulti(
   targets: ReadonlyArray<RssTarget | number>,
@@ -71,125 +45,13 @@ export function readHostRssBytesMulti(
   if (normalised.length === 0) {
     return new Map<number, number>();
   }
-  if (osPlatform() === "linux") {
-    return readHostRssBytesLinuxMulti(normalised);
+  const out = new Map<number, number>();
+  for (const { pid, rssBytes } of hostRssNative(normalised)) {
+    out.set(pid, rssBytes);
   }
-  if (osPlatform() === "darwin") {
-    return readHostRssBytesDarwinMulti(normalised);
-  }
-  return new Map<number, number>();
+  return out;
 }
 
 function normaliseRssTargets(targets: ReadonlyArray<RssTarget | number>): RssTarget[] {
   return targets.map((target) => (typeof target === "number" ? { pid: target } : target));
-}
-
-function readHostRssBytesLinuxMulti(targets: RssTarget[]): Map<number, number> {
-  const out = new Map<number, number>();
-  for (const { pid } of targets) {
-    const value = readVmRssLinux(pid);
-    if (value !== null) {
-      out.set(pid, value);
-    }
-  }
-  return out;
-}
-
-function readHostRssBytesDarwinMulti(targets: RssTarget[]): Map<number, number> {
-  // Per-VM phys_footprint from the stats file is free (one
-  // readFileSync per VM, ~µs). Anything that doesn't have a
-  // statsPath, or whose stats file hasn't been written to yet,
-  // falls through to a single bulk `ps` call.
-  const out = new Map<number, number>();
-  const fallbackPids = collectDarwinRssFromStats(targets, out);
-  appendDarwinPsFallback(out, fallbackPids);
-  return out;
-}
-
-function collectDarwinRssFromStats(targets: RssTarget[], out: Map<number, number>): number[] {
-  const fallbackPids: number[] = [];
-  for (const { pid, statsPath } of targets) {
-    const fromStats = readPhysFootprintFromStats(statsPath);
-    if (fromStats !== null) {
-      out.set(pid, fromStats);
-    } else {
-      fallbackPids.push(pid);
-    }
-  }
-  return fallbackPids;
-}
-
-function appendDarwinPsFallback(out: Map<number, number>, fallbackPids: number[]): void {
-  if (fallbackPids.length === 0) {
-    return;
-  }
-  for (const [pid, rss] of readPsRssDarwin(fallbackPids)) {
-    out.set(pid, rss);
-  }
-}
-
-function readVmRssLinux(pid: number): number | null {
-  try {
-    const text = readFileSync(`/proc/${pid}/status`, "utf8");
-    const m = /^VmRSS:\s+(\d+)\s+kB$/m.exec(text);
-    return m ? Number(m[1]) * 1024 : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Read `phys_footprint` from a VMM's stats file. Returns null when
- * no path was supplied, the file is missing/short, or the sampler
- * hasn't written its first reading yet (counter still 0).
- */
-function readPhysFootprintFromStats(statsPath: string | undefined): number | null {
-  if (!statsPath) {
-    return null;
-  }
-  const stats = readBalloonStats(statsPath);
-  if (!stats || stats.hostPhysFootprintBytes === 0) {
-    return null;
-  }
-  return stats.hostPhysFootprintBytes;
-}
-
-function readPsRssDarwin(pids: readonly number[]): Map<number, number> {
-  const out = new Map<number, number>();
-  // Pre-filter out dead / out-of-range pids: macOS `ps` errors out the
-  // whole call when *any* argument fails its validation (e.g. a pid
-  // larger than the kernel's MAXPID). `kill(pid, 0)` is a permission-
-  // less liveness probe.
-  const live: number[] = [];
-  for (const pid of pids) {
-    try {
-      process.kill(pid, 0);
-      live.push(pid);
-    } catch {
-      // Dead, recycled, or out of range — leave it out of the call.
-    }
-  }
-  if (live.length === 0) {
-    return out;
-  }
-  let stdout: string;
-  try {
-    stdout = execFileSync("/bin/ps", ["-o", "pid=,rss=", "-p", live.join(",")], {
-      encoding: "utf8",
-      timeout: 1_000,
-    });
-  } catch {
-    return out;
-  }
-  for (const line of stdout.split("\n")) {
-    const m = /^\s*(\d+)\s+(\d+)\s*$/.exec(line);
-    if (!m) {
-      continue;
-    }
-    const rss = Number(m[2]);
-    if (Number.isFinite(rss) && rss > 0) {
-      out.set(Number(m[1]), rss * 1024);
-    }
-  }
-  return out;
 }

--- a/packages/runtime/src/proc-rss.ts
+++ b/packages/runtime/src/proc-rss.ts
@@ -1,18 +1,12 @@
-// Read the resident-set size of a host pid, in bytes (#274).
+// Host RSS probes for running VMM processes.
 //
-// Linux  → machinen-runtime-helper reads /proc/<pid>/status:VmRSS.
-// Darwin → machinen-runtime-helper prefers the VMM stats file's
-//          phys_footprint sample, then falls back to `ps -o rss=`.
-// other  → null / absent map entries (unsupported by the native helper).
+// Used by `machinen ls` and `vm.memoryStats()` to report how much host memory a
+// VMM process is currently holding. This module calls the native runtime helper
+// and returns best-effort readings: unreadable/dead pids become `null` or absent
+// map entries instead of hard failures.
 //
-// Synchronous because callers — `machinen ls` and `vm.memoryStats()` —
-// fetch the number once, at the moment they need it. There's no
-// daemon, no caching: a stale RSS would be worse than a fresh one a
-// few ms later.
-//
-// Returns `null` (not 0) when the read fails so the caller can tell
-// "VMM is gone / unreadable" apart from "VMM is alive but using zero
-// pages" (which never happens in practice but is the natural floor).
+// On Darwin, Machinen prefers the VMM stats file's `phys_footprint` because it
+// reflects reclaimed balloon pages better than plain `ps` RSS.
 
 import { hostRssNative } from "./native/host-rss.ts";
 

--- a/packages/runtime/src/proc-rss.ts
+++ b/packages/runtime/src/proc-rss.ts
@@ -53,5 +53,16 @@ export function readHostRssBytesMulti(
 }
 
 function normaliseRssTargets(targets: ReadonlyArray<RssTarget | number>): RssTarget[] {
-  return targets.map((target) => (typeof target === "number" ? { pid: target } : target));
+  const out: RssTarget[] = [];
+  for (const target of targets) {
+    const item = typeof target === "number" ? { pid: target } : target;
+    if (isValidPid(item.pid)) {
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+function isValidPid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 0 && pid <= 0xffff_ffff;
 }

--- a/packages/runtime/src/vm-handle.ts
+++ b/packages/runtime/src/vm-handle.ts
@@ -520,9 +520,9 @@ export interface ForkOptions extends Omit<RestoreOptions, "snapDir"> {
   lazy?: boolean;
   /**
    * Backpressure gate (#274). Fraction of host total memory that must
-   * be free before `vm.fork()` is allowed to proceed; if `MemAvailable`
-   * (Linux) / `vm_stat free+speculative+purgeable` (Darwin) drops below
-   * `totalmem() * threshold`, the fork is refused with
+   * be free before `vm.fork()` is allowed to proceed; if native host
+   * available memory drops below total physical memory * threshold,
+   * the fork is refused with
    * `FORK_MEMORY_BACKPRESSURE`. Mirrors the throw-immediately shape of
    * #267's port-conflict gate — caller decides whether to retry.
    *

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -6,12 +6,13 @@
 import { randomBytes } from "node:crypto";
 import { closeSync, existsSync, openSync, writeSync } from "node:fs";
 import { createRequire } from "node:module";
-import { arch as osArch, platform as osPlatform, totalmem } from "node:os";
+import { arch as osArch, platform as osPlatform } from "node:os";
 import { resolve } from "node:path";
 import type { Readable } from "node:stream";
 import debugLib from "debug";
 
 import { BootError } from "../errors.ts";
+import { readHostTotalBytes } from "../host-mem.ts";
 import type { VsockExecOptions } from "../exec.ts";
 import type { OnLog } from "../log.ts";
 import type { VmHandle, WriteFileOptions } from "../vm-handle.ts";
@@ -50,7 +51,7 @@ export function allocateSparseFile(path: string, sizeBytes: number): void {
 const MEMORY_FLOOR_MIB = 512;
 const MEMORY_DEFAULT_CEILING_MIB = 4096;
 
-export function autoSizeMemoryMib(hostBytes: number = totalmem()): number {
+export function autoSizeMemoryMib(hostBytes: number = readHostTotalBytes()): number {
   const hostMib = Math.floor(hostBytes / (1024 * 1024));
   const hostAwareCeiling = Math.floor(hostMib / 2);
   return Math.max(MEMORY_FLOOR_MIB, Math.min(hostAwareCeiling, MEMORY_DEFAULT_CEILING_MIB));


### PR DESCRIPTION
## Problem

Basic host probes still had parsing and validation logic in TypeScript. That made platform-sensitive behavior harder to keep inside the native runtime core.

## Solution

Move host RSS reads, CPU cgroup controls, pid validation, and host memory probes into Zig helper commands. TypeScript keeps the policy decisions and public wrappers.

## Technical Summary

- Keeps this PR focused on host probes, not process shims.
- Preserves the TypeScript API while moving deterministic host parsing into Zig.
- Continues to use command-specific wrappers instead of raw helper calls from product modules.
