### PR TITLE
Move core boot planning to Zig

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -30623,7 +30623,7 @@ much the snapshot path is (or isn't) buying us.
 
 ##### hostBytes?
 
-`number` = `...`
+`number`
 
 #### Returns
 

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -36,6 +36,18 @@ pub const VsockPlan = struct {
     vmm_vsock: ?[]const u8,
 };
 
+pub const PortForwardMapping = struct {
+    host_port: i64,
+    guest_port: i64,
+};
+
+pub const PortForwardValidation = union(enum) {
+    ok,
+    invalid_host_port: i64,
+    invalid_guest_port: i64,
+    duplicate_host_port: u16,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -114,6 +126,22 @@ pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
         if (path.len > 0) return path;
     }
     return null;
+}
+
+pub fn validatePortForward(mappings: []const PortForwardMapping) PortForwardValidation {
+    var seen = std.StaticBitSet(65536).initEmpty();
+    for (mappings) |mapping| {
+        const host_port = validateTcpPort(mapping.host_port) orelse return .{ .invalid_host_port = mapping.host_port };
+        _ = validateTcpPort(mapping.guest_port) orelse return .{ .invalid_guest_port = mapping.guest_port };
+        if (seen.isSet(host_port)) return .{ .duplicate_host_port = @intCast(host_port) };
+        seen.set(host_port);
+    }
+    return .ok;
+}
+
+fn validateTcpPort(port: i64) ?usize {
+    if (port < 1 or port > 65535) return null;
+    return @intCast(port);
 }
 
 pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
@@ -266,6 +294,28 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "validatePortForward rejects invalid and duplicate ports" {
+    try std.testing.expectEqual(PortForwardValidation.ok, validatePortForward(&.{
+        .{ .host_port = 8080, .guest_port = 3000 },
+        .{ .host_port = 8081, .guest_port = 3001 },
+    }));
+    try std.testing.expectEqual(
+        PortForwardValidation{ .invalid_host_port = 0 },
+        validatePortForward(&.{.{ .host_port = 0, .guest_port = 3000 }}),
+    );
+    try std.testing.expectEqual(
+        PortForwardValidation{ .invalid_guest_port = 70000 },
+        validatePortForward(&.{.{ .host_port = 8080, .guest_port = 70000 }}),
+    );
+    try std.testing.expectEqual(
+        PortForwardValidation{ .duplicate_host_port = 8080 },
+        validatePortForward(&.{
+            .{ .host_port = 8080, .guest_port = 3000 },
+            .{ .host_port = 8080, .guest_port = 3001 },
+        }),
+    );
 }
 
 test "planVsock parses existing specs and formats auto specs" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -26,6 +26,16 @@ pub const GuestEnvInput = struct {
     vsock_uds_path: ?[]const u8 = null,
 };
 
+pub const VsockPlanInput = struct {
+    existing_spec: ?[]const u8 = null,
+    auto_uds_path: ?[]const u8 = null,
+};
+
+pub const VsockPlan = struct {
+    uds_path: ?[]const u8,
+    vmm_vsock: ?[]const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -76,6 +86,34 @@ pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPa
         try out.append(allocator, .{ .key = "MACHINEN_VM_HOSTNAME_WAIT", .value = "1" });
     }
     return out.toOwnedSlice(allocator);
+}
+
+pub fn planVsock(allocator: std.mem.Allocator, input: VsockPlanInput) !VsockPlan {
+    if (input.existing_spec) |spec| {
+        return .{ .uds_path = parseVsockUdsPath(spec), .vmm_vsock = null };
+    }
+    if (input.auto_uds_path) |uds| {
+        return .{
+            .uds_path = uds,
+            .vmm_vsock = try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds}),
+        };
+    }
+    return .{ .uds_path = null, .vmm_vsock = null };
+}
+
+pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
+    var entries = std.mem.splitScalar(u8, spec, ',');
+    while (entries.next()) |entry| {
+        const first_colon = std.mem.indexOfScalar(u8, entry, ':') orelse continue;
+        const rest = entry[first_colon + 1 ..];
+        const second_rel = std.mem.indexOfScalar(u8, rest, ':') orelse continue;
+        const port = rest[0..second_rel];
+        if (port.len == 0) continue;
+        if (!isDecimal(port)) continue;
+        const path = rest[second_rel + 1 ..];
+        if (path.len > 0) return path;
+    }
+    return null;
 }
 
 pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
@@ -136,6 +174,14 @@ pub fn normalizeMountGuest(guest: []const u8) PlanError![]const u8 {
         return error.InvalidMountGuestRoot;
     }
     return trimmed;
+}
+
+fn isDecimal(text: []const u8) bool {
+    if (text.len == 0) return false;
+    for (text) |c| {
+        if (c < '0' or c > '9') return false;
+    }
+    return true;
 }
 
 fn resolveExplicitMemory(input: Input) PlanError!?u64 {
@@ -220,6 +266,27 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planVsock parses existing specs and formats auto specs" {
+    try std.testing.expectEqualStrings(
+        "/tmp/exec.sock",
+        parseVsockUdsPath("in:1978:/tmp/exec.sock").?,
+    );
+    try std.testing.expectEqualStrings(
+        "/tmp/first.sock",
+        parseVsockUdsPath("out:1970:/tmp/first.sock,in:1978:/tmp/second.sock").?,
+    );
+    try std.testing.expectEqual(@as(?[]const u8, null), parseVsockUdsPath("in:not-a-port:/tmp/nope"));
+
+    const existing = try planVsock(std.testing.allocator, .{ .existing_spec = "in:1978:/tmp/caller.sock" });
+    try std.testing.expectEqualStrings("/tmp/caller.sock", existing.uds_path.?);
+    try std.testing.expectEqual(@as(?[]const u8, null), existing.vmm_vsock);
+
+    const auto = try planVsock(std.testing.allocator, .{ .auto_uds_path = "/tmp/auto.sock" });
+    defer std.testing.allocator.free(auto.vmm_vsock.?);
+    try std.testing.expectEqualStrings("/tmp/auto.sock", auto.uds_path.?);
+    try std.testing.expectEqualStrings("in:1978:/tmp/auto.sock", auto.vmm_vsock.?);
 }
 
 test "planGuestEnv applies name and hostname wait defaults without overriding caller env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -88,6 +88,16 @@ pub const LiveMount = struct {
     tag: []const u8,
 };
 
+pub const StatsFileInput = struct {
+    existing_path: ?[]const u8 = null,
+    planned_path: ?[]const u8 = null,
+};
+
+pub const StatsFilePlan = struct {
+    stats_file_path: ?[]const u8,
+    vmm_stats_file: ?[]const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -192,6 +202,13 @@ pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) 
         try out.append(allocator, .{ .key = key, .value = value });
     }
     return out.toOwnedSlice(allocator);
+}
+
+pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
+    if (input.existing_path) |path| {
+        return .{ .stats_file_path = path, .vmm_stats_file = null };
+    }
+    return .{ .stats_file_path = input.planned_path, .vmm_stats_file = input.planned_path };
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -371,6 +388,16 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planStatsFile preserves caller path or returns runtime-owned env value" {
+    const existing = planStatsFile(.{ .existing_path = "/tmp/caller-stats.bin" });
+    try std.testing.expectEqualStrings("/tmp/caller-stats.bin", existing.stats_file_path.?);
+    try std.testing.expectEqual(@as(?[]const u8, null), existing.vmm_stats_file);
+
+    const planned = planStatsFile(.{ .planned_path = "/tmp/runtime-stats.bin" });
+    try std.testing.expectEqualStrings("/tmp/runtime-stats.bin", planned.stats_file_path.?);
+    try std.testing.expectEqualStrings("/tmp/runtime-stats.bin", planned.vmm_stats_file.?);
 }
 
 test "planVirtiofsEnv formats indexed virtiofs env entries" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -1,0 +1,155 @@
+const std = @import("std");
+
+const memory_floor_mib: u64 = 512;
+const memory_default_ceiling_mib: u64 = 4096;
+
+pub const RootDiskMode = enum {
+    unset,
+    false_value,
+    path,
+    true_value,
+};
+
+pub const ResourcesMemory = struct {
+    max_mib: u64,
+    reclaim: ?[]const u8,
+};
+
+pub const Input = struct {
+    memory_mib: ?u64 = null,
+    resources_memory: ?ResourcesMemory = null,
+    auto_memory_mib: ?u64 = null,
+    host_total_bytes: ?u64 = null,
+    vmm_memory_preset: bool = false,
+    has_image: bool = false,
+    has_cmd: bool = false,
+    root_disk: RootDiskMode = .unset,
+};
+
+pub const Plan = struct {
+    memory_ceiling_mib: ?u64,
+    vmm_memory_mib: ?u64,
+    wants_root_disk: bool,
+};
+
+pub const PlanError = error{
+    InvalidMemory,
+    ConflictingMemory,
+    InvalidReclaim,
+    CmdWithoutImage,
+    RootDiskWithoutImage,
+    MissingAutoMemory,
+};
+
+pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
+    const host_mib = host_total_bytes / (1024 * 1024);
+    const host_aware_ceiling = host_mib / 2;
+    return @max(memory_floor_mib, @min(host_aware_ceiling, memory_default_ceiling_mib));
+}
+
+pub fn validateMemoryMib(mib: u64) PlanError!u64 {
+    if (mib < memory_floor_mib) return error.InvalidMemory;
+    return mib;
+}
+
+pub fn planCore(input: Input) PlanError!Plan {
+    if (input.has_cmd and !input.has_image) return error.CmdWithoutImage;
+
+    const wants_root_disk = input.root_disk != .false_value and
+        (input.root_disk == .path or input.root_disk == .true_value or input.has_image);
+    if (wants_root_disk and input.root_disk != .path and !input.has_image) {
+        return error.RootDiskWithoutImage;
+    }
+
+    const explicit = try resolveExplicitMemory(input);
+    if (input.vmm_memory_preset) {
+        return .{
+            .memory_ceiling_mib = null,
+            .vmm_memory_mib = null,
+            .wants_root_disk = wants_root_disk,
+        };
+    }
+
+    const ceiling = explicit orelse input.auto_memory_mib orelse if (input.host_total_bytes) |bytes|
+        autoSizeMemoryMib(bytes)
+    else
+        return error.MissingAutoMemory;
+    return .{
+        .memory_ceiling_mib = ceiling,
+        .vmm_memory_mib = ceiling,
+        .wants_root_disk = wants_root_disk,
+    };
+}
+
+fn resolveExplicitMemory(input: Input) PlanError!?u64 {
+    const alias_ceiling = if (input.memory_mib) |mib| try validateMemoryMib(mib) else null;
+    const resource_ceiling = if (input.resources_memory) |memory| blk: {
+        if (memory.reclaim) |reclaim| {
+            if (!std.mem.eql(u8, reclaim, "auto")) return error.InvalidReclaim;
+        }
+        break :blk try validateMemoryMib(memory.max_mib);
+    } else null;
+    if (alias_ceiling != null and resource_ceiling != null and alias_ceiling.? != resource_ceiling.?) {
+        return error.ConflictingMemory;
+    }
+    return resource_ceiling orelse alias_ceiling;
+}
+
+test "autoSizeMemoryMib applies floor, half-host, and default ceiling" {
+    try std.testing.expectEqual(@as(u64, 4096), autoSizeMemoryMib(32 * 1024 * 1024 * 1024));
+    try std.testing.expectEqual(@as(u64, 3072), autoSizeMemoryMib(6 * 1024 * 1024 * 1024));
+    try std.testing.expectEqual(@as(u64, 512), autoSizeMemoryMib(256 * 1024 * 1024));
+}
+
+test "planCore resolves explicit memory aliases" {
+    try std.testing.expectEqual(@as(?u64, 2048), (try planCore(.{
+        .memory_mib = 2048,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    })).memory_ceiling_mib);
+    try std.testing.expectEqual(@as(?u64, 4096), (try planCore(.{
+        .resources_memory = .{ .max_mib = 4096, .reclaim = "auto" },
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    })).memory_ceiling_mib);
+    try std.testing.expectError(error.ConflictingMemory, planCore(.{
+        .memory_mib = 1024,
+        .resources_memory = .{ .max_mib = 2048, .reclaim = "auto" },
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expectError(error.InvalidReclaim, planCore(.{
+        .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+}
+
+test "planCore validates command and rootdisk image requirements" {
+    try std.testing.expectError(error.CmdWithoutImage, planCore(.{
+        .has_cmd = true,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expectError(error.RootDiskWithoutImage, planCore(.{
+        .root_disk = .true_value,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expect((try planCore(.{
+        .has_image = true,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    })).wants_root_disk);
+    try std.testing.expect(!(try planCore(.{
+        .has_image = true,
+        .root_disk = .false_value,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    })).wants_root_disk);
+}
+
+test "planCore honors preset VMM memory after validating public input" {
+    const plan = try planCore(.{
+        .memory_mib = 1024,
+        .vmm_memory_preset = true,
+    });
+    try std.testing.expectEqual(@as(?u64, null), plan.memory_ceiling_mib);
+    try std.testing.expectEqual(@as(?u64, null), plan.vmm_memory_mib);
+    try std.testing.expectError(error.InvalidMemory, planCore(.{
+        .memory_mib = 64,
+        .vmm_memory_preset = true,
+    }));
+}

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -69,6 +69,19 @@ pub const KernelDtbPlan = struct {
     vmm_dtb: ?[]const u8,
 };
 
+pub const VmstateEnvInput = struct {
+    state_path: ?[]const u8 = null,
+    restore_path: ?[]const u8 = null,
+    enable_timing: bool = false,
+    existing_timing: ?[]const u8 = null,
+};
+
+pub const VmstateEnvPlan = struct {
+    snapshot_path: ?[]const u8,
+    restore_path: ?[]const u8,
+    vmstate_timing: ?[]const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -151,6 +164,17 @@ pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
 
 pub fn planKernelDtb(input: KernelDtbInput) KernelDtbPlan {
     return .{ .vmm_kernel = input.kernel_path, .vmm_dtb = input.dtb_path };
+}
+
+pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
+    const should_set_timing = input.restore_path != null and
+        input.enable_timing and
+        (input.existing_timing == null or input.existing_timing.?.len == 0);
+    return .{
+        .snapshot_path = input.state_path,
+        .restore_path = input.restore_path,
+        .vmstate_timing = if (should_set_timing) "1" else null,
+    };
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -330,6 +354,24 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planVmstateEnv forwards snapshot restore and timing env" {
+    const plan = planVmstateEnv(.{
+        .state_path = "/tmp/state.vmstate",
+        .restore_path = "/tmp/restore.vmstate",
+        .enable_timing = true,
+    });
+    try std.testing.expectEqualStrings("/tmp/state.vmstate", plan.snapshot_path.?);
+    try std.testing.expectEqualStrings("/tmp/restore.vmstate", plan.restore_path.?);
+    try std.testing.expectEqualStrings("1", plan.vmstate_timing.?);
+
+    const preset = planVmstateEnv(.{
+        .restore_path = "/tmp/restore.vmstate",
+        .enable_timing = true,
+        .existing_timing = "0",
+    });
+    try std.testing.expectEqual(@as(?[]const u8, null), preset.vmstate_timing);
 }
 
 test "planKernelDtb forwards resolved kernel and dtb paths" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -1,4 +1,14 @@
+// Pure boot-planning rules shared by the native `boot-plan` command.
+//
+// TypeScript still owns effects such as mkdir, fd opening, gvproxy startup,
+// and VMM spawn. This module owns the deterministic decisions that turn boot
+// options into memory ceilings, guest env defaults, vsock/env strings, VMM
+// argv, and validation errors. Keeping these rules native lets later PRs move
+// more boot setup without scattering policy across TS and Zig.
+
 const std = @import("std");
+
+const assert = std.debug.assert;
 
 const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
@@ -132,7 +142,9 @@ pub const PlanError = error{
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
-    var out: std.ArrayList(EnvPair) = .empty;
+    assert(@sizeOf(GuestEnvInput) > 0);
+
+    var out: std.array_list.Aligned(EnvPair, null) = .empty;
     errdefer out.deinit(allocator);
     var has_name = false;
     var has_hostname_wait = false;
@@ -151,19 +163,23 @@ pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPa
 }
 
 pub fn planVsock(allocator: std.mem.Allocator, input: VsockPlanInput) !VsockPlan {
+    assert(@sizeOf(VsockPlanInput) > 0);
+
     if (input.existing_spec) |spec| {
         return .{ .uds_path = parseVsockUdsPath(spec), .vmm_vsock = null };
     }
     if (input.auto_uds_path) |uds| {
         return .{
             .uds_path = uds,
-            .vmm_vsock = try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds}),
+            .vmm_vsock = try std.mem.concat(allocator, u8, &.{ "in:1978:", uds }),
         };
     }
     return .{ .uds_path = null, .vmm_vsock = null };
 }
 
 pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
+    assert(@sizeOf([]const u8) > 0);
+
     var entries = std.mem.splitScalar(u8, spec, ',');
     while (entries.next()) |entry| {
         const first_colon = std.mem.indexOfScalar(u8, entry, ':') orelse continue;
@@ -179,10 +195,14 @@ pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
 }
 
 pub fn planKernelDtb(input: KernelDtbInput) KernelDtbPlan {
+    assert(@sizeOf(KernelDtbInput) > 0);
+
     return .{ .vmm_kernel = input.kernel_path, .vmm_dtb = input.dtb_path };
 }
 
 pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
+    assert(@sizeOf(VmstateEnvInput) > 0);
+
     const should_set_timing = input.restore_path != null and
         input.enable_timing and
         (input.existing_timing == null or input.existing_timing.?.len == 0);
@@ -194,17 +214,27 @@ pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
 }
 
 pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) ![]EnvPair {
-    var out: std.ArrayList(EnvPair) = .empty;
+    assert(@sizeOf(LiveMount) > 0);
+
+    var out: std.array_list.Aligned(EnvPair, null) = .empty;
     errdefer out.deinit(allocator);
     for (mounts, 0..) |mount, i| {
-        const key = try std.fmt.allocPrint(allocator, "MACHINEN_VIRTIOFS_{d}", .{i});
-        const value = try std.fmt.allocPrint(allocator, "{s}:{s}:{s}", .{ mount.tag, mount.mode, mount.host });
+        var key_buf: [64]u8 = undefined;
+        const key_text = try std.fmt.bufPrint(&key_buf, "MACHINEN_VIRTIOFS_{d}", .{i});
+        const key = try std.mem.concat(allocator, u8, &.{key_text});
+        const value = try std.mem.concat(
+            allocator,
+            u8,
+            &.{ mount.tag, ":", mount.mode, ":", mount.host },
+        );
         try out.append(allocator, .{ .key = key, .value = value });
     }
     return out.toOwnedSlice(allocator);
 }
 
 pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
+    assert(@sizeOf(StatsFileInput) > 0);
+
     if (input.existing_path) |path| {
         return .{ .stats_file_path = path, .vmm_stats_file = null };
     }
@@ -212,44 +242,60 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
+    assert(@sizeOf(VmmArgvInput) > 0);
+
     const binary = input.binary orelse return .{ .command = null, .args = &.{} };
     if (input.pdeathsig_path) |pdeathsig| {
-        var args = try allocator.alloc([]const u8, input.args.len + 1);
-        args[0] = binary;
-        @memcpy(args[1..], input.args);
-        return .{ .command = pdeathsig, .args = args };
+        var args: std.array_list.Aligned([]const u8, null) = .empty;
+        errdefer args.deinit(allocator);
+        try args.append(allocator, binary);
+        try args.appendSlice(allocator, input.args);
+        return .{ .command = pdeathsig, .args = try args.toOwnedSlice(allocator) };
     }
     return .{ .command = binary, .args = input.args };
 }
 
 pub fn validatePortForward(mappings: []const PortForwardMapping) PortForwardValidation {
+    assert(@sizeOf(PortForwardMapping) > 0);
+
     var seen = std.StaticBitSet(65536).initEmpty();
     for (mappings) |mapping| {
-        const host_port = validateTcpPort(mapping.host_port) orelse return .{ .invalid_host_port = mapping.host_port };
-        _ = validateTcpPort(mapping.guest_port) orelse return .{ .invalid_guest_port = mapping.guest_port };
-        if (seen.isSet(host_port)) return .{ .duplicate_host_port = @intCast(host_port) };
-        seen.set(host_port);
+        const host_port = validateTcpPort(mapping.host_port) orelse
+            return .{ .invalid_host_port = mapping.host_port };
+        if (validateTcpPort(mapping.guest_port) == null) {
+            return .{ .invalid_guest_port = mapping.guest_port };
+        }
+        if (seen.isSet(@intCast(host_port))) return .{ .duplicate_host_port = host_port };
+        seen.set(@intCast(host_port));
     }
     return .ok;
 }
 
-fn validateTcpPort(port: i64) ?usize {
+fn validateTcpPort(port: i64) ?u16 {
+    assert(@sizeOf(i64) == 8);
+
     if (port < 1 or port > 65535) return null;
     return @intCast(port);
 }
 
 pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
-    const host_mib = host_total_bytes / (1024 * 1024);
-    const host_aware_ceiling = host_mib / 2;
+    assert(memory_floor_mib > 0);
+
+    const host_mib = @divFloor(host_total_bytes, 1024 * 1024);
+    const host_aware_ceiling = @divFloor(host_mib, 2);
     return @max(memory_floor_mib, @min(host_aware_ceiling, memory_default_ceiling_mib));
 }
 
 pub fn validateMemoryMib(mib: u64) PlanError!u64 {
+    assert(memory_floor_mib > 0);
+
     if (mib < memory_floor_mib) return error.InvalidMemory;
     return mib;
 }
 
 pub fn planCore(input: Input) PlanError!Plan {
+    assert(@sizeOf(Input) > 0);
+
     if (input.has_cmd and !input.has_image) return error.CmdWithoutImage;
 
     const wants_root_disk = input.root_disk != .false_value and
@@ -258,7 +304,10 @@ pub fn planCore(input: Input) PlanError!Plan {
         return error.RootDiskWithoutImage;
     }
     if (input.guest_cwd) |cwd| try validateGuestCwd(cwd);
-    const normalized_mount_guest = if (input.mount_guest) |guest| try normalizeMountGuest(guest) else null;
+    const normalized_mount_guest = if (input.mount_guest) |guest|
+        try normalizeMountGuest(guest)
+    else
+        null;
 
     const explicit = try resolveExplicitMemory(input);
     if (input.vmm_memory_preset) {
@@ -270,9 +319,11 @@ pub fn planCore(input: Input) PlanError!Plan {
         };
     }
 
-    const ceiling = explicit orelse input.auto_memory_mib orelse if (input.host_total_bytes) |bytes|
+    const host_ceiling = if (input.host_total_bytes) |bytes|
         autoSizeMemoryMib(bytes)
     else
+        null;
+    const ceiling = explicit orelse input.auto_memory_mib orelse host_ceiling orelse
         return error.MissingAutoMemory;
     return .{
         .memory_ceiling_mib = ceiling,
@@ -283,11 +334,15 @@ pub fn planCore(input: Input) PlanError!Plan {
 }
 
 pub fn validateGuestCwd(cwd: []const u8) PlanError!void {
+    assert(@sizeOf([]const u8) > 0);
+
     if (cwd.len == 0 or cwd[0] != '/') return error.InvalidGuestCwdAbsolute;
     if (std.mem.indexOfScalar(u8, cwd, 0) != null) return error.InvalidGuestCwdNul;
 }
 
 pub fn normalizeMountGuest(guest: []const u8) PlanError![]const u8 {
+    assert(@sizeOf([]const u8) > 0);
+
     if (guest.len == 0 or guest[0] != '/') return error.InvalidMountGuestAbsolute;
     var end = guest.len;
     while (end > 0 and guest[end - 1] == '/') : (end -= 1) {}
@@ -299,6 +354,8 @@ pub fn normalizeMountGuest(guest: []const u8) PlanError![]const u8 {
 }
 
 fn isDecimal(text: []const u8) bool {
+    assert(@sizeOf([]const u8) > 0);
+
     if (text.len == 0) return false;
     for (text) |c| {
         if (c < '0' or c > '9') return false;
@@ -307,6 +364,8 @@ fn isDecimal(text: []const u8) bool {
 }
 
 fn resolveExplicitMemory(input: Input) PlanError!?u64 {
+    assert(@sizeOf(ResourcesMemory) > 0);
+
     const alias_ceiling = if (input.memory_mib) |mib| try validateMemoryMib(mib) else null;
     const resource_ceiling = if (input.resources_memory) |memory| blk: {
         if (memory.reclaim) |reclaim| {
@@ -314,7 +373,10 @@ fn resolveExplicitMemory(input: Input) PlanError!?u64 {
         }
         break :blk try validateMemoryMib(memory.max_mib);
     } else null;
-    if (alias_ceiling != null and resource_ceiling != null and alias_ceiling.? != resource_ceiling.?) {
+    if (alias_ceiling != null and
+        resource_ceiling != null and
+        alias_ceiling.? != resource_ceiling.?)
+    {
         return error.ConflictingMemory;
     }
     return resource_ceiling orelse alias_ceiling;
@@ -413,7 +475,7 @@ test "planVirtiofsEnv formats indexed virtiofs env entries" {
         }
         std.testing.allocator.free(env);
     }
-    try std.testing.expectEqual(@as(usize, 2), env.len);
+    try std.testing.expectEqual(@as(@TypeOf(env.len), 2), env.len);
     try std.testing.expectEqualStrings("MACHINEN_VIRTIOFS_0", env[0].key);
     try std.testing.expectEqualStrings("machinen-lm0:rw:/host/a", env[0].value);
     try std.testing.expectEqualStrings("MACHINEN_VIRTIOFS_1", env[1].key);
@@ -453,7 +515,7 @@ test "planVmmArgv wraps VMM argv with pdeathsig when present" {
         .args = &.{ "--dev", "1" },
     });
     try std.testing.expectEqualStrings("/bin/vmm", direct.command.?);
-    try std.testing.expectEqual(@as(usize, 2), direct.args.len);
+    try std.testing.expectEqual(@as(@TypeOf(direct.args.len), 2), direct.args.len);
     try std.testing.expectEqualStrings("--dev", direct.args[0]);
 
     const wrapped = try planVmmArgv(std.testing.allocator, .{
@@ -463,7 +525,7 @@ test "planVmmArgv wraps VMM argv with pdeathsig when present" {
     });
     defer std.testing.allocator.free(wrapped.args);
     try std.testing.expectEqualStrings("/bin/pdeathsig", wrapped.command.?);
-    try std.testing.expectEqual(@as(usize, 2), wrapped.args.len);
+    try std.testing.expectEqual(@as(@TypeOf(wrapped.args.len), 2), wrapped.args.len);
     try std.testing.expectEqualStrings("/bin/vmm", wrapped.args[0]);
     try std.testing.expectEqualStrings("--dev", wrapped.args[1]);
 }
@@ -499,9 +561,14 @@ test "planVsock parses existing specs and formats auto specs" {
         "/tmp/first.sock",
         parseVsockUdsPath("out:1970:/tmp/first.sock,in:1978:/tmp/second.sock").?,
     );
-    try std.testing.expectEqual(@as(?[]const u8, null), parseVsockUdsPath("in:not-a-port:/tmp/nope"));
+    try std.testing.expectEqual(
+        @as(?[]const u8, null),
+        parseVsockUdsPath("in:not-a-port:/tmp/nope"),
+    );
 
-    const existing = try planVsock(std.testing.allocator, .{ .existing_spec = "in:1978:/tmp/caller.sock" });
+    const existing = try planVsock(std.testing.allocator, .{
+        .existing_spec = "in:1978:/tmp/caller.sock",
+    });
     try std.testing.expectEqualStrings("/tmp/caller.sock", existing.uds_path.?);
     try std.testing.expectEqual(@as(?[]const u8, null), existing.vmm_vsock);
 
@@ -519,7 +586,7 @@ test "planGuestEnv applies name and hostname wait defaults without overriding ca
         .vsock_uds_path = "/tmp/exec.sock",
     });
     defer std.testing.allocator.free(planned);
-    try std.testing.expectEqual(@as(usize, 3), planned.len);
+    try std.testing.expectEqual(@as(@TypeOf(planned.len), 3), planned.len);
     try std.testing.expectEqualStrings("FOO", planned[0].key);
     try std.testing.expectEqualStrings("MACHINEN_VM_NAME", planned[1].key);
     try std.testing.expectEqualStrings("worker", planned[1].value);
@@ -536,7 +603,7 @@ test "planGuestEnv applies name and hostname wait defaults without overriding ca
         .vsock_uds_path = "/tmp/exec.sock",
     });
     defer std.testing.allocator.free(preserved);
-    try std.testing.expectEqual(@as(usize, 2), preserved.len);
+    try std.testing.expectEqual(@as(@TypeOf(preserved.len), 2), preserved.len);
     try std.testing.expectEqualStrings("caller", preserved[0].value);
     try std.testing.expectEqualStrings("0", preserved[1].value);
 }

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -24,12 +24,15 @@ pub const Input = struct {
     has_image: bool = false,
     has_cmd: bool = false,
     root_disk: RootDiskMode = .unset,
+    guest_cwd: ?[]const u8 = null,
+    mount_guest: ?[]const u8 = null,
 };
 
 pub const Plan = struct {
     memory_ceiling_mib: ?u64,
     vmm_memory_mib: ?u64,
     wants_root_disk: bool,
+    normalized_mount_guest: ?[]const u8,
 };
 
 pub const PlanError = error{
@@ -39,6 +42,10 @@ pub const PlanError = error{
     CmdWithoutImage,
     RootDiskWithoutImage,
     MissingAutoMemory,
+    InvalidGuestCwdAbsolute,
+    InvalidGuestCwdNul,
+    InvalidMountGuestAbsolute,
+    InvalidMountGuestRoot,
 };
 
 pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
@@ -60,6 +67,8 @@ pub fn planCore(input: Input) PlanError!Plan {
     if (wants_root_disk and input.root_disk != .path and !input.has_image) {
         return error.RootDiskWithoutImage;
     }
+    if (input.guest_cwd) |cwd| try validateGuestCwd(cwd);
+    const normalized_mount_guest = if (input.mount_guest) |guest| try normalizeMountGuest(guest) else null;
 
     const explicit = try resolveExplicitMemory(input);
     if (input.vmm_memory_preset) {
@@ -67,6 +76,7 @@ pub fn planCore(input: Input) PlanError!Plan {
             .memory_ceiling_mib = null,
             .vmm_memory_mib = null,
             .wants_root_disk = wants_root_disk,
+            .normalized_mount_guest = normalized_mount_guest,
         };
     }
 
@@ -78,7 +88,24 @@ pub fn planCore(input: Input) PlanError!Plan {
         .memory_ceiling_mib = ceiling,
         .vmm_memory_mib = ceiling,
         .wants_root_disk = wants_root_disk,
+        .normalized_mount_guest = normalized_mount_guest,
     };
+}
+
+pub fn validateGuestCwd(cwd: []const u8) PlanError!void {
+    if (cwd.len == 0 or cwd[0] != '/') return error.InvalidGuestCwdAbsolute;
+    if (std.mem.indexOfScalar(u8, cwd, 0) != null) return error.InvalidGuestCwdNul;
+}
+
+pub fn normalizeMountGuest(guest: []const u8) PlanError![]const u8 {
+    if (guest.len == 0 or guest[0] != '/') return error.InvalidMountGuestAbsolute;
+    var end = guest.len;
+    while (end > 0 and guest[end - 1] == '/') : (end -= 1) {}
+    const trimmed = guest[0..end];
+    if (!std.mem.startsWith(u8, trimmed, "/mnt/") or std.mem.eql(u8, trimmed, "/mnt")) {
+        return error.InvalidMountGuestRoot;
+    }
+    return trimmed;
 }
 
 fn resolveExplicitMemory(input: Input) PlanError!?u64 {
@@ -139,6 +166,30 @@ test "planCore validates command and rootdisk image requirements" {
         .root_disk = .false_value,
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     })).wants_root_disk);
+}
+
+test "planCore validates guest cwd and normalizes mount guest paths" {
+    try std.testing.expectError(error.InvalidGuestCwdAbsolute, planCore(.{
+        .guest_cwd = "relative/dir",
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expectError(error.InvalidGuestCwdNul, planCore(.{
+        .guest_cwd = "/mnt/work\x00space",
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expectError(error.InvalidMountGuestAbsolute, planCore(.{
+        .mount_guest = "mnt/app",
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    try std.testing.expectError(error.InvalidMountGuestRoot, planCore(.{
+        .mount_guest = "/srv/app",
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    }));
+    const plan = try planCore(.{
+        .mount_guest = "/mnt/app///",
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    });
+    try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
 }
 
 test "planCore honors preset VMM memory after validating public input" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -48,6 +48,17 @@ pub const PortForwardValidation = union(enum) {
     duplicate_host_port: u16,
 };
 
+pub const VmmArgvInput = struct {
+    binary: ?[]const u8 = null,
+    args: []const []const u8 = &.{},
+    pdeathsig_path: ?[]const u8 = null,
+};
+
+pub const VmmArgvPlan = struct {
+    command: ?[]const u8,
+    args: []const []const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -126,6 +137,17 @@ pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
         if (path.len > 0) return path;
     }
     return null;
+}
+
+pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
+    const binary = input.binary orelse return .{ .command = null, .args = &.{} };
+    if (input.pdeathsig_path) |pdeathsig| {
+        var args = try allocator.alloc([]const u8, input.args.len + 1);
+        args[0] = binary;
+        @memcpy(args[1..], input.args);
+        return .{ .command = pdeathsig, .args = args };
+    }
+    return .{ .command = binary, .args = input.args };
 }
 
 pub fn validatePortForward(mappings: []const PortForwardMapping) PortForwardValidation {
@@ -294,6 +316,27 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planVmmArgv wraps VMM argv with pdeathsig when present" {
+    const direct = try planVmmArgv(std.testing.allocator, .{
+        .binary = "/bin/vmm",
+        .args = &.{ "--dev", "1" },
+    });
+    try std.testing.expectEqualStrings("/bin/vmm", direct.command.?);
+    try std.testing.expectEqual(@as(usize, 2), direct.args.len);
+    try std.testing.expectEqualStrings("--dev", direct.args[0]);
+
+    const wrapped = try planVmmArgv(std.testing.allocator, .{
+        .binary = "/bin/vmm",
+        .args = &.{"--dev"},
+        .pdeathsig_path = "/bin/pdeathsig",
+    });
+    defer std.testing.allocator.free(wrapped.args);
+    try std.testing.expectEqualStrings("/bin/pdeathsig", wrapped.command.?);
+    try std.testing.expectEqual(@as(usize, 2), wrapped.args.len);
+    try std.testing.expectEqualStrings("/bin/vmm", wrapped.args[0]);
+    try std.testing.expectEqualStrings("--dev", wrapped.args[1]);
 }
 
 test "validatePortForward rejects invalid and duplicate ports" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -15,6 +15,17 @@ pub const ResourcesMemory = struct {
     reclaim: ?[]const u8,
 };
 
+pub const EnvPair = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+pub const GuestEnvInput = struct {
+    env: []const EnvPair,
+    name: ?[]const u8 = null,
+    vsock_uds_path: ?[]const u8 = null,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -47,6 +58,25 @@ pub const PlanError = error{
     InvalidMountGuestAbsolute,
     InvalidMountGuestRoot,
 };
+
+pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
+    var out: std.ArrayList(EnvPair) = .empty;
+    errdefer out.deinit(allocator);
+    var has_name = false;
+    var has_hostname_wait = false;
+    for (input.env) |pair| {
+        try out.append(allocator, pair);
+        if (std.mem.eql(u8, pair.key, "MACHINEN_VM_NAME")) has_name = true;
+        if (std.mem.eql(u8, pair.key, "MACHINEN_VM_HOSTNAME_WAIT")) has_hostname_wait = true;
+    }
+    if (input.name) |name| {
+        if (!has_name) try out.append(allocator, .{ .key = "MACHINEN_VM_NAME", .value = name });
+    }
+    if (input.vsock_uds_path != null and !has_hostname_wait) {
+        try out.append(allocator, .{ .key = "MACHINEN_VM_HOSTNAME_WAIT", .value = "1" });
+    }
+    return out.toOwnedSlice(allocator);
+}
 
 pub fn autoSizeMemoryMib(host_total_bytes: u64) u64 {
     const host_mib = host_total_bytes / (1024 * 1024);
@@ -190,6 +220,36 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planGuestEnv applies name and hostname wait defaults without overriding caller env" {
+    const env = [_]EnvPair{.{ .key = "FOO", .value = "bar" }};
+    const planned = try planGuestEnv(std.testing.allocator, .{
+        .env = &env,
+        .name = "worker",
+        .vsock_uds_path = "/tmp/exec.sock",
+    });
+    defer std.testing.allocator.free(planned);
+    try std.testing.expectEqual(@as(usize, 3), planned.len);
+    try std.testing.expectEqualStrings("FOO", planned[0].key);
+    try std.testing.expectEqualStrings("MACHINEN_VM_NAME", planned[1].key);
+    try std.testing.expectEqualStrings("worker", planned[1].value);
+    try std.testing.expectEqualStrings("MACHINEN_VM_HOSTNAME_WAIT", planned[2].key);
+    try std.testing.expectEqualStrings("1", planned[2].value);
+
+    const caller_env = [_]EnvPair{
+        .{ .key = "MACHINEN_VM_NAME", .value = "caller" },
+        .{ .key = "MACHINEN_VM_HOSTNAME_WAIT", .value = "0" },
+    };
+    const preserved = try planGuestEnv(std.testing.allocator, .{
+        .env = &caller_env,
+        .name = "worker",
+        .vsock_uds_path = "/tmp/exec.sock",
+    });
+    defer std.testing.allocator.free(preserved);
+    try std.testing.expectEqual(@as(usize, 2), preserved.len);
+    try std.testing.expectEqualStrings("caller", preserved[0].value);
+    try std.testing.expectEqualStrings("0", preserved[1].value);
 }
 
 test "planCore honors preset VMM memory after validating public input" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -59,6 +59,16 @@ pub const VmmArgvPlan = struct {
     args: []const []const u8,
 };
 
+pub const KernelDtbInput = struct {
+    kernel_path: ?[]const u8 = null,
+    dtb_path: ?[]const u8 = null,
+};
+
+pub const KernelDtbPlan = struct {
+    vmm_kernel: ?[]const u8,
+    vmm_dtb: ?[]const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -137,6 +147,10 @@ pub fn parseVsockUdsPath(spec: []const u8) ?[]const u8 {
         if (path.len > 0) return path;
     }
     return null;
+}
+
+pub fn planKernelDtb(input: KernelDtbInput) KernelDtbPlan {
+    return .{ .vmm_kernel = input.kernel_path, .vmm_dtb = input.dtb_path };
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -316,6 +330,15 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planKernelDtb forwards resolved kernel and dtb paths" {
+    const plan = planKernelDtb(.{ .kernel_path = "/tmp/Image", .dtb_path = "/tmp/virt.dtb" });
+    try std.testing.expectEqualStrings("/tmp/Image", plan.vmm_kernel.?);
+    try std.testing.expectEqualStrings("/tmp/virt.dtb", plan.vmm_dtb.?);
+    const empty = planKernelDtb(.{});
+    try std.testing.expectEqual(@as(?[]const u8, null), empty.vmm_kernel);
+    try std.testing.expectEqual(@as(?[]const u8, null), empty.vmm_dtb);
 }
 
 test "planVmmArgv wraps VMM argv with pdeathsig when present" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -82,6 +82,12 @@ pub const VmstateEnvPlan = struct {
     vmstate_timing: ?[]const u8,
 };
 
+pub const LiveMount = struct {
+    host: []const u8,
+    mode: []const u8,
+    tag: []const u8,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -175,6 +181,17 @@ pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
         .restore_path = input.restore_path,
         .vmstate_timing = if (should_set_timing) "1" else null,
     };
+}
+
+pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) ![]EnvPair {
+    var out: std.ArrayList(EnvPair) = .empty;
+    errdefer out.deinit(allocator);
+    for (mounts, 0..) |mount, i| {
+        const key = try std.fmt.allocPrint(allocator, "MACHINEN_VIRTIOFS_{d}", .{i});
+        const value = try std.fmt.allocPrint(allocator, "{s}:{s}:{s}", .{ mount.tag, mount.mode, mount.host });
+        try out.append(allocator, .{ .key = key, .value = value });
+    }
+    return out.toOwnedSlice(allocator);
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -354,6 +371,26 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planVirtiofsEnv formats indexed virtiofs env entries" {
+    const mounts = [_]LiveMount{
+        .{ .host = "/host/a", .mode = "rw", .tag = "machinen-lm0" },
+        .{ .host = "/host/b", .mode = "ro", .tag = "machinen-lm1" },
+    };
+    const env = try planVirtiofsEnv(std.testing.allocator, &mounts);
+    defer {
+        for (env) |pair| {
+            std.testing.allocator.free(pair.key);
+            std.testing.allocator.free(pair.value);
+        }
+        std.testing.allocator.free(env);
+    }
+    try std.testing.expectEqual(@as(usize, 2), env.len);
+    try std.testing.expectEqualStrings("MACHINEN_VIRTIOFS_0", env[0].key);
+    try std.testing.expectEqualStrings("machinen-lm0:rw:/host/a", env[0].value);
+    try std.testing.expectEqualStrings("MACHINEN_VIRTIOFS_1", env[1].key);
+    try std.testing.expectEqualStrings("machinen-lm1:ro:/host/b", env[1].value);
 }
 
 test "planVmstateEnv forwards snapshot restore and timing env" {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -31,6 +31,7 @@ const ParsedRequest = struct {
     restore_path: ?[]const u8,
     enable_vmstate_timing: bool,
     existing_vmstate_timing: ?[]const u8,
+    live_mounts_resolved: []const boot_plan.LiveMount,
 };
 
 const ParsedResourcesMemory = struct {
@@ -78,6 +79,10 @@ const RequestError = error{
     InvalidRestorePath,
     InvalidEnableVmstateTiming,
     InvalidExistingVmstateTiming,
+    InvalidLiveMountsResolved,
+    InvalidLiveMountHost,
+    InvalidLiveMountMode,
+    InvalidLiveMountTag,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -137,8 +142,9 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .enable_timing = parsed.enable_vmstate_timing,
         .existing_timing = parsed.existing_vmstate_timing,
     });
+    const virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved);
 
-    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env);
+    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env, virtiofs_env);
     return .ok;
 }
 
@@ -150,6 +156,7 @@ fn writePlan(
     vmm_argv: boot_plan.VmmArgvPlan,
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
+    virtiofs_env: []const boot_plan.EnvPair,
 ) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
@@ -216,6 +223,14 @@ fn writePlan(
     } else {
         try protocol.stdout(io, "null");
     }
+    try protocol.stdout(io, ",\"virtiofsEnv\":{");
+    for (virtiofs_env, 0..) |pair, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.writeJsonString(io, pair.key);
+        try protocol.stdout(io, ":");
+        try protocol.writeJsonString(io, pair.value);
+    }
+    try protocol.stdout(io, "}");
     try protocol.stdout(io, ",\"vmmCommand\":");
     if (vmm_argv.command) |command| {
         try protocol.writeJsonString(io, command);
@@ -312,7 +327,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming", "liveMountsResolved" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -339,7 +354,29 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .restore_path = try optionalStringDefaultNull(object, "restorePath", error.InvalidRestorePath),
         .enable_vmstate_timing = try optionalBoolDefaultFalse(object, "enableVmstateTiming", error.InvalidEnableVmstateTiming),
         .existing_vmstate_timing = try optionalStringDefaultNull(object, "existingVmstateTiming", error.InvalidExistingVmstateTiming),
+        .live_mounts_resolved = try optionalLiveMountsResolved(allocator, object),
     };
+}
+
+fn optionalLiveMountsResolved(allocator: std.mem.Allocator, object: std.json.ObjectMap) RequestError![]const boot_plan.LiveMount {
+    const value = object.get("liveMountsResolved") orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return error.InvalidLiveMountsResolved;
+    var mounts: std.ArrayList(boot_plan.LiveMount) = .empty;
+    errdefer mounts.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .object) return error.InvalidLiveMountsResolved;
+        try protocol.rejectUnknownFields(item.object, &.{ "host", "mode", "tag" });
+        const host = item.object.get("host") orelse return error.InvalidLiveMountHost;
+        const mode = item.object.get("mode") orelse return error.InvalidLiveMountMode;
+        const tag = item.object.get("tag") orelse return error.InvalidLiveMountTag;
+        if (host != .string) return error.InvalidLiveMountHost;
+        if (mode != .string) return error.InvalidLiveMountMode;
+        if (!std.mem.eql(u8, mode.string, "ro") and !std.mem.eql(u8, mode.string, "rw")) return error.InvalidLiveMountMode;
+        if (tag != .string) return error.InvalidLiveMountTag;
+        try mounts.append(allocator, .{ .host = host.string, .mode = mode.string, .tag = tag.string });
+    }
+    return mounts.toOwnedSlice(allocator);
 }
 
 fn optionalBoolDefaultFalse(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!bool {
@@ -499,6 +536,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
         error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
         error.InvalidPortForward, error.InvalidHostPort, error.InvalidGuestPort => try protocol.writeError(io, "BOOT_PORT_FORWARD_INVALID", "portForward: hostPort and guestPort must be integers in 1..65535"),
+        error.InvalidLiveMountsResolved, error.InvalidLiveMountHost, error.InvalidLiveMountMode, error.InvalidLiveMountTag => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "liveMounts: resolved live mount entries must include host, tag, and mode ro/rw"),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -19,6 +19,8 @@ const ParsedRequest = struct {
     guest_env: std.json.ObjectMap,
     name: ?[]const u8,
     vsock_uds_path: ?[]const u8,
+    existing_vsock_spec: ?[]const u8,
+    auto_vsock_uds_path: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -52,6 +54,8 @@ const RequestError = error{
     InvalidGuestEnvValue,
     InvalidName,
     InvalidVsockUdsPath,
+    InvalidExistingVsockSpec,
+    InvalidAutoVsockUdsPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -73,16 +77,20 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         try writePlanError(io, err);
         return .fail;
     };
+    const vsock_plan = try boot_plan.planVsock(arena, .{
+        .existing_spec = parsed.existing_vsock_spec,
+        .auto_uds_path = parsed.auto_vsock_uds_path,
+    });
     const guest_env = makeGuestEnv(arena, parsed) catch |err| {
         try writePlanError(io, err);
         return .fail;
     };
 
-    try writePlan(io, plan, guest_env);
+    try writePlan(io, plan, guest_env, vsock_plan);
     return .ok;
 }
 
-fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvPair) !void {
+fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvPair, vsock_plan: boot_plan.VsockPlan) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
     if (plan.memory_ceiling_mib) |mib| {
@@ -103,6 +111,18 @@ fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvP
     try protocol.stdout(io, ",\"normalizedMountGuest\":");
     if (plan.normalized_mount_guest) |guest| {
         try protocol.writeJsonString(io, guest);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vsockUdsPath\":");
+    if (vsock_plan.uds_path) |path| {
+        try protocol.writeJsonString(io, path);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmVsock\":");
+    if (vsock_plan.vmm_vsock) |spec| {
+        try protocol.writeJsonString(io, spec);
     } else {
         try protocol.stdout(io, "null");
     }
@@ -190,7 +210,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -205,6 +225,8 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv),
         .name = try optionalStringDefaultNull(object, "name", error.InvalidName),
         .vsock_uds_path = try optionalStringDefaultNull(object, "vsockUdsPath", error.InvalidVsockUdsPath),
+        .existing_vsock_spec = try optionalStringDefaultNull(object, "existingVsockSpec", error.InvalidExistingVsockSpec),
+        .auto_vsock_uds_path = try optionalStringDefaultNull(object, "autoVsockUdsPath", error.InvalidAutoVsockUdsPath),
     };
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -25,6 +25,8 @@ const ParsedRequest = struct {
     vmm_binary: ?[]const u8,
     vmm_args: []const []const u8,
     pdeathsig_path: ?[]const u8,
+    kernel_path: ?[]const u8,
+    dtb_path: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -66,6 +68,8 @@ const RequestError = error{
     InvalidVmmBinary,
     InvalidVmmArgs,
     InvalidPdeathsigPath,
+    InvalidKernelPath,
+    InvalidDtbPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -115,8 +119,12 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .args = parsed.vmm_args,
         .pdeathsig_path = parsed.pdeathsig_path,
     });
+    const kernel_dtb = boot_plan.planKernelDtb(.{
+        .kernel_path = parsed.kernel_path,
+        .dtb_path = parsed.dtb_path,
+    });
 
-    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv);
+    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb);
     return .ok;
 }
 
@@ -126,6 +134,7 @@ fn writePlan(
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
     vmm_argv: boot_plan.VmmArgvPlan,
+    kernel_dtb: boot_plan.KernelDtbPlan,
 ) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
@@ -159,6 +168,18 @@ fn writePlan(
     try protocol.stdout(io, ",\"vmmVsock\":");
     if (vsock_plan.vmm_vsock) |spec| {
         try protocol.writeJsonString(io, spec);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmKernel\":");
+    if (kernel_dtb.vmm_kernel) |kernel| {
+        try protocol.writeJsonString(io, kernel);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmDtb\":");
+    if (kernel_dtb.vmm_dtb) |dtb| {
+        try protocol.writeJsonString(io, dtb);
     } else {
         try protocol.stdout(io, "null");
     }
@@ -258,7 +279,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -279,6 +300,8 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary),
         .vmm_args = try optionalStringArrayDefaultEmpty(allocator, object, "vmmArgs", error.InvalidVmmArgs),
         .pdeathsig_path = try optionalStringDefaultNull(object, "pdeathsigPath", error.InvalidPdeathsigPath),
+        .kernel_path = try optionalStringDefaultNull(object, "kernelPath", error.InvalidKernelPath),
+        .dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath),
     };
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -32,6 +32,8 @@ const ParsedRequest = struct {
     enable_vmstate_timing: bool,
     existing_vmstate_timing: ?[]const u8,
     live_mounts_resolved: []const boot_plan.LiveMount,
+    existing_stats_file: ?[]const u8,
+    stats_file_path: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -83,6 +85,8 @@ const RequestError = error{
     InvalidLiveMountHost,
     InvalidLiveMountMode,
     InvalidLiveMountTag,
+    InvalidExistingStatsFile,
+    InvalidStatsFilePath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -143,8 +147,12 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .existing_timing = parsed.existing_vmstate_timing,
     });
     const virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved);
+    const stats_file = boot_plan.planStatsFile(.{
+        .existing_path = parsed.existing_stats_file,
+        .planned_path = parsed.stats_file_path,
+    });
 
-    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env, virtiofs_env);
+    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env, virtiofs_env, stats_file);
     return .ok;
 }
 
@@ -157,6 +165,7 @@ fn writePlan(
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
     virtiofs_env: []const boot_plan.EnvPair,
+    stats_file: boot_plan.StatsFilePlan,
 ) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
@@ -220,6 +229,18 @@ fn writePlan(
     try protocol.stdout(io, ",\"vmmVmstateTiming\":");
     if (vmstate_env.vmstate_timing) |timing| {
         try protocol.writeJsonString(io, timing);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"statsFilePath\":");
+    if (stats_file.stats_file_path) |path| {
+        try protocol.writeJsonString(io, path);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmStatsFile\":");
+    if (stats_file.vmm_stats_file) |path| {
+        try protocol.writeJsonString(io, path);
     } else {
         try protocol.stdout(io, "null");
     }
@@ -327,7 +348,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming", "liveMountsResolved" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming", "liveMountsResolved", "existingStatsFile", "statsFilePath" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -355,6 +376,8 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .enable_vmstate_timing = try optionalBoolDefaultFalse(object, "enableVmstateTiming", error.InvalidEnableVmstateTiming),
         .existing_vmstate_timing = try optionalStringDefaultNull(object, "existingVmstateTiming", error.InvalidExistingVmstateTiming),
         .live_mounts_resolved = try optionalLiveMountsResolved(allocator, object),
+        .existing_stats_file = try optionalStringDefaultNull(object, "existingStatsFile", error.InvalidExistingStatsFile),
+        .stats_file_path = try optionalStringDefaultNull(object, "statsFilePath", error.InvalidStatsFilePath),
     };
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -16,6 +16,9 @@ const ParsedRequest = struct {
     root_disk: boot_plan.RootDiskMode,
     guest_cwd: ?[]const u8,
     mount_guest: ?[]const u8,
+    guest_env: std.json.ObjectMap,
+    name: ?[]const u8,
+    vsock_uds_path: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -45,6 +48,10 @@ const RequestError = error{
     InvalidRootDisk,
     InvalidGuestCwd,
     InvalidMountGuest,
+    InvalidGuestEnv,
+    InvalidGuestEnvValue,
+    InvalidName,
+    InvalidVsockUdsPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -66,12 +73,16 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         try writePlanError(io, err);
         return .fail;
     };
+    const guest_env = makeGuestEnv(arena, parsed) catch |err| {
+        try writePlanError(io, err);
+        return .fail;
+    };
 
-    try writePlan(io, plan);
+    try writePlan(io, plan, guest_env);
     return .ok;
 }
 
-fn writePlan(io: std.Io, plan: boot_plan.Plan) !void {
+fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvPair) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
     if (plan.memory_ceiling_mib) |mib| {
@@ -95,7 +106,30 @@ fn writePlan(io: std.Io, plan: boot_plan.Plan) !void {
     } else {
         try protocol.stdout(io, "null");
     }
-    try protocol.stdout(io, "}}\n");
+    try protocol.stdout(io, ",\"mergedGuestEnv\":{");
+    for (guest_env, 0..) |pair, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.writeJsonString(io, pair.key);
+        try protocol.stdout(io, ":");
+        try protocol.writeJsonString(io, pair.value);
+    }
+    try protocol.stdout(io, "}}}\n");
+}
+
+fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
+    var pairs: std.ArrayList(boot_plan.EnvPair) = .empty;
+    errdefer pairs.deinit(allocator);
+    var it = parsed.guest_env.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.* != .string) return error.InvalidGuestEnvValue;
+        try pairs.append(allocator, .{ .key = entry.key_ptr.*, .value = entry.value_ptr.string });
+    }
+    const env_pairs = try pairs.toOwnedSlice(allocator);
+    return boot_plan.planGuestEnv(allocator, .{
+        .env = env_pairs,
+        .name = parsed.name,
+        .vsock_uds_path = parsed.vsock_uds_path,
+    });
 }
 
 fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest) anyerror!boot_plan.Input {
@@ -156,7 +190,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -168,6 +202,9 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .root_disk = try requiredRootDisk(object),
         .guest_cwd = try optionalStringDefaultNull(object, "guestCwd", error.InvalidGuestCwd),
         .mount_guest = try optionalStringDefaultNull(object, "mountGuest", error.InvalidMountGuest),
+        .guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv),
+        .name = try optionalStringDefaultNull(object, "name", error.InvalidName),
+        .vsock_uds_path = try optionalStringDefaultNull(object, "vsockUdsPath", error.InvalidVsockUdsPath),
     };
 }
 
@@ -176,6 +213,14 @@ fn optionalString(object: std.json.ObjectMap, field: []const u8, missing: Reques
     return switch (value) {
         .null => null,
         .string => |s| s,
+        else => invalid,
+    };
+}
+
+fn optionalObjectDefaultEmpty(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!std.json.ObjectMap {
+    const value = object.get(field) orelse return .{};
+    return switch (value) {
+        .object => |o| o,
         else => invalid,
     };
 }
@@ -235,6 +280,7 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
         error.InvalidMountGuestAbsolute => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must be absolute"),
         error.InvalidMountGuestRoot => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must live under /mnt/"),
         error.UnsupportedHostMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: host memory probing is unsupported on this platform"),
+        error.InvalidGuestEnvValue => try protocol.writeError(io, "INVALID_REQUEST", "boot-plan guestEnv values must be strings"),
         else => try protocol.writeError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const boot_plan = @import("../boot_plan.zig");
+const protocol = @import("../protocol.zig");
+
+pub const name = "boot-plan";
+
+const ParsedRequest = struct {
+    memory_mib_text: ?[]const u8,
+    resources_memory: ?ParsedResourcesMemory,
+    auto_memory_mib_text: ?[]const u8,
+    host_total_bytes_text: ?[]const u8,
+    vmm_memory_preset: bool,
+    has_image: bool,
+    has_cmd: bool,
+    root_disk: boot_plan.RootDiskMode,
+};
+
+const ParsedResourcesMemory = struct {
+    max_mib_text: []const u8,
+    reclaim: ?[]const u8,
+};
+
+const RequestError = error{
+    MissingMemoryMib,
+    InvalidMemoryMib,
+    MissingResourcesMemory,
+    InvalidResourcesMemory,
+    MissingResourcesMaxMib,
+    InvalidResourcesMaxMib,
+    InvalidResourcesReclaim,
+    MissingAutoMemoryMib,
+    InvalidAutoMemoryMib,
+    MissingHostTotalBytes,
+    InvalidHostTotalBytes,
+    MissingVmmMemoryPreset,
+    InvalidVmmMemoryPreset,
+    MissingHasImage,
+    InvalidHasImage,
+    MissingHasCmd,
+    InvalidHasCmd,
+    MissingRootDisk,
+    InvalidRootDisk,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const parsed = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const input = makePlanInput(allocator, io, parsed) catch |err| {
+        try writePlanError(io, err);
+        return .fail;
+    };
+
+    const plan = boot_plan.planCore(input) catch |err| {
+        try writePlanError(io, err);
+        return .fail;
+    };
+
+    const memory_text = if (plan.memory_ceiling_mib) |mib|
+        try std.fmt.allocPrint(allocator, "{d}", .{mib})
+    else
+        try allocator.dupe(u8, "null");
+    defer allocator.free(memory_text);
+    const vmm_memory_text = if (plan.vmm_memory_mib) |mib|
+        try std.fmt.allocPrint(allocator, "\"{d}\"", .{mib})
+    else
+        try allocator.dupe(u8, "null");
+    defer allocator.free(vmm_memory_text);
+    const wants_root_disk = if (plan.wants_root_disk) "true" else "false";
+    const out = try std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{{\"memoryCeilingMib\":{s},\"vmmMemory\":{s},\"wantsRootDisk\":{s}}}}}\n",
+        .{ memory_text, vmm_memory_text, wants_root_disk },
+    );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest) anyerror!boot_plan.Input {
+    const explicit_memory = if (parsed.memory_mib_text) |text| try parseMib(text) else null;
+    const resources_memory = if (parsed.resources_memory) |memory| boot_plan.ResourcesMemory{
+        .max_mib = try parseMib(memory.max_mib_text),
+        .reclaim = memory.reclaim,
+    } else null;
+    const auto_memory = if (parsed.auto_memory_mib_text) |text| try parseMib(text) else null;
+    const host_total_bytes = if (parsed.host_total_bytes_text) |text|
+        parseUnsigned(text) catch return error.InvalidMemory
+    else if (explicit_memory == null and resources_memory == null and auto_memory == null and !parsed.vmm_memory_preset)
+        (try runtime_helper.host.readHostMemory(allocator, io)).total_bytes
+    else
+        null;
+    return .{
+        .memory_mib = explicit_memory,
+        .resources_memory = resources_memory,
+        .auto_memory_mib = auto_memory,
+        .host_total_bytes = host_total_bytes,
+        .vmm_memory_preset = parsed.vmm_memory_preset,
+        .has_image = parsed.has_image,
+        .has_cmd = parsed.has_cmd,
+        .root_disk = parsed.root_disk,
+    };
+}
+
+fn parseMib(text: []const u8) boot_plan.PlanError!u64 {
+    const value = parseUnsigned(text) catch return error.InvalidMemory;
+    return boot_plan.validateMemoryMib(value);
+}
+
+fn parseUnsigned(text: []const u8) !u64 {
+    if (text.len == 0) return error.Invalid;
+    for (text) |c| {
+        if (c < '0' or c > '9') return error.Invalid;
+    }
+    return std.fmt.parseUnsigned(u64, text, 10);
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedRequest {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk" });
+    return .{
+        .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
+        .resources_memory = try optionalResourcesMemory(object),
+        .auto_memory_mib_text = try optionalString(object, "autoMemoryMib", error.MissingAutoMemoryMib, error.InvalidAutoMemoryMib),
+        .host_total_bytes_text = try optionalString(object, "hostTotalBytes", error.MissingHostTotalBytes, error.InvalidHostTotalBytes),
+        .vmm_memory_preset = try requiredBool(object, "vmmMemoryPreset", error.MissingVmmMemoryPreset, error.InvalidVmmMemoryPreset),
+        .has_image = try requiredBool(object, "hasImage", error.MissingHasImage, error.InvalidHasImage),
+        .has_cmd = try requiredBool(object, "hasCmd", error.MissingHasCmd, error.InvalidHasCmd),
+        .root_disk = try requiredRootDisk(object),
+    };
+}
+
+fn optionalString(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!?[]const u8 {
+    const value = object.get(field) orelse return missing;
+    return switch (value) {
+        .null => null,
+        .string => |s| s,
+        else => invalid,
+    };
+}
+
+fn requiredBool(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!bool {
+    const value = object.get(field) orelse return missing;
+    return switch (value) {
+        .bool => |b| b,
+        else => invalid,
+    };
+}
+
+fn optionalResourcesMemory(object: std.json.ObjectMap) RequestError!?ParsedResourcesMemory {
+    const value = object.get("resourcesMemory") orelse return error.MissingResourcesMemory;
+    if (value == .null) return null;
+    if (value != .object) return error.InvalidResourcesMemory;
+    try protocol.rejectUnknownFields(value.object, &.{ "maxMib", "reclaim" });
+    const max_mib = value.object.get("maxMib") orelse return error.MissingResourcesMaxMib;
+    if (max_mib != .string) return error.InvalidResourcesMaxMib;
+    const reclaim = value.object.get("reclaim") orelse .null;
+    if (reclaim != .null and reclaim != .string) return error.InvalidResourcesReclaim;
+    return .{
+        .max_mib_text = max_mib.string,
+        .reclaim = if (reclaim == .string) reclaim.string else null,
+    };
+}
+
+fn requiredRootDisk(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskMode {
+    const value = object.get("rootDisk") orelse return error.MissingRootDisk;
+    if (value != .string) return error.InvalidRootDisk;
+    if (std.mem.eql(u8, value.string, "unset")) return .unset;
+    if (std.mem.eql(u8, value.string, "false")) return .false_value;
+    if (std.mem.eql(u8, value.string, "path")) return .path;
+    if (std.mem.eql(u8, value.string, "true")) return .true_value;
+    return error.InvalidRootDisk;
+}
+
+fn writePlanError(io: std.Io, err: anyerror) !void {
+    switch (err) {
+        error.InvalidMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory must be a positive integer at least 512 MiB"),
+        error.ConflictingMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory conflicts with resources.memory.maxMib. Use one value."),
+        error.InvalidReclaim => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: resources.memory.reclaim must be \"auto\" when set."),
+        error.CmdWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set."),
+        error.RootDiskWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: rootDisk: true requires an `image` (the .tar.gz to materialize)."),
+        error.MissingAutoMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory auto-size input is missing"),
+        error.UnsupportedHostMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: host memory probing is unsupported on this platform"),
+        else => try protocol.writeError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
+    }
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -21,6 +21,7 @@ const ParsedRequest = struct {
     vsock_uds_path: ?[]const u8,
     existing_vsock_spec: ?[]const u8,
     auto_vsock_uds_path: ?[]const u8,
+    port_forward: []const boot_plan.PortForwardMapping,
 };
 
 const ParsedResourcesMemory = struct {
@@ -56,6 +57,9 @@ const RequestError = error{
     InvalidVsockUdsPath,
     InvalidExistingVsockSpec,
     InvalidAutoVsockUdsPath,
+    InvalidPortForward,
+    InvalidHostPort,
+    InvalidGuestPort,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -77,6 +81,21 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         try writePlanError(io, err);
         return .fail;
     };
+    switch (boot_plan.validatePortForward(parsed.port_forward)) {
+        .ok => {},
+        .invalid_host_port => |port| {
+            try writePortForwardInvalid(io, "hostPort", port);
+            return .fail;
+        },
+        .invalid_guest_port => |port| {
+            try writePortForwardInvalid(io, "guestPort", port);
+            return .fail;
+        },
+        .duplicate_host_port => |port| {
+            try writeDuplicateHostPort(io, port);
+            return .fail;
+        },
+    }
     const vsock_plan = try boot_plan.planVsock(arena, .{
         .existing_spec = parsed.existing_vsock_spec,
         .auto_uds_path = parsed.auto_vsock_uds_path,
@@ -210,7 +229,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -227,6 +246,33 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .vsock_uds_path = try optionalStringDefaultNull(object, "vsockUdsPath", error.InvalidVsockUdsPath),
         .existing_vsock_spec = try optionalStringDefaultNull(object, "existingVsockSpec", error.InvalidExistingVsockSpec),
         .auto_vsock_uds_path = try optionalStringDefaultNull(object, "autoVsockUdsPath", error.InvalidAutoVsockUdsPath),
+        .port_forward = try optionalPortForward(allocator, object),
+    };
+}
+
+fn optionalPortForward(allocator: std.mem.Allocator, object: std.json.ObjectMap) RequestError![]const boot_plan.PortForwardMapping {
+    const value = object.get("portForward") orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return error.InvalidPortForward;
+    var mappings: std.ArrayList(boot_plan.PortForwardMapping) = .empty;
+    errdefer mappings.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .object) return error.InvalidPortForward;
+        try protocol.rejectUnknownFields(item.object, &.{ "hostPort", "guestPort", "hostAddr" });
+        const host_port = try requiredPort(item.object, "hostPort", error.InvalidHostPort);
+        const guest_port = try requiredPort(item.object, "guestPort", error.InvalidGuestPort);
+        const host_addr = item.object.get("hostAddr") orelse .null;
+        if (host_addr != .null and host_addr != .string) return error.InvalidPortForward;
+        try mappings.append(allocator, .{ .host_port = host_port, .guest_port = guest_port });
+    }
+    return mappings.toOwnedSlice(allocator);
+}
+
+fn requiredPort(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!i64 {
+    const value = object.get(field) orelse return invalid;
+    return switch (value) {
+        .integer => |i| i,
+        else => invalid,
     };
 }
 
@@ -289,6 +335,24 @@ fn requiredRootDisk(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskM
     return error.InvalidRootDisk;
 }
 
+fn writePortForwardInvalid(io: std.Io, label: []const u8, port: i64) !void {
+    var buf: [256]u8 = undefined;
+    try protocol.writeError(
+        io,
+        "BOOT_PORT_FORWARD_INVALID",
+        try std.fmt.bufPrint(&buf, "portForward: {s} must be an integer in 1..65535 (got {d})", .{ label, port }),
+    );
+}
+
+fn writeDuplicateHostPort(io: std.Io, port: u16) !void {
+    var buf: [128]u8 = undefined;
+    try protocol.writeError(
+        io,
+        "BOOT_PORT_FORWARD_CONFLICT",
+        try std.fmt.bufPrint(&buf, "portForward: duplicate hostPort {d}", .{port}),
+    );
+}
+
 fn writePlanError(io: std.Io, err: anyerror) !void {
     switch (err) {
         error.InvalidMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory must be a positive integer at least 512 MiB"),
@@ -316,6 +380,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
         error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
         error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        error.InvalidPortForward, error.InvalidHostPort, error.InvalidGuestPort => try protocol.writeError(io, "BOOT_PORT_FORWARD_INVALID", "portForward: hostPort and guestPort must be integers in 1..65535"),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -14,6 +14,8 @@ const ParsedRequest = struct {
     has_image: bool,
     has_cmd: bool,
     root_disk: boot_plan.RootDiskMode,
+    guest_cwd: ?[]const u8,
+    mount_guest: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -41,6 +43,8 @@ const RequestError = error{
     InvalidHasCmd,
     MissingRootDisk,
     InvalidRootDisk,
+    InvalidGuestCwd,
+    InvalidMountGuest,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -63,25 +67,35 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         return .fail;
     };
 
-    const memory_text = if (plan.memory_ceiling_mib) |mib|
-        try std.fmt.allocPrint(allocator, "{d}", .{mib})
-    else
-        try allocator.dupe(u8, "null");
-    defer allocator.free(memory_text);
-    const vmm_memory_text = if (plan.vmm_memory_mib) |mib|
-        try std.fmt.allocPrint(allocator, "\"{d}\"", .{mib})
-    else
-        try allocator.dupe(u8, "null");
-    defer allocator.free(vmm_memory_text);
-    const wants_root_disk = if (plan.wants_root_disk) "true" else "false";
-    const out = try std.fmt.allocPrint(
-        allocator,
-        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{{\"memoryCeilingMib\":{s},\"vmmMemory\":{s},\"wantsRootDisk\":{s}}}}}\n",
-        .{ memory_text, vmm_memory_text, wants_root_disk },
-    );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writePlan(io, plan);
     return .ok;
+}
+
+fn writePlan(io: std.Io, plan: boot_plan.Plan) !void {
+    try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
+    try protocol.stdout(io, "\"memoryCeilingMib\":");
+    if (plan.memory_ceiling_mib) |mib| {
+        var buf: [32]u8 = undefined;
+        try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{mib}));
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmMemory\":");
+    if (plan.vmm_memory_mib) |mib| {
+        var buf: [32]u8 = undefined;
+        try protocol.writeJsonString(io, try std.fmt.bufPrint(&buf, "{d}", .{mib}));
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"wantsRootDisk\":");
+    try protocol.stdout(io, if (plan.wants_root_disk) "true" else "false");
+    try protocol.stdout(io, ",\"normalizedMountGuest\":");
+    if (plan.normalized_mount_guest) |guest| {
+        try protocol.writeJsonString(io, guest);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, "}}\n");
 }
 
 fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest) anyerror!boot_plan.Input {
@@ -106,6 +120,8 @@ fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest
         .has_image = parsed.has_image,
         .has_cmd = parsed.has_cmd,
         .root_disk = parsed.root_disk,
+        .guest_cwd = parsed.guest_cwd,
+        .mount_guest = parsed.mount_guest,
     };
 }
 
@@ -140,7 +156,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -150,11 +166,22 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .has_image = try requiredBool(object, "hasImage", error.MissingHasImage, error.InvalidHasImage),
         .has_cmd = try requiredBool(object, "hasCmd", error.MissingHasCmd, error.InvalidHasCmd),
         .root_disk = try requiredRootDisk(object),
+        .guest_cwd = try optionalStringDefaultNull(object, "guestCwd", error.InvalidGuestCwd),
+        .mount_guest = try optionalStringDefaultNull(object, "mountGuest", error.InvalidMountGuest),
     };
 }
 
 fn optionalString(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!?[]const u8 {
     const value = object.get(field) orelse return missing;
+    return switch (value) {
+        .null => null,
+        .string => |s| s,
+        else => invalid,
+    };
+}
+
+fn optionalStringDefaultNull(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!?[]const u8 {
+    const value = object.get(field) orelse return null;
     return switch (value) {
         .null => null,
         .string => |s| s,
@@ -203,6 +230,10 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
         error.CmdWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set."),
         error.RootDiskWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: rootDisk: true requires an `image` (the .tar.gz to materialize)."),
         error.MissingAutoMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory auto-size input is missing"),
+        error.InvalidGuestCwdAbsolute => try protocol.writeError(io, "BOOT_CWD_INVALID", "guestCwd must be an absolute path"),
+        error.InvalidGuestCwdNul => try protocol.writeError(io, "BOOT_CWD_INVALID", "guestCwd must not contain NUL bytes"),
+        error.InvalidMountGuestAbsolute => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must be absolute"),
+        error.InvalidMountGuestRoot => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must live under /mnt/"),
         error.UnsupportedHostMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: host memory probing is unsupported on this platform"),
         else => try protocol.writeError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -22,6 +22,9 @@ const ParsedRequest = struct {
     existing_vsock_spec: ?[]const u8,
     auto_vsock_uds_path: ?[]const u8,
     port_forward: []const boot_plan.PortForwardMapping,
+    vmm_binary: ?[]const u8,
+    vmm_args: []const []const u8,
+    pdeathsig_path: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -60,6 +63,9 @@ const RequestError = error{
     InvalidPortForward,
     InvalidHostPort,
     InvalidGuestPort,
+    InvalidVmmBinary,
+    InvalidVmmArgs,
+    InvalidPdeathsigPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -104,12 +110,23 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         try writePlanError(io, err);
         return .fail;
     };
+    const vmm_argv = try boot_plan.planVmmArgv(arena, .{
+        .binary = parsed.vmm_binary,
+        .args = parsed.vmm_args,
+        .pdeathsig_path = parsed.pdeathsig_path,
+    });
 
-    try writePlan(io, plan, guest_env, vsock_plan);
+    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv);
     return .ok;
 }
 
-fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvPair, vsock_plan: boot_plan.VsockPlan) !void {
+fn writePlan(
+    io: std.Io,
+    plan: boot_plan.Plan,
+    guest_env: []const boot_plan.EnvPair,
+    vsock_plan: boot_plan.VsockPlan,
+    vmm_argv: boot_plan.VmmArgvPlan,
+) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
     if (plan.memory_ceiling_mib) |mib| {
@@ -145,6 +162,18 @@ fn writePlan(io: std.Io, plan: boot_plan.Plan, guest_env: []const boot_plan.EnvP
     } else {
         try protocol.stdout(io, "null");
     }
+    try protocol.stdout(io, ",\"vmmCommand\":");
+    if (vmm_argv.command) |command| {
+        try protocol.writeJsonString(io, command);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmArgs\":[");
+    for (vmm_argv.args, 0..) |arg, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.writeJsonString(io, arg);
+    }
+    try protocol.stdout(io, "]");
     try protocol.stdout(io, ",\"mergedGuestEnv\":{");
     for (guest_env, 0..) |pair, i| {
         if (i != 0) try protocol.stdout(io, ",");
@@ -229,7 +258,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -247,7 +276,28 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .existing_vsock_spec = try optionalStringDefaultNull(object, "existingVsockSpec", error.InvalidExistingVsockSpec),
         .auto_vsock_uds_path = try optionalStringDefaultNull(object, "autoVsockUdsPath", error.InvalidAutoVsockUdsPath),
         .port_forward = try optionalPortForward(allocator, object),
+        .vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary),
+        .vmm_args = try optionalStringArrayDefaultEmpty(allocator, object, "vmmArgs", error.InvalidVmmArgs),
+        .pdeathsig_path = try optionalStringDefaultNull(object, "pdeathsigPath", error.InvalidPdeathsigPath),
     };
+}
+
+fn optionalStringArrayDefaultEmpty(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError![]const []const u8 {
+    const value = object.get(field) orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return invalid;
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .string) return invalid;
+        try out.append(allocator, item.string);
+    }
+    return out.toOwnedSlice(allocator);
 }
 
 fn optionalPortForward(allocator: std.mem.Allocator, object: std.json.ObjectMap) RequestError![]const boot_plan.PortForwardMapping {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -27,6 +27,10 @@ const ParsedRequest = struct {
     pdeathsig_path: ?[]const u8,
     kernel_path: ?[]const u8,
     dtb_path: ?[]const u8,
+    vmstate_path: ?[]const u8,
+    restore_path: ?[]const u8,
+    enable_vmstate_timing: bool,
+    existing_vmstate_timing: ?[]const u8,
 };
 
 const ParsedResourcesMemory = struct {
@@ -70,6 +74,10 @@ const RequestError = error{
     InvalidPdeathsigPath,
     InvalidKernelPath,
     InvalidDtbPath,
+    InvalidVmstatePath,
+    InvalidRestorePath,
+    InvalidEnableVmstateTiming,
+    InvalidExistingVmstateTiming,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -123,8 +131,14 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .kernel_path = parsed.kernel_path,
         .dtb_path = parsed.dtb_path,
     });
+    const vmstate_env = boot_plan.planVmstateEnv(.{
+        .state_path = parsed.vmstate_path,
+        .restore_path = parsed.restore_path,
+        .enable_timing = parsed.enable_vmstate_timing,
+        .existing_timing = parsed.existing_vmstate_timing,
+    });
 
-    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb);
+    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env);
     return .ok;
 }
 
@@ -135,6 +149,7 @@ fn writePlan(
     vsock_plan: boot_plan.VsockPlan,
     vmm_argv: boot_plan.VmmArgvPlan,
     kernel_dtb: boot_plan.KernelDtbPlan,
+    vmstate_env: boot_plan.VmstateEnvPlan,
 ) !void {
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
     try protocol.stdout(io, "\"memoryCeilingMib\":");
@@ -180,6 +195,24 @@ fn writePlan(
     try protocol.stdout(io, ",\"vmmDtb\":");
     if (kernel_dtb.vmm_dtb) |dtb| {
         try protocol.writeJsonString(io, dtb);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmSnapshotPath\":");
+    if (vmstate_env.snapshot_path) |snapshot_path| {
+        try protocol.writeJsonString(io, snapshot_path);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmRestorePath\":");
+    if (vmstate_env.restore_path) |restore_path| {
+        try protocol.writeJsonString(io, restore_path);
+    } else {
+        try protocol.stdout(io, "null");
+    }
+    try protocol.stdout(io, ",\"vmmVmstateTiming\":");
+    if (vmstate_env.vmstate_timing) |timing| {
+        try protocol.writeJsonString(io, timing);
     } else {
         try protocol.stdout(io, "null");
     }
@@ -279,7 +312,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath" });
+    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming" });
     return .{
         .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
         .resources_memory = try optionalResourcesMemory(object),
@@ -302,6 +335,18 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
         .pdeathsig_path = try optionalStringDefaultNull(object, "pdeathsigPath", error.InvalidPdeathsigPath),
         .kernel_path = try optionalStringDefaultNull(object, "kernelPath", error.InvalidKernelPath),
         .dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath),
+        .vmstate_path = try optionalStringDefaultNull(object, "vmstatePath", error.InvalidVmstatePath),
+        .restore_path = try optionalStringDefaultNull(object, "restorePath", error.InvalidRestorePath),
+        .enable_vmstate_timing = try optionalBoolDefaultFalse(object, "enableVmstateTiming", error.InvalidEnableVmstateTiming),
+        .existing_vmstate_timing = try optionalStringDefaultNull(object, "existingVmstateTiming", error.InvalidExistingVmstateTiming),
+    };
+}
+
+fn optionalBoolDefaultFalse(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!bool {
+    const value = object.get(field) orelse return false;
+    return switch (value) {
+        .bool => |b| b,
+        else => invalid,
     };
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -3,42 +3,75 @@ const runtime_helper = @import("runtime_helper");
 const boot_plan = @import("../boot_plan.zig");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "boot-plan";
 
 const ParsedRequest = struct {
-    memory_mib_text: ?[]const u8,
-    resources_memory: ?ParsedResourcesMemory,
-    auto_memory_mib_text: ?[]const u8,
-    host_total_bytes_text: ?[]const u8,
-    vmm_memory_preset: bool,
-    has_image: bool,
-    has_cmd: bool,
-    root_disk: boot_plan.RootDiskMode,
-    guest_cwd: ?[]const u8,
-    mount_guest: ?[]const u8,
-    guest_env: std.json.ObjectMap,
-    name: ?[]const u8,
-    vsock_uds_path: ?[]const u8,
-    existing_vsock_spec: ?[]const u8,
-    auto_vsock_uds_path: ?[]const u8,
-    port_forward: []const boot_plan.PortForwardMapping,
-    vmm_binary: ?[]const u8,
-    vmm_args: []const []const u8,
-    pdeathsig_path: ?[]const u8,
-    kernel_path: ?[]const u8,
-    dtb_path: ?[]const u8,
-    vmstate_path: ?[]const u8,
-    restore_path: ?[]const u8,
-    enable_vmstate_timing: bool,
-    existing_vmstate_timing: ?[]const u8,
-    live_mounts_resolved: []const boot_plan.LiveMount,
-    existing_stats_file: ?[]const u8,
-    stats_file_path: ?[]const u8,
+    memory_mib_text: ?[]const u8 = null,
+    resources_memory: ?ParsedResourcesMemory = null,
+    auto_memory_mib_text: ?[]const u8 = null,
+    host_total_bytes_text: ?[]const u8 = null,
+    vmm_memory_preset: bool = false,
+    has_image: bool = false,
+    has_cmd: bool = false,
+    root_disk: boot_plan.RootDiskMode = .unset,
+    guest_cwd: ?[]const u8 = null,
+    mount_guest: ?[]const u8 = null,
+    guest_env: std.json.ObjectMap = .{},
+    name: ?[]const u8 = null,
+    vsock_uds_path: ?[]const u8 = null,
+    existing_vsock_spec: ?[]const u8 = null,
+    auto_vsock_uds_path: ?[]const u8 = null,
+    port_forward: []const boot_plan.PortForwardMapping = &.{},
+    vmm_binary: ?[]const u8 = null,
+    vmm_args: []const []const u8 = &.{},
+    pdeathsig_path: ?[]const u8 = null,
+    kernel_path: ?[]const u8 = null,
+    dtb_path: ?[]const u8 = null,
+    vmstate_path: ?[]const u8 = null,
+    restore_path: ?[]const u8 = null,
+    enable_vmstate_timing: bool = false,
+    existing_vmstate_timing: ?[]const u8 = null,
+    live_mounts_resolved: []const boot_plan.LiveMount = &.{},
+    existing_stats_file: ?[]const u8 = null,
+    stats_file_path: ?[]const u8 = null,
 };
 
 const ParsedResourcesMemory = struct {
     max_mib_text: []const u8,
     reclaim: ?[]const u8,
+};
+
+const boot_plan_fields = [_][]const u8{
+    "memoryMib",
+    "resourcesMemory",
+    "autoMemoryMib",
+    "hostTotalBytes",
+    "vmmMemoryPreset",
+    "hasImage",
+    "hasCmd",
+    "rootDisk",
+    "guestCwd",
+    "mountGuest",
+    "guestEnv",
+    "name",
+    "vsockUdsPath",
+    "existingVsockSpec",
+    "autoVsockUdsPath",
+    "portForward",
+    "vmmBinary",
+    "vmmArgs",
+    "pdeathsigPath",
+    "kernelPath",
+    "dtbPath",
+    "vmstatePath",
+    "restorePath",
+    "enableVmstateTiming",
+    "existingVmstateTiming",
+    "liveMountsResolved",
+    "existingStatsFile",
+    "statsFilePath",
 };
 
 const RequestError = error{
@@ -90,6 +123,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -99,38 +134,54 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         return .fail;
     };
 
-    const input = makePlanInput(allocator, io, parsed) catch |err| {
+    const plan = makeCorePlan(allocator, io, parsed) catch |err| {
         try writePlanError(io, err);
         return .fail;
     };
+    if (try writePortForwardFailure(io, parsed.port_forward)) return .fail;
 
-    const plan = boot_plan.planCore(input) catch |err| {
+    const parts = makePlanParts(arena, parsed, plan) catch |err| {
         try writePlanError(io, err);
         return .fail;
     };
-    switch (boot_plan.validatePortForward(parsed.port_forward)) {
-        .ok => {},
-        .invalid_host_port => |port| {
-            try writePortForwardInvalid(io, "hostPort", port);
-            return .fail;
-        },
-        .invalid_guest_port => |port| {
-            try writePortForwardInvalid(io, "guestPort", port);
-            return .fail;
-        },
-        .duplicate_host_port => |port| {
-            try writeDuplicateHostPort(io, port);
-            return .fail;
-        },
-    }
+    try writePlan(io, parts);
+    return .ok;
+}
+
+const PlanParts = struct {
+    plan: boot_plan.Plan,
+    guest_env: []const boot_plan.EnvPair,
+    vsock_plan: boot_plan.VsockPlan,
+    vmm_argv: boot_plan.VmmArgvPlan,
+    kernel_dtb: boot_plan.KernelDtbPlan,
+    vmstate_env: boot_plan.VmstateEnvPlan,
+    virtiofs_env: []const boot_plan.EnvPair,
+    stats_file: boot_plan.StatsFilePlan,
+};
+
+fn makeCorePlan(
+    helper_allocator: std.mem.Allocator,
+    io: std.Io,
+    parsed: ParsedRequest,
+) !boot_plan.Plan {
+    assert(@sizeOf(boot_plan.Plan) > 0);
+
+    const input = try makePlanInput(helper_allocator, io, parsed);
+    return boot_plan.planCore(input);
+}
+
+fn makePlanParts(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+    plan: boot_plan.Plan,
+) !PlanParts {
+    assert(@sizeOf(PlanParts) > 0);
+
     const vsock_plan = try boot_plan.planVsock(arena, .{
         .existing_spec = parsed.existing_vsock_spec,
         .auto_uds_path = parsed.auto_vsock_uds_path,
     });
-    const guest_env = makeGuestEnv(arena, parsed) catch |err| {
-        try writePlanError(io, err);
-        return .fail;
-    };
+    const guest_env = try makeGuestEnv(arena, parsed);
     const vmm_argv = try boot_plan.planVmmArgv(arena, .{
         .binary = parsed.vmm_binary,
         .args = parsed.vmm_args,
@@ -151,131 +202,199 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         .existing_path = parsed.existing_stats_file,
         .planned_path = parsed.stats_file_path,
     });
-
-    try writePlan(io, plan, guest_env, vsock_plan, vmm_argv, kernel_dtb, vmstate_env, virtiofs_env, stats_file);
-    return .ok;
+    return .{
+        .plan = plan,
+        .guest_env = guest_env,
+        .vsock_plan = vsock_plan,
+        .vmm_argv = vmm_argv,
+        .kernel_dtb = kernel_dtb,
+        .vmstate_env = vmstate_env,
+        .virtiofs_env = virtiofs_env,
+        .stats_file = stats_file,
+    };
 }
 
-fn writePlan(
+fn writePortForwardFailure(
     io: std.Io,
-    plan: boot_plan.Plan,
-    guest_env: []const boot_plan.EnvPair,
+    mappings: []const boot_plan.PortForwardMapping,
+) !bool {
+    assert(@sizeOf(boot_plan.PortForwardMapping) > 0);
+
+    switch (boot_plan.validatePortForward(mappings)) {
+        .ok => return false,
+        .invalid_host_port => |port| try writePortForwardInvalid(io, "hostPort", port),
+        .invalid_guest_port => |port| try writePortForwardInvalid(io, "guestPort", port),
+        .duplicate_host_port => |port| try writeDuplicateHostPort(io, port),
+    }
+    return true;
+}
+
+fn writePlan(io: std.Io, parts: PlanParts) !void {
+    assert(@sizeOf(PlanParts) > 0);
+
+    try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,");
+    try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
+    try writeCoreFields(io, parts.plan);
+    try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
+    try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
+    try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
+    try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
+    try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
+    try writeEnvObjectField(io, "mergedGuestEnv", parts.guest_env, true);
+    try protocol.stdout(io, "}}\n");
+}
+
+fn writeCoreFields(io: std.Io, plan: boot_plan.Plan) !void {
+    assert(@sizeOf(boot_plan.Plan) > 0);
+
+    try writeNullableU64Field(io, "memoryCeilingMib", plan.memory_ceiling_mib, false);
+    try writeNullableU64StringField(io, "vmmMemory", plan.vmm_memory_mib, true);
+    try writeBoolField(io, "wantsRootDisk", plan.wants_root_disk, true);
+    try writeNullableStringField(
+        io,
+        "normalizedMountGuest",
+        plan.normalized_mount_guest,
+        true,
+    );
+}
+
+fn writeVsockKernelFields(
+    io: std.Io,
     vsock_plan: boot_plan.VsockPlan,
-    vmm_argv: boot_plan.VmmArgvPlan,
     kernel_dtb: boot_plan.KernelDtbPlan,
+) !void {
+    assert(@sizeOf(boot_plan.VsockPlan) > 0);
+
+    try writeNullableStringField(io, "vsockUdsPath", vsock_plan.uds_path, true);
+    try writeNullableStringField(io, "vmmVsock", vsock_plan.vmm_vsock, true);
+    try writeNullableStringField(io, "vmmKernel", kernel_dtb.vmm_kernel, true);
+    try writeNullableStringField(io, "vmmDtb", kernel_dtb.vmm_dtb, true);
+}
+
+fn writeVmstateStatsFields(
+    io: std.Io,
     vmstate_env: boot_plan.VmstateEnvPlan,
-    virtiofs_env: []const boot_plan.EnvPair,
     stats_file: boot_plan.StatsFilePlan,
 ) !void {
-    try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,\"command\":\"boot-plan\",\"data\":{");
-    try protocol.stdout(io, "\"memoryCeilingMib\":");
-    if (plan.memory_ceiling_mib) |mib| {
+    assert(@sizeOf(boot_plan.VmstateEnvPlan) > 0);
+
+    try writeNullableStringField(io, "vmmSnapshotPath", vmstate_env.snapshot_path, true);
+    try writeNullableStringField(io, "vmmRestorePath", vmstate_env.restore_path, true);
+    try writeNullableStringField(io, "vmmVmstateTiming", vmstate_env.vmstate_timing, true);
+    try writeNullableStringField(io, "statsFilePath", stats_file.stats_file_path, true);
+    try writeNullableStringField(io, "vmmStatsFile", stats_file.vmm_stats_file, true);
+}
+
+fn writeFieldName(io: std.Io, comptime field: []const u8, comma: bool) !void {
+    assert(field.len > 0);
+
+    if (comma) try protocol.stdout(io, ",");
+    try protocol.writeJsonString(io, field);
+    try protocol.stdout(io, ":");
+}
+
+fn writeNullableU64Field(
+    io: std.Io,
+    comptime field: []const u8,
+    value: ?u64,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (value) |number| {
         var buf: [32]u8 = undefined;
-        try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{mib}));
+        try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{number}));
     } else {
         try protocol.stdout(io, "null");
     }
-    try protocol.stdout(io, ",\"vmmMemory\":");
-    if (plan.vmm_memory_mib) |mib| {
+}
+
+fn writeNullableU64StringField(
+    io: std.Io,
+    comptime field: []const u8,
+    value: ?u64,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (value) |number| {
         var buf: [32]u8 = undefined;
-        try protocol.writeJsonString(io, try std.fmt.bufPrint(&buf, "{d}", .{mib}));
+        try protocol.writeJsonString(io, try std.fmt.bufPrint(&buf, "{d}", .{number}));
     } else {
         try protocol.stdout(io, "null");
     }
-    try protocol.stdout(io, ",\"wantsRootDisk\":");
-    try protocol.stdout(io, if (plan.wants_root_disk) "true" else "false");
-    try protocol.stdout(io, ",\"normalizedMountGuest\":");
-    if (plan.normalized_mount_guest) |guest| {
-        try protocol.writeJsonString(io, guest);
+}
+
+fn writeNullableStringField(
+    io: std.Io,
+    comptime field: []const u8,
+    value: ?[]const u8,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (value) |text| {
+        try protocol.writeJsonString(io, text);
     } else {
         try protocol.stdout(io, "null");
     }
-    try protocol.stdout(io, ",\"vsockUdsPath\":");
-    if (vsock_plan.uds_path) |path| {
-        try protocol.writeJsonString(io, path);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmVsock\":");
-    if (vsock_plan.vmm_vsock) |spec| {
-        try protocol.writeJsonString(io, spec);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmKernel\":");
-    if (kernel_dtb.vmm_kernel) |kernel| {
-        try protocol.writeJsonString(io, kernel);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmDtb\":");
-    if (kernel_dtb.vmm_dtb) |dtb| {
-        try protocol.writeJsonString(io, dtb);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmSnapshotPath\":");
-    if (vmstate_env.snapshot_path) |snapshot_path| {
-        try protocol.writeJsonString(io, snapshot_path);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmRestorePath\":");
-    if (vmstate_env.restore_path) |restore_path| {
-        try protocol.writeJsonString(io, restore_path);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmVmstateTiming\":");
-    if (vmstate_env.vmstate_timing) |timing| {
-        try protocol.writeJsonString(io, timing);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"statsFilePath\":");
-    if (stats_file.stats_file_path) |path| {
-        try protocol.writeJsonString(io, path);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmStatsFile\":");
-    if (stats_file.vmm_stats_file) |path| {
-        try protocol.writeJsonString(io, path);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"virtiofsEnv\":{");
-    for (virtiofs_env, 0..) |pair, i| {
+}
+
+fn writeBoolField(
+    io: std.Io,
+    comptime field: []const u8,
+    value: bool,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, if (value) "true" else "false");
+}
+
+fn writeEnvObjectField(
+    io: std.Io,
+    comptime field: []const u8,
+    pairs: []const boot_plan.EnvPair,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    for (pairs, 0..) |pair, i| {
         if (i != 0) try protocol.stdout(io, ",");
         try protocol.writeJsonString(io, pair.key);
         try protocol.stdout(io, ":");
         try protocol.writeJsonString(io, pair.value);
     }
     try protocol.stdout(io, "}");
-    try protocol.stdout(io, ",\"vmmCommand\":");
-    if (vmm_argv.command) |command| {
-        try protocol.writeJsonString(io, command);
-    } else {
-        try protocol.stdout(io, "null");
-    }
-    try protocol.stdout(io, ",\"vmmArgs\":[");
-    for (vmm_argv.args, 0..) |arg, i| {
+}
+
+fn writeStringArrayField(
+    io: std.Io,
+    comptime field: []const u8,
+    values: []const []const u8,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (values, 0..) |value, i| {
         if (i != 0) try protocol.stdout(io, ",");
-        try protocol.writeJsonString(io, arg);
+        try protocol.writeJsonString(io, value);
     }
     try protocol.stdout(io, "]");
-    try protocol.stdout(io, ",\"mergedGuestEnv\":{");
-    for (guest_env, 0..) |pair, i| {
-        if (i != 0) try protocol.stdout(io, ",");
-        try protocol.writeJsonString(io, pair.key);
-        try protocol.stdout(io, ":");
-        try protocol.writeJsonString(io, pair.value);
-    }
-    try protocol.stdout(io, "}}}\n");
 }
 
 fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
-    var pairs: std.ArrayList(boot_plan.EnvPair) = .empty;
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    var pairs: std.array_list.Aligned(boot_plan.EnvPair, null) = .empty;
     errdefer pairs.deinit(allocator);
     var it = parsed.guest_env.iterator();
     while (it.next()) |entry| {
@@ -290,19 +409,31 @@ fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_pla
     });
 }
 
-fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest) anyerror!boot_plan.Input {
+fn makePlanInput(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    parsed: ParsedRequest,
+) anyerror!boot_plan.Input {
+    assert(@sizeOf(boot_plan.Input) > 0);
+
     const explicit_memory = if (parsed.memory_mib_text) |text| try parseMib(text) else null;
     const resources_memory = if (parsed.resources_memory) |memory| boot_plan.ResourcesMemory{
         .max_mib = try parseMib(memory.max_mib_text),
         .reclaim = memory.reclaim,
     } else null;
     const auto_memory = if (parsed.auto_memory_mib_text) |text| try parseMib(text) else null;
-    const host_total_bytes = if (parsed.host_total_bytes_text) |text|
-        parseUnsigned(text) catch return error.InvalidMemory
-    else if (explicit_memory == null and resources_memory == null and auto_memory == null and !parsed.vmm_memory_preset)
+    const should_probe_host = explicit_memory == null and
+        resources_memory == null and
+        auto_memory == null and
+        !parsed.vmm_memory_preset;
+    const probed_host_bytes = if (should_probe_host)
         (try runtime_helper.host.readHostMemory(allocator, io)).total_bytes
     else
         null;
+    const host_total_bytes = if (parsed.host_total_bytes_text) |text|
+        parseUnsigned(text) catch return error.InvalidMemory
+    else
+        probed_host_bytes;
     return .{
         .memory_mib = explicit_memory,
         .resources_memory = resources_memory,
@@ -318,11 +449,15 @@ fn makePlanInput(allocator: std.mem.Allocator, io: std.Io, parsed: ParsedRequest
 }
 
 fn parseMib(text: []const u8) boot_plan.PlanError!u64 {
+    assert(@sizeOf(u64) > 0);
+
     const value = parseUnsigned(text) catch return error.InvalidMemory;
     return boot_plan.validateMemoryMib(value);
 }
 
 fn parseUnsigned(text: []const u8) !u64 {
+    assert(@sizeOf(u64) > 0);
+
     if (text.len == 0) return error.Invalid;
     for (text) |c| {
         if (c < '0' or c > '9') return error.Invalid;
@@ -331,6 +466,8 @@ fn parseUnsigned(text: []const u8) !u64 {
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedRequest {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -343,49 +480,181 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedReq
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
-    const object = data_value.object;
-    try protocol.rejectUnknownFields(object, &.{ "memoryMib", "resourcesMemory", "autoMemoryMib", "hostTotalBytes", "vmmMemoryPreset", "hasImage", "hasCmd", "rootDisk", "guestCwd", "mountGuest", "guestEnv", "name", "vsockUdsPath", "existingVsockSpec", "autoVsockUdsPath", "portForward", "vmmBinary", "vmmArgs", "pdeathsigPath", "kernelPath", "dtbPath", "vmstatePath", "restorePath", "enableVmstateTiming", "existingVmstateTiming", "liveMountsResolved", "existingStatsFile", "statsFilePath" });
-    return .{
-        .memory_mib_text = try optionalString(object, "memoryMib", error.MissingMemoryMib, error.InvalidMemoryMib),
-        .resources_memory = try optionalResourcesMemory(object),
-        .auto_memory_mib_text = try optionalString(object, "autoMemoryMib", error.MissingAutoMemoryMib, error.InvalidAutoMemoryMib),
-        .host_total_bytes_text = try optionalString(object, "hostTotalBytes", error.MissingHostTotalBytes, error.InvalidHostTotalBytes),
-        .vmm_memory_preset = try requiredBool(object, "vmmMemoryPreset", error.MissingVmmMemoryPreset, error.InvalidVmmMemoryPreset),
-        .has_image = try requiredBool(object, "hasImage", error.MissingHasImage, error.InvalidHasImage),
-        .has_cmd = try requiredBool(object, "hasCmd", error.MissingHasCmd, error.InvalidHasCmd),
-        .root_disk = try requiredRootDisk(object),
-        .guest_cwd = try optionalStringDefaultNull(object, "guestCwd", error.InvalidGuestCwd),
-        .mount_guest = try optionalStringDefaultNull(object, "mountGuest", error.InvalidMountGuest),
-        .guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv),
-        .name = try optionalStringDefaultNull(object, "name", error.InvalidName),
-        .vsock_uds_path = try optionalStringDefaultNull(object, "vsockUdsPath", error.InvalidVsockUdsPath),
-        .existing_vsock_spec = try optionalStringDefaultNull(object, "existingVsockSpec", error.InvalidExistingVsockSpec),
-        .auto_vsock_uds_path = try optionalStringDefaultNull(object, "autoVsockUdsPath", error.InvalidAutoVsockUdsPath),
-        .port_forward = try optionalPortForward(allocator, object),
-        .vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary),
-        .vmm_args = try optionalStringArrayDefaultEmpty(allocator, object, "vmmArgs", error.InvalidVmmArgs),
-        .pdeathsig_path = try optionalStringDefaultNull(object, "pdeathsigPath", error.InvalidPdeathsigPath),
-        .kernel_path = try optionalStringDefaultNull(object, "kernelPath", error.InvalidKernelPath),
-        .dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath),
-        .vmstate_path = try optionalStringDefaultNull(object, "vmstatePath", error.InvalidVmstatePath),
-        .restore_path = try optionalStringDefaultNull(object, "restorePath", error.InvalidRestorePath),
-        .enable_vmstate_timing = try optionalBoolDefaultFalse(object, "enableVmstateTiming", error.InvalidEnableVmstateTiming),
-        .existing_vmstate_timing = try optionalStringDefaultNull(object, "existingVmstateTiming", error.InvalidExistingVmstateTiming),
-        .live_mounts_resolved = try optionalLiveMountsResolved(allocator, object),
-        .existing_stats_file = try optionalStringDefaultNull(object, "existingStatsFile", error.InvalidExistingStatsFile),
-        .stats_file_path = try optionalStringDefaultNull(object, "statsFilePath", error.InvalidStatsFilePath),
-    };
+    return parseRequestObject(allocator, data_value.object);
 }
 
-fn optionalLiveMountsResolved(allocator: std.mem.Allocator, object: std.json.ObjectMap) RequestError![]const boot_plan.LiveMount {
+fn parseRequestObject(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError!ParsedRequest {
+    assert(boot_plan_fields.len > 0);
+
+    try protocol.rejectUnknownFields(object, &boot_plan_fields);
+    var request: ParsedRequest = .{};
+    try parseMemoryFields(object, &request);
+    try parseBootShapeFields(object, &request);
+    try parseTransportFields(allocator, object, &request);
+    try parseKernelVmstateFields(allocator, object, &request);
+    return request;
+}
+
+fn parseMemoryFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.memory_mib_text = try optionalString(
+        object,
+        "memoryMib",
+        error.MissingMemoryMib,
+        error.InvalidMemoryMib,
+    );
+    request.resources_memory = try optionalResourcesMemory(object);
+    request.auto_memory_mib_text = try optionalString(
+        object,
+        "autoMemoryMib",
+        error.MissingAutoMemoryMib,
+        error.InvalidAutoMemoryMib,
+    );
+    request.host_total_bytes_text = try optionalString(
+        object,
+        "hostTotalBytes",
+        error.MissingHostTotalBytes,
+        error.InvalidHostTotalBytes,
+    );
+    request.vmm_memory_preset = try requiredBool(
+        object,
+        "vmmMemoryPreset",
+        error.MissingVmmMemoryPreset,
+        error.InvalidVmmMemoryPreset,
+    );
+}
+
+fn parseBootShapeFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.has_image = try requiredBool(
+        object,
+        "hasImage",
+        error.MissingHasImage,
+        error.InvalidHasImage,
+    );
+    request.has_cmd = try requiredBool(object, "hasCmd", error.MissingHasCmd, error.InvalidHasCmd);
+    request.root_disk = try requiredRootDisk(object);
+    request.guest_cwd = try optionalStringDefaultNull(
+        object,
+        "guestCwd",
+        error.InvalidGuestCwd,
+    );
+    request.mount_guest = try optionalStringDefaultNull(
+        object,
+        "mountGuest",
+        error.InvalidMountGuest,
+    );
+    request.guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv);
+    request.name = try optionalStringDefaultNull(object, "name", error.InvalidName);
+}
+
+fn parseTransportFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.vsock_uds_path = try optionalStringDefaultNull(
+        object,
+        "vsockUdsPath",
+        error.InvalidVsockUdsPath,
+    );
+    request.existing_vsock_spec = try optionalStringDefaultNull(
+        object,
+        "existingVsockSpec",
+        error.InvalidExistingVsockSpec,
+    );
+    request.auto_vsock_uds_path = try optionalStringDefaultNull(
+        object,
+        "autoVsockUdsPath",
+        error.InvalidAutoVsockUdsPath,
+    );
+    request.port_forward = try optionalPortForward(allocator, object);
+    request.vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary);
+    request.vmm_args = try optionalStringArrayDefaultEmpty(
+        allocator,
+        object,
+        "vmmArgs",
+        error.InvalidVmmArgs,
+    );
+    request.pdeathsig_path = try optionalStringDefaultNull(
+        object,
+        "pdeathsigPath",
+        error.InvalidPdeathsigPath,
+    );
+}
+
+fn parseKernelVmstateFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.kernel_path = try optionalStringDefaultNull(
+        object,
+        "kernelPath",
+        error.InvalidKernelPath,
+    );
+    request.dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath);
+    request.vmstate_path = try optionalStringDefaultNull(
+        object,
+        "vmstatePath",
+        error.InvalidVmstatePath,
+    );
+    request.restore_path = try optionalStringDefaultNull(
+        object,
+        "restorePath",
+        error.InvalidRestorePath,
+    );
+    request.enable_vmstate_timing = try optionalBoolDefaultFalse(
+        object,
+        "enableVmstateTiming",
+        error.InvalidEnableVmstateTiming,
+    );
+    request.existing_vmstate_timing = try optionalStringDefaultNull(
+        object,
+        "existingVmstateTiming",
+        error.InvalidExistingVmstateTiming,
+    );
+    request.live_mounts_resolved = try optionalLiveMountsResolved(allocator, object);
+    request.existing_stats_file = try optionalStringDefaultNull(
+        object,
+        "existingStatsFile",
+        error.InvalidExistingStatsFile,
+    );
+    request.stats_file_path = try optionalStringDefaultNull(
+        object,
+        "statsFilePath",
+        error.InvalidStatsFilePath,
+    );
+}
+
+fn optionalLiveMountsResolved(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError![]const boot_plan.LiveMount {
+    assert(@sizeOf(boot_plan.LiveMount) > 0);
+
     const value = object.get("liveMountsResolved") orelse return &.{};
     if (value == .null) return &.{};
     if (value != .array) return error.InvalidLiveMountsResolved;
-    var mounts: std.ArrayList(boot_plan.LiveMount) = .empty;
+    var mounts: std.array_list.Aligned(boot_plan.LiveMount, null) = .empty;
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidLiveMountsResolved;
@@ -395,14 +664,28 @@ fn optionalLiveMountsResolved(allocator: std.mem.Allocator, object: std.json.Obj
         const tag = item.object.get("tag") orelse return error.InvalidLiveMountTag;
         if (host != .string) return error.InvalidLiveMountHost;
         if (mode != .string) return error.InvalidLiveMountMode;
-        if (!std.mem.eql(u8, mode.string, "ro") and !std.mem.eql(u8, mode.string, "rw")) return error.InvalidLiveMountMode;
+        if (!std.mem.eql(u8, mode.string, "ro") and
+            !std.mem.eql(u8, mode.string, "rw"))
+        {
+            return error.InvalidLiveMountMode;
+        }
         if (tag != .string) return error.InvalidLiveMountTag;
-        try mounts.append(allocator, .{ .host = host.string, .mode = mode.string, .tag = tag.string });
+        try mounts.append(allocator, .{
+            .host = host.string,
+            .mode = mode.string,
+            .tag = tag.string,
+        });
     }
     return mounts.toOwnedSlice(allocator);
 }
 
-fn optionalBoolDefaultFalse(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!bool {
+fn optionalBoolDefaultFalse(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!bool {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return false;
     return switch (value) {
         .bool => |b| b,
@@ -419,7 +702,9 @@ fn optionalStringArrayDefaultEmpty(
     const value = object.get(field) orelse return &.{};
     if (value == .null) return &.{};
     if (value != .array) return invalid;
-    var out: std.ArrayList([]const u8) = .empty;
+    assert(field.len > 0);
+
+    var out: std.array_list.Aligned([]const u8, null) = .empty;
     errdefer out.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .string) return invalid;
@@ -428,11 +713,16 @@ fn optionalStringArrayDefaultEmpty(
     return out.toOwnedSlice(allocator);
 }
 
-fn optionalPortForward(allocator: std.mem.Allocator, object: std.json.ObjectMap) RequestError![]const boot_plan.PortForwardMapping {
+fn optionalPortForward(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError![]const boot_plan.PortForwardMapping {
+    assert(@sizeOf(boot_plan.PortForwardMapping) > 0);
+
     const value = object.get("portForward") orelse return &.{};
     if (value == .null) return &.{};
     if (value != .array) return error.InvalidPortForward;
-    var mappings: std.ArrayList(boot_plan.PortForwardMapping) = .empty;
+    var mappings: std.array_list.Aligned(boot_plan.PortForwardMapping, null) = .empty;
     errdefer mappings.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidPortForward;
@@ -446,7 +736,13 @@ fn optionalPortForward(allocator: std.mem.Allocator, object: std.json.ObjectMap)
     return mappings.toOwnedSlice(allocator);
 }
 
-fn requiredPort(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!i64 {
+fn requiredPort(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!i64 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return invalid;
     return switch (value) {
         .integer => |i| i,
@@ -454,7 +750,14 @@ fn requiredPort(object: std.json.ObjectMap, field: []const u8, invalid: RequestE
     };
 }
 
-fn optionalString(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!?[]const u8 {
+fn optionalString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError!?[]const u8 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return missing;
     return switch (value) {
         .null => null,
@@ -463,7 +766,13 @@ fn optionalString(object: std.json.ObjectMap, field: []const u8, missing: Reques
     };
 }
 
-fn optionalObjectDefaultEmpty(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!std.json.ObjectMap {
+fn optionalObjectDefaultEmpty(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!std.json.ObjectMap {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return .{};
     return switch (value) {
         .object => |o| o,
@@ -471,7 +780,13 @@ fn optionalObjectDefaultEmpty(object: std.json.ObjectMap, field: []const u8, inv
     };
 }
 
-fn optionalStringDefaultNull(object: std.json.ObjectMap, field: []const u8, invalid: RequestError) RequestError!?[]const u8 {
+fn optionalStringDefaultNull(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!?[]const u8 {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return null;
     return switch (value) {
         .null => null,
@@ -480,7 +795,14 @@ fn optionalStringDefaultNull(object: std.json.ObjectMap, field: []const u8, inva
     };
 }
 
-fn requiredBool(object: std.json.ObjectMap, field: []const u8, missing: RequestError, invalid: RequestError) RequestError!bool {
+fn requiredBool(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError!bool {
+    assert(field.len > 0);
+
     const value = object.get(field) orelse return missing;
     return switch (value) {
         .bool => |b| b,
@@ -489,6 +811,8 @@ fn requiredBool(object: std.json.ObjectMap, field: []const u8, missing: RequestE
 }
 
 fn optionalResourcesMemory(object: std.json.ObjectMap) RequestError!?ParsedResourcesMemory {
+    assert(@sizeOf(ParsedResourcesMemory) > 0);
+
     const value = object.get("resourcesMemory") orelse return error.MissingResourcesMemory;
     if (value == .null) return null;
     if (value != .object) return error.InvalidResourcesMemory;
@@ -504,6 +828,8 @@ fn optionalResourcesMemory(object: std.json.ObjectMap) RequestError!?ParsedResou
 }
 
 fn requiredRootDisk(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskMode {
+    assert(@sizeOf(boot_plan.RootDiskMode) > 0);
+
     const value = object.get("rootDisk") orelse return error.MissingRootDisk;
     if (value != .string) return error.InvalidRootDisk;
     if (std.mem.eql(u8, value.string, "unset")) return .unset;
@@ -514,15 +840,23 @@ fn requiredRootDisk(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskM
 }
 
 fn writePortForwardInvalid(io: std.Io, label: []const u8, port: i64) !void {
+    assert(label.len > 0);
+
     var buf: [256]u8 = undefined;
     try protocol.writeError(
         io,
         "BOOT_PORT_FORWARD_INVALID",
-        try std.fmt.bufPrint(&buf, "portForward: {s} must be an integer in 1..65535 (got {d})", .{ label, port }),
+        try std.fmt.bufPrint(
+            &buf,
+            "portForward: {s} must be an integer in 1..65535 (got {d})",
+            .{ label, port },
+        ),
     );
 }
 
 fn writeDuplicateHostPort(io: std.Io, port: u16) !void {
+    assert(port > 0);
+
     var buf: [128]u8 = undefined;
     try protocol.writeError(
         io,
@@ -532,34 +866,102 @@ fn writeDuplicateHostPort(io: std.Io, port: u16) !void {
 }
 
 fn writePlanError(io: std.Io, err: anyerror) !void {
+    assert(@errorName(err).len > 0);
+
     switch (err) {
-        error.InvalidMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory must be a positive integer at least 512 MiB"),
-        error.ConflictingMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory conflicts with resources.memory.maxMib. Use one value."),
-        error.InvalidReclaim => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: resources.memory.reclaim must be \"auto\" when set."),
-        error.CmdWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set."),
-        error.RootDiskWithoutImage => try protocol.writeError(io, "BOOT_CMD_WITHOUT_IMAGE", "boot: rootDisk: true requires an `image` (the .tar.gz to materialize)."),
-        error.MissingAutoMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: memory auto-size input is missing"),
-        error.InvalidGuestCwdAbsolute => try protocol.writeError(io, "BOOT_CWD_INVALID", "guestCwd must be an absolute path"),
-        error.InvalidGuestCwdNul => try protocol.writeError(io, "BOOT_CWD_INVALID", "guestCwd must not contain NUL bytes"),
-        error.InvalidMountGuestAbsolute => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must be absolute"),
-        error.InvalidMountGuestRoot => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "mount guest path must live under /mnt/"),
-        error.UnsupportedHostMemory => try protocol.writeError(io, "BOOT_MEMORY_INVALID", "boot: host memory probing is unsupported on this platform"),
-        error.InvalidGuestEnvValue => try protocol.writeError(io, "INVALID_REQUEST", "boot-plan guestEnv values must be strings"),
-        else => try protocol.writeError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
+        error.InvalidMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: memory must be a positive integer at least 512 MiB",
+        ),
+        error.ConflictingMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: memory conflicts with resources.memory.maxMib. Use one value.",
+        ),
+        error.InvalidReclaim => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: resources.memory.reclaim must be \"auto\" when set.",
+        ),
+        error.CmdWithoutImage => try writeBootError(
+            io,
+            "BOOT_CMD_WITHOUT_IMAGE",
+            "boot: `image` is required when `cmd` is set.",
+        ),
+        error.RootDiskWithoutImage => try writeBootError(
+            io,
+            "BOOT_CMD_WITHOUT_IMAGE",
+            "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
+        ),
+        error.MissingAutoMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: memory auto-size input is missing",
+        ),
+        error.InvalidGuestCwdAbsolute => try writeBootError(
+            io,
+            "BOOT_CWD_INVALID",
+            "guestCwd must be an absolute path",
+        ),
+        error.InvalidGuestCwdNul => try writeBootError(
+            io,
+            "BOOT_CWD_INVALID",
+            "guestCwd must not contain NUL bytes",
+        ),
+        error.InvalidMountGuestAbsolute => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "mount guest path must be absolute",
+        ),
+        error.InvalidMountGuestRoot => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "mount guest path must live under /mnt/",
+        ),
+        error.UnsupportedHostMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: host memory probing is unsupported on this platform",
+        ),
+        error.InvalidGuestEnvValue => try writeBootError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan guestEnv values must be strings",
+        ),
+        else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }
 }
 
+fn writeBootError(io: std.Io, code: []const u8, message: []const u8) !void {
+    assert(code.len > 0);
+    assert(message.len > 0);
+
+    try protocol.writeError(io, code, message);
+}
+
 fn writeRequestError(io: std.Io, err: RequestError) !void {
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+
     switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        error.InvalidPortForward, error.InvalidHostPort, error.InvalidGuestPort => try protocol.writeError(io, "BOOT_PORT_FORWARD_INVALID", "portForward: hostPort and guestPort must be integers in 1..65535"),
-        error.InvalidLiveMountsResolved, error.InvalidLiveMountHost, error.InvalidLiveMountMode, error.InvalidLiveMountTag => try protocol.writeError(io, "BOOT_MOUNT_INVALID", "liveMounts: resolved live mount entries must include host, tag, and mode ro/rw"),
+        error.InvalidPortForward,
+        error.InvalidHostPort,
+        error.InvalidGuestPort,
+        => try protocol.writeError(
+            io,
+            "BOOT_PORT_FORWARD_INVALID",
+            "portForward: hostPort and guestPort must be integers in 1..65535",
+        ),
+        error.InvalidLiveMountsResolved,
+        error.InvalidLiveMountHost,
+        error.InvalidLiveMountMode,
+        error.InvalidLiveMountTag,
+        => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "liveMounts: resolved entries must include host, tag, and mode ro/rw",
+        ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }
 }

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
 const balloon_stats = @import("commands/balloon_stats.zig");
+const boot_plan = @import("commands/boot_plan.zig");
 const cleanup_path = @import("commands/cleanup_path.zig");
 const cpu_cgroup_apply = @import("commands/cpu_cgroup_apply.zig");
 const cpu_cgroup_remove = @import("commands/cpu_cgroup_remove.zig");
@@ -25,6 +26,7 @@ var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
     assert(balloon_stats.name.len > 0);
+    assert(boot_plan.name.len > 0);
     assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
@@ -84,6 +86,12 @@ fn runHostCommand(
             return @intFromEnum(protocol.Exit.usage);
         }
         return @intFromEnum(try balloon_stats.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, boot_plan.name)) {
+        if (try rejectExtraArgs(it, boot_plan.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try boot_plan.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, cpu_cgroup_apply.name)) {
         if (try rejectExtraArgs(it, cpu_cgroup_apply.name)) {
@@ -224,6 +232,7 @@ fn isHelp(command: []const u8) bool {
 
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
     assert(balloon_stats.name.len > 0);
+    assert(boot_plan.name.len > 0);
     assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
@@ -247,6 +256,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .protocolVersion = @as(u8, protocol.version),
         .commands = .{
             balloon_stats.name,
+            boot_plan.name,
             cleanup_path.name,
             cpu_cgroup_apply.name,
             cpu_cgroup_remove.name,

--- a/packages/runtime/native/src/protocol.zig
+++ b/packages/runtime/native/src/protocol.zig
@@ -143,7 +143,7 @@ pub fn writeError(io: std.Io, code: []const u8, message: []const u8) !void {
     try stdout(io, "}}\n");
 }
 
-fn writeJsonString(io: std.Io, s: []const u8) !void {
+pub fn writeJsonString(io: std.Io, s: []const u8) !void {
     assert(s.len > 0);
 
     try stdout(io, "\"");

--- a/packages/runtime/native/src/protocol.zig
+++ b/packages/runtime/native/src/protocol.zig
@@ -144,7 +144,7 @@ pub fn writeError(io: std.Io, code: []const u8, message: []const u8) !void {
 }
 
 pub fn writeJsonString(io: std.Io, s: []const u8) !void {
-    assert(s.len > 0);
+    assert(@sizeOf([]const u8) > 0);
 
     try stdout(io, "\"");
     var start: @TypeOf(s.len) = 0;

--- a/packages/runtime/native/src/protocol.zig
+++ b/packages/runtime/native/src/protocol.zig
@@ -136,14 +136,41 @@ pub fn writeError(io: std.Io, code: []const u8, message: []const u8) !void {
     assert(code.len > 0);
     assert(message.len > 0);
 
-    var buf: [1024]u8 = undefined;
-    const payload = try std.fmt.bufPrint(
-        &buf,
-        "{{\"ok\":false,\"protocolVersion\":1," ++
-            "\"error\":{{\"code\":\"{s}\",\"message\":\"{s}\"}}}}\n",
-        .{ code, message },
-    );
-    try stdout(io, payload);
+    try stdout(io, "{\"ok\":false,\"protocolVersion\":1,\"error\":{\"code\":");
+    try writeJsonString(io, code);
+    try stdout(io, ",\"message\":");
+    try writeJsonString(io, message);
+    try stdout(io, "}}\n");
+}
+
+fn writeJsonString(io: std.Io, s: []const u8) !void {
+    assert(s.len > 0);
+
+    try stdout(io, "\"");
+    var start: @TypeOf(s.len) = 0;
+    for (s, 0..) |c, i| {
+        const replacement: ?[]const u8 = switch (c) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            else => if (c < 0x20) "" else null,
+        };
+        if (replacement) |r| {
+            if (i > start) try stdout(io, s[start..i]);
+            if (r.len == 0) {
+                var buf: [6]u8 = undefined;
+                const escaped = try std.fmt.bufPrint(&buf, "\\u00{x:0>2}", .{c});
+                try stdout(io, escaped);
+            } else {
+                try stdout(io, r);
+            }
+            start = i + 1;
+        }
+    }
+    if (start < s.len) try stdout(io, s[start..]);
+    try stdout(io, "\"");
 }
 
 pub fn writeJson(allocator: std.mem.Allocator, io: std.Io, value: anytype) !void {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -141,6 +141,32 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans kernel and dtb env paths", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      kernelPath: "/tmp/Image",
+      dtbPath: "/tmp/virt.dtb",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data).toMatchObject({
+      vmmKernel: "/tmp/Image",
+      vmmDtb: "/tmp/virt.dtb",
+    });
+  });
+
   it("plans VMM argv with optional pdeathsig wrapping", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -169,6 +169,46 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans stats-file env from caller or runtime-owned paths", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const existing = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, existingStatsFile: "/tmp/caller-stats.bin" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(existing.status).toBe(0);
+    expect(JSON.parse(existing.stdout).data).toMatchObject({
+      statsFilePath: "/tmp/caller-stats.bin",
+      vmmStatsFile: null,
+    });
+
+    const planned = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, statsFilePath: "/tmp/runtime-stats.bin" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(planned.status).toBe(0);
+    expect(JSON.parse(planned.stdout).data).toMatchObject({
+      statsFilePath: "/tmp/runtime-stats.bin",
+      vmmStatsFile: "/tmp/runtime-stats.bin",
+    });
+  });
+
   it("plans virtiofs env entries for resolved live mounts", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -73,6 +73,34 @@ describe("autoSizeMemoryMib", () => {
 });
 
 describe("boot-plan helper schema", () => {
+  it("plans guest env defaults without overriding caller-provided values", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      guestEnv: { FOO: "bar", MACHINEN_VM_HOSTNAME_WAIT: "0" },
+      name: "worker",
+      vsockUdsPath: "/tmp/exec.sock",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.mergedGuestEnv).toEqual({
+      FOO: "bar",
+      MACHINEN_VM_HOSTNAME_WAIT: "0",
+      MACHINEN_VM_NAME: "worker",
+    });
+  });
+
   it("rejects unknown request fields", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -169,6 +169,34 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans virtiofs env entries for resolved live mounts", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      liveMountsResolved: [
+        { host: "/host/a", mode: "rw", tag: "machinen-lm0" },
+        { host: "/host/b", mode: "ro", tag: "machinen-lm1" },
+      ],
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.virtiofsEnv).toEqual({
+      MACHINEN_VIRTIOFS_0: "machinen-lm0:rw:/host/a",
+      MACHINEN_VIRTIOFS_1: "machinen-lm1:ro:/host/b",
+    });
+  });
+
   it("plans kernel and dtb env paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -3,7 +3,7 @@
 // the guest actually see N MiB?" check lives in the smoke suite —
 // this file just covers the policy + validation logic.
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -69,6 +69,36 @@ describe("autoSizeMemoryMib", () => {
     expect(autoSizeMemoryMib(512 * 1024 * 1024)).toBe(512);
     expect(autoSizeMemoryMib(256 * 1024 * 1024)).toBe(512);
     expect(autoSizeMemoryMib(0)).toBe(512);
+  });
+});
+
+describe("boot-plan helper schema", () => {
+  it("rejects unknown request fields", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          memoryMib: null,
+          resourcesMemory: null,
+          autoMemoryMib: "1024",
+          hostTotalBytes: null,
+          vmmMemoryPreset: false,
+          hasImage: false,
+          hasCmd: false,
+          rootDisk: "false",
+          extra: true,
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      protocolVersion: 1,
+      error: { code: "UNKNOWN_FIELD" },
+    });
   });
 });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -101,6 +101,46 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans vsock specs from caller env or auto UDS paths", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const existing = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, existingVsockSpec: "out:1970:/tmp/a.sock,in:1978:/tmp/b.sock" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(existing.status).toBe(0);
+    expect(JSON.parse(existing.stdout).data).toMatchObject({
+      vsockUdsPath: "/tmp/a.sock",
+      vmmVsock: null,
+    });
+
+    const auto = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, autoVsockUdsPath: "/tmp/exec.sock" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(auto.status).toBe(0);
+    expect(JSON.parse(auto.stdout).data).toMatchObject({
+      vsockUdsPath: "/tmp/exec.sock",
+      vmmVsock: "in:1978:/tmp/exec.sock",
+    });
+  });
+
   it("rejects unknown request fields", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -141,6 +141,34 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans vmstate snapshot restore and timing env", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      vmstatePath: "/tmp/state.vmstate",
+      restorePath: "/tmp/restore.vmstate",
+      enableVmstateTiming: true,
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data).toMatchObject({
+      vmmSnapshotPath: "/tmp/state.vmstate",
+      vmmRestorePath: "/tmp/restore.vmstate",
+      vmmVmstateTiming: "1",
+    });
+  });
+
   it("plans kernel and dtb env paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -141,6 +141,32 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("rejects invalid portForward shape", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      portForward: [{ hostPort: 8080, guestPort: 70000 }],
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      protocolVersion: 1,
+      error: { code: "BOOT_PORT_FORWARD_INVALID" },
+    });
+  });
+
   it("rejects unknown request fields", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -141,6 +141,33 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans VMM argv with optional pdeathsig wrapping", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      vmmBinary: "/bin/vmm",
+      vmmArgs: ["--dev", "1"],
+      pdeathsigPath: "/bin/pdeathsig",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data).toMatchObject({
+      vmmCommand: "/bin/pdeathsig",
+      vmmArgs: ["/bin/vmm", "--dev", "1"],
+    });
+  });
+
   it("rejects invalid portForward shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/port-forward.test.ts
+++ b/packages/runtime/src/__tests__/port-forward.test.ts
@@ -3,14 +3,39 @@
 // server on a unix socket that impersonates gvproxy's control API and
 // verify the request shape.
 
+import { execFileSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createServer as createNetServer, type AddressInfo, type Server } from "node:net";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { describePortHolder, exposePort, probeHostPortFree } from "../gvproxy.ts";
 import { boot } from "../index.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 interface FakeGvproxy {
   socketPath: string;

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -1,0 +1,87 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
+
+type RootDiskPlanMode = "unset" | "false" | "path" | "true";
+
+export interface NativeBootPlanInput {
+  memoryMib?: number;
+  resourcesMemory?: BootMemoryResourceOptions;
+  autoMemoryMib?: number;
+  hostTotalBytes?: number;
+  vmmMemoryPreset: boolean;
+  hasImage: boolean;
+  hasCmd: boolean;
+  rootDisk: RootDiskPlanMode;
+}
+
+export interface NativeBootPlanResult {
+  memoryCeilingMib: number | null;
+  vmmMemory: string | null;
+  wantsRootDisk: boolean;
+}
+
+export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: numberText(input.memoryMib),
+      resourcesMemory: input.resourcesMemory
+        ? {
+            maxMib: numberTextRequired(input.resourcesMemory.maxMib),
+            reclaim: input.resourcesMemory.reclaim ?? null,
+          }
+        : null,
+      autoMemoryMib: numberText(input.autoMemoryMib),
+      hostTotalBytes: numberText(input.hostTotalBytes),
+      vmmMemoryPreset: input.vmmMemoryPreset,
+      hasImage: input.hasImage,
+      hasCmd: input.hasCmd,
+      rootDisk: input.rootDisk,
+    },
+    errorCode: "BOOT_MEMORY_INVALID",
+    makeError: bootPlanError,
+    isData: isNativeBootPlanResult,
+  });
+}
+
+export function rootDiskPlanMode(rootDisk: boolean | string | undefined): RootDiskPlanMode {
+  if (rootDisk === false) {
+    return "false";
+  }
+  if (rootDisk === true) {
+    return "true";
+  }
+  if (typeof rootDisk === "string") {
+    return "path";
+  }
+  return "unset";
+}
+
+function bootPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function numberText(value: number | undefined): string | null {
+  return value === undefined ? null : String(value);
+}
+
+function numberTextRequired(value: number): string {
+  return String(value);
+}
+
+function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<NativeBootPlanResult>;
+  return (
+    nullableNonNegativeNumber(data.memoryCeilingMib) &&
+    (data.vmmMemory === null || typeof data.vmmMemory === "string") &&
+    typeof data.wantsRootDisk === "boolean"
+  );
+}
+
+function nullableNonNegativeNumber(value: unknown): boolean {
+  return value === null || (typeof value === "number" && Number.isFinite(value) && value >= 0);
+}

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -23,6 +23,9 @@ interface NativeBootPlanInput {
   existingVsockSpec?: string;
   autoVsockUdsPath?: string;
   portForward?: PortForwardPlanMapping[];
+  vmmBinary?: string;
+  vmmArgs?: string[];
+  pdeathsigPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -33,6 +36,8 @@ interface NativeBootPlanResult {
   mergedGuestEnv: Record<string, string>;
   vsockUdsPath: string | null;
   vmmVsock: string | null;
+  vmmCommand: string | null;
+  vmmArgs: string[];
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -60,11 +65,34 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       existingVsockSpec: input.existingVsockSpec ?? null,
       autoVsockUdsPath: input.autoVsockUdsPath ?? null,
       portForward: input.portForward ?? [],
+      vmmBinary: input.vmmBinary ?? null,
+      vmmArgs: input.vmmArgs ?? [],
+      pdeathsigPath: input.pdeathsigPath ?? null,
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
     isData: isNativeBootPlanResult,
   });
+}
+
+export function planBootVmmArgvNative(input: {
+  binary: string;
+  args: string[];
+  pdeathsigPath: string | null;
+}): { command: string; args: string[] } {
+  const plan = planBootCoreNative({
+    vmmBinary: input.binary,
+    vmmArgs: input.args,
+    pdeathsigPath: input.pdeathsigPath ?? undefined,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.vmmCommand === null) {
+    throw new BootError("BOOT_VMM_MISSING", "boot: native planner returned no VMM command");
+  }
+  return { command: plan.vmmCommand, args: plan.vmmArgs };
 }
 
 export function validateBootPortForwardNative(portForward: PortForwardPlanMapping[]): void {
@@ -115,7 +143,13 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isStringRecord(data.mergedGuestEnv),
     nullableString(data.vsockUdsPath),
     nullableString(data.vmmVsock),
+    nullableString(data.vmmCommand),
+    isStringArray(data.vmmArgs),
   ].every(Boolean);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
 function nullableString(value: unknown): boolean {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -26,6 +26,8 @@ interface NativeBootPlanInput {
   vmmBinary?: string;
   vmmArgs?: string[];
   pdeathsigPath?: string;
+  kernelPath?: string;
+  dtbPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -38,6 +40,8 @@ interface NativeBootPlanResult {
   vmmVsock: string | null;
   vmmCommand: string | null;
   vmmArgs: string[];
+  vmmKernel: string | null;
+  vmmDtb: string | null;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -68,11 +72,31 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       vmmBinary: input.vmmBinary ?? null,
       vmmArgs: input.vmmArgs ?? [],
       pdeathsigPath: input.pdeathsigPath ?? null,
+      kernelPath: input.kernelPath ?? null,
+      dtbPath: input.dtbPath ?? null,
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
     isData: isNativeBootPlanResult,
   });
+}
+
+export function planBootKernelDtbNative(input: { kernelPath?: string; dtbPath?: string }): {
+  kernelPath?: string;
+  dtbPath?: string;
+} {
+  const plan = planBootCoreNative({
+    kernelPath: input.kernelPath,
+    dtbPath: input.dtbPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  return {
+    kernelPath: plan.vmmKernel ?? undefined,
+    dtbPath: plan.vmmDtb ?? undefined,
+  };
 }
 
 export function planBootVmmArgvNative(input: {
@@ -145,6 +169,8 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmVsock),
     nullableString(data.vmmCommand),
     isStringArray(data.vmmArgs),
+    nullableString(data.vmmKernel),
+    nullableString(data.vmmDtb),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -18,6 +18,8 @@ interface NativeBootPlanInput {
   guestEnv?: Record<string, string>;
   name?: string;
   vsockUdsPath?: string;
+  existingVsockSpec?: string;
+  autoVsockUdsPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -26,6 +28,8 @@ interface NativeBootPlanResult {
   wantsRootDisk: boolean;
   normalizedMountGuest: string | null;
   mergedGuestEnv: Record<string, string>;
+  vsockUdsPath: string | null;
+  vmmVsock: string | null;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -50,6 +54,8 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       guestEnv: input.guestEnv ?? {},
       name: input.name ?? null,
       vsockUdsPath: input.vsockUdsPath ?? null,
+      existingVsockSpec: input.existingVsockSpec ?? null,
+      autoVsockUdsPath: input.autoVsockUdsPath ?? null,
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
@@ -87,13 +93,19 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     return false;
   }
   const data = value as Partial<NativeBootPlanResult>;
-  return (
-    nullableNonNegativeNumber(data.memoryCeilingMib) &&
-    (data.vmmMemory === null || typeof data.vmmMemory === "string") &&
-    typeof data.wantsRootDisk === "boolean" &&
-    (data.normalizedMountGuest === null || typeof data.normalizedMountGuest === "string") &&
-    isStringRecord(data.mergedGuestEnv)
-  );
+  return [
+    nullableNonNegativeNumber(data.memoryCeilingMib),
+    nullableString(data.vmmMemory),
+    typeof data.wantsRootDisk === "boolean",
+    nullableString(data.normalizedMountGuest),
+    isStringRecord(data.mergedGuestEnv),
+    nullableString(data.vsockUdsPath),
+    nullableString(data.vmmVsock),
+  ].every(Boolean);
+}
+
+function nullableString(value: unknown): boolean {
+  return value === null || typeof value === "string";
 }
 
 function isStringRecord(value: unknown): value is Record<string, string> {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -5,6 +5,7 @@ import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
+type LiveMountPlanInput = { host: string; mode: "ro" | "rw"; tag: string };
 
 interface NativeBootPlanInput {
   memoryMib?: number;
@@ -32,6 +33,7 @@ interface NativeBootPlanInput {
   restorePath?: string;
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
+  liveMountsResolved?: LiveMountPlanInput[];
 }
 
 interface NativeBootPlanResult {
@@ -49,6 +51,7 @@ interface NativeBootPlanResult {
   vmmSnapshotPath: string | null;
   vmmRestorePath: string | null;
   vmmVmstateTiming: string | null;
+  virtiofsEnv: Record<string, string>;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -88,6 +91,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     restorePath: nullDefault(input.restorePath),
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
+    liveMountsResolved: input.liveMountsResolved ?? [],
   };
 }
 
@@ -103,6 +107,18 @@ function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unk
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootVirtiofsEnvNative(
+  liveMounts: LiveMountPlanInput[],
+): Record<string, string> {
+  return planBootCoreNative({
+    liveMountsResolved: liveMounts,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).virtiofsEnv;
 }
 
 export function planBootVmstateEnvNative(input: {
@@ -221,6 +237,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmSnapshotPath),
     nullableString(data.vmmRestorePath),
     nullableString(data.vmmVmstateTiming),
+    isStringRecord(data.virtiofsEnv),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -28,6 +28,10 @@ interface NativeBootPlanInput {
   pdeathsigPath?: string;
   kernelPath?: string;
   dtbPath?: string;
+  vmstatePath?: string;
+  restorePath?: string;
+  enableVmstateTiming?: boolean;
+  existingVmstateTiming?: string;
 }
 
 interface NativeBootPlanResult {
@@ -42,43 +46,86 @@ interface NativeBootPlanResult {
   vmmArgs: string[];
   vmmKernel: string | null;
   vmmDtb: string | null;
+  vmmSnapshotPath: string | null;
+  vmmRestorePath: string | null;
+  vmmVmstateTiming: string | null;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
   return callRuntimeHelper({
     command: "boot-plan",
-    data: {
-      memoryMib: numberText(input.memoryMib),
-      resourcesMemory: input.resourcesMemory
-        ? {
-            maxMib: numberTextRequired(input.resourcesMemory.maxMib),
-            reclaim: input.resourcesMemory.reclaim ?? null,
-          }
-        : null,
-      autoMemoryMib: numberText(input.autoMemoryMib),
-      hostTotalBytes: numberText(input.hostTotalBytes),
-      vmmMemoryPreset: input.vmmMemoryPreset,
-      hasImage: input.hasImage,
-      hasCmd: input.hasCmd,
-      rootDisk: input.rootDisk,
-      guestCwd: input.guestCwd ?? null,
-      mountGuest: input.mountGuest ?? null,
-      guestEnv: input.guestEnv ?? {},
-      name: input.name ?? null,
-      vsockUdsPath: input.vsockUdsPath ?? null,
-      existingVsockSpec: input.existingVsockSpec ?? null,
-      autoVsockUdsPath: input.autoVsockUdsPath ?? null,
-      portForward: input.portForward ?? [],
-      vmmBinary: input.vmmBinary ?? null,
-      vmmArgs: input.vmmArgs ?? [],
-      pdeathsigPath: input.pdeathsigPath ?? null,
-      kernelPath: input.kernelPath ?? null,
-      dtbPath: input.dtbPath ?? null,
-    },
+    data: buildBootPlanRequestData(input),
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
     isData: isNativeBootPlanResult,
   });
+}
+
+function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    memoryMib: numberText(input.memoryMib),
+    resourcesMemory: resourcesMemoryData(input.resourcesMemory),
+    autoMemoryMib: numberText(input.autoMemoryMib),
+    hostTotalBytes: numberText(input.hostTotalBytes),
+    vmmMemoryPreset: input.vmmMemoryPreset,
+    hasImage: input.hasImage,
+    hasCmd: input.hasCmd,
+    rootDisk: input.rootDisk,
+    guestCwd: nullDefault(input.guestCwd),
+    mountGuest: nullDefault(input.mountGuest),
+    guestEnv: input.guestEnv ?? {},
+    name: nullDefault(input.name),
+    vsockUdsPath: nullDefault(input.vsockUdsPath),
+    existingVsockSpec: nullDefault(input.existingVsockSpec),
+    autoVsockUdsPath: nullDefault(input.autoVsockUdsPath),
+    portForward: input.portForward ?? [],
+    vmmBinary: nullDefault(input.vmmBinary),
+    vmmArgs: input.vmmArgs ?? [],
+    pdeathsigPath: nullDefault(input.pdeathsigPath),
+    kernelPath: nullDefault(input.kernelPath),
+    dtbPath: nullDefault(input.dtbPath),
+    vmstatePath: nullDefault(input.vmstatePath),
+    restorePath: nullDefault(input.restorePath),
+    enableVmstateTiming: input.enableVmstateTiming === true,
+    existingVmstateTiming: nullDefault(input.existingVmstateTiming),
+  };
+}
+
+function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unknown {
+  if (!memory) {
+    return null;
+  }
+  return {
+    maxMib: numberTextRequired(memory.maxMib),
+    reclaim: nullDefault(memory.reclaim),
+  };
+}
+
+function nullDefault<T>(value: T | undefined): T | null {
+  return value === undefined ? null : value;
+}
+
+export function planBootVmstateEnvNative(input: {
+  vmstatePath?: string;
+  restorePath?: string;
+  enableTiming: boolean;
+  existingTiming?: string;
+}): { snapshotPath?: string; restorePath?: string; vmstateTiming?: string } {
+  const plan = planBootCoreNative({
+    vmstatePath: input.vmstatePath,
+    restorePath: input.restorePath,
+    enableVmstateTiming: input.enableTiming,
+    existingVmstateTiming: input.existingTiming,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  return {
+    snapshotPath: plan.vmmSnapshotPath ?? undefined,
+    restorePath: plan.vmmRestorePath ?? undefined,
+    vmstateTiming: plan.vmmVmstateTiming ?? undefined,
+  };
 }
 
 export function planBootKernelDtbNative(input: { kernelPath?: string; dtbPath?: string }): {
@@ -171,6 +218,9 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isStringArray(data.vmmArgs),
     nullableString(data.vmmKernel),
     nullableString(data.vmmDtb),
+    nullableString(data.vmmSnapshotPath),
+    nullableString(data.vmmRestorePath),
+    nullableString(data.vmmVmstateTiming),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -4,7 +4,7 @@ import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 
-export interface NativeBootPlanInput {
+interface NativeBootPlanInput {
   memoryMib?: number;
   resourcesMemory?: BootMemoryResourceOptions;
   autoMemoryMib?: number;
@@ -13,12 +13,15 @@ export interface NativeBootPlanInput {
   hasImage: boolean;
   hasCmd: boolean;
   rootDisk: RootDiskPlanMode;
+  guestCwd?: string;
+  mountGuest?: string;
 }
 
-export interface NativeBootPlanResult {
+interface NativeBootPlanResult {
   memoryCeilingMib: number | null;
   vmmMemory: string | null;
   wantsRootDisk: boolean;
+  normalizedMountGuest: string | null;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -38,6 +41,8 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       hasImage: input.hasImage,
       hasCmd: input.hasCmd,
       rootDisk: input.rootDisk,
+      guestCwd: input.guestCwd ?? null,
+      mountGuest: input.mountGuest ?? null,
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
@@ -78,7 +83,8 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
   return (
     nullableNonNegativeNumber(data.memoryCeilingMib) &&
     (data.vmmMemory === null || typeof data.vmmMemory === "string") &&
-    typeof data.wantsRootDisk === "boolean"
+    typeof data.wantsRootDisk === "boolean" &&
+    (data.normalizedMountGuest === null || typeof data.normalizedMountGuest === "string")
   );
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -4,6 +4,8 @@ import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 
+type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
+
 interface NativeBootPlanInput {
   memoryMib?: number;
   resourcesMemory?: BootMemoryResourceOptions;
@@ -20,6 +22,7 @@ interface NativeBootPlanInput {
   vsockUdsPath?: string;
   existingVsockSpec?: string;
   autoVsockUdsPath?: string;
+  portForward?: PortForwardPlanMapping[];
 }
 
 interface NativeBootPlanResult {
@@ -56,10 +59,21 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       vsockUdsPath: input.vsockUdsPath ?? null,
       existingVsockSpec: input.existingVsockSpec ?? null,
       autoVsockUdsPath: input.autoVsockUdsPath ?? null,
+      portForward: input.portForward ?? [],
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
     isData: isNativeBootPlanResult,
+  });
+}
+
+export function validateBootPortForwardNative(portForward: PortForwardPlanMapping[]): void {
+  planBootCoreNative({
+    portForward,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
   });
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -34,6 +34,8 @@ interface NativeBootPlanInput {
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
   liveMountsResolved?: LiveMountPlanInput[];
+  existingStatsFile?: string;
+  statsFilePath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -52,6 +54,8 @@ interface NativeBootPlanResult {
   vmmRestorePath: string | null;
   vmmVmstateTiming: string | null;
   virtiofsEnv: Record<string, string>;
+  statsFilePath: string | null;
+  vmmStatsFile: string | null;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -92,6 +96,8 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
     liveMountsResolved: input.liveMountsResolved ?? [],
+    existingStatsFile: nullDefault(input.existingStatsFile),
+    statsFilePath: nullDefault(input.statsFilePath),
   };
 }
 
@@ -107,6 +113,24 @@ function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unk
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootStatsFileNative(input: { existingPath?: string; plannedPath?: string }): {
+  statsFilePath?: string;
+  vmmStatsFile?: string;
+} {
+  const plan = planBootCoreNative({
+    existingStatsFile: input.existingPath,
+    statsFilePath: input.plannedPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  return {
+    statsFilePath: plan.statsFilePath ?? undefined,
+    vmmStatsFile: plan.vmmStatsFile ?? undefined,
+  };
 }
 
 export function planBootVirtiofsEnvNative(
@@ -238,6 +262,8 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmRestorePath),
     nullableString(data.vmmVmstateTiming),
     isStringRecord(data.virtiofsEnv),
+    nullableString(data.statsFilePath),
+    nullableString(data.vmmStatsFile),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -15,6 +15,9 @@ interface NativeBootPlanInput {
   rootDisk: RootDiskPlanMode;
   guestCwd?: string;
   mountGuest?: string;
+  guestEnv?: Record<string, string>;
+  name?: string;
+  vsockUdsPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -22,6 +25,7 @@ interface NativeBootPlanResult {
   vmmMemory: string | null;
   wantsRootDisk: boolean;
   normalizedMountGuest: string | null;
+  mergedGuestEnv: Record<string, string>;
 }
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
@@ -43,6 +47,9 @@ export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanRe
       rootDisk: input.rootDisk,
       guestCwd: input.guestCwd ?? null,
       mountGuest: input.mountGuest ?? null,
+      guestEnv: input.guestEnv ?? {},
+      name: input.name ?? null,
+      vsockUdsPath: input.vsockUdsPath ?? null,
     },
     errorCode: "BOOT_MEMORY_INVALID",
     makeError: bootPlanError,
@@ -84,8 +91,16 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableNonNegativeNumber(data.memoryCeilingMib) &&
     (data.vmmMemory === null || typeof data.vmmMemory === "string") &&
     typeof data.wantsRootDisk === "boolean" &&
-    (data.normalizedMountGuest === null || typeof data.normalizedMountGuest === "string")
+    (data.normalizedMountGuest === null || typeof data.normalizedMountGuest === "string") &&
+    isStringRecord(data.mergedGuestEnv)
   );
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
 }
 
 function nullableNonNegativeNumber(value: unknown): boolean {

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -53,6 +53,7 @@ import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
+  planBootKernelDtbNative,
   planBootVmmArgvNative,
   rootDiskPlanMode,
   validateBootPortForwardNative,
@@ -959,7 +960,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
   const cpuPolicy = resolveCpuResourcePolicy(opts.resources?.cpu);
   const scratch = prepareBootScratchDisk(opts, env, phases);
   const wantsRootDisk = corePlan.wantsRootDisk;
-  validateKernelDtb(opts, env);
+  setupKernelDtbEnv(opts, env);
   const vsock = setupVsockBridge(env);
   const stats = setupStatsFile(env, vsock.vsockTempDir);
   const vmstateSetup = setupVmstateBoot(opts, env, vsock.vsockTempDir);
@@ -1247,21 +1248,37 @@ function prepareScratchDisk(
   return { diskAbs: scratchPath, perBootSnapDisk: scratchPath };
 }
 
-function validateKernelDtb(opts: BootOptions, env: Record<string, string>): void {
-  if (opts.kernel) {
-    const abs = resolve(opts.cwd ?? process.cwd(), opts.kernel);
-    if (!existsSync(abs)) {
-      throw new BootError("BOOT_KERNEL_NOT_FOUND", `kernel not found: ${abs}`);
-    }
-    env.MACHINEN_KERNEL = abs;
+function setupKernelDtbEnv(opts: BootOptions, env: Record<string, string>): void {
+  const kernelPath = resolveOptionalBootPath(
+    opts.kernel,
+    opts.cwd,
+    "BOOT_KERNEL_NOT_FOUND",
+    "kernel",
+  );
+  const dtbPath = resolveOptionalBootPath(opts.dtb, opts.cwd, "BOOT_DTB_NOT_FOUND", "dtb");
+  const plan = planBootKernelDtbNative({ kernelPath, dtbPath });
+  if (plan.kernelPath) {
+    env.MACHINEN_KERNEL = plan.kernelPath;
   }
-  if (opts.dtb) {
-    const abs = resolve(opts.cwd ?? process.cwd(), opts.dtb);
-    if (!existsSync(abs)) {
-      throw new BootError("BOOT_DTB_NOT_FOUND", `dtb not found: ${abs}`);
-    }
-    env.MACHINEN_DTB = abs;
+  if (plan.dtbPath) {
+    env.MACHINEN_DTB = plan.dtbPath;
   }
+}
+
+function resolveOptionalBootPath(
+  input: string | undefined,
+  cwd: string | undefined,
+  code: "BOOT_KERNEL_NOT_FOUND" | "BOOT_DTB_NOT_FOUND",
+  label: "kernel" | "dtb",
+): string | undefined {
+  if (!input) {
+    return undefined;
+  }
+  const abs = resolve(cwd ?? process.cwd(), input);
+  if (!existsSync(abs)) {
+    throw new BootError(code, `${label} not found: ${abs}`);
+  }
+  return abs;
 }
 
 // #94: always wire up a vsock UDS bridge so `vm.exec()` works out of

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import debugLib from "debug";
 
-import { readBalloonStats } from "../balloon-stats.ts";
+import { readBalloonStats, STATS_FILE_SIZE } from "../balloon-stats.ts";
 import {
   bootReadinessFailureMessage,
   bootStderrTail,
@@ -1319,7 +1319,6 @@ function setupVsockBridge(env: Record<string, string>): {
 }
 
 // #274: shared stats file the balloon backend writes counters to.
-// 16 bytes (two u64 LE atomics, see balloon-stats.ts + stats.zig).
 // Pre-allocated zero-filled here so the VMM's mmap'd writer and our
 // host-side reader see a coherent layout even before the first
 // reporting chain. Co-located under `vsockTempDir` when we own one
@@ -1348,7 +1347,7 @@ function setupStatsFile(
   }
   const fd = openSync(plan.statsFilePath, "w");
   try {
-    writeSync(fd, Buffer.alloc(16), 0, 16, 0);
+    writeSync(fd, Buffer.alloc(STATS_FILE_SIZE), 0, STATS_FILE_SIZE, 0);
   } finally {
     closeSync(fd);
   }

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootVmstateEnvNative,
   planBootVmmArgvNative,
   rootDiskPlanMode,
   validateBootPortForwardNative,
@@ -1036,9 +1037,8 @@ function setupVmstateBoot(
   if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
     vsockTempDir = ensureVsockTempDir(vsockTempDir);
     vmstate.statePath = join(vsockTempDir, VMSTATE_FILE);
-    env.MACHINEN_SNAPSHOT_PATH = vmstate.statePath;
   }
-  configureVmstateRestoreEnv(opts, env);
+  applyVmstateEnvPlan(opts, env, vmstate.statePath);
   return { vmstate, vsockTempDir };
 }
 
@@ -1046,18 +1046,26 @@ function ensureVsockTempDir(vsockTempDir: string | undefined): string {
   return vsockTempDir ?? mkdtempSync(join(tmpdir(), "machinen-vsock-"));
 }
 
-function configureVmstateRestoreEnv(opts: BootOptions, env: Record<string, string>): void {
-  if (!opts._vmstateRestorePath) {
-    return;
+function applyVmstateEnvPlan(
+  opts: BootOptions,
+  env: Record<string, string>,
+  vmstatePath: string | undefined,
+): void {
+  const plan = planBootVmstateEnvNative({
+    vmstatePath,
+    restorePath: opts._vmstateRestorePath,
+    enableTiming: vmstateDebug.enabled || restoreDebug.enabled,
+    existingTiming: env.MACHINEN_VMSTATE_TIMING,
+  });
+  if (plan.snapshotPath) {
+    env.MACHINEN_SNAPSHOT_PATH = plan.snapshotPath;
   }
-  env.MACHINEN_RESTORE_PATH = opts._vmstateRestorePath;
-  if (shouldEnableVmstateTiming(env)) {
-    env.MACHINEN_VMSTATE_TIMING = "1";
+  if (plan.restorePath) {
+    env.MACHINEN_RESTORE_PATH = plan.restorePath;
   }
-}
-
-function shouldEnableVmstateTiming(env: Record<string, string>): boolean {
-  return (vmstateDebug.enabled || restoreDebug.enabled) && !env.MACHINEN_VMSTATE_TIMING;
+  if (plan.vmstateTiming) {
+    env.MACHINEN_VMSTATE_TIMING = plan.vmstateTiming;
+  }
 }
 
 function setupLiveMountEnv(opts: BootOptions, env: Record<string, string>): ResolvedLiveMount[] {

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -69,7 +69,6 @@ import {
   buildWriteFileCmds,
   collect,
   CONSOLE_TAIL_BYTES,
-  parseVsockUdsPath,
   resolveVmmBinary,
   setGuestHostname,
   SNAP_SCRATCH_BYTES,
@@ -1307,20 +1306,26 @@ function setupVsockBridge(env: Record<string, string>): {
   vsockUdsPath: string | undefined;
   vsockTempDir: string | undefined;
 } {
-  if (env.MACHINEN_VSOCK) {
-    const vsockUdsPath = parseVsockUdsPath(env.MACHINEN_VSOCK);
-    debug(
-      "vsock spec from caller env: %s (uds=%s)",
-      env.MACHINEN_VSOCK,
-      vsockUdsPath ?? "<unparsed>",
-    );
-    return { vsockUdsPath, vsockTempDir: undefined };
+  const existingSpec = env.MACHINEN_VSOCK;
+  const vsockTempDir = existingSpec ? undefined : mkdtempSync(join(tmpdir(), "machinen-vsock-"));
+  const autoVsockUdsPath = vsockTempDir ? join(vsockTempDir, "exec.sock") : undefined;
+  const plan = planBootCoreNative({
+    existingVsockSpec: existingSpec,
+    autoVsockUdsPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.vmmVsock !== null) {
+    env.MACHINEN_VSOCK = plan.vmmVsock;
   }
-  const vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
-  const vsockUdsPath = join(vsockTempDir, "exec.sock");
-  env.MACHINEN_VSOCK = `in:1978:${vsockUdsPath}`;
-  debug("vsock auto uds=%s", vsockUdsPath);
-  return { vsockUdsPath, vsockTempDir };
+  debug(
+    existingSpec ? "vsock spec from caller env: %s (uds=%s)" : "vsock auto spec=%s uds=%s",
+    existingSpec ?? plan.vmmVsock ?? "<unset>",
+    plan.vsockUdsPath ?? "<unparsed>",
+  );
+  return { vsockUdsPath: plan.vsockUdsPath ?? undefined, vsockTempDir };
 }
 
 // #274: shared stats file the balloon backend writes counters to.

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -1961,6 +1961,10 @@ function buildBootSnapshotContext(
   args: BootSnapshotContextArgs,
   handle: VmHandle,
 ): SnapshotContext {
+  const execRawForSnapshot: SnapshotContext["execRaw"] = handle.execRaw.bind(handle);
+  const syncVmstateForSnapshot = handle.syncVmstateSnapshot?.bind(handle);
+  const waitForSnapshot = handle.wait.bind(handle);
+  const killForSnapshot = handle.kill.bind(handle);
   return {
     pid: args.childPid,
     sourceName: args.vmName,
@@ -1977,10 +1981,10 @@ function buildBootSnapshotContext(
     vmstateChain: snapshotVmstateChain(args.vmstate),
     updateVmstateChain: snapshotVmstateUpdater(args.vmstate, args.childPid),
     nested: args.nested,
-    execRaw: (cmd, execOpts) => handle.execRaw(cmd, execOpts),
-    syncVmstateSnapshot: (execOpts) => handle.syncVmstateSnapshot?.(execOpts),
-    wait: () => handle.wait(),
-    kill: () => handle.kill(),
+    execRaw: execRawForSnapshot,
+    syncVmstateSnapshot: syncVmstateForSnapshot,
+    wait: waitForSnapshot,
+    kill: killForSnapshot,
     teeGuestConsole: (onChunk) => {
       args.child.stderr.on("data", onChunk);
     },

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -51,7 +51,11 @@ import { PhaseTimer } from "../phase-timer.ts";
 import { readProcessIdentity } from "../pid-validate.ts";
 import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
-import { planBootCoreNative, rootDiskPlanMode } from "../native/boot-plan.ts";
+import {
+  planBootCoreNative,
+  rootDiskPlanMode,
+  validateBootPortForwardNative,
+} from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
@@ -1089,7 +1093,7 @@ async function validatePortForwardOpts(
     return;
   }
   rejectPresetNetSocket(opts);
-  validatePortForwardShape(portForward);
+  validateBootPortForwardNative(portForward);
   await validatePortForwardAvailability(portForward);
 }
 
@@ -1104,50 +1108,6 @@ function rejectPresetNetSocket(opts: BootOptions): void {
         "against your gvproxy's control API.",
     );
   }
-}
-
-function validatePortForwardShape(portForward: NonNullable<BootOptions["portForward"]>): void {
-  const seen = new Set<number>();
-  for (const mapping of portForward) {
-    validatePortMappingNumbers(mapping);
-    rejectDuplicateHostPort(mapping.hostPort, seen);
-  }
-}
-
-function validatePortMappingNumbers(
-  mapping: NonNullable<BootOptions["portForward"]>[number],
-): void {
-  for (const [label, port] of portMappingPorts(mapping)) {
-    if (!validTcpPort(port)) {
-      throw new BootError(
-        "BOOT_PORT_FORWARD_INVALID",
-        `portForward: ${label} must be an integer in 1..65535 (got ${port})`,
-      );
-    }
-  }
-}
-
-function portMappingPorts(
-  mapping: NonNullable<BootOptions["portForward"]>[number],
-): Array<readonly ["hostPort" | "guestPort", number]> {
-  return [
-    ["hostPort", mapping.hostPort],
-    ["guestPort", mapping.guestPort],
-  ];
-}
-
-function validTcpPort(port: number): boolean {
-  return Number.isInteger(port) && port >= 1 && port <= 65535;
-}
-
-function rejectDuplicateHostPort(hostPort: number, seen: Set<number>): void {
-  if (seen.has(hostPort)) {
-    throw new BootError(
-      "BOOT_PORT_FORWARD_CONFLICT",
-      `portForward: duplicate hostPort ${hostPort}`,
-    );
-  }
-  seen.add(hostPort);
 }
 
 async function validatePortForwardAvailability(

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -46,13 +46,14 @@ import {
   preflightNestedVirtualization,
   probeVmmNestedVirtualization,
 } from "../nested-virt.ts";
-import { ensurePdeathsig, wrapWithPdeathsig } from "../pdeathsig.ts";
+import { ensurePdeathsig } from "../pdeathsig.ts";
 import { PhaseTimer } from "../phase-timer.ts";
 import { readProcessIdentity } from "../pid-validate.ts";
 import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
+  planBootVmmArgvNative,
   rootDiskPlanMode,
   validateBootPortForwardNative,
 } from "../native/boot-plan.ts";
@@ -686,10 +687,14 @@ interface SpawnedBootVmm {
 async function spawnBootVmm(args: SpawnBootArgs): Promise<SpawnedBootVmm> {
   args.phases.start("vmm-spawn");
   const vmmPdeathsig = await resolveVmmPdeathsig(args.opts);
-  const wrappedVmm = wrapWithPdeathsig(vmmPdeathsig, args.plan.binary, args.opts.args ?? []);
+  const vmmArgv = planBootVmmArgvNative({
+    binary: args.plan.binary,
+    args: args.opts.args ?? [],
+    pdeathsigPath: vmmPdeathsig,
+  });
   const stdio: Array<"pipe" | number> = ["pipe", "pipe", "pipe"];
   const mountDiskFds = maybeOpenMountDiskFds(args.resources.mountDiskPaths, args.plan.env, stdio);
-  const child = nodeSpawn(wrappedVmm.command, wrappedVmm.args, {
+  const child = nodeSpawn(vmmArgv.command, vmmArgv.args, {
     cwd: args.opts.cwd,
     env: args.plan.env,
     stdio,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootStatsFileNative,
   planBootVirtiofsEnvNative,
   planBootVmstateEnvNative,
   planBootVmmArgvNative,
@@ -1330,24 +1331,31 @@ function setupStatsFile(
   vsockTempDir: string | undefined,
 ): { statsFilePath: string | undefined; statsTempDir: string | undefined } {
   if (env.MACHINEN_STATS_FILE !== undefined) {
-    return { statsFilePath: env.MACHINEN_STATS_FILE, statsTempDir: undefined };
+    const plan = planBootStatsFileNative({ existingPath: env.MACHINEN_STATS_FILE });
+    return { statsFilePath: plan.statsFilePath, statsTempDir: undefined };
   }
   let statsTempDir: string | undefined;
-  let statsFilePath: string;
+  let plannedPath: string;
   if (vsockTempDir) {
-    statsFilePath = join(vsockTempDir, "stats.bin");
+    plannedPath = join(vsockTempDir, "stats.bin");
   } else {
     statsTempDir = mkdtempSync(join(tmpdir(), "machinen-stats-"));
-    statsFilePath = join(statsTempDir, "stats.bin");
+    plannedPath = join(statsTempDir, "stats.bin");
   }
-  const fd = openSync(statsFilePath, "w");
+  const plan = planBootStatsFileNative({ plannedPath });
+  if (!plan.statsFilePath) {
+    return { statsFilePath: undefined, statsTempDir };
+  }
+  const fd = openSync(plan.statsFilePath, "w");
   try {
     writeSync(fd, Buffer.alloc(16), 0, 16, 0);
   } finally {
     closeSync(fd);
   }
-  env.MACHINEN_STATS_FILE = statsFilePath;
-  return { statsFilePath, statsTempDir };
+  if (plan.vmmStatsFile) {
+    env.MACHINEN_STATS_FILE = plan.vmmStatsFile;
+  }
+  return { statsFilePath: plan.statsFilePath, statsTempDir };
 }
 
 interface GvproxyResult {

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootVirtiofsEnvNative,
   planBootVmstateEnvNative,
   planBootVmmArgvNative,
   rootDiskPlanMode,
@@ -1074,9 +1075,7 @@ function setupLiveMountEnv(opts: BootOptions, env: Record<string, string>): Reso
     return [];
   }
   const resolved = resolveLiveMounts(liveMounts, opts.cwd);
-  resolved.forEach((lm, i) => {
-    env[`MACHINEN_VIRTIOFS_${i}`] = `${lm.tag}:${lm.mode}:${lm.host}`;
-  });
+  Object.assign(env, planBootVirtiofsEnvNative(resolved));
   return resolved;
 }
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -1067,25 +1067,15 @@ function buildMergedGuestEnv(
   opts: BootOptions,
   vsockUdsPath: string | undefined,
 ): Record<string, string> {
-  const mergedGuestEnv: Record<string, string> = { ...opts.env };
-  applyGuestNameFallback(opts, mergedGuestEnv);
-  applyHostnameWait(vsockUdsPath, mergedGuestEnv);
-  return mergedGuestEnv;
-}
-
-function applyGuestNameFallback(opts: BootOptions, mergedGuestEnv: Record<string, string>): void {
-  if (opts.name && !mergedGuestEnv.MACHINEN_VM_NAME) {
-    mergedGuestEnv.MACHINEN_VM_NAME = opts.name;
-  }
-}
-
-function applyHostnameWait(
-  vsockUdsPath: string | undefined,
-  mergedGuestEnv: Record<string, string>,
-): void {
-  if (vsockUdsPath && !mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT) {
-    mergedGuestEnv.MACHINEN_VM_HOSTNAME_WAIT = "1";
-  }
+  return planBootCoreNative({
+    guestEnv: opts.env,
+    name: opts.name,
+    vsockUdsPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).mergedGuestEnv;
 }
 
 // Validate portForward up front — before resolving the binary or

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -51,6 +51,7 @@ import { PhaseTimer } from "../phase-timer.ts";
 import { readProcessIdentity } from "../pid-validate.ts";
 import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
+import { planBootCoreNative, rootDiskPlanMode } from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
@@ -59,12 +60,11 @@ import { resolveLiveMounts, synthesizeAndPackBundle, type ResolvedLiveMount } fr
 import { installVmExitCleanup } from "./exit-cleanup.ts";
 import { performForkWithRestore } from "./fork-core.ts";
 import { validateBatchLiveMounts, withBatchLiveMountSync } from "./live-mount-batch.ts";
-import { resolveExplicitMemoryCeilingMib, type BootResourcesOptions } from "./memory-resources.ts";
+import type { BootResourcesOptions } from "./memory-resources.ts";
 import { registryCpu } from "./registry-cpu.ts";
 import type { VmHandle } from "../vm-handle.ts";
 import {
   allocateSparseFile,
-  autoSizeMemoryMib,
   buildGuestHostname,
   buildWriteFileCmds,
   collect,
@@ -931,11 +931,26 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
   const assets = await resolveBootAssets(opts, phases);
   const env = buildVmmEnv(opts);
   configureNestedVirtualization(opts, assets.binary, env);
-  const memoryCeilingMib = setMemoryCeiling(opts, env);
+  const corePlan = planBootCoreNative({
+    memoryMib: opts.memory,
+    resourcesMemory: opts.resources?.memory,
+    vmmMemoryPreset: env.MACHINEN_MEMORY !== undefined,
+    hasImage: opts.image !== undefined,
+    hasCmd: opts.cmd !== undefined,
+    rootDisk:
+      opts.rootDisk === false
+        ? "false"
+        : opts._rootDiskRestorePath !== undefined
+          ? "path"
+          : rootDiskPlanMode(opts.rootDisk),
+  });
+  if (corePlan.vmmMemory !== null) {
+    env.MACHINEN_MEMORY = corePlan.vmmMemory;
+  }
+  const memoryCeilingMib = corePlan.memoryCeilingMib ?? undefined;
   const cpuPolicy = resolveCpuResourcePolicy(opts.resources?.cpu);
   const scratch = prepareBootScratchDisk(opts, env, phases);
-  const wantsRootDisk = wantsRootDiskBoot(opts);
-  validateRootDiskRequest(opts, wantsRootDisk);
+  const wantsRootDisk = corePlan.wantsRootDisk;
   validateKernelDtb(opts, env);
   const vsock = setupVsockBridge(env);
   const stats = setupStatsFile(env, vsock.vsockTempDir);
@@ -966,7 +981,6 @@ async function resolveBootAssets(
   const portForward = opts.portForward ?? [];
   await validatePortForwardOpts(opts, portForward);
   const binary = resolveBootBinary(opts);
-  validateBootCommandPair(opts);
   phases.end("asset-resolve");
   return { portForward, binary };
 }
@@ -978,12 +992,6 @@ function resolveBootBinary(opts: BootOptions): string {
     throw new BootError("BOOT_VMM_MISSING", `VMM binary not found at ${binary}`);
   }
   return binary;
-}
-
-function validateBootCommandPair(opts: BootOptions): void {
-  if (opts.cmd && !opts.image) {
-    throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
-  }
 }
 
 function buildVmmEnv(opts: BootOptions): Record<string, string> {
@@ -1002,22 +1010,6 @@ function prepareBootScratchDisk(
   const scratch = prepareScratchDisk(opts, env);
   phases.end("disk-prep");
   return scratch;
-}
-
-function wantsRootDiskBoot(opts: BootOptions): boolean {
-  return (
-    opts.rootDisk !== false &&
-    (opts._rootDiskRestorePath !== undefined || opts.rootDisk !== undefined || !!opts.image)
-  );
-}
-
-function validateRootDiskRequest(opts: BootOptions, wantsRootDisk: boolean): void {
-  if (wantsRootDisk && typeof opts.rootDisk !== "string" && !opts.image) {
-    throw new BootError(
-      "BOOT_CMD_WITHOUT_IMAGE",
-      "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
-    );
-  }
 }
 
 function setupVmstateBoot(
@@ -1230,17 +1222,6 @@ function runtimeEntryImportPath(): string {
     return "../index.js";
   }
   return "./index.js";
-}
-
-function setMemoryCeiling(opts: BootOptions, env: Record<string, string>): number | undefined {
-  // Validate public API input even when lower-level vmmEnv wins.
-  const explicitCeiling = resolveExplicitMemoryCeilingMib(opts);
-  if (env.MACHINEN_MEMORY !== undefined) {
-    return undefined;
-  }
-  const ceiling = explicitCeiling ?? autoSizeMemoryMib();
-  env.MACHINEN_MEMORY = String(ceiling);
-  return ceiling;
 }
 
 // The scratch virtio-blk device serves two unrelated workloads:

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -12,7 +12,7 @@ import type { Readable } from "node:stream";
 import debugLib from "debug";
 
 import { BootError } from "../errors.ts";
-import { readHostTotalBytes } from "../host-mem.ts";
+import { planBootCoreNative } from "../native/boot-plan.ts";
 import type { VsockExecOptions } from "../exec.ts";
 import type { OnLog } from "../log.ts";
 import type { VmHandle, WriteFileOptions } from "../vm-handle.ts";
@@ -48,30 +48,32 @@ export function allocateSparseFile(path: string, sizeBytes: number): void {
 // `packages/microvm/docs/memory.md`), but raising it still increases
 // guest metadata and the possible high-water mark, so the default
 // should not scale with large developer machines.
-const MEMORY_FLOOR_MIB = 512;
-const MEMORY_DEFAULT_CEILING_MIB = 4096;
-
-export function autoSizeMemoryMib(hostBytes: number = readHostTotalBytes()): number {
-  const hostMib = Math.floor(hostBytes / (1024 * 1024));
-  const hostAwareCeiling = Math.floor(hostMib / 2);
-  return Math.max(MEMORY_FLOOR_MIB, Math.min(hostAwareCeiling, MEMORY_DEFAULT_CEILING_MIB));
+export function autoSizeMemoryMib(hostBytes?: number): number {
+  const plan = planBootCoreNative({
+    hostTotalBytes: hostBytes,
+    vmmMemoryPreset: false,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.memoryCeilingMib === null) {
+    throw new BootError("BOOT_MEMORY_INVALID", "boot: native memory planner returned no ceiling");
+  }
+  return plan.memoryCeilingMib;
 }
 
 export function validateMemoryMib(mib: number): number {
-  if (!Number.isInteger(mib) || mib <= 0) {
-    throw new BootError(
-      "BOOT_MEMORY_INVALID",
-      `boot: memory must be a positive integer (MiB, no unit suffix), got ${mib}`,
-    );
+  const plan = planBootCoreNative({
+    memoryMib: mib,
+    vmmMemoryPreset: false,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.memoryCeilingMib === null) {
+    throw new BootError("BOOT_MEMORY_INVALID", "boot: native memory planner returned no ceiling");
   }
-  if (mib < MEMORY_FLOOR_MIB) {
-    throw new BootError(
-      "BOOT_MEMORY_INVALID",
-      `boot: memory must be at least ${MEMORY_FLOOR_MIB} MiB (got ${mib}); the kernel + ` +
-        `initramfs need headroom to boot.`,
-    );
-  }
-  return mib;
+  return plan.memoryCeilingMib;
 }
 
 /**

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -126,25 +126,6 @@ export function resolveVmmBinary(): string {
   }
 }
 
-/**
- * Parse the UDS path out of a `MACHINEN_VSOCK` spec. The spec may be a
- * single `<direction>:<port>:<uds-path>` entry or a comma-joined list
- * of them (`in:1978:/a,in:1974:/b,out:1970:/c`). For attach/exec we want
- * the FIRST `in:` entry's path — that's the exec-agent UDS the runtime
- * just allocated (or, when the caller set MACHINEN_VSOCK explicitly,
- * the entry they put first). Returns undefined on unrecognized shapes
- * so the handle can throw a clear error if `.exec()` ends up called on it.
- */
-export function parseVsockUdsPath(spec: string): string | undefined {
-  for (const entry of spec.split(",")) {
-    const match = entry.match(/^[^:]+:\d+:(.+)$/);
-    if (match) {
-      return match[1];
-    }
-  }
-  return undefined;
-}
-
 // Guest path validation lives in the native boot planner so mount
 // planning rules stay aligned across boot, restore, and live mounts.
 export function normalizeMountGuest(guest: string): string {

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -145,35 +145,34 @@ export function parseVsockUdsPath(spec: string): string | undefined {
   return undefined;
 }
 
-// The user-facing mount root. Guest paths must live under this prefix
-// so mounts can never shadow the base rootfs or kernel filesystems.
-const MOUNT_ROOT = "/mnt/";
-
+// Guest path validation lives in the native boot planner so mount
+// planning rules stay aligned across boot, restore, and live mounts.
 export function normalizeMountGuest(guest: string): string {
-  return guest.replace(/\/+$/, "");
+  const plan = planBootCoreNative({
+    mountGuest: guest,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.normalizedMountGuest === null) {
+    throw new BootError("BOOT_MOUNT_INVALID", "boot: native planner returned no mount guest");
+  }
+  return plan.normalizedMountGuest;
 }
 
 export function validateGuestCwd(cwd: string): void {
-  if (!cwd || !cwd.startsWith("/")) {
-    throw new BootError("BOOT_CWD_INVALID", `guestCwd must be an absolute path (got '${cwd}')`);
-  }
-  if (cwd.includes("\0")) {
-    throw new BootError("BOOT_CWD_INVALID", "guestCwd must not contain NUL bytes");
-  }
+  planBootCoreNative({
+    guestCwd: cwd,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
 }
 
 export function validateMountGuest(guest: string): void {
-  if (!guest || !guest.startsWith("/")) {
-    throw new BootError("BOOT_MOUNT_INVALID", `mount guest path must be absolute: ${guest}`);
-  }
-  const trimmed = normalizeMountGuest(guest);
-  if (!trimmed.startsWith(MOUNT_ROOT) || trimmed === MOUNT_ROOT.replace(/\/$/, "")) {
-    throw new BootError(
-      "BOOT_MOUNT_INVALID",
-      `mount guest path must live under ${MOUNT_ROOT} (got ${guest}) — ` +
-        `pick a sub-path like ${MOUNT_ROOT}app`,
-    );
-  }
+  normalizeMountGuest(guest);
 }
 
 /**

--- a/packages/runtime/src/vm/memory-resources.ts
+++ b/packages/runtime/src/vm/memory-resources.ts
@@ -26,11 +26,6 @@ export interface BootMemoryResourceOptions {
   reclaim?: "auto";
 }
 
-type MemoryCeilingInput = {
-  memory?: number;
-  resources?: BootResourcesOptions;
-};
-
 export function resolveMemoryCeilingMib(
   opts: { memory?: number; resources?: BootResourcesOptions },
   autoSize: () => number = autoSizeMemoryMib,
@@ -49,20 +44,4 @@ export function resolveMemoryCeilingMib(
     throw new Error("boot: native memory planner returned no ceiling");
   }
   return plan.memoryCeilingMib;
-}
-
-export function resolveExplicitMemoryCeilingMib(opts: MemoryCeilingInput): number | undefined {
-  if (opts.memory === undefined && opts.resources?.memory === undefined) {
-    return undefined;
-  }
-  const plan = planBootCoreNative({
-    memoryMib: opts.memory,
-    resourcesMemory: opts.resources?.memory,
-    autoMemoryMib: 512,
-    vmmMemoryPreset: false,
-    hasImage: false,
-    hasCmd: false,
-    rootDisk: "false",
-  });
-  return plan.memoryCeilingMib ?? undefined;
 }

--- a/packages/runtime/src/vm/memory-resources.ts
+++ b/packages/runtime/src/vm/memory-resources.ts
@@ -1,6 +1,6 @@
-import { BootError } from "../errors.ts";
 import type { BootCpuResourceOptions } from "./cpu-resources.ts";
-import { autoSizeMemoryMib, validateMemoryMib } from "./helpers.ts";
+import { planBootCoreNative } from "../native/boot-plan.ts";
+import { autoSizeMemoryMib } from "./helpers.ts";
 
 export interface BootResourcesOptions {
   /**
@@ -35,41 +35,34 @@ export function resolveMemoryCeilingMib(
   opts: { memory?: number; resources?: BootResourcesOptions },
   autoSize: () => number = autoSizeMemoryMib,
 ): number {
-  return resolveExplicitMemoryCeilingMib(opts) ?? autoSize();
+  const hasExplicit = opts.memory !== undefined || opts.resources?.memory !== undefined;
+  const plan = planBootCoreNative({
+    memoryMib: opts.memory,
+    resourcesMemory: opts.resources?.memory,
+    autoMemoryMib: !hasExplicit && autoSize !== autoSizeMemoryMib ? autoSize() : undefined,
+    vmmMemoryPreset: false,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.memoryCeilingMib === null) {
+    throw new Error("boot: native memory planner returned no ceiling");
+  }
+  return plan.memoryCeilingMib;
 }
 
 export function resolveExplicitMemoryCeilingMib(opts: MemoryCeilingInput): number | undefined {
-  const aliasCeiling = opts.memory !== undefined ? validateMemoryMib(opts.memory) : undefined;
-  const resourceCeiling = resolveResourceMemoryCeiling(opts.resources?.memory);
-  if (
-    aliasCeiling !== undefined &&
-    resourceCeiling !== undefined &&
-    aliasCeiling !== resourceCeiling
-  ) {
-    throw new BootError(
-      "BOOT_MEMORY_INVALID",
-      `boot: memory (${aliasCeiling} MiB) conflicts with resources.memory.maxMib (${resourceCeiling} MiB). Use one value.`,
-    );
-  }
-  return resourceCeiling ?? aliasCeiling;
-}
-
-function resolveResourceMemoryCeiling(
-  memory: BootMemoryResourceOptions | undefined,
-): number | undefined {
-  if (memory === undefined) {
+  if (opts.memory === undefined && opts.resources?.memory === undefined) {
     return undefined;
   }
-  validateMemoryReclaim(memory.reclaim);
-  return validateMemoryMib(memory.maxMib);
-}
-
-function validateMemoryReclaim(reclaim: BootMemoryResourceOptions["reclaim"] | undefined): void {
-  if (reclaim === undefined || reclaim === "auto") {
-    return;
-  }
-  throw new BootError(
-    "BOOT_MEMORY_INVALID",
-    `boot: resources.memory.reclaim must be "auto" when set (got ${JSON.stringify(reclaim)}).`,
-  );
+  const plan = planBootCoreNative({
+    memoryMib: opts.memory,
+    resourcesMemory: opts.resources?.memory,
+    autoMemoryMib: 512,
+    vmmMemoryPreset: false,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  return plan.memoryCeilingMib ?? undefined;
 }


### PR DESCRIPTION
## Problem

Boot setup had many small decisions spread through TypeScript. Those decisions were easy to change accidentally because they were mixed with process spawning and host setup.

## Solution

This PR starts the Zig boot planner. It moves the core boot choices into a strict helper command while TypeScript keeps spawning the VM and wiring host resources.

## Technical Summary

- Add the first `boot-plan` command shape and schema.
- Move memory, path, guest env, vsock, port-forward validation, VMM argv, kernel/DTB, vmstate, virtiofs, and stats env planning into Zig.
- Keep host path checks, temp directory creation, file descriptors, and child process lifecycle in TypeScript.
