### PR TITLE
Move boot runtime planners to Zig

### DIFF
--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -175,6 +175,30 @@ pub const RootDiskRuntimePlan = struct {
     vmm_root_disk: ?[]const u8,
 };
 
+pub const MountDiskRuntimeMode = enum {
+    none,
+    restore,
+    fresh,
+};
+
+pub const MountDiskRuntimeInput = struct {
+    mode: MountDiskRuntimeMode = .none,
+    lower_path: ?[]const u8 = null,
+    upper_path: ?[]const u8 = null,
+    source_upper_path: ?[]const u8 = null,
+    guest: ?[]const u8 = null,
+    upper_size_bytes: ?u64 = null,
+};
+
+pub const MountDiskRuntimePlan = struct {
+    action: []const u8,
+    lower_path: ?[]const u8,
+    upper_path: ?[]const u8,
+    source_upper_path: ?[]const u8,
+    guest: ?[]const u8,
+    upper_size_bytes: ?u64,
+};
+
 pub const MachinenConfigInput = struct {
     guest_cwd: ?[]const u8 = null,
     image_cwd: ?[]const u8 = null,
@@ -216,6 +240,7 @@ pub const PlanError = error{
     MissingBundleCommand,
     MissingScratchPath,
     MissingRootDiskRuntimePath,
+    MissingMountDiskRuntimeField,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -398,6 +423,48 @@ pub fn planRootDiskRuntime(input: RootDiskRuntimeInput) PlanError!RootDiskRuntim
                 .target_path = target,
                 .per_boot_root_disk = target,
                 .vmm_root_disk = target,
+            };
+        },
+    };
+}
+
+pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRuntimePlan {
+    return switch (input.mode) {
+        .none => .{
+            .action = "none",
+            .lower_path = null,
+            .upper_path = null,
+            .source_upper_path = null,
+            .guest = null,
+            .upper_size_bytes = null,
+        },
+        .restore => blk: {
+            const lower = input.lower_path orelse return error.MissingMountDiskRuntimeField;
+            const upper = input.upper_path orelse return error.MissingMountDiskRuntimeField;
+            const source_upper = input.source_upper_path orelse return error.MissingMountDiskRuntimeField;
+            const guest = input.guest orelse return error.MissingMountDiskRuntimeField;
+            const upper_size = input.upper_size_bytes orelse return error.MissingMountDiskRuntimeField;
+            break :blk .{
+                .action = "restore",
+                .lower_path = lower,
+                .upper_path = upper,
+                .source_upper_path = source_upper,
+                .guest = guest,
+                .upper_size_bytes = upper_size,
+            };
+        },
+        .fresh => blk: {
+            const lower = input.lower_path orelse return error.MissingMountDiskRuntimeField;
+            const upper = input.upper_path orelse return error.MissingMountDiskRuntimeField;
+            const guest = input.guest orelse return error.MissingMountDiskRuntimeField;
+            const upper_size = input.upper_size_bytes orelse return error.MissingMountDiskRuntimeField;
+            break :blk .{
+                .action = "fresh",
+                .lower_path = lower,
+                .upper_path = upper,
+                .source_upper_path = null,
+                .guest = guest,
+                .upper_size_bytes = upper_size,
             };
         },
     };
@@ -703,6 +770,38 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planMountDiskRuntime selects restore and fresh actions" {
+    const none = try planMountDiskRuntime(.{});
+    try std.testing.expectEqualStrings("none", none.action);
+    try std.testing.expect(none.lower_path == null);
+
+    const restore = try planMountDiskRuntime(.{
+        .mode = .restore,
+        .lower_path = "/lower.sqfs",
+        .upper_path = "/upper-copy.img",
+        .source_upper_path = "/upper.img",
+        .guest = "/mnt/data",
+        .upper_size_bytes = 4096,
+    });
+    try std.testing.expectEqualStrings("restore", restore.action);
+    try std.testing.expectEqualStrings("/lower.sqfs", restore.lower_path.?);
+    try std.testing.expectEqualStrings("/upper-copy.img", restore.upper_path.?);
+    try std.testing.expectEqualStrings("/upper.img", restore.source_upper_path.?);
+    try std.testing.expectEqualStrings("/mnt/data", restore.guest.?);
+    try std.testing.expectEqual(@as(u64, 4096), restore.upper_size_bytes.?);
+
+    const fresh = try planMountDiskRuntime(.{
+        .mode = .fresh,
+        .lower_path = "/lower.sqfs",
+        .upper_path = "/upper.img",
+        .guest = "/mnt/data",
+        .upper_size_bytes = 8192,
+    });
+    try std.testing.expectEqualStrings("fresh", fresh.action);
+    try std.testing.expect(fresh.source_upper_path == null);
+    try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
 }
 
 test "planBundleEnv overlays guest env on image env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -12,6 +12,7 @@ const assert = std.debug.assert;
 
 const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
+const max_live_mounts: usize = 5;
 
 pub const RootDiskMode = enum {
     unset,
@@ -92,8 +93,15 @@ pub const VmstateEnvPlan = struct {
     vmstate_timing: ?[]const u8,
 };
 
+pub const LiveMountInput = struct {
+    host: []const u8,
+    guest: []const u8,
+    mode: ?[]const u8 = null,
+};
+
 pub const LiveMount = struct {
     host: []const u8,
+    guest: []const u8,
     mode: []const u8,
     tag: []const u8,
 };
@@ -139,6 +147,8 @@ pub const PlanError = error{
     InvalidGuestCwdNul,
     InvalidMountGuestAbsolute,
     InvalidMountGuestRoot,
+    TooManyLiveMounts,
+    InvalidLiveMountMode,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -211,6 +221,20 @@ pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
         .restore_path = input.restore_path,
         .vmstate_timing = if (should_set_timing) "1" else null,
     };
+}
+
+pub fn planLiveMounts(allocator: std.mem.Allocator, mounts: []const LiveMountInput) ![]LiveMount {
+    if (mounts.len > max_live_mounts) return error.TooManyLiveMounts;
+    var out: std.ArrayList(LiveMount) = .empty;
+    errdefer out.deinit(allocator);
+    for (mounts, 0..) |mount, i| {
+        const mode = mount.mode orelse "rw";
+        if (!std.mem.eql(u8, mode, "ro") and !std.mem.eql(u8, mode, "rw")) return error.InvalidLiveMountMode;
+        const guest = try normalizeMountGuest(mount.guest);
+        const tag = try std.fmt.allocPrint(allocator, "machinen-lm{d}", .{i});
+        try out.append(allocator, .{ .host = mount.host, .guest = guest, .mode = mode, .tag = tag });
+    }
+    return out.toOwnedSlice(allocator);
 }
 
 pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) ![]EnvPair {
@@ -452,6 +476,29 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
 }
 
+test "planLiveMounts validates count guest paths modes and tags" {
+    const mounts = [_]LiveMountInput{
+        .{ .host = "./a", .guest = "/mnt/a", .mode = null },
+        .{ .host = "./b", .guest = "/mnt/b/", .mode = "ro" },
+    };
+    const planned = try planLiveMounts(std.testing.allocator, &mounts);
+    defer {
+        for (planned) |mount| std.testing.allocator.free(mount.tag);
+        std.testing.allocator.free(planned);
+    }
+    try std.testing.expectEqual(@as(usize, 2), planned.len);
+    try std.testing.expectEqualStrings("./a", planned[0].host);
+    try std.testing.expectEqualStrings("/mnt/a", planned[0].guest);
+    try std.testing.expectEqualStrings("rw", planned[0].mode);
+    try std.testing.expectEqualStrings("machinen-lm0", planned[0].tag);
+    try std.testing.expectEqualStrings("/mnt/b", planned[1].guest);
+    try std.testing.expectEqualStrings("ro", planned[1].mode);
+    try std.testing.expectEqualStrings("machinen-lm1", planned[1].tag);
+
+    const bad_mode = [_]LiveMountInput{.{ .host = "./a", .guest = "/mnt/a", .mode = "eager" }};
+    try std.testing.expectError(error.InvalidLiveMountMode, planLiveMounts(std.testing.allocator, &bad_mode));
+}
+
 test "planStatsFile preserves caller path or returns runtime-owned env value" {
     const existing = planStatsFile(.{ .existing_path = "/tmp/caller-stats.bin" });
     try std.testing.expectEqualStrings("/tmp/caller-stats.bin", existing.stats_file_path.?);
@@ -464,8 +511,8 @@ test "planStatsFile preserves caller path or returns runtime-owned env value" {
 
 test "planVirtiofsEnv formats indexed virtiofs env entries" {
     const mounts = [_]LiveMount{
-        .{ .host = "/host/a", .mode = "rw", .tag = "machinen-lm0" },
-        .{ .host = "/host/b", .mode = "ro", .tag = "machinen-lm1" },
+        .{ .host = "/host/a", .guest = "/mnt/a", .mode = "rw", .tag = "machinen-lm0" },
+        .{ .host = "/host/b", .guest = "/mnt/b", .mode = "ro", .tag = "machinen-lm1" },
     };
     const env = try planVirtiofsEnv(std.testing.allocator, &mounts);
     defer {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -13,6 +13,8 @@ const assert = std.debug.assert;
 const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
 const max_live_mounts: usize = 5;
+const restore_command = [_][]const u8{"/sbin/machinen-restore"};
+const poweroff_command = [_][]const u8{"/sbin/machinen-poweroff"};
 
 pub const RootDiskMode = enum {
     unset,
@@ -68,6 +70,14 @@ pub const VmmArgvInput = struct {
 pub const VmmArgvPlan = struct {
     command: ?[]const u8,
     args: []const []const u8,
+};
+
+pub const BundleCommandInput = struct {
+    explicit_cmd: ?[]const []const u8 = null,
+    image_cmd: ?[]const []const u8 = null,
+    snapshot_restore: bool = false,
+    vmstate_restore: bool = false,
+    live_mounts: []const LiveMount = &.{},
 };
 
 pub const KernelDtbInput = struct {
@@ -154,6 +164,7 @@ pub const PlanError = error{
     InvalidMountGuestRoot,
     TooManyLiveMounts,
     InvalidLiveMountMode,
+    MissingBundleCommand,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -272,6 +283,54 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planBundleCommand(allocator: std.mem.Allocator, input: BundleCommandInput) ![]const []const u8 {
+    const base_cmd = input.explicit_cmd orelse if (input.snapshot_restore)
+        restore_command[0..]
+    else if (input.vmstate_restore)
+        poweroff_command[0..]
+    else
+        input.image_cmd orelse return error.MissingBundleCommand;
+
+    if (base_cmd.len > 0 and (std.mem.eql(u8, base_cmd[0], "/exec-agent") or std.mem.eql(u8, base_cmd[0], "/sbin/machinen-restore"))) {
+        return base_cmd;
+    }
+
+    const workload = if (hasWritableLiveMount(input.live_mounts))
+        try wrapBatchWorkloadCommand(allocator, base_cmd)
+    else
+        base_cmd;
+    const session_count: usize = if (input.snapshot_restore) 1 else 0;
+    const out = try allocator.alloc([]const u8, 1 + session_count + workload.len);
+    out[0] = "/sbin/machinen-supervisor";
+    var index: usize = 1;
+    if (input.snapshot_restore) {
+        out[index] = "--session";
+        index += 1;
+    }
+    @memcpy(out[index..], workload);
+    return out;
+}
+
+fn hasWritableLiveMount(mounts: []const LiveMount) bool {
+    for (mounts) |mount| {
+        if (std.mem.eql(u8, mount.mode, "rw")) return true;
+    }
+    return false;
+}
+
+fn wrapBatchWorkloadCommand(allocator: std.mem.Allocator, cmd: []const []const u8) ![]const []const u8 {
+    const prefix = [_][]const u8{
+        "/bin/sh",
+        "-c",
+        "batch_sync() { if [ -s /run/machinen-batch-sync.sh ]; then sh /run/machinen-batch-sync.sh; fi; }; \"$@\" & child=$!; trap 'kill -TERM \"$child\" 2>/dev/null' TERM; trap 'kill -INT \"$child\" 2>/dev/null' INT; wait \"$child\"; status=$?; batch_sync || { sync_status=$?; if [ \"$status\" -eq 0 ]; then status=$sync_status; fi; }; exit \"$status\"",
+        "machinen-batch-wrapper",
+    };
+    const out = try allocator.alloc([]const u8, prefix.len + cmd.len);
+    @memcpy(out[0..prefix.len], &prefix);
+    @memcpy(out[prefix.len..], cmd);
+    return out;
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -483,6 +542,27 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planBundleCommand resolves image restore supervisor and batch wrappers" {
+    const ro_mounts = [_]LiveMount{.{ .host = "/host", .guest = "/mnt/ro", .mode = "ro", .tag = "machinen-lm0" }};
+    const image = [_][]const u8{"/bin/true"};
+    const planned = try planBundleCommand(std.testing.allocator, .{ .image_cmd = &image, .live_mounts = &ro_mounts });
+    defer std.testing.allocator.free(planned);
+    try std.testing.expectEqualStrings("/sbin/machinen-supervisor", planned[0]);
+    try std.testing.expectEqualStrings("/bin/true", planned[1]);
+
+    const restore = try planBundleCommand(std.testing.allocator, .{ .snapshot_restore = true });
+    try std.testing.expectEqualStrings("/sbin/machinen-restore", restore[0]);
+
+    const rw_mounts = [_]LiveMount{.{ .host = "/host", .guest = "/mnt/rw", .mode = "rw", .tag = "machinen-lm0" }};
+    const explicit = [_][]const u8{ "/bin/echo", "hi" };
+    const batched = try planBundleCommand(std.testing.allocator, .{ .explicit_cmd = &explicit, .live_mounts = &rw_mounts });
+    defer std.testing.allocator.free(batched);
+    try std.testing.expectEqualStrings("/sbin/machinen-supervisor", batched[0]);
+    try std.testing.expectEqualStrings("/bin/sh", batched[1]);
+    try std.testing.expectEqualStrings("machinen-batch-wrapper", batched[4]);
+    try std.testing.expectEqualStrings("/bin/echo", batched[5]);
 }
 
 test "planMachinenConfigCwd prefers guest cwd over image cwd" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -126,6 +126,29 @@ pub const StatsFilePlan = struct {
     vmm_stats_file: ?[]const u8,
 };
 
+pub const ScratchDiskMode = enum {
+    unset,
+    false_value,
+    path,
+    auto,
+};
+
+pub const ScratchDiskInput = struct {
+    mode: ScratchDiskMode = .unset,
+    has_cmd: bool = false,
+    has_image: bool = false,
+    snapshot_path: ?[]const u8 = null,
+    restore_clone_path: ?[]const u8 = null,
+    auto_path: ?[]const u8 = null,
+};
+
+pub const ScratchDiskPlan = struct {
+    action: []const u8,
+    disk_path: ?[]const u8,
+    per_boot_snap_disk: ?[]const u8,
+    vmm_disk: ?[]const u8,
+};
+
 pub const MachinenConfigInput = struct {
     guest_cwd: ?[]const u8 = null,
     image_cwd: ?[]const u8 = null,
@@ -165,6 +188,7 @@ pub const PlanError = error{
     TooManyLiveMounts,
     InvalidLiveMountMode,
     MissingBundleCommand,
+    MissingScratchPath,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -283,6 +307,49 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planScratchDisk(input: ScratchDiskInput) PlanError!ScratchDiskPlan {
+    return switch (input.mode) {
+        .unset, .false_value => .{
+            .action = "none",
+            .disk_path = null,
+            .per_boot_snap_disk = null,
+            .vmm_disk = null,
+        },
+        .path => blk: {
+            const snapshot_path = input.snapshot_path orelse return error.MissingScratchPath;
+            if (input.has_cmd) {
+                break :blk .{
+                    .action = "existing",
+                    .disk_path = snapshot_path,
+                    .per_boot_snap_disk = null,
+                    .vmm_disk = snapshot_path,
+                };
+            }
+            const clone_path = input.restore_clone_path orelse return error.MissingScratchPath;
+            break :blk .{
+                .action = "clone",
+                .disk_path = clone_path,
+                .per_boot_snap_disk = clone_path,
+                .vmm_disk = clone_path,
+            };
+        },
+        .auto => if (!input.has_image) .{
+            .action = "none",
+            .disk_path = null,
+            .per_boot_snap_disk = null,
+            .vmm_disk = null,
+        } else blk: {
+            const auto_path = input.auto_path orelse return error.MissingScratchPath;
+            break :blk .{
+                .action = "allocate",
+                .disk_path = auto_path,
+                .per_boot_snap_disk = auto_path,
+                .vmm_disk = auto_path,
+            };
+        },
+    };
 }
 
 pub fn planBundleCommand(allocator: std.mem.Allocator, input: BundleCommandInput) ![]const []const u8 {
@@ -542,6 +609,29 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planScratchDisk selects restore clone auto allocation and no-disk cases" {
+    const disabled = try planScratchDisk(.{ .mode = .false_value, .has_image = true });
+    try std.testing.expectEqualStrings("none", disabled.action);
+    try std.testing.expect(disabled.vmm_disk == null);
+
+    const existing = try planScratchDisk(.{ .mode = .path, .has_cmd = true, .snapshot_path = "/snap.img", .restore_clone_path = "/clone.img" });
+    try std.testing.expectEqualStrings("existing", existing.action);
+    try std.testing.expectEqualStrings("/snap.img", existing.vmm_disk.?);
+    try std.testing.expect(existing.per_boot_snap_disk == null);
+
+    const clone = try planScratchDisk(.{ .mode = .path, .snapshot_path = "/snap.img", .restore_clone_path = "/clone.img" });
+    try std.testing.expectEqualStrings("clone", clone.action);
+    try std.testing.expectEqualStrings("/clone.img", clone.disk_path.?);
+    try std.testing.expectEqualStrings("/clone.img", clone.per_boot_snap_disk.?);
+
+    const auto_without_image = try planScratchDisk(.{ .mode = .auto });
+    try std.testing.expectEqualStrings("none", auto_without_image.action);
+
+    const auto = try planScratchDisk(.{ .mode = .auto, .has_image = true, .auto_path = "/auto.img" });
+    try std.testing.expectEqualStrings("allocate", auto.action);
+    try std.testing.expectEqualStrings("/auto.img", auto.vmm_disk.?);
 }
 
 test "planBundleCommand resolves image restore supervisor and batch wrappers" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -12,7 +12,7 @@ const assert = std.debug.assert;
 
 const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
-const max_live_mounts: usize = 5;
+const max_live_mounts = 5;
 const restore_command = [_][]const u8{"/sbin/machinen-restore"};
 const poweroff_command = [_][]const u8{"/sbin/machinen-poweroff"};
 
@@ -316,15 +316,26 @@ pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
 }
 
 pub fn planLiveMounts(allocator: std.mem.Allocator, mounts: []const LiveMountInput) ![]LiveMount {
+    assert(@sizeOf(LiveMountInput) > 0);
+
     if (mounts.len > max_live_mounts) return error.TooManyLiveMounts;
-    var out: std.ArrayList(LiveMount) = .empty;
+    var out: std.array_list.Aligned(LiveMount, null) = .empty;
     errdefer out.deinit(allocator);
     for (mounts, 0..) |mount, i| {
         const mode = mount.mode orelse "rw";
-        if (!std.mem.eql(u8, mode, "ro") and !std.mem.eql(u8, mode, "rw")) return error.InvalidLiveMountMode;
+        if (!std.mem.eql(u8, mode, "ro") and !std.mem.eql(u8, mode, "rw")) {
+            return error.InvalidLiveMountMode;
+        }
         const guest = try normalizeMountGuest(mount.guest);
-        const tag = try std.fmt.allocPrint(allocator, "machinen-lm{d}", .{i});
-        try out.append(allocator, .{ .host = mount.host, .guest = guest, .mode = mode, .tag = tag });
+        var tag_buf: [64]u8 = undefined;
+        const tag_text = try std.fmt.bufPrint(&tag_buf, "machinen-lm{d}", .{i});
+        const tag = try std.mem.concat(allocator, u8, &.{tag_text});
+        try out.append(allocator, .{
+            .host = mount.host,
+            .guest = guest,
+            .mode = mode,
+            .tag = tag,
+        });
     }
     return out.toOwnedSlice(allocator);
 }
@@ -358,33 +369,34 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 }
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
+    assert(@sizeOf(MachinenConfigInput) > 0);
+
     return input.guest_cwd orelse input.image_cwd;
 }
 
 pub fn planBundleEnv(allocator: std.mem.Allocator, input: BundleEnvInput) ![]EnvPair {
-    var out: std.ArrayList(EnvPair) = .empty;
+    assert(@sizeOf(BundleEnvInput) > 0);
+
+    var out: std.array_list.Aligned(EnvPair, null) = .empty;
     errdefer out.deinit(allocator);
-    for (input.image_env) |pair| {
-        try out.append(allocator, pair);
-    }
+    try out.appendSlice(allocator, input.image_env);
     for (input.guest_env) |pair| {
-        if (indexOfEnvKey(out.items, pair.key)) |index| {
-            out.items[index].value = pair.value;
-        } else {
-            try out.append(allocator, pair);
+        var replaced = false;
+        for (out.items) |*existing| {
+            if (std.mem.eql(u8, existing.key, pair.key)) {
+                existing.value = pair.value;
+                replaced = true;
+                break;
+            }
         }
+        if (!replaced) try out.append(allocator, pair);
     }
     return out.toOwnedSlice(allocator);
 }
 
-fn indexOfEnvKey(pairs: []const EnvPair, key: []const u8) ?usize {
-    for (pairs, 0..) |pair, i| {
-        if (std.mem.eql(u8, pair.key, key)) return i;
-    }
-    return null;
-}
-
 pub fn planRootDiskRuntime(input: RootDiskRuntimeInput) PlanError!RootDiskRuntimePlan {
+    assert(@sizeOf(RootDiskRuntimeInput) > 0);
+
     return switch (input.mode) {
         .none => .{
             .action = "none",
@@ -429,6 +441,8 @@ pub fn planRootDiskRuntime(input: RootDiskRuntimeInput) PlanError!RootDiskRuntim
 }
 
 pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRuntimePlan {
+    assert(@sizeOf(MountDiskRuntimeInput) > 0);
+
     return switch (input.mode) {
         .none => .{
             .action = "none",
@@ -441,9 +455,11 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
         .restore => blk: {
             const lower = input.lower_path orelse return error.MissingMountDiskRuntimeField;
             const upper = input.upper_path orelse return error.MissingMountDiskRuntimeField;
-            const source_upper = input.source_upper_path orelse return error.MissingMountDiskRuntimeField;
+            const source_upper = input.source_upper_path orelse
+                return error.MissingMountDiskRuntimeField;
             const guest = input.guest orelse return error.MissingMountDiskRuntimeField;
-            const upper_size = input.upper_size_bytes orelse return error.MissingMountDiskRuntimeField;
+            const upper_size = input.upper_size_bytes orelse
+                return error.MissingMountDiskRuntimeField;
             break :blk .{
                 .action = "restore",
                 .lower_path = lower,
@@ -457,7 +473,8 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
             const lower = input.lower_path orelse return error.MissingMountDiskRuntimeField;
             const upper = input.upper_path orelse return error.MissingMountDiskRuntimeField;
             const guest = input.guest orelse return error.MissingMountDiskRuntimeField;
-            const upper_size = input.upper_size_bytes orelse return error.MissingMountDiskRuntimeField;
+            const upper_size = input.upper_size_bytes orelse
+                return error.MissingMountDiskRuntimeField;
             break :blk .{
                 .action = "fresh",
                 .lower_path = lower,
@@ -471,6 +488,8 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
 }
 
 pub fn planScratchDisk(input: ScratchDiskInput) PlanError!ScratchDiskPlan {
+    assert(@sizeOf(ScratchDiskInput) > 0);
+
     return switch (input.mode) {
         .unset, .false_value => .{
             .action = "none",
@@ -513,52 +532,81 @@ pub fn planScratchDisk(input: ScratchDiskInput) PlanError!ScratchDiskPlan {
     };
 }
 
-pub fn planBundleCommand(allocator: std.mem.Allocator, input: BundleCommandInput) ![]const []const u8 {
-    const base_cmd = input.explicit_cmd orelse if (input.snapshot_restore)
-        restore_command[0..]
-    else if (input.vmstate_restore)
-        poweroff_command[0..]
-    else
-        input.image_cmd orelse return error.MissingBundleCommand;
+pub fn planBundleCommand(
+    allocator: std.mem.Allocator,
+    input: BundleCommandInput,
+) ![]const []const u8 {
+    assert(@sizeOf(BundleCommandInput) > 0);
 
-    if (base_cmd.len > 0 and (std.mem.eql(u8, base_cmd[0], "/exec-agent") or std.mem.eql(u8, base_cmd[0], "/sbin/machinen-restore"))) {
-        return base_cmd;
-    }
+    const base_cmd = input.explicit_cmd orelse
+        fallbackBundleBaseCommand(input) orelse
+        return error.MissingBundleCommand;
+    if (isSupervisorCommand(base_cmd)) return base_cmd;
 
     const workload = if (hasWritableLiveMount(input.live_mounts))
         try wrapBatchWorkloadCommand(allocator, base_cmd)
     else
         base_cmd;
-    const session_count: usize = if (input.snapshot_restore) 1 else 0;
-    const out = try allocator.alloc([]const u8, 1 + session_count + workload.len);
-    out[0] = "/sbin/machinen-supervisor";
-    var index: usize = 1;
-    if (input.snapshot_restore) {
-        out[index] = "--session";
-        index += 1;
-    }
-    @memcpy(out[index..], workload);
-    return out;
+    var out: std.array_list.Aligned([]const u8, null) = .empty;
+    errdefer out.deinit(allocator);
+    try out.append(allocator, "/sbin/machinen-supervisor");
+    if (input.snapshot_restore) try out.append(allocator, "--session");
+    try out.appendSlice(allocator, workload);
+    return out.toOwnedSlice(allocator);
+}
+
+fn fallbackBundleBaseCommand(input: BundleCommandInput) ?[]const []const u8 {
+    assert(@sizeOf(BundleCommandInput) > 0);
+
+    if (input.snapshot_restore) return restore_command[0..];
+    if (input.vmstate_restore) return poweroff_command[0..];
+    return input.image_cmd;
+}
+
+fn isSupervisorCommand(cmd: []const []const u8) bool {
+    assert(@sizeOf([]const []const u8) > 0);
+
+    if (cmd.len == 0) return false;
+    return std.mem.eql(u8, cmd[0], "/exec-agent") or
+        std.mem.eql(u8, cmd[0], "/sbin/machinen-restore");
 }
 
 fn hasWritableLiveMount(mounts: []const LiveMount) bool {
+    assert(@sizeOf(LiveMount) > 0);
+
     for (mounts) |mount| {
         if (std.mem.eql(u8, mount.mode, "rw")) return true;
     }
     return false;
 }
 
-fn wrapBatchWorkloadCommand(allocator: std.mem.Allocator, cmd: []const []const u8) ![]const []const u8 {
+fn wrapBatchWorkloadCommand(
+    allocator: std.mem.Allocator,
+    cmd: []const []const u8,
+) ![]const []const u8 {
+    assert(@sizeOf([]const []const u8) > 0);
+
+    const batch_script = "batch_sync() { " ++
+        "if [ -s /run/machinen-batch-sync.sh ]; then " ++
+        "sh /run/machinen-batch-sync.sh; fi; }; " ++
+        "\"$@\" & child=$!; " ++
+        "trap 'kill -TERM \"$child\" 2>/dev/null' TERM; " ++
+        "trap 'kill -INT \"$child\" 2>/dev/null' INT; " ++
+        "wait \"$child\"; status=$?; " ++
+        "batch_sync || { sync_status=$?; " ++
+        "if [ \"$status\" -eq 0 ]; then status=$sync_status; fi; }; " ++
+        "exit \"$status\"";
     const prefix = [_][]const u8{
         "/bin/sh",
         "-c",
-        "batch_sync() { if [ -s /run/machinen-batch-sync.sh ]; then sh /run/machinen-batch-sync.sh; fi; }; \"$@\" & child=$!; trap 'kill -TERM \"$child\" 2>/dev/null' TERM; trap 'kill -INT \"$child\" 2>/dev/null' INT; wait \"$child\"; status=$?; batch_sync || { sync_status=$?; if [ \"$status\" -eq 0 ]; then status=$sync_status; fi; }; exit \"$status\"",
+        batch_script,
         "machinen-batch-wrapper",
     };
-    const out = try allocator.alloc([]const u8, prefix.len + cmd.len);
-    @memcpy(out[0..prefix.len], &prefix);
-    @memcpy(out[prefix.len..], cmd);
-    return out;
+    var out: std.array_list.Aligned([]const u8, null) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, &prefix);
+    try out.appendSlice(allocator, cmd);
+    return out.toOwnedSlice(allocator);
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -813,9 +861,12 @@ test "planBundleEnv overlays guest env on image env" {
         .{ .key = "FOO", .value = "guest" },
         .{ .key = "BAZ", .value = "guest" },
     };
-    const planned = try planBundleEnv(std.testing.allocator, .{ .image_env = &image, .guest_env = &guest });
+    const planned = try planBundleEnv(std.testing.allocator, .{
+        .image_env = &image,
+        .guest_env = &guest,
+    });
     defer std.testing.allocator.free(planned);
-    try std.testing.expectEqual(@as(usize, 3), planned.len);
+    try std.testing.expectEqual(@as(@TypeOf(planned.len), 3), planned.len);
     try std.testing.expectEqualStrings("FOO", planned[0].key);
     try std.testing.expectEqualStrings("guest", planned[0].value);
     try std.testing.expectEqualStrings("BAR", planned[1].key);
@@ -834,13 +885,21 @@ test "planRootDiskRuntime selects existing restore and cached clone actions" {
     try std.testing.expectEqualStrings("/root.img", existing.vmm_root_disk.?);
     try std.testing.expect(existing.per_boot_root_disk == null);
 
-    const restore = try planRootDiskRuntime(.{ .mode = .restore, .source_path = "/restore.img", .clone_path = "/restore-clone.img" });
+    const restore = try planRootDiskRuntime(.{
+        .mode = .restore,
+        .source_path = "/restore.img",
+        .clone_path = "/restore-clone.img",
+    });
     try std.testing.expectEqualStrings("clone-restore", restore.action);
     try std.testing.expectEqualStrings("/restore.img", restore.source_path.?);
     try std.testing.expectEqualStrings("/restore-clone.img", restore.target_path.?);
     try std.testing.expectEqualStrings("/restore-clone.img", restore.per_boot_root_disk.?);
 
-    const cached = try planRootDiskRuntime(.{ .mode = .cached, .source_path = "/cache.img", .clone_path = "/boot.img" });
+    const cached = try planRootDiskRuntime(.{
+        .mode = .cached,
+        .source_path = "/cache.img",
+        .clone_path = "/boot.img",
+    });
     try std.testing.expectEqualStrings("clone-cached", cached.action);
     try std.testing.expectEqualStrings("/cache.img", cached.source_path.?);
     try std.testing.expectEqualStrings("/boot.img", cached.vmm_root_disk.?);
@@ -851,12 +910,21 @@ test "planScratchDisk selects restore clone auto allocation and no-disk cases" {
     try std.testing.expectEqualStrings("none", disabled.action);
     try std.testing.expect(disabled.vmm_disk == null);
 
-    const existing = try planScratchDisk(.{ .mode = .path, .has_cmd = true, .snapshot_path = "/snap.img", .restore_clone_path = "/clone.img" });
+    const existing = try planScratchDisk(.{
+        .mode = .path,
+        .has_cmd = true,
+        .snapshot_path = "/snap.img",
+        .restore_clone_path = "/clone.img",
+    });
     try std.testing.expectEqualStrings("existing", existing.action);
     try std.testing.expectEqualStrings("/snap.img", existing.vmm_disk.?);
     try std.testing.expect(existing.per_boot_snap_disk == null);
 
-    const clone = try planScratchDisk(.{ .mode = .path, .snapshot_path = "/snap.img", .restore_clone_path = "/clone.img" });
+    const clone = try planScratchDisk(.{
+        .mode = .path,
+        .snapshot_path = "/snap.img",
+        .restore_clone_path = "/clone.img",
+    });
     try std.testing.expectEqualStrings("clone", clone.action);
     try std.testing.expectEqualStrings("/clone.img", clone.disk_path.?);
     try std.testing.expectEqualStrings("/clone.img", clone.per_boot_snap_disk.?);
@@ -864,15 +932,27 @@ test "planScratchDisk selects restore clone auto allocation and no-disk cases" {
     const auto_without_image = try planScratchDisk(.{ .mode = .auto });
     try std.testing.expectEqualStrings("none", auto_without_image.action);
 
-    const auto = try planScratchDisk(.{ .mode = .auto, .has_image = true, .auto_path = "/auto.img" });
+    const auto = try planScratchDisk(.{
+        .mode = .auto,
+        .has_image = true,
+        .auto_path = "/auto.img",
+    });
     try std.testing.expectEqualStrings("allocate", auto.action);
     try std.testing.expectEqualStrings("/auto.img", auto.vmm_disk.?);
 }
 
 test "planBundleCommand resolves image restore supervisor and batch wrappers" {
-    const ro_mounts = [_]LiveMount{.{ .host = "/host", .guest = "/mnt/ro", .mode = "ro", .tag = "machinen-lm0" }};
+    const ro_mounts = [_]LiveMount{.{
+        .host = "/host",
+        .guest = "/mnt/ro",
+        .mode = "ro",
+        .tag = "machinen-lm0",
+    }};
     const image = [_][]const u8{"/bin/true"};
-    const planned = try planBundleCommand(std.testing.allocator, .{ .image_cmd = &image, .live_mounts = &ro_mounts });
+    const planned = try planBundleCommand(std.testing.allocator, .{
+        .image_cmd = &image,
+        .live_mounts = &ro_mounts,
+    });
     defer std.testing.allocator.free(planned);
     try std.testing.expectEqualStrings("/sbin/machinen-supervisor", planned[0]);
     try std.testing.expectEqualStrings("/bin/true", planned[1]);
@@ -880,9 +960,17 @@ test "planBundleCommand resolves image restore supervisor and batch wrappers" {
     const restore = try planBundleCommand(std.testing.allocator, .{ .snapshot_restore = true });
     try std.testing.expectEqualStrings("/sbin/machinen-restore", restore[0]);
 
-    const rw_mounts = [_]LiveMount{.{ .host = "/host", .guest = "/mnt/rw", .mode = "rw", .tag = "machinen-lm0" }};
+    const rw_mounts = [_]LiveMount{.{
+        .host = "/host",
+        .guest = "/mnt/rw",
+        .mode = "rw",
+        .tag = "machinen-lm0",
+    }};
     const explicit = [_][]const u8{ "/bin/echo", "hi" };
-    const batched = try planBundleCommand(std.testing.allocator, .{ .explicit_cmd = &explicit, .live_mounts = &rw_mounts });
+    const batched = try planBundleCommand(std.testing.allocator, .{
+        .explicit_cmd = &explicit,
+        .live_mounts = &rw_mounts,
+    });
     defer std.testing.allocator.free(batched);
     try std.testing.expectEqualStrings("/sbin/machinen-supervisor", batched[0]);
     try std.testing.expectEqualStrings("/bin/sh", batched[1]);
@@ -891,8 +979,14 @@ test "planBundleCommand resolves image restore supervisor and batch wrappers" {
 }
 
 test "planMachinenConfigCwd prefers guest cwd over image cwd" {
-    try std.testing.expectEqualStrings("/mnt/work", planMachinenConfigCwd(.{ .guest_cwd = "/mnt/work", .image_cwd = "/srv/app" }).?);
-    try std.testing.expectEqualStrings("/srv/app", planMachinenConfigCwd(.{ .image_cwd = "/srv/app" }).?);
+    try std.testing.expectEqualStrings(
+        "/mnt/work",
+        planMachinenConfigCwd(.{ .guest_cwd = "/mnt/work", .image_cwd = "/srv/app" }).?,
+    );
+    try std.testing.expectEqualStrings(
+        "/srv/app",
+        planMachinenConfigCwd(.{ .image_cwd = "/srv/app" }).?,
+    );
     try std.testing.expectEqual(@as(?[]const u8, null), planMachinenConfigCwd(.{}));
 }
 
@@ -906,7 +1000,7 @@ test "planLiveMounts validates count guest paths modes and tags" {
         for (planned) |mount| std.testing.allocator.free(mount.tag);
         std.testing.allocator.free(planned);
     }
-    try std.testing.expectEqual(@as(usize, 2), planned.len);
+    try std.testing.expectEqual(@as(@TypeOf(planned.len), 2), planned.len);
     try std.testing.expectEqualStrings("./a", planned[0].host);
     try std.testing.expectEqualStrings("/mnt/a", planned[0].guest);
     try std.testing.expectEqualStrings("rw", planned[0].mode);
@@ -915,8 +1009,15 @@ test "planLiveMounts validates count guest paths modes and tags" {
     try std.testing.expectEqualStrings("ro", planned[1].mode);
     try std.testing.expectEqualStrings("machinen-lm1", planned[1].tag);
 
-    const bad_mode = [_]LiveMountInput{.{ .host = "./a", .guest = "/mnt/a", .mode = "eager" }};
-    try std.testing.expectError(error.InvalidLiveMountMode, planLiveMounts(std.testing.allocator, &bad_mode));
+    const bad_mode = [_]LiveMountInput{.{
+        .host = "./a",
+        .guest = "/mnt/a",
+        .mode = "eager",
+    }};
+    try std.testing.expectError(
+        error.InvalidLiveMountMode,
+        planLiveMounts(std.testing.allocator, &bad_mode),
+    );
 }
 
 test "planStatsFile preserves caller path or returns runtime-owned env value" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -116,6 +116,11 @@ pub const StatsFilePlan = struct {
     vmm_stats_file: ?[]const u8,
 };
 
+pub const MachinenConfigInput = struct {
+    guest_cwd: ?[]const u8 = null,
+    image_cwd: ?[]const u8 = null,
+};
+
 pub const Input = struct {
     memory_mib: ?u64 = null,
     resources_memory: ?ResourcesMemory = null,
@@ -263,6 +268,10 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
         return .{ .stats_file_path = path, .vmm_stats_file = null };
     }
     return .{ .stats_file_path = input.planned_path, .vmm_stats_file = input.planned_path };
+}
+
+pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
+    return input.guest_cwd orelse input.image_cwd;
 }
 
 pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPlan {
@@ -474,6 +483,12 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planMachinenConfigCwd prefers guest cwd over image cwd" {
+    try std.testing.expectEqualStrings("/mnt/work", planMachinenConfigCwd(.{ .guest_cwd = "/mnt/work", .image_cwd = "/srv/app" }).?);
+    try std.testing.expectEqualStrings("/srv/app", planMachinenConfigCwd(.{ .image_cwd = "/srv/app" }).?);
+    try std.testing.expectEqual(@as(?[]const u8, null), planMachinenConfigCwd(.{}));
 }
 
 test "planLiveMounts validates count guest paths modes and tags" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -149,6 +149,27 @@ pub const ScratchDiskPlan = struct {
     vmm_disk: ?[]const u8,
 };
 
+pub const RootDiskRuntimeMode = enum {
+    none,
+    path,
+    restore,
+    cached,
+};
+
+pub const RootDiskRuntimeInput = struct {
+    mode: RootDiskRuntimeMode = .none,
+    source_path: ?[]const u8 = null,
+    clone_path: ?[]const u8 = null,
+};
+
+pub const RootDiskRuntimePlan = struct {
+    action: []const u8,
+    source_path: ?[]const u8,
+    target_path: ?[]const u8,
+    per_boot_root_disk: ?[]const u8,
+    vmm_root_disk: ?[]const u8,
+};
+
 pub const MachinenConfigInput = struct {
     guest_cwd: ?[]const u8 = null,
     image_cwd: ?[]const u8 = null,
@@ -189,6 +210,7 @@ pub const PlanError = error{
     InvalidLiveMountMode,
     MissingBundleCommand,
     MissingScratchPath,
+    MissingRootDiskRuntimePath,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -307,6 +329,50 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planRootDiskRuntime(input: RootDiskRuntimeInput) PlanError!RootDiskRuntimePlan {
+    return switch (input.mode) {
+        .none => .{
+            .action = "none",
+            .source_path = null,
+            .target_path = null,
+            .per_boot_root_disk = null,
+            .vmm_root_disk = null,
+        },
+        .path => blk: {
+            const source = input.source_path orelse return error.MissingRootDiskRuntimePath;
+            break :blk .{
+                .action = "existing",
+                .source_path = source,
+                .target_path = null,
+                .per_boot_root_disk = null,
+                .vmm_root_disk = source,
+            };
+        },
+        .restore => blk: {
+            const source = input.source_path orelse return error.MissingRootDiskRuntimePath;
+            const target = input.clone_path orelse return error.MissingRootDiskRuntimePath;
+            break :blk .{
+                .action = "clone-restore",
+                .source_path = source,
+                .target_path = target,
+                .per_boot_root_disk = target,
+                .vmm_root_disk = target,
+            };
+        },
+        .cached => blk: {
+            const source = input.source_path orelse return error.MissingRootDiskRuntimePath;
+            const target = input.clone_path orelse return error.MissingRootDiskRuntimePath;
+            break :blk .{
+                .action = "clone-cached",
+                .source_path = source,
+                .target_path = target,
+                .per_boot_root_disk = target,
+                .vmm_root_disk = target,
+            };
+        },
+    };
 }
 
 pub fn planScratchDisk(input: ScratchDiskInput) PlanError!ScratchDiskPlan {
@@ -609,6 +675,28 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planRootDiskRuntime selects existing restore and cached clone actions" {
+    const none = try planRootDiskRuntime(.{});
+    try std.testing.expectEqualStrings("none", none.action);
+    try std.testing.expect(none.vmm_root_disk == null);
+
+    const existing = try planRootDiskRuntime(.{ .mode = .path, .source_path = "/root.img" });
+    try std.testing.expectEqualStrings("existing", existing.action);
+    try std.testing.expectEqualStrings("/root.img", existing.vmm_root_disk.?);
+    try std.testing.expect(existing.per_boot_root_disk == null);
+
+    const restore = try planRootDiskRuntime(.{ .mode = .restore, .source_path = "/restore.img", .clone_path = "/restore-clone.img" });
+    try std.testing.expectEqualStrings("clone-restore", restore.action);
+    try std.testing.expectEqualStrings("/restore.img", restore.source_path.?);
+    try std.testing.expectEqualStrings("/restore-clone.img", restore.target_path.?);
+    try std.testing.expectEqualStrings("/restore-clone.img", restore.per_boot_root_disk.?);
+
+    const cached = try planRootDiskRuntime(.{ .mode = .cached, .source_path = "/cache.img", .clone_path = "/boot.img" });
+    try std.testing.expectEqualStrings("clone-cached", cached.action);
+    try std.testing.expectEqualStrings("/cache.img", cached.source_path.?);
+    try std.testing.expectEqualStrings("/boot.img", cached.vmm_root_disk.?);
 }
 
 test "planScratchDisk selects restore clone auto allocation and no-disk cases" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -80,6 +80,11 @@ pub const BundleCommandInput = struct {
     live_mounts: []const LiveMount = &.{},
 };
 
+pub const BundleEnvInput = struct {
+    image_env: []const EnvPair = &.{},
+    guest_env: []const EnvPair = &.{},
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -329,6 +334,29 @@ pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planBundleEnv(allocator: std.mem.Allocator, input: BundleEnvInput) ![]EnvPair {
+    var out: std.ArrayList(EnvPair) = .empty;
+    errdefer out.deinit(allocator);
+    for (input.image_env) |pair| {
+        try out.append(allocator, pair);
+    }
+    for (input.guest_env) |pair| {
+        if (indexOfEnvKey(out.items, pair.key)) |index| {
+            out.items[index].value = pair.value;
+        } else {
+            try out.append(allocator, pair);
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn indexOfEnvKey(pairs: []const EnvPair, key: []const u8) ?usize {
+    for (pairs, 0..) |pair, i| {
+        if (std.mem.eql(u8, pair.key, key)) return i;
+    }
+    return null;
 }
 
 pub fn planRootDiskRuntime(input: RootDiskRuntimeInput) PlanError!RootDiskRuntimePlan {
@@ -675,6 +703,26 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planBundleEnv overlays guest env on image env" {
+    const image = [_]EnvPair{
+        .{ .key = "FOO", .value = "image" },
+        .{ .key = "BAR", .value = "image" },
+    };
+    const guest = [_]EnvPair{
+        .{ .key = "FOO", .value = "guest" },
+        .{ .key = "BAZ", .value = "guest" },
+    };
+    const planned = try planBundleEnv(std.testing.allocator, .{ .image_env = &image, .guest_env = &guest });
+    defer std.testing.allocator.free(planned);
+    try std.testing.expectEqual(@as(usize, 3), planned.len);
+    try std.testing.expectEqualStrings("FOO", planned[0].key);
+    try std.testing.expectEqualStrings("guest", planned[0].value);
+    try std.testing.expectEqualStrings("BAR", planned[1].key);
+    try std.testing.expectEqualStrings("image", planned[1].value);
+    try std.testing.expectEqualStrings("BAZ", planned[2].key);
+    try std.testing.expectEqualStrings("guest", planned[2].value);
 }
 
 test "planRootDiskRuntime selects existing restore and cached clone actions" {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -57,6 +57,12 @@ const ParsedRequest = struct {
     root_disk_runtime_mode: boot_plan.RootDiskRuntimeMode = .none,
     root_disk_source_path: ?[]const u8 = null,
     root_disk_clone_path: ?[]const u8 = null,
+    mount_disk_runtime_mode: boot_plan.MountDiskRuntimeMode = .none,
+    mount_disk_lower_path: ?[]const u8 = null,
+    mount_disk_upper_path: ?[]const u8 = null,
+    mount_disk_source_upper_path: ?[]const u8 = null,
+    mount_disk_guest: ?[]const u8 = null,
+    mount_disk_upper_size_text: ?[]const u8 = null,
 };
 
 const ParsedResourcesMemory = struct {
@@ -114,6 +120,12 @@ const boot_plan_fields = [_][]const u8{
     "rootDiskRuntimeMode",
     "rootDiskSourcePath",
     "rootDiskClonePath",
+    "mountDiskRuntimeMode",
+    "mountDiskLowerPath",
+    "mountDiskUpperPath",
+    "mountDiskSourceUpperPath",
+    "mountDiskGuest",
+    "mountDiskUpperSize",
 };
 
 const RequestError = error{
@@ -186,6 +198,12 @@ const RequestError = error{
     InvalidRootDiskRuntimeMode,
     InvalidRootDiskSourcePath,
     InvalidRootDiskClonePath,
+    InvalidMountDiskRuntimeMode,
+    InvalidMountDiskLowerPath,
+    InvalidMountDiskUpperPath,
+    InvalidMountDiskSourceUpperPath,
+    InvalidMountDiskGuest,
+    InvalidMountDiskUpperSize,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -232,6 +250,7 @@ const PlanParts = struct {
     bundle_env: []const boot_plan.EnvPair,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
+    mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
 };
 
 fn makeCorePlan(
@@ -307,6 +326,18 @@ fn makePlanParts(
         .source_path = parsed.root_disk_source_path,
         .clone_path = parsed.root_disk_clone_path,
     });
+    const mount_disk_upper_size = if (parsed.mount_disk_upper_size_text) |text|
+        parseUnsigned(text) catch return error.InvalidMountDiskUpperSize
+    else
+        null;
+    const mount_disk_runtime = try boot_plan.planMountDiskRuntime(.{
+        .mode = parsed.mount_disk_runtime_mode,
+        .lower_path = parsed.mount_disk_lower_path,
+        .upper_path = parsed.mount_disk_upper_path,
+        .source_upper_path = parsed.mount_disk_source_upper_path,
+        .guest = parsed.mount_disk_guest,
+        .upper_size_bytes = mount_disk_upper_size,
+    });
     return .{
         .plan = plan,
         .guest_env = guest_env,
@@ -325,6 +356,7 @@ fn makePlanParts(
         .bundle_env = bundle_env,
         .scratch_disk = scratch_disk,
         .root_disk_runtime = root_disk_runtime,
+        .mount_disk_runtime = mount_disk_runtime,
     };
 }
 
@@ -364,6 +396,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
+    try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -540,6 +573,30 @@ fn writeRootDiskRuntimeField(
         true,
     );
     try writeNullableStringField(io, "vmmRootDisk", root_disk.vmm_root_disk, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeMountDiskRuntimeField(
+    io: std.Io,
+    comptime field: []const u8,
+    mount_disk: boot_plan.MountDiskRuntimePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{\"action\":");
+    try protocol.writeJsonString(io, mount_disk.action);
+    try writeNullableStringField(io, "lowerPath", mount_disk.lower_path, true);
+    try writeNullableStringField(io, "upperPath", mount_disk.upper_path, true);
+    try writeNullableStringField(
+        io,
+        "sourceUpperPath",
+        mount_disk.source_upper_path,
+        true,
+    );
+    try writeNullableStringField(io, "guest", mount_disk.guest, true);
+    try writeNullableU64Field(io, "upperSizeBytes", mount_disk.upper_size_bytes, true);
     try protocol.stdout(io, "}");
 }
 
@@ -987,6 +1044,32 @@ fn parseKernelVmstateFields(
         "rootDiskClonePath",
         error.InvalidRootDiskClonePath,
     );
+    request.mount_disk_runtime_mode = try optionalMountDiskRuntimeMode(object);
+    request.mount_disk_lower_path = try optionalStringDefaultNull(
+        object,
+        "mountDiskLowerPath",
+        error.InvalidMountDiskLowerPath,
+    );
+    request.mount_disk_upper_path = try optionalStringDefaultNull(
+        object,
+        "mountDiskUpperPath",
+        error.InvalidMountDiskUpperPath,
+    );
+    request.mount_disk_source_upper_path = try optionalStringDefaultNull(
+        object,
+        "mountDiskSourceUpperPath",
+        error.InvalidMountDiskSourceUpperPath,
+    );
+    request.mount_disk_guest = try optionalStringDefaultNull(
+        object,
+        "mountDiskGuest",
+        error.InvalidMountDiskGuest,
+    );
+    request.mount_disk_upper_size_text = try optionalStringDefaultNull(
+        object,
+        "mountDiskUpperSize",
+        error.InvalidMountDiskUpperSize,
+    );
 }
 
 fn hasBundleCommandField(object: std.json.ObjectMap) bool {
@@ -1024,6 +1107,16 @@ fn optionalRootDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_pla
     if (std.mem.eql(u8, value.string, "restore")) return .restore;
     if (std.mem.eql(u8, value.string, "cached")) return .cached;
     return error.InvalidRootDiskRuntimeMode;
+}
+
+fn optionalMountDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_plan.MountDiskRuntimeMode {
+    const value = object.get("mountDiskRuntimeMode") orelse return .none;
+    if (value == .null) return .none;
+    if (value != .string) return error.InvalidMountDiskRuntimeMode;
+    if (std.mem.eql(u8, value.string, "none")) return .none;
+    if (std.mem.eql(u8, value.string, "restore")) return .restore;
+    if (std.mem.eql(u8, value.string, "fresh")) return .fresh;
+    return error.InvalidMountDiskRuntimeMode;
 }
 
 fn optionalLiveMounts(
@@ -1398,6 +1491,16 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "BOOT_IMAGE_NOT_FOUND",
             "boot-plan rootDisk path missing",
+        ),
+        error.MissingMountDiskRuntimeField => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "boot-plan mountDisk field missing",
+        ),
+        error.InvalidMountDiskUpperSize => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "boot-plan mountDisk upper size must be an integer",
         ),
         else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -47,7 +47,11 @@ const ParsedRequest = struct {
     bundle_snapshot_restore: bool = false,
     bundle_vmstate_restore: bool = false,
     bundle_live_mounts: []const boot_plan.LiveMount = &.{},
-    bundle_command_requested: bool = false,
+    bundle_command_required: bool = false,
+    scratch_mode: boot_plan.ScratchDiskMode = .unset,
+    scratch_snapshot_path: ?[]const u8 = null,
+    scratch_restore_clone_path: ?[]const u8 = null,
+    scratch_auto_path: ?[]const u8 = null,
 };
 
 const ParsedResourcesMemory = struct {
@@ -95,7 +99,11 @@ const boot_plan_fields = [_][]const u8{
     "bundleSnapshotRestore",
     "bundleVmstateRestore",
     "bundleLiveMounts",
-    "bundleCommandRequested",
+    "bundleCommandRequired",
+    "scratchMode",
+    "scratchSnapshotPath",
+    "scratchRestoreClonePath",
+    "scratchAutoPath",
 };
 
 const RequestError = error{
@@ -157,7 +165,11 @@ const RequestError = error{
     InvalidBundleSnapshotRestore,
     InvalidBundleVmstateRestore,
     InvalidBundleLiveMounts,
-    InvalidBundleCommandRequested,
+    InvalidBundleCommandRequired,
+    InvalidScratchMode,
+    InvalidScratchSnapshotPath,
+    InvalidScratchRestoreClonePath,
+    InvalidScratchAutoPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -201,6 +213,7 @@ const PlanParts = struct {
     config_cwd: ?[]const u8,
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
+    scratch_disk: boot_plan.ScratchDiskPlan,
 };
 
 fn makeCorePlan(
@@ -252,7 +265,7 @@ fn makePlanParts(
         .guest_cwd = parsed.config_guest_cwd,
         .image_cwd = parsed.config_image_cwd,
     });
-    const bundle_command = if (parsed.bundle_command_requested)
+    const bundle_command = if (parsed.bundle_command_required)
         try boot_plan.planBundleCommand(arena, .{
             .explicit_cmd = parsed.bundle_explicit_cmd,
             .image_cmd = parsed.bundle_image_cmd,
@@ -262,6 +275,14 @@ fn makePlanParts(
         })
     else
         &.{};
+    const scratch_disk = try boot_plan.planScratchDisk(.{
+        .mode = parsed.scratch_mode,
+        .has_cmd = parsed.has_cmd,
+        .has_image = parsed.has_image,
+        .snapshot_path = parsed.scratch_snapshot_path,
+        .restore_clone_path = parsed.scratch_restore_clone_path,
+        .auto_path = parsed.scratch_auto_path,
+    });
     return .{
         .plan = plan,
         .guest_env = guest_env,
@@ -277,6 +298,7 @@ fn makePlanParts(
         .config_cwd = config_cwd,
         .config_live_mounts = parsed.config_live_mounts,
         .bundle_command = bundle_command,
+        .scratch_disk = scratch_disk,
     };
 }
 
@@ -313,6 +335,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeNullableStringField(io, "configCwd", parts.config_cwd, true);
     try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
+    try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -450,6 +473,23 @@ fn writeLiveMountsArrayField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeScratchDiskField(
+    io: std.Io,
+    comptime field: []const u8,
+    scratch: boot_plan.ScratchDiskPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{\"action\":");
+    try protocol.writeJsonString(io, scratch.action);
+    try writeNullableStringField(io, "diskPath", scratch.disk_path, true);
+    try writeNullableStringField(io, "perBootSnapDisk", scratch.per_boot_snap_disk, true);
+    try writeNullableStringField(io, "vmmDisk", scratch.vmm_disk, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeEnvObjectField(
@@ -817,11 +857,53 @@ fn parseKernelVmstateFields(
         "bundleLiveMounts",
         error.InvalidBundleLiveMounts,
     );
-    request.bundle_command_requested = try optionalBoolDefaultFalse(
+    request.bundle_command_required = (try optionalBoolDefaultFalse(
         object,
-        "bundleCommandRequested",
-        error.InvalidBundleCommandRequested,
+        "bundleCommandRequired",
+        error.InvalidBundleCommandRequired,
+    )) or hasBundleCommandField(object);
+    request.scratch_mode = try optionalScratchMode(object);
+    request.scratch_snapshot_path = try optionalStringDefaultNull(
+        object,
+        "scratchSnapshotPath",
+        error.InvalidScratchSnapshotPath,
     );
+    request.scratch_restore_clone_path = try optionalStringDefaultNull(
+        object,
+        "scratchRestoreClonePath",
+        error.InvalidScratchRestoreClonePath,
+    );
+    request.scratch_auto_path = try optionalStringDefaultNull(
+        object,
+        "scratchAutoPath",
+        error.InvalidScratchAutoPath,
+    );
+}
+
+fn hasBundleCommandField(object: std.json.ObjectMap) bool {
+    if (object.get("bundleExplicitCmd")) |value| {
+        if (value != .null) return true;
+    }
+    if (object.get("bundleImageCmd")) |value| {
+        if (value != .null) return true;
+    }
+    if (object.get("bundleSnapshotRestore")) |value| {
+        if (value == .bool and value.bool) return true;
+    }
+    if (object.get("bundleVmstateRestore")) |value| {
+        if (value == .bool and value.bool) return true;
+    }
+    return false;
+}
+
+fn optionalScratchMode(object: std.json.ObjectMap) RequestError!boot_plan.ScratchDiskMode {
+    const value = object.get("scratchMode") orelse return .unset;
+    if (value == .null) return .unset;
+    if (value != .string) return error.InvalidScratchMode;
+    if (std.mem.eql(u8, value.string, "false")) return .false_value;
+    if (std.mem.eql(u8, value.string, "path")) return .path;
+    if (std.mem.eql(u8, value.string, "auto")) return .auto;
+    return error.InvalidScratchMode;
 }
 
 fn optionalLiveMounts(
@@ -1176,6 +1258,16 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "INVALID_REQUEST",
             "boot-plan configEnv values must be strings",
+        ),
+        error.MissingBundleCommand => try writeBootError(
+            io,
+            "BOOT_CMD_WITHOUT_IMAGE",
+            "boot-plan bundle command input is missing",
+        ),
+        error.MissingScratchPath => try writeBootError(
+            io,
+            "BOOT_SNAPSHOT_NOT_FOUND",
+            "boot-plan scratch disk path missing",
         ),
         else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -33,6 +33,7 @@ const ParsedRequest = struct {
     restore_path: ?[]const u8 = null,
     enable_vmstate_timing: bool = false,
     existing_vmstate_timing: ?[]const u8 = null,
+    live_mounts: []const boot_plan.LiveMountInput = &.{},
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
     existing_stats_file: ?[]const u8 = null,
     stats_file_path: ?[]const u8 = null,
@@ -69,6 +70,7 @@ const boot_plan_fields = [_][]const u8{
     "restorePath",
     "enableVmstateTiming",
     "existingVmstateTiming",
+    "liveMounts",
     "liveMountsResolved",
     "existingStatsFile",
     "statsFilePath",
@@ -114,6 +116,8 @@ const RequestError = error{
     InvalidRestorePath,
     InvalidEnableVmstateTiming,
     InvalidExistingVmstateTiming,
+    InvalidLiveMounts,
+    InvalidLiveMountGuest,
     InvalidLiveMountsResolved,
     InvalidLiveMountHost,
     InvalidLiveMountMode,
@@ -157,6 +161,7 @@ const PlanParts = struct {
     vmstate_env: boot_plan.VmstateEnvPlan,
     virtiofs_env: []const boot_plan.EnvPair,
     stats_file: boot_plan.StatsFilePlan,
+    planned_live_mounts: []const boot_plan.LiveMount,
 };
 
 fn makeCorePlan(
@@ -197,6 +202,7 @@ fn makePlanParts(
         .enable_timing = parsed.enable_vmstate_timing,
         .existing_timing = parsed.existing_vmstate_timing,
     });
+    const planned_live_mounts = try boot_plan.planLiveMounts(arena, parsed.live_mounts);
     const virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved);
     const stats_file = boot_plan.planStatsFile(.{
         .existing_path = parsed.existing_stats_file,
@@ -211,6 +217,7 @@ fn makePlanParts(
         .vmstate_env = vmstate_env,
         .virtiofs_env = virtiofs_env,
         .stats_file = stats_file,
+        .planned_live_mounts = planned_live_mounts,
     };
 }
 
@@ -237,6 +244,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeCoreFields(io, parts.plan);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
+    try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
     try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
@@ -353,6 +361,31 @@ fn writeBoolField(
 
     try writeFieldName(io, field, comma);
     try protocol.stdout(io, if (value) "true" else "false");
+}
+
+fn writeLiveMountsArrayField(
+    io: std.Io,
+    comptime field: []const u8,
+    mounts: []const boot_plan.LiveMount,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mounts, 0..) |mount, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{\"host\":");
+        try protocol.writeJsonString(io, mount.host);
+        try protocol.stdout(io, ",\"guest\":");
+        try protocol.writeJsonString(io, mount.guest);
+        try protocol.stdout(io, ",\"mode\":");
+        try protocol.writeJsonString(io, mount.mode);
+        try protocol.stdout(io, ",\"tag\":");
+        try protocol.writeJsonString(io, mount.tag);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
 }
 
 fn writeEnvObjectField(
@@ -632,6 +665,7 @@ fn parseKernelVmstateFields(
         "existingVmstateTiming",
         error.InvalidExistingVmstateTiming,
     );
+    request.live_mounts = try optionalLiveMounts(allocator, object);
     request.live_mounts_resolved = try optionalLiveMountsResolved(allocator, object);
     request.existing_stats_file = try optionalStringDefaultNull(
         object,
@@ -643,6 +677,35 @@ fn parseKernelVmstateFields(
         "statsFilePath",
         error.InvalidStatsFilePath,
     );
+}
+
+fn optionalLiveMounts(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError![]const boot_plan.LiveMountInput {
+    assert(@sizeOf(boot_plan.LiveMountInput) > 0);
+
+    const value = object.get("liveMounts") orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return error.InvalidLiveMounts;
+    var mounts: std.array_list.Aligned(boot_plan.LiveMountInput, null) = .empty;
+    errdefer mounts.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .object) return error.InvalidLiveMounts;
+        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        const host = item.object.get("host") orelse return error.InvalidLiveMountHost;
+        const guest = item.object.get("guest") orelse return error.InvalidLiveMountGuest;
+        const mode = item.object.get("mode") orelse .null;
+        if (host != .string) return error.InvalidLiveMountHost;
+        if (guest != .string) return error.InvalidLiveMountGuest;
+        if (mode != .null and mode != .string) return error.InvalidLiveMountMode;
+        try mounts.append(allocator, .{
+            .host = host.string,
+            .guest = guest.string,
+            .mode = if (mode == .string) mode.string else null,
+        });
+    }
+    return mounts.toOwnedSlice(allocator);
 }
 
 fn optionalLiveMountsResolved(
@@ -658,11 +721,13 @@ fn optionalLiveMountsResolved(
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidLiveMountsResolved;
-        try protocol.rejectUnknownFields(item.object, &.{ "host", "mode", "tag" });
+        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode", "tag" });
         const host = item.object.get("host") orelse return error.InvalidLiveMountHost;
+        const guest = item.object.get("guest") orelse return error.InvalidLiveMountGuest;
         const mode = item.object.get("mode") orelse return error.InvalidLiveMountMode;
         const tag = item.object.get("tag") orelse return error.InvalidLiveMountTag;
         if (host != .string) return error.InvalidLiveMountHost;
+        if (guest != .string) return error.InvalidLiveMountGuest;
         if (mode != .string) return error.InvalidLiveMountMode;
         if (!std.mem.eql(u8, mode.string, "ro") and
             !std.mem.eql(u8, mode.string, "rw"))
@@ -672,6 +737,7 @@ fn optionalLiveMountsResolved(
         if (tag != .string) return error.InvalidLiveMountTag;
         try mounts.append(allocator, .{
             .host = host.string,
+            .guest = guest.string,
             .mode = mode.string,
             .tag = tag.string,
         });
@@ -919,6 +985,16 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "BOOT_MOUNT_INVALID",
             "mount guest path must live under /mnt/",
         ),
+        error.TooManyLiveMounts => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "liveMounts: at most 5 live mounts are supported per VM",
+        ),
+        error.InvalidLiveMountMode => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "liveMounts: mode must be ro or rw",
+        ),
         error.UnsupportedHostMemory => try writeBootError(
             io,
             "BOOT_MEMORY_INVALID",
@@ -953,6 +1029,13 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             "BOOT_PORT_FORWARD_INVALID",
             "portForward: hostPort and guestPort must be integers in 1..65535",
         ),
+        error.InvalidLiveMounts,
+        error.InvalidLiveMountGuest,
+        => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "liveMounts: entries must include host and guest paths",
+        ),
         error.InvalidLiveMountsResolved,
         error.InvalidLiveMountHost,
         error.InvalidLiveMountMode,
@@ -960,7 +1043,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         => try protocol.writeError(
             io,
             "BOOT_MOUNT_INVALID",
-            "liveMounts: resolved entries must include host, tag, and mode ro/rw",
+            "liveMounts: resolved entries must include host, guest, tag, and mode ro/rw",
         ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -48,6 +48,8 @@ const ParsedRequest = struct {
     bundle_vmstate_restore: bool = false,
     bundle_live_mounts: []const boot_plan.LiveMount = &.{},
     bundle_command_required: bool = false,
+    bundle_image_env: std.json.ObjectMap = .{},
+    bundle_guest_env: std.json.ObjectMap = .{},
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -103,6 +105,8 @@ const boot_plan_fields = [_][]const u8{
     "bundleVmstateRestore",
     "bundleLiveMounts",
     "bundleCommandRequired",
+    "bundleImageEnv",
+    "bundleGuestEnv",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -172,6 +176,9 @@ const RequestError = error{
     InvalidBundleVmstateRestore,
     InvalidBundleLiveMounts,
     InvalidBundleCommandRequired,
+    InvalidBundleImageEnv,
+    InvalidBundleGuestEnv,
+    InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
     InvalidScratchRestoreClonePath,
@@ -222,6 +229,7 @@ const PlanParts = struct {
     config_cwd: ?[]const u8,
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
+    bundle_env: []const boot_plan.EnvPair,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
 };
@@ -285,6 +293,7 @@ fn makePlanParts(
         })
     else
         &.{};
+    const bundle_env = try makeBundleEnv(arena, parsed);
     const scratch_disk = try boot_plan.planScratchDisk(.{
         .mode = parsed.scratch_mode,
         .has_cmd = parsed.has_cmd,
@@ -313,6 +322,7 @@ fn makePlanParts(
         .config_cwd = config_cwd,
         .config_live_mounts = parsed.config_live_mounts,
         .bundle_command = bundle_command,
+        .bundle_env = bundle_env,
         .scratch_disk = scratch_disk,
         .root_disk_runtime = root_disk_runtime,
     };
@@ -351,6 +361,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeNullableStringField(io, "configCwd", parts.config_cwd, true);
     try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
+    try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try protocol.stdout(io, "}}\n");
@@ -594,6 +605,43 @@ fn makeConfigEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_pl
     var it = parsed.config_env.iterator();
     while (it.next()) |entry| {
         if (entry.value_ptr.* != .string) return error.InvalidConfigEnvValue;
+        try pairs.append(allocator, .{
+            .key = entry.key_ptr.*,
+            .value = entry.value_ptr.string,
+        });
+    }
+    return pairs.toOwnedSlice(allocator);
+}
+
+fn makeBundleEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    return boot_plan.planBundleEnv(allocator, .{
+        .image_env = try objectStringPairs(
+            allocator,
+            parsed.bundle_image_env,
+            error.InvalidBundleEnvValue,
+        ),
+        .guest_env = try objectStringPairs(
+            allocator,
+            parsed.bundle_guest_env,
+            error.InvalidBundleEnvValue,
+        ),
+    });
+}
+
+fn objectStringPairs(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    invalid: anyerror,
+) ![]boot_plan.EnvPair {
+    assert(@sizeOf(boot_plan.EnvPair) > 0);
+
+    var pairs: std.array_list.Aligned(boot_plan.EnvPair, null) = .empty;
+    errdefer pairs.deinit(allocator);
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.* != .string) return invalid;
         try pairs.append(allocator, .{
             .key = entry.key_ptr.*,
             .value = entry.value_ptr.string,
@@ -902,6 +950,16 @@ fn parseKernelVmstateFields(
         "bundleCommandRequired",
         error.InvalidBundleCommandRequired,
     )) or hasBundleCommandField(object);
+    request.bundle_image_env = try optionalObjectDefaultEmpty(
+        object,
+        "bundleImageEnv",
+        error.InvalidBundleImageEnv,
+    );
+    request.bundle_guest_env = try optionalObjectDefaultEmpty(
+        object,
+        "bundleGuestEnv",
+        error.InvalidBundleGuestEnv,
+    );
     request.scratch_mode = try optionalScratchMode(object);
     request.scratch_snapshot_path = try optionalStringDefaultNull(
         object,
@@ -1320,6 +1378,11 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "INVALID_REQUEST",
             "boot-plan configEnv values must be strings",
+        ),
+        error.InvalidBundleEnvValue => try writeBootError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan bundle env values must be strings",
         ),
         error.MissingBundleCommand => try writeBootError(
             io,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -52,6 +52,9 @@ const ParsedRequest = struct {
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
     scratch_auto_path: ?[]const u8 = null,
+    root_disk_runtime_mode: boot_plan.RootDiskRuntimeMode = .none,
+    root_disk_source_path: ?[]const u8 = null,
+    root_disk_clone_path: ?[]const u8 = null,
 };
 
 const ParsedResourcesMemory = struct {
@@ -104,6 +107,9 @@ const boot_plan_fields = [_][]const u8{
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
     "scratchAutoPath",
+    "rootDiskRuntimeMode",
+    "rootDiskSourcePath",
+    "rootDiskClonePath",
 };
 
 const RequestError = error{
@@ -170,6 +176,9 @@ const RequestError = error{
     InvalidScratchSnapshotPath,
     InvalidScratchRestoreClonePath,
     InvalidScratchAutoPath,
+    InvalidRootDiskRuntimeMode,
+    InvalidRootDiskSourcePath,
+    InvalidRootDiskClonePath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -214,6 +223,7 @@ const PlanParts = struct {
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
     scratch_disk: boot_plan.ScratchDiskPlan,
+    root_disk_runtime: boot_plan.RootDiskRuntimePlan,
 };
 
 fn makeCorePlan(
@@ -283,6 +293,11 @@ fn makePlanParts(
         .restore_clone_path = parsed.scratch_restore_clone_path,
         .auto_path = parsed.scratch_auto_path,
     });
+    const root_disk_runtime = try boot_plan.planRootDiskRuntime(.{
+        .mode = parsed.root_disk_runtime_mode,
+        .source_path = parsed.root_disk_source_path,
+        .clone_path = parsed.root_disk_clone_path,
+    });
     return .{
         .plan = plan,
         .guest_env = guest_env,
@@ -299,6 +314,7 @@ fn makePlanParts(
         .config_live_mounts = parsed.config_live_mounts,
         .bundle_command = bundle_command,
         .scratch_disk = scratch_disk,
+        .root_disk_runtime = root_disk_runtime,
     };
 }
 
@@ -336,6 +352,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
+    try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -489,6 +506,29 @@ fn writeScratchDiskField(
     try writeNullableStringField(io, "diskPath", scratch.disk_path, true);
     try writeNullableStringField(io, "perBootSnapDisk", scratch.per_boot_snap_disk, true);
     try writeNullableStringField(io, "vmmDisk", scratch.vmm_disk, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeRootDiskRuntimeField(
+    io: std.Io,
+    comptime field: []const u8,
+    root_disk: boot_plan.RootDiskRuntimePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{\"action\":");
+    try protocol.writeJsonString(io, root_disk.action);
+    try writeNullableStringField(io, "sourcePath", root_disk.source_path, true);
+    try writeNullableStringField(io, "targetPath", root_disk.target_path, true);
+    try writeNullableStringField(
+        io,
+        "perBootRootDisk",
+        root_disk.per_boot_root_disk,
+        true,
+    );
+    try writeNullableStringField(io, "vmmRootDisk", root_disk.vmm_root_disk, true);
     try protocol.stdout(io, "}");
 }
 
@@ -878,6 +918,17 @@ fn parseKernelVmstateFields(
         "scratchAutoPath",
         error.InvalidScratchAutoPath,
     );
+    request.root_disk_runtime_mode = try optionalRootDiskRuntimeMode(object);
+    request.root_disk_source_path = try optionalStringDefaultNull(
+        object,
+        "rootDiskSourcePath",
+        error.InvalidRootDiskSourcePath,
+    );
+    request.root_disk_clone_path = try optionalStringDefaultNull(
+        object,
+        "rootDiskClonePath",
+        error.InvalidRootDiskClonePath,
+    );
 }
 
 fn hasBundleCommandField(object: std.json.ObjectMap) bool {
@@ -904,6 +955,17 @@ fn optionalScratchMode(object: std.json.ObjectMap) RequestError!boot_plan.Scratc
     if (std.mem.eql(u8, value.string, "path")) return .path;
     if (std.mem.eql(u8, value.string, "auto")) return .auto;
     return error.InvalidScratchMode;
+}
+
+fn optionalRootDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskRuntimeMode {
+    const value = object.get("rootDiskRuntimeMode") orelse return .none;
+    if (value == .null) return .none;
+    if (value != .string) return error.InvalidRootDiskRuntimeMode;
+    if (std.mem.eql(u8, value.string, "none")) return .none;
+    if (std.mem.eql(u8, value.string, "path")) return .path;
+    if (std.mem.eql(u8, value.string, "restore")) return .restore;
+    if (std.mem.eql(u8, value.string, "cached")) return .cached;
+    return error.InvalidRootDiskRuntimeMode;
 }
 
 fn optionalLiveMounts(
@@ -1268,6 +1330,11 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "BOOT_SNAPSHOT_NOT_FOUND",
             "boot-plan scratch disk path missing",
+        ),
+        error.MissingRootDiskRuntimePath => try writeBootError(
+            io,
+            "BOOT_IMAGE_NOT_FOUND",
+            "boot-plan rootDisk path missing",
         ),
         else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -42,6 +42,12 @@ const ParsedRequest = struct {
     config_guest_cwd: ?[]const u8 = null,
     config_image_cwd: ?[]const u8 = null,
     config_live_mounts: []const boot_plan.LiveMount = &.{},
+    bundle_explicit_cmd: ?[]const []const u8 = null,
+    bundle_image_cmd: ?[]const []const u8 = null,
+    bundle_snapshot_restore: bool = false,
+    bundle_vmstate_restore: bool = false,
+    bundle_live_mounts: []const boot_plan.LiveMount = &.{},
+    bundle_command_requested: bool = false,
 };
 
 const ParsedResourcesMemory = struct {
@@ -84,6 +90,12 @@ const boot_plan_fields = [_][]const u8{
     "configGuestCwd",
     "configImageCwd",
     "configLiveMounts",
+    "bundleExplicitCmd",
+    "bundleImageCmd",
+    "bundleSnapshotRestore",
+    "bundleVmstateRestore",
+    "bundleLiveMounts",
+    "bundleCommandRequested",
 };
 
 const RequestError = error{
@@ -140,6 +152,12 @@ const RequestError = error{
     InvalidConfigGuestCwd,
     InvalidConfigImageCwd,
     InvalidConfigLiveMounts,
+    InvalidBundleExplicitCmd,
+    InvalidBundleImageCmd,
+    InvalidBundleSnapshotRestore,
+    InvalidBundleVmstateRestore,
+    InvalidBundleLiveMounts,
+    InvalidBundleCommandRequested,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -182,6 +200,7 @@ const PlanParts = struct {
     config_env: []const boot_plan.EnvPair,
     config_cwd: ?[]const u8,
     config_live_mounts: []const boot_plan.LiveMount,
+    bundle_command: []const []const u8,
 };
 
 fn makeCorePlan(
@@ -233,6 +252,16 @@ fn makePlanParts(
         .guest_cwd = parsed.config_guest_cwd,
         .image_cwd = parsed.config_image_cwd,
     });
+    const bundle_command = if (parsed.bundle_command_requested)
+        try boot_plan.planBundleCommand(arena, .{
+            .explicit_cmd = parsed.bundle_explicit_cmd,
+            .image_cmd = parsed.bundle_image_cmd,
+            .snapshot_restore = parsed.bundle_snapshot_restore,
+            .vmstate_restore = parsed.bundle_vmstate_restore,
+            .live_mounts = parsed.bundle_live_mounts,
+        })
+    else
+        &.{};
     return .{
         .plan = plan,
         .guest_env = guest_env,
@@ -247,6 +276,7 @@ fn makePlanParts(
         .config_env = config_env,
         .config_cwd = config_cwd,
         .config_live_mounts = parsed.config_live_mounts,
+        .bundle_command = bundle_command,
     };
 }
 
@@ -282,6 +312,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "configEnv", parts.config_env, true);
     try writeNullableStringField(io, "configCwd", parts.config_cwd, true);
     try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
+    try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -758,6 +789,39 @@ fn parseKernelVmstateFields(
         "configLiveMounts",
         error.InvalidConfigLiveMounts,
     );
+    request.bundle_explicit_cmd = try optionalStringArrayOrNull(
+        allocator,
+        object,
+        "bundleExplicitCmd",
+        error.InvalidBundleExplicitCmd,
+    );
+    request.bundle_image_cmd = try optionalStringArrayOrNull(
+        allocator,
+        object,
+        "bundleImageCmd",
+        error.InvalidBundleImageCmd,
+    );
+    request.bundle_snapshot_restore = try optionalBoolDefaultFalse(
+        object,
+        "bundleSnapshotRestore",
+        error.InvalidBundleSnapshotRestore,
+    );
+    request.bundle_vmstate_restore = try optionalBoolDefaultFalse(
+        object,
+        "bundleVmstateRestore",
+        error.InvalidBundleVmstateRestore,
+    );
+    request.bundle_live_mounts = try optionalLiveMountsResolved(
+        allocator,
+        object,
+        "bundleLiveMounts",
+        error.InvalidBundleLiveMounts,
+    );
+    request.bundle_command_requested = try optionalBoolDefaultFalse(
+        object,
+        "bundleCommandRequested",
+        error.InvalidBundleCommandRequested,
+    );
 }
 
 fn optionalLiveMounts(
@@ -853,6 +917,26 @@ fn optionalStringArrayDefaultEmpty(
     if (value != .array) return invalid;
     assert(field.len > 0);
 
+    var out: std.array_list.Aligned([]const u8, null) = .empty;
+    errdefer out.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .string) return invalid;
+        try out.append(allocator, item.string);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn optionalStringArrayOrNull(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!?[]const []const u8 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return null;
+    if (value == .null) return null;
+    if (value != .array) return invalid;
     var out: std.array_list.Aligned([]const u8, null) = .empty;
     errdefer out.deinit(allocator);
     for (value.array.items) |item| {
@@ -1126,6 +1210,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         ),
         error.InvalidLiveMountsResolved,
         error.InvalidConfigLiveMounts,
+        error.InvalidBundleLiveMounts,
         error.InvalidLiveMountHost,
         error.InvalidLiveMountMode,
         error.InvalidLiveMountTag,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -264,6 +264,19 @@ fn makeCorePlan(
     return boot_plan.planCore(input);
 }
 
+const RuntimeParts = struct {
+    planned_live_mounts: []const boot_plan.LiveMount,
+    config_cmd: []const []const u8,
+    config_env: []const boot_plan.EnvPair,
+    config_cwd: ?[]const u8,
+    config_live_mounts: []const boot_plan.LiveMount,
+    bundle_command: []const []const u8,
+    bundle_env: []const boot_plan.EnvPair,
+    scratch_disk: boot_plan.ScratchDiskPlan,
+    root_disk_runtime: boot_plan.RootDiskRuntimePlan,
+    mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
+};
+
 fn makePlanParts(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -271,38 +284,78 @@ fn makePlanParts(
 ) !PlanParts {
     assert(@sizeOf(PlanParts) > 0);
 
-    const vsock_plan = try boot_plan.planVsock(arena, .{
-        .existing_spec = parsed.existing_vsock_spec,
-        .auto_uds_path = parsed.auto_vsock_uds_path,
-    });
-    const guest_env = try makeGuestEnv(arena, parsed);
-    const vmm_argv = try boot_plan.planVmmArgv(arena, .{
-        .binary = parsed.vmm_binary,
-        .args = parsed.vmm_args,
-        .pdeathsig_path = parsed.pdeathsig_path,
-    });
-    const kernel_dtb = boot_plan.planKernelDtb(.{
-        .kernel_path = parsed.kernel_path,
-        .dtb_path = parsed.dtb_path,
-    });
-    const vmstate_env = boot_plan.planVmstateEnv(.{
-        .state_path = parsed.vmstate_path,
-        .restore_path = parsed.restore_path,
-        .enable_timing = parsed.enable_vmstate_timing,
-        .existing_timing = parsed.existing_vmstate_timing,
-    });
-    const planned_live_mounts = try boot_plan.planLiveMounts(arena, parsed.live_mounts);
-    const virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved);
-    const stats_file = boot_plan.planStatsFile(.{
-        .existing_path = parsed.existing_stats_file,
-        .planned_path = parsed.stats_file_path,
-    });
-    const config_env = try makeConfigEnv(arena, parsed);
-    const config_cwd = boot_plan.planMachinenConfigCwd(.{
-        .guest_cwd = parsed.config_guest_cwd,
-        .image_cwd = parsed.config_image_cwd,
-    });
-    const bundle_command = if (parsed.bundle_command_required)
+    const runtime = try makeRuntimeParts(arena, parsed);
+    return .{
+        .plan = plan,
+        .guest_env = try makeGuestEnv(arena, parsed),
+        .vsock_plan = try boot_plan.planVsock(arena, .{
+            .existing_spec = parsed.existing_vsock_spec,
+            .auto_uds_path = parsed.auto_vsock_uds_path,
+        }),
+        .vmm_argv = try boot_plan.planVmmArgv(arena, .{
+            .binary = parsed.vmm_binary,
+            .args = parsed.vmm_args,
+            .pdeathsig_path = parsed.pdeathsig_path,
+        }),
+        .kernel_dtb = boot_plan.planKernelDtb(.{
+            .kernel_path = parsed.kernel_path,
+            .dtb_path = parsed.dtb_path,
+        }),
+        .vmstate_env = boot_plan.planVmstateEnv(.{
+            .state_path = parsed.vmstate_path,
+            .restore_path = parsed.restore_path,
+            .enable_timing = parsed.enable_vmstate_timing,
+            .existing_timing = parsed.existing_vmstate_timing,
+        }),
+        .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
+        .stats_file = boot_plan.planStatsFile(.{
+            .existing_path = parsed.existing_stats_file,
+            .planned_path = parsed.stats_file_path,
+        }),
+        .planned_live_mounts = runtime.planned_live_mounts,
+        .config_cmd = runtime.config_cmd,
+        .config_env = runtime.config_env,
+        .config_cwd = runtime.config_cwd,
+        .config_live_mounts = runtime.config_live_mounts,
+        .bundle_command = runtime.bundle_command,
+        .bundle_env = runtime.bundle_env,
+        .scratch_disk = runtime.scratch_disk,
+        .root_disk_runtime = runtime.root_disk_runtime,
+        .mount_disk_runtime = runtime.mount_disk_runtime,
+    };
+}
+
+fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimeParts {
+    assert(@sizeOf(RuntimeParts) > 0);
+
+    const bundle = try makeBundleParts(arena, parsed);
+    const disks = try makeDiskParts(parsed);
+    return .{
+        .planned_live_mounts = try boot_plan.planLiveMounts(arena, parsed.live_mounts),
+        .config_cmd = parsed.config_cmd,
+        .config_env = try makeConfigEnv(arena, parsed),
+        .config_cwd = boot_plan.planMachinenConfigCwd(.{
+            .guest_cwd = parsed.config_guest_cwd,
+            .image_cwd = parsed.config_image_cwd,
+        }),
+        .config_live_mounts = parsed.config_live_mounts,
+        .bundle_command = bundle.command,
+        .bundle_env = bundle.env,
+        .scratch_disk = disks.scratch,
+        .root_disk_runtime = disks.root,
+        .mount_disk_runtime = disks.mount,
+    };
+}
+
+const BundleParts = struct {
+    command: []const []const u8,
+    env: []const boot_plan.EnvPair,
+};
+
+fn makeBundleParts(arena: std.mem.Allocator, parsed: ParsedRequest) !BundleParts {
+    assert(@sizeOf(BundleParts) > 0);
+
+    const command = if (parsed.bundle_command_required)
         try boot_plan.planBundleCommand(arena, .{
             .explicit_cmd = parsed.bundle_explicit_cmd,
             .image_cmd = parsed.bundle_image_cmd,
@@ -312,52 +365,54 @@ fn makePlanParts(
         })
     else
         &.{};
-    const bundle_env = try makeBundleEnv(arena, parsed);
-    const scratch_disk = try boot_plan.planScratchDisk(.{
-        .mode = parsed.scratch_mode,
-        .has_cmd = parsed.has_cmd,
-        .has_image = parsed.has_image,
-        .snapshot_path = parsed.scratch_snapshot_path,
-        .restore_clone_path = parsed.scratch_restore_clone_path,
-        .auto_path = parsed.scratch_auto_path,
-    });
-    const root_disk_runtime = try boot_plan.planRootDiskRuntime(.{
-        .mode = parsed.root_disk_runtime_mode,
-        .source_path = parsed.root_disk_source_path,
-        .clone_path = parsed.root_disk_clone_path,
-    });
-    const mount_disk_upper_size = if (parsed.mount_disk_upper_size_text) |text|
+    return .{
+        .command = command,
+        .env = try makeBundleEnv(arena, parsed),
+    };
+}
+
+const DiskParts = struct {
+    scratch: boot_plan.ScratchDiskPlan,
+    root: boot_plan.RootDiskRuntimePlan,
+    mount: boot_plan.MountDiskRuntimePlan,
+};
+
+fn makeDiskParts(parsed: ParsedRequest) !DiskParts {
+    assert(@sizeOf(DiskParts) > 0);
+
+    return .{
+        .scratch = try boot_plan.planScratchDisk(.{
+            .mode = parsed.scratch_mode,
+            .has_cmd = parsed.has_cmd,
+            .has_image = parsed.has_image,
+            .snapshot_path = parsed.scratch_snapshot_path,
+            .restore_clone_path = parsed.scratch_restore_clone_path,
+            .auto_path = parsed.scratch_auto_path,
+        }),
+        .root = try boot_plan.planRootDiskRuntime(.{
+            .mode = parsed.root_disk_runtime_mode,
+            .source_path = parsed.root_disk_source_path,
+            .clone_path = parsed.root_disk_clone_path,
+        }),
+        .mount = try makeMountDiskRuntime(parsed),
+    };
+}
+
+fn makeMountDiskRuntime(parsed: ParsedRequest) !boot_plan.MountDiskRuntimePlan {
+    assert(@sizeOf(boot_plan.MountDiskRuntimePlan) > 0);
+
+    const upper_size = if (parsed.mount_disk_upper_size_text) |text|
         parseUnsigned(text) catch return error.InvalidMountDiskUpperSize
     else
         null;
-    const mount_disk_runtime = try boot_plan.planMountDiskRuntime(.{
+    return boot_plan.planMountDiskRuntime(.{
         .mode = parsed.mount_disk_runtime_mode,
         .lower_path = parsed.mount_disk_lower_path,
         .upper_path = parsed.mount_disk_upper_path,
         .source_upper_path = parsed.mount_disk_source_upper_path,
         .guest = parsed.mount_disk_guest,
-        .upper_size_bytes = mount_disk_upper_size,
+        .upper_size_bytes = upper_size,
     });
-    return .{
-        .plan = plan,
-        .guest_env = guest_env,
-        .vsock_plan = vsock_plan,
-        .vmm_argv = vmm_argv,
-        .kernel_dtb = kernel_dtb,
-        .vmstate_env = vmstate_env,
-        .virtiofs_env = virtiofs_env,
-        .stats_file = stats_file,
-        .planned_live_mounts = planned_live_mounts,
-        .config_cmd = parsed.config_cmd,
-        .config_env = config_env,
-        .config_cwd = config_cwd,
-        .config_live_mounts = parsed.config_live_mounts,
-        .bundle_command = bundle_command,
-        .bundle_env = bundle_env,
-        .scratch_disk = scratch_disk,
-        .root_disk_runtime = root_disk_runtime,
-        .mount_disk_runtime = mount_disk_runtime,
-    };
 }
 
 fn writePortForwardFailure(
@@ -388,10 +443,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
     try writeEnvObjectField(io, "mergedGuestEnv", parts.guest_env, true);
-    try writeStringArrayField(io, "configCmd", parts.config_cmd, true);
-    try writeEnvObjectField(io, "configEnv", parts.config_env, true);
-    try writeNullableStringField(io, "configCwd", parts.config_cwd, true);
-    try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
+    try writeMachinenConfigField(io, "machinenConfig", parts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
@@ -598,6 +650,49 @@ fn writeMountDiskRuntimeField(
     try writeNullableStringField(io, "guest", mount_disk.guest, true);
     try writeNullableU64Field(io, "upperSizeBytes", mount_disk.upper_size_bytes, true);
     try protocol.stdout(io, "}");
+}
+
+fn writeMachinenConfigField(
+    io: std.Io,
+    comptime field: []const u8,
+    parts: PlanParts,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeStringArrayField(io, "cmd", parts.config_cmd, false);
+    try writeEnvObjectField(io, "env", parts.config_env, true);
+    if (parts.config_cwd) |cwd| {
+        try writeFieldName(io, "cwd", true);
+        try protocol.writeJsonString(io, cwd);
+    }
+    try writeConfigLiveMountsField(io, "liveMounts", parts.config_live_mounts, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeConfigLiveMountsField(
+    io: std.Io,
+    comptime field: []const u8,
+    mounts: []const boot_plan.LiveMount,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mounts, 0..) |mount, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{\"guest\":");
+        try protocol.writeJsonString(io, mount.guest);
+        try protocol.stdout(io, ",\"tag\":");
+        try protocol.writeJsonString(io, mount.tag);
+        try protocol.stdout(io, ",\"mode\":");
+        try protocol.writeJsonString(io, mount.mode);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
 }
 
 fn writeEnvObjectField(
@@ -904,12 +999,28 @@ fn parseKernelVmstateFields(
 ) RequestError!void {
     assert(@sizeOf(ParsedRequest) > 0);
 
+    try parseKernelFields(object, request);
+    try parseVmstateFields(object, request);
+    try parseRuntimeMountStatsFields(allocator, object, request);
+    try parseConfigFields(allocator, object, request);
+    try parseBundleFields(allocator, object, request);
+    try parseDiskRuntimeFields(object, request);
+}
+
+fn parseKernelFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.kernel_path = try optionalStringDefaultNull(
         object,
         "kernelPath",
         error.InvalidKernelPath,
     );
     request.dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath);
+}
+
+fn parseVmstateFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.vmstate_path = try optionalStringDefaultNull(
         object,
         "vmstatePath",
@@ -930,6 +1041,15 @@ fn parseKernelVmstateFields(
         "existingVmstateTiming",
         error.InvalidExistingVmstateTiming,
     );
+}
+
+fn parseRuntimeMountStatsFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.live_mounts = try optionalLiveMounts(allocator, object);
     request.live_mounts_resolved = try optionalLiveMountsResolved(
         allocator,
@@ -947,6 +1067,15 @@ fn parseKernelVmstateFields(
         "statsFilePath",
         error.InvalidStatsFilePath,
     );
+}
+
+fn parseConfigFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.config_cmd = try optionalStringArrayDefaultEmpty(
         allocator,
         object,
@@ -974,6 +1103,15 @@ fn parseKernelVmstateFields(
         "configLiveMounts",
         error.InvalidConfigLiveMounts,
     );
+}
+
+fn parseBundleFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.bundle_explicit_cmd = try optionalStringArrayOrNull(
         allocator,
         object,
@@ -1017,6 +1155,22 @@ fn parseKernelVmstateFields(
         "bundleGuestEnv",
         error.InvalidBundleGuestEnv,
     );
+}
+
+fn parseDiskRuntimeFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    try parseScratchFields(object, request);
+    try parseRootDiskRuntimeFields(object, request);
+    try parseMountDiskRuntimeFields(object, request);
+}
+
+fn parseScratchFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.scratch_mode = try optionalScratchMode(object);
     request.scratch_snapshot_path = try optionalStringDefaultNull(
         object,
@@ -1033,6 +1187,14 @@ fn parseKernelVmstateFields(
         "scratchAutoPath",
         error.InvalidScratchAutoPath,
     );
+}
+
+fn parseRootDiskRuntimeFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.root_disk_runtime_mode = try optionalRootDiskRuntimeMode(object);
     request.root_disk_source_path = try optionalStringDefaultNull(
         object,
@@ -1044,6 +1206,14 @@ fn parseKernelVmstateFields(
         "rootDiskClonePath",
         error.InvalidRootDiskClonePath,
     );
+}
+
+fn parseMountDiskRuntimeFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.mount_disk_runtime_mode = try optionalMountDiskRuntimeMode(object);
     request.mount_disk_lower_path = try optionalStringDefaultNull(
         object,
@@ -1073,6 +1243,8 @@ fn parseKernelVmstateFields(
 }
 
 fn hasBundleCommandField(object: std.json.ObjectMap) bool {
+    assert(@sizeOf(std.json.ObjectMap) > 0);
+
     if (object.get("bundleExplicitCmd")) |value| {
         if (value != .null) return true;
     }
@@ -1089,6 +1261,8 @@ fn hasBundleCommandField(object: std.json.ObjectMap) bool {
 }
 
 fn optionalScratchMode(object: std.json.ObjectMap) RequestError!boot_plan.ScratchDiskMode {
+    assert(@sizeOf(boot_plan.ScratchDiskMode) > 0);
+
     const value = object.get("scratchMode") orelse return .unset;
     if (value == .null) return .unset;
     if (value != .string) return error.InvalidScratchMode;
@@ -1098,7 +1272,11 @@ fn optionalScratchMode(object: std.json.ObjectMap) RequestError!boot_plan.Scratc
     return error.InvalidScratchMode;
 }
 
-fn optionalRootDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_plan.RootDiskRuntimeMode {
+fn optionalRootDiskRuntimeMode(
+    object: std.json.ObjectMap,
+) RequestError!boot_plan.RootDiskRuntimeMode {
+    assert(@sizeOf(boot_plan.RootDiskRuntimeMode) > 0);
+
     const value = object.get("rootDiskRuntimeMode") orelse return .none;
     if (value == .null) return .none;
     if (value != .string) return error.InvalidRootDiskRuntimeMode;
@@ -1109,7 +1287,11 @@ fn optionalRootDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_pla
     return error.InvalidRootDiskRuntimeMode;
 }
 
-fn optionalMountDiskRuntimeMode(object: std.json.ObjectMap) RequestError!boot_plan.MountDiskRuntimeMode {
+fn optionalMountDiskRuntimeMode(
+    object: std.json.ObjectMap,
+) RequestError!boot_plan.MountDiskRuntimeMode {
+    assert(@sizeOf(boot_plan.MountDiskRuntimeMode) > 0);
+
     const value = object.get("mountDiskRuntimeMode") orelse return .none;
     if (value == .null) return .none;
     if (value != .string) return error.InvalidMountDiskRuntimeMode;
@@ -1238,7 +1420,8 @@ fn optionalStringArrayOrNull(
         if (item != .string) return invalid;
         try out.append(allocator, item.string);
     }
-    return out.toOwnedSlice(allocator);
+    const owned: []const []const u8 = try out.toOwnedSlice(allocator);
+    return owned;
 }
 
 fn optionalPortForward(
@@ -1396,6 +1579,16 @@ fn writeDuplicateHostPort(io: std.Io, port: u16) !void {
 fn writePlanError(io: std.Io, err: anyerror) !void {
     assert(@errorName(err).len > 0);
 
+    if (try writeMemoryPlanError(io, err)) return;
+    if (try writePathPlanError(io, err)) return;
+    if (try writeEnvPlanError(io, err)) return;
+    if (try writeDiskPlanError(io, err)) return;
+    try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err));
+}
+
+fn writeMemoryPlanError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
     switch (err) {
         error.InvalidMemory => try writeBootError(
             io,
@@ -1412,6 +1605,25 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "BOOT_MEMORY_INVALID",
             "boot: resources.memory.reclaim must be \"auto\" when set.",
         ),
+        error.MissingAutoMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: memory auto-size input is missing",
+        ),
+        error.UnsupportedHostMemory => try writeBootError(
+            io,
+            "BOOT_MEMORY_INVALID",
+            "boot: host memory probing is unsupported on this platform",
+        ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writePathPlanError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
         error.CmdWithoutImage => try writeBootError(
             io,
             "BOOT_CMD_WITHOUT_IMAGE",
@@ -1421,11 +1633,6 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "BOOT_CMD_WITHOUT_IMAGE",
             "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
-        ),
-        error.MissingAutoMemory => try writeBootError(
-            io,
-            "BOOT_MEMORY_INVALID",
-            "boot: memory auto-size input is missing",
         ),
         error.InvalidGuestCwdAbsolute => try writeBootError(
             io,
@@ -1447,6 +1654,15 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "BOOT_MOUNT_INVALID",
             "mount guest path must live under /mnt/",
         ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writeEnvPlanError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
         error.TooManyLiveMounts => try writeBootError(
             io,
             "BOOT_MOUNT_INVALID",
@@ -1456,11 +1672,6 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             io,
             "BOOT_MOUNT_INVALID",
             "liveMounts: mode must be ro or rw",
-        ),
-        error.UnsupportedHostMemory => try writeBootError(
-            io,
-            "BOOT_MEMORY_INVALID",
-            "boot: host memory probing is unsupported on this platform",
         ),
         error.InvalidGuestEnvValue => try writeBootError(
             io,
@@ -1477,10 +1688,20 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "INVALID_REQUEST",
             "boot-plan bundle env values must be strings",
         ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writeDiskPlanError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
         error.MissingBundleCommand => try writeBootError(
             io,
-            "BOOT_CMD_WITHOUT_IMAGE",
-            "boot-plan bundle command input is missing",
+            "BOOT_CMD_MISSING",
+            "boot: no cmd to run — pass `cmd` on boot() or bake one into the " ++
+                "image via `provision({ cmd })`.",
         ),
         error.MissingScratchPath => try writeBootError(
             io,
@@ -1502,8 +1723,9 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "BOOT_MOUNT_INVALID",
             "boot-plan mountDisk upper size must be an integer",
         ),
-        else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
+        else => return false,
     }
+    return true;
 }
 
 fn writeBootError(io: std.Io, code: []const u8, message: []const u8) !void {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -37,6 +37,11 @@ const ParsedRequest = struct {
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
     existing_stats_file: ?[]const u8 = null,
     stats_file_path: ?[]const u8 = null,
+    config_cmd: []const []const u8 = &.{},
+    config_env: std.json.ObjectMap = .{},
+    config_guest_cwd: ?[]const u8 = null,
+    config_image_cwd: ?[]const u8 = null,
+    config_live_mounts: []const boot_plan.LiveMount = &.{},
 };
 
 const ParsedResourcesMemory = struct {
@@ -74,6 +79,11 @@ const boot_plan_fields = [_][]const u8{
     "liveMountsResolved",
     "existingStatsFile",
     "statsFilePath",
+    "configCmd",
+    "configEnv",
+    "configGuestCwd",
+    "configImageCwd",
+    "configLiveMounts",
 };
 
 const RequestError = error{
@@ -124,6 +134,12 @@ const RequestError = error{
     InvalidLiveMountTag,
     InvalidExistingStatsFile,
     InvalidStatsFilePath,
+    InvalidConfigCmd,
+    InvalidConfigEnv,
+    InvalidConfigEnvValue,
+    InvalidConfigGuestCwd,
+    InvalidConfigImageCwd,
+    InvalidConfigLiveMounts,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -162,6 +178,10 @@ const PlanParts = struct {
     virtiofs_env: []const boot_plan.EnvPair,
     stats_file: boot_plan.StatsFilePlan,
     planned_live_mounts: []const boot_plan.LiveMount,
+    config_cmd: []const []const u8,
+    config_env: []const boot_plan.EnvPair,
+    config_cwd: ?[]const u8,
+    config_live_mounts: []const boot_plan.LiveMount,
 };
 
 fn makeCorePlan(
@@ -208,6 +228,11 @@ fn makePlanParts(
         .existing_path = parsed.existing_stats_file,
         .planned_path = parsed.stats_file_path,
     });
+    const config_env = try makeConfigEnv(arena, parsed);
+    const config_cwd = boot_plan.planMachinenConfigCwd(.{
+        .guest_cwd = parsed.config_guest_cwd,
+        .image_cwd = parsed.config_image_cwd,
+    });
     return .{
         .plan = plan,
         .guest_env = guest_env,
@@ -218,6 +243,10 @@ fn makePlanParts(
         .virtiofs_env = virtiofs_env,
         .stats_file = stats_file,
         .planned_live_mounts = planned_live_mounts,
+        .config_cmd = parsed.config_cmd,
+        .config_env = config_env,
+        .config_cwd = config_cwd,
+        .config_live_mounts = parsed.config_live_mounts,
     };
 }
 
@@ -249,6 +278,10 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
     try writeEnvObjectField(io, "mergedGuestEnv", parts.guest_env, true);
+    try writeStringArrayField(io, "configCmd", parts.config_cmd, true);
+    try writeEnvObjectField(io, "configEnv", parts.config_env, true);
+    try writeNullableStringField(io, "configCwd", parts.config_cwd, true);
+    try writeLiveMountsArrayField(io, "configLiveMounts", parts.config_live_mounts, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -440,6 +473,22 @@ fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_pla
         .name = parsed.name,
         .vsock_uds_path = parsed.vsock_uds_path,
     });
+}
+
+fn makeConfigEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    var pairs: std.array_list.Aligned(boot_plan.EnvPair, null) = .empty;
+    errdefer pairs.deinit(allocator);
+    var it = parsed.config_env.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.* != .string) return error.InvalidConfigEnvValue;
+        try pairs.append(allocator, .{
+            .key = entry.key_ptr.*,
+            .value = entry.value_ptr.string,
+        });
+    }
+    return pairs.toOwnedSlice(allocator);
 }
 
 fn makePlanInput(
@@ -666,7 +715,12 @@ fn parseKernelVmstateFields(
         error.InvalidExistingVmstateTiming,
     );
     request.live_mounts = try optionalLiveMounts(allocator, object);
-    request.live_mounts_resolved = try optionalLiveMountsResolved(allocator, object);
+    request.live_mounts_resolved = try optionalLiveMountsResolved(
+        allocator,
+        object,
+        "liveMountsResolved",
+        error.InvalidLiveMountsResolved,
+    );
     request.existing_stats_file = try optionalStringDefaultNull(
         object,
         "existingStatsFile",
@@ -676,6 +730,33 @@ fn parseKernelVmstateFields(
         object,
         "statsFilePath",
         error.InvalidStatsFilePath,
+    );
+    request.config_cmd = try optionalStringArrayDefaultEmpty(
+        allocator,
+        object,
+        "configCmd",
+        error.InvalidConfigCmd,
+    );
+    request.config_env = try optionalObjectDefaultEmpty(
+        object,
+        "configEnv",
+        error.InvalidConfigEnv,
+    );
+    request.config_guest_cwd = try optionalStringDefaultNull(
+        object,
+        "configGuestCwd",
+        error.InvalidConfigGuestCwd,
+    );
+    request.config_image_cwd = try optionalStringDefaultNull(
+        object,
+        "configImageCwd",
+        error.InvalidConfigImageCwd,
+    );
+    request.config_live_mounts = try optionalLiveMountsResolved(
+        allocator,
+        object,
+        "configLiveMounts",
+        error.InvalidConfigLiveMounts,
     );
 }
 
@@ -711,16 +792,18 @@ fn optionalLiveMounts(
 fn optionalLiveMountsResolved(
     allocator: std.mem.Allocator,
     object: std.json.ObjectMap,
+    comptime field: []const u8,
+    invalid: RequestError,
 ) RequestError![]const boot_plan.LiveMount {
     assert(@sizeOf(boot_plan.LiveMount) > 0);
 
-    const value = object.get("liveMountsResolved") orelse return &.{};
+    const value = object.get(field) orelse return &.{};
     if (value == .null) return &.{};
-    if (value != .array) return error.InvalidLiveMountsResolved;
+    if (value != .array) return invalid;
     var mounts: std.array_list.Aligned(boot_plan.LiveMount, null) = .empty;
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
-        if (item != .object) return error.InvalidLiveMountsResolved;
+        if (item != .object) return invalid;
         try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode", "tag" });
         const host = item.object.get("host") orelse return error.InvalidLiveMountHost;
         const guest = item.object.get("guest") orelse return error.InvalidLiveMountGuest;
@@ -1005,6 +1088,11 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
             "INVALID_REQUEST",
             "boot-plan guestEnv values must be strings",
         ),
+        error.InvalidConfigEnvValue => try writeBootError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan configEnv values must be strings",
+        ),
         else => try writeBootError(io, "BOOT_MEMORY_INVALID", @errorName(err)),
     }
 }
@@ -1037,6 +1125,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             "liveMounts: entries must include host and guest paths",
         ),
         error.InvalidLiveMountsResolved,
+        error.InvalidConfigLiveMounts,
         error.InvalidLiveMountHost,
         error.InvalidLiveMountMode,
         error.InvalidLiveMountTag,

--- a/packages/runtime/src/__tests__/live-mount-cache.test.ts
+++ b/packages/runtime/src/__tests__/live-mount-cache.test.ts
@@ -1,12 +1,36 @@
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { isMachinenError } from "../errors.ts";
 import { resolveLiveMounts } from "../vm/bundle.ts";
 
 let hostDir: string;
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-live-mount-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 beforeEach(() => {
   hostDir = mkdtempSync(join(tmpdir(), "machinen-live-mount-"));

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,33 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans bundle env overlays", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      bundleImageEnv: { FOO: "image", BAR: "image" },
+      bundleGuestEnv: { FOO: "guest", BAZ: "guest" },
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.bundleEnv).toEqual({
+      FOO: "guest",
+      BAR: "image",
+      BAZ: "guest",
+    });
+  });
+
   it("plans rootdisk runtime actions", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,57 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans rootdisk runtime actions", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const existing = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, rootDiskRuntimeMode: "path", rootDiskSourcePath: "/tmp/root.img" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(existing.status).toBe(0);
+    expect(JSON.parse(existing.stdout).data.rootDiskRuntime).toEqual({
+      action: "existing",
+      sourcePath: "/tmp/root.img",
+      targetPath: null,
+      perBootRootDisk: null,
+      vmmRootDisk: "/tmp/root.img",
+    });
+
+    const cached = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          rootDiskRuntimeMode: "cached",
+          rootDiskSourcePath: "/tmp/cache.img",
+          rootDiskClonePath: "/tmp/boot.img",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(cached.status).toBe(0);
+    expect(JSON.parse(cached.stdout).data.rootDiskRuntime).toEqual({
+      action: "clone-cached",
+      sourcePath: "/tmp/cache.img",
+      targetPath: "/tmp/boot.img",
+      perBootRootDisk: "/tmp/boot.img",
+      vmmRootDisk: "/tmp/boot.img",
+    });
+  });
+
   it("plans machinen-config guest payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -224,6 +224,76 @@ describe("boot-plan helper schema", () => {
     expect(liveCommand.slice(5)).toEqual(["/bin/echo", "hi"]);
   });
 
+  it("plans scratch disk modes", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: true,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const restore = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          scratchMode: "path",
+          scratchSnapshotPath: "/tmp/source.img",
+          scratchRestoreClonePath: "/tmp/clone.img",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(restore.status).toBe(0);
+    expect(JSON.parse(restore.stdout).data.scratchDisk).toEqual({
+      action: "clone",
+      diskPath: "/tmp/clone.img",
+      perBootSnapDisk: "/tmp/clone.img",
+      vmmDisk: "/tmp/clone.img",
+    });
+
+    const existing = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          hasCmd: true,
+          scratchMode: "path",
+          scratchSnapshotPath: "/tmp/source.img",
+          scratchRestoreClonePath: "/tmp/clone.img",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(existing.status).toBe(0);
+    expect(JSON.parse(existing.stdout).data.scratchDisk).toEqual({
+      action: "existing",
+      diskPath: "/tmp/source.img",
+      perBootSnapDisk: null,
+      vmmDisk: "/tmp/source.img",
+    });
+
+    const auto = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, scratchMode: "auto", scratchAutoPath: "/tmp/auto.img" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(auto.status).toBe(0);
+    expect(JSON.parse(auto.stdout).data.scratchDisk).toEqual({
+      action: "allocate",
+      diskPath: "/tmp/auto.img",
+      perBootSnapDisk: "/tmp/auto.img",
+      vmmDisk: "/tmp/auto.img",
+    });
+  });
+
   it("plans machinen-config guest payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -169,6 +169,61 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans bundle commands from explicit image restore and live-mount inputs", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const image = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bundleImageCmd: ["/bin/true"] } })}\n`,
+      encoding: "utf8",
+    });
+    expect(image.status).toBe(0);
+    expect(JSON.parse(image.stdout).data.bundleCommand).toEqual([
+      "/sbin/machinen-supervisor",
+      "/bin/true",
+    ]);
+
+    const restore = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bundleSnapshotRestore: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(restore.status).toBe(0);
+    expect(JSON.parse(restore.stdout).data.bundleCommand).toEqual(["/sbin/machinen-restore"]);
+
+    const live = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          bundleExplicitCmd: ["/bin/echo", "hi"],
+          bundleLiveMounts: [
+            { host: "/host", guest: "/mnt/live", mode: "rw", tag: "machinen-lm0" },
+          ],
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(live.status).toBe(0);
+    const liveCommand = JSON.parse(live.stdout).data.bundleCommand;
+    expect(liveCommand.slice(0, 5)).toEqual([
+      "/sbin/machinen-supervisor",
+      "/bin/sh",
+      "-c",
+      expect.stringContaining("batch_sync"),
+      "machinen-batch-wrapper",
+    ]);
+    expect(liveCommand.slice(5)).toEqual(["/bin/echo", "hi"]);
+  });
+
   it("plans machinen-config guest payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -169,6 +169,34 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans live-mount guest paths modes and tags", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      liveMounts: [
+        { host: "./a", guest: "/mnt/a/" },
+        { host: "./b", guest: "/mnt/b", mode: "ro" },
+      ],
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.plannedLiveMounts).toEqual([
+      { host: "./a", guest: "/mnt/a", mode: "rw", tag: "machinen-lm0" },
+      { host: "./b", guest: "/mnt/b", mode: "ro", tag: "machinen-lm1" },
+    ]);
+  });
+
   it("plans stats-file env from caller or runtime-owned paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
@@ -222,8 +250,8 @@ describe("boot-plan helper schema", () => {
       hasCmd: false,
       rootDisk: "false",
       liveMountsResolved: [
-        { host: "/host/a", mode: "rw", tag: "machinen-lm0" },
-        { host: "/host/b", mode: "ro", tag: "machinen-lm1" },
+        { host: "/host/a", guest: "/mnt/a", mode: "rw", tag: "machinen-lm0" },
+        { host: "/host/b", guest: "/mnt/b", mode: "ro", tag: "machinen-lm1" },
       ],
     };
     const result = spawnSync(helper, ["boot-plan"], {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -372,6 +372,69 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans mountdisk runtime actions", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const restore = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          mountDiskRuntimeMode: "restore",
+          mountDiskLowerPath: "/tmp/lower.sqfs",
+          mountDiskUpperPath: "/tmp/upper-copy.img",
+          mountDiskSourceUpperPath: "/tmp/upper.img",
+          mountDiskGuest: "/mnt/data",
+          mountDiskUpperSize: "4096",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(restore.status).toBe(0);
+    expect(JSON.parse(restore.stdout).data.mountDiskRuntime).toEqual({
+      action: "restore",
+      lowerPath: "/tmp/lower.sqfs",
+      upperPath: "/tmp/upper-copy.img",
+      sourceUpperPath: "/tmp/upper.img",
+      guest: "/mnt/data",
+      upperSizeBytes: 4096,
+    });
+
+    const fresh = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          mountDiskRuntimeMode: "fresh",
+          mountDiskLowerPath: "/tmp/lower.sqfs",
+          mountDiskUpperPath: "/tmp/upper.img",
+          mountDiskGuest: "/mnt/data",
+          mountDiskUpperSize: "8192",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(fresh.status).toBe(0);
+    expect(JSON.parse(fresh.stdout).data.mountDiskRuntime).toEqual({
+      action: "fresh",
+      lowerPath: "/tmp/lower.sqfs",
+      upperPath: "/tmp/upper.img",
+      sourceUpperPath: null,
+      guest: "/mnt/data",
+      upperSizeBytes: 8192,
+    });
+  });
+
   it("plans machinen-config guest payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -169,6 +169,37 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans machinen-config guest payloads", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      configCmd: ["/bin/sh", "-c", "echo hi"],
+      configEnv: { FOO: "bar" },
+      configGuestCwd: "/mnt/work",
+      configImageCwd: "/srv/app",
+      configLiveMounts: [{ host: "/host", guest: "/mnt/live", mode: "ro", tag: "machinen-lm0" }],
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.machinenConfig).toEqual({
+      cmd: ["/bin/sh", "-c", "echo hi"],
+      env: { FOO: "bar" },
+      cwd: "/mnt/work",
+      liveMounts: [{ guest: "/mnt/live", tag: "machinen-lm0", mode: "ro" }],
+    });
+  });
+
   it("plans live-mount guest paths modes and tags", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -7,6 +7,8 @@ type ScratchDiskMode = "false" | "path" | "auto";
 type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeMode = "none" | "path" | "restore" | "cached";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
+type MountDiskRuntimeMode = "none" | "restore" | "fresh";
+type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
@@ -62,6 +64,12 @@ interface NativeBootPlanInput {
   rootDiskRuntimeMode?: RootDiskRuntimeMode;
   rootDiskSourcePath?: string;
   rootDiskClonePath?: string;
+  mountDiskRuntimeMode?: MountDiskRuntimeMode;
+  mountDiskLowerPath?: string;
+  mountDiskUpperPath?: string;
+  mountDiskSourceUpperPath?: string;
+  mountDiskGuest?: string;
+  mountDiskUpperSize?: number;
 }
 
 interface NativeBootPlanResult {
@@ -88,6 +96,7 @@ interface NativeBootPlanResult {
   bundleEnv: Record<string, string>;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
+  mountDiskRuntime: MountDiskRuntimePlan;
 }
 
 type ScratchDiskPlan = {
@@ -103,6 +112,15 @@ type RootDiskRuntimePlan = {
   targetPath: string | null;
   perBootRootDisk: string | null;
   vmmRootDisk: string | null;
+};
+
+type MountDiskRuntimePlan = {
+  action: MountDiskRuntimeAction;
+  lowerPath: string | null;
+  upperPath: string | null;
+  sourceUpperPath: string | null;
+  guest: string | null;
+  upperSizeBytes: number | null;
 };
 
 type MachinenConfigPlan = Record<string, unknown> & {
@@ -161,6 +179,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     ...bundleCommandData(input),
     ...scratchDiskData(input),
     ...rootDiskRuntimeData(input),
+    ...mountDiskRuntimeData(input),
   };
 }
 
@@ -194,6 +213,17 @@ function rootDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknown
   };
 }
 
+function mountDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    mountDiskRuntimeMode: input.mountDiskRuntimeMode ?? null,
+    mountDiskLowerPath: nullDefault(input.mountDiskLowerPath),
+    mountDiskUpperPath: nullDefault(input.mountDiskUpperPath),
+    mountDiskSourceUpperPath: nullDefault(input.mountDiskSourceUpperPath),
+    mountDiskGuest: nullDefault(input.mountDiskGuest),
+    mountDiskUpperSize: numberText(input.mountDiskUpperSize),
+  };
+}
+
 function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unknown {
   if (!memory) {
     return null;
@@ -214,6 +244,28 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootMountDiskRuntimeNative(input: {
+  mode: MountDiskRuntimeMode;
+  lowerPath?: string;
+  upperPath?: string;
+  sourceUpperPath?: string;
+  guest?: string;
+  upperSizeBytes?: number;
+}): MountDiskRuntimePlan {
+  return planBootCoreNative({
+    mountDiskRuntimeMode: input.mode,
+    mountDiskLowerPath: input.lowerPath,
+    mountDiskUpperPath: input.upperPath,
+    mountDiskSourceUpperPath: input.sourceUpperPath,
+    mountDiskGuest: input.guest,
+    mountDiskUpperSize: input.upperSizeBytes,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).mountDiskRuntime;
 }
 
 export function planBootBundleEnvNative(input: {
@@ -470,6 +522,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isStringRecord(data.bundleEnv),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
+    isMountDiskRuntimePlan(data.mountDiskRuntime),
   ].every(Boolean);
 }
 
@@ -519,6 +572,25 @@ function isRootDiskRuntimeAction(value: unknown): value is RootDiskRuntimeAction
     value === "clone-restore" ||
     value === "clone-cached"
   );
+}
+
+function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<MountDiskRuntimePlan>;
+  return (
+    isMountDiskRuntimeAction(plan.action) &&
+    nullableString(plan.lowerPath) &&
+    nullableString(plan.upperPath) &&
+    nullableString(plan.sourceUpperPath) &&
+    nullableString(plan.guest) &&
+    nullableNonNegativeNumber(plan.upperSizeBytes)
+  );
+}
+
+function isMountDiskRuntimeAction(value: unknown): value is MountDiskRuntimeAction {
+  return value === "none" || value === "restore" || value === "fresh";
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -43,6 +43,12 @@ interface NativeBootPlanInput {
   configGuestCwd?: string;
   configImageCwd?: string;
   configLiveMounts?: PlannedLiveMount[];
+  bundleExplicitCmd?: string[];
+  bundleImageCmd?: string[];
+  bundleSnapshotRestore?: boolean;
+  bundleVmstateRestore?: boolean;
+  bundleLiveMounts?: PlannedLiveMount[];
+  bundleCommandRequired?: boolean;
 }
 
 interface NativeBootPlanResult {
@@ -65,6 +71,7 @@ interface NativeBootPlanResult {
   statsFilePath: string | null;
   vmmStatsFile: string | null;
   machinenConfig: MachinenConfigPlan;
+  bundleCommand: string[];
 }
 
 type MachinenConfigPlan = Record<string, unknown> & {
@@ -120,6 +127,18 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     configGuestCwd: nullDefault(input.configGuestCwd),
     configImageCwd: nullDefault(input.configImageCwd),
     configLiveMounts: input.configLiveMounts ?? [],
+    ...bundleCommandData(input),
+  };
+}
+
+function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    bundleExplicitCmd: input.bundleExplicitCmd ?? null,
+    bundleImageCmd: input.bundleImageCmd ?? null,
+    bundleSnapshotRestore: input.bundleSnapshotRestore === true,
+    bundleVmstateRestore: input.bundleVmstateRestore === true,
+    bundleLiveMounts: input.bundleLiveMounts ?? [],
+    bundleCommandRequired: input.bundleCommandRequired === true,
   };
 }
 
@@ -143,6 +162,27 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootBundleCommandNative(input: {
+  explicitCmd?: string[];
+  imageCmd?: string[];
+  snapshotRestore: boolean;
+  vmstateRestore: boolean;
+  liveMounts: PlannedLiveMount[];
+}): string[] {
+  return planBootCoreNative({
+    bundleExplicitCmd: input.explicitCmd,
+    bundleImageCmd: input.imageCmd,
+    bundleSnapshotRestore: input.snapshotRestore,
+    bundleVmstateRestore: input.vmstateRestore,
+    bundleLiveMounts: input.liveMounts,
+    bundleCommandRequired: true,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).bundleCommand;
 }
 
 export function planBootMachinenConfigNative(input: {
@@ -324,6 +364,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
     isMachinenConfigPlan(data.machinenConfig),
+    isStringArray(data.bundleCommand),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -3,6 +3,8 @@ import { callRuntimeHelper } from "../native-helper.ts";
 import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
+type ScratchDiskMode = "false" | "path" | "auto";
+type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
@@ -49,6 +51,10 @@ interface NativeBootPlanInput {
   bundleVmstateRestore?: boolean;
   bundleLiveMounts?: PlannedLiveMount[];
   bundleCommandRequired?: boolean;
+  scratchMode?: ScratchDiskMode;
+  scratchSnapshotPath?: string;
+  scratchRestoreClonePath?: string;
+  scratchAutoPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -72,7 +78,15 @@ interface NativeBootPlanResult {
   vmmStatsFile: string | null;
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
+  scratchDisk: ScratchDiskPlan;
 }
+
+type ScratchDiskPlan = {
+  action: ScratchDiskAction;
+  diskPath: string | null;
+  perBootSnapDisk: string | null;
+  vmmDisk: string | null;
+};
 
 type MachinenConfigPlan = Record<string, unknown> & {
   cmd: string[];
@@ -128,6 +142,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     configImageCwd: nullDefault(input.configImageCwd),
     configLiveMounts: input.configLiveMounts ?? [],
     ...bundleCommandData(input),
+    ...scratchDiskData(input),
   };
 }
 
@@ -139,6 +154,15 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
     bundleVmstateRestore: input.bundleVmstateRestore === true,
     bundleLiveMounts: input.bundleLiveMounts ?? [],
     bundleCommandRequired: input.bundleCommandRequired === true,
+  };
+}
+
+function scratchDiskData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    scratchMode: input.scratchMode ?? null,
+    scratchSnapshotPath: nullDefault(input.scratchSnapshotPath),
+    scratchRestoreClonePath: nullDefault(input.scratchRestoreClonePath),
+    scratchAutoPath: nullDefault(input.scratchAutoPath),
   };
 }
 
@@ -162,6 +186,26 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootScratchDiskNative(input: {
+  mode: ScratchDiskMode;
+  hasCmd: boolean;
+  hasImage: boolean;
+  snapshotPath?: string;
+  restoreClonePath?: string;
+  autoPath?: string;
+}): ScratchDiskPlan {
+  return planBootCoreNative({
+    scratchMode: input.mode,
+    scratchSnapshotPath: input.snapshotPath,
+    scratchRestoreClonePath: input.restoreClonePath,
+    scratchAutoPath: input.autoPath,
+    vmmMemoryPreset: true,
+    hasImage: input.hasImage,
+    hasCmd: input.hasCmd,
+    rootDisk: "false",
+  }).scratchDisk;
 }
 
 export function planBootBundleCommandNative(input: {
@@ -365,6 +409,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmStatsFile),
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
+    isScratchDiskPlan(data.scratchDisk),
   ].every(Boolean);
 }
 
@@ -374,6 +419,23 @@ function isStringArray(value: unknown): value is string[] {
 
 function isPlannedLiveMountArray(value: unknown): value is PlannedLiveMount[] {
   return Array.isArray(value) && value.every(isPlannedLiveMount);
+}
+
+function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ScratchDiskPlan>;
+  return (
+    isScratchDiskAction(plan.action) &&
+    nullableString(plan.diskPath) &&
+    nullableString(plan.perBootSnapDisk) &&
+    nullableString(plan.vmmDisk)
+  );
+}
+
+function isScratchDiskAction(value: unknown): value is ScratchDiskAction {
+  return value === "none" || value === "existing" || value === "clone" || value === "allocate";
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -5,7 +5,8 @@ import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
-type LiveMountPlanInput = { host: string; mode: "ro" | "rw"; tag: string };
+type LiveMountPlanInput = { host: string; guest: string; mode?: string };
+type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 
 interface NativeBootPlanInput {
   memoryMib?: number;
@@ -33,7 +34,8 @@ interface NativeBootPlanInput {
   restorePath?: string;
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
-  liveMountsResolved?: LiveMountPlanInput[];
+  liveMounts?: LiveMountPlanInput[];
+  liveMountsResolved?: PlannedLiveMount[];
   existingStatsFile?: string;
   statsFilePath?: string;
 }
@@ -54,6 +56,7 @@ interface NativeBootPlanResult {
   vmmRestorePath: string | null;
   vmmVmstateTiming: string | null;
   virtiofsEnv: Record<string, string>;
+  plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
 }
@@ -95,6 +98,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     restorePath: nullDefault(input.restorePath),
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
+    liveMounts: liveMountsData(input.liveMounts),
     liveMountsResolved: input.liveMountsResolved ?? [],
     existingStatsFile: nullDefault(input.existingStatsFile),
     statsFilePath: nullDefault(input.statsFilePath),
@@ -109,6 +113,14 @@ function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unk
     maxMib: numberTextRequired(memory.maxMib),
     reclaim: nullDefault(memory.reclaim),
   };
+}
+
+function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[] {
+  return (liveMounts ?? []).map((mount) => ({
+    host: mount.host,
+    guest: mount.guest,
+    mode: mount.mode ?? null,
+  }));
 }
 
 function nullDefault<T>(value: T | undefined): T | null {
@@ -133,9 +145,17 @@ export function planBootStatsFileNative(input: { existingPath?: string; plannedP
   };
 }
 
-export function planBootVirtiofsEnvNative(
-  liveMounts: LiveMountPlanInput[],
-): Record<string, string> {
+export function planBootLiveMountsNative(liveMounts: LiveMountPlanInput[]): PlannedLiveMount[] {
+  return planBootCoreNative({
+    liveMounts,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).plannedLiveMounts;
+}
+
+export function planBootVirtiofsEnvNative(liveMounts: PlannedLiveMount[]): Record<string, string> {
   return planBootCoreNative({
     liveMountsResolved: liveMounts,
     vmmMemoryPreset: true,
@@ -262,6 +282,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmRestorePath),
     nullableString(data.vmmVmstateTiming),
     isStringRecord(data.virtiofsEnv),
+    isPlannedLiveMountArray(data.plannedLiveMounts),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
   ].every(Boolean);
@@ -269,6 +290,23 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isPlannedLiveMountArray(value: unknown): value is PlannedLiveMount[] {
+  return Array.isArray(value) && value.every(isPlannedLiveMount);
+}
+
+function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<PlannedLiveMount>;
+  return (
+    typeof mount.host === "string" &&
+    typeof mount.guest === "string" &&
+    (mount.mode === "ro" || mount.mode === "rw") &&
+    typeof mount.tag === "string"
+  );
 }
 
 function nullableString(value: unknown): boolean {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -5,6 +5,8 @@ import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 type ScratchDiskMode = "false" | "path" | "auto";
 type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
+type RootDiskRuntimeMode = "none" | "path" | "restore" | "cached";
+type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
@@ -55,6 +57,9 @@ interface NativeBootPlanInput {
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
   scratchAutoPath?: string;
+  rootDiskRuntimeMode?: RootDiskRuntimeMode;
+  rootDiskSourcePath?: string;
+  rootDiskClonePath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -79,6 +84,7 @@ interface NativeBootPlanResult {
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
   scratchDisk: ScratchDiskPlan;
+  rootDiskRuntime: RootDiskRuntimePlan;
 }
 
 type ScratchDiskPlan = {
@@ -86,6 +92,14 @@ type ScratchDiskPlan = {
   diskPath: string | null;
   perBootSnapDisk: string | null;
   vmmDisk: string | null;
+};
+
+type RootDiskRuntimePlan = {
+  action: RootDiskRuntimeAction;
+  sourcePath: string | null;
+  targetPath: string | null;
+  perBootRootDisk: string | null;
+  vmmRootDisk: string | null;
 };
 
 type MachinenConfigPlan = Record<string, unknown> & {
@@ -143,6 +157,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     configLiveMounts: input.configLiveMounts ?? [],
     ...bundleCommandData(input),
     ...scratchDiskData(input),
+    ...rootDiskRuntimeData(input),
   };
 }
 
@@ -166,6 +181,14 @@ function scratchDiskData(input: NativeBootPlanInput): Record<string, unknown> {
   };
 }
 
+function rootDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    rootDiskRuntimeMode: input.rootDiskRuntimeMode ?? null,
+    rootDiskSourcePath: nullDefault(input.rootDiskSourcePath),
+    rootDiskClonePath: nullDefault(input.rootDiskClonePath),
+  };
+}
+
 function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unknown {
   if (!memory) {
     return null;
@@ -186,6 +209,22 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootRootDiskRuntimeNative(input: {
+  mode: RootDiskRuntimeMode;
+  sourcePath?: string;
+  clonePath?: string;
+}): RootDiskRuntimePlan {
+  return planBootCoreNative({
+    rootDiskRuntimeMode: input.mode,
+    rootDiskSourcePath: input.sourcePath,
+    rootDiskClonePath: input.clonePath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).rootDiskRuntime;
 }
 
 export function planBootScratchDiskNative(input: {
@@ -410,6 +449,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
     isScratchDiskPlan(data.scratchDisk),
+    isRootDiskRuntimePlan(data.rootDiskRuntime),
   ].every(Boolean);
 }
 
@@ -436,6 +476,29 @@ function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {
 
 function isScratchDiskAction(value: unknown): value is ScratchDiskAction {
   return value === "none" || value === "existing" || value === "clone" || value === "allocate";
+}
+
+function isRootDiskRuntimePlan(value: unknown): value is RootDiskRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RootDiskRuntimePlan>;
+  return (
+    isRootDiskRuntimeAction(plan.action) &&
+    nullableString(plan.sourcePath) &&
+    nullableString(plan.targetPath) &&
+    nullableString(plan.perBootRootDisk) &&
+    nullableString(plan.vmmRootDisk)
+  );
+}
+
+function isRootDiskRuntimeAction(value: unknown): value is RootDiskRuntimeAction {
+  return (
+    value === "none" ||
+    value === "existing" ||
+    value === "clone-restore" ||
+    value === "clone-cached"
+  );
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -38,6 +38,11 @@ interface NativeBootPlanInput {
   liveMountsResolved?: PlannedLiveMount[];
   existingStatsFile?: string;
   statsFilePath?: string;
+  configCmd?: string[];
+  configEnv?: Record<string, string>;
+  configGuestCwd?: string;
+  configImageCwd?: string;
+  configLiveMounts?: PlannedLiveMount[];
 }
 
 interface NativeBootPlanResult {
@@ -59,7 +64,15 @@ interface NativeBootPlanResult {
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
+  machinenConfig: MachinenConfigPlan;
 }
+
+type MachinenConfigPlan = Record<string, unknown> & {
+  cmd: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  liveMounts?: Array<{ guest: string; tag: string; mode: "ro" | "rw" }>;
+};
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
   return callRuntimeHelper({
@@ -102,6 +115,11 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     liveMountsResolved: input.liveMountsResolved ?? [],
     existingStatsFile: nullDefault(input.existingStatsFile),
     statsFilePath: nullDefault(input.statsFilePath),
+    configCmd: input.configCmd ?? [],
+    configEnv: input.configEnv ?? {},
+    configGuestCwd: nullDefault(input.configGuestCwd),
+    configImageCwd: nullDefault(input.configImageCwd),
+    configLiveMounts: input.configLiveMounts ?? [],
   };
 }
 
@@ -125,6 +143,26 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootMachinenConfigNative(input: {
+  cmd: string[];
+  env: Record<string, string>;
+  guestCwd?: string;
+  imageCwd?: string;
+  liveMounts: PlannedLiveMount[];
+}): Record<string, unknown> {
+  return planBootCoreNative({
+    configCmd: input.cmd,
+    configEnv: input.env,
+    configGuestCwd: input.guestCwd,
+    configImageCwd: input.imageCwd,
+    configLiveMounts: input.liveMounts,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).machinenConfig;
 }
 
 export function planBootStatsFileNative(input: { existingPath?: string; plannedPath?: string }): {
@@ -285,6 +323,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isPlannedLiveMountArray(data.plannedLiveMounts),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
+    isMachinenConfigPlan(data.machinenConfig),
   ].every(Boolean);
 }
 
@@ -307,6 +346,43 @@ function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {
     (mount.mode === "ro" || mount.mode === "rw") &&
     typeof mount.tag === "string"
   );
+}
+
+function isMachinenConfigPlan(value: unknown): value is MachinenConfigPlan {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const config = value as Partial<MachinenConfigPlan>;
+  return (
+    isStringArray(config.cmd) &&
+    isStringRecord(config.env) &&
+    optionalString(config.cwd) &&
+    optionalConfigLiveMounts(config.liveMounts)
+  );
+}
+
+function optionalConfigLiveMounts(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  return (
+    Array.isArray(value) &&
+    value.every((mount) => {
+      if (!mount || typeof mount !== "object") {
+        return false;
+      }
+      const entry = mount as { guest?: unknown; tag?: unknown; mode?: unknown };
+      return (
+        typeof entry.guest === "string" &&
+        typeof entry.tag === "string" &&
+        (entry.mode === "ro" || entry.mode === "rw")
+      );
+    })
+  );
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
 }
 
 function nullableString(value: unknown): boolean {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -53,6 +53,8 @@ interface NativeBootPlanInput {
   bundleVmstateRestore?: boolean;
   bundleLiveMounts?: PlannedLiveMount[];
   bundleCommandRequired?: boolean;
+  bundleImageEnv?: Record<string, string>;
+  bundleGuestEnv?: Record<string, string>;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -83,6 +85,7 @@ interface NativeBootPlanResult {
   vmmStatsFile: string | null;
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
+  bundleEnv: Record<string, string>;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
 }
@@ -169,6 +172,8 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
     bundleVmstateRestore: input.bundleVmstateRestore === true,
     bundleLiveMounts: input.bundleLiveMounts ?? [],
     bundleCommandRequired: input.bundleCommandRequired === true,
+    bundleImageEnv: input.bundleImageEnv ?? {},
+    bundleGuestEnv: input.bundleGuestEnv ?? {},
   };
 }
 
@@ -209,6 +214,20 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootBundleEnvNative(input: {
+  imageEnv?: Record<string, string>;
+  guestEnv: Record<string, string>;
+}): Record<string, string> {
+  return planBootCoreNative({
+    bundleImageEnv: input.imageEnv,
+    bundleGuestEnv: input.guestEnv,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).bundleEnv;
 }
 
 export function planBootRootDiskRuntimeNative(input: {
@@ -448,6 +467,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     nullableString(data.vmmStatsFile),
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
+    isStringRecord(data.bundleEnv),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
   ].every(Boolean);

--- a/packages/runtime/src/vm/boot-rootdisk.ts
+++ b/packages/runtime/src/vm/boot-rootdisk.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { BootError } from "../errors.ts";
+import { planBootRootDiskRuntimeNative } from "../native/boot-plan.ts";
 import type { PhaseTimer } from "../phase-timer.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { ensureRootfsImage, markRootfsImageClean } from "../rootfs-img.ts";
@@ -25,14 +26,19 @@ export function materializeRootdisk(
     return materializeRestoredRootdisk(opts, env, phases);
   }
   if (typeof opts.rootDisk === "string") {
-    const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk);
-    if (!existsSync(rootDiskAbs)) {
-      throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
-    }
-    env.MACHINEN_ROOTDISK = rootDiskAbs;
-    return undefined;
+    return useCallerRootdisk(opts, env);
   }
   return materializeCachedRootdisk(opts, env, phases);
+}
+
+function useCallerRootdisk(opts: BootOptions, env: Record<string, string>): undefined {
+  const rootDiskAbs = resolve(opts.cwd ?? process.cwd(), opts.rootDisk as string);
+  if (!existsSync(rootDiskAbs)) {
+    throw new BootError("BOOT_IMAGE_NOT_FOUND", `rootDisk image not found: ${rootDiskAbs}`);
+  }
+  const plan = planBootRootDiskRuntimeNative({ mode: "path", sourcePath: rootDiskAbs });
+  applyRootDiskRuntimePlan(plan, env);
+  return undefined;
 }
 
 function materializeRestoredRootdisk(
@@ -51,11 +57,15 @@ function materializeRestoredRootdisk(
     tmpdir(),
     `machinen-rootdisk-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
   );
+  const plan = planBootRootDiskRuntimeNative({
+    mode: "restore",
+    sourcePath: rootDiskAbs,
+    clonePath: perBoot,
+  });
   const reflinkT0 = Date.now();
-  reflinkCopy(rootDiskAbs, perBoot);
+  applyRootDiskRuntimePlan(plan, env);
   phases.mark("rootdisk-materialize.restore-reflink", Date.now() - reflinkT0);
-  env.MACHINEN_ROOTDISK = perBoot;
-  return perBoot;
+  return plan.perBootRootDisk!;
 }
 
 function materializeCachedRootdisk(
@@ -76,18 +86,34 @@ function materializeCachedRootdisk(
     tmpdir(),
     `machinen-rootdisk-${process.pid}-${randomBytes(6).toString("hex")}.img`,
   );
+  const plan = planBootRootDiskRuntimeNative({
+    mode: "cached",
+    sourcePath: cachedImg,
+    clonePath: perBoot,
+  });
   const trustedTemplateIdentity = trustedRootfsTemplateIdentity(cachedImg);
   const reflinkT0 = Date.now();
-  reflinkCopy(cachedImg, perBoot);
+  applyRootDiskRuntimePlan(plan, env);
   phases.mark("rootdisk-materialize.reflink", Date.now() - reflinkT0);
   if (trustedTemplateIdentity) {
-    rememberTrustedFileIdentity({ ...trustedTemplateIdentity, path: perBoot });
-    rememberManagedRootDisk(perBoot);
+    rememberTrustedFileIdentity({ ...trustedTemplateIdentity, path: plan.perBootRootDisk! });
+    rememberManagedRootDisk(plan.perBootRootDisk!);
   }
   // The cache file was only READ here — restore the clean-shutdown
   // marker so the next boot finds a usable template instead of wiping
   // and rematerializing (#170).
   markRootfsImageClean(cachedImg);
-  env.MACHINEN_ROOTDISK = perBoot;
-  return perBoot;
+  return plan.perBootRootDisk!;
+}
+
+function applyRootDiskRuntimePlan(
+  plan: ReturnType<typeof planBootRootDiskRuntimeNative>,
+  env: Record<string, string>,
+): void {
+  if (plan.action === "clone-cached" || plan.action === "clone-restore") {
+    reflinkCopy(plan.sourcePath!, plan.targetPath!);
+  }
+  if (plan.vmmRootDisk) {
+    env.MACHINEN_ROOTDISK = plan.vmmRootDisk;
+  }
 }

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootScratchDiskNative,
   planBootStatsFileNative,
   planBootVirtiofsEnvNative,
   planBootVmstateEnvNative,
@@ -1204,56 +1205,72 @@ function prepareScratchDisk(
   opts: BootOptions,
   env: Record<string, string>,
 ): { diskAbs: string | undefined; perBootSnapDisk: string | undefined } {
-  if (opts.snapshot === false) {
-    return { diskAbs: undefined, perBootSnapDisk: undefined };
+  const snapshotPath = resolveSnapshotDiskPath(opts);
+  const scratchPlan = planBootScratchDiskNative({
+    mode: scratchMode(opts.snapshot),
+    hasCmd: opts.cmd !== undefined,
+    hasImage: opts.image !== undefined,
+    snapshotPath,
+    restoreClonePath: snapshotPath ? scratchRestoreClonePath() : undefined,
+    autoPath: opts.snapshot === undefined ? autoScratchPath() : undefined,
+  });
+  applyScratchDiskPlan(scratchPlan, snapshotPath, env);
+  return {
+    diskAbs: scratchPlan.diskPath ?? undefined,
+    perBootSnapDisk: scratchPlan.perBootSnapDisk ?? undefined,
+  };
+}
+
+function resolveSnapshotDiskPath(opts: BootOptions): string | undefined {
+  if (typeof opts.snapshot !== "string") {
+    return undefined;
   }
-  if (typeof opts.snapshot === "string") {
-    const bundleDisk = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
-    if (!existsSync(bundleDisk)) {
-      throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${bundleDisk}`);
-    }
-    // An explicit `cmd` means the caller is running their own workload
-    // (e.g. provision()'s tar-to-/dev/vdb dump), not restoring a CRIU
-    // bundle — so attach the disk in place. The reflink-clone below is
-    // only needed for the restore path, where machinen-dump.sh later
-    // mkfs's the scratch disk and would otherwise corrupt the source
-    // bundle on the host fs (#207).
-    if (opts.cmd) {
-      env.MACHINEN_DISK = bundleDisk;
-      debug("snap-restore in-place (explicit cmd) path=%s", bundleDisk);
-      return { diskAbs: bundleDisk, perBootSnapDisk: undefined };
-    }
-    // Reflink-clone the bundle disk into a per-boot path so the
-    // restored VM can be snapshotted again (#207). Same pattern as
-    // #121 for the rootdisk: COPYFILE_FICLONE → cheap shared blocks
-    // until guest writes, falls back to a full copy on non-reflink
-    // filesystems.
-    const perBoot = join(
-      tmpdir(),
-      `machinen-snap-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
-    );
-    reflinkCopy(bundleDisk, perBoot);
-    env.MACHINEN_DISK = perBoot;
-    debug("snap-restore reflink-clone src=%s dst=%s", bundleDisk, perBoot);
-    return { diskAbs: perBoot, perBootSnapDisk: perBoot };
+  const bundleDisk = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
+  if (!existsSync(bundleDisk)) {
+    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${bundleDisk}`);
   }
-  if (!opts.image) {
-    return { diskAbs: undefined, perBootSnapDisk: undefined };
+  return bundleDisk;
+}
+
+function scratchMode(snapshot: BootOptions["snapshot"]): "false" | "path" | "auto" {
+  if (snapshot === false) {
+    return "false";
   }
-  // Auto-allocate only when the caller is booting a real image-backed
-  // guest. VMM-only smoke boots (no image — e.g. MACHINEN_BOOT_TEST=1)
-  // would otherwise be handed a zero-byte file as /dev/vda, failing
-  // root mount; they have nothing to snapshot anyway. `cmd && !image`
-  // already errors above, so this check covers all snapshotable
-  // workload paths.
-  const scratchPath = join(
+  return typeof snapshot === "string" ? "path" : "auto";
+}
+
+function scratchRestoreClonePath(): string {
+  return join(
     tmpdir(),
-    `machinen-snap-${process.pid}-${randomBytes(6).toString("hex")}.img`,
+    `machinen-snap-restore-${process.pid}-${randomBytes(6).toString("hex")}.img`,
   );
-  allocateSparseFile(scratchPath, SNAP_SCRATCH_BYTES);
-  env.MACHINEN_DISK = scratchPath;
-  debug("snap-scratch auto path=%s sizeBytes=%d", scratchPath, SNAP_SCRATCH_BYTES);
-  return { diskAbs: scratchPath, perBootSnapDisk: scratchPath };
+}
+
+function autoScratchPath(): string {
+  return join(tmpdir(), `machinen-snap-${process.pid}-${randomBytes(6).toString("hex")}.img`);
+}
+
+function applyScratchDiskPlan(
+  plan: ReturnType<typeof planBootScratchDiskNative>,
+  snapshotPath: string | undefined,
+  env: Record<string, string>,
+): void {
+  if (plan.vmmDisk) {
+    env.MACHINEN_DISK = plan.vmmDisk;
+  }
+  if (plan.action === "existing") {
+    debug("snap-restore in-place (explicit cmd) path=%s", plan.diskPath);
+    return;
+  }
+  if (plan.action === "clone") {
+    reflinkCopy(snapshotPath!, plan.diskPath!);
+    debug("snap-restore reflink-clone src=%s dst=%s", snapshotPath, plan.diskPath);
+    return;
+  }
+  if (plan.action === "allocate") {
+    allocateSparseFile(plan.diskPath!, SNAP_SCRATCH_BYTES);
+    debug("snap-scratch auto path=%s sizeBytes=%d", plan.diskPath, SNAP_SCRATCH_BYTES);
+  }
 }
 
 function setupKernelDtbEnv(opts: BootOptions, env: Record<string, string>): void {

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -22,6 +22,7 @@ import {
   markMountDiskImageClean,
 } from "../mountdisk-img.ts";
 import { reflinkCopy } from "../reflink.ts";
+import { planBootLiveMountsNative } from "../native/boot-plan.ts";
 import type { BootOptions } from "./boot.ts";
 import type { SnapshotMeta } from "../vm-handle.ts";
 import { normalizeMountGuest, validateGuestCwd, validateMountGuest } from "./helpers.ts";
@@ -42,15 +43,6 @@ export interface ResolvedLiveMount {
   tag: string;
 }
 
-/**
- * The VMM wires this many virtio-fs slots (slots 7..11 — see
- * `MAX_VIRTIOFS_SLOTS` in boot_hvf.zig / boot_kvm.zig). One
- * `--mount-live` per slot. Note `restore({ lazy: true })` consumes
- * one slot internally to serve the page image, so a lazy restore can
- * carry at most `MAX_LIVE_MOUNTS - 1` user mounts.
- */
-const MAX_LIVE_MOUNTS = 5;
-
 export function resolveLiveMounts(
   mounts: Array<{
     host: string;
@@ -59,43 +51,23 @@ export function resolveLiveMounts(
   }>,
   cwd: string | undefined,
 ): ResolvedLiveMount[] {
-  // Every live mount is served by an in-VMM virtio-fs device (#332).
-  // The VMM wires MAX_LIVE_MOUNTS slots; a caller asking for more has
-  // nowhere to put the extras, so reject up front. (FUSE-over-vsock,
-  // the old unbounded fallback transport, was removed in #338.)
-  // Note: a `restore({ lazy: true })` appends one internal mount for
-  // the page image, so this cap counts that entry too.
-  if (mounts.length > MAX_LIVE_MOUNTS) {
-    throw new BootError(
-      "BOOT_MOUNT_INVALID",
-      `liveMounts: at most ${MAX_LIVE_MOUNTS} live mounts are supported per VM ` +
-        `(got ${mounts.length}) — the VMM wires ${MAX_LIVE_MOUNTS} virtio-fs slots.`,
-    );
-  }
-  return mounts.map((m, i) => {
-    validateMountGuest(m.guest);
-    const hostAbs = resolve(cwd ?? process.cwd(), m.host);
+  const planned = planBootLiveMountsNative(mounts);
+  return planned.map((mount, i) => {
+    const hostAbs = resolve(cwd ?? process.cwd(), mount.host);
     if (!existsSync(hostAbs)) {
       throw new BootError(
         "BOOT_MOUNT_HOST_NOT_FOUND",
-        `liveMounts[${i}] host path not found: ${m.host}`,
+        `liveMounts[${i}] host path not found: ${mount.host}`,
       );
     }
     if (!statSync(hostAbs).isDirectory()) {
       throw new BootError(
         "BOOT_MOUNT_INVALID",
-        `liveMounts[${i}] host path must be a directory: ${m.host}`,
+        `liveMounts[${i}] host path must be a directory: ${mount.host}`,
       );
     }
-    rejectRemovedLiveMountOptions(m, i);
-    return {
-      host: hostAbs,
-      guest: normalizeMountGuest(m.guest),
-      mode: m.mode ?? "rw",
-      // Tag is the virtio-fs device's config-space identifier and must
-      // be ≤ 36 bytes (FsConfig.tag). `machinen-lm<i>` stays well under.
-      tag: `machinen-lm${i}`,
-    };
+    rejectRemovedLiveMountOptions(mounts[i] ?? {}, i);
+    return { ...mount, host: hostAbs };
   });
 }
 

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -22,7 +22,11 @@ import {
   markMountDiskImageClean,
 } from "../mountdisk-img.ts";
 import { reflinkCopy } from "../reflink.ts";
-import { planBootLiveMountsNative, planBootMachinenConfigNative } from "../native/boot-plan.ts";
+import {
+  planBootBundleCommandNative,
+  planBootLiveMountsNative,
+  planBootMachinenConfigNative,
+} from "../native/boot-plan.ts";
 import type { BootOptions } from "./boot.ts";
 import type { SnapshotMeta } from "../vm-handle.ts";
 import { normalizeMountGuest, validateGuestCwd, validateMountGuest } from "./helpers.ts";
@@ -225,7 +229,7 @@ export function synthesizeAndPackBundle(
   try {
     validateOptionalGuestCwd(opts);
     const image = resolveBundleImage(opts, packerOpts);
-    const cmd = wrapBundleCommand(resolveBundleCommand(opts, image.imageConfig), opts, liveMounts);
+    const cmd = planBundleCommand(opts, image.imageConfig, liveMounts);
     const effectiveEnv = { ...image.imageConfig?.env, ...mergedGuestEnv };
     writeBundleConfig(workspace, {
       cmd,
@@ -281,65 +285,18 @@ function resolveBundleImage(opts: BootOptions, packerOpts: BundlePackerOptions):
   return { baseAbs, imageConfig };
 }
 
-function resolveBundleCommand(
+function planBundleCommand(
   opts: BootOptions,
   imageConfig: BundleImageConfig | undefined,
-): string[] {
-  const cmd = explicitOrSyntheticCommand(opts, imageConfig);
-  if (cmd) {
-    return cmd;
-  }
-  throw new BootError(
-    "BOOT_CMD_MISSING",
-    "boot: no cmd to run — pass `cmd` on boot() or bake one into the " +
-      "image via `provision({ cmd })`.",
-  );
-}
-
-function explicitOrSyntheticCommand(
-  opts: BootOptions,
-  imageConfig: BundleImageConfig | undefined,
-): string[] | undefined {
-  if (opts.cmd) {
-    return opts.cmd;
-  }
-  if (typeof opts.snapshot === "string") {
-    // Only synthesize the restore helper when the caller explicitly
-    // passed a snapshot path. The auto-allocated scratch (default
-    // `snapshot: undefined`) is empty, so synthesizing here would feed
-    // CRIU a bundle-less file and fail.
-    return ["/sbin/machinen-restore"];
-  }
-  if (opts._vmstateRestorePath) {
-    // Vmstate restore: the VMM overwrites guest RAM before /init runs,
-    // but the VMM still needs a valid initramfs path.
-    return ["/sbin/machinen-poweroff"];
-  }
-  return imageConfig?.cmd;
-}
-
-function wrapBundleCommand(
-  cmd: string[],
-  opts: BootOptions,
   liveMounts: ResolvedLiveMount[],
 ): string[] {
-  const cmdHead = cmd[0];
-  if (cmdHead === "/exec-agent" || cmdHead === "/sbin/machinen-restore") {
-    return cmd;
-  }
-  const workload = liveMounts.some((lm) => lm.mode === "rw") ? wrapBatchWorkloadCommand(cmd) : cmd;
-  const supervisorArgs = typeof opts.snapshot === "string" ? ["--session"] : [];
-  return ["/sbin/machinen-supervisor", ...supervisorArgs, ...workload];
-}
-
-function wrapBatchWorkloadCommand(cmd: string[]): string[] {
-  return [
-    "/bin/sh",
-    "-c",
-    'batch_sync() { if [ -s /run/machinen-batch-sync.sh ]; then sh /run/machinen-batch-sync.sh; fi; }; "$@" & child=$!; trap \'kill -TERM "$child" 2>/dev/null\' TERM; trap \'kill -INT "$child" 2>/dev/null\' INT; wait "$child"; status=$?; batch_sync || { sync_status=$?; if [ "$status" -eq 0 ]; then status=$sync_status; fi; }; exit "$status"',
-    "machinen-batch-wrapper",
-    ...cmd,
-  ];
+  return planBootBundleCommandNative({
+    explicitCmd: opts.cmd,
+    imageCmd: imageConfig?.cmd,
+    snapshotRestore: typeof opts.snapshot === "string",
+    vmstateRestore: opts._vmstateRestorePath !== undefined,
+    liveMounts,
+  });
 }
 
 function writeBundleConfig(

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -22,7 +22,7 @@ import {
   markMountDiskImageClean,
 } from "../mountdisk-img.ts";
 import { reflinkCopy } from "../reflink.ts";
-import { planBootLiveMountsNative } from "../native/boot-plan.ts";
+import { planBootLiveMountsNative, planBootMachinenConfigNative } from "../native/boot-plan.ts";
 import type { BootOptions } from "./boot.ts";
 import type { SnapshotMeta } from "../vm-handle.ts";
 import { normalizeMountGuest, validateGuestCwd, validateMountGuest } from "./helpers.ts";
@@ -104,25 +104,7 @@ export function buildMachinenConfig(input: {
   imageCwd?: string;
   liveMounts: ResolvedLiveMount[];
 }): Record<string, unknown> {
-  // cwd: image-baked default overlaid by user's guestCwd (same
-  // precedence as cmd/env). /init reads `cwd` and chdirs before exec.
-  const effectiveCwd = input.guestCwd ?? input.imageCwd;
-
-  const cfg: Record<string, unknown> = { cmd: input.cmd, env: input.env };
-  if (effectiveCwd !== undefined) {
-    cfg.cwd = effectiveCwd;
-  }
-  if (input.liveMounts.length > 0) {
-    // Host paths never cross into the guest's view. /init reads this
-    // and mounts read-only entries directly over virtio-fs (#332);
-    // writable entries get a guest-local overlay upper plus a sync script.
-    cfg.liveMounts = input.liveMounts.map((lm) => ({
-      guest: lm.guest,
-      tag: lm.tag,
-      mode: lm.mode,
-    }));
-  }
-  return cfg;
+  return planBootMachinenConfigNative(input);
 }
 
 /**

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -26,6 +26,7 @@ import {
   planBootBundleCommandNative,
   planBootBundleEnvNative,
   planBootLiveMountsNative,
+  planBootMountDiskRuntimeNative,
   planBootMachinenConfigNative,
 } from "../native/boot-plan.ts";
 import type { BootOptions } from "./boot.ts";
@@ -426,12 +427,16 @@ function materializeRestoredMountDisk(
     `machinen-mountdisk-upper-${process.pid}-${randomBytes(6).toString("hex")}.img`,
   );
   reflinkCopy(restoreMount.upperPath, perVMUpper);
-  return {
-    lowerPath: restoreMount.lowerPath,
-    upperPath: perVMUpper,
-    guest: restoreMount.guest,
-    upperSizeBytes: statSync(perVMUpper).size,
-  };
+  return requireMountDiskPlan(
+    planBootMountDiskRuntimeNative({
+      mode: "restore",
+      lowerPath: restoreMount.lowerPath,
+      upperPath: perVMUpper,
+      sourceUpperPath: restoreMount.upperPath,
+      guest: restoreMount.guest,
+      upperSizeBytes: statSync(perVMUpper).size,
+    }),
+  );
 }
 
 function materializeFreshMountDisk(
@@ -447,10 +452,35 @@ function materializeFreshMountDisk(
     sizeBytes: packerOpts.mountDiskUpperSizeBytes,
   });
   markMountDiskImageClean(lower.lowerPath);
+  return requireMountDiskPlan(
+    planBootMountDiskRuntimeNative({
+      mode: "fresh",
+      lowerPath: lower.lowerPath,
+      upperPath: upper.upperPath,
+      guest: mount.guest,
+      upperSizeBytes: upper.sizeBytes,
+    }),
+  );
+}
+
+function requireMountDiskPlan(
+  plan: ReturnType<typeof planBootMountDiskRuntimeNative>,
+): BundleMountDisk {
+  if (
+    plan.lowerPath === null ||
+    plan.upperPath === null ||
+    plan.guest === null ||
+    plan.upperSizeBytes === null
+  ) {
+    throw new BootError(
+      "BOOT_MOUNT_INVALID",
+      "boot: native planner returned incomplete mount disk plan",
+    );
+  }
   return {
-    lowerPath: lower.lowerPath,
-    upperPath: upper.upperPath,
-    guest: mount.guest,
-    upperSizeBytes: upper.sizeBytes,
+    lowerPath: plan.lowerPath,
+    upperPath: plan.upperPath,
+    guest: plan.guest,
+    upperSizeBytes: plan.upperSizeBytes,
   };
 }

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -24,6 +24,7 @@ import {
 import { reflinkCopy } from "../reflink.ts";
 import {
   planBootBundleCommandNative,
+  planBootBundleEnvNative,
   planBootLiveMountsNative,
   planBootMachinenConfigNative,
 } from "../native/boot-plan.ts";
@@ -230,7 +231,10 @@ export function synthesizeAndPackBundle(
     validateOptionalGuestCwd(opts);
     const image = resolveBundleImage(opts, packerOpts);
     const cmd = planBundleCommand(opts, image.imageConfig, liveMounts);
-    const effectiveEnv = { ...image.imageConfig?.env, ...mergedGuestEnv };
+    const effectiveEnv = planBootBundleEnvNative({
+      imageEnv: image.imageConfig?.env,
+      guestEnv: mergedGuestEnv,
+    });
     writeBundleConfig(workspace, {
       cmd,
       env: effectiveEnv,


### PR DESCRIPTION
## Problem

Boot runtime planning still had several deterministic branches in TypeScript. That made the boot shell larger than it needed to be.

## Solution

Move live mount, Machinen config, bundle command/env, scratch disk, rootdisk, and mountdisk runtime planning into the Zig boot planner. TypeScript keeps host checks and orchestration.

## Technical Summary

- Keeps this PR focused on boot-side runtime planners.
- Leaves registry shape and provision planning for the next stacked PR.
- Preserves public TypeScript API behavior through command-specific wrappers.
