### PR TITLE
Expand boot registry planning in Zig

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -4820,7 +4820,7 @@ Size in bytes the file was allocated at.
 
 ###### sourceArch?
 
-> `optional` **sourceArch?**: `"amd64"` \| `"arm64"`
+> `optional` **sourceArch?**: `"arm64"` \| `"amd64"`
 
 ###### resources
 
@@ -6152,7 +6152,7 @@ by default when `output` is a TTY.
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### targetRoot?
 
@@ -6201,7 +6201,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ##### kind
 
@@ -6837,7 +6837,7 @@ by default when `output` is a TTY.
 
 ###### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ###### pid?
 
@@ -6857,7 +6857,7 @@ by default when `output` is a TTY.
 
 ###### arch
 
-> **arch**: `"amd64"` \| `"arm64"`
+> **arch**: `"arm64"` \| `"amd64"`
 
 ###### abi
 
@@ -7437,11 +7437,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### codeLocations
 
@@ -7569,7 +7569,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ###### Inherited from
 
@@ -7677,7 +7677,7 @@ by default when `output` is a TTY.
 
 ##### arch?
 
-> `optional` **arch?**: `"amd64"` \| `"arm64"`
+> `optional` **arch?**: `"arm64"` \| `"amd64"`
 
 ###### Inherited from
 
@@ -7923,7 +7923,7 @@ by default when `output` is a TTY.
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### targetModules
 
@@ -8087,11 +8087,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### threads
 
@@ -8139,11 +8139,11 @@ by default when `output` is a TTY.
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### threads
 
@@ -11558,11 +11558,11 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### sourceArch
 
-> **sourceArch**: `"amd64"` \| `"arm64"`
+> **sourceArch**: `"arm64"` \| `"amd64"`
 
 ##### targetArch
 
-> **targetArch**: `"amd64"` \| `"arm64"`
+> **targetArch**: `"arm64"` \| `"amd64"`
 
 ##### sourceThreadPointer?
 
@@ -11600,7 +11600,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ##### targetArch?
 
-> `optional` **targetArch?**: `"amd64"` \| `"arm64"`
+> `optional` **targetArch?**: `"arm64"` \| `"amd64"`
 
 ##### targetFsBase?
 
@@ -14395,7 +14395,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### guestArch
 
-> **guestArch**: `"amd64"` \| `"arm64"`
+> **guestArch**: `"arm64"` \| `"amd64"`
 
 ###### vmstate
 
@@ -14427,7 +14427,7 @@ Legacy single-bucket failure status. Prefer failureExitBuckets for new continuat
 
 ###### guestArch
 
-> **guestArch**: `"amd64"` \| `"arm64"`
+> **guestArch**: `"arm64"` \| `"amd64"`
 
 ###### mode
 
@@ -15287,7 +15287,7 @@ whole-VM state captures RAM/device/vCPU state, not disk blocks.
 
 ##### rootDiskMode?
 
-> `optional` **rootDiskMode?**: `"none"` \| `"block"`
+> `optional` **rootDiskMode?**: `"block"` \| `"none"`
 
 Whether the VM intentionally booted without a root block device.
 
@@ -15450,7 +15450,7 @@ CPU resource policy and host enforcement state resolved at boot.
 
 ###### enforcement.status
 
-> **status**: `"unsupported"` \| `"linux-cgroup-v2"` \| `"none"`
+> **status**: `"unsupported"` \| `"none"` \| `"linux-cgroup-v2"`
 
 ###### enforcement.reason?
 
@@ -17239,7 +17239,7 @@ VMM backend that wrote `state.vmstate`.
 
 ##### guestArch?
 
-> `optional` **guestArch?**: `"amd64"` \| `"arm64"` \| `"unknown"`
+> `optional` **guestArch?**: `"arm64"` \| `"amd64"` \| `"unknown"`
 
 Guest CPU architecture captured in `state.vmstate`; restore must match.
 

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -393,6 +393,7 @@ pub const Input = struct {
     vmm_memory_preset: bool = false,
     has_image: bool = false,
     has_cmd: bool = false,
+    has_snapshot: bool = false,
     root_disk: RootDiskMode = .unset,
     guest_cwd: ?[]const u8 = null,
     mount_guest: ?[]const u8 = null,
@@ -402,6 +403,7 @@ pub const Plan = struct {
     memory_ceiling_mib: ?u64,
     vmm_memory_mib: ?u64,
     wants_root_disk: bool,
+    needs_initramfs: bool,
     normalized_mount_guest: ?[]const u8,
 };
 
@@ -1166,6 +1168,7 @@ pub fn planCore(input: Input) PlanError!Plan {
 
     const wants_root_disk = input.root_disk != .false_value and
         (input.root_disk == .path or input.root_disk == .true_value or input.has_image);
+    const needs_initramfs = input.has_image or input.has_cmd or input.has_snapshot;
     if (wants_root_disk and input.root_disk != .path and !input.has_image) {
         return error.RootDiskWithoutImage;
     }
@@ -1181,6 +1184,7 @@ pub fn planCore(input: Input) PlanError!Plan {
             .memory_ceiling_mib = null,
             .vmm_memory_mib = null,
             .wants_root_disk = wants_root_disk,
+            .needs_initramfs = needs_initramfs,
             .normalized_mount_guest = normalized_mount_guest,
         };
     }
@@ -1195,6 +1199,7 @@ pub fn planCore(input: Input) PlanError!Plan {
         .memory_ceiling_mib = ceiling,
         .vmm_memory_mib = ceiling,
         .wants_root_disk = wants_root_disk,
+        .needs_initramfs = needs_initramfs,
         .normalized_mount_guest = normalized_mount_guest,
     };
 }
@@ -1882,6 +1887,20 @@ test "planGuestEnv applies name and hostname wait defaults without overriding ca
     try std.testing.expectEqual(@as(@TypeOf(preserved.len), 2), preserved.len);
     try std.testing.expectEqualStrings("caller", preserved[0].value);
     try std.testing.expectEqualStrings("0", preserved[1].value);
+}
+
+test "planCore plans whether initramfs packing is needed" {
+    const none = try planCore(.{ .vmm_memory_preset = true });
+    try std.testing.expect(!none.needs_initramfs);
+
+    const image = try planCore(.{ .vmm_memory_preset = true, .has_image = true });
+    try std.testing.expect(image.needs_initramfs);
+
+    const command = try planCore(.{ .vmm_memory_preset = true, .has_image = true, .has_cmd = true });
+    try std.testing.expect(command.needs_initramfs);
+
+    const snapshot = try planCore(.{ .vmm_memory_preset = true, .has_snapshot = true });
+    try std.testing.expect(snapshot.needs_initramfs);
 }
 
 test "planCore honors preset VMM memory after validating public input" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -97,6 +97,7 @@ pub const BundleCommandInput = struct {
     cpu_policy: ?CpuPolicyPlan = null,
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
+    vmstate: RegistryVmstateInput = .{},
 };
 
 pub const BundleEnvInput = struct {
@@ -336,6 +337,20 @@ pub const RegistryCpuPlan = struct {
     enforcement_reason: ?[]const u8,
 };
 
+pub const RegistryVmstateInput = struct {
+    state_path: ?[]const u8 = null,
+    chain_id: ?[]const u8 = null,
+    checkpoint_parent: ?[]const u8 = null,
+    checkpoint_sequence: ?u64 = null,
+};
+
+pub const RegistryVmstatePlan = struct {
+    state_path: ?[]const u8,
+    chain_id: ?[]const u8,
+    checkpoint_parent: ?[]const u8,
+    checkpoint_sequence: ?u64,
+};
+
 pub const RegistryShapeInput = struct {
     source_image_path: ?[]const u8 = null,
     per_boot_root_disk: ?[]const u8 = null,
@@ -346,6 +361,7 @@ pub const RegistryShapeInput = struct {
     cpu_policy: ?CpuPolicyPlan = null,
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
+    vmstate: RegistryVmstateInput = .{},
 };
 
 pub const RegistryShapePlan = struct {
@@ -356,6 +372,7 @@ pub const RegistryShapePlan = struct {
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
     cpu: ?RegistryCpuPlan,
+    vmstate: RegistryVmstatePlan,
 };
 
 pub const MachinenConfigInput = struct {
@@ -409,6 +426,7 @@ pub const PlanError = error{
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
+    MissingRegistryVmstateField,
 };
 
 pub fn planNestedEnv(nested: bool) ?[]const u8 {
@@ -858,6 +876,27 @@ pub fn planRegistryShape(
         .mount_disk = try planRegistryMountDisk(input.mount_disk),
         .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
         .cpu = try planRegistryCpu(input),
+        .vmstate = try planRegistryVmstate(input.vmstate),
+    };
+}
+
+fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePlan {
+    assert(@sizeOf(RegistryVmstateInput) > 0);
+
+    if (input.state_path == null) {
+        return .{
+            .state_path = null,
+            .chain_id = null,
+            .checkpoint_parent = null,
+            .checkpoint_sequence = null,
+        };
+    }
+    return .{
+        .state_path = input.state_path,
+        .chain_id = input.chain_id orelse return error.MissingRegistryVmstateField,
+        .checkpoint_parent = input.checkpoint_parent,
+        .checkpoint_sequence = input.checkpoint_sequence orelse
+            return error.MissingRegistryVmstateField,
     };
 }
 
@@ -1345,6 +1384,10 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqual(@as(u64, 200), plan.cpu.?.weight);
     try std.testing.expectEqualStrings("linux-cgroup-v2", plan.cpu.?.enforcement_status);
     try std.testing.expectEqualStrings("limited", plan.cpu.?.enforcement_reason.?);
+    try std.testing.expectEqualStrings("/tmp/state.vmstate", plan.vmstate.state_path.?);
+    try std.testing.expectEqualStrings("chain-1", plan.vmstate.chain_id.?);
+    try std.testing.expectEqualStrings("/snap/parent", plan.vmstate.checkpoint_parent.?);
+    try std.testing.expectEqual(@as(u64, 3), plan.vmstate.checkpoint_sequence.?);
     try std.testing.expectEqual(@as(@TypeOf(plan.live_mounts.len), 2), plan.live_mounts.len);
     try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
     try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -77,6 +77,11 @@ pub const PortForwardValidation = union(enum) {
     duplicate_host_port: u16,
 };
 
+pub const PdeathsigInput = struct {
+    detached: bool = false,
+    pdeathsig: ?bool = null,
+};
+
 pub const VmmArgvInput = struct {
     binary: ?[]const u8 = null,
     args: []const []const u8 = &.{},
@@ -428,6 +433,13 @@ pub const PlanError = error{
     MissingRegistryCpuStatus,
     MissingRegistryVmstateField,
 };
+
+pub fn planPdeathsig(input: PdeathsigInput) bool {
+    assert(@sizeOf(PdeathsigInput) > 0);
+
+    if (input.detached) return false;
+    return input.pdeathsig orelse true;
+}
 
 pub fn planNestedEnv(nested: bool) ?[]const u8 {
     assert(@sizeOf(bool) > 0);
@@ -1260,6 +1272,13 @@ test "planCore resolves explicit memory aliases" {
         .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+}
+
+test "planPdeathsig defaults on and lets detach or explicit false disable it" {
+    try std.testing.expect(planPdeathsig(.{}));
+    try std.testing.expect(planPdeathsig(.{ .pdeathsig = true }));
+    try std.testing.expect(!planPdeathsig(.{ .pdeathsig = false }));
+    try std.testing.expect(!planPdeathsig(.{ .detached = true, .pdeathsig = true }));
 }
 
 test "planNestedEnv sets nested only when requested" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -391,6 +391,10 @@ pub const RegistryShapeInput = struct {
     child_pid: ?i64 = null,
     detached: bool = false,
     caller_root_disk_path: ?[]const u8 = null,
+    disk_path: ?[]const u8 = null,
+    forked_from: ?[]const u8 = null,
+    memory_ceiling_mib: ?u64 = null,
+    stats_path: ?[]const u8 = null,
     cleanup: RegistryCleanupInput = .{},
     mount_disk: RegistryMountDiskInput = .{},
     live_mounts: []const LiveMount = &.{},
@@ -406,6 +410,10 @@ pub const RegistryShapePlan = struct {
     root_disk_path: ?[]const u8,
     root_disk_mode: []const u8,
     boot_log_path: ?[]const u8,
+    disk_path: ?[]const u8,
+    forked_from: ?[]const u8,
+    memory_ceiling_mib: ?u64,
+    stats_path: ?[]const u8,
     cleanup_paths: []const []const u8,
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
@@ -990,6 +998,10 @@ pub fn planRegistryShape(
         .root_disk_path = root_disk_path,
         .root_disk_mode = if (root_disk_path != null) "block" else "none",
         .boot_log_path = boot_log_path,
+        .disk_path = input.disk_path,
+        .forked_from = input.forked_from,
+        .memory_ceiling_mib = input.memory_ceiling_mib,
+        .stats_path = input.stats_path,
         .cleanup_paths = try planRegistryCleanupPaths(allocator, input.cleanup),
         .mount_disk = try planRegistryMountDisk(input.mount_disk),
         .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
@@ -1588,6 +1600,10 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
         .boot_log_root = "/tmp/machinen-logs",
         .child_pid = 1234,
         .detached = true,
+        .disk_path = "/disk.img",
+        .forked_from = "/snap/source",
+        .memory_ceiling_mib = 2048,
+        .stats_path = "/stats.json",
         .port_forwards = &[_]PortForwardMapping{
             .{ .host_port = 8080, .guest_port = 80, .host_addr = "127.0.0.1" },
             .{ .host_port = 8443, .guest_port = 443 },
@@ -1602,6 +1618,10 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);
     try std.testing.expectEqualStrings("block", plan.root_disk_mode);
     try std.testing.expectEqualStrings("/tmp/machinen-logs/1234.boot.log", plan.boot_log_path.?);
+    try std.testing.expectEqualStrings("/disk.img", plan.disk_path.?);
+    try std.testing.expectEqualStrings("/snap/source", plan.forked_from.?);
+    try std.testing.expectEqual(@as(u64, 2048), plan.memory_ceiling_mib.?);
+    try std.testing.expectEqualStrings("/stats.json", plan.stats_path.?);
     try std.testing.expectEqual(@as(@TypeOf(plan.cleanup_paths.len), 6), plan.cleanup_paths.len);
     try std.testing.expectEqualStrings("/tmp/root.img", plan.cleanup_paths[0]);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.cleanup_paths[1]);

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -411,6 +411,12 @@ pub const PlanError = error{
     MissingRegistryCpuStatus,
 };
 
+pub fn planNestedEnv(nested: bool) ?[]const u8 {
+    assert(@sizeOf(bool) > 0);
+
+    return if (nested) "1" else null;
+}
+
 pub fn planCpuResources(input: ?CpuResourcesInput) PlanError!?CpuPolicyPlan {
     const cpu = input orelse return null;
     const max_vcpus = cpu.max_vcpus orelse default_cpu_max_vcpus;
@@ -1215,6 +1221,11 @@ test "planCore resolves explicit memory aliases" {
         .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+}
+
+test "planNestedEnv sets nested only when requested" {
+    try std.testing.expectEqualStrings("1", planNestedEnv(true).?);
+    try std.testing.expect(planNestedEnv(false) == null);
 }
 
 test "planCpuResources applies defaults and validates cpu policy" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -18,6 +18,7 @@ const default_boot_timeout_ms: u64 = 60_000;
 const min_cpu_weight: u64 = 1;
 const max_cpu_weight: u64 = 10_000;
 const max_live_mounts = 5;
+const max_registry_boot_log_path = std.fs.max_path_bytes;
 const restore_command = [_][]const u8{"/sbin/machinen-restore"};
 const poweroff_command = [_][]const u8{"/sbin/machinen-poweroff"};
 
@@ -111,6 +112,7 @@ pub const BundleCommandInput = struct {
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
     vmstate: RegistryVmstateInput = .{},
+    nested: bool = false,
 };
 
 pub const BundleEnvInput = struct {
@@ -403,13 +405,26 @@ pub const RegistryShapeInput = struct {
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
     vmstate: RegistryVmstateInput = .{},
+    nested: bool = false,
+};
+
+pub const RegistryBootLogPath = struct {
+    bytes: [max_registry_boot_log_path]u8 = undefined,
+    len: u16 = 0,
+
+    pub fn value(self: *const RegistryBootLogPath) ?[]const u8 {
+        assert(self.len <= max_registry_boot_log_path);
+
+        if (self.len == 0) return null;
+        return self.bytes[0..self.len];
+    }
 };
 
 pub const RegistryShapePlan = struct {
     source_image_path: ?[]const u8,
     root_disk_path: ?[]const u8,
     root_disk_mode: []const u8,
-    boot_log_path: ?[]const u8,
+    boot_log_path: RegistryBootLogPath,
     disk_path: ?[]const u8,
     forked_from: ?[]const u8,
     memory_ceiling_mib: ?u64,
@@ -420,6 +435,7 @@ pub const RegistryShapePlan = struct {
     port_forwards: []const RegistryPortForwardPlan,
     cpu: ?RegistryCpuPlan,
     vmstate: RegistryVmstatePlan,
+    nested: bool,
 };
 
 pub const MachinenConfigInput = struct {
@@ -447,6 +463,7 @@ pub const Plan = struct {
     memory_ceiling_mib: ?u64,
     vmm_memory_mib: ?u64,
     timeout_ms: ?u64,
+    detached_readiness_timeout_ms: u64,
     wants_root_disk: bool,
     needs_initramfs: bool,
     normalized_mount_guest: ?[]const u8,
@@ -482,7 +499,15 @@ pub const PlanError = error{
     MissingVmstateRuntimeChainId,
 };
 
+pub fn planDetachedReadinessTimeout(timeout_ms: ?u64) u64 {
+    assert(default_boot_timeout_ms > 0);
+
+    return timeout_ms orelse default_boot_timeout_ms;
+}
+
 pub fn planBootTimeout(timeout_ms: ?u64, forever: bool) ?u64 {
+    assert(default_boot_timeout_ms > 0);
+
     if (forever) return null;
     return timeout_ms orelse default_boot_timeout_ms;
 }
@@ -494,43 +519,61 @@ pub fn planPdeathsig(input: PdeathsigInput) bool {
     return input.pdeathsig orelse true;
 }
 
-pub fn planGuestHostname(allocator: std.mem.Allocator, input: GuestHostnameInput) !?[]const u8 {
-    assert(@sizeOf(GuestHostnameInput) > 0);
+pub fn formatGuestHostname(buffer: []u8, input: GuestHostnameInput) !?[]const u8 {
+    assert(buffer.len > 0);
 
     const pid = input.pid orelse return null;
-    const safe_name = try sanitizeHostnameName(allocator, input.name orelse "");
-    defer allocator.free(safe_name);
-    if (safe_name.len == 0) {
-        const hostname = try std.fmt.allocPrint(allocator, "vm-{d}", .{pid});
-        return hostname;
+    var len: u16 = 0;
+    try appendSanitizedHostnameName(buffer, &len, input.name orelse "");
+    if (len == 0) {
+        try appendHostnameText(buffer, &len, "vm");
     }
-    const hostname = try std.fmt.allocPrint(allocator, "vm-{d}-{s}", .{ pid, safe_name });
-    return hostname;
+    try appendHostnameText(buffer, &len, "-pid-");
+    const pid_text = try std.fmt.bufPrint(buffer[len..], "{d}", .{pid});
+    len += @intCast(pid_text.len);
+    return buffer[0..len];
 }
 
-fn sanitizeHostnameName(allocator: std.mem.Allocator, name: []const u8) ![]const u8 {
-    assert(@sizeOf(std.mem.Allocator) > 0);
+fn appendSanitizedHostnameName(buffer: []u8, len: *u16, name: []const u8) !void {
+    assert(name.len <= buffer.len or buffer.len > 0);
 
-    var output = try std.ArrayList(u8).initCapacity(allocator, name.len);
-    errdefer output.deinit(allocator);
     for (name) |c| {
         if (isHostnameAlnum(c)) {
-            output.appendAssumeCapacity(std.ascii.toLower(c));
-        } else if (output.items.len > 0 and output.items[output.items.len - 1] != '-') {
-            output.appendAssumeCapacity('-');
+            try appendHostnameByte(buffer, len, c);
+        } else {
+            if (len.* > 0 and buffer[len.* - 1] != '-') {
+                try appendHostnameByte(buffer, len, '-');
+            }
         }
     }
-    while (output.items.len > 0 and output.items[output.items.len - 1] == '-') {
-        _ = output.pop();
+    while (len.* > 0 and buffer[len.* - 1] == '-') {
+        len.* -= 1;
     }
-    return output.toOwnedSlice(allocator);
+}
+
+fn appendHostnameText(buffer: []u8, len: *u16, text: []const u8) !void {
+    assert(text.len > 0);
+
+    for (text) |c| try appendHostnameByte(buffer, len, c);
+}
+
+fn appendHostnameByte(buffer: []u8, len: *u16, byte: u8) !void {
+    assert(buffer.len > 0);
+
+    if (len.* >= buffer.len) return error.NoSpaceLeft;
+    buffer[len.*] = byte;
+    len.* += 1;
 }
 
 fn isHostnameAlnum(c: u8) bool {
+    assert(@sizeOf(u8) == 1);
+
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9');
 }
 
 pub fn planVmstateRuntime(input: VmstateRuntimeInput) PlanError!VmstateRuntimePlan {
+    assert(@sizeOf(VmstateRuntimeInput) > 0);
+
     if (input.state_path == null and
         input.chain_id == null and
         input.restore_path == null and
@@ -559,6 +602,8 @@ pub fn planNestedEnv(nested: bool) ?[]const u8 {
 }
 
 pub fn planCpuResources(input: ?CpuResourcesInput) PlanError!?CpuPolicyPlan {
+    assert(@sizeOf(CpuResourcesInput) > 0);
+
     const cpu = input orelse return null;
     const max_vcpus = cpu.max_vcpus orelse default_cpu_max_vcpus;
     if (max_vcpus < 1) return error.InvalidCpuMaxVcpus;
@@ -991,8 +1036,7 @@ pub fn planRegistryShape(
     assert(@sizeOf(RegistryShapeInput) > 0);
 
     const root_disk_path = input.per_boot_root_disk orelse input.caller_root_disk_path;
-    const boot_log_path = try planRegistryBootLogPath(allocator, input);
-    errdefer if (boot_log_path) |path| allocator.free(path);
+    const boot_log_path = try planRegistryBootLogPath(input);
     return .{
         .source_image_path = input.source_image_path,
         .root_disk_path = root_disk_path,
@@ -1008,6 +1052,7 @@ pub fn planRegistryShape(
         .port_forwards = try planRegistryPortForwards(allocator, input.port_forwards),
         .cpu = try planRegistryCpu(input),
         .vmstate = try planRegistryVmstate(input.vmstate),
+        .nested = input.nested,
     };
 }
 
@@ -1029,14 +1074,18 @@ fn planRegistryPortForwards(
     return forwards.toOwnedSlice(allocator);
 }
 
-fn planRegistryBootLogPath(allocator: std.mem.Allocator, input: RegistryShapeInput) !?[]const u8 {
-    if (!input.detached) return null;
-    const pid = input.child_pid orelse return null;
-    if (pid <= 0) return null;
-    const root = input.boot_log_root orelse return null;
-    const file = try std.fmt.allocPrint(allocator, "{d}.boot.log", .{pid});
-    defer allocator.free(file);
-    return try std.fs.path.join(allocator, &.{ root, file });
+fn planRegistryBootLogPath(input: RegistryShapeInput) !RegistryBootLogPath {
+    assert(@sizeOf(RegistryShapeInput) > 0);
+
+    var path: RegistryBootLogPath = .{};
+    if (!input.detached) return path;
+    const pid = input.child_pid orelse return path;
+    if (pid <= 0) return path;
+    const root = input.boot_log_root orelse return path;
+    const text = std.fmt.bufPrint(&path.bytes, "{s}/{d}.boot.log", .{ root, pid }) catch
+        return error.OutOfMemory;
+    path.len = @intCast(text.len);
+    return path;
 }
 
 fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePlan {
@@ -1330,6 +1379,7 @@ pub fn planCore(input: Input) PlanError!Plan {
             .memory_ceiling_mib = null,
             .vmm_memory_mib = null,
             .timeout_ms = timeout_ms,
+            .detached_readiness_timeout_ms = planDetachedReadinessTimeout(timeout_ms),
             .wants_root_disk = wants_root_disk,
             .needs_initramfs = needs_initramfs,
             .normalized_mount_guest = normalized_mount_guest,
@@ -1346,6 +1396,7 @@ pub fn planCore(input: Input) PlanError!Plan {
         .memory_ceiling_mib = ceiling,
         .vmm_memory_mib = ceiling,
         .timeout_ms = timeout_ms,
+        .detached_readiness_timeout_ms = planDetachedReadinessTimeout(timeout_ms),
         .wants_root_disk = wants_root_disk,
         .needs_initramfs = needs_initramfs,
         .normalized_mount_guest = normalized_mount_guest,
@@ -1428,6 +1479,7 @@ test "planCore resolves explicit memory aliases" {
 }
 
 test "planBootTimeout defaults, preserves explicit values, and supports forever" {
+    try std.testing.expectEqual(@as(u64, 60_000), planDetachedReadinessTimeout(null));
     try std.testing.expectEqual(@as(?u64, 60_000), planBootTimeout(null, false));
     try std.testing.expectEqual(@as(?u64, 2_500), planBootTimeout(2_500, false));
     try std.testing.expect(planBootTimeout(2_500, true) == null);
@@ -1442,23 +1494,27 @@ test "planBootTimeout defaults, preserves explicit values, and supports forever"
 }
 
 test "planGuestHostname sanitizes names and includes pid" {
-    const named = (try planGuestHostname(std.testing.allocator, .{ .pid = 1234, .name = "worker" })).?;
-    defer std.testing.allocator.free(named);
-    try std.testing.expectEqualStrings("vm-1234-worker", named);
+    var named_buffer: [128]u8 = undefined;
+    const named = (try formatGuestHostname(&named_buffer, .{ .pid = 1234, .name = "worker" })).?;
+    try std.testing.expectEqualStrings("worker-pid-1234", named);
 
-    const nameless = (try planGuestHostname(std.testing.allocator, .{ .pid = 1234 })).?;
-    defer std.testing.allocator.free(nameless);
-    try std.testing.expectEqualStrings("vm-1234", nameless);
+    var nameless_buffer: [128]u8 = undefined;
+    const nameless = (try formatGuestHostname(&nameless_buffer, .{ .pid = 1234 })).?;
+    try std.testing.expectEqualStrings("vm-pid-1234", nameless);
 
-    const sanitized = (try planGuestHostname(std.testing.allocator, .{ .pid = 99, .name = "src/name~fork" })).?;
-    defer std.testing.allocator.free(sanitized);
-    try std.testing.expectEqualStrings("vm-99-src-name-fork", sanitized);
+    var sanitized_buffer: [128]u8 = undefined;
+    const sanitized = (try formatGuestHostname(
+        &sanitized_buffer,
+        .{ .pid = 99, .name = "src/name~fork" },
+    )).?;
+    try std.testing.expectEqualStrings("src-name-fork-pid-99", sanitized);
 
-    const empty = (try planGuestHostname(std.testing.allocator, .{ .pid = 99, .name = "///" })).?;
-    defer std.testing.allocator.free(empty);
-    try std.testing.expectEqualStrings("vm-99", empty);
+    var empty_buffer: [128]u8 = undefined;
+    const empty = (try formatGuestHostname(&empty_buffer, .{ .pid = 99, .name = "///" })).?;
+    try std.testing.expectEqualStrings("vm-pid-99", empty);
 
-    try std.testing.expect((try planGuestHostname(std.testing.allocator, .{})) == null);
+    var missing_buffer: [128]u8 = undefined;
+    try std.testing.expect((try formatGuestHostname(&missing_buffer, .{})) == null);
 }
 
 test "planPdeathsig defaults on and lets detach or explicit false disable it" {
@@ -1520,9 +1576,15 @@ test "planCpuResources applies defaults and validates cpu policy" {
     try std.testing.expectEqual(@as(u64, 200), constrained.weight);
 
     try std.testing.expectError(error.InvalidCpuMaxVcpus, planCpuResources(.{ .max_vcpus = 0 }));
-    try std.testing.expectError(error.UnsupportedCpuMaxVcpus, planCpuResources(.{ .max_vcpus = 2 }));
+    try std.testing.expectError(
+        error.UnsupportedCpuMaxVcpus,
+        planCpuResources(.{ .max_vcpus = 2 }),
+    );
     try std.testing.expectError(error.InvalidCpuQuotaCpus, planCpuResources(.{ .quota_cpus = 0 }));
-    try std.testing.expectError(error.CpuQuotaExceedsMaxVcpus, planCpuResources(.{ .quota_cpus = 1.5 }));
+    try std.testing.expectError(
+        error.CpuQuotaExceedsMaxVcpus,
+        planCpuResources(.{ .quota_cpus = 1.5 }),
+    );
     try std.testing.expectError(error.InvalidCpuWeight, planCpuResources(.{ .weight = 0 }));
     try std.testing.expectError(error.InvalidCpuWeight, planCpuResources(.{ .weight = 10_001 }));
 }
@@ -1609,7 +1671,6 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
             .{ .host_port = 8443, .guest_port = 443 },
         },
     });
-    defer allocator.free(plan.boot_log_path.?);
     defer allocator.free(plan.cleanup_paths);
     defer allocator.free(plan.live_mounts);
     defer allocator.free(plan.port_forwards);
@@ -1617,7 +1678,10 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/images/rootfs.tar.gz", plan.source_image_path.?);
     try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);
     try std.testing.expectEqualStrings("block", plan.root_disk_mode);
-    try std.testing.expectEqualStrings("/tmp/machinen-logs/1234.boot.log", plan.boot_log_path.?);
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-logs/1234.boot.log",
+        plan.boot_log_path.value().?,
+    );
     try std.testing.expectEqualStrings("/disk.img", plan.disk_path.?);
     try std.testing.expectEqualStrings("/snap/source", plan.forked_from.?);
     try std.testing.expectEqual(@as(u64, 2048), plan.memory_ceiling_mib.?);
@@ -1641,6 +1705,7 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("chain-1", plan.vmstate.chain_id.?);
     try std.testing.expectEqualStrings("/snap/parent", plan.vmstate.checkpoint_parent.?);
     try std.testing.expectEqual(@as(u64, 3), plan.vmstate.checkpoint_sequence.?);
+    try std.testing.expect(!plan.nested);
     try std.testing.expectEqual(@as(@TypeOf(plan.live_mounts.len), 2), plan.live_mounts.len);
     try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
     try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);
@@ -2125,7 +2190,11 @@ test "planCore plans whether initramfs packing is needed" {
     const image = try planCore(.{ .vmm_memory_preset = true, .has_image = true });
     try std.testing.expect(image.needs_initramfs);
 
-    const command = try planCore(.{ .vmm_memory_preset = true, .has_image = true, .has_cmd = true });
+    const command = try planCore(.{
+        .vmm_memory_preset = true,
+        .has_image = true,
+        .has_cmd = true,
+    });
     try std.testing.expect(command.needs_initramfs);
 
     const snapshot = try planCore(.{ .vmm_memory_preset = true, .has_snapshot = true });

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -55,6 +55,11 @@ pub const GuestEnvInput = struct {
     vsock_uds_path: ?[]const u8 = null,
 };
 
+pub const GuestHostnameInput = struct {
+    pid: ?i64 = null,
+    name: ?[]const u8 = null,
+};
+
 pub const VsockPlanInput = struct {
     existing_spec: ?[]const u8 = null,
     auto_uds_path: ?[]const u8 = null,
@@ -441,6 +446,42 @@ pub fn planPdeathsig(input: PdeathsigInput) bool {
 
     if (input.detached) return false;
     return input.pdeathsig orelse true;
+}
+
+pub fn planGuestHostname(allocator: std.mem.Allocator, input: GuestHostnameInput) !?[]const u8 {
+    assert(@sizeOf(GuestHostnameInput) > 0);
+
+    const pid = input.pid orelse return null;
+    const safe_name = try sanitizeHostnameName(allocator, input.name orelse "");
+    defer allocator.free(safe_name);
+    if (safe_name.len == 0) {
+        const hostname = try std.fmt.allocPrint(allocator, "vm-{d}", .{pid});
+        return hostname;
+    }
+    const hostname = try std.fmt.allocPrint(allocator, "vm-{d}-{s}", .{ pid, safe_name });
+    return hostname;
+}
+
+fn sanitizeHostnameName(allocator: std.mem.Allocator, name: []const u8) ![]const u8 {
+    assert(@sizeOf(std.mem.Allocator) > 0);
+
+    var output = try std.ArrayList(u8).initCapacity(allocator, name.len);
+    errdefer output.deinit(allocator);
+    for (name) |c| {
+        if (isHostnameAlnum(c)) {
+            output.appendAssumeCapacity(std.ascii.toLower(c));
+        } else if (output.items.len > 0 and output.items[output.items.len - 1] != '-') {
+            output.appendAssumeCapacity('-');
+        }
+    }
+    while (output.items.len > 0 and output.items[output.items.len - 1] == '-') {
+        _ = output.pop();
+    }
+    return output.toOwnedSlice(allocator);
+}
+
+fn isHostnameAlnum(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9');
 }
 
 pub fn planNestedEnv(nested: bool) ?[]const u8 {
@@ -1277,6 +1318,26 @@ test "planCore resolves explicit memory aliases" {
         .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+}
+
+test "planGuestHostname sanitizes names and includes pid" {
+    const named = (try planGuestHostname(std.testing.allocator, .{ .pid = 1234, .name = "worker" })).?;
+    defer std.testing.allocator.free(named);
+    try std.testing.expectEqualStrings("vm-1234-worker", named);
+
+    const nameless = (try planGuestHostname(std.testing.allocator, .{ .pid = 1234 })).?;
+    defer std.testing.allocator.free(nameless);
+    try std.testing.expectEqualStrings("vm-1234", nameless);
+
+    const sanitized = (try planGuestHostname(std.testing.allocator, .{ .pid = 99, .name = "src/name~fork" })).?;
+    defer std.testing.allocator.free(sanitized);
+    try std.testing.expectEqualStrings("vm-99-src-name-fork", sanitized);
+
+    const empty = (try planGuestHostname(std.testing.allocator, .{ .pid = 99, .name = "///" })).?;
+    defer std.testing.allocator.free(empty);
+    try std.testing.expectEqualStrings("vm-99", empty);
+
+    try std.testing.expect((try planGuestHostname(std.testing.allocator, .{})) == null);
 }
 
 test "planPdeathsig defaults on and lets detach or explicit false disable it" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -373,6 +373,9 @@ pub const RegistryVmstatePlan = struct {
 pub const RegistryShapeInput = struct {
     source_image_path: ?[]const u8 = null,
     per_boot_root_disk: ?[]const u8 = null,
+    boot_log_root: ?[]const u8 = null,
+    child_pid: ?i64 = null,
+    detached: bool = false,
     caller_root_disk_path: ?[]const u8 = null,
     cleanup: RegistryCleanupInput = .{},
     mount_disk: RegistryMountDiskInput = .{},
@@ -388,6 +391,7 @@ pub const RegistryShapePlan = struct {
     source_image_path: ?[]const u8,
     root_disk_path: ?[]const u8,
     root_disk_mode: []const u8,
+    boot_log_path: ?[]const u8,
     cleanup_paths: []const []const u8,
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
@@ -942,10 +946,13 @@ pub fn planRegistryShape(
     assert(@sizeOf(RegistryShapeInput) > 0);
 
     const root_disk_path = input.per_boot_root_disk orelse input.caller_root_disk_path;
+    const boot_log_path = try planRegistryBootLogPath(allocator, input);
+    errdefer if (boot_log_path) |path| allocator.free(path);
     return .{
         .source_image_path = input.source_image_path,
         .root_disk_path = root_disk_path,
         .root_disk_mode = if (root_disk_path != null) "block" else "none",
+        .boot_log_path = boot_log_path,
         .cleanup_paths = try planRegistryCleanupPaths(allocator, input.cleanup),
         .mount_disk = try planRegistryMountDisk(input.mount_disk),
         .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
@@ -971,6 +978,16 @@ fn planRegistryPortForwards(
         });
     }
     return forwards.toOwnedSlice(allocator);
+}
+
+fn planRegistryBootLogPath(allocator: std.mem.Allocator, input: RegistryShapeInput) !?[]const u8 {
+    if (!input.detached) return null;
+    const pid = input.child_pid orelse return null;
+    if (pid <= 0) return null;
+    const root = input.boot_log_root orelse return null;
+    const file = try std.fmt.allocPrint(allocator, "{d}.boot.log", .{pid});
+    defer allocator.free(file);
+    return try std.fs.path.join(allocator, &.{ root, file });
 }
 
 fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePlan {
@@ -1502,11 +1519,15 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
             .upper_path = "/tmp/upper.img",
         },
         .live_mounts = &live,
+        .boot_log_root = "/tmp/machinen-logs",
+        .child_pid = 1234,
+        .detached = true,
         .port_forwards = &[_]PortForwardMapping{
             .{ .host_port = 8080, .guest_port = 80, .host_addr = "127.0.0.1" },
             .{ .host_port = 8443, .guest_port = 443 },
         },
     });
+    defer allocator.free(plan.boot_log_path.?);
     defer allocator.free(plan.cleanup_paths);
     defer allocator.free(plan.live_mounts);
     defer allocator.free(plan.port_forwards);
@@ -1514,6 +1535,7 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/images/rootfs.tar.gz", plan.source_image_path.?);
     try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);
     try std.testing.expectEqualStrings("block", plan.root_disk_mode);
+    try std.testing.expectEqualStrings("/tmp/machinen-logs/1234.boot.log", plan.boot_log_path.?);
     try std.testing.expectEqual(@as(@TypeOf(plan.cleanup_paths.len), 6), plan.cleanup_paths.len);
     try std.testing.expectEqualStrings("/tmp/root.img", plan.cleanup_paths[0]);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.cleanup_paths[1]);

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -222,6 +222,20 @@ pub const VmstateEnvPlan = struct {
     vmstate_timing: ?[]const u8,
 };
 
+pub const VmstateRuntimeInput = struct {
+    state_path: ?[]const u8 = null,
+    chain_id: ?[]const u8 = null,
+    restore_path: ?[]const u8 = null,
+    forked_from: ?[]const u8 = null,
+};
+
+pub const VmstateRuntimePlan = struct {
+    state_path: ?[]const u8,
+    chain_id: ?[]const u8,
+    checkpoint_parent: ?[]const u8,
+    checkpoint_sequence: ?u64,
+};
+
 pub const LiveMountInput = struct {
     host: []const u8,
     guest: []const u8,
@@ -457,6 +471,7 @@ pub const PlanError = error{
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
     MissingRegistryVmstateField,
+    MissingVmstateRuntimeChainId,
 };
 
 pub fn planBootTimeout(timeout_ms: ?u64, forever: bool) ?u64 {
@@ -505,6 +520,28 @@ fn sanitizeHostnameName(allocator: std.mem.Allocator, name: []const u8) ![]const
 
 fn isHostnameAlnum(c: u8) bool {
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9');
+}
+
+pub fn planVmstateRuntime(input: VmstateRuntimeInput) PlanError!VmstateRuntimePlan {
+    if (input.state_path == null and
+        input.chain_id == null and
+        input.restore_path == null and
+        input.forked_from == null)
+    {
+        return .{
+            .state_path = null,
+            .chain_id = null,
+            .checkpoint_parent = null,
+            .checkpoint_sequence = null,
+        };
+    }
+    const chain_id = input.chain_id orelse return error.MissingVmstateRuntimeChainId;
+    return .{
+        .state_path = input.state_path,
+        .chain_id = chain_id,
+        .checkpoint_parent = if (input.restore_path != null) input.forked_from else null,
+        .checkpoint_sequence = 0,
+    };
 }
 
 pub fn planNestedEnv(nested: bool) ?[]const u8 {
@@ -1417,6 +1454,35 @@ test "planPdeathsig defaults on and lets detach or explicit false disable it" {
     try std.testing.expect(planPdeathsig(.{ .pdeathsig = true }));
     try std.testing.expect(!planPdeathsig(.{ .pdeathsig = false }));
     try std.testing.expect(!planPdeathsig(.{ .detached = true, .pdeathsig = true }));
+}
+
+test "planVmstateRuntime projects chain defaults and restore parent" {
+    const fresh = try planVmstateRuntime(.{
+        .state_path = "/tmp/state.vmstate",
+        .chain_id = "chain-1",
+    });
+    try std.testing.expectEqualStrings("/tmp/state.vmstate", fresh.state_path.?);
+    try std.testing.expectEqualStrings("chain-1", fresh.chain_id.?);
+    try std.testing.expect(fresh.checkpoint_parent == null);
+    try std.testing.expectEqual(@as(u64, 0), fresh.checkpoint_sequence.?);
+
+    const restore = try planVmstateRuntime(.{
+        .state_path = "/tmp/state.vmstate",
+        .chain_id = "chain-2",
+        .restore_path = "/tmp/restore.vmstate",
+        .forked_from = "/snap/parent",
+    });
+    try std.testing.expectEqualStrings("/snap/parent", restore.checkpoint_parent.?);
+    try std.testing.expectEqual(@as(u64, 0), restore.checkpoint_sequence.?);
+
+    const empty = try planVmstateRuntime(.{});
+    try std.testing.expect(empty.state_path == null);
+    try std.testing.expect(empty.chain_id == null);
+    try std.testing.expect(empty.checkpoint_sequence == null);
+
+    try std.testing.expectError(error.MissingVmstateRuntimeChainId, planVmstateRuntime(.{
+        .state_path = "/tmp/state.vmstate",
+    }));
 }
 
 test "planNestedEnv sets nested only when requested" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -12,6 +12,10 @@ const assert = std.debug.assert;
 
 const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
+const default_cpu_max_vcpus: u64 = 1;
+const default_cpu_weight: u64 = 100;
+const min_cpu_weight: u64 = 1;
+const max_cpu_weight: u64 = 10_000;
 const max_live_mounts = 5;
 const restore_command = [_][]const u8{"/sbin/machinen-restore"};
 const poweroff_command = [_][]const u8{"/sbin/machinen-poweroff"};
@@ -26,6 +30,18 @@ pub const RootDiskMode = enum {
 pub const ResourcesMemory = struct {
     max_mib: u64,
     reclaim: ?[]const u8,
+};
+
+pub const CpuResourcesInput = struct {
+    max_vcpus: ?u64 = null,
+    quota_cpus: ?f64 = null,
+    weight: ?u64 = null,
+};
+
+pub const CpuPolicyPlan = struct {
+    max_vcpus: u64,
+    quota_cpus: ?f64,
+    weight: u64,
 };
 
 pub const EnvPair = struct {
@@ -357,6 +373,11 @@ pub const PlanError = error{
     InvalidMemory,
     ConflictingMemory,
     InvalidReclaim,
+    InvalidCpuMaxVcpus,
+    UnsupportedCpuMaxVcpus,
+    InvalidCpuQuotaCpus,
+    CpuQuotaExceedsMaxVcpus,
+    InvalidCpuWeight,
     CmdWithoutImage,
     RootDiskWithoutImage,
     MissingAutoMemory,
@@ -373,6 +394,23 @@ pub const PlanError = error{
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
 };
+
+pub fn planCpuResources(input: ?CpuResourcesInput) PlanError!?CpuPolicyPlan {
+    const cpu = input orelse return null;
+    const max_vcpus = cpu.max_vcpus orelse default_cpu_max_vcpus;
+    if (max_vcpus < 1) return error.InvalidCpuMaxVcpus;
+    if (max_vcpus != default_cpu_max_vcpus) return error.UnsupportedCpuMaxVcpus;
+
+    const quota_cpus = if (cpu.quota_cpus) |quota| blk: {
+        if (!std.math.isFinite(quota) or quota <= 0) return error.InvalidCpuQuotaCpus;
+        if (quota > @as(f64, @floatFromInt(max_vcpus))) return error.CpuQuotaExceedsMaxVcpus;
+        break :blk quota;
+    } else null;
+
+    const weight = cpu.weight orelse default_cpu_weight;
+    if (weight < min_cpu_weight or weight > max_cpu_weight) return error.InvalidCpuWeight;
+    return .{ .max_vcpus = max_vcpus, .quota_cpus = quota_cpus, .weight = weight };
+}
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
     assert(@sizeOf(GuestEnvInput) > 0);
@@ -1146,6 +1184,31 @@ test "planCore resolves explicit memory aliases" {
         .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+}
+
+test "planCpuResources applies defaults and validates cpu policy" {
+    try std.testing.expect((try planCpuResources(null)) == null);
+
+    const defaults = (try planCpuResources(.{})).?;
+    try std.testing.expectEqual(@as(u64, 1), defaults.max_vcpus);
+    try std.testing.expect(defaults.quota_cpus == null);
+    try std.testing.expectEqual(@as(u64, 100), defaults.weight);
+
+    const constrained = (try planCpuResources(.{
+        .max_vcpus = 1,
+        .quota_cpus = 0.5,
+        .weight = 200,
+    })).?;
+    try std.testing.expectEqual(@as(u64, 1), constrained.max_vcpus);
+    try std.testing.expectEqual(@as(f64, 0.5), constrained.quota_cpus.?);
+    try std.testing.expectEqual(@as(u64, 200), constrained.weight);
+
+    try std.testing.expectError(error.InvalidCpuMaxVcpus, planCpuResources(.{ .max_vcpus = 0 }));
+    try std.testing.expectError(error.UnsupportedCpuMaxVcpus, planCpuResources(.{ .max_vcpus = 2 }));
+    try std.testing.expectError(error.InvalidCpuQuotaCpus, planCpuResources(.{ .quota_cpus = 0 }));
+    try std.testing.expectError(error.CpuQuotaExceedsMaxVcpus, planCpuResources(.{ .quota_cpus = 1.5 }));
+    try std.testing.expectError(error.InvalidCpuWeight, planCpuResources(.{ .weight = 0 }));
+    try std.testing.expectError(error.InvalidCpuWeight, planCpuResources(.{ .weight = 10_001 }));
 }
 
 test "planCore validates command and rootdisk image requirements" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -14,6 +14,7 @@ const memory_floor_mib: u64 = 512;
 const memory_default_ceiling_mib: u64 = 4096;
 const default_cpu_max_vcpus: u64 = 1;
 const default_cpu_weight: u64 = 100;
+const default_boot_timeout_ms: u64 = 60_000;
 const min_cpu_weight: u64 = 1;
 const max_cpu_weight: u64 = 10_000;
 const max_live_mounts = 5;
@@ -406,6 +407,8 @@ pub const Input = struct {
     auto_memory_mib: ?u64 = null,
     host_total_bytes: ?u64 = null,
     vmm_memory_preset: bool = false,
+    boot_timeout_ms: ?u64 = null,
+    boot_timeout_forever: bool = false,
     has_image: bool = false,
     has_cmd: bool = false,
     has_snapshot: bool = false,
@@ -417,6 +420,7 @@ pub const Input = struct {
 pub const Plan = struct {
     memory_ceiling_mib: ?u64,
     vmm_memory_mib: ?u64,
+    timeout_ms: ?u64,
     wants_root_disk: bool,
     needs_initramfs: bool,
     normalized_mount_guest: ?[]const u8,
@@ -450,6 +454,11 @@ pub const PlanError = error{
     MissingRegistryCpuStatus,
     MissingRegistryVmstateField,
 };
+
+pub fn planBootTimeout(timeout_ms: ?u64, forever: bool) ?u64 {
+    if (forever) return null;
+    return timeout_ms orelse default_boot_timeout_ms;
+}
 
 pub fn planPdeathsig(input: PdeathsigInput) bool {
     assert(@sizeOf(PdeathsigInput) > 0);
@@ -1239,6 +1248,7 @@ pub fn planCore(input: Input) PlanError!Plan {
     const wants_root_disk = input.root_disk != .false_value and
         (input.root_disk == .path or input.root_disk == .true_value or input.has_image);
     const needs_initramfs = input.has_image or input.has_cmd or input.has_snapshot;
+    const timeout_ms = planBootTimeout(input.boot_timeout_ms, input.boot_timeout_forever);
     if (wants_root_disk and input.root_disk != .path and !input.has_image) {
         return error.RootDiskWithoutImage;
     }
@@ -1253,6 +1263,7 @@ pub fn planCore(input: Input) PlanError!Plan {
         return .{
             .memory_ceiling_mib = null,
             .vmm_memory_mib = null,
+            .timeout_ms = timeout_ms,
             .wants_root_disk = wants_root_disk,
             .needs_initramfs = needs_initramfs,
             .normalized_mount_guest = normalized_mount_guest,
@@ -1268,6 +1279,7 @@ pub fn planCore(input: Input) PlanError!Plan {
     return .{
         .memory_ceiling_mib = ceiling,
         .vmm_memory_mib = ceiling,
+        .timeout_ms = timeout_ms,
         .wants_root_disk = wants_root_disk,
         .needs_initramfs = needs_initramfs,
         .normalized_mount_guest = normalized_mount_guest,
@@ -1347,6 +1359,20 @@ test "planCore resolves explicit memory aliases" {
         .resources_memory = .{ .max_mib = 2048, .reclaim = "manual" },
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+}
+
+test "planBootTimeout defaults, preserves explicit values, and supports forever" {
+    try std.testing.expectEqual(@as(?u64, 60_000), planBootTimeout(null, false));
+    try std.testing.expectEqual(@as(?u64, 2_500), planBootTimeout(2_500, false));
+    try std.testing.expect(planBootTimeout(2_500, true) == null);
+    try std.testing.expect((try planCore(std.testing.allocator, .{
+        .memory_mib = 256,
+        .boot_timeout_ms = 1_234,
+    })).timeout_ms.? == 1_234);
+    try std.testing.expect((try planCore(std.testing.allocator, .{
+        .memory_mib = 256,
+        .boot_timeout_forever = true,
+    })).timeout_ms == null);
 }
 
 test "planGuestHostname sanitizes names and includes pid" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -73,6 +73,7 @@ pub const VsockPlan = struct {
 pub const PortForwardMapping = struct {
     host_port: i64,
     guest_port: i64,
+    host_addr: ?[]const u8 = null,
 };
 
 pub const PortForwardValidation = union(enum) {
@@ -104,6 +105,7 @@ pub const BundleCommandInput = struct {
     snapshot_restore: bool = false,
     vmstate_restore: bool = false,
     live_mounts: []const LiveMount = &.{},
+    port_forwards: []const PortForwardMapping = &.{},
     cpu_policy: ?CpuPolicyPlan = null,
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
@@ -339,6 +341,12 @@ pub const RegistryLiveMountPlan = struct {
     mode: []const u8,
 };
 
+pub const RegistryPortForwardPlan = struct {
+    host_port: i64,
+    guest_port: i64,
+    host_addr: ?[]const u8,
+};
+
 pub const RegistryCpuPlan = struct {
     max_vcpus: u64,
     quota_cpus: ?f64,
@@ -368,6 +376,7 @@ pub const RegistryShapeInput = struct {
     cleanup: RegistryCleanupInput = .{},
     mount_disk: RegistryMountDiskInput = .{},
     live_mounts: []const LiveMount = &.{},
+    port_forwards: []const PortForwardMapping = &.{},
     cpu_policy: ?CpuPolicyPlan = null,
     cpu_control_status: ?[]const u8 = null,
     cpu_control_reason: ?[]const u8 = null,
@@ -381,6 +390,7 @@ pub const RegistryShapePlan = struct {
     cleanup_paths: []const []const u8,
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
+    port_forwards: []const RegistryPortForwardPlan,
     cpu: ?RegistryCpuPlan,
     vmstate: RegistryVmstatePlan,
 };
@@ -930,9 +940,28 @@ pub fn planRegistryShape(
         .cleanup_paths = try planRegistryCleanupPaths(allocator, input.cleanup),
         .mount_disk = try planRegistryMountDisk(input.mount_disk),
         .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
+        .port_forwards = try planRegistryPortForwards(allocator, input.port_forwards),
         .cpu = try planRegistryCpu(input),
         .vmstate = try planRegistryVmstate(input.vmstate),
     };
+}
+
+fn planRegistryPortForwards(
+    allocator: std.mem.Allocator,
+    input: []const PortForwardMapping,
+) ![]const RegistryPortForwardPlan {
+    assert(@sizeOf(PortForwardMapping) > 0);
+
+    var forwards: std.array_list.Aligned(RegistryPortForwardPlan, null) = .empty;
+    errdefer forwards.deinit(allocator);
+    for (input) |mapping| {
+        try forwards.append(allocator, .{
+            .host_port = mapping.host_port,
+            .guest_port = mapping.guest_port,
+            .host_addr = mapping.host_addr,
+        });
+    }
+    return forwards.toOwnedSlice(allocator);
 }
 
 fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePlan {
@@ -1447,9 +1476,14 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
             .upper_path = "/tmp/upper.img",
         },
         .live_mounts = &live,
+        .port_forwards = &[_]PortForwardMapping{
+            .{ .host_port = 8080, .guest_port = 80, .host_addr = "127.0.0.1" },
+            .{ .host_port = 8443, .guest_port = 443 },
+        },
     });
     defer allocator.free(plan.cleanup_paths);
     defer allocator.free(plan.live_mounts);
+    defer allocator.free(plan.port_forwards);
 
     try std.testing.expectEqualStrings("/images/rootfs.tar.gz", plan.source_image_path.?);
     try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -94,6 +94,9 @@ pub const BundleCommandInput = struct {
     snapshot_restore: bool = false,
     vmstate_restore: bool = false,
     live_mounts: []const LiveMount = &.{},
+    cpu_policy: ?CpuPolicyPlan = null,
+    cpu_control_status: ?[]const u8 = null,
+    cpu_control_reason: ?[]const u8 = null,
 };
 
 pub const BundleEnvInput = struct {
@@ -325,6 +328,14 @@ pub const RegistryLiveMountPlan = struct {
     mode: []const u8,
 };
 
+pub const RegistryCpuPlan = struct {
+    max_vcpus: u64,
+    quota_cpus: ?f64,
+    weight: u64,
+    enforcement_status: []const u8,
+    enforcement_reason: ?[]const u8,
+};
+
 pub const RegistryShapeInput = struct {
     source_image_path: ?[]const u8 = null,
     per_boot_root_disk: ?[]const u8 = null,
@@ -332,6 +343,9 @@ pub const RegistryShapeInput = struct {
     cleanup: RegistryCleanupInput = .{},
     mount_disk: RegistryMountDiskInput = .{},
     live_mounts: []const LiveMount = &.{},
+    cpu_policy: ?CpuPolicyPlan = null,
+    cpu_control_status: ?[]const u8 = null,
+    cpu_control_reason: ?[]const u8 = null,
 };
 
 pub const RegistryShapePlan = struct {
@@ -341,6 +355,7 @@ pub const RegistryShapePlan = struct {
     cleanup_paths: []const []const u8,
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
+    cpu: ?RegistryCpuPlan,
 };
 
 pub const MachinenConfigInput = struct {
@@ -393,6 +408,7 @@ pub const PlanError = error{
     MissingMountDiskRuntimeField,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
+    MissingRegistryCpuStatus,
 };
 
 pub fn planCpuResources(input: ?CpuResourcesInput) PlanError!?CpuPolicyPlan {
@@ -835,6 +851,21 @@ pub fn planRegistryShape(
         .cleanup_paths = try planRegistryCleanupPaths(allocator, input.cleanup),
         .mount_disk = try planRegistryMountDisk(input.mount_disk),
         .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
+        .cpu = try planRegistryCpu(input),
+    };
+}
+
+fn planRegistryCpu(input: RegistryShapeInput) PlanError!?RegistryCpuPlan {
+    assert(@sizeOf(RegistryShapeInput) > 0);
+
+    const policy = input.cpu_policy orelse return null;
+    const status = input.cpu_control_status orelse return error.MissingRegistryCpuStatus;
+    return .{
+        .max_vcpus = policy.max_vcpus,
+        .quota_cpus = policy.quota_cpus,
+        .weight = policy.weight,
+        .enforcement_status = status,
+        .enforcement_reason = input.cpu_control_reason,
     };
 }
 
@@ -1298,6 +1329,11 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/mnt/data", plan.mount_disk.?.guest);
     try std.testing.expectEqualStrings("/cache/lower.sqfs", plan.mount_disk.?.lower_path);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.mount_disk.?.upper_path);
+    try std.testing.expectEqual(@as(u64, 1), plan.cpu.?.max_vcpus);
+    try std.testing.expectEqual(@as(f64, 0.5), plan.cpu.?.quota_cpus.?);
+    try std.testing.expectEqual(@as(u64, 200), plan.cpu.?.weight);
+    try std.testing.expectEqualStrings("linux-cgroup-v2", plan.cpu.?.enforcement_status);
+    try std.testing.expectEqualStrings("limited", plan.cpu.?.enforcement_reason.?);
     try std.testing.expectEqual(@as(@TypeOf(plan.live_mounts.len), 2), plan.live_mounts.len);
     try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
     try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -798,6 +798,7 @@ fn writeCoreFields(
 
     try writeNullableU64Field(io, "memoryCeilingMib", plan.memory_ceiling_mib, false);
     try writeNullableU64StringField(io, "vmmMemory", plan.vmm_memory_mib, true);
+    try writeBoolField(io, "needsInitramfs", plan.needs_initramfs, true);
     try writeCpuPolicyField(io, "cpuPolicy", cpu_policy, true);
     try writeBoolField(io, "wantsRootDisk", plan.wants_root_disk, true);
     try writeNullableStringField(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -97,6 +97,10 @@ const ParsedRequest = struct {
     registry_cpu_policy_weight_text: ?[]const u8 = null,
     registry_cpu_control_status: ?[]const u8 = null,
     registry_cpu_control_reason: ?[]const u8 = null,
+    registry_vmstate_path: ?[]const u8 = null,
+    registry_vmstate_chain_id: ?[]const u8 = null,
+    registry_vmstate_checkpoint_parent: ?[]const u8 = null,
+    registry_vmstate_checkpoint_sequence_text: ?[]const u8 = null,
     registry_mount_guest: ?[]const u8 = null,
     registry_mount_lower_path: ?[]const u8 = null,
     registry_mount_upper_path: ?[]const u8 = null,
@@ -203,6 +207,10 @@ const boot_plan_fields = [_][]const u8{
     "registryCpuPolicyWeight",
     "registryCpuControlStatus",
     "registryCpuControlReason",
+    "registryVmstatePath",
+    "registryVmstateChainId",
+    "registryVmstateCheckpointParent",
+    "registryVmstateCheckpointSequence",
     "registryMountGuest",
     "registryMountLowerPath",
     "registryMountUpperPath",
@@ -313,6 +321,10 @@ const RequestError = error{
     InvalidRegistryCpuPolicy,
     InvalidRegistryCpuControlStatus,
     InvalidRegistryCpuControlReason,
+    InvalidRegistryVmstatePath,
+    InvalidRegistryVmstateChainId,
+    InvalidRegistryVmstateCheckpointParent,
+    InvalidRegistryVmstateCheckpointSequence,
     InvalidRegistryMountGuest,
     InvalidRegistryMountLowerPath,
     InvalidRegistryMountUpperPath,
@@ -679,6 +691,10 @@ fn makeRegistryShape(
 ) !boot_plan.RegistryShapePlan {
     assert(@sizeOf(boot_plan.RegistryShapePlan) > 0);
 
+    const registry_vmstate_checkpoint_sequence = try optionalUnsignedText(
+        parsed.registry_vmstate_checkpoint_sequence_text,
+        error.InvalidRegistryVmstateCheckpointSequence,
+    );
     return boot_plan.planRegistryShape(arena, .{
         .source_image_path = parsed.registry_source_image_path,
         .per_boot_root_disk = parsed.registry_per_boot_root_disk,
@@ -702,6 +718,12 @@ fn makeRegistryShape(
         .cpu_policy = try makeRegistryCpuPolicy(parsed),
         .cpu_control_status = parsed.registry_cpu_control_status,
         .cpu_control_reason = parsed.registry_cpu_control_reason,
+        .vmstate = .{
+            .state_path = parsed.registry_vmstate_path,
+            .chain_id = parsed.registry_vmstate_chain_id,
+            .checkpoint_parent = parsed.registry_vmstate_checkpoint_parent,
+            .checkpoint_sequence = registry_vmstate_checkpoint_sequence,
+        },
     });
 }
 
@@ -1170,6 +1192,7 @@ fn writeRegistryShapeField(
     try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
     try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
     try writeRegistryCpuField(io, "cpu", registry.cpu, true);
+    try writeRegistryVmstateField(io, "vmstate", registry.vmstate, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1216,6 +1239,23 @@ fn writeRegistryLiveMountsField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeRegistryVmstateField(
+    io: std.Io,
+    comptime field: []const u8,
+    vmstate: boot_plan.RegistryVmstatePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "statePath", vmstate.state_path, false);
+    try writeNullableStringField(io, "chainId", vmstate.chain_id, true);
+    try writeNullableStringField(io, "checkpointParent", vmstate.checkpoint_parent, true);
+    try writeNullableU64Field(io, "checkpointSequence", vmstate.checkpoint_sequence, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeRegistryCpuField(
@@ -2020,6 +2060,26 @@ fn parseRegistryCleanupFields(
         object,
         "registryCpuControlReason",
         error.InvalidRegistryCpuControlReason,
+    );
+    request.registry_vmstate_path = try optionalStringDefaultNull(
+        object,
+        "registryVmstatePath",
+        error.InvalidRegistryVmstatePath,
+    );
+    request.registry_vmstate_chain_id = try optionalStringDefaultNull(
+        object,
+        "registryVmstateChainId",
+        error.InvalidRegistryVmstateChainId,
+    );
+    request.registry_vmstate_checkpoint_parent = try optionalStringDefaultNull(
+        object,
+        "registryVmstateCheckpointParent",
+        error.InvalidRegistryVmstateCheckpointParent,
+    );
+    request.registry_vmstate_checkpoint_sequence_text = try optionalStringDefaultNull(
+        object,
+        "registryVmstateCheckpointSequence",
+        error.InvalidRegistryVmstateCheckpointSequence,
     );
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -34,6 +34,7 @@ const ParsedRequest = struct {
     restore_path: ?[]const u8 = null,
     enable_vmstate_timing: bool = false,
     existing_vmstate_timing: ?[]const u8 = null,
+    nested_requested: bool = false,
     live_mounts: []const boot_plan.LiveMountInput = &.{},
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
     existing_stats_file: ?[]const u8 = null,
@@ -139,6 +140,7 @@ const boot_plan_fields = [_][]const u8{
     "restorePath",
     "enableVmstateTiming",
     "existingVmstateTiming",
+    "nested",
     "liveMounts",
     "liveMountsResolved",
     "existingStatsFile",
@@ -250,6 +252,7 @@ const RequestError = error{
     InvalidRestorePath,
     InvalidEnableVmstateTiming,
     InvalidExistingVmstateTiming,
+    InvalidNested,
     InvalidLiveMounts,
     InvalidLiveMountGuest,
     InvalidLiveMountsResolved,
@@ -349,6 +352,7 @@ const PlanParts = struct {
     vmm_argv: boot_plan.VmmArgvPlan,
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
+    nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
     stats_file: boot_plan.StatsFilePlan,
     planned_live_mounts: []const boot_plan.LiveMount,
@@ -426,6 +430,7 @@ fn makePlanParts(
             .enable_timing = parsed.enable_vmstate_timing,
             .existing_timing = parsed.existing_vmstate_timing,
         }),
+        .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
         .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
         .stats_file = boot_plan.planStatsFile(.{
             .existing_path = parsed.existing_stats_file,
@@ -723,6 +728,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeCoreFields(io, parts.plan, parts.cpu_policy);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
+    try writeNullableStringField(io, "vmmNested", parts.nested_env, true);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
     try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
@@ -1597,6 +1603,7 @@ fn parseVmstateFields(object: std.json.ObjectMap, request: *ParsedRequest) Reque
         "existingVmstateTiming",
         error.InvalidExistingVmstateTiming,
     );
+    request.nested_requested = try optionalBoolDefaultFalse(object, "nested", error.InvalidNested);
 }
 
 fn parseRuntimeMountStatsFields(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -10,6 +10,7 @@ pub const name = "boot-plan";
 const ParsedRequest = struct {
     memory_mib_text: ?[]const u8 = null,
     resources_memory: ?ParsedResourcesMemory = null,
+    resources_cpu: ?ParsedResourcesCpu = null,
     auto_memory_mib_text: ?[]const u8 = null,
     host_total_bytes_text: ?[]const u8 = null,
     vmm_memory_preset: bool = false,
@@ -100,9 +101,16 @@ const ParsedResourcesMemory = struct {
     reclaim: ?[]const u8,
 };
 
+const ParsedResourcesCpu = struct {
+    max_vcpus_text: ?[]const u8,
+    quota_cpus_text: ?[]const u8,
+    weight_text: ?[]const u8,
+};
+
 const boot_plan_fields = [_][]const u8{
     "memoryMib",
     "resourcesMemory",
+    "resourcesCpu",
     "autoMemoryMib",
     "hostTotalBytes",
     "vmmMemoryPreset",
@@ -196,6 +204,10 @@ const RequestError = error{
     MissingResourcesMaxMib,
     InvalidResourcesMaxMib,
     InvalidResourcesReclaim,
+    InvalidResourcesCpu,
+    InvalidResourcesCpuMaxVcpus,
+    InvalidResourcesCpuQuotaCpus,
+    InvalidResourcesCpuWeight,
     MissingAutoMemoryMib,
     InvalidAutoMemoryMib,
     MissingHostTotalBytes,
@@ -318,6 +330,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
 
 const PlanParts = struct {
     plan: boot_plan.Plan,
+    cpu_policy: ?boot_plan.CpuPolicyPlan,
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
     vmm_argv: boot_plan.VmmArgvPlan,
@@ -379,6 +392,7 @@ fn makePlanParts(
     const runtime = try makeRuntimeParts(arena, parsed);
     return .{
         .plan = plan,
+        .cpu_policy = try makeCpuResources(parsed),
         .guest_env = try makeGuestEnv(arena, parsed),
         .vsock_plan = try boot_plan.planVsock(arena, .{
             .existing_spec = parsed.existing_vsock_spec,
@@ -533,6 +547,30 @@ fn makeProvisionBoot(
     });
 }
 
+fn makeCpuResources(parsed: ParsedRequest) !?boot_plan.CpuPolicyPlan {
+    const cpu = parsed.resources_cpu orelse return null;
+    return boot_plan.planCpuResources(.{
+        .max_vcpus = try optionalUnsignedText(
+            cpu.max_vcpus_text,
+            error.InvalidResourcesCpuMaxVcpus,
+        ),
+        .quota_cpus = try optionalFloatText(
+            cpu.quota_cpus_text,
+            error.InvalidResourcesCpuQuotaCpus,
+        ),
+        .weight = try optionalUnsignedText(cpu.weight_text, error.InvalidResourcesCpuWeight),
+    });
+}
+
+fn optionalFloatText(text: ?[]const u8, err: RequestError) RequestError!?f64 {
+    assert(@errorName(err).len > 0);
+
+    if (text) |value| {
+        return parseFloat(value) catch err;
+    }
+    return null;
+}
+
 fn makeProvisionRuntime(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -644,7 +682,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
 
     try protocol.stdout(io, "{\"ok\":true,\"protocolVersion\":1,");
     try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
-    try writeCoreFields(io, parts.plan);
+    try writeCoreFields(io, parts.plan, parts.cpu_policy);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
@@ -673,11 +711,16 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try protocol.stdout(io, "}}\n");
 }
 
-fn writeCoreFields(io: std.Io, plan: boot_plan.Plan) !void {
+fn writeCoreFields(
+    io: std.Io,
+    plan: boot_plan.Plan,
+    cpu_policy: ?boot_plan.CpuPolicyPlan,
+) !void {
     assert(@sizeOf(boot_plan.Plan) > 0);
 
     try writeNullableU64Field(io, "memoryCeilingMib", plan.memory_ceiling_mib, false);
     try writeNullableU64StringField(io, "vmmMemory", plan.vmm_memory_mib, true);
+    try writeCpuPolicyField(io, "cpuPolicy", cpu_policy, true);
     try writeBoolField(io, "wantsRootDisk", plan.wants_root_disk, true);
     try writeNullableStringField(
         io,
@@ -685,6 +728,40 @@ fn writeCoreFields(io: std.Io, plan: boot_plan.Plan) !void {
         plan.normalized_mount_guest,
         true,
     );
+}
+
+fn writeCpuPolicyField(
+    io: std.Io,
+    comptime field: []const u8,
+    cpu_policy: ?boot_plan.CpuPolicyPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (cpu_policy) |cpu| {
+        try protocol.stdout(io, "{\"maxVcpus\":");
+        try writeU64Bare(io, cpu.max_vcpus);
+        if (cpu.quota_cpus) |quota| {
+            try protocol.stdout(io, ",\"quotaCpus\":");
+            try writeF64Bare(io, quota);
+        }
+        try protocol.stdout(io, ",\"weight\":");
+        try writeU64Bare(io, cpu.weight);
+        try protocol.stdout(io, "}");
+    } else {
+        try protocol.stdout(io, "null");
+    }
+}
+
+fn writeU64Bare(io: std.Io, value: u64) !void {
+    var buf: [32]u8 = undefined;
+    try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
+}
+
+fn writeF64Bare(io: std.Io, value: f64) !void {
+    var buf: [64]u8 = undefined;
+    try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
 }
 
 fn writeVsockKernelFields(
@@ -1259,6 +1336,13 @@ fn parseUnsigned(text: []const u8) !u64 {
     return std.fmt.parseUnsigned(u64, text, 10);
 }
 
+fn parseFloat(text: []const u8) !f64 {
+    assert(@sizeOf(f64) > 0);
+
+    if (text.len == 0) return error.Invalid;
+    return std.fmt.parseFloat(f64, text);
+}
+
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!ParsedRequest {
     assert(protocol.version == 1);
 
@@ -1308,6 +1392,7 @@ fn parseMemoryFields(
         error.InvalidMemoryMib,
     );
     request.resources_memory = try optionalResourcesMemory(object);
+    request.resources_cpu = try optionalResourcesCpu(object);
     request.auto_memory_mib_text = try optionalString(
         object,
         "autoMemoryMib",
@@ -2153,6 +2238,30 @@ fn requiredBool(
     return switch (value) {
         .bool => |b| b,
         else => invalid,
+    };
+}
+
+fn optionalResourcesCpu(object: std.json.ObjectMap) RequestError!?ParsedResourcesCpu {
+    const value = object.get("resourcesCpu") orelse return null;
+    if (value == .null) return null;
+    if (value != .object) return error.InvalidResourcesCpu;
+    try protocol.rejectUnknownFields(value.object, &.{ "maxVcpus", "quotaCpus", "weight" });
+    return .{
+        .max_vcpus_text = try optionalStringDefaultNull(
+            value.object,
+            "maxVcpus",
+            error.InvalidResourcesCpuMaxVcpus,
+        ),
+        .quota_cpus_text = try optionalStringDefaultNull(
+            value.object,
+            "quotaCpus",
+            error.InvalidResourcesCpuQuotaCpus,
+        ),
+        .weight_text = try optionalStringDefaultNull(
+            value.object,
+            "weight",
+            error.InvalidResourcesCpuWeight,
+        ),
     };
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -92,6 +92,9 @@ const ParsedRequest = struct {
     registry_source_image_path: ?[]const u8 = null,
     registry_per_boot_root_disk: ?[]const u8 = null,
     registry_caller_root_disk_path: ?[]const u8 = null,
+    registry_boot_log_root: ?[]const u8 = null,
+    registry_child_pid_text: ?[]const u8 = null,
+    registry_detached: bool = false,
     registry_per_boot_snap_disk: ?[]const u8 = null,
     registry_per_boot_mount_upper: ?[]const u8 = null,
     registry_bundle_temp_dir: ?[]const u8 = null,
@@ -208,6 +211,9 @@ const boot_plan_fields = [_][]const u8{
     "registrySourceImagePath",
     "registryPerBootRootDisk",
     "registryCallerRootDiskPath",
+    "registryBootLogRoot",
+    "registryChildPid",
+    "registryDetached",
     "registryPerBootSnapDisk",
     "registryPerBootMountUpper",
     "registryBundleTempDir",
@@ -337,6 +343,9 @@ const RequestError = error{
     InvalidMountDiskUpperSize,
     InvalidRegistrySourceImagePath,
     InvalidRegistryRootDiskPath,
+    InvalidRegistryBootLogRoot,
+    InvalidRegistryChildPid,
+    InvalidRegistryDetached,
     InvalidRegistryCleanupPath,
     InvalidRegistryCpuPolicy,
     InvalidRegistryCpuControlStatus,
@@ -724,10 +733,17 @@ fn makeRegistryShape(
         parsed.registry_vmstate_checkpoint_sequence_text,
         error.InvalidRegistryVmstateCheckpointSequence,
     );
+    const registry_child_pid = if (parsed.registry_child_pid_text) |text|
+        parseSigned(text) catch return error.InvalidRegistryChildPid
+    else
+        null;
     return boot_plan.planRegistryShape(arena, .{
         .source_image_path = parsed.registry_source_image_path,
         .per_boot_root_disk = parsed.registry_per_boot_root_disk,
         .caller_root_disk_path = parsed.registry_caller_root_disk_path,
+        .boot_log_root = parsed.registry_boot_log_root,
+        .child_pid = registry_child_pid,
+        .detached = parsed.registry_detached,
         .cleanup = .{
             .per_boot_root_disk = parsed.registry_per_boot_root_disk,
             .per_boot_snap_disk = parsed.registry_per_boot_snap_disk,
@@ -2126,6 +2142,21 @@ fn parseRegistryRootDiskFields(
         object,
         "registryCallerRootDiskPath",
         error.InvalidRegistryRootDiskPath,
+    );
+    request.registry_boot_log_root = try optionalStringDefaultNull(
+        object,
+        "registryBootLogRoot",
+        error.InvalidRegistryBootLogRoot,
+    );
+    request.registry_child_pid_text = try optionalStringDefaultNull(
+        object,
+        "registryChildPid",
+        error.InvalidRegistryChildPid,
+    );
+    request.registry_detached = try optionalBoolDefaultFalse(
+        object,
+        "registryDetached",
+        error.InvalidRegistryDetached,
     );
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -846,6 +846,11 @@ fn writeU64Bare(io: std.Io, value: u64) !void {
     try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
 }
 
+fn writeI64Bare(io: std.Io, value: i64) !void {
+    var buf: [32]u8 = undefined;
+    try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
+}
+
 fn writeF64Bare(io: std.Io, value: f64) !void {
     var buf: [64]u8 = undefined;
     try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
@@ -1212,6 +1217,7 @@ fn writeRegistryShapeField(
     try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, true);
     try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
     try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
+    try writeRegistryPortForwardsField(io, "portForward", registry.port_forwards, true);
     try writeRegistryCpuField(io, "cpu", registry.cpu, true);
     try writeRegistryVmstateField(io, "vmstate", registry.vmstate, true);
     try protocol.stdout(io, "}");
@@ -1257,6 +1263,35 @@ fn writeRegistryLiveMountsField(
         try protocol.writeJsonString(io, mount.host);
         try protocol.stdout(io, ",\"mode\":");
         try protocol.writeJsonString(io, mount.mode);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
+}
+
+fn writeRegistryPortForwardsField(
+    io: std.Io,
+    comptime field: []const u8,
+    forwards: []const boot_plan.RegistryPortForwardPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (forwards.len == 0) {
+        try protocol.stdout(io, "null");
+        return;
+    }
+    try protocol.stdout(io, "[");
+    for (forwards, 0..) |mapping, i| {
+        if (i > 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{\"hostPort\":");
+        try writeI64Bare(io, mapping.host_port);
+        try protocol.stdout(io, ",\"guestPort\":");
+        try writeI64Bare(io, mapping.guest_port);
+        if (mapping.host_addr) |host_addr| {
+            try protocol.stdout(io, ",\"hostAddr\":");
+            try protocol.writeJsonString(io, host_addr);
+        }
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
@@ -2407,7 +2442,11 @@ fn optionalPortForward(
         const guest_port = try requiredPort(item.object, "guestPort", error.InvalidGuestPort);
         const host_addr = item.object.get("hostAddr") orelse .null;
         if (host_addr != .null and host_addr != .string) return error.InvalidPortForward;
-        try mappings.append(allocator, .{ .host_port = host_port, .guest_port = guest_port });
+        try mappings.append(allocator, .{
+            .host_port = host_port,
+            .guest_port = guest_port,
+            .host_addr = if (host_addr == .string) host_addr.string else null,
+        });
     }
     return mappings.toOwnedSlice(allocator);
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -96,6 +96,10 @@ const ParsedRequest = struct {
     registry_source_image_path: ?[]const u8 = null,
     registry_per_boot_root_disk: ?[]const u8 = null,
     registry_caller_root_disk_path: ?[]const u8 = null,
+    registry_disk_path: ?[]const u8 = null,
+    registry_forked_from: ?[]const u8 = null,
+    registry_memory_ceiling_mib_text: ?[]const u8 = null,
+    registry_stats_path: ?[]const u8 = null,
     registry_boot_log_root: ?[]const u8 = null,
     registry_child_pid_text: ?[]const u8 = null,
     registry_detached: bool = false,
@@ -219,6 +223,10 @@ const boot_plan_fields = [_][]const u8{
     "registrySourceImagePath",
     "registryPerBootRootDisk",
     "registryCallerRootDiskPath",
+    "registryDiskPath",
+    "registryForkedFrom",
+    "registryMemoryCeilingMib",
+    "registryStatsPath",
     "registryBootLogRoot",
     "registryChildPid",
     "registryDetached",
@@ -358,6 +366,10 @@ const RequestError = error{
     InvalidRegistryBootLogRoot,
     InvalidRegistryChildPid,
     InvalidRegistryDetached,
+    InvalidRegistryDiskPath,
+    InvalidRegistryForkedFrom,
+    InvalidRegistryMemoryCeilingMib,
+    InvalidRegistryStatsPath,
     InvalidRegistryCleanupPath,
     InvalidRegistryCpuPolicy,
     InvalidRegistryCpuControlStatus,
@@ -756,6 +768,10 @@ fn makeRegistryShape(
         parseSigned(text) catch return error.InvalidRegistryChildPid
     else
         null;
+    const registry_memory_ceiling_mib = try optionalUnsignedText(
+        parsed.registry_memory_ceiling_mib_text,
+        error.InvalidRegistryMemoryCeilingMib,
+    );
     return boot_plan.planRegistryShape(arena, .{
         .source_image_path = parsed.registry_source_image_path,
         .per_boot_root_disk = parsed.registry_per_boot_root_disk,
@@ -763,6 +779,10 @@ fn makeRegistryShape(
         .boot_log_root = parsed.registry_boot_log_root,
         .child_pid = registry_child_pid,
         .detached = parsed.registry_detached,
+        .disk_path = parsed.registry_disk_path,
+        .forked_from = parsed.registry_forked_from,
+        .memory_ceiling_mib = registry_memory_ceiling_mib,
+        .stats_path = parsed.registry_stats_path,
         .cleanup = .{
             .per_boot_root_disk = parsed.registry_per_boot_root_disk,
             .per_boot_snap_disk = parsed.registry_per_boot_snap_disk,
@@ -2181,6 +2201,26 @@ fn parseRegistryRootDiskFields(
         object,
         "registryCallerRootDiskPath",
         error.InvalidRegistryRootDiskPath,
+    );
+    request.registry_disk_path = try optionalStringDefaultNull(
+        object,
+        "registryDiskPath",
+        error.InvalidRegistryDiskPath,
+    );
+    request.registry_forked_from = try optionalStringDefaultNull(
+        object,
+        "registryForkedFrom",
+        error.InvalidRegistryForkedFrom,
+    );
+    request.registry_memory_ceiling_mib_text = try optionalStringDefaultNull(
+        object,
+        "registryMemoryCeilingMib",
+        error.InvalidRegistryMemoryCeilingMib,
+    );
+    request.registry_stats_path = try optionalStringDefaultNull(
+        object,
+        "registryStatsPath",
+        error.InvalidRegistryStatsPath,
     );
     request.registry_boot_log_root = try optionalStringDefaultNull(
         object,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -28,6 +28,8 @@ const ParsedRequest = struct {
     vmm_binary: ?[]const u8 = null,
     vmm_args: []const []const u8 = &.{},
     pdeathsig_path: ?[]const u8 = null,
+    pdeathsig_requested: ?bool = null,
+    detached: bool = false,
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
     vmstate_path: ?[]const u8 = null,
@@ -138,6 +140,8 @@ const boot_plan_fields = [_][]const u8{
     "vmmBinary",
     "vmmArgs",
     "pdeathsigPath",
+    "pdeathsig",
+    "detached",
     "kernelPath",
     "dtbPath",
     "vmstatePath",
@@ -254,6 +258,8 @@ const RequestError = error{
     InvalidVmmBinary,
     InvalidVmmArgs,
     InvalidPdeathsigPath,
+    InvalidPdeathsig,
+    InvalidDetached,
     InvalidKernelPath,
     InvalidDtbPath,
     InvalidVmstatePath,
@@ -362,6 +368,7 @@ const PlanParts = struct {
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
     vmm_argv: boot_plan.VmmArgvPlan,
+    use_pdeathsig: bool,
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
     nested_env: ?[]const u8,
@@ -431,6 +438,10 @@ fn makePlanParts(
             .binary = parsed.vmm_binary,
             .args = parsed.vmm_args,
             .pdeathsig_path = parsed.pdeathsig_path,
+        }),
+        .use_pdeathsig = boot_plan.planPdeathsig(.{
+            .detached = parsed.detached,
+            .pdeathsig = parsed.pdeathsig_requested,
         }),
         .kernel_dtb = boot_plan.planKernelDtb(.{
             .kernel_path = parsed.kernel_path,
@@ -755,6 +766,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
+    try writeBoolField(io, "usePdeathsig", parts.use_pdeathsig, true);
     try writeEnvObjectField(io, "mergedGuestEnv", parts.guest_env, true);
     try writeMachinenConfigField(io, "machinenConfig", parts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
@@ -1591,6 +1603,12 @@ fn parseTransportFields(
         "pdeathsigPath",
         error.InvalidPdeathsigPath,
     );
+    request.pdeathsig_requested = try optionalBoolDefaultNull(
+        object,
+        "pdeathsig",
+        error.InvalidPdeathsig,
+    );
+    request.detached = try optionalBoolDefaultFalse(object, "detached", error.InvalidDetached);
 }
 
 fn parseKernelVmstateFields(
@@ -2256,6 +2274,21 @@ fn optionalLiveMountsResolved(
         });
     }
     return mounts.toOwnedSlice(allocator);
+}
+
+fn optionalBoolDefaultNull(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!?bool {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return null;
+    return switch (value) {
+        .null => null,
+        .bool => |b| b,
+        else => invalid,
+    };
 }
 
 fn optionalBoolDefaultFalse(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -16,6 +16,7 @@ const ParsedRequest = struct {
     vmm_memory_preset: bool = false,
     has_image: bool = false,
     has_cmd: bool = false,
+    has_snapshot: bool = false,
     root_disk: boot_plan.RootDiskMode = .unset,
     guest_cwd: ?[]const u8 = null,
     mount_guest: ?[]const u8 = null,
@@ -32,6 +33,8 @@ const ParsedRequest = struct {
     pdeathsig_path: ?[]const u8 = null,
     pdeathsig_requested: ?bool = null,
     detached: bool = false,
+    boot_timeout_ms_text: ?[]const u8 = null,
+    boot_timeout_forever: bool = false,
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
     vmstate_path: ?[]const u8 = null,
@@ -146,6 +149,8 @@ const boot_plan_fields = [_][]const u8{
     "pdeathsigPath",
     "pdeathsig",
     "detached",
+    "bootTimeoutMs",
+    "bootTimeoutForever",
     "kernelPath",
     "dtbPath",
     "vmstatePath",
@@ -246,6 +251,7 @@ const RequestError = error{
     InvalidHasImage,
     MissingHasCmd,
     InvalidHasCmd,
+    InvalidHasSnapshot,
     MissingRootDisk,
     InvalidRootDisk,
     InvalidGuestCwd,
@@ -266,6 +272,8 @@ const RequestError = error{
     InvalidPdeathsigPath,
     InvalidPdeathsig,
     InvalidDetached,
+    InvalidBootTimeoutMs,
+    InvalidBootTimeoutForever,
     InvalidKernelPath,
     InvalidDtbPath,
     InvalidVmstatePath,
@@ -808,6 +816,7 @@ fn writeCoreFields(
 
     try writeNullableU64Field(io, "memoryCeilingMib", plan.memory_ceiling_mib, false);
     try writeNullableU64StringField(io, "vmmMemory", plan.vmm_memory_mib, true);
+    try writeNullableU64Field(io, "timeoutMs", plan.timeout_ms, true);
     try writeBoolField(io, "needsInitramfs", plan.needs_initramfs, true);
     try writeCpuPolicyField(io, "cpuPolicy", cpu_policy, true);
     try writeBoolField(io, "wantsRootDisk", plan.wants_root_disk, true);
@@ -1486,14 +1495,21 @@ fn makePlanInput(
         parseUnsigned(text) catch return error.InvalidMemory
     else
         probed_host_bytes;
+    const boot_timeout_ms = try optionalUnsignedText(
+        parsed.boot_timeout_ms_text,
+        error.InvalidBootTimeoutMs,
+    );
     return .{
         .memory_mib = explicit_memory,
         .resources_memory = resources_memory,
         .auto_memory_mib = auto_memory,
         .host_total_bytes = host_total_bytes,
         .vmm_memory_preset = parsed.vmm_memory_preset,
+        .boot_timeout_ms = boot_timeout_ms,
+        .boot_timeout_forever = parsed.boot_timeout_forever,
         .has_image = parsed.has_image,
         .has_cmd = parsed.has_cmd,
+        .has_snapshot = parsed.has_snapshot,
         .root_disk = parsed.root_disk,
         .guest_cwd = parsed.guest_cwd,
         .mount_guest = parsed.mount_guest,
@@ -1614,6 +1630,11 @@ fn parseBootShapeFields(
         error.InvalidHasImage,
     );
     request.has_cmd = try requiredBool(object, "hasCmd", error.MissingHasCmd, error.InvalidHasCmd);
+    request.has_snapshot = try optionalBoolDefaultFalse(
+        object,
+        "hasSnapshot",
+        error.InvalidHasSnapshot,
+    );
     request.root_disk = try requiredRootDisk(object);
     request.guest_cwd = try optionalStringDefaultNull(
         object,
@@ -1690,6 +1711,16 @@ fn parseTransportFields(
         error.InvalidPdeathsig,
     );
     request.detached = try optionalBoolDefaultFalse(object, "detached", error.InvalidDetached);
+    request.boot_timeout_ms_text = try optionalStringDefaultNull(
+        object,
+        "bootTimeoutMs",
+        error.InvalidBootTimeoutMs,
+    );
+    request.boot_timeout_forever = try optionalBoolDefaultFalse(
+        object,
+        "bootTimeoutForever",
+        error.InvalidBootTimeoutForever,
+    );
 }
 
 fn parseKernelVmstateFields(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -41,6 +41,10 @@ const ParsedRequest = struct {
     restore_path: ?[]const u8 = null,
     enable_vmstate_timing: bool = false,
     existing_vmstate_timing: ?[]const u8 = null,
+    boot_vmstate_state_path: ?[]const u8 = null,
+    boot_vmstate_chain_id: ?[]const u8 = null,
+    boot_vmstate_restore_path: ?[]const u8 = null,
+    boot_vmstate_forked_from: ?[]const u8 = null,
     nested_requested: bool = false,
     live_mounts: []const boot_plan.LiveMountInput = &.{},
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
@@ -160,6 +164,10 @@ const boot_plan_fields = [_][]const u8{
     "restorePath",
     "enableVmstateTiming",
     "existingVmstateTiming",
+    "bootVmstateStatePath",
+    "bootVmstateChainId",
+    "bootVmstateRestorePath",
+    "bootVmstateForkedFrom",
     "nested",
     "liveMounts",
     "liveMountsResolved",
@@ -286,6 +294,10 @@ const RequestError = error{
     InvalidRestorePath,
     InvalidEnableVmstateTiming,
     InvalidExistingVmstateTiming,
+    InvalidBootVmstateStatePath,
+    InvalidBootVmstateChainId,
+    InvalidBootVmstateRestorePath,
+    InvalidBootVmstateForkedFrom,
     InvalidNested,
     InvalidLiveMounts,
     InvalidLiveMountGuest,
@@ -396,6 +408,7 @@ const PlanParts = struct {
     planned_port_forwards: []const boot_plan.PortForwardMapping,
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
+    vmstate_runtime: boot_plan.VmstateRuntimePlan,
     nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
     stats_file: boot_plan.StatsFilePlan,
@@ -479,6 +492,12 @@ fn makePlanParts(
             .restore_path = parsed.restore_path,
             .enable_timing = parsed.enable_vmstate_timing,
             .existing_timing = parsed.existing_vmstate_timing,
+        }),
+        .vmstate_runtime = try boot_plan.planVmstateRuntime(.{
+            .state_path = parsed.boot_vmstate_state_path,
+            .chain_id = parsed.boot_vmstate_chain_id,
+            .restore_path = parsed.boot_vmstate_restore_path,
+            .forked_from = parsed.boot_vmstate_forked_from,
         }),
         .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
         .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
@@ -1788,6 +1807,26 @@ fn parseVmstateFields(object: std.json.ObjectMap, request: *ParsedRequest) Reque
         object,
         "existingVmstateTiming",
         error.InvalidExistingVmstateTiming,
+    );
+    request.boot_vmstate_state_path = try optionalStringDefaultNull(
+        object,
+        "bootVmstateStatePath",
+        error.InvalidBootVmstateStatePath,
+    );
+    request.boot_vmstate_chain_id = try optionalStringDefaultNull(
+        object,
+        "bootVmstateChainId",
+        error.InvalidBootVmstateChainId,
+    );
+    request.boot_vmstate_restore_path = try optionalStringDefaultNull(
+        object,
+        "bootVmstateRestorePath",
+        error.InvalidBootVmstateRestorePath,
+    );
+    request.boot_vmstate_forked_from = try optionalStringDefaultNull(
+        object,
+        "bootVmstateForkedFrom",
+        error.InvalidBootVmstateForkedFrom,
     );
     request.nested_requested = try optionalBoolDefaultFalse(object, "nested", error.InvalidNested);
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -91,6 +91,11 @@ const ParsedRequest = struct {
     registry_stats_temp_dir: ?[]const u8 = null,
     registry_gv_socket_dir: ?[]const u8 = null,
     registry_cpu_cgroup_path: ?[]const u8 = null,
+    registry_cpu_policy_max_vcpus_text: ?[]const u8 = null,
+    registry_cpu_policy_quota_cpus_text: ?[]const u8 = null,
+    registry_cpu_policy_weight_text: ?[]const u8 = null,
+    registry_cpu_control_status: ?[]const u8 = null,
+    registry_cpu_control_reason: ?[]const u8 = null,
     registry_mount_guest: ?[]const u8 = null,
     registry_mount_lower_path: ?[]const u8 = null,
     registry_mount_upper_path: ?[]const u8 = null,
@@ -191,6 +196,11 @@ const boot_plan_fields = [_][]const u8{
     "registryStatsTempDir",
     "registryGvSocketDir",
     "registryCpuCgroupPath",
+    "registryCpuPolicyMaxVcpus",
+    "registryCpuPolicyQuotaCpus",
+    "registryCpuPolicyWeight",
+    "registryCpuControlStatus",
+    "registryCpuControlReason",
     "registryMountGuest",
     "registryMountLowerPath",
     "registryMountUpperPath",
@@ -297,6 +307,9 @@ const RequestError = error{
     InvalidRegistrySourceImagePath,
     InvalidRegistryRootDiskPath,
     InvalidRegistryCleanupPath,
+    InvalidRegistryCpuPolicy,
+    InvalidRegistryCpuControlStatus,
+    InvalidRegistryCpuControlReason,
     InvalidRegistryMountGuest,
     InvalidRegistryMountLowerPath,
     InvalidRegistryMountUpperPath,
@@ -633,6 +646,28 @@ fn makeProvisionRepack(
     });
 }
 
+fn makeRegistryCpuPolicy(parsed: ParsedRequest) RequestError!?boot_plan.CpuPolicyPlan {
+    if (parsed.registry_cpu_policy_max_vcpus_text == null and
+        parsed.registry_cpu_policy_quota_cpus_text == null and
+        parsed.registry_cpu_policy_weight_text == null)
+    {
+        return null;
+    }
+
+    const max_vcpus_text = parsed.registry_cpu_policy_max_vcpus_text orelse
+        return error.InvalidRegistryCpuPolicy;
+    const weight_text = parsed.registry_cpu_policy_weight_text orelse
+        return error.InvalidRegistryCpuPolicy;
+    return .{
+        .max_vcpus = parseUnsigned(max_vcpus_text) catch return error.InvalidRegistryCpuPolicy,
+        .quota_cpus = try optionalFloatText(
+            parsed.registry_cpu_policy_quota_cpus_text,
+            error.InvalidRegistryCpuPolicy,
+        ),
+        .weight = parseUnsigned(weight_text) catch return error.InvalidRegistryCpuPolicy,
+    };
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -659,6 +694,9 @@ fn makeRegistryShape(
             .upper_path = parsed.registry_mount_upper_path,
         },
         .live_mounts = parsed.live_mounts_resolved,
+        .cpu_policy = try makeRegistryCpuPolicy(parsed),
+        .cpu_control_status = parsed.registry_cpu_control_status,
+        .cpu_control_reason = parsed.registry_cpu_control_reason,
     });
 }
 
@@ -1125,6 +1163,7 @@ fn writeRegistryShapeField(
     try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, true);
     try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
     try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
+    try writeRegistryCpuField(io, "cpu", registry.cpu, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1171,6 +1210,36 @@ fn writeRegistryLiveMountsField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeRegistryCpuField(
+    io: std.Io,
+    comptime field: []const u8,
+    cpu: ?boot_plan.RegistryCpuPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (cpu) |plan| {
+        try protocol.stdout(io, "{\"maxVcpus\":");
+        try writeU64Bare(io, plan.max_vcpus);
+        if (plan.quota_cpus) |quota| {
+            try protocol.stdout(io, ",\"quotaCpus\":");
+            try writeF64Bare(io, quota);
+        }
+        try protocol.stdout(io, ",\"weight\":");
+        try writeU64Bare(io, plan.weight);
+        try protocol.stdout(io, ",\"enforcement\":{\"status\":");
+        try protocol.writeJsonString(io, plan.enforcement_status);
+        if (plan.enforcement_reason) |reason| {
+            try protocol.stdout(io, ",\"reason\":");
+            try protocol.writeJsonString(io, reason);
+        }
+        try protocol.stdout(io, "}}");
+    } else {
+        try protocol.stdout(io, "null");
+    }
 }
 
 fn writeEnvObjectField(
@@ -1924,6 +1993,27 @@ fn parseRegistryCleanupFields(
         "registryCpuCgroupPath",
         error.InvalidRegistryCleanupPath,
     );
+    request.registry_cpu_policy_max_vcpus_text = try optionalStringDefaultNull(
+        object,
+        "registryCpuPolicyMaxVcpus",
+        error.InvalidRegistryCpuPolicy,
+    );
+    request.registry_cpu_policy_quota_cpus_text = try optionalStringDefaultNull(
+        object,
+        "registryCpuPolicyQuotaCpus",
+        error.InvalidRegistryCpuPolicy,
+    );
+    request.registry_cpu_policy_weight_text = try optionalStringDefaultNull(
+        object,
+        "registryCpuPolicyWeight",
+        error.InvalidRegistryCpuPolicy,
+    );
+    request.registry_cpu_control_status = try optionalRegistryCpuControlStatus(object);
+    request.registry_cpu_control_reason = try optionalStringDefaultNull(
+        object,
+        "registryCpuControlReason",
+        error.InvalidRegistryCpuControlReason,
+    );
 }
 
 fn parseRegistryMountDiskFields(
@@ -1965,6 +2055,18 @@ fn hasBundleCommandField(object: std.json.ObjectMap) bool {
         if (value == .bool and value.bool) return true;
     }
     return false;
+}
+
+fn optionalRegistryCpuControlStatus(object: std.json.ObjectMap) RequestError!?[]const u8 {
+    assert(@sizeOf(std.json.ObjectMap) > 0);
+
+    const value = object.get("registryCpuControlStatus") orelse return null;
+    if (value == .null) return null;
+    if (value != .string) return error.InvalidRegistryCpuControlStatus;
+    if (std.mem.eql(u8, value.string, "none")) return value.string;
+    if (std.mem.eql(u8, value.string, "linux-cgroup-v2")) return value.string;
+    if (std.mem.eql(u8, value.string, "unsupported")) return value.string;
+    return error.InvalidRegistryCpuControlStatus;
 }
 
 fn optionalProvisionGuestCpu(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -376,6 +376,7 @@ const PlanParts = struct {
     guest_hostname: ?[]const u8,
     vmm_argv: boot_plan.VmmArgvPlan,
     use_pdeathsig: bool,
+    planned_port_forwards: []const boot_plan.PortForwardMapping,
     kernel_dtb: boot_plan.KernelDtbPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
     nested_env: ?[]const u8,
@@ -451,6 +452,7 @@ fn makePlanParts(
             .detached = parsed.detached,
             .pdeathsig = parsed.pdeathsig_requested,
         }),
+        .planned_port_forwards = parsed.port_forward,
         .kernel_dtb = boot_plan.planKernelDtb(.{
             .kernel_path = parsed.kernel_path,
             .dtb_path = parsed.dtb_path,
@@ -1217,7 +1219,7 @@ fn writeRegistryShapeField(
     try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, true);
     try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
     try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
-    try writeRegistryPortForwardsField(io, "portForward", registry.port_forwards, true);
+    try writePortForwardField(io, "portForward", registry.port_forwards, true, true);
     try writeRegistryCpuField(io, "cpu", registry.cpu, true);
     try writeRegistryVmstateField(io, "vmstate", registry.vmstate, true);
     try protocol.stdout(io, "}");
@@ -1268,21 +1270,22 @@ fn writeRegistryLiveMountsField(
     try protocol.stdout(io, "]");
 }
 
-fn writeRegistryPortForwardsField(
+fn writePortForwardField(
     io: std.Io,
     comptime field: []const u8,
-    forwards: []const boot_plan.RegistryPortForwardPlan,
+    mappings: anytype,
+    null_when_empty: bool,
     comma: bool,
 ) !void {
     assert(field.len > 0);
 
     try writeFieldName(io, field, comma);
-    if (forwards.len == 0) {
+    if (mappings.len == 0 and null_when_empty) {
         try protocol.stdout(io, "null");
         return;
     }
     try protocol.stdout(io, "[");
-    for (forwards, 0..) |mapping, i| {
+    for (mappings, 0..) |mapping, i| {
         if (i > 0) try protocol.stdout(io, ",");
         try protocol.stdout(io, "{\"hostPort\":");
         try writeI64Bare(io, mapping.host_port);

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -27,6 +27,8 @@ const ParsedRequest = struct {
     port_forward: []const boot_plan.PortForwardMapping = &.{},
     vmm_binary: ?[]const u8 = null,
     vmm_args: []const []const u8 = &.{},
+    guest_hostname_pid_text: ?[]const u8 = null,
+    guest_hostname_name: ?[]const u8 = null,
     pdeathsig_path: ?[]const u8 = null,
     pdeathsig_requested: ?bool = null,
     detached: bool = false,
@@ -139,6 +141,8 @@ const boot_plan_fields = [_][]const u8{
     "portForward",
     "vmmBinary",
     "vmmArgs",
+    "guestHostnamePid",
+    "guestHostnameName",
     "pdeathsigPath",
     "pdeathsig",
     "detached",
@@ -257,6 +261,8 @@ const RequestError = error{
     InvalidGuestPort,
     InvalidVmmBinary,
     InvalidVmmArgs,
+    InvalidGuestHostnamePid,
+    InvalidGuestHostnameName,
     InvalidPdeathsigPath,
     InvalidPdeathsig,
     InvalidDetached,
@@ -367,6 +373,7 @@ const PlanParts = struct {
     cpu_policy: ?boot_plan.CpuPolicyPlan,
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
+    guest_hostname: ?[]const u8,
     vmm_argv: boot_plan.VmmArgvPlan,
     use_pdeathsig: bool,
     kernel_dtb: boot_plan.KernelDtbPlan,
@@ -430,6 +437,7 @@ fn makePlanParts(
         .plan = plan,
         .cpu_policy = try makeCpuResources(parsed),
         .guest_env = try makeGuestEnv(arena, parsed),
+        .guest_hostname = try makeGuestHostname(arena, parsed),
         .vsock_plan = try boot_plan.planVsock(arena, .{
             .existing_spec = parsed.existing_vsock_spec,
             .auto_uds_path = parsed.auto_vsock_uds_path,
@@ -1337,6 +1345,13 @@ fn writeStringArrayField(
     try protocol.stdout(io, "]");
 }
 
+fn makeGuestHostname(allocator: std.mem.Allocator, parsed: ParsedRequest) RequestError!?[]const u8 {
+    return boot_plan.planGuestHostname(allocator, .{
+        .pid = if (parsed.guest_hostname_pid_text) |text| parseSigned(text) catch return error.InvalidGuestHostnamePid else null,
+        .name = parsed.guest_hostname_name,
+    }) catch return error.InvalidGuestHostnameName;
+}
+
 fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
     assert(@sizeOf(ParsedRequest) > 0);
 
@@ -1464,6 +1479,13 @@ fn parseUnsigned(text: []const u8) !u64 {
     return std.fmt.parseUnsigned(u64, text, 10);
 }
 
+fn parseSigned(text: []const u8) !i64 {
+    assert(@sizeOf(i64) > 0);
+
+    if (text.len == 0) return error.Invalid;
+    return std.fmt.parseInt(i64, text, 10);
+}
+
 fn parseFloat(text: []const u8) !f64 {
     assert(@sizeOf(f64) > 0);
 
@@ -1581,6 +1603,16 @@ fn parseTransportFields(
         "vsockUdsPath",
         error.InvalidVsockUdsPath,
     );
+    request.guest_hostname_pid_text = try optionalStringDefaultNull(
+        object,
+        "guestHostnamePid",
+        error.InvalidGuestHostnamePid,
+    );
+    request.guest_hostname_name = try optionalStringDefaultNull(
+        object,
+        "guestHostnameName",
+        error.InvalidGuestHostnameName,
+    );
     request.existing_vsock_spec = try optionalStringDefaultNull(
         object,
         "existingVsockSpec",
@@ -1598,6 +1630,16 @@ fn parseTransportFields(
         object,
         "vmmArgs",
         error.InvalidVmmArgs,
+    );
+    request.guest_hostname_pid_text = try optionalStringDefaultNull(
+        object,
+        "guestHostnamePid",
+        error.InvalidGuestHostnamePid,
+    );
+    request.guest_hostname_name = try optionalStringDefaultNull(
+        object,
+        "guestHostnameName",
+        error.InvalidGuestHostnameName,
     );
     request.pdeathsig_path = try optionalStringDefaultNull(
         object,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -119,6 +119,7 @@ const ParsedRequest = struct {
     registry_vmstate_chain_id: ?[]const u8 = null,
     registry_vmstate_checkpoint_parent: ?[]const u8 = null,
     registry_vmstate_checkpoint_sequence_text: ?[]const u8 = null,
+    registry_nested: bool = false,
     registry_mount_guest: ?[]const u8 = null,
     registry_mount_lower_path: ?[]const u8 = null,
     registry_mount_upper_path: ?[]const u8 = null,
@@ -144,6 +145,7 @@ const boot_plan_fields = [_][]const u8{
     "vmmMemoryPreset",
     "hasImage",
     "hasCmd",
+    "hasSnapshot",
     "rootDisk",
     "guestCwd",
     "mountGuest",
@@ -246,6 +248,7 @@ const boot_plan_fields = [_][]const u8{
     "registryVmstateChainId",
     "registryVmstateCheckpointParent",
     "registryVmstateCheckpointSequence",
+    "registryNested",
     "registryMountGuest",
     "registryMountLowerPath",
     "registryMountUpperPath",
@@ -378,6 +381,7 @@ const RequestError = error{
     InvalidRegistryVmstateChainId,
     InvalidRegistryVmstateCheckpointParent,
     InvalidRegistryVmstateCheckpointSequence,
+    InvalidRegistryNested,
     InvalidRegistryMountGuest,
     InvalidRegistryMountLowerPath,
     InvalidRegistryMountUpperPath,
@@ -414,7 +418,7 @@ const PlanParts = struct {
     cpu_policy: ?boot_plan.CpuPolicyPlan,
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
-    guest_hostname: ?[]const u8,
+    guest_hostname: boot_plan.GuestHostnameInput,
     vmm_argv: boot_plan.VmmArgvPlan,
     use_pdeathsig: bool,
     planned_port_forwards: []const boot_plan.PortForwardMapping,
@@ -480,7 +484,7 @@ fn makePlanParts(
         .plan = plan,
         .cpu_policy = try makeCpuResources(parsed),
         .guest_env = try makeGuestEnv(arena, parsed),
-        .guest_hostname = try makeGuestHostname(arena, parsed),
+        .guest_hostname = try makeGuestHostname(parsed),
         .vsock_plan = try boot_plan.planVsock(arena, .{
             .existing_spec = parsed.existing_vsock_spec,
             .auto_uds_path = parsed.auto_vsock_uds_path,
@@ -647,6 +651,8 @@ fn makeProvisionBoot(
 }
 
 fn makeCpuResources(parsed: ParsedRequest) !?boot_plan.CpuPolicyPlan {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     const cpu = parsed.resources_cpu orelse return null;
     return boot_plan.planCpuResources(.{
         .max_vcpus = try optionalUnsignedText(
@@ -733,6 +739,8 @@ fn makeProvisionRepack(
 }
 
 fn makeRegistryCpuPolicy(parsed: ParsedRequest) RequestError!?boot_plan.CpuPolicyPlan {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     if (parsed.registry_cpu_policy_max_vcpus_text == null and
         parsed.registry_cpu_policy_quota_cpus_text == null and
         parsed.registry_cpu_policy_weight_text == null)
@@ -799,6 +807,7 @@ fn makeRegistryShape(
             .upper_path = parsed.registry_mount_upper_path,
         },
         .live_mounts = parsed.live_mounts_resolved,
+        .port_forwards = parsed.port_forward,
         .cpu_policy = try makeRegistryCpuPolicy(parsed),
         .cpu_control_status = parsed.registry_cpu_control_status,
         .cpu_control_reason = parsed.registry_cpu_control_reason,
@@ -808,6 +817,7 @@ fn makeRegistryShape(
             .checkpoint_parent = parsed.registry_vmstate_checkpoint_parent,
             .checkpoint_sequence = registry_vmstate_checkpoint_sequence,
         },
+        .nested = parsed.registry_nested,
     });
 }
 
@@ -833,9 +843,12 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
     try writeCoreFields(io, parts.plan, parts.cpu_policy);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
+    try writeGuestHostnameField(io, "guestHostname", parts.guest_hostname, true);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
+    try writeVmstateRuntimeField(io, "vmstateRuntime", parts.vmstate_runtime, true);
     try writeNullableStringField(io, "vmmNested", parts.nested_env, true);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
+    try writePortForwardField(io, "plannedPortForward", parts.planned_port_forwards, false, true);
     try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
@@ -872,6 +885,7 @@ fn writeCoreFields(
     try writeNullableU64Field(io, "memoryCeilingMib", plan.memory_ceiling_mib, false);
     try writeNullableU64StringField(io, "vmmMemory", plan.vmm_memory_mib, true);
     try writeNullableU64Field(io, "timeoutMs", plan.timeout_ms, true);
+    try writeU64Field(io, "detachedReadinessTimeoutMs", plan.detached_readiness_timeout_ms, true);
     try writeBoolField(io, "needsInitramfs", plan.needs_initramfs, true);
     try writeCpuPolicyField(io, "cpuPolicy", cpu_policy, true);
     try writeBoolField(io, "wantsRootDisk", plan.wants_root_disk, true);
@@ -908,16 +922,22 @@ fn writeCpuPolicyField(
 }
 
 fn writeU64Bare(io: std.Io, value: u64) !void {
+    assert(@sizeOf(u64) > 0);
+
     var buf: [32]u8 = undefined;
     try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
 }
 
 fn writeI64Bare(io: std.Io, value: i64) !void {
+    assert(@sizeOf(i64) > 0);
+
     var buf: [32]u8 = undefined;
     try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
 }
 
 fn writeF64Bare(io: std.Io, value: f64) !void {
+    assert(@sizeOf(f64) > 0);
+
     var buf: [64]u8 = undefined;
     try protocol.stdout(io, try std.fmt.bufPrint(&buf, "{d}", .{value}));
 }
@@ -933,6 +953,37 @@ fn writeVsockKernelFields(
     try writeNullableStringField(io, "vmmVsock", vsock_plan.vmm_vsock, true);
     try writeNullableStringField(io, "vmmKernel", kernel_dtb.vmm_kernel, true);
     try writeNullableStringField(io, "vmmDtb", kernel_dtb.vmm_dtb, true);
+}
+
+fn writeGuestHostnameField(
+    io: std.Io,
+    comptime field: []const u8,
+    input: boot_plan.GuestHostnameInput,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    var buffer: [256]u8 = undefined;
+    const hostname = boot_plan.formatGuestHostname(&buffer, input) catch
+        return error.InvalidGuestHostnameName;
+    try writeNullableStringField(io, field, hostname, comma);
+}
+
+fn writeVmstateRuntimeField(
+    io: std.Io,
+    comptime field: []const u8,
+    runtime: boot_plan.VmstateRuntimePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "statePath", runtime.state_path, false);
+    try writeNullableStringField(io, "chainId", runtime.chain_id, true);
+    try writeNullableStringField(io, "checkpointParent", runtime.checkpoint_parent, true);
+    try writeNullableU64Field(io, "checkpointSequence", runtime.checkpoint_sequence, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeVmstateStatsFields(
@@ -955,6 +1006,18 @@ fn writeFieldName(io: std.Io, comptime field: []const u8, comma: bool) !void {
     if (comma) try protocol.stdout(io, ",");
     try protocol.writeJsonString(io, field);
     try protocol.stdout(io, ":");
+}
+
+fn writeU64Field(
+    io: std.Io,
+    comptime field: []const u8,
+    value: u64,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try writeU64Bare(io, value);
 }
 
 fn writeNullableU64Field(
@@ -1277,7 +1340,12 @@ fn writeRegistryShapeField(
     try writeFieldName(io, field, comma);
     try protocol.stdout(io, "{");
     try writeNullableStringField(io, "sourceImagePath", registry.source_image_path, false);
+    try writeNullableStringField(io, "diskPath", registry.disk_path, true);
+    try writeNullableStringField(io, "forkedFrom", registry.forked_from, true);
+    try writeNullableU64Field(io, "memoryCeilingMib", registry.memory_ceiling_mib, true);
+    try writeNullableStringField(io, "statsPath", registry.stats_path, true);
     try writeNullableStringField(io, "rootDiskPath", registry.root_disk_path, true);
+    try writeNullableStringField(io, "bootLogPath", registry.boot_log_path.value(), true);
     try writeFieldName(io, "rootDiskMode", true);
     try protocol.writeJsonString(io, registry.root_disk_mode);
     try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, true);
@@ -1286,6 +1354,7 @@ fn writeRegistryShapeField(
     try writePortForwardField(io, "portForward", registry.port_forwards, true, true);
     try writeRegistryCpuField(io, "cpu", registry.cpu, true);
     try writeRegistryVmstateField(io, "vmstate", registry.vmstate, true);
+    try writeBoolField(io, "nested", registry.nested, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1447,11 +1516,16 @@ fn writeStringArrayField(
     try protocol.stdout(io, "]");
 }
 
-fn makeGuestHostname(allocator: std.mem.Allocator, parsed: ParsedRequest) RequestError!?[]const u8 {
-    return boot_plan.planGuestHostname(allocator, .{
-        .pid = if (parsed.guest_hostname_pid_text) |text| parseSigned(text) catch return error.InvalidGuestHostnamePid else null,
+fn makeGuestHostname(parsed: ParsedRequest) RequestError!boot_plan.GuestHostnameInput {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    return .{
+        .pid = if (parsed.guest_hostname_pid_text) |text|
+            parseSigned(text) catch return error.InvalidGuestHostnamePid
+        else
+            null,
         .name = parsed.guest_hostname_name,
-    }) catch return error.InvalidGuestHostnameName;
+    };
 }
 
 fn makeGuestEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
@@ -1712,6 +1786,13 @@ fn parseTransportFields(
 ) RequestError!void {
     assert(@sizeOf(ParsedRequest) > 0);
 
+    try parseVsockFields(object, request);
+    try parseVmmLaunchFields(allocator, object, request);
+}
+
+fn parseVsockFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.vsock_uds_path = try optionalStringDefaultNull(
         object,
         "vsockUdsPath",
@@ -1737,6 +1818,15 @@ fn parseTransportFields(
         "autoVsockUdsPath",
         error.InvalidAutoVsockUdsPath,
     );
+}
+
+fn parseVmmLaunchFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.port_forward = try optionalPortForward(allocator, object);
     request.vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary);
     request.vmm_args = try optionalStringArrayDefaultEmpty(
@@ -1744,16 +1834,6 @@ fn parseTransportFields(
         object,
         "vmmArgs",
         error.InvalidVmmArgs,
-    );
-    request.guest_hostname_pid_text = try optionalStringDefaultNull(
-        object,
-        "guestHostnamePid",
-        error.InvalidGuestHostnamePid,
-    );
-    request.guest_hostname_name = try optionalStringDefaultNull(
-        object,
-        "guestHostnameName",
-        error.InvalidGuestHostnameName,
     );
     request.pdeathsig_path = try optionalStringDefaultNull(
         object,
@@ -2245,6 +2325,17 @@ fn parseRegistryCleanupFields(
 ) RequestError!void {
     assert(@sizeOf(ParsedRequest) > 0);
 
+    try parseRegistryCleanupPathFields(object, request);
+    try parseRegistryCpuFields(object, request);
+    try parseRegistryVmstateFields(object, request);
+}
+
+fn parseRegistryCleanupPathFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.registry_per_boot_snap_disk = try optionalStringDefaultNull(
         object,
         "registryPerBootSnapDisk",
@@ -2280,6 +2371,11 @@ fn parseRegistryCleanupFields(
         "registryCpuCgroupPath",
         error.InvalidRegistryCleanupPath,
     );
+}
+
+fn parseRegistryCpuFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.registry_cpu_policy_max_vcpus_text = try optionalStringDefaultNull(
         object,
         "registryCpuPolicyMaxVcpus",
@@ -2301,6 +2397,14 @@ fn parseRegistryCleanupFields(
         "registryCpuControlReason",
         error.InvalidRegistryCpuControlReason,
     );
+}
+
+fn parseRegistryVmstateFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.registry_vmstate_path = try optionalStringDefaultNull(
         object,
         "registryVmstatePath",
@@ -2320,6 +2424,11 @@ fn parseRegistryCleanupFields(
         object,
         "registryVmstateCheckpointSequence",
         error.InvalidRegistryVmstateCheckpointSequence,
+    );
+    request.registry_nested = try optionalBoolDefaultFalse(
+        object,
+        "registryNested",
+        error.InvalidRegistryNested,
     );
 }
 
@@ -2670,6 +2779,8 @@ fn requiredBool(
 }
 
 fn optionalResourcesCpu(object: std.json.ObjectMap) RequestError!?ParsedResourcesCpu {
+    assert(@sizeOf(ParsedResourcesCpu) > 0);
+
     const value = object.get("resourcesCpu") orelse return null;
     if (value == .null) return null;
     if (value != .object) return error.InvalidResourcesCpu;
@@ -2752,6 +2863,7 @@ fn writePlanError(io: std.Io, err: anyerror) !void {
     assert(@errorName(err).len > 0);
 
     if (try writeMemoryPlanError(io, err)) return;
+    if (try writeCpuPlanError(io, err)) return;
     if (try writePathPlanError(io, err)) return;
     if (try writeEnvPlanError(io, err)) return;
     if (try writeDiskPlanError(io, err)) return;
@@ -2786,6 +2898,47 @@ fn writeMemoryPlanError(io: std.Io, err: anyerror) !bool {
             io,
             "BOOT_MEMORY_INVALID",
             "boot: host memory probing is unsupported on this platform",
+        ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writeCpuPlanError(io: std.Io, err: anyerror) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.InvalidCpuMaxVcpus,
+        error.InvalidResourcesCpuMaxVcpus,
+        => try writeBootError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.maxVcpus must be a positive integer",
+        ),
+        error.UnsupportedCpuMaxVcpus => try writeBootError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.maxVcpus greater than 1 is not supported yet. " ++
+                "CPU quota is scheduling budget, not extra guest-visible CPUs.",
+        ),
+        error.InvalidCpuQuotaCpus,
+        error.InvalidResourcesCpuQuotaCpus,
+        => try writeBootError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.quotaCpus must be > 0 when set",
+        ),
+        error.CpuQuotaExceedsMaxVcpus => try writeBootError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.quotaCpus cannot exceed resources.cpu.maxVcpus",
+        ),
+        error.InvalidCpuWeight,
+        error.InvalidResourcesCpuWeight,
+        => try writeBootError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.weight must be an integer in 1..10000",
         ),
         else => return false,
     }
@@ -2931,6 +3084,21 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_MOUNT_INVALID",
             "liveMounts: entries must include host and guest paths",
+        ),
+        error.InvalidResourcesCpuMaxVcpus => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.maxVcpus must be a positive integer",
+        ),
+        error.InvalidResourcesCpuQuotaCpus => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.quotaCpus must be > 0 when set",
+        ),
+        error.InvalidResourcesCpuWeight => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.weight must be an integer in 1..10000",
         ),
         error.InvalidLiveMountsResolved,
         error.InvalidConfigLiveMounts,

--- a/packages/runtime/src/__tests__/cpu-resources.test.ts
+++ b/packages/runtime/src/__tests__/cpu-resources.test.ts
@@ -1,7 +1,35 @@
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { _internal, BootError } from "../index.ts";
 
 const { resolveCpuResourcePolicy } = _internal;
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("resolveCpuResourcePolicy", () => {
   it("returns undefined when CPU resources are omitted", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -739,6 +739,10 @@ describe("boot-plan helper schema", () => {
           registryMountGuest: "/mnt/data",
           registryMountLowerPath: "/cache/lower.sqfs",
           registryMountUpperPath: "/tmp/upper.img",
+          portForward: [
+            { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+            { hostPort: 8443, guestPort: 443 },
+          ],
           liveMountsResolved: [
             { host: "/host/work", guest: "/mnt/work", mode: "rw", tag: "machinen-lm0" },
             { host: "/host/cache", guest: "/mnt/cache", mode: "ro", tag: "machinen-lm1" },
@@ -768,6 +772,10 @@ describe("boot-plan helper schema", () => {
       liveMounts: [
         { guest: "/mnt/work", host: "/host/work", mode: "rw" },
         { guest: "/mnt/cache", host: "/host/cache", mode: "ro" },
+      ],
+      portForward: [
+        { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+        { hostPort: 8443, guestPort: 443 },
       ],
       cpu: {
         maxVcpus: 1,

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -101,6 +101,32 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans CPU resource policy defaults and fractional quota", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      resourcesCpu: { maxVcpus: "1", quotaCpus: "0.5", weight: "200" },
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.cpuPolicy).toEqual({
+      maxVcpus: 1,
+      quotaCpus: 0.5,
+      weight: 200,
+    });
+  });
+
   it("plans vsock specs from caller env or auto UDS paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -787,6 +787,10 @@ describe("boot-plan helper schema", () => {
         data: {
           ...baseData,
           registrySourceImagePath: "/images/rootfs.tar.gz",
+          registryDiskPath: "/tmp/scratch.img",
+          registryForkedFrom: "/snap/source",
+          registryMemoryCeilingMib: "2048",
+          registryStatsPath: "/tmp/stats.bin",
           registryPerBootRootDisk: "/tmp/root.img",
           registryCallerRootDiskPath: "/caller/root.img",
           registryBootLogRoot: "/tmp/machinen-logs",
@@ -827,6 +831,10 @@ describe("boot-plan helper schema", () => {
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout).data.registryShape).toEqual({
       sourceImagePath: "/images/rootfs.tar.gz",
+      diskPath: "/tmp/scratch.img",
+      forkedFrom: "/snap/source",
+      memoryCeilingMib: 2048,
+      statsPath: "/tmp/stats.bin",
       rootDiskPath: "/tmp/root.img",
       rootDiskMode: "block",
       bootLogPath: "/tmp/machinen-logs/1234.boot.log",

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -195,6 +195,34 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans nested virtualization VMM env", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const requested = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, nested: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(requested.status).toBe(0);
+    expect(JSON.parse(requested.stdout).data.vmmNested).toBe("1");
+
+    const omitted = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(omitted.status).toBe(0);
+    expect(JSON.parse(omitted.stdout).data.vmmNested).toBeNull();
+  });
+
   it("plans bundle commands from explicit image restore and live-mount inputs", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1143,21 +1143,30 @@ describe("boot-plan helper schema", () => {
       encoding: "utf8",
     });
     expect(defaulted.status).toBe(0);
-    expect(JSON.parse(defaulted.stdout).data.timeoutMs).toBe(60_000);
+    expect(JSON.parse(defaulted.stdout).data).toMatchObject({
+      timeoutMs: 60_000,
+      detachedReadinessTimeoutMs: 60_000,
+    });
 
     const explicit = spawnSync(helper, ["boot-plan"], {
       input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bootTimeoutMs: "2500" } })}\n`,
       encoding: "utf8",
     });
     expect(explicit.status).toBe(0);
-    expect(JSON.parse(explicit.stdout).data.timeoutMs).toBe(2_500);
+    expect(JSON.parse(explicit.stdout).data).toMatchObject({
+      timeoutMs: 2_500,
+      detachedReadinessTimeoutMs: 2_500,
+    });
 
     const forever = spawnSync(helper, ["boot-plan"], {
       input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bootTimeoutForever: true } })}\n`,
       encoding: "utf8",
     });
     expect(forever.status).toBe(0);
-    expect(JSON.parse(forever.stdout).data.timeoutMs).toBeNull();
+    expect(JSON.parse(forever.stdout).data).toMatchObject({
+      timeoutMs: null,
+      detachedReadinessTimeoutMs: 60_000,
+    });
   });
 
   it("rejects invalid portForward shape", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -235,6 +235,36 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans vmstate runtime chain metadata", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      bootVmstateStatePath: "/tmp/state.vmstate",
+      bootVmstateChainId: "chain-1",
+      bootVmstateRestorePath: "/tmp/restore.vmstate",
+      bootVmstateForkedFrom: "/snap/parent",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.vmstateRuntime).toEqual({
+      statePath: "/tmp/state.vmstate",
+      chainId: "chain-1",
+      checkpointParent: "/snap/parent",
+      checkpointSequence: 0,
+    });
+  });
+
   it("plans nested virtualization VMM env", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -965,6 +965,41 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans whether initramfs packing is needed", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const none = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(none.status).toBe(0);
+    expect(JSON.parse(none.stdout).data.needsInitramfs).toBe(false);
+
+    const image = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, hasImage: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(image.status).toBe(0);
+    expect(JSON.parse(image.stdout).data.needsInitramfs).toBe(true);
+
+    const snapshot = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, hasSnapshot: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(snapshot.status).toBe(0);
+    expect(JSON.parse(snapshot.stdout).data.needsInitramfs).toBe(true);
+  });
+
   it("plans pdeathsig default detach and explicit opt-out", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -670,7 +670,7 @@ describe("boot-plan helper schema", () => {
     });
   });
 
-  it("plans registry cleanup paths and mount shapes", () => {
+  it("plans registry cleanup paths, mount shapes, and CPU shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
     const baseData = {
@@ -698,6 +698,11 @@ describe("boot-plan helper schema", () => {
           registryStatsTempDir: null,
           registryGvSocketDir: "/tmp/gv",
           registryCpuCgroupPath: "/sys/fs/cgroup/machinen",
+          registryCpuPolicyMaxVcpus: "1",
+          registryCpuPolicyQuotaCpus: "0.5",
+          registryCpuPolicyWeight: "200",
+          registryCpuControlStatus: "linux-cgroup-v2",
+          registryCpuControlReason: "limited",
           registryMountGuest: "/mnt/data",
           registryMountLowerPath: "/cache/lower.sqfs",
           registryMountUpperPath: "/tmp/upper.img",
@@ -731,6 +736,12 @@ describe("boot-plan helper schema", () => {
         { guest: "/mnt/work", host: "/host/work", mode: "rw" },
         { guest: "/mnt/cache", host: "/host/cache", mode: "ro" },
       ],
+      cpu: {
+        maxVcpus: 1,
+        quotaCpus: 0.5,
+        weight: 200,
+        enforcement: { status: "linux-cgroup-v2", reason: "limited" },
+      },
     });
   });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -731,6 +731,11 @@ describe("boot-plan helper schema", () => {
           registryCpuPolicyWeight: "200",
           registryCpuControlStatus: "linux-cgroup-v2",
           registryCpuControlReason: "limited",
+          registryVmstatePath: "/tmp/state.vmstate",
+          registryVmstateChainId: "chain-1",
+          registryVmstateCheckpointParent: "/snap/parent",
+          registryVmstateCheckpointSequence: "3",
+          registryNested: true,
           registryMountGuest: "/mnt/data",
           registryMountLowerPath: "/cache/lower.sqfs",
           registryMountUpperPath: "/tmp/upper.img",
@@ -770,6 +775,13 @@ describe("boot-plan helper schema", () => {
         weight: 200,
         enforcement: { status: "linux-cgroup-v2", reason: "limited" },
       },
+      vmstate: {
+        statePath: "/tmp/state.vmstate",
+        chainId: "chain-1",
+        checkpointParent: "/snap/parent",
+        checkpointSequence: 3,
+      },
+      nested: true,
     });
   });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -759,6 +759,9 @@ describe("boot-plan helper schema", () => {
           registrySourceImagePath: "/images/rootfs.tar.gz",
           registryPerBootRootDisk: "/tmp/root.img",
           registryCallerRootDiskPath: "/caller/root.img",
+          registryBootLogRoot: "/tmp/machinen-logs",
+          registryChildPid: "1234",
+          registryDetached: true,
           registryPerBootSnapDisk: null,
           registryPerBootMountUpper: "/tmp/upper.img",
           registryBundleTempDir: "/tmp/bundle",
@@ -796,6 +799,7 @@ describe("boot-plan helper schema", () => {
       sourceImagePath: "/images/rootfs.tar.gz",
       rootDiskPath: "/tmp/root.img",
       rootDiskMode: "block",
+      bootLogPath: "/tmp/machinen-logs/1234.boot.log",
       cleanupPaths: [
         "/tmp/root.img",
         "/tmp/upper.img",

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -127,6 +127,46 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans portForward defaults and preserves hostAddr", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const omitted = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(omitted.status).toBe(0);
+    expect(JSON.parse(omitted.stdout).data.plannedPortForward).toEqual([]);
+
+    const planned = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          portForward: [
+            { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+            { hostPort: 8443, guestPort: 443 },
+          ],
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(planned.status).toBe(0);
+    expect(JSON.parse(planned.stdout).data.plannedPortForward).toEqual([
+      { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+      { hostPort: 8443, guestPort: 443 },
+    ]);
+  });
+
   it("plans vsock specs from caller env or auto UDS paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -965,6 +965,41 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans pdeathsig default detach and explicit opt-out", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const enabled = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(enabled.status).toBe(0);
+    expect(JSON.parse(enabled.stdout).data.usePdeathsig).toBe(true);
+
+    const detached = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, detached: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(detached.status).toBe(0);
+    expect(JSON.parse(detached.stdout).data.usePdeathsig).toBe(false);
+
+    const disabled = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, pdeathsig: false } })}\n`,
+      encoding: "utf8",
+    });
+    expect(disabled.status).toBe(0);
+    expect(JSON.parse(disabled.stdout).data.usePdeathsig).toBe(false);
+  });
+
   it("rejects invalid portForward shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1083,6 +1083,41 @@ describe("boot-plan helper schema", () => {
     expect(JSON.parse(disabled.stdout).data.usePdeathsig).toBe(false);
   });
 
+  it("plans boot timeout default explicit and forever values", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const defaulted = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(defaulted.status).toBe(0);
+    expect(JSON.parse(defaulted.stdout).data.timeoutMs).toBe(60_000);
+
+    const explicit = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bootTimeoutMs: "2500" } })}\n`,
+      encoding: "utf8",
+    });
+    expect(explicit.status).toBe(0);
+    expect(JSON.parse(explicit.stdout).data.timeoutMs).toBe(2_500);
+
+    const forever = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: { ...baseData, bootTimeoutForever: true } })}\n`,
+      encoding: "utf8",
+    });
+    expect(forever.status).toBe(0);
+    expect(JSON.parse(forever.stdout).data.timeoutMs).toBeNull();
+  });
+
   it("rejects invalid portForward shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -15,6 +15,14 @@ type RegistryVmstatePlan = {
   checkpointParent: string | null;
   checkpointSequence: number | null;
 };
+export type PlannedPortForward = { hostPort: number; guestPort: number; hostAddr?: string };
+type RegistryPortForwardPlan = PlannedPortForward;
+export type BootVmstateRuntimePlan = {
+  statePath: string | null;
+  chainId: string | null;
+  checkpointParent: string | null;
+  checkpointSequence: number | null;
+};
 export type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
@@ -51,12 +59,15 @@ export type RegistryShapePlan = {
   memoryCeilingMib: number | null;
   statsPath: string | null;
   rootDiskPath: string | null;
+  bootLogPath: string | null;
   rootDiskMode: "block" | "none";
   cleanupPaths: string[];
   mountDisk: RegistryMountDiskPlan | null;
   liveMounts: RegistryLiveMountPlan[];
+  portForward: RegistryPortForwardPlan[] | null;
   cpu: RegistryCpuPlan | null;
   vmstate: RegistryVmstatePlan;
+  nested: boolean;
 };
 export type ScratchDiskPlan = {
   action: ScratchDiskAction;
@@ -100,6 +111,7 @@ export interface NativeBootPlanResult {
   wantsRootDisk: boolean;
   needsInitramfs: boolean;
   timeoutMs: number | null;
+  detachedReadinessTimeoutMs: number;
   normalizedMountGuest: string | null;
   guestHostname: string | null;
   mergedGuestEnv: Record<string, string>;
@@ -147,6 +159,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     typeof data.wantsRootDisk === "boolean",
     typeof data.needsInitramfs === "boolean",
     nullableNonNegativeNumber(data.timeoutMs),
+    nonNegativeNumber(data.detachedReadinessTimeoutMs),
     nullableString(data.normalizedMountGuest),
     nullableString(data.guestHostname),
     isStringRecord(data.mergedGuestEnv),
@@ -330,13 +343,16 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
     nullableNonNegativeNumber(plan.memoryCeilingMib),
     nullableString(plan.statsPath),
     nullableString(plan.rootDiskPath),
+    nullableString(plan.bootLogPath),
     isOneOf(plan.rootDiskMode, registryRootDiskModes),
     isStringArray(plan.cleanupPaths),
     nullableRegistryMountDisk(plan.mountDisk),
     Array.isArray(plan.liveMounts),
     plan.liveMounts?.every(isRegistryLiveMount) === true,
+    nullableObject(plan.portForward, isRegistryPortForwardArray),
     nullableRegistryCpu(plan.cpu),
     isRegistryVmstatePlan(plan.vmstate),
+    typeof plan.nested === "boolean",
   ].every(Boolean);
 }
 
@@ -488,6 +504,14 @@ function isOneOf<T extends string>(value: unknown, values: readonly T[]): value 
 
 function nullableString(value: unknown): boolean {
   return value === null || typeof value === "string";
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function nullableObject<T>(value: unknown, check: (candidate: unknown) => candidate is T): boolean {
+  return value === null || check(value);
 }
 
 function isStringRecord(value: unknown): value is Record<string, string> {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -113,6 +113,7 @@ export interface NativeBootPlanResult {
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
+  plannedPortForward: PlannedPortForward[];
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
@@ -157,6 +158,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
+    Array.isArray(data.plannedPortForward) && data.plannedPortForward.every(isPlannedPortForward),
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
@@ -327,14 +329,14 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
 }
 
 function isRegistryPortForwardArray(value: unknown): value is RegistryPortForwardPlan[] {
-  return Array.isArray(value) && value.every(isRegistryPortForward);
+  return Array.isArray(value) && value.every(isPlannedPortForward);
 }
 
-function isRegistryPortForward(value: unknown): value is RegistryPortForwardPlan {
+function isPlannedPortForward(value: unknown): value is PlannedPortForward {
   if (!value || typeof value !== "object") {
     return false;
   }
-  const mapping = value as Partial<RegistryPortForwardPlan>;
+  const mapping = value as Partial<PlannedPortForward>;
   return [
     nonNegativeNumber(mapping.hostPort),
     nonNegativeNumber(mapping.guestPort),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -95,6 +95,7 @@ export interface NativeBootPlanResult {
   cpuPolicy: CpuPolicyPlan | null;
   wantsRootDisk: boolean;
   needsInitramfs: boolean;
+  timeoutMs: number | null;
   normalizedMountGuest: string | null;
   guestHostname: string | null;
   mergedGuestEnv: Record<string, string>;
@@ -140,6 +141,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableCpuPolicy(data.cpuPolicy),
     typeof data.wantsRootDisk === "boolean",
     typeof data.needsInitramfs === "boolean",
+    nullableNonNegativeNumber(data.timeoutMs),
     nullableString(data.normalizedMountGuest),
     nullableString(data.guestHostname),
     isStringRecord(data.mergedGuestEnv),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -9,6 +9,12 @@ type RegistryCpuPlan = {
   weight: number;
   enforcement: { status: "none" | "linux-cgroup-v2" | "unsupported"; reason?: string };
 };
+type RegistryVmstatePlan = {
+  statePath: string | null;
+  chainId: string | null;
+  checkpointParent: string | null;
+  checkpointSequence: number | null;
+};
 export type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
@@ -46,6 +52,7 @@ export type RegistryShapePlan = {
   mountDisk: RegistryMountDiskPlan | null;
   liveMounts: RegistryLiveMountPlan[];
   cpu: RegistryCpuPlan | null;
+  vmstate: RegistryVmstatePlan;
 };
 export type ScratchDiskPlan = {
   action: ScratchDiskAction;
@@ -309,6 +316,20 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
     Array.isArray(plan.liveMounts),
     plan.liveMounts?.every(isRegistryLiveMount) === true,
     nullableRegistryCpu(plan.cpu),
+    isRegistryVmstatePlan(plan.vmstate),
+  ].every(Boolean);
+}
+
+function isRegistryVmstatePlan(value: unknown): value is RegistryVmstatePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryVmstatePlan>;
+  return [
+    nullableString(plan.statePath),
+    nullableString(plan.chainId),
+    nullableString(plan.checkpointParent),
+    nullableNonNegativeNumber(plan.checkpointSequence),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -100,6 +100,7 @@ export interface NativeBootPlanResult {
   vmmVsock: string | null;
   vmmCommand: string | null;
   vmmArgs: string[];
+  usePdeathsig: boolean;
   vmmKernel: string | null;
   vmmDtb: string | null;
   vmmSnapshotPath: string | null;
@@ -141,6 +142,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmVsock),
     nullableString(data.vmmCommand),
     isStringArray(data.vmmArgs),
+    typeof data.usePdeathsig === "boolean",
     nullableString(data.vmmKernel),
     nullableString(data.vmmDtb),
     nullableString(data.vmmSnapshotPath),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -46,6 +46,10 @@ export type ProvisionRuntimePlan = {
 };
 export type RegistryShapePlan = {
   sourceImagePath: string | null;
+  diskPath: string | null;
+  forkedFrom: string | null;
+  memoryCeilingMib: number | null;
+  statsPath: string | null;
   rootDiskPath: string | null;
   rootDiskMode: "block" | "none";
   cleanupPaths: string[];
@@ -321,6 +325,10 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
   const plan = value as Partial<RegistryShapePlan>;
   return [
     nullableString(plan.sourceImagePath),
+    nullableString(plan.diskPath),
+    nullableString(plan.forkedFrom),
+    nullableNonNegativeNumber(plan.memoryCeilingMib),
+    nullableString(plan.statsPath),
     nullableString(plan.rootDiskPath),
     isOneOf(plan.rootDiskMode, registryRootDiskModes),
     isStringArray(plan.cleanupPaths),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -2,6 +2,7 @@ type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 export type ProvisionGuestCpu = "arm64" | "amd64";
+type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
 export type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
@@ -77,6 +78,7 @@ const liveMountModes = ["ro", "rw"] as const;
 export interface NativeBootPlanResult {
   memoryCeilingMib: number | null;
   vmmMemory: string | null;
+  cpuPolicy: CpuPolicyPlan | null;
   wantsRootDisk: boolean;
   normalizedMountGuest: string | null;
   mergedGuestEnv: Record<string, string>;
@@ -116,6 +118,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
   return [
     nullableNonNegativeNumber(data.memoryCeilingMib),
     nullableString(data.vmmMemory),
+    nullableCpuPolicy(data.cpuPolicy),
     typeof data.wantsRootDisk === "boolean",
     nullableString(data.normalizedMountGuest),
     isStringRecord(data.mergedGuestEnv),
@@ -145,6 +148,22 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
     isRegistryShapePlan(data.registryShape),
+  ].every(Boolean);
+}
+
+function nullableCpuPolicy(value: unknown): value is CpuPolicyPlan | null {
+  return value === null || isCpuPolicyPlan(value);
+}
+
+function isCpuPolicyPlan(value: unknown): value is CpuPolicyPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<CpuPolicyPlan>;
+  return [
+    nonNegativeNumber(plan.maxVcpus),
+    plan.quotaCpus === undefined || nonNegativeNumber(plan.quotaCpus),
+    nonNegativeNumber(plan.weight),
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -3,6 +3,12 @@ type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cach
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 export type ProvisionGuestCpu = "arm64" | "amd64";
 type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
+type RegistryCpuPlan = {
+  maxVcpus: number;
+  quotaCpus?: number;
+  weight: number;
+  enforcement: { status: "none" | "linux-cgroup-v2" | "unsupported"; reason?: string };
+};
 export type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
@@ -39,6 +45,7 @@ export type RegistryShapePlan = {
   cleanupPaths: string[];
   mountDisk: RegistryMountDiskPlan | null;
   liveMounts: RegistryLiveMountPlan[];
+  cpu: RegistryCpuPlan | null;
 };
 export type ScratchDiskPlan = {
   action: ScratchDiskAction;
@@ -299,6 +306,35 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
     nullableRegistryMountDisk(plan.mountDisk),
     Array.isArray(plan.liveMounts),
     plan.liveMounts?.every(isRegistryLiveMount) === true,
+    nullableRegistryCpu(plan.cpu),
+  ].every(Boolean);
+}
+
+function nullableRegistryCpu(value: unknown): value is RegistryCpuPlan | null {
+  return value === null || isRegistryCpuPlan(value);
+}
+
+function isRegistryCpuPlan(value: unknown): value is RegistryCpuPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryCpuPlan>;
+  return [
+    nonNegativeNumber(plan.maxVcpus),
+    plan.quotaCpus === undefined || nonNegativeNumber(plan.quotaCpus),
+    nonNegativeNumber(plan.weight),
+    isRegistryCpuEnforcement(plan.enforcement),
+  ].every(Boolean);
+}
+
+function isRegistryCpuEnforcement(value: unknown): value is RegistryCpuPlan["enforcement"] {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const enforcement = value as Partial<RegistryCpuPlan["enforcement"]>;
+  return [
+    isOneOf(enforcement.status, ["none", "linux-cgroup-v2", "unsupported"] as const),
+    enforcement.reason === undefined || typeof enforcement.reason === "string",
   ].every(Boolean);
 }
 

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -96,6 +96,7 @@ export interface NativeBootPlanResult {
   wantsRootDisk: boolean;
   needsInitramfs: boolean;
   normalizedMountGuest: string | null;
+  guestHostname: string | null;
   mergedGuestEnv: Record<string, string>;
   vsockUdsPath: string | null;
   vmmVsock: string | null;
@@ -139,6 +140,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     typeof data.wantsRootDisk === "boolean",
     typeof data.needsInitramfs === "boolean",
     nullableString(data.normalizedMountGuest),
+    nullableString(data.guestHostname),
     isStringRecord(data.mergedGuestEnv),
     nullableString(data.vsockUdsPath),
     nullableString(data.vmmVsock),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -94,6 +94,7 @@ export interface NativeBootPlanResult {
   vmmMemory: string | null;
   cpuPolicy: CpuPolicyPlan | null;
   wantsRootDisk: boolean;
+  needsInitramfs: boolean;
   normalizedMountGuest: string | null;
   mergedGuestEnv: Record<string, string>;
   vsockUdsPath: string | null;
@@ -136,6 +137,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmMemory),
     nullableCpuPolicy(data.cpuPolicy),
     typeof data.wantsRootDisk === "boolean",
+    typeof data.needsInitramfs === "boolean",
     nullableString(data.normalizedMountGuest),
     isStringRecord(data.mergedGuestEnv),
     nullableString(data.vsockUdsPath),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -114,6 +114,7 @@ export interface NativeBootPlanResult {
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
+  vmstateRuntime: BootVmstateRuntimePlan;
   plannedPortForward: PlannedPortForward[];
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
@@ -160,6 +161,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
+    isBootVmstateRuntimePlan(data.vmstateRuntime),
     Array.isArray(data.plannedPortForward) && data.plannedPortForward.every(isPlannedPortForward),
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
@@ -330,6 +332,22 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
   ].every(Boolean);
 }
 
+function isBootVmstateRuntimePlan(value: unknown): value is BootVmstateRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return isVmstatePlanShape(value as Partial<BootVmstateRuntimePlan>);
+}
+
+function isVmstatePlanShape(plan: Partial<BootVmstateRuntimePlan>): boolean {
+  return (
+    nullableString(plan.statePath) &&
+    nullableString(plan.chainId) &&
+    nullableString(plan.checkpointParent) &&
+    nullableNonNegativeNumber(plan.checkpointSequence)
+  );
+}
+
 function isRegistryPortForwardArray(value: unknown): value is RegistryPortForwardPlan[] {
   return Array.isArray(value) && value.every(isPlannedPortForward);
 }
@@ -350,13 +368,7 @@ function isRegistryVmstatePlan(value: unknown): value is RegistryVmstatePlan {
   if (!value || typeof value !== "object") {
     return false;
   }
-  const plan = value as Partial<RegistryVmstatePlan>;
-  return [
-    nullableString(plan.statePath),
-    nullableString(plan.chainId),
-    nullableString(plan.checkpointParent),
-    nullableNonNegativeNumber(plan.checkpointSequence),
-  ].every(Boolean);
+  return isVmstatePlanShape(value as Partial<RegistryVmstatePlan>);
 }
 
 function nullableRegistryCpu(value: unknown): value is RegistryCpuPlan | null {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -98,6 +98,7 @@ export interface NativeBootPlanResult {
   vmmSnapshotPath: string | null;
   vmmRestorePath: string | null;
   vmmVmstateTiming: string | null;
+  vmmNested: string | null;
   virtiofsEnv: Record<string, string>;
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
@@ -138,6 +139,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmSnapshotPath),
     nullableString(data.vmmRestorePath),
     nullableString(data.vmmVmstateTiming),
+    nullableString(data.vmmNested),
     isStringRecord(data.virtiofsEnv),
     Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
     nullableString(data.statsFilePath),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -326,6 +326,22 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
   ].every(Boolean);
 }
 
+function isRegistryPortForwardArray(value: unknown): value is RegistryPortForwardPlan[] {
+  return Array.isArray(value) && value.every(isRegistryPortForward);
+}
+
+function isRegistryPortForward(value: unknown): value is RegistryPortForwardPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mapping = value as Partial<RegistryPortForwardPlan>;
+  return [
+    nonNegativeNumber(mapping.hostPort),
+    nonNegativeNumber(mapping.guestPort),
+    optionalString(mapping.hostAddr),
+  ].every(Boolean);
+}
+
 function isRegistryVmstatePlan(value: unknown): value is RegistryVmstatePlan {
   if (!value || typeof value !== "object") {
     return false;

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -55,6 +55,7 @@ interface NativeBootPlanInput {
   pdeathsigPath?: string;
   pdeathsig?: boolean;
   detached?: boolean;
+  bootTimeoutMs?: number | null;
   kernelPath?: string;
   dtbPath?: string;
   vmstatePath?: string;
@@ -167,6 +168,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     pdeathsigPath: nullDefault(input.pdeathsigPath),
     pdeathsig: input.pdeathsig ?? null,
     detached: input.detached === true,
+    ...bootTimeoutData(input),
     kernelPath: nullDefault(input.kernelPath),
     dtbPath: nullDefault(input.dtbPath),
     vmstatePath: nullDefault(input.vmstatePath),
@@ -189,6 +191,13 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     ...rootDiskRuntimeData(input),
     ...mountDiskRuntimeData(input),
     ...registryShapeData(input),
+  };
+}
+
+function bootTimeoutData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    bootTimeoutMs: input.bootTimeoutMs === null ? null : numberText(input.bootTimeoutMs),
+    bootTimeoutForever: input.bootTimeoutMs === null,
   };
 }
 

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -1,3 +1,4 @@
+import type { CpuControlResult } from "../cpu-cgroup.ts";
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
 import type { BootCpuResourceOptions, ResolvedCpuResourcePolicy } from "../vm/cpu-resources.ts";
@@ -109,6 +110,9 @@ interface NativeBootPlanInput {
   registryStatsTempDir?: string;
   registryGvSocketDir?: string;
   registryCpuCgroupPath?: string;
+  registryCpuPolicy?: ResolvedCpuResourcePolicy;
+  registryCpuControlStatus?: CpuControlResult["status"];
+  registryCpuControlReason?: string;
   registryMountGuest?: string;
   registryMountLowerPath?: string;
   registryMountUpperPath?: string;
@@ -245,6 +249,11 @@ function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> 
     registryStatsTempDir: nullDefault(input.registryStatsTempDir),
     registryGvSocketDir: nullDefault(input.registryGvSocketDir),
     registryCpuCgroupPath: nullDefault(input.registryCpuCgroupPath),
+    registryCpuPolicyMaxVcpus: numberText(input.registryCpuPolicy?.maxVcpus),
+    registryCpuPolicyQuotaCpus: numberText(input.registryCpuPolicy?.quotaCpus),
+    registryCpuPolicyWeight: numberText(input.registryCpuPolicy?.weight),
+    registryCpuControlStatus: nullDefault(input.registryCpuControlStatus),
+    registryCpuControlReason: nullDefault(input.registryCpuControlReason),
     registryMountGuest: nullDefault(input.registryMountGuest),
     registryMountLowerPath: nullDefault(input.registryMountLowerPath),
     registryMountUpperPath: nullDefault(input.registryMountUpperPath),
@@ -423,6 +432,10 @@ export function planBootRegistryShapeNative(input: {
     gvSocketDir?: string;
     cpuCgroupPath?: string;
   };
+  cpu?: {
+    policy: ResolvedCpuResourcePolicy | undefined;
+    control: CpuControlResult;
+  };
   mountDisk?: { guest: string; lowerPath: string; upperPath: string };
   liveMounts?: PlannedLiveMount[];
 }): RegistryShapePlan {
@@ -437,6 +450,9 @@ export function planBootRegistryShapeNative(input: {
     registryStatsTempDir: input.cleanup?.statsTempDir,
     registryGvSocketDir: input.cleanup?.gvSocketDir,
     registryCpuCgroupPath: input.cleanup?.cpuCgroupPath,
+    registryCpuPolicy: input.cpu?.policy,
+    registryCpuControlStatus: input.cpu?.control.status,
+    registryCpuControlReason: input.cpu?.control.reason,
     registryMountGuest: input.mountDisk?.guest,
     registryMountLowerPath: input.mountDisk?.lowerPath,
     registryMountUpperPath: input.mountDisk?.upperPath,
@@ -446,6 +462,13 @@ export function planBootRegistryShapeNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).registryShape;
+}
+
+export function planBootRegistryCpuNative(input: {
+  policy: ResolvedCpuResourcePolicy | undefined;
+  control: CpuControlResult;
+}): RegistryShapePlan["cpu"] | undefined {
+  return planBootRegistryShapeNative({ cpu: input }).cpu ?? undefined;
 }
 
 export function planBootBundleEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -1,5 +1,6 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
+import type { BootCpuResourceOptions, ResolvedCpuResourcePolicy } from "../vm/cpu-resources.ts";
 import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
 import type {
@@ -29,6 +30,7 @@ type LiveMountPlanInput = { host: string; guest: string; mode?: string };
 interface NativeBootPlanInput {
   memoryMib?: number;
   resourcesMemory?: BootMemoryResourceOptions;
+  resourcesCpu?: BootCpuResourceOptions;
   autoMemoryMib?: number;
   hostTotalBytes?: number;
   vmmMemoryPreset: boolean;
@@ -126,6 +128,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
   return {
     memoryMib: numberText(input.memoryMib),
     resourcesMemory: resourcesMemoryData(input.resourcesMemory),
+    resourcesCpu: resourcesCpuData(input.resourcesCpu),
     autoMemoryMib: numberText(input.autoMemoryMib),
     hostTotalBytes: numberText(input.hostTotalBytes),
     vmmMemoryPreset: input.vmmMemoryPreset,
@@ -258,6 +261,17 @@ function resourcesMemoryData(memory: BootMemoryResourceOptions | undefined): unk
   };
 }
 
+function resourcesCpuData(cpu: BootCpuResourceOptions | undefined): unknown {
+  if (!cpu) {
+    return null;
+  }
+  return {
+    maxVcpus: numberText(cpu.maxVcpus),
+    quotaCpus: numberText(cpu.quotaCpus),
+    weight: numberText(cpu.weight),
+  };
+}
+
 function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[] {
   return (liveMounts ?? []).map((mount) => ({
     host: mount.host,
@@ -268,6 +282,20 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planBootCpuResourcesNative(
+  cpu: BootCpuResourceOptions | undefined,
+): ResolvedCpuResourcePolicy | undefined {
+  return (
+    planBootCoreNative({
+      resourcesCpu: cpu,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    }).cpuPolicy ?? undefined
+  );
 }
 
 export function planProvisionWorkloadNative(): ProvisionWorkloadPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -8,6 +8,7 @@ import type {
   MountDiskRuntimePlan,
   PlannedLiveMount,
   PlannedPortForward,
+  BootVmstateRuntimePlan,
   ProvisionAssetsPlan,
   ProvisionBootPlan,
   ProvisionGuestCpu,
@@ -62,6 +63,10 @@ interface NativeBootPlanInput {
   restorePath?: string;
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
+  bootVmstateStatePath?: string;
+  bootVmstateChainId?: string;
+  bootVmstateRestorePath?: string;
+  bootVmstateForkedFrom?: string;
   nested?: boolean;
   liveMounts?: LiveMountPlanInput[];
   liveMountsResolved?: PlannedLiveMount[];
@@ -178,6 +183,10 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     restorePath: nullDefault(input.restorePath),
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
+    bootVmstateStatePath: nullDefault(input.bootVmstateStatePath),
+    bootVmstateChainId: nullDefault(input.bootVmstateChainId),
+    bootVmstateRestorePath: nullDefault(input.bootVmstateRestorePath),
+    bootVmstateForkedFrom: nullDefault(input.bootVmstateForkedFrom),
     nested: input.nested === true,
     liveMounts: liveMountsData(input.liveMounts),
     liveMountsResolved: input.liveMountsResolved ?? [],
@@ -775,6 +784,24 @@ export function planBootVmstateEnvNative(input: {
     restorePath: plan.vmmRestorePath ?? undefined,
     vmstateTiming: plan.vmmVmstateTiming ?? undefined,
   };
+}
+
+export function planBootVmstateRuntimeNative(input: {
+  statePath?: string;
+  chainId: string;
+  restorePath?: string;
+  forkedFrom?: string;
+}): BootVmstateRuntimePlan {
+  return planBootCoreNative({
+    bootVmstateStatePath: input.statePath,
+    bootVmstateChainId: input.chainId,
+    bootVmstateRestorePath: input.restorePath,
+    bootVmstateForkedFrom: input.forkedFrom,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).vmstateRuntime;
 }
 
 export function planBootKernelDtbNative(input: { kernelPath?: string; dtbPath?: string }): {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -49,6 +49,8 @@ interface NativeBootPlanInput {
   vmmBinary?: string;
   vmmArgs?: string[];
   pdeathsigPath?: string;
+  pdeathsig?: boolean;
+  detached?: boolean;
   kernelPath?: string;
   dtbPath?: string;
   vmstatePath?: string;
@@ -156,6 +158,8 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     vmmBinary: nullDefault(input.vmmBinary),
     vmmArgs: input.vmmArgs ?? [],
     pdeathsigPath: nullDefault(input.pdeathsigPath),
+    pdeathsig: input.pdeathsig ?? null,
+    detached: input.detached === true,
     kernelPath: nullDefault(input.kernelPath),
     dtbPath: nullDefault(input.dtbPath),
     vmstatePath: nullDefault(input.vmstatePath),

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -482,6 +482,7 @@ export function planBootRegistryShapeNative(input: {
   nested?: boolean;
   mountDisk?: { guest: string; lowerPath: string; upperPath: string };
   liveMounts?: PlannedLiveMount[];
+  portForward?: PortForwardPlanMapping[];
 }): RegistryShapePlan {
   return planBootCoreNative({
     registrySourceImagePath: input.sourceImagePath,
@@ -506,6 +507,7 @@ export function planBootRegistryShapeNative(input: {
     registryMountLowerPath: input.mountDisk?.lowerPath,
     registryMountUpperPath: input.mountDisk?.upperPath,
     liveMountsResolved: input.liveMounts,
+    portForward: input.portForward,
     vmmMemoryPreset: true,
     hasImage: false,
     hasCmd: false,
@@ -531,6 +533,12 @@ export function planBootRegistryVmstateNative(input: {
 
 export function planBootRegistryNestedNative(nested: boolean | undefined): boolean | undefined {
   return planBootRegistryShapeNative({ nested }).nested || undefined;
+}
+
+export function planBootRegistryPortForwardNative(
+  portForward: PortForwardPlanMapping[],
+): RegistryShapePlan["portForward"] | undefined {
+  return planBootRegistryShapeNative({ portForward }).portForward ?? undefined;
 }
 
 export function planBootBundleEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -37,6 +37,7 @@ interface NativeBootPlanInput {
   vmmMemoryPreset: boolean;
   hasImage: boolean;
   hasCmd: boolean;
+  hasSnapshot?: boolean;
   rootDisk: RootDiskPlanMode;
   guestCwd?: string;
   mountGuest?: string;
@@ -146,6 +147,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     vmmMemoryPreset: input.vmmMemoryPreset,
     hasImage: input.hasImage,
     hasCmd: input.hasCmd,
+    hasSnapshot: input.hasSnapshot === true,
     rootDisk: input.rootDisk,
     guestCwd: nullDefault(input.guestCwd),
     mountGuest: nullDefault(input.mountGuest),

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -114,6 +114,11 @@ interface NativeBootPlanInput {
   registryCpuPolicy?: ResolvedCpuResourcePolicy;
   registryCpuControlStatus?: CpuControlResult["status"];
   registryCpuControlReason?: string;
+  registryVmstatePath?: string;
+  registryVmstateChainId?: string;
+  registryVmstateCheckpointParent?: string;
+  registryVmstateCheckpointSequence?: number;
+  registryNested?: boolean;
   registryMountGuest?: string;
   registryMountLowerPath?: string;
   registryMountUpperPath?: string;
@@ -256,6 +261,11 @@ function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> 
     registryCpuPolicyWeight: numberText(input.registryCpuPolicy?.weight),
     registryCpuControlStatus: nullDefault(input.registryCpuControlStatus),
     registryCpuControlReason: nullDefault(input.registryCpuControlReason),
+    registryVmstatePath: nullDefault(input.registryVmstatePath),
+    registryVmstateChainId: nullDefault(input.registryVmstateChainId),
+    registryVmstateCheckpointParent: nullDefault(input.registryVmstateCheckpointParent),
+    registryVmstateCheckpointSequence: numberText(input.registryVmstateCheckpointSequence),
+    registryNested: input.registryNested === true,
     registryMountGuest: nullDefault(input.registryMountGuest),
     registryMountLowerPath: nullDefault(input.registryMountLowerPath),
     registryMountUpperPath: nullDefault(input.registryMountUpperPath),
@@ -438,6 +448,13 @@ export function planBootRegistryShapeNative(input: {
     policy: ResolvedCpuResourcePolicy | undefined;
     control: CpuControlResult;
   };
+  vmstate?: {
+    statePath?: string;
+    chainId?: string;
+    checkpointParent?: string;
+    checkpointSequence?: number;
+  };
+  nested?: boolean;
   mountDisk?: { guest: string; lowerPath: string; upperPath: string };
   liveMounts?: PlannedLiveMount[];
 }): RegistryShapePlan {
@@ -455,6 +472,11 @@ export function planBootRegistryShapeNative(input: {
     registryCpuPolicy: input.cpu?.policy,
     registryCpuControlStatus: input.cpu?.control.status,
     registryCpuControlReason: input.cpu?.control.reason,
+    registryVmstatePath: input.vmstate?.statePath,
+    registryVmstateChainId: input.vmstate?.chainId,
+    registryVmstateCheckpointParent: input.vmstate?.checkpointParent,
+    registryVmstateCheckpointSequence: input.vmstate?.checkpointSequence,
+    registryNested: input.nested,
     registryMountGuest: input.mountDisk?.guest,
     registryMountLowerPath: input.mountDisk?.lowerPath,
     registryMountUpperPath: input.mountDisk?.upperPath,
@@ -471,6 +493,19 @@ export function planBootRegistryCpuNative(input: {
   control: CpuControlResult;
 }): RegistryShapePlan["cpu"] | undefined {
   return planBootRegistryShapeNative({ cpu: input }).cpu ?? undefined;
+}
+
+export function planBootRegistryVmstateNative(input: {
+  statePath?: string;
+  chainId?: string;
+  checkpointParent?: string;
+  checkpointSequence?: number;
+}): RegistryShapePlan["vmstate"] {
+  return planBootRegistryShapeNative({ vmstate: input }).vmstate;
+}
+
+export function planBootRegistryNestedNative(nested: boolean | undefined): boolean | undefined {
+  return planBootRegistryShapeNative({ nested }).nested || undefined;
 }
 
 export function planBootBundleEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -55,6 +55,7 @@ interface NativeBootPlanInput {
   restorePath?: string;
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
+  nested?: boolean;
   liveMounts?: LiveMountPlanInput[];
   liveMountsResolved?: PlannedLiveMount[];
   existingStatsFile?: string;
@@ -156,6 +157,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     restorePath: nullDefault(input.restorePath),
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
+    nested: input.nested === true,
     liveMounts: liveMountsData(input.liveMounts),
     liveMountsResolved: input.liveMountsResolved ?? [],
     existingStatsFile: nullDefault(input.existingStatsFile),
@@ -598,6 +600,18 @@ export function planBootVirtiofsEnvNative(liveMounts: PlannedLiveMount[]): Recor
     hasCmd: false,
     rootDisk: "false",
   }).virtiofsEnv;
+}
+
+export function planBootNestedEnvNative(nested: boolean | undefined): string | undefined {
+  return (
+    planBootCoreNative({
+      nested,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    }).vmmNested ?? undefined
+  );
 }
 
 export function planBootVmstateEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -44,6 +44,8 @@ interface NativeBootPlanInput {
   guestEnv?: Record<string, string>;
   name?: string;
   vsockUdsPath?: string;
+  guestHostnamePid?: number;
+  guestHostnameName?: string;
   existingVsockSpec?: string;
   autoVsockUdsPath?: string;
   portForward?: PortForwardPlanMapping[];
@@ -154,6 +156,8 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     guestEnv: input.guestEnv ?? {},
     name: nullDefault(input.name),
     vsockUdsPath: nullDefault(input.vsockUdsPath),
+    guestHostnamePid: numberText(input.guestHostnamePid),
+    guestHostnameName: nullDefault(input.guestHostnameName),
     existingVsockSpec: nullDefault(input.existingVsockSpec),
     autoVsockUdsPath: nullDefault(input.autoVsockUdsPath),
     portForward: input.portForward ?? [],
@@ -323,6 +327,21 @@ export function planBootCpuResourcesNative(
       rootDisk: "false",
     }).cpuPolicy ?? undefined
   );
+}
+
+export function planBootGuestHostnameNative(pid: number, name?: string): string {
+  const plan = planBootCoreNative({
+    guestHostnamePid: pid,
+    guestHostnameName: name,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.guestHostname === null) {
+    throw new BootError("BOOT_VMM_MISSING", "boot: native planner returned no guest hostname");
+  }
+  return plan.guestHostname;
 }
 
 export function planProvisionWorkloadNative(): ProvisionWorkloadPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -7,6 +7,7 @@ import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
 import type {
   MountDiskRuntimePlan,
   PlannedLiveMount,
+  PlannedPortForward,
   ProvisionAssetsPlan,
   ProvisionBootPlan,
   ProvisionGuestCpu,
@@ -541,6 +542,18 @@ export function planBootRegistryPortForwardNative(
   return planBootRegistryShapeNative({ portForward }).portForward ?? undefined;
 }
 
+export function planBootPortForwardNative(
+  portForward: PortForwardPlanMapping[] | undefined,
+): PlannedPortForward[] {
+  return planBootCoreNative({
+    portForward,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).plannedPortForward;
+}
+
 export function planBootBundleEnvNative(input: {
   imageEnv?: Record<string, string>;
   guestEnv: Record<string, string>;
@@ -741,16 +754,6 @@ export function planBootVmmArgvNative(input: {
     throw new BootError("BOOT_VMM_MISSING", "boot: native planner returned no VMM command");
   }
   return { command: plan.vmmCommand, args: plan.vmmArgs };
-}
-
-export function validateBootPortForwardNative(portForward: PortForwardPlanMapping[]): void {
-  planBootCoreNative({
-    portForward,
-    vmmMemoryPreset: true,
-    hasImage: false,
-    hasCmd: false,
-    rootDisk: "false",
-  });
 }
 
 export function rootDiskPlanMode(rootDisk: boolean | string | undefined): RootDiskPlanMode {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -111,6 +111,9 @@ interface NativeBootPlanInput {
   registrySourceImagePath?: string;
   registryPerBootRootDisk?: string;
   registryCallerRootDiskPath?: string;
+  registryBootLogRoot?: string;
+  registryChildPid?: number;
+  registryDetached?: boolean;
   registryPerBootSnapDisk?: string;
   registryPerBootMountUpper?: string;
   registryBundleTempDir?: string;
@@ -269,6 +272,9 @@ function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> 
     registrySourceImagePath: nullDefault(input.registrySourceImagePath),
     registryPerBootRootDisk: nullDefault(input.registryPerBootRootDisk),
     registryCallerRootDiskPath: nullDefault(input.registryCallerRootDiskPath),
+    registryBootLogRoot: nullDefault(input.registryBootLogRoot),
+    registryChildPid: numberText(input.registryChildPid),
+    registryDetached: input.registryDetached === true,
     registryPerBootSnapDisk: nullDefault(input.registryPerBootSnapDisk),
     registryPerBootMountUpper: nullDefault(input.registryPerBootMountUpper),
     registryBundleTempDir: nullDefault(input.registryBundleTempDir),
@@ -463,12 +469,13 @@ export function planBootMountDiskRuntimeNative(input: {
   }).mountDiskRuntime;
 }
 
-export function planBootRegistryShapeNative(input: {
+interface BootRegistryShapeNativeInput {
   sourceImagePath?: string;
   rootDisk?: {
     perBootRootDisk?: string;
     callerRootDiskPath?: string;
   };
+  bootLog?: { root: string; childPid: number; detached?: boolean };
   cleanup?: {
     perBootRootDisk?: string;
     perBootSnapDisk?: string;
@@ -493,29 +500,20 @@ export function planBootRegistryShapeNative(input: {
   mountDisk?: { guest: string; lowerPath: string; upperPath: string };
   liveMounts?: PlannedLiveMount[];
   portForward?: PortForwardPlanMapping[];
-}): RegistryShapePlan {
+}
+
+export function planBootRegistryShapeNative(
+  input: BootRegistryShapeNativeInput,
+): RegistryShapePlan {
   return planBootCoreNative({
     registrySourceImagePath: input.sourceImagePath,
-    registryPerBootRootDisk: input.rootDisk?.perBootRootDisk ?? input.cleanup?.perBootRootDisk,
-    registryCallerRootDiskPath: input.rootDisk?.callerRootDiskPath,
-    registryPerBootSnapDisk: input.cleanup?.perBootSnapDisk,
-    registryPerBootMountUpper: input.cleanup?.perBootMountUpper,
-    registryBundleTempDir: input.cleanup?.bundleTempDir,
-    registryVsockTempDir: input.cleanup?.vsockTempDir,
-    registryStatsTempDir: input.cleanup?.statsTempDir,
-    registryGvSocketDir: input.cleanup?.gvSocketDir,
-    registryCpuCgroupPath: input.cleanup?.cpuCgroupPath,
-    registryCpuPolicy: input.cpu?.policy,
-    registryCpuControlStatus: input.cpu?.control.status,
-    registryCpuControlReason: input.cpu?.control.reason,
-    registryVmstatePath: input.vmstate?.statePath,
-    registryVmstateChainId: input.vmstate?.chainId,
-    registryVmstateCheckpointParent: input.vmstate?.checkpointParent,
-    registryVmstateCheckpointSequence: input.vmstate?.checkpointSequence,
+    ...registryRootDiskData(input),
+    ...registryBootLogData(input),
+    ...registryCleanupData(input),
+    ...registryCpuData(input),
+    ...registryVmstateData(input),
     registryNested: input.nested,
-    registryMountGuest: input.mountDisk?.guest,
-    registryMountLowerPath: input.mountDisk?.lowerPath,
-    registryMountUpperPath: input.mountDisk?.upperPath,
+    ...registryMountDiskData(input),
     liveMountsResolved: input.liveMounts,
     portForward: input.portForward,
     vmmMemoryPreset: true,
@@ -523,6 +521,58 @@ export function planBootRegistryShapeNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).registryShape;
+}
+
+function registryRootDiskData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryPerBootRootDisk: input.rootDisk?.perBootRootDisk ?? input.cleanup?.perBootRootDisk,
+    registryCallerRootDiskPath: input.rootDisk?.callerRootDiskPath,
+  };
+}
+
+function registryBootLogData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryBootLogRoot: input.bootLog?.root,
+    registryChildPid: input.bootLog?.childPid,
+    registryDetached: input.bootLog?.detached,
+  };
+}
+
+function registryCleanupData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryPerBootSnapDisk: input.cleanup?.perBootSnapDisk,
+    registryPerBootMountUpper: input.cleanup?.perBootMountUpper,
+    registryBundleTempDir: input.cleanup?.bundleTempDir,
+    registryVsockTempDir: input.cleanup?.vsockTempDir,
+    registryStatsTempDir: input.cleanup?.statsTempDir,
+    registryGvSocketDir: input.cleanup?.gvSocketDir,
+    registryCpuCgroupPath: input.cleanup?.cpuCgroupPath,
+  };
+}
+
+function registryCpuData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryCpuPolicy: input.cpu?.policy,
+    registryCpuControlStatus: input.cpu?.control.status,
+    registryCpuControlReason: input.cpu?.control.reason,
+  };
+}
+
+function registryVmstateData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryVmstatePath: input.vmstate?.statePath,
+    registryVmstateChainId: input.vmstate?.chainId,
+    registryVmstateCheckpointParent: input.vmstate?.checkpointParent,
+    registryVmstateCheckpointSequence: input.vmstate?.checkpointSequence,
+  };
+}
+
+function registryMountDiskData(input: BootRegistryShapeNativeInput): Partial<NativeBootPlanInput> {
+  return {
+    registryMountGuest: input.mountDisk?.guest,
+    registryMountLowerPath: input.mountDisk?.lowerPath,
+    registryMountUpperPath: input.mountDisk?.upperPath,
+  };
 }
 
 export function planBootRegistryCpuNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -114,6 +114,10 @@ interface NativeBootPlanInput {
   mountDiskGuest?: string;
   mountDiskUpperSize?: number;
   registrySourceImagePath?: string;
+  registryDiskPath?: string;
+  registryForkedFrom?: string;
+  registryMemoryCeilingMib?: number;
+  registryStatsPath?: string;
   registryPerBootRootDisk?: string;
   registryCallerRootDiskPath?: string;
   registryBootLogRoot?: string;
@@ -279,6 +283,10 @@ function mountDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknow
 function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> {
   return {
     registrySourceImagePath: nullDefault(input.registrySourceImagePath),
+    registryDiskPath: nullDefault(input.registryDiskPath),
+    registryForkedFrom: nullDefault(input.registryForkedFrom),
+    registryMemoryCeilingMib: numberText(input.registryMemoryCeilingMib),
+    registryStatsPath: nullDefault(input.registryStatsPath),
     registryPerBootRootDisk: nullDefault(input.registryPerBootRootDisk),
     registryCallerRootDiskPath: nullDefault(input.registryCallerRootDiskPath),
     registryBootLogRoot: nullDefault(input.registryBootLogRoot),
@@ -480,6 +488,10 @@ export function planBootMountDiskRuntimeNative(input: {
 
 interface BootRegistryShapeNativeInput {
   sourceImagePath?: string;
+  diskPath?: string;
+  forkedFrom?: string;
+  memoryCeilingMib?: number;
+  statsPath?: string;
   rootDisk?: {
     perBootRootDisk?: string;
     callerRootDiskPath?: string;
@@ -516,6 +528,10 @@ export function planBootRegistryShapeNative(
 ): RegistryShapePlan {
   return planBootCoreNative({
     registrySourceImagePath: input.sourceImagePath,
+    registryDiskPath: input.diskPath,
+    registryForkedFrom: input.forkedFrom,
+    registryMemoryCeilingMib: input.memoryCeilingMib,
+    registryStatsPath: input.statsPath,
     ...registryRootDiskData(input),
     ...registryBootLogData(input),
     ...registryCleanupData(input),
@@ -608,6 +624,21 @@ export function planBootRegistryPortForwardNative(
   portForward: PortForwardPlanMapping[],
 ): RegistryShapePlan["portForward"] | undefined {
   return planBootRegistryShapeNative({ portForward }).portForward ?? undefined;
+}
+
+export function planBootRegistryScalarsNative(input: {
+  diskPath?: string;
+  forkedFrom?: string;
+  memoryCeilingMib?: number;
+  statsPath?: string;
+}): Pick<RegistryShapePlan, "diskPath" | "forkedFrom" | "memoryCeilingMib" | "statsPath"> {
+  const plan = planBootRegistryShapeNative(input);
+  return {
+    diskPath: plan.diskPath,
+    forkedFrom: plan.forkedFrom,
+    memoryCeilingMib: plan.memoryCeilingMib,
+    statsPath: plan.statsPath,
+  };
 }
 
 export function planBootPortForwardNative(

--- a/packages/runtime/src/nested-virt.ts
+++ b/packages/runtime/src/nested-virt.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { BootError } from "./errors.ts";
+import { planBootNestedEnvNative } from "./native/boot-plan.ts";
 import {
   probeNestedVirtualizationNative,
   type NestedVirtProbeObservation,
@@ -121,7 +122,8 @@ export function applyNestedVirtualizationEnv(
   nested: boolean | undefined,
   env: Record<string, string>,
 ): void {
-  if (nested) {
-    env.MACHINEN_NESTED = "1";
+  const planned = planBootNestedEnvNative(nested);
+  if (planned) {
+    env.MACHINEN_NESTED = planned;
   }
 }

--- a/packages/runtime/src/vm/boot-diagnostics.ts
+++ b/packages/runtime/src/vm/boot-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
 
 import { ExecError } from "../errors.ts";
 import type { VmHandle } from "../vm-handle.ts";
@@ -17,17 +18,27 @@ export async function runVsockWithBootDiagnostics<T>(
   try {
     return await run();
   } catch (err) {
-    if (err instanceof ExecError && (child.exitCode !== null || child.signalCode !== null)) {
-      const stderrTail = (await errorCollector).slice(-CONSOLE_TAIL_BYTES);
-      if (stderrTail) {
-        throw new ExecError(err.code, `${err.message}\n${bootStderrDiagnostic(stderrTail)}`, {
-          cause: err,
-          retryable: err.retryable,
-        });
+    if (err instanceof ExecError) {
+      await waitBrieflyForExit(child);
+      if (child.exitCode !== null || child.signalCode !== null) {
+        const stderrTail = (await errorCollector).slice(-CONSOLE_TAIL_BYTES);
+        if (stderrTail) {
+          throw new ExecError(err.code, `${err.message}\n${bootStderrDiagnostic(stderrTail)}`, {
+            cause: err,
+            retryable: err.retryable,
+          });
+        }
       }
     }
     throw err;
   }
+}
+
+async function waitBrieflyForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await Promise.race([once(child, "exit"), delay(25)]);
 }
 
 export async function waitForDetachedExecAgent(

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -57,6 +57,7 @@ import {
   planBootPortForwardNative,
   planBootRegistryNestedNative,
   planBootRegistryPortForwardNative,
+  planBootRegistryScalarsNative,
   planBootRegistryShapeNative,
   planBootRegistryVmstateNative,
   planBootScratchDiskNative,
@@ -891,7 +892,7 @@ function buildRegisterArgs(
     sourceImageAbs: state.sourceImageAbs,
     rootDiskPath: state.rootDiskPath,
     rootDiskMode: state.rootDiskMode,
-    diskAbs: args.plan.diskAbs,
+    diskPath: args.plan.diskAbs,
     forkedFrom: args.opts.forkedFrom,
     bootLogPath: state.bootLogPath,
     cleanupPaths: cleanupPathsForBoot(args.plan, args.resources, args.spawned),
@@ -903,7 +904,7 @@ function buildRegisterArgs(
     memoryCeilingMib: args.plan.memoryCeilingMib,
     cpuPolicy: args.plan.cpuPolicy,
     cpuControl: args.spawned.cpuControl,
-    statsFilePath: args.plan.statsFilePath,
+    statsPath: args.plan.statsFilePath,
     mountDiskPaths: args.resources.mountDiskPaths,
     liveMountsResolved: args.plan.liveMountsResolved,
     vmstateStatePath: vmstate.statePath ?? undefined,
@@ -1574,7 +1575,7 @@ interface RegisterArgs {
   sourceImageAbs: string | undefined;
   rootDiskPath: string | undefined;
   rootDiskMode: "block" | "none";
-  diskAbs: string | undefined;
+  diskPath: string | undefined;
   forkedFrom: string | undefined;
   bootLogPath: string | undefined;
   cleanupPaths: string[];
@@ -1586,7 +1587,7 @@ interface RegisterArgs {
   memoryCeilingMib: number | undefined;
   cpuPolicy: ResolvedCpuResourcePolicy | undefined;
   cpuControl: CpuControlResult;
-  statsFilePath: string | undefined;
+  statsPath: string | undefined;
   mountDiskPaths: MountDiskPaths | undefined;
   liveMountsResolved: ResolvedLiveMount[];
   vmstateStatePath: string | undefined;
@@ -1614,6 +1615,7 @@ function registerInRegistry(args: RegisterArgs): boolean {
 }
 
 function buildRegistryEntry(args: RegisterArgs) {
+  const scalars = planBootRegistryScalarsNative(args);
   return {
     pid: args.childPid,
     name: args.vmName,
@@ -1621,17 +1623,17 @@ function buildRegistryEntry(args: RegisterArgs) {
     imagePath: args.sourceImageAbs,
     rootDiskPath: args.rootDiskPath,
     rootDiskMode: args.rootDiskMode,
-    diskPath: args.diskAbs,
-    forkedFrom: args.forkedFrom,
+    diskPath: scalars.diskPath ?? undefined,
+    forkedFrom: scalars.forkedFrom ?? undefined,
     bootLogPath: args.bootLogPath,
     cleanupPaths: nonEmptyList(args.cleanupPaths),
     vmmExe: registryVmmExe(args),
     gvproxyPid: args.gvPid,
     gvproxyExe: registryGvproxyExe(args),
     portForward: registryPortForward(args.portForward),
-    memoryCeilingMib: args.memoryCeilingMib,
+    memoryCeilingMib: scalars.memoryCeilingMib ?? undefined,
     cpu: registryCpu(args.cpuPolicy, args.cpuControl),
-    statsPath: args.statsFilePath,
+    statsPath: scalars.statsPath ?? undefined,
     vmstatePath: args.vmstateStatePath,
     vmstateChainId: args.vmstateChainId,
     vmstateCheckpointParent: args.vmstateCheckpointParent,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,7 +54,9 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootRegistryNestedNative,
   planBootRegistryShapeNative,
+  planBootRegistryVmstateNative,
   planBootScratchDiskNative,
   planBootStatsFileNative,
   planBootVirtiofsEnvNative,
@@ -861,6 +863,7 @@ function buildRegisterArgs(
   },
   state: BootRegistryState,
 ): RegisterArgs {
+  const vmstate = registryVmstate(args.plan.vmstate);
   return {
     childPid: state.childPid,
     vmName: state.vmName,
@@ -883,19 +886,21 @@ function buildRegisterArgs(
     statsFilePath: args.plan.statsFilePath,
     mountDiskPaths: args.resources.mountDiskPaths,
     liveMountsResolved: args.plan.liveMountsResolved,
-    vmstateStatePath: args.plan.vmstate.statePath,
-    vmstateChainId: vmstateValue(args.plan.vmstate, args.plan.vmstate.chainId),
-    vmstateCheckpointParent: vmstateValue(args.plan.vmstate, args.plan.vmstate.checkpointParent),
-    vmstateCheckpointSequence: vmstateValue(
-      args.plan.vmstate,
-      args.plan.vmstate.checkpointSequence,
-    ),
-    nested: args.opts.nested,
+    vmstateStatePath: vmstate.statePath ?? undefined,
+    vmstateChainId: vmstate.chainId ?? undefined,
+    vmstateCheckpointParent: vmstate.checkpointParent ?? undefined,
+    vmstateCheckpointSequence: vmstate.checkpointSequence ?? undefined,
+    nested: planBootRegistryNestedNative(args.opts.nested),
   };
 }
 
-function vmstateValue<T>(vmstate: BootVmstateRuntime, value: T): T | undefined {
-  return vmstate.statePath ? value : undefined;
+function registryVmstate(vmstate: BootVmstateRuntime) {
+  return planBootRegistryVmstateNative({
+    statePath: vmstate.statePath,
+    chainId: vmstate.chainId,
+    checkpointParent: vmstate.checkpointParent,
+    checkpointSequence: vmstate.checkpointSequence,
+  });
 }
 
 function cleanupPathsForBoot(

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -66,7 +66,7 @@ import {
 import { reflinkCopy } from "../reflink.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
-import { resolveCpuResourcePolicy, type ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
+import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
 import { resolveLiveMounts, synthesizeAndPackBundle, type ResolvedLiveMount } from "./bundle.ts";
 import { installVmExitCleanup } from "./exit-cleanup.ts";
 import { performForkWithRestore } from "./fork-core.ts";
@@ -950,6 +950,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
   const corePlan = planBootCoreNative({
     memoryMib: opts.memory,
     resourcesMemory: opts.resources?.memory,
+    resourcesCpu: opts.resources?.cpu,
     vmmMemoryPreset: env.MACHINEN_MEMORY !== undefined,
     hasImage: opts.image !== undefined,
     hasCmd: opts.cmd !== undefined,
@@ -964,7 +965,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     env.MACHINEN_MEMORY = corePlan.vmmMemory;
   }
   const memoryCeilingMib = corePlan.memoryCeilingMib ?? undefined;
-  const cpuPolicy = resolveCpuResourcePolicy(opts.resources?.cpu);
+  const cpuPolicy = corePlan.cpuPolicy ?? undefined;
   const scratch = prepareBootScratchDisk(opts, env, phases);
   const wantsRootDisk = corePlan.wantsRootDisk;
   setupKernelDtbEnv(opts, env);

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -63,6 +63,7 @@ import {
   planBootStatsFileNative,
   planBootVirtiofsEnvNative,
   planBootVmstateEnvNative,
+  planBootVmstateRuntimeNative,
   planBootVmmArgvNative,
   rootDiskPlanMode,
 } from "../native/boot-plan.ts";
@@ -1065,16 +1066,24 @@ function setupVmstateBoot(
   inputVsockTempDir: string | undefined,
 ): { vmstate: BootVmstateRuntime; vsockTempDir: string | undefined } {
   let vsockTempDir = inputVsockTempDir;
-  const vmstate: BootVmstateRuntime = {
-    statePath: undefined,
-    chainId: randomBytes(16).toString("hex"),
-    checkpointParent: opts._vmstateRestorePath ? opts.forkedFrom : undefined,
-    checkpointSequence: 0,
-  };
+  let statePath: string | undefined;
+  const chainId = randomBytes(16).toString("hex");
   if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
     vsockTempDir = ensureVsockTempDir(vsockTempDir);
-    vmstate.statePath = join(vsockTempDir, VMSTATE_FILE);
+    statePath = join(vsockTempDir, VMSTATE_FILE);
   }
+  const runtime = planBootVmstateRuntimeNative({
+    statePath,
+    chainId,
+    restorePath: opts._vmstateRestorePath,
+    forkedFrom: opts.forkedFrom,
+  });
+  const vmstate: BootVmstateRuntime = {
+    statePath: runtime.statePath ?? undefined,
+    chainId: runtime.chainId ?? chainId,
+    checkpointParent: runtime.checkpointParent ?? undefined,
+    checkpointSequence: runtime.checkpointSequence ?? 0,
+  };
   applyVmstateEnvPlan(opts, env, vmstate.statePath);
   return { vmstate, vsockTempDir };
 }

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -55,6 +55,7 @@ import {
   planBootCoreNative,
   planBootKernelDtbNative,
   planBootRegistryNestedNative,
+  planBootRegistryPortForwardNative,
   planBootRegistryShapeNative,
   planBootRegistryVmstateNative,
   planBootScratchDiskNative,
@@ -1612,7 +1613,7 @@ function buildRegistryEntry(args: RegisterArgs) {
     vmmExe: registryVmmExe(args),
     gvproxyPid: args.gvPid,
     gvproxyExe: registryGvproxyExe(args),
-    portForward: nonEmptyList(args.portForward),
+    portForward: registryPortForward(args.portForward),
     memoryCeilingMib: args.memoryCeilingMib,
     cpu: registryCpu(args.cpuPolicy, args.cpuControl),
     statsPath: args.statsFilePath,
@@ -1665,6 +1666,10 @@ function registryMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
 
 function registryLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
   return nonEmptyList(planBootRegistryShapeNative({ liveMounts: liveMountsResolved }).liveMounts);
+}
+
+function registryPortForward(portForward: NonNullable<BootOptions["portForward"]>) {
+  return planBootRegistryPortForwardNative(portForward);
 }
 
 // #221/#233: stamp first-guest-byte and emit the boot timeline. Either

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -572,6 +572,7 @@ interface BootPlan {
   vsockTempDir: string | undefined;
   statsFilePath: string | undefined;
   statsTempDir: string | undefined;
+  usePdeathsig: boolean;
   vmstate: BootVmstateRuntime;
   liveMountsResolved: ResolvedLiveMount[];
   mergedGuestEnv: Record<string, string>;
@@ -694,7 +695,7 @@ interface SpawnedBootVmm {
 
 async function spawnBootVmm(args: SpawnBootArgs): Promise<SpawnedBootVmm> {
   args.phases.start("vmm-spawn");
-  const vmmPdeathsig = await resolveVmmPdeathsig(args.opts);
+  const vmmPdeathsig = await resolveVmmPdeathsig(args.plan.usePdeathsig);
   const vmmArgv = planBootVmmArgvNative({
     binary: args.plan.binary,
     args: args.opts.args ?? [],
@@ -734,11 +735,8 @@ function applySpawnedCpuControls(
   }
 }
 
-async function resolveVmmPdeathsig(opts: BootOptions): Promise<string | null> {
-  if (opts.detached || opts.pdeathsig === false) {
-    return null;
-  }
-  return ensurePdeathsig();
+async function resolveVmmPdeathsig(usePdeathsig: boolean): Promise<string | null> {
+  return usePdeathsig ? ensurePdeathsig() : null;
 }
 
 function maybeOpenMountDiskFds(
@@ -959,6 +957,8 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     vmmMemoryPreset: env.MACHINEN_MEMORY !== undefined,
     hasImage: opts.image !== undefined,
     hasCmd: opts.cmd !== undefined,
+    detached: opts.detached,
+    pdeathsig: opts.pdeathsig,
     rootDisk:
       opts.rootDisk === false
         ? "false"
@@ -989,6 +989,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     vsockUdsPath: vsock.vsockUdsPath,
     vsockTempDir: vmstateSetup.vsockTempDir,
     ...stats,
+    usePdeathsig: corePlan.usePdeathsig,
     vmstate: vmstateSetup.vmstate,
     liveMountsResolved,
     mergedGuestEnv: buildMergedGuestEnv(opts, vsock.vsockUdsPath),

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -460,7 +460,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     bootLogPath,
   } = registry;
 
-  const timeoutMs = opts.timeoutMs === undefined ? 60_000 : opts.timeoutMs;
+  const timeoutMs = plan.timeoutMs;
 
   // Start collecting stdout/stderr eagerly. Doing it lazily on the
   // first call to `.output()` / `.errorOutput()` loses data: the
@@ -584,6 +584,7 @@ interface BootPlan {
   env: Record<string, string>;
   memoryCeilingMib: number | undefined;
   cpuPolicy: ResolvedCpuResourcePolicy | undefined;
+  timeoutMs: number | null;
   diskAbs: string | undefined;
   perBootSnapDisk: string | undefined;
   wantsRootDisk: boolean;
@@ -976,6 +977,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     hasSnapshot: Boolean(opts.snapshot),
     detached: opts.detached,
     pdeathsig: opts.pdeathsig,
+    bootTimeoutMs: opts.timeoutMs,
     rootDisk:
       opts.rootDisk === false
         ? "false"
@@ -1001,6 +1003,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     env,
     memoryCeilingMib,
     cpuPolicy,
+    timeoutMs: corePlan.timeoutMs,
     ...scratch,
     wantsRootDisk,
     needsInitramfs: corePlan.needsInitramfs,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -568,6 +568,7 @@ interface BootPlan {
   diskAbs: string | undefined;
   perBootSnapDisk: string | undefined;
   wantsRootDisk: boolean;
+  needsInitramfs: boolean;
   vsockUdsPath: string | undefined;
   vsockTempDir: string | undefined;
   statsFilePath: string | undefined;
@@ -645,7 +646,7 @@ function packBootInitramfsIfNeeded(
   plan: BootPlan,
   phases: PhaseTimer,
 ): Pick<BootResources, "bundleTempDir" | "mountDiskPaths"> {
-  if (!bootNeedsInitramfs(opts)) {
+  if (!plan.needsInitramfs) {
     return { bundleTempDir: undefined, mountDiskPaths: undefined };
   }
   phases.start("initramfs-pack");
@@ -659,10 +660,6 @@ function packBootInitramfsIfNeeded(
   const packMs = phases.end("initramfs-pack");
   debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
   return { bundleTempDir: packed.tempDir, mountDiskPaths: packed.mountDisk };
-}
-
-function bootNeedsInitramfs(opts: BootOptions): boolean {
-  return Boolean(opts.image || opts.cmd || opts.snapshot);
 }
 
 function materializeRootdiskIfNeeded(
@@ -957,6 +954,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     vmmMemoryPreset: env.MACHINEN_MEMORY !== undefined,
     hasImage: opts.image !== undefined,
     hasCmd: opts.cmd !== undefined,
+    hasSnapshot: Boolean(opts.snapshot),
     detached: opts.detached,
     pdeathsig: opts.pdeathsig,
     rootDisk:
@@ -986,6 +984,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     cpuPolicy,
     ...scratch,
     wantsRootDisk,
+    needsInitramfs: corePlan.needsInitramfs,
     vsockUdsPath: vsock.vsockUdsPath,
     vsockTempDir: vmstateSetup.vsockTempDir,
     ...stats,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -540,12 +540,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // (`(none)` on Linux). Subsequent shells (e.g. via
   // `machinen attach`) read the post-call value. Suppressed when
   // we have no vsock UDS (boot-without-exec-agent paths).
-  setPlannedGuestHostnameIfEnabled(handle, vsockUdsPath, env);
+  if (vsockUdsPath && env.MACHINEN_SKIP_GUEST_HOSTNAME !== "1") {
+    void setGuestHostname(handle, buildGuestHostname(handle.pid, handle.name));
+  }
 
   if (opts.detached && bootLogPath) {
     await gateOnDetachedReadiness({
       child,
-      timeoutMs,
+      timeoutMs: plan.detachedReadinessTimeoutMs,
       bootLogPath,
       detachedBootChunks,
       handle,
@@ -560,26 +562,6 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 // Helpers
 // =============================================================
 
-function setPlannedGuestHostnameIfEnabled(
-  handle: VmHandle,
-  vsockUdsPath: string | undefined,
-  env: Record<string, string>,
-): void {
-  if (!vsockUdsPath || env.MACHINEN_SKIP_GUEST_HOSTNAME === "1") {
-    return;
-  }
-  try {
-    void setGuestHostname(handle, buildGuestHostname(handle.pid, handle.name));
-  } catch (err) {
-    debug(
-      "setGuestHostname: planner failed pid=%d name=%s err=%s",
-      handle.pid,
-      handle.name ?? "",
-      err instanceof Error ? err.message : String(err),
-    );
-  }
-}
-
 interface BootPlan {
   portForward: NonNullable<BootOptions["portForward"]>;
   binary: string;
@@ -587,6 +569,7 @@ interface BootPlan {
   memoryCeilingMib: number | undefined;
   cpuPolicy: ResolvedCpuResourcePolicy | undefined;
   timeoutMs: number | null;
+  detachedReadinessTimeoutMs: number;
   diskAbs: string | undefined;
   perBootSnapDisk: string | undefined;
   wantsRootDisk: boolean;
@@ -1010,6 +993,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
     memoryCeilingMib,
     cpuPolicy,
     timeoutMs: corePlan.timeoutMs,
+    detachedReadinessTimeoutMs: corePlan.detachedReadinessTimeoutMs,
     ...scratch,
     wantsRootDisk,
     needsInitramfs: corePlan.needsInitramfs,
@@ -2085,13 +2069,12 @@ function updateVmstateChainState(
 // the first console byte, so early guest panics become BootErrors.
 async function gateOnDetachedReadiness(args: {
   child: ChildProcessWithoutNullStreams;
-  timeoutMs: number | null;
+  timeoutMs: number;
   bootLogPath: string;
   detachedBootChunks: Buffer[];
   handle: VmHandle;
 }): Promise<void> {
-  const readinessTimeoutMs = args.timeoutMs ?? 60_000;
-  const outcome = await waitForDetachedExecAgent(args, readinessTimeoutMs);
+  const outcome = await waitForDetachedExecAgent(args, args.timeoutMs);
   const stderrTail = bootStderrTail(args.detachedBootChunks);
   writeBootSnapshot(args.bootLogPath, stderrTail);
   if (outcome.kind === "exit") {
@@ -2112,7 +2095,7 @@ async function gateOnDetachedReadiness(args: {
     throw new BootError(
       "BOOT_DETACHED_READINESS_FAILED",
       bootReadinessFailureMessage(
-        `boot --detached: exec-agent did not become reachable within ${readinessTimeoutMs}ms.`,
+        `boot --detached: exec-agent did not become reachable within ${args.timeoutMs}ms.`,
         args.bootLogPath,
         stderrTail,
       ),

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -537,9 +537,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   // (`(none)` on Linux). Subsequent shells (e.g. via
   // `machinen attach`) read the post-call value. Suppressed when
   // we have no vsock UDS (boot-without-exec-agent paths).
-  if (vsockUdsPath && env.MACHINEN_SKIP_GUEST_HOSTNAME !== "1") {
-    void setGuestHostname(handle, buildGuestHostname(handle.pid, handle.name));
-  }
+  setPlannedGuestHostnameIfEnabled(handle, vsockUdsPath, env);
 
   if (opts.detached && bootLogPath) {
     await gateOnDetachedReadiness({
@@ -558,6 +556,26 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 // =============================================================
 // Helpers
 // =============================================================
+
+function setPlannedGuestHostnameIfEnabled(
+  handle: VmHandle,
+  vsockUdsPath: string | undefined,
+  env: Record<string, string>,
+): void {
+  if (!vsockUdsPath || env.MACHINEN_SKIP_GUEST_HOSTNAME === "1") {
+    return;
+  }
+  try {
+    void setGuestHostname(handle, buildGuestHostname(handle.pid, handle.name));
+  } catch (err) {
+    debug(
+      "setGuestHostname: planner failed pid=%d name=%s err=%s",
+      handle.pid,
+      handle.name ?? "",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
 
 interface BootPlan {
   portForward: NonNullable<BootOptions["portForward"]>;

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootPortForwardNative,
   planBootRegistryNestedNative,
   planBootRegistryPortForwardNative,
   planBootRegistryShapeNative,
@@ -64,7 +65,6 @@ import {
   planBootVmstateEnvNative,
   planBootVmmArgvNative,
   rootDiskPlanMode,
-  validateBootPortForwardNative,
 } from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
@@ -1019,8 +1019,7 @@ async function resolveBootAssets(
   phases: PhaseTimer,
 ): Promise<Pick<BootPlan, "portForward" | "binary">> {
   phases.start("asset-resolve");
-  const portForward = opts.portForward ?? [];
-  await validatePortForwardOpts(opts, portForward);
+  const portForward = await planPortForwardOpts(opts);
   const binary = resolveBootBinary(opts);
   phases.end("asset-resolve");
   return { portForward, binary };
@@ -1128,16 +1127,16 @@ function buildMergedGuestEnv(
 // touching the filesystem — so caller-input errors surface with a
 // clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
 // check happens alongside since it only reads env.
-async function validatePortForwardOpts(
+async function planPortForwardOpts(
   opts: BootOptions,
-  portForward: NonNullable<BootOptions["portForward"]>,
-): Promise<void> {
-  if (portForward.length === 0) {
-    return;
+): Promise<NonNullable<BootOptions["portForward"]>> {
+  if ((opts.portForward ?? []).length === 0) {
+    return planBootPortForwardNative(opts.portForward);
   }
   rejectPresetNetSocket(opts);
-  validateBootPortForwardNative(portForward);
+  const portForward = planBootPortForwardNative(opts.portForward);
   await validatePortForwardAvailability(portForward);
+  return portForward;
 }
 
 function rejectPresetNetSocket(opts: BootOptions): void {

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -28,7 +28,7 @@ import {
   waitForDetachedExecAgent,
 } from "./boot-diagnostics.ts";
 import { makeReseedVmstateEntropy, makeSyncVmstateSnapshot } from "./vsock-handle-ops.ts";
-import { bootSnapshotPath, writeBootSnapshot } from "../detached-log.ts";
+import { detachedLogRoot, writeBootSnapshot } from "../detached-log.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "../errors.ts";
 import { VsockExec } from "../exec.ts";
 import { runGc } from "../gc.ts";
@@ -842,7 +842,11 @@ function registryCallerRootDiskPath(opts: BootOptions): string | undefined {
 }
 
 function registryBootLogPath(opts: BootOptions, childPid: number): string | undefined {
-  return opts.detached && childPid > 0 ? bootSnapshotPath(childPid) : undefined;
+  return (
+    planBootRegistryShapeNative({
+      bootLog: { root: detachedLogRoot(), childPid, detached: opts.detached },
+    }).bootLogPath ?? undefined
+  );
 }
 
 function claimBootNameIfNeeded(

--- a/packages/runtime/src/vm/cpu-resources.ts
+++ b/packages/runtime/src/vm/cpu-resources.ts
@@ -1,4 +1,4 @@
-import { BootError } from "../errors.ts";
+import { planBootCpuResourcesNative } from "../native/boot-plan.ts";
 
 export interface BootCpuResourceOptions {
   /** Maximum guest-visible vCPUs. Phase 1 supports only 1. */
@@ -15,65 +15,10 @@ export interface ResolvedCpuResourcePolicy {
   weight: number;
 }
 
-const DEFAULT_CPU_MAX_VCPUS = 1;
 export const DEFAULT_CPU_WEIGHT = 100;
-const MIN_CPU_WEIGHT = 1;
-const MAX_CPU_WEIGHT = 10_000;
 
 export function resolveCpuResourcePolicy(
   cpu: BootCpuResourceOptions | undefined,
 ): ResolvedCpuResourcePolicy | undefined {
-  if (cpu === undefined) {
-    return undefined;
-  }
-  const maxVcpus = validateMaxVcpus(cpu.maxVcpus ?? DEFAULT_CPU_MAX_VCPUS);
-  const quotaCpus = validateQuotaCpus(cpu.quotaCpus, maxVcpus);
-  const weight = validateCpuWeight(cpu.weight ?? DEFAULT_CPU_WEIGHT);
-  return quotaCpus === undefined ? { maxVcpus, weight } : { maxVcpus, quotaCpus, weight };
-}
-
-function validateMaxVcpus(value: number): number {
-  if (!Number.isInteger(value) || value < 1) {
-    throw new BootError(
-      "BOOT_CPU_INVALID",
-      `boot: resources.cpu.maxVcpus must be a positive integer (got ${String(value)}).`,
-    );
-  }
-  if (value !== DEFAULT_CPU_MAX_VCPUS) {
-    throw new BootError(
-      "BOOT_CPU_INVALID",
-      "boot: resources.cpu.maxVcpus greater than 1 is not supported yet. " +
-        "CPU quota is scheduling budget, not extra guest-visible CPUs.",
-    );
-  }
-  return value;
-}
-
-function validateQuotaCpus(value: number | undefined, maxVcpus: number): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Number.isFinite(value) || value <= 0) {
-    throw new BootError(
-      "BOOT_CPU_INVALID",
-      `boot: resources.cpu.quotaCpus must be > 0 when set (got ${String(value)}).`,
-    );
-  }
-  if (value > maxVcpus) {
-    throw new BootError(
-      "BOOT_CPU_INVALID",
-      `boot: resources.cpu.quotaCpus (${value}) cannot exceed resources.cpu.maxVcpus (${maxVcpus}).`,
-    );
-  }
-  return value;
-}
-
-function validateCpuWeight(value: number): number {
-  if (!Number.isInteger(value) || value < MIN_CPU_WEIGHT || value > MAX_CPU_WEIGHT) {
-    throw new BootError(
-      "BOOT_CPU_INVALID",
-      `boot: resources.cpu.weight must be an integer in ${MIN_CPU_WEIGHT}..${MAX_CPU_WEIGHT} (got ${String(value)}).`,
-    );
-  }
-  return value;
+  return planBootCpuResourcesNative(cpu);
 }

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -12,7 +12,7 @@ import type { Readable } from "node:stream";
 import debugLib from "debug";
 
 import { BootError } from "../errors.ts";
-import { planBootCoreNative } from "../native/boot-plan.ts";
+import { planBootCoreNative, planBootGuestHostnameNative } from "../native/boot-plan.ts";
 import type { VsockExecOptions } from "../exec.ts";
 import type { OnLog } from "../log.ts";
 import type { VmHandle, WriteFileOptions } from "../vm-handle.ts";
@@ -342,17 +342,7 @@ export function collect(stream: Readable, capBytes: number = CONSOLE_TAIL_BYTES)
  * `<src>/<pid>` becomes a valid hostname instead of being rejected.
  */
 export function buildGuestHostname(pid: number, name?: string): string {
-  const tag = `pid-${pid}`;
-  if (!name) {
-    return `vm-${tag}`;
-  }
-  // RFC 952/1123: letters, digits, hyphen. Map everything else to `-`,
-  // collapse runs of `-`, and trim leading/trailing `-`.
-  const safe = name
-    .replace(/[^A-Za-z0-9-]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return safe.length > 0 ? `${safe}-${tag}` : `vm-${tag}`;
+  return planBootGuestHostnameNative(pid, name);
 }
 
 /**

--- a/packages/runtime/src/vm/registry-cpu.ts
+++ b/packages/runtime/src/vm/registry-cpu.ts
@@ -1,4 +1,5 @@
 import type { CpuControlResult } from "../cpu-cgroup.ts";
+import { planBootRegistryCpuNative } from "../native/boot-plan.ts";
 import type { RegistryEntry } from "../registry.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
 
@@ -8,16 +9,5 @@ export function registryCpu(
   policy: ResolvedCpuResourcePolicy | undefined,
   control: CpuControlResult,
 ): CpuRegistryEntry | undefined {
-  if (!policy) {
-    return undefined;
-  }
-  return {
-    maxVcpus: policy.maxVcpus,
-    quotaCpus: policy.quotaCpus,
-    weight: policy.weight,
-    enforcement: {
-      status: control.status,
-      reason: control.reason,
-    },
-  };
+  return planBootRegistryCpuNative({ policy, control });
 }

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -416,7 +416,21 @@ function persistLazyPagesTotal(vm: VmHandle, lazyPagesTotal: number | undefined)
 
 function probeRestoredGuestHostname(vm: VmHandle, phases: PhaseTimer): void {
   phases.start("criu-restore-probe");
-  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).finally(() => {
+  let hostname: string;
+  try {
+    hostname = buildGuestHostname(vm.pid, vm.name);
+  } catch (err) {
+    debugRestore(
+      "setGuestHostname: planner failed pid=%d name=%s err=%s",
+      vm.pid,
+      vm.name ?? "",
+      err instanceof Error ? err.message : String(err),
+    );
+    phases.end("criu-restore-probe");
+    phases.flush(debugRestore, "restore");
+    return;
+  }
+  void setGuestHostname(vm, hostname).finally(() => {
     phases.end("criu-restore-probe");
     phases.flush(debugRestore, "restore");
   });
@@ -955,5 +969,14 @@ function cleanupMaterializedVmstate(materializedTempDir: string | undefined): vo
 }
 
 function restampRestoredHostname(vm: VmHandle): void {
-  void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).catch(() => {});
+  try {
+    void setGuestHostname(vm, buildGuestHostname(vm.pid, vm.name)).catch(() => {});
+  } catch (err) {
+    debugRestore(
+      "setGuestHostname: planner failed pid=%d name=%s err=%s",
+      vm.pid,
+      vm.name ?? "",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }


### PR DESCRIPTION
## Problem

Boot and registry planning still had many small TypeScript branches for scalar choices. They were safe branches, but they made the shell harder to audit.

## Solution

Move the first part of the second planning wave into Zig. This slice covers CPU, nested virtualization, pdeathsig, initramfs, hostname, port-forward registry data, boot timeouts, readiness, vmstate runtime, and registry scalar planning.

## Technical Summary

- Keeps this PR to boot and registry scalar planning.
- Leaves temp path, restore/snapshot, bundle, and provision option planners for follow-up stacked PRs.
- TypeScript still resolves host paths, spawns processes, writes registries, and owns user-facing errors.
