### PR TITLE
Add runtime native boundary guardrails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Then dive deeper:
 
 Product docs:
 
+- [Runtime Zig core migration boundary](./architecture/runtime-zig-core-migration.md) — native helper boundary, guardrail, and package payload
 - [Snapshot, restore, and move](./snapshot/README.md) — current product surfaces
 - [vmstate specification](./snapshot/vmstate-specification.md) — whole-VM snapshot file format and saved state
 - [vmstate portability policy](./snapshot/vmstate-portability.md) — restore invariants and cross-HVF/KVM policy

--- a/docs/architecture/runtime-zig-core-migration.md
+++ b/docs/architecture/runtime-zig-core-migration.md
@@ -30,7 +30,10 @@ The helper uses strict JSON stdin/stdout envelopes with `protocolVersion: 1`.
 
 - a non-wrapper product module references `callRuntimeHelper`
 - a wrapper re-exports `callRuntimeHelper`
+- any non-test `packages/runtime/src/**/*.ts` module lacks an explicit shell role
 - an `@machinen/native-*` package stops advertising the required host binaries
+
+The TypeScript role audit covers every non-test runtime module and allows only these roles: native command wrapper, helper protocol boundary, public API shell, VM orchestration glue, host integration glue, CLI supervisor glue, and proof/policy boundary. New runtime TypeScript files must choose one of those roles instead of silently becoming a new systems implementation home.
 
 Run it directly with:
 

--- a/docs/architecture/runtime-zig-core-migration.md
+++ b/docs/architecture/runtime-zig-core-migration.md
@@ -1,0 +1,54 @@
+# Runtime Zig core migration boundary
+
+`@machinen/runtime` keeps the public TypeScript API stable, but runtime systems logic should live in the native helper under `packages/runtime/native`.
+
+## TypeScript shell
+
+TypeScript may keep:
+
+- public API types and exported functions
+- path resolution and host existence checks needed for user-facing errors
+- lifecycle orchestration, process spawning, streams, timers, and registry writes
+- command-specific wrappers under `packages/runtime/src/native/`
+
+Product modules must not call `callRuntimeHelper` directly. They should call a wrapper in `packages/runtime/src/native/` so each helper command has one typed TypeScript boundary.
+
+## Zig native core
+
+Zig owns deterministic and low-level runtime behavior behind `machinen-runtime-helper` commands:
+
+- filesystem/archive/image builders
+- host probes and process primitives
+- boot/provision/snapshot planning
+- native process proof planners as they migrate
+
+The helper uses strict JSON stdin/stdout envelopes with `protocolVersion: 1`.
+
+## Guardrail
+
+`pnpm run lint` runs `scripts/runtime-native-boundary-check.mjs`. The check fails when:
+
+- a non-wrapper product module references `callRuntimeHelper`
+- a wrapper re-exports `callRuntimeHelper`
+- an `@machinen/native-*` package stops advertising the required host binaries
+
+Run it directly with:
+
+```sh
+pnpm run runtime-native-boundary-check
+```
+
+## Native package payload
+
+Each `@machinen/native-*` host package must expose these spawned host binaries through `package.json#bin` and `index.mjs`:
+
+- `machinen-vm`
+- `machinen-runtime-helper`
+- `machinen-pdeathsig`
+- `machinen-pty`
+- `machinen-winsize`
+- `gvproxy`
+- `mke2fs`
+- `mksquashfs`
+
+The runtime helper binary carries command migrations; adding a helper command does not require a new package-level binary export.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsgo --noEmit",
     "pretest": "pnpm build",
     "test": "vitest run",
-    "lint": "oxlint --deny-warnings && node scripts/fallow-health-guard.mjs",
+    "lint": "oxlint --deny-warnings && node scripts/fallow-health-guard.mjs && node scripts/runtime-native-boundary-check.mjs",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",
     "format:fix": "oxfmt",
@@ -100,7 +100,8 @@
     "archive-node-ecosystem-restore": "node scripts/archived-smoke.mjs scripts/smoke/node-ecosystem-restore.sh",
     "archive-non-node-cross-arch": "node scripts/archived-smoke.mjs scripts/smoke/non-node-cross-arch.sh",
     "archive-go-quiescent-runtime": "node scripts/archived-smoke.mjs scripts/smoke/go-quiescent-runtime.sh",
-    "fallow:health": "node scripts/fallow-health-guard.mjs"
+    "fallow:health": "node scripts/fallow-health-guard.mjs",
+    "runtime-native-boundary-check": "node scripts/runtime-native-boundary-check.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/scripts/runtime-native-boundary-check.mjs
+++ b/scripts/runtime-native-boundary-check.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const RUNTIME_SRC = join(ROOT, "packages", "runtime", "src");
+const NATIVE_PACKAGES = ["native-arm64-darwin", "native-arm64-linux", "native-x64-linux"];
+
+const EXPECTED_HOST_BINS = {
+  "machinen-gvproxy": "./vmm/bin/gvproxy",
+  "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
+  "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+  "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
+  "machinen-pty": "./vmm/bin/machinen-pty",
+  "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
+  "machinen-vm": "./vmm/bin/machinen-vm",
+  "machinen-winsize": "./vmm/bin/machinen-winsize",
+};
+
+const EXPECTED_INDEX_EXPORTS = {
+  binary: "machinen-vm",
+  runtimeHelper: "machinen-runtime-helper",
+  pdeathsig: "machinen-pdeathsig",
+  pty: "machinen-pty",
+  winsize: "machinen-winsize",
+  gvproxy: "gvproxy",
+  initPath: "init",
+  execAgentPath: "exec-agent",
+  mke2fs: "mke2fs",
+  mksquashfs: "mksquashfs",
+};
+
+const failures = [];
+checkRuntimeHelperBoundary();
+checkNativePackageManifests();
+
+if (failures.length > 0) {
+  console.error(`runtime-native-boundary-check: ${failures.length} issue(s)`);
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "runtime-native-boundary-check: runtime native boundaries and package manifests are valid",
+);
+
+function checkRuntimeHelperBoundary() {
+  for (const file of walkTsFiles(RUNTIME_SRC)) {
+    const rel = relative(RUNTIME_SRC, file).split(sep).join("/");
+    const text = readFileSync(file, "utf8");
+    const allowed = rel === "native-helper.ts" || rel.startsWith("native/");
+    if (!allowed && /\bcallRuntimeHelper\b/.test(text)) {
+      failures.push(
+        `${rel} references callRuntimeHelper directly; product modules must use a command-specific wrapper under packages/runtime/src/native/`,
+      );
+    }
+    if (!allowed && /from\s+["'][^"']*native-helper\.ts["']/.test(text)) {
+      failures.push(
+        `${rel} imports native-helper.ts directly; add a command-specific wrapper under packages/runtime/src/native/`,
+      );
+    }
+    if (rel.startsWith("native/") && /export\s*\{[^}]*callRuntimeHelper/.test(text)) {
+      failures.push(
+        `${rel} re-exports callRuntimeHelper; wrappers must not broaden the public native boundary`,
+      );
+    }
+  }
+}
+
+function checkNativePackageManifests() {
+  for (const pkgName of NATIVE_PACKAGES) {
+    const pkgDir = join(ROOT, "packages", pkgName);
+    const pkgJsonPath = join(pkgDir, "package.json");
+    const indexPath = join(pkgDir, "index.mjs");
+    const manifest = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    for (const [binName, binPath] of Object.entries(EXPECTED_HOST_BINS)) {
+      if (manifest.bin?.[binName] !== binPath) {
+        failures.push(`${pkgName}/package.json bin.${binName} must be ${binPath}`);
+      }
+    }
+    const index = readFileSync(indexPath, "utf8");
+    for (const [exportName, marker] of Object.entries(EXPECTED_INDEX_EXPORTS)) {
+      if (!new RegExp(`export\\s+const\\s+${exportName}\\b`).test(index)) {
+        failures.push(`${pkgName}/index.mjs must export ${exportName}`);
+      }
+      if (!index.includes(marker)) {
+        failures.push(`${pkgName}/index.mjs export ${exportName} must reference ${marker}`);
+      }
+    }
+  }
+}
+
+function* walkTsFiles(dir) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const st = statSync(path);
+    if (st.isDirectory()) {
+      if (entry === "__tests__" || entry === "dist" || entry === "node_modules") {
+        continue;
+      }
+      yield* walkTsFiles(path);
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts") && existsSync(path)) {
+      yield path;
+    }
+  }
+}

--- a/scripts/runtime-native-boundary-check.mjs
+++ b/scripts/runtime-native-boundary-check.mjs
@@ -5,6 +5,7 @@ import { join, relative, resolve, sep } from "node:path";
 const ROOT = resolve(import.meta.dirname, "..");
 const RUNTIME_SRC = join(ROOT, "packages", "runtime", "src");
 const NATIVE_PACKAGES = ["native-arm64-darwin", "native-arm64-linux", "native-x64-linux"];
+const SKIP_DIRS = new Set(["__tests__", "dist", "node_modules"]);
 
 const EXPECTED_HOST_BINS = {
   "machinen-gvproxy": "./vmm/bin/gvproxy",
@@ -30,8 +31,82 @@ const EXPECTED_INDEX_EXPORTS = {
   mksquashfs: "mksquashfs",
 };
 
+const ROOT_SHELL_MODULES = new Set([
+  "errors.ts",
+  "index.ts",
+  "log.ts",
+  "native-hex.ts",
+  "phase-timer.ts",
+  "target-native-consumption-results.ts",
+  "vm-handle.ts",
+]);
+
+const HOST_OR_INTEGRATION_GLUE_MODULES = new Set([
+  "advanced-linux-facility-probe.ts",
+  "balloon-stats.ts",
+  "cpu-cgroup.ts",
+  "detached-log.ts",
+  "exec.ts",
+  "files.ts",
+  "gc.ts",
+  "gvproxy.ts",
+  "host-mem.ts",
+  "mkinitramfs.ts",
+  "mount-resolver.ts",
+  "mountdisk-img.ts",
+  "multiplex.ts",
+  "nested-virt.ts",
+  "pdeathsig.ts",
+  "pid-validate.ts",
+  "proc-rss.ts",
+  "provision.ts",
+  "pty.ts",
+  "reflink.ts",
+  "registry.ts",
+  "rootfs-img.ts",
+  "rootfs-template-metadata.ts",
+  "secrets.ts",
+  "winsize.ts",
+]);
+
+const PROOF_OR_POLICY_MODULE_PATTERNS = [
+  /^architecture-portable-snapshot-gauntlet\.ts$/,
+  /^guest-checkpoint-substrate\.ts$/,
+  /^lazy-pagemap\.ts$/,
+  /^level5-runtime-adapter\.ts$/,
+  /^move-pid-graph\.ts$/,
+  /^native-[^/]+\.ts$/,
+  /^nested-virtualization-stretch-proof\.ts$/,
+  /^node-level5-[^/]+\.ts$/,
+  /^node-proper-level5-[^/]+\.ts$/,
+  /^opposite-isa-vm-execution\.ts$/,
+  /^portable-machine-[^/]+\.ts$/,
+  /^portable-snapshot-guest-checkpoint-composition\.ts$/,
+  /^product-claim-registry\.ts$/,
+  /^runtime-confidence-profile\.ts$/,
+  /^stateful-database-restore\.ts$/,
+  /^target-guest-[^/]+\.ts$/,
+];
+
+const RUNTIME_TS_ROLE_RULES = [
+  ["native-command-wrapper", (rel) => rel.startsWith("native/")],
+  ["helper-protocol-boundary", (rel) => rel === "native-helper.ts"],
+  ["cli-supervisor-glue", (rel) => rel.startsWith("bin/")],
+  ["public-api-shell", (rel) => ROOT_SHELL_MODULES.has(rel)],
+  ["vm-orchestration-glue", (rel) => rel.startsWith("vm/")],
+  ["host-integration-glue", (rel) => HOST_OR_INTEGRATION_GLUE_MODULES.has(rel)],
+  [
+    "proof-or-policy-boundary",
+    (rel) => PROOF_OR_POLICY_MODULE_PATTERNS.some((pattern) => pattern.test(rel)),
+  ],
+];
+
+const roleCounts = new Map();
 const failures = [];
+const runtimeTsFiles = Array.from(walkTsFiles(RUNTIME_SRC));
+
 checkRuntimeHelperBoundary();
+checkRuntimeTsShellRoleCoverage();
 checkNativePackageManifests();
 
 if (failures.length > 0) {
@@ -43,66 +118,140 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "runtime-native-boundary-check: runtime native boundaries and package manifests are valid",
+  "runtime-native-boundary-check: runtime native boundaries, TypeScript shell roles, and package manifests are valid",
 );
+console.log(`runtime-native-boundary-check: TypeScript role coverage ${formatRoleSummary()}`);
 
 function checkRuntimeHelperBoundary() {
-  for (const file of walkTsFiles(RUNTIME_SRC)) {
-    const rel = relative(RUNTIME_SRC, file).split(sep).join("/");
-    const text = readFileSync(file, "utf8");
-    const allowed = rel === "native-helper.ts" || rel.startsWith("native/");
-    if (!allowed && /\bcallRuntimeHelper\b/.test(text)) {
-      failures.push(
-        `${rel} references callRuntimeHelper directly; product modules must use a command-specific wrapper under packages/runtime/src/native/`,
-      );
-    }
-    if (!allowed && /from\s+["'][^"']*native-helper\.ts["']/.test(text)) {
-      failures.push(
-        `${rel} imports native-helper.ts directly; add a command-specific wrapper under packages/runtime/src/native/`,
-      );
-    }
-    if (rel.startsWith("native/") && /export\s*\{[^}]*callRuntimeHelper/.test(text)) {
-      failures.push(
-        `${rel} re-exports callRuntimeHelper; wrappers must not broaden the public native boundary`,
-      );
-    }
+  for (const file of runtimeTsFiles) {
+    checkRuntimeHelperBoundaryFile(file);
   }
+}
+
+function checkRuntimeHelperBoundaryFile(file) {
+  const rel = runtimeRel(file);
+  const text = readFileSync(file, "utf8");
+  const wrapper = rel.startsWith("native/");
+  if (wrapper) {
+    checkWrapperDoesNotReexportHelper(rel, text);
+    return;
+  }
+  if (rel !== "native-helper.ts") {
+    checkProductModuleDoesNotBypassWrapper(rel, text);
+  }
+}
+
+function checkProductModuleDoesNotBypassWrapper(rel, text) {
+  if (/\bcallRuntimeHelper\b/.test(text)) {
+    failures.push(
+      `${rel} references callRuntimeHelper directly; product modules must use a command-specific wrapper under packages/runtime/src/native/`,
+    );
+  }
+  if (/from\s+["'][^"']*native-helper\.ts["']/.test(text)) {
+    failures.push(
+      `${rel} imports native-helper.ts directly; add a command-specific wrapper under packages/runtime/src/native/`,
+    );
+  }
+}
+
+function checkWrapperDoesNotReexportHelper(rel, text) {
+  if (/export\s*\{[^}]*callRuntimeHelper/.test(text)) {
+    failures.push(
+      `${rel} re-exports callRuntimeHelper; wrappers must not broaden the public native boundary`,
+    );
+  }
+}
+
+function checkRuntimeTsShellRoleCoverage() {
+  for (const file of runtimeTsFiles) {
+    checkRuntimeTsShellRoleFile(file);
+  }
+}
+
+function checkRuntimeTsShellRoleFile(file) {
+  const rel = runtimeRel(file);
+  const role = classifyRuntimeTsModule(rel);
+  if (role === null) {
+    failures.push(
+      `${rel} has no runtime TypeScript shell role; classify it as a public shell, native wrapper, orchestration glue, host integration glue, or proof/policy boundary`,
+    );
+    return;
+  }
+  roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
 }
 
 function checkNativePackageManifests() {
   for (const pkgName of NATIVE_PACKAGES) {
     const pkgDir = join(ROOT, "packages", pkgName);
-    const pkgJsonPath = join(pkgDir, "package.json");
-    const indexPath = join(pkgDir, "index.mjs");
-    const manifest = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
-    for (const [binName, binPath] of Object.entries(EXPECTED_HOST_BINS)) {
-      if (manifest.bin?.[binName] !== binPath) {
-        failures.push(`${pkgName}/package.json bin.${binName} must be ${binPath}`);
-      }
-    }
-    const index = readFileSync(indexPath, "utf8");
-    for (const [exportName, marker] of Object.entries(EXPECTED_INDEX_EXPORTS)) {
-      if (!new RegExp(`export\\s+const\\s+${exportName}\\b`).test(index)) {
-        failures.push(`${pkgName}/index.mjs must export ${exportName}`);
-      }
-      if (!index.includes(marker)) {
-        failures.push(`${pkgName}/index.mjs export ${exportName} must reference ${marker}`);
-      }
+    const manifest = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+    const index = readFileSync(join(pkgDir, "index.mjs"), "utf8");
+    checkNativePackageBin(pkgName, manifest.bin ?? {});
+    checkNativePackageIndex(pkgName, index);
+  }
+}
+
+function checkNativePackageBin(pkgName, bin) {
+  for (const [binName, binPath] of Object.entries(EXPECTED_HOST_BINS)) {
+    if (bin[binName] !== binPath) {
+      failures.push(`${pkgName}/package.json bin.${binName} must be ${binPath}`);
     }
   }
 }
 
+function checkNativePackageIndex(pkgName, index) {
+  for (const [exportName, marker] of Object.entries(EXPECTED_INDEX_EXPORTS)) {
+    checkNativePackageIndexExport(pkgName, index, exportName, marker);
+  }
+}
+
+function checkNativePackageIndexExport(pkgName, index, exportName, marker) {
+  if (!new RegExp(`export\\s+const\\s+${exportName}\\b`).test(index)) {
+    failures.push(`${pkgName}/index.mjs must export ${exportName}`);
+  }
+  if (!index.includes(marker)) {
+    failures.push(`${pkgName}/index.mjs export ${exportName} must reference ${marker}`);
+  }
+}
+
+function classifyRuntimeTsModule(rel) {
+  const rule = RUNTIME_TS_ROLE_RULES.find(([, test]) => test(rel));
+  return rule?.[0] ?? null;
+}
+
+function formatRoleSummary() {
+  return Array.from(roleCounts.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([role, count]) => `${role}=${count}`)
+    .join(", ");
+}
+
+function runtimeRel(file) {
+  return relative(RUNTIME_SRC, file).split(sep).join("/");
+}
+
 function* walkTsFiles(dir) {
   for (const entry of readdirSync(dir)) {
-    const path = join(dir, entry);
-    const st = statSync(path);
-    if (st.isDirectory()) {
-      if (entry === "__tests__" || entry === "dist" || entry === "node_modules") {
-        continue;
-      }
-      yield* walkTsFiles(path);
-    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts") && existsSync(path)) {
-      yield path;
-    }
+    yield* walkTsEntry(join(dir, entry), entry);
   }
+}
+
+function* walkTsEntry(path, entry) {
+  const st = statSync(path);
+  if (st.isDirectory()) {
+    yield* walkTsDirectory(path, entry);
+    return;
+  }
+  if (isRuntimeTsFile(path, entry)) {
+    yield path;
+  }
+}
+
+function* walkTsDirectory(path, entry) {
+  if (!SKIP_DIRS.has(entry)) {
+    yield* walkTsFiles(path);
+  }
+}
+
+function isRuntimeTsFile(path, entry) {
+  return entry.endsWith(".ts") && !entry.endsWith(".d.ts") && existsSync(path);
 }


### PR DESCRIPTION
## Problem

After moving runtime logic to Zig, it was still too easy for new TypeScript files to bypass the helper boundary. That could slowly undo the migration.

## Solution

This PR adds a lint-time guardrail for the runtime native boundary. It also documents which parts belong in TypeScript and which parts belong in Zig.

## Technical Summary

- Block product modules from calling the generic helper directly.
- Require every non-test runtime TypeScript module to have an explicit shell, glue, wrapper, or proof role.
- Verify the native package manifests keep exporting the host binaries the runtime needs.
