### PR TITLE
Move process and nested virt shims into helper build

### DIFF
--- a/packages/native-arm64-darwin/index.mjs
+++ b/packages/native-arm64-darwin/index.mjs
@@ -19,6 +19,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 export const binary = join(here, "vmm", "bin", "machinen-vm");
 /** Host-side Zig helper for runtime-owned native operations. */
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
+/** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
+export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-darwin/package.json
+++ b/packages/native-arm64-darwin/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/native-arm64-linux/index.mjs
+++ b/packages/native-arm64-linux/index.mjs
@@ -19,6 +19,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 export const binary = join(here, "vmm", "bin", "machinen-vm");
 /** Host-side Zig helper for runtime-owned native operations. */
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
+/** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
+export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-linux/package.json
+++ b/packages/native-arm64-linux/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/native-x64-linux/index.mjs
+++ b/packages/native-x64-linux/index.mjs
@@ -19,6 +19,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 export const binary = join(here, "vmm", "bin", "machinen-vm");
 /** Host-side Zig helper for runtime-owned native operations. */
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
+/** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
+export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-x64-linux/package.json
+++ b/packages/native-x64-linux/package.json
@@ -12,6 +12,7 @@
     "machinen-gvproxy": "./vmm/bin/gvproxy",
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
+    "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -6249,7 +6249,7 @@ by default when `output` is a TTY.
 
 ##### metadata
 
-> **metadata**: `"symbol"` \| `"dwarf"` \| `"sidecar"`
+> **metadata**: `"symbol"` \| `"sidecar"` \| `"dwarf"`
 
 ##### moduleId?
 
@@ -6753,7 +6753,7 @@ by default when `output` is a TTY.
 
 ##### proof
 
-> **proof**: `"symbol"` \| `"none"` \| `"dwarf"` \| `"sidecar"` \| `"policy"`
+> **proof**: `"symbol"` \| `"none"` \| `"sidecar"` \| `"dwarf"` \| `"policy"`
 
 ***
 
@@ -8617,7 +8617,7 @@ by default when `output` is a TTY.
 
 ##### metadata
 
-> **metadata**: `"unknown"` \| `"dwarf"` \| `"sidecar"`
+> **metadata**: `"unknown"` \| `"sidecar"` \| `"dwarf"`
 
 ##### locals
 
@@ -14702,9 +14702,9 @@ A pid plus the absolute path to its stats file (when available).
 > `optional` **statsPath?**: `string`
 
 MACHINEN_STATS_FILE path for this VMM (registry entry's
-`statsPath`). On Darwin we read `phys_footprint` from this file
-in preference to `ps -o rss=`. Optional / undefined for arbitrary
-pids that aren't machinen-managed; those fall back to ps.
+`statsPath`). On Darwin the native helper reads `phys_footprint`
+from this file in preference to `ps -o rss=`. Optional / undefined
+for arbitrary pids that aren't machinen-managed; those fall back to ps.
 
 ***
 
@@ -15452,7 +15452,7 @@ CPU resource policy and host enforcement state resolved at boot.
 
 ###### enforcement.status
 
-> **status**: `"unsupported"` \| `"none"` \| `"linux-cgroup-v2"`
+> **status**: `"unsupported"` \| `"linux-cgroup-v2"` \| `"none"`
 
 ###### enforcement.reason?
 
@@ -17241,7 +17241,7 @@ VMM backend that wrote `state.vmstate`.
 
 ##### guestArch?
 
-> `optional` **guestArch?**: `"amd64"` \| `"unknown"` \| `"arm64"`
+> `optional` **guestArch?**: `"amd64"` \| `"arm64"` \| `"unknown"`
 
 Guest CPU architecture captured in `state.vmstate`; restore must match.
 
@@ -17557,9 +17557,9 @@ you need to experiment with that combination.
 > `optional` **freeMemoryThreshold?**: `number`
 
 Backpressure gate (#274). Fraction of host total memory that must
-be free before `vm.fork()` is allowed to proceed; if `MemAvailable`
-(Linux) / `vm_stat free+speculative+purgeable` (Darwin) drops below
-`totalmem() * threshold`, the fork is refused with
+be free before `vm.fork()` is allowed to proceed; if native host
+available memory drops below total physical memory * threshold,
+the fork is refused with
 `FORK_MEMORY_BACKPRESSURE`. Mirrors the throw-immediately shape of
 #267's port-conflict gate — caller decides whether to retry.
 
@@ -26547,8 +26547,7 @@ is the loose union the kernel exposes:
   - Darwin → vm_stat free + speculative + purgeable. Inactive is
              excluded because it's dirty and needs a pageout, which
              wouldn't help a fork that needs RAM right now.
-  - other  → totalmem(). Soft-fail rather than block fork on a
-             platform we can't measure.
+  - other  → explicit helper error on platforms we do not support.
 
 #### Returns
 
@@ -26560,9 +26559,7 @@ is the loose union the kernel exposes:
 
 > **readHostTotalBytes**(): `number`
 
-Total physical memory in bytes. Thin wrapper over `os.totalmem()`
-exported alongside the free reader so tests and the backpressure
-check pull both numbers from the same module.
+Total physical memory in bytes, read by the native runtime helper.
 
 #### Returns
 
@@ -28115,7 +28112,7 @@ available.
 
 ##### host?
 
-[`NestedVirtProbeHost`](#nestedvirtprobehost) = `...`
+[`NestedVirtProbeHost`](#nestedvirtprobehost)
 
 #### Returns
 
@@ -29486,15 +29483,12 @@ available.
 Return whether the running process at `pid` is still our VMM.
 
 - `alive`     — pid is alive AND the exe + start-time match.
-- `dead`      — kill(pid, 0) failed (gone or permission-denied,
-                either way unreachable).
-- `recycled`  — pid is alive but the process isn't ours (different
-                exe, or start time outside skew).
+- `dead`      — pid is gone or unreachable.
+- `recycled`  — pid is alive but the process is not ours.
 
 Falls back to `alive` when the recorded entry lacks `vmmExe` /
 `startedAt` (older entries from before PR2). Conservative on
-purpose: the gc decision then leans on `kill(pid, 0)` alone, same
-behaviour we had before.
+purpose: the gc decision then leans on process liveness alone.
 
 #### Parameters
 
@@ -29732,10 +29726,9 @@ RSS bytes for one pid, or null if not readable.
 
 > **readHostRssBytesMulti**(`targets`): `Map`\<`number`, `number`\>
 
-Bulk variant for `machinen ls`: one syscall (Linux) or one
-subprocess (Darwin) for every live VM, instead of N. Pids that
-can't be read are simply absent from the result map — caller
-decides whether to render "?" or skip the row.
+Bulk variant for `machinen ls`. Pids that can't be read are simply
+absent from the result map — caller decides whether to render "?" or
+skip the row.
 
 #### Parameters
 

--- a/packages/runtime/native/build.zig
+++ b/packages/runtime/native/build.zig
@@ -26,6 +26,21 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
+    const pdeathsig_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    pdeathsig_mod.addCSourceFile(.{
+        .file = b.path("src/pdeathsig.c"),
+        .flags = &.{ "-O2", "-Wall", "-Wextra" },
+    });
+    const pdeathsig = b.addExecutable(.{
+        .name = "machinen-pdeathsig",
+        .root_module = pdeathsig_mod,
+    });
+    b.installArtifact(pdeathsig);
+
     const run_step = b.step("run", "Run machinen-runtime-helper");
     const run_cmd = b.addRunArtifact(exe);
     run_step.dependOn(&run_cmd.step);

--- a/packages/runtime/native/src/commands/nested_virt_probe.zig
+++ b/packages/runtime/native/src/commands/nested_virt_probe.zig
@@ -1,0 +1,125 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "nested-virt-probe";
+
+const Request = struct {
+    observed: ?runtime_helper.host.NestedVirtObservation = null,
+};
+
+const RequestError = error{
+    InvalidObserved,
+    InvalidPlatform,
+    InvalidArch,
+    InvalidLinuxDevKvm,
+    InvalidLinuxKvmNested,
+    InvalidLinuxKvmArmNested,
+    InvalidDarwinHvSupport,
+    InvalidDarwinProductVersion,
+    InvalidDarwinCpuBrand,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const result = runtime_helper.host.probeNestedVirtualization(allocator, io, request.observed) catch |err| {
+        try protocol.writeError(io, "BOOT_NESTED_VIRT_UNSUPPORTED", @errorName(err));
+        return .fail;
+    };
+    defer result.deinit(allocator);
+
+    const out = if (result.reason) |reason|
+        try std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"nested-virt-probe\",\"data\":{{\"supported\":{},\"reason\":\"{s}\"}}}}\n",
+            .{ result.supported, reason },
+        )
+    else
+        try std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"nested-virt-probe\",\"data\":{{\"supported\":{}}}}}\n",
+            .{result.supported},
+        );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{"observed"});
+    var request: Request = .{};
+    if (object.get("observed")) |observed_value| {
+        if (observed_value != .object) return error.InvalidObserved;
+        request.observed = try parseObserved(observed_value.object);
+    }
+    return request;
+}
+
+fn parseObserved(object: std.json.ObjectMap) RequestError!runtime_helper.host.NestedVirtObservation {
+    try protocol.rejectUnknownFields(object, &.{ "platform", "arch", "linuxDevKvm", "linuxKvmNested", "linuxKvmArmNested", "darwinHvSupport", "darwinProductVersion", "darwinCpuBrand" });
+    const platform = object.get("platform") orelse return error.InvalidPlatform;
+    if (platform != .string) return error.InvalidPlatform;
+    const arch = object.get("arch") orelse return error.InvalidArch;
+    if (arch != .string) return error.InvalidArch;
+    return .{
+        .platform = platform.string,
+        .arch = arch.string,
+        .linux_dev_kvm = try optionalBool(object, "linuxDevKvm", error.InvalidLinuxDevKvm),
+        .linux_kvm_nested = try optionalString(object, "linuxKvmNested", error.InvalidLinuxKvmNested),
+        .linux_kvm_arm_nested = try optionalString(object, "linuxKvmArmNested", error.InvalidLinuxKvmArmNested),
+        .darwin_hv_support = try optionalString(object, "darwinHvSupport", error.InvalidDarwinHvSupport),
+        .darwin_product_version = try optionalString(object, "darwinProductVersion", error.InvalidDarwinProductVersion),
+        .darwin_cpu_brand = try optionalString(object, "darwinCpuBrand", error.InvalidDarwinCpuBrand),
+    };
+}
+
+fn optionalBool(object: std.json.ObjectMap, name_text: []const u8, invalid: RequestError) RequestError!?bool {
+    const value = object.get(name_text) orelse return null;
+    if (value != .bool) return invalid;
+    return value.bool;
+}
+
+fn optionalString(object: std.json.ObjectMap, name_text: []const u8, invalid: RequestError) RequestError!?[]const u8 {
+    const value = object.get(name_text) orelse return null;
+    if (value == .null) return null;
+    if (value != .string) return invalid;
+    return value.string;
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/nested_virt_probe.zig
+++ b/packages/runtime/native/src/commands/nested_virt_probe.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "nested-virt-probe";
 
 const Request = struct {
@@ -21,6 +23,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -30,30 +34,47 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         return .fail;
     };
 
-    const result = runtime_helper.host.probeNestedVirtualization(allocator, io, request.observed) catch |err| {
+    const result = runtime_helper.host.probeNestedVirtualization(
+        allocator,
+        io,
+        request.observed,
+    ) catch |err| {
         try protocol.writeError(io, "BOOT_NESTED_VIRT_UNSUPPORTED", @errorName(err));
         return .fail;
     };
     defer result.deinit(allocator);
 
-    const out = if (result.reason) |reason|
-        try std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"nested-virt-probe\",\"data\":{{\"supported\":{},\"reason\":\"{s}\"}}}}\n",
-            .{ result.supported, reason },
-        )
-    else
-        try std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"nested-virt-probe\",\"data\":{{\"supported\":{}}}}}\n",
-            .{result.supported},
-        );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writeResponse(allocator, io, result);
     return .ok;
 }
 
+fn writeResponse(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    result: runtime_helper.host.NestedVirtResult,
+) !void {
+    assert(name.len > 0);
+
+    if (result.reason) |reason| {
+        try protocol.writeJson(allocator, io, .{
+            .ok = true,
+            .protocolVersion = @as(u8, protocol.version),
+            .command = name,
+            .data = .{ .supported = result.supported, .reason = reason },
+        });
+        return;
+    }
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .supported = result.supported },
+    });
+}
+
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -66,8 +87,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
@@ -80,8 +100,21 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     return request;
 }
 
-fn parseObserved(object: std.json.ObjectMap) RequestError!runtime_helper.host.NestedVirtObservation {
-    try protocol.rejectUnknownFields(object, &.{ "platform", "arch", "linuxDevKvm", "linuxKvmNested", "linuxKvmArmNested", "darwinHvSupport", "darwinProductVersion", "darwinCpuBrand" });
+fn parseObserved(
+    object: std.json.ObjectMap,
+) RequestError!runtime_helper.host.NestedVirtObservation {
+    assert(@sizeOf(runtime_helper.host.NestedVirtObservation) > 0);
+
+    try protocol.rejectUnknownFields(object, &.{
+        "platform",
+        "arch",
+        "linuxDevKvm",
+        "linuxKvmNested",
+        "linuxKvmArmNested",
+        "darwinHvSupport",
+        "darwinProductVersion",
+        "darwinCpuBrand",
+    });
     const platform = object.get("platform") orelse return error.InvalidPlatform;
     if (platform != .string) return error.InvalidPlatform;
     const arch = object.get("arch") orelse return error.InvalidArch;
@@ -90,21 +123,53 @@ fn parseObserved(object: std.json.ObjectMap) RequestError!runtime_helper.host.Ne
         .platform = platform.string,
         .arch = arch.string,
         .linux_dev_kvm = try optionalBool(object, "linuxDevKvm", error.InvalidLinuxDevKvm),
-        .linux_kvm_nested = try optionalString(object, "linuxKvmNested", error.InvalidLinuxKvmNested),
-        .linux_kvm_arm_nested = try optionalString(object, "linuxKvmArmNested", error.InvalidLinuxKvmArmNested),
-        .darwin_hv_support = try optionalString(object, "darwinHvSupport", error.InvalidDarwinHvSupport),
-        .darwin_product_version = try optionalString(object, "darwinProductVersion", error.InvalidDarwinProductVersion),
-        .darwin_cpu_brand = try optionalString(object, "darwinCpuBrand", error.InvalidDarwinCpuBrand),
+        .linux_kvm_nested = try optionalString(
+            object,
+            "linuxKvmNested",
+            error.InvalidLinuxKvmNested,
+        ),
+        .linux_kvm_arm_nested = try optionalString(
+            object,
+            "linuxKvmArmNested",
+            error.InvalidLinuxKvmArmNested,
+        ),
+        .darwin_hv_support = try optionalString(
+            object,
+            "darwinHvSupport",
+            error.InvalidDarwinHvSupport,
+        ),
+        .darwin_product_version = try optionalString(
+            object,
+            "darwinProductVersion",
+            error.InvalidDarwinProductVersion,
+        ),
+        .darwin_cpu_brand = try optionalString(
+            object,
+            "darwinCpuBrand",
+            error.InvalidDarwinCpuBrand,
+        ),
     };
 }
 
-fn optionalBool(object: std.json.ObjectMap, name_text: []const u8, invalid: RequestError) RequestError!?bool {
+fn optionalBool(
+    object: std.json.ObjectMap,
+    name_text: []const u8,
+    invalid: RequestError,
+) RequestError!?bool {
+    assert(name_text.len > 0);
+
     const value = object.get(name_text) orelse return null;
     if (value != .bool) return invalid;
     return value.bool;
 }
 
-fn optionalString(object: std.json.ObjectMap, name_text: []const u8, invalid: RequestError) RequestError!?[]const u8 {
+fn optionalString(
+    object: std.json.ObjectMap,
+    name_text: []const u8,
+    invalid: RequestError,
+) RequestError!?[]const u8 {
+    assert(name_text.len > 0);
+
     const value = object.get(name_text) orelse return null;
     if (value == .null) return null;
     if (value != .string) return invalid;
@@ -112,14 +177,7 @@ fn optionalString(object: std.json.ObjectMap, name_text: []const u8, invalid: Re
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -1,7 +1,8 @@
 // Host-side probes and controls used by the TypeScript runtime.
 //
 // This file keeps OS-specific, synchronous host operations in the native
-// helper: memory/RSS reads, pid identity checks, and Linux cgroup CPU setup.
+// helper: memory/RSS reads, pid identity checks, nested-virt probes, and Linux
+// cgroup CPU setup.
 // The command files translate JSON protocol requests into these functions;
 // this module owns the actual platform behavior so the TS layer stays small.
 
@@ -64,6 +65,7 @@ pub const NestedVirtResult = struct {
     reason: ?[]u8 = null,
 
     pub fn deinit(self: NestedVirtResult, allocator: std.mem.Allocator) void {
+        assert(@sizeOf(NestedVirtResult) > 0);
         if (self.reason) |reason| allocator.free(reason);
     }
 };
@@ -89,7 +91,9 @@ pub const CpuCgroupResult = struct {
 
 const CPU_PERIOD_US = 100_000;
 const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
-const NESTED_UNSUPPORTED_MESSAGE = "nested virtualization needs Linux/arm64 KVM with EL2 support, or macOS 15+ on M3/M4-class Apple Silicon";
+const NESTED_UNSUPPORTED_MESSAGE =
+    "nested virtualization needs Linux/arm64 KVM with EL2 support, or " ++
+    "macOS 15+ on M3/M4-class Apple Silicon";
 const STARTTIME_SKEW_MS = 5_000;
 
 pub fn readProcessIdentity(
@@ -159,6 +163,9 @@ fn observeNestedVirtualizationHost(
     allocator: std.mem.Allocator,
     io: std.Io,
 ) Error!NestedVirtObservation {
+    assert(actualPlatform().len > 0);
+    assert(actualArch().len > 0);
+
     var observation: NestedVirtObservation = .{
         .platform = actualPlatform(),
         .arch = actualArch(),
@@ -175,7 +182,8 @@ fn observeNestedVirtualizationHost(
             io,
             "/sys/module/kvm_arm/parameters/nested",
         );
-    } else if (builtin.os.tag == .macos) {
+    }
+    if (builtin.os.tag == .macos) {
         observation.darwin_hv_support = try runTextCommand(
             allocator,
             io,
@@ -199,6 +207,9 @@ fn deinitObservedNestedVirtualizationHost(
     allocator: std.mem.Allocator,
     observation: NestedVirtObservation,
 ) void {
+    assert(observation.platform.len > 0);
+    assert(observation.arch.len > 0);
+
     if (observation.linux_kvm_nested) |value| allocator.free(value);
     if (observation.linux_kvm_arm_nested) |value| allocator.free(value);
     if (observation.darwin_hv_support) |value| allocator.free(value);
@@ -214,7 +225,11 @@ fn evaluateNestedVirtualization(
     assert(observation.arch.len > 0);
 
     if (!std.mem.eql(u8, observation.arch, "arm64")) {
-        return nestedUnsupported(allocator, "this host is not arm64", .{});
+        return nestedUnsupported(
+            allocator,
+            "this host is {s}, not arm64",
+            .{observation.arch},
+        );
     }
     if (std.mem.eql(u8, observation.platform, "linux")) {
         return evaluateLinuxNestedVirtualization(allocator, observation);
@@ -222,7 +237,11 @@ fn evaluateNestedVirtualization(
     if (std.mem.eql(u8, observation.platform, "darwin")) {
         return evaluateDarwinNestedVirtualization(allocator, observation);
     }
-    return nestedUnsupported(allocator, "this host platform is not supported", .{});
+    return nestedUnsupported(
+        allocator,
+        "{s} hosts are not supported",
+        .{observation.platform},
+    );
 }
 
 fn evaluateLinuxNestedVirtualization(
@@ -299,6 +318,8 @@ fn evaluateDarwinNestedVirtualization(
 }
 
 fn darwinMajor(version: ?[]const u8) ?u32 {
+    assert(@sizeOf(u32) == 4);
+
     const raw = std.mem.trim(u8, version orelse return null, " \t\r\n");
     var it = std.mem.splitScalar(u8, raw, '.');
     const first = it.next() orelse return null;
@@ -308,6 +329,8 @@ fn darwinMajor(version: ?[]const u8) ?u32 {
 }
 
 fn appleSiliconGeneration(brand: ?[]const u8) ?u32 {
+    assert(@sizeOf(u32) == 4);
+
     const raw = brand orelse return null;
     const apple = std.mem.indexOf(u8, raw, "Apple M") orelse return null;
     const start = apple + "Apple M".len;
@@ -324,19 +347,21 @@ fn nestedUnsupported(
 ) Error!NestedVirtResult {
     assert(fmt.len > 0);
 
-    const detail = try std.fmt.allocPrint(allocator, fmt, args);
-    defer allocator.free(detail);
+    var detail_buf: [256]u8 = undefined;
+    const detail = try std.fmt.bufPrint(&detail_buf, fmt, args);
     return .{
         .supported = false,
-        .reason = try std.fmt.allocPrint(
+        .reason = try std.mem.concat(
             allocator,
-            "{s}; {s}",
-            .{ NESTED_UNSUPPORTED_MESSAGE, detail },
+            u8,
+            &.{ NESTED_UNSUPPORTED_MESSAGE, "; ", detail },
         ),
     };
 }
 
 fn actualPlatform() []const u8 {
+    assert(@tagName(builtin.os.tag).len > 0);
+
     return switch (builtin.os.tag) {
         .linux => "linux",
         .macos => "darwin",
@@ -345,6 +370,8 @@ fn actualPlatform() []const u8 {
 }
 
 fn actualArch() []const u8 {
+    assert(@tagName(builtin.cpu.arch).len > 0);
+
     return switch (builtin.cpu.arch) {
         .aarch64 => "arm64",
         .x86_64 => "x64",
@@ -775,14 +802,22 @@ fn looksLikeCgroupV2(io: std.Io, parent_dir: []const u8) bool {
 fn existsPath(io: std.Io, path: []const u8) bool {
     assert(path.len > 0);
 
-    const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    const st = std.Io.Dir.cwd().statFile(
+        io,
+        path,
+        .{ .follow_symlinks = false },
+    ) catch return false;
     return st.kind != .unknown;
 }
 
 fn existsFile(io: std.Io, path: []const u8) bool {
     assert(path.len > 0);
 
-    const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    const st = std.Io.Dir.cwd().statFile(
+        io,
+        path,
+        .{ .follow_symlinks = false },
+    ) catch return false;
     return st.kind == .file;
 }
 
@@ -836,7 +871,11 @@ fn writeCgroupFile(
     try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = data });
 }
 
-fn joinCgroupFile(allocator: std.mem.Allocator, cgroup_path: []const u8, name: []const u8) Error![]u8 {
+fn joinCgroupFile(
+    allocator: std.mem.Allocator,
+    cgroup_path: []const u8,
+    name: []const u8,
+) Error![]u8 {
     assert(cgroup_path.len > 0);
     assert(name.len > 0);
 
@@ -935,7 +974,9 @@ test "evaluateNestedVirtualization rejects disabled Linux nested toggles" {
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.supported);
     try std.testing.expect(result.reason != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.reason.?, "/sys/module/kvm/parameters/nested") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, result.reason.?, "/sys/module/kvm/parameters/nested") != null,
+    );
 }
 
 test "evaluateNestedVirtualization rejects macOS M1 and M2" {
@@ -1011,7 +1052,12 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
 
     const cpu_max_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cpu.max");
     defer allocator.free(cpu_max_path);
-    const cpu_max = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, cpu_max_path, 1024);
+    const cpu_max = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        allocator,
+        cpu_max_path,
+        1024,
+    );
     defer allocator.free(cpu_max);
     try std.testing.expectEqualStrings("50000 100000\n", cpu_max);
 

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -48,6 +48,26 @@ pub const HostMemory = struct {
     total_bytes: u64,
 };
 
+pub const NestedVirtObservation = struct {
+    platform: []const u8,
+    arch: []const u8,
+    linux_dev_kvm: ?bool = null,
+    linux_kvm_nested: ?[]const u8 = null,
+    linux_kvm_arm_nested: ?[]const u8 = null,
+    darwin_hv_support: ?[]const u8 = null,
+    darwin_product_version: ?[]const u8 = null,
+    darwin_cpu_brand: ?[]const u8 = null,
+};
+
+pub const NestedVirtResult = struct {
+    supported: bool,
+    reason: ?[]u8 = null,
+
+    pub fn deinit(self: NestedVirtResult, allocator: std.mem.Allocator) void {
+        if (self.reason) |reason| allocator.free(reason);
+    }
+};
+
 pub const CpuCgroupOptions = struct {
     pid: u32,
     weight: u32,
@@ -69,6 +89,7 @@ pub const CpuCgroupResult = struct {
 
 const CPU_PERIOD_US = 100_000;
 const DEFAULT_CGROUP_PARENT = "/sys/fs/cgroup";
+const NESTED_UNSUPPORTED_MESSAGE = "nested virtualization needs Linux/arm64 KVM with EL2 support, or macOS 15+ on M3/M4-class Apple Silicon";
 const STARTTIME_SKEW_MS = 5_000;
 
 pub fn readProcessIdentity(
@@ -120,6 +141,254 @@ pub fn readHostMemory(allocator: std.mem.Allocator, io: std.Io) Error!HostMemory
         .macos => readHostMemoryDarwin(allocator, io),
         else => error.UnsupportedHostMemory,
     };
+}
+
+pub fn probeNestedVirtualization(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    observed: ?NestedVirtObservation,
+) Error!NestedVirtResult {
+    assert(@sizeOf(NestedVirtObservation) > 0);
+
+    const observation = observed orelse try observeNestedVirtualizationHost(allocator, io);
+    defer if (observed == null) deinitObservedNestedVirtualizationHost(allocator, observation);
+    return evaluateNestedVirtualization(allocator, observation);
+}
+
+fn observeNestedVirtualizationHost(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+) Error!NestedVirtObservation {
+    var observation: NestedVirtObservation = .{
+        .platform = actualPlatform(),
+        .arch = actualArch(),
+    };
+    if (builtin.os.tag == .linux) {
+        observation.linux_dev_kvm = existsPath(io, "/dev/kvm");
+        observation.linux_kvm_nested = try readOptionalTextFile(
+            allocator,
+            io,
+            "/sys/module/kvm/parameters/nested",
+        );
+        observation.linux_kvm_arm_nested = try readOptionalTextFile(
+            allocator,
+            io,
+            "/sys/module/kvm_arm/parameters/nested",
+        );
+    } else if (builtin.os.tag == .macos) {
+        observation.darwin_hv_support = try runTextCommand(
+            allocator,
+            io,
+            &.{ "/usr/sbin/sysctl", "-n", "kern.hv_support" },
+        );
+        observation.darwin_product_version = try runTextCommand(
+            allocator,
+            io,
+            &.{ "/usr/bin/sw_vers", "-productVersion" },
+        );
+        observation.darwin_cpu_brand = try runTextCommand(
+            allocator,
+            io,
+            &.{ "/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string" },
+        );
+    }
+    return observation;
+}
+
+fn deinitObservedNestedVirtualizationHost(
+    allocator: std.mem.Allocator,
+    observation: NestedVirtObservation,
+) void {
+    if (observation.linux_kvm_nested) |value| allocator.free(value);
+    if (observation.linux_kvm_arm_nested) |value| allocator.free(value);
+    if (observation.darwin_hv_support) |value| allocator.free(value);
+    if (observation.darwin_product_version) |value| allocator.free(value);
+    if (observation.darwin_cpu_brand) |value| allocator.free(value);
+}
+
+fn evaluateNestedVirtualization(
+    allocator: std.mem.Allocator,
+    observation: NestedVirtObservation,
+) Error!NestedVirtResult {
+    assert(observation.platform.len > 0);
+    assert(observation.arch.len > 0);
+
+    if (!std.mem.eql(u8, observation.arch, "arm64")) {
+        return nestedUnsupported(allocator, "this host is not arm64", .{});
+    }
+    if (std.mem.eql(u8, observation.platform, "linux")) {
+        return evaluateLinuxNestedVirtualization(allocator, observation);
+    }
+    if (std.mem.eql(u8, observation.platform, "darwin")) {
+        return evaluateDarwinNestedVirtualization(allocator, observation);
+    }
+    return nestedUnsupported(allocator, "this host platform is not supported", .{});
+}
+
+fn evaluateLinuxNestedVirtualization(
+    allocator: std.mem.Allocator,
+    observation: NestedVirtObservation,
+) Error!NestedVirtResult {
+    assert(std.mem.eql(u8, observation.platform, "linux"));
+
+    if (observation.linux_dev_kvm != true) {
+        return nestedUnsupported(allocator, "/dev/kvm is not present", .{});
+    }
+    if (firstDisabledLinuxNestedToggle(observation)) |toggle_path| {
+        return nestedUnsupported(allocator, "{s} is disabled", .{toggle_path});
+    }
+    return .{ .supported = true };
+}
+
+fn firstDisabledLinuxNestedToggle(observation: NestedVirtObservation) ?[]const u8 {
+    assert(std.mem.eql(u8, observation.platform, "linux"));
+
+    if (observation.linux_kvm_nested) |value| {
+        if (isDisabledKernelToggle(value)) return "/sys/module/kvm/parameters/nested";
+    }
+    if (observation.linux_kvm_arm_nested) |value| {
+        if (isDisabledKernelToggle(value)) return "/sys/module/kvm_arm/parameters/nested";
+    }
+    return null;
+}
+
+fn isDisabledKernelToggle(value: []const u8) bool {
+    assert(value.len > 0);
+
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.ascii.eqlIgnoreCase(trimmed, "0") or
+        std.ascii.eqlIgnoreCase(trimmed, "n") or
+        std.ascii.eqlIgnoreCase(trimmed, "no") or
+        std.ascii.eqlIgnoreCase(trimmed, "false") or
+        std.ascii.eqlIgnoreCase(trimmed, "off");
+}
+
+fn evaluateDarwinNestedVirtualization(
+    allocator: std.mem.Allocator,
+    observation: NestedVirtObservation,
+) Error!NestedVirtResult {
+    assert(std.mem.eql(u8, observation.platform, "darwin"));
+
+    const hv = std.mem.trim(u8, observation.darwin_hv_support orelse "", " \t\r\n");
+    if (!std.mem.eql(u8, hv, "1")) {
+        return nestedUnsupported(
+            allocator,
+            "Hypervisor.framework support is not available",
+            .{},
+        );
+    }
+    if (darwinMajor(observation.darwin_product_version)) |major| {
+        if (major < 15) {
+            return nestedUnsupported(
+                allocator,
+                "macOS {d} is older than macOS 15",
+                .{major},
+            );
+        }
+    }
+    if (appleSiliconGeneration(observation.darwin_cpu_brand)) |generation| {
+        if (generation < 3) {
+            return nestedUnsupported(
+                allocator,
+                "Apple M{d} does not expose nested EL2",
+                .{generation},
+            );
+        }
+    }
+    return .{ .supported = true };
+}
+
+fn darwinMajor(version: ?[]const u8) ?u32 {
+    const raw = std.mem.trim(u8, version orelse return null, " \t\r\n");
+    var it = std.mem.splitScalar(u8, raw, '.');
+    const first = it.next() orelse return null;
+    if (first.len == 0) return null;
+    for (first) |c| if (!std.ascii.isDigit(c)) return null;
+    return std.fmt.parseUnsigned(u32, first, 10) catch null;
+}
+
+fn appleSiliconGeneration(brand: ?[]const u8) ?u32 {
+    const raw = brand orelse return null;
+    const apple = std.mem.indexOf(u8, raw, "Apple M") orelse return null;
+    const start = apple + "Apple M".len;
+    if (start >= raw.len or !std.ascii.isDigit(raw[start])) return null;
+    var end_index = start;
+    while (end_index < raw.len and std.ascii.isDigit(raw[end_index])) : (end_index += 1) {}
+    return std.fmt.parseUnsigned(u32, raw[start..end_index], 10) catch null;
+}
+
+fn nestedUnsupported(
+    allocator: std.mem.Allocator,
+    comptime fmt: []const u8,
+    args: anytype,
+) Error!NestedVirtResult {
+    assert(fmt.len > 0);
+
+    const detail = try std.fmt.allocPrint(allocator, fmt, args);
+    defer allocator.free(detail);
+    return .{
+        .supported = false,
+        .reason = try std.fmt.allocPrint(
+            allocator,
+            "{s}; {s}",
+            .{ NESTED_UNSUPPORTED_MESSAGE, detail },
+        ),
+    };
+}
+
+fn actualPlatform() []const u8 {
+    return switch (builtin.os.tag) {
+        .linux => "linux",
+        .macos => "darwin",
+        else => @tagName(builtin.os.tag),
+    };
+}
+
+fn actualArch() []const u8 {
+    return switch (builtin.cpu.arch) {
+        .aarch64 => "arm64",
+        .x86_64 => "x64",
+        else => @tagName(builtin.cpu.arch),
+    };
+}
+
+fn readOptionalTextFile(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+) Error!?[]u8 {
+    assert(path.len > 0);
+
+    return readFileAlloc(allocator, io, path) catch |err| switch (err) {
+        error.FileNotFound => null,
+        else => null,
+    };
+}
+
+fn runTextCommand(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    argv: []const []const u8,
+) Error!?[]u8 {
+    assert(argv.len > 0);
+
+    const result = std.process.run(allocator, io, .{
+        .argv = argv,
+        .stdout_limit = .limited(16 * 1024),
+        .stderr_limit = .limited(16 * 1024),
+    }) catch return null;
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            allocator.free(result.stdout);
+            return null;
+        },
+        else => {
+            allocator.free(result.stdout);
+            return null;
+        },
+    }
+    return result.stdout;
 }
 
 pub fn applyCpuCgroup(
@@ -642,6 +911,57 @@ fn readFileAlloc(allocator: std.mem.Allocator, io: std.Io, path: []const u8) Err
     assert(path.len > 0);
 
     return std.Io.Dir.cwd().readFileAlloc(io, allocator, path, 16 * 1024 * 1024);
+}
+
+test "evaluateNestedVirtualization accepts Linux arm64 KVM when toggles are enabled" {
+    const result = try evaluateNestedVirtualization(std.testing.allocator, .{
+        .platform = "linux",
+        .arch = "arm64",
+        .linux_dev_kvm = true,
+        .linux_kvm_nested = "Y\n",
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(result.supported);
+    try std.testing.expect(result.reason == null);
+}
+
+test "evaluateNestedVirtualization rejects disabled Linux nested toggles" {
+    const result = try evaluateNestedVirtualization(std.testing.allocator, .{
+        .platform = "linux",
+        .arch = "arm64",
+        .linux_dev_kvm = true,
+        .linux_kvm_nested = "N\n",
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.supported);
+    try std.testing.expect(result.reason != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.reason.?, "/sys/module/kvm/parameters/nested") != null);
+}
+
+test "evaluateNestedVirtualization rejects macOS M1 and M2" {
+    const result = try evaluateNestedVirtualization(std.testing.allocator, .{
+        .platform = "darwin",
+        .arch = "arm64",
+        .darwin_hv_support = "1\n",
+        .darwin_product_version = "15.0\n",
+        .darwin_cpu_brand = "Apple M2 Max\n",
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.supported);
+    try std.testing.expect(result.reason != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.reason.?, "Apple M2") != null);
+}
+
+test "evaluateNestedVirtualization rejects non-arm64 hosts explicitly" {
+    const result = try evaluateNestedVirtualization(std.testing.allocator, .{
+        .platform = "linux",
+        .arch = "x64",
+        .linux_dev_kvm = true,
+    });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.supported);
+    try std.testing.expect(result.reason != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.reason.?, "not arm64") != null);
 }
 
 fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -7,6 +7,7 @@ const host_rss = @import("commands/host_rss.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
 const mountdisk_image = @import("commands/mountdisk_image.zig");
 const mountdisk_upper = @import("commands/mountdisk_upper.zig");
+const nested_virt_probe = @import("commands/nested_virt_probe.zig");
 const pid_validate = @import("commands/pid_validate.zig");
 const process_identity = @import("commands/process_identity.zig");
 const reflink_copy = @import("commands/reflink_copy.zig");
@@ -28,6 +29,7 @@ pub fn main(init: std.process.Init) !u8 {
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
+    assert(nested_virt_probe.name.len > 0);
     assert(pid_validate.name.len > 0);
     assert(process_identity.name.len > 0);
     assert(reflink_copy.name.len > 0);
@@ -96,6 +98,12 @@ fn runHostCommand(
             return @intFromEnum(protocol.Exit.usage);
         }
         return @intFromEnum(try host_rss.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, nested_virt_probe.name)) {
+        if (try rejectExtraArgs(it, nested_virt_probe.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try nested_virt_probe.run(allocator, g_io));
     }
     if (std.mem.eql(u8, command, pid_validate.name)) {
         if (try rejectExtraArgs(it, pid_validate.name)) {
@@ -206,6 +214,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
     assert(mkinitramfs.name.len > 0);
     assert(mountdisk_image.name.len > 0);
     assert(mountdisk_upper.name.len > 0);
+    assert(nested_virt_probe.name.len > 0);
     assert(pid_validate.name.len > 0);
     assert(process_identity.name.len > 0);
     assert(reflink_copy.name.len > 0);
@@ -226,6 +235,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
             mkinitramfs.name,
             mountdisk_image.name,
             mountdisk_upper.name,
+            nested_virt_probe.name,
             pid_validate.name,
             process_identity.name,
             reflink_copy.name,

--- a/packages/runtime/native/src/pdeathsig.c
+++ b/packages/runtime/native/src/pdeathsig.c
@@ -1,0 +1,338 @@
+// pdeathsig: tiny exec wrapper that arranges for the target to die
+// when a watched process dies. See packages/runtime/src/pdeathsig.ts.
+//
+// Modes:
+//   pdeathsig <cmd> [args...]                   - watch immediate parent
+//   pdeathsig --watch-pid <pid> <cmd> [args]    - watch the given pid
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#if defined(__linux__)
+#include <sys/prctl.h>
+#include <poll.h>
+#include <sys/syscall.h>
+#include <sys/signalfd.h>
+#elif defined(__APPLE__)
+#include <sys/event.h>
+#include <sys/types.h>
+#endif
+
+#if defined(__linux__) && !defined(SYS_pidfd_open)
+#define SYS_pidfd_open 434
+#endif
+
+// Wait up to ~5s for the target to exit after SIGTERM, then escalate.
+static int reap_then_exit(pid_t child, int code) {
+    for (int i = 0; i < 50; i++) {
+        int status;
+        pid_t r = waitpid(child, &status, WNOHANG);
+        if (r == child) return code;
+        usleep(100000);
+    }
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    return code;
+}
+
+static int parse_pid(const char *s, pid_t *out) {
+    char *end = NULL;
+    errno = 0;
+    long n = strtol(s, &end, 10);
+    if (errno != 0 || end == s || end == NULL || *end != '\0' ||
+        n <= 0 || n > 0x7fffffff) {
+        return -1;
+    }
+    *out = (pid_t)n;
+    return 0;
+}
+
+#if defined(__linux__)
+
+// Default mode: prctl + execvp. Single process. Parent of pdeathsig
+// becomes the watched pid by definition.
+static int run_default_linux(char **target) {
+    if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1) {
+        perror("pdeathsig: prctl");
+        return 127;
+    }
+    // Race: parent may already be gone. PDEATHSIG won't fire because
+    // there's nothing to fire on. Detect via reparenting to PID 1.
+    if (getppid() == 1) {
+        return 0;
+    }
+    execvp(target[0], target);
+    perror("pdeathsig: execvp");
+    return 127;
+}
+
+// Watch-pid mode on Linux: fork + exec; parent watches the explicit
+// pid via pidfd_open + poll. Falls back to a kill(pid,0) polling loop
+// when pidfd_open is unavailable (kernel < 5.3) or returns ENOSYS.
+static int run_watch_pid_linux(pid_t watch_pid, char **target) {
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGHUP);
+    sigprocmask(SIG_BLOCK, &mask, NULL);
+
+    pid_t child = fork();
+    if (child == -1) {
+        perror("pdeathsig: fork");
+        return 127;
+    }
+    if (child == 0) {
+        sigprocmask(SIG_UNBLOCK, &mask, NULL);
+        execvp(target[0], target);
+        perror("pdeathsig: execvp");
+        _exit(127);
+    }
+
+    int sigfd = signalfd(-1, &mask, SFD_CLOEXEC);
+    if (sigfd == -1) {
+        perror("pdeathsig: signalfd");
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 127);
+    }
+
+    int pidfd = (int)syscall(SYS_pidfd_open, watch_pid, 0);
+    int saved_errno = errno;
+    if (pidfd == -1 && saved_errno == ESRCH) {
+        // Watched pid died between the pre-fork ESRCH check and now.
+        kill(child, SIGTERM);
+        close(sigfd);
+        return reap_then_exit(child, 0);
+    }
+
+    if (pidfd == -1) {
+        // pidfd_open unavailable (ENOSYS) or denied. Polling fallback:
+        // poll signalfd with a 250ms timeout and recheck the watched
+        // pid via kill(pid, 0) on every wake.
+        struct pollfd pfd = { .fd = sigfd, .events = POLLIN, .revents = 0 };
+        for (;;) {
+            int n = poll(&pfd, 1, 250);
+            if (n == -1) {
+                if (errno == EINTR) continue;
+                perror("pdeathsig: poll");
+                kill(child, SIGTERM);
+                close(sigfd);
+                return reap_then_exit(child, 127);
+            }
+            if (n == 1 && (pfd.revents & POLLIN)) {
+                struct signalfd_siginfo si;
+                if (read(sigfd, &si, sizeof si) == sizeof si) {
+                    kill(child, (int)si.ssi_signo);
+                    close(sigfd);
+                    return reap_then_exit(child, 128 + (int)si.ssi_signo);
+                }
+            }
+            if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
+                kill(child, SIGTERM);
+                close(sigfd);
+                return reap_then_exit(child, 0);
+            }
+            int status;
+            pid_t r = waitpid(child, &status, WNOHANG);
+            if (r == child) {
+                close(sigfd);
+                return WIFEXITED(status) ? WEXITSTATUS(status)
+                                         : 128 + WTERMSIG(status);
+            }
+        }
+    }
+
+    // pidfd path: poll signalfd + pidfd; pidfd POLLIN fires on exit.
+    struct pollfd pfds[2] = {
+        { .fd = sigfd,  .events = POLLIN, .revents = 0 },
+        { .fd = pidfd,  .events = POLLIN, .revents = 0 },
+    };
+    for (;;) {
+        int n = poll(pfds, 2, -1);
+        if (n == -1) {
+            if (errno == EINTR) continue;
+            perror("pdeathsig: poll");
+            kill(child, SIGTERM);
+            close(sigfd);
+            close(pidfd);
+            return reap_then_exit(child, 127);
+        }
+        if (pfds[1].revents & POLLIN) {
+            kill(child, SIGTERM);
+            close(sigfd);
+            close(pidfd);
+            return reap_then_exit(child, 0);
+        }
+        if (pfds[0].revents & POLLIN) {
+            struct signalfd_siginfo si;
+            if (read(sigfd, &si, sizeof si) == sizeof si) {
+                kill(child, (int)si.ssi_signo);
+                close(sigfd);
+                close(pidfd);
+                return reap_then_exit(child, 128 + (int)si.ssi_signo);
+            }
+        }
+    }
+}
+
+#elif defined(__APPLE__)
+
+// Shared by default mode (watch_pid = getppid()) and --watch-pid mode
+// (watch_pid from argv). kqueue NOTE_EXIT on the watched pid.
+static int run_watch_pid_macos(pid_t watch_pid, char **target) {
+    // Block the signals we'll consume via EVFILT_SIGNAL. Without this
+    // the default disposition would kill the guard before kqueue
+    // delivers the event, leaving the target alive and orphaned to
+    // PID 1 — defeating the whole point of the shim.
+    //
+    // SIGUSR1/SIGUSR2 are included for the vmstate snapshot protocol:
+    // the runtime signals the wrapped VMM's pid, which on macOS is
+    // *this* shim (the watch loop forks). Blocking + kqueue-ing them
+    // lets us forward them to the VMM instead of dying by the default
+    // disposition. The child unblocks the whole mask before execvp,
+    // so the VMM's own handlers still fire.
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGHUP);
+    sigaddset(&mask, SIGUSR1);
+    sigaddset(&mask, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &mask, NULL);
+
+    pid_t child = fork();
+    if (child == -1) {
+        perror("pdeathsig: fork");
+        return 127;
+    }
+    if (child == 0) {
+        // Restore default signal disposition so the target inherits a
+        // clean mask — gvproxy and friends expect to receive SIGTERM
+        // normally.
+        sigprocmask(SIG_UNBLOCK, &mask, NULL);
+        execvp(target[0], target);
+        perror("pdeathsig: execvp");
+        _exit(127);
+    }
+
+    int kq = kqueue();
+    if (kq == -1) {
+        perror("pdeathsig: kqueue");
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 127);
+    }
+
+    struct kevent changes[7];
+    EV_SET(&changes[0], watch_pid, EVFILT_PROC, EV_ADD | EV_ONESHOT,
+           NOTE_EXIT, 0, NULL);
+    EV_SET(&changes[1], child, EVFILT_PROC, EV_ADD | EV_ONESHOT,
+           NOTE_EXIT, 0, NULL);
+    EV_SET(&changes[2], SIGTERM, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[3], SIGINT,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[4], SIGHUP,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[5], SIGUSR1, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[6], SIGUSR2, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
+    if (kevent(kq, changes, 7, NULL, 0, NULL) == -1) {
+        perror("pdeathsig: kevent register");
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 127);
+    }
+
+    // Race: watched pid may have died between the pre-fork check and
+    // EV_SET. EVFILT_PROC on a dead pid silently never fires, so
+    // recheck explicitly.
+    if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
+        kill(child, SIGTERM);
+        return reap_then_exit(child, 0);
+    }
+
+    for (;;) {
+        struct kevent ev;
+        int n = kevent(kq, NULL, 0, &ev, 1, NULL);
+        if (n == -1) {
+            if (errno == EINTR) continue;
+            perror("pdeathsig: kevent wait");
+            kill(child, SIGTERM);
+            return reap_then_exit(child, 127);
+        }
+        if (n == 0) continue;
+        if (ev.filter == EVFILT_SIGNAL) {
+            if ((int)ev.ident == SIGUSR1 || (int)ev.ident == SIGUSR2) {
+                // Vmstate snapshot trigger / resume ack. Forward to
+                // the VMM and keep watching — neither is a shutdown
+                // signal for the pdeathsig guard.
+                kill(child, (int)ev.ident);
+                continue;
+            }
+            // Runtime is signaling us (typical: child.kill('SIGTERM')
+            // from the Node side, or Ctrl-C). Forward to the target
+            // and reap. Keep the original signal so callers that look
+            // at WTERMSIG see what they sent.
+            kill(child, (int)ev.ident);
+            return reap_then_exit(child, 128 + (int)ev.ident);
+        }
+        pid_t fired = (pid_t)ev.ident;
+        if (fired == watch_pid) {
+            kill(child, SIGTERM);
+            return reap_then_exit(child, 0);
+        }
+        if (fired == child) {
+            int status;
+            waitpid(child, &status, 0);
+            return WIFEXITED(status) ? WEXITSTATUS(status)
+                                     : 128 + WTERMSIG(status);
+        }
+    }
+}
+
+#endif
+
+int main(int argc, char **argv) {
+    pid_t watch_pid = -1;
+    char **target = NULL;
+
+    if (argc >= 4 && strcmp(argv[1], "--watch-pid") == 0) {
+        if (parse_pid(argv[2], &watch_pid) != 0) {
+            fprintf(stderr, "pdeathsig: invalid pid '%s'\n", argv[2]);
+            return 2;
+        }
+        target = argv + 3;
+    } else if (argc >= 2) {
+        target = argv + 1;
+    } else {
+        fprintf(stderr,
+                "pdeathsig: usage: pdeathsig [--watch-pid <pid>] "
+                "<command> [args...]\n");
+        return 2;
+    }
+
+#if defined(__linux__)
+    if (watch_pid > 0) {
+        if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
+            return 0;  // already dead; nothing to do
+        }
+        return run_watch_pid_linux(watch_pid, target);
+    }
+    return run_default_linux(target);
+#elif defined(__APPLE__)
+    if (watch_pid <= 0) {
+        watch_pid = getppid();
+        if (watch_pid == 1) {
+            return 0;  // parent already gone; don't run target
+        }
+    } else if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
+        return 0;  // watched pid already gone
+    }
+    return run_watch_pid_macos(watch_pid, target);
+#else
+    (void)target;
+    fprintf(stderr, "pdeathsig: unsupported platform\n");
+    return 127;
+#endif
+}

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -6,7 +6,7 @@
 // expression. Skipped (not failed) if the prerequisites aren't there:
 // Image/virt.dtb/initramfs fixtures, or the HVF-entitled test binary.
 
-import { execSync, spawn } from "node:child_process";
+import { execFileSync, execSync, spawn } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -21,7 +21,7 @@ import {
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { BootError, ExecError, boot, buildMachinenConfig, measureFirstByte } from "../index.ts";
 import {
   applyNestedVirtualizationEnv,
@@ -33,6 +33,30 @@ import { performSnapshot } from "../vm/snapshot.ts";
 import { buildGuestHostname } from "../vm/helpers.ts";
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-boot-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 function writePanicVmm(path: string): void {
   writeFileSync(

--- a/packages/runtime/src/__tests__/pdeathsig.test.ts
+++ b/packages/runtime/src/__tests__/pdeathsig.test.ts
@@ -3,10 +3,36 @@
 // pdeathsig-wrapped child with it. This is the bug PR #169 only
 // diagnosed; the shim is what actually fixes it.
 
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ensurePdeathsig, wrapWithPdeathsig } from "../pdeathsig.ts";
+
+let nativeTmp: string | undefined;
+let previousPdeathsig: string | undefined;
+
+beforeAll(() => {
+  nativeTmp = mkdtempSync(join(tmpdir(), "machinen-pdeathsig-test-"));
+  execFileSync("zig", ["build", "--prefix", nativeTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousPdeathsig = process.env.MACHINEN_PDEATHSIG;
+  process.env.MACHINEN_PDEATHSIG = join(nativeTmp, "bin", "machinen-pdeathsig");
+});
+
+afterAll(() => {
+  if (previousPdeathsig === undefined) {
+    delete process.env.MACHINEN_PDEATHSIG;
+  } else {
+    process.env.MACHINEN_PDEATHSIG = previousPdeathsig;
+  }
+  if (nativeTmp) {
+    rmSync(nativeTmp, { recursive: true, force: true });
+  }
+});
 
 // Wait until `predicate()` returns true or we hit the deadline. Used
 // for "did this PID disappear?" polls — kill -9 + reap takes a few ms.
@@ -35,7 +61,7 @@ function pidAlive(pid: number): boolean {
 }
 
 describe("ensurePdeathsig", () => {
-  it("compiles or resolves an executable shim on a supported platform", async () => {
+  it("resolves an executable native shim on a supported platform", async () => {
     if (process.platform !== "linux" && process.platform !== "darwin") {
       // Other platforms intentionally return null — nothing to assert.
       expect(await ensurePdeathsig()).toBeNull();
@@ -110,8 +136,6 @@ describe("pdeathsig kill -9 survival", () => {
     }
     const shim = await ensurePdeathsig();
     if (!shim) {
-      // No C toolchain on this machine. Skip rather than fail — the
-      // graceful-fallback path is exercised by the unit tests above.
       console.warn("pdeathsig shim unavailable; skipping kill -9 survival test");
       return;
     }

--- a/packages/runtime/src/native/nested-virt.ts
+++ b/packages/runtime/src/native/nested-virt.ts
@@ -12,7 +12,7 @@ export interface NestedVirtProbeObservation {
   darwinCpuBrand?: string | null;
 }
 
-export interface NestedVirtNativeProbeResult {
+interface NestedVirtNativeProbeResult {
   supported: boolean;
   reason?: string;
 }

--- a/packages/runtime/src/native/nested-virt.ts
+++ b/packages/runtime/src/native/nested-virt.ts
@@ -1,0 +1,45 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+export interface NestedVirtProbeObservation {
+  platform: string;
+  arch: string;
+  linuxDevKvm?: boolean;
+  linuxKvmNested?: string | null;
+  linuxKvmArmNested?: string | null;
+  darwinHvSupport?: string | null;
+  darwinProductVersion?: string | null;
+  darwinCpuBrand?: string | null;
+}
+
+export interface NestedVirtNativeProbeResult {
+  supported: boolean;
+  reason?: string;
+}
+
+export function probeNestedVirtualizationNative(
+  observed?: NestedVirtProbeObservation,
+): NestedVirtNativeProbeResult {
+  return callRuntimeHelper({
+    command: "nested-virt-probe",
+    data: observed ? { observed } : {},
+    errorCode: "BOOT_NESTED_VIRT_UNSUPPORTED",
+    makeError: nestedVirtError,
+    isData: isNestedVirtNativeProbeResult,
+  });
+}
+
+function nestedVirtError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function isNestedVirtNativeProbeResult(value: unknown): value is NestedVirtNativeProbeResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<NestedVirtNativeProbeResult>;
+  if (typeof data.supported !== "boolean") {
+    return false;
+  }
+  return data.reason === undefined || typeof data.reason === "string";
+}

--- a/packages/runtime/src/nested-virt.ts
+++ b/packages/runtime/src/nested-virt.ts
@@ -1,6 +1,9 @@
-import { execFileSync as nodeExecFileSync, spawnSync } from "node:child_process";
-import { existsSync as nodeExistsSync, readFileSync as nodeReadFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { BootError } from "./errors.ts";
+import {
+  probeNestedVirtualizationNative,
+  type NestedVirtProbeObservation,
+} from "./native/nested-virt.ts";
 
 const UNSUPPORTED_MESSAGE =
   "nested virtualization needs Linux/arm64 KVM with EL2 support, or macOS 15+ on M3/M4-class Apple Silicon";
@@ -18,27 +21,44 @@ export interface NestedVirtProbeResult {
   reason?: string;
 }
 
-function defaultProbeHost(): NestedVirtProbeHost {
-  return {
-    platform: process.platform,
-    arch: process.arch,
-    existsSync: nodeExistsSync,
-    readText: (path) => nodeReadFileSync(path, "utf8"),
-    execFileSync: (file, args) => nodeExecFileSync(file, args, { encoding: "utf8" }),
+export function probeNestedVirtualization(host?: NestedVirtProbeHost): NestedVirtProbeResult {
+  return probeNestedVirtualizationNative(host ? observeNestedVirtHost(host) : undefined);
+}
+
+function observeNestedVirtHost(host: NestedVirtProbeHost): NestedVirtProbeObservation {
+  const observed: NestedVirtProbeObservation = {
+    platform: host.platform,
+    arch: host.arch,
   };
+  if (host.platform === "linux") {
+    observed.linuxDevKvm = safeExists(host, "/dev/kvm");
+    observed.linuxKvmNested = readIfPresent(host, "/sys/module/kvm/parameters/nested");
+    observed.linuxKvmArmNested = readIfPresent(host, "/sys/module/kvm_arm/parameters/nested");
+  } else if (host.platform === "darwin") {
+    observed.darwinHvSupport = sysctl(host, "kern.hv_support") ?? null;
+    observed.darwinProductVersion = swVersProductVersion(host) ?? null;
+    observed.darwinCpuBrand = sysctl(host, "machdep.cpu.brand_string") ?? null;
+  }
+  return observed;
 }
 
-function unsupported(reason: string): NestedVirtProbeResult {
-  return { supported: false, reason };
+function safeExists(host: NestedVirtProbeHost, path: string): boolean {
+  try {
+    return host.existsSync(path);
+  } catch {
+    return false;
+  }
 }
 
-function trimLower(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function isDisabledKernelToggle(value: string): boolean {
-  const v = trimLower(value);
-  return v === "0" || v === "n" || v === "no" || v === "false" || v === "off";
+function readIfPresent(host: NestedVirtProbeHost, path: string): string | null {
+  if (!safeExists(host, path)) {
+    return null;
+  }
+  try {
+    return host.readText(path);
+  } catch {
+    return null;
+  }
 }
 
 function sysctl(host: NestedVirtProbeHost, name: string): string | undefined {
@@ -65,91 +85,7 @@ function swVersProductVersion(host: NestedVirtProbeHost): string | undefined {
   }
 }
 
-function darwinMajor(version: string | undefined): number | undefined {
-  const first = version?.split(".")[0];
-  if (!first || !/^[0-9]+$/.test(first)) {
-    return undefined;
-  }
-  return Number(first);
-}
-
-function appleSiliconGeneration(brand: string | undefined): number | undefined {
-  const m = brand?.match(/\bApple\s+M(\d+)\b/i);
-  return m ? Number(m[1]) : undefined;
-}
-
-export function probeNestedVirtualization(host = defaultProbeHost()): NestedVirtProbeResult {
-  if (host.arch !== "arm64") {
-    return unsupported(`${UNSUPPORTED_MESSAGE}; this host is ${host.arch}, not arm64`);
-  }
-  if (host.platform === "linux") {
-    return probeLinuxNestedVirtualization(host);
-  }
-  if (host.platform === "darwin") {
-    return probeDarwinNestedVirtualization(host);
-  }
-  return unsupported(`${UNSUPPORTED_MESSAGE}; ${host.platform} hosts are not supported`);
-}
-
-function probeLinuxNestedVirtualization(host: NestedVirtProbeHost): NestedVirtProbeResult {
-  if (!host.existsSync("/dev/kvm")) {
-    return unsupported(`${UNSUPPORTED_MESSAGE}; /dev/kvm is not present`);
-  }
-  const disabled = firstDisabledLinuxNestedToggle(host);
-  if (disabled) {
-    return unsupported(`${UNSUPPORTED_MESSAGE}; ${disabled}`);
-  }
-  return { supported: true };
-}
-
-function firstDisabledLinuxNestedToggle(host: NestedVirtProbeHost): string | undefined {
-  for (const path of [
-    "/sys/module/kvm/parameters/nested",
-    "/sys/module/kvm_arm/parameters/nested",
-  ]) {
-    if (!host.existsSync(path)) {
-      continue;
-    }
-    const value = host.readText(path);
-    if (isDisabledKernelToggle(value)) {
-      return `${path} is ${value.trim() || "disabled"}`;
-    }
-  }
-  return undefined;
-}
-
-function probeDarwinNestedVirtualization(host: NestedVirtProbeHost): NestedVirtProbeResult {
-  if (sysctl(host, "kern.hv_support") !== "1") {
-    return unsupported(`${UNSUPPORTED_MESSAGE}; Hypervisor.framework support is not available`);
-  }
-  const osReason = unsupportedDarwinVersionReason(host);
-  if (osReason) {
-    return unsupported(osReason);
-  }
-  const cpuReason = unsupportedAppleSiliconReason(host);
-  if (cpuReason) {
-    return unsupported(cpuReason);
-  }
-  return { supported: true };
-}
-
-function unsupportedDarwinVersionReason(host: NestedVirtProbeHost): string | undefined {
-  const major = darwinMajor(swVersProductVersion(host));
-  if (major !== undefined && major < 15) {
-    return `${UNSUPPORTED_MESSAGE}; macOS ${major} is older than macOS 15`;
-  }
-  return undefined;
-}
-
-function unsupportedAppleSiliconReason(host: NestedVirtProbeHost): string | undefined {
-  const generation = appleSiliconGeneration(sysctl(host, "machdep.cpu.brand_string"));
-  if (generation !== undefined && generation < 3) {
-    return `${UNSUPPORTED_MESSAGE}; Apple M${generation} does not expose nested EL2`;
-  }
-  return undefined;
-}
-
-export function preflightNestedVirtualization(host = defaultProbeHost()): void {
+export function preflightNestedVirtualization(host?: NestedVirtProbeHost): void {
   const result = probeNestedVirtualization(host);
   if (!result.supported) {
     throw new BootError("BOOT_NESTED_VIRT_UNSUPPORTED", result.reason ?? UNSUPPORTED_MESSAGE);

--- a/packages/runtime/src/pdeathsig.ts
+++ b/packages/runtime/src/pdeathsig.ts
@@ -1,420 +1,17 @@
 // Parent-death-binding shim for child processes (#115).
 //
 // Node's `child_process.spawn` has no way to say "die when I die." The
-// gap shows up the moment the runtime is killed -9 (OOM, IDE crash,
-// `kill -9`): the kernel reparents children like `gvproxy` to PID 1
-// and they keep running, holding host ports. PR #169 fails fast with a
-// useful error on the *next* boot, but that's diagnosis — this module
-// closes the loop by making the child actually die with the runtime.
-//
-// Two modes:
-//
-//   1. Default — watch the immediate parent (the process that exec'd
-//      the shim). Used by gvproxy and the VMM today.
-//   2. `--watch-pid <pid>` — watch an explicit, non-parent PID. Kept
-//      for helpers whose immediate parent may exit before the process
-//      they should track.
-//
-// Cross-platform via a tiny C shim, ~200 lines, three branches:
-//
-//   - Linux + default:   `prctl(PR_SET_PDEATHSIG, SIGTERM)` then
-//     `execvp` the target. The kernel sends SIGTERM to the target
-//     when its parent exits. PDEATHSIG is preserved across exec as
-//     long as the target doesn't change UID. One process.
-//   - Linux + watch-pid: fork + exec; parent uses `pidfd_open(2)` +
-//     `poll(2)` to wait for the watched pid's exit. Falls back to a
-//     `kill(pid, 0)` polling loop on pre-5.3 kernels (or where
-//     pidfd_open is denied). Two processes.
-//   - macOS:             no PDEATHSIG, no pidfd. Fork; the child
-//     execs the target; the parent (the shim, now reparented to PID
-//     1) kqueue-watches the watched pid (`getppid()` in default mode,
-//     argv pid in watch-pid mode) for `NOTE_EXIT` and SIGTERMs the
-//     target when it fires. Two processes.
-//
-// We compile the shim on first use into `~/.machinen/pdeathsig/<ver>/
-// pdeathsig` (mirrors `gvproxyCachePath`). If `cc` is missing we log
-// a one-shot warning and fall through to spawning unwrapped — the
-// machine still works, the next abnormal exit just leaks a gvproxy
-// (recoverable via PR #169's BOOT_PORT_FORWARD_IN_USE message).
-//
-// Opt-out: `MACHINEN_PDEATHSIG=disabled` skips the shim entirely.
-// Useful for debugging or environments where the C toolchain is gone.
+// runtime uses a native pdeathsig wrapper for gvproxy and the VMM so a
+// killed parent does not leave host sidecars orphaned. The wrapper is
+// built in packages/runtime/native and shipped through @machinen/native-*.
 
-import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir, platform as osPlatform } from "node:os";
-import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { arch, platform as osPlatform } from "node:os";
 import debugLib from "debug";
 
 const debug = debugLib("machinen:pdeathsig");
-
-/**
- * Bumped whenever the C source below changes in a way that changes
- * behavior. Recompiles instead of silently reusing a stale binary.
- */
-const PDEATHSIG_VERSION = "v5";
-
-let warnedNoCompiler = false;
-// Keyed by the resolved cache path. Two reasons it has to be a map and
-// not a single global: tests rebind `process.env.HOME` per-case (so the
-// cache path differs across calls in the same process), and the
-// runtime now calls `ensurePdeathsig()` in two spots per `boot()`
-// (gvproxy + the VMM, #200) — caching by path keeps the dedup correct
-// without leaking a stale promise from one HOME into the next call.
-const installInFlight = new Map<string, Promise<string | null>>();
-
-/**
- * The shim's source. Embedded so the runtime ships exactly one file
- * and `tsup` doesn't need to copy non-TS assets into `dist/`. Reads
- * verbatim from the same string at compile time.
- */
-const PDEATHSIG_C_SOURCE = `// pdeathsig: tiny exec wrapper that arranges for the target to die
-// when a watched process dies. See packages/runtime/src/pdeathsig.ts.
-//
-// Modes:
-//   pdeathsig <cmd> [args...]                   - watch immediate parent
-//   pdeathsig --watch-pid <pid> <cmd> [args]    - watch the given pid
-
-#define _GNU_SOURCE
-#include <errno.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/wait.h>
-
-#if defined(__linux__)
-#include <sys/prctl.h>
-#include <poll.h>
-#include <sys/syscall.h>
-#include <sys/signalfd.h>
-#elif defined(__APPLE__)
-#include <sys/event.h>
-#include <sys/types.h>
-#endif
-
-#if defined(__linux__) && !defined(SYS_pidfd_open)
-#define SYS_pidfd_open 434
-#endif
-
-// Wait up to ~5s for the target to exit after SIGTERM, then escalate.
-static int reap_then_exit(pid_t child, int code) {
-    for (int i = 0; i < 50; i++) {
-        int status;
-        pid_t r = waitpid(child, &status, WNOHANG);
-        if (r == child) return code;
-        usleep(100000);
-    }
-    kill(child, SIGKILL);
-    waitpid(child, NULL, 0);
-    return code;
-}
-
-static int parse_pid(const char *s, pid_t *out) {
-    char *end = NULL;
-    errno = 0;
-    long n = strtol(s, &end, 10);
-    if (errno != 0 || end == s || end == NULL || *end != '\\0' ||
-        n <= 0 || n > 0x7fffffff) {
-        return -1;
-    }
-    *out = (pid_t)n;
-    return 0;
-}
-
-#if defined(__linux__)
-
-// Default mode: prctl + execvp. Single process. Parent of pdeathsig
-// becomes the watched pid by definition.
-static int run_default_linux(char **target) {
-    if (prctl(PR_SET_PDEATHSIG, SIGTERM) == -1) {
-        perror("pdeathsig: prctl");
-        return 127;
-    }
-    // Race: parent may already be gone. PDEATHSIG won't fire because
-    // there's nothing to fire on. Detect via reparenting to PID 1.
-    if (getppid() == 1) {
-        return 0;
-    }
-    execvp(target[0], target);
-    perror("pdeathsig: execvp");
-    return 127;
-}
-
-// Watch-pid mode on Linux: fork + exec; parent watches the explicit
-// pid via pidfd_open + poll. Falls back to a kill(pid,0) polling loop
-// when pidfd_open is unavailable (kernel < 5.3) or returns ENOSYS.
-static int run_watch_pid_linux(pid_t watch_pid, char **target) {
-    sigset_t mask;
-    sigemptyset(&mask);
-    sigaddset(&mask, SIGTERM);
-    sigaddset(&mask, SIGINT);
-    sigaddset(&mask, SIGHUP);
-    sigprocmask(SIG_BLOCK, &mask, NULL);
-
-    pid_t child = fork();
-    if (child == -1) {
-        perror("pdeathsig: fork");
-        return 127;
-    }
-    if (child == 0) {
-        sigprocmask(SIG_UNBLOCK, &mask, NULL);
-        execvp(target[0], target);
-        perror("pdeathsig: execvp");
-        _exit(127);
-    }
-
-    int sigfd = signalfd(-1, &mask, SFD_CLOEXEC);
-    if (sigfd == -1) {
-        perror("pdeathsig: signalfd");
-        kill(child, SIGTERM);
-        return reap_then_exit(child, 127);
-    }
-
-    int pidfd = (int)syscall(SYS_pidfd_open, watch_pid, 0);
-    int saved_errno = errno;
-    if (pidfd == -1 && saved_errno == ESRCH) {
-        // Watched pid died between the pre-fork ESRCH check and now.
-        kill(child, SIGTERM);
-        close(sigfd);
-        return reap_then_exit(child, 0);
-    }
-
-    if (pidfd == -1) {
-        // pidfd_open unavailable (ENOSYS) or denied. Polling fallback:
-        // poll signalfd with a 250ms timeout and recheck the watched
-        // pid via kill(pid, 0) on every wake.
-        struct pollfd pfd = { .fd = sigfd, .events = POLLIN, .revents = 0 };
-        for (;;) {
-            int n = poll(&pfd, 1, 250);
-            if (n == -1) {
-                if (errno == EINTR) continue;
-                perror("pdeathsig: poll");
-                kill(child, SIGTERM);
-                close(sigfd);
-                return reap_then_exit(child, 127);
-            }
-            if (n == 1 && (pfd.revents & POLLIN)) {
-                struct signalfd_siginfo si;
-                if (read(sigfd, &si, sizeof si) == sizeof si) {
-                    kill(child, (int)si.ssi_signo);
-                    close(sigfd);
-                    return reap_then_exit(child, 128 + (int)si.ssi_signo);
-                }
-            }
-            if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
-                kill(child, SIGTERM);
-                close(sigfd);
-                return reap_then_exit(child, 0);
-            }
-            int status;
-            pid_t r = waitpid(child, &status, WNOHANG);
-            if (r == child) {
-                close(sigfd);
-                return WIFEXITED(status) ? WEXITSTATUS(status)
-                                         : 128 + WTERMSIG(status);
-            }
-        }
-    }
-
-    // pidfd path: poll signalfd + pidfd; pidfd POLLIN fires on exit.
-    struct pollfd pfds[2] = {
-        { .fd = sigfd,  .events = POLLIN, .revents = 0 },
-        { .fd = pidfd,  .events = POLLIN, .revents = 0 },
-    };
-    for (;;) {
-        int n = poll(pfds, 2, -1);
-        if (n == -1) {
-            if (errno == EINTR) continue;
-            perror("pdeathsig: poll");
-            kill(child, SIGTERM);
-            close(sigfd);
-            close(pidfd);
-            return reap_then_exit(child, 127);
-        }
-        if (pfds[1].revents & POLLIN) {
-            kill(child, SIGTERM);
-            close(sigfd);
-            close(pidfd);
-            return reap_then_exit(child, 0);
-        }
-        if (pfds[0].revents & POLLIN) {
-            struct signalfd_siginfo si;
-            if (read(sigfd, &si, sizeof si) == sizeof si) {
-                kill(child, (int)si.ssi_signo);
-                close(sigfd);
-                close(pidfd);
-                return reap_then_exit(child, 128 + (int)si.ssi_signo);
-            }
-        }
-    }
-}
-
-#elif defined(__APPLE__)
-
-// Shared by default mode (watch_pid = getppid()) and --watch-pid mode
-// (watch_pid from argv). kqueue NOTE_EXIT on the watched pid.
-static int run_watch_pid_macos(pid_t watch_pid, char **target) {
-    // Block the signals we'll consume via EVFILT_SIGNAL. Without this
-    // the default disposition would kill the guard before kqueue
-    // delivers the event, leaving the target alive and orphaned to
-    // PID 1 — defeating the whole point of the shim.
-    //
-    // SIGUSR1/SIGUSR2 are included for the vmstate snapshot protocol:
-    // the runtime signals the wrapped VMM's pid, which on macOS is
-    // *this* shim (the watch loop forks). Blocking + kqueue-ing them
-    // lets us forward them to the VMM instead of dying by the default
-    // disposition. The child unblocks the whole mask before execvp,
-    // so the VMM's own handlers still fire.
-    sigset_t mask;
-    sigemptyset(&mask);
-    sigaddset(&mask, SIGTERM);
-    sigaddset(&mask, SIGINT);
-    sigaddset(&mask, SIGHUP);
-    sigaddset(&mask, SIGUSR1);
-    sigaddset(&mask, SIGUSR2);
-    sigprocmask(SIG_BLOCK, &mask, NULL);
-
-    pid_t child = fork();
-    if (child == -1) {
-        perror("pdeathsig: fork");
-        return 127;
-    }
-    if (child == 0) {
-        // Restore default signal disposition so the target inherits a
-        // clean mask — gvproxy and friends expect to receive SIGTERM
-        // normally.
-        sigprocmask(SIG_UNBLOCK, &mask, NULL);
-        execvp(target[0], target);
-        perror("pdeathsig: execvp");
-        _exit(127);
-    }
-
-    int kq = kqueue();
-    if (kq == -1) {
-        perror("pdeathsig: kqueue");
-        kill(child, SIGTERM);
-        return reap_then_exit(child, 127);
-    }
-
-    struct kevent changes[7];
-    EV_SET(&changes[0], watch_pid, EVFILT_PROC, EV_ADD | EV_ONESHOT,
-           NOTE_EXIT, 0, NULL);
-    EV_SET(&changes[1], child, EVFILT_PROC, EV_ADD | EV_ONESHOT,
-           NOTE_EXIT, 0, NULL);
-    EV_SET(&changes[2], SIGTERM, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    EV_SET(&changes[3], SIGINT,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    EV_SET(&changes[4], SIGHUP,  EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    EV_SET(&changes[5], SIGUSR1, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    EV_SET(&changes[6], SIGUSR2, EVFILT_SIGNAL, EV_ADD, 0, 0, NULL);
-    if (kevent(kq, changes, 7, NULL, 0, NULL) == -1) {
-        perror("pdeathsig: kevent register");
-        kill(child, SIGTERM);
-        return reap_then_exit(child, 127);
-    }
-
-    // Race: watched pid may have died between the pre-fork check and
-    // EV_SET. EVFILT_PROC on a dead pid silently never fires, so
-    // recheck explicitly.
-    if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
-        kill(child, SIGTERM);
-        return reap_then_exit(child, 0);
-    }
-
-    for (;;) {
-        struct kevent ev;
-        int n = kevent(kq, NULL, 0, &ev, 1, NULL);
-        if (n == -1) {
-            if (errno == EINTR) continue;
-            perror("pdeathsig: kevent wait");
-            kill(child, SIGTERM);
-            return reap_then_exit(child, 127);
-        }
-        if (n == 0) continue;
-        if (ev.filter == EVFILT_SIGNAL) {
-            if ((int)ev.ident == SIGUSR1 || (int)ev.ident == SIGUSR2) {
-                // Vmstate snapshot trigger / resume ack. Forward to
-                // the VMM and keep watching — neither is a shutdown
-                // signal for the pdeathsig guard.
-                kill(child, (int)ev.ident);
-                continue;
-            }
-            // Runtime is signaling us (typical: child.kill('SIGTERM')
-            // from the Node side, or Ctrl-C). Forward to the target
-            // and reap. Keep the original signal so callers that look
-            // at WTERMSIG see what they sent.
-            kill(child, (int)ev.ident);
-            return reap_then_exit(child, 128 + (int)ev.ident);
-        }
-        pid_t fired = (pid_t)ev.ident;
-        if (fired == watch_pid) {
-            kill(child, SIGTERM);
-            return reap_then_exit(child, 0);
-        }
-        if (fired == child) {
-            int status;
-            waitpid(child, &status, 0);
-            return WIFEXITED(status) ? WEXITSTATUS(status)
-                                     : 128 + WTERMSIG(status);
-        }
-    }
-}
-
-#endif
-
-int main(int argc, char **argv) {
-    pid_t watch_pid = -1;
-    char **target = NULL;
-
-    if (argc >= 4 && strcmp(argv[1], "--watch-pid") == 0) {
-        if (parse_pid(argv[2], &watch_pid) != 0) {
-            fprintf(stderr, "pdeathsig: invalid pid '%s'\\n", argv[2]);
-            return 2;
-        }
-        target = argv + 3;
-    } else if (argc >= 2) {
-        target = argv + 1;
-    } else {
-        fprintf(stderr,
-                "pdeathsig: usage: pdeathsig [--watch-pid <pid>] "
-                "<command> [args...]\\n");
-        return 2;
-    }
-
-#if defined(__linux__)
-    if (watch_pid > 0) {
-        if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
-            return 0;  // already dead; nothing to do
-        }
-        return run_watch_pid_linux(watch_pid, target);
-    }
-    return run_default_linux(target);
-#elif defined(__APPLE__)
-    if (watch_pid <= 0) {
-        watch_pid = getppid();
-        if (watch_pid == 1) {
-            return 0;  // parent already gone; don't run target
-        }
-    } else if (kill(watch_pid, 0) == -1 && errno == ESRCH) {
-        return 0;  // watched pid already gone
-    }
-    return run_watch_pid_macos(watch_pid, target);
-#else
-    (void)target;
-    fprintf(stderr, "pdeathsig: unsupported platform\\n");
-    return 127;
-#endif
-}
-`;
-
-/**
- * Where the compiled shim lands. Versioned so a source bump
- * recompiles instead of reusing a stale binary.
- */
-function pdeathsigCachePath(): string {
-  return join(homedir(), ".machinen", "pdeathsig", PDEATHSIG_VERSION, "pdeathsig");
-}
+const require_ = createRequire(import.meta.url);
 
 /**
  * Recognize the opt-out tokens for `MACHINEN_PDEATHSIG`. Same shape
@@ -426,14 +23,9 @@ function isPdeathsigDisabledSentinel(value: string): boolean {
 }
 
 /**
- * Resolve and (if needed) compile the parent-death shim. Returns the
- * absolute path to a usable binary, or `null` when:
- *   - the user opted out via `MACHINEN_PDEATHSIG=disabled`
- *   - the platform is unsupported (Windows etc.)
- *   - compilation failed (e.g. no `cc` on PATH) — emits a one-shot
- *     stderr warning, then `null` so the caller can fall through.
- *
- * Compilation is sub-second and cached in `~/.machinen/pdeathsig/`.
+ * Resolve the parent-death shim. Returns the absolute path to a usable
+ * binary, or `null` when the user opted out, the platform is
+ * unsupported, or the matching native package is not installed.
  */
 export async function ensurePdeathsig(): Promise<string | null> {
   const override = process.env.MACHINEN_PDEATHSIG;
@@ -441,9 +33,13 @@ export async function ensurePdeathsig(): Promise<string | null> {
     debug("opted out via MACHINEN_PDEATHSIG=%s", override);
     return null;
   }
-  if (override && override.length > 0 && existsSync(override)) {
-    debug("resolved via MACHINEN_PDEATHSIG=%s", override);
-    return override;
+  if (override && override.length > 0) {
+    if (existsSync(override)) {
+      debug("resolved via MACHINEN_PDEATHSIG=%s", override);
+      return override;
+    }
+    debug("MACHINEN_PDEATHSIG=%s does not exist", override);
+    return null;
   }
 
   const plat = osPlatform();
@@ -451,77 +47,24 @@ export async function ensurePdeathsig(): Promise<string | null> {
     debug("unsupported platform=%s", plat);
     return null;
   }
-
-  const cached = pdeathsigCachePath();
-  if (existsSync(cached)) {
-    return cached;
+  const bundled = findBundledPdeathsig();
+  if (!bundled) {
+    debug("pdeathsig binary not found in @machinen/native-%s-%s", arch(), plat);
   }
-  const existing = installInFlight.get(cached);
-  if (existing) {
-    return existing;
-  }
-  const promise = (async () => {
-    try {
-      return compilePdeathsig(cached);
-    } catch (err) {
-      if (!warnedNoCompiler) {
-        warnedNoCompiler = true;
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `machinen: failed to compile pdeathsig shim (${msg}). ` +
-            "gvproxy will not be auto-killed when the runtime exits abnormally. " +
-            "Install Xcode CLI tools (macOS: `xcode-select --install`) or " +
-            "build-essential (Linux). To silence this warning set " +
-            "MACHINEN_PDEATHSIG=disabled.\n",
-        );
-      }
-      debug("compile failed err=%s", err instanceof Error ? err.message : String(err));
-      return null;
-    }
-  })();
-  installInFlight.set(cached, promise);
-  void promise.finally(() => {
-    if (installInFlight.get(cached) === promise) {
-      installInFlight.delete(cached);
-    }
-  });
-  return promise;
+  return bundled ?? null;
 }
 
-/**
- * Compile the embedded C source to `outPath`. Atomic via tmp+rename
- * so a concurrent caller never sees a half-written binary.
- */
-function compilePdeathsig(outPath: string): string {
-  const dir = dirname(outPath);
-  mkdirSync(dir, { recursive: true });
-
-  const srcPath = join(dir, "pdeathsig.c");
-  writeFileSync(srcPath, PDEATHSIG_C_SOURCE);
-
-  const tmpOut = `${outPath}.${process.pid}.tmp`;
-  const cc = process.env.CC ?? "cc";
-  // Suppress stdout, capture stderr so we surface useful failures
-  // (cc not found, syntax errors after a source bump, etc.).
-  execFileSync(cc, ["-O2", "-Wall", "-Wextra", "-o", tmpOut, srcPath], {
-    stdio: ["ignore", "ignore", "pipe"],
-  });
-  chmodSync(tmpOut, 0o755);
+function findBundledPdeathsig(): string | undefined {
+  const pkg = `@machinen/native-${arch()}-${osPlatform()}`;
   try {
-    renameSync(tmpOut, outPath);
-  } catch (err) {
-    // Lost a race with a concurrent compile. The other one's binary
-    // is fine; clean up our tmp and return the cached path.
-    try {
-      unlinkSync(tmpOut);
-    } catch {}
-    if (existsSync(outPath)) {
-      return outPath;
+    const mod = require_(pkg) as { pdeathsig?: string };
+    if (mod.pdeathsig && existsSync(mod.pdeathsig)) {
+      return mod.pdeathsig;
     }
-    throw err;
+  } catch {
+    // Optional dep not installed for this arch+os.
   }
-  debug("compiled %s", outPath);
-  return outPath;
+  return undefined;
 }
 
 /**

--- a/scripts/build-runtime-helper.sh
+++ b/scripts/build-runtime-helper.sh
@@ -22,6 +22,7 @@ esac
 
 DEST_DIR="$ROOT/packages/native-${PKG_ARCH}-${PKG_OS}/vmm/bin"
 DEST="$DEST_DIR/machinen-runtime-helper"
+PDEATHSIG_DEST="$DEST_DIR/machinen-pdeathsig"
 
 echo "==> building machinen-runtime-helper (zig ReleaseSafe)"
 ( cd "$PKG" && zig build -Doptimize=ReleaseSafe )
@@ -29,11 +30,13 @@ echo "==> building machinen-runtime-helper (zig ReleaseSafe)"
 echo "==> staging into $DEST"
 mkdir -p "$DEST_DIR"
 cp "$PKG/zig-out/bin/machinen-runtime-helper" "$DEST"
+cp "$PKG/zig-out/bin/machinen-pdeathsig" "$PDEATHSIG_DEST"
 
 if [[ "$OS" == "Darwin" ]]; then
   # machinen-runtime-helper does not need entitlements, but clearing provenance
   # keeps the staged host tool consistent with the VMM staging flow.
   xattr -c "$DEST" || true
+  xattr -c "$PDEATHSIG_DEST" || true
 fi
 
 echo "==> Done."

--- a/scripts/verify-bin-packages.sh
+++ b/scripts/verify-bin-packages.sh
@@ -100,7 +100,7 @@ check_pkg() {
 
 # --- native-* ------------------------------------------------------------
 # One consolidated package per host arch. Per-tool subdirs:
-#   vmm/bin/{machinen-vm,machinen-runtime-helper,gvproxy}   host binaries node spawns.
+#   vmm/bin/{machinen-vm,machinen-runtime-helper,machinen-pdeathsig,gvproxy}   host binaries node spawns.
 #   vmm/guest/{init,exec-agent}  guest-arch Linux ELFs the runtime
 #       reads as data to pack into the initramfs cpio (mode irrelevant).
 #   e2fsprogs/bin/mke2fs, squashfs/bin/mksquashfs  host binaries node spawns.
@@ -108,6 +108,7 @@ for pkg in native-arm64-darwin native-arm64-linux native-x64-linux; do
   check_pkg "$pkg" \
     vmm/bin/machinen-vm \
     vmm/bin/machinen-runtime-helper \
+    vmm/bin/machinen-pdeathsig \
     vmm/bin/gvproxy \
     e2fsprogs/bin/mke2fs \
     squashfs/bin/mksquashfs \


### PR DESCRIPTION
## Problem

Process and virtualization probes were still split between TypeScript paths and native snippets. That made platform behavior harder to keep in one place.

## Solution

Move the pdeathsig shim and nested virtualization probe into the native helper build. TypeScript still decides when these helpers are used.

## Technical Summary

- Keeps this PR focused on process and virtualization shims.
- Leaves terminal-specific shims for the next stacked PR.
- Does not change the public runtime API or VM orchestration model.
