### PR TITLE
Move cleanup and balloon stats helpers to Zig

### DIFF
--- a/packages/runtime/native/src/commands/balloon_stats.zig
+++ b/packages/runtime/native/src/commands/balloon_stats.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "balloon-stats";
 
 const Request = struct {
@@ -14,6 +16,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -24,24 +28,43 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
     };
 
     const counters = runtime_helper.host.readBalloonStats(io, request.path);
-    const out = if (counters) |stats|
-        try std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"balloon-stats\",\"data\":{{\"counters\":{{\"bytesReported\":{d},\"bytesInflated\":{d},\"hostPhysFootprintBytes\":{d}}}}}}}\n",
-            .{ stats.bytes_reported, stats.bytes_inflated, stats.host_phys_footprint_bytes },
-        )
-    else
-        try std.fmt.allocPrint(
-            allocator,
-            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"balloon-stats\",\"data\":{{\"counters\":null}}}}\n",
-            .{},
-        );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try writeResponse(allocator, io, counters);
     return .ok;
 }
 
+fn writeResponse(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    counters: ?runtime_helper.host.BalloonStats,
+) !void {
+    assert(name.len > 0);
+
+    if (counters) |stats| {
+        try protocol.writeJson(allocator, io, .{
+            .ok = true,
+            .protocolVersion = @as(u8, protocol.version),
+            .command = name,
+            .data = .{
+                .counters = .{
+                    .bytesReported = stats.bytes_reported,
+                    .bytesInflated = stats.bytes_inflated,
+                    .hostPhysFootprintBytes = stats.host_phys_footprint_bytes,
+                },
+            },
+        });
+        return;
+    }
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .counters = null },
+    });
+}
+
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -54,8 +77,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
@@ -66,14 +88,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/balloon_stats.zig
+++ b/packages/runtime/native/src/commands/balloon_stats.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "balloon-stats";
+
+const Request = struct {
+    path: []const u8,
+};
+
+const RequestError = error{
+    MissingPath,
+    InvalidPath,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const counters = runtime_helper.host.readBalloonStats(io, request.path);
+    const out = if (counters) |stats|
+        try std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"balloon-stats\",\"data\":{{\"counters\":{{\"bytesReported\":{d},\"bytesInflated\":{d},\"hostPhysFootprintBytes\":{d}}}}}}}\n",
+            .{ stats.bytes_reported, stats.bytes_inflated, stats.host_phys_footprint_bytes },
+        )
+    else
+        try std.fmt.allocPrint(
+            allocator,
+            "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"balloon-stats\",\"data\":{{\"counters\":null}}}}\n",
+            .{},
+        );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{"path"});
+    const path = object.get("path") orelse return error.MissingPath;
+    if (path != .string or path.string.len == 0) return error.InvalidPath;
+    return .{ .path = path.string };
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/cleanup_path.zig
+++ b/packages/runtime/native/src/commands/cleanup_path.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const runtime_helper = @import("runtime_helper");
 const protocol = @import("../protocol.zig");
 
+const assert = std.debug.assert;
+
 pub const name = "cleanup-path";
 
 const Request = struct {
@@ -16,6 +18,8 @@ const RequestError = error{
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -26,17 +30,18 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
     };
 
     const result = runtime_helper.host.cleanupPath(io, request.path, request.dry_run);
-    const out = try std.fmt.allocPrint(
-        allocator,
-        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cleanup-path\",\"data\":{{\"removed\":{},\"failed\":{}}}}}\n",
-        .{ result.removed, result.failed },
-    );
-    defer allocator.free(out);
-    try protocol.stdout(io, out);
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{ .removed = result.removed, .failed = result.failed },
+    });
     return .ok;
 }
 
 fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+
     const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
         .duplicate_field_behavior = .@"error",
@@ -49,8 +54,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
     if (request_value != .object) return error.InvalidShape;
     const envelope = request_value.object;
     try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
-    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
-    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    try protocol.requireProtocolVersion(envelope);
     const data_value = envelope.get("data") orelse return error.MissingData;
     if (data_value != .object) return error.InvalidData;
     const object = data_value.object;
@@ -66,14 +70,7 @@ fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
 }
 
 fn writeRequestError(io: std.Io, err: RequestError) !void {
-    switch (err) {
-        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
-        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
-        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
-        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
-        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
-        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
-        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
-    }
+    assert(@errorName(err).len > 0);
+    if (try protocol.writeCommonRequestError(io, err)) return;
+    try protocol.writeError(io, "INVALID_REQUEST", @errorName(err));
 }

--- a/packages/runtime/native/src/commands/cleanup_path.zig
+++ b/packages/runtime/native/src/commands/cleanup_path.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+pub const name = "cleanup-path";
+
+const Request = struct {
+    path: []const u8,
+    dry_run: bool = false,
+};
+
+const RequestError = error{
+    MissingPath,
+    InvalidPath,
+    InvalidDryRun,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const result = runtime_helper.host.cleanupPath(io, request.path, request.dry_run);
+    const out = try std.fmt.allocPrint(
+        allocator,
+        "{{\"ok\":true,\"protocolVersion\":1,\"command\":\"cleanup-path\",\"data\":{{\"removed\":{},\"failed\":{}}}}}\n",
+        .{ result.removed, result.failed },
+    );
+    defer allocator.free(out);
+    try protocol.stdout(io, out);
+    return .ok;
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+    const protocol_version = envelope.get("protocolVersion") orelse return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer or protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    const object = data_value.object;
+    try protocol.rejectUnknownFields(object, &.{ "path", "dryRun" });
+    const path = object.get("path") orelse return error.MissingPath;
+    if (path != .string or path.string.len == 0) return error.InvalidPath;
+    var request: Request = .{ .path = path.string };
+    if (object.get("dryRun")) |dry_run| {
+        if (dry_run != .bool) return error.InvalidDryRun;
+        request.dry_run = dry_run.bool;
+    }
+    return request;
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(io, "REQUEST_TOO_LARGE", "request JSON exceeds the maximum size"),
+        error.UnknownField => try protocol.writeError(io, "UNKNOWN_FIELD", "request contains an unknown field"),
+        error.UnsupportedProtocolVersion => try protocol.writeError(io, "UNSUPPORTED_PROTOCOL_VERSION", "request protocolVersion must be 1"),
+        error.MissingData => try protocol.writeError(io, "INVALID_REQUEST", "request must include a data object"),
+        error.InvalidData => try protocol.writeError(io, "INVALID_REQUEST", "request data field must be an object"),
+        error.InvalidJson => try protocol.writeError(io, "INVALID_JSON", "request body is not valid JSON"),
+        error.InvalidShape => try protocol.writeError(io, "INVALID_REQUEST", "request body must be a JSON object"),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -1,8 +1,8 @@
 // Host-side probes and controls used by the TypeScript runtime.
 //
 // This file keeps OS-specific, synchronous host operations in the native
-// helper: memory/RSS reads, pid identity checks, nested-virt probes, and Linux
-// cgroup CPU setup.
+// helper: memory/RSS reads, pid identity checks, nested-virt probes, balloon
+// stats reads, GC cleanup-path removal, and Linux cgroup CPU setup.
 // The command files translate JSON protocol requests into these functions;
 // this module owns the actual platform behavior so the TS layer stays small.
 

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -70,6 +70,11 @@ pub const NestedVirtResult = struct {
     }
 };
 
+pub const CleanupPathResult = struct {
+    removed: bool,
+    failed: bool,
+};
+
 pub const CpuCgroupOptions = struct {
     pid: u32,
     weight: u32,
@@ -157,6 +162,36 @@ pub fn probeNestedVirtualization(
     const observation = observed orelse try observeNestedVirtualizationHost(allocator, io);
     defer if (observed == null) deinitObservedNestedVirtualizationHost(allocator, observation);
     return evaluateNestedVirtualization(allocator, observation);
+}
+
+pub fn cleanupPath(io: std.Io, path: []const u8, dry_run: bool) CleanupPathResult {
+    assert(path.len > 0);
+
+    const st = std.Io.Dir.cwd().statFile(
+        io,
+        path,
+        .{ .follow_symlinks = false },
+    ) catch return .{ .removed = false, .failed = false };
+    if (dry_run) return .{ .removed = true, .failed = false };
+    if (st.kind == .directory) {
+        if (std.mem.startsWith(u8, path, DEFAULT_CGROUP_PARENT ++ "/")) {
+            std.Io.Dir.cwd().deleteDir(io, path) catch return .{
+                .removed = false,
+                .failed = true,
+            };
+        } else {
+            std.Io.Dir.cwd().deleteTree(io, path) catch return .{
+                .removed = false,
+                .failed = true,
+            };
+        }
+    } else {
+        std.Io.Dir.cwd().deleteFile(io, path) catch return .{
+            .removed = false,
+            .failed = true,
+        };
+    }
+    return .{ .removed = true, .failed = false };
 }
 
 fn observeNestedVirtualizationHost(
@@ -1016,6 +1051,41 @@ fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u
     const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
     defer allocator.free(cwd);
     return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
+}
+
+test "cleanupPath removes files and directories" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "file.txt", .data = "x" });
+    try tmp.dir.createDir(std.testing.io, "dir", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "dir/nested.txt", .data = "y" });
+    const root = try tmpRootAbs(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(root);
+    const file_path = try std.fs.path.join(std.testing.allocator, &.{ root, "file.txt" });
+    defer std.testing.allocator.free(file_path);
+    const dir_path = try std.fs.path.join(std.testing.allocator, &.{ root, "dir" });
+    defer std.testing.allocator.free(dir_path);
+
+    try std.testing.expectEqual(CleanupPathResult{ .removed = true, .failed = false }, cleanupPath(std.testing.io, file_path, false));
+    try std.testing.expectEqual(CleanupPathResult{ .removed = true, .failed = false }, cleanupPath(std.testing.io, dir_path, false));
+    try std.testing.expect(!existsPath(std.testing.io, file_path));
+    try std.testing.expect(!existsPath(std.testing.io, dir_path));
+}
+
+test "cleanupPath dry-run and missing paths do not touch disk" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "file.txt", .data = "x" });
+    const root = try tmpRootAbs(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(root);
+    const file_path = try std.fs.path.join(std.testing.allocator, &.{ root, "file.txt" });
+    defer std.testing.allocator.free(file_path);
+    const missing_path = try std.fs.path.join(std.testing.allocator, &.{ root, "missing.txt" });
+    defer std.testing.allocator.free(missing_path);
+
+    try std.testing.expectEqual(CleanupPathResult{ .removed = true, .failed = false }, cleanupPath(std.testing.io, file_path, true));
+    try std.testing.expect(existsPath(std.testing.io, file_path));
+    try std.testing.expectEqual(CleanupPathResult{ .removed = false, .failed = false }, cleanupPath(std.testing.io, missing_path, false));
 }
 
 test "applyCpuCgroup returns explicit unsupported outside Linux" {

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -70,6 +70,12 @@ pub const NestedVirtResult = struct {
     }
 };
 
+pub const BalloonStats = struct {
+    bytes_reported: u64,
+    bytes_inflated: u64,
+    host_phys_footprint_bytes: u64,
+};
+
 pub const CleanupPathResult = struct {
     removed: bool,
     failed: bool,
@@ -162,6 +168,25 @@ pub fn probeNestedVirtualization(
     const observation = observed orelse try observeNestedVirtualizationHost(allocator, io);
     defer if (observed == null) deinitObservedNestedVirtualizationHost(allocator, observation);
     return evaluateNestedVirtualization(allocator, observation);
+}
+
+pub fn readBalloonStats(io: std.Io, path: []const u8) ?BalloonStats {
+    assert(path.len > 0);
+
+    var file = std.Io.Dir.cwd().openFile(
+        io,
+        path,
+        .{ .allow_directory = false },
+    ) catch return null;
+    defer file.close(io);
+    var buf: [24]u8 = undefined;
+    const n = file.readStreaming(io, &.{buf[0..]}) catch return null;
+    if (n < buf.len) return null;
+    return .{
+        .bytes_reported = std.mem.readInt(u64, buf[0..8], .little),
+        .bytes_inflated = std.mem.readInt(u64, buf[8..16], .little),
+        .host_phys_footprint_bytes = std.mem.readInt(u64, buf[16..24], .little),
+    };
 }
 
 pub fn cleanupPath(io: std.Io, path: []const u8, dry_run: bool) CleanupPathResult {
@@ -1051,6 +1076,40 @@ fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u
     const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
     defer allocator.free(cwd);
     return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
+}
+
+test "readBalloonStats decodes 24-byte little-endian counters" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [24]u8 = undefined;
+    std.mem.writeInt(u64, buf[0..8], 0x1122_3344_5566_7788, .little);
+    std.mem.writeInt(u64, buf[8..16], 0x99aa_bbcc_ddee_ff00, .little);
+    std.mem.writeInt(u64, buf[16..24], 0x0011_2233_4455_6677, .little);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "stats.bin", .data = &buf });
+    const root = try tmpRootAbs(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(root);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ root, "stats.bin" });
+    defer std.testing.allocator.free(path);
+
+    const stats = readBalloonStats(std.testing.io, path).?;
+    try std.testing.expectEqual(@as(u64, 0x1122_3344_5566_7788), stats.bytes_reported);
+    try std.testing.expectEqual(@as(u64, 0x99aa_bbcc_ddee_ff00), stats.bytes_inflated);
+    try std.testing.expectEqual(@as(u64, 0x0011_2233_4455_6677), stats.host_phys_footprint_bytes);
+}
+
+test "readBalloonStats returns null for missing or short files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "short.bin", .data = "too short" });
+    const root = try tmpRootAbs(std.testing.allocator, &tmp);
+    defer std.testing.allocator.free(root);
+    const short_path = try std.fs.path.join(std.testing.allocator, &.{ root, "short.bin" });
+    defer std.testing.allocator.free(short_path);
+    const missing_path = try std.fs.path.join(std.testing.allocator, &.{ root, "missing.bin" });
+    defer std.testing.allocator.free(missing_path);
+
+    try std.testing.expect(readBalloonStats(std.testing.io, short_path) == null);
+    try std.testing.expect(readBalloonStats(std.testing.io, missing_path) == null);
 }
 
 test "cleanupPath removes files and directories" {

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
+const cleanup_path = @import("commands/cleanup_path.zig");
 const cpu_cgroup_apply = @import("commands/cpu_cgroup_apply.zig");
 const cpu_cgroup_remove = @import("commands/cpu_cgroup_remove.zig");
 const host_memory = @import("commands/host_memory.zig");
@@ -22,6 +23,7 @@ const assert = std.debug.assert;
 var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
+    assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
     assert(host_memory.name.len > 0);
@@ -127,6 +129,12 @@ fn runFilesystemCommand(
 ) !?u8 {
     assert(command.len > 0);
 
+    if (std.mem.eql(u8, command, cleanup_path.name)) {
+        if (try rejectExtraArgs(it, cleanup_path.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try cleanup_path.run(allocator, g_io));
+    }
     if (std.mem.eql(u8, command, mkinitramfs.name)) {
         if (try rejectExtraArgs(it, mkinitramfs.name)) {
             return @intFromEnum(protocol.Exit.usage);
@@ -207,6 +215,7 @@ fn isHelp(command: []const u8) bool {
 }
 
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
+    assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
     assert(host_memory.name.len > 0);
@@ -228,6 +237,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .ok = true,
         .protocolVersion = @as(u8, protocol.version),
         .commands = .{
+            cleanup_path.name,
             cpu_cgroup_apply.name,
             cpu_cgroup_remove.name,
             host_memory.name,

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
+const balloon_stats = @import("commands/balloon_stats.zig");
 const cleanup_path = @import("commands/cleanup_path.zig");
 const cpu_cgroup_apply = @import("commands/cpu_cgroup_apply.zig");
 const cpu_cgroup_remove = @import("commands/cpu_cgroup_remove.zig");
@@ -23,6 +24,7 @@ const assert = std.debug.assert;
 var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
+    assert(balloon_stats.name.len > 0);
     assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
@@ -77,6 +79,12 @@ fn runHostCommand(
 ) !?u8 {
     assert(command.len > 0);
 
+    if (std.mem.eql(u8, command, balloon_stats.name)) {
+        if (try rejectExtraArgs(it, balloon_stats.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try balloon_stats.run(allocator, g_io));
+    }
     if (std.mem.eql(u8, command, cpu_cgroup_apply.name)) {
         if (try rejectExtraArgs(it, cpu_cgroup_apply.name)) {
             return @intFromEnum(protocol.Exit.usage);
@@ -215,6 +223,7 @@ fn isHelp(command: []const u8) bool {
 }
 
 fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
+    assert(balloon_stats.name.len > 0);
     assert(cleanup_path.name.len > 0);
     assert(cpu_cgroup_apply.name.len > 0);
     assert(cpu_cgroup_remove.name.len > 0);
@@ -237,6 +246,7 @@ fn writeHelp(allocator: std.mem.Allocator, io: std.Io) !u8 {
         .ok = true,
         .protocolVersion = @as(u8, protocol.version),
         .commands = .{
+            balloon_stats.name,
             cleanup_path.name,
             cpu_cgroup_apply.name,
             cpu_cgroup_remove.name,

--- a/packages/runtime/src/__tests__/balloon-stats.test.ts
+++ b/packages/runtime/src/__tests__/balloon-stats.test.ts
@@ -3,11 +3,36 @@
 // LE counters into a 24-byte file; the host reader walks the same
 // bytes. This test pretends to be the Zig writer.
 
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { readBalloonStats, STATS_FILE_SIZE } from "../balloon-stats.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-balloon-stats-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("readBalloonStats", () => {
   let dir: string;

--- a/packages/runtime/src/balloon-stats.ts
+++ b/packages/runtime/src/balloon-stats.ts
@@ -3,9 +3,8 @@
 // `MACHINEN_STATS_FILE`, mmaps it MAP_SHARED, and atomically updates
 // three u64 LE counters: two from the balloon handler (reported /
 // inflated bytes) and one from a Darwin-only sampler thread that
-// polls this VMM's `phys_footprint`. The host reads those bytes via
-// plain `readFileSync` — the OS's page cache already gives us a
-// coherent view of the mmap'd region.
+// polls this VMM's `phys_footprint`. The native runtime helper reads
+// the same layout so the host-side wire parsing stays in native code.
 //
 // Wire layout (must match `packages/microvm/src/stats.zig`):
 //   offset  0:  u64 LE  bytesReported           (free-page-reporting reclaim)
@@ -16,7 +15,7 @@
 // across compiler revisions; bumping it requires updating both files
 // together.
 
-import { readFileSync } from "node:fs";
+import { readBalloonStatsNative } from "./native/balloon-stats.ts";
 
 export const STATS_FILE_SIZE = 24;
 
@@ -52,18 +51,5 @@ export interface BalloonCounters {
  *   - it's unreadable (permissions, gone between stat and read).
  */
 export function readBalloonStats(path: string): BalloonCounters | null {
-  let buf: Buffer;
-  try {
-    buf = readFileSync(path);
-  } catch {
-    return null;
-  }
-  if (buf.length < STATS_FILE_SIZE) {
-    return null;
-  }
-  return {
-    bytesReported: Number(buf.readBigUInt64LE(0)),
-    bytesInflated: Number(buf.readBigUInt64LE(8)),
-    hostPhysFootprintBytes: Number(buf.readBigUInt64LE(16)),
-  };
+  return readBalloonStatsNative(path);
 }

--- a/packages/runtime/src/gc.ts
+++ b/packages/runtime/src/gc.ts
@@ -11,8 +11,8 @@
 //
 // Pid recycling is handled by `validatePid` (see pid-validate.ts).
 
-import { existsSync, rmdirSync, rmSync, statSync, unlinkSync } from "node:fs";
 import debugLib from "debug";
+import { cleanupPathNative } from "./native/gc.ts";
 import { validatePid, type PidStatus } from "./pid-validate.ts";
 import { listAll, removeEntry, type RegistryEntry } from "./registry.ts";
 
@@ -107,22 +107,11 @@ function reapPath(
   removedPaths: string[],
   failedPaths: string[],
 ): void {
-  if (!existsSync(path)) {
-    // Treat already-gone as success — the goal is that the path
-    // doesn't exist after gc runs.
-    return;
-  }
-  if (dryRun) {
+  const result = cleanupPathNative(path, dryRun);
+  if (result.removed) {
     removedPaths.push(path);
-    return;
   }
-  recordRmPath(path, removedPaths, failedPaths);
-}
-
-function recordRmPath(path: string, removedPaths: string[], failedPaths: string[]): void {
-  if (rmPath(path)) {
-    removedPaths.push(path);
-  } else {
+  if (result.failed) {
     failedPaths.push(path);
   }
 }
@@ -130,23 +119,5 @@ function recordRmPath(path: string, removedPaths: string[], failedPaths: string[
 function removeRegistryEntry(entry: RegistryEntry, dryRun: boolean): void {
   if (!dryRun) {
     removeEntry(entry.pid);
-  }
-}
-
-function rmPath(p: string): boolean {
-  try {
-    const st = statSync(p);
-    if (st.isDirectory()) {
-      if (p.startsWith("/sys/fs/cgroup/")) {
-        rmdirSync(p);
-      } else {
-        rmSync(p, { recursive: true, force: true });
-      }
-    } else {
-      unlinkSync(p);
-    }
-    return true;
-  } catch {
-    return false;
   }
 }

--- a/packages/runtime/src/native/balloon-stats.ts
+++ b/packages/runtime/src/native/balloon-stats.ts
@@ -1,0 +1,45 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import type { BalloonCounters } from "../balloon-stats.ts";
+
+interface BalloonStatsResult {
+  counters: BalloonCounters | null;
+}
+
+export function readBalloonStatsNative(path: string): BalloonCounters | null {
+  return callRuntimeHelper({
+    command: "balloon-stats",
+    data: { path },
+    errorCode: "BOOT_VMM_PACKAGE_BROKEN",
+    makeError: balloonStatsError,
+    isData: isBalloonStatsResult,
+  }).counters;
+}
+
+function balloonStatsError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}
+
+function isBalloonStatsResult(value: unknown): value is BalloonStatsResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<BalloonStatsResult>;
+  return data.counters === null || isBalloonCounters(data.counters);
+}
+
+function isBalloonCounters(value: unknown): value is BalloonCounters {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<BalloonCounters>;
+  return (
+    nonNegativeNumber(data.bytesReported) &&
+    nonNegativeNumber(data.bytesInflated) &&
+    nonNegativeNumber(data.hostPhysFootprintBytes)
+  );
+}
+
+function nonNegativeNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}

--- a/packages/runtime/src/native/gc.ts
+++ b/packages/runtime/src/native/gc.ts
@@ -1,0 +1,29 @@
+import { RegistryError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+interface CleanupPathResult {
+  removed: boolean;
+  failed: boolean;
+}
+
+export function cleanupPathNative(path: string, dryRun: boolean): CleanupPathResult {
+  return callRuntimeHelper({
+    command: "cleanup-path",
+    data: { path, dryRun },
+    errorCode: "REGISTRY_VM_NOT_FOUND",
+    makeError: cleanupPathError,
+    isData: isCleanupPathResult,
+  });
+}
+
+function cleanupPathError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new RegistryError(code, message, opts);
+}
+
+function isCleanupPathResult(value: unknown): value is CleanupPathResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<CleanupPathResult>;
+  return typeof data.removed === "boolean" && typeof data.failed === "boolean";
+}


### PR DESCRIPTION
## Problem

Cleanup and balloon stats reads still had small pieces of host logic in TypeScript. They fit the same native-helper pattern as the other host primitives.

## Solution

Move GC cleanup path removal and balloon stats reads into Zig helper commands. TypeScript keeps calling clear wrappers and handling the surrounding runtime flow.

## Technical Summary

- Splits this small tail off from the larger host primitive PR.
- Keeps filesystem mutation and host stats parsing behind command-specific native wrappers.
- Does not add a daemon, socket, or FFI path.
