### PR TITLE
Move temp path and env planning to Zig

### DIFF
--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -358,6 +358,11 @@ pub const MountDiskRuntimePlan = struct {
     upper_size_bytes: ?u64,
 };
 
+pub const MountDiskFdEnvInput = struct {
+    lower_fd: ?u64 = null,
+    upper_fd: ?u64 = null,
+};
+
 pub const RegistryCleanupInput = struct {
     per_boot_root_disk: ?[]const u8 = null,
     per_boot_snap_disk: ?[]const u8 = null,
@@ -521,6 +526,7 @@ pub const PlanError = error{
     MissingScratchPath,
     MissingRootDiskRuntimePath,
     MissingMountDiskRuntimeField,
+    MissingMountDiskFdField,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
@@ -1203,6 +1209,23 @@ fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePla
     };
 }
 
+pub fn planMountDiskFdEnv(allocator: std.mem.Allocator, input: MountDiskFdEnvInput) ![]EnvPair {
+    assert(@sizeOf(MountDiskFdEnvInput) > 0);
+
+    if (input.lower_fd == null and input.upper_fd == null) return &.{};
+    const lower_fd = input.lower_fd orelse return error.MissingMountDiskFdField;
+    const upper_fd = input.upper_fd orelse return error.MissingMountDiskFdField;
+    const lower_value = try std.fmt.allocPrint(allocator, "{d}", .{lower_fd});
+    errdefer allocator.free(lower_value);
+    const upper_value = try std.fmt.allocPrint(allocator, "{d}", .{upper_fd});
+    errdefer allocator.free(upper_value);
+    const env = try allocator.alloc(EnvPair, 2);
+    errdefer allocator.free(env);
+    env[0] = .{ .key = "MACHINEN_MOUNTDISK_LOWER_FD", .value = lower_value };
+    env[1] = .{ .key = "MACHINEN_MOUNTDISK_UPPER_FD", .value = upper_value };
+    return env;
+}
+
 fn planRegistryCpu(input: RegistryShapeInput) PlanError!?RegistryCpuPlan {
     assert(@sizeOf(RegistryShapeInput) > 0);
 
@@ -1813,6 +1836,23 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
     try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);
     try std.testing.expectEqualStrings("rw", plan.live_mounts[0].mode);
+}
+
+test "planMountDiskFdEnv formats inherited fd env entries" {
+    const allocator = std.testing.allocator;
+    const env = try planMountDiskFdEnv(allocator, .{ .lower_fd = 3, .upper_fd = 4 });
+    defer allocator.free(env[0].value);
+    defer allocator.free(env[1].value);
+    defer allocator.free(env);
+    try std.testing.expectEqual(@as(usize, 2), env.len);
+    try std.testing.expectEqualStrings("MACHINEN_MOUNTDISK_LOWER_FD", env[0].key);
+    try std.testing.expectEqualStrings("3", env[0].value);
+    try std.testing.expectEqualStrings("MACHINEN_MOUNTDISK_UPPER_FD", env[1].key);
+    try std.testing.expectEqualStrings("4", env[1].value);
+
+    const none = try planMountDiskFdEnv(allocator, .{});
+    try std.testing.expectEqual(@as(usize, 0), none.len);
+    try std.testing.expectError(error.MissingMountDiskFdField, planMountDiskFdEnv(allocator, .{ .lower_fd = 3 }));
 }
 
 test "planMountDiskRuntime selects restore and fresh actions" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -271,6 +271,7 @@ pub const LiveMount = struct {
 pub const StatsFileInput = struct {
     existing_path: ?[]const u8 = null,
     planned_path: ?[]const u8 = null,
+    planned_temp_dir: ?[]const u8 = null,
 };
 
 pub const StatsFilePlan = struct {
@@ -761,13 +762,20 @@ pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) 
     return out.toOwnedSlice(allocator);
 }
 
-pub fn planStatsFile(input: StatsFileInput) StatsFilePlan {
+pub fn planStatsFile(allocator: std.mem.Allocator, input: StatsFileInput) !StatsFilePlan {
     assert(@sizeOf(StatsFileInput) > 0);
 
     if (input.existing_path) |path| {
         return .{ .stats_file_path = path, .vmm_stats_file = null };
     }
-    return .{ .stats_file_path = input.planned_path, .vmm_stats_file = input.planned_path };
+    const planned_path = input.planned_path orelse if (input.planned_temp_dir) |dir|
+        try std.fs.path.join(allocator, &.{ dir, "stats.bin" })
+    else
+        null;
+    if (planned_path) |path| {
+        return .{ .stats_file_path = path, .vmm_stats_file = path };
+    }
+    return .{ .stats_file_path = null, .vmm_stats_file = null };
 }
 
 pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
@@ -2107,13 +2115,27 @@ test "planLiveMounts validates count guest paths modes and tags" {
 }
 
 test "planStatsFile preserves caller path or returns runtime-owned env value" {
-    const existing = planStatsFile(.{ .existing_path = "/tmp/caller-stats.bin" });
+    const existing = try planStatsFile(std.testing.allocator, .{
+        .existing_path = "/tmp/caller-stats.bin",
+    });
     try std.testing.expectEqualStrings("/tmp/caller-stats.bin", existing.stats_file_path.?);
     try std.testing.expectEqual(@as(?[]const u8, null), existing.vmm_stats_file);
 
-    const planned = planStatsFile(.{ .planned_path = "/tmp/runtime-stats.bin" });
+    const planned = try planStatsFile(std.testing.allocator, .{
+        .planned_path = "/tmp/runtime-stats.bin",
+    });
     try std.testing.expectEqualStrings("/tmp/runtime-stats.bin", planned.stats_file_path.?);
     try std.testing.expectEqualStrings("/tmp/runtime-stats.bin", planned.vmm_stats_file.?);
+
+    const planned_dir = try planStatsFile(std.testing.allocator, .{
+        .planned_temp_dir = "/tmp/machinen-stats-abc",
+    });
+    defer std.testing.allocator.free(planned_dir.stats_file_path.?);
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-stats-abc/stats.bin",
+        planned_dir.stats_file_path.?,
+    );
+    try std.testing.expectEqualStrings(planned_dir.stats_file_path.?, planned_dir.vmm_stats_file.?);
 }
 
 test "planVirtiofsEnv formats indexed virtiofs env entries" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -238,6 +238,14 @@ pub const KernelDtbPlan = struct {
     vmm_dtb: ?[]const u8,
 };
 
+pub const InitrdInput = struct {
+    initrd_path: ?[]const u8 = null,
+};
+
+pub const InitrdPlan = struct {
+    vmm_initrd: ?[]const u8,
+};
+
 pub const VmstateEnvInput = struct {
     state_path: ?[]const u8 = null,
     restore_path: ?[]const u8 = null,
@@ -606,7 +614,10 @@ fn isHostnameAlnum(c: u8) bool {
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9');
 }
 
-pub fn planVmstateRuntime(allocator: std.mem.Allocator, input: VmstateRuntimeInput) PlanError!VmstateRuntimePlan {
+pub fn planVmstateRuntime(
+    allocator: std.mem.Allocator,
+    input: VmstateRuntimeInput,
+) PlanError!VmstateRuntimePlan {
     assert(@sizeOf(VmstateRuntimeInput) > 0);
 
     if (input.state_path == null and
@@ -698,7 +709,7 @@ pub fn planVsock(allocator: std.mem.Allocator, input: VsockPlanInput) !VsockPlan
         errdefer allocator.free(uds);
         return .{
             .uds_path = uds,
-            .vmm_vsock = try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds}),
+            .vmm_vsock = try std.mem.concat(allocator, u8, &.{ "in:1978:", uds }),
         };
     }
     return .{ .uds_path = null, .vmm_vsock = null };
@@ -725,6 +736,12 @@ pub fn planKernelDtb(input: KernelDtbInput) KernelDtbPlan {
     assert(@sizeOf(KernelDtbInput) > 0);
 
     return .{ .vmm_kernel = input.kernel_path, .vmm_dtb = input.dtb_path };
+}
+
+pub fn planInitrdEnv(input: InitrdInput) InitrdPlan {
+    assert(@sizeOf(InitrdInput) > 0);
+
+    return .{ .vmm_initrd = input.initrd_path };
 }
 
 pub fn planVmstateEnv(input: VmstateEnvInput) VmstateEnvPlan {
@@ -997,8 +1014,16 @@ pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
     };
 }
 
-pub fn planBundleWorkspace(allocator: std.mem.Allocator, input: BundleWorkspaceInput) !BundleWorkspacePlan {
-    const temp_dir = input.temp_dir orelse return .{ .cpio_path = null, .synth_bundle_dir = null };
+pub fn planBundleWorkspace(
+    allocator: std.mem.Allocator,
+    input: BundleWorkspaceInput,
+) !BundleWorkspacePlan {
+    assert(@sizeOf(BundleWorkspaceInput) > 0);
+
+    const temp_dir = input.temp_dir orelse return .{
+        .cpio_path = null,
+        .synth_bundle_dir = null,
+    };
     const cpio_path = try std.fs.path.join(allocator, &.{ temp_dir, "initramfs.cpio" });
     errdefer allocator.free(cpio_path);
     return .{
@@ -1007,13 +1032,24 @@ pub fn planBundleWorkspace(allocator: std.mem.Allocator, input: BundleWorkspaceI
     };
 }
 
-pub fn planBundleConfigPaths(allocator: std.mem.Allocator, input: BundleConfigPathsInput) !BundleConfigPathsPlan {
-    const synth_bundle_dir = input.synth_bundle_dir orelse return .{ .rootfs_dir = null, .config_path = null };
+pub fn planBundleConfigPaths(
+    allocator: std.mem.Allocator,
+    input: BundleConfigPathsInput,
+) !BundleConfigPathsPlan {
+    assert(@sizeOf(BundleConfigPathsInput) > 0);
+
+    const synth_bundle_dir = input.synth_bundle_dir orelse return .{
+        .rootfs_dir = null,
+        .config_path = null,
+    };
     const rootfs_dir = try std.fs.path.join(allocator, &.{ synth_bundle_dir, "rootfs" });
     errdefer allocator.free(rootfs_dir);
     return .{
         .rootfs_dir = rootfs_dir,
-        .config_path = try std.fs.path.join(allocator, &.{ synth_bundle_dir, "machinen-config.json" }),
+        .config_path = try std.fs.path.join(allocator, &.{
+            synth_bundle_dir,
+            "machinen-config.json",
+        }),
     };
 }
 
@@ -1209,21 +1245,27 @@ fn planRegistryVmstate(input: RegistryVmstateInput) PlanError!RegistryVmstatePla
     };
 }
 
-pub fn planMountDiskFdEnv(allocator: std.mem.Allocator, input: MountDiskFdEnvInput) ![]EnvPair {
+pub fn planMountDiskFdEnv(
+    allocator: std.mem.Allocator,
+    input: MountDiskFdEnvInput,
+) ![]EnvPair {
     assert(@sizeOf(MountDiskFdEnvInput) > 0);
 
     if (input.lower_fd == null and input.upper_fd == null) return &.{};
     const lower_fd = input.lower_fd orelse return error.MissingMountDiskFdField;
     const upper_fd = input.upper_fd orelse return error.MissingMountDiskFdField;
-    const lower_value = try std.fmt.allocPrint(allocator, "{d}", .{lower_fd});
+    var lower_buf: [20]u8 = undefined;
+    var upper_buf: [20]u8 = undefined;
+    const lower_text = try std.fmt.bufPrint(&lower_buf, "{d}", .{lower_fd});
+    const upper_text = try std.fmt.bufPrint(&upper_buf, "{d}", .{upper_fd});
+    const lower_value = try std.mem.concat(allocator, u8, &.{lower_text});
     errdefer allocator.free(lower_value);
-    const upper_value = try std.fmt.allocPrint(allocator, "{d}", .{upper_fd});
+    const upper_value = try std.mem.concat(allocator, u8, &.{upper_text});
     errdefer allocator.free(upper_value);
-    const env = try allocator.alloc(EnvPair, 2);
-    errdefer allocator.free(env);
-    env[0] = .{ .key = "MACHINEN_MOUNTDISK_LOWER_FD", .value = lower_value };
-    env[1] = .{ .key = "MACHINEN_MOUNTDISK_UPPER_FD", .value = upper_value };
-    return env;
+    return try std.mem.concat(allocator, EnvPair, &.{&[_]EnvPair{
+        .{ .key = "MACHINEN_MOUNTDISK_LOWER_FD", .value = lower_value },
+        .{ .key = "MACHINEN_MOUNTDISK_UPPER_FD", .value = upper_value },
+    }});
 }
 
 fn planRegistryCpu(input: RegistryShapeInput) PlanError!?RegistryCpuPlan {
@@ -1844,15 +1886,18 @@ test "planMountDiskFdEnv formats inherited fd env entries" {
     defer allocator.free(env[0].value);
     defer allocator.free(env[1].value);
     defer allocator.free(env);
-    try std.testing.expectEqual(@as(usize, 2), env.len);
+    try std.testing.expect(env.len == 2);
     try std.testing.expectEqualStrings("MACHINEN_MOUNTDISK_LOWER_FD", env[0].key);
     try std.testing.expectEqualStrings("3", env[0].value);
     try std.testing.expectEqualStrings("MACHINEN_MOUNTDISK_UPPER_FD", env[1].key);
     try std.testing.expectEqualStrings("4", env[1].value);
 
     const none = try planMountDiskFdEnv(allocator, .{});
-    try std.testing.expectEqual(@as(usize, 0), none.len);
-    try std.testing.expectError(error.MissingMountDiskFdField, planMountDiskFdEnv(allocator, .{ .lower_fd = 3 }));
+    try std.testing.expect(none.len == 0);
+    try std.testing.expectError(
+        error.MissingMountDiskFdField,
+        planMountDiskFdEnv(allocator, .{ .lower_fd = 3 }),
+    );
 }
 
 test "planMountDiskRuntime selects restore and fresh actions" {
@@ -2020,22 +2065,40 @@ test "planProvisionAssets selects asset names by guest CPU" {
 }
 
 test "planBundleWorkspace derives staging paths from the runtime-owned temp dir" {
-    const planned = try planBundleWorkspace(std.testing.allocator, .{ .temp_dir = "/tmp/machinen-bundle-abc" });
+    const planned = try planBundleWorkspace(
+        std.testing.allocator,
+        .{ .temp_dir = "/tmp/machinen-bundle-abc" },
+    );
     defer std.testing.allocator.free(planned.cpio_path.?);
     defer std.testing.allocator.free(planned.synth_bundle_dir.?);
-    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/initramfs.cpio", planned.cpio_path.?);
-    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle", planned.synth_bundle_dir.?);
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-bundle-abc/initramfs.cpio",
+        planned.cpio_path.?,
+    );
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-bundle-abc/bundle",
+        planned.synth_bundle_dir.?,
+    );
     const none = try planBundleWorkspace(std.testing.allocator, .{});
     try std.testing.expect(none.cpio_path == null);
     try std.testing.expect(none.synth_bundle_dir == null);
 }
 
 test "planBundleConfigPaths derives bundle config staging paths" {
-    const planned = try planBundleConfigPaths(std.testing.allocator, .{ .synth_bundle_dir = "/tmp/machinen-bundle-abc/bundle" });
+    const planned = try planBundleConfigPaths(
+        std.testing.allocator,
+        .{ .synth_bundle_dir = "/tmp/machinen-bundle-abc/bundle" },
+    );
     defer std.testing.allocator.free(planned.rootfs_dir.?);
     defer std.testing.allocator.free(planned.config_path.?);
-    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle/rootfs", planned.rootfs_dir.?);
-    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle/machinen-config.json", planned.config_path.?);
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-bundle-abc/bundle/rootfs",
+        planned.rootfs_dir.?,
+    );
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-bundle-abc/bundle/machinen-config.json",
+        planned.config_path.?,
+    );
     const none = try planBundleConfigPaths(std.testing.allocator, .{});
     try std.testing.expect(none.rootfs_dir == null);
     try std.testing.expect(none.config_path == null);
@@ -2280,6 +2343,13 @@ test "planKernelDtb forwards resolved kernel and dtb paths" {
     try std.testing.expectEqual(@as(?[]const u8, null), empty.vmm_dtb);
 }
 
+test "planInitrdEnv forwards resolved initrd path" {
+    const plan = planInitrdEnv(.{ .initrd_path = "/tmp/initramfs.cpio" });
+    try std.testing.expectEqualStrings("/tmp/initramfs.cpio", plan.vmm_initrd.?);
+    const empty = planInitrdEnv(.{});
+    try std.testing.expectEqual(@as(?[]const u8, null), empty.vmm_initrd);
+}
+
 test "planVmmArgv wraps VMM argv with pdeathsig when present" {
     const direct = try planVmmArgv(std.testing.allocator, .{
         .binary = "/bin/vmm",
@@ -2348,11 +2418,17 @@ test "planVsock parses existing specs and formats auto specs" {
     try std.testing.expectEqualStrings("/tmp/auto.sock", auto.uds_path.?);
     try std.testing.expectEqualStrings("in:1978:/tmp/auto.sock", auto.vmm_vsock.?);
 
-    const auto_dir = try planVsock(std.testing.allocator, .{ .auto_temp_dir = "/tmp/machinen-vsock-abc" });
+    const auto_dir = try planVsock(
+        std.testing.allocator,
+        .{ .auto_temp_dir = "/tmp/machinen-vsock-abc" },
+    );
     defer std.testing.allocator.free(auto_dir.uds_path.?);
     defer std.testing.allocator.free(auto_dir.vmm_vsock.?);
     try std.testing.expectEqualStrings("/tmp/machinen-vsock-abc/exec.sock", auto_dir.uds_path.?);
-    try std.testing.expectEqualStrings("in:1978:/tmp/machinen-vsock-abc/exec.sock", auto_dir.vmm_vsock.?);
+    try std.testing.expectEqualStrings(
+        "in:1978:/tmp/machinen-vsock-abc/exec.sock",
+        auto_dir.vmm_vsock.?,
+    );
 }
 
 test "planGuestEnv applies name and hostname wait defaults without overriding caller env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -196,6 +196,7 @@ pub const ProvisionRepackInput = struct {
 pub const ProvisionRepackPlan = struct {
     extract_args: []const []const u8,
     targz_args: []const []const u8,
+    image_config_path: ?[]const u8,
 };
 
 pub const ProvisionImageConfigInput = struct {
@@ -880,7 +881,7 @@ pub fn planProvisionRepack(
     assert(@sizeOf(ProvisionRepackInput) > 0);
 
     if (provisionRepackInputEmpty(input)) {
-        return .{ .extract_args = &.{}, .targz_args = &.{} };
+        return .{ .extract_args = &.{}, .targz_args = &.{}, .image_config_path = null };
     }
     const disk_path = input.disk_path orelse return error.MissingProvisionRepackField;
     const out_path = input.out_path orelse return error.MissingProvisionRepackField;
@@ -897,7 +898,16 @@ pub fn planProvisionRepack(
         &.{&[_][]const u8{ "-czf", out_path, "-C", extract_dir, "." }},
     );
     errdefer allocator.free(targz_args);
-    return .{ .extract_args = extract_args, .targz_args = targz_args };
+    const image_config_path = try std.fs.path.join(allocator, &.{
+        extract_dir,
+        "machinen-config.json",
+    });
+    errdefer allocator.free(image_config_path);
+    return .{
+        .extract_args = extract_args,
+        .targz_args = targz_args,
+        .image_config_path = image_config_path,
+    };
 }
 
 fn provisionRepackInputEmpty(input: ProvisionRepackInput) bool {
@@ -1899,6 +1909,7 @@ test "planProvisionWorkload and planProvisionRepack build commands" {
     });
     defer allocator.free(repack.extract_args);
     defer allocator.free(repack.targz_args);
+    defer allocator.free(repack.image_config_path.?);
     try std.testing.expectEqualSlices(
         []const u8,
         &[_][]const u8{ "-xf", "/tmp/scratch.img", "-C", "/tmp/extract" },

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -130,6 +130,15 @@ pub const BundleWorkspacePlan = struct {
     synth_bundle_dir: ?[]const u8,
 };
 
+pub const BundleConfigPathsInput = struct {
+    synth_bundle_dir: ?[]const u8 = null,
+};
+
+pub const BundleConfigPathsPlan = struct {
+    rootfs_dir: ?[]const u8,
+    config_path: ?[]const u8,
+};
+
 pub const ProvisionGuestCpu = enum {
     arm64,
     amd64,
@@ -979,6 +988,16 @@ pub fn planBundleWorkspace(allocator: std.mem.Allocator, input: BundleWorkspaceI
     return .{
         .cpio_path = cpio_path,
         .synth_bundle_dir = try std.fs.path.join(allocator, &.{ temp_dir, "bundle" }),
+    };
+}
+
+pub fn planBundleConfigPaths(allocator: std.mem.Allocator, input: BundleConfigPathsInput) !BundleConfigPathsPlan {
+    const synth_bundle_dir = input.synth_bundle_dir orelse return .{ .rootfs_dir = null, .config_path = null };
+    const rootfs_dir = try std.fs.path.join(allocator, &.{ synth_bundle_dir, "rootfs" });
+    errdefer allocator.free(rootfs_dir);
+    return .{
+        .rootfs_dir = rootfs_dir,
+        .config_path = try std.fs.path.join(allocator, &.{ synth_bundle_dir, "machinen-config.json" }),
     };
 }
 
@@ -1958,6 +1977,17 @@ test "planBundleWorkspace derives staging paths from the runtime-owned temp dir"
     const none = try planBundleWorkspace(std.testing.allocator, .{});
     try std.testing.expect(none.cpio_path == null);
     try std.testing.expect(none.synth_bundle_dir == null);
+}
+
+test "planBundleConfigPaths derives bundle config staging paths" {
+    const planned = try planBundleConfigPaths(std.testing.allocator, .{ .synth_bundle_dir = "/tmp/machinen-bundle-abc/bundle" });
+    defer std.testing.allocator.free(planned.rootfs_dir.?);
+    defer std.testing.allocator.free(planned.config_path.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle/rootfs", planned.rootfs_dir.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle/machinen-config.json", planned.config_path.?);
+    const none = try planBundleConfigPaths(std.testing.allocator, .{});
+    try std.testing.expect(none.rootfs_dir == null);
+    try std.testing.expect(none.config_path == null);
 }
 
 test "planBundleEnv overlays guest env on image env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -65,6 +65,7 @@ pub const GuestHostnameInput = struct {
 pub const VsockPlanInput = struct {
     existing_spec: ?[]const u8 = null,
     auto_uds_path: ?[]const u8 = null,
+    auto_temp_dir: ?[]const u8 = null,
 };
 
 pub const VsockPlan = struct {
@@ -667,6 +668,14 @@ pub fn planVsock(allocator: std.mem.Allocator, input: VsockPlanInput) !VsockPlan
         return .{
             .uds_path = uds,
             .vmm_vsock = try std.mem.concat(allocator, u8, &.{ "in:1978:", uds }),
+        };
+    }
+    if (input.auto_temp_dir) |dir| {
+        const uds = try std.fs.path.join(allocator, &.{ dir, "exec.sock" });
+        errdefer allocator.free(uds);
+        return .{
+            .uds_path = uds,
+            .vmm_vsock = try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds}),
         };
     }
     return .{ .uds_path = null, .vmm_vsock = null };
@@ -2221,6 +2230,12 @@ test "planVsock parses existing specs and formats auto specs" {
     defer std.testing.allocator.free(auto.vmm_vsock.?);
     try std.testing.expectEqualStrings("/tmp/auto.sock", auto.uds_path.?);
     try std.testing.expectEqualStrings("in:1978:/tmp/auto.sock", auto.vmm_vsock.?);
+
+    const auto_dir = try planVsock(std.testing.allocator, .{ .auto_temp_dir = "/tmp/machinen-vsock-abc" });
+    defer std.testing.allocator.free(auto_dir.uds_path.?);
+    defer std.testing.allocator.free(auto_dir.vmm_vsock.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-vsock-abc/exec.sock", auto_dir.uds_path.?);
+    try std.testing.expectEqualStrings("in:1978:/tmp/machinen-vsock-abc/exec.sock", auto_dir.vmm_vsock.?);
 }
 
 test "planGuestEnv applies name and hostname wait defaults without overriding caller env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -120,6 +120,15 @@ pub const BundleEnvInput = struct {
     guest_env: []const EnvPair = &.{},
 };
 
+pub const BundleWorkspaceInput = struct {
+    temp_dir: ?[]const u8 = null,
+};
+
+pub const BundleWorkspacePlan = struct {
+    cpio_path: ?[]const u8,
+    synth_bundle_dir: ?[]const u8,
+};
+
 pub const ProvisionGuestCpu = enum {
     arm64,
     amd64,
@@ -937,6 +946,16 @@ pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
             .dtb_asset = "virt-arm64.dtb",
             .rootfs_asset = "rootfs-debian-arm64.tar.gz",
         },
+    };
+}
+
+pub fn planBundleWorkspace(allocator: std.mem.Allocator, input: BundleWorkspaceInput) !BundleWorkspacePlan {
+    const temp_dir = input.temp_dir orelse return .{ .cpio_path = null, .synth_bundle_dir = null };
+    const cpio_path = try std.fs.path.join(allocator, &.{ temp_dir, "initramfs.cpio" });
+    errdefer allocator.free(cpio_path);
+    return .{
+        .cpio_path = cpio_path,
+        .synth_bundle_dir = try std.fs.path.join(allocator, &.{ temp_dir, "bundle" }),
     };
 }
 
@@ -1897,6 +1916,17 @@ test "planProvisionAssets selects asset names by guest CPU" {
     try std.testing.expectEqualStrings("bzImage-x86_64", x64.kernel_asset);
     try std.testing.expect(x64.dtb_asset == null);
     try std.testing.expectEqualStrings("rootfs-debian-amd64.tar.gz", x64.rootfs_asset);
+}
+
+test "planBundleWorkspace derives staging paths from the runtime-owned temp dir" {
+    const planned = try planBundleWorkspace(std.testing.allocator, .{ .temp_dir = "/tmp/machinen-bundle-abc" });
+    defer std.testing.allocator.free(planned.cpio_path.?);
+    defer std.testing.allocator.free(planned.synth_bundle_dir.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/initramfs.cpio", planned.cpio_path.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-bundle-abc/bundle", planned.synth_bundle_dir.?);
+    const none = try planBundleWorkspace(std.testing.allocator, .{});
+    try std.testing.expect(none.cpio_path == null);
+    try std.testing.expect(none.synth_bundle_dir == null);
 }
 
 test "planBundleEnv overlays guest env on image env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -243,6 +243,7 @@ pub const VmstateEnvPlan = struct {
 
 pub const VmstateRuntimeInput = struct {
     state_path: ?[]const u8 = null,
+    state_temp_dir: ?[]const u8 = null,
     chain_id: ?[]const u8 = null,
     restore_path: ?[]const u8 = null,
     forked_from: ?[]const u8 = null,
@@ -589,10 +590,11 @@ fn isHostnameAlnum(c: u8) bool {
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9');
 }
 
-pub fn planVmstateRuntime(input: VmstateRuntimeInput) PlanError!VmstateRuntimePlan {
+pub fn planVmstateRuntime(allocator: std.mem.Allocator, input: VmstateRuntimeInput) PlanError!VmstateRuntimePlan {
     assert(@sizeOf(VmstateRuntimeInput) > 0);
 
     if (input.state_path == null and
+        input.state_temp_dir == null and
         input.chain_id == null and
         input.restore_path == null and
         input.forked_from == null)
@@ -605,8 +607,12 @@ pub fn planVmstateRuntime(input: VmstateRuntimeInput) PlanError!VmstateRuntimePl
         };
     }
     const chain_id = input.chain_id orelse return error.MissingVmstateRuntimeChainId;
+    const state_path = input.state_path orelse blk: {
+        const dir = input.state_temp_dir orelse break :blk null;
+        break :blk try std.fs.path.join(allocator, &.{ dir, "state.vmstate" });
+    };
     return .{
-        .state_path = input.state_path,
+        .state_path = state_path,
         .chain_id = chain_id,
         .checkpoint_parent = if (input.restore_path != null) input.forked_from else null,
         .checkpoint_sequence = 0,
@@ -1585,7 +1591,7 @@ test "planPdeathsig defaults on and lets detach or explicit false disable it" {
 }
 
 test "planVmstateRuntime projects chain defaults and restore parent" {
-    const fresh = try planVmstateRuntime(.{
+    const fresh = try planVmstateRuntime(std.testing.allocator, .{
         .state_path = "/tmp/state.vmstate",
         .chain_id = "chain-1",
     });
@@ -1594,7 +1600,7 @@ test "planVmstateRuntime projects chain defaults and restore parent" {
     try std.testing.expect(fresh.checkpoint_parent == null);
     try std.testing.expectEqual(@as(u64, 0), fresh.checkpoint_sequence.?);
 
-    const restore = try planVmstateRuntime(.{
+    const restore = try planVmstateRuntime(std.testing.allocator, .{
         .state_path = "/tmp/state.vmstate",
         .chain_id = "chain-2",
         .restore_path = "/tmp/restore.vmstate",
@@ -1603,14 +1609,22 @@ test "planVmstateRuntime projects chain defaults and restore parent" {
     try std.testing.expectEqualStrings("/snap/parent", restore.checkpoint_parent.?);
     try std.testing.expectEqual(@as(u64, 0), restore.checkpoint_sequence.?);
 
-    const empty = try planVmstateRuntime(.{});
+    const empty = try planVmstateRuntime(std.testing.allocator, .{});
     try std.testing.expect(empty.state_path == null);
     try std.testing.expect(empty.chain_id == null);
     try std.testing.expect(empty.checkpoint_sequence == null);
 
-    try std.testing.expectError(error.MissingVmstateRuntimeChainId, planVmstateRuntime(.{
-        .state_path = "/tmp/state.vmstate",
-    }));
+    const temp = try planVmstateRuntime(std.testing.allocator, .{
+        .state_temp_dir = "/tmp/machinen-vsock-abc",
+        .chain_id = "chain-3",
+    });
+    defer std.testing.allocator.free(temp.state_path.?);
+    try std.testing.expectEqualStrings("/tmp/machinen-vsock-abc/state.vmstate", temp.state_path.?);
+
+    try std.testing.expectError(error.MissingVmstateRuntimeChainId, planVmstateRuntime(
+        std.testing.allocator,
+        .{ .state_path = "/tmp/state.vmstate" },
+    ));
 }
 
 test "planNestedEnv sets nested only when requested" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -125,8 +125,15 @@ pub const ProvisionGuestCpu = enum {
     amd64,
 };
 
+pub const ProvisionGuestCpuInput = struct {
+    arch_override: ?[]const u8 = null,
+    host_arch: ?[]const u8 = null,
+};
+
 pub const ProvisionAssetsInput = struct {
-    guest_cpu: ProvisionGuestCpu = .arm64,
+    guest_cpu: ?ProvisionGuestCpu = null,
+    arch_override: ?[]const u8 = null,
+    host_arch: ?[]const u8 = null,
 };
 
 pub const ProvisionAssetsPlan = struct {
@@ -897,10 +904,27 @@ fn planProvisionVsock(
     return null;
 }
 
+pub fn planProvisionGuestCpu(input: ProvisionGuestCpuInput) ProvisionGuestCpu {
+    assert(@sizeOf(ProvisionGuestCpuInput) > 0);
+
+    if (input.arch_override) |override| {
+        if (std.mem.eql(u8, override, "arm64")) return .arm64;
+        if (std.mem.eql(u8, override, "amd64")) return .amd64;
+    }
+    if (input.host_arch) |host_arch| {
+        if (std.mem.eql(u8, host_arch, "x64")) return .amd64;
+    }
+    return .arm64;
+}
+
 pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
     assert(@sizeOf(ProvisionAssetsInput) > 0);
 
-    return switch (input.guest_cpu) {
+    const cpu = input.guest_cpu orelse planProvisionGuestCpu(.{
+        .arch_override = input.arch_override,
+        .host_arch = input.host_arch,
+    });
+    return switch (cpu) {
         .amd64 => .{
             .cpu = "amd64",
             .kernel_asset = "bzImage-x86_64",
@@ -1843,6 +1867,22 @@ test "planProvisionBoot builds provision boot inputs" {
     try std.testing.expectEqualStrings("/usr/local/bin:/usr/bin:/bin:/sbin", plan.env[0].value);
     try std.testing.expectEqualStrings("/tmp/scratch.img", plan.snapshot_path.?);
     try std.testing.expectEqualStrings("/tmp/rootfs.img", plan.root_disk_path.?);
+}
+
+test "planProvisionGuestCpu uses override, host arch, and arm64 fallback" {
+    try std.testing.expectEqual(.arm64, planProvisionGuestCpu(.{}));
+    try std.testing.expectEqual(.amd64, planProvisionGuestCpu(.{
+        .arch_override = "amd64",
+        .host_arch = "arm64",
+    }));
+    try std.testing.expectEqual(.arm64, planProvisionGuestCpu(.{
+        .arch_override = "arm64",
+        .host_arch = "x64",
+    }));
+    try std.testing.expectEqual(.amd64, planProvisionGuestCpu(.{
+        .arch_override = "bogus",
+        .host_arch = "x64",
+    }));
 }
 
 test "planProvisionAssets selects asset names by guest CPU" {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -1241,6 +1241,7 @@ fn writeProvisionRepackField(
     try protocol.stdout(io, "{");
     try writeStringArrayField(io, "extractArgs", repack.extract_args, false);
     try writeStringArrayField(io, "targzArgs", repack.targz_args, true);
+    try writeNullableStringField(io, "imageConfigPath", repack.image_config_path, true);
     try protocol.stdout(io, "}");
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -63,6 +63,7 @@ const ParsedRequest = struct {
     bundle_command_required: bool = false,
     bundle_image_env: std.json.ObjectMap = .{},
     bundle_guest_env: std.json.ObjectMap = .{},
+    bundle_workspace_temp_dir: ?[]const u8 = null,
     provision_guest_cpu: ?boot_plan.ProvisionGuestCpu = null,
     provision_guest_arch_override: ?[]const u8 = null,
     provision_host_arch: ?[]const u8 = null,
@@ -194,6 +195,7 @@ const boot_plan_fields = [_][]const u8{
     "bundleCommandRequired",
     "bundleImageEnv",
     "bundleGuestEnv",
+    "bundleWorkspaceTempDir",
     "provisionGuestCpu",
     "provisionGuestArchOverride",
     "provisionHostArch",
@@ -336,6 +338,7 @@ const RequestError = error{
     InvalidBundleCommandRequired,
     InvalidBundleImageEnv,
     InvalidBundleGuestEnv,
+    InvalidBundleWorkspaceTempDir,
     InvalidProvisionGuestCpu,
     InvalidProvisionGuestArchOverride,
     InvalidProvisionHostArch,
@@ -441,6 +444,7 @@ const PlanParts = struct {
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
+    bundle_workspace: boot_plan.BundleWorkspacePlan,
     provision_assets: boot_plan.ProvisionAssetsPlan,
     provision_boot: boot_plan.ProvisionBootPlan,
     provision_workload: boot_plan.ProvisionWorkloadPlan,
@@ -534,6 +538,9 @@ fn makePlanParts(
         .config_live_mounts = runtime.config_live_mounts,
         .bundle_command = runtime.bundle_command,
         .bundle_env = runtime.bundle_env,
+        .bundle_workspace = try boot_plan.planBundleWorkspace(arena, .{
+            .temp_dir = parsed.bundle_workspace_temp_dir,
+        }),
         .provision_assets = boot_plan.planProvisionAssets(.{
             .guest_cpu = parsed.provision_guest_cpu,
             .arch_override = parsed.provision_guest_arch_override,
@@ -865,6 +872,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeMachinenConfigField(io, "machinenConfig", parts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
+    try writeBundleWorkspaceField(io, "bundleWorkspace", parts.bundle_workspace, true);
     try writeProvisionAssetsField(io, "provisionAssets", parts.provision_assets, true);
     try writeProvisionBootField(io, "provisionBoot", parts.provision_boot, true);
     try writeProvisionWorkloadField(io, "provisionWorkload", parts.provision_workload, true);
@@ -1113,6 +1121,21 @@ fn writeLiveMountsArrayField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeBundleWorkspaceField(
+    io: std.Io,
+    comptime field: []const u8,
+    workspace: boot_plan.BundleWorkspacePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "cpioPath", workspace.cpio_path, false);
+    try writeNullableStringField(io, "synthBundleDir", workspace.synth_bundle_dir, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeProvisionAssetsField(
@@ -2050,6 +2073,11 @@ fn parseBundleFields(
         object,
         "bundleGuestEnv",
         error.InvalidBundleGuestEnv,
+    );
+    request.bundle_workspace_temp_dir = try optionalStringDefaultNull(
+        object,
+        "bundleWorkspaceTempDir",
+        error.InvalidBundleWorkspaceTempDir,
     );
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -38,6 +38,7 @@ const ParsedRequest = struct {
     boot_timeout_forever: bool = false,
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
+    initrd_path: ?[]const u8 = null,
     vmstate_path: ?[]const u8 = null,
     restore_path: ?[]const u8 = null,
     enable_vmstate_timing: bool = false,
@@ -176,6 +177,7 @@ const boot_plan_fields = [_][]const u8{
     "bootTimeoutForever",
     "kernelPath",
     "dtbPath",
+    "initrdPath",
     "vmstatePath",
     "restorePath",
     "enableVmstateTiming",
@@ -320,6 +322,7 @@ const RequestError = error{
     InvalidBootTimeoutForever,
     InvalidKernelPath,
     InvalidDtbPath,
+    InvalidInitrdPath,
     InvalidVmstatePath,
     InvalidRestorePath,
     InvalidEnableVmstateTiming,
@@ -450,6 +453,7 @@ const PlanParts = struct {
     use_pdeathsig: bool,
     planned_port_forwards: []const boot_plan.PortForwardMapping,
     kernel_dtb: boot_plan.KernelDtbPlan,
+    initrd_env: boot_plan.InitrdPlan,
     vmstate_env: boot_plan.VmstateEnvPlan,
     vmstate_runtime: boot_plan.VmstateRuntimePlan,
     nested_env: ?[]const u8,
@@ -488,6 +492,19 @@ fn makeCorePlan(
     return boot_plan.planCore(input);
 }
 
+const BootEnvParts = struct {
+    vsock_plan: boot_plan.VsockPlan,
+    vmm_argv: boot_plan.VmmArgvPlan,
+    use_pdeathsig: bool,
+    kernel_dtb: boot_plan.KernelDtbPlan,
+    initrd_env: boot_plan.InitrdPlan,
+    vmstate_env: boot_plan.VmstateEnvPlan,
+    vmstate_runtime: boot_plan.VmstateRuntimePlan,
+    nested_env: ?[]const u8,
+    virtiofs_env: []const boot_plan.EnvPair,
+    stats_file: boot_plan.StatsFilePlan,
+};
+
 const RuntimeParts = struct {
     planned_live_mounts: []const boot_plan.LiveMount,
     config_cmd: []const []const u8,
@@ -510,51 +527,24 @@ fn makePlanParts(
 ) !PlanParts {
     assert(@sizeOf(PlanParts) > 0);
 
+    const boot_env = try makeBootEnvParts(arena, parsed);
     const runtime = try makeRuntimeParts(arena, parsed);
     return .{
         .plan = plan,
         .cpu_policy = try makeCpuResources(parsed),
         .guest_env = try makeGuestEnv(arena, parsed),
         .guest_hostname = try makeGuestHostname(parsed),
-        .vsock_plan = try boot_plan.planVsock(arena, .{
-            .existing_spec = parsed.existing_vsock_spec,
-            .auto_uds_path = parsed.auto_vsock_uds_path,
-            .auto_temp_dir = parsed.auto_vsock_temp_dir,
-        }),
-        .vmm_argv = try boot_plan.planVmmArgv(arena, .{
-            .binary = parsed.vmm_binary,
-            .args = parsed.vmm_args,
-            .pdeathsig_path = parsed.pdeathsig_path,
-        }),
-        .use_pdeathsig = boot_plan.planPdeathsig(.{
-            .detached = parsed.detached,
-            .pdeathsig = parsed.pdeathsig_requested,
-        }),
+        .vsock_plan = boot_env.vsock_plan,
+        .vmm_argv = boot_env.vmm_argv,
+        .use_pdeathsig = boot_env.use_pdeathsig,
         .planned_port_forwards = parsed.port_forward,
-        .kernel_dtb = boot_plan.planKernelDtb(.{
-            .kernel_path = parsed.kernel_path,
-            .dtb_path = parsed.dtb_path,
-        }),
-        .vmstate_env = boot_plan.planVmstateEnv(.{
-            .state_path = parsed.vmstate_path,
-            .restore_path = parsed.restore_path,
-            .enable_timing = parsed.enable_vmstate_timing,
-            .existing_timing = parsed.existing_vmstate_timing,
-        }),
-        .vmstate_runtime = try boot_plan.planVmstateRuntime(arena, .{
-            .state_path = parsed.boot_vmstate_state_path,
-            .state_temp_dir = parsed.boot_vmstate_temp_dir,
-            .chain_id = parsed.boot_vmstate_chain_id,
-            .restore_path = parsed.boot_vmstate_restore_path,
-            .forked_from = parsed.boot_vmstate_forked_from,
-        }),
-        .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
-        .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
-        .stats_file = try boot_plan.planStatsFile(arena, .{
-            .existing_path = parsed.existing_stats_file,
-            .planned_path = parsed.stats_file_path,
-            .planned_temp_dir = parsed.stats_file_temp_dir,
-        }),
+        .kernel_dtb = boot_env.kernel_dtb,
+        .initrd_env = boot_env.initrd_env,
+        .vmstate_env = boot_env.vmstate_env,
+        .vmstate_runtime = boot_env.vmstate_runtime,
+        .nested_env = boot_env.nested_env,
+        .virtiofs_env = boot_env.virtiofs_env,
+        .stats_file = boot_env.stats_file,
         .planned_live_mounts = runtime.planned_live_mounts,
         .config_cmd = runtime.config_cmd,
         .config_env = runtime.config_env,
@@ -583,6 +573,54 @@ fn makePlanParts(
         .mount_disk_runtime = runtime.mount_disk_runtime,
         .mount_disk_fd_env = runtime.mount_disk_fd_env,
         .registry_shape = runtime.registry_shape,
+    };
+}
+
+fn makeBootEnvParts(arena: std.mem.Allocator, parsed: ParsedRequest) !BootEnvParts {
+    assert(@sizeOf(BootEnvParts) > 0);
+
+    return .{
+        .vsock_plan = try boot_plan.planVsock(arena, .{
+            .existing_spec = parsed.existing_vsock_spec,
+            .auto_uds_path = parsed.auto_vsock_uds_path,
+            .auto_temp_dir = parsed.auto_vsock_temp_dir,
+        }),
+        .vmm_argv = try boot_plan.planVmmArgv(arena, .{
+            .binary = parsed.vmm_binary,
+            .args = parsed.vmm_args,
+            .pdeathsig_path = parsed.pdeathsig_path,
+        }),
+        .use_pdeathsig = boot_plan.planPdeathsig(.{
+            .detached = parsed.detached,
+            .pdeathsig = parsed.pdeathsig_requested,
+        }),
+        .kernel_dtb = boot_plan.planKernelDtb(.{
+            .kernel_path = parsed.kernel_path,
+            .dtb_path = parsed.dtb_path,
+        }),
+        .initrd_env = boot_plan.planInitrdEnv(.{
+            .initrd_path = parsed.initrd_path,
+        }),
+        .vmstate_env = boot_plan.planVmstateEnv(.{
+            .state_path = parsed.vmstate_path,
+            .restore_path = parsed.restore_path,
+            .enable_timing = parsed.enable_vmstate_timing,
+            .existing_timing = parsed.existing_vmstate_timing,
+        }),
+        .vmstate_runtime = try boot_plan.planVmstateRuntime(arena, .{
+            .state_path = parsed.boot_vmstate_state_path,
+            .state_temp_dir = parsed.boot_vmstate_temp_dir,
+            .chain_id = parsed.boot_vmstate_chain_id,
+            .restore_path = parsed.boot_vmstate_restore_path,
+            .forked_from = parsed.boot_vmstate_forked_from,
+        }),
+        .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
+        .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
+        .stats_file = try boot_plan.planStatsFile(arena, .{
+            .existing_path = parsed.existing_stats_file,
+            .planned_path = parsed.stats_file_path,
+            .planned_temp_dir = parsed.stats_file_temp_dir,
+        }),
     };
 }
 
@@ -810,6 +848,8 @@ fn makeMountDiskFdEnv(
     allocator: std.mem.Allocator,
     parsed: ParsedRequest,
 ) ![]const boot_plan.EnvPair {
+    assert(@sizeOf(boot_plan.MountDiskFdEnvInput) > 0);
+
     const lower_fd = if (parsed.mount_disk_lower_fd_text) |text|
         parseUnsigned(text) catch return error.InvalidMountDiskLowerFd
     else
@@ -902,6 +942,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
     try writeCoreFields(io, parts.plan, parts.cpu_policy);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
+    try writeNullableStringField(io, "vmmInitrd", parts.initrd_env.vmm_initrd, true);
     try writeGuestHostnameField(io, "guestHostname", parts.guest_hostname, true);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
     try writeVmstateRuntimeField(io, "vmstateRuntime", parts.vmstate_runtime, true);
@@ -1981,6 +2022,11 @@ fn parseKernelFields(object: std.json.ObjectMap, request: *ParsedRequest) Reques
         error.InvalidKernelPath,
     );
     request.dtb_path = try optionalStringDefaultNull(object, "dtbPath", error.InvalidDtbPath);
+    request.initrd_path = try optionalStringDefaultNull(
+        object,
+        "initrdPath",
+        error.InvalidInitrdPath,
+    );
 }
 
 fn parseVmstateFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -43,6 +43,7 @@ const ParsedRequest = struct {
     enable_vmstate_timing: bool = false,
     existing_vmstate_timing: ?[]const u8 = null,
     boot_vmstate_state_path: ?[]const u8 = null,
+    boot_vmstate_temp_dir: ?[]const u8 = null,
     boot_vmstate_chain_id: ?[]const u8 = null,
     boot_vmstate_restore_path: ?[]const u8 = null,
     boot_vmstate_forked_from: ?[]const u8 = null,
@@ -177,6 +178,7 @@ const boot_plan_fields = [_][]const u8{
     "enableVmstateTiming",
     "existingVmstateTiming",
     "bootVmstateStatePath",
+    "bootVmstateTempDir",
     "bootVmstateChainId",
     "bootVmstateRestorePath",
     "bootVmstateForkedFrom",
@@ -317,6 +319,7 @@ const RequestError = error{
     InvalidEnableVmstateTiming,
     InvalidExistingVmstateTiming,
     InvalidBootVmstateStatePath,
+    InvalidBootVmstateTempDir,
     InvalidBootVmstateChainId,
     InvalidBootVmstateRestorePath,
     InvalidBootVmstateForkedFrom,
@@ -526,8 +529,9 @@ fn makePlanParts(
             .enable_timing = parsed.enable_vmstate_timing,
             .existing_timing = parsed.existing_vmstate_timing,
         }),
-        .vmstate_runtime = try boot_plan.planVmstateRuntime(.{
+        .vmstate_runtime = try boot_plan.planVmstateRuntime(arena, .{
             .state_path = parsed.boot_vmstate_state_path,
+            .state_temp_dir = parsed.boot_vmstate_temp_dir,
             .chain_id = parsed.boot_vmstate_chain_id,
             .restore_path = parsed.boot_vmstate_restore_path,
             .forked_from = parsed.boot_vmstate_forked_from,
@@ -1956,6 +1960,11 @@ fn parseVmstateFields(object: std.json.ObjectMap, request: *ParsedRequest) Reque
         object,
         "bootVmstateStatePath",
         error.InvalidBootVmstateStatePath,
+    );
+    request.boot_vmstate_temp_dir = try optionalStringDefaultNull(
+        object,
+        "bootVmstateTempDir",
+        error.InvalidBootVmstateTempDir,
     );
     request.boot_vmstate_chain_id = try optionalStringDefaultNull(
         object,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -100,6 +100,8 @@ const ParsedRequest = struct {
     mount_disk_source_upper_path: ?[]const u8 = null,
     mount_disk_guest: ?[]const u8 = null,
     mount_disk_upper_size_text: ?[]const u8 = null,
+    mount_disk_lower_fd_text: ?[]const u8 = null,
+    mount_disk_upper_fd_text: ?[]const u8 = null,
     registry_source_image_path: ?[]const u8 = null,
     registry_per_boot_root_disk: ?[]const u8 = null,
     registry_caller_root_disk_path: ?[]const u8 = null,
@@ -236,6 +238,8 @@ const boot_plan_fields = [_][]const u8{
     "mountDiskSourceUpperPath",
     "mountDiskGuest",
     "mountDiskUpperSize",
+    "mountDiskLowerFd",
+    "mountDiskUpperFd",
     "registrySourceImagePath",
     "registryPerBootRootDisk",
     "registryCallerRootDiskPath",
@@ -385,6 +389,8 @@ const RequestError = error{
     InvalidMountDiskSourceUpperPath,
     InvalidMountDiskGuest,
     InvalidMountDiskUpperSize,
+    InvalidMountDiskLowerFd,
+    InvalidMountDiskUpperFd,
     InvalidRegistrySourceImagePath,
     InvalidRegistryRootDiskPath,
     InvalidRegistryBootLogRoot,
@@ -467,6 +473,7 @@ const PlanParts = struct {
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
+    mount_disk_fd_env: []const boot_plan.EnvPair,
     registry_shape: boot_plan.RegistryShapePlan,
 };
 
@@ -492,6 +499,7 @@ const RuntimeParts = struct {
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
+    mount_disk_fd_env: []const boot_plan.EnvPair,
     registry_shape: boot_plan.RegistryShapePlan,
 };
 
@@ -573,6 +581,7 @@ fn makePlanParts(
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
+        .mount_disk_fd_env = runtime.mount_disk_fd_env,
         .registry_shape = runtime.registry_shape,
     };
 }
@@ -596,6 +605,7 @@ fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimePar
         .scratch_disk = disks.scratch,
         .root_disk_runtime = disks.root,
         .mount_disk_runtime = disks.mount,
+        .mount_disk_fd_env = try makeMountDiskFdEnv(arena, parsed),
         .registry_shape = try makeRegistryShape(arena, parsed),
     };
 }
@@ -796,6 +806,21 @@ fn makeRegistryCpuPolicy(parsed: ParsedRequest) RequestError!?boot_plan.CpuPolic
     };
 }
 
+fn makeMountDiskFdEnv(
+    allocator: std.mem.Allocator,
+    parsed: ParsedRequest,
+) ![]const boot_plan.EnvPair {
+    const lower_fd = if (parsed.mount_disk_lower_fd_text) |text|
+        parseUnsigned(text) catch return error.InvalidMountDiskLowerFd
+    else
+        null;
+    const upper_fd = if (parsed.mount_disk_upper_fd_text) |text|
+        parseUnsigned(text) catch return error.InvalidMountDiskUpperFd
+    else
+        null;
+    return boot_plan.planMountDiskFdEnv(allocator, .{ .lower_fd = lower_fd, .upper_fd = upper_fd });
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -907,6 +932,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
+    try writeEnvObjectField(io, "mountDiskFdEnv", parts.mount_disk_fd_env, true);
     try writeRegistryShapeField(io, "registryShape", parts.registry_shape, true);
     try protocol.stdout(io, "}}\n");
 }
@@ -2349,6 +2375,16 @@ fn parseMountDiskRuntimeFields(
         "mountDiskUpperSize",
         error.InvalidMountDiskUpperSize,
     );
+    request.mount_disk_lower_fd_text = try optionalStringDefaultNull(
+        object,
+        "mountDiskLowerFd",
+        error.InvalidMountDiskLowerFd,
+    );
+    request.mount_disk_upper_fd_text = try optionalStringDefaultNull(
+        object,
+        "mountDiskUpperFd",
+        error.InvalidMountDiskUpperFd,
+    );
     try parseRegistryShapeFields(object, request);
 }
 
@@ -3144,6 +3180,11 @@ fn writeDiskPlanError(io: std.Io, err: anyerror) !bool {
             io,
             "BOOT_MOUNT_INVALID",
             "boot-plan mountDisk field missing",
+        ),
+        error.MissingMountDiskFdField => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "boot-plan mountDisk fd field missing",
         ),
         error.IncompleteRegistryMountDisk => try writeBootError(
             io,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -25,6 +25,7 @@ const ParsedRequest = struct {
     vsock_uds_path: ?[]const u8 = null,
     existing_vsock_spec: ?[]const u8 = null,
     auto_vsock_uds_path: ?[]const u8 = null,
+    auto_vsock_temp_dir: ?[]const u8 = null,
     port_forward: []const boot_plan.PortForwardMapping = &.{},
     vmm_binary: ?[]const u8 = null,
     vmm_args: []const []const u8 = &.{},
@@ -157,6 +158,7 @@ const boot_plan_fields = [_][]const u8{
     "vsockUdsPath",
     "existingVsockSpec",
     "autoVsockUdsPath",
+    "autoVsockTempDir",
     "portForward",
     "vmmBinary",
     "vmmArgs",
@@ -293,6 +295,7 @@ const RequestError = error{
     InvalidVsockUdsPath,
     InvalidExistingVsockSpec,
     InvalidAutoVsockUdsPath,
+    InvalidAutoVsockTempDir,
     InvalidPortForward,
     InvalidHostPort,
     InvalidGuestPort,
@@ -498,6 +501,7 @@ fn makePlanParts(
         .vsock_plan = try boot_plan.planVsock(arena, .{
             .existing_spec = parsed.existing_vsock_spec,
             .auto_uds_path = parsed.auto_vsock_uds_path,
+            .auto_temp_dir = parsed.auto_vsock_temp_dir,
         }),
         .vmm_argv = try boot_plan.planVmmArgv(arena, .{
             .binary = parsed.vmm_binary,
@@ -1848,6 +1852,11 @@ fn parseVsockFields(object: std.json.ObjectMap, request: *ParsedRequest) Request
         object,
         "autoVsockUdsPath",
         error.InvalidAutoVsockUdsPath,
+    );
+    request.auto_vsock_temp_dir = try optionalStringDefaultNull(
+        object,
+        "autoVsockTempDir",
+        error.InvalidAutoVsockTempDir,
     );
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -63,7 +63,9 @@ const ParsedRequest = struct {
     bundle_command_required: bool = false,
     bundle_image_env: std.json.ObjectMap = .{},
     bundle_guest_env: std.json.ObjectMap = .{},
-    provision_guest_cpu: boot_plan.ProvisionGuestCpu = .arm64,
+    provision_guest_cpu: ?boot_plan.ProvisionGuestCpu = null,
+    provision_guest_arch_override: ?[]const u8 = null,
+    provision_host_arch: ?[]const u8 = null,
     provision_base_path: ?[]const u8 = null,
     provision_kernel_path: ?[]const u8 = null,
     provision_dtb_path: ?[]const u8 = null,
@@ -193,6 +195,8 @@ const boot_plan_fields = [_][]const u8{
     "bundleImageEnv",
     "bundleGuestEnv",
     "provisionGuestCpu",
+    "provisionGuestArchOverride",
+    "provisionHostArch",
     "provisionBasePath",
     "provisionKernelPath",
     "provisionDtbPath",
@@ -333,6 +337,8 @@ const RequestError = error{
     InvalidBundleImageEnv,
     InvalidBundleGuestEnv,
     InvalidProvisionGuestCpu,
+    InvalidProvisionGuestArchOverride,
+    InvalidProvisionHostArch,
     InvalidProvisionBasePath,
     InvalidProvisionKernelPath,
     InvalidProvisionDtbPath,
@@ -530,6 +536,8 @@ fn makePlanParts(
         .bundle_env = runtime.bundle_env,
         .provision_assets = boot_plan.planProvisionAssets(.{
             .guest_cpu = parsed.provision_guest_cpu,
+            .arch_override = parsed.provision_guest_arch_override,
+            .host_arch = parsed.provision_host_arch,
         }),
         .provision_boot = try makeProvisionBoot(arena, parsed),
         .provision_workload = boot_plan.planProvisionWorkload(),
@@ -2053,6 +2061,16 @@ fn parseProvisionFields(
     assert(@sizeOf(ParsedRequest) > 0);
 
     request.provision_guest_cpu = try optionalProvisionGuestCpu(object);
+    request.provision_guest_arch_override = try optionalStringDefaultNull(
+        object,
+        "provisionGuestArchOverride",
+        error.InvalidProvisionGuestArchOverride,
+    );
+    request.provision_host_arch = try optionalStringDefaultNull(
+        object,
+        "provisionHostArch",
+        error.InvalidProvisionHostArch,
+    );
     try parseProvisionBootFields(object, request);
     try parseProvisionRepackFields(object, request);
     try parseProvisionImageConfigFields(allocator, object, request);
@@ -2487,11 +2505,11 @@ fn optionalRegistryCpuControlStatus(object: std.json.ObjectMap) RequestError!?[]
 
 fn optionalProvisionGuestCpu(
     object: std.json.ObjectMap,
-) RequestError!boot_plan.ProvisionGuestCpu {
+) RequestError!?boot_plan.ProvisionGuestCpu {
     assert(@sizeOf(boot_plan.ProvisionGuestCpu) > 0);
 
-    const value = object.get("provisionGuestCpu") orelse return .arm64;
-    if (value == .null) return .arm64;
+    const value = object.get("provisionGuestCpu") orelse return null;
+    if (value == .null) return null;
     if (value != .string) return error.InvalidProvisionGuestCpu;
     if (std.mem.eql(u8, value.string, "amd64")) return .amd64;
     if (std.mem.eql(u8, value.string, "arm64")) return .arm64;

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -67,6 +67,7 @@ const ParsedRequest = struct {
     bundle_image_env: std.json.ObjectMap = .{},
     bundle_guest_env: std.json.ObjectMap = .{},
     bundle_workspace_temp_dir: ?[]const u8 = null,
+    bundle_config_synth_dir: ?[]const u8 = null,
     provision_guest_cpu: ?boot_plan.ProvisionGuestCpu = null,
     provision_guest_arch_override: ?[]const u8 = null,
     provision_host_arch: ?[]const u8 = null,
@@ -202,6 +203,7 @@ const boot_plan_fields = [_][]const u8{
     "bundleImageEnv",
     "bundleGuestEnv",
     "bundleWorkspaceTempDir",
+    "bundleConfigSynthDir",
     "provisionGuestCpu",
     "provisionGuestArchOverride",
     "provisionHostArch",
@@ -348,6 +350,7 @@ const RequestError = error{
     InvalidBundleImageEnv,
     InvalidBundleGuestEnv,
     InvalidBundleWorkspaceTempDir,
+    InvalidBundleConfigSynthDir,
     InvalidProvisionGuestCpu,
     InvalidProvisionGuestArchOverride,
     InvalidProvisionHostArch,
@@ -454,6 +457,7 @@ const PlanParts = struct {
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
     bundle_workspace: boot_plan.BundleWorkspacePlan,
+    bundle_config_paths: boot_plan.BundleConfigPathsPlan,
     provision_assets: boot_plan.ProvisionAssetsPlan,
     provision_boot: boot_plan.ProvisionBootPlan,
     provision_workload: boot_plan.ProvisionWorkloadPlan,
@@ -552,6 +556,9 @@ fn makePlanParts(
         .bundle_env = runtime.bundle_env,
         .bundle_workspace = try boot_plan.planBundleWorkspace(arena, .{
             .temp_dir = parsed.bundle_workspace_temp_dir,
+        }),
+        .bundle_config_paths = try boot_plan.planBundleConfigPaths(arena, .{
+            .synth_bundle_dir = parsed.bundle_config_synth_dir,
         }),
         .provision_assets = boot_plan.planProvisionAssets(.{
             .guest_cpu = parsed.provision_guest_cpu,
@@ -885,6 +892,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeBundleWorkspaceField(io, "bundleWorkspace", parts.bundle_workspace, true);
+    try writeBundleConfigPathsField(io, "bundleConfigPaths", parts.bundle_config_paths, true);
     try writeProvisionAssetsField(io, "provisionAssets", parts.provision_assets, true);
     try writeProvisionBootField(io, "provisionBoot", parts.provision_boot, true);
     try writeProvisionWorkloadField(io, "provisionWorkload", parts.provision_workload, true);
@@ -1147,6 +1155,21 @@ fn writeBundleWorkspaceField(
     try protocol.stdout(io, "{");
     try writeNullableStringField(io, "cpioPath", workspace.cpio_path, false);
     try writeNullableStringField(io, "synthBundleDir", workspace.synth_bundle_dir, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeBundleConfigPathsField(
+    io: std.Io,
+    comptime field: []const u8,
+    paths: boot_plan.BundleConfigPathsPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "rootfsDir", paths.rootfs_dir, false);
+    try writeNullableStringField(io, "configPath", paths.config_path, true);
     try protocol.stdout(io, "}");
 }
 
@@ -2105,6 +2128,11 @@ fn parseBundleFields(
         object,
         "bundleWorkspaceTempDir",
         error.InvalidBundleWorkspaceTempDir,
+    );
+    request.bundle_config_synth_dir = try optionalStringDefaultNull(
+        object,
+        "bundleConfigSynthDir",
+        error.InvalidBundleConfigSynthDir,
     );
 }
 

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -51,6 +51,7 @@ const ParsedRequest = struct {
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
     existing_stats_file: ?[]const u8 = null,
     stats_file_path: ?[]const u8 = null,
+    stats_file_temp_dir: ?[]const u8 = null,
     config_cmd: []const []const u8 = &.{},
     config_env: std.json.ObjectMap = .{},
     config_guest_cwd: ?[]const u8 = null,
@@ -184,6 +185,7 @@ const boot_plan_fields = [_][]const u8{
     "liveMountsResolved",
     "existingStatsFile",
     "statsFilePath",
+    "statsFileTempDir",
     "configCmd",
     "configEnv",
     "configGuestCwd",
@@ -327,6 +329,7 @@ const RequestError = error{
     InvalidLiveMountTag,
     InvalidExistingStatsFile,
     InvalidStatsFilePath,
+    InvalidStatsFileTempDir,
     InvalidConfigCmd,
     InvalidConfigEnv,
     InvalidConfigEnvValue,
@@ -531,9 +534,10 @@ fn makePlanParts(
         }),
         .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
         .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
-        .stats_file = boot_plan.planStatsFile(.{
+        .stats_file = try boot_plan.planStatsFile(arena, .{
             .existing_path = parsed.existing_stats_file,
             .planned_path = parsed.stats_file_path,
+            .planned_temp_dir = parsed.stats_file_temp_dir,
         }),
         .planned_live_mounts = runtime.planned_live_mounts,
         .config_cmd = runtime.config_cmd,
@@ -1994,6 +1998,11 @@ fn parseRuntimeMountStatsFields(
         object,
         "statsFilePath",
         error.InvalidStatsFilePath,
+    );
+    request.stats_file_temp_dir = try optionalStringDefaultNull(
+        object,
+        "statsFileTempDir",
+        error.InvalidStatsFileTempDir,
     );
 }
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -661,6 +661,31 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans bundle workspace paths", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      bundleWorkspaceTempDir: "/tmp/machinen-bundle-test",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.bundleWorkspace).toEqual({
+      cpioPath: "/tmp/machinen-bundle-test/initramfs.cpio",
+      synthBundleDir: "/tmp/machinen-bundle-test/bundle",
+    });
+  });
+
   it("plans bundle env overlays", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1044,6 +1044,19 @@ describe("boot-plan helper schema", () => {
       statsFilePath: "/tmp/runtime-stats.bin",
       vmmStatsFile: "/tmp/runtime-stats.bin",
     });
+
+    const tempDir = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, statsFileTempDir: "/tmp/machinen-stats-test" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(tempDir.status).toBe(0);
+    expect(JSON.parse(tempDir.stdout).data).toMatchObject({
+      statsFilePath: "/tmp/machinen-stats-test/stats.bin",
+      vmmStatsFile: "/tmp/machinen-stats-test/stats.bin",
+    });
   });
 
   it("plans virtiofs env entries for resolved live mounts", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -721,6 +721,31 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans bundle config staging paths", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      bundleConfigSynthDir: "/tmp/machinen-bundle-test/bundle",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.bundleConfigPaths).toEqual({
+      rootfsDir: "/tmp/machinen-bundle-test/bundle/rootfs",
+      configPath: "/tmp/machinen-bundle-test/bundle/machinen-config.json",
+    });
+  });
+
   it("plans bundle env overlays", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -276,6 +276,28 @@ describe("boot-plan helper schema", () => {
       checkpointParent: "/snap/parent",
       checkpointSequence: 0,
     });
+
+    const tempDir = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...requestData,
+          bootVmstateStatePath: null,
+          bootVmstateTempDir: "/tmp/machinen-vsock-test",
+          bootVmstateChainId: "chain-temp",
+          bootVmstateRestorePath: null,
+          bootVmstateForkedFrom: null,
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(tempDir.status).toBe(0);
+    expect(JSON.parse(tempDir.stdout).data.vmstateRuntime).toEqual({
+      statePath: "/tmp/machinen-vsock-test/state.vmstate",
+      chainId: "chain-temp",
+      checkpointParent: null,
+      checkpointSequence: 0,
+    });
   });
 
   it("plans nested virtualization VMM env", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -625,6 +625,40 @@ describe("boot-plan helper schema", () => {
       dtbAsset: "virt-arm64.dtb",
       rootfsAsset: "rootfs-debian-arm64.tar.gz",
     });
+
+    const override = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionGuestArchOverride: "amd64",
+          provisionHostArch: "arm64",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(override.status).toBe(0);
+    expect(JSON.parse(override.stdout).data.provisionAssets).toMatchObject({
+      cpu: "amd64",
+      kernelAsset: "bzImage-x86_64",
+    });
+
+    const hostFallback = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionGuestArchOverride: "unknown",
+          provisionHostArch: "x64",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(hostFallback.status).toBe(0);
+    expect(JSON.parse(hostFallback.stdout).data.provisionAssets).toMatchObject({
+      cpu: "amd64",
+      kernelAsset: "bzImage-x86_64",
+    });
   });
 
   it("plans bundle env overlays", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1161,7 +1161,7 @@ describe("boot-plan helper schema", () => {
     });
   });
 
-  it("plans kernel and dtb env paths", () => {
+  it("plans kernel dtb and initrd env paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
     const requestData = {
@@ -1175,6 +1175,7 @@ describe("boot-plan helper schema", () => {
       rootDisk: "false",
       kernelPath: "/tmp/Image",
       dtbPath: "/tmp/virt.dtb",
+      initrdPath: "/tmp/initramfs.cpio",
     };
     const result = spawnSync(helper, ["boot-plan"], {
       input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
@@ -1184,6 +1185,7 @@ describe("boot-plan helper schema", () => {
     expect(JSON.parse(result.stdout).data).toMatchObject({
       vmmKernel: "/tmp/Image",
       vmmDtb: "/tmp/virt.dtb",
+      vmmInitrd: "/tmp/initramfs.cpio",
     });
   });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -574,6 +574,7 @@ describe("boot-plan helper schema", () => {
     expect(data.provisionRepack).toEqual({
       extractArgs: ["-xf", "/tmp/scratch.img", "-C", "/tmp/extract"],
       targzArgs: ["-czf", "/tmp/out.tar.gz", "-C", "/tmp/extract", "."],
+      imageConfigPath: "/tmp/extract/machinen-config.json",
     });
   });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -167,7 +167,7 @@ describe("boot-plan helper schema", () => {
     ]);
   });
 
-  it("plans vsock specs from caller env or auto UDS paths", () => {
+  it("plans vsock specs from caller env auto UDS paths or auto temp dirs", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
     const baseData = {
@@ -204,6 +204,19 @@ describe("boot-plan helper schema", () => {
     expect(JSON.parse(auto.stdout).data).toMatchObject({
       vsockUdsPath: "/tmp/exec.sock",
       vmmVsock: "in:1978:/tmp/exec.sock",
+    });
+
+    const autoTempDir = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, autoVsockTempDir: "/tmp/machinen-vsock-test" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(autoTempDir.status).toBe(0);
+    expect(JSON.parse(autoTempDir.stdout).data).toMatchObject({
+      vsockUdsPath: "/tmp/machinen-vsock-test/exec.sock",
+      vmmVsock: "in:1978:/tmp/machinen-vsock-test/exec.sock",
     });
   });
 

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -888,6 +888,32 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans mountdisk inherited fd env", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      mountDiskLowerFd: "3",
+      mountDiskUpperFd: "4",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.mountDiskFdEnv).toEqual({
+      MACHINEN_MOUNTDISK_LOWER_FD: "3",
+      MACHINEN_MOUNTDISK_UPPER_FD: "4",
+    });
+  });
+
   it("plans registry cleanup paths, mount shapes, and CPU shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -152,6 +152,7 @@ export interface NativeBootPlanResult {
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
+  mountDiskFdEnv: Record<string, string>;
   registryShape: RegistryShapePlan;
 }
 
@@ -202,6 +203,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
+    isStringRecord(data.mountDiskFdEnv),
     isRegistryShapePlan(data.registryShape),
   ].every(Boolean);
 }

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -17,6 +17,7 @@ type RegistryVmstatePlan = {
 };
 export type PlannedPortForward = { hostPort: number; guestPort: number; hostAddr?: string };
 export type BundleWorkspacePlan = { cpioPath: string | null; synthBundleDir: string | null };
+export type BundleConfigPathsPlan = { rootfsDir: string | null; configPath: string | null };
 type RegistryPortForwardPlan = PlannedPortForward;
 export type BootVmstateRuntimePlan = {
   statePath: string | null;
@@ -137,6 +138,7 @@ export interface NativeBootPlanResult {
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
   bundleWorkspace: BundleWorkspacePlan;
+  bundleConfigPaths: BundleConfigPathsPlan;
   provisionAssets: ProvisionAssetsPlan;
   provisionBoot: ProvisionBootPlan;
   provisionWorkload: ProvisionWorkloadPlan;
@@ -186,6 +188,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
     isBundleWorkspacePlan(data.bundleWorkspace),
+    isBundleConfigPathsPlan(data.bundleConfigPaths),
     isProvisionAssetsPlan(data.provisionAssets),
     isProvisionBootPlan(data.provisionBoot),
     isProvisionWorkloadPlan(data.provisionWorkload),
@@ -205,6 +208,14 @@ function isBundleWorkspacePlan(value: unknown): value is BundleWorkspacePlan {
   }
   const plan = value as Partial<BundleWorkspacePlan>;
   return [nullableString(plan.cpioPath), nullableString(plan.synthBundleDir)].every(Boolean);
+}
+
+function isBundleConfigPathsPlan(value: unknown): value is BundleConfigPathsPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<BundleConfigPathsPlan>;
+  return [nullableString(plan.rootfsDir), nullableString(plan.configPath)].every(Boolean);
 }
 
 function nullableCpuPolicy(value: unknown): value is CpuPolicyPlan | null {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -16,6 +16,7 @@ type RegistryVmstatePlan = {
   checkpointSequence: number | null;
 };
 export type PlannedPortForward = { hostPort: number; guestPort: number; hostAddr?: string };
+export type BundleWorkspacePlan = { cpioPath: string | null; synthBundleDir: string | null };
 type RegistryPortForwardPlan = PlannedPortForward;
 export type BootVmstateRuntimePlan = {
   statePath: string | null;
@@ -135,6 +136,7 @@ export interface NativeBootPlanResult {
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
+  bundleWorkspace: BundleWorkspacePlan;
   provisionAssets: ProvisionAssetsPlan;
   provisionBoot: ProvisionBootPlan;
   provisionWorkload: ProvisionWorkloadPlan;
@@ -183,6 +185,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
+    isBundleWorkspacePlan(data.bundleWorkspace),
     isProvisionAssetsPlan(data.provisionAssets),
     isProvisionBootPlan(data.provisionBoot),
     isProvisionWorkloadPlan(data.provisionWorkload),
@@ -194,6 +197,14 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isMountDiskRuntimePlan(data.mountDiskRuntime),
     isRegistryShapePlan(data.registryShape),
   ].every(Boolean);
+}
+
+function isBundleWorkspacePlan(value: unknown): value is BundleWorkspacePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<BundleWorkspacePlan>;
+  return [nullableString(plan.cpioPath), nullableString(plan.synthBundleDir)].every(Boolean);
 }
 
 function nullableCpuPolicy(value: unknown): value is CpuPolicyPlan | null {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -128,6 +128,7 @@ export interface NativeBootPlanResult {
   usePdeathsig: boolean;
   vmmKernel: string | null;
   vmmDtb: string | null;
+  vmmInitrd: string | null;
   vmmSnapshotPath: string | null;
   vmmRestorePath: string | null;
   vmmVmstateTiming: string | null;
@@ -179,6 +180,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     typeof data.usePdeathsig === "boolean",
     nullableString(data.vmmKernel),
     nullableString(data.vmmDtb),
+    nullableString(data.vmmInitrd),
     nullableString(data.vmmSnapshotPath),
     nullableString(data.vmmRestorePath),
     nullableString(data.vmmVmstateTiming),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -45,7 +45,11 @@ export type ProvisionBootPlan = {
   rootDiskPath: string | null;
 };
 export type ProvisionWorkloadPlan = { tarToDiskCommand: string; poweroffCommand: string };
-export type ProvisionRepackPlan = { extractArgs: string[]; targzArgs: string[] };
+export type ProvisionRepackPlan = {
+  extractArgs: string[];
+  targzArgs: string[];
+  imageConfigPath: string | null;
+};
 export type ProvisionImageConfigPlan = { cmd?: string[]; env?: Record<string, string> } | null;
 export type ProvisionRuntimePlan = {
   scratchSizeBytes: number;
@@ -277,7 +281,11 @@ function isProvisionRepackPlan(value: unknown): value is ProvisionRepackPlan {
     return false;
   }
   const plan = value as Partial<ProvisionRepackPlan>;
-  return isStringArray(plan.extractArgs) && isStringArray(plan.targzArgs);
+  return (
+    isStringArray(plan.extractArgs) &&
+    isStringArray(plan.targzArgs) &&
+    nullableString(plan.imageConfigPath)
+  );
 }
 
 function isProvisionImageConfigPlan(value: unknown): value is ProvisionImageConfigPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -78,6 +78,7 @@ interface NativeBootPlanInput {
   liveMountsResolved?: PlannedLiveMount[];
   existingStatsFile?: string;
   statsFilePath?: string;
+  statsFileTempDir?: string;
   configCmd?: string[];
   configEnv?: Record<string, string>;
   configGuestCwd?: string;
@@ -206,6 +207,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     liveMountsResolved: input.liveMountsResolved ?? [],
     existingStatsFile: nullDefault(input.existingStatsFile),
     statsFilePath: nullDefault(input.statsFilePath),
+    statsFileTempDir: nullDefault(input.statsFileTempDir),
     configCmd: input.configCmd ?? [],
     configEnv: input.configEnv ?? {},
     configGuestCwd: nullDefault(input.configGuestCwd),
@@ -778,13 +780,18 @@ export function planBootMachinenConfigNative(input: {
   }).machinenConfig;
 }
 
-export function planBootStatsFileNative(input: { existingPath?: string; plannedPath?: string }): {
+export function planBootStatsFileNative(input: {
+  existingPath?: string;
+  plannedPath?: string;
+  tempDir?: string;
+}): {
   statsFilePath?: string;
   vmmStatsFile?: string;
 } {
   const plan = planBootCoreNative({
     existingStatsFile: input.existingPath,
     statsFilePath: input.plannedPath,
+    statsFileTempDir: input.tempDir,
     vmmMemoryPreset: true,
     hasImage: false,
     hasCmd: false,

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -5,6 +5,7 @@ import type { BootCpuResourceOptions, ResolvedCpuResourcePolicy } from "../vm/cp
 import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
 import type {
+  BundleWorkspacePlan,
   MountDiskRuntimePlan,
   PlannedLiveMount,
   PlannedPortForward,
@@ -26,6 +27,10 @@ type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 type ScratchDiskMode = "false" | "path" | "auto";
 type RootDiskRuntimeMode = "none" | "path" | "restore" | "cached";
 type MountDiskRuntimeMode = "none" | "restore" | "fresh";
+type RequiredBundleWorkspacePlan = {
+  cpioPath: NonNullable<BundleWorkspacePlan["cpioPath"]>;
+  synthBundleDir: NonNullable<BundleWorkspacePlan["synthBundleDir"]>;
+};
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
@@ -85,6 +90,7 @@ interface NativeBootPlanInput {
   bundleCommandRequired?: boolean;
   bundleImageEnv?: Record<string, string>;
   bundleGuestEnv?: Record<string, string>;
+  bundleWorkspaceTempDir?: string;
   provisionGuestCpu?: ProvisionGuestCpu;
   provisionGuestArchOverride?: string;
   provisionHostArch?: string;
@@ -229,6 +235,7 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
     bundleCommandRequired: input.bundleCommandRequired === true,
     bundleImageEnv: input.bundleImageEnv ?? {},
     bundleGuestEnv: input.bundleGuestEnv ?? {},
+    bundleWorkspaceTempDir: nullDefault(input.bundleWorkspaceTempDir),
   };
 }
 
@@ -659,6 +666,23 @@ export function planBootPortForwardNative(
     hasCmd: false,
     rootDisk: "false",
   }).plannedPortForward;
+}
+
+export function planBootBundleWorkspaceNative(tempDir: string): RequiredBundleWorkspacePlan {
+  const plan = planBootCoreNative({
+    bundleWorkspaceTempDir: tempDir,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).bundleWorkspace;
+  if (plan.cpioPath === null || plan.synthBundleDir === null) {
+    throw new BootError(
+      "BOOT_PACK_FAILED",
+      "boot: native planner returned incomplete bundle workspace",
+    );
+  }
+  return { cpioPath: plan.cpioPath, synthBundleDir: plan.synthBundleDir };
 }
 
 export function planBootBundleEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -70,6 +70,7 @@ interface NativeBootPlanInput {
   enableVmstateTiming?: boolean;
   existingVmstateTiming?: string;
   bootVmstateStatePath?: string;
+  bootVmstateTempDir?: string;
   bootVmstateChainId?: string;
   bootVmstateRestorePath?: string;
   bootVmstateForkedFrom?: string;
@@ -199,6 +200,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     enableVmstateTiming: input.enableVmstateTiming === true,
     existingVmstateTiming: nullDefault(input.existingVmstateTiming),
     bootVmstateStatePath: nullDefault(input.bootVmstateStatePath),
+    bootVmstateTempDir: nullDefault(input.bootVmstateTempDir),
     bootVmstateChainId: nullDefault(input.bootVmstateChainId),
     bootVmstateRestorePath: nullDefault(input.bootVmstateRestorePath),
     bootVmstateForkedFrom: nullDefault(input.bootVmstateForkedFrom),
@@ -860,12 +862,14 @@ export function planBootVmstateEnvNative(input: {
 
 export function planBootVmstateRuntimeNative(input: {
   statePath?: string;
+  stateTempDir?: string;
   chainId: string;
   restorePath?: string;
   forkedFrom?: string;
 }): BootVmstateRuntimePlan {
   return planBootCoreNative({
     bootVmstateStatePath: input.statePath,
+    bootVmstateTempDir: input.stateTempDir,
     bootVmstateChainId: input.chainId,
     bootVmstateRestorePath: input.restorePath,
     bootVmstateForkedFrom: input.forkedFrom,

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -86,6 +86,8 @@ interface NativeBootPlanInput {
   bundleImageEnv?: Record<string, string>;
   bundleGuestEnv?: Record<string, string>;
   provisionGuestCpu?: ProvisionGuestCpu;
+  provisionGuestArchOverride?: string;
+  provisionHostArch?: string;
   provisionBasePath?: string;
   provisionKernelPath?: string;
   provisionDtbPath?: string;
@@ -233,6 +235,8 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
 function provisionData(input: NativeBootPlanInput): Record<string, unknown> {
   return {
     provisionGuestCpu: input.provisionGuestCpu ?? null,
+    provisionGuestArchOverride: nullDefault(input.provisionGuestArchOverride),
+    provisionHostArch: nullDefault(input.provisionHostArch),
     provisionBasePath: nullDefault(input.provisionBasePath),
     provisionKernelPath: nullDefault(input.provisionKernelPath),
     provisionDtbPath: nullDefault(input.provisionDtbPath),
@@ -454,9 +458,13 @@ export function planProvisionBootNative(input: {
   }).provisionBoot;
 }
 
-export function planProvisionAssetsNative(cpu: ProvisionGuestCpu): ProvisionAssetsPlan {
+export function planProvisionAssetsForHostNative(input: {
+  guestArchOverride?: string;
+  hostArch: string;
+}): ProvisionAssetsPlan {
   return planBootCoreNative({
-    provisionGuestCpu: cpu,
+    provisionGuestArchOverride: input.guestArchOverride,
+    provisionHostArch: input.hostArch,
     vmmMemoryPreset: true,
     hasImage: false,
     hasCmd: false,

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -55,6 +55,7 @@ interface NativeBootPlanInput {
   guestHostnameName?: string;
   existingVsockSpec?: string;
   autoVsockUdsPath?: string;
+  autoVsockTempDir?: string;
   portForward?: PortForwardPlanMapping[];
   vmmBinary?: string;
   vmmArgs?: string[];
@@ -182,6 +183,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     guestHostnameName: nullDefault(input.guestHostnameName),
     existingVsockSpec: nullDefault(input.existingVsockSpec),
     autoVsockUdsPath: nullDefault(input.autoVsockUdsPath),
+    autoVsockTempDir: nullDefault(input.autoVsockTempDir),
     portForward: input.portForward ?? [],
     vmmBinary: nullDefault(input.vmmBinary),
     vmmArgs: input.vmmArgs ?? [],

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -5,6 +5,7 @@ import type { BootCpuResourceOptions, ResolvedCpuResourcePolicy } from "../vm/cp
 import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
 import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
 import type {
+  BundleConfigPathsPlan,
   BundleWorkspacePlan,
   MountDiskRuntimePlan,
   PlannedLiveMount,
@@ -30,6 +31,10 @@ type MountDiskRuntimeMode = "none" | "restore" | "fresh";
 type RequiredBundleWorkspacePlan = {
   cpioPath: NonNullable<BundleWorkspacePlan["cpioPath"]>;
   synthBundleDir: NonNullable<BundleWorkspacePlan["synthBundleDir"]>;
+};
+type RequiredBundleConfigPathsPlan = {
+  rootfsDir: NonNullable<BundleConfigPathsPlan["rootfsDir"]>;
+  configPath: NonNullable<BundleConfigPathsPlan["configPath"]>;
 };
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
@@ -94,6 +99,7 @@ interface NativeBootPlanInput {
   bundleImageEnv?: Record<string, string>;
   bundleGuestEnv?: Record<string, string>;
   bundleWorkspaceTempDir?: string;
+  bundleConfigSynthDir?: string;
   provisionGuestCpu?: ProvisionGuestCpu;
   provisionGuestArchOverride?: string;
   provisionHostArch?: string;
@@ -242,6 +248,7 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
     bundleImageEnv: input.bundleImageEnv ?? {},
     bundleGuestEnv: input.bundleGuestEnv ?? {},
     bundleWorkspaceTempDir: nullDefault(input.bundleWorkspaceTempDir),
+    bundleConfigSynthDir: nullDefault(input.bundleConfigSynthDir),
   };
 }
 
@@ -689,6 +696,25 @@ export function planBootBundleWorkspaceNative(tempDir: string): RequiredBundleWo
     );
   }
   return { cpioPath: plan.cpioPath, synthBundleDir: plan.synthBundleDir };
+}
+
+export function planBootBundleConfigPathsNative(
+  synthBundleDir: string,
+): RequiredBundleConfigPathsPlan {
+  const plan = planBootCoreNative({
+    bundleConfigSynthDir: synthBundleDir,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).bundleConfigPaths;
+  if (plan.rootfsDir === null || plan.configPath === null) {
+    throw new BootError(
+      "BOOT_PACK_FAILED",
+      "boot: native planner returned incomplete bundle config paths",
+    );
+  }
+  return { rootfsDir: plan.rootfsDir, configPath: plan.configPath };
 }
 
 export function planBootBundleEnvNative(input: {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -70,6 +70,7 @@ interface NativeBootPlanInput {
   bootTimeoutMs?: number | null;
   kernelPath?: string;
   dtbPath?: string;
+  initrdPath?: string;
   vmstatePath?: string;
   restorePath?: string;
   enableVmstateTiming?: boolean;
@@ -203,6 +204,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     ...bootTimeoutData(input),
     kernelPath: nullDefault(input.kernelPath),
     dtbPath: nullDefault(input.dtbPath),
+    initrdPath: nullDefault(input.initrdPath),
     vmstatePath: nullDefault(input.vmstatePath),
     restorePath: nullDefault(input.restorePath),
     enableVmstateTiming: input.enableVmstateTiming === true,
@@ -942,6 +944,20 @@ export function planBootKernelDtbNative(input: { kernelPath?: string; dtbPath?: 
   };
 }
 
+export function planBootInitrdEnvNative(initrdPath: string): string {
+  const plan = planBootCoreNative({
+    initrdPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  });
+  if (plan.vmmInitrd === null) {
+    throw new BootError("BOOT_PACK_FAILED", "boot: native planner returned no initrd path");
+  }
+  return plan.vmmInitrd;
+}
+
 export function planBootVmmArgvNative(input: {
   binary: string;
   args: string[];
@@ -963,16 +979,13 @@ export function planBootVmmArgvNative(input: {
 }
 
 export function rootDiskPlanMode(rootDisk: boolean | string | undefined): RootDiskPlanMode {
-  if (rootDisk === false) {
-    return "false";
-  }
-  if (rootDisk === true) {
-    return "true";
-  }
-  if (typeof rootDisk === "string") {
-    return "path";
-  }
-  return "unset";
+  return rootDisk === false
+    ? "false"
+    : rootDisk === true
+      ? "true"
+      : typeof rootDisk === "string"
+        ? "path"
+        : "unset";
 }
 
 function bootPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
@@ -983,6 +996,4 @@ function numberText(value: number | undefined): string | null {
   return value === undefined ? null : String(value);
 }
 
-function numberTextRequired(value: number): string {
-  return String(value);
-}
+const numberTextRequired = (value: number): string => String(value);

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -130,6 +130,8 @@ interface NativeBootPlanInput {
   mountDiskSourceUpperPath?: string;
   mountDiskGuest?: string;
   mountDiskUpperSize?: number;
+  mountDiskLowerFd?: number;
+  mountDiskUpperFd?: number;
   registrySourceImagePath?: string;
   registryDiskPath?: string;
   registryForkedFrom?: string;
@@ -301,6 +303,8 @@ function mountDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknow
     mountDiskSourceUpperPath: nullDefault(input.mountDiskSourceUpperPath),
     mountDiskGuest: nullDefault(input.mountDiskGuest),
     mountDiskUpperSize: numberText(input.mountDiskUpperSize),
+    mountDiskLowerFd: numberText(input.mountDiskLowerFd),
+    mountDiskUpperFd: numberText(input.mountDiskUpperFd),
   };
 }
 
@@ -512,6 +516,20 @@ export function planBootMountDiskRuntimeNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).mountDiskRuntime;
+}
+
+export function planBootMountDiskFdEnvNative(input: {
+  lowerFd: number;
+  upperFd: number;
+}): Record<string, string> {
+  return planBootCoreNative({
+    mountDiskLowerFd: input.lowerFd,
+    mountDiskUpperFd: input.upperFd,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).mountDiskFdEnv;
 }
 
 interface BootRegistryShapeNativeInput {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -679,7 +679,10 @@ function repackDiskTarToGz(
     // same cmd. User-supplied cmd/env on boot() still override.
     const imageConfig = planProvisionImageConfigNative({ cmd: opts.cmd, env: opts.env });
     if (imageConfig) {
-      writeFileSync(join(extractDir, "machinen-config.json"), JSON.stringify(imageConfig));
+      writeFileSync(
+        requireProvisionPlanString(repackPlan.imageConfigPath, "provisionRepack.imageConfigPath"),
+        JSON.stringify(imageConfig),
+      );
     }
     const tarT0 = Date.now();
     execFileSync("tar", repackPlan.targzArgs, {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -38,7 +38,7 @@ import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import type { OnLog } from "./log.ts";
 import {
-  planProvisionAssetsNative,
+  planProvisionAssetsForHostNative,
   planProvisionBootNative,
   planProvisionImageConfigNative,
   planProvisionRepackNative,
@@ -229,10 +229,10 @@ export function resolveBaseKernel(explicit?: string, cwd: string = process.cwd()
  *   PROVISION_ASSETS_DIR_INVALID
  */
 export function resolveBaseDtb(explicit?: string, cwd: string = process.cwd()): string | undefined {
-  if (!explicit && guestCpu() === "amd64") {
+  const spec = baseAssetSpec();
+  if (!explicit && spec.cpu === "amd64") {
     return undefined;
   }
-  const spec = baseAssetSpec();
   return resolveBaseAsset(
     {
       kind: "device tree blob",
@@ -248,21 +248,16 @@ export function resolveBaseDtb(explicit?: string, cwd: string = process.cwd()): 
 
 type GuestCpu = "arm64" | "amd64";
 
-function guestCpu(): GuestCpu {
-  const override = process.env.MACHINEN_GUEST_ARCH;
-  if (override === "arm64" || override === "amd64") {
-    return override;
-  }
-  return osArch() === "x64" ? "amd64" : "arm64";
-}
-
 function baseAssetSpec(): {
   cpu: GuestCpu;
   kernelAsset: string;
   dtbAsset?: string;
   rootfsAsset: string;
 } {
-  const plan = planProvisionAssetsNative(guestCpu());
+  const plan = planProvisionAssetsForHostNative({
+    guestArchOverride: process.env.MACHINEN_GUEST_ARCH,
+    hostArch: osArch(),
+  });
   return {
     cpu: plan.cpu,
     kernelAsset: plan.kernelAsset,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -1343,10 +1343,9 @@ function setupVsockBridge(env: Record<string, string>): {
 } {
   const existingSpec = env.MACHINEN_VSOCK;
   const vsockTempDir = existingSpec ? undefined : mkdtempSync(join(tmpdir(), "machinen-vsock-"));
-  const autoVsockUdsPath = vsockTempDir ? join(vsockTempDir, "exec.sock") : undefined;
   const plan = planBootCoreNative({
     existingVsockSpec: existingSpec,
-    autoVsockUdsPath,
+    autoVsockTempDir: vsockTempDir,
     vmmMemoryPreset: true,
     hasImage: false,
     hasCmd: false,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -53,6 +53,7 @@ import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
+  planBootInitrdEnvNative,
   planBootKernelDtbNative,
   planBootMountDiskFdEnvNative,
   planBootPortForwardNative,
@@ -662,7 +663,7 @@ function packBootInitramfsIfNeeded(
     mountDiskUpperSizeBytes: opts.mountDiskUpperSizeBytes,
     onPhase: (name, ms) => phases.mark(`initramfs-pack.${name}`, ms),
   });
-  plan.env.MACHINEN_INITRD = packed.cpioPath;
+  plan.env.MACHINEN_INITRD = planBootInitrdEnvNative(packed.cpioPath);
   const packMs = phases.end("initramfs-pack");
   debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
   return { bundleTempDir: packed.tempDir, mountDiskPaths: packed.mountDisk };

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -91,7 +91,7 @@ import {
   teeOnLog,
 } from "./helpers.ts";
 import { performSnapshot, type SnapshotContext } from "./snapshot.ts";
-import { resolveSnapshotEngine, VMSTATE_FILE } from "./snapshot-engine.ts";
+import { resolveSnapshotEngine } from "./snapshot-engine.ts";
 
 const debug = debugLib("machinen:boot");
 const vmmDebug = debugLib("machinen:vmm");
@@ -1051,14 +1051,13 @@ function setupVmstateBoot(
   inputVsockTempDir: string | undefined,
 ): { vmstate: BootVmstateRuntime; vsockTempDir: string | undefined } {
   let vsockTempDir = inputVsockTempDir;
-  let statePath: string | undefined;
+  let stateTempDir: string | undefined;
   const chainId = randomBytes(16).toString("hex");
   if (resolveSnapshotEngine() === "vmstate" && opts.snapshot !== false) {
-    vsockTempDir = ensureVsockTempDir(vsockTempDir);
-    statePath = join(vsockTempDir, VMSTATE_FILE);
+    stateTempDir = vsockTempDir = ensureVsockTempDir(vsockTempDir);
   }
   const runtime = planBootVmstateRuntimeNative({
-    statePath,
+    stateTempDir,
     chainId,
     restorePath: opts._vmstateRestorePath,
     forkedFrom: opts.forkedFrom,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootMountDiskFdEnvNative,
   planBootPortForwardNative,
   planBootRegistryNestedNative,
   planBootRegistryPortForwardNative,
@@ -1502,9 +1503,14 @@ function openMountDiskFds(
       { cause: err },
     );
   }
-  stdio.push(lowerFd, upperFd);
-  env.MACHINEN_MOUNTDISK_LOWER_FD = "3";
-  env.MACHINEN_MOUNTDISK_UPPER_FD = "4";
+  const lowerChildFd = stdio.length;
+  stdio.push(lowerFd);
+  const upperChildFd = stdio.length;
+  stdio.push(upperFd);
+  Object.assign(
+    env,
+    planBootMountDiskFdEnvNative({ lowerFd: lowerChildFd, upperFd: upperChildFd }),
+  );
   return { lowerFd, upperFd };
 }
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -1378,14 +1378,9 @@ function setupStatsFile(
     return { statsFilePath: plan.statsFilePath, statsTempDir: undefined };
   }
   let statsTempDir: string | undefined;
-  let plannedPath: string;
-  if (vsockTempDir) {
-    plannedPath = join(vsockTempDir, "stats.bin");
-  } else {
-    statsTempDir = mkdtempSync(join(tmpdir(), "machinen-stats-"));
-    plannedPath = join(statsTempDir, "stats.bin");
-  }
-  const plan = planBootStatsFileNative({ plannedPath });
+  const statsFileTempDir =
+    vsockTempDir ?? (statsTempDir = mkdtempSync(join(tmpdir(), "machinen-stats-")));
+  const plan = planBootStatsFileNative({ tempDir: statsFileTempDir });
   if (!plan.statsFilePath) {
     return { statsFilePath: undefined, statsTempDir };
   }

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -25,6 +25,7 @@ import { reflinkCopy } from "../reflink.ts";
 import {
   planBootBundleCommandNative,
   planBootBundleEnvNative,
+  planBootBundleWorkspaceNative,
   planBootLiveMountsNative,
   planBootMountDiskRuntimeNative,
   planBootMachinenConfigNative,
@@ -258,10 +259,11 @@ export function synthesizeAndPackBundle(
 
 function createBundleWorkspace(): BundleWorkspace {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
+  const plan = planBootBundleWorkspaceNative(tempDir);
   return {
     tempDir,
-    cpioPath: join(tempDir, "initramfs.cpio"),
-    synthBundleDir: join(tempDir, "bundle"),
+    cpioPath: plan.cpioPath,
+    synthBundleDir: plan.synthBundleDir,
     cleanup: () => {
       try {
         rmSync(tempDir, { recursive: true, force: true });

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -24,6 +24,7 @@ import {
 import { reflinkCopy } from "../reflink.ts";
 import {
   planBootBundleCommandNative,
+  planBootBundleConfigPathsNative,
   planBootBundleEnvNative,
   planBootBundleWorkspaceNative,
   planBootLiveMountsNative,
@@ -316,9 +317,10 @@ function writeBundleConfig(
     liveMounts: ResolvedLiveMount[];
   },
 ): void {
-  mkdirSync(join(workspace.synthBundleDir, "rootfs"), { recursive: true });
+  const paths = planBootBundleConfigPathsNative(workspace.synthBundleDir);
+  mkdirSync(paths.rootfsDir, { recursive: true });
   const configJson = buildMachinenConfig(input);
-  writeFileSync(join(workspace.synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
+  writeFileSync(paths.configPath, JSON.stringify(configJson));
 }
 
 function resolveBundleMount(opts: BootOptions): ResolvedMountInput | undefined {


### PR DESCRIPTION
## Problem

Several boot and provision paths still planned temporary paths and environment values in TypeScript. That made the planning logic harder to audit as one native core.

## Solution

Move the temp-path, config-path, initrd, mountdisk-fd, and related provision arch planning pieces into the Zig boot planner. TypeScript still resolves host paths and wires the process environment.

## Technical Summary

- Keeps this slice focused on path/env planning after the boot registry planning slice.
- Uses JSON helper input and output, with TypeScript wrappers preserving the existing call sites.
- Keeps host existence checks and process spawning in TypeScript.
