### PR TITLE
Move restore and snapshot planning to Zig

### DIFF
--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -420,6 +420,49 @@ pub const MountDiskFdEnvInput = struct {
     upper_fd: ?u64 = null,
 };
 
+pub const SnapshotMountDiskInput = struct {
+    guest: ?[]const u8 = null,
+    lower_path: ?[]const u8 = null,
+    upper_path: ?[]const u8 = null,
+};
+
+pub const SnapshotMountDiskPlan = struct {
+    guest: []const u8,
+    lower_path: []const u8,
+    upper_path: []const u8,
+};
+
+pub const SnapshotLiveMountPlan = struct {
+    host: []const u8,
+    guest: []const u8,
+    mode: []const u8,
+};
+
+pub const SnapshotVmstateInput = struct {
+    state_path: ?[]const u8 = null,
+    chain_id: ?[]const u8 = null,
+    checkpoint_parent: ?[]const u8 = null,
+    checkpoint_sequence: ?u64 = null,
+};
+
+pub const SnapshotVmstateChainPlan = struct {
+    chain_id: []const u8,
+    parent_dir: ?[]const u8,
+    sequence: u64,
+};
+
+pub const SnapshotContextInput = struct {
+    mount_disk: SnapshotMountDiskInput = .{},
+    live_mounts: []const LiveMount = &.{},
+    vmstate: SnapshotVmstateInput = .{},
+};
+
+pub const SnapshotContextPlan = struct {
+    mount_disk: ?SnapshotMountDiskPlan,
+    live_mounts: []const SnapshotLiveMountPlan,
+    vmstate_chain: ?SnapshotVmstateChainPlan,
+};
+
 pub const RegistryCleanupInput = struct {
     per_boot_root_disk: ?[]const u8 = null,
     per_boot_snap_disk: ?[]const u8 = null,
@@ -587,6 +630,8 @@ pub const PlanError = error{
     MissingBatchLiveMountVsock,
     PortForwardNetSocketPreset,
     MissingGvproxy,
+    MissingSnapshotMountDiskField,
+    MissingSnapshotVmstateField,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
@@ -1268,6 +1313,55 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
     };
 }
 
+pub fn planSnapshotContext(
+    allocator: std.mem.Allocator,
+    input: SnapshotContextInput,
+) PlanError!SnapshotContextPlan {
+    assert(@sizeOf(SnapshotContextInput) > 0);
+
+    return .{
+        .mount_disk = try planSnapshotMountDisk(input.mount_disk),
+        .live_mounts = try planSnapshotLiveMounts(allocator, input.live_mounts),
+        .vmstate_chain = try planSnapshotVmstateChain(input.vmstate),
+    };
+}
+
+fn planSnapshotMountDisk(input: SnapshotMountDiskInput) PlanError!?SnapshotMountDiskPlan {
+    assert(@sizeOf(SnapshotMountDiskInput) > 0);
+
+    if (input.guest == null and input.lower_path == null and input.upper_path == null) return null;
+    return .{
+        .guest = input.guest orelse return error.MissingSnapshotMountDiskField,
+        .lower_path = input.lower_path orelse return error.MissingSnapshotMountDiskField,
+        .upper_path = input.upper_path orelse return error.MissingSnapshotMountDiskField,
+    };
+}
+
+fn planSnapshotLiveMounts(
+    allocator: std.mem.Allocator,
+    input: []const LiveMount,
+) PlanError![]const SnapshotLiveMountPlan {
+    assert(@sizeOf(LiveMount) > 0);
+
+    if (input.len > max_live_mounts) return error.TooManyLiveMounts;
+    var mounts: [max_live_mounts]SnapshotLiveMountPlan = undefined;
+    for (input, 0..) |mount, i| {
+        mounts[i] = .{ .host = mount.host, .guest = mount.guest, .mode = mount.mode };
+    }
+    return std.mem.concat(allocator, SnapshotLiveMountPlan, &.{mounts[0..input.len]});
+}
+
+fn planSnapshotVmstateChain(input: SnapshotVmstateInput) PlanError!?SnapshotVmstateChainPlan {
+    assert(@sizeOf(SnapshotVmstateInput) > 0);
+
+    if (input.state_path == null) return null;
+    return .{
+        .chain_id = input.chain_id orelse return error.MissingSnapshotVmstateField,
+        .parent_dir = input.checkpoint_parent,
+        .sequence = input.checkpoint_sequence orelse return error.MissingSnapshotVmstateField,
+    };
+}
+
 pub fn planRegistryShape(
     allocator: std.mem.Allocator,
     input: RegistryShapeInput,
@@ -1901,6 +1995,53 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planSnapshotContext projects mount live mount and vmstate chain fields" {
+    const allocator = std.testing.allocator;
+    const live = [_]LiveMount{.{
+        .host = "/host/work",
+        .guest = "/mnt/work",
+        .mode = "rw",
+        .tag = "machinen-lm0",
+    }};
+    const plan = try planSnapshotContext(allocator, .{
+        .mount_disk = .{
+            .guest = "/mnt/data",
+            .lower_path = "/cache/lower.sqfs",
+            .upper_path = "/tmp/upper.img",
+        },
+        .live_mounts = &live,
+        .vmstate = .{
+            .state_path = "/tmp/state.vmstate",
+            .chain_id = "chain-1",
+            .checkpoint_parent = "/snap/parent",
+            .checkpoint_sequence = 3,
+        },
+    });
+    defer allocator.free(plan.live_mounts);
+    try std.testing.expectEqualStrings("/mnt/data", plan.mount_disk.?.guest);
+    try std.testing.expectEqualStrings("/cache/lower.sqfs", plan.mount_disk.?.lower_path);
+    try std.testing.expectEqualStrings("/tmp/upper.img", plan.mount_disk.?.upper_path);
+    try std.testing.expect(plan.live_mounts.len == 1);
+    try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);
+    try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
+    try std.testing.expectEqualStrings("rw", plan.live_mounts[0].mode);
+    try std.testing.expectEqualStrings("chain-1", plan.vmstate_chain.?.chain_id);
+    try std.testing.expectEqualStrings("/snap/parent", plan.vmstate_chain.?.parent_dir.?);
+    try std.testing.expectEqual(@as(u64, 3), plan.vmstate_chain.?.sequence);
+
+    const empty = try planSnapshotContext(allocator, .{});
+    defer allocator.free(empty.live_mounts);
+    try std.testing.expect(empty.mount_disk == null);
+    try std.testing.expect(empty.vmstate_chain == null);
+
+    try std.testing.expectError(error.MissingSnapshotMountDiskField, planSnapshotContext(allocator, .{
+        .mount_disk = .{ .guest = "/mnt/data" },
+    }));
+    try std.testing.expectError(error.MissingSnapshotVmstateField, planSnapshotContext(allocator, .{
+        .vmstate = .{ .state_path = "/tmp/state.vmstate" },
+    }));
 }
 
 test "planRegistryShape collects cleanup paths and strips registry-only mount fields" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -79,6 +79,11 @@ pub const PortForwardMapping = struct {
     host_addr: ?[]const u8 = null,
 };
 
+pub const PortForwardNetSocketInput = struct {
+    port_forwards: []const PortForwardMapping = &.{},
+    net_socket: ?[]const u8 = null,
+};
+
 pub const PortForwardValidation = union(enum) {
     ok,
     invalid_host_port: i64,
@@ -568,6 +573,7 @@ pub const PlanError = error{
     MissingMountDiskRuntimeField,
     MissingMountDiskFdField,
     MissingBatchLiveMountVsock,
+    PortForwardNetSocketPreset,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
@@ -2499,6 +2505,24 @@ test "planVmmArgv wraps VMM argv with pdeathsig when present" {
     try std.testing.expectEqual(@as(@TypeOf(wrapped.args.len), 2), wrapped.args.len);
     try std.testing.expectEqualStrings("/bin/vmm", wrapped.args[0]);
     try std.testing.expectEqualStrings("--dev", wrapped.args[1]);
+}
+
+pub fn validatePortForwardNetSocket(input: PortForwardNetSocketInput) PlanError!void {
+    assert(@sizeOf(PortForwardNetSocketInput) > 0);
+
+    if (input.port_forwards.len > 0 and input.net_socket != null) {
+        return error.PortForwardNetSocketPreset;
+    }
+}
+
+test "validatePortForwardNetSocket rejects caller-owned net socket with forwards" {
+    const forwards = [_]PortForwardMapping{.{ .host_port = 8080, .guest_port = 3000 }};
+    try std.testing.expectError(error.PortForwardNetSocketPreset, validatePortForwardNetSocket(.{
+        .port_forwards = &forwards,
+        .net_socket = "/tmp/net.sock",
+    }));
+    try validatePortForwardNetSocket(.{ .port_forwards = &forwards });
+    try validatePortForwardNetSocket(.{ .net_socket = "/tmp/net.sock" });
 }
 
 test "validatePortForward rejects invalid and duplicate ports" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -84,6 +84,18 @@ pub const PortForwardNetSocketInput = struct {
     net_socket: ?[]const u8 = null,
 };
 
+pub const GvproxyPlanInput = struct {
+    planning_required: bool = false,
+    existing_net_socket: ?[]const u8 = null,
+    gvproxy_path: ?[]const u8 = null,
+    port_forwards: []const PortForwardMapping = &.{},
+};
+
+pub const GvproxyPlan = struct {
+    action: []const u8,
+    gvproxy_path: ?[]const u8,
+};
+
 pub const PortForwardValidation = union(enum) {
     ok,
     invalid_host_port: i64,
@@ -574,6 +586,7 @@ pub const PlanError = error{
     MissingMountDiskFdField,
     MissingBatchLiveMountVsock,
     PortForwardNetSocketPreset,
+    MissingGvproxy,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
@@ -2513,6 +2526,35 @@ pub fn validatePortForwardNetSocket(input: PortForwardNetSocketInput) PlanError!
     if (input.port_forwards.len > 0 and input.net_socket != null) {
         return error.PortForwardNetSocketPreset;
     }
+}
+
+pub fn planGvproxy(input: GvproxyPlanInput) PlanError!GvproxyPlan {
+    assert(@sizeOf(GvproxyPlanInput) > 0);
+
+    if (input.existing_net_socket != null) {
+        return .{ .action = "skip-existing", .gvproxy_path = null };
+    }
+    if (input.gvproxy_path) |path| return .{ .action = "spawn", .gvproxy_path = path };
+    if (input.planning_required and input.port_forwards.len > 0) return error.MissingGvproxy;
+    return .{ .action = "missing-ok", .gvproxy_path = null };
+}
+
+test "planGvproxy selects skip spawn missing-ok and missing-gvproxy actions" {
+    const forwards = [_]PortForwardMapping{.{ .host_port = 8080, .guest_port = 3000 }};
+    const existing = try planGvproxy(.{ .existing_net_socket = "/tmp/net.sock", .port_forwards = &forwards });
+    try std.testing.expectEqualStrings("skip-existing", existing.action);
+    try std.testing.expect(existing.gvproxy_path == null);
+
+    const spawn = try planGvproxy(.{ .gvproxy_path = "/bin/gvproxy", .port_forwards = &forwards });
+    try std.testing.expectEqualStrings("spawn", spawn.action);
+    try std.testing.expectEqualStrings("/bin/gvproxy", spawn.gvproxy_path.?);
+
+    const missing_ok = try planGvproxy(.{ .planning_required = true });
+    try std.testing.expectEqualStrings("missing-ok", missing_ok.action);
+    try std.testing.expectError(error.MissingGvproxy, planGvproxy(.{
+        .planning_required = true,
+        .port_forwards = &forwards,
+    }));
 }
 
 test "validatePortForwardNetSocket rejects caller-owned net socket with forwards" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -520,6 +520,21 @@ pub const RegistryVmstatePlan = struct {
     checkpoint_sequence: ?u64,
 };
 
+pub const RegistryProcessInput = struct {
+    host_platform: ?[]const u8 = null,
+    vmm_binary: ?[]const u8 = null,
+    vmm_pdeathsig: bool = false,
+    vmm_observed_exe_base: ?[]const u8 = null,
+    gv_pid: ?i64 = null,
+    gv_exe: ?[]const u8 = null,
+    gv_observed_exe_base: ?[]const u8 = null,
+};
+
+pub const RegistryProcessPlan = struct {
+    vmm_exe: ?[]const u8,
+    gvproxy_exe: ?[]const u8,
+};
+
 pub const RegistryShapeInput = struct {
     source_image_path: ?[]const u8 = null,
     per_boot_root_disk: ?[]const u8 = null,
@@ -899,25 +914,34 @@ pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) 
 }
 
 pub fn planBatchLiveMountSync(input: BatchLiveMountInput) PlanError!BatchLiveMountPlan {
+    assert(@sizeOf(BatchLiveMountInput) > 0);
+
     for (input.live_mounts) |mount| {
         if (std.mem.eql(u8, mount.mode, "rw")) {
-            if (input.validation_required and input.vsock_uds_path == null) return error.MissingBatchLiveMountVsock;
+            if (input.validation_required and input.vsock_uds_path == null) {
+                return error.MissingBatchLiveMountVsock;
+            }
             return .{ .sync_required = true };
         }
     }
     return .{ .sync_required = false };
 }
 
-pub fn planRestoreLiveMounts(allocator: std.mem.Allocator, input: RestoreLiveMountPlanInput) !RestoreLiveMountPlan {
+pub fn planRestoreLiveMounts(
+    allocator: std.mem.Allocator,
+    input: RestoreLiveMountPlanInput,
+) !RestoreLiveMountPlan {
+    assert(@sizeOf(RestoreLiveMountPlanInput) > 0);
+
     if (input.recorded.len == 0) {
-        return .{ .mounts = try allocator.dupe(RestoreLiveMountInput, input.overrides) };
+        return .{ .mounts = input.overrides };
     }
     for (input.overrides) |override| {
         if (findRecordedLiveMount(input.recorded, override.guest) == null) {
             return .{ .mounts = &.{}, .unknown_guest = override.guest };
         }
     }
-    var out: std.ArrayList(RestoreLiveMountInput) = .empty;
+    var out: std.array_list.Aligned(RestoreLiveMountInput, null) = .empty;
     errdefer out.deinit(allocator);
     for (input.recorded) |recorded| {
         if (findRestoreLiveMountOverride(input.overrides, recorded.guest)) |override| {
@@ -927,20 +951,34 @@ pub fn planRestoreLiveMounts(allocator: std.mem.Allocator, input: RestoreLiveMou
                 .mode = override.mode orelse recorded.mode,
             });
         } else {
-            try out.append(allocator, .{ .host = recorded.host, .guest = recorded.guest, .mode = recorded.mode });
+            try out.append(allocator, .{
+                .host = recorded.host,
+                .guest = recorded.guest,
+                .mode = recorded.mode,
+            });
         }
     }
     return .{ .mounts = try out.toOwnedSlice(allocator) };
 }
 
-fn findRecordedLiveMount(recorded: []const RestoreRecordedLiveMount, guest: []const u8) ?RestoreRecordedLiveMount {
+fn findRecordedLiveMount(
+    recorded: []const RestoreRecordedLiveMount,
+    guest: []const u8,
+) ?RestoreRecordedLiveMount {
+    assert(@sizeOf(RestoreRecordedLiveMount) > 0);
+
     for (recorded) |mount| {
         if (std.mem.eql(u8, mount.guest, guest)) return mount;
     }
     return null;
 }
 
-fn findRestoreLiveMountOverride(overrides: []const RestoreLiveMountInput, guest: []const u8) ?RestoreLiveMountInput {
+fn findRestoreLiveMountOverride(
+    overrides: []const RestoreLiveMountInput,
+    guest: []const u8,
+) ?RestoreLiveMountInput {
+    assert(@sizeOf(RestoreLiveMountInput) > 0);
+
     var found: ?RestoreLiveMountInput = null;
     for (overrides) |mount| {
         if (std.mem.eql(u8, mount.guest, guest)) found = mount;
@@ -1360,6 +1398,24 @@ fn planSnapshotVmstateChain(input: SnapshotVmstateInput) PlanError!?SnapshotVmst
         .parent_dir = input.checkpoint_parent,
         .sequence = input.checkpoint_sequence orelse return error.MissingSnapshotVmstateField,
     };
+}
+
+pub fn planRegistryProcess(input: RegistryProcessInput) RegistryProcessPlan {
+    assert(@sizeOf(RegistryProcessInput) > 0);
+
+    const is_darwin = if (input.host_platform) |platform|
+        std.mem.eql(u8, platform, "darwin")
+    else
+        false;
+    const vmm_exe = if (input.vmm_binary) |binary|
+        if (is_darwin and input.vmm_pdeathsig) input.vmm_observed_exe_base orelse binary else binary
+    else
+        null;
+    const gvproxy_exe = if (is_darwin and (input.gv_pid orelse 0) > 0)
+        input.gv_observed_exe_base orelse input.gv_exe
+    else
+        input.gv_exe;
+    return .{ .vmm_exe = vmm_exe, .gvproxy_exe = gvproxy_exe };
 }
 
 pub fn planRegistryShape(
@@ -1997,6 +2053,43 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
 }
 
+test "planRegistryProcess projects platform-specific executable metadata" {
+    const darwin = planRegistryProcess(.{
+        .host_platform = "darwin",
+        .vmm_binary = "/pkg/machinen-vm",
+        .vmm_pdeathsig = true,
+        .vmm_observed_exe_base = "machinen-pdeathsig",
+        .gv_pid = 42,
+        .gv_exe = "/pkg/gvproxy",
+        .gv_observed_exe_base = "gvproxy",
+    });
+    try std.testing.expectEqualStrings("machinen-pdeathsig", darwin.vmm_exe.?);
+    try std.testing.expectEqualStrings("gvproxy", darwin.gvproxy_exe.?);
+
+    const linux = planRegistryProcess(.{
+        .host_platform = "linux",
+        .vmm_binary = "/pkg/machinen-vm",
+        .vmm_pdeathsig = true,
+        .vmm_observed_exe_base = "machinen-pdeathsig",
+        .gv_pid = 42,
+        .gv_exe = "/pkg/gvproxy",
+        .gv_observed_exe_base = "gvproxy-observed",
+    });
+    try std.testing.expectEqualStrings("/pkg/machinen-vm", linux.vmm_exe.?);
+    try std.testing.expectEqualStrings("/pkg/gvproxy", linux.gvproxy_exe.?);
+
+    const fallback = planRegistryProcess(.{
+        .host_platform = "darwin",
+        .vmm_binary = "/pkg/machinen-vm",
+        .vmm_pdeathsig = true,
+        .gv_pid = -1,
+        .gv_exe = "/pkg/gvproxy",
+        .gv_observed_exe_base = "ignored",
+    });
+    try std.testing.expectEqualStrings("/pkg/machinen-vm", fallback.vmm_exe.?);
+    try std.testing.expectEqualStrings("/pkg/gvproxy", fallback.gvproxy_exe.?);
+}
+
 test "planSnapshotContext projects mount live mount and vmstate chain fields" {
     const allocator = std.testing.allocator;
     const live = [_]LiveMount{.{
@@ -2036,9 +2129,12 @@ test "planSnapshotContext projects mount live mount and vmstate chain fields" {
     try std.testing.expect(empty.mount_disk == null);
     try std.testing.expect(empty.vmstate_chain == null);
 
-    try std.testing.expectError(error.MissingSnapshotMountDiskField, planSnapshotContext(allocator, .{
-        .mount_disk = .{ .guest = "/mnt/data" },
-    }));
+    try std.testing.expectError(
+        error.MissingSnapshotMountDiskField,
+        planSnapshotContext(allocator, .{
+            .mount_disk = .{ .guest = "/mnt/data" },
+        }),
+    );
     try std.testing.expectError(error.MissingSnapshotVmstateField, planSnapshotContext(allocator, .{
         .vmstate = .{ .state_path = "/tmp/state.vmstate" },
     }));
@@ -2542,10 +2638,13 @@ test "planRestoreLiveMounts merges recorded mounts with overrides" {
     const overrides = [_]RestoreLiveMountInput{
         .{ .host = "/new/cache", .guest = "/mnt/cache" },
     };
-    const planned = try planRestoreLiveMounts(std.testing.allocator, .{ .recorded = &recorded, .overrides = &overrides });
+    const planned = try planRestoreLiveMounts(
+        std.testing.allocator,
+        .{ .recorded = &recorded, .overrides = &overrides },
+    );
     defer std.testing.allocator.free(planned.mounts);
     try std.testing.expect(planned.unknown_guest == null);
-    try std.testing.expectEqual(@as(usize, 2), planned.mounts.len);
+    try std.testing.expect(planned.mounts.len == 2);
     try std.testing.expectEqualStrings("/host/work", planned.mounts[0].host);
     try std.testing.expectEqualStrings("rw", planned.mounts[0].mode.?);
     try std.testing.expectEqualStrings("/new/cache", planned.mounts[1].host);
@@ -2553,12 +2652,19 @@ test "planRestoreLiveMounts merges recorded mounts with overrides" {
 
     const legacy = try planRestoreLiveMounts(std.testing.allocator, .{ .overrides = &overrides });
     defer std.testing.allocator.free(legacy.mounts);
-    try std.testing.expectEqual(@as(usize, 1), legacy.mounts.len);
+    try std.testing.expect(legacy.mounts.len == 1);
     try std.testing.expectEqualStrings("/new/cache", legacy.mounts[0].host);
     try std.testing.expect(legacy.mounts[0].mode == null);
 
-    const bad = [_]RestoreLiveMountInput{.{ .host = "/new/extra", .guest = "/mnt/extra", .mode = "rw" }};
-    const rejected = try planRestoreLiveMounts(std.testing.allocator, .{ .recorded = &recorded, .overrides = &bad });
+    const bad = [_]RestoreLiveMountInput{.{
+        .host = "/new/extra",
+        .guest = "/mnt/extra",
+        .mode = "rw",
+    }};
+    const rejected = try planRestoreLiveMounts(
+        std.testing.allocator,
+        .{ .recorded = &recorded, .overrides = &bad },
+    );
     try std.testing.expectEqualStrings("/mnt/extra", rejected.unknown_guest.?);
 }
 
@@ -2682,7 +2788,10 @@ pub fn planGvproxy(input: GvproxyPlanInput) PlanError!GvproxyPlan {
 
 test "planGvproxy selects skip spawn missing-ok and missing-gvproxy actions" {
     const forwards = [_]PortForwardMapping{.{ .host_port = 8080, .guest_port = 3000 }};
-    const existing = try planGvproxy(.{ .existing_net_socket = "/tmp/net.sock", .port_forwards = &forwards });
+    const existing = try planGvproxy(.{
+        .existing_net_socket = "/tmp/net.sock",
+        .port_forwards = &forwards,
+    });
     try std.testing.expectEqualStrings("skip-existing", existing.action);
     try std.testing.expect(existing.gvproxy_path == null);
 

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -287,6 +287,16 @@ pub const LiveMount = struct {
     tag: []const u8,
 };
 
+pub const BatchLiveMountInput = struct {
+    live_mounts: []const LiveMount = &.{},
+    vsock_uds_path: ?[]const u8 = null,
+    validation_required: bool = false,
+};
+
+pub const BatchLiveMountPlan = struct {
+    sync_required: bool,
+};
+
 pub const StatsFileInput = struct {
     existing_path: ?[]const u8 = null,
     planned_path: ?[]const u8 = null,
@@ -535,6 +545,7 @@ pub const PlanError = error{
     MissingRootDiskRuntimePath,
     MissingMountDiskRuntimeField,
     MissingMountDiskFdField,
+    MissingBatchLiveMountVsock,
     IncompleteRegistryMountDisk,
     MissingProvisionRepackField,
     MissingRegistryCpuStatus,
@@ -799,6 +810,16 @@ pub fn planVirtiofsEnv(allocator: std.mem.Allocator, mounts: []const LiveMount) 
         try out.append(allocator, .{ .key = key, .value = value });
     }
     return out.toOwnedSlice(allocator);
+}
+
+pub fn planBatchLiveMountSync(input: BatchLiveMountInput) PlanError!BatchLiveMountPlan {
+    for (input.live_mounts) |mount| {
+        if (std.mem.eql(u8, mount.mode, "rw")) {
+            if (input.validation_required and input.vsock_uds_path == null) return error.MissingBatchLiveMountVsock;
+            return .{ .sync_required = true };
+        }
+    }
+    return .{ .sync_required = false };
 }
 
 pub fn planStatsFile(allocator: std.mem.Allocator, input: StatsFileInput) !StatsFilePlan {
@@ -2270,6 +2291,25 @@ test "planLiveMounts validates count guest paths modes and tags" {
         error.InvalidLiveMountMode,
         planLiveMounts(std.testing.allocator, &bad_mode),
     );
+}
+
+test "planBatchLiveMountSync requires vsock for rw mounts when validation is requested" {
+    const mounts = [_]LiveMount{
+        .{ .host = "/host/a", .guest = "/mnt/a", .mode = "ro", .tag = "machinen-lm0" },
+        .{ .host = "/host/b", .guest = "/mnt/b", .mode = "rw", .tag = "machinen-lm1" },
+    };
+    try std.testing.expectError(error.MissingBatchLiveMountVsock, planBatchLiveMountSync(.{
+        .live_mounts = &mounts,
+        .validation_required = true,
+    }));
+    const planned = try planBatchLiveMountSync(.{
+        .live_mounts = &mounts,
+        .vsock_uds_path = "/tmp/exec.sock",
+        .validation_required = true,
+    });
+    try std.testing.expect(planned.sync_required);
+    const none = try planBatchLiveMountSync(.{});
+    try std.testing.expect(!none.sync_required);
 }
 
 test "planStatsFile preserves caller path or returns runtime-owned env value" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -287,6 +287,28 @@ pub const LiveMount = struct {
     tag: []const u8,
 };
 
+pub const RestoreLiveMountInput = struct {
+    host: []const u8,
+    guest: []const u8,
+    mode: ?[]const u8 = null,
+};
+
+pub const RestoreRecordedLiveMount = struct {
+    host: []const u8,
+    guest: []const u8,
+    mode: []const u8,
+};
+
+pub const RestoreLiveMountPlanInput = struct {
+    recorded: []const RestoreRecordedLiveMount = &.{},
+    overrides: []const RestoreLiveMountInput = &.{},
+};
+
+pub const RestoreLiveMountPlan = struct {
+    mounts: []const RestoreLiveMountInput,
+    unknown_guest: ?[]const u8 = null,
+};
+
 pub const BatchLiveMountInput = struct {
     live_mounts: []const LiveMount = &.{},
     vsock_uds_path: ?[]const u8 = null,
@@ -820,6 +842,46 @@ pub fn planBatchLiveMountSync(input: BatchLiveMountInput) PlanError!BatchLiveMou
         }
     }
     return .{ .sync_required = false };
+}
+
+pub fn planRestoreLiveMounts(allocator: std.mem.Allocator, input: RestoreLiveMountPlanInput) !RestoreLiveMountPlan {
+    if (input.recorded.len == 0) {
+        return .{ .mounts = try allocator.dupe(RestoreLiveMountInput, input.overrides) };
+    }
+    for (input.overrides) |override| {
+        if (findRecordedLiveMount(input.recorded, override.guest) == null) {
+            return .{ .mounts = &.{}, .unknown_guest = override.guest };
+        }
+    }
+    var out: std.ArrayList(RestoreLiveMountInput) = .empty;
+    errdefer out.deinit(allocator);
+    for (input.recorded) |recorded| {
+        if (findRestoreLiveMountOverride(input.overrides, recorded.guest)) |override| {
+            try out.append(allocator, .{
+                .host = override.host,
+                .guest = recorded.guest,
+                .mode = override.mode orelse recorded.mode,
+            });
+        } else {
+            try out.append(allocator, .{ .host = recorded.host, .guest = recorded.guest, .mode = recorded.mode });
+        }
+    }
+    return .{ .mounts = try out.toOwnedSlice(allocator) };
+}
+
+fn findRecordedLiveMount(recorded: []const RestoreRecordedLiveMount, guest: []const u8) ?RestoreRecordedLiveMount {
+    for (recorded) |mount| {
+        if (std.mem.eql(u8, mount.guest, guest)) return mount;
+    }
+    return null;
+}
+
+fn findRestoreLiveMountOverride(overrides: []const RestoreLiveMountInput, guest: []const u8) ?RestoreLiveMountInput {
+    var found: ?RestoreLiveMountInput = null;
+    for (overrides) |mount| {
+        if (std.mem.eql(u8, mount.guest, guest)) found = mount;
+    }
+    return found;
 }
 
 pub fn planStatsFile(allocator: std.mem.Allocator, input: StatsFileInput) !StatsFilePlan {
@@ -2310,6 +2372,34 @@ test "planBatchLiveMountSync requires vsock for rw mounts when validation is req
     try std.testing.expect(planned.sync_required);
     const none = try planBatchLiveMountSync(.{});
     try std.testing.expect(!none.sync_required);
+}
+
+test "planRestoreLiveMounts merges recorded mounts with overrides" {
+    const recorded = [_]RestoreRecordedLiveMount{
+        .{ .host = "/host/work", .guest = "/mnt/work", .mode = "rw" },
+        .{ .host = "/host/cache", .guest = "/mnt/cache", .mode = "ro" },
+    };
+    const overrides = [_]RestoreLiveMountInput{
+        .{ .host = "/new/cache", .guest = "/mnt/cache" },
+    };
+    const planned = try planRestoreLiveMounts(std.testing.allocator, .{ .recorded = &recorded, .overrides = &overrides });
+    defer std.testing.allocator.free(planned.mounts);
+    try std.testing.expect(planned.unknown_guest == null);
+    try std.testing.expectEqual(@as(usize, 2), planned.mounts.len);
+    try std.testing.expectEqualStrings("/host/work", planned.mounts[0].host);
+    try std.testing.expectEqualStrings("rw", planned.mounts[0].mode.?);
+    try std.testing.expectEqualStrings("/new/cache", planned.mounts[1].host);
+    try std.testing.expectEqualStrings("ro", planned.mounts[1].mode.?);
+
+    const legacy = try planRestoreLiveMounts(std.testing.allocator, .{ .overrides = &overrides });
+    defer std.testing.allocator.free(legacy.mounts);
+    try std.testing.expectEqual(@as(usize, 1), legacy.mounts.len);
+    try std.testing.expectEqualStrings("/new/cache", legacy.mounts[0].host);
+    try std.testing.expect(legacy.mounts[0].mode == null);
+
+    const bad = [_]RestoreLiveMountInput{.{ .host = "/new/extra", .guest = "/mnt/extra", .mode = "rw" }};
+    const rejected = try planRestoreLiveMounts(std.testing.allocator, .{ .recorded = &recorded, .overrides = &bad });
+    try std.testing.expectEqualStrings("/mnt/extra", rejected.unknown_guest.?);
 }
 
 test "planStatsFile preserves caller path or returns runtime-owned env value" {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -27,6 +27,7 @@ const ParsedRequest = struct {
     auto_vsock_uds_path: ?[]const u8 = null,
     auto_vsock_temp_dir: ?[]const u8 = null,
     port_forward: []const boot_plan.PortForwardMapping = &.{},
+    port_forward_net_socket: ?[]const u8 = null,
     vmm_binary: ?[]const u8 = null,
     vmm_args: []const []const u8 = &.{},
     guest_hostname_pid_text: ?[]const u8 = null,
@@ -169,6 +170,7 @@ const boot_plan_fields = [_][]const u8{
     "autoVsockUdsPath",
     "autoVsockTempDir",
     "portForward",
+    "portForwardNetSocket",
     "vmmBinary",
     "vmmArgs",
     "guestHostnamePid",
@@ -317,6 +319,7 @@ const RequestError = error{
     InvalidPortForward,
     InvalidHostPort,
     InvalidGuestPort,
+    InvalidPortForwardNetSocket,
     InvalidVmmBinary,
     InvalidVmmArgs,
     InvalidGuestHostnamePid,
@@ -442,7 +445,11 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
         try writePlanError(io, err);
         return .fail;
     };
-    if (try writePortForwardFailure(io, parsed.port_forward)) return .fail;
+    if (try writePortForwardFailure(
+        io,
+        parsed.port_forward,
+        parsed.port_forward_net_socket,
+    )) return .fail;
 
     const parts = makePlanParts(arena, parsed, plan) catch |err| {
         if (err == error.RestoreLiveMountOverrideUnknown) {
@@ -962,16 +969,28 @@ fn makeRegistryShape(
 fn writePortForwardFailure(
     io: std.Io,
     mappings: []const boot_plan.PortForwardMapping,
+    net_socket: ?[]const u8,
 ) !bool {
     assert(@sizeOf(boot_plan.PortForwardMapping) > 0);
 
     switch (boot_plan.validatePortForward(mappings)) {
-        .ok => return false,
+        .ok => {},
         .invalid_host_port => |port| try writePortForwardInvalid(io, "hostPort", port),
         .invalid_guest_port => |port| try writePortForwardInvalid(io, "guestPort", port),
         .duplicate_host_port => |port| try writeDuplicateHostPort(io, port),
     }
-    return true;
+    boot_plan.validatePortForwardNetSocket(.{
+        .port_forwards = mappings,
+        .net_socket = net_socket,
+    }) catch |err| switch (err) {
+        error.PortForwardNetSocketPreset => try writeBootError(
+            io,
+            "BOOT_PORT_FORWARD_INVALID",
+            "portForward requires the runtime to own gvproxy, but MACHINEN_NET_SOCKET is already set",
+        ),
+        else => return err,
+    };
+    return false;
 }
 
 fn writePlan(io: std.Io, parts: PlanParts) !void {
@@ -2034,6 +2053,11 @@ fn parseVmmLaunchFields(
     assert(@sizeOf(ParsedRequest) > 0);
 
     request.port_forward = try optionalPortForward(allocator, object);
+    request.port_forward_net_socket = try optionalStringDefaultNull(
+        object,
+        "portForwardNetSocket",
+        error.InvalidPortForwardNetSocket,
+    );
     request.vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary);
     request.vmm_args = try optionalStringArrayDefaultEmpty(
         allocator,
@@ -3441,6 +3465,11 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_PORT_FORWARD_INVALID",
             "portForward: hostPort and guestPort must be integers in 1..65535",
+        ),
+        error.InvalidPortForwardNetSocket => try protocol.writeError(
+            io,
+            "BOOT_PORT_FORWARD_INVALID",
+            "boot-plan portForward net socket field must be a string",
         ),
         error.InvalidLiveMounts,
         error.InvalidLiveMountGuest,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -145,6 +145,13 @@ const ParsedRequest = struct {
     registry_vmstate_checkpoint_parent: ?[]const u8 = null,
     registry_vmstate_checkpoint_sequence_text: ?[]const u8 = null,
     registry_nested: bool = false,
+    registry_host_platform: ?[]const u8 = null,
+    registry_vmm_binary: ?[]const u8 = null,
+    registry_vmm_pdeathsig: bool = false,
+    registry_vmm_observed_exe_base: ?[]const u8 = null,
+    registry_gv_pid_text: ?[]const u8 = null,
+    registry_gv_exe: ?[]const u8 = null,
+    registry_gv_observed_exe_base: ?[]const u8 = null,
     registry_mount_guest: ?[]const u8 = null,
     registry_mount_lower_path: ?[]const u8 = null,
     registry_mount_upper_path: ?[]const u8 = null,
@@ -299,6 +306,13 @@ const boot_plan_fields = [_][]const u8{
     "registryVmstateCheckpointParent",
     "registryVmstateCheckpointSequence",
     "registryNested",
+    "registryHostPlatform",
+    "registryVmmBinary",
+    "registryVmmPdeathsig",
+    "registryVmmObservedExeBase",
+    "registryGvPid",
+    "registryGvExe",
+    "registryGvObservedExeBase",
     "registryMountGuest",
     "registryMountLowerPath",
     "registryMountUpperPath",
@@ -457,6 +471,13 @@ const RequestError = error{
     InvalidRegistryVmstateCheckpointParent,
     InvalidRegistryVmstateCheckpointSequence,
     InvalidRegistryNested,
+    InvalidRegistryHostPlatform,
+    InvalidRegistryVmmBinary,
+    InvalidRegistryVmmPdeathsig,
+    InvalidRegistryVmmObservedExeBase,
+    InvalidRegistryGvPid,
+    InvalidRegistryGvExe,
+    InvalidRegistryGvObservedExeBase,
     InvalidRegistryMountGuest,
     InvalidRegistryMountLowerPath,
     InvalidRegistryMountUpperPath,
@@ -536,6 +557,7 @@ const PlanParts = struct {
     mount_disk_fd_env: []const boot_plan.EnvPair,
     snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
+    registry_process: boot_plan.RegistryProcessPlan,
 };
 
 fn makeCorePlan(
@@ -579,6 +601,7 @@ const RuntimeParts = struct {
     mount_disk_fd_env: []const boot_plan.EnvPair,
     snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
+    registry_process: boot_plan.RegistryProcessPlan,
 };
 
 fn makePlanParts(
@@ -638,6 +661,7 @@ fn makePlanParts(
         .mount_disk_fd_env = runtime.mount_disk_fd_env,
         .snapshot_context = runtime.snapshot_context,
         .registry_shape = runtime.registry_shape,
+        .registry_process = runtime.registry_process,
     };
 }
 
@@ -737,6 +761,7 @@ fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimePar
         .mount_disk_fd_env = try makeMountDiskFdEnv(arena, parsed),
         .snapshot_context = try makeSnapshotContext(arena, parsed),
         .registry_shape = try makeRegistryShape(arena, parsed),
+        .registry_process = try makeRegistryProcess(parsed),
     };
 }
 
@@ -978,6 +1003,24 @@ fn makeSnapshotContext(
     });
 }
 
+fn makeRegistryProcess(parsed: ParsedRequest) !boot_plan.RegistryProcessPlan {
+    assert(@sizeOf(boot_plan.RegistryProcessInput) > 0);
+
+    const gv_pid = if (parsed.registry_gv_pid_text) |text|
+        parseSigned(text) catch return error.InvalidRegistryGvPid
+    else
+        null;
+    return boot_plan.planRegistryProcess(.{
+        .host_platform = parsed.registry_host_platform,
+        .vmm_binary = parsed.registry_vmm_binary,
+        .vmm_pdeathsig = parsed.registry_vmm_pdeathsig,
+        .vmm_observed_exe_base = parsed.registry_vmm_observed_exe_base,
+        .gv_pid = gv_pid,
+        .gv_exe = parsed.registry_gv_exe,
+        .gv_observed_exe_base = parsed.registry_gv_observed_exe_base,
+    });
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -1046,19 +1089,32 @@ fn writePortForwardFailure(
 
     switch (boot_plan.validatePortForward(mappings)) {
         .ok => {},
-        .invalid_host_port => |port| try writePortForwardInvalid(io, "hostPort", port),
-        .invalid_guest_port => |port| try writePortForwardInvalid(io, "guestPort", port),
-        .duplicate_host_port => |port| try writeDuplicateHostPort(io, port),
+        .invalid_host_port => |port| {
+            try writePortForwardInvalid(io, "hostPort", port);
+            return true;
+        },
+        .invalid_guest_port => |port| {
+            try writePortForwardInvalid(io, "guestPort", port);
+            return true;
+        },
+        .duplicate_host_port => |port| {
+            try writeDuplicateHostPort(io, port);
+            return true;
+        },
     }
     boot_plan.validatePortForwardNetSocket(.{
         .port_forwards = mappings,
         .net_socket = net_socket,
     }) catch |err| switch (err) {
-        error.PortForwardNetSocketPreset => try writeBootError(
-            io,
-            "BOOT_PORT_FORWARD_INVALID",
-            "portForward requires the runtime to own gvproxy, but MACHINEN_NET_SOCKET is already set",
-        ),
+        error.PortForwardNetSocketPreset => {
+            try writeBootError(
+                io,
+                "BOOT_PORT_FORWARD_INVALID",
+                "portForward requires the runtime to own gvproxy, " ++
+                    "MACHINEN_NET_SOCKET is already set",
+            );
+            return true;
+        },
         else => return err,
     };
     return false;
@@ -1113,6 +1169,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "mountDiskFdEnv", parts.mount_disk_fd_env, true);
     try writeSnapshotContextField(io, "snapshotContext", parts.snapshot_context, true);
     try writeRegistryShapeField(io, "registryShape", parts.registry_shape, true);
+    try writeRegistryProcessField(io, "registryProcess", parts.registry_process, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -1659,6 +1716,8 @@ fn writeSnapshotMountDiskField(
     mount: ?boot_plan.SnapshotMountDiskPlan,
     comma: bool,
 ) !void {
+    assert(field.len > 0);
+
     try writeFieldName(io, field, comma);
     if (mount) |disk| {
         try protocol.stdout(io, "{");
@@ -1675,6 +1734,8 @@ fn writeSnapshotLiveMountsField(
     mounts: []const boot_plan.SnapshotLiveMountPlan,
     comma: bool,
 ) !void {
+    assert(field.len > 0);
+
     try writeFieldName(io, field, comma);
     try protocol.stdout(io, "[");
     for (mounts, 0..) |mount, i| {
@@ -1694,6 +1755,8 @@ fn writeSnapshotVmstateChainField(
     chain: ?boot_plan.SnapshotVmstateChainPlan,
     comma: bool,
 ) !void {
+    assert(field.len > 0);
+
     try writeFieldName(io, field, comma);
     if (chain) |vmstate| {
         try protocol.stdout(io, "{");
@@ -1702,6 +1765,21 @@ fn writeSnapshotVmstateChainField(
         try writeU64Field(io, "sequence", vmstate.sequence, true);
         try protocol.stdout(io, "}");
     } else try protocol.stdout(io, "null");
+}
+
+fn writeRegistryProcessField(
+    io: std.Io,
+    comptime field: []const u8,
+    process: boot_plan.RegistryProcessPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "vmmExe", process.vmm_exe, false);
+    try writeNullableStringField(io, "gvproxyExe", process.gvproxy_exe, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeRegistryShapeField(
@@ -2707,6 +2785,17 @@ fn parseMountDiskRuntimeFields(
         "mountDiskUpperFd",
         error.InvalidMountDiskUpperFd,
     );
+    try parseSnapshotContextFields(allocator, object, request);
+    try parseRegistryShapeFields(object, request);
+}
+
+fn parseSnapshotContextFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.snapshot_mount_guest = try optionalStringDefaultNull(
         object,
         "snapshotMountGuest",
@@ -2748,7 +2837,6 @@ fn parseMountDiskRuntimeFields(
         "snapshotVmstateCheckpointSequence",
         error.InvalidSnapshotVmstateCheckpointSequence,
     );
-    try parseRegistryShapeFields(object, request);
 }
 
 fn parseRegistryShapeFields(
@@ -2930,6 +3018,41 @@ fn parseRegistryVmstateFields(
         object,
         "registryNested",
         error.InvalidRegistryNested,
+    );
+    request.registry_host_platform = try optionalStringDefaultNull(
+        object,
+        "registryHostPlatform",
+        error.InvalidRegistryHostPlatform,
+    );
+    request.registry_vmm_binary = try optionalStringDefaultNull(
+        object,
+        "registryVmmBinary",
+        error.InvalidRegistryVmmBinary,
+    );
+    request.registry_vmm_pdeathsig = try optionalBoolDefaultFalse(
+        object,
+        "registryVmmPdeathsig",
+        error.InvalidRegistryVmmPdeathsig,
+    );
+    request.registry_vmm_observed_exe_base = try optionalStringDefaultNull(
+        object,
+        "registryVmmObservedExeBase",
+        error.InvalidRegistryVmmObservedExeBase,
+    );
+    request.registry_gv_pid_text = try optionalStringDefaultNull(
+        object,
+        "registryGvPid",
+        error.InvalidRegistryGvPid,
+    );
+    request.registry_gv_exe = try optionalStringDefaultNull(
+        object,
+        "registryGvExe",
+        error.InvalidRegistryGvExe,
+    );
+    request.registry_gv_observed_exe_base = try optionalStringDefaultNull(
+        object,
+        "registryGvObservedExeBase",
+        error.InvalidRegistryGvObservedExeBase,
     );
 }
 
@@ -3121,7 +3244,10 @@ fn optionalRestoreLiveMountsRecorded(
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidRestoreLiveMountsRecorded;
-        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        try protocol.rejectUnknownFields(
+            item.object,
+            &.{ "host", "guest", "mode", "sync", "cache" },
+        );
         const host = item.object.get("host") orelse return error.InvalidRestoreLiveMountsRecorded;
         const guest = item.object.get("guest") orelse return error.InvalidRestoreLiveMountsRecorded;
         const mode = item.object.get("mode") orelse return error.InvalidRestoreLiveMountsRecorded;
@@ -3129,7 +3255,11 @@ fn optionalRestoreLiveMountsRecorded(
             return error.InvalidRestoreLiveMountsRecorded;
         }
         if (!isLiveMountMode(mode.string)) return error.InvalidRestoreLiveMountsRecorded;
-        try mounts.append(allocator, .{ .host = host.string, .guest = guest.string, .mode = mode.string });
+        try mounts.append(allocator, .{
+            .host = host.string,
+            .guest = guest.string,
+            .mode = mode.string,
+        });
     }
     return mounts.toOwnedSlice(allocator);
 }
@@ -3149,7 +3279,9 @@ fn optionalRestoreLiveMountsOverrides(
         if (item != .object) return error.InvalidRestoreLiveMountsOverrides;
         try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
         const host = item.object.get("host") orelse return error.InvalidRestoreLiveMountsOverrides;
-        const guest = item.object.get("guest") orelse return error.InvalidRestoreLiveMountsOverrides;
+        const guest = item.object.get("guest") orelse {
+            return error.InvalidRestoreLiveMountsOverrides;
+        };
         const mode = item.object.get("mode") orelse .null;
         if (host != .string or guest != .string) return error.InvalidRestoreLiveMountsOverrides;
         if (mode != .null and (mode != .string or !isLiveMountMode(mode.string))) {
@@ -3444,7 +3576,7 @@ fn writeRestoreLiveMountOverrideError(
         "BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN",
         try std.fmt.bufPrint(
             &buf,
-            "restore: liveMounts override for guest={s} doesn't match any recorded mount; recorded includes {s}",
+            "restore: liveMounts override guest={s} has no recorded mount; recorded includes {s}",
             .{ guest, recorded },
         ),
     );
@@ -3684,6 +3816,32 @@ fn writeBootError(io: std.Io, code: []const u8, message: []const u8) !void {
 fn writeRequestError(io: std.Io, err: RequestError) !void {
     assert(@errorName(err).len > 0);
     if (try protocol.writeCommonRequestError(io, err)) return;
+    if (try writePortForwardRequestError(io, err)) return;
+    if (try writeSnapshotRequestError(io, err)) return;
+    if (try writeLiveMountRequestError(io, err)) return;
+
+    switch (err) {
+        error.InvalidResourcesCpuMaxVcpus => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.maxVcpus must be a positive integer",
+        ),
+        error.InvalidResourcesCpuQuotaCpus => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.quotaCpus must be > 0 when set",
+        ),
+        error.InvalidResourcesCpuWeight => try protocol.writeError(
+            io,
+            "BOOT_CPU_INVALID",
+            "boot: resources.cpu.weight must be an integer in 1..10000",
+        ),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}
+
+fn writePortForwardRequestError(io: std.Io, err: RequestError) !bool {
+    assert(@errorName(err).len > 0);
 
     switch (err) {
         error.InvalidPortForward,
@@ -3704,11 +3862,22 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             "BOOT_PORT_FORWARD_NO_GVPROXY",
             "boot-plan gvproxy planning flag must be a boolean",
         ),
-        error.InvalidGvproxyNetSocket, error.InvalidGvproxyPath => try protocol.writeError(
+        error.InvalidGvproxyNetSocket,
+        error.InvalidGvproxyPath,
+        => try protocol.writeError(
             io,
             "BOOT_PORT_FORWARD_NO_GVPROXY",
             "boot-plan gvproxy fields must be strings",
         ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writeSnapshotRequestError(io: std.Io, err: RequestError) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
         error.InvalidSnapshotMountGuest,
         error.InvalidSnapshotMountLowerPath,
         error.InvalidSnapshotMountUpperPath,
@@ -3726,27 +3895,21 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             "INVALID_REQUEST",
             "boot-plan snapshot vmstate checkpoint sequence must be a decimal integer",
         ),
+        else => return false,
+    }
+    return true;
+}
+
+fn writeLiveMountRequestError(io: std.Io, err: RequestError) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
         error.InvalidLiveMounts,
         error.InvalidLiveMountGuest,
         => try protocol.writeError(
             io,
             "BOOT_MOUNT_INVALID",
             "liveMounts: entries must include host and guest paths",
-        ),
-        error.InvalidResourcesCpuMaxVcpus => try protocol.writeError(
-            io,
-            "BOOT_CPU_INVALID",
-            "boot: resources.cpu.maxVcpus must be a positive integer",
-        ),
-        error.InvalidResourcesCpuQuotaCpus => try protocol.writeError(
-            io,
-            "BOOT_CPU_INVALID",
-            "boot: resources.cpu.quotaCpus must be > 0 when set",
-        ),
-        error.InvalidResourcesCpuWeight => try protocol.writeError(
-            io,
-            "BOOT_CPU_INVALID",
-            "boot: resources.cpu.weight must be an integer in 1..10000",
         ),
         error.InvalidLiveMountsResolved,
         error.InvalidConfigLiveMounts,
@@ -3771,6 +3934,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             "BOOT_MOUNT_INVALID",
             "restore liveMount entries must include host, guest, and valid mode fields",
         ),
-        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+        else => return false,
     }
+    return true;
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -52,6 +52,8 @@ const ParsedRequest = struct {
     live_mounts: []const boot_plan.LiveMountInput = &.{},
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
     batch_live_mount_validation_required: bool = false,
+    restore_live_mounts_recorded: []const boot_plan.RestoreRecordedLiveMount = &.{},
+    restore_live_mounts_overrides: []const boot_plan.RestoreLiveMountInput = &.{},
     existing_stats_file: ?[]const u8 = null,
     stats_file_path: ?[]const u8 = null,
     stats_file_temp_dir: ?[]const u8 = null,
@@ -192,6 +194,8 @@ const boot_plan_fields = [_][]const u8{
     "liveMounts",
     "liveMountsResolved",
     "batchLiveMountValidationRequired",
+    "restoreLiveMountsRecorded",
+    "restoreLiveMountsOverrides",
     "existingStatsFile",
     "statsFilePath",
     "statsFileTempDir",
@@ -342,6 +346,8 @@ const RequestError = error{
     InvalidLiveMountMode,
     InvalidLiveMountTag,
     InvalidBatchLiveMountValidationRequired,
+    InvalidRestoreLiveMountsRecorded,
+    InvalidRestoreLiveMountsOverrides,
     InvalidExistingStatsFile,
     InvalidStatsFilePath,
     InvalidStatsFileTempDir,
@@ -439,6 +445,10 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
     if (try writePortForwardFailure(io, parsed.port_forward)) return .fail;
 
     const parts = makePlanParts(arena, parsed, plan) catch |err| {
+        if (err == error.RestoreLiveMountOverrideUnknown) {
+            try writeRestoreLiveMountOverrideError(arena, io, parsed);
+            return .fail;
+        }
         try writePlanError(io, err);
         return .fail;
     };
@@ -462,6 +472,7 @@ const PlanParts = struct {
     nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
     batch_live_mount_sync: boot_plan.BatchLiveMountPlan,
+    restore_live_mounts: []const boot_plan.RestoreLiveMountInput,
     stats_file: boot_plan.StatsFilePlan,
     planned_live_mounts: []const boot_plan.LiveMount,
     config_cmd: []const []const u8,
@@ -507,6 +518,7 @@ const BootEnvParts = struct {
     nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
     batch_live_mount_sync: boot_plan.BatchLiveMountPlan,
+    restore_live_mounts: []const boot_plan.RestoreLiveMountInput,
     stats_file: boot_plan.StatsFilePlan,
 };
 
@@ -550,6 +562,7 @@ fn makePlanParts(
         .nested_env = boot_env.nested_env,
         .virtiofs_env = boot_env.virtiofs_env,
         .batch_live_mount_sync = boot_env.batch_live_mount_sync,
+        .restore_live_mounts = boot_env.restore_live_mounts,
         .stats_file = boot_env.stats_file,
         .planned_live_mounts = runtime.planned_live_mounts,
         .config_cmd = runtime.config_cmd,
@@ -627,12 +640,27 @@ fn makeBootEnvParts(arena: std.mem.Allocator, parsed: ParsedRequest) !BootEnvPar
             .vsock_uds_path = parsed.vsock_uds_path,
             .validation_required = parsed.batch_live_mount_validation_required,
         }),
+        .restore_live_mounts = try makeRestoreLiveMounts(arena, parsed),
         .stats_file = try boot_plan.planStatsFile(arena, .{
             .existing_path = parsed.existing_stats_file,
             .planned_path = parsed.stats_file_path,
             .planned_temp_dir = parsed.stats_file_temp_dir,
         }),
     };
+}
+
+fn makeRestoreLiveMounts(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) ![]const boot_plan.RestoreLiveMountInput {
+    assert(@sizeOf(boot_plan.RestoreLiveMountPlanInput) > 0);
+
+    const plan = try boot_plan.planRestoreLiveMounts(arena, .{
+        .recorded = parsed.restore_live_mounts_recorded,
+        .overrides = parsed.restore_live_mounts_overrides,
+    });
+    if (plan.unknown_guest != null) return error.RestoreLiveMountOverrideUnknown;
+    return plan.mounts;
 }
 
 fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimeParts {
@@ -963,6 +991,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
         parts.batch_live_mount_sync.sync_required,
         true,
     );
+    try writeRestoreLiveMountsField(io, "restoreLiveMounts", parts.restore_live_mounts, true);
     try writeNullableStringField(io, "vmmNested", parts.nested_env, true);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
     try writePortForwardField(io, "plannedPortForward", parts.planned_port_forwards, false, true);
@@ -1087,6 +1116,27 @@ fn writeGuestHostnameField(
     const hostname = boot_plan.formatGuestHostname(&buffer, input) catch
         return error.InvalidGuestHostnameName;
     try writeNullableStringField(io, field, hostname, comma);
+}
+
+fn writeRestoreLiveMountsField(
+    io: std.Io,
+    comptime field: []const u8,
+    mounts: []const boot_plan.RestoreLiveMountInput,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mounts, 0..) |mount, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{");
+        try writeNullableStringField(io, "host", mount.host, false);
+        try writeNullableStringField(io, "guest", mount.guest, true);
+        if (mount.mode) |mode| try writeNullableStringField(io, "mode", mode, true);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
 }
 
 fn writeVmstateRuntimeField(
@@ -2116,6 +2166,14 @@ fn parseRuntimeMountStatsFields(
         "batchLiveMountValidationRequired",
         error.InvalidBatchLiveMountValidationRequired,
     );
+    request.restore_live_mounts_recorded = try optionalRestoreLiveMountsRecorded(
+        allocator,
+        object,
+    );
+    request.restore_live_mounts_overrides = try optionalRestoreLiveMountsOverrides(
+        allocator,
+        object,
+    );
     request.existing_stats_file = try optionalStringDefaultNull(
         object,
         "existingStatsFile",
@@ -2813,6 +2871,68 @@ fn optionalLiveMountsResolved(
     return mounts.toOwnedSlice(allocator);
 }
 
+fn optionalRestoreLiveMountsRecorded(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError![]const boot_plan.RestoreRecordedLiveMount {
+    assert(@sizeOf(boot_plan.RestoreRecordedLiveMount) > 0);
+
+    const value = object.get("restoreLiveMountsRecorded") orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return error.InvalidRestoreLiveMountsRecorded;
+    var mounts: std.array_list.Aligned(boot_plan.RestoreRecordedLiveMount, null) = .empty;
+    errdefer mounts.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .object) return error.InvalidRestoreLiveMountsRecorded;
+        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        const host = item.object.get("host") orelse return error.InvalidRestoreLiveMountsRecorded;
+        const guest = item.object.get("guest") orelse return error.InvalidRestoreLiveMountsRecorded;
+        const mode = item.object.get("mode") orelse return error.InvalidRestoreLiveMountsRecorded;
+        if (host != .string or guest != .string or mode != .string) {
+            return error.InvalidRestoreLiveMountsRecorded;
+        }
+        if (!isLiveMountMode(mode.string)) return error.InvalidRestoreLiveMountsRecorded;
+        try mounts.append(allocator, .{ .host = host.string, .guest = guest.string, .mode = mode.string });
+    }
+    return mounts.toOwnedSlice(allocator);
+}
+
+fn optionalRestoreLiveMountsOverrides(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError![]const boot_plan.RestoreLiveMountInput {
+    assert(@sizeOf(boot_plan.RestoreLiveMountInput) > 0);
+
+    const value = object.get("restoreLiveMountsOverrides") orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return error.InvalidRestoreLiveMountsOverrides;
+    var mounts: std.array_list.Aligned(boot_plan.RestoreLiveMountInput, null) = .empty;
+    errdefer mounts.deinit(allocator);
+    for (value.array.items) |item| {
+        if (item != .object) return error.InvalidRestoreLiveMountsOverrides;
+        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        const host = item.object.get("host") orelse return error.InvalidRestoreLiveMountsOverrides;
+        const guest = item.object.get("guest") orelse return error.InvalidRestoreLiveMountsOverrides;
+        const mode = item.object.get("mode") orelse .null;
+        if (host != .string or guest != .string) return error.InvalidRestoreLiveMountsOverrides;
+        if (mode != .null and (mode != .string or !isLiveMountMode(mode.string))) {
+            return error.InvalidRestoreLiveMountsOverrides;
+        }
+        try mounts.append(allocator, .{
+            .host = host.string,
+            .guest = guest.string,
+            .mode = if (mode == .string) mode.string else null,
+        });
+    }
+    return mounts.toOwnedSlice(allocator);
+}
+
+fn isLiveMountMode(mode: []const u8) bool {
+    assert(mode.len > 0);
+
+    return std.mem.eql(u8, mode, "ro") or std.mem.eql(u8, mode, "rw");
+}
+
 fn optionalBoolDefaultNull(
     object: std.json.ObjectMap,
     field: []const u8,
@@ -3062,6 +3182,34 @@ fn writeDuplicateHostPort(io: std.Io, port: u16) !void {
         io,
         "BOOT_PORT_FORWARD_CONFLICT",
         try std.fmt.bufPrint(&buf, "portForward: duplicate hostPort {d}", .{port}),
+    );
+}
+
+fn writeRestoreLiveMountOverrideError(
+    arena: std.mem.Allocator,
+    io: std.Io,
+    parsed: ParsedRequest,
+) !void {
+    assert(parsed.restore_live_mounts_overrides.len > 0);
+
+    const plan = try boot_plan.planRestoreLiveMounts(arena, .{
+        .recorded = parsed.restore_live_mounts_recorded,
+        .overrides = parsed.restore_live_mounts_overrides,
+    });
+    const guest = plan.unknown_guest orelse "<unknown>";
+    const recorded = if (parsed.restore_live_mounts_recorded.len > 0)
+        parsed.restore_live_mounts_recorded[0].guest
+    else
+        "<none>";
+    var buf: [512]u8 = undefined;
+    try protocol.writeError(
+        io,
+        "BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN",
+        try std.fmt.bufPrint(
+            &buf,
+            "restore: liveMounts override for guest={s} doesn't match any recorded mount; recorded includes {s}",
+            .{ guest, recorded },
+        ),
     );
 }
 
@@ -3331,6 +3479,13 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_MOUNT_INVALID",
             "boot-plan batch live mount validation flag must be a boolean",
+        ),
+        error.InvalidRestoreLiveMountsRecorded,
+        error.InvalidRestoreLiveMountsOverrides,
+        => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "restore liveMount entries must include host, guest, and valid mode fields",
         ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -28,6 +28,9 @@ const ParsedRequest = struct {
     auto_vsock_temp_dir: ?[]const u8 = null,
     port_forward: []const boot_plan.PortForwardMapping = &.{},
     port_forward_net_socket: ?[]const u8 = null,
+    gvproxy_planning_required: bool = false,
+    gvproxy_net_socket: ?[]const u8 = null,
+    gvproxy_path: ?[]const u8 = null,
     vmm_binary: ?[]const u8 = null,
     vmm_args: []const []const u8 = &.{},
     guest_hostname_pid_text: ?[]const u8 = null,
@@ -171,6 +174,9 @@ const boot_plan_fields = [_][]const u8{
     "autoVsockTempDir",
     "portForward",
     "portForwardNetSocket",
+    "gvproxyPlanningRequired",
+    "gvproxyNetSocket",
+    "gvproxyPath",
     "vmmBinary",
     "vmmArgs",
     "guestHostnamePid",
@@ -320,6 +326,9 @@ const RequestError = error{
     InvalidHostPort,
     InvalidGuestPort,
     InvalidPortForwardNetSocket,
+    InvalidGvproxyPlanningRequired,
+    InvalidGvproxyNetSocket,
+    InvalidGvproxyPath,
     InvalidVmmBinary,
     InvalidVmmArgs,
     InvalidGuestHostnamePid,
@@ -468,6 +477,7 @@ const PlanParts = struct {
     cpu_policy: ?boot_plan.CpuPolicyPlan,
     guest_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
+    gvproxy_plan: boot_plan.GvproxyPlan,
     guest_hostname: boot_plan.GuestHostnameInput,
     vmm_argv: boot_plan.VmmArgvPlan,
     use_pdeathsig: bool,
@@ -516,6 +526,7 @@ fn makeCorePlan(
 
 const BootEnvParts = struct {
     vsock_plan: boot_plan.VsockPlan,
+    gvproxy_plan: boot_plan.GvproxyPlan,
     vmm_argv: boot_plan.VmmArgvPlan,
     use_pdeathsig: bool,
     kernel_dtb: boot_plan.KernelDtbPlan,
@@ -559,6 +570,7 @@ fn makePlanParts(
         .guest_env = try makeGuestEnv(arena, parsed),
         .guest_hostname = try makeGuestHostname(parsed),
         .vsock_plan = boot_env.vsock_plan,
+        .gvproxy_plan = boot_env.gvproxy_plan,
         .vmm_argv = boot_env.vmm_argv,
         .use_pdeathsig = boot_env.use_pdeathsig,
         .planned_port_forwards = parsed.port_forward,
@@ -610,6 +622,12 @@ fn makeBootEnvParts(arena: std.mem.Allocator, parsed: ParsedRequest) !BootEnvPar
             .existing_spec = parsed.existing_vsock_spec,
             .auto_uds_path = parsed.auto_vsock_uds_path,
             .auto_temp_dir = parsed.auto_vsock_temp_dir,
+        }),
+        .gvproxy_plan = try boot_plan.planGvproxy(.{
+            .planning_required = parsed.gvproxy_planning_required,
+            .existing_net_socket = parsed.gvproxy_net_socket,
+            .gvproxy_path = parsed.gvproxy_path,
+            .port_forwards = parsed.port_forward,
         }),
         .vmm_argv = try boot_plan.planVmmArgv(arena, .{
             .binary = parsed.vmm_binary,
@@ -1000,6 +1018,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
     try writeCoreFields(io, parts.plan, parts.cpu_policy);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
+    try writeGvproxyPlanField(io, "gvproxyPlan", parts.gvproxy_plan, true);
     try writeNullableStringField(io, "vmmInitrd", parts.initrd_env.vmm_initrd, true);
     try writeGuestHostnameField(io, "guestHostname", parts.guest_hostname, true);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
@@ -1121,6 +1140,21 @@ fn writeVsockKernelFields(
     try writeNullableStringField(io, "vmmVsock", vsock_plan.vmm_vsock, true);
     try writeNullableStringField(io, "vmmKernel", kernel_dtb.vmm_kernel, true);
     try writeNullableStringField(io, "vmmDtb", kernel_dtb.vmm_dtb, true);
+}
+
+fn writeGvproxyPlanField(
+    io: std.Io,
+    comptime field: []const u8,
+    plan: boot_plan.GvproxyPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "action", plan.action, false);
+    try writeNullableStringField(io, "gvproxyPath", plan.gvproxy_path, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeGuestHostnameField(
@@ -2057,6 +2091,21 @@ fn parseVmmLaunchFields(
         object,
         "portForwardNetSocket",
         error.InvalidPortForwardNetSocket,
+    );
+    request.gvproxy_planning_required = try optionalBoolDefaultFalse(
+        object,
+        "gvproxyPlanningRequired",
+        error.InvalidGvproxyPlanningRequired,
+    );
+    request.gvproxy_net_socket = try optionalStringDefaultNull(
+        object,
+        "gvproxyNetSocket",
+        error.InvalidGvproxyNetSocket,
+    );
+    request.gvproxy_path = try optionalStringDefaultNull(
+        object,
+        "gvproxyPath",
+        error.InvalidGvproxyPath,
     );
     request.vmm_binary = try optionalStringDefaultNull(object, "vmmBinary", error.InvalidVmmBinary);
     request.vmm_args = try optionalStringArrayDefaultEmpty(
@@ -3381,6 +3430,11 @@ fn writeEnvPlanError(io: std.Io, err: anyerror) !bool {
             "BOOT_MOUNT_INVALID",
             "liveMounts: writable mounts require the exec vsock bridge for batched sync",
         ),
+        error.MissingGvproxy => try writeBootError(
+            io,
+            "BOOT_PORT_FORWARD_NO_GVPROXY",
+            "portForward requires gvproxy, but no gvproxy binary was found",
+        ),
         error.InvalidGuestEnvValue => try writeBootError(
             io,
             "INVALID_REQUEST",
@@ -3470,6 +3524,16 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_PORT_FORWARD_INVALID",
             "boot-plan portForward net socket field must be a string",
+        ),
+        error.InvalidGvproxyPlanningRequired => try protocol.writeError(
+            io,
+            "BOOT_PORT_FORWARD_NO_GVPROXY",
+            "boot-plan gvproxy planning flag must be a boolean",
+        ),
+        error.InvalidGvproxyNetSocket, error.InvalidGvproxyPath => try protocol.writeError(
+            io,
+            "BOOT_PORT_FORWARD_NO_GVPROXY",
+            "boot-plan gvproxy fields must be strings",
         ),
         error.InvalidLiveMounts,
         error.InvalidLiveMountGuest,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -51,6 +51,7 @@ const ParsedRequest = struct {
     nested_requested: bool = false,
     live_mounts: []const boot_plan.LiveMountInput = &.{},
     live_mounts_resolved: []const boot_plan.LiveMount = &.{},
+    batch_live_mount_validation_required: bool = false,
     existing_stats_file: ?[]const u8 = null,
     stats_file_path: ?[]const u8 = null,
     stats_file_temp_dir: ?[]const u8 = null,
@@ -190,6 +191,7 @@ const boot_plan_fields = [_][]const u8{
     "nested",
     "liveMounts",
     "liveMountsResolved",
+    "batchLiveMountValidationRequired",
     "existingStatsFile",
     "statsFilePath",
     "statsFileTempDir",
@@ -339,6 +341,7 @@ const RequestError = error{
     InvalidLiveMountHost,
     InvalidLiveMountMode,
     InvalidLiveMountTag,
+    InvalidBatchLiveMountValidationRequired,
     InvalidExistingStatsFile,
     InvalidStatsFilePath,
     InvalidStatsFileTempDir,
@@ -458,6 +461,7 @@ const PlanParts = struct {
     vmstate_runtime: boot_plan.VmstateRuntimePlan,
     nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
+    batch_live_mount_sync: boot_plan.BatchLiveMountPlan,
     stats_file: boot_plan.StatsFilePlan,
     planned_live_mounts: []const boot_plan.LiveMount,
     config_cmd: []const []const u8,
@@ -502,6 +506,7 @@ const BootEnvParts = struct {
     vmstate_runtime: boot_plan.VmstateRuntimePlan,
     nested_env: ?[]const u8,
     virtiofs_env: []const boot_plan.EnvPair,
+    batch_live_mount_sync: boot_plan.BatchLiveMountPlan,
     stats_file: boot_plan.StatsFilePlan,
 };
 
@@ -544,6 +549,7 @@ fn makePlanParts(
         .vmstate_runtime = boot_env.vmstate_runtime,
         .nested_env = boot_env.nested_env,
         .virtiofs_env = boot_env.virtiofs_env,
+        .batch_live_mount_sync = boot_env.batch_live_mount_sync,
         .stats_file = boot_env.stats_file,
         .planned_live_mounts = runtime.planned_live_mounts,
         .config_cmd = runtime.config_cmd,
@@ -616,6 +622,11 @@ fn makeBootEnvParts(arena: std.mem.Allocator, parsed: ParsedRequest) !BootEnvPar
         }),
         .nested_env = boot_plan.planNestedEnv(parsed.nested_requested),
         .virtiofs_env = try boot_plan.planVirtiofsEnv(arena, parsed.live_mounts_resolved),
+        .batch_live_mount_sync = try boot_plan.planBatchLiveMountSync(.{
+            .live_mounts = parsed.live_mounts_resolved,
+            .vsock_uds_path = parsed.vsock_uds_path,
+            .validation_required = parsed.batch_live_mount_validation_required,
+        }),
         .stats_file = try boot_plan.planStatsFile(arena, .{
             .existing_path = parsed.existing_stats_file,
             .planned_path = parsed.stats_file_path,
@@ -946,6 +957,12 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeGuestHostnameField(io, "guestHostname", parts.guest_hostname, true);
     try writeVmstateStatsFields(io, parts.vmstate_env, parts.stats_file);
     try writeVmstateRuntimeField(io, "vmstateRuntime", parts.vmstate_runtime, true);
+    try writeBoolField(
+        io,
+        "batchLiveMountSyncRequired",
+        parts.batch_live_mount_sync.sync_required,
+        true,
+    );
     try writeNullableStringField(io, "vmmNested", parts.nested_env, true);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
     try writePortForwardField(io, "plannedPortForward", parts.planned_port_forwards, false, true);
@@ -2094,6 +2111,11 @@ fn parseRuntimeMountStatsFields(
         "liveMountsResolved",
         error.InvalidLiveMountsResolved,
     );
+    request.batch_live_mount_validation_required = try optionalBoolDefaultFalse(
+        object,
+        "batchLiveMountValidationRequired",
+        error.InvalidBatchLiveMountValidationRequired,
+    );
     request.existing_stats_file = try optionalStringDefaultNull(
         object,
         "existingStatsFile",
@@ -3182,6 +3204,11 @@ fn writeEnvPlanError(io: std.Io, err: anyerror) !bool {
             "BOOT_MOUNT_INVALID",
             "liveMounts: mode must be ro or rw",
         ),
+        error.MissingBatchLiveMountVsock => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "liveMounts: writable mounts require the exec vsock bridge for batched sync",
+        ),
         error.InvalidGuestEnvValue => try writeBootError(
             io,
             "INVALID_REQUEST",
@@ -3299,6 +3326,11 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_MOUNT_INVALID",
             "liveMounts: resolved entries must include host, guest, tag, and mode ro/rw",
+        ),
+        error.InvalidBatchLiveMountValidationRequired => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "boot-plan batch live mount validation flag must be a boolean",
         ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -110,6 +110,14 @@ const ParsedRequest = struct {
     mount_disk_upper_size_text: ?[]const u8 = null,
     mount_disk_lower_fd_text: ?[]const u8 = null,
     mount_disk_upper_fd_text: ?[]const u8 = null,
+    snapshot_mount_guest: ?[]const u8 = null,
+    snapshot_mount_lower_path: ?[]const u8 = null,
+    snapshot_mount_upper_path: ?[]const u8 = null,
+    snapshot_live_mounts: []const boot_plan.LiveMount = &.{},
+    snapshot_vmstate_path: ?[]const u8 = null,
+    snapshot_vmstate_chain_id: ?[]const u8 = null,
+    snapshot_vmstate_checkpoint_parent: ?[]const u8 = null,
+    snapshot_vmstate_checkpoint_sequence_text: ?[]const u8 = null,
     registry_source_image_path: ?[]const u8 = null,
     registry_per_boot_root_disk: ?[]const u8 = null,
     registry_caller_root_disk_path: ?[]const u8 = null,
@@ -256,6 +264,14 @@ const boot_plan_fields = [_][]const u8{
     "mountDiskUpperSize",
     "mountDiskLowerFd",
     "mountDiskUpperFd",
+    "snapshotMountGuest",
+    "snapshotMountLowerPath",
+    "snapshotMountUpperPath",
+    "snapshotLiveMounts",
+    "snapshotVmstatePath",
+    "snapshotVmstateChainId",
+    "snapshotVmstateCheckpointParent",
+    "snapshotVmstateCheckpointSequence",
     "registrySourceImagePath",
     "registryPerBootRootDisk",
     "registryCallerRootDiskPath",
@@ -415,6 +431,14 @@ const RequestError = error{
     InvalidMountDiskUpperSize,
     InvalidMountDiskLowerFd,
     InvalidMountDiskUpperFd,
+    InvalidSnapshotMountGuest,
+    InvalidSnapshotMountLowerPath,
+    InvalidSnapshotMountUpperPath,
+    InvalidSnapshotLiveMounts,
+    InvalidSnapshotVmstatePath,
+    InvalidSnapshotVmstateChainId,
+    InvalidSnapshotVmstateCheckpointParent,
+    InvalidSnapshotVmstateCheckpointSequence,
     InvalidRegistrySourceImagePath,
     InvalidRegistryRootDiskPath,
     InvalidRegistryBootLogRoot,
@@ -510,6 +534,7 @@ const PlanParts = struct {
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
     mount_disk_fd_env: []const boot_plan.EnvPair,
+    snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
 };
 
@@ -552,6 +577,7 @@ const RuntimeParts = struct {
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
     mount_disk_fd_env: []const boot_plan.EnvPair,
+    snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
 };
 
@@ -610,6 +636,7 @@ fn makePlanParts(
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
         .mount_disk_fd_env = runtime.mount_disk_fd_env,
+        .snapshot_context = runtime.snapshot_context,
         .registry_shape = runtime.registry_shape,
     };
 }
@@ -708,6 +735,7 @@ fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimePar
         .root_disk_runtime = disks.root,
         .mount_disk_runtime = disks.mount,
         .mount_disk_fd_env = try makeMountDiskFdEnv(arena, parsed),
+        .snapshot_context = try makeSnapshotContext(arena, parsed),
         .registry_shape = try makeRegistryShape(arena, parsed),
     };
 }
@@ -925,6 +953,31 @@ fn makeMountDiskFdEnv(
     return boot_plan.planMountDiskFdEnv(allocator, .{ .lower_fd = lower_fd, .upper_fd = upper_fd });
 }
 
+fn makeSnapshotContext(
+    allocator: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.SnapshotContextPlan {
+    assert(@sizeOf(boot_plan.SnapshotContextInput) > 0);
+
+    return boot_plan.planSnapshotContext(allocator, .{
+        .mount_disk = .{
+            .guest = parsed.snapshot_mount_guest,
+            .lower_path = parsed.snapshot_mount_lower_path,
+            .upper_path = parsed.snapshot_mount_upper_path,
+        },
+        .live_mounts = parsed.snapshot_live_mounts,
+        .vmstate = .{
+            .state_path = parsed.snapshot_vmstate_path,
+            .chain_id = parsed.snapshot_vmstate_chain_id,
+            .checkpoint_parent = parsed.snapshot_vmstate_checkpoint_parent,
+            .checkpoint_sequence = try optionalUnsignedText(
+                parsed.snapshot_vmstate_checkpoint_sequence_text,
+                error.InvalidSnapshotVmstateCheckpointSequence,
+            ),
+        },
+    });
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -1058,6 +1111,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
     try writeEnvObjectField(io, "mountDiskFdEnv", parts.mount_disk_fd_env, true);
+    try writeSnapshotContextField(io, "snapshotContext", parts.snapshot_context, true);
     try writeRegistryShapeField(io, "registryShape", parts.registry_shape, true);
     try protocol.stdout(io, "}}\n");
 }
@@ -1581,6 +1635,73 @@ fn writeConfigLiveMountsField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeSnapshotContextField(
+    io: std.Io,
+    comptime field: []const u8,
+    context: boot_plan.SnapshotContextPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeSnapshotMountDiskField(io, "mountDisk", context.mount_disk, false);
+    try writeSnapshotLiveMountsField(io, "liveMounts", context.live_mounts, true);
+    try writeSnapshotVmstateChainField(io, "vmstateChain", context.vmstate_chain, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeSnapshotMountDiskField(
+    io: std.Io,
+    comptime field: []const u8,
+    mount: ?boot_plan.SnapshotMountDiskPlan,
+    comma: bool,
+) !void {
+    try writeFieldName(io, field, comma);
+    if (mount) |disk| {
+        try protocol.stdout(io, "{");
+        try writeNullableStringField(io, "guest", disk.guest, false);
+        try writeNullableStringField(io, "lowerPath", disk.lower_path, true);
+        try writeNullableStringField(io, "upperPath", disk.upper_path, true);
+        try protocol.stdout(io, "}");
+    } else try protocol.stdout(io, "null");
+}
+
+fn writeSnapshotLiveMountsField(
+    io: std.Io,
+    comptime field: []const u8,
+    mounts: []const boot_plan.SnapshotLiveMountPlan,
+    comma: bool,
+) !void {
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mounts, 0..) |mount, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{");
+        try writeNullableStringField(io, "host", mount.host, false);
+        try writeNullableStringField(io, "guest", mount.guest, true);
+        try writeNullableStringField(io, "mode", mount.mode, true);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
+}
+
+fn writeSnapshotVmstateChainField(
+    io: std.Io,
+    comptime field: []const u8,
+    chain: ?boot_plan.SnapshotVmstateChainPlan,
+    comma: bool,
+) !void {
+    try writeFieldName(io, field, comma);
+    if (chain) |vmstate| {
+        try protocol.stdout(io, "{");
+        try writeNullableStringField(io, "chainId", vmstate.chain_id, false);
+        try writeNullableStringField(io, "parentDir", vmstate.parent_dir, true);
+        try writeU64Field(io, "sequence", vmstate.sequence, true);
+        try protocol.stdout(io, "}");
+    } else try protocol.stdout(io, "null");
 }
 
 fn writeRegistryShapeField(
@@ -2150,7 +2271,7 @@ fn parseKernelVmstateFields(
     try parseConfigFields(allocator, object, request);
     try parseBundleFields(allocator, object, request);
     try parseProvisionFields(allocator, object, request);
-    try parseDiskRuntimeFields(object, request);
+    try parseDiskRuntimeFields(allocator, object, request);
 }
 
 fn parseKernelFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
@@ -2492,6 +2613,7 @@ fn parseProvisionImageConfigFields(
 }
 
 fn parseDiskRuntimeFields(
+    allocator: std.mem.Allocator,
     object: std.json.ObjectMap,
     request: *ParsedRequest,
 ) RequestError!void {
@@ -2499,7 +2621,7 @@ fn parseDiskRuntimeFields(
 
     try parseScratchFields(object, request);
     try parseRootDiskRuntimeFields(object, request);
-    try parseMountDiskRuntimeFields(object, request);
+    try parseMountDiskRuntimeFields(allocator, object, request);
 }
 
 fn parseScratchFields(object: std.json.ObjectMap, request: *ParsedRequest) RequestError!void {
@@ -2543,6 +2665,7 @@ fn parseRootDiskRuntimeFields(
 }
 
 fn parseMountDiskRuntimeFields(
+    allocator: std.mem.Allocator,
     object: std.json.ObjectMap,
     request: *ParsedRequest,
 ) RequestError!void {
@@ -2583,6 +2706,47 @@ fn parseMountDiskRuntimeFields(
         object,
         "mountDiskUpperFd",
         error.InvalidMountDiskUpperFd,
+    );
+    request.snapshot_mount_guest = try optionalStringDefaultNull(
+        object,
+        "snapshotMountGuest",
+        error.InvalidSnapshotMountGuest,
+    );
+    request.snapshot_mount_lower_path = try optionalStringDefaultNull(
+        object,
+        "snapshotMountLowerPath",
+        error.InvalidSnapshotMountLowerPath,
+    );
+    request.snapshot_mount_upper_path = try optionalStringDefaultNull(
+        object,
+        "snapshotMountUpperPath",
+        error.InvalidSnapshotMountUpperPath,
+    );
+    request.snapshot_live_mounts = try optionalLiveMountsResolved(
+        allocator,
+        object,
+        "snapshotLiveMounts",
+        error.InvalidSnapshotLiveMounts,
+    );
+    request.snapshot_vmstate_path = try optionalStringDefaultNull(
+        object,
+        "snapshotVmstatePath",
+        error.InvalidSnapshotVmstatePath,
+    );
+    request.snapshot_vmstate_chain_id = try optionalStringDefaultNull(
+        object,
+        "snapshotVmstateChainId",
+        error.InvalidSnapshotVmstateChainId,
+    );
+    request.snapshot_vmstate_checkpoint_parent = try optionalStringDefaultNull(
+        object,
+        "snapshotVmstateCheckpointParent",
+        error.InvalidSnapshotVmstateCheckpointParent,
+    );
+    request.snapshot_vmstate_checkpoint_sequence_text = try optionalStringDefaultNull(
+        object,
+        "snapshotVmstateCheckpointSequence",
+        error.InvalidSnapshotVmstateCheckpointSequence,
     );
     try parseRegistryShapeFields(object, request);
 }
@@ -3435,6 +3599,16 @@ fn writeEnvPlanError(io: std.Io, err: anyerror) !bool {
             "BOOT_PORT_FORWARD_NO_GVPROXY",
             "portForward requires gvproxy, but no gvproxy binary was found",
         ),
+        error.MissingSnapshotMountDiskField => try writeBootError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan snapshot mountDisk fields are incomplete",
+        ),
+        error.MissingSnapshotVmstateField => try writeBootError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan snapshot vmstate fields are incomplete",
+        ),
         error.InvalidGuestEnvValue => try writeBootError(
             io,
             "INVALID_REQUEST",
@@ -3534,6 +3708,23 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
             io,
             "BOOT_PORT_FORWARD_NO_GVPROXY",
             "boot-plan gvproxy fields must be strings",
+        ),
+        error.InvalidSnapshotMountGuest,
+        error.InvalidSnapshotMountLowerPath,
+        error.InvalidSnapshotMountUpperPath,
+        error.InvalidSnapshotLiveMounts,
+        error.InvalidSnapshotVmstatePath,
+        error.InvalidSnapshotVmstateChainId,
+        error.InvalidSnapshotVmstateCheckpointParent,
+        => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan snapshot fields must be strings or resolved live mounts",
+        ),
+        error.InvalidSnapshotVmstateCheckpointSequence => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan snapshot vmstate checkpoint sequence must be a decimal integer",
         ),
         error.InvalidLiveMounts,
         error.InvalidLiveMountGuest,

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1161,6 +1161,51 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans restore live-mount overrides", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      restoreLiveMountsRecorded: [
+        { host: "/host/work", guest: "/mnt/work", mode: "rw" },
+        { host: "/host/cache", guest: "/mnt/cache", mode: "ro" },
+      ],
+      restoreLiveMountsOverrides: [{ host: "/new/cache", guest: "/mnt/cache" }],
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.restoreLiveMounts).toEqual([
+      { host: "/host/work", guest: "/mnt/work", mode: "rw" },
+      { host: "/new/cache", guest: "/mnt/cache", mode: "ro" },
+    ]);
+
+    const rejected = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...requestData,
+          restoreLiveMountsOverrides: [{ host: "/new/extra", guest: "/mnt/extra" }],
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(rejected.status).toBe(1);
+    const error = JSON.parse(rejected.stdout).error;
+    expect(error.code).toBe("BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN");
+    expect(error.message).toContain("guest=/mnt/extra");
+    expect(error.message).toContain("/mnt/work");
+  });
+
   it("validates batch live-mount sync vsock requirements", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -968,6 +968,45 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans snapshot context mount live-mount and vmstate shapes", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      snapshotMountGuest: "/mnt/data",
+      snapshotMountLowerPath: "/cache/lower.sqfs",
+      snapshotMountUpperPath: "/tmp/upper.img",
+      snapshotLiveMounts: [
+        { host: "/host/work", guest: "/mnt/work", mode: "rw", tag: "machinen-lm0" },
+      ],
+      snapshotVmstatePath: "/tmp/state.vmstate",
+      snapshotVmstateChainId: "chain-1",
+      snapshotVmstateCheckpointParent: "/snap/parent",
+      snapshotVmstateCheckpointSequence: "3",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.snapshotContext).toEqual({
+      mountDisk: {
+        guest: "/mnt/data",
+        lowerPath: "/cache/lower.sqfs",
+        upperPath: "/tmp/upper.img",
+      },
+      liveMounts: [{ host: "/host/work", guest: "/mnt/work", mode: "rw" }],
+      vmstateChain: { chainId: "chain-1", parentDir: "/snap/parent", sequence: 3 },
+    });
+  });
+
   it("plans registry cleanup paths, mount shapes, and CPU shape", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1161,6 +1161,40 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("validates batch live-mount sync vsock requirements", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      liveMountsResolved: [{ host: "/host/a", guest: "/mnt/a", mode: "rw", tag: "machinen-lm0" }],
+      vsockUdsPath: "/tmp/exec.sock",
+      batchLiveMountValidationRequired: true,
+    };
+    const ok = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(ok.status).toBe(0);
+    expect(JSON.parse(ok.stdout).data.batchLiveMountSyncRequired).toBe(true);
+
+    const missingVsock = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...requestData, vsockUdsPath: null },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(missingVsock.status).toBe(1);
+    expect(JSON.parse(missingVsock.stdout).error.code).toBe("BOOT_MOUNT_INVALID");
+  });
+
   it("plans kernel dtb and initrd env paths", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -179,6 +179,46 @@ describe("boot-plan helper schema", () => {
     });
     expect(presetNetSocket.status).toBe(1);
     expect(JSON.parse(presetNetSocket.stdout).error.code).toBe("BOOT_PORT_FORWARD_INVALID");
+
+    const existingGvproxy = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, gvproxyNetSocket: "/tmp/net.sock" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(existingGvproxy.status).toBe(0);
+    expect(JSON.parse(existingGvproxy.stdout).data.gvproxyPlan).toEqual({
+      action: "skip-existing",
+      gvproxyPath: null,
+    });
+
+    const spawnGvproxy = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, gvproxyPath: "/bin/gvproxy" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(spawnGvproxy.status).toBe(0);
+    expect(JSON.parse(spawnGvproxy.stdout).data.gvproxyPlan).toEqual({
+      action: "spawn",
+      gvproxyPath: "/bin/gvproxy",
+    });
+
+    const missingGvproxy = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          portForward: [{ hostPort: 8080, guestPort: 80 }],
+          gvproxyPlanningRequired: true,
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(missingGvproxy.status).toBe(1);
+    expect(JSON.parse(missingGvproxy.stdout).error.code).toBe("BOOT_PORT_FORWARD_NO_GVPROXY");
   });
 
   it("plans vsock specs from caller env auto UDS paths or auto temp dirs", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -165,6 +165,20 @@ describe("boot-plan helper schema", () => {
       { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
       { hostPort: 8443, guestPort: 443 },
     ]);
+
+    const presetNetSocket = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          portForward: [{ hostPort: 8080, guestPort: 80 }],
+          portForwardNetSocket: "/tmp/net.sock",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(presetNetSocket.status).toBe(1);
+    expect(JSON.parse(presetNetSocket.stdout).error.code).toBe("BOOT_PORT_FORWARD_INVALID");
   });
 
   it("plans vsock specs from caller env auto UDS paths or auto temp dirs", () => {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1055,6 +1055,13 @@ describe("boot-plan helper schema", () => {
           registryMountGuest: "/mnt/data",
           registryMountLowerPath: "/cache/lower.sqfs",
           registryMountUpperPath: "/tmp/upper.img",
+          registryHostPlatform: "darwin",
+          registryVmmBinary: "/pkg/machinen-vm",
+          registryVmmPdeathsig: true,
+          registryVmmObservedExeBase: "machinen-pdeathsig",
+          registryGvPid: "4321",
+          registryGvExe: "/pkg/gvproxy",
+          registryGvObservedExeBase: "gvproxy",
           portForward: [
             { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
             { hostPort: 8443, guestPort: 443 },
@@ -1068,7 +1075,8 @@ describe("boot-plan helper schema", () => {
       encoding: "utf8",
     });
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout).data.registryShape).toEqual({
+    const parsed = JSON.parse(result.stdout).data;
+    expect(parsed.registryShape).toEqual({
       sourceImagePath: "/images/rootfs.tar.gz",
       diskPath: "/tmp/scratch.img",
       forkedFrom: "/snap/source",
@@ -1111,6 +1119,10 @@ describe("boot-plan helper schema", () => {
         checkpointSequence: 3,
       },
       nested: true,
+    });
+    expect(parsed.registryProcess).toEqual({
+      vmmExe: "machinen-pdeathsig",
+      gvproxyExe: "gvproxy",
     });
   });
 

--- a/packages/runtime/src/__tests__/restore-livemounts.test.ts
+++ b/packages/runtime/src/__tests__/restore-livemounts.test.ts
@@ -4,9 +4,37 @@
 // (override matching, BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN, legacy bundle
 // passthrough) that don't need a running VM to verify.
 
-import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { resolveRestoreLiveMounts } from "../vm/index.ts";
 import { BootError, isMachinenError } from "../errors.ts";
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-runtime-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 describe("resolveRestoreLiveMounts", () => {
   it("returns undefined for a legacy bundle with no caller overrides", () => {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -134,6 +134,7 @@ export interface NativeBootPlanResult {
   vmmVmstateTiming: string | null;
   vmmNested: string | null;
   virtiofsEnv: Record<string, string>;
+  batchLiveMountSyncRequired: boolean;
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
@@ -186,6 +187,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmVmstateTiming),
     nullableString(data.vmmNested),
     isStringRecord(data.virtiofsEnv),
+    typeof data.batchLiveMountSyncRequired === "boolean",
     Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -2,6 +2,7 @@ type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 export type ProvisionGuestCpu = "arm64" | "amd64";
+export type RestoreLiveMount = { host: string; guest: string; mode?: "ro" | "rw" };
 type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
 type RegistryCpuPlan = {
   maxVcpus: number;
@@ -135,6 +136,7 @@ export interface NativeBootPlanResult {
   vmmNested: string | null;
   virtiofsEnv: Record<string, string>;
   batchLiveMountSyncRequired: boolean;
+  restoreLiveMounts: RestoreLiveMount[];
   plannedLiveMounts: PlannedLiveMount[];
   statsFilePath: string | null;
   vmmStatsFile: string | null;
@@ -188,6 +190,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmNested),
     isStringRecord(data.virtiofsEnv),
     typeof data.batchLiveMountSyncRequired === "boolean",
+    Array.isArray(data.restoreLiveMounts) && data.restoreLiveMounts.every(isRestoreLiveMount),
     Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
     nullableString(data.statsFilePath),
     nullableString(data.vmmStatsFile),
@@ -485,6 +488,15 @@ function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
     typeof mount.host === "string",
     isOneOf(mount.mode, liveMountModes),
   ].every(Boolean);
+}
+
+function isRestoreLiveMount(value: unknown): value is RestoreLiveMount {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<RestoreLiveMount>;
+  return [typeof mount.host === "string", typeof mount.guest === "string"].every(Boolean) &&
+    (mount.mode === undefined || oneOfString(mount.mode, liveMountModes));
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -2,6 +2,11 @@ type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 type GvproxyAction = "skip-existing" | "spawn" | "missing-ok";
+type SnapshotContextPlan = {
+  mountDisk: { guest: string; lowerPath: string; upperPath: string } | null;
+  liveMounts: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  vmstateChain: { chainId: string; parentDir: string | null; sequence: number } | null;
+};
 export type ProvisionGuestCpu = "arm64" | "amd64";
 export type RestoreLiveMount = { host: string; guest: string; mode?: "ro" | "rw" };
 export type GvproxyPlan = { action: GvproxyAction; gvproxyPath: string | null };
@@ -161,6 +166,7 @@ export interface NativeBootPlanResult {
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
   mountDiskFdEnv: Record<string, string>;
+  snapshotContext: SnapshotContextPlan;
   registryShape: RegistryShapePlan;
 }
 
@@ -216,6 +222,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
     isStringRecord(data.mountDiskFdEnv),
+    isSnapshotContextPlan(data.snapshotContext),
     isRegistryShapePlan(data.registryShape),
   ].every(Boolean);
 }
@@ -493,6 +500,42 @@ function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
     typeof mount.host === "string",
     isOneOf(mount.mode, liveMountModes),
   ].every(Boolean);
+}
+
+function isSnapshotContextPlan(value: unknown): value is SnapshotContextPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<SnapshotContextPlan>;
+  return [
+    plan.mountDisk === null || isSnapshotMountDisk(plan.mountDisk),
+    Array.isArray(plan.liveMounts) && plan.liveMounts.every(isSnapshotLiveMount),
+    plan.vmstateChain === null || isSnapshotVmstateChain(plan.vmstateChain),
+  ].every(Boolean);
+}
+
+function isSnapshotMountDisk(value: unknown): value is NonNullable<SnapshotContextPlan["mountDisk"]> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const disk = value as Partial<NonNullable<SnapshotContextPlan["mountDisk"]>>;
+  return [typeof disk.guest === "string", typeof disk.lowerPath === "string", typeof disk.upperPath === "string"].every(Boolean);
+}
+
+function isSnapshotLiveMount(value: unknown): value is SnapshotContextPlan["liveMounts"][number] {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<SnapshotContextPlan["liveMounts"][number]>;
+  return [typeof mount.host === "string", typeof mount.guest === "string", oneOfString(mount.mode, liveMountModes)].every(Boolean);
+}
+
+function isSnapshotVmstateChain(value: unknown): value is NonNullable<SnapshotContextPlan["vmstateChain"]> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const chain = value as Partial<NonNullable<SnapshotContextPlan["vmstateChain"]>>;
+  return [typeof chain.chainId === "string", nullableString(chain.parentDir), nonNegativeNumber(chain.sequence)].every(Boolean);
 }
 
 function isGvproxyPlan(value: unknown): value is GvproxyPlan {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -1,8 +1,10 @@
 type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
+type GvproxyAction = "skip-existing" | "spawn" | "missing-ok";
 export type ProvisionGuestCpu = "arm64" | "amd64";
 export type RestoreLiveMount = { host: string; guest: string; mode?: "ro" | "rw" };
+export type GvproxyPlan = { action: GvproxyAction; gvproxyPath: string | null };
 type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
 type RegistryCpuPlan = {
   maxVcpus: number;
@@ -108,6 +110,7 @@ const provisionGuestCpuValues = ["arm64", "amd64"] as const;
 const scratchDiskActions = ["none", "existing", "clone", "allocate"] as const;
 const rootDiskRuntimeActions = ["none", "existing", "clone-restore", "clone-cached"] as const;
 const mountDiskRuntimeActions = ["none", "restore", "fresh"] as const;
+const gvproxyActions = ["skip-existing", "spawn", "missing-ok"] as const;
 const registryRootDiskModes = ["block", "none"] as const;
 const liveMountModes = ["ro", "rw"] as const;
 
@@ -124,6 +127,7 @@ export interface NativeBootPlanResult {
   mergedGuestEnv: Record<string, string>;
   vsockUdsPath: string | null;
   vmmVsock: string | null;
+  gvproxyPlan: GvproxyPlan;
   vmmCommand: string | null;
   vmmArgs: string[];
   usePdeathsig: boolean;
@@ -178,6 +182,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isStringRecord(data.mergedGuestEnv),
     nullableString(data.vsockUdsPath),
     nullableString(data.vmmVsock),
+    isGvproxyPlan(data.gvproxyPlan),
     nullableString(data.vmmCommand),
     isStringArray(data.vmmArgs),
     typeof data.usePdeathsig === "boolean",
@@ -488,6 +493,14 @@ function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
     typeof mount.host === "string",
     isOneOf(mount.mode, liveMountModes),
   ].every(Boolean);
+}
+
+function isGvproxyPlan(value: unknown): value is GvproxyPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<GvproxyPlan>;
+  return oneOfString(plan.action, gvproxyActions) && nullableString(plan.gvproxyPath);
 }
 
 function isRestoreLiveMount(value: unknown): value is RestoreLiveMount {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -10,6 +10,10 @@ type SnapshotContextPlan = {
 export type ProvisionGuestCpu = "arm64" | "amd64";
 export type RestoreLiveMount = { host: string; guest: string; mode?: "ro" | "rw" };
 export type GvproxyPlan = { action: GvproxyAction; gvproxyPath: string | null };
+export type RegistryProcessPlan = {
+  vmmExe: string | null;
+  gvproxyExe: string | null;
+};
 type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
 type RegistryCpuPlan = {
   maxVcpus: number;
@@ -168,6 +172,7 @@ export interface NativeBootPlanResult {
   mountDiskFdEnv: Record<string, string>;
   snapshotContext: SnapshotContextPlan;
   registryShape: RegistryShapePlan;
+  registryProcess: RegistryProcessPlan;
 }
 
 export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
@@ -224,6 +229,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isStringRecord(data.mountDiskFdEnv),
     isSnapshotContextPlan(data.snapshotContext),
     isRegistryShapePlan(data.registryShape),
+    isRegistryProcessPlan(data.registryProcess),
   ].every(Boolean);
 }
 
@@ -382,6 +388,14 @@ function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
   ].every(Boolean);
 }
 
+function isRegistryProcessPlan(value: unknown): value is RegistryProcessPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryProcessPlan>;
+  return nullableString(plan.vmmExe) && nullableString(plan.gvproxyExe);
+}
+
 function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
   if (!value || typeof value !== "object") {
     return false;
@@ -514,12 +528,18 @@ function isSnapshotContextPlan(value: unknown): value is SnapshotContextPlan {
   ].every(Boolean);
 }
 
-function isSnapshotMountDisk(value: unknown): value is NonNullable<SnapshotContextPlan["mountDisk"]> {
+function isSnapshotMountDisk(
+  value: unknown,
+): value is NonNullable<SnapshotContextPlan["mountDisk"]> {
   if (!value || typeof value !== "object") {
     return false;
   }
   const disk = value as Partial<NonNullable<SnapshotContextPlan["mountDisk"]>>;
-  return [typeof disk.guest === "string", typeof disk.lowerPath === "string", typeof disk.upperPath === "string"].every(Boolean);
+  return [
+    typeof disk.guest === "string",
+    typeof disk.lowerPath === "string",
+    typeof disk.upperPath === "string",
+  ].every(Boolean);
 }
 
 function isSnapshotLiveMount(value: unknown): value is SnapshotContextPlan["liveMounts"][number] {
@@ -527,15 +547,25 @@ function isSnapshotLiveMount(value: unknown): value is SnapshotContextPlan["live
     return false;
   }
   const mount = value as Partial<SnapshotContextPlan["liveMounts"][number]>;
-  return [typeof mount.host === "string", typeof mount.guest === "string", oneOfString(mount.mode, liveMountModes)].every(Boolean);
+  return [
+    typeof mount.host === "string",
+    typeof mount.guest === "string",
+    isOneOf(mount.mode, liveMountModes),
+  ].every(Boolean);
 }
 
-function isSnapshotVmstateChain(value: unknown): value is NonNullable<SnapshotContextPlan["vmstateChain"]> {
+function isSnapshotVmstateChain(
+  value: unknown,
+): value is NonNullable<SnapshotContextPlan["vmstateChain"]> {
   if (!value || typeof value !== "object") {
     return false;
   }
   const chain = value as Partial<NonNullable<SnapshotContextPlan["vmstateChain"]>>;
-  return [typeof chain.chainId === "string", nullableString(chain.parentDir), nonNegativeNumber(chain.sequence)].every(Boolean);
+  return [
+    typeof chain.chainId === "string",
+    nullableString(chain.parentDir),
+    nonNegativeNumber(chain.sequence),
+  ].every(Boolean);
 }
 
 function isGvproxyPlan(value: unknown): value is GvproxyPlan {
@@ -543,7 +573,7 @@ function isGvproxyPlan(value: unknown): value is GvproxyPlan {
     return false;
   }
   const plan = value as Partial<GvproxyPlan>;
-  return oneOfString(plan.action, gvproxyActions) && nullableString(plan.gvproxyPath);
+  return isOneOf(plan.action, gvproxyActions) && nullableString(plan.gvproxyPath);
 }
 
 function isRestoreLiveMount(value: unknown): value is RestoreLiveMount {
@@ -551,8 +581,10 @@ function isRestoreLiveMount(value: unknown): value is RestoreLiveMount {
     return false;
   }
   const mount = value as Partial<RestoreLiveMount>;
-  return [typeof mount.host === "string", typeof mount.guest === "string"].every(Boolean) &&
-    (mount.mode === undefined || oneOfString(mount.mode, liveMountModes));
+  return (
+    [typeof mount.host === "string", typeof mount.guest === "string"].every(Boolean) &&
+    (mount.mode === undefined || isOneOf(mount.mode, liveMountModes))
+  );
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -83,6 +83,7 @@ interface NativeBootPlanInput {
   nested?: boolean;
   liveMounts?: LiveMountPlanInput[];
   liveMountsResolved?: PlannedLiveMount[];
+  batchLiveMountValidationRequired?: boolean;
   existingStatsFile?: string;
   statsFilePath?: string;
   statsFileTempDir?: string;
@@ -217,6 +218,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     nested: input.nested === true,
     liveMounts: liveMountsData(input.liveMounts),
     liveMountsResolved: input.liveMountsResolved ?? [],
+    batchLiveMountValidationRequired: input.batchLiveMountValidationRequired === true,
     existingStatsFile: nullDefault(input.existingStatsFile),
     statsFilePath: nullDefault(input.statsFilePath),
     statsFileTempDir: nullDefault(input.statsFileTempDir),
@@ -988,12 +990,10 @@ export function rootDiskPlanMode(rootDisk: boolean | string | undefined): RootDi
         : "unset";
 }
 
-function bootPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
-  return new BootError(code, message, opts);
-}
+const bootPlanError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
+  new BootError(code, message, opts);
 
-function numberText(value: number | undefined): string | null {
-  return value === undefined ? null : String(value);
-}
+const numberText = (value: number | undefined): string | null =>
+  value === undefined ? null : String(value);
 
 const numberTextRequired = (value: number): string => String(value);

--- a/packages/runtime/src/native/gvproxy-plan.ts
+++ b/packages/runtime/src/native/gvproxy-plan.ts
@@ -1,0 +1,36 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult, type GvproxyPlan } from "./boot-plan-schema.ts";
+
+type PortForwardMapping = { hostPort: number; guestPort: number; hostAddr?: string };
+
+export function planGvproxyNative(input: {
+  portForward: ReadonlyArray<PortForwardMapping>;
+  existingNetSocket?: string;
+  gvproxyPath?: string;
+  planningRequired?: boolean;
+}): GvproxyPlan {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      portForward: [...input.portForward],
+      gvproxyPlanningRequired: input.planningRequired === true,
+      gvproxyNetSocket: input.existingNetSocket ?? null,
+      gvproxyPath: input.gvproxyPath ?? null,
+    },
+    errorCode: "BOOT_PORT_FORWARD_NO_GVPROXY",
+    makeError: gvproxyPlanError,
+    isData: isNativeBootPlanResult,
+  }).gvproxyPlan;
+}
+
+const gvproxyPlanError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
+  new BootError(code, message, opts);

--- a/packages/runtime/src/native/live-mount-batch.ts
+++ b/packages/runtime/src/native/live-mount-batch.ts
@@ -1,0 +1,17 @@
+import type { PlannedLiveMount } from "./boot-plan-schema.ts";
+import { planBootCoreNative } from "./boot-plan.ts";
+
+export function validateBatchLiveMountsNative(
+  liveMounts: ReadonlyArray<PlannedLiveMount>,
+  vsockUdsPath: string | undefined,
+): boolean {
+  return planBootCoreNative({
+    liveMountsResolved: [...liveMounts],
+    vsockUdsPath,
+    batchLiveMountValidationRequired: true,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).batchLiveMountSyncRequired;
+}

--- a/packages/runtime/src/native/port-forward.ts
+++ b/packages/runtime/src/native/port-forward.ts
@@ -1,0 +1,35 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+
+type PortForwardMapping = { hostPort: number; guestPort: number; hostAddr?: string };
+
+export function validatePortForwardNetSocketNative(
+  portForward: ReadonlyArray<PortForwardMapping>,
+  netSocket: string | undefined,
+): void {
+  callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      portForward: [...portForward],
+      portForwardNetSocket: netSocket ?? null,
+    },
+    errorCode: "BOOT_PORT_FORWARD_INVALID",
+    makeError: portForwardPlanError,
+    isData: isNativeBootPlanResult,
+  });
+}
+
+const portForwardPlanError = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+): Error => new BootError(code, message, opts);

--- a/packages/runtime/src/native/registry-process.ts
+++ b/packages/runtime/src/native/registry-process.ts
@@ -1,0 +1,50 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult, type RegistryProcessPlan } from "./boot-plan-schema.ts";
+
+export function planBootRegistryProcessNative(input: {
+  hostPlatform: string;
+  vmmBinary: string;
+  vmmPdeathsig: boolean;
+  vmmObservedExeBase?: string;
+  gvPid?: number;
+  gvExe?: string;
+  gvObservedExeBase?: string;
+}): { vmmExe: string; gvproxyExe?: string } {
+  const plan: RegistryProcessPlan = callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      registryHostPlatform: input.hostPlatform,
+      registryVmmBinary: input.vmmBinary,
+      registryVmmPdeathsig: input.vmmPdeathsig,
+      registryVmmObservedExeBase: input.vmmObservedExeBase ?? null,
+      registryGvPid: input.gvPid === undefined ? null : String(input.gvPid),
+      registryGvExe: input.gvExe ?? null,
+      registryGvObservedExeBase: input.gvObservedExeBase ?? null,
+    },
+    errorCode: "BOOT_VMM_MISSING",
+    makeError: registryProcessPlanError,
+    isData: isNativeBootPlanResult,
+  }).registryProcess;
+  if (!plan.vmmExe) {
+    throw new BootError(
+      "BOOT_VMM_MISSING",
+      "boot: native planner returned no registry VMM executable",
+    );
+  }
+  return { vmmExe: plan.vmmExe, gvproxyExe: plan.gvproxyExe ?? undefined };
+}
+
+const registryProcessPlanError = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+): Error => new BootError(code, message, opts);

--- a/packages/runtime/src/native/restore-live-mounts.ts
+++ b/packages/runtime/src/native/restore-live-mounts.ts
@@ -1,0 +1,36 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult, type RestoreLiveMount } from "./boot-plan-schema.ts";
+
+type RestoreLiveMountInput = { host: string; guest: string; mode?: "ro" | "rw" };
+type RecordedRestoreLiveMount = { host: string; guest: string; mode: "ro" | "rw" };
+
+export function planRestoreLiveMountsNative(
+  recorded: ReadonlyArray<RecordedRestoreLiveMount> | undefined,
+  overrides: ReadonlyArray<RestoreLiveMountInput> | undefined,
+): RestoreLiveMount[] {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      restoreLiveMountsRecorded: recorded ?? [],
+      restoreLiveMountsOverrides: overrides ?? [],
+    },
+    errorCode: "BOOT_MOUNT_INVALID",
+    makeError: restoreLiveMountPlanError,
+    isData: isNativeBootPlanResult,
+  }).restoreLiveMounts;
+}
+
+const restoreLiveMountPlanError = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+): Error => new BootError(code, message, opts);

--- a/packages/runtime/src/native/snapshot-context.ts
+++ b/packages/runtime/src/native/snapshot-context.ts
@@ -1,0 +1,63 @@
+import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult, type PlannedLiveMount } from "./boot-plan-schema.ts";
+
+type SnapshotMountDiskInput = { guest: string; lowerPath: string; upperPath: string };
+type SnapshotVmstateInput = {
+  statePath?: string;
+  chainId: string;
+  checkpointParent?: string;
+  checkpointSequence: number;
+};
+
+export function planBootSnapshotContextNative(input: {
+  mountDisk?: SnapshotMountDiskInput;
+  liveMounts: ReadonlyArray<PlannedLiveMount>;
+  vmstate: SnapshotVmstateInput;
+}): {
+  mountDisk?: SnapshotMountDiskInput;
+  liveMounts?: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
+  vmstateChain?: { chainId: string; parentDir?: string; sequence: number };
+} {
+  const plan = callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      snapshotMountGuest: input.mountDisk?.guest ?? null,
+      snapshotMountLowerPath: input.mountDisk?.lowerPath ?? null,
+      snapshotMountUpperPath: input.mountDisk?.upperPath ?? null,
+      snapshotLiveMounts: [...input.liveMounts],
+      snapshotVmstatePath: input.vmstate.statePath ?? null,
+      snapshotVmstateChainId: input.vmstate.chainId,
+      snapshotVmstateCheckpointParent: input.vmstate.checkpointParent ?? null,
+      snapshotVmstateCheckpointSequence: String(input.vmstate.checkpointSequence),
+    },
+    errorCode: "BOOT_SNAPSHOT_NOT_FOUND",
+    makeError: snapshotContextPlanError,
+    isData: isNativeBootPlanResult,
+  }).snapshotContext;
+  return {
+    mountDisk: plan.mountDisk ?? undefined,
+    liveMounts: plan.liveMounts.length > 0 ? plan.liveMounts : undefined,
+    vmstateChain: plan.vmstateChain
+      ? {
+          chainId: plan.vmstateChain.chainId,
+          parentDir: plan.vmstateChain.parentDir ?? undefined,
+          sequence: plan.vmstateChain.sequence,
+        }
+      : undefined,
+  };
+}
+
+const snapshotContextPlanError = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+): Error => new BootError(code, message, opts);

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -71,6 +71,7 @@ import {
   rootDiskPlanMode,
 } from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
+import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
@@ -1135,23 +1136,20 @@ async function planPortForwardOpts(
   if ((opts.portForward ?? []).length === 0) {
     return planBootPortForwardNative(opts.portForward);
   }
-  rejectPresetNetSocket(opts);
   const portForward = planBootPortForwardNative(opts.portForward);
+  validatePresetNetSocket(opts, portForward);
   await validatePortForwardAvailability(portForward);
   return portForward;
 }
 
-function rejectPresetNetSocket(opts: BootOptions): void {
-  const preSetNetSock =
-    (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET;
-  if (preSetNetSock) {
-    throw new BootError(
-      "BOOT_PORT_FORWARD_INVALID",
-      "portForward requires the runtime to own gvproxy, but MACHINEN_NET_SOCKET " +
-        "is already set. Either drop the env var or install the forwards yourself " +
-        "against your gvproxy's control API.",
-    );
-  }
+function validatePresetNetSocket(
+  opts: BootOptions,
+  portForward: NonNullable<BootOptions["portForward"]>,
+): void {
+  validatePortForwardNetSocketNative(
+    portForward,
+    (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET,
+  );
 }
 
 async function validatePortForwardAvailability(

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -71,6 +71,7 @@ import {
   rootDiskPlanMode,
 } from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
+import { planGvproxyNative } from "../native/gvproxy-plan.ts";
 import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
@@ -1408,7 +1409,11 @@ async function bringUpGvproxy(
   env: Record<string, string>,
   portForward: NonNullable<BootOptions["portForward"]>,
 ): Promise<GvproxyResult> {
-  if (env.MACHINEN_NET_SOCKET) {
+  const existingPlan = planGvproxyNative({
+    portForward,
+    existingNetSocket: env.MACHINEN_NET_SOCKET,
+  });
+  if (existingPlan.action === "skip-existing") {
     debug("MACHINEN_NET_SOCKET already set — skipping gvproxy spawn");
     return { gvStop: undefined, gvPid: undefined, gvExe: undefined, gvSocketDir: undefined };
   }
@@ -1416,22 +1421,21 @@ async function bringUpGvproxy(
   // visible stderr line; cached under ~/.machinen so subsequent
   // boots are silent. See #83 follow-up.
   const gvBin = await ensureGvproxy(binary);
-  if (!gvBin) {
-    if (portForward.length > 0) {
-      throw new BootError(
-        "BOOT_PORT_FORWARD_NO_GVPROXY",
-        "portForward requires gvproxy, but no gvproxy binary was found. " +
-          "Install gvproxy or point MACHINEN_GVPROXY at one.",
-      );
-    }
+  const gvproxyPlan = planGvproxyNative({
+    portForward,
+    gvproxyPath: gvBin ?? undefined,
+    planningRequired: true,
+  });
+  if (gvproxyPlan.action === "missing-ok") {
     debug("gvproxy not found — booting without networking");
     warnGvproxyMissing();
     return { gvStop: undefined, gvPid: undefined, gvExe: undefined, gvSocketDir: undefined };
   }
-  debug("starting gvproxy bin=%s", gvBin);
+  const gvproxyPath = gvproxyPlan.gvproxyPath!;
+  debug("starting gvproxy bin=%s", gvproxyPath);
   // Detach gvproxy alongside the VMM so the parent can exit
   // without stranding the guest's networking (#150 phase 2 PR3).
-  const gv = await spawnGvproxy(gvBin, { detached: opts.detached });
+  const gv = await spawnGvproxy(gvproxyPath, { detached: opts.detached });
   env.MACHINEN_NET_SOCKET = gv.socketPath;
   for (const m of portForward) {
     await exposePort(gv.controlSocketPath, m);
@@ -1439,7 +1443,7 @@ async function bringUpGvproxy(
   return {
     gvStop: gv.stop,
     gvPid: gv.child.pid,
-    gvExe: gvBin,
+    gvExe: gvproxyPath,
     gvSocketDir: gv.socketDir,
   };
 }

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -73,6 +73,7 @@ import {
 import { reflinkCopy } from "../reflink.ts";
 import { planGvproxyNative } from "../native/gvproxy-plan.ts";
 import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
+import { planBootSnapshotContextNative } from "../native/snapshot-context.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
@@ -1978,6 +1979,11 @@ function buildBootSnapshotContext(
   const syncVmstateForSnapshot = handle.syncVmstateSnapshot?.bind(handle);
   const waitForSnapshot = handle.wait.bind(handle);
   const killForSnapshot = handle.kill.bind(handle);
+  const snapshotPlan = planBootSnapshotContextNative({
+    mountDisk: args.mountDiskPaths,
+    liveMounts: args.liveMountsResolved,
+    vmstate: args.vmstate,
+  });
   return {
     pid: args.childPid,
     sourceName: args.vmName,
@@ -1988,10 +1994,10 @@ function buildBootSnapshotContext(
     kernelPath: args.env.MACHINEN_KERNEL,
     dtbPath: args.env.MACHINEN_DTB,
     diskPath: args.diskAbs!,
-    mountDisk: snapshotMountDisk(args.mountDiskPaths),
-    liveMounts: snapshotLiveMounts(args.liveMountsResolved),
+    mountDisk: snapshotPlan.mountDisk,
+    liveMounts: snapshotPlan.liveMounts,
     vmstatePath: args.vmstate.statePath,
-    vmstateChain: snapshotVmstateChain(args.vmstate),
+    vmstateChain: snapshotPlan.vmstateChain,
     updateVmstateChain: snapshotVmstateUpdater(args.vmstate, args.childPid),
     nested: args.nested,
     execRaw: execRawForSnapshot,
@@ -2002,38 +2008,6 @@ function buildBootSnapshotContext(
       args.child.stderr.on("data", onChunk);
     },
     errorOutput: () => handle.errorOutput(),
-  };
-}
-
-function snapshotMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
-  if (!mountDiskPaths) {
-    return undefined;
-  }
-  return {
-    guest: mountDiskPaths.guest,
-    lowerPath: mountDiskPaths.lowerPath,
-    upperPath: mountDiskPaths.upperPath,
-  };
-}
-
-function snapshotLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
-  return nonEmptyList(
-    liveMountsResolved.map((lm) => ({
-      host: lm.host,
-      guest: lm.guest,
-      mode: lm.mode,
-    })),
-  );
-}
-
-function snapshotVmstateChain(vmstate: BootVmstateRuntime): SnapshotContext["vmstateChain"] {
-  if (!vmstate.statePath) {
-    return undefined;
-  }
-  return {
-    chainId: vmstate.chainId,
-    parentDir: vmstate.checkpointParent,
-    sequence: vmstate.checkpointSequence,
   };
 }
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -73,6 +73,7 @@ import {
 import { reflinkCopy } from "../reflink.ts";
 import { planGvproxyNative } from "../native/gvproxy-plan.ts";
 import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
+import { planBootRegistryProcessNative } from "../native/registry-process.ts";
 import { planBootSnapshotContextNative } from "../native/snapshot-context.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
@@ -1603,6 +1604,15 @@ function registerInRegistry(args: RegisterArgs): boolean {
 
 function buildRegistryEntry(args: RegisterArgs) {
   const scalars = planBootRegistryScalarsNative(args);
+  const processPlan = planBootRegistryProcessNative({
+    hostPlatform: process.platform,
+    vmmBinary: args.binary,
+    vmmPdeathsig: args.vmmPdeathsig !== null,
+    vmmObservedExeBase: observedDarwinVmmExe(args),
+    gvPid: args.gvPid,
+    gvExe: args.gvExe,
+    gvObservedExeBase: observedDarwinGvproxyExe(args),
+  });
   return {
     pid: args.childPid,
     name: args.vmName,
@@ -1614,9 +1624,9 @@ function buildRegistryEntry(args: RegisterArgs) {
     forkedFrom: scalars.forkedFrom ?? undefined,
     bootLogPath: args.bootLogPath,
     cleanupPaths: nonEmptyList(args.cleanupPaths),
-    vmmExe: registryVmmExe(args),
+    vmmExe: processPlan.vmmExe,
     gvproxyPid: args.gvPid,
-    gvproxyExe: registryGvproxyExe(args),
+    gvproxyExe: processPlan.gvproxyExe,
     portForward: registryPortForward(args.portForward),
     memoryCeilingMib: scalars.memoryCeilingMib ?? undefined,
     cpu: registryCpu(args.cpuPolicy, args.cpuControl),
@@ -1636,21 +1646,21 @@ function nonEmptyList<T>(items: T[]): T[] | undefined {
   return items.length > 0 ? items : undefined;
 }
 
-function registryVmmExe(args: RegisterArgs): string {
+function observedDarwinVmmExe(args: RegisterArgs): string | undefined {
   // The pdeathsig shim works differently per platform. On macOS child.pid
   // is the watcher, so snapshot its identity now; on Linux the shim execs in
   // place, so deferring avoids recording the shim during the exec race.
-  if (process.platform === "darwin" && args.vmmPdeathsig) {
-    return readProcessIdentity(args.childPid)?.exeBase ?? args.binary;
+  if (process.platform !== "darwin" || !args.vmmPdeathsig) {
+    return undefined;
   }
-  return args.binary;
+  return readProcessIdentity(args.childPid)?.exeBase;
 }
 
-function registryGvproxyExe(args: RegisterArgs): string | undefined {
-  if (process.platform === "darwin" && args.gvPid !== undefined && args.gvPid > 0) {
-    return readProcessIdentity(args.gvPid)?.exeBase ?? args.gvExe;
+function observedDarwinGvproxyExe(args: RegisterArgs): string | undefined {
+  if (process.platform !== "darwin" || args.gvPid === undefined || args.gvPid <= 0) {
+    return undefined;
   }
-  return args.gvExe;
+  return readProcessIdentity(args.gvPid)?.exeBase;
 }
 
 function registryMountDisk(mountDiskPaths: MountDiskPaths | undefined) {

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -31,6 +31,7 @@ import {
   planBootMountDiskRuntimeNative,
   planBootMachinenConfigNative,
 } from "../native/boot-plan.ts";
+import { planRestoreLiveMountsNative } from "../native/restore-live-mounts.ts";
 import type { BootOptions } from "./boot.ts";
 import type { SnapshotMeta } from "../vm-handle.ts";
 import { normalizeMountGuest, validateGuestCwd, validateMountGuest } from "./helpers.ts";
@@ -138,46 +139,10 @@ export function resolveRestoreLiveMounts(
   recorded: SnapshotMeta["liveMounts"] | undefined,
   overrides: BootOptions["liveMounts"] | undefined,
 ): BootOptions["liveMounts"] {
-  const recordedList = recorded ?? [];
   const overrideList = overrides ?? [];
   overrideList.forEach((ov, i) => rejectRemovedLiveMountOptions(ov, i));
-  if (recordedList.length === 0) {
-    return overrideList.length > 0 ? overrideList : undefined;
-  }
-  const recordedByGuest = new Map(recordedList.map((m) => [m.guest, m]));
-  const overridesByGuest = new Map<
-    string,
-    {
-      host: string;
-      guest: string;
-      mode?: "ro" | "rw";
-    }
-  >();
-  for (const ov of overrideList) {
-    if (!recordedByGuest.has(ov.guest)) {
-      const known = recordedList.map((m) => m.guest).join(", ");
-      throw new BootError(
-        "BOOT_LIVE_MOUNT_OVERRIDE_UNKNOWN",
-        `restore: liveMounts override for guest=${ov.guest} doesn't match any\n` +
-          `  liveMount recorded in the bundle. The bundle's recorded guest paths are:\n` +
-          `    ${known}\n` +
-          `  restore() reproduces the snapshot's mount topology — opts.liveMounts is\n` +
-          `  an override map, not an additive list. To override, set 'guest' to one\n` +
-          `  of the recorded paths above and supply a new 'host' / 'mode'.`,
-      );
-    }
-    overridesByGuest.set(ov.guest, ov);
-  }
-  return recordedList.map((rec) => {
-    const ov = overridesByGuest.get(rec.guest);
-    return ov
-      ? {
-          guest: rec.guest,
-          host: ov.host,
-          mode: ov.mode ?? rec.mode,
-        }
-      : { guest: rec.guest, host: rec.host, mode: rec.mode };
-  });
+  const planned = planRestoreLiveMountsNative(recorded, overrideList);
+  return planned.length > 0 ? planned : undefined;
 }
 
 type BundleMountDisk = {

--- a/packages/runtime/src/vm/live-mount-batch.ts
+++ b/packages/runtime/src/vm/live-mount-batch.ts
@@ -3,7 +3,8 @@ import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { BootError, ExecError } from "../errors.ts";
+import { ExecError } from "../errors.ts";
+import { validateBatchLiveMountsNative } from "../native/live-mount-batch.ts";
 import type { VmHandle } from "../vm-handle.ts";
 import type { BootOptions } from "./boot.ts";
 interface BatchLiveMount {
@@ -14,18 +15,10 @@ interface BatchLiveMount {
 
 export function validateBatchLiveMounts(
   _opts: BootOptions,
-  liveMounts: ReadonlyArray<BatchLiveMount>,
+  liveMounts: ReadonlyArray<BatchLiveMount & { tag: string; mode: "ro" | "rw" }>,
   vsockUdsPath: string | undefined,
 ): void {
-  if (!liveMounts.some(isWritableBatchLiveMount)) {
-    return;
-  }
-  if (!vsockUdsPath) {
-    throw new BootError(
-      "BOOT_MOUNT_INVALID",
-      "liveMounts: writable mounts require the exec vsock bridge for batched sync",
-    );
-  }
+  validateBatchLiveMountsNative(liveMounts, vsockUdsPath);
 }
 
 export function withBatchLiveMountSync(


### PR DESCRIPTION
## Problem

Restore, gvproxy, snapshot, and registry process planning were mixed into one very large review slice. That made the PR harder to read.

## Solution

Split those related planners into their own Zig boot-plan slice. TypeScript still keeps the host checks, registry writes, and process orchestration.

## Technical Summary

- Moves batch live mount validation, restore live mount planning, gvproxy setup, snapshot context, and registry process metadata planning together.
- Keeps product behavior at the same TypeScript API boundary.
- Avoids expanding snapshot/restore product claims; this is planner migration only.
