### PR TITLE
Move final VMM env and port probes to Zig

### DIFF
--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -604,6 +604,17 @@ pub const RegistryProcessPlan = struct {
     gvproxy_exe: ?[]const u8,
 };
 
+pub const RegistryLifecycleInput = struct {
+    name: ?[]const u8 = null,
+    child_pid: ?i64 = null,
+    vsock_uds_path: ?[]const u8 = null,
+};
+
+pub const RegistryLifecyclePlan = struct {
+    claim_name: ?[]const u8,
+    should_write: bool,
+};
+
 pub const RegistryShapeInput = struct {
     source_image_path: ?[]const u8 = null,
     per_boot_root_disk: ?[]const u8 = null,
@@ -1582,6 +1593,17 @@ pub fn planRegistryProcess(input: RegistryProcessInput) RegistryProcessPlan {
     return .{ .vmm_exe = vmm_exe, .gvproxy_exe = gvproxy_exe };
 }
 
+pub fn planRegistryLifecycle(input: RegistryLifecycleInput) RegistryLifecyclePlan {
+    assert(@sizeOf(RegistryLifecycleInput) > 0);
+
+    const has_live_pid = (input.child_pid orelse 0) > 0;
+    const claim_name = if (has_live_pid) input.name else null;
+    return .{
+        .claim_name = claim_name,
+        .should_write = has_live_pid and input.vsock_uds_path != null,
+    };
+}
+
 pub fn planRegistryShape(
     allocator: std.mem.Allocator,
     input: RegistryShapeInput,
@@ -2316,6 +2338,28 @@ test "planSnapshotContext projects mount live mount and vmstate chain fields" {
     try std.testing.expectError(error.MissingSnapshotVmstateField, planSnapshotContext(allocator, .{
         .vmstate = .{ .state_path = "/tmp/state.vmstate" },
     }));
+}
+
+test "planRegistryLifecycle gates name claim and registry writes" {
+    const ready = planRegistryLifecycle(.{
+        .name = "worker",
+        .child_pid = 42,
+        .vsock_uds_path = "/tmp/exec.sock",
+    });
+    try std.testing.expectEqualStrings("worker", ready.claim_name.?);
+    try std.testing.expect(ready.should_write);
+
+    const no_name = planRegistryLifecycle(.{ .child_pid = 42, .vsock_uds_path = "/tmp/exec.sock" });
+    try std.testing.expect(no_name.claim_name == null);
+    try std.testing.expect(no_name.should_write);
+
+    const dead_pid = planRegistryLifecycle(.{ .name = "worker", .child_pid = 0 });
+    try std.testing.expect(dead_pid.claim_name == null);
+    try std.testing.expect(!dead_pid.should_write);
+
+    const no_vsock = planRegistryLifecycle(.{ .name = "worker", .child_pid = 42 });
+    try std.testing.expectEqualStrings("worker", no_vsock.claim_name.?);
+    try std.testing.expect(!no_vsock.should_write);
 }
 
 test "planRegistryShape collects cleanup paths and strips registry-only mount fields" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -98,6 +98,11 @@ pub const PortForwardMapping = struct {
     host_addr: ?[]const u8 = null,
 };
 
+pub const PortForwardProbePlan = struct {
+    host_port: i64,
+    probe_host: []const u8,
+};
+
 pub const PortForwardNetSocketInput = struct {
     port_forwards: []const PortForwardMapping = &.{},
     net_socket: ?[]const u8 = null,
@@ -1934,6 +1939,15 @@ pub fn planVmmArgv(allocator: std.mem.Allocator, input: VmmArgvInput) !VmmArgvPl
         return .{ .command = pdeathsig, .args = try args.toOwnedSlice(allocator) };
     }
     return .{ .command = binary, .args = input.args };
+}
+
+pub fn planPortForwardProbe(mapping: PortForwardMapping) PortForwardProbePlan {
+    assert(@sizeOf(PortForwardMapping) > 0);
+
+    return .{
+        .host_port = mapping.host_port,
+        .probe_host = mapping.host_addr orelse "127.0.0.1",
+    };
 }
 
 pub fn validatePortForward(mappings: []const PortForwardMapping) PortForwardValidation {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -64,6 +64,11 @@ pub const GuestEnvInput = struct {
     vsock_uds_path: ?[]const u8 = null,
 };
 
+pub const VmmEnvInput = struct {
+    base: []const EnvPair = &.{},
+    overrides: []const EnvPair = &.{},
+};
+
 pub const GuestHostnameInput = struct {
     pid: ?i64 = null,
     name: ?[]const u8 = null,
@@ -902,6 +907,12 @@ pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPa
     return out.toOwnedSlice(allocator);
 }
 
+pub fn planVmmEnv(allocator: std.mem.Allocator, input: VmmEnvInput) ![]EnvPair {
+    assert(@sizeOf(VmmEnvInput) > 0);
+
+    return mergeEnvPairs(allocator, input.base, input.overrides);
+}
+
 pub fn planVsock(allocator: std.mem.Allocator, input: VsockPlanInput) !VsockPlan {
     assert(@sizeOf(VsockPlanInput) > 0);
 
@@ -1416,10 +1427,20 @@ pub fn planBundlePack(input: BundlePackInput) BundlePackPlan {
 pub fn planBundleEnv(allocator: std.mem.Allocator, input: BundleEnvInput) ![]EnvPair {
     assert(@sizeOf(BundleEnvInput) > 0);
 
+    return mergeEnvPairs(allocator, input.image_env, input.guest_env);
+}
+
+fn mergeEnvPairs(
+    allocator: std.mem.Allocator,
+    base: []const EnvPair,
+    overrides: []const EnvPair,
+) ![]EnvPair {
+    assert(@sizeOf(EnvPair) > 0);
+
     var out: std.array_list.Aligned(EnvPair, null) = .empty;
     errdefer out.deinit(allocator);
-    try out.appendSlice(allocator, input.image_env);
-    for (input.guest_env) |pair| {
+    try out.appendSlice(allocator, base);
+    for (overrides) |pair| {
         var replaced = false;
         for (out.items) |*existing| {
             if (std.mem.eql(u8, existing.key, pair.key)) {
@@ -2774,6 +2795,24 @@ test "planBundlePack selects fat or tiny initramfs inputs" {
     });
     try std.testing.expectEqualStrings("tiny", tiny_restore.kind);
     try std.testing.expectEqualStrings("/mnt/restore", tiny_restore.tiny_mount_guest.?);
+}
+
+test "planVmmEnv overlays caller env on host env" {
+    const host = [_]EnvPair{
+        .{ .key = "PATH", .value = "/usr/bin" },
+        .{ .key = "MACHINEN_MEMORY", .value = "512" },
+    };
+    const caller = [_]EnvPair{
+        .{ .key = "MACHINEN_MEMORY", .value = "1024" },
+        .{ .key = "MACHINEN_TRACE", .value = "1" },
+    };
+    const planned = try planVmmEnv(std.testing.allocator, .{ .base = &host, .overrides = &caller });
+    defer std.testing.allocator.free(planned);
+    try std.testing.expectEqualStrings("PATH", planned[0].key);
+    try std.testing.expectEqualStrings("/usr/bin", planned[0].value);
+    try std.testing.expectEqualStrings("MACHINEN_MEMORY", planned[1].key);
+    try std.testing.expectEqualStrings("1024", planned[1].value);
+    try std.testing.expectEqualStrings("MACHINEN_TRACE", planned[2].key);
 }
 
 test "planBundleEnv overlays guest env on image env" {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -1316,6 +1316,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeNullableStringField(io, "vmmNested", parts.nested_env, true);
     try writeLiveMountsArrayField(io, "plannedLiveMounts", parts.planned_live_mounts, true);
     try writePortForwardField(io, "plannedPortForward", parts.planned_port_forwards, false, true);
+    try writePortForwardProbeField(io, "portForwardProbe", parts.planned_port_forwards, true);
     try writeEnvObjectField(io, "virtiofsEnv", parts.virtiofs_env, true);
     try writeNullableStringField(io, "vmmCommand", parts.vmm_argv.command, true);
     try writeStringArrayField(io, "vmmArgs", parts.vmm_argv.args, true);
@@ -2204,6 +2205,28 @@ fn writePortForwardField(
             try protocol.stdout(io, ",\"hostAddr\":");
             try protocol.writeJsonString(io, host_addr);
         }
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
+}
+
+fn writePortForwardProbeField(
+    io: std.Io,
+    comptime field: []const u8,
+    mappings: []const boot_plan.PortForwardMapping,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mappings, 0..) |mapping, i| {
+        const probe = boot_plan.planPortForwardProbe(mapping);
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{\"hostPort\":");
+        try writeI64Bare(io, probe.host_port);
+        try protocol.stdout(io, ",\"probeHost\":");
+        try protocol.writeJsonString(io, probe.probe_host);
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -25,6 +25,8 @@ const ParsedRequest = struct {
     guest_cwd: ?[]const u8 = null,
     mount_guest: ?[]const u8 = null,
     guest_env: std.json.ObjectMap = .{},
+    vmm_env_base: std.json.ObjectMap = .{},
+    vmm_env_overrides: std.json.ObjectMap = .{},
     name: ?[]const u8 = null,
     vsock_uds_path: ?[]const u8 = null,
     existing_vsock_spec: ?[]const u8 = null,
@@ -210,6 +212,8 @@ const boot_plan_fields = [_][]const u8{
     "guestCwd",
     "mountGuest",
     "guestEnv",
+    "vmmEnvBase",
+    "vmmEnvOverrides",
     "name",
     "vsockUdsPath",
     "existingVsockSpec",
@@ -399,6 +403,9 @@ const RequestError = error{
     InvalidMountGuest,
     InvalidGuestEnv,
     InvalidGuestEnvValue,
+    InvalidVmmEnvBase,
+    InvalidVmmEnvOverrides,
+    InvalidVmmEnvValue,
     InvalidName,
     InvalidVsockUdsPath,
     InvalidExistingVsockSpec,
@@ -594,6 +601,7 @@ const PlanParts = struct {
     cpu_policy: ?boot_plan.CpuPolicyPlan,
     root_disk_mode: boot_plan.RootDiskMode,
     guest_env: []const boot_plan.EnvPair,
+    vmm_env: []const boot_plan.EnvPair,
     vsock_plan: boot_plan.VsockPlan,
     gvproxy_plan: boot_plan.GvproxyPlan,
     guest_hostname: boot_plan.GuestHostnameInput,
@@ -701,6 +709,7 @@ fn makePlanParts(
         .cpu_policy = try makeCpuResources(parsed),
         .root_disk_mode = parsed.root_disk,
         .guest_env = try makeGuestEnv(arena, parsed),
+        .vmm_env = try makeVmmEnv(arena, parsed),
         .guest_hostname = try makeGuestHostname(parsed),
         .guest_hostname_set = try makeGuestHostnameSet(parsed),
         .vsock_plan = boot_env.vsock_plan,
@@ -1290,6 +1299,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try protocol.stdout(io, "\"command\":\"boot-plan\",\"data\":{");
     try writeCoreFields(io, parts.plan, parts.cpu_policy, parts.root_disk_mode);
     try writeVsockKernelFields(io, parts.vsock_plan, parts.kernel_dtb);
+    try writeEnvObjectField(io, "vmmEnv", parts.vmm_env, true);
     try writeGvproxyPlanField(io, "gvproxyPlan", parts.gvproxy_plan, true);
     try writeNullableStringField(io, "vmmInitrd", parts.initrd_env.vmm_initrd, true);
     try writeGuestHostnameField(io, "guestHostname", parts.guest_hostname, true);
@@ -2282,6 +2292,15 @@ fn writeStringArrayField(
     try protocol.stdout(io, "]");
 }
 
+fn makeVmmEnv(allocator: std.mem.Allocator, parsed: ParsedRequest) ![]boot_plan.EnvPair {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    return boot_plan.planVmmEnv(allocator, .{
+        .base = try objectStringPairs(allocator, parsed.vmm_env_base, error.InvalidVmmEnvValue),
+        .overrides = try objectStringPairs(allocator, parsed.vmm_env_overrides, error.InvalidVmmEnvValue),
+    });
+}
+
 fn makeGuestHostname(parsed: ParsedRequest) RequestError!boot_plan.GuestHostnameInput {
     assert(@sizeOf(ParsedRequest) > 0);
 
@@ -2583,6 +2602,16 @@ fn parseBootShapeFields(
         error.InvalidMountGuest,
     );
     request.guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv);
+    request.vmm_env_base = try optionalObjectDefaultEmpty(
+        object,
+        "vmmEnvBase",
+        error.InvalidVmmEnvBase,
+    );
+    request.vmm_env_overrides = try optionalObjectDefaultEmpty(
+        object,
+        "vmmEnvOverrides",
+        error.InvalidVmmEnvOverrides,
+    );
     request.name = try optionalStringDefaultNull(object, "name", error.InvalidName);
 }
 
@@ -4290,6 +4319,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
     if (try writeProvisionCliCacheRequestError(io, err)) return;
     if (try writeProvisionAssetLookupRequestError(io, err)) return;
     if (try writeRegistryLifecycleRequestError(io, err)) return;
+    if (try writeVmmEnvRequestError(io, err)) return;
 
     switch (err) {
         error.InvalidResourcesCpuMaxVcpus => try protocol.writeError(
@@ -4309,6 +4339,27 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }
+}
+
+fn writeVmmEnvRequestError(io: std.Io, err: RequestError) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.InvalidVmmEnvBase,
+        error.InvalidVmmEnvOverrides,
+        => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan vmm env fields must be objects",
+        ),
+        error.InvalidVmmEnvValue => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan vmm env values must be strings",
+        ),
+        else => return false,
+    }
+    return true;
 }
 
 fn writeRegistryLifecycleRequestError(io: std.Io, err: RequestError) !bool {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -150,6 +150,8 @@ const ParsedRequest = struct {
     registry_boot_log_root: ?[]const u8 = null,
     registry_child_pid_text: ?[]const u8 = null,
     registry_detached: bool = false,
+    registry_lifecycle_name: ?[]const u8 = null,
+    registry_lifecycle_vsock_uds_path: ?[]const u8 = null,
     registry_per_boot_snap_disk: ?[]const u8 = null,
     registry_per_boot_mount_upper: ?[]const u8 = null,
     registry_bundle_temp_dir: ?[]const u8 = null,
@@ -333,6 +335,8 @@ const boot_plan_fields = [_][]const u8{
     "registryBootLogRoot",
     "registryChildPid",
     "registryDetached",
+    "registryLifecycleName",
+    "registryLifecycleVsockUdsPath",
     "registryPerBootSnapDisk",
     "registryPerBootMountUpper",
     "registryBundleTempDir",
@@ -524,6 +528,8 @@ const RequestError = error{
     InvalidRegistryBootLogRoot,
     InvalidRegistryChildPid,
     InvalidRegistryDetached,
+    InvalidRegistryLifecycleName,
+    InvalidRegistryLifecycleVsockUdsPath,
     InvalidRegistryDiskPath,
     InvalidRegistryForkedFrom,
     InvalidRegistryMemoryCeilingMib,
@@ -630,6 +636,7 @@ const PlanParts = struct {
     mount_disk_fd_env: []const boot_plan.EnvPair,
     snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
+    registry_lifecycle: boot_plan.RegistryLifecyclePlan,
     registry_process: boot_plan.RegistryProcessPlan,
 };
 
@@ -675,6 +682,7 @@ const RuntimeParts = struct {
     mount_disk_fd_env: []const boot_plan.EnvPair,
     snapshot_context: boot_plan.SnapshotContextPlan,
     registry_shape: boot_plan.RegistryShapePlan,
+    registry_lifecycle: boot_plan.RegistryLifecyclePlan,
     registry_process: boot_plan.RegistryProcessPlan,
 };
 
@@ -743,6 +751,7 @@ fn makePlanParts(
         .mount_disk_fd_env = runtime.mount_disk_fd_env,
         .snapshot_context = runtime.snapshot_context,
         .registry_shape = runtime.registry_shape,
+        .registry_lifecycle = runtime.registry_lifecycle,
         .registry_process = runtime.registry_process,
     };
 }
@@ -844,6 +853,7 @@ fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimePar
         .mount_disk_fd_env = try makeMountDiskFdEnv(arena, parsed),
         .snapshot_context = try makeSnapshotContext(arena, parsed),
         .registry_shape = try makeRegistryShape(arena, parsed),
+        .registry_lifecycle = try makeRegistryLifecycle(parsed),
         .registry_process = try makeRegistryProcess(parsed),
     };
 }
@@ -1142,6 +1152,20 @@ fn makeSnapshotContext(
     });
 }
 
+fn makeRegistryLifecycle(parsed: ParsedRequest) RequestError!boot_plan.RegistryLifecyclePlan {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    const child_pid = if (parsed.registry_child_pid_text) |text|
+        parseSigned(text) catch return error.InvalidRegistryChildPid
+    else
+        null;
+    return boot_plan.planRegistryLifecycle(.{
+        .name = parsed.registry_lifecycle_name,
+        .child_pid = child_pid,
+        .vsock_uds_path = parsed.registry_lifecycle_vsock_uds_path,
+    });
+}
+
 fn makeRegistryProcess(parsed: ParsedRequest) !boot_plan.RegistryProcessPlan {
     assert(@sizeOf(boot_plan.RegistryProcessInput) > 0);
 
@@ -1319,6 +1343,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "mountDiskFdEnv", parts.mount_disk_fd_env, true);
     try writeSnapshotContextField(io, "snapshotContext", parts.snapshot_context, true);
     try writeRegistryShapeField(io, "registryShape", parts.registry_shape, true);
+    try writeRegistryLifecycleField(io, "registryLifecycle", parts.registry_lifecycle, true);
     try writeRegistryProcessField(io, "registryProcess", parts.registry_process, true);
     try protocol.stdout(io, "}}\n");
 }
@@ -2038,6 +2063,21 @@ fn writeSnapshotVmstateChainField(
         try writeU64Field(io, "sequence", vmstate.sequence, true);
         try protocol.stdout(io, "}");
     } else try protocol.stdout(io, "null");
+}
+
+fn writeRegistryLifecycleField(
+    io: std.Io,
+    comptime field: []const u8,
+    lifecycle: boot_plan.RegistryLifecyclePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "claimName", lifecycle.claim_name, false);
+    try writeBoolField(io, "shouldWrite", lifecycle.should_write, true);
+    try protocol.stdout(io, "}");
 }
 
 fn writeRegistryProcessField(
@@ -3319,6 +3359,16 @@ fn parseRegistryRootDiskFields(
         "registryDetached",
         error.InvalidRegistryDetached,
     );
+    request.registry_lifecycle_name = try optionalStringDefaultNull(
+        object,
+        "registryLifecycleName",
+        error.InvalidRegistryLifecycleName,
+    );
+    request.registry_lifecycle_vsock_uds_path = try optionalStringDefaultNull(
+        object,
+        "registryLifecycleVsockUdsPath",
+        error.InvalidRegistryLifecycleVsockUdsPath,
+    );
 }
 
 fn parseRegistryCleanupFields(
@@ -4239,6 +4289,7 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
     if (try writeProvisionDtbRequestError(io, err)) return;
     if (try writeProvisionCliCacheRequestError(io, err)) return;
     if (try writeProvisionAssetLookupRequestError(io, err)) return;
+    if (try writeRegistryLifecycleRequestError(io, err)) return;
 
     switch (err) {
         error.InvalidResourcesCpuMaxVcpus => try protocol.writeError(
@@ -4258,6 +4309,22 @@ fn writeRequestError(io: std.Io, err: RequestError) !void {
         ),
         else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
     }
+}
+
+fn writeRegistryLifecycleRequestError(io: std.Io, err: RequestError) !bool {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.InvalidRegistryLifecycleName,
+        error.InvalidRegistryLifecycleVsockUdsPath,
+        => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "boot-plan registry lifecycle fields must be strings",
+        ),
+        else => return false,
+    }
+    return true;
 }
 
 fn writeProvisionAssetLookupRequestError(io: std.Io, err: RequestError) !bool {

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -1256,6 +1256,8 @@ describe("boot-plan helper schema", () => {
           registryBootLogRoot: "/tmp/machinen-logs",
           registryChildPid: "1234",
           registryDetached: true,
+          registryLifecycleName: "worker",
+          registryLifecycleVsockUdsPath: "/tmp/exec.sock",
           registryPerBootSnapDisk: null,
           registryPerBootMountUpper: "/tmp/upper.img",
           registryBundleTempDir: "/tmp/bundle",
@@ -1340,6 +1342,10 @@ describe("boot-plan helper schema", () => {
         checkpointSequence: 3,
       },
       nested: true,
+    });
+    expect(parsed.registryLifecycle).toEqual({
+      claimName: "worker",
+      shouldWrite: true,
     });
     expect(parsed.registryProcess).toEqual({
       vmmExe: "machinen-pdeathsig",

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -101,6 +101,33 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans VMM env overrides", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const requestData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      vmmEnvBase: { PATH: "/usr/bin", MACHINEN_MEMORY: "512" },
+      vmmEnvOverrides: { MACHINEN_MEMORY: "1024", MACHINEN_TRACE: "1" },
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: requestData })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.vmmEnv).toEqual({
+      PATH: "/usr/bin",
+      MACHINEN_MEMORY: "1024",
+      MACHINEN_TRACE: "1",
+    });
+  });
+
   it("plans rootDisk option mode with restore precedence", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -252,6 +252,7 @@ describe("boot-plan helper schema", () => {
     });
     expect(omitted.status).toBe(0);
     expect(JSON.parse(omitted.stdout).data.plannedPortForward).toEqual([]);
+    expect(JSON.parse(omitted.stdout).data.portForwardProbe).toEqual([]);
 
     const planned = spawnSync(helper, ["boot-plan"], {
       input: `${JSON.stringify({
@@ -259,7 +260,7 @@ describe("boot-plan helper schema", () => {
         data: {
           ...baseData,
           portForward: [
-            { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+            { hostPort: 8080, guestPort: 80, hostAddr: "0.0.0.0" },
             { hostPort: 8443, guestPort: 443 },
           ],
         },
@@ -267,9 +268,14 @@ describe("boot-plan helper schema", () => {
       encoding: "utf8",
     });
     expect(planned.status).toBe(0);
-    expect(JSON.parse(planned.stdout).data.plannedPortForward).toEqual([
-      { hostPort: 8080, guestPort: 80, hostAddr: "127.0.0.1" },
+    const plannedData = JSON.parse(planned.stdout).data;
+    expect(plannedData.plannedPortForward).toEqual([
+      { hostPort: 8080, guestPort: 80, hostAddr: "0.0.0.0" },
       { hostPort: 8443, guestPort: 443 },
+    ]);
+    expect(plannedData.portForwardProbe).toEqual([
+      { hostPort: 8080, probeHost: "0.0.0.0" },
+      { hostPort: 8443, probeHost: "127.0.0.1" },
     ]);
 
     const presetNetSocket = spawnSync(helper, ["boot-plan"], {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -16,6 +16,7 @@ export type RegistryProcessPlan = {
   vmmExe: string | null;
   gvproxyExe: string | null;
 };
+export type RegistryLifecyclePlan = { claimName: string | null; shouldWrite: boolean };
 type CpuPolicyPlan = { maxVcpus: number; quotaCpus?: number; weight: number };
 type RegistryCpuPlan = {
   maxVcpus: number;
@@ -193,6 +194,7 @@ export interface NativeBootPlanResult {
   mountDiskFdEnv: Record<string, string>;
   snapshotContext: SnapshotContextPlan;
   registryShape: RegistryShapePlan;
+  registryLifecycle: RegistryLifecyclePlan;
   registryProcess: RegistryProcessPlan;
 }
 
@@ -257,6 +259,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     isStringRecord(data.mountDiskFdEnv),
     isSnapshotContextPlan(data.snapshotContext),
     isRegistryShapePlan(data.registryShape),
+    isRegistryLifecyclePlan(data.registryLifecycle),
     isRegistryProcessPlan(data.registryProcess),
   ].every(Boolean);
 }
@@ -452,6 +455,14 @@ function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
     nullableString(plan.guest),
     nullableNonNegativeNumber(plan.upperSizeBytes),
   ].every(Boolean);
+}
+
+function isRegistryLifecyclePlan(value: unknown): value is RegistryLifecyclePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryLifecyclePlan>;
+  return nullableString(plan.claimName) && typeof plan.shouldWrite === "boolean";
 }
 
 function isRegistryProcessPlan(value: unknown): value is RegistryProcessPlan {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -31,6 +31,7 @@ type RegistryVmstatePlan = {
   checkpointSequence: number | null;
 };
 export type PlannedPortForward = { hostPort: number; guestPort: number; hostAddr?: string };
+export type PortForwardProbePlan = { hostPort: number; probeHost: string };
 export type BundleWorkspacePlan = { cpioPath: string | null; synthBundleDir: string | null };
 export type BundleConfigPathsPlan = { rootfsDir: string | null; configPath: string | null };
 export type BundlePackPlan = { kind: "fat" | "tiny"; tinyMountGuest: string | null };
@@ -173,6 +174,7 @@ export interface NativeBootPlanResult {
   vmmStatsFile: string | null;
   vmstateRuntime: BootVmstateRuntimePlan;
   plannedPortForward: PlannedPortForward[];
+  portForwardProbe: PortForwardProbePlan[];
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
@@ -239,6 +241,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.vmmStatsFile),
     isBootVmstateRuntimePlan(data.vmstateRuntime),
     Array.isArray(data.plannedPortForward) && data.plannedPortForward.every(isPlannedPortForward),
+    Array.isArray(data.portForwardProbe) && data.portForwardProbe.every(isPortForwardProbePlan),
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
@@ -518,6 +521,14 @@ function isVmstatePlanShape(plan: Partial<BootVmstateRuntimePlan>): boolean {
 
 function isRegistryPortForwardArray(value: unknown): value is RegistryPortForwardPlan[] {
   return Array.isArray(value) && value.every(isPlannedPortForward);
+}
+
+function isPortForwardProbePlan(value: unknown): value is PortForwardProbePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<PortForwardProbePlan>;
+  return nonNegativeNumber(plan.hostPort) && typeof plan.probeHost === "string";
 }
 
 function isPlannedPortForward(value: unknown): value is PlannedPortForward {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -151,6 +151,7 @@ export interface NativeBootPlanResult {
   guestHostname: string | null;
   guestHostnameSet: string | null;
   mergedGuestEnv: Record<string, string>;
+  vmmEnv: Record<string, string>;
   vsockUdsPath: string | null;
   vmmVsock: string | null;
   gvproxyPlan: GvproxyPlan;
@@ -216,6 +217,7 @@ export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanR
     nullableString(data.guestHostname),
     nullableString(data.guestHostnameSet),
     isStringRecord(data.mergedGuestEnv),
+    isStringRecord(data.vmmEnv),
     nullableString(data.vsockUdsPath),
     nullableString(data.vmmVsock),
     isGvproxyPlan(data.gvproxyPlan),

--- a/packages/runtime/src/native/port-forward.ts
+++ b/packages/runtime/src/native/port-forward.ts
@@ -1,8 +1,30 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import { isNativeBootPlanResult, type PortForwardProbePlan } from "./boot-plan-schema.ts";
 
 type PortForwardMapping = { hostPort: number; guestPort: number; hostAddr?: string };
+
+export function planPortForwardProbeNative(
+  portForward: ReadonlyArray<PortForwardMapping>,
+): PortForwardProbePlan[] {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      portForward: [...portForward],
+    },
+    errorCode: "BOOT_PORT_FORWARD_INVALID",
+    makeError: portForwardPlanError,
+    isData: isNativeBootPlanResult,
+  }).portForwardProbe;
+}
 
 export function validatePortForwardNetSocketNative(
   portForward: ReadonlyArray<PortForwardMapping>,

--- a/packages/runtime/src/native/registry-lifecycle.ts
+++ b/packages/runtime/src/native/registry-lifecycle.ts
@@ -1,0 +1,26 @@
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult, type RegistryLifecyclePlan } from "./boot-plan-schema.ts";
+
+export function planBootRegistryLifecycleNative(input: {
+  name?: string;
+  childPid: number;
+  vsockUdsPath?: string;
+}): RegistryLifecyclePlan {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      registryLifecycleName: input.name ?? null,
+      registryChildPid: String(input.childPid),
+      registryLifecycleVsockUdsPath: input.vsockUdsPath ?? null,
+    },
+    isData: isNativeBootPlanResult,
+  }).registryLifecycle;
+}

--- a/packages/runtime/src/native/vmm-env.ts
+++ b/packages/runtime/src/native/vmm-env.ts
@@ -1,0 +1,34 @@
+import { callRuntimeHelper } from "../native-helper.ts";
+import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+
+export function planBootVmmEnvNative(input: {
+  hostEnv: Record<string, string | undefined>;
+  overrides?: Record<string, string>;
+}): Record<string, string> {
+  return callRuntimeHelper({
+    command: "boot-plan",
+    data: {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: null,
+      hostTotalBytes: null,
+      vmmMemoryPreset: true,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+      vmmEnvBase: definedStringRecord(input.hostEnv),
+      vmmEnvOverrides: input.overrides ?? {},
+    },
+    isData: isNativeBootPlanResult,
+  }).vmmEnv;
+}
+
+function definedStringRecord(input: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -78,6 +78,7 @@ import { planBootRegistryProcessNative } from "../native/registry-process.ts";
 import { planBootRootDiskModeNative } from "../native/root-disk-mode.ts";
 import { planBootScratchModeNative } from "../native/scratch-mode.ts";
 import { planBootSnapshotContextNative } from "../native/snapshot-context.ts";
+import { planBootVmmEnvNative } from "../native/vmm-env.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
@@ -1054,10 +1055,10 @@ function resolveBootBinary(opts: BootOptions): string {
 }
 
 function buildVmmEnv(opts: BootOptions): Record<string, string> {
-  return {
-    ...(process.env as Record<string, string>),
-    ...opts.vmmEnv,
-  };
+  return planBootVmmEnvNative({
+    hostEnv: process.env,
+    overrides: opts.vmmEnv,
+  });
 }
 
 function prepareBootScratchDisk(

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -73,6 +73,7 @@ import { reflinkCopy } from "../reflink.ts";
 import { planGvproxyNative } from "../native/gvproxy-plan.ts";
 import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
 import { planGuestHostnameSetNative } from "../native/guest-hostname.ts";
+import { planBootRegistryLifecycleNative } from "../native/registry-lifecycle.ts";
 import { planBootRegistryProcessNative } from "../native/registry-process.ts";
 import { planBootRootDiskModeNative } from "../native/root-disk-mode.ts";
 import { planBootScratchModeNative } from "../native/scratch-mode.ts";
@@ -792,6 +793,8 @@ interface BootRegistryState {
   bootLogPath: string | undefined;
 }
 
+type BootRegistryLifecyclePlan = ReturnType<typeof planBootRegistryLifecycleNative>;
+
 function registerSpawnedBoot(args: {
   opts: BootOptions;
   plan: BootPlan;
@@ -800,8 +803,13 @@ function registerSpawnedBoot(args: {
   bootT0: number;
 }): BootRegistryState {
   const state = buildBootRegistryState(args.opts, args.resources, args.spawned);
-  claimBootNameIfNeeded(state, args.spawned.child);
-  const registered = writeBootRegistryIfPossible(args, state);
+  const lifecycle = planBootRegistryLifecycleNative({
+    name: state.vmName,
+    childPid: state.childPid,
+    vsockUdsPath: args.plan.vsockUdsPath,
+  });
+  claimBootNameIfNeeded(state, args.spawned.child, lifecycle);
+  const registered = writeBootRegistryIfPossible(args, state, lifecycle);
   installBootExitCleanup(args, state, registered);
   return state;
 }
@@ -850,9 +858,10 @@ function registryBootLogPath(opts: BootOptions, childPid: number): string | unde
 function claimBootNameIfNeeded(
   state: BootRegistryState,
   child: ChildProcessWithoutNullStreams,
+  lifecycle: BootRegistryLifecyclePlan,
 ): void {
-  if (state.vmName && state.childPid > 0) {
-    claimNameOrThrow(state.vmName, state.childPid, child);
+  if (lifecycle.claimName) {
+    claimNameOrThrow(lifecycle.claimName, state.childPid, child);
   }
 }
 
@@ -864,8 +873,9 @@ function writeBootRegistryIfPossible(
     spawned: SpawnedBootVmm;
   },
   state: BootRegistryState,
+  lifecycle: BootRegistryLifecyclePlan,
 ): boolean {
-  if (state.childPid <= 0 || !args.plan.vsockUdsPath) {
+  if (!lifecycle.shouldWrite) {
     return false;
   }
   return registerInRegistry(buildRegisterArgs(args, state));

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -71,7 +71,10 @@ import {
 } from "../native/boot-plan.ts";
 import { reflinkCopy } from "../reflink.ts";
 import { planGvproxyNative } from "../native/gvproxy-plan.ts";
-import { validatePortForwardNetSocketNative } from "../native/port-forward.ts";
+import {
+  planPortForwardProbeNative,
+  validatePortForwardNetSocketNative,
+} from "../native/port-forward.ts";
 import { planGuestHostnameSetNative } from "../native/guest-hostname.ts";
 import { planBootRegistryLifecycleNative } from "../native/registry-lifecycle.ts";
 import { planBootRegistryProcessNative } from "../native/registry-process.ts";
@@ -1179,22 +1182,19 @@ function validatePresetNetSocket(
 async function validatePortForwardAvailability(
   portForward: NonNullable<BootOptions["portForward"]>,
 ): Promise<void> {
-  for (const mapping of portForward) {
-    await validateHostPortFree(mapping);
+  for (const probe of planPortForwardProbeNative(portForward)) {
+    await validateHostPortFree(probe);
   }
 }
 
-async function validateHostPortFree(
-  mapping: NonNullable<BootOptions["portForward"]>[number],
-): Promise<void> {
-  const host = mapping.hostAddr ?? "127.0.0.1";
-  const errno = await probeHostPortFree(host, mapping.hostPort);
+async function validateHostPortFree(probe: { hostPort: number; probeHost: string }): Promise<void> {
+  const errno = await probeHostPortFree(probe.probeHost, probe.hostPort);
   if (!errno) {
     return;
   }
   throw new BootError(
     "BOOT_PORT_FORWARD_IN_USE",
-    `portForward: host port ${host}:${mapping.hostPort} is already in use (${errno}). ${await portHolderDetail(mapping.hostPort)}`,
+    `portForward: host port ${probe.probeHost}:${probe.hostPort} is already in use (${errno}). ${await portHolderDetail(probe.hostPort)}`,
   );
 }
 


### PR DESCRIPTION
## Problem

The end of the boot/provision planning wave still had a few small planners mixed into the large PR. Reviewers had to scan unrelated VMM env and port-forward probe changes together with bigger moves.

## Solution

Split the final registry lifecycle, VMM environment overlay, and port-forward probe planners into a small follow-up PR.

## Technical Summary

- Keeps the tail of the planning wave small and easy to review.
- Leaves TypeScript as the process and registry orchestrator.
- Keeps all helper access behind command-specific native wrappers.
