### PR TITLE
Reduce runtime helper wrapper boilerplate

### DIFF
--- a/packages/runtime/src/native/balloon-stats.ts
+++ b/packages/runtime/src/native/balloon-stats.ts
@@ -1,20 +1,23 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 import type { BalloonCounters } from "../balloon-stats.ts";
 
 interface BalloonStatsResult {
   counters: BalloonCounters | null;
 }
 
-export function readBalloonStatsNative(path: string): BalloonCounters | null {
-  return callRuntimeHelper({
-    command: "balloon-stats",
-    data: { path },
-    errorCode: "BOOT_VMM_PACKAGE_BROKEN",
-    makeError: balloonStatsError,
-    isData: isBalloonStatsResult,
-  }).counters;
-}
+export const readBalloonStatsNative = defineRuntimeCommand<
+  string,
+  BalloonStatsResult,
+  BalloonCounters | null
+>({
+  command: "balloon-stats",
+  errorCode: "BOOT_VMM_PACKAGE_BROKEN",
+  data: (path) => ({ path }),
+  output: (response) => response.counters,
+  makeError: balloonStatsError,
+  isData: isBalloonStatsResult,
+});
 
 function balloonStatsError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
   return new BootError(code, message, opts);

--- a/packages/runtime/src/native/boot-plan-command.ts
+++ b/packages/runtime/src/native/boot-plan-command.ts
@@ -1,0 +1,64 @@
+import { type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineRuntimeCommand, defineRuntimeCommandWithArgs } from "./runtime-command.ts";
+
+type BootPlanErrorFactory = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+) => Error;
+
+export function defineBootPlanProjection<
+  TInput,
+  TOutput,
+  TResponse extends NativeBootPlanResult = NativeBootPlanResult,
+>(opts: {
+  data: (input: TInput) => Record<string, unknown>;
+  output: (response: TResponse) => TOutput;
+  isData?: (value: unknown) => value is TResponse;
+  errorCode?: ErrorCode;
+  makeError?: BootPlanErrorFactory;
+}): (input: TInput) => TOutput {
+  return defineRuntimeCommand<TInput, TResponse, TOutput>({
+    command: "boot-plan",
+    errorCode: opts.errorCode ?? "BOOT_MOUNTDISK_TOOL_MISSING",
+    data: (input) => ({ ...minimalBootPlanData(), ...opts.data(input) }),
+    output: opts.output,
+    makeError: opts.makeError,
+    isData: opts.isData ?? (isNativeBootPlanResult as (value: unknown) => value is TResponse),
+  });
+}
+
+export function defineBootPlanProjectionWithArgs<
+  TArgs extends unknown[],
+  TOutput,
+  TResponse extends NativeBootPlanResult = NativeBootPlanResult,
+>(opts: {
+  data: (...args: TArgs) => Record<string, unknown>;
+  output: (response: TResponse) => TOutput;
+  isData?: (value: unknown) => value is TResponse;
+  errorCode?: ErrorCode;
+  makeError?: BootPlanErrorFactory;
+}): (...args: TArgs) => TOutput {
+  return defineRuntimeCommandWithArgs<TArgs, TResponse, TOutput>({
+    command: "boot-plan",
+    errorCode: opts.errorCode ?? "BOOT_MOUNTDISK_TOOL_MISSING",
+    data: (...args) => ({ ...minimalBootPlanData(), ...opts.data(...args) }),
+    output: opts.output,
+    makeError: opts.makeError,
+    isData: opts.isData ?? (isNativeBootPlanResult as (value: unknown) => value is TResponse),
+  });
+}
+
+function minimalBootPlanData(): Record<string, unknown> {
+  return {
+    memoryMib: null,
+    resourcesMemory: null,
+    autoMemoryMib: null,
+    hostTotalBytes: null,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  };
+}

--- a/packages/runtime/src/native/bundle-mount-disk-mode.ts
+++ b/packages/runtime/src/native/bundle-mount-disk-mode.ts
@@ -1,34 +1,30 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type BundleMountDiskModePlan = { action: "none" | "restore" | "fresh" };
 type BundleMountDiskModeResult = NativeBootPlanResult & {
   bundleMountDiskMode: BundleMountDiskModePlan;
 };
 
-export function planBootBundleMountDiskModeNative(input: {
+type BundleMountDiskModeInput = {
   useTiny: boolean;
   mountGuest?: string;
   restoreMountGuest?: string;
-}): BundleMountDiskModePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      bundlePackUseTiny: input.useTiny,
-      bundlePackMountGuest: input.mountGuest ?? null,
-      bundlePackRestoreMountGuest: input.restoreMountGuest ?? null,
-    },
-    isData: isBundleMountDiskModeResult,
-  }).bundleMountDiskMode;
-}
+};
+
+export const planBootBundleMountDiskModeNative = defineBootPlanProjection<
+  BundleMountDiskModeInput,
+  BundleMountDiskModePlan,
+  BundleMountDiskModeResult
+>({
+  data: (input) => ({
+    bundlePackUseTiny: input.useTiny,
+    bundlePackMountGuest: input.mountGuest ?? null,
+    bundlePackRestoreMountGuest: input.restoreMountGuest ?? null,
+  }),
+  output: (plan) => plan.bundleMountDiskMode,
+  isData: isBundleMountDiskModeResult,
+});
 
 function isBundleMountDiskModeResult(value: unknown): value is BundleMountDiskModeResult {
   return (

--- a/packages/runtime/src/native/bundle-pack.ts
+++ b/packages/runtime/src/native/bundle-pack.ts
@@ -1,35 +1,24 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type BundlePackPlan } from "./boot-plan-schema.ts";
+import { type BundlePackPlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planBootBundlePackNative(input: {
+type BundlePackInput = {
   useTiny: boolean;
   mountGuest?: string;
   restoreMountGuest?: string;
-}): BundlePackPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      bundlePackUseTiny: input.useTiny,
-      bundlePackMountGuest: input.mountGuest ?? null,
-      bundlePackRestoreMountGuest: input.restoreMountGuest ?? null,
-    },
-    errorCode: "BOOT_PACK_FAILED",
-    makeError: bundlePackPlanError,
-    isData: isNativeBootPlanResult,
-  }).bundlePack;
-}
+};
 
-const bundlePackPlanError = (
-  code: ErrorCode,
-  message: string,
-  opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+export const planBootBundlePackNative = defineBootPlanProjection<BundlePackInput, BundlePackPlan>({
+  errorCode: "BOOT_PACK_FAILED",
+  makeError: bundlePackPlanError,
+  data: (input) => ({
+    bundlePackUseTiny: input.useTiny,
+    bundlePackMountGuest: input.mountGuest ?? null,
+    bundlePackRestoreMountGuest: input.restoreMountGuest ?? null,
+  }),
+  output: (plan) => plan.bundlePack,
+});
+
+function bundlePackPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/gc.ts
+++ b/packages/runtime/src/native/gc.ts
@@ -1,20 +1,21 @@
 import { RegistryError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommandWithArgs } from "./runtime-command.ts";
 
 interface CleanupPathResult {
   removed: boolean;
   failed: boolean;
 }
 
-export function cleanupPathNative(path: string, dryRun: boolean): CleanupPathResult {
-  return callRuntimeHelper({
-    command: "cleanup-path",
-    data: { path, dryRun },
-    errorCode: "REGISTRY_VM_NOT_FOUND",
-    makeError: cleanupPathError,
-    isData: isCleanupPathResult,
-  });
-}
+export const cleanupPathNative = defineRuntimeCommandWithArgs<
+  [path: string, dryRun: boolean],
+  CleanupPathResult
+>({
+  command: "cleanup-path",
+  errorCode: "REGISTRY_VM_NOT_FOUND",
+  data: (path, dryRun) => ({ path, dryRun }),
+  makeError: cleanupPathError,
+  isData: isCleanupPathResult,
+});
 
 function cleanupPathError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
   return new RegistryError(code, message, opts);

--- a/packages/runtime/src/native/guest-hostname.ts
+++ b/packages/runtime/src/native/guest-hostname.ts
@@ -1,38 +1,32 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planGuestHostnameSetNative(input: {
+type GuestHostnameSetInput = {
   pid: number;
   name?: string;
   vsockUdsPath?: string;
   skip?: boolean;
-}): string | undefined {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      guestHostnameSetPid: String(input.pid),
-      guestHostnameSetName: input.name ?? null,
-      guestHostnameSetVsockUdsPath: input.vsockUdsPath ?? null,
-      guestHostnameSetSkip: input.skip === true,
-    },
-    errorCode: "BOOT_VMM_MISSING",
-    makeError: guestHostnamePlanError,
-    isData: isNativeBootPlanResult,
-  });
-  return plan.guestHostnameSet ?? undefined;
-}
+};
 
-const guestHostnamePlanError = (
+export const planGuestHostnameSetNative = defineBootPlanProjection<
+  GuestHostnameSetInput,
+  string | undefined
+>({
+  errorCode: "BOOT_VMM_MISSING",
+  makeError: guestHostnamePlanError,
+  data: (input) => ({
+    guestHostnameSetPid: String(input.pid),
+    guestHostnameSetName: input.name ?? null,
+    guestHostnameSetVsockUdsPath: input.vsockUdsPath ?? null,
+    guestHostnameSetSkip: input.skip === true,
+  }),
+  output: (plan) => plan.guestHostnameSet ?? undefined,
+});
+
+function guestHostnamePlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/gvproxy-plan.ts
+++ b/packages/runtime/src/native/gvproxy-plan.ts
@@ -1,36 +1,28 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type GvproxyPlan } from "./boot-plan-schema.ts";
+import { type GvproxyPlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type PortForwardMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 
-export function planGvproxyNative(input: {
+type GvproxyInput = {
   portForward: ReadonlyArray<PortForwardMapping>;
   existingNetSocket?: string;
   gvproxyPath?: string;
   planningRequired?: boolean;
-}): GvproxyPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      portForward: [...input.portForward],
-      gvproxyPlanningRequired: input.planningRequired === true,
-      gvproxyNetSocket: input.existingNetSocket ?? null,
-      gvproxyPath: input.gvproxyPath ?? null,
-    },
-    errorCode: "BOOT_PORT_FORWARD_NO_GVPROXY",
-    makeError: gvproxyPlanError,
-    isData: isNativeBootPlanResult,
-  }).gvproxyPlan;
-}
+};
 
-const gvproxyPlanError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new BootError(code, message, opts);
+export const planGvproxyNative = defineBootPlanProjection<GvproxyInput, GvproxyPlan>({
+  errorCode: "BOOT_PORT_FORWARD_NO_GVPROXY",
+  makeError: gvproxyPlanError,
+  data: (input) => ({
+    portForward: [...input.portForward],
+    gvproxyPlanningRequired: input.planningRequired === true,
+    gvproxyNetSocket: input.existingNetSocket ?? null,
+    gvproxyPath: input.gvproxyPath ?? null,
+  }),
+  output: (plan) => plan.gvproxyPlan,
+});
+
+function gvproxyPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/host-memory.ts
+++ b/packages/runtime/src/native/host-memory.ts
@@ -1,20 +1,18 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 
 interface HostMemoryReading {
   freeBytes: number;
   totalBytes: number;
 }
 
-export function readHostMemoryNative(): HostMemoryReading {
-  return callRuntimeHelper({
-    command: "host-memory",
-    data: {},
-    errorCode: "FORK_MEMORY_BACKPRESSURE",
-    makeError: hostMemoryError,
-    isData: isHostMemoryReading,
-  });
-}
+export const readHostMemoryNative = defineRuntimeCommand<void, HostMemoryReading>({
+  command: "host-memory",
+  errorCode: "FORK_MEMORY_BACKPRESSURE",
+  data: () => ({}),
+  makeError: hostMemoryError,
+  isData: isHostMemoryReading,
+});
 
 function hostMemoryError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
   return new BootError(code, message, opts);

--- a/packages/runtime/src/native/host-rss.ts
+++ b/packages/runtime/src/native/host-rss.ts
@@ -1,5 +1,5 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 
 interface HostRssTarget {
   pid: number;
@@ -15,15 +15,18 @@ interface HostRssData {
   readings: HostRssReading[];
 }
 
-export function hostRssNative(targets: readonly HostRssTarget[]): HostRssReading[] {
-  return callRuntimeHelper({
-    command: "host-rss",
-    data: { targets },
-    errorCode: "BOOT_PACK_FAILED",
-    makeError: hostRssError,
-    isData: isHostRssData,
-  }).readings;
-}
+export const hostRssNative = defineRuntimeCommand<
+  readonly HostRssTarget[],
+  HostRssData,
+  HostRssReading[]
+>({
+  command: "host-rss",
+  errorCode: "BOOT_PACK_FAILED",
+  data: (targets) => ({ targets }),
+  output: (response) => response.readings,
+  makeError: hostRssError,
+  isData: isHostRssData,
+});
 
 function hostRssError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
   return new BootError(code, message, opts);

--- a/packages/runtime/src/native/live-mount-options.ts
+++ b/packages/runtime/src/native/live-mount-options.ts
@@ -1,33 +1,28 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
+
+const validateLiveMountRemovedOptionsCommand = defineBootPlanProjection<
+  { hasCache: boolean; hasSync: boolean; index: number },
+  void
+>({
+  errorCode: "BOOT_MOUNT_INVALID",
+  makeError: bootPlanError,
+  data: (input) => ({
+    liveMountRemovedOptionIndex: String(input.index),
+    liveMountRemovedOptionHasCache: input.hasCache,
+    liveMountRemovedOptionHasSync: input.hasSync,
+  }),
+  output: () => undefined,
+});
 
 export function validateLiveMountRemovedOptionsNative(mount: object, index: number): void {
   const hasCache = "cache" in mount;
   const hasSync = "sync" in mount;
-  if (!hasCache && !hasSync) {
-    return;
+  if (hasCache || hasSync) {
+    validateLiveMountRemovedOptionsCommand({ hasCache, hasSync, index });
   }
-  callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      liveMountRemovedOptionIndex: String(index),
-      liveMountRemovedOptionHasCache: hasCache,
-      liveMountRemovedOptionHasSync: hasSync,
-    },
-    errorCode: "BOOT_MOUNT_INVALID",
-    makeError: bootPlanError,
-    isData: isNativeBootPlanResult,
-  });
 }
 
-const bootPlanError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new BootError(code, message, opts);
+function bootPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/mkinitramfs.ts
+++ b/packages/runtime/src/native/mkinitramfs.ts
@@ -1,5 +1,5 @@
 import { MkinitramfsError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 
 interface NativeMkinitramfsRequest {
   mode: "tiny" | "rootfs" | "workspace" | "minimal";
@@ -24,15 +24,15 @@ interface NativeMkinitramfsData {
   workspaceBytes: number;
 }
 
-export function packMkinitramfsNative(request: NativeMkinitramfsRequest): NativeMkinitramfsData {
-  return callRuntimeHelper({
-    command: "mkinitramfs",
-    data: request,
-    errorCode: "MKINITRAMFS_BASE_EXTRACT_FAILED",
-    makeError: mkinitramfsError,
-    isData: isNativeMkinitramfsData,
-  });
-}
+export const packMkinitramfsNative = defineRuntimeCommand<
+  NativeMkinitramfsRequest,
+  NativeMkinitramfsData
+>({
+  command: "mkinitramfs",
+  errorCode: "MKINITRAMFS_BASE_EXTRACT_FAILED",
+  makeError: mkinitramfsError,
+  isData: isNativeMkinitramfsData,
+});
 
 function mkinitramfsError(
   code: ErrorCode,

--- a/packages/runtime/src/native/mount-disk-temp-path.ts
+++ b/packages/runtime/src/native/mount-disk-temp-path.ts
@@ -1,33 +1,29 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type MountDiskTempPathResult = NativeBootPlanResult & { mountDiskTempPath: string };
 
-export function planBootMountDiskTempPathNative(input: {
+type MountDiskTempPathInput = {
   kind: "restore-upper";
   tmpDir: string;
   pid: number;
   nonce: string;
-}): string {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      mountDiskTempKind: input.kind,
-      mountDiskTempDir: input.tmpDir,
-      mountDiskTempPid: String(input.pid),
-      mountDiskTempNonce: input.nonce,
-    },
-    isData: isMountDiskTempPathResult,
-  }).mountDiskTempPath;
-}
+};
+
+export const planBootMountDiskTempPathNative = defineBootPlanProjection<
+  MountDiskTempPathInput,
+  string,
+  MountDiskTempPathResult
+>({
+  data: (input) => ({
+    mountDiskTempKind: input.kind,
+    mountDiskTempDir: input.tmpDir,
+    mountDiskTempPid: String(input.pid),
+    mountDiskTempNonce: input.nonce,
+  }),
+  output: (plan) => plan.mountDiskTempPath,
+  isData: isMountDiskTempPathResult,
+});
 
 function isMountDiskTempPathResult(value: unknown): value is MountDiskTempPathResult {
   if (!isNativeBootPlanResult(value)) {

--- a/packages/runtime/src/native/mount-disk-upper-size.ts
+++ b/packages/runtime/src/native/mount-disk-upper-size.ts
@@ -1,28 +1,22 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type MountDiskUpperSizeResult = NativeBootPlanResult & { mountDiskUpperSizeBytes: number };
 
-export function planMountDiskUpperSizeNative(sizeBytes: number | undefined): number {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      mountDiskUpperSizeOption: sizeBytes === undefined ? null : String(sizeBytes),
-    },
-    errorCode: "BOOT_MOUNT_INVALID",
-    makeError: bootPlanError,
-    isData: isMountDiskUpperSizeResult,
-  }).mountDiskUpperSizeBytes;
-}
+export const planMountDiskUpperSizeNative = defineBootPlanProjection<
+  number | undefined,
+  number,
+  MountDiskUpperSizeResult
+>({
+  errorCode: "BOOT_MOUNT_INVALID",
+  makeError: bootPlanError,
+  data: (sizeBytes) => ({
+    mountDiskUpperSizeOption: sizeBytes === undefined ? null : String(sizeBytes),
+  }),
+  output: (plan) => plan.mountDiskUpperSizeBytes,
+  isData: isMountDiskUpperSizeResult,
+});
 
 function isMountDiskUpperSizeResult(value: unknown): value is MountDiskUpperSizeResult {
   if (!isNativeBootPlanResult(value)) {
@@ -35,5 +29,6 @@ function isMountDiskUpperSizeResult(value: unknown): value is MountDiskUpperSize
   );
 }
 
-const bootPlanError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new BootError(code, message, opts);
+function bootPlanError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/native-code-map.ts
+++ b/packages/runtime/src/native/native-code-map.ts
@@ -1,17 +1,17 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 import type { NativeProcessImageRefusal } from "../native-process-image.ts";
 import type { NativeCodeMapRequest, NativeCodeMapResult } from "../native-code-map.ts";
 
-export function buildNativeCodeMapNative(request: NativeCodeMapRequest): NativeCodeMapResult {
-  return callRuntimeHelper({
-    command: "native-code-map",
-    data: request,
-    errorCode: "BOOT_PORTABLE_UNSUPPORTED",
-    makeError: nativeCodeMapError,
-    isData: isNativeCodeMapResult,
-  });
-}
+export const buildNativeCodeMapNative = defineRuntimeCommand<
+  NativeCodeMapRequest,
+  NativeCodeMapResult
+>({
+  command: "native-code-map",
+  errorCode: "BOOT_PORTABLE_UNSUPPORTED",
+  makeError: nativeCodeMapError,
+  isData: isNativeCodeMapResult,
+});
 
 function isNativeCodeMapResult(value: unknown): value is NativeCodeMapResult {
   if (!value || typeof value !== "object") {
@@ -26,19 +26,19 @@ function isNativeCodeMapResult(value: unknown): value is NativeCodeMapResult {
   );
 }
 
+type CodeLocationCheck = (location: Record<string, unknown>) => boolean;
+
+const codeLocationChecks: CodeLocationCheck[] = [
+  (location) => typeof location.id === "string",
+  (location) => typeof location.sourceMapping === "string",
+  (location) => typeof location.sourceAddress === "string",
+  (location) => isOptionalString(location.targetAddress),
+  (location) => isCodeLocationState(location.state),
+  (location) => location.refusal === undefined || isRefusal(location.refusal),
+];
+
 function isCodeLocation(value: unknown): boolean {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const location = value as Record<string, unknown>;
-  return [
-    typeof location.id === "string",
-    typeof location.sourceMapping === "string",
-    typeof location.sourceAddress === "string",
-    isOptionalString(location.targetAddress),
-    isCodeLocationState(location.state),
-    location.refusal === undefined || isRefusal(location.refusal),
-  ].every(Boolean);
+  return isObject(value) && codeLocationChecks.every((check) => check(value));
 }
 
 function isCodeLocationState(value: unknown): boolean {
@@ -49,6 +49,10 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === "string";
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
 function isRefusal(value: unknown): value is NativeProcessImageRefusal {
   if (!value || typeof value !== "object") {
     return false;
@@ -57,5 +61,6 @@ function isRefusal(value: unknown): value is NativeProcessImageRefusal {
   return typeof refusal.code === "string" && typeof refusal.message === "string";
 }
 
-const nativeCodeMapError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new BootError(code, message, opts);
+function nativeCodeMapError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/port-forward.ts
+++ b/packages/runtime/src/native/port-forward.ts
@@ -1,57 +1,43 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type PortForwardProbePlan } from "./boot-plan-schema.ts";
+import { type PortForwardProbePlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection, defineBootPlanProjectionWithArgs } from "./boot-plan-command.ts";
 
 type PortForwardMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 
-export function planPortForwardProbeNative(
-  portForward: ReadonlyArray<PortForwardMapping>,
-): PortForwardProbePlan[] {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      portForward: [...portForward],
-    },
-    errorCode: "BOOT_PORT_FORWARD_INVALID",
-    makeError: portForwardPlanError,
-    isData: isNativeBootPlanResult,
-  }).portForwardProbe;
-}
+export const planPortForwardProbeNative = defineBootPlanProjection<
+  ReadonlyArray<PortForwardMapping>,
+  PortForwardProbePlan[]
+>({
+  errorCode: "BOOT_PORT_FORWARD_INVALID",
+  makeError: portForwardPlanError,
+  data: (portForward) => ({ portForward: [...portForward] }),
+  output: (plan) => plan.portForwardProbe,
+});
+
+const validatePortForwardNetSocketCommand = defineBootPlanProjectionWithArgs<
+  [portForward: ReadonlyArray<PortForwardMapping>, netSocket: string | undefined],
+  void
+>({
+  errorCode: "BOOT_PORT_FORWARD_INVALID",
+  makeError: portForwardPlanError,
+  data: (portForward, netSocket) => ({
+    portForward: [...portForward],
+    portForwardNetSocket: netSocket ?? null,
+  }),
+  output: () => undefined,
+});
 
 export function validatePortForwardNetSocketNative(
   portForward: ReadonlyArray<PortForwardMapping>,
   netSocket: string | undefined,
 ): void {
-  callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      portForward: [...portForward],
-      portForwardNetSocket: netSocket ?? null,
-    },
-    errorCode: "BOOT_PORT_FORWARD_INVALID",
-    makeError: portForwardPlanError,
-    isData: isNativeBootPlanResult,
-  });
+  validatePortForwardNetSocketCommand(portForward, netSocket);
 }
 
-const portForwardPlanError = (
+function portForwardPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/process-signal.ts
+++ b/packages/runtime/src/native/process-signal.ts
@@ -1,5 +1,5 @@
 import { RegistryError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 
 type NativeProcessSignal = "0" | "SIGTERM" | "SIGKILL";
 
@@ -8,21 +8,15 @@ type ProcessSignalResult = {
   alive: boolean;
 };
 
-export function signalProcessNative(input: {
-  pid: number;
-  signal: NativeProcessSignal;
-}): ProcessSignalResult {
-  return callRuntimeHelper({
-    command: "process-signal",
-    data: {
-      pid: input.pid,
-      signal: input.signal,
-    },
-    errorCode: "REGISTRY_VM_NOT_FOUND",
-    makeError: processSignalError,
-    isData: isProcessSignalResult,
-  });
-}
+export const signalProcessNative = defineRuntimeCommand<
+  { pid: number; signal: NativeProcessSignal },
+  ProcessSignalResult
+>({
+  command: "process-signal",
+  errorCode: "REGISTRY_VM_NOT_FOUND",
+  makeError: processSignalError,
+  isData: isProcessSignalResult,
+});
 
 function isProcessSignalResult(value: unknown): value is ProcessSignalResult {
   if (!value || typeof value !== "object") {
@@ -32,5 +26,6 @@ function isProcessSignalResult(value: unknown): value is ProcessSignalResult {
   return typeof result.signaled === "boolean" && typeof result.alive === "boolean";
 }
 
-const processSignalError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new RegistryError(code, message, opts);
+function processSignalError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new RegistryError(code, message, opts);
+}

--- a/packages/runtime/src/native/provision-asset-lookup.ts
+++ b/packages/runtime/src/native/provision-asset-lookup.ts
@@ -1,41 +1,37 @@
 import { ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type ProvisionAssetLookupPlan } from "./boot-plan-schema.ts";
+import { type ProvisionAssetLookupPlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planProvisionAssetLookupNative(input: {
+type ProvisionAssetLookupInput = {
   explicitPath?: string;
   explicitExists?: boolean;
   assetsDirPath?: string;
   assetsDirExists?: boolean;
   cachePath?: string;
   cacheExists?: boolean;
-}): ProvisionAssetLookupPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      provisionAssetExplicitPath: input.explicitPath ?? null,
-      provisionAssetExplicitExists: input.explicitExists ?? null,
-      provisionAssetAssetsDirPath: input.assetsDirPath ?? null,
-      provisionAssetAssetsDirExists: input.assetsDirExists ?? null,
-      provisionAssetCachePath: input.cachePath ?? null,
-      provisionAssetCacheExists: input.cacheExists ?? null,
-    },
-    errorCode: "PROVISION_BASE_NOT_FOUND",
-    makeError: provisionAssetLookupPlanError,
-    isData: isNativeBootPlanResult,
-  }).provisionAssetLookup;
-}
+};
 
-const provisionAssetLookupPlanError = (
+export const planProvisionAssetLookupNative = defineBootPlanProjection<
+  ProvisionAssetLookupInput,
+  ProvisionAssetLookupPlan
+>({
+  errorCode: "PROVISION_BASE_NOT_FOUND",
+  makeError: provisionAssetLookupPlanError,
+  data: (input) => ({
+    provisionAssetExplicitPath: input.explicitPath ?? null,
+    provisionAssetExplicitExists: input.explicitExists ?? null,
+    provisionAssetAssetsDirPath: input.assetsDirPath ?? null,
+    provisionAssetAssetsDirExists: input.assetsDirExists ?? null,
+    provisionAssetCachePath: input.cachePath ?? null,
+    provisionAssetCacheExists: input.cacheExists ?? null,
+  }),
+  output: (plan) => plan.provisionAssetLookup,
+});
+
+function provisionAssetLookupPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new ProvisionError(code, message, opts);
+): Error {
+  return new ProvisionError(code, message, opts);
+}

--- a/packages/runtime/src/native/provision-boot.ts
+++ b/packages/runtime/src/native/provision-boot.ts
@@ -1,8 +1,8 @@
 import { ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type ProvisionBootPlan } from "./boot-plan-schema.ts";
+import { type ProvisionBootPlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planProvisionBootNative(input: {
+type ProvisionBootInput = {
   basePath: string;
   kernelPath: string;
   dtbPath?: string;
@@ -10,34 +10,30 @@ export function planProvisionBootNative(input: {
   scratchDiskPath: string;
   rootDiskPath: string;
   vmmEnv?: Record<string, string>;
-}): ProvisionBootPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      provisionBasePath: input.basePath,
-      provisionKernelPath: input.kernelPath,
-      provisionDtbPath: input.dtbPath ?? null,
-      provisionUdsPath: input.udsPath,
-      provisionScratchDiskPath: input.scratchDiskPath,
-      provisionRootDiskPath: input.rootDiskPath,
-      provisionBootVmmEnv: input.vmmEnv ?? {},
-    },
-    errorCode: "PROVISION_BASE_NOT_FOUND",
-    makeError: provisionBootPlanError,
-    isData: isNativeBootPlanResult,
-  }).provisionBoot;
-}
+};
 
-const provisionBootPlanError = (
+export const planProvisionBootNative = defineBootPlanProjection<
+  ProvisionBootInput,
+  ProvisionBootPlan
+>({
+  errorCode: "PROVISION_BASE_NOT_FOUND",
+  makeError: provisionBootPlanError,
+  data: (input) => ({
+    provisionBasePath: input.basePath,
+    provisionKernelPath: input.kernelPath,
+    provisionDtbPath: input.dtbPath ?? null,
+    provisionUdsPath: input.udsPath,
+    provisionScratchDiskPath: input.scratchDiskPath,
+    provisionRootDiskPath: input.rootDiskPath,
+    provisionBootVmmEnv: input.vmmEnv ?? {},
+  }),
+  output: (plan) => plan.provisionBoot,
+});
+
+function provisionBootPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new ProvisionError(code, message, opts);
+): Error {
+  return new ProvisionError(code, message, opts);
+}

--- a/packages/runtime/src/native/provision-cli-cache.ts
+++ b/packages/runtime/src/native/provision-cli-cache.ts
@@ -1,37 +1,33 @@
 import { ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type ProvisionCliCachePlan } from "./boot-plan-schema.ts";
+import { type ProvisionCliCachePlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planProvisionCliCacheNative(input: {
+type ProvisionCliCacheInput = {
   homeDir: string;
   version: string;
   guestArchOverride?: string;
   hostArch?: string;
-}): ProvisionCliCachePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      provisionCliCacheHome: input.homeDir,
-      provisionCliCacheVersion: input.version,
-      provisionGuestArchOverride: input.guestArchOverride ?? null,
-      provisionHostArch: input.hostArch ?? null,
-    },
-    errorCode: "PROVISION_BASE_NOT_FOUND",
-    makeError: provisionCliCachePlanError,
-    isData: isNativeBootPlanResult,
-  }).provisionCliCache;
-}
+};
 
-const provisionCliCachePlanError = (
+export const planProvisionCliCacheNative = defineBootPlanProjection<
+  ProvisionCliCacheInput,
+  ProvisionCliCachePlan
+>({
+  errorCode: "PROVISION_BASE_NOT_FOUND",
+  makeError: provisionCliCachePlanError,
+  data: (input) => ({
+    provisionCliCacheHome: input.homeDir,
+    provisionCliCacheVersion: input.version,
+    provisionGuestArchOverride: input.guestArchOverride ?? null,
+    provisionHostArch: input.hostArch ?? null,
+  }),
+  output: (plan) => plan.provisionCliCache,
+});
+
+function provisionCliCachePlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new ProvisionError(code, message, opts);
+): Error {
+  return new ProvisionError(code, message, opts);
+}

--- a/packages/runtime/src/native/provision-dtb.ts
+++ b/packages/runtime/src/native/provision-dtb.ts
@@ -1,33 +1,28 @@
 import { ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type ProvisionDtbPlan } from "./boot-plan-schema.ts";
+import { type ProvisionDtbPlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planProvisionDtbNative(input: {
+type ProvisionDtbInput = {
   guestArchOverride?: string;
   hostArch?: string;
-}): ProvisionDtbPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      provisionGuestArchOverride: input.guestArchOverride ?? null,
-      provisionHostArch: input.hostArch ?? null,
-    },
+};
+
+export const planProvisionDtbNative = defineBootPlanProjection<ProvisionDtbInput, ProvisionDtbPlan>(
+  {
     errorCode: "PROVISION_DTB_NOT_FOUND",
     makeError: provisionDtbPlanError,
-    isData: isNativeBootPlanResult,
-  }).provisionDtb;
-}
+    data: (input) => ({
+      provisionGuestArchOverride: input.guestArchOverride ?? null,
+      provisionHostArch: input.hostArch ?? null,
+    }),
+    output: (plan) => plan.provisionDtb,
+  },
+);
 
-const provisionDtbPlanError = (
+function provisionDtbPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new ProvisionError(code, message, opts);
+): Error {
+  return new ProvisionError(code, message, opts);
+}

--- a/packages/runtime/src/native/provision-result.ts
+++ b/packages/runtime/src/native/provision-result.ts
@@ -1,6 +1,6 @@
 import { ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type ProvisionResultPlan = {
   imagePath: string;
@@ -12,33 +12,21 @@ type ProvisionResultNativeData = NativeBootPlanResult & {
   provisionResult: ProvisionResultPlan;
 };
 
-export function planProvisionResultNative(input: ProvisionResultPlan): ProvisionResultPlan {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      provisionResultImagePath: input.imagePath,
-      provisionResultSizeBytes: String(input.sizeBytes),
-      provisionResultElapsedMs: String(input.elapsedMs),
-    },
-    errorCode: "PROVISION_BASE_NOT_FOUND",
-    makeError: provisionResultPlanError,
-    isData: isProvisionResultData,
-  }).provisionResult;
-
-  return {
-    imagePath: plan.imagePath,
-    sizeBytes: plan.sizeBytes,
-    elapsedMs: plan.elapsedMs,
-  };
-}
+export const planProvisionResultNative = defineBootPlanProjection<
+  ProvisionResultPlan,
+  ProvisionResultPlan,
+  ProvisionResultNativeData
+>({
+  errorCode: "PROVISION_BASE_NOT_FOUND",
+  makeError: provisionResultPlanError,
+  data: (input) => ({
+    provisionResultImagePath: input.imagePath,
+    provisionResultSizeBytes: String(input.sizeBytes),
+    provisionResultElapsedMs: String(input.elapsedMs),
+  }),
+  output: (plan) => plan.provisionResult,
+  isData: isProvisionResultData,
+});
 
 function isProvisionResultData(value: unknown): value is ProvisionResultNativeData {
   if (!isNativeBootPlanResult(value)) {
@@ -56,8 +44,10 @@ function isProvisionResultData(value: unknown): value is ProvisionResultNativeDa
   );
 }
 
-const provisionResultPlanError = (
+function provisionResultPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new ProvisionError(code, message, opts);
+): Error {
+  return new ProvisionError(code, message, opts);
+}

--- a/packages/runtime/src/native/reflink.ts
+++ b/packages/runtime/src/native/reflink.ts
@@ -1,5 +1,5 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommandWithArgs } from "./runtime-command.ts";
 
 export interface NativeReflinkCopyResult {
   mode: "cow" | "copy";
@@ -7,15 +7,16 @@ export interface NativeReflinkCopyResult {
   fallbackReason?: string;
 }
 
-export function reflinkCopyNative(src: string, dst: string): NativeReflinkCopyResult {
-  return callRuntimeHelper({
-    command: "reflink-copy",
-    data: { src, dst },
-    errorCode: "BOOT_PACK_FAILED",
-    makeError: reflinkError,
-    isData: isNativeReflinkCopyResult,
-  });
-}
+export const reflinkCopyNative = defineRuntimeCommandWithArgs<
+  [src: string, dst: string],
+  NativeReflinkCopyResult
+>({
+  command: "reflink-copy",
+  errorCode: "BOOT_PACK_FAILED",
+  data: (src, dst) => ({ src, dst }),
+  makeError: reflinkError,
+  isData: isNativeReflinkCopyResult,
+});
 
 function reflinkError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
   return new BootError(code, message, opts);

--- a/packages/runtime/src/native/registry-lifecycle.ts
+++ b/packages/runtime/src/native/registry-lifecycle.ts
@@ -1,26 +1,20 @@
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type RegistryLifecyclePlan } from "./boot-plan-schema.ts";
+import { type RegistryLifecyclePlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planBootRegistryLifecycleNative(input: {
+type RegistryLifecycleInput = {
   name?: string;
   childPid: number;
   vsockUdsPath?: string;
-}): RegistryLifecyclePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      registryLifecycleName: input.name ?? null,
-      registryChildPid: String(input.childPid),
-      registryLifecycleVsockUdsPath: input.vsockUdsPath ?? null,
-    },
-    isData: isNativeBootPlanResult,
-  }).registryLifecycle;
-}
+};
+
+export const planBootRegistryLifecycleNative = defineBootPlanProjection<
+  RegistryLifecycleInput,
+  RegistryLifecyclePlan
+>({
+  data: (input) => ({
+    registryLifecycleName: input.name ?? null,
+    registryChildPid: String(input.childPid),
+    registryLifecycleVsockUdsPath: input.vsockUdsPath ?? null,
+  }),
+  output: (plan) => plan.registryLifecycle,
+});

--- a/packages/runtime/src/native/registry-process.ts
+++ b/packages/runtime/src/native/registry-process.ts
@@ -1,40 +1,24 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type RegistryProcessPlan } from "./boot-plan-schema.ts";
+import {
+  isNativeBootPlanResult,
+  type NativeBootPlanResult,
+  type RegistryProcessPlan,
+} from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type RegistryProcessIdentityPlan = { vmmPid: number | null; gvPid: number | null };
-type RegistryProcessIdentityResult = { registryProcessIdentity: RegistryProcessIdentityPlan };
+type RegistryProcessIdentityResult = NativeBootPlanResult & {
+  registryProcessIdentity: RegistryProcessIdentityPlan;
+};
 
-export function planBootRegistryProcessIdentityNative(input: {
+type RegistryProcessIdentityInput = {
   hostPlatform: string;
   childPid: number;
   vmmPdeathsig: boolean;
   gvPid?: number;
-}): { vmmPid?: number; gvPid?: number } {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      registryHostPlatform: input.hostPlatform,
-      registryChildPid: String(input.childPid),
-      registryVmmPdeathsig: input.vmmPdeathsig,
-      registryGvPid: input.gvPid === undefined ? null : String(input.gvPid),
-    },
-    errorCode: "BOOT_VMM_MISSING",
-    makeError: registryProcessPlanError,
-    isData: isRegistryProcessIdentityResult,
-  }).registryProcessIdentity;
-  return { vmmPid: plan.vmmPid ?? undefined, gvPid: plan.gvPid ?? undefined };
-}
+};
 
-export function planBootRegistryProcessNative(input: {
+type RegistryProcessInput = {
   hostPlatform: string;
   vmmBinary: string;
   vmmPdeathsig: boolean;
@@ -42,30 +26,55 @@ export function planBootRegistryProcessNative(input: {
   gvPid?: number;
   gvExe?: string;
   gvObservedExeBase?: string;
-}): { vmmExe: string; gvproxyExe?: string } {
-  const plan: RegistryProcessPlan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      registryHostPlatform: input.hostPlatform,
-      registryVmmBinary: input.vmmBinary,
-      registryVmmPdeathsig: input.vmmPdeathsig,
-      registryVmmObservedExeBase: input.vmmObservedExeBase ?? null,
-      registryGvPid: input.gvPid === undefined ? null : String(input.gvPid),
-      registryGvExe: input.gvExe ?? null,
-      registryGvObservedExeBase: input.gvObservedExeBase ?? null,
-    },
-    errorCode: "BOOT_VMM_MISSING",
-    makeError: registryProcessPlanError,
-    isData: isNativeBootPlanResult,
-  }).registryProcess;
+};
+
+export const planBootRegistryProcessIdentityNative = defineBootPlanProjection<
+  RegistryProcessIdentityInput,
+  { vmmPid?: number; gvPid?: number },
+  RegistryProcessIdentityResult
+>({
+  errorCode: "BOOT_VMM_MISSING",
+  makeError: registryProcessPlanError,
+  data: registryProcessIdentityData,
+  output: (plan) => ({
+    vmmPid: plan.registryProcessIdentity.vmmPid ?? undefined,
+    gvPid: plan.registryProcessIdentity.gvPid ?? undefined,
+  }),
+  isData: isRegistryProcessIdentityResult,
+});
+
+export const planBootRegistryProcessNative = defineBootPlanProjection<
+  RegistryProcessInput,
+  { vmmExe: string; gvproxyExe?: string }
+>({
+  errorCode: "BOOT_VMM_MISSING",
+  makeError: registryProcessPlanError,
+  data: registryProcessData,
+  output: (plan) => registryProcessOutput(plan.registryProcess),
+});
+
+function registryProcessIdentityData(input: RegistryProcessIdentityInput): Record<string, unknown> {
+  return {
+    registryHostPlatform: input.hostPlatform,
+    registryChildPid: String(input.childPid),
+    registryVmmPdeathsig: input.vmmPdeathsig,
+    registryGvPid: input.gvPid === undefined ? null : String(input.gvPid),
+  };
+}
+
+function registryProcessData(input: RegistryProcessInput): Record<string, unknown> {
+  return {
+    registryHostPlatform: input.hostPlatform,
+    registryVmmBinary: input.vmmBinary,
+    registryVmmPdeathsig: input.vmmPdeathsig,
+    registryVmmObservedExeBase: input.vmmObservedExeBase ?? null,
+    registryGvPid: input.gvPid === undefined ? null : String(input.gvPid),
+    registryGvExe: input.gvExe ?? null,
+    registryGvObservedExeBase: input.gvObservedExeBase ?? null,
+  };
+}
+
+function registryProcessOutput(plan: RegistryProcessPlan): { vmmExe: string; gvproxyExe?: string } {
   if (!plan.vmmExe) {
     throw new BootError(
       "BOOT_VMM_MISSING",
@@ -91,8 +100,10 @@ function isNullableFiniteNumber(value: unknown): value is number | null {
   return value === null || (typeof value === "number" && Number.isFinite(value));
 }
 
-const registryProcessPlanError = (
+function registryProcessPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/restore-image.ts
+++ b/packages/runtime/src/native/restore-image.ts
@@ -1,6 +1,6 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type RestoreImagePlan = {
   path: string | null;
@@ -11,32 +11,32 @@ type RestoreImageNativeData = NativeBootPlanResult & {
   restoreImage: RestoreImagePlan;
 };
 
-export function planRestoreImageNative(input: {
+type RestoreImageInput = {
   explicitPath?: string;
   explicitExists?: boolean;
   metaSourcePath?: string;
   metaSourceExists?: boolean;
-}): RestoreImagePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      restoreImageExplicitPath: input.explicitPath ?? null,
-      restoreImageExplicitExists: input.explicitExists ?? null,
-      restoreImageMetaSourcePath: input.metaSourcePath ?? null,
-      restoreImageMetaSourceExists: input.metaSourceExists ?? null,
-    },
-    errorCode: "BOOT_IMAGE_NOT_FOUND",
-    makeError: restoreImagePlanError,
-    isData: isRestoreImageData,
-  }).restoreImage;
+};
+
+export const planRestoreImageNative = defineBootPlanProjection<
+  RestoreImageInput,
+  RestoreImagePlan,
+  RestoreImageNativeData
+>({
+  errorCode: "BOOT_IMAGE_NOT_FOUND",
+  data: restoreImageRequestData,
+  output: (response) => response.restoreImage,
+  isData: isRestoreImageData,
+  makeError: restoreImagePlanError,
+});
+
+function restoreImageRequestData(input: RestoreImageInput): Record<string, unknown> {
+  return {
+    restoreImageExplicitPath: input.explicitPath ?? null,
+    restoreImageExplicitExists: input.explicitExists ?? null,
+    restoreImageMetaSourcePath: input.metaSourcePath ?? null,
+    restoreImageMetaSourceExists: input.metaSourceExists ?? null,
+  };
 }
 
 function isRestoreImageData(value: unknown): value is RestoreImageNativeData {
@@ -64,8 +64,10 @@ function isRestoreImageError(value: unknown): value is RestoreImagePlan["error"]
   );
 }
 
-const restoreImagePlanError = (
+function restoreImagePlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/restore-live-mounts.ts
+++ b/packages/runtime/src/native/restore-live-mounts.ts
@@ -1,36 +1,30 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type RestoreLiveMount } from "./boot-plan-schema.ts";
+import { type RestoreLiveMount } from "./boot-plan-schema.ts";
+import { defineBootPlanProjectionWithArgs } from "./boot-plan-command.ts";
 
 type RestoreLiveMountInput = { host: string; guest: string; mode?: "ro" | "rw" };
 type RecordedRestoreLiveMount = { host: string; guest: string; mode: "ro" | "rw" };
 
-export function planRestoreLiveMountsNative(
-  recorded: ReadonlyArray<RecordedRestoreLiveMount> | undefined,
-  overrides: ReadonlyArray<RestoreLiveMountInput> | undefined,
-): RestoreLiveMount[] {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      restoreLiveMountsRecorded: recorded ?? [],
-      restoreLiveMountsOverrides: overrides ?? [],
-    },
-    errorCode: "BOOT_MOUNT_INVALID",
-    makeError: restoreLiveMountPlanError,
-    isData: isNativeBootPlanResult,
-  }).restoreLiveMounts;
-}
+export const planRestoreLiveMountsNative = defineBootPlanProjectionWithArgs<
+  [
+    recorded: ReadonlyArray<RecordedRestoreLiveMount> | undefined,
+    overrides: ReadonlyArray<RestoreLiveMountInput> | undefined,
+  ],
+  RestoreLiveMount[]
+>({
+  errorCode: "BOOT_MOUNT_INVALID",
+  makeError: restoreLiveMountPlanError,
+  data: (recorded, overrides) => ({
+    restoreLiveMountsRecorded: recorded ?? [],
+    restoreLiveMountsOverrides: overrides ?? [],
+  }),
+  output: (plan) => plan.restoreLiveMounts,
+});
 
-const restoreLiveMountPlanError = (
+function restoreLiveMountPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/root-disk-materialize-mode.ts
+++ b/packages/runtime/src/native/root-disk-materialize-mode.ts
@@ -1,32 +1,28 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type RootDiskMaterializeModePlan = { action: "restore" | "caller" | "cached" };
 type RootDiskMaterializeModeResult = NativeBootPlanResult & {
   rootDiskMaterializeMode: RootDiskMaterializeModePlan;
 };
 
-export function planBootRootDiskMaterializeModeNative(input: {
+type RootDiskMaterializeModeInput = {
   restorePath?: string;
   callerPath?: string;
-}): RootDiskMaterializeModePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      rootDiskMaterializeRestorePath: input.restorePath ?? null,
-      rootDiskMaterializeCallerPath: input.callerPath ?? null,
-    },
-    isData: isRootDiskMaterializeModeResult,
-  }).rootDiskMaterializeMode;
-}
+};
+
+export const planBootRootDiskMaterializeModeNative = defineBootPlanProjection<
+  RootDiskMaterializeModeInput,
+  RootDiskMaterializeModePlan,
+  RootDiskMaterializeModeResult
+>({
+  data: (input) => ({
+    rootDiskMaterializeRestorePath: input.restorePath ?? null,
+    rootDiskMaterializeCallerPath: input.callerPath ?? null,
+  }),
+  output: (plan) => plan.rootDiskMaterializeMode,
+  isData: isRootDiskMaterializeModeResult,
+});
 
 function isRootDiskMaterializeModeResult(value: unknown): value is RootDiskMaterializeModeResult {
   if (!isNativeBootPlanResult(value)) {

--- a/packages/runtime/src/native/root-disk-mode.ts
+++ b/packages/runtime/src/native/root-disk-mode.ts
@@ -1,35 +1,33 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type BootRootDiskMode } from "./boot-plan-schema.ts";
+import { type BootRootDiskMode } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planBootRootDiskModeNative(input: {
+type RootDiskModeInput = {
   rootDisk?: boolean | string;
   restorePath?: string;
-}): BootRootDiskMode {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: input.rootDisk === true,
-      hasCmd: false,
-      rootDiskOptionFalse: input.rootDisk === false,
-      rootDiskOptionTrue: input.rootDisk === true,
-      rootDiskOptionPath: typeof input.rootDisk === "string" ? input.rootDisk : null,
-      rootDiskRestorePath: input.restorePath ?? null,
-    },
-    errorCode: "BOOT_VMM_MISSING",
-    makeError: rootDiskModePlanError,
-    isData: isNativeBootPlanResult,
-  });
-  return plan.rootDiskMode;
-}
+};
 
-const rootDiskModePlanError = (
+export const planBootRootDiskModeNative = defineBootPlanProjection<
+  RootDiskModeInput,
+  BootRootDiskMode
+>({
+  errorCode: "BOOT_VMM_MISSING",
+  makeError: rootDiskModePlanError,
+  data: (input) => ({
+    rootDisk: "unset",
+    hasImage: input.rootDisk === true,
+    rootDiskOptionFalse: input.rootDisk === false,
+    rootDiskOptionTrue: input.rootDisk === true,
+    rootDiskOptionPath: typeof input.rootDisk === "string" ? input.rootDisk : null,
+    rootDiskRestorePath: input.restorePath ?? null,
+  }),
+  output: (plan) => plan.rootDiskMode,
+});
+
+function rootDiskModePlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/root-disk-temp-path.ts
+++ b/packages/runtime/src/native/root-disk-temp-path.ts
@@ -1,33 +1,29 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type RootDiskTempPathResult = NativeBootPlanResult & { rootDiskTempPath: string };
 
-export function planBootRootDiskTempPathNative(input: {
+type RootDiskTempPathInput = {
   kind: "restore" | "cached";
   tmpDir: string;
   pid: number;
   nonce: string;
-}): string {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      rootDiskTempKind: input.kind,
-      rootDiskTempDir: input.tmpDir,
-      rootDiskTempPid: String(input.pid),
-      rootDiskTempNonce: input.nonce,
-    },
-    isData: isRootDiskTempPathResult,
-  }).rootDiskTempPath;
-}
+};
+
+export const planBootRootDiskTempPathNative = defineBootPlanProjection<
+  RootDiskTempPathInput,
+  string,
+  RootDiskTempPathResult
+>({
+  data: (input) => ({
+    rootDiskTempKind: input.kind,
+    rootDiskTempDir: input.tmpDir,
+    rootDiskTempPid: String(input.pid),
+    rootDiskTempNonce: input.nonce,
+  }),
+  output: (plan) => plan.rootDiskTempPath,
+  isData: isRootDiskTempPathResult,
+});
 
 function isRootDiskTempPathResult(value: unknown): value is RootDiskTempPathResult {
   if (!isNativeBootPlanResult(value)) {

--- a/packages/runtime/src/native/runtime-command.ts
+++ b/packages/runtime/src/native/runtime-command.ts
@@ -1,0 +1,57 @@
+import { type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+type RuntimeCommandErrorFactory = (
+  code: ErrorCode,
+  message: string,
+  opts?: MachinenErrorOptions,
+) => Error;
+
+type RuntimeCommandFailureMapper = (error: {
+  code: string;
+  message: string;
+}) => { errorCode?: ErrorCode; message?: string } | undefined;
+
+interface RuntimeCommandOptions<TResponse, TOutput> {
+  command: string;
+  errorCode: ErrorCode;
+  isData: (value: unknown) => value is TResponse;
+  output?: (response: TResponse) => TOutput;
+  makeError?: RuntimeCommandErrorFactory;
+  mapFailure?: RuntimeCommandFailureMapper;
+}
+
+export function defineRuntimeCommand<TInput, TResponse, TOutput = TResponse>(
+  opts: RuntimeCommandOptions<TResponse, TOutput> & {
+    data?: (input: TInput) => unknown;
+  },
+): (input: TInput) => TOutput {
+  return (input) => callDefinedRuntimeCommand(opts, opts.data ? opts.data(input) : input);
+}
+
+export function defineRuntimeCommandWithArgs<
+  TArgs extends unknown[],
+  TResponse,
+  TOutput = TResponse,
+>(
+  opts: RuntimeCommandOptions<TResponse, TOutput> & {
+    data: (...args: TArgs) => unknown;
+  },
+): (...args: TArgs) => TOutput {
+  return (...args) => callDefinedRuntimeCommand(opts, opts.data(...args));
+}
+
+function callDefinedRuntimeCommand<TResponse, TOutput>(
+  opts: RuntimeCommandOptions<TResponse, TOutput>,
+  data: unknown,
+): TOutput {
+  const response = callRuntimeHelper({
+    command: opts.command,
+    data,
+    errorCode: opts.errorCode,
+    makeError: opts.makeError,
+    mapFailure: opts.mapFailure,
+    isData: opts.isData,
+  });
+  return opts.output ? opts.output(response) : (response as unknown as TOutput);
+}

--- a/packages/runtime/src/native/scratch-mode.ts
+++ b/packages/runtime/src/native/scratch-mode.ts
@@ -1,32 +1,25 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type ScratchModePlan = "false" | "path" | "auto";
 
-export function planBootScratchModeNative(snapshot: string | false | undefined): ScratchModePlan {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      scratchOptionFalse: snapshot === false,
-      scratchOptionPath: typeof snapshot === "string" ? snapshot : null,
-    },
-    errorCode: "BOOT_VMM_MISSING",
-    makeError: scratchModePlanError,
-    isData: isNativeBootPlanResult,
-  });
-  return plan.plannedScratchMode === "unset" ? "auto" : plan.plannedScratchMode;
-}
+export const planBootScratchModeNative = defineBootPlanProjection<
+  string | false | undefined,
+  ScratchModePlan
+>({
+  errorCode: "BOOT_VMM_MISSING",
+  makeError: scratchModePlanError,
+  data: (snapshot) => ({
+    scratchOptionFalse: snapshot === false,
+    scratchOptionPath: typeof snapshot === "string" ? snapshot : null,
+  }),
+  output: (plan) => (plan.plannedScratchMode === "unset" ? "auto" : plan.plannedScratchMode),
+});
 
-const scratchModePlanError = (
+function scratchModePlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/scratch-temp-path.ts
+++ b/packages/runtime/src/native/scratch-temp-path.ts
@@ -1,33 +1,29 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type ScratchTempPathResult = NativeBootPlanResult & { scratchTempPath: string };
 
-export function planBootScratchTempPathNative(input: {
+type ScratchTempPathInput = {
   kind: "restore" | "auto";
   tmpDir: string;
   pid: number;
   nonce: string;
-}): string {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      scratchTempKind: input.kind,
-      scratchTempDir: input.tmpDir,
-      scratchTempPid: String(input.pid),
-      scratchTempNonce: input.nonce,
-    },
-    isData: isScratchTempPathResult,
-  }).scratchTempPath;
-}
+};
+
+export const planBootScratchTempPathNative = defineBootPlanProjection<
+  ScratchTempPathInput,
+  string,
+  ScratchTempPathResult
+>({
+  data: (input) => ({
+    scratchTempKind: input.kind,
+    scratchTempDir: input.tmpDir,
+    scratchTempPid: String(input.pid),
+    scratchTempNonce: input.nonce,
+  }),
+  output: (plan) => plan.scratchTempPath,
+  isData: isScratchTempPathResult,
+});
 
 function isScratchTempPathResult(value: unknown): value is ScratchTempPathResult {
   if (!isNativeBootPlanResult(value)) {

--- a/packages/runtime/src/native/snapshot-backing.ts
+++ b/packages/runtime/src/native/snapshot-backing.ts
@@ -1,34 +1,23 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjectionWithArgs } from "./boot-plan-command.ts";
 
 type SnapshotBackingPlan = { allowed: boolean };
 type SnapshotBackingResult = NativeBootPlanResult & { snapshotBacking: SnapshotBackingPlan };
 
-export function planBootSnapshotBackingNative(
-  engine: string,
-  action: "snapshot" | "fork",
-  diskPath?: string,
-  vmstatePath?: string,
-): SnapshotBackingPlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      snapshotBackingEngine: engine,
-      snapshotBackingAction: action,
-      snapshotBackingDiskPath: diskPath ?? null,
-      snapshotBackingVmstatePath: vmstatePath ?? null,
-    },
-    isData: isSnapshotBackingResult,
-  }).snapshotBacking;
-}
+export const planBootSnapshotBackingNative = defineBootPlanProjectionWithArgs<
+  [engine: string, action: "snapshot" | "fork", diskPath?: string, vmstatePath?: string],
+  SnapshotBackingPlan,
+  SnapshotBackingResult
+>({
+  data: (engine, action, diskPath, vmstatePath) => ({
+    snapshotBackingEngine: engine,
+    snapshotBackingAction: action,
+    snapshotBackingDiskPath: diskPath ?? null,
+    snapshotBackingVmstatePath: vmstatePath ?? null,
+  }),
+  output: (plan) => plan.snapshotBacking,
+  isData: isSnapshotBackingResult,
+});
 
 function isSnapshotBackingResult(value: unknown): value is SnapshotBackingResult {
   return (

--- a/packages/runtime/src/native/snapshot-context.ts
+++ b/packages/runtime/src/native/snapshot-context.ts
@@ -1,6 +1,6 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type PlannedLiveMount } from "./boot-plan-schema.ts";
+import { type PlannedLiveMount } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type SnapshotMountDiskInput = { guest: string; lowerPath: string; upperPath: string };
 type SnapshotVmstateInput = {
@@ -10,54 +10,56 @@ type SnapshotVmstateInput = {
   checkpointSequence: number;
 };
 
-export function planBootSnapshotContextNative(input: {
+type SnapshotContextInput = {
   mountDisk?: SnapshotMountDiskInput;
   liveMounts: ReadonlyArray<PlannedLiveMount>;
   vmstate: SnapshotVmstateInput;
-}): {
+};
+
+type SnapshotContextPlan = {
   mountDisk?: SnapshotMountDiskInput;
   liveMounts?: Array<{ host: string; guest: string; mode: "ro" | "rw" }>;
   vmstateChain?: { chainId: string; parentDir?: string; sequence: number };
-} {
-  const plan = callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      snapshotMountGuest: input.mountDisk?.guest ?? null,
-      snapshotMountLowerPath: input.mountDisk?.lowerPath ?? null,
-      snapshotMountUpperPath: input.mountDisk?.upperPath ?? null,
-      snapshotLiveMounts: [...input.liveMounts],
-      snapshotVmstatePath: input.vmstate.statePath ?? null,
-      snapshotVmstateChainId: input.vmstate.chainId,
-      snapshotVmstateCheckpointParent: input.vmstate.checkpointParent ?? null,
-      snapshotVmstateCheckpointSequence: String(input.vmstate.checkpointSequence),
-    },
-    errorCode: "BOOT_SNAPSHOT_NOT_FOUND",
-    makeError: snapshotContextPlanError,
-    isData: isNativeBootPlanResult,
-  }).snapshotContext;
-  return {
-    mountDisk: plan.mountDisk ?? undefined,
-    liveMounts: plan.liveMounts.length > 0 ? plan.liveMounts : undefined,
-    vmstateChain: plan.vmstateChain
+};
+
+export const planBootSnapshotContextNative = defineBootPlanProjection<
+  SnapshotContextInput,
+  SnapshotContextPlan
+>({
+  errorCode: "BOOT_SNAPSHOT_NOT_FOUND",
+  makeError: snapshotContextPlanError,
+  data: snapshotContextData,
+  output: (plan) => ({
+    mountDisk: plan.snapshotContext.mountDisk ?? undefined,
+    liveMounts:
+      plan.snapshotContext.liveMounts.length > 0 ? plan.snapshotContext.liveMounts : undefined,
+    vmstateChain: plan.snapshotContext.vmstateChain
       ? {
-          chainId: plan.vmstateChain.chainId,
-          parentDir: plan.vmstateChain.parentDir ?? undefined,
-          sequence: plan.vmstateChain.sequence,
+          chainId: plan.snapshotContext.vmstateChain.chainId,
+          parentDir: plan.snapshotContext.vmstateChain.parentDir ?? undefined,
+          sequence: plan.snapshotContext.vmstateChain.sequence,
         }
       : undefined,
+  }),
+});
+
+function snapshotContextData(input: SnapshotContextInput): Record<string, unknown> {
+  return {
+    snapshotMountGuest: input.mountDisk?.guest ?? null,
+    snapshotMountLowerPath: input.mountDisk?.lowerPath ?? null,
+    snapshotMountUpperPath: input.mountDisk?.upperPath ?? null,
+    snapshotLiveMounts: [...input.liveMounts],
+    snapshotVmstatePath: input.vmstate.statePath ?? null,
+    snapshotVmstateChainId: input.vmstate.chainId,
+    snapshotVmstateCheckpointParent: input.vmstate.checkpointParent ?? null,
+    snapshotVmstateCheckpointSequence: String(input.vmstate.checkpointSequence),
   };
 }
 
-const snapshotContextPlanError = (
+function snapshotContextPlanError(
   code: ErrorCode,
   message: string,
   opts?: MachinenErrorOptions,
-): Error => new BootError(code, message, opts);
+): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/stats-file-mode.ts
+++ b/packages/runtime/src/native/stats-file-mode.ts
@@ -1,5 +1,5 @@
-import { callRuntimeHelper } from "../native-helper.ts";
 import { isNativeBootPlanResult, type NativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
 type StatsFileTempModePlan = {
   action: "existing" | "reuse" | "allocate";
@@ -11,33 +11,23 @@ type StatsFileTempModeResult = NativeBootPlanResult & {
   statsFileTempMode: StatsFileTempModePlan;
 };
 
-export function planBootStatsFileTempModeNative(input: {
+type StatsFileTempModeInput = {
   existingPath?: string;
   vsockTempDir?: string;
-}): StatsFileTempModePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      ...baseStatsFileModeData(input),
-      statsFileVsockTempDir: input.vsockTempDir ?? null,
-    },
-    isData: isStatsFileTempModeResult,
-  }).statsFileTempMode;
-}
+};
 
-function baseStatsFileModeData(input: { existingPath?: string }) {
-  return {
-    memoryMib: null,
-    resourcesMemory: null,
-    autoMemoryMib: null,
-    hostTotalBytes: null,
-    vmmMemoryPreset: true,
-    hasImage: false,
-    hasCmd: false,
-    rootDisk: "false",
+export const planBootStatsFileTempModeNative = defineBootPlanProjection<
+  StatsFileTempModeInput,
+  StatsFileTempModePlan,
+  StatsFileTempModeResult
+>({
+  data: (input) => ({
     existingStatsFile: input.existingPath ?? null,
-  };
-}
+    statsFileVsockTempDir: input.vsockTempDir ?? null,
+  }),
+  output: (plan) => plan.statsFileTempMode,
+  isData: isStatsFileTempModeResult,
+});
 
 function isStatsFileTempModeResult(value: unknown): value is StatsFileTempModeResult {
   if (!isNativeBootPlanResult(value)) {

--- a/packages/runtime/src/native/tree-manifest-hash.ts
+++ b/packages/runtime/src/native/tree-manifest-hash.ts
@@ -1,19 +1,18 @@
 import type { ErrorCode } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 
 interface TreeManifestHashData {
   hash: string;
 }
 
-export function treeManifestHashNative(root: string): string {
-  return callRuntimeHelper({
-    command: "tree-manifest-hash",
-    data: { root },
-    errorCode: "BOOT_MOUNTDISK_TOOL_MISSING",
-    isData: isTreeManifestHashData,
-    mapFailure: mapTreeManifestHashFailure,
-  }).hash;
-}
+export const treeManifestHashNative = defineRuntimeCommand<string, TreeManifestHashData, string>({
+  command: "tree-manifest-hash",
+  errorCode: "BOOT_MOUNTDISK_TOOL_MISSING",
+  data: (root) => ({ root }),
+  output: (response) => response.hash,
+  mapFailure: mapTreeManifestHashFailure,
+  isData: isTreeManifestHashData,
+});
 
 function mapTreeManifestHashFailure(error: {
   code: string;

--- a/packages/runtime/src/native/vmm-env.ts
+++ b/packages/runtime/src/native/vmm-env.ts
@@ -1,27 +1,17 @@
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planBootVmmEnvNative(input: {
+type VmmEnvInput = {
   hostEnv: Record<string, string | undefined>;
   overrides?: Record<string, string>;
-}): Record<string, string> {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      vmmEnvBase: definedStringRecord(input.hostEnv),
-      vmmEnvOverrides: input.overrides ?? {},
-    },
-    isData: isNativeBootPlanResult,
-  }).vmmEnv;
-}
+};
+
+export const planBootVmmEnvNative = defineBootPlanProjection<VmmEnvInput, Record<string, string>>({
+  data: (input) => ({
+    vmmEnvBase: definedStringRecord(input.hostEnv),
+    vmmEnvOverrides: input.overrides ?? {},
+  }),
+  output: (plan) => plan.vmmEnv,
+});
 
 function definedStringRecord(input: Record<string, string | undefined>): Record<string, string> {
   const out: Record<string, string> = {};

--- a/packages/runtime/src/native/vmstate-facts.ts
+++ b/packages/runtime/src/native/vmstate-facts.ts
@@ -1,16 +1,14 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
-import { callRuntimeHelper } from "../native-helper.ts";
+import { defineRuntimeCommand } from "./runtime-command.ts";
 import type { VmstateFacts } from "../vm/vmstate-metadata.ts";
 
-export function readVmstateFactsNative(path: string): VmstateFacts {
-  return callRuntimeHelper({
-    command: "vmstate-facts",
-    data: { path },
-    errorCode: "BOOT_SNAPSHOT_NOT_FOUND",
-    makeError: vmstateFactsError,
-    isData: isVmstateFacts,
-  });
-}
+export const readVmstateFactsNative = defineRuntimeCommand<string, VmstateFacts>({
+  command: "vmstate-facts",
+  errorCode: "BOOT_SNAPSHOT_NOT_FOUND",
+  data: (path) => ({ path }),
+  makeError: vmstateFactsError,
+  isData: isVmstateFacts,
+});
 
 function isVmstateFacts(value: unknown): value is VmstateFacts {
   if (!value || typeof value !== "object") {
@@ -42,5 +40,6 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === "string";
 }
 
-const vmstateFactsError = (code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error =>
-  new BootError(code, message, opts);
+function vmstateFactsError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  return new BootError(code, message, opts);
+}

--- a/packages/runtime/src/native/vmstate-temp-mode.ts
+++ b/packages/runtime/src/native/vmstate-temp-mode.ts
@@ -1,26 +1,14 @@
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type VmstateTempModePlan } from "./boot-plan-schema.ts";
+import { type VmstateTempModePlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjectionWithArgs } from "./boot-plan-command.ts";
 
-export function planBootVmstateTempModeNative(
-  engine: string,
-  snapshotDisabled: boolean,
-  existingTempDir?: string,
-): VmstateTempModePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      bootVmstateEngine: engine,
-      bootVmstateSnapshotDisabled: snapshotDisabled,
-      bootVmstateExistingTempDir: existingTempDir ?? null,
-    },
-    isData: isNativeBootPlanResult,
-  }).vmstateTempMode;
-}
+export const planBootVmstateTempModeNative = defineBootPlanProjectionWithArgs<
+  [engine: string, snapshotDisabled: boolean, existingTempDir?: string],
+  VmstateTempModePlan
+>({
+  data: (engine, snapshotDisabled, existingTempDir) => ({
+    bootVmstateEngine: engine,
+    bootVmstateSnapshotDisabled: snapshotDisabled,
+    bootVmstateExistingTempDir: existingTempDir ?? null,
+  }),
+  output: (plan) => plan.vmstateTempMode,
+});

--- a/packages/runtime/src/native/vsock-mode.ts
+++ b/packages/runtime/src/native/vsock-mode.ts
@@ -1,20 +1,7 @@
-import { callRuntimeHelper } from "../native-helper.ts";
-import { isNativeBootPlanResult, type VsockModePlan } from "./boot-plan-schema.ts";
+import { type VsockModePlan } from "./boot-plan-schema.ts";
+import { defineBootPlanProjection } from "./boot-plan-command.ts";
 
-export function planBootVsockModeNative(existingSpec: string | undefined): VsockModePlan {
-  return callRuntimeHelper({
-    command: "boot-plan",
-    data: {
-      memoryMib: null,
-      resourcesMemory: null,
-      autoMemoryMib: null,
-      hostTotalBytes: null,
-      vmmMemoryPreset: true,
-      hasImage: false,
-      hasCmd: false,
-      rootDisk: "false",
-      existingVsockSpec: existingSpec ?? null,
-    },
-    isData: isNativeBootPlanResult,
-  }).vsockMode;
-}
+export const planBootVsockModeNative = defineBootPlanProjection<string | undefined, VsockModePlan>({
+  data: (existingSpec) => ({ existingVsockSpec: existingSpec ?? null }),
+  output: (plan) => plan.vsockMode,
+});


### PR DESCRIPTION
## Problem

The native runtime wrappers repeated the same helper-call boilerplate over and over. That made each new Zig helper command longer than it needed to be.

## Solution

Add small shared wrapper builders for runtime commands and boot-plan projections. Existing wrappers now use those builders while keeping command-specific TypeScript APIs.

## Technical Summary

- Keeps product modules from calling the raw helper protocol directly.
- Centralizes the repeated boot-plan minimum payload in one place.
- Keeps custom validation where wrappers need stricter output checks.
