### PR TITLE
Move registry and provision planners to Zig

### DIFF
--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -85,6 +85,22 @@ pub const BundleEnvInput = struct {
     guest_env: []const EnvPair = &.{},
 };
 
+pub const ProvisionGuestCpu = enum {
+    arm64,
+    amd64,
+};
+
+pub const ProvisionAssetsInput = struct {
+    guest_cpu: ProvisionGuestCpu = .arm64,
+};
+
+pub const ProvisionAssetsPlan = struct {
+    cpu: []const u8,
+    kernel_asset: []const u8,
+    dtb_asset: ?[]const u8,
+    rootfs_asset: []const u8,
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -421,6 +437,23 @@ pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     assert(@sizeOf(MachinenConfigInput) > 0);
 
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
+    return switch (input.guest_cpu) {
+        .amd64 => .{
+            .cpu = "amd64",
+            .kernel_asset = "bzImage-x86_64",
+            .dtb_asset = null,
+            .rootfs_asset = "rootfs-debian-amd64.tar.gz",
+        },
+        .arm64 => .{
+            .cpu = "arm64",
+            .kernel_asset = "Image-arm64",
+            .dtb_asset = "virt-arm64.dtb",
+            .rootfs_asset = "rootfs-debian-arm64.tar.gz",
+        },
+    };
 }
 
 pub fn planBundleEnv(allocator: std.mem.Allocator, input: BundleEnvInput) ![]EnvPair {
@@ -995,6 +1028,20 @@ test "planMountDiskRuntime selects restore and fresh actions" {
     try std.testing.expectEqualStrings("fresh", fresh.action);
     try std.testing.expect(fresh.source_upper_path == null);
     try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
+}
+
+test "planProvisionAssets selects asset names by guest CPU" {
+    const arm = planProvisionAssets(.{ .guest_cpu = .arm64 });
+    try std.testing.expectEqualStrings("arm64", arm.cpu);
+    try std.testing.expectEqualStrings("Image-arm64", arm.kernel_asset);
+    try std.testing.expectEqualStrings("virt-arm64.dtb", arm.dtb_asset.?);
+    try std.testing.expectEqualStrings("rootfs-debian-arm64.tar.gz", arm.rootfs_asset);
+
+    const x64 = planProvisionAssets(.{ .guest_cpu = .amd64 });
+    try std.testing.expectEqualStrings("amd64", x64.cpu);
+    try std.testing.expectEqualStrings("bzImage-x86_64", x64.kernel_asset);
+    try std.testing.expect(x64.dtb_asset == null);
+    try std.testing.expectEqualStrings("rootfs-debian-amd64.tar.gz", x64.rootfs_asset);
 }
 
 test "planBundleEnv overlays guest env on image env" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -121,6 +121,22 @@ pub const ProvisionBootPlan = struct {
     root_disk_path: ?[]const u8,
 };
 
+pub const ProvisionWorkloadPlan = struct {
+    tar_to_disk_command: []const u8,
+    poweroff_command: []const u8,
+};
+
+pub const ProvisionRepackInput = struct {
+    disk_path: ?[]const u8 = null,
+    out_path: ?[]const u8 = null,
+    extract_dir: ?[]const u8 = null,
+};
+
+pub const ProvisionRepackPlan = struct {
+    extract_args: []const []const u8,
+    targz_args: []const []const u8,
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -326,6 +342,7 @@ pub const PlanError = error{
     MissingRootDiskRuntimePath,
     MissingMountDiskRuntimeField,
     IncompleteRegistryMountDisk,
+    MissingProvisionRepackField,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -457,6 +474,33 @@ pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     assert(@sizeOf(MachinenConfigInput) > 0);
 
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planProvisionWorkload() ProvisionWorkloadPlan {
+    return .{
+        .tar_to_disk_command = "tar -C / --exclude=./proc --exclude=./sys --exclude=./dev --exclude=./tmp --exclude=./run --exclude=./machinen-config.json --exclude=./etc/machinen-boot-epoch --sort=name --numeric-owner --owner=0 --group=0 -cf /dev/vdb .",
+        .poweroff_command = "/sbin/machinen-poweroff",
+    };
+}
+
+pub fn planProvisionRepack(allocator: std.mem.Allocator, input: ProvisionRepackInput) !ProvisionRepackPlan {
+    if (input.disk_path == null and input.out_path == null and input.extract_dir == null) {
+        return .{
+            .extract_args = &.{},
+            .targz_args = &.{},
+        };
+    }
+    const disk_path = input.disk_path orelse return error.MissingProvisionRepackField;
+    const out_path = input.out_path orelse return error.MissingProvisionRepackField;
+    const extract_dir = input.extract_dir orelse return error.MissingProvisionRepackField;
+    const extract_args = try allocator.dupe([]const u8, &[_][]const u8{ "-xf", disk_path, "-C", extract_dir });
+    errdefer allocator.free(extract_args);
+    const targz_args = try allocator.dupe([]const u8, &[_][]const u8{ "-czf", out_path, "-C", extract_dir, "." });
+    errdefer allocator.free(targz_args);
+    return .{
+        .extract_args = extract_args,
+        .targz_args = targz_args,
+    };
 }
 
 pub fn planProvisionBoot(allocator: std.mem.Allocator, input: ProvisionBootInput) !ProvisionBootPlan {
@@ -1070,6 +1114,24 @@ test "planMountDiskRuntime selects restore and fresh actions" {
     try std.testing.expectEqualStrings("fresh", fresh.action);
     try std.testing.expect(fresh.source_upper_path == null);
     try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
+}
+
+test "planProvisionWorkload and planProvisionRepack build commands" {
+    const workload = planProvisionWorkload();
+    try std.testing.expect(std.mem.startsWith(u8, workload.tar_to_disk_command, "tar -C /"));
+    try std.testing.expect(std.mem.endsWith(u8, workload.tar_to_disk_command, "-cf /dev/vdb ."));
+    try std.testing.expectEqualStrings("/sbin/machinen-poweroff", workload.poweroff_command);
+
+    const allocator = std.testing.allocator;
+    const repack = try planProvisionRepack(allocator, .{
+        .disk_path = "/tmp/scratch.img",
+        .out_path = "/tmp/out.tar.gz",
+        .extract_dir = "/tmp/extract",
+    });
+    defer allocator.free(repack.extract_args);
+    defer allocator.free(repack.targz_args);
+    try std.testing.expectEqualSlices([]const u8, &[_][]const u8{ "-xf", "/tmp/scratch.img", "-C", "/tmp/extract" }, repack.extract_args);
+    try std.testing.expectEqualSlices([]const u8, &[_][]const u8{ "-czf", "/tmp/out.tar.gz", "-C", "/tmp/extract", "." }, repack.targz_args);
 }
 
 test "planProvisionBoot builds provision boot inputs" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -101,6 +101,26 @@ pub const ProvisionAssetsPlan = struct {
     rootfs_asset: []const u8,
 };
 
+pub const ProvisionBootInput = struct {
+    base_path: ?[]const u8 = null,
+    kernel_path: ?[]const u8 = null,
+    dtb_path: ?[]const u8 = null,
+    uds_path: ?[]const u8 = null,
+    scratch_disk_path: ?[]const u8 = null,
+    root_disk_path: ?[]const u8 = null,
+};
+
+pub const ProvisionBootPlan = struct {
+    image_path: ?[]const u8,
+    kernel_path: ?[]const u8,
+    dtb_path: ?[]const u8,
+    vmm_vsock: ?[]const u8,
+    cmd: []const []const u8,
+    env: []const EnvPair,
+    snapshot_path: ?[]const u8,
+    root_disk_path: ?[]const u8,
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -437,6 +457,28 @@ pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     assert(@sizeOf(MachinenConfigInput) > 0);
 
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planProvisionBoot(allocator: std.mem.Allocator, input: ProvisionBootInput) !ProvisionBootPlan {
+    const cmd = try allocator.dupe([]const u8, &[_][]const u8{"/exec-agent"});
+    errdefer allocator.free(cmd);
+    const env = try allocator.dupe(EnvPair, &[_]EnvPair{.{ .key = "PATH", .value = "/usr/local/bin:/usr/bin:/bin:/sbin" }});
+    errdefer allocator.free(env);
+    const vmm_vsock = if (input.uds_path) |uds|
+        try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds})
+    else
+        null;
+    errdefer if (vmm_vsock) |spec| allocator.free(spec);
+    return .{
+        .image_path = input.base_path,
+        .kernel_path = input.kernel_path,
+        .dtb_path = input.dtb_path,
+        .vmm_vsock = vmm_vsock,
+        .cmd = cmd,
+        .env = env,
+        .snapshot_path = input.scratch_disk_path,
+        .root_disk_path = input.root_disk_path,
+    };
 }
 
 pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
@@ -1028,6 +1070,33 @@ test "planMountDiskRuntime selects restore and fresh actions" {
     try std.testing.expectEqualStrings("fresh", fresh.action);
     try std.testing.expect(fresh.source_upper_path == null);
     try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
+}
+
+test "planProvisionBoot builds provision boot inputs" {
+    const allocator = std.testing.allocator;
+    const plan = try planProvisionBoot(allocator, .{
+        .base_path = "/base.tar.gz",
+        .kernel_path = "/Image",
+        .dtb_path = "/virt.dtb",
+        .uds_path = "/tmp/exec.sock",
+        .scratch_disk_path = "/tmp/scratch.img",
+        .root_disk_path = "/tmp/rootfs.img",
+    });
+    defer allocator.free(plan.cmd);
+    defer allocator.free(plan.env);
+    defer if (plan.vmm_vsock) |spec| allocator.free(spec);
+
+    try std.testing.expectEqualStrings("/base.tar.gz", plan.image_path.?);
+    try std.testing.expectEqualStrings("/Image", plan.kernel_path.?);
+    try std.testing.expectEqualStrings("/virt.dtb", plan.dtb_path.?);
+    try std.testing.expectEqualStrings("in:1978:/tmp/exec.sock", plan.vmm_vsock.?);
+    try std.testing.expectEqual(@as(usize, 1), plan.cmd.len);
+    try std.testing.expectEqualStrings("/exec-agent", plan.cmd[0]);
+    try std.testing.expectEqual(@as(usize, 1), plan.env.len);
+    try std.testing.expectEqualStrings("PATH", plan.env[0].key);
+    try std.testing.expectEqualStrings("/usr/local/bin:/usr/bin:/bin:/sbin", plan.env[0].value);
+    try std.testing.expectEqualStrings("/tmp/scratch.img", plan.snapshot_path.?);
+    try std.testing.expectEqualStrings("/tmp/rootfs.img", plan.root_disk_path.?);
 }
 
 test "planProvisionAssets selects asset names by guest CPU" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -152,6 +152,20 @@ pub const ProvisionImageConfigPlan = struct {
     env: []const EnvPair,
 };
 
+pub const ProvisionRuntimeInput = struct {
+    work_dir: ?[]const u8 = null,
+    scratch_size_bytes: ?u64 = null,
+    timeout_ms: ?u64 = null,
+};
+
+pub const ProvisionRuntimePlan = struct {
+    scratch_size_bytes: u64,
+    deadline_ms: u64,
+    disk_path: ?[]const u8,
+    root_disk_path: ?[]const u8,
+    uds_path: ?[]const u8,
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -491,7 +505,50 @@ pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     return input.guest_cwd orelse input.image_cwd;
 }
 
+pub fn planProvisionRuntime(
+    allocator: std.mem.Allocator,
+    input: ProvisionRuntimeInput,
+) !ProvisionRuntimePlan {
+    assert(@sizeOf(ProvisionRuntimeInput) > 0);
+
+    var paths = ProvisionRuntimePaths{};
+    if (input.work_dir) |work_dir| paths = try planProvisionRuntimePaths(allocator, work_dir);
+    return .{
+        .scratch_size_bytes = input.scratch_size_bytes orelse 1024 * 1024 * 1024,
+        .deadline_ms = input.timeout_ms orelse 10 * 60 * 1000,
+        .disk_path = paths.disk_path,
+        .root_disk_path = paths.root_disk_path,
+        .uds_path = paths.uds_path,
+    };
+}
+
+const ProvisionRuntimePaths = struct {
+    disk_path: ?[]const u8 = null,
+    root_disk_path: ?[]const u8 = null,
+    uds_path: ?[]const u8 = null,
+};
+
+fn planProvisionRuntimePaths(
+    allocator: std.mem.Allocator,
+    work_dir: []const u8,
+) !ProvisionRuntimePaths {
+    assert(work_dir.len > 0);
+
+    const disk_path = try std.fs.path.join(allocator, &.{ work_dir, "scratch.img" });
+    errdefer allocator.free(disk_path);
+    const root_disk_path = try std.fs.path.join(allocator, &.{ work_dir, "rootfs.img" });
+    errdefer allocator.free(root_disk_path);
+    const uds_path = try std.fs.path.join(allocator, &.{ work_dir, "exec.sock" });
+    return .{
+        .disk_path = disk_path,
+        .root_disk_path = root_disk_path,
+        .uds_path = uds_path,
+    };
+}
+
 pub fn planProvisionImageConfig(input: ProvisionImageConfigInput) ProvisionImageConfigPlan {
+    assert(@sizeOf(ProvisionImageConfigInput) > 0);
+
     return .{
         .has_config = input.has_cmd or input.has_env,
         .has_cmd = input.has_cmd,
@@ -502,41 +559,70 @@ pub fn planProvisionImageConfig(input: ProvisionImageConfigInput) ProvisionImage
 }
 
 pub fn planProvisionWorkload() ProvisionWorkloadPlan {
+    assert(poweroff_command.len == 1);
+
     return .{
-        .tar_to_disk_command = "tar -C / --exclude=./proc --exclude=./sys --exclude=./dev --exclude=./tmp --exclude=./run --exclude=./machinen-config.json --exclude=./etc/machinen-boot-epoch --sort=name --numeric-owner --owner=0 --group=0 -cf /dev/vdb .",
-        .poweroff_command = "/sbin/machinen-poweroff",
+        .tar_to_disk_command = provision_tar_to_disk_command,
+        .poweroff_command = poweroff_command[0],
     };
 }
 
-pub fn planProvisionRepack(allocator: std.mem.Allocator, input: ProvisionRepackInput) !ProvisionRepackPlan {
-    if (input.disk_path == null and input.out_path == null and input.extract_dir == null) {
-        return .{
-            .extract_args = &.{},
-            .targz_args = &.{},
-        };
+const provision_tar_to_disk_command =
+    "tar -C / " ++
+    "--exclude=./proc " ++
+    "--exclude=./sys " ++
+    "--exclude=./dev " ++
+    "--exclude=./tmp " ++
+    "--exclude=./run " ++
+    "--exclude=./machinen-config.json " ++
+    "--exclude=./etc/machinen-boot-epoch " ++
+    "--sort=name --numeric-owner --owner=0 --group=0 " ++
+    "-cf /dev/vdb .";
+
+pub fn planProvisionRepack(
+    allocator: std.mem.Allocator,
+    input: ProvisionRepackInput,
+) !ProvisionRepackPlan {
+    assert(@sizeOf(ProvisionRepackInput) > 0);
+
+    if (provisionRepackInputEmpty(input)) {
+        return .{ .extract_args = &.{}, .targz_args = &.{} };
     }
     const disk_path = input.disk_path orelse return error.MissingProvisionRepackField;
     const out_path = input.out_path orelse return error.MissingProvisionRepackField;
     const extract_dir = input.extract_dir orelse return error.MissingProvisionRepackField;
-    const extract_args = try allocator.dupe([]const u8, &[_][]const u8{ "-xf", disk_path, "-C", extract_dir });
+    const extract_args = try std.mem.concat(
+        allocator,
+        []const u8,
+        &.{&[_][]const u8{ "-xf", disk_path, "-C", extract_dir }},
+    );
     errdefer allocator.free(extract_args);
-    const targz_args = try allocator.dupe([]const u8, &[_][]const u8{ "-czf", out_path, "-C", extract_dir, "." });
+    const targz_args = try std.mem.concat(
+        allocator,
+        []const u8,
+        &.{&[_][]const u8{ "-czf", out_path, "-C", extract_dir, "." }},
+    );
     errdefer allocator.free(targz_args);
-    return .{
-        .extract_args = extract_args,
-        .targz_args = targz_args,
-    };
+    return .{ .extract_args = extract_args, .targz_args = targz_args };
 }
 
-pub fn planProvisionBoot(allocator: std.mem.Allocator, input: ProvisionBootInput) !ProvisionBootPlan {
-    const cmd = try allocator.dupe([]const u8, &[_][]const u8{"/exec-agent"});
+fn provisionRepackInputEmpty(input: ProvisionRepackInput) bool {
+    assert(@sizeOf(ProvisionRepackInput) > 0);
+
+    return input.disk_path == null and input.out_path == null and input.extract_dir == null;
+}
+
+pub fn planProvisionBoot(
+    allocator: std.mem.Allocator,
+    input: ProvisionBootInput,
+) !ProvisionBootPlan {
+    assert(@sizeOf(ProvisionBootInput) > 0);
+
+    const cmd = try std.mem.concat(allocator, []const u8, &.{&[_][]const u8{"/exec-agent"}});
     errdefer allocator.free(cmd);
-    const env = try allocator.dupe(EnvPair, &[_]EnvPair{.{ .key = "PATH", .value = "/usr/local/bin:/usr/bin:/bin:/sbin" }});
+    const env = try std.mem.concat(allocator, EnvPair, &.{&provision_boot_env});
     errdefer allocator.free(env);
-    const vmm_vsock = if (input.uds_path) |uds|
-        try std.fmt.allocPrint(allocator, "in:1978:{s}", .{uds})
-    else
-        null;
+    const vmm_vsock = try planProvisionVsock(allocator, input.uds_path);
     errdefer if (vmm_vsock) |spec| allocator.free(spec);
     return .{
         .image_path = input.base_path,
@@ -550,7 +636,24 @@ pub fn planProvisionBoot(allocator: std.mem.Allocator, input: ProvisionBootInput
     };
 }
 
+const provision_boot_env = [_]EnvPair{.{
+    .key = "PATH",
+    .value = "/usr/local/bin:/usr/bin:/bin:/sbin",
+}};
+
+fn planProvisionVsock(
+    allocator: std.mem.Allocator,
+    uds_path: ?[]const u8,
+) !?[]const u8 {
+    assert(@sizeOf(@TypeOf(uds_path)) > 0);
+
+    if (uds_path) |path| return try std.mem.concat(allocator, u8, &.{ "in:1978:", path });
+    return null;
+}
+
 pub fn planProvisionAssets(input: ProvisionAssetsInput) ProvisionAssetsPlan {
+    assert(@sizeOf(ProvisionAssetsInput) > 0);
+
     return switch (input.guest_cpu) {
         .amd64 => .{
             .cpu = "amd64",
@@ -680,10 +783,31 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
     };
 }
 
-pub fn planRegistryShape(allocator: std.mem.Allocator, input: RegistryShapeInput) PlanError!RegistryShapePlan {
-    var cleanup_paths: std.ArrayList([]const u8) = .empty;
-    errdefer cleanup_paths.deinit(allocator);
-    const cleanup = input.cleanup;
+pub fn planRegistryShape(
+    allocator: std.mem.Allocator,
+    input: RegistryShapeInput,
+) PlanError!RegistryShapePlan {
+    assert(@sizeOf(RegistryShapeInput) > 0);
+
+    const root_disk_path = input.per_boot_root_disk orelse input.caller_root_disk_path;
+    return .{
+        .source_image_path = input.source_image_path,
+        .root_disk_path = root_disk_path,
+        .root_disk_mode = if (root_disk_path != null) "block" else "none",
+        .cleanup_paths = try planRegistryCleanupPaths(allocator, input.cleanup),
+        .mount_disk = try planRegistryMountDisk(input.mount_disk),
+        .live_mounts = try planRegistryLiveMounts(allocator, input.live_mounts),
+    };
+}
+
+fn planRegistryCleanupPaths(
+    allocator: std.mem.Allocator,
+    cleanup: RegistryCleanupInput,
+) ![]const []const u8 {
+    assert(@sizeOf(RegistryCleanupInput) > 0);
+
+    var paths: [8][]const u8 = undefined;
+    var count: u8 = 0;
     for ([_]?[]const u8{
         cleanup.per_boot_root_disk,
         cleanup.per_boot_snap_disk,
@@ -694,37 +818,45 @@ pub fn planRegistryShape(allocator: std.mem.Allocator, input: RegistryShapeInput
         cleanup.gv_socket_dir,
         cleanup.cpu_cgroup_path,
     }) |path| {
-        if (path) |p| try cleanup_paths.append(allocator, p);
+        if (path) |value| {
+            paths[count] = value;
+            count += 1;
+        }
     }
+    return std.mem.concat(allocator, []const u8, &.{paths[0..count]});
+}
 
-    var live_mounts: std.ArrayList(RegistryLiveMountPlan) = .empty;
-    errdefer live_mounts.deinit(allocator);
-    for (input.live_mounts) |mount| {
-        try live_mounts.append(allocator, .{
-            .guest = mount.guest,
-            .host = mount.host,
-            .mode = mount.mode,
-        });
-    }
+fn planRegistryMountDisk(
+    input: RegistryMountDiskInput,
+) PlanError!?RegistryMountDiskPlan {
+    assert(@sizeOf(RegistryMountDiskInput) > 0);
 
-    const mount_disk = if (input.mount_disk.guest == null and input.mount_disk.lower_path == null and input.mount_disk.upper_path == null)
-        null
-    else
-        RegistryMountDiskPlan{
-            .guest = input.mount_disk.guest orelse return error.IncompleteRegistryMountDisk,
-            .lower_path = input.mount_disk.lower_path orelse return error.IncompleteRegistryMountDisk,
-            .upper_path = input.mount_disk.upper_path orelse return error.IncompleteRegistryMountDisk,
-        };
-
-    const root_disk_path = input.per_boot_root_disk orelse input.caller_root_disk_path;
+    if (registryMountDiskEmpty(input)) return null;
     return .{
-        .source_image_path = input.source_image_path,
-        .root_disk_path = root_disk_path,
-        .root_disk_mode = if (root_disk_path != null) "block" else "none",
-        .cleanup_paths = try cleanup_paths.toOwnedSlice(allocator),
-        .mount_disk = mount_disk,
-        .live_mounts = try live_mounts.toOwnedSlice(allocator),
+        .guest = input.guest orelse return error.IncompleteRegistryMountDisk,
+        .lower_path = input.lower_path orelse return error.IncompleteRegistryMountDisk,
+        .upper_path = input.upper_path orelse return error.IncompleteRegistryMountDisk,
     };
+}
+
+fn registryMountDiskEmpty(input: RegistryMountDiskInput) bool {
+    assert(@sizeOf(RegistryMountDiskInput) > 0);
+
+    return input.guest == null and input.lower_path == null and input.upper_path == null;
+}
+
+fn planRegistryLiveMounts(
+    allocator: std.mem.Allocator,
+    input: []const LiveMount,
+) PlanError![]const RegistryLiveMountPlan {
+    assert(@sizeOf(LiveMount) > 0);
+
+    if (input.len > max_live_mounts) return error.TooManyLiveMounts;
+    var mounts: [max_live_mounts]RegistryLiveMountPlan = undefined;
+    for (input, 0..) |mount, i| {
+        mounts[i] = .{ .guest = mount.guest, .host = mount.host, .mode = mount.mode };
+    }
+    return std.mem.concat(allocator, RegistryLiveMountPlan, &.{mounts[0..input.len]});
 }
 
 pub fn planScratchDisk(input: ScratchDiskInput) PlanError!ScratchDiskPlan {
@@ -1093,7 +1225,7 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/images/rootfs.tar.gz", plan.source_image_path.?);
     try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);
     try std.testing.expectEqualStrings("block", plan.root_disk_mode);
-    try std.testing.expectEqual(@as(usize, 6), plan.cleanup_paths.len);
+    try std.testing.expectEqual(@as(@TypeOf(plan.cleanup_paths.len), 6), plan.cleanup_paths.len);
     try std.testing.expectEqualStrings("/tmp/root.img", plan.cleanup_paths[0]);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.cleanup_paths[1]);
     try std.testing.expectEqualStrings("/tmp/bundle", plan.cleanup_paths[2]);
@@ -1103,7 +1235,7 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     try std.testing.expectEqualStrings("/mnt/data", plan.mount_disk.?.guest);
     try std.testing.expectEqualStrings("/cache/lower.sqfs", plan.mount_disk.?.lower_path);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.mount_disk.?.upper_path);
-    try std.testing.expectEqual(@as(usize, 2), plan.live_mounts.len);
+    try std.testing.expectEqual(@as(@TypeOf(plan.live_mounts.len), 2), plan.live_mounts.len);
     try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
     try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);
     try std.testing.expectEqualStrings("rw", plan.live_mounts[0].mode);
@@ -1141,15 +1273,45 @@ test "planMountDiskRuntime selects restore and fresh actions" {
     try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
 }
 
+test "planProvisionRuntime defaults and derives workdir paths" {
+    const allocator = std.testing.allocator;
+    const plan = try planProvisionRuntime(allocator, .{
+        .work_dir = "/tmp/machinen-provision-a",
+        .scratch_size_bytes = 42,
+        .timeout_ms = 99,
+    });
+    defer allocator.free(plan.disk_path.?);
+    defer allocator.free(plan.root_disk_path.?);
+    defer allocator.free(plan.uds_path.?);
+    try std.testing.expectEqual(@as(u64, 42), plan.scratch_size_bytes);
+    try std.testing.expectEqual(@as(u64, 99), plan.deadline_ms);
+    try std.testing.expectEqualStrings("/tmp/machinen-provision-a/scratch.img", plan.disk_path.?);
+    try std.testing.expectEqualStrings(
+        "/tmp/machinen-provision-a/rootfs.img",
+        plan.root_disk_path.?,
+    );
+    try std.testing.expectEqualStrings("/tmp/machinen-provision-a/exec.sock", plan.uds_path.?);
+
+    const defaults = try planProvisionRuntime(allocator, .{});
+    try std.testing.expectEqual(@as(u64, 1024 * 1024 * 1024), defaults.scratch_size_bytes);
+    try std.testing.expectEqual(@as(u64, 10 * 60 * 1000), defaults.deadline_ms);
+    try std.testing.expect(defaults.disk_path == null);
+}
+
 test "planProvisionImageConfig preserves optional cmd and env" {
     const env = [_]EnvPair{.{ .key = "FOO", .value = "bar" }};
     const cmd = [_][]const u8{ "/bin/echo", "hi" };
-    const both = planProvisionImageConfig(.{ .has_cmd = true, .cmd = &cmd, .has_env = true, .env = &env });
+    const both = planProvisionImageConfig(.{
+        .has_cmd = true,
+        .cmd = &cmd,
+        .has_env = true,
+        .env = &env,
+    });
     try std.testing.expect(both.has_config);
     try std.testing.expect(both.has_cmd);
     try std.testing.expect(both.has_env);
     try std.testing.expectEqualSlices([]const u8, &cmd, both.cmd);
-    try std.testing.expectEqual(@as(usize, 1), both.env.len);
+    try std.testing.expectEqual(@as(@TypeOf(both.env.len), 1), both.env.len);
     try std.testing.expectEqualStrings("FOO", both.env[0].key);
     try std.testing.expectEqualStrings("bar", both.env[0].value);
 
@@ -1173,8 +1335,16 @@ test "planProvisionWorkload and planProvisionRepack build commands" {
     });
     defer allocator.free(repack.extract_args);
     defer allocator.free(repack.targz_args);
-    try std.testing.expectEqualSlices([]const u8, &[_][]const u8{ "-xf", "/tmp/scratch.img", "-C", "/tmp/extract" }, repack.extract_args);
-    try std.testing.expectEqualSlices([]const u8, &[_][]const u8{ "-czf", "/tmp/out.tar.gz", "-C", "/tmp/extract", "." }, repack.targz_args);
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &[_][]const u8{ "-xf", "/tmp/scratch.img", "-C", "/tmp/extract" },
+        repack.extract_args,
+    );
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &[_][]const u8{ "-czf", "/tmp/out.tar.gz", "-C", "/tmp/extract", "." },
+        repack.targz_args,
+    );
 }
 
 test "planProvisionBoot builds provision boot inputs" {
@@ -1195,9 +1365,9 @@ test "planProvisionBoot builds provision boot inputs" {
     try std.testing.expectEqualStrings("/Image", plan.kernel_path.?);
     try std.testing.expectEqualStrings("/virt.dtb", plan.dtb_path.?);
     try std.testing.expectEqualStrings("in:1978:/tmp/exec.sock", plan.vmm_vsock.?);
-    try std.testing.expectEqual(@as(usize, 1), plan.cmd.len);
+    try std.testing.expectEqual(@as(@TypeOf(plan.cmd.len), 1), plan.cmd.len);
     try std.testing.expectEqualStrings("/exec-agent", plan.cmd[0]);
-    try std.testing.expectEqual(@as(usize, 1), plan.env.len);
+    try std.testing.expectEqual(@as(@TypeOf(plan.env.len), 1), plan.env.len);
     try std.testing.expectEqualStrings("PATH", plan.env[0].key);
     try std.testing.expectEqualStrings("/usr/local/bin:/usr/bin:/bin:/sbin", plan.env[0].value);
     try std.testing.expectEqualStrings("/tmp/scratch.img", plan.snapshot_path.?);

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -137,6 +137,21 @@ pub const ProvisionRepackPlan = struct {
     targz_args: []const []const u8,
 };
 
+pub const ProvisionImageConfigInput = struct {
+    has_cmd: bool = false,
+    cmd: []const []const u8 = &.{},
+    has_env: bool = false,
+    env: []const EnvPair = &.{},
+};
+
+pub const ProvisionImageConfigPlan = struct {
+    has_config: bool,
+    has_cmd: bool,
+    cmd: []const []const u8,
+    has_env: bool,
+    env: []const EnvPair,
+};
+
 pub const KernelDtbInput = struct {
     kernel_path: ?[]const u8 = null,
     dtb_path: ?[]const u8 = null,
@@ -474,6 +489,16 @@ pub fn planMachinenConfigCwd(input: MachinenConfigInput) ?[]const u8 {
     assert(@sizeOf(MachinenConfigInput) > 0);
 
     return input.guest_cwd orelse input.image_cwd;
+}
+
+pub fn planProvisionImageConfig(input: ProvisionImageConfigInput) ProvisionImageConfigPlan {
+    return .{
+        .has_config = input.has_cmd or input.has_env,
+        .has_cmd = input.has_cmd,
+        .cmd = input.cmd,
+        .has_env = input.has_env,
+        .env = input.env,
+    };
 }
 
 pub fn planProvisionWorkload() ProvisionWorkloadPlan {
@@ -1114,6 +1139,24 @@ test "planMountDiskRuntime selects restore and fresh actions" {
     try std.testing.expectEqualStrings("fresh", fresh.action);
     try std.testing.expect(fresh.source_upper_path == null);
     try std.testing.expectEqual(@as(u64, 8192), fresh.upper_size_bytes.?);
+}
+
+test "planProvisionImageConfig preserves optional cmd and env" {
+    const env = [_]EnvPair{.{ .key = "FOO", .value = "bar" }};
+    const cmd = [_][]const u8{ "/bin/echo", "hi" };
+    const both = planProvisionImageConfig(.{ .has_cmd = true, .cmd = &cmd, .has_env = true, .env = &env });
+    try std.testing.expect(both.has_config);
+    try std.testing.expect(both.has_cmd);
+    try std.testing.expect(both.has_env);
+    try std.testing.expectEqualSlices([]const u8, &cmd, both.cmd);
+    try std.testing.expectEqual(@as(usize, 1), both.env.len);
+    try std.testing.expectEqualStrings("FOO", both.env[0].key);
+    try std.testing.expectEqualStrings("bar", both.env[0].value);
+
+    const none = planProvisionImageConfig(.{});
+    try std.testing.expect(!none.has_config);
+    try std.testing.expect(!none.has_cmd);
+    try std.testing.expect(!none.has_env);
 }
 
 test "planProvisionWorkload and planProvisionRepack build commands" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -199,6 +199,47 @@ pub const MountDiskRuntimePlan = struct {
     upper_size_bytes: ?u64,
 };
 
+pub const RegistryCleanupInput = struct {
+    per_boot_root_disk: ?[]const u8 = null,
+    per_boot_snap_disk: ?[]const u8 = null,
+    per_boot_mount_upper: ?[]const u8 = null,
+    bundle_temp_dir: ?[]const u8 = null,
+    vsock_temp_dir: ?[]const u8 = null,
+    stats_temp_dir: ?[]const u8 = null,
+    gv_socket_dir: ?[]const u8 = null,
+    cpu_cgroup_path: ?[]const u8 = null,
+};
+
+pub const RegistryMountDiskInput = struct {
+    guest: ?[]const u8 = null,
+    lower_path: ?[]const u8 = null,
+    upper_path: ?[]const u8 = null,
+};
+
+pub const RegistryMountDiskPlan = struct {
+    guest: []const u8,
+    lower_path: []const u8,
+    upper_path: []const u8,
+};
+
+pub const RegistryLiveMountPlan = struct {
+    guest: []const u8,
+    host: []const u8,
+    mode: []const u8,
+};
+
+pub const RegistryShapeInput = struct {
+    cleanup: RegistryCleanupInput = .{},
+    mount_disk: RegistryMountDiskInput = .{},
+    live_mounts: []const LiveMount = &.{},
+};
+
+pub const RegistryShapePlan = struct {
+    cleanup_paths: []const []const u8,
+    mount_disk: ?RegistryMountDiskPlan,
+    live_mounts: []const RegistryLiveMountPlan,
+};
+
 pub const MachinenConfigInput = struct {
     guest_cwd: ?[]const u8 = null,
     image_cwd: ?[]const u8 = null,
@@ -225,6 +266,7 @@ pub const Plan = struct {
 };
 
 pub const PlanError = error{
+    OutOfMemory,
     InvalidMemory,
     ConflictingMemory,
     InvalidReclaim,
@@ -241,6 +283,7 @@ pub const PlanError = error{
     MissingScratchPath,
     MissingRootDiskRuntimePath,
     MissingMountDiskRuntimeField,
+    IncompleteRegistryMountDisk,
 };
 
 pub fn planGuestEnv(allocator: std.mem.Allocator, input: GuestEnvInput) ![]EnvPair {
@@ -484,6 +527,49 @@ pub fn planMountDiskRuntime(input: MountDiskRuntimeInput) PlanError!MountDiskRun
                 .upper_size_bytes = upper_size,
             };
         },
+    };
+}
+
+pub fn planRegistryShape(allocator: std.mem.Allocator, input: RegistryShapeInput) PlanError!RegistryShapePlan {
+    var cleanup_paths: std.ArrayList([]const u8) = .empty;
+    errdefer cleanup_paths.deinit(allocator);
+    const cleanup = input.cleanup;
+    for ([_]?[]const u8{
+        cleanup.per_boot_root_disk,
+        cleanup.per_boot_snap_disk,
+        cleanup.per_boot_mount_upper,
+        cleanup.bundle_temp_dir,
+        cleanup.vsock_temp_dir,
+        cleanup.stats_temp_dir,
+        cleanup.gv_socket_dir,
+        cleanup.cpu_cgroup_path,
+    }) |path| {
+        if (path) |p| try cleanup_paths.append(allocator, p);
+    }
+
+    var live_mounts: std.ArrayList(RegistryLiveMountPlan) = .empty;
+    errdefer live_mounts.deinit(allocator);
+    for (input.live_mounts) |mount| {
+        try live_mounts.append(allocator, .{
+            .guest = mount.guest,
+            .host = mount.host,
+            .mode = mount.mode,
+        });
+    }
+
+    const mount_disk = if (input.mount_disk.guest == null and input.mount_disk.lower_path == null and input.mount_disk.upper_path == null)
+        null
+    else
+        RegistryMountDiskPlan{
+            .guest = input.mount_disk.guest orelse return error.IncompleteRegistryMountDisk,
+            .lower_path = input.mount_disk.lower_path orelse return error.IncompleteRegistryMountDisk,
+            .upper_path = input.mount_disk.upper_path orelse return error.IncompleteRegistryMountDisk,
+        };
+
+    return .{
+        .cleanup_paths = try cleanup_paths.toOwnedSlice(allocator),
+        .mount_disk = mount_disk,
+        .live_mounts = try live_mounts.toOwnedSlice(allocator),
     };
 }
 
@@ -818,6 +904,49 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
     try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+}
+
+test "planRegistryShape collects cleanup paths and strips registry-only mount fields" {
+    const allocator = std.testing.allocator;
+    const live = [_]LiveMount{
+        .{ .host = "/host/work", .guest = "/mnt/work", .mode = "rw", .tag = "machinen-lm0" },
+        .{ .host = "/host/cache", .guest = "/mnt/cache", .mode = "ro", .tag = "machinen-lm1" },
+    };
+    const plan = try planRegistryShape(allocator, .{
+        .cleanup = .{
+            .per_boot_root_disk = "/tmp/root.img",
+            .per_boot_snap_disk = null,
+            .per_boot_mount_upper = "/tmp/upper.img",
+            .bundle_temp_dir = "/tmp/bundle",
+            .vsock_temp_dir = "/tmp/vsock",
+            .stats_temp_dir = null,
+            .gv_socket_dir = "/tmp/gv",
+            .cpu_cgroup_path = "/sys/fs/cgroup/machinen",
+        },
+        .mount_disk = .{
+            .guest = "/mnt/data",
+            .lower_path = "/cache/lower.sqfs",
+            .upper_path = "/tmp/upper.img",
+        },
+        .live_mounts = &live,
+    });
+    defer allocator.free(plan.cleanup_paths);
+    defer allocator.free(plan.live_mounts);
+
+    try std.testing.expectEqual(@as(usize, 6), plan.cleanup_paths.len);
+    try std.testing.expectEqualStrings("/tmp/root.img", plan.cleanup_paths[0]);
+    try std.testing.expectEqualStrings("/tmp/upper.img", plan.cleanup_paths[1]);
+    try std.testing.expectEqualStrings("/tmp/bundle", plan.cleanup_paths[2]);
+    try std.testing.expectEqualStrings("/tmp/vsock", plan.cleanup_paths[3]);
+    try std.testing.expectEqualStrings("/tmp/gv", plan.cleanup_paths[4]);
+    try std.testing.expectEqualStrings("/sys/fs/cgroup/machinen", plan.cleanup_paths[5]);
+    try std.testing.expectEqualStrings("/mnt/data", plan.mount_disk.?.guest);
+    try std.testing.expectEqualStrings("/cache/lower.sqfs", plan.mount_disk.?.lower_path);
+    try std.testing.expectEqualStrings("/tmp/upper.img", plan.mount_disk.?.upper_path);
+    try std.testing.expectEqual(@as(usize, 2), plan.live_mounts.len);
+    try std.testing.expectEqualStrings("/mnt/work", plan.live_mounts[0].guest);
+    try std.testing.expectEqualStrings("/host/work", plan.live_mounts[0].host);
+    try std.testing.expectEqualStrings("rw", plan.live_mounts[0].mode);
 }
 
 test "planMountDiskRuntime selects restore and fresh actions" {

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -229,12 +229,18 @@ pub const RegistryLiveMountPlan = struct {
 };
 
 pub const RegistryShapeInput = struct {
+    source_image_path: ?[]const u8 = null,
+    per_boot_root_disk: ?[]const u8 = null,
+    caller_root_disk_path: ?[]const u8 = null,
     cleanup: RegistryCleanupInput = .{},
     mount_disk: RegistryMountDiskInput = .{},
     live_mounts: []const LiveMount = &.{},
 };
 
 pub const RegistryShapePlan = struct {
+    source_image_path: ?[]const u8,
+    root_disk_path: ?[]const u8,
+    root_disk_mode: []const u8,
     cleanup_paths: []const []const u8,
     mount_disk: ?RegistryMountDiskPlan,
     live_mounts: []const RegistryLiveMountPlan,
@@ -566,7 +572,11 @@ pub fn planRegistryShape(allocator: std.mem.Allocator, input: RegistryShapeInput
             .upper_path = input.mount_disk.upper_path orelse return error.IncompleteRegistryMountDisk,
         };
 
+    const root_disk_path = input.per_boot_root_disk orelse input.caller_root_disk_path;
     return .{
+        .source_image_path = input.source_image_path,
+        .root_disk_path = root_disk_path,
+        .root_disk_mode = if (root_disk_path != null) "block" else "none",
         .cleanup_paths = try cleanup_paths.toOwnedSlice(allocator),
         .mount_disk = mount_disk,
         .live_mounts = try live_mounts.toOwnedSlice(allocator),
@@ -913,6 +923,9 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
         .{ .host = "/host/cache", .guest = "/mnt/cache", .mode = "ro", .tag = "machinen-lm1" },
     };
     const plan = try planRegistryShape(allocator, .{
+        .source_image_path = "/images/rootfs.tar.gz",
+        .per_boot_root_disk = "/tmp/per-boot-root.img",
+        .caller_root_disk_path = "/caller/root.img",
         .cleanup = .{
             .per_boot_root_disk = "/tmp/root.img",
             .per_boot_snap_disk = null,
@@ -933,6 +946,9 @@ test "planRegistryShape collects cleanup paths and strips registry-only mount fi
     defer allocator.free(plan.cleanup_paths);
     defer allocator.free(plan.live_mounts);
 
+    try std.testing.expectEqualStrings("/images/rootfs.tar.gz", plan.source_image_path.?);
+    try std.testing.expectEqualStrings("/tmp/per-boot-root.img", plan.root_disk_path.?);
+    try std.testing.expectEqualStrings("block", plan.root_disk_mode);
     try std.testing.expectEqual(@as(usize, 6), plan.cleanup_paths.len);
     try std.testing.expectEqualStrings("/tmp/root.img", plan.cleanup_paths[0]);
     try std.testing.expectEqualStrings("/tmp/upper.img", plan.cleanup_paths[1]);

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -57,6 +57,9 @@ const ParsedRequest = struct {
     provision_uds_path: ?[]const u8 = null,
     provision_scratch_disk_path: ?[]const u8 = null,
     provision_root_disk_path: ?[]const u8 = null,
+    provision_repack_disk_path: ?[]const u8 = null,
+    provision_repack_out_path: ?[]const u8 = null,
+    provision_repack_extract_dir: ?[]const u8 = null,
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -140,6 +143,9 @@ const boot_plan_fields = [_][]const u8{
     "provisionUdsPath",
     "provisionScratchDiskPath",
     "provisionRootDiskPath",
+    "provisionRepackDiskPath",
+    "provisionRepackOutPath",
+    "provisionRepackExtractDir",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -237,6 +243,9 @@ const RequestError = error{
     InvalidProvisionUdsPath,
     InvalidProvisionScratchDiskPath,
     InvalidProvisionRootDiskPath,
+    InvalidProvisionRepackDiskPath,
+    InvalidProvisionRepackOutPath,
+    InvalidProvisionRepackExtractDir,
     InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
@@ -303,6 +312,8 @@ const PlanParts = struct {
     bundle_env: []const boot_plan.EnvPair,
     provision_assets: boot_plan.ProvisionAssetsPlan,
     provision_boot: boot_plan.ProvisionBootPlan,
+    provision_workload: boot_plan.ProvisionWorkloadPlan,
+    provision_repack: boot_plan.ProvisionRepackPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -330,6 +341,8 @@ const RuntimeParts = struct {
     bundle_env: []const boot_plan.EnvPair,
     provision_assets: boot_plan.ProvisionAssetsPlan,
     provision_boot: boot_plan.ProvisionBootPlan,
+    provision_workload: boot_plan.ProvisionWorkloadPlan,
+    provision_repack: boot_plan.ProvisionRepackPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -382,6 +395,8 @@ fn makePlanParts(
             .guest_cpu = parsed.provision_guest_cpu,
         }),
         .provision_boot = try makeProvisionBoot(arena, parsed),
+        .provision_workload = boot_plan.planProvisionWorkload(),
+        .provision_repack = try makeProvisionRepack(arena, parsed),
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
@@ -496,6 +511,19 @@ fn makeProvisionBoot(
     });
 }
 
+fn makeProvisionRepack(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.ProvisionRepackPlan {
+    assert(@sizeOf(boot_plan.ProvisionRepackPlan) > 0);
+
+    return boot_plan.planProvisionRepack(arena, .{
+        .disk_path = parsed.provision_repack_disk_path,
+        .out_path = parsed.provision_repack_out_path,
+        .extract_dir = parsed.provision_repack_extract_dir,
+    });
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -558,6 +586,8 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeProvisionAssetsField(io, "provisionAssets", parts.provision_assets, true);
     try writeProvisionBootField(io, "provisionBoot", parts.provision_boot, true);
+    try writeProvisionWorkloadField(io, "provisionWorkload", parts.provision_workload, true);
+    try writeProvisionRepackField(io, "provisionRepack", parts.provision_repack, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
@@ -738,6 +768,37 @@ fn writeProvisionBootField(
     try writeEnvObjectField(io, "env", boot.env, true);
     try writeNullableStringField(io, "snapshotPath", boot.snapshot_path, true);
     try writeNullableStringField(io, "rootDiskPath", boot.root_disk_path, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeProvisionWorkloadField(
+    io: std.Io,
+    comptime field: []const u8,
+    workload: boot_plan.ProvisionWorkloadPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{\"tarToDiskCommand\":");
+    try protocol.writeJsonString(io, workload.tar_to_disk_command);
+    try protocol.stdout(io, ",\"poweroffCommand\":");
+    try protocol.writeJsonString(io, workload.poweroff_command);
+    try protocol.stdout(io, "}");
+}
+
+fn writeProvisionRepackField(
+    io: std.Io,
+    comptime field: []const u8,
+    repack: boot_plan.ProvisionRepackPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeStringArrayField(io, "extractArgs", repack.extract_args, false);
+    try writeStringArrayField(io, "targzArgs", repack.targz_args, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1378,6 +1439,9 @@ fn parseBundleFields(
         "provisionUdsPath",
         "provisionScratchDiskPath",
         "provisionRootDiskPath",
+        "provisionRepackDiskPath",
+        "provisionRepackOutPath",
+        "provisionRepackExtractDir",
         error.InvalidBundleGuestEnv,
     );
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -60,6 +60,10 @@ const ParsedRequest = struct {
     provision_repack_disk_path: ?[]const u8 = null,
     provision_repack_out_path: ?[]const u8 = null,
     provision_repack_extract_dir: ?[]const u8 = null,
+    provision_image_config_has_cmd: bool = false,
+    provision_image_config_cmd: []const []const u8 = &.{},
+    provision_image_config_has_env: bool = false,
+    provision_image_config_env: std.json.ObjectMap = .{},
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -146,6 +150,10 @@ const boot_plan_fields = [_][]const u8{
     "provisionRepackDiskPath",
     "provisionRepackOutPath",
     "provisionRepackExtractDir",
+    "provisionImageConfigHasCmd",
+    "provisionImageConfigCmd",
+    "provisionImageConfigHasEnv",
+    "provisionImageConfigEnv",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -246,6 +254,11 @@ const RequestError = error{
     InvalidProvisionRepackDiskPath,
     InvalidProvisionRepackOutPath,
     InvalidProvisionRepackExtractDir,
+    InvalidProvisionImageConfigHasCmd,
+    InvalidProvisionImageConfigCmd,
+    InvalidProvisionImageConfigHasEnv,
+    InvalidProvisionImageConfigEnv,
+    InvalidProvisionImageConfigEnvValue,
     InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
@@ -314,6 +327,7 @@ const PlanParts = struct {
     provision_boot: boot_plan.ProvisionBootPlan,
     provision_workload: boot_plan.ProvisionWorkloadPlan,
     provision_repack: boot_plan.ProvisionRepackPlan,
+    provision_image_config: boot_plan.ProvisionImageConfigPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -343,6 +357,7 @@ const RuntimeParts = struct {
     provision_boot: boot_plan.ProvisionBootPlan,
     provision_workload: boot_plan.ProvisionWorkloadPlan,
     provision_repack: boot_plan.ProvisionRepackPlan,
+    provision_image_config: boot_plan.ProvisionImageConfigPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -397,6 +412,7 @@ fn makePlanParts(
         .provision_boot = try makeProvisionBoot(arena, parsed),
         .provision_workload = boot_plan.planProvisionWorkload(),
         .provision_repack = try makeProvisionRepack(arena, parsed),
+        .provision_image_config = try makeProvisionImageConfig(arena, parsed),
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
@@ -511,6 +527,24 @@ fn makeProvisionBoot(
     });
 }
 
+fn makeProvisionImageConfig(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.ProvisionImageConfigPlan {
+    assert(@sizeOf(boot_plan.ProvisionImageConfigPlan) > 0);
+
+    return boot_plan.planProvisionImageConfig(.{
+        .has_cmd = parsed.provision_image_config_has_cmd,
+        .cmd = parsed.provision_image_config_cmd,
+        .has_env = parsed.provision_image_config_has_env,
+        .env = try objectStringPairs(
+            arena,
+            parsed.provision_image_config_env,
+            error.InvalidProvisionImageConfigEnvValue,
+        ),
+    });
+}
+
 fn makeProvisionRepack(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -588,6 +622,12 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeProvisionBootField(io, "provisionBoot", parts.provision_boot, true);
     try writeProvisionWorkloadField(io, "provisionWorkload", parts.provision_workload, true);
     try writeProvisionRepackField(io, "provisionRepack", parts.provision_repack, true);
+    try writeProvisionImageConfigField(
+        io,
+        "provisionImageConfig",
+        parts.provision_image_config,
+        true,
+    );
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
@@ -799,6 +839,32 @@ fn writeProvisionRepackField(
     try protocol.stdout(io, "{");
     try writeStringArrayField(io, "extractArgs", repack.extract_args, false);
     try writeStringArrayField(io, "targzArgs", repack.targz_args, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeProvisionImageConfigField(
+    io: std.Io,
+    comptime field: []const u8,
+    config: boot_plan.ProvisionImageConfigPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (!config.has_config) {
+        try protocol.stdout(io, "null");
+        return;
+    }
+
+    try protocol.stdout(io, "{");
+    var wrote = false;
+    if (config.has_cmd) {
+        try writeStringArrayField(io, "cmd", config.cmd, false);
+        wrote = true;
+    }
+    if (config.has_env) {
+        try writeEnvObjectField(io, "env", config.env, wrote);
+    }
     try protocol.stdout(io, "}");
 }
 
@@ -1442,6 +1508,10 @@ fn parseBundleFields(
         "provisionRepackDiskPath",
         "provisionRepackOutPath",
         "provisionRepackExtractDir",
+        "provisionImageConfigHasCmd",
+        "provisionImageConfigCmd",
+        "provisionImageConfigHasEnv",
+        "provisionImageConfigEnv",
         error.InvalidBundleGuestEnv,
     );
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -64,6 +64,9 @@ const ParsedRequest = struct {
     provision_image_config_cmd: []const []const u8 = &.{},
     provision_image_config_has_env: bool = false,
     provision_image_config_env: std.json.ObjectMap = .{},
+    provision_work_dir: ?[]const u8 = null,
+    provision_scratch_size_bytes_text: ?[]const u8 = null,
+    provision_timeout_ms_text: ?[]const u8 = null,
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -154,6 +157,9 @@ const boot_plan_fields = [_][]const u8{
     "provisionImageConfigCmd",
     "provisionImageConfigHasEnv",
     "provisionImageConfigEnv",
+    "provisionWorkDir",
+    "provisionScratchSizeBytes",
+    "provisionTimeoutMs",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -259,6 +265,9 @@ const RequestError = error{
     InvalidProvisionImageConfigHasEnv,
     InvalidProvisionImageConfigEnv,
     InvalidProvisionImageConfigEnvValue,
+    InvalidProvisionWorkDir,
+    InvalidProvisionScratchSizeBytes,
+    InvalidProvisionTimeoutMs,
     InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
@@ -328,6 +337,7 @@ const PlanParts = struct {
     provision_workload: boot_plan.ProvisionWorkloadPlan,
     provision_repack: boot_plan.ProvisionRepackPlan,
     provision_image_config: boot_plan.ProvisionImageConfigPlan,
+    provision_runtime: boot_plan.ProvisionRuntimePlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -353,11 +363,6 @@ const RuntimeParts = struct {
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
-    provision_assets: boot_plan.ProvisionAssetsPlan,
-    provision_boot: boot_plan.ProvisionBootPlan,
-    provision_workload: boot_plan.ProvisionWorkloadPlan,
-    provision_repack: boot_plan.ProvisionRepackPlan,
-    provision_image_config: boot_plan.ProvisionImageConfigPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -413,6 +418,7 @@ fn makePlanParts(
         .provision_workload = boot_plan.planProvisionWorkload(),
         .provision_repack = try makeProvisionRepack(arena, parsed),
         .provision_image_config = try makeProvisionImageConfig(arena, parsed),
+        .provision_runtime = try makeProvisionRuntime(arena, parsed),
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
@@ -527,6 +533,37 @@ fn makeProvisionBoot(
     });
 }
 
+fn makeProvisionRuntime(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.ProvisionRuntimePlan {
+    assert(@sizeOf(boot_plan.ProvisionRuntimePlan) > 0);
+
+    return boot_plan.planProvisionRuntime(arena, .{
+        .work_dir = parsed.provision_work_dir,
+        .scratch_size_bytes = try optionalUnsignedText(
+            parsed.provision_scratch_size_bytes_text,
+            error.InvalidProvisionScratchSizeBytes,
+        ),
+        .timeout_ms = try optionalUnsignedText(
+            parsed.provision_timeout_ms_text,
+            error.InvalidProvisionTimeoutMs,
+        ),
+    });
+}
+
+fn optionalUnsignedText(
+    text: ?[]const u8,
+    err: RequestError,
+) RequestError!?u64 {
+    assert(@errorName(err).len > 0);
+
+    if (text) |value| {
+        return parseUnsigned(value) catch err;
+    }
+    return null;
+}
+
 fn makeProvisionImageConfig(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -628,6 +665,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
         parts.provision_image_config,
         true,
     );
+    try writeProvisionRuntimeField(io, "provisionRuntime", parts.provision_runtime, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
@@ -865,6 +903,24 @@ fn writeProvisionImageConfigField(
     if (config.has_env) {
         try writeEnvObjectField(io, "env", config.env, wrote);
     }
+    try protocol.stdout(io, "}");
+}
+
+fn writeProvisionRuntimeField(
+    io: std.Io,
+    comptime field: []const u8,
+    runtime: boot_plan.ProvisionRuntimePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableU64Field(io, "scratchSizeBytes", runtime.scratch_size_bytes, false);
+    try writeNullableU64Field(io, "deadlineMs", runtime.deadline_ms, true);
+    try writeNullableStringField(io, "diskPath", runtime.disk_path, true);
+    try writeNullableStringField(io, "rootDiskPath", runtime.root_disk_path, true);
+    try writeNullableStringField(io, "udsPath", runtime.uds_path, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1349,6 +1405,7 @@ fn parseKernelVmstateFields(
     try parseRuntimeMountStatsFields(allocator, object, request);
     try parseConfigFields(allocator, object, request);
     try parseBundleFields(allocator, object, request);
+    try parseProvisionFields(allocator, object, request);
     try parseDiskRuntimeFields(object, request);
 }
 
@@ -1498,21 +1555,126 @@ fn parseBundleFields(
     request.bundle_guest_env = try optionalObjectDefaultEmpty(
         object,
         "bundleGuestEnv",
-        "provisionGuestCpu",
-        "provisionBasePath",
-        "provisionKernelPath",
-        "provisionDtbPath",
-        "provisionUdsPath",
-        "provisionScratchDiskPath",
-        "provisionRootDiskPath",
-        "provisionRepackDiskPath",
-        "provisionRepackOutPath",
-        "provisionRepackExtractDir",
-        "provisionImageConfigHasCmd",
-        "provisionImageConfigCmd",
-        "provisionImageConfigHasEnv",
-        "provisionImageConfigEnv",
         error.InvalidBundleGuestEnv,
+    );
+}
+
+fn parseProvisionFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.provision_guest_cpu = try optionalProvisionGuestCpu(object);
+    try parseProvisionBootFields(object, request);
+    try parseProvisionRepackFields(object, request);
+    try parseProvisionImageConfigFields(allocator, object, request);
+}
+
+fn parseProvisionBootFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.provision_base_path = try optionalStringDefaultNull(
+        object,
+        "provisionBasePath",
+        error.InvalidProvisionBasePath,
+    );
+    request.provision_kernel_path = try optionalStringDefaultNull(
+        object,
+        "provisionKernelPath",
+        error.InvalidProvisionKernelPath,
+    );
+    request.provision_dtb_path = try optionalStringDefaultNull(
+        object,
+        "provisionDtbPath",
+        error.InvalidProvisionDtbPath,
+    );
+    request.provision_uds_path = try optionalStringDefaultNull(
+        object,
+        "provisionUdsPath",
+        error.InvalidProvisionUdsPath,
+    );
+    request.provision_scratch_disk_path = try optionalStringDefaultNull(
+        object,
+        "provisionScratchDiskPath",
+        error.InvalidProvisionScratchDiskPath,
+    );
+    request.provision_root_disk_path = try optionalStringDefaultNull(
+        object,
+        "provisionRootDiskPath",
+        error.InvalidProvisionRootDiskPath,
+    );
+}
+
+fn parseProvisionRepackFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.provision_repack_disk_path = try optionalStringDefaultNull(
+        object,
+        "provisionRepackDiskPath",
+        error.InvalidProvisionRepackDiskPath,
+    );
+    request.provision_repack_out_path = try optionalStringDefaultNull(
+        object,
+        "provisionRepackOutPath",
+        error.InvalidProvisionRepackOutPath,
+    );
+    request.provision_repack_extract_dir = try optionalStringDefaultNull(
+        object,
+        "provisionRepackExtractDir",
+        error.InvalidProvisionRepackExtractDir,
+    );
+    request.provision_work_dir = try optionalStringDefaultNull(
+        object,
+        "provisionWorkDir",
+        error.InvalidProvisionWorkDir,
+    );
+    request.provision_scratch_size_bytes_text = try optionalStringDefaultNull(
+        object,
+        "provisionScratchSizeBytes",
+        error.InvalidProvisionScratchSizeBytes,
+    );
+    request.provision_timeout_ms_text = try optionalStringDefaultNull(
+        object,
+        "provisionTimeoutMs",
+        error.InvalidProvisionTimeoutMs,
+    );
+}
+
+fn parseProvisionImageConfigFields(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.provision_image_config_has_cmd = try optionalBoolDefaultFalse(
+        object,
+        "provisionImageConfigHasCmd",
+        error.InvalidProvisionImageConfigHasCmd,
+    );
+    request.provision_image_config_cmd = try optionalStringArrayDefaultEmpty(
+        allocator,
+        object,
+        "provisionImageConfigCmd",
+        error.InvalidProvisionImageConfigCmd,
+    );
+    request.provision_image_config_has_env = try optionalBoolDefaultFalse(
+        object,
+        "provisionImageConfigHasEnv",
+        error.InvalidProvisionImageConfigHasEnv,
+    );
+    request.provision_image_config_env = try optionalObjectDefaultEmpty(
+        object,
+        "provisionImageConfigEnv",
+        error.InvalidProvisionImageConfigEnv,
     );
 }
 
@@ -1597,21 +1759,9 @@ fn parseMountDiskRuntimeFields(
     request.mount_disk_upper_size_text = try optionalStringDefaultNull(
         object,
         "mountDiskUpperSize",
-        "registrySourceImagePath",
-        "registryPerBootRootDisk",
-        "registryCallerRootDiskPath",
-        "registryPerBootSnapDisk",
-        "registryPerBootMountUpper",
-        "registryBundleTempDir",
-        "registryVsockTempDir",
-        "registryStatsTempDir",
-        "registryGvSocketDir",
-        "registryCpuCgroupPath",
-        "registryMountGuest",
-        "registryMountLowerPath",
-        "registryMountUpperPath",
         error.InvalidMountDiskUpperSize,
     );
+    try parseRegistryShapeFields(object, request);
 }
 
 fn parseRegistryShapeFields(
@@ -1620,13 +1770,40 @@ fn parseRegistryShapeFields(
 ) RequestError!void {
     assert(@sizeOf(ParsedRequest) > 0);
 
-    request.registry_per_boot_root_disk = try optionalStringDefaultNull(
+    try parseRegistryRootDiskFields(object, request);
+    try parseRegistryCleanupFields(object, request);
+    try parseRegistryMountDiskFields(object, request);
+}
+
+fn parseRegistryRootDiskFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.registry_source_image_path = try optionalStringDefaultNull(
         object,
         "registrySourceImagePath",
-        "registryPerBootRootDisk",
-        "registryCallerRootDiskPath",
-        error.InvalidRegistryCleanupPath,
+        error.InvalidRegistrySourceImagePath,
     );
+    request.registry_per_boot_root_disk = try optionalStringDefaultNull(
+        object,
+        "registryPerBootRootDisk",
+        error.InvalidRegistryRootDiskPath,
+    );
+    request.registry_caller_root_disk_path = try optionalStringDefaultNull(
+        object,
+        "registryCallerRootDiskPath",
+        error.InvalidRegistryRootDiskPath,
+    );
+}
+
+fn parseRegistryCleanupFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.registry_per_boot_snap_disk = try optionalStringDefaultNull(
         object,
         "registryPerBootSnapDisk",
@@ -1662,6 +1839,14 @@ fn parseRegistryShapeFields(
         "registryCpuCgroupPath",
         error.InvalidRegistryCleanupPath,
     );
+}
+
+fn parseRegistryMountDiskFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.registry_mount_guest = try optionalStringDefaultNull(
         object,
         "registryMountGuest",
@@ -1695,6 +1880,19 @@ fn hasBundleCommandField(object: std.json.ObjectMap) bool {
         if (value == .bool and value.bool) return true;
     }
     return false;
+}
+
+fn optionalProvisionGuestCpu(
+    object: std.json.ObjectMap,
+) RequestError!boot_plan.ProvisionGuestCpu {
+    assert(@sizeOf(boot_plan.ProvisionGuestCpu) > 0);
+
+    const value = object.get("provisionGuestCpu") orelse return .arm64;
+    if (value == .null) return .arm64;
+    if (value != .string) return error.InvalidProvisionGuestCpu;
+    if (std.mem.eql(u8, value.string, "amd64")) return .amd64;
+    if (std.mem.eql(u8, value.string, "arm64")) return .arm64;
+    return error.InvalidProvisionGuestCpu;
 }
 
 fn optionalScratchMode(object: std.json.ObjectMap) RequestError!boot_plan.ScratchDiskMode {

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -63,6 +63,17 @@ const ParsedRequest = struct {
     mount_disk_source_upper_path: ?[]const u8 = null,
     mount_disk_guest: ?[]const u8 = null,
     mount_disk_upper_size_text: ?[]const u8 = null,
+    registry_per_boot_root_disk: ?[]const u8 = null,
+    registry_per_boot_snap_disk: ?[]const u8 = null,
+    registry_per_boot_mount_upper: ?[]const u8 = null,
+    registry_bundle_temp_dir: ?[]const u8 = null,
+    registry_vsock_temp_dir: ?[]const u8 = null,
+    registry_stats_temp_dir: ?[]const u8 = null,
+    registry_gv_socket_dir: ?[]const u8 = null,
+    registry_cpu_cgroup_path: ?[]const u8 = null,
+    registry_mount_guest: ?[]const u8 = null,
+    registry_mount_lower_path: ?[]const u8 = null,
+    registry_mount_upper_path: ?[]const u8 = null,
 };
 
 const ParsedResourcesMemory = struct {
@@ -126,6 +137,17 @@ const boot_plan_fields = [_][]const u8{
     "mountDiskSourceUpperPath",
     "mountDiskGuest",
     "mountDiskUpperSize",
+    "registryPerBootRootDisk",
+    "registryPerBootSnapDisk",
+    "registryPerBootMountUpper",
+    "registryBundleTempDir",
+    "registryVsockTempDir",
+    "registryStatsTempDir",
+    "registryGvSocketDir",
+    "registryCpuCgroupPath",
+    "registryMountGuest",
+    "registryMountLowerPath",
+    "registryMountUpperPath",
 };
 
 const RequestError = error{
@@ -204,6 +226,10 @@ const RequestError = error{
     InvalidMountDiskSourceUpperPath,
     InvalidMountDiskGuest,
     InvalidMountDiskUpperSize,
+    InvalidRegistryCleanupPath,
+    InvalidRegistryMountGuest,
+    InvalidRegistryMountLowerPath,
+    InvalidRegistryMountUpperPath,
 } || protocol.RequestError;
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
@@ -251,6 +277,7 @@ const PlanParts = struct {
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
+    registry_shape: boot_plan.RegistryShapePlan,
 };
 
 fn makeCorePlan(
@@ -275,6 +302,7 @@ const RuntimeParts = struct {
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
+    registry_shape: boot_plan.RegistryShapePlan,
 };
 
 fn makePlanParts(
@@ -322,6 +350,7 @@ fn makePlanParts(
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
+        .registry_shape = runtime.registry_shape,
     };
 }
 
@@ -344,6 +373,7 @@ fn makeRuntimeParts(arena: std.mem.Allocator, parsed: ParsedRequest) !RuntimePar
         .scratch_disk = disks.scratch,
         .root_disk_runtime = disks.root,
         .mount_disk_runtime = disks.mount,
+        .registry_shape = try makeRegistryShape(arena, parsed),
     };
 }
 
@@ -415,6 +445,32 @@ fn makeMountDiskRuntime(parsed: ParsedRequest) !boot_plan.MountDiskRuntimePlan {
     });
 }
 
+fn makeRegistryShape(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.RegistryShapePlan {
+    assert(@sizeOf(boot_plan.RegistryShapePlan) > 0);
+
+    return boot_plan.planRegistryShape(arena, .{
+        .cleanup = .{
+            .per_boot_root_disk = parsed.registry_per_boot_root_disk,
+            .per_boot_snap_disk = parsed.registry_per_boot_snap_disk,
+            .per_boot_mount_upper = parsed.registry_per_boot_mount_upper,
+            .bundle_temp_dir = parsed.registry_bundle_temp_dir,
+            .vsock_temp_dir = parsed.registry_vsock_temp_dir,
+            .stats_temp_dir = parsed.registry_stats_temp_dir,
+            .gv_socket_dir = parsed.registry_gv_socket_dir,
+            .cpu_cgroup_path = parsed.registry_cpu_cgroup_path,
+        },
+        .mount_disk = .{
+            .guest = parsed.registry_mount_guest,
+            .lower_path = parsed.registry_mount_lower_path,
+            .upper_path = parsed.registry_mount_upper_path,
+        },
+        .live_mounts = parsed.live_mounts_resolved,
+    });
+}
+
 fn writePortForwardFailure(
     io: std.Io,
     mappings: []const boot_plan.PortForwardMapping,
@@ -449,6 +505,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
+    try writeRegistryShapeField(io, "registryShape", parts.registry_shape, true);
     try protocol.stdout(io, "}}\n");
 }
 
@@ -688,6 +745,67 @@ fn writeConfigLiveMountsField(
         try protocol.writeJsonString(io, mount.guest);
         try protocol.stdout(io, ",\"tag\":");
         try protocol.writeJsonString(io, mount.tag);
+        try protocol.stdout(io, ",\"mode\":");
+        try protocol.writeJsonString(io, mount.mode);
+        try protocol.stdout(io, "}");
+    }
+    try protocol.stdout(io, "]");
+}
+
+fn writeRegistryShapeField(
+    io: std.Io,
+    comptime field: []const u8,
+    registry: boot_plan.RegistryShapePlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, false);
+    try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
+    try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
+    try protocol.stdout(io, "}");
+}
+
+fn writeRegistryMountDiskField(
+    io: std.Io,
+    comptime field: []const u8,
+    mount_disk: ?boot_plan.RegistryMountDiskPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    if (mount_disk) |disk| {
+        try protocol.stdout(io, "{\"guest\":");
+        try protocol.writeJsonString(io, disk.guest);
+        try protocol.stdout(io, ",\"lowerPath\":");
+        try protocol.writeJsonString(io, disk.lower_path);
+        try protocol.stdout(io, ",\"upperPath\":");
+        try protocol.writeJsonString(io, disk.upper_path);
+        try protocol.stdout(io, "}");
+    } else {
+        try protocol.stdout(io, "null");
+    }
+}
+
+fn writeRegistryLiveMountsField(
+    io: std.Io,
+    comptime field: []const u8,
+    mounts: []const boot_plan.RegistryLiveMountPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "[");
+    for (mounts, 0..) |mount, i| {
+        if (i != 0) try protocol.stdout(io, ",");
+        try protocol.stdout(io, "{\"guest\":");
+        try protocol.writeJsonString(io, mount.guest);
+        try protocol.stdout(io, ",\"host\":");
+        try protocol.writeJsonString(io, mount.host);
         try protocol.stdout(io, ",\"mode\":");
         try protocol.writeJsonString(io, mount.mode);
         try protocol.stdout(io, "}");
@@ -1238,7 +1356,81 @@ fn parseMountDiskRuntimeFields(
     request.mount_disk_upper_size_text = try optionalStringDefaultNull(
         object,
         "mountDiskUpperSize",
+        "registryPerBootRootDisk",
+        "registryPerBootSnapDisk",
+        "registryPerBootMountUpper",
+        "registryBundleTempDir",
+        "registryVsockTempDir",
+        "registryStatsTempDir",
+        "registryGvSocketDir",
+        "registryCpuCgroupPath",
+        "registryMountGuest",
+        "registryMountLowerPath",
+        "registryMountUpperPath",
         error.InvalidMountDiskUpperSize,
+    );
+}
+
+fn parseRegistryShapeFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
+    request.registry_per_boot_root_disk = try optionalStringDefaultNull(
+        object,
+        "registryPerBootRootDisk",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_per_boot_snap_disk = try optionalStringDefaultNull(
+        object,
+        "registryPerBootSnapDisk",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_per_boot_mount_upper = try optionalStringDefaultNull(
+        object,
+        "registryPerBootMountUpper",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_bundle_temp_dir = try optionalStringDefaultNull(
+        object,
+        "registryBundleTempDir",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_vsock_temp_dir = try optionalStringDefaultNull(
+        object,
+        "registryVsockTempDir",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_stats_temp_dir = try optionalStringDefaultNull(
+        object,
+        "registryStatsTempDir",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_gv_socket_dir = try optionalStringDefaultNull(
+        object,
+        "registryGvSocketDir",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_cpu_cgroup_path = try optionalStringDefaultNull(
+        object,
+        "registryCpuCgroupPath",
+        error.InvalidRegistryCleanupPath,
+    );
+    request.registry_mount_guest = try optionalStringDefaultNull(
+        object,
+        "registryMountGuest",
+        error.InvalidRegistryMountGuest,
+    );
+    request.registry_mount_lower_path = try optionalStringDefaultNull(
+        object,
+        "registryMountLowerPath",
+        error.InvalidRegistryMountLowerPath,
+    );
+    request.registry_mount_upper_path = try optionalStringDefaultNull(
+        object,
+        "registryMountUpperPath",
+        error.InvalidRegistryMountUpperPath,
     );
 }
 
@@ -1717,6 +1909,11 @@ fn writeDiskPlanError(io: std.Io, err: anyerror) !bool {
             io,
             "BOOT_MOUNT_INVALID",
             "boot-plan mountDisk field missing",
+        ),
+        error.IncompleteRegistryMountDisk => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "boot-plan registry mountDisk field missing",
         ),
         error.InvalidMountDiskUpperSize => try writeBootError(
             io,

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -51,6 +51,12 @@ const ParsedRequest = struct {
     bundle_image_env: std.json.ObjectMap = .{},
     bundle_guest_env: std.json.ObjectMap = .{},
     provision_guest_cpu: boot_plan.ProvisionGuestCpu = .arm64,
+    provision_base_path: ?[]const u8 = null,
+    provision_kernel_path: ?[]const u8 = null,
+    provision_dtb_path: ?[]const u8 = null,
+    provision_uds_path: ?[]const u8 = null,
+    provision_scratch_disk_path: ?[]const u8 = null,
+    provision_root_disk_path: ?[]const u8 = null,
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -128,6 +134,12 @@ const boot_plan_fields = [_][]const u8{
     "bundleImageEnv",
     "bundleGuestEnv",
     "provisionGuestCpu",
+    "provisionBasePath",
+    "provisionKernelPath",
+    "provisionDtbPath",
+    "provisionUdsPath",
+    "provisionScratchDiskPath",
+    "provisionRootDiskPath",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -219,6 +231,12 @@ const RequestError = error{
     InvalidBundleImageEnv,
     InvalidBundleGuestEnv,
     InvalidProvisionGuestCpu,
+    InvalidProvisionBasePath,
+    InvalidProvisionKernelPath,
+    InvalidProvisionDtbPath,
+    InvalidProvisionUdsPath,
+    InvalidProvisionScratchDiskPath,
+    InvalidProvisionRootDiskPath,
     InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
@@ -284,6 +302,7 @@ const PlanParts = struct {
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
     provision_assets: boot_plan.ProvisionAssetsPlan,
+    provision_boot: boot_plan.ProvisionBootPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -310,6 +329,7 @@ const RuntimeParts = struct {
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
     provision_assets: boot_plan.ProvisionAssetsPlan,
+    provision_boot: boot_plan.ProvisionBootPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -361,6 +381,7 @@ fn makePlanParts(
         .provision_assets = boot_plan.planProvisionAssets(.{
             .guest_cpu = parsed.provision_guest_cpu,
         }),
+        .provision_boot = try makeProvisionBoot(arena, parsed),
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
@@ -459,6 +480,22 @@ fn makeMountDiskRuntime(parsed: ParsedRequest) !boot_plan.MountDiskRuntimePlan {
     });
 }
 
+fn makeProvisionBoot(
+    arena: std.mem.Allocator,
+    parsed: ParsedRequest,
+) !boot_plan.ProvisionBootPlan {
+    assert(@sizeOf(boot_plan.ProvisionBootPlan) > 0);
+
+    return boot_plan.planProvisionBoot(arena, .{
+        .base_path = parsed.provision_base_path,
+        .kernel_path = parsed.provision_kernel_path,
+        .dtb_path = parsed.provision_dtb_path,
+        .uds_path = parsed.provision_uds_path,
+        .scratch_disk_path = parsed.provision_scratch_disk_path,
+        .root_disk_path = parsed.provision_root_disk_path,
+    });
+}
+
 fn makeRegistryShape(
     arena: std.mem.Allocator,
     parsed: ParsedRequest,
@@ -520,6 +557,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
     try writeProvisionAssetsField(io, "provisionAssets", parts.provision_assets, true);
+    try writeProvisionBootField(io, "provisionBoot", parts.provision_boot, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
@@ -679,6 +717,27 @@ fn writeProvisionAssetsField(
     try writeNullableStringField(io, "dtbAsset", assets.dtb_asset, true);
     try protocol.stdout(io, ",\"rootfsAsset\":");
     try protocol.writeJsonString(io, assets.rootfs_asset);
+    try protocol.stdout(io, "}");
+}
+
+fn writeProvisionBootField(
+    io: std.Io,
+    comptime field: []const u8,
+    boot: boot_plan.ProvisionBootPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{");
+    try writeNullableStringField(io, "imagePath", boot.image_path, false);
+    try writeNullableStringField(io, "kernelPath", boot.kernel_path, true);
+    try writeNullableStringField(io, "dtbPath", boot.dtb_path, true);
+    try writeNullableStringField(io, "vmmVsock", boot.vmm_vsock, true);
+    try writeStringArrayField(io, "cmd", boot.cmd, true);
+    try writeEnvObjectField(io, "env", boot.env, true);
+    try writeNullableStringField(io, "snapshotPath", boot.snapshot_path, true);
+    try writeNullableStringField(io, "rootDiskPath", boot.root_disk_path, true);
     try protocol.stdout(io, "}");
 }
 
@@ -1313,6 +1372,12 @@ fn parseBundleFields(
         object,
         "bundleGuestEnv",
         "provisionGuestCpu",
+        "provisionBasePath",
+        "provisionKernelPath",
+        "provisionDtbPath",
+        "provisionUdsPath",
+        "provisionScratchDiskPath",
+        "provisionRootDiskPath",
         error.InvalidBundleGuestEnv,
     );
 }

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -63,7 +63,9 @@ const ParsedRequest = struct {
     mount_disk_source_upper_path: ?[]const u8 = null,
     mount_disk_guest: ?[]const u8 = null,
     mount_disk_upper_size_text: ?[]const u8 = null,
+    registry_source_image_path: ?[]const u8 = null,
     registry_per_boot_root_disk: ?[]const u8 = null,
+    registry_caller_root_disk_path: ?[]const u8 = null,
     registry_per_boot_snap_disk: ?[]const u8 = null,
     registry_per_boot_mount_upper: ?[]const u8 = null,
     registry_bundle_temp_dir: ?[]const u8 = null,
@@ -137,7 +139,9 @@ const boot_plan_fields = [_][]const u8{
     "mountDiskSourceUpperPath",
     "mountDiskGuest",
     "mountDiskUpperSize",
+    "registrySourceImagePath",
     "registryPerBootRootDisk",
+    "registryCallerRootDiskPath",
     "registryPerBootSnapDisk",
     "registryPerBootMountUpper",
     "registryBundleTempDir",
@@ -226,6 +230,8 @@ const RequestError = error{
     InvalidMountDiskSourceUpperPath,
     InvalidMountDiskGuest,
     InvalidMountDiskUpperSize,
+    InvalidRegistrySourceImagePath,
+    InvalidRegistryRootDiskPath,
     InvalidRegistryCleanupPath,
     InvalidRegistryMountGuest,
     InvalidRegistryMountLowerPath,
@@ -452,6 +458,9 @@ fn makeRegistryShape(
     assert(@sizeOf(boot_plan.RegistryShapePlan) > 0);
 
     return boot_plan.planRegistryShape(arena, .{
+        .source_image_path = parsed.registry_source_image_path,
+        .per_boot_root_disk = parsed.registry_per_boot_root_disk,
+        .caller_root_disk_path = parsed.registry_caller_root_disk_path,
         .cleanup = .{
             .per_boot_root_disk = parsed.registry_per_boot_root_disk,
             .per_boot_snap_disk = parsed.registry_per_boot_snap_disk,
@@ -762,7 +771,11 @@ fn writeRegistryShapeField(
 
     try writeFieldName(io, field, comma);
     try protocol.stdout(io, "{");
-    try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, false);
+    try writeNullableStringField(io, "sourceImagePath", registry.source_image_path, false);
+    try writeNullableStringField(io, "rootDiskPath", registry.root_disk_path, true);
+    try writeFieldName(io, "rootDiskMode", true);
+    try protocol.writeJsonString(io, registry.root_disk_mode);
+    try writeStringArrayField(io, "cleanupPaths", registry.cleanup_paths, true);
     try writeRegistryMountDiskField(io, "mountDisk", registry.mount_disk, true);
     try writeRegistryLiveMountsField(io, "liveMounts", registry.live_mounts, true);
     try protocol.stdout(io, "}");
@@ -1356,7 +1369,9 @@ fn parseMountDiskRuntimeFields(
     request.mount_disk_upper_size_text = try optionalStringDefaultNull(
         object,
         "mountDiskUpperSize",
+        "registrySourceImagePath",
         "registryPerBootRootDisk",
+        "registryCallerRootDiskPath",
         "registryPerBootSnapDisk",
         "registryPerBootMountUpper",
         "registryBundleTempDir",
@@ -1379,7 +1394,9 @@ fn parseRegistryShapeFields(
 
     request.registry_per_boot_root_disk = try optionalStringDefaultNull(
         object,
+        "registrySourceImagePath",
         "registryPerBootRootDisk",
+        "registryCallerRootDiskPath",
         error.InvalidRegistryCleanupPath,
     );
     request.registry_per_boot_snap_disk = try optionalStringDefaultNull(

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -50,6 +50,7 @@ const ParsedRequest = struct {
     bundle_command_required: bool = false,
     bundle_image_env: std.json.ObjectMap = .{},
     bundle_guest_env: std.json.ObjectMap = .{},
+    provision_guest_cpu: boot_plan.ProvisionGuestCpu = .arm64,
     scratch_mode: boot_plan.ScratchDiskMode = .unset,
     scratch_snapshot_path: ?[]const u8 = null,
     scratch_restore_clone_path: ?[]const u8 = null,
@@ -126,6 +127,7 @@ const boot_plan_fields = [_][]const u8{
     "bundleCommandRequired",
     "bundleImageEnv",
     "bundleGuestEnv",
+    "provisionGuestCpu",
     "scratchMode",
     "scratchSnapshotPath",
     "scratchRestoreClonePath",
@@ -216,6 +218,7 @@ const RequestError = error{
     InvalidBundleCommandRequired,
     InvalidBundleImageEnv,
     InvalidBundleGuestEnv,
+    InvalidProvisionGuestCpu,
     InvalidBundleEnvValue,
     InvalidScratchMode,
     InvalidScratchSnapshotPath,
@@ -280,6 +283,7 @@ const PlanParts = struct {
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
+    provision_assets: boot_plan.ProvisionAssetsPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -305,6 +309,7 @@ const RuntimeParts = struct {
     config_live_mounts: []const boot_plan.LiveMount,
     bundle_command: []const []const u8,
     bundle_env: []const boot_plan.EnvPair,
+    provision_assets: boot_plan.ProvisionAssetsPlan,
     scratch_disk: boot_plan.ScratchDiskPlan,
     root_disk_runtime: boot_plan.RootDiskRuntimePlan,
     mount_disk_runtime: boot_plan.MountDiskRuntimePlan,
@@ -353,6 +358,9 @@ fn makePlanParts(
         .config_live_mounts = runtime.config_live_mounts,
         .bundle_command = runtime.bundle_command,
         .bundle_env = runtime.bundle_env,
+        .provision_assets = boot_plan.planProvisionAssets(.{
+            .guest_cpu = parsed.provision_guest_cpu,
+        }),
         .scratch_disk = runtime.scratch_disk,
         .root_disk_runtime = runtime.root_disk_runtime,
         .mount_disk_runtime = runtime.mount_disk_runtime,
@@ -511,6 +519,7 @@ fn writePlan(io: std.Io, parts: PlanParts) !void {
     try writeMachinenConfigField(io, "machinenConfig", parts, true);
     try writeStringArrayField(io, "bundleCommand", parts.bundle_command, true);
     try writeEnvObjectField(io, "bundleEnv", parts.bundle_env, true);
+    try writeProvisionAssetsField(io, "provisionAssets", parts.provision_assets, true);
     try writeScratchDiskField(io, "scratchDisk", parts.scratch_disk, true);
     try writeRootDiskRuntimeField(io, "rootDiskRuntime", parts.root_disk_runtime, true);
     try writeMountDiskRuntimeField(io, "mountDiskRuntime", parts.mount_disk_runtime, true);
@@ -652,6 +661,25 @@ fn writeLiveMountsArrayField(
         try protocol.stdout(io, "}");
     }
     try protocol.stdout(io, "]");
+}
+
+fn writeProvisionAssetsField(
+    io: std.Io,
+    comptime field: []const u8,
+    assets: boot_plan.ProvisionAssetsPlan,
+    comma: bool,
+) !void {
+    assert(field.len > 0);
+
+    try writeFieldName(io, field, comma);
+    try protocol.stdout(io, "{\"cpu\":");
+    try protocol.writeJsonString(io, assets.cpu);
+    try protocol.stdout(io, ",\"kernelAsset\":");
+    try protocol.writeJsonString(io, assets.kernel_asset);
+    try writeNullableStringField(io, "dtbAsset", assets.dtb_asset, true);
+    try protocol.stdout(io, ",\"rootfsAsset\":");
+    try protocol.writeJsonString(io, assets.rootfs_asset);
+    try protocol.stdout(io, "}");
 }
 
 fn writeScratchDiskField(
@@ -1284,6 +1312,7 @@ fn parseBundleFields(
     request.bundle_guest_env = try optionalObjectDefaultEmpty(
         object,
         "bundleGuestEnv",
+        "provisionGuestCpu",
         error.InvalidBundleGuestEnv,
     );
 }

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,47 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans provision boot inputs", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionBasePath: "/base.tar.gz",
+          provisionKernelPath: "/Image",
+          provisionDtbPath: "/virt.dtb",
+          provisionUdsPath: "/tmp/exec.sock",
+          provisionScratchDiskPath: "/tmp/scratch.img",
+          provisionRootDiskPath: "/tmp/rootfs.img",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.provisionBoot).toEqual({
+      imagePath: "/base.tar.gz",
+      kernelPath: "/Image",
+      dtbPath: "/virt.dtb",
+      vmmVsock: "in:1978:/tmp/exec.sock",
+      cmd: ["/exec-agent"],
+      env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
+      snapshotPath: "/tmp/scratch.img",
+      rootDiskPath: "/tmp/rootfs.img",
+    });
+  });
+
   it("plans provision asset names", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -435,6 +435,65 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans registry cleanup paths and mount shapes", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          registryPerBootRootDisk: "/tmp/root.img",
+          registryPerBootSnapDisk: null,
+          registryPerBootMountUpper: "/tmp/upper.img",
+          registryBundleTempDir: "/tmp/bundle",
+          registryVsockTempDir: "/tmp/vsock",
+          registryStatsTempDir: null,
+          registryGvSocketDir: "/tmp/gv",
+          registryCpuCgroupPath: "/sys/fs/cgroup/machinen",
+          registryMountGuest: "/mnt/data",
+          registryMountLowerPath: "/cache/lower.sqfs",
+          registryMountUpperPath: "/tmp/upper.img",
+          liveMountsResolved: [
+            { host: "/host/work", guest: "/mnt/work", mode: "rw", tag: "machinen-lm0" },
+            { host: "/host/cache", guest: "/mnt/cache", mode: "ro", tag: "machinen-lm1" },
+          ],
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).data.registryShape).toEqual({
+      cleanupPaths: [
+        "/tmp/root.img",
+        "/tmp/upper.img",
+        "/tmp/bundle",
+        "/tmp/vsock",
+        "/tmp/gv",
+        "/sys/fs/cgroup/machinen",
+      ],
+      mountDisk: {
+        guest: "/mnt/data",
+        lowerPath: "/cache/lower.sqfs",
+        upperPath: "/tmp/upper.img",
+      },
+      liveMounts: [
+        { guest: "/mnt/work", host: "/host/work", mode: "rw" },
+        { guest: "/mnt/cache", host: "/host/cache", mode: "ro" },
+      ],
+    });
+  });
+
   it("plans machinen-config guest payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -453,7 +453,9 @@ describe("boot-plan helper schema", () => {
         protocolVersion: 1,
         data: {
           ...baseData,
+          registrySourceImagePath: "/images/rootfs.tar.gz",
           registryPerBootRootDisk: "/tmp/root.img",
+          registryCallerRootDiskPath: "/caller/root.img",
           registryPerBootSnapDisk: null,
           registryPerBootMountUpper: "/tmp/upper.img",
           registryBundleTempDir: "/tmp/bundle",
@@ -474,6 +476,9 @@ describe("boot-plan helper schema", () => {
     });
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout).data.registryShape).toEqual({
+      sourceImagePath: "/images/rootfs.tar.gz",
+      rootDiskPath: "/tmp/root.img",
+      rootDiskMode: "block",
       cleanupPaths: [
         "/tmp/root.img",
         "/tmp/upper.img",

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,50 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans provision asset names", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const amd64 = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, provisionGuestCpu: "amd64" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(amd64.status).toBe(0);
+    expect(JSON.parse(amd64.stdout).data.provisionAssets).toEqual({
+      cpu: "amd64",
+      kernelAsset: "bzImage-x86_64",
+      dtbAsset: null,
+      rootfsAsset: "rootfs-debian-amd64.tar.gz",
+    });
+
+    const arm64 = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: { ...baseData, provisionGuestCpu: "arm64" },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(arm64.status).toBe(0);
+    expect(JSON.parse(arm64.stdout).data.provisionAssets).toEqual({
+      cpu: "arm64",
+      kernelAsset: "Image-arm64",
+      dtbAsset: "virt-arm64.dtb",
+      rootfsAsset: "rootfs-debian-arm64.tar.gz",
+    });
+  });
+
   it("plans bundle env overlays", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,46 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans provision image config payloads", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const withConfig = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionImageConfigHasCmd: true,
+          provisionImageConfigCmd: ["/bin/echo", "hi"],
+          provisionImageConfigHasEnv: true,
+          provisionImageConfigEnv: { FOO: "bar" },
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(withConfig.status).toBe(0);
+    expect(JSON.parse(withConfig.stdout).data.provisionImageConfig).toEqual({
+      cmd: ["/bin/echo", "hi"],
+      env: { FOO: "bar" },
+    });
+
+    const empty = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(empty.status).toBe(0);
+    expect(JSON.parse(empty.stdout).data.provisionImageConfig).toBeNull();
+  });
+
   it("plans provision workload and repack commands", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,54 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans provision runtime defaults paths and explicit limits", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const explicit = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionWorkDir: "/tmp/machinen-provision-test",
+          provisionScratchSizeBytes: "4096",
+          provisionTimeoutMs: "12345",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(explicit.status).toBe(0);
+    expect(JSON.parse(explicit.stdout).data.provisionRuntime).toEqual({
+      scratchSizeBytes: 4096,
+      deadlineMs: 12345,
+      diskPath: "/tmp/machinen-provision-test/scratch.img",
+      rootDiskPath: "/tmp/machinen-provision-test/rootfs.img",
+      udsPath: "/tmp/machinen-provision-test/exec.sock",
+    });
+
+    const defaults = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({ protocolVersion: 1, data: baseData })}\n`,
+      encoding: "utf8",
+    });
+    expect(defaults.status).toBe(0);
+    expect(JSON.parse(defaults.stdout).data.provisionRuntime).toEqual({
+      scratchSizeBytes: 1024 * 1024 * 1024,
+      deadlineMs: 10 * 60 * 1000,
+      diskPath: null,
+      rootDiskPath: null,
+      udsPath: null,
+    });
+  });
+
   it("plans provision image config payloads", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/memory.test.ts
+++ b/packages/runtime/src/__tests__/memory.test.ts
@@ -294,6 +294,42 @@ describe("boot-plan helper schema", () => {
     });
   });
 
+  it("plans provision workload and repack commands", () => {
+    expect(helperTmp).toBeDefined();
+    const helper = join(helperTmp!, "bin", "machinen-runtime-helper");
+    const baseData = {
+      memoryMib: null,
+      resourcesMemory: null,
+      autoMemoryMib: "1024",
+      hostTotalBytes: null,
+      vmmMemoryPreset: false,
+      hasImage: false,
+      hasCmd: false,
+      rootDisk: "false",
+    };
+    const result = spawnSync(helper, ["boot-plan"], {
+      input: `${JSON.stringify({
+        protocolVersion: 1,
+        data: {
+          ...baseData,
+          provisionRepackDiskPath: "/tmp/scratch.img",
+          provisionRepackOutPath: "/tmp/out.tar.gz",
+          provisionRepackExtractDir: "/tmp/extract",
+        },
+      })}\n`,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    const data = JSON.parse(result.stdout).data;
+    expect(data.provisionWorkload.tarToDiskCommand).toContain("--exclude=./proc");
+    expect(data.provisionWorkload.tarToDiskCommand).toContain("-cf /dev/vdb .");
+    expect(data.provisionWorkload.poweroffCommand).toBe("/sbin/machinen-poweroff");
+    expect(data.provisionRepack).toEqual({
+      extractArgs: ["-xf", "/tmp/scratch.img", "-C", "/tmp/extract"],
+      targzArgs: ["-czf", "/tmp/out.tar.gz", "-C", "/tmp/extract", "."],
+    });
+  });
+
   it("plans provision boot inputs", () => {
     expect(helperTmp).toBeDefined();
     const helper = join(helperTmp!, "bin", "machinen-runtime-helper");

--- a/packages/runtime/src/__tests__/provision.test.ts
+++ b/packages/runtime/src/__tests__/provision.test.ts
@@ -8,11 +8,11 @@
 //              off the network path — this test is about filesystem
 //              round-trip, not download reliability.
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   boot,
   provision,
@@ -24,6 +24,30 @@ import {
 
 const microvmRoot = resolve(import.meta.dirname, "../../../microvm");
 const releaseAssets = resolve(microvmRoot, "../../release-assets");
+
+let helperTmp: string | undefined;
+let previousHelper: string | undefined;
+
+beforeAll(() => {
+  helperTmp = mkdtempSync(join(tmpdir(), "machinen-provision-helper-test-"));
+  execFileSync("zig", ["build", "--prefix", helperTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousHelper = process.env.MACHINEN_RUNTIME_HELPER;
+  process.env.MACHINEN_RUNTIME_HELPER = join(helperTmp, "bin", "machinen-runtime-helper");
+});
+
+afterAll(() => {
+  if (previousHelper === undefined) {
+    delete process.env.MACHINEN_RUNTIME_HELPER;
+  } else {
+    process.env.MACHINEN_RUNTIME_HELPER = previousHelper;
+  }
+  if (helperTmp) {
+    rmSync(helperTmp, { recursive: true, force: true });
+  }
+});
 
 function findBootTestBinary(): string | undefined {
   const cacheDir = resolve(microvmRoot, ".zig-cache/o");
@@ -119,6 +143,19 @@ describe("provision", () => {
       }
     });
 
+    it("uses native-planned amd64 rootfs asset names", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-base-amd64-envdir-"));
+      const p = join(dir, "rootfs-debian-amd64.tar.gz");
+      try {
+        writeFileSync(p, "");
+        process.env.MACHINEN_GUEST_ARCH = "amd64";
+        process.env.MACHINEN_ASSETS_DIR = dir;
+        expect(resolveBaseRootfs()).toBe(p);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it("throws if MACHINEN_ASSETS_DIR is set but missing the tarball", () => {
       const dir = mkdtempSync(join(tmpdir(), "machinen-base-envdir-empty-"));
       try {
@@ -167,6 +204,19 @@ describe("provision", () => {
       }
     });
 
+    it("uses native-planned amd64 kernel asset names", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-kernel-amd64-envdir-"));
+      const p = join(dir, "bzImage-x86_64");
+      try {
+        writeFileSync(p, "");
+        process.env.MACHINEN_GUEST_ARCH = "amd64";
+        process.env.MACHINEN_ASSETS_DIR = dir;
+        expect(resolveBaseKernel()).toBe(p);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it("throws if MACHINEN_ASSETS_DIR is set but missing the kernel", () => {
       const dir = mkdtempSync(join(tmpdir(), "machinen-kernel-envdir-empty-"));
       try {
@@ -201,6 +251,17 @@ describe("provision", () => {
 
     it("throws if the explicit path is missing", () => {
       expect(() => resolveBaseDtb("/nope/does/not/exist/virt.dtb")).toThrow(ProvisionError);
+    });
+
+    it("omits DTB for native-planned amd64 assets when dtb is omitted", () => {
+      const dir = mkdtempSync(join(tmpdir(), "machinen-dtb-amd64-envdir-"));
+      try {
+        process.env.MACHINEN_GUEST_ARCH = "amd64";
+        process.env.MACHINEN_ASSETS_DIR = dir;
+        expect(resolveBaseDtb()).toBeUndefined();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it("falls back to MACHINEN_ASSETS_DIR/virt-arm64.dtb when dtb is omitted", () => {

--- a/packages/runtime/src/native/boot-plan-schema.ts
+++ b/packages/runtime/src/native/boot-plan-schema.ts
@@ -1,0 +1,384 @@
+type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
+type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
+type MountDiskRuntimeAction = "none" | "restore" | "fresh";
+export type ProvisionGuestCpu = "arm64" | "amd64";
+export type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
+type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
+type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
+export type ProvisionAssetsPlan = {
+  cpu: ProvisionGuestCpu;
+  kernelAsset: string;
+  dtbAsset: string | null;
+  rootfsAsset: string;
+};
+export type ProvisionBootPlan = {
+  imagePath: string | null;
+  kernelPath: string | null;
+  dtbPath: string | null;
+  vmmVsock: string | null;
+  cmd: string[];
+  env: Record<string, string>;
+  snapshotPath: string | null;
+  rootDiskPath: string | null;
+};
+export type ProvisionWorkloadPlan = { tarToDiskCommand: string; poweroffCommand: string };
+export type ProvisionRepackPlan = { extractArgs: string[]; targzArgs: string[] };
+export type ProvisionImageConfigPlan = { cmd?: string[]; env?: Record<string, string> } | null;
+export type ProvisionRuntimePlan = {
+  scratchSizeBytes: number;
+  deadlineMs: number;
+  diskPath: string | null;
+  rootDiskPath: string | null;
+  udsPath: string | null;
+};
+export type RegistryShapePlan = {
+  sourceImagePath: string | null;
+  rootDiskPath: string | null;
+  rootDiskMode: "block" | "none";
+  cleanupPaths: string[];
+  mountDisk: RegistryMountDiskPlan | null;
+  liveMounts: RegistryLiveMountPlan[];
+};
+export type ScratchDiskPlan = {
+  action: ScratchDiskAction;
+  diskPath: string | null;
+  perBootSnapDisk: string | null;
+  vmmDisk: string | null;
+};
+export type RootDiskRuntimePlan = {
+  action: RootDiskRuntimeAction;
+  sourcePath: string | null;
+  targetPath: string | null;
+  perBootRootDisk: string | null;
+  vmmRootDisk: string | null;
+};
+export type MountDiskRuntimePlan = {
+  action: MountDiskRuntimeAction;
+  lowerPath: string | null;
+  upperPath: string | null;
+  sourceUpperPath: string | null;
+  guest: string | null;
+  upperSizeBytes: number | null;
+};
+type MachinenConfigPlan = Record<string, unknown> & {
+  cmd: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  liveMounts?: Array<{ guest: string; tag: string; mode: "ro" | "rw" }>;
+};
+
+const provisionGuestCpuValues = ["arm64", "amd64"] as const;
+const scratchDiskActions = ["none", "existing", "clone", "allocate"] as const;
+const rootDiskRuntimeActions = ["none", "existing", "clone-restore", "clone-cached"] as const;
+const mountDiskRuntimeActions = ["none", "restore", "fresh"] as const;
+const registryRootDiskModes = ["block", "none"] as const;
+const liveMountModes = ["ro", "rw"] as const;
+
+export interface NativeBootPlanResult {
+  memoryCeilingMib: number | null;
+  vmmMemory: string | null;
+  wantsRootDisk: boolean;
+  normalizedMountGuest: string | null;
+  mergedGuestEnv: Record<string, string>;
+  vsockUdsPath: string | null;
+  vmmVsock: string | null;
+  vmmCommand: string | null;
+  vmmArgs: string[];
+  vmmKernel: string | null;
+  vmmDtb: string | null;
+  vmmSnapshotPath: string | null;
+  vmmRestorePath: string | null;
+  vmmVmstateTiming: string | null;
+  virtiofsEnv: Record<string, string>;
+  plannedLiveMounts: PlannedLiveMount[];
+  statsFilePath: string | null;
+  vmmStatsFile: string | null;
+  machinenConfig: MachinenConfigPlan;
+  bundleCommand: string[];
+  bundleEnv: Record<string, string>;
+  provisionAssets: ProvisionAssetsPlan;
+  provisionBoot: ProvisionBootPlan;
+  provisionWorkload: ProvisionWorkloadPlan;
+  provisionRepack: ProvisionRepackPlan;
+  provisionImageConfig: ProvisionImageConfigPlan;
+  provisionRuntime: ProvisionRuntimePlan;
+  scratchDisk: ScratchDiskPlan;
+  rootDiskRuntime: RootDiskRuntimePlan;
+  mountDiskRuntime: MountDiskRuntimePlan;
+  registryShape: RegistryShapePlan;
+}
+
+export function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<NativeBootPlanResult>;
+  return [
+    nullableNonNegativeNumber(data.memoryCeilingMib),
+    nullableString(data.vmmMemory),
+    typeof data.wantsRootDisk === "boolean",
+    nullableString(data.normalizedMountGuest),
+    isStringRecord(data.mergedGuestEnv),
+    nullableString(data.vsockUdsPath),
+    nullableString(data.vmmVsock),
+    nullableString(data.vmmCommand),
+    isStringArray(data.vmmArgs),
+    nullableString(data.vmmKernel),
+    nullableString(data.vmmDtb),
+    nullableString(data.vmmSnapshotPath),
+    nullableString(data.vmmRestorePath),
+    nullableString(data.vmmVmstateTiming),
+    isStringRecord(data.virtiofsEnv),
+    Array.isArray(data.plannedLiveMounts) && data.plannedLiveMounts.every(isPlannedLiveMount),
+    nullableString(data.statsFilePath),
+    nullableString(data.vmmStatsFile),
+    isMachinenConfigPlan(data.machinenConfig),
+    isStringArray(data.bundleCommand),
+    isStringRecord(data.bundleEnv),
+    isProvisionAssetsPlan(data.provisionAssets),
+    isProvisionBootPlan(data.provisionBoot),
+    isProvisionWorkloadPlan(data.provisionWorkload),
+    isProvisionRepackPlan(data.provisionRepack),
+    isProvisionImageConfigPlan(data.provisionImageConfig),
+    isProvisionRuntimePlan(data.provisionRuntime),
+    isScratchDiskPlan(data.scratchDisk),
+    isRootDiskRuntimePlan(data.rootDiskRuntime),
+    isMountDiskRuntimePlan(data.mountDiskRuntime),
+    isRegistryShapePlan(data.registryShape),
+  ].every(Boolean);
+}
+
+function isProvisionAssetsPlan(value: unknown): value is ProvisionAssetsPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionAssetsPlan>;
+  return [
+    isOneOf(plan.cpu, provisionGuestCpuValues),
+    typeof plan.kernelAsset === "string",
+    nullableString(plan.dtbAsset),
+    typeof plan.rootfsAsset === "string",
+  ].every(Boolean);
+}
+
+function isProvisionBootPlan(value: unknown): value is ProvisionBootPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionBootPlan>;
+  return [
+    nullableString(plan.imagePath),
+    nullableString(plan.kernelPath),
+    nullableString(plan.dtbPath),
+    nullableString(plan.vmmVsock),
+    isStringArray(plan.cmd),
+    isStringRecord(plan.env),
+    nullableString(plan.snapshotPath),
+    nullableString(plan.rootDiskPath),
+  ].every(Boolean);
+}
+
+function isProvisionWorkloadPlan(value: unknown): value is ProvisionWorkloadPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionWorkloadPlan>;
+  return typeof plan.tarToDiskCommand === "string" && typeof plan.poweroffCommand === "string";
+}
+
+function isProvisionRepackPlan(value: unknown): value is ProvisionRepackPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionRepackPlan>;
+  return isStringArray(plan.extractArgs) && isStringArray(plan.targzArgs);
+}
+
+function isProvisionImageConfigPlan(value: unknown): value is ProvisionImageConfigPlan {
+  if (value === null) {
+    return true;
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<NonNullable<ProvisionImageConfigPlan>>;
+  if (plan.cmd !== undefined && !isStringArray(plan.cmd)) {
+    return false;
+  }
+  if (plan.env !== undefined && !isStringRecord(plan.env)) {
+    return false;
+  }
+  return plan.cmd !== undefined || plan.env !== undefined;
+}
+
+function isProvisionRuntimePlan(value: unknown): value is ProvisionRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionRuntimePlan>;
+  return (
+    nonNegativeNumber(plan.scratchSizeBytes) &&
+    nonNegativeNumber(plan.deadlineMs) &&
+    nullableString(plan.diskPath) &&
+    nullableString(plan.rootDiskPath) &&
+    nullableString(plan.udsPath)
+  );
+}
+
+function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ScratchDiskPlan>;
+  return [
+    isOneOf(plan.action, scratchDiskActions),
+    nullableString(plan.diskPath),
+    nullableString(plan.perBootSnapDisk),
+    nullableString(plan.vmmDisk),
+  ].every(Boolean);
+}
+
+function isRootDiskRuntimePlan(value: unknown): value is RootDiskRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RootDiskRuntimePlan>;
+  return [
+    isOneOf(plan.action, rootDiskRuntimeActions),
+    nullableString(plan.sourcePath),
+    nullableString(plan.targetPath),
+    nullableString(plan.perBootRootDisk),
+    nullableString(plan.vmmRootDisk),
+  ].every(Boolean);
+}
+
+function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<MountDiskRuntimePlan>;
+  return [
+    isOneOf(plan.action, mountDiskRuntimeActions),
+    nullableString(plan.lowerPath),
+    nullableString(plan.upperPath),
+    nullableString(plan.sourceUpperPath),
+    nullableString(plan.guest),
+    nullableNonNegativeNumber(plan.upperSizeBytes),
+  ].every(Boolean);
+}
+
+function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryShapePlan>;
+  return [
+    nullableString(plan.sourceImagePath),
+    nullableString(plan.rootDiskPath),
+    isOneOf(plan.rootDiskMode, registryRootDiskModes),
+    isStringArray(plan.cleanupPaths),
+    nullableRegistryMountDisk(plan.mountDisk),
+    Array.isArray(plan.liveMounts),
+    plan.liveMounts?.every(isRegistryLiveMount) === true,
+  ].every(Boolean);
+}
+
+function isRegistryMountDisk(value: unknown): value is RegistryMountDiskPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<RegistryMountDiskPlan>;
+  return [
+    typeof mount.guest === "string",
+    typeof mount.lowerPath === "string",
+    typeof mount.upperPath === "string",
+  ].every(Boolean);
+}
+
+function nullableRegistryMountDisk(value: unknown): boolean {
+  return value === null || isRegistryMountDisk(value);
+}
+
+function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<RegistryLiveMountPlan>;
+  return [
+    typeof mount.guest === "string",
+    typeof mount.host === "string",
+    isOneOf(mount.mode, liveMountModes),
+  ].every(Boolean);
+}
+
+function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<PlannedLiveMount>;
+  return [
+    typeof mount.host === "string",
+    typeof mount.guest === "string",
+    isOneOf(mount.mode, liveMountModes),
+    typeof mount.tag === "string",
+  ].every(Boolean);
+}
+
+function isMachinenConfigPlan(value: unknown): value is MachinenConfigPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const config = value as Partial<MachinenConfigPlan>;
+  if (!isStringArray(config.cmd) || !isStringRecord(config.env)) {
+    return false;
+  }
+  if (config.cwd !== undefined && typeof config.cwd !== "string") {
+    return false;
+  }
+  if (config.liveMounts !== undefined) {
+    if (!Array.isArray(config.liveMounts)) {
+      return false;
+    }
+    return config.liveMounts.every((mount) => {
+      if (!mount || typeof mount !== "object") {
+        return false;
+      }
+      const candidate = mount as { guest?: unknown; tag?: unknown; mode?: unknown };
+      return (
+        typeof candidate.guest === "string" &&
+        typeof candidate.tag === "string" &&
+        (candidate.mode === "ro" || candidate.mode === "rw")
+      );
+    });
+  }
+  return true;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isOneOf<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function nullableString(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
+function nonNegativeNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function nullableNonNegativeNumber(value: unknown): boolean {
+  return value === null || nonNegativeNumber(value);
+}

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -9,12 +9,20 @@ type RootDiskRuntimeMode = "none" | "path" | "restore" | "cached";
 type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeMode = "none" | "restore" | "fresh";
 type MountDiskRuntimeAction = "none" | "restore" | "fresh";
+type ProvisionGuestCpu = "arm64" | "amd64";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
 type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
+type ProvisionAssetsPlan = {
+  cpu: ProvisionGuestCpu;
+  kernelAsset: string;
+  dtbAsset: string | null;
+  rootfsAsset: string;
+};
+
 type RegistryShapePlan = {
   sourceImagePath: string | null;
   rootDiskPath: string | null;
@@ -67,6 +75,7 @@ interface NativeBootPlanInput {
   bundleCommandRequired?: boolean;
   bundleImageEnv?: Record<string, string>;
   bundleGuestEnv?: Record<string, string>;
+  provisionGuestCpu?: ProvisionGuestCpu;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -117,6 +126,7 @@ interface NativeBootPlanResult {
   machinenConfig: MachinenConfigPlan;
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
+  provisionAssets: ProvisionAssetsPlan;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
@@ -201,6 +211,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     configImageCwd: nullDefault(input.configImageCwd),
     configLiveMounts: input.configLiveMounts ?? [],
     ...bundleCommandData(input),
+    provisionGuestCpu: input.provisionGuestCpu ?? null,
     ...scratchDiskData(input),
     ...rootDiskRuntimeData(input),
     ...mountDiskRuntimeData(input),
@@ -287,6 +298,16 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planProvisionAssetsNative(cpu: ProvisionGuestCpu): ProvisionAssetsPlan {
+  return planBootCoreNative({
+    provisionGuestCpu: cpu,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionAssets;
 }
 
 export function planBootMountDiskRuntimeNative(input: {
@@ -604,6 +625,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isMachinenConfigPlan(data.machinenConfig),
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
+    isProvisionAssetsPlan(data.provisionAssets),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
@@ -617,6 +639,19 @@ function isStringArray(value: unknown): value is string[] {
 
 function isPlannedLiveMountArray(value: unknown): value is PlannedLiveMount[] {
   return Array.isArray(value) && value.every(isPlannedLiveMount);
+}
+
+function isProvisionAssetsPlan(value: unknown): value is ProvisionAssetsPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionAssetsPlan>;
+  return (
+    (plan.cpu === "arm64" || plan.cpu === "amd64") &&
+    typeof plan.kernelAsset === "string" &&
+    nullableString(plan.dtbAsset) &&
+    typeof plan.rootfsAsset === "string"
+  );
 }
 
 function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -44,6 +44,11 @@ type ProvisionRepackPlan = {
   targzArgs: string[];
 };
 
+type ProvisionImageConfigPlan = {
+  cmd?: string[];
+  env?: Record<string, string>;
+} | null;
+
 type RegistryShapePlan = {
   sourceImagePath: string | null;
   rootDiskPath: string | null;
@@ -106,6 +111,8 @@ interface NativeBootPlanInput {
   provisionRepackDiskPath?: string;
   provisionRepackOutPath?: string;
   provisionRepackExtractDir?: string;
+  provisionImageConfigCmd?: string[];
+  provisionImageConfigEnv?: Record<string, string>;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -160,6 +167,7 @@ interface NativeBootPlanResult {
   provisionBoot: ProvisionBootPlan;
   provisionWorkload: ProvisionWorkloadPlan;
   provisionRepack: ProvisionRepackPlan;
+  provisionImageConfig: ProvisionImageConfigPlan;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
@@ -277,6 +285,10 @@ function provisionData(input: NativeBootPlanInput): Record<string, unknown> {
     provisionRepackDiskPath: nullDefault(input.provisionRepackDiskPath),
     provisionRepackOutPath: nullDefault(input.provisionRepackOutPath),
     provisionRepackExtractDir: nullDefault(input.provisionRepackExtractDir),
+    provisionImageConfigHasCmd: input.provisionImageConfigCmd !== undefined,
+    provisionImageConfigCmd: input.provisionImageConfigCmd ?? [],
+    provisionImageConfigHasEnv: input.provisionImageConfigEnv !== undefined,
+    provisionImageConfigEnv: input.provisionImageConfigEnv ?? {},
   };
 }
 
@@ -371,6 +383,20 @@ export function planProvisionRepackNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).provisionRepack;
+}
+
+export function planProvisionImageConfigNative(input: {
+  cmd?: string[];
+  env?: Record<string, string>;
+}): ProvisionImageConfigPlan {
+  return planBootCoreNative({
+    provisionImageConfigCmd: input.cmd,
+    provisionImageConfigEnv: input.env,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionImageConfig;
 }
 
 export function planProvisionBootNative(input: {
@@ -724,6 +750,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isProvisionBootPlan(data.provisionBoot),
     isProvisionWorkloadPlan(data.provisionWorkload),
     isProvisionRepackPlan(data.provisionRepack),
+    isProvisionImageConfigPlan(data.provisionImageConfig),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
@@ -766,6 +793,23 @@ function isProvisionRepackPlan(value: unknown): value is ProvisionRepackPlan {
   }
   const plan = value as Partial<ProvisionRepackPlan>;
   return isStringArray(plan.extractArgs) && isStringArray(plan.targzArgs);
+}
+
+function isProvisionImageConfigPlan(value: unknown): value is ProvisionImageConfigPlan {
+  if (value === null) {
+    return true;
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<NonNullable<ProvisionImageConfigPlan>>;
+  if (plan.cmd !== undefined && !isStringArray(plan.cmd)) {
+    return false;
+  }
+  if (plan.env !== undefined && !isStringRecord(plan.env)) {
+    return false;
+  }
+  return plan.cmd !== undefined || plan.env !== undefined;
 }
 
 function isProvisionBootPlan(value: unknown): value is ProvisionBootPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -16,6 +16,9 @@ type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: s
 type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
 type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
 type RegistryShapePlan = {
+  sourceImagePath: string | null;
+  rootDiskPath: string | null;
+  rootDiskMode: "block" | "none";
   cleanupPaths: string[];
   mountDisk: RegistryMountDiskPlan | null;
   liveMounts: RegistryLiveMountPlan[];
@@ -77,7 +80,9 @@ interface NativeBootPlanInput {
   mountDiskSourceUpperPath?: string;
   mountDiskGuest?: string;
   mountDiskUpperSize?: number;
+  registrySourceImagePath?: string;
   registryPerBootRootDisk?: string;
+  registryCallerRootDiskPath?: string;
   registryPerBootSnapDisk?: string;
   registryPerBootMountUpper?: string;
   registryBundleTempDir?: string;
@@ -246,7 +251,9 @@ function mountDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknow
 
 function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> {
   return {
+    registrySourceImagePath: nullDefault(input.registrySourceImagePath),
     registryPerBootRootDisk: nullDefault(input.registryPerBootRootDisk),
+    registryCallerRootDiskPath: nullDefault(input.registryCallerRootDiskPath),
     registryPerBootSnapDisk: nullDefault(input.registryPerBootSnapDisk),
     registryPerBootMountUpper: nullDefault(input.registryPerBootMountUpper),
     registryBundleTempDir: nullDefault(input.registryBundleTempDir),
@@ -305,6 +312,11 @@ export function planBootMountDiskRuntimeNative(input: {
 }
 
 export function planBootRegistryShapeNative(input: {
+  sourceImagePath?: string;
+  rootDisk?: {
+    perBootRootDisk?: string;
+    callerRootDiskPath?: string;
+  };
   cleanup?: {
     perBootRootDisk?: string;
     perBootSnapDisk?: string;
@@ -319,7 +331,9 @@ export function planBootRegistryShapeNative(input: {
   liveMounts?: PlannedLiveMount[];
 }): RegistryShapePlan {
   return planBootCoreNative({
-    registryPerBootRootDisk: input.cleanup?.perBootRootDisk,
+    registrySourceImagePath: input.sourceImagePath,
+    registryPerBootRootDisk: input.rootDisk?.perBootRootDisk ?? input.cleanup?.perBootRootDisk,
+    registryCallerRootDiskPath: input.rootDisk?.callerRootDiskPath,
     registryPerBootSnapDisk: input.cleanup?.perBootSnapDisk,
     registryPerBootMountUpper: input.cleanup?.perBootMountUpper,
     registryBundleTempDir: input.cleanup?.bundleTempDir,
@@ -669,13 +683,18 @@ function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
     return false;
   }
   const plan = value as Partial<RegistryShapePlan>;
-  return (
-    Array.isArray(plan.cleanupPaths) &&
-    plan.cleanupPaths.every((path) => typeof path === "string") &&
-    (plan.mountDisk === null || isRegistryMountDisk(plan.mountDisk)) &&
-    Array.isArray(plan.liveMounts) &&
-    plan.liveMounts.every(isRegistryLiveMount)
-  );
+  return [
+    nullableString(plan.sourceImagePath),
+    nullableString(plan.rootDiskPath),
+    isRegistryRootDiskMode(plan.rootDiskMode),
+    isStringArray(plan.cleanupPaths),
+    plan.mountDisk === null || isRegistryMountDisk(plan.mountDisk),
+    Array.isArray(plan.liveMounts) && plan.liveMounts.every(isRegistryLiveMount),
+  ].every(Boolean);
+}
+
+function isRegistryRootDiskMode(value: unknown): value is "block" | "none" {
+  return value === "block" || value === "none";
 }
 
 function isRegistryMountDisk(value: unknown): value is RegistryMountDiskPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -1,62 +1,30 @@
 import { BootError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
 import { callRuntimeHelper } from "../native-helper.ts";
 import type { BootMemoryResourceOptions } from "../vm/memory-resources.ts";
+import { isNativeBootPlanResult } from "./boot-plan-schema.ts";
+import type {
+  MountDiskRuntimePlan,
+  PlannedLiveMount,
+  ProvisionAssetsPlan,
+  ProvisionBootPlan,
+  ProvisionGuestCpu,
+  ProvisionImageConfigPlan,
+  ProvisionRepackPlan,
+  ProvisionRuntimePlan,
+  ProvisionWorkloadPlan,
+  RegistryShapePlan,
+  RootDiskRuntimePlan,
+  ScratchDiskPlan,
+  NativeBootPlanResult,
+} from "./boot-plan-schema.ts";
 
 type RootDiskPlanMode = "unset" | "false" | "path" | "true";
 type ScratchDiskMode = "false" | "path" | "auto";
-type ScratchDiskAction = "none" | "existing" | "clone" | "allocate";
 type RootDiskRuntimeMode = "none" | "path" | "restore" | "cached";
-type RootDiskRuntimeAction = "none" | "existing" | "clone-restore" | "clone-cached";
 type MountDiskRuntimeMode = "none" | "restore" | "fresh";
-type MountDiskRuntimeAction = "none" | "restore" | "fresh";
-type ProvisionGuestCpu = "arm64" | "amd64";
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
-type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
-type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
-type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
-type ProvisionAssetsPlan = {
-  cpu: ProvisionGuestCpu;
-  kernelAsset: string;
-  dtbAsset: string | null;
-  rootfsAsset: string;
-};
-
-type ProvisionBootPlan = {
-  imagePath: string | null;
-  kernelPath: string | null;
-  dtbPath: string | null;
-  vmmVsock: string | null;
-  cmd: string[];
-  env: Record<string, string>;
-  snapshotPath: string | null;
-  rootDiskPath: string | null;
-};
-
-type ProvisionWorkloadPlan = {
-  tarToDiskCommand: string;
-  poweroffCommand: string;
-};
-
-type ProvisionRepackPlan = {
-  extractArgs: string[];
-  targzArgs: string[];
-};
-
-type ProvisionImageConfigPlan = {
-  cmd?: string[];
-  env?: Record<string, string>;
-} | null;
-
-type RegistryShapePlan = {
-  sourceImagePath: string | null;
-  rootDiskPath: string | null;
-  rootDiskMode: "block" | "none";
-  cleanupPaths: string[];
-  mountDisk: RegistryMountDiskPlan | null;
-  liveMounts: RegistryLiveMountPlan[];
-};
 
 interface NativeBootPlanInput {
   memoryMib?: number;
@@ -113,6 +81,9 @@ interface NativeBootPlanInput {
   provisionRepackExtractDir?: string;
   provisionImageConfigCmd?: string[];
   provisionImageConfigEnv?: Record<string, string>;
+  provisionWorkDir?: string;
+  provisionScratchSizeBytes?: number;
+  provisionTimeoutMs?: number;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -140,70 +111,6 @@ interface NativeBootPlanInput {
   registryMountLowerPath?: string;
   registryMountUpperPath?: string;
 }
-
-interface NativeBootPlanResult {
-  memoryCeilingMib: number | null;
-  vmmMemory: string | null;
-  wantsRootDisk: boolean;
-  normalizedMountGuest: string | null;
-  mergedGuestEnv: Record<string, string>;
-  vsockUdsPath: string | null;
-  vmmVsock: string | null;
-  vmmCommand: string | null;
-  vmmArgs: string[];
-  vmmKernel: string | null;
-  vmmDtb: string | null;
-  vmmSnapshotPath: string | null;
-  vmmRestorePath: string | null;
-  vmmVmstateTiming: string | null;
-  virtiofsEnv: Record<string, string>;
-  plannedLiveMounts: PlannedLiveMount[];
-  statsFilePath: string | null;
-  vmmStatsFile: string | null;
-  machinenConfig: MachinenConfigPlan;
-  bundleCommand: string[];
-  bundleEnv: Record<string, string>;
-  provisionAssets: ProvisionAssetsPlan;
-  provisionBoot: ProvisionBootPlan;
-  provisionWorkload: ProvisionWorkloadPlan;
-  provisionRepack: ProvisionRepackPlan;
-  provisionImageConfig: ProvisionImageConfigPlan;
-  scratchDisk: ScratchDiskPlan;
-  rootDiskRuntime: RootDiskRuntimePlan;
-  mountDiskRuntime: MountDiskRuntimePlan;
-  registryShape: RegistryShapePlan;
-}
-
-type ScratchDiskPlan = {
-  action: ScratchDiskAction;
-  diskPath: string | null;
-  perBootSnapDisk: string | null;
-  vmmDisk: string | null;
-};
-
-type RootDiskRuntimePlan = {
-  action: RootDiskRuntimeAction;
-  sourcePath: string | null;
-  targetPath: string | null;
-  perBootRootDisk: string | null;
-  vmmRootDisk: string | null;
-};
-
-type MountDiskRuntimePlan = {
-  action: MountDiskRuntimeAction;
-  lowerPath: string | null;
-  upperPath: string | null;
-  sourceUpperPath: string | null;
-  guest: string | null;
-  upperSizeBytes: number | null;
-};
-
-type MachinenConfigPlan = Record<string, unknown> & {
-  cmd: string[];
-  env: Record<string, string>;
-  cwd?: string;
-  liveMounts?: Array<{ guest: string; tag: string; mode: "ro" | "rw" }>;
-};
 
 export function planBootCoreNative(input: NativeBootPlanInput): NativeBootPlanResult {
   return callRuntimeHelper({
@@ -289,6 +196,9 @@ function provisionData(input: NativeBootPlanInput): Record<string, unknown> {
     provisionImageConfigCmd: input.provisionImageConfigCmd ?? [],
     provisionImageConfigHasEnv: input.provisionImageConfigEnv !== undefined,
     provisionImageConfigEnv: input.provisionImageConfigEnv ?? {},
+    provisionWorkDir: nullDefault(input.provisionWorkDir),
+    provisionScratchSizeBytes: numberText(input.provisionScratchSizeBytes),
+    provisionTimeoutMs: numberText(input.provisionTimeoutMs),
   };
 }
 
@@ -383,6 +293,22 @@ export function planProvisionRepackNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).provisionRepack;
+}
+
+export function planProvisionRuntimeNative(input: {
+  workDir: string;
+  scratchDiskSizeBytes?: number;
+  timeoutMs?: number;
+}): ProvisionRuntimePlan {
+  return planBootCoreNative({
+    provisionWorkDir: input.workDir,
+    provisionScratchSizeBytes: input.scratchDiskSizeBytes,
+    provisionTimeoutMs: input.timeoutMs,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionRuntime;
 }
 
 export function planProvisionImageConfigNative(input: {
@@ -717,281 +643,4 @@ function numberText(value: number | undefined): string | null {
 
 function numberTextRequired(value: number): string {
   return String(value);
-}
-
-function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const data = value as Partial<NativeBootPlanResult>;
-  return [
-    nullableNonNegativeNumber(data.memoryCeilingMib),
-    nullableString(data.vmmMemory),
-    typeof data.wantsRootDisk === "boolean",
-    nullableString(data.normalizedMountGuest),
-    isStringRecord(data.mergedGuestEnv),
-    nullableString(data.vsockUdsPath),
-    nullableString(data.vmmVsock),
-    nullableString(data.vmmCommand),
-    isStringArray(data.vmmArgs),
-    nullableString(data.vmmKernel),
-    nullableString(data.vmmDtb),
-    nullableString(data.vmmSnapshotPath),
-    nullableString(data.vmmRestorePath),
-    nullableString(data.vmmVmstateTiming),
-    isStringRecord(data.virtiofsEnv),
-    isPlannedLiveMountArray(data.plannedLiveMounts),
-    nullableString(data.statsFilePath),
-    nullableString(data.vmmStatsFile),
-    isMachinenConfigPlan(data.machinenConfig),
-    isStringArray(data.bundleCommand),
-    isStringRecord(data.bundleEnv),
-    isProvisionAssetsPlan(data.provisionAssets),
-    isProvisionBootPlan(data.provisionBoot),
-    isProvisionWorkloadPlan(data.provisionWorkload),
-    isProvisionRepackPlan(data.provisionRepack),
-    isProvisionImageConfigPlan(data.provisionImageConfig),
-    isScratchDiskPlan(data.scratchDisk),
-    isRootDiskRuntimePlan(data.rootDiskRuntime),
-    isMountDiskRuntimePlan(data.mountDiskRuntime),
-    isRegistryShapePlan(data.registryShape),
-  ].every(Boolean);
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
-}
-
-function isPlannedLiveMountArray(value: unknown): value is PlannedLiveMount[] {
-  return Array.isArray(value) && value.every(isPlannedLiveMount);
-}
-
-function isProvisionAssetsPlan(value: unknown): value is ProvisionAssetsPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<ProvisionAssetsPlan>;
-  return (
-    (plan.cpu === "arm64" || plan.cpu === "amd64") &&
-    typeof plan.kernelAsset === "string" &&
-    nullableString(plan.dtbAsset) &&
-    typeof plan.rootfsAsset === "string"
-  );
-}
-
-function isProvisionWorkloadPlan(value: unknown): value is ProvisionWorkloadPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<ProvisionWorkloadPlan>;
-  return typeof plan.tarToDiskCommand === "string" && typeof plan.poweroffCommand === "string";
-}
-
-function isProvisionRepackPlan(value: unknown): value is ProvisionRepackPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<ProvisionRepackPlan>;
-  return isStringArray(plan.extractArgs) && isStringArray(plan.targzArgs);
-}
-
-function isProvisionImageConfigPlan(value: unknown): value is ProvisionImageConfigPlan {
-  if (value === null) {
-    return true;
-  }
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<NonNullable<ProvisionImageConfigPlan>>;
-  if (plan.cmd !== undefined && !isStringArray(plan.cmd)) {
-    return false;
-  }
-  if (plan.env !== undefined && !isStringRecord(plan.env)) {
-    return false;
-  }
-  return plan.cmd !== undefined || plan.env !== undefined;
-}
-
-function isProvisionBootPlan(value: unknown): value is ProvisionBootPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<ProvisionBootPlan>;
-  return [
-    nullableString(plan.imagePath),
-    nullableString(plan.kernelPath),
-    nullableString(plan.dtbPath),
-    nullableString(plan.vmmVsock),
-    isStringArray(plan.cmd),
-    isStringRecord(plan.env),
-    nullableString(plan.snapshotPath),
-    nullableString(plan.rootDiskPath),
-  ].every(Boolean);
-}
-
-function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<ScratchDiskPlan>;
-  return (
-    isScratchDiskAction(plan.action) &&
-    nullableString(plan.diskPath) &&
-    nullableString(plan.perBootSnapDisk) &&
-    nullableString(plan.vmmDisk)
-  );
-}
-
-function isScratchDiskAction(value: unknown): value is ScratchDiskAction {
-  return value === "none" || value === "existing" || value === "clone" || value === "allocate";
-}
-
-function isRootDiskRuntimePlan(value: unknown): value is RootDiskRuntimePlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<RootDiskRuntimePlan>;
-  return (
-    isRootDiskRuntimeAction(plan.action) &&
-    nullableString(plan.sourcePath) &&
-    nullableString(plan.targetPath) &&
-    nullableString(plan.perBootRootDisk) &&
-    nullableString(plan.vmmRootDisk)
-  );
-}
-
-function isRootDiskRuntimeAction(value: unknown): value is RootDiskRuntimeAction {
-  return (
-    value === "none" ||
-    value === "existing" ||
-    value === "clone-restore" ||
-    value === "clone-cached"
-  );
-}
-
-function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<MountDiskRuntimePlan>;
-  return (
-    isMountDiskRuntimeAction(plan.action) &&
-    nullableString(plan.lowerPath) &&
-    nullableString(plan.upperPath) &&
-    nullableString(plan.sourceUpperPath) &&
-    nullableString(plan.guest) &&
-    nullableNonNegativeNumber(plan.upperSizeBytes)
-  );
-}
-
-function isMountDiskRuntimeAction(value: unknown): value is MountDiskRuntimeAction {
-  return value === "none" || value === "restore" || value === "fresh";
-}
-
-function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const plan = value as Partial<RegistryShapePlan>;
-  return [
-    nullableString(plan.sourceImagePath),
-    nullableString(plan.rootDiskPath),
-    isRegistryRootDiskMode(plan.rootDiskMode),
-    isStringArray(plan.cleanupPaths),
-    plan.mountDisk === null || isRegistryMountDisk(plan.mountDisk),
-    Array.isArray(plan.liveMounts) && plan.liveMounts.every(isRegistryLiveMount),
-  ].every(Boolean);
-}
-
-function isRegistryRootDiskMode(value: unknown): value is "block" | "none" {
-  return value === "block" || value === "none";
-}
-
-function isRegistryMountDisk(value: unknown): value is RegistryMountDiskPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const mount = value as Partial<RegistryMountDiskPlan>;
-  return (
-    typeof mount.guest === "string" &&
-    typeof mount.lowerPath === "string" &&
-    typeof mount.upperPath === "string"
-  );
-}
-
-function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const mount = value as Partial<RegistryLiveMountPlan>;
-  return (
-    typeof mount.guest === "string" &&
-    typeof mount.host === "string" &&
-    (mount.mode === "ro" || mount.mode === "rw")
-  );
-}
-
-function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const mount = value as Partial<PlannedLiveMount>;
-  return (
-    typeof mount.host === "string" &&
-    typeof mount.guest === "string" &&
-    (mount.mode === "ro" || mount.mode === "rw") &&
-    typeof mount.tag === "string"
-  );
-}
-
-function isMachinenConfigPlan(value: unknown): value is MachinenConfigPlan {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const config = value as Partial<MachinenConfigPlan>;
-  return (
-    isStringArray(config.cmd) &&
-    isStringRecord(config.env) &&
-    optionalString(config.cwd) &&
-    optionalConfigLiveMounts(config.liveMounts)
-  );
-}
-
-function optionalConfigLiveMounts(value: unknown): boolean {
-  if (value === undefined) {
-    return true;
-  }
-  return (
-    Array.isArray(value) &&
-    value.every((mount) => {
-      if (!mount || typeof mount !== "object") {
-        return false;
-      }
-      const entry = mount as { guest?: unknown; tag?: unknown; mode?: unknown };
-      return (
-        typeof entry.guest === "string" &&
-        typeof entry.tag === "string" &&
-        (entry.mode === "ro" || entry.mode === "rw")
-      );
-    })
-  );
-}
-
-function optionalString(value: unknown): boolean {
-  return value === undefined || typeof value === "string";
-}
-
-function nullableString(value: unknown): boolean {
-  return value === null || typeof value === "string";
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  return Object.values(value).every((entry) => typeof entry === "string");
-}
-
-function nullableNonNegativeNumber(value: unknown): boolean {
-  return value === null || (typeof value === "number" && Number.isFinite(value) && value >= 0);
 }

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -13,6 +13,13 @@ type MountDiskRuntimeAction = "none" | "restore" | "fresh";
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
 type LiveMountPlanInput = { host: string; guest: string; mode?: string };
 type PlannedLiveMount = { host: string; guest: string; mode: "ro" | "rw"; tag: string };
+type RegistryMountDiskPlan = { guest: string; lowerPath: string; upperPath: string };
+type RegistryLiveMountPlan = { guest: string; host: string; mode: "ro" | "rw" };
+type RegistryShapePlan = {
+  cleanupPaths: string[];
+  mountDisk: RegistryMountDiskPlan | null;
+  liveMounts: RegistryLiveMountPlan[];
+};
 
 interface NativeBootPlanInput {
   memoryMib?: number;
@@ -70,6 +77,17 @@ interface NativeBootPlanInput {
   mountDiskSourceUpperPath?: string;
   mountDiskGuest?: string;
   mountDiskUpperSize?: number;
+  registryPerBootRootDisk?: string;
+  registryPerBootSnapDisk?: string;
+  registryPerBootMountUpper?: string;
+  registryBundleTempDir?: string;
+  registryVsockTempDir?: string;
+  registryStatsTempDir?: string;
+  registryGvSocketDir?: string;
+  registryCpuCgroupPath?: string;
+  registryMountGuest?: string;
+  registryMountLowerPath?: string;
+  registryMountUpperPath?: string;
 }
 
 interface NativeBootPlanResult {
@@ -97,6 +115,7 @@ interface NativeBootPlanResult {
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
+  registryShape: RegistryShapePlan;
 }
 
 type ScratchDiskPlan = {
@@ -180,6 +199,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     ...scratchDiskData(input),
     ...rootDiskRuntimeData(input),
     ...mountDiskRuntimeData(input),
+    ...registryShapeData(input),
   };
 }
 
@@ -221,6 +241,22 @@ function mountDiskRuntimeData(input: NativeBootPlanInput): Record<string, unknow
     mountDiskSourceUpperPath: nullDefault(input.mountDiskSourceUpperPath),
     mountDiskGuest: nullDefault(input.mountDiskGuest),
     mountDiskUpperSize: numberText(input.mountDiskUpperSize),
+  };
+}
+
+function registryShapeData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    registryPerBootRootDisk: nullDefault(input.registryPerBootRootDisk),
+    registryPerBootSnapDisk: nullDefault(input.registryPerBootSnapDisk),
+    registryPerBootMountUpper: nullDefault(input.registryPerBootMountUpper),
+    registryBundleTempDir: nullDefault(input.registryBundleTempDir),
+    registryVsockTempDir: nullDefault(input.registryVsockTempDir),
+    registryStatsTempDir: nullDefault(input.registryStatsTempDir),
+    registryGvSocketDir: nullDefault(input.registryGvSocketDir),
+    registryCpuCgroupPath: nullDefault(input.registryCpuCgroupPath),
+    registryMountGuest: nullDefault(input.registryMountGuest),
+    registryMountLowerPath: nullDefault(input.registryMountLowerPath),
+    registryMountUpperPath: nullDefault(input.registryMountUpperPath),
   };
 }
 
@@ -266,6 +302,40 @@ export function planBootMountDiskRuntimeNative(input: {
     hasCmd: false,
     rootDisk: "false",
   }).mountDiskRuntime;
+}
+
+export function planBootRegistryShapeNative(input: {
+  cleanup?: {
+    perBootRootDisk?: string;
+    perBootSnapDisk?: string;
+    perBootMountUpper?: string;
+    bundleTempDir?: string;
+    vsockTempDir?: string;
+    statsTempDir?: string;
+    gvSocketDir?: string;
+    cpuCgroupPath?: string;
+  };
+  mountDisk?: { guest: string; lowerPath: string; upperPath: string };
+  liveMounts?: PlannedLiveMount[];
+}): RegistryShapePlan {
+  return planBootCoreNative({
+    registryPerBootRootDisk: input.cleanup?.perBootRootDisk,
+    registryPerBootSnapDisk: input.cleanup?.perBootSnapDisk,
+    registryPerBootMountUpper: input.cleanup?.perBootMountUpper,
+    registryBundleTempDir: input.cleanup?.bundleTempDir,
+    registryVsockTempDir: input.cleanup?.vsockTempDir,
+    registryStatsTempDir: input.cleanup?.statsTempDir,
+    registryGvSocketDir: input.cleanup?.gvSocketDir,
+    registryCpuCgroupPath: input.cleanup?.cpuCgroupPath,
+    registryMountGuest: input.mountDisk?.guest,
+    registryMountLowerPath: input.mountDisk?.lowerPath,
+    registryMountUpperPath: input.mountDisk?.upperPath,
+    liveMountsResolved: input.liveMounts,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).registryShape;
 }
 
 export function planBootBundleEnvNative(input: {
@@ -523,6 +593,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
+    isRegistryShapePlan(data.registryShape),
   ].every(Boolean);
 }
 
@@ -591,6 +662,44 @@ function isMountDiskRuntimePlan(value: unknown): value is MountDiskRuntimePlan {
 
 function isMountDiskRuntimeAction(value: unknown): value is MountDiskRuntimeAction {
   return value === "none" || value === "restore" || value === "fresh";
+}
+
+function isRegistryShapePlan(value: unknown): value is RegistryShapePlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<RegistryShapePlan>;
+  return (
+    Array.isArray(plan.cleanupPaths) &&
+    plan.cleanupPaths.every((path) => typeof path === "string") &&
+    (plan.mountDisk === null || isRegistryMountDisk(plan.mountDisk)) &&
+    Array.isArray(plan.liveMounts) &&
+    plan.liveMounts.every(isRegistryLiveMount)
+  );
+}
+
+function isRegistryMountDisk(value: unknown): value is RegistryMountDiskPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<RegistryMountDiskPlan>;
+  return (
+    typeof mount.guest === "string" &&
+    typeof mount.lowerPath === "string" &&
+    typeof mount.upperPath === "string"
+  );
+}
+
+function isRegistryLiveMount(value: unknown): value is RegistryLiveMountPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const mount = value as Partial<RegistryLiveMountPlan>;
+  return (
+    typeof mount.guest === "string" &&
+    typeof mount.host === "string" &&
+    (mount.mode === "ro" || mount.mode === "rw")
+  );
 }
 
 function isPlannedLiveMount(value: unknown): value is PlannedLiveMount {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -23,6 +23,17 @@ type ProvisionAssetsPlan = {
   rootfsAsset: string;
 };
 
+type ProvisionBootPlan = {
+  imagePath: string | null;
+  kernelPath: string | null;
+  dtbPath: string | null;
+  vmmVsock: string | null;
+  cmd: string[];
+  env: Record<string, string>;
+  snapshotPath: string | null;
+  rootDiskPath: string | null;
+};
+
 type RegistryShapePlan = {
   sourceImagePath: string | null;
   rootDiskPath: string | null;
@@ -76,6 +87,12 @@ interface NativeBootPlanInput {
   bundleImageEnv?: Record<string, string>;
   bundleGuestEnv?: Record<string, string>;
   provisionGuestCpu?: ProvisionGuestCpu;
+  provisionBasePath?: string;
+  provisionKernelPath?: string;
+  provisionDtbPath?: string;
+  provisionUdsPath?: string;
+  provisionScratchDiskPath?: string;
+  provisionRootDiskPath?: string;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -127,6 +144,7 @@ interface NativeBootPlanResult {
   bundleCommand: string[];
   bundleEnv: Record<string, string>;
   provisionAssets: ProvisionAssetsPlan;
+  provisionBoot: ProvisionBootPlan;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
@@ -211,7 +229,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     configImageCwd: nullDefault(input.configImageCwd),
     configLiveMounts: input.configLiveMounts ?? [],
     ...bundleCommandData(input),
-    provisionGuestCpu: input.provisionGuestCpu ?? null,
+    ...provisionData(input),
     ...scratchDiskData(input),
     ...rootDiskRuntimeData(input),
     ...mountDiskRuntimeData(input),
@@ -229,6 +247,18 @@ function bundleCommandData(input: NativeBootPlanInput): Record<string, unknown> 
     bundleCommandRequired: input.bundleCommandRequired === true,
     bundleImageEnv: input.bundleImageEnv ?? {},
     bundleGuestEnv: input.bundleGuestEnv ?? {},
+  };
+}
+
+function provisionData(input: NativeBootPlanInput): Record<string, unknown> {
+  return {
+    provisionGuestCpu: input.provisionGuestCpu ?? null,
+    provisionBasePath: nullDefault(input.provisionBasePath),
+    provisionKernelPath: nullDefault(input.provisionKernelPath),
+    provisionDtbPath: nullDefault(input.provisionDtbPath),
+    provisionUdsPath: nullDefault(input.provisionUdsPath),
+    provisionScratchDiskPath: nullDefault(input.provisionScratchDiskPath),
+    provisionRootDiskPath: nullDefault(input.provisionRootDiskPath),
   };
 }
 
@@ -298,6 +328,28 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planProvisionBootNative(input: {
+  basePath: string;
+  kernelPath: string;
+  dtbPath?: string;
+  udsPath: string;
+  scratchDiskPath: string;
+  rootDiskPath: string;
+}): ProvisionBootPlan {
+  return planBootCoreNative({
+    provisionBasePath: input.basePath,
+    provisionKernelPath: input.kernelPath,
+    provisionDtbPath: input.dtbPath,
+    provisionUdsPath: input.udsPath,
+    provisionScratchDiskPath: input.scratchDiskPath,
+    provisionRootDiskPath: input.rootDiskPath,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionBoot;
 }
 
 export function planProvisionAssetsNative(cpu: ProvisionGuestCpu): ProvisionAssetsPlan {
@@ -626,6 +678,7 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isStringArray(data.bundleCommand),
     isStringRecord(data.bundleEnv),
     isProvisionAssetsPlan(data.provisionAssets),
+    isProvisionBootPlan(data.provisionBoot),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
@@ -652,6 +705,23 @@ function isProvisionAssetsPlan(value: unknown): value is ProvisionAssetsPlan {
     nullableString(plan.dtbAsset) &&
     typeof plan.rootfsAsset === "string"
   );
+}
+
+function isProvisionBootPlan(value: unknown): value is ProvisionBootPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionBootPlan>;
+  return [
+    nullableString(plan.imagePath),
+    nullableString(plan.kernelPath),
+    nullableString(plan.dtbPath),
+    nullableString(plan.vmmVsock),
+    isStringArray(plan.cmd),
+    isStringRecord(plan.env),
+    nullableString(plan.snapshotPath),
+    nullableString(plan.rootDiskPath),
+  ].every(Boolean);
 }
 
 function isScratchDiskPlan(value: unknown): value is ScratchDiskPlan {

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -34,6 +34,16 @@ type ProvisionBootPlan = {
   rootDiskPath: string | null;
 };
 
+type ProvisionWorkloadPlan = {
+  tarToDiskCommand: string;
+  poweroffCommand: string;
+};
+
+type ProvisionRepackPlan = {
+  extractArgs: string[];
+  targzArgs: string[];
+};
+
 type RegistryShapePlan = {
   sourceImagePath: string | null;
   rootDiskPath: string | null;
@@ -93,6 +103,9 @@ interface NativeBootPlanInput {
   provisionUdsPath?: string;
   provisionScratchDiskPath?: string;
   provisionRootDiskPath?: string;
+  provisionRepackDiskPath?: string;
+  provisionRepackOutPath?: string;
+  provisionRepackExtractDir?: string;
   scratchMode?: ScratchDiskMode;
   scratchSnapshotPath?: string;
   scratchRestoreClonePath?: string;
@@ -145,6 +158,8 @@ interface NativeBootPlanResult {
   bundleEnv: Record<string, string>;
   provisionAssets: ProvisionAssetsPlan;
   provisionBoot: ProvisionBootPlan;
+  provisionWorkload: ProvisionWorkloadPlan;
+  provisionRepack: ProvisionRepackPlan;
   scratchDisk: ScratchDiskPlan;
   rootDiskRuntime: RootDiskRuntimePlan;
   mountDiskRuntime: MountDiskRuntimePlan;
@@ -259,6 +274,9 @@ function provisionData(input: NativeBootPlanInput): Record<string, unknown> {
     provisionUdsPath: nullDefault(input.provisionUdsPath),
     provisionScratchDiskPath: nullDefault(input.provisionScratchDiskPath),
     provisionRootDiskPath: nullDefault(input.provisionRootDiskPath),
+    provisionRepackDiskPath: nullDefault(input.provisionRepackDiskPath),
+    provisionRepackOutPath: nullDefault(input.provisionRepackOutPath),
+    provisionRepackExtractDir: nullDefault(input.provisionRepackExtractDir),
   };
 }
 
@@ -328,6 +346,31 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
 
 function nullDefault<T>(value: T | undefined): T | null {
   return value === undefined ? null : value;
+}
+
+export function planProvisionWorkloadNative(): ProvisionWorkloadPlan {
+  return planBootCoreNative({
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionWorkload;
+}
+
+export function planProvisionRepackNative(input: {
+  diskPath: string;
+  outPath: string;
+  extractDir: string;
+}): ProvisionRepackPlan {
+  return planBootCoreNative({
+    provisionRepackDiskPath: input.diskPath,
+    provisionRepackOutPath: input.outPath,
+    provisionRepackExtractDir: input.extractDir,
+    vmmMemoryPreset: true,
+    hasImage: false,
+    hasCmd: false,
+    rootDisk: "false",
+  }).provisionRepack;
 }
 
 export function planProvisionBootNative(input: {
@@ -679,6 +722,8 @@ function isNativeBootPlanResult(value: unknown): value is NativeBootPlanResult {
     isStringRecord(data.bundleEnv),
     isProvisionAssetsPlan(data.provisionAssets),
     isProvisionBootPlan(data.provisionBoot),
+    isProvisionWorkloadPlan(data.provisionWorkload),
+    isProvisionRepackPlan(data.provisionRepack),
     isScratchDiskPlan(data.scratchDisk),
     isRootDiskRuntimePlan(data.rootDiskRuntime),
     isMountDiskRuntimePlan(data.mountDiskRuntime),
@@ -705,6 +750,22 @@ function isProvisionAssetsPlan(value: unknown): value is ProvisionAssetsPlan {
     nullableString(plan.dtbAsset) &&
     typeof plan.rootfsAsset === "string"
   );
+}
+
+function isProvisionWorkloadPlan(value: unknown): value is ProvisionWorkloadPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionWorkloadPlan>;
+  return typeof plan.tarToDiskCommand === "string" && typeof plan.poweroffCommand === "string";
+}
+
+function isProvisionRepackPlan(value: unknown): value is ProvisionRepackPlan {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const plan = value as Partial<ProvisionRepackPlan>;
+  return isStringArray(plan.extractArgs) && isStringArray(plan.targzArgs);
 }
 
 function isProvisionBootPlan(value: unknown): value is ProvisionBootPlan {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -40,6 +40,7 @@ import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import type { OnLog } from "./log.ts";
+import { planProvisionAssetsNative } from "./native/boot-plan.ts";
 import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot, warmImageConfigCache } from "./vm/index.ts";
@@ -284,18 +285,13 @@ function baseAssetSpec(): {
   dtbAsset?: string;
   rootfsAsset: string;
 } {
-  return guestCpu() === "amd64"
-    ? {
-        cpu: "amd64",
-        kernelAsset: "bzImage-x86_64",
-        rootfsAsset: "rootfs-debian-amd64.tar.gz",
-      }
-    : {
-        cpu: "arm64",
-        kernelAsset: "Image-arm64",
-        dtbAsset: "virt-arm64.dtb",
-        rootfsAsset: "rootfs-debian-arm64.tar.gz",
-      };
+  const plan = planProvisionAssetsNative(guestCpu());
+  return {
+    cpu: plan.cpu,
+    kernelAsset: plan.kernelAsset,
+    ...(plan.dtbAsset ? { dtbAsset: plan.dtbAsset } : {}),
+    rootfsAsset: plan.rootfsAsset,
+  };
 }
 
 interface BaseAssetSpec {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -43,6 +43,7 @@ import type { OnLog } from "./log.ts";
 import {
   planProvisionAssetsNative,
   planProvisionBootNative,
+  planProvisionImageConfigNative,
   planProvisionRepackNative,
   planProvisionWorkloadNative,
 } from "./native/boot-plan.ts";
@@ -602,13 +603,7 @@ function finishProvision(opts: ProvisionOptions, ctx: ProvisionContext): Provisi
 function provisionImageConfig(
   opts: ProvisionOptions,
 ): { cmd?: string[]; env?: Record<string, string> } | null {
-  if (!opts.cmd && !opts.env) {
-    return null;
-  }
-  return {
-    ...(opts.cmd ? { cmd: opts.cmd } : {}),
-    ...(opts.env ? { env: opts.env } : {}),
-  };
+  return planProvisionImageConfigNative({ cmd: opts.cmd, env: opts.env });
 }
 
 function cleanupProvisionWorkDir(workDir: string): void {
@@ -691,14 +686,9 @@ function repackDiskTarToGz(
     // Bake the image's default cmd/env into /machinen-config.json so
     // `boot({ image })` can run without every caller re-passing the
     // same cmd. User-supplied cmd/env on boot() still override.
-    if (opts.cmd || opts.env) {
-      writeFileSync(
-        join(extractDir, "machinen-config.json"),
-        JSON.stringify({
-          ...(opts.cmd ? { cmd: opts.cmd } : {}),
-          ...(opts.env ? { env: opts.env } : {}),
-        }),
-      );
+    const imageConfig = planProvisionImageConfigNative({ cmd: opts.cmd, env: opts.env });
+    if (imageConfig) {
+      writeFileSync(join(extractDir, "machinen-config.json"), JSON.stringify(imageConfig));
     }
     const tarT0 = Date.now();
     execFileSync("tar", repackPlan.targzArgs, {

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -40,7 +40,7 @@ import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import type { OnLog } from "./log.ts";
-import { planProvisionAssetsNative } from "./native/boot-plan.ts";
+import { planProvisionAssetsNative, planProvisionBootNative } from "./native/boot-plan.ts";
 import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot, warmImageConfigCache } from "./vm/index.ts";
@@ -446,25 +446,43 @@ function cloneProvisionRootDisk(ctx: ProvisionContext): void {
 
 async function bootProvisionVm(opts: ProvisionOptions, ctx: ProvisionContext): Promise<VmHandle> {
   ctx.phases.start("boot");
+  const plan = planProvisionBootNative({
+    basePath: ctx.baseAbs,
+    kernelPath: ctx.kernelAbs,
+    dtbPath: ctx.dtbAbs,
+    udsPath: ctx.udsPath,
+    scratchDiskPath: ctx.diskPath,
+    rootDiskPath: ctx.rootDiskPath,
+  });
   const vm = await boot({
     binary: opts.binary,
     cwd: opts.cwd,
     vmmEnv: {
       ...opts.vmmEnv,
-      MACHINEN_VSOCK: `in:1978:${ctx.udsPath}`,
+      ...(plan.vmmVsock ? { MACHINEN_VSOCK: plan.vmmVsock } : {}),
     },
-    kernel: ctx.kernelAbs,
-    ...(ctx.dtbAbs ? { dtb: ctx.dtbAbs } : {}),
-    image: ctx.baseAbs,
-    cmd: ["/exec-agent"],
-    env: { PATH: "/usr/local/bin:/usr/bin:/bin:/sbin" },
-    snapshot: ctx.diskPath,
-    rootDisk: ctx.rootDiskPath,
+    kernel: requireProvisionPlanString(plan.kernelPath, "kernelPath"),
+    ...(plan.dtbPath ? { dtb: plan.dtbPath } : {}),
+    image: requireProvisionPlanString(plan.imagePath, "imagePath"),
+    cmd: plan.cmd,
+    env: plan.env,
+    snapshot: requireProvisionPlanString(plan.snapshotPath, "snapshotPath"),
+    rootDisk: requireProvisionPlanString(plan.rootDiskPath, "rootDiskPath"),
     timeoutMs: null,
     onLog: opts.onLog,
   });
   ctx.phases.end("boot");
   return vm;
+}
+
+function requireProvisionPlanString(value: string | null, field: string): string {
+  if (value === null) {
+    throw new ProvisionError(
+      "PROVISION_BASE_NOT_FOUND",
+      `provision native planner returned missing ${field}`,
+    );
+  }
+  return value;
 }
 
 async function runProvisionVmWorkload(

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -40,7 +40,12 @@ import debugLib from "debug";
 import { ProvisionError } from "./errors.ts";
 import { VsockExec } from "./exec.ts";
 import type { OnLog } from "./log.ts";
-import { planProvisionAssetsNative, planProvisionBootNative } from "./native/boot-plan.ts";
+import {
+  planProvisionAssetsNative,
+  planProvisionBootNative,
+  planProvisionRepackNative,
+  planProvisionWorkloadNative,
+} from "./native/boot-plan.ts";
 import { PhaseTimer } from "./phase-timer.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot, warmImageConfigCache } from "./vm/index.ts";
@@ -156,34 +161,6 @@ export interface ProvisionResult {
   /** Wall-clock time from build() entry to return. */
   elapsedMs: number;
 }
-
-/**
- * The guest-side command we run after `install` completes to capture
- * the rootfs state onto the scratch disk. Excludes volatile + special
- * filesystems; everything else goes into the tar stream we write raw
- * to `/dev/vdb`. The scratch disk is the second virtio-blk slot (vda
- * holds the live ext4 rootfs the guest is running from); at pack-time
- * vdb has no filesystem so we append tar directly to the block device.
- * The host reads it back the same way (the trailing two zero blocks
- * mark the end).
- */
-const TAR_TO_DISK_CMD = [
-  "tar",
-  "-C /",
-  "--exclude=./proc",
-  "--exclude=./sys",
-  "--exclude=./dev",
-  "--exclude=./tmp",
-  "--exclude=./run",
-  "--exclude=./machinen-config.json",
-  "--exclude=./etc/machinen-boot-epoch",
-  "--sort=name",
-  "--numeric-owner",
-  "--owner=0",
-  "--group=0",
-  "-cf /dev/vdb",
-  ".",
-].join(" ");
 
 /**
  * Resolve the path to the base rootfs tarball, in the same order
@@ -559,9 +536,10 @@ async function tarProvisionRootfsToDisk(
   debug("tar / -> /dev/vdb starting");
   const tarT0 = Date.now();
   ctx.phases.start("tar-to-disk");
-  const tar = await VsockExec.run(ctx.udsPath, TAR_TO_DISK_CMD, {
+  const workload = planProvisionWorkloadNative();
+  const tar = await VsockExec.run(ctx.udsPath, workload.tarToDiskCommand, {
     execTimeoutMs: deadlineMs,
-    ...tapExecForLog(TAR_TO_DISK_CMD, opts.onLog),
+    ...tapExecForLog(workload.tarToDiskCommand, opts.onLog),
   });
   ctx.phases.end("tar-to-disk");
   debug("tar / -> /dev/vdb done exit=%d elapsed=%dms", tar.exitCode, Date.now() - tarT0);
@@ -581,9 +559,10 @@ async function poweroffProvisionGuest(
 ): Promise<void> {
   debug("requesting guest poweroff");
   ctx.phases.start("poweroff-wait");
-  await VsockExec.run(ctx.udsPath, "/sbin/machinen-poweroff", {
+  const workload = planProvisionWorkloadNative();
+  await VsockExec.run(ctx.udsPath, workload.poweroffCommand, {
     connectTimeoutMs: 2_000,
-    ...tapExecForLog("/sbin/machinen-poweroff", opts.onLog),
+    ...tapExecForLog(workload.poweroffCommand, opts.onLog),
   }).catch(() => {});
   console.error("provision: waiting for guest exit…");
   await vm.wait();
@@ -705,8 +684,9 @@ function repackDiskTarToGz(
     // Visible progress so the silent multi-GB tar pass doesn't look
     // like a hang. See #162.
     console.error("provision: packaging rootfs…");
+    const repackPlan = planProvisionRepackNative({ diskPath, outPath: outAbs, extractDir });
     const extractT0 = Date.now();
-    execFileSync("tar", ["-xf", diskPath, "-C", extractDir]);
+    execFileSync("tar", repackPlan.extractArgs);
     opts.onPhase?.("disk-tar-extract", Date.now() - extractT0);
     // Bake the image's default cmd/env into /machinen-config.json so
     // `boot({ image })` can run without every caller re-passing the
@@ -721,7 +701,7 @@ function repackDiskTarToGz(
       );
     }
     const tarT0 = Date.now();
-    execFileSync("tar", ["-czf", outAbs, "-C", extractDir, "."], {
+    execFileSync("tar", repackPlan.targzArgs, {
       stdio: ["ignore", "ignore", "inherit"],
     });
     opts.onPhase?.("targz", Date.now() - tarT0);

--- a/packages/runtime/src/provision.ts
+++ b/packages/runtime/src/provision.ts
@@ -23,16 +23,13 @@
 
 import { execFileSync } from "node:child_process";
 import {
-  closeSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
-  openSync,
   readFileSync,
   rmSync,
   statSync,
   writeFileSync,
-  writeSync,
 } from "node:fs";
 import { arch as osArch, homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -45,9 +42,11 @@ import {
   planProvisionBootNative,
   planProvisionImageConfigNative,
   planProvisionRepackNative,
+  planProvisionRuntimeNative,
   planProvisionWorkloadNative,
 } from "./native/boot-plan.ts";
 import { PhaseTimer } from "./phase-timer.ts";
+import { allocateSparseFile } from "./vm/helpers.ts";
 import { reflinkCopy } from "./reflink.ts";
 import { boot, warmImageConfigCache } from "./vm/index.ts";
 import type { VmHandle } from "./vm-handle.ts";
@@ -340,6 +339,8 @@ interface ProvisionContext {
   diskPath: string;
   rootDiskPath: string;
   udsPath: string;
+  scratchDiskSizeBytes: number;
+  deadlineMs: number;
   phases: PhaseTimer;
 }
 
@@ -362,7 +363,7 @@ const PROVISION_STDERR_TAIL_MAX = 128 * 1024;
 export async function provision(opts: ProvisionOptions): Promise<ProvisionResult> {
   const ctx = createProvisionContext(opts);
   try {
-    prepareProvisionDisks(opts, ctx);
+    prepareProvisionDisks(ctx);
     const vm = await bootProvisionVm(opts, ctx);
     await runProvisionVmWorkload(opts, ctx, vm);
     repackProvisionOutput(opts, ctx);
@@ -381,6 +382,11 @@ function createProvisionContext(opts: ProvisionOptions): ProvisionContext {
   mkdirSync(dirname(outAbs), { recursive: true });
 
   const workDir = mkdtempSync(join(tmpdir(), "machinen-provision-"));
+  const runtimePlan = planProvisionRuntimeNative({
+    workDir,
+    scratchDiskSizeBytes: opts.scratchDiskSizeBytes,
+    timeoutMs: opts.timeoutMs,
+  });
   const ctx = {
     cwd,
     baseAbs,
@@ -389,24 +395,25 @@ function createProvisionContext(opts: ProvisionOptions): ProvisionContext {
     outAbs,
     t0: Date.now(),
     workDir,
-    diskPath: join(workDir, "scratch.img"),
-    rootDiskPath: join(workDir, "rootfs.img"),
-    udsPath: join(workDir, "exec.sock"),
+    diskPath: requireProvisionPlanString(runtimePlan.diskPath, "diskPath"),
+    rootDiskPath: requireProvisionPlanString(runtimePlan.rootDiskPath, "rootDiskPath"),
+    udsPath: requireProvisionPlanString(runtimePlan.udsPath, "udsPath"),
+    scratchDiskSizeBytes: runtimePlan.scratchSizeBytes,
+    deadlineMs: runtimePlan.deadlineMs,
     phases: new PhaseTimer(),
   };
   debug("provision start base=%s out=%s workDir=%s", baseAbs, outAbs, workDir);
   return ctx;
 }
 
-function prepareProvisionDisks(opts: ProvisionOptions, ctx: ProvisionContext): void {
-  allocateProvisionScratch(opts, ctx);
+function prepareProvisionDisks(ctx: ProvisionContext): void {
+  allocateProvisionScratch(ctx);
   cloneProvisionRootDisk(ctx);
 }
 
-function allocateProvisionScratch(opts: ProvisionOptions, ctx: ProvisionContext): void {
-  const scratchBytes = opts.scratchDiskSizeBytes ?? 1024 * 1024 * 1024;
-  allocateSparseFile(ctx.diskPath, scratchBytes);
-  debug("scratch disk allocated path=%s sizeBytes=%d", ctx.diskPath, scratchBytes);
+function allocateProvisionScratch(ctx: ProvisionContext): void {
+  allocateSparseFile(ctx.diskPath, ctx.scratchDiskSizeBytes);
+  debug("scratch disk allocated path=%s sizeBytes=%d", ctx.diskPath, ctx.scratchDiskSizeBytes);
 }
 
 function cloneProvisionRootDisk(ctx: ProvisionContext): void {
@@ -468,13 +475,12 @@ async function runProvisionVmWorkload(
   ctx: ProvisionContext,
   vm: VmHandle,
 ): Promise<void> {
-  const deadlineMs = opts.timeoutMs ?? 10 * 60 * 1000;
-  const killTimer = setTimeout(() => void vm.kill(), deadlineMs);
+  const killTimer = setTimeout(() => void vm.kill(), ctx.deadlineMs);
   killTimer.unref();
   const stderrTail = captureProvisionStderrTail(vm);
   try {
     await runInstallHook(opts, ctx, vm, stderrTail);
-    await tarProvisionRootfsToDisk(opts, ctx, deadlineMs);
+    await tarProvisionRootfsToDisk(opts, ctx, ctx.deadlineMs);
     await poweroffProvisionGuest(opts, ctx, vm);
   } finally {
     clearTimeout(killTimer);
@@ -629,16 +635,6 @@ function tapExecForLog(
     onStdout: (chunk) => onLog({ source: "exec-stdout", cmd, chunk }),
     onStderr: (chunk) => onLog({ source: "exec-stderr", cmd, chunk }),
   };
-}
-
-function allocateSparseFile(path: string, sizeBytes: number): void {
-  const fd = openSync(path, "w");
-  try {
-    const buf = Buffer.alloc(1);
-    writeSync(fd, buf, 0, 1, sizeBytes - 1);
-  } finally {
-    closeSync(fd);
-  }
 }
 
 /**

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -797,13 +797,19 @@ function buildBootRegistryState(
   spawned: SpawnedBootVmm,
 ): BootRegistryState {
   const childPid = spawned.child.pid ?? -1;
-  const rootDiskPath = registryRootDiskPath(opts, resources.perBootRootDisk);
+  const registryShape = planBootRegistryShapeNative({
+    sourceImagePath: registrySourceImage(opts),
+    rootDisk: {
+      perBootRootDisk: resources.perBootRootDisk,
+      callerRootDiskPath: registryCallerRootDiskPath(opts),
+    },
+  });
   return {
     childPid,
     vmName: opts.name,
-    sourceImageAbs: registrySourceImage(opts),
-    rootDiskPath,
-    rootDiskMode: rootDiskPath ? "block" : "none",
+    sourceImageAbs: registryShape.sourceImagePath ?? undefined,
+    rootDiskPath: registryShape.rootDiskPath ?? undefined,
+    rootDiskMode: registryShape.rootDiskMode,
     bootLogPath: registryBootLogPath(opts, childPid),
   };
 }
@@ -812,13 +818,7 @@ function registrySourceImage(opts: BootOptions): string | undefined {
   return opts.image ? resolve(opts.cwd ?? process.cwd(), opts.image) : undefined;
 }
 
-function registryRootDiskPath(
-  opts: BootOptions,
-  perBootRootDisk: string | undefined,
-): string | undefined {
-  if (perBootRootDisk) {
-    return perBootRootDisk;
-  }
+function registryCallerRootDiskPath(opts: BootOptions): string | undefined {
   return typeof opts.rootDisk === "string"
     ? resolve(opts.cwd ?? process.cwd(), opts.rootDisk)
     : undefined;

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -54,6 +54,7 @@ import { readHostRssBytes } from "../proc-rss.ts";
 import {
   planBootCoreNative,
   planBootKernelDtbNative,
+  planBootRegistryShapeNative,
   planBootScratchDiskNative,
   planBootStatsFileNative,
   planBootVirtiofsEnvNative,
@@ -902,16 +903,18 @@ function cleanupPathsForBoot(
   resources: BootResources,
   spawned: SpawnedBootVmm,
 ): string[] {
-  return collectCleanupPaths({
-    perBootRootDisk: resources.perBootRootDisk,
-    perBootSnapDisk: plan.perBootSnapDisk,
-    perBootMountUpper: spawned.perBootMountUpper,
-    bundleTempDir: resources.bundleTempDir,
-    vsockTempDir: plan.vsockTempDir,
-    statsTempDir: plan.statsTempDir,
-    gvSocketDir: resources.gvSocketDir,
-    cpuCgroupPath: spawned.cpuControl.cgroupPath,
-  });
+  return planBootRegistryShapeNative({
+    cleanup: {
+      perBootRootDisk: resources.perBootRootDisk,
+      perBootSnapDisk: plan.perBootSnapDisk,
+      perBootMountUpper: spawned.perBootMountUpper,
+      bundleTempDir: resources.bundleTempDir,
+      vsockTempDir: plan.vsockTempDir,
+      statsTempDir: plan.statsTempDir,
+      gvSocketDir: resources.gvSocketDir,
+      cpuCgroupPath: spawned.cpuControl.cgroupPath,
+    },
+  }).cleanupPaths;
 }
 
 function installBootExitCleanup(
@@ -1524,34 +1527,6 @@ function claimNameOrThrow(
   );
 }
 
-function collectCleanupPaths(state: {
-  perBootRootDisk: string | undefined;
-  perBootSnapDisk: string | undefined;
-  perBootMountUpper: string | undefined;
-  bundleTempDir: string | undefined;
-  vsockTempDir: string | undefined;
-  statsTempDir: string | undefined;
-  gvSocketDir: string | undefined;
-  cpuCgroupPath: string | undefined;
-}): string[] {
-  const paths: string[] = [];
-  for (const p of [
-    state.perBootRootDisk,
-    state.perBootSnapDisk,
-    state.perBootMountUpper,
-    state.bundleTempDir,
-    state.vsockTempDir,
-    state.statsTempDir,
-    state.gvSocketDir,
-    state.cpuCgroupPath,
-  ]) {
-    if (p) {
-      paths.push(p);
-    }
-  }
-  return paths;
-}
-
 interface RegisterArgs {
   childPid: number;
   vmName: string | undefined;
@@ -1653,21 +1628,19 @@ function registryMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
   if (!mountDiskPaths) {
     return undefined;
   }
-  return {
-    guest: mountDiskPaths.guest,
-    lowerPath: mountDiskPaths.lowerPath,
-    upperPath: mountDiskPaths.upperPath,
-  };
+  return (
+    planBootRegistryShapeNative({
+      mountDisk: {
+        guest: mountDiskPaths.guest,
+        lowerPath: mountDiskPaths.lowerPath,
+        upperPath: mountDiskPaths.upperPath,
+      },
+    }).mountDisk ?? undefined
+  );
 }
 
 function registryLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
-  return nonEmptyList(
-    liveMountsResolved.map(({ guest, host, mode }) => ({
-      guest,
-      host,
-      mode,
-    })),
-  );
+  return nonEmptyList(planBootRegistryShapeNative({ liveMounts: liveMountsResolved }).liveMounts);
 }
 
 // #221/#233: stamp first-guest-byte and emit the boot timeline. Either


### PR DESCRIPTION
## Problem

Registry shape and provision planning were grouped with boot runtime planning. That made one PR larger than it needed to be.

## Solution

Move registry shape/rootdisk planning and the first provision planning wave into Zig in a separate slice. TypeScript still owns host files, spawning, and user-facing errors.

## Technical Summary

- Covers provision asset, boot input, workload, image config, and runtime planning.
- Keeps registry and provision branches together because they share boot-plan schema growth.
- Preserves command-specific wrappers at the TypeScript boundary.
