### PR TITLE
Move terminal shims into helper build

### DIFF
--- a/packages/native-arm64-darwin/index.mjs
+++ b/packages/native-arm64-darwin/index.mjs
@@ -23,6 +23,8 @@ export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper")
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /** Native PTY shim used by bootPty(). */
 export const pty = join(here, "vmm", "bin", "machinen-pty");
+/** Native winsize socket forwarder used by VsockWinsize. */
+export const winsize = join(here, "vmm", "bin", "machinen-winsize");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-darwin/index.mjs
+++ b/packages/native-arm64-darwin/index.mjs
@@ -21,6 +21,8 @@ export const binary = join(here, "vmm", "bin", "machinen-vm");
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
+/** Native PTY shim used by bootPty(). */
+export const pty = join(here, "vmm", "bin", "machinen-pty");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-darwin/package.json
+++ b/packages/native-arm64-darwin/package.json
@@ -13,6 +13,7 @@
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
+    "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/native-arm64-darwin/package.json
+++ b/packages/native-arm64-darwin/package.json
@@ -15,7 +15,8 @@
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
-    "machinen-vm": "./vmm/bin/machinen-vm"
+    "machinen-vm": "./vmm/bin/machinen-vm",
+    "machinen-winsize": "./vmm/bin/machinen-winsize"
   },
   "files": [
     "vmm/bin/",

--- a/packages/native-arm64-linux/index.mjs
+++ b/packages/native-arm64-linux/index.mjs
@@ -23,6 +23,8 @@ export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper")
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /** Native PTY shim used by bootPty(). */
 export const pty = join(here, "vmm", "bin", "machinen-pty");
+/** Native winsize socket forwarder used by VsockWinsize. */
+export const winsize = join(here, "vmm", "bin", "machinen-winsize");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-linux/index.mjs
+++ b/packages/native-arm64-linux/index.mjs
@@ -21,6 +21,8 @@ export const binary = join(here, "vmm", "bin", "machinen-vm");
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
+/** Native PTY shim used by bootPty(). */
+export const pty = join(here, "vmm", "bin", "machinen-pty");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-arm64-linux/package.json
+++ b/packages/native-arm64-linux/package.json
@@ -13,6 +13,7 @@
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
+    "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/native-arm64-linux/package.json
+++ b/packages/native-arm64-linux/package.json
@@ -15,7 +15,8 @@
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
-    "machinen-vm": "./vmm/bin/machinen-vm"
+    "machinen-vm": "./vmm/bin/machinen-vm",
+    "machinen-winsize": "./vmm/bin/machinen-winsize"
   },
   "files": [
     "vmm/bin/",

--- a/packages/native-x64-linux/index.mjs
+++ b/packages/native-x64-linux/index.mjs
@@ -23,6 +23,8 @@ export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper")
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
 /** Native PTY shim used by bootPty(). */
 export const pty = join(here, "vmm", "bin", "machinen-pty");
+/** Native winsize socket forwarder used by VsockWinsize. */
+export const winsize = join(here, "vmm", "bin", "machinen-winsize");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-x64-linux/index.mjs
+++ b/packages/native-x64-linux/index.mjs
@@ -21,6 +21,8 @@ export const binary = join(here, "vmm", "bin", "machinen-vm");
 export const runtimeHelper = join(here, "vmm", "bin", "machinen-runtime-helper");
 /** Parent-death wrapper used to keep host sidecars bound to the runtime process. */
 export const pdeathsig = join(here, "vmm", "bin", "machinen-pdeathsig");
+/** Native PTY shim used by bootPty(). */
+export const pty = join(here, "vmm", "bin", "machinen-pty");
 /**
  * gvproxy (containers/gvisor-tap-vsock) — the userspace TCP/IP sidecar
  * the runtime auto-spawns for virtio-net. Optional; absent installs

--- a/packages/native-x64-linux/package.json
+++ b/packages/native-x64-linux/package.json
@@ -13,6 +13,7 @@
     "machinen-mke2fs": "./e2fsprogs/bin/mke2fs",
     "machinen-mksquashfs": "./squashfs/bin/mksquashfs",
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
+    "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
     "machinen-vm": "./vmm/bin/machinen-vm"
   },

--- a/packages/native-x64-linux/package.json
+++ b/packages/native-x64-linux/package.json
@@ -15,7 +15,8 @@
     "machinen-pdeathsig": "./vmm/bin/machinen-pdeathsig",
     "machinen-pty": "./vmm/bin/machinen-pty",
     "machinen-runtime-helper": "./vmm/bin/machinen-runtime-helper",
-    "machinen-vm": "./vmm/bin/machinen-vm"
+    "machinen-vm": "./vmm/bin/machinen-vm",
+    "machinen-winsize": "./vmm/bin/machinen-winsize"
   },
   "files": [
     "index.mjs",

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2359,10 +2359,8 @@ Attach to `id`. Throws if id doesn't exist.
 > `static` **connect**(`udsPath`, `opts?`): `Promise`\<[`VsockWinsize`](#vsockwinsize)\>
 
 Open a host Unix socket and keep retrying until the vsock bridge
-+ guest agent wire themselves up. Resolves once the TCP-like
-connect completes — the agent may still be registering the
-vsock listener on its side, but any bytes we send will be
-buffered by the bridge's connection table.
++ guest agent wire themselves up. Resolves once the native helper
+connects; any bytes sent afterward are relayed to the bridge.
 
 ###### Parameters
 
@@ -2382,8 +2380,8 @@ buffered by the bridge's connection table.
 
 > **send**(`cols`, `rows`): `void`
 
-Send a new size. Idempotent against the most recent send — repeats
-are dropped so a chatty SIGWINCH doesn't spam the bridge.
+Send a new size. Idempotence against the most recent send is owned
+by the native helper so SIGWINCH storms do not spam the bridge.
 
 ###### Parameters
 

--- a/packages/runtime/native/build.zig
+++ b/packages/runtime/native/build.zig
@@ -56,6 +56,21 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(pty);
 
+    const winsize_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    winsize_mod.addCSourceFile(.{
+        .file = b.path("src/winsize.c"),
+        .flags = &.{ "-O2", "-Wall", "-Wextra" },
+    });
+    const winsize = b.addExecutable(.{
+        .name = "machinen-winsize",
+        .root_module = winsize_mod,
+    });
+    b.installArtifact(winsize);
+
     const run_step = b.step("run", "Run machinen-runtime-helper");
     const run_cmd = b.addRunArtifact(exe);
     run_step.dependOn(&run_cmd.step);

--- a/packages/runtime/native/build.zig
+++ b/packages/runtime/native/build.zig
@@ -41,6 +41,21 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(pdeathsig);
 
+    const pty_mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    pty_mod.addCSourceFile(.{
+        .file = b.path("src/pty.c"),
+        .flags = &.{ "-O2", "-Wall", "-Wextra" },
+    });
+    const pty = b.addExecutable(.{
+        .name = "machinen-pty",
+        .root_module = pty_mod,
+    });
+    b.installArtifact(pty);
+
     const run_step = b.step("run", "Run machinen-runtime-helper");
     const run_cmd = b.addRunArtifact(exe);
     run_step.dependOn(&run_cmd.step);

--- a/packages/runtime/native/build.zig
+++ b/packages/runtime/native/build.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const assert = std.debug.assert;
+
 pub fn build(b: *std.Build) void {
     std.debug.assert(builtin.zig_version.major > 0 or builtin.zig_version.minor >= 16);
 
@@ -26,50 +28,9 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
-    const pdeathsig_mod = b.createModule(.{
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    });
-    pdeathsig_mod.addCSourceFile(.{
-        .file = b.path("src/pdeathsig.c"),
-        .flags = &.{ "-O2", "-Wall", "-Wextra" },
-    });
-    const pdeathsig = b.addExecutable(.{
-        .name = "machinen-pdeathsig",
-        .root_module = pdeathsig_mod,
-    });
-    b.installArtifact(pdeathsig);
-
-    const pty_mod = b.createModule(.{
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    });
-    pty_mod.addCSourceFile(.{
-        .file = b.path("src/pty.c"),
-        .flags = &.{ "-O2", "-Wall", "-Wextra" },
-    });
-    const pty = b.addExecutable(.{
-        .name = "machinen-pty",
-        .root_module = pty_mod,
-    });
-    b.installArtifact(pty);
-
-    const winsize_mod = b.createModule(.{
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
-    });
-    winsize_mod.addCSourceFile(.{
-        .file = b.path("src/winsize.c"),
-        .flags = &.{ "-O2", "-Wall", "-Wextra" },
-    });
-    const winsize = b.addExecutable(.{
-        .name = "machinen-winsize",
-        .root_module = winsize_mod,
-    });
-    b.installArtifact(winsize);
+    installCShim(b, target, optimize, "machinen-pdeathsig", "src/pdeathsig.c");
+    installCShim(b, target, optimize, "machinen-pty", "src/pty.c");
+    installCShim(b, target, optimize, "machinen-winsize", "src/winsize.c");
 
     const run_step = b.step("run", "Run machinen-runtime-helper");
     const run_cmd = b.addRunArtifact(exe);
@@ -94,4 +55,30 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_mod_tests.step);
     test_step.dependOn(&run_exe_tests.step);
+}
+
+fn installCShim(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    name: []const u8,
+    source: []const u8,
+) void {
+    assert(name.len > 0);
+    assert(source.len > 0);
+
+    const mod = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    mod.addCSourceFile(.{
+        .file = b.path(source),
+        .flags = &.{ "-O2", "-Wall", "-Wextra" },
+    });
+    const exe = b.addExecutable(.{
+        .name = name,
+        .root_module = mod,
+    });
+    b.installArtifact(exe);
 }

--- a/packages/runtime/native/src/host.zig
+++ b/packages/runtime/native/src/host.zig
@@ -448,7 +448,7 @@ fn applyCpuCgroupLinux(
     try std.Io.Dir.cwd().createDirPath(io, opts.parent_dir);
     const safe_id = try sanitizeCgroupId(allocator, opts.id);
     defer allocator.free(safe_id);
-    const suffix = randomHexSuffix();
+    const suffix = randomHexSuffix(io);
     const leaf = try std.mem.concat(allocator, u8, &.{
         "machinen-vm-",
         safe_id,
@@ -834,11 +834,11 @@ fn sanitizeCgroupId(allocator: std.mem.Allocator, id: []const u8) Error![]u8 {
     return out;
 }
 
-fn randomHexSuffix() [8]u8 {
+fn randomHexSuffix(io: std.Io) [8]u8 {
     assert(@sizeOf([8]u8) == 8);
 
     var bytes: [4]u8 = undefined;
-    std.crypto.random.bytes(&bytes);
+    io.random(&bytes);
     const digits = "0123456789abcdef";
     var out: [8]u8 = undefined;
     for (bytes, 0..) |byte, i| {
@@ -949,7 +949,12 @@ fn readPsRssDarwin(allocator: std.mem.Allocator, io: std.Io, pid: u32) Error!?u6
 fn readFileAlloc(allocator: std.mem.Allocator, io: std.Io, path: []const u8) Error![]u8 {
     assert(path.len > 0);
 
-    return std.Io.Dir.cwd().readFileAlloc(io, allocator, path, 16 * 1024 * 1024);
+    return std.Io.Dir.cwd().readFileAlloc(
+        io,
+        path,
+        allocator,
+        .limited(16 * 1024 * 1024),
+    );
 }
 
 test "evaluateNestedVirtualization accepts Linux arm64 KVM when toggles are enabled" {
@@ -1054,22 +1059,32 @@ test "applyCpuCgroupLinux writes cgroup v2 files" {
     defer allocator.free(cpu_max_path);
     const cpu_max = try std.Io.Dir.cwd().readFileAlloc(
         std.testing.io,
-        allocator,
         cpu_max_path,
-        1024,
+        allocator,
+        .limited(1024),
     );
     defer allocator.free(cpu_max);
     try std.testing.expectEqualStrings("50000 100000\n", cpu_max);
 
     const weight_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cpu.weight");
     defer allocator.free(weight_path);
-    const weight = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, weight_path, 1024);
+    const weight = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        weight_path,
+        allocator,
+        .limited(1024),
+    );
     defer allocator.free(weight);
     try std.testing.expectEqualStrings("250\n", weight);
 
     const procs_path = try joinCgroupFile(allocator, result.cgroup_path.?, "cgroup.procs");
     defer allocator.free(procs_path);
-    const procs = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, allocator, procs_path, 1024);
+    const procs = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        procs_path,
+        allocator,
+        .limited(1024),
+    );
     defer allocator.free(procs);
     try std.testing.expectEqualStrings("4321\n", procs);
 

--- a/packages/runtime/native/src/pty.c
+++ b/packages/runtime/native/src/pty.c
@@ -1,11 +1,11 @@
 // Native PTY shim used by bootPty().
 //
-// Node spawns this small host binary instead of loading node-pty native
-// bindings. The shim owns forkpty(), copies host stdin to the PTY master,
-// copies PTY output back to stdout, and listens on fd 3 for control lines:
-// `R <cols> <rows>` resizes the PTY, `K` kills the child. Keeping this as a
-// Zig-built C binary makes the terminal path publish like the rest of the
-// runtime helper tools, without node-gyp or prebuilt Node addon packages.
+// The TypeScript runtime spawns this host helper when Machinen needs a real
+// terminal for a child process. Node's built-in child_process pipes are not
+// PTYs, so the helper owns forkpty(), relays stdin/stdout, and handles fd 3
+// control messages: `R <cols> <rows>` resizes the PTY, `K` kills the child.
+// Keeping this as a Zig-built C binary lets the terminal path publish with the
+// other host helper tools, without node-gyp or prebuilt Node addon packages.
 
 #define _DARWIN_C_SOURCE
 #define _GNU_SOURCE

--- a/packages/runtime/native/src/pty.c
+++ b/packages/runtime/native/src/pty.c
@@ -1,0 +1,300 @@
+#define _DARWIN_C_SOURCE
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE 600
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+#if defined(__APPLE__)
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+
+#define CONTROL_FD 3
+#define BUF_SIZE 4096
+#define CONTROL_BUF_SIZE 256
+
+static int write_all(int fd, const char *buf, ssize_t len) {
+  ssize_t off = 0;
+  while (off < len) {
+    ssize_t n = write(fd, buf + off, (size_t)(len - off));
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return -1;
+    }
+    off += n;
+  }
+  return 0;
+}
+
+static int parse_uint16(const char *text, unsigned short *out) {
+  char *end = NULL;
+  errno = 0;
+  long value = strtol(text, &end, 10);
+  if (errno != 0 || end == text || value <= 0 || value > 65535) {
+    return -1;
+  }
+  *out = (unsigned short)value;
+  return 0;
+}
+
+static void resize_pty(int master_fd, pid_t child_pid, unsigned short cols, unsigned short rows) {
+  (void)child_pid;
+  struct winsize ws;
+  memset(&ws, 0, sizeof(ws));
+  ws.ws_col = cols;
+  ws.ws_row = rows;
+  (void)ioctl(master_fd, TIOCSWINSZ, &ws);
+}
+
+static void handle_control_line(char *line, int master_fd, pid_t child_pid) {
+  if (line[0] == 'R' && (line[1] == ' ' || line[1] == '\t')) {
+    char *cols_text = line + 2;
+    while (*cols_text == ' ' || *cols_text == '\t') {
+      cols_text++;
+    }
+    char *rows_text = cols_text;
+    while (*rows_text != '\0' && *rows_text != ' ' && *rows_text != '\t') {
+      rows_text++;
+    }
+    if (*rows_text == '\0') {
+      return;
+    }
+    *rows_text++ = '\0';
+    while (*rows_text == ' ' || *rows_text == '\t') {
+      rows_text++;
+    }
+    unsigned short cols = 0;
+    unsigned short rows = 0;
+    if (parse_uint16(cols_text, &cols) == 0 && parse_uint16(rows_text, &rows) == 0) {
+      resize_pty(master_fd, child_pid, cols, rows);
+    }
+    return;
+  }
+  if (strcmp(line, "K") == 0) {
+    if (child_pid > 0) {
+      (void)kill(child_pid, SIGKILL);
+    }
+  }
+}
+
+static void process_control_bytes(
+  char *control_buf,
+  size_t *control_len,
+  const char *buf,
+  ssize_t n,
+  int master_fd,
+  pid_t child_pid
+) {
+  for (ssize_t i = 0; i < n; i++) {
+    char c = buf[i];
+    if (c == '\r') {
+      continue;
+    }
+    if (c == '\n') {
+      control_buf[*control_len] = '\0';
+      handle_control_line(control_buf, master_fd, child_pid);
+      *control_len = 0;
+      continue;
+    }
+    if (*control_len + 1 < CONTROL_BUF_SIZE) {
+      control_buf[(*control_len)++] = c;
+    } else {
+      *control_len = 0;
+    }
+  }
+}
+
+static int child_exit_code(int status) {
+  if (WIFEXITED(status)) {
+    return WEXITSTATUS(status);
+  }
+  if (WIFSIGNALED(status)) {
+    return 128 + WTERMSIG(status);
+  }
+  return 1;
+}
+
+static void usage(const char *argv0) {
+  fprintf(stderr, "usage: %s --cols <cols> --rows <rows> --term <term> -- <binary> [args...]\n", argv0);
+}
+
+int main(int argc, char **argv) {
+  unsigned short cols = 80;
+  unsigned short rows = 24;
+  const char *term = "xterm-256color";
+  int command_index = -1;
+
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--") == 0) {
+      command_index = i + 1;
+      break;
+    }
+    if (strcmp(argv[i], "--cols") == 0 && i + 1 < argc) {
+      if (parse_uint16(argv[++i], &cols) != 0) {
+        usage(argv[0]);
+        return 2;
+      }
+      continue;
+    }
+    if (strcmp(argv[i], "--rows") == 0 && i + 1 < argc) {
+      if (parse_uint16(argv[++i], &rows) != 0) {
+        usage(argv[0]);
+        return 2;
+      }
+      continue;
+    }
+    if (strcmp(argv[i], "--term") == 0 && i + 1 < argc) {
+      term = argv[++i];
+      continue;
+    }
+    usage(argv[0]);
+    return 2;
+  }
+
+  if (command_index < 0 || command_index >= argc) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  struct winsize ws;
+  memset(&ws, 0, sizeof(ws));
+  ws.ws_col = cols;
+  ws.ws_row = rows;
+
+  int master_fd = -1;
+  pid_t child_pid = forkpty(&master_fd, NULL, NULL, &ws);
+  if (child_pid < 0) {
+    perror("forkpty");
+    return 1;
+  }
+
+  if (child_pid == 0) {
+    setenv("TERM", term, 1);
+    execvp(argv[command_index], &argv[command_index]);
+    perror("execvp");
+    _exit(127);
+  }
+
+  char buf[BUF_SIZE];
+  char control_buf[CONTROL_BUF_SIZE];
+  size_t control_len = 0;
+  bool stdin_open = true;
+  bool control_open = fcntl(CONTROL_FD, F_GETFD) != -1 || errno != EBADF;
+  bool master_open = true;
+  int status = 0;
+  bool child_done = false;
+
+  while (master_open || !child_done) {
+    int waited = waitpid(child_pid, &status, WNOHANG);
+    if (waited == child_pid) {
+      child_done = true;
+    }
+
+    struct pollfd fds[3];
+    nfds_t nfds = 0;
+    if (stdin_open) {
+      fds[nfds++] = (struct pollfd){ .fd = STDIN_FILENO, .events = POLLIN | POLLHUP };
+    }
+    if (control_open) {
+      fds[nfds++] = (struct pollfd){ .fd = CONTROL_FD, .events = POLLIN | POLLHUP };
+    }
+    if (master_open) {
+      fds[nfds++] = (struct pollfd){ .fd = master_fd, .events = POLLIN | POLLHUP };
+    }
+
+    if (nfds == 0) {
+      break;
+    }
+
+    int rc = poll(fds, nfds, child_done ? 50 : -1);
+    if (rc < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if (rc == 0) {
+      if (child_done && master_open) {
+        close(master_fd);
+        master_open = false;
+      }
+      continue;
+    }
+
+    nfds_t idx = 0;
+    if (stdin_open) {
+      short revents = fds[idx++].revents;
+      if (revents & POLLIN) {
+        ssize_t n = read(STDIN_FILENO, buf, sizeof(buf));
+        if (n > 0) {
+          (void)write_all(master_fd, buf, n);
+        } else if (n == 0 || errno != EINTR) {
+          stdin_open = false;
+        }
+      }
+      if (revents & (POLLHUP | POLLERR | POLLNVAL)) {
+        stdin_open = false;
+      }
+    }
+
+    if (control_open) {
+      short revents = fds[idx++].revents;
+      if (revents & POLLIN) {
+        ssize_t n = read(CONTROL_FD, buf, sizeof(buf));
+        if (n > 0) {
+          process_control_bytes(control_buf, &control_len, buf, n, master_fd, child_pid);
+        } else if (n == 0 || errno != EINTR) {
+          control_open = false;
+        }
+      }
+      if (revents & (POLLHUP | POLLERR | POLLNVAL)) {
+        control_open = false;
+      }
+    }
+
+    if (master_open) {
+      short revents = fds[idx++].revents;
+      if (revents & POLLIN) {
+        ssize_t n = read(master_fd, buf, sizeof(buf));
+        if (n > 0) {
+          if (write_all(STDOUT_FILENO, buf, n) != 0) {
+            master_open = false;
+          }
+        } else if (n == 0 || errno != EINTR) {
+          master_open = false;
+        }
+      }
+      if (revents & (POLLHUP | POLLERR | POLLNVAL)) {
+        master_open = false;
+      }
+    }
+  }
+
+  if (!child_done) {
+    while (waitpid(child_pid, &status, 0) < 0) {
+      if (errno != EINTR) {
+        return 1;
+      }
+    }
+  }
+  if (master_fd >= 0) {
+    close(master_fd);
+  }
+  return child_exit_code(status);
+}

--- a/packages/runtime/native/src/pty.c
+++ b/packages/runtime/native/src/pty.c
@@ -1,3 +1,12 @@
+// Native PTY shim used by bootPty().
+//
+// Node spawns this small host binary instead of loading node-pty native
+// bindings. The shim owns forkpty(), copies host stdin to the PTY master,
+// copies PTY output back to stdout, and listens on fd 3 for control lines:
+// `R <cols> <rows>` resizes the PTY, `K` kills the child. Keeping this as a
+// Zig-built C binary makes the terminal path publish like the rest of the
+// runtime helper tools, without node-gyp or prebuilt Node addon packages.
+
 #define _DARWIN_C_SOURCE
 #define _GNU_SOURCE
 #define _XOPEN_SOURCE 600
@@ -37,6 +46,9 @@ static int write_all(int fd, const char *buf, ssize_t len) {
       }
       return -1;
     }
+    if (n == 0) {
+      return -1;
+    }
     off += n;
   }
   return 0;
@@ -46,7 +58,7 @@ static int parse_uint16(const char *text, unsigned short *out) {
   char *end = NULL;
   errno = 0;
   long value = strtol(text, &end, 10);
-  if (errno != 0 || end == text || value <= 0 || value > 65535) {
+  if (errno != 0 || end == text || *end != '\0' || value <= 0 || value > 65535) {
     return -1;
   }
   *out = (unsigned short)value;

--- a/packages/runtime/native/src/winsize.c
+++ b/packages/runtime/native/src/winsize.c
@@ -1,3 +1,11 @@
+// Native terminal-size forwarder used by VsockWinsize.
+//
+// The guest winsize agent is reached through a host Unix socket created by the
+// VMM vsock bridge. This helper retries that socket connect, prints READY once
+// connected, then relays validated `cols rows` lines from stdin to the bridge
+// while dropping duplicates. Keeping the loop native removes per-resize JS
+// socket churn and packages the path with the other host helper binaries.
+
 #define _DARWIN_C_SOURCE
 #define _GNU_SOURCE
 #define _XOPEN_SOURCE 700
@@ -43,6 +51,9 @@ static int write_all(int fd, const char *buf, size_t len) {
       if (errno == EINTR) {
         continue;
       }
+      return -1;
+    }
+    if (n == 0) {
       return -1;
     }
     off += (size_t)n;

--- a/packages/runtime/native/src/winsize.c
+++ b/packages/runtime/native/src/winsize.c
@@ -1,0 +1,242 @@
+#define _DARWIN_C_SOURCE
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE 700
+
+#include <errno.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define LINE_BUF_SIZE 128
+#define IO_BUF_SIZE 4096
+
+static uint64_t now_ms(void) {
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return ((uint64_t)tv.tv_sec * 1000u) + ((uint64_t)tv.tv_usec / 1000u);
+}
+
+static int parse_int_arg(const char *text, int min, int max, int *out) {
+  char *end = NULL;
+  errno = 0;
+  long value = strtol(text, &end, 10);
+  if (errno != 0 || end == text || *end != '\0' || value < min || value > max) {
+    return -1;
+  }
+  *out = (int)value;
+  return 0;
+}
+
+static int write_all(int fd, const char *buf, size_t len) {
+  size_t off = 0;
+  while (off < len) {
+    ssize_t n = write(fd, buf + off, len - off);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return -1;
+    }
+    off += (size_t)n;
+  }
+  return 0;
+}
+
+static int connect_uds_once(const char *path) {
+  if (strlen(path) >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) {
+    return -1;
+  }
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+  if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+    return fd;
+  }
+  int saved = errno;
+  close(fd);
+  errno = saved;
+  return -1;
+}
+
+static int connect_with_retry(const char *path, int timeout_ms, int retry_ms) {
+  const uint64_t deadline = now_ms() + (uint64_t)timeout_ms;
+  int last_errno = 0;
+  while (now_ms() < deadline) {
+    int fd = connect_uds_once(path);
+    if (fd >= 0) {
+      return fd;
+    }
+    last_errno = errno;
+    usleep((useconds_t)retry_ms * 1000u);
+  }
+  errno = last_errno ? last_errno : ETIMEDOUT;
+  return -1;
+}
+
+static bool valid_size_line(const char *line) {
+  char *end = NULL;
+  errno = 0;
+  long cols = strtol(line, &end, 10);
+  if (errno != 0 || end == line || cols <= 0 || cols > 65535) {
+    return false;
+  }
+  while (*end == ' ' || *end == '\t') {
+    end++;
+  }
+  char *rows_start = end;
+  errno = 0;
+  long rows = strtol(rows_start, &end, 10);
+  if (errno != 0 || end == rows_start || rows <= 0 || rows > 65535) {
+    return false;
+  }
+  while (*end == ' ' || *end == '\t') {
+    end++;
+  }
+  return *end == '\0';
+}
+
+static void process_line(int sock, char *line, char *last_sent) {
+  if (!valid_size_line(line)) {
+    return;
+  }
+  if (strcmp(line, last_sent) == 0) {
+    return;
+  }
+  if (write_all(sock, line, strlen(line)) == 0 && write_all(sock, "\n", 1) == 0) {
+    strncpy(last_sent, line, LINE_BUF_SIZE - 1);
+    last_sent[LINE_BUF_SIZE - 1] = '\0';
+  }
+}
+
+static void process_stdin_bytes(
+  int sock,
+  const char *buf,
+  ssize_t n,
+  char *line,
+  size_t *line_len,
+  char *last_sent
+) {
+  for (ssize_t i = 0; i < n; i++) {
+    char c = buf[i];
+    if (c == '\r') {
+      continue;
+    }
+    if (c == '\n') {
+      line[*line_len] = '\0';
+      process_line(sock, line, last_sent);
+      *line_len = 0;
+      continue;
+    }
+    if (*line_len + 1 < LINE_BUF_SIZE) {
+      line[(*line_len)++] = c;
+    } else {
+      *line_len = 0;
+    }
+  }
+}
+
+static void usage(const char *argv0) {
+  fprintf(stderr, "usage: %s --timeout-ms <ms> --retry-ms <ms> -- <uds-path>\n", argv0);
+}
+
+int main(int argc, char **argv) {
+  int timeout_ms = 10000;
+  int retry_ms = 250;
+  int path_index = -1;
+
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--") == 0) {
+      path_index = i + 1;
+      break;
+    }
+    if (strcmp(argv[i], "--timeout-ms") == 0 && i + 1 < argc) {
+      if (parse_int_arg(argv[++i], 1, 3600000, &timeout_ms) != 0) {
+        usage(argv[0]);
+        return 2;
+      }
+      continue;
+    }
+    if (strcmp(argv[i], "--retry-ms") == 0 && i + 1 < argc) {
+      if (parse_int_arg(argv[++i], 1, 60000, &retry_ms) != 0) {
+        usage(argv[0]);
+        return 2;
+      }
+      continue;
+    }
+    usage(argv[0]);
+    return 2;
+  }
+
+  if (path_index < 0 || path_index >= argc) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  int sock = connect_with_retry(argv[path_index], timeout_ms, retry_ms);
+  if (sock < 0) {
+    fprintf(stderr, "machinen-winsize: connect(%s) failed after %dms: %s\n", argv[path_index], timeout_ms, strerror(errno));
+    return 1;
+  }
+
+  if (write_all(STDOUT_FILENO, "READY\n", 6) != 0) {
+    close(sock);
+    return 1;
+  }
+
+  char io_buf[IO_BUF_SIZE];
+  char line[LINE_BUF_SIZE] = {0};
+  char last_sent[LINE_BUF_SIZE] = {0};
+  size_t line_len = 0;
+  bool stdin_open = true;
+  bool sock_open = true;
+
+  while (stdin_open && sock_open) {
+    struct pollfd fds[2];
+    fds[0] = (struct pollfd){ .fd = STDIN_FILENO, .events = POLLIN | POLLHUP };
+    fds[1] = (struct pollfd){ .fd = sock, .events = POLLIN | POLLHUP };
+    int rc = poll(fds, 2, -1);
+    if (rc < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if (fds[0].revents & POLLIN) {
+      ssize_t n = read(STDIN_FILENO, io_buf, sizeof(io_buf));
+      if (n > 0) {
+        process_stdin_bytes(sock, io_buf, n, line, &line_len, last_sent);
+      } else if (n == 0 || errno != EINTR) {
+        stdin_open = false;
+      }
+    }
+    if (fds[0].revents & (POLLHUP | POLLERR | POLLNVAL)) {
+      stdin_open = false;
+    }
+    if (fds[1].revents & POLLIN) {
+      ssize_t n = read(sock, io_buf, sizeof(io_buf));
+      if (n <= 0 && (n == 0 || errno != EINTR)) {
+        sock_open = false;
+      }
+    }
+    if (fds[1].revents & (POLLHUP | POLLERR | POLLNVAL)) {
+      sock_open = false;
+    }
+  }
+
+  close(sock);
+  return 0;
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,7 +27,6 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@homebridge/node-pty-prebuilt-multiarch": "^0.12.0",
     "debug": "^4.4.1"
   },
   "devDependencies": {

--- a/packages/runtime/src/__tests__/pty.test.ts
+++ b/packages/runtime/src/__tests__/pty.test.ts
@@ -10,7 +10,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PassThrough } from "node:stream";
+import { PassThrough, type Readable } from "node:stream";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Sandboxes, Supervisor, bootPty } from "../index.ts";
 
@@ -38,6 +38,39 @@ afterAll(() => {
   }
 });
 
+function waitForText(
+  stream: Readable,
+  chunks: Buffer[],
+  expected: RegExp,
+  timeoutMs = 1_000,
+): Promise<string> {
+  const snapshot = () => Buffer.concat(chunks).toString("utf8");
+  const current = snapshot();
+  if (expected.test(current)) {
+    return Promise.resolve(current);
+  }
+
+  return new Promise((done, fail) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      stream.off("data", onData);
+    };
+    const onData = () => {
+      const text = snapshot();
+      if (expected.test(text)) {
+        cleanup();
+        done(text);
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      fail(new Error(`timed out waiting for ${expected}; saw ${JSON.stringify(snapshot())}`));
+    }, timeoutMs);
+    stream.on("data", onData);
+    onData();
+  });
+}
+
 describe("bootPty", () => {
   it("the child sees a real TTY on stdin (tty prints /dev/pts/N)", async () => {
     const vm = bootPty({
@@ -47,9 +80,8 @@ describe("bootPty", () => {
     const chunks: Buffer[] = [];
     vm.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
     try {
-      await new Promise((r) => setTimeout(r, 300));
-      const out = Buffer.concat(chunks).toString("utf8");
       // Linux emits `/dev/pts/N`, macOS emits `/dev/ttys0NN` (no trailing slash).
+      const out = await waitForText(vm.stdout, chunks, /\/dev\/(pts\/|ttys)/);
       expect(out).toMatch(/\/dev\/(pts\/|ttys)/);
     } finally {
       await vm.kill();

--- a/packages/runtime/src/__tests__/pty.test.ts
+++ b/packages/runtime/src/__tests__/pty.test.ts
@@ -6,50 +6,80 @@
 //   - `stty size` prints "rows cols" (proving TIOCGWINSZ works).
 //   - After resize(), `stty size` reflects the new shape.
 
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Sandboxes, Supervisor, bootPty } from "../index.ts";
 
-async function read(handle: { stdout: NodeJS.ReadableStream }, ms: number): Promise<Buffer> {
-  return new Promise((done) => {
-    const chunks: Buffer[] = [];
-    const onData = (c: Buffer) => chunks.push(c);
-    handle.stdout.on("data", onData);
-    setTimeout(() => {
-      handle.stdout.off("data", onData);
-      done(Buffer.concat(chunks));
-    }, ms).unref();
+let nativeTmp: string | undefined;
+let previousPty: string | undefined;
+
+beforeAll(() => {
+  nativeTmp = mkdtempSync(join(tmpdir(), "machinen-pty-test-"));
+  execFileSync("zig", ["build", "--prefix", nativeTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
   });
-}
+  previousPty = process.env.MACHINEN_PTY;
+  process.env.MACHINEN_PTY = join(nativeTmp, "bin", "machinen-pty");
+});
+
+afterAll(() => {
+  if (previousPty === undefined) {
+    delete process.env.MACHINEN_PTY;
+  } else {
+    process.env.MACHINEN_PTY = previousPty;
+  }
+  if (nativeTmp) {
+    rmSync(nativeTmp, { recursive: true, force: true });
+  }
+});
 
 describe("bootPty", () => {
   it("the child sees a real TTY on stdin (tty prints /dev/pts/N)", async () => {
     const vm = bootPty({
       binary: "/bin/sh",
-      args: ["-c", "tty; exit"],
+      args: ["-c", "tty; sleep 1"],
     });
-    const out = (await read(vm, 500)).toString();
-    await vm.wait();
-    // Linux emits `/dev/pts/N`, macOS emits `/dev/ttys0NN` (no trailing slash).
-    expect(out).toMatch(/\/dev\/(pts\/|ttys)/);
+    const chunks: Buffer[] = [];
+    vm.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    try {
+      await new Promise((r) => setTimeout(r, 300));
+      const out = Buffer.concat(chunks).toString("utf8");
+      // Linux emits `/dev/pts/N`, macOS emits `/dev/ttys0NN` (no trailing slash).
+      expect(out).toMatch(/\/dev\/(pts\/|ttys)/);
+    } finally {
+      await vm.kill();
+    }
   });
 
   it("resize() reshapes the pty — stty size reflects the new rows/cols", async () => {
     const vm = bootPty({
       binary: "/bin/sh",
-      args: ["-c", "stty size; sleep 0.1; stty size; exit"],
+      args: ["-c", "stty size; IFS= read -r _; stty size; exit"],
       cols: 80,
       rows: 24,
     });
-    // Give sh time to print the first size, then resize.
-    await new Promise((r) => setTimeout(r, 50));
-    vm.resize(132, 50);
-    const out = (await read(vm, 400)).toString();
-    await vm.wait();
-    // First line has initial shape, second has the resized shape.
-    const lines = out.split(/\r?\n/).filter((l) => /^\d+\s+\d+/.test(l));
-    expect(lines.length).toBeGreaterThanOrEqual(2);
-    expect(lines[1]).toMatch(/^50\s+132/);
+    const chunks: Buffer[] = [];
+    vm.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    try {
+      // Give sh time to print the first size, then resize and release
+      // the read gate so the second stty observes the new size.
+      await new Promise((r) => setTimeout(r, 50));
+      vm.resize(132, 50);
+      vm.stdin.end("\n");
+      await new Promise((r) => setTimeout(r, 300));
+      const out = Buffer.concat(chunks).toString("utf8");
+      // First line has initial shape, second has the resized shape.
+      const lines = out.split(/\r?\n/).filter((l) => /^\d+\s+\d+/.test(l));
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      expect(lines[1]).toMatch(/^50\s+132/);
+    } finally {
+      await vm.kill();
+    }
   });
 
   it("the handle plugs into Sandboxes.add just like a piped VmHandle", async () => {

--- a/packages/runtime/src/__tests__/winsize.test.ts
+++ b/packages/runtime/src/__tests__/winsize.test.ts
@@ -8,14 +8,39 @@
 // storms — losing it would re-introduce the smear-on-resize bug this
 // issue exists to fix.
 
+import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { WinsizeError } from "../errors.ts";
 import { VsockWinsize } from "../winsize.ts";
+
+let nativeTmp: string | undefined;
+let previousWinsize: string | undefined;
+
+beforeAll(() => {
+  nativeTmp = mkdtempSync(join(tmpdir(), "machinen-winsize-test-"));
+  execFileSync("zig", ["build", "--prefix", nativeTmp], {
+    cwd: join(process.cwd(), "packages", "runtime/native"),
+    stdio: "pipe",
+  });
+  previousWinsize = process.env.MACHINEN_WINSIZE;
+  process.env.MACHINEN_WINSIZE = join(nativeTmp, "bin", "machinen-winsize");
+});
+
+afterAll(() => {
+  if (previousWinsize === undefined) {
+    delete process.env.MACHINEN_WINSIZE;
+  } else {
+    process.env.MACHINEN_WINSIZE = previousWinsize;
+  }
+  if (nativeTmp) {
+    rmSync(nativeTmp, { recursive: true, force: true });
+  }
+});
 
 interface FakeAgent {
   server: Server;

--- a/packages/runtime/src/native/pty.ts
+++ b/packages/runtime/src/native/pty.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { arch, platform } from "node:os";
+import { BootError } from "../errors.ts";
+
+const PTY_NAME = "machinen-pty";
+const require_ = createRequire(import.meta.url);
+
+export function resolvePtyShim(): string {
+  return resolvePtyShimEnvOverride() ?? findBundledPtyShim() ?? missingPtyShim();
+}
+
+function resolvePtyShimEnvOverride(): string | undefined {
+  const envOverride = process.env.MACHINEN_PTY;
+  if (!envOverride) {
+    return undefined;
+  }
+  if (existsSync(envOverride)) {
+    return envOverride;
+  }
+  throw new BootError(
+    "BOOT_VMM_PACKAGE_BROKEN",
+    `MACHINEN_PTY=${envOverride} is set but that file does not exist.`,
+  );
+}
+
+function findBundledPtyShim(): string | undefined {
+  const pkg = `@machinen/native-${arch()}-${platform()}`;
+  try {
+    const mod = require_(pkg) as { pty?: string };
+    if (mod.pty && existsSync(mod.pty)) {
+      return mod.pty;
+    }
+  } catch {
+    // Optional dep not installed for this arch+os.
+  }
+  return undefined;
+}
+
+function missingPtyShim(): never {
+  throw new BootError(
+    "BOOT_VMM_PACKAGE_BROKEN",
+    `${PTY_NAME} was not found. Build it with scripts/build-runtime-helper.sh, install the matching @machinen/native-* package, or set MACHINEN_PTY=/abs/path/to/${PTY_NAME}.`,
+  );
+}

--- a/packages/runtime/src/native/winsize.ts
+++ b/packages/runtime/src/native/winsize.ts
@@ -1,0 +1,47 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { arch, platform } from "node:os";
+import { WinsizeError } from "../errors.ts";
+
+const WINSIZE_NAME = "machinen-winsize";
+const require_ = createRequire(import.meta.url);
+
+export function resolveWinsizeShim(): string {
+  return resolveWinsizeShimEnvOverride() ?? findBundledWinsizeShim() ?? missingWinsizeShim();
+}
+
+function resolveWinsizeShimEnvOverride(): string | undefined {
+  const envOverride = process.env.MACHINEN_WINSIZE;
+  if (!envOverride) {
+    return undefined;
+  }
+  if (existsSync(envOverride)) {
+    return envOverride;
+  }
+  throw new WinsizeError(
+    "WINSIZE_AGENT_UNAVAILABLE",
+    `MACHINEN_WINSIZE=${envOverride} is set but that file does not exist.`,
+    { retryable: false },
+  );
+}
+
+function findBundledWinsizeShim(): string | undefined {
+  const pkg = `@machinen/native-${arch()}-${platform()}`;
+  try {
+    const mod = require_(pkg) as { winsize?: string };
+    if (mod.winsize && existsSync(mod.winsize)) {
+      return mod.winsize;
+    }
+  } catch {
+    // Optional dep not installed for this arch+os.
+  }
+  return undefined;
+}
+
+function missingWinsizeShim(): never {
+  throw new WinsizeError(
+    "WINSIZE_AGENT_UNAVAILABLE",
+    `${WINSIZE_NAME} was not found. Build it with scripts/build-runtime-helper.sh, install the matching @machinen/native-* package, or set MACHINEN_WINSIZE=/abs/path/to/${WINSIZE_NAME}.`,
+    { retryable: false },
+  );
+}

--- a/packages/runtime/src/pty.ts
+++ b/packages/runtime/src/pty.ts
@@ -2,91 +2,12 @@
 //
 // `bootPty()` is the terminal-aware sibling of `boot()`. Same handle
 // shape (Sandboxes.add takes either one) plus a `.resize(cols, rows)`
-// method that routes through to the master fd, so SIGWINCH on the
-// supervisor's terminal can shrink/grow the attached sandbox's view.
-//
-// On the inside it's `@homebridge/node-pty-prebuilt-multiarch`: an
-// API-compatible fork of node-pty that ships prebuilt binaries for
-// darwin/linux (arm64 + x64) without requiring python/node-gyp at
-// install time. The only gotcha is that on macOS the companion
-// `spawn-helper` binary sometimes lands with its exec bit stripped
-// after a pnpm install; `ensureSpawnHelper` fixes that up lazily.
+// method that routes through to the native PTY shim, so SIGWINCH on
+// the supervisor's terminal can shrink/grow the attached sandbox's view.
 
-import { chmodSync, constants as fsConstants, readdirSync, statSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { spawn } from "node:child_process";
 import { PassThrough, type Readable, type Writable } from "node:stream";
-import { createRequire } from "node:module";
-
-const PTY_MODULE = "@homebridge/node-pty-prebuilt-multiarch";
-
-// The prebuilt-multiarch fork publishes CommonJS only; import via
-// createRequire so this file stays ESM like the rest of the package.
-const require_ = createRequire(import.meta.url);
-type NodePty = typeof import("@homebridge/node-pty-prebuilt-multiarch");
-let ptyMod: NodePty | null = null;
-function loadPty(): NodePty {
-  if (ptyMod) {
-    return ptyMod;
-  }
-  ensureSpawnHelper();
-  ptyMod = require_(PTY_MODULE) as NodePty;
-  return ptyMod;
-}
-
-/**
- * Walk the pty package's prebuilds dir and make sure the spawn-helper
- * is executable. pnpm sometimes unpacks prebuilt binaries without the
- * exec bit; posix_spawnp then fails with a cryptic "posix_spawnp
- * failed." This is a one-shot no-op on healthy installs.
- */
-function ensureSpawnHelper(): void {
-  try {
-    const resolved = require_.resolve(PTY_MODULE);
-    const pkgDir = findPackageDir(resolved);
-    if (!pkgDir) {
-      return;
-    }
-    const prebuilds = join(pkgDir, "prebuilds");
-    const platforms = readdirSync(prebuilds, { withFileTypes: true });
-    for (const p of platforms) {
-      if (!p.isDirectory()) {
-        continue;
-      }
-      const helper = join(prebuilds, p.name, "spawn-helper");
-      try {
-        const s = statSync(helper);
-        if ((s.mode & fsConstants.S_IXUSR) === 0) {
-          chmodSync(helper, 0o755);
-        }
-      } catch {
-        // Missing helpers for other platforms are fine.
-      }
-    }
-  } catch {
-    // Best-effort only. If we can't find the package dir, fall through
-    // and let the require() error bubble up with a real stack.
-  }
-}
-
-function findPackageDir(entry: string): string | null {
-  let dir = dirname(entry);
-  for (let i = 0; i < 6; i++) {
-    try {
-      const pkg = statSync(join(dir, "package.json"));
-      if (pkg.isFile()) {
-        return dir;
-      }
-    } catch {
-      // keep walking up
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      break;
-    }
-    dir = parent;
-  }
-  return null;
-}
+import { resolvePtyShim } from "./native/pty.ts";
 
 export interface PtyBootOptions {
   /** Absolute or cwd-relative path to the binary to fork. */
@@ -123,66 +44,84 @@ export interface PtyVmHandle {
  * registry can hold it.
  */
 export function bootPty(opts: PtyBootOptions): PtyVmHandle {
-  const pty = loadPty();
-  const child = pty.spawn(opts.binary, opts.args ?? [], {
-    name: opts.name ?? "xterm-256color",
-    cols: opts.cols ?? 80,
-    rows: opts.rows ?? 24,
-    cwd: opts.cwd ?? process.cwd(),
-    env: { ...(process.env as Record<string, string>), ...opts.env },
-  });
-
-  // Wrap the pty data stream as a Node Readable so it works with
-  // Sandboxes.add (which listens on `.on('data', ...)`). The pty
-  // emits strings by default; we forward them as Buffers — matching
-  // what a child_process.spawn'd child gives us.
-  //
-  // Collection happens at the node-pty callback layer (not via a
-  // PassThrough 'data' listener), so the PassThrough stays in paused
-  // mode until the real consumer (Sandboxes / Supervisor / caller)
-  // attaches. Otherwise an internal listener would drain data before
-  // the consumer subscribed.
-  const collected: Buffer[] = [];
-  const out = new PassThrough();
-  const dataUnsub = child.onData((chunk) => {
-    const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
-    collected.push(buf);
-    out.write(buf);
-  });
-
-  // stdin side: Writable adapter that pipes into pty.write(). Bytes
-  // go through the kernel's tty line discipline on the way to the
-  // child — i.e. Ctrl-C generates SIGINT just like in a real terminal.
-  const stdin = new PassThrough();
-  stdin.on("data", (buf: Buffer) => child.write(buf.toString("utf8")));
+  const shim = resolvePtyShim();
+  const cols = opts.cols ?? 80;
+  const rows = opts.rows ?? 24;
+  const term = opts.name ?? "xterm-256color";
+  const child = spawn(
+    shim,
+    [
+      "--cols",
+      String(cols),
+      "--rows",
+      String(rows),
+      "--term",
+      term,
+      "--",
+      opts.binary,
+      ...(opts.args ?? []),
+    ],
+    {
+      cwd: opts.cwd ?? process.cwd(),
+      env: { ...(process.env as Record<string, string>), ...opts.env },
+      stdio: ["pipe", "pipe", "ignore", "pipe"],
+    },
+  );
+  const control = child.stdio[3] as Writable | undefined;
 
   const exitP = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((done) => {
-    child.onExit((ev) => {
-      dataUnsub.dispose();
-      out.end();
-      done({
-        code: ev.exitCode ?? null,
-        signal: ev.signal ? (("SIG" + ev.signal) as NodeJS.Signals) : null,
-      });
+    child.on("error", () => {
+      done({ code: null, signal: null });
+    });
+    child.on("exit", (code, signal) => {
+      done({ code, signal });
     });
   });
 
+  // Wrap the pty data stream as a Node Readable so it works with
+  // Sandboxes.add (which listens on `.on('data', ...)`). Collection
+  // happens at the native shim stdout layer, so the PassThrough stays
+  // in paused mode until the real consumer attaches.
+  const collected: Buffer[] = [];
+  const out = new PassThrough();
+  child.stdout.on("data", (chunk: Buffer) => {
+    collected.push(chunk);
+    out.write(chunk);
+  });
+  child.stdout.on("close", () => out.end());
+
+  // stdin side: Writable adapter that pipes into the shim. Bytes go
+  // through the kernel's tty line discipline on the way to the child
+  // — i.e. Ctrl-C generates SIGINT just like in a real terminal.
+  const stdin = new PassThrough();
+  stdin.on("data", (buf: Buffer) => {
+    child.stdin.write(buf);
+  });
+  stdin.on("end", () => {
+    child.stdin.end();
+  });
+
+  exitP.then(
+    () => out.end(),
+    () => out.end(),
+  );
+
   return {
-    pid: child.pid,
+    pid: child.pid ?? 0,
     stdin,
     stdout: out,
     stderr: out,
-    resize(cols, rows) {
-      child.resize(cols, rows);
+    resize(nextCols, nextRows) {
+      control?.write(`R ${nextCols} ${nextRows}\n`);
     },
     wait: () => exitP,
     async kill() {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        /* already gone */
-      }
+      control?.write("K\n");
+      child.stdin.end();
+      const force = setTimeout(() => child.kill("SIGKILL"), 500);
+      force.unref();
       await exitP;
+      clearTimeout(force);
     },
     async output() {
       await exitP;

--- a/packages/runtime/src/pty.ts
+++ b/packages/runtime/src/pty.ts
@@ -68,12 +68,15 @@ export function bootPty(opts: PtyBootOptions): PtyVmHandle {
     },
   );
   const control = child.stdio[3] as Writable | undefined;
+  const ignoreStreamError = () => undefined;
+  control?.on("error", ignoreStreamError);
+  child.stdin.on("error", ignoreStreamError);
 
   const exitP = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((done) => {
-    child.on("error", () => {
+    child.once("error", () => {
       done({ code: null, signal: null });
     });
-    child.on("exit", (code, signal) => {
+    child.once("exit", (code, signal) => {
       done({ code, signal });
     });
   });
@@ -84,27 +87,43 @@ export function bootPty(opts: PtyBootOptions): PtyVmHandle {
   // in paused mode until the real consumer attaches.
   const collected: Buffer[] = [];
   const out = new PassThrough();
+  let outputEnded = false;
+  const endOutput = () => {
+    if (outputEnded) {
+      return;
+    }
+    outputEnded = true;
+    out.end();
+  };
+  const outputClosedP = new Promise<void>((done) => {
+    const finish = () => {
+      endOutput();
+      done();
+    };
+    child.stdout.once("close", finish);
+    child.once("error", finish);
+  });
   child.stdout.on("data", (chunk: Buffer) => {
     collected.push(chunk);
-    out.write(chunk);
+    if (!outputEnded) {
+      out.write(chunk);
+    }
   });
-  child.stdout.on("close", () => out.end());
 
   // stdin side: Writable adapter that pipes into the shim. Bytes go
   // through the kernel's tty line discipline on the way to the child
   // — i.e. Ctrl-C generates SIGINT just like in a real terminal.
   const stdin = new PassThrough();
   stdin.on("data", (buf: Buffer) => {
-    child.stdin.write(buf);
+    if (!child.stdin.destroyed) {
+      child.stdin.write(buf);
+    }
   });
   stdin.on("end", () => {
-    child.stdin.end();
+    if (!child.stdin.destroyed) {
+      child.stdin.end();
+    }
   });
-
-  exitP.then(
-    () => out.end(),
-    () => out.end(),
-  );
 
   return {
     pid: child.pid ?? 0,
@@ -112,23 +131,29 @@ export function bootPty(opts: PtyBootOptions): PtyVmHandle {
     stdout: out,
     stderr: out,
     resize(nextCols, nextRows) {
-      control?.write(`R ${nextCols} ${nextRows}\n`);
+      if (control && !control.destroyed) {
+        control.write(`R ${nextCols} ${nextRows}\n`);
+      }
     },
     wait: () => exitP,
     async kill() {
-      control?.write("K\n");
-      child.stdin.end();
+      if (control && !control.destroyed) {
+        control.write("K\n");
+      }
+      if (!child.stdin.destroyed) {
+        child.stdin.end();
+      }
       const force = setTimeout(() => child.kill("SIGKILL"), 500);
       force.unref();
-      await exitP;
+      await Promise.all([exitP, outputClosedP]);
       clearTimeout(force);
     },
     async output() {
-      await exitP;
+      await Promise.all([exitP, outputClosedP]);
       return Buffer.concat(collected).toString("utf8");
     },
     async errorOutput() {
-      await exitP;
+      await Promise.all([exitP, outputClosedP]);
       return Buffer.concat(collected).toString("utf8");
     },
   };

--- a/packages/runtime/src/winsize.ts
+++ b/packages/runtime/src/winsize.ts
@@ -3,29 +3,13 @@
 // The Supervisor already knows how to reshape the host pty on
 // SIGWINCH. What it can't do is tell the GUEST to reshape its own
 // ttys. The vsock bridge (#44) gives us a byte pipe into the guest;
-// this class wraps that pipe with a tiny "C R\n" protocol that a
-// matching guest agent (`assets/winsize-agent.zig`) translates
-// into `ioctl(fd, TIOCSWINSZ)` on /dev/console + /dev/ttyAMA0 + any
-// tty-owning process's fd 0/1/2.
-//
-// Usage:
-//
-//   // 1. boot the VMM with a vsock port mapped through
-//   const vm = await boot({
-//     binary: VMM,
-//     vmmEnv: { MACHINEN_VSOCK: "in:1974:/tmp/machinen-winsize.sock" },
-//   });
-//
-//   // 2. connect once the guest agent is listening
-//   const ws = await VsockWinsize.connect("/tmp/machinen-winsize.sock");
-//
-//   // 3. wrap the vm's resize (or hook the Supervisor's
-//   //    forwardResize path) so every host resize fans out to both
-//   //    the host pty (if bootPty was used) and the guest agent
-//   ws.send(process.stdout.columns ?? 80, process.stdout.rows ?? 24);
+// this class wraps a native helper that connects to that pipe and
+// forwards a tiny "C R\n" protocol to the guest agent
+// (`assets/winsize-agent.zig`).
 
-import { connect as netConnect, type Socket } from "node:net";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { WinsizeError } from "./errors.ts";
+import { resolveWinsizeShim } from "./native/winsize.ts";
 
 export interface VsockWinsizeOptions {
   /** How long to keep retrying the UDS connect. Default 10s. */
@@ -35,63 +19,47 @@ export interface VsockWinsizeOptions {
 }
 
 export class VsockWinsize {
-  private socket: Socket;
+  private child: ChildProcessWithoutNullStreams;
   private closed = false;
-  private lastSent: { cols: number; rows: number } | null = null;
 
-  private constructor(socket: Socket) {
-    this.socket = socket;
-    socket.on("error", () => {
+  private constructor(child: ChildProcessWithoutNullStreams) {
+    this.child = child;
+    child.on("error", () => {
       this.closed = true;
     });
-    socket.on("close", () => {
+    child.on("close", () => {
       this.closed = true;
     });
   }
 
   /**
    * Open a host Unix socket and keep retrying until the vsock bridge
-   * + guest agent wire themselves up. Resolves once the TCP-like
-   * connect completes — the agent may still be registering the
-   * vsock listener on its side, but any bytes we send will be
-   * buffered by the bridge's connection table.
+   * + guest agent wire themselves up. Resolves once the native helper
+   * connects; any bytes sent afterward are relayed to the bridge.
    */
   static async connect(udsPath: string, opts: VsockWinsizeOptions = {}): Promise<VsockWinsize> {
-    const deadline = Date.now() + (opts.timeoutMs ?? 10_000);
+    const timeoutMs = opts.timeoutMs ?? 10_000;
     const retryMs = opts.retryMs ?? 250;
-    // First successful connect wins; any earlier ENOENT / ECONNREFUSED
-    // just means the bridge hasn't opened the UDS yet.
-    let lastErr: Error | null = null;
-    while (Date.now() < deadline) {
-      try {
-        const s = await connectOnce(udsPath);
-        return new VsockWinsize(s);
-      } catch (err) {
-        lastErr = err as Error;
-        await new Promise((r) => setTimeout(r, retryMs));
-      }
-    }
-    throw new WinsizeError(
-      "WINSIZE_AGENT_UNAVAILABLE",
-      `VsockWinsize.connect(${udsPath}) gave up after ${opts.timeoutMs ?? 10_000}ms: ${lastErr?.message ?? "no error"}`,
-      { retryable: true, cause: lastErr ?? undefined },
+    const child = spawn(
+      resolveWinsizeShim(),
+      ["--timeout-ms", String(timeoutMs), "--retry-ms", String(retryMs), "--", udsPath],
+      { stdio: "pipe" },
     );
+
+    await waitForReady(child, udsPath, timeoutMs);
+    return new VsockWinsize(child);
   }
 
   /**
-   * Send a new size. Idempotent against the most recent send — repeats
-   * are dropped so a chatty SIGWINCH doesn't spam the bridge.
+   * Send a new size. Idempotence against the most recent send is owned
+   * by the native helper so SIGWINCH storms do not spam the bridge.
    */
   // fallow-ignore-next-line unused-class-member
   send(cols: number, rows: number): void {
     if (this.closed) {
       return;
     }
-    if (this.lastSent && this.lastSent.cols === cols && this.lastSent.rows === rows) {
-      return;
-    }
-    this.lastSent = { cols, rows };
-    this.socket.write(`${cols} ${rows}\n`);
+    this.child.stdin.write(`${cols} ${rows}\n`);
   }
 
   // fallow-ignore-next-line unused-class-member
@@ -100,22 +68,77 @@ export class VsockWinsize {
       return;
     }
     this.closed = true;
-    this.socket.end();
+    this.child.stdin.end();
   }
 }
 
-function connectOnce(udsPath: string): Promise<Socket> {
+function waitForReady(
+  child: ChildProcessWithoutNullStreams,
+  udsPath: string,
+  timeoutMs: number,
+): Promise<void> {
   return new Promise((done, fail) => {
-    const s = netConnect(udsPath);
-    const onErr = (e: Error) => {
-      s.removeListener("connect", onConnect);
-      fail(e);
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(
+        new WinsizeError(
+          "WINSIZE_AGENT_UNAVAILABLE",
+          `VsockWinsize.connect(${udsPath}) gave up after ${timeoutMs}ms: native helper did not report readiness`,
+          { retryable: true },
+        ),
+      );
+    }, timeoutMs + 1_000);
+
+    const finish = (err?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      if (err) {
+        fail(err);
+      } else {
+        done();
+      }
     };
-    const onConnect = () => {
-      s.removeListener("error", onErr);
-      done(s);
+    const onStdout = (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+      if (stdout.includes("READY\n")) {
+        finish();
+      }
     };
-    s.once("error", onErr);
-    s.once("connect", onConnect);
+    const onStderr = (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    };
+    const onError = (err: Error) => {
+      finish(
+        new WinsizeError(
+          "WINSIZE_AGENT_UNAVAILABLE",
+          `VsockWinsize.connect(${udsPath}) failed to start native helper: ${err.message}`,
+          { retryable: true, cause: err },
+        ),
+      );
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish(
+        new WinsizeError(
+          "WINSIZE_AGENT_UNAVAILABLE",
+          `VsockWinsize.connect(${udsPath}) gave up after ${timeoutMs}ms: ${stderr.trim() || `native helper exited ${code ?? signal ?? "without a status"}`}`,
+          { retryable: true },
+        ),
+      );
+    };
+
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.once("error", onError);
+    child.once("exit", onExit);
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,6 @@ importers:
 
   packages/runtime:
     dependencies:
-      '@homebridge/node-pty-prebuilt-multiarch':
-        specifier: ^0.12.0
-        version: 0.12.0
       debug:
         specifier: ^4.4.1
         version: 4.4.3
@@ -564,9 +561,6 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
-
-  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
-    resolution: {integrity: sha512-hJCGcfOnMeRh2KUdWPlVN/1egnfqI4yxgpDhqHSkF2DLn5fiJNdjEHHlcM1K2w9+QBmRE2D/wfmM4zUOb8aMyQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1584,14 +1578,6 @@ packages:
       supports-color:
         optional: true
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1773,10 +1759,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1920,9 +1902,6 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1993,9 +1972,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2259,19 +2235,12 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -2297,9 +2266,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -2310,13 +2276,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
-
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -2483,12 +2442,6 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2543,10 +2496,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2689,12 +2638,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -2763,10 +2706,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2880,9 +2819,6 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -3575,11 +3511,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
-
-  '@homebridge/node-pty-prebuilt-multiarch@0.12.0':
-    dependencies:
-      node-addon-api: 7.1.1
-      prebuild-install: 7.1.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -4361,12 +4292,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
-  deep-extend@0.6.0: {}
-
   deep-is@0.1.4: {}
 
   depd@2.0.0: {}
@@ -4586,8 +4511,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   express@5.2.1:
@@ -4795,8 +4718,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0: {}
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4860,8 +4781,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5070,8 +4989,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -5079,8 +4996,6 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
-
-  minimist@1.2.8: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -5106,19 +5021,11 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
-
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
 
   negotiator@1.0.0: {}
-
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
-
-  node-addon-api@7.1.1: {}
 
   node-releases@2.0.37: {}
 
@@ -5298,21 +5205,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -5368,13 +5260,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -5565,14 +5450,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   slash@3.0.0: {}
 
   slice-ansi@8.0.0:
@@ -5637,8 +5514,6 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
-
-  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -5757,10 +5632,6 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
 

--- a/scripts/build-runtime-helper.sh
+++ b/scripts/build-runtime-helper.sh
@@ -23,6 +23,7 @@ esac
 DEST_DIR="$ROOT/packages/native-${PKG_ARCH}-${PKG_OS}/vmm/bin"
 DEST="$DEST_DIR/machinen-runtime-helper"
 PDEATHSIG_DEST="$DEST_DIR/machinen-pdeathsig"
+PTY_DEST="$DEST_DIR/machinen-pty"
 
 echo "==> building machinen-runtime-helper (zig ReleaseSafe)"
 ( cd "$PKG" && zig build -Doptimize=ReleaseSafe )
@@ -31,12 +32,14 @@ echo "==> staging into $DEST"
 mkdir -p "$DEST_DIR"
 cp "$PKG/zig-out/bin/machinen-runtime-helper" "$DEST"
 cp "$PKG/zig-out/bin/machinen-pdeathsig" "$PDEATHSIG_DEST"
+cp "$PKG/zig-out/bin/machinen-pty" "$PTY_DEST"
 
 if [[ "$OS" == "Darwin" ]]; then
   # machinen-runtime-helper does not need entitlements, but clearing provenance
   # keeps the staged host tool consistent with the VMM staging flow.
   xattr -c "$DEST" || true
   xattr -c "$PDEATHSIG_DEST" || true
+  xattr -c "$PTY_DEST" || true
 fi
 
 echo "==> Done."

--- a/scripts/build-runtime-helper.sh
+++ b/scripts/build-runtime-helper.sh
@@ -24,6 +24,7 @@ DEST_DIR="$ROOT/packages/native-${PKG_ARCH}-${PKG_OS}/vmm/bin"
 DEST="$DEST_DIR/machinen-runtime-helper"
 PDEATHSIG_DEST="$DEST_DIR/machinen-pdeathsig"
 PTY_DEST="$DEST_DIR/machinen-pty"
+WINSIZE_DEST="$DEST_DIR/machinen-winsize"
 
 echo "==> building machinen-runtime-helper (zig ReleaseSafe)"
 ( cd "$PKG" && zig build -Doptimize=ReleaseSafe )
@@ -33,6 +34,7 @@ mkdir -p "$DEST_DIR"
 cp "$PKG/zig-out/bin/machinen-runtime-helper" "$DEST"
 cp "$PKG/zig-out/bin/machinen-pdeathsig" "$PDEATHSIG_DEST"
 cp "$PKG/zig-out/bin/machinen-pty" "$PTY_DEST"
+cp "$PKG/zig-out/bin/machinen-winsize" "$WINSIZE_DEST"
 
 if [[ "$OS" == "Darwin" ]]; then
   # machinen-runtime-helper does not need entitlements, but clearing provenance
@@ -40,6 +42,7 @@ if [[ "$OS" == "Darwin" ]]; then
   xattr -c "$DEST" || true
   xattr -c "$PDEATHSIG_DEST" || true
   xattr -c "$PTY_DEST" || true
+  xattr -c "$WINSIZE_DEST" || true
 fi
 
 echo "==> Done."

--- a/scripts/verify-bin-packages.sh
+++ b/scripts/verify-bin-packages.sh
@@ -100,7 +100,7 @@ check_pkg() {
 
 # --- native-* ------------------------------------------------------------
 # One consolidated package per host arch. Per-tool subdirs:
-#   vmm/bin/{machinen-vm,machinen-runtime-helper,machinen-pdeathsig,gvproxy}   host binaries node spawns.
+#   vmm/bin/{machinen-vm,machinen-runtime-helper,machinen-pdeathsig,machinen-pty,gvproxy}   host binaries node spawns.
 #   vmm/guest/{init,exec-agent}  guest-arch Linux ELFs the runtime
 #       reads as data to pack into the initramfs cpio (mode irrelevant).
 #   e2fsprogs/bin/mke2fs, squashfs/bin/mksquashfs  host binaries node spawns.
@@ -109,6 +109,7 @@ for pkg in native-arm64-darwin native-arm64-linux native-x64-linux; do
     vmm/bin/machinen-vm \
     vmm/bin/machinen-runtime-helper \
     vmm/bin/machinen-pdeathsig \
+    vmm/bin/machinen-pty \
     vmm/bin/gvproxy \
     e2fsprogs/bin/mke2fs \
     squashfs/bin/mksquashfs \

--- a/scripts/verify-bin-packages.sh
+++ b/scripts/verify-bin-packages.sh
@@ -100,7 +100,7 @@ check_pkg() {
 
 # --- native-* ------------------------------------------------------------
 # One consolidated package per host arch. Per-tool subdirs:
-#   vmm/bin/{machinen-vm,machinen-runtime-helper,machinen-pdeathsig,machinen-pty,gvproxy}   host binaries node spawns.
+#   vmm/bin/{machinen-vm,machinen-runtime-helper,machinen-pdeathsig,machinen-pty,machinen-winsize,gvproxy}   host binaries node spawns.
 #   vmm/guest/{init,exec-agent}  guest-arch Linux ELFs the runtime
 #       reads as data to pack into the initramfs cpio (mode irrelevant).
 #   e2fsprogs/bin/mke2fs, squashfs/bin/mksquashfs  host binaries node spawns.
@@ -110,6 +110,7 @@ for pkg in native-arm64-darwin native-arm64-linux native-x64-linux; do
     vmm/bin/machinen-runtime-helper \
     vmm/bin/machinen-pdeathsig \
     vmm/bin/machinen-pty \
+    vmm/bin/machinen-winsize \
     vmm/bin/gvproxy \
     e2fsprogs/bin/mke2fs \
     squashfs/bin/mksquashfs \


### PR DESCRIPTION
## Problem

Boot PTY and winsize forwarding need platform-specific native code. Keeping them mixed into the broader host shim review made that PR too large.

## Solution

Move the terminal-specific shims into their own native helper build slice. TypeScript still wires the VM process and terminal lifecycle.

## Technical Summary

- Covers the boot PTY shim and winsize socket forwarding.
- Keeps terminal behavior separate from process and nested-virt probing.
- Preserves the subprocess-first helper model.
