### PR TITLE
Move mountdisk assembly to Zig

### DIFF
--- a/packages/runtime/native/src/commands/mountdisk_image.zig
+++ b/packages/runtime/native/src/commands/mountdisk_image.zig
@@ -1,0 +1,276 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+const assert = std.debug.assert;
+const StringList = std.array_list.Aligned([]const u8, null);
+
+pub const name = "mountdisk-image";
+
+const Request = struct {
+    host: []const u8,
+    cache_dir: []const u8,
+    force: bool = false,
+    mksquashfs_candidates: []const []const u8 = &.{},
+    mksquashfs_env_override: ?[]const u8 = null,
+};
+
+const RequestError = error{
+    MissingHost,
+    InvalidHost,
+    MissingCacheDir,
+    InvalidCacheDir,
+    InvalidForce,
+    InvalidMksquashfsCandidates,
+    InvalidMksquashfsEnvOverride,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const result = runtime_helper.mountdisk.ensureLower(allocator, io, .{
+        .host = request.host,
+        .cache_dir = request.cache_dir,
+        .force = request.force,
+        .mksquashfs_candidates = request.mksquashfs_candidates,
+        .mksquashfs_env_override = request.mksquashfs_env_override,
+    }) catch |err| {
+        try writeMountdiskError(io, err);
+        return .fail;
+    };
+    defer allocator.free(result.lower_path);
+
+    try writeSuccess(allocator, io, result);
+    return .ok;
+}
+
+fn writeSuccess(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    result: runtime_helper.mountdisk.LowerResult,
+) !void {
+    assert(result.lower_path.len > 0);
+    assert(result.key.len == 64);
+
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{
+            .lowerPath = result.lower_path,
+            .key = result.key[0..],
+            .cacheHit = result.cache_hit,
+            .phases = .{
+                .manifestHash = result.manifest_hash_ms,
+                .mksquashfs = result.mksquashfs_ms,
+                .stagingRename = result.staging_rename_ms,
+            },
+        },
+    });
+}
+
+fn writeMountdiskError(io: std.Io, err: runtime_helper.mountdisk.Error) !void {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.HostNotFound => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_HOST_NOT_FOUND",
+            "ensureMountDiskImage: host directory not found",
+        ),
+        error.HostNotDirectory => try protocol.writeError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "ensureMountDiskImage: host path must be a directory",
+        ),
+        error.MksquashfsEnvMissing => try protocol.writeError(
+            io,
+            "BOOT_MOUNTDISK_TOOL_MISSING",
+            "MACHINEN_MKSQUASHFS is set but that file does not exist",
+        ),
+        error.MksquashfsMissing => try protocol.writeError(
+            io,
+            "BOOT_MOUNTDISK_TOOL_MISSING",
+            "ensureMountDiskImage: no mksquashfs binary found",
+        ),
+        error.MksquashfsFailed => try protocol.writeError(
+            io,
+            "PROVISION_INSTALL_HOOK_FAILED",
+            "ensureMountDiskImage: mksquashfs failed",
+        ),
+        else => try protocol.writeError(io, "PROVISION_INSTALL_HOOK_FAILED", @errorName(err)),
+    }
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+    assert(protocol.max_request_bytes > 0);
+
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+
+    const protocol_version = envelope.get("protocolVersion") orelse
+        return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer) return error.UnsupportedProtocolVersion;
+    if (protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    return parseRequestData(allocator, data_value.object);
+}
+
+fn parseRequestData(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+) RequestError!Request {
+    assert(object.count() > 0);
+
+    try protocol.rejectUnknownFields(object, &.{
+        "host",
+        "cacheDir",
+        "force",
+        "mksquashfsCandidates",
+        "mksquashfsEnvOverride",
+    });
+    return .{
+        .host = try requiredString(object, "host", error.MissingHost, error.InvalidHost),
+        .cache_dir = try requiredString(
+            object,
+            "cacheDir",
+            error.MissingCacheDir,
+            error.InvalidCacheDir,
+        ),
+        .force = try optionalBool(object, "force", error.InvalidForce) orelse false,
+        .mksquashfs_candidates = try optionalStringArray(
+            allocator,
+            object,
+            "mksquashfsCandidates",
+            error.InvalidMksquashfsCandidates,
+        ),
+        .mksquashfs_env_override = try optionalString(
+            object,
+            "mksquashfsEnvOverride",
+            error.InvalidMksquashfsEnvOverride,
+        ),
+    };
+}
+
+fn requiredString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError![]const u8 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return missing;
+    if (value != .string) return invalid;
+    return value.string;
+}
+
+fn optionalString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!?[]const u8 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return null;
+    if (value == .null) return null;
+    if (value != .string) return invalid;
+    return value.string;
+}
+
+fn optionalBool(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError!?bool {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return null;
+    if (value == .null) return null;
+    if (value != .bool) return invalid;
+    return value.bool;
+}
+
+fn optionalStringArray(
+    allocator: std.mem.Allocator,
+    object: std.json.ObjectMap,
+    field: []const u8,
+    invalid: RequestError,
+) RequestError![]const []const u8 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return &.{};
+    if (value == .null) return &.{};
+    if (value != .array) return invalid;
+    var out: StringList = .empty;
+    for (value.array.items) |item| {
+        if (item != .string) return invalid;
+        try out.append(allocator, item.string);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(
+            io,
+            "REQUEST_TOO_LARGE",
+            "request JSON exceeds the maximum size",
+        ),
+        error.UnknownField => try protocol.writeError(
+            io,
+            "UNKNOWN_FIELD",
+            "request contains an unknown field",
+        ),
+        error.UnsupportedProtocolVersion => try protocol.writeError(
+            io,
+            "UNSUPPORTED_PROTOCOL_VERSION",
+            "request protocolVersion must be 1",
+        ),
+        error.MissingData => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request must include a data object",
+        ),
+        error.InvalidData => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request data field must be an object",
+        ),
+        error.InvalidJson => try protocol.writeError(
+            io,
+            "INVALID_JSON",
+            "request body is not valid JSON",
+        ),
+        error.InvalidShape => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request body must be a JSON object",
+        ),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/commands/mountdisk_upper.zig
+++ b/packages/runtime/native/src/commands/mountdisk_upper.zig
@@ -1,0 +1,201 @@
+const std = @import("std");
+const runtime_helper = @import("runtime_helper");
+const protocol = @import("../protocol.zig");
+
+const assert = std.debug.assert;
+
+pub const name = "mountdisk-upper";
+
+const Request = struct {
+    tmp_dir: []const u8,
+    size_bytes: u64,
+    mke2fs: []const u8,
+};
+
+const RequestError = error{
+    MissingTmpDir,
+    InvalidTmpDir,
+    MissingSizeBytes,
+    InvalidSizeBytes,
+    MissingMke2fs,
+    InvalidMke2fs,
+} || protocol.RequestError;
+
+pub fn run(allocator: std.mem.Allocator, io: std.Io) !protocol.Exit {
+    assert(name.len > 0);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const request = parseRequest(arena, io) catch |err| {
+        try writeRequestError(io, err);
+        return .fail;
+    };
+
+    const result = runtime_helper.mountdisk.ensureUpper(allocator, io, .{
+        .tmp_dir = request.tmp_dir,
+        .size_bytes = request.size_bytes,
+        .mke2fs = request.mke2fs,
+    }) catch |err| {
+        try writeMountdiskError(io, err);
+        return .fail;
+    };
+    defer allocator.free(result.upper_path);
+
+    try writeSuccess(allocator, io, result);
+    return .ok;
+}
+
+fn writeSuccess(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    result: runtime_helper.mountdisk.UpperResult,
+) !void {
+    assert(result.upper_path.len > 0);
+
+    try protocol.writeJson(allocator, io, .{
+        .ok = true,
+        .protocolVersion = @as(u8, protocol.version),
+        .command = name,
+        .data = .{
+            .upperPath = result.upper_path,
+            .sizeBytes = result.size_bytes,
+        },
+    });
+}
+
+fn writeMountdiskError(io: std.Io, err: runtime_helper.mountdisk.Error) !void {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.Mke2fsFailed => try protocol.writeError(
+            io,
+            "PROVISION_INSTALL_HOOK_FAILED",
+            "ensureMountDiskUpper: mke2fs failed",
+        ),
+        else => try protocol.writeError(io, "PROVISION_INSTALL_HOOK_FAILED", @errorName(err)),
+    }
+}
+
+fn parseRequest(allocator: std.mem.Allocator, io: std.Io) RequestError!Request {
+    assert(protocol.version == 1);
+    assert(protocol.max_request_bytes > 0);
+
+    const data = try protocol.readStdinAll(allocator, io, protocol.max_request_bytes);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{
+        .duplicate_field_behavior = .@"error",
+        .ignore_unknown_fields = false,
+        .max_value_len = data.len,
+        .allocate = .alloc_if_needed,
+        .parse_numbers = true,
+    }) catch return error.InvalidJson;
+    const request_value = parsed.value;
+    if (request_value != .object) return error.InvalidShape;
+    const envelope = request_value.object;
+    try protocol.rejectUnknownFields(envelope, &.{ "protocolVersion", "data" });
+
+    const protocol_version = envelope.get("protocolVersion") orelse
+        return error.UnsupportedProtocolVersion;
+    if (protocol_version != .integer) return error.UnsupportedProtocolVersion;
+    if (protocol_version.integer != protocol.version) return error.UnsupportedProtocolVersion;
+
+    const data_value = envelope.get("data") orelse return error.MissingData;
+    if (data_value != .object) return error.InvalidData;
+    return parseRequestData(data_value.object);
+}
+
+fn parseRequestData(object: std.json.ObjectMap) RequestError!Request {
+    assert(object.count() > 0);
+
+    try protocol.rejectUnknownFields(object, &.{ "tmpDir", "sizeBytes", "mke2fs" });
+    return .{
+        .tmp_dir = try requiredString(
+            object,
+            "tmpDir",
+            error.MissingTmpDir,
+            error.InvalidTmpDir,
+        ),
+        .size_bytes = try requiredU64(
+            object,
+            "sizeBytes",
+            error.MissingSizeBytes,
+            error.InvalidSizeBytes,
+        ),
+        .mke2fs = try requiredString(
+            object,
+            "mke2fs",
+            error.MissingMke2fs,
+            error.InvalidMke2fs,
+        ),
+    };
+}
+
+fn requiredString(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError![]const u8 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return missing;
+    if (value != .string) return invalid;
+    return value.string;
+}
+
+fn requiredU64(
+    object: std.json.ObjectMap,
+    field: []const u8,
+    missing: RequestError,
+    invalid: RequestError,
+) RequestError!u64 {
+    assert(field.len > 0);
+
+    const value = object.get(field) orelse return missing;
+    if (value != .integer or value.integer < 0) return invalid;
+    return @intCast(value.integer);
+}
+
+fn writeRequestError(io: std.Io, err: RequestError) !void {
+    assert(@errorName(err).len > 0);
+
+    switch (err) {
+        error.RequestTooLarge => try protocol.writeError(
+            io,
+            "REQUEST_TOO_LARGE",
+            "request JSON exceeds the maximum size",
+        ),
+        error.UnknownField => try protocol.writeError(
+            io,
+            "UNKNOWN_FIELD",
+            "request contains an unknown field",
+        ),
+        error.UnsupportedProtocolVersion => try protocol.writeError(
+            io,
+            "UNSUPPORTED_PROTOCOL_VERSION",
+            "request protocolVersion must be 1",
+        ),
+        error.MissingData => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request must include a data object",
+        ),
+        error.InvalidData => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request data field must be an object",
+        ),
+        error.InvalidJson => try protocol.writeError(
+            io,
+            "INVALID_JSON",
+            "request body is not valid JSON",
+        ),
+        error.InvalidShape => try protocol.writeError(
+            io,
+            "INVALID_REQUEST",
+            "request body must be a JSON object",
+        ),
+        else => try protocol.writeError(io, "INVALID_REQUEST", @errorName(err)),
+    }
+}

--- a/packages/runtime/native/src/main.zig
+++ b/packages/runtime/native/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
 const mkinitramfs = @import("commands/mkinitramfs.zig");
+const mountdisk_image = @import("commands/mountdisk_image.zig");
+const mountdisk_upper = @import("commands/mountdisk_upper.zig");
 const tree_manifest_hash = @import("commands/tree_manifest_hash.zig");
 
 const assert = std.debug.assert;
@@ -9,6 +11,8 @@ var g_io: std.Io = undefined;
 
 pub fn main(init: std.process.Init) !u8 {
     assert(mkinitramfs.name.len > 0);
+    assert(mountdisk_image.name.len > 0);
+    assert(mountdisk_upper.name.len > 0);
     assert(tree_manifest_hash.name.len > 0);
 
     g_io = init.io;
@@ -21,44 +25,75 @@ pub fn main(init: std.process.Init) !u8 {
     };
     assert(command.len > 0);
 
-    if (std.mem.eql(u8, command, mkinitramfs.name)) {
-        if (it.next() != null) {
-            try protocol.writeError(
-                g_io,
-                "USAGE",
-                "mkinitramfs reads its JSON request from stdin " ++
-                    "and accepts no positional arguments",
-            );
-            return @intFromEnum(protocol.Exit.usage);
-        }
-        return @intFromEnum(try mkinitramfs.run(init.gpa, g_io));
-    }
-
-    if (std.mem.eql(u8, command, tree_manifest_hash.name)) {
-        if (it.next() != null) {
-            try protocol.writeError(
-                g_io,
-                "USAGE",
-                "tree-manifest-hash reads its JSON request from stdin " ++
-                    "and accepts no positional arguments",
-            );
-            return @intFromEnum(protocol.Exit.usage);
-        }
-        return @intFromEnum(try tree_manifest_hash.run(init.gpa, g_io));
-    }
-
-    const wants_help = std.mem.eql(u8, command, "--help") or
-        std.mem.eql(u8, command, "-h") or
-        std.mem.eql(u8, command, "help");
-    if (wants_help) {
-        try protocol.stdout(
-            g_io,
-            "{\"ok\":true,\"protocolVersion\":1," ++
-                "\"commands\":[\"mkinitramfs\",\"tree-manifest-hash\"]}\n",
-        );
-        return @intFromEnum(protocol.Exit.ok);
-    }
+    if (try runKnownCommand(init.gpa, &it, command)) |exit| return exit;
+    if (isHelp(command)) return try writeHelp(g_io);
 
     try protocol.writeError(g_io, "UNKNOWN_COMMAND", "unknown command");
     return @intFromEnum(protocol.Exit.usage);
+}
+
+fn runKnownCommand(
+    allocator: std.mem.Allocator,
+    it: anytype,
+    command: []const u8,
+) !?u8 {
+    assert(command.len > 0);
+
+    if (std.mem.eql(u8, command, mkinitramfs.name)) {
+        if (try rejectExtraArgs(it, mkinitramfs.name)) return @intFromEnum(protocol.Exit.usage);
+        return @intFromEnum(try mkinitramfs.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, mountdisk_image.name)) {
+        if (try rejectExtraArgs(it, mountdisk_image.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try mountdisk_image.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, mountdisk_upper.name)) {
+        if (try rejectExtraArgs(it, mountdisk_upper.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try mountdisk_upper.run(allocator, g_io));
+    }
+    if (std.mem.eql(u8, command, tree_manifest_hash.name)) {
+        if (try rejectExtraArgs(it, tree_manifest_hash.name)) {
+            return @intFromEnum(protocol.Exit.usage);
+        }
+        return @intFromEnum(try tree_manifest_hash.run(allocator, g_io));
+    }
+    return null;
+}
+
+fn rejectExtraArgs(it: anytype, command_name: []const u8) !bool {
+    assert(command_name.len > 0);
+
+    if (it.next() == null) return false;
+    var message_buf: [128]u8 = undefined;
+    const message = try std.fmt.bufPrint(
+        &message_buf,
+        "{s} reads its JSON request from stdin and accepts no positional arguments",
+        .{command_name},
+    );
+    try protocol.writeError(g_io, "USAGE", message);
+    return true;
+}
+
+fn isHelp(command: []const u8) bool {
+    assert(command.len > 0);
+
+    return std.mem.eql(u8, command, "--help") or
+        std.mem.eql(u8, command, "-h") or
+        std.mem.eql(u8, command, "help");
+}
+
+fn writeHelp(io: std.Io) !u8 {
+    assert(mkinitramfs.name.len > 0);
+
+    try protocol.stdout(
+        io,
+        "{\"ok\":true,\"protocolVersion\":1," ++
+            "\"commands\":[\"mkinitramfs\",\"mountdisk-image\"," ++
+            "\"mountdisk-upper\",\"tree-manifest-hash\"]}\n",
+    );
+    return @intFromEnum(protocol.Exit.ok);
 }

--- a/packages/runtime/native/src/mountdisk.zig
+++ b/packages/runtime/native/src/mountdisk.zig
@@ -1,0 +1,549 @@
+// Mountdisk is the native machinery behind Machinen's `--mount`.
+//
+// It turns a host directory into VM disk images:
+//
+// 1. Lower image
+//    - Reads the host directory.
+//    - Builds a deterministic SquashFS image from it.
+//    - Caches it by content hash.
+//    - The guest sees this as the read-only base contents.
+//
+// 2. Upper image
+//    - Creates a fresh sparse ext4 image.
+//    - Guest writes go here.
+//
+// Inside the VM, `/init` mounts both and combines them with overlayfs, so the
+// guest sees one writable directory at the requested path, like `/mnt/data`.
+//
+// Example:
+//
+//   machinen boot --mount ./my-dir:/mnt/data -- ls /mnt/data
+//
+// Mountdisk packages `./my-dir` as a disk-backed mount instead of stuffing it
+// into the initramfs. This keeps boot archives small and lets writes stay
+// isolated in the per-VM upper image.
+
+const std = @import("std");
+const manifest = @import("manifest.zig");
+
+const assert = std.debug.assert;
+
+pub const Error = anyerror;
+
+pub const LowerOptions = struct {
+    host: []const u8,
+    cache_dir: []const u8,
+    force: bool = false,
+    mksquashfs_candidates: []const []const u8 = &.{},
+    mksquashfs_env_override: ?[]const u8 = null,
+};
+
+pub const LowerResult = struct {
+    lower_path: []u8,
+    key: [64]u8,
+    cache_hit: bool,
+    manifest_hash_ms: i64,
+    mksquashfs_ms: i64,
+    staging_rename_ms: i64,
+};
+
+pub const UpperOptions = struct {
+    tmp_dir: []const u8,
+    size_bytes: u64,
+    mke2fs: []const u8,
+};
+
+pub const UpperResult = struct {
+    upper_path: []u8,
+    size_bytes: u64,
+};
+
+pub fn ensureLower(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: LowerOptions,
+) Error!LowerResult {
+    assert(opts.host.len > 0);
+    assert(opts.cache_dir.len > 0);
+
+    const host_stat = std.Io.Dir.cwd().statFile(
+        io,
+        opts.host,
+        .{ .follow_symlinks = true },
+    ) catch |err| switch (err) {
+        error.FileNotFound => return error.HostNotFound,
+        else => |e| return e,
+    };
+    if (host_stat.kind != .directory) return error.HostNotDirectory;
+
+    const hash_start = nowMs(io);
+    const key = try manifest.treeManifestHash(allocator, io, opts.host);
+    const manifest_hash_ms = nowMs(io) - hash_start;
+
+    const img_path = try fmtOwned(allocator, "{s}/{s}.sqfs", .{ opts.cache_dir, &key });
+    errdefer allocator.free(img_path);
+    const ok_path = try fmtOwned(allocator, "{s}.ok", .{img_path});
+    defer allocator.free(ok_path);
+
+    if (try maybeCachedLower(io, opts.force, img_path, ok_path, key, manifest_hash_ms)) |hit| {
+        return hit;
+    }
+
+    const lower = try buildLower(allocator, io, opts, img_path, key, manifest_hash_ms);
+    return lower;
+}
+
+fn maybeCachedLower(
+    io: std.Io,
+    force: bool,
+    img_path: []u8,
+    ok_path: []const u8,
+    key: [64]u8,
+    manifest_hash_ms: i64,
+) Error!?LowerResult {
+    assert(img_path.len > 0);
+    assert(ok_path.len > 0);
+
+    if (force or !fileExists(io, img_path)) return null;
+    if (!fileExists(io, ok_path)) return null;
+    std.Io.Dir.cwd().deleteFile(io, ok_path) catch |err| ignoreCleanupError(err);
+    return .{
+        .lower_path = img_path,
+        .key = key,
+        .cache_hit = true,
+        .manifest_hash_ms = manifest_hash_ms,
+        .mksquashfs_ms = 0,
+        .staging_rename_ms = 0,
+    };
+}
+
+fn buildLower(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: LowerOptions,
+    img_path: []u8,
+    key: [64]u8,
+    manifest_hash_ms: i64,
+) Error!LowerResult {
+    assert(img_path.len > 0);
+
+    const mksquashfs = try selectMksquashfs(io, opts);
+    const staging_dir = try createUniqueStagingDir(allocator, io, opts.cache_dir, &key);
+    defer allocator.free(staging_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, staging_dir) catch |err| ignoreCleanupError(err);
+    const staging_img = try fmtOwned(allocator, "{s}/lower.sqfs", .{staging_dir});
+    defer allocator.free(staging_img);
+
+    const mk_start = nowMs(io);
+    try runMksquashfs(allocator, io, mksquashfs, opts.host, staging_img);
+    const mksquashfs_ms = nowMs(io) - mk_start;
+
+    const rename_start = nowMs(io);
+    try padTo512Boundary(io, staging_img);
+    try std.Io.Dir.renameAbsolute(staging_img, img_path, io);
+    const staging_rename_ms = nowMs(io) - rename_start;
+
+    return .{
+        .lower_path = img_path,
+        .key = key,
+        .cache_hit = false,
+        .manifest_hash_ms = manifest_hash_ms,
+        .mksquashfs_ms = mksquashfs_ms,
+        .staging_rename_ms = staging_rename_ms,
+    };
+}
+
+pub fn ensureUpper(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: UpperOptions,
+) Error!UpperResult {
+    assert(opts.tmp_dir.len > 0);
+    assert(opts.size_bytes > 0);
+    assert(opts.mke2fs.len > 0);
+
+    const upper_path = try allocateUniqueSparseFile(allocator, io, opts.tmp_dir, opts.size_bytes);
+    errdefer allocator.free(upper_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, upper_path) catch |err| {
+        ignoreCleanupError(err);
+    };
+    const blocks = @divFloor(opts.size_bytes, 4096);
+    try runMke2fs(allocator, io, opts.mke2fs, upper_path, blocks);
+    return .{ .upper_path = upper_path, .size_bytes = opts.size_bytes };
+}
+
+fn selectMksquashfs(io: std.Io, opts: LowerOptions) Error![]const u8 {
+    assert(opts.host.len > 0);
+    assert(opts.cache_dir.len > 0);
+
+    if (opts.mksquashfs_env_override) |env_override| {
+        if (env_override.len > 0) {
+            if (!fileExists(io, env_override)) return error.MksquashfsEnvMissing;
+            return env_override;
+        }
+    }
+    for (opts.mksquashfs_candidates) |candidate| {
+        if (fileExists(io, candidate)) return candidate;
+    }
+    return error.MksquashfsMissing;
+}
+
+fn runMksquashfs(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    mksquashfs: []const u8,
+    host: []const u8,
+    out: []const u8,
+) Error!void {
+    assert(mksquashfs.len > 0);
+    assert(host.len > 0);
+    assert(out.len > 0);
+
+    const result = try std.process.run(allocator, io, .{
+        .argv = &.{
+            mksquashfs,
+            host,
+            out,
+            "-mkfs-time",
+            "0",
+            "-all-time",
+            "0",
+            "-no-progress",
+            "-no-recovery",
+            "-comp",
+            "zstd",
+            "-no-xattrs",
+        },
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code == 0) return else return error.MksquashfsFailed,
+        else => return error.MksquashfsFailed,
+    }
+}
+
+fn runMke2fs(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    mke2fs: []const u8,
+    path: []const u8,
+    blocks: u64,
+) Error!void {
+    assert(mke2fs.len > 0);
+    assert(path.len > 0);
+    assert(blocks > 0);
+
+    const blocks_text = try fmtOwned(allocator, "{d}", .{blocks});
+    defer allocator.free(blocks_text);
+    const result = try std.process.run(allocator, io, .{
+        .argv = &.{ mke2fs, "-t", "ext4", "-F", "-q", "-b", "4096", path, blocks_text },
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code == 0) return else return error.Mke2fsFailed,
+        else => return error.Mke2fsFailed,
+    }
+}
+
+fn allocateUniqueSparseFile(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    tmp_dir: []const u8,
+    size_bytes: u64,
+) Error![]u8 {
+    assert(tmp_dir.len > 0);
+    assert(size_bytes > 0);
+
+    var attempt: u8 = 0;
+    while (attempt < 64) : (attempt += 1) {
+        const path = try upperPath(allocator, io, tmp_dir, attempt);
+        createSparseFileExclusive(io, path, size_bytes) catch |err| {
+            allocator.free(path);
+            switch (err) {
+                error.PathAlreadyExists => continue,
+                else => |e| return e,
+            }
+        };
+        return path;
+    }
+    return error.UniquePathExhausted;
+}
+
+fn createSparseFileExclusive(io: std.Io, path: []const u8, size_bytes: u64) Error!void {
+    assert(path.len > 0);
+    assert(size_bytes > 0);
+
+    var file = try std.Io.Dir.cwd().createFile(io, path, .{
+        .truncate = false,
+        .exclusive = true,
+    });
+    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch |err| ignoreCleanupError(err);
+    defer file.close(io);
+    const zero = [_]u8{0};
+    try file.writePositionalAll(io, &zero, size_bytes - 1);
+}
+
+fn padTo512Boundary(io: std.Io, path: []const u8) Error!void {
+    assert(path.len > 0);
+
+    const st = try std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false });
+    const remainder = st.size % 512;
+    if (remainder == 0) return;
+    const padded = st.size + (512 - remainder);
+    var file = try std.Io.Dir.cwd().openFile(io, path, .{
+        .mode = .write_only,
+        .allow_directory = false,
+    });
+    defer file.close(io);
+    const zero = [_]u8{0};
+    try file.writePositionalAll(io, &zero, padded - 1);
+}
+
+fn createUniqueStagingDir(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    cache_dir: []const u8,
+    key: *const [64]u8,
+) Error![]u8 {
+    assert(cache_dir.len > 0);
+    assert(key.len == 64);
+
+    var attempt: u8 = 0;
+    while (attempt < 64) : (attempt += 1) {
+        const path = try stagingDirPath(allocator, io, cache_dir, key, attempt);
+        std.Io.Dir.cwd().createDir(io, path, .default_dir) catch |err| {
+            allocator.free(path);
+            switch (err) {
+                error.PathAlreadyExists => continue,
+                else => |e| return e,
+            }
+        };
+        return path;
+    }
+    return error.UniquePathExhausted;
+}
+
+fn stagingDirPath(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    cache_dir: []const u8,
+    key: *const [64]u8,
+    attempt: u8,
+) Error![]u8 {
+    assert(cache_dir.len > 0);
+    assert(key.len == 64);
+
+    return fmtOwned(allocator, "{s}/{s}-staging-{d}-{d}", .{
+        cache_dir,
+        key[0..12],
+        nowNs(io),
+        attempt,
+    });
+}
+
+fn upperPath(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    tmp_dir: []const u8,
+    attempt: u8,
+) Error![]u8 {
+    assert(tmp_dir.len > 0);
+
+    return fmtOwned(allocator, "{s}/machinen-mountdisk-upper-{d}-{d}.img", .{
+        tmp_dir,
+        nowNs(io),
+        attempt,
+    });
+}
+
+fn fileExists(io: std.Io, path: []const u8) bool {
+    assert(path.len > 0);
+
+    const st = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return false;
+    return switch (st.kind) {
+        else => true,
+    };
+}
+
+fn nowMs(io: std.Io) i64 {
+    const ms = @as(i64, @intCast(@divFloor(nowNs(io), std.time.ns_per_ms)));
+    assert(ms >= 0);
+    return ms;
+}
+
+fn nowNs(io: std.Io) i96 {
+    const ns = std.Io.Clock.awake.now(io).nanoseconds;
+    assert(ns >= 0);
+    return ns;
+}
+
+fn ignoreCleanupError(err: anyerror) void {
+    assert(@errorName(err).len > 0);
+}
+
+fn fmtOwned(
+    allocator: std.mem.Allocator,
+    comptime fmt: []const u8,
+    args: anytype,
+) std.mem.Allocator.Error![]u8 {
+    assert(fmt.len > 0);
+
+    var writer = std.Io.Writer.Allocating.init(allocator);
+    errdefer writer.deinit();
+    writer.writer.print(fmt, args) catch return error.OutOfMemory;
+    return writer.toOwnedSlice();
+}
+
+fn tmpRootAbs(allocator: std.mem.Allocator, tmp: *const std.testing.TmpDir) ![]u8 {
+    assert(tmp.sub_path.len > 0);
+
+    const cwd = try std.process.currentPathAlloc(std.testing.io, allocator);
+    defer allocator.free(cwd);
+    return std.fs.path.join(allocator, &.{ cwd, ".zig-cache", "tmp", &tmp.sub_path });
+}
+
+test "selectMksquashfs treats an empty env override as absent" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "mksquashfs", .data = "fake" });
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const fake = try std.fs.path.join(allocator, &.{ root, "mksquashfs" });
+    defer allocator.free(fake);
+    const candidates = [_][]const u8{fake};
+
+    const selected = try selectMksquashfs(std.testing.io, .{
+        .host = root,
+        .cache_dir = root,
+        .mksquashfs_candidates = &candidates,
+        .mksquashfs_env_override = "",
+    });
+    try std.testing.expectEqualStrings(fake, selected);
+}
+
+test "createSparseFileExclusive refuses to truncate an existing path" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "upper.img", .data = "keep" });
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const path = try std.fs.path.join(allocator, &.{ root, "upper.img" });
+    defer allocator.free(path);
+
+    try std.testing.expectError(
+        error.PathAlreadyExists,
+        createSparseFileExclusive(std.testing.io, path, 4096),
+    );
+    const st = try std.Io.Dir.cwd().statFile(std.testing.io, path, .{});
+    try std.testing.expectEqual(@as(u64, 4), st.size);
+}
+
+test "allocateUniqueSparseFile returns distinct exclusive files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const first = try allocateUniqueSparseFile(allocator, std.testing.io, root, 4096);
+    defer allocator.free(first);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, first) catch |err| ignoreCleanupError(err);
+    const second = try allocateUniqueSparseFile(allocator, std.testing.io, root, 4096);
+    defer allocator.free(second);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, second) catch |err| ignoreCleanupError(err);
+
+    try std.testing.expect(!std.mem.eql(u8, first, second));
+    const first_st = try std.Io.Dir.cwd().statFile(std.testing.io, first, .{});
+    const second_st = try std.Io.Dir.cwd().statFile(std.testing.io, second, .{});
+    try std.testing.expectEqual(@as(u64, 4096), first_st.size);
+    try std.testing.expectEqual(@as(u64, 4096), second_st.size);
+}
+
+test "ensureLower returns host errors before tool lookup" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "file.txt", .data = "x" });
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const missing = try std.fs.path.join(allocator, &.{ root, "missing" });
+    defer allocator.free(missing);
+    const file = try std.fs.path.join(allocator, &.{ root, "file.txt" });
+    defer allocator.free(file);
+    try std.testing.expectError(error.HostNotFound, ensureLower(allocator, std.testing.io, .{
+        .host = missing,
+        .cache_dir = root,
+    }));
+    try std.testing.expectError(error.HostNotDirectory, ensureLower(allocator, std.testing.io, .{
+        .host = file,
+        .cache_dir = root,
+    }));
+}
+
+test "ensureLower accepts a symlink host root that points at a directory" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "host", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "host/file.txt", .data = "x" });
+    try tmp.dir.createDir(std.testing.io, "cache", .default_dir);
+    try tmp.dir.symLink(std.testing.io, "host", "host-link", .{});
+
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const host = try std.fs.path.join(allocator, &.{ root, "host-link" });
+    defer allocator.free(host);
+    const cache = try std.fs.path.join(allocator, &.{ root, "cache" });
+    defer allocator.free(cache);
+
+    try std.testing.expectError(error.MksquashfsMissing, ensureLower(
+        allocator,
+        std.testing.io,
+        .{ .host = host, .cache_dir = cache },
+    ));
+}
+
+test "ensureLower returns clean cache hit without mksquashfs" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "host", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "host/hello.txt", .data = "world" });
+    try tmp.dir.createDir(std.testing.io, "cache", .default_dir);
+    const root = try tmpRootAbs(allocator, &tmp);
+    defer allocator.free(root);
+    const host = try std.fs.path.join(allocator, &.{ root, "host" });
+    defer allocator.free(host);
+    const cache = try std.fs.path.join(allocator, &.{ root, "cache" });
+    defer allocator.free(cache);
+    const key = try manifest.treeManifestHash(allocator, std.testing.io, host);
+    const img = try fmtOwned(allocator, "{s}/{s}.sqfs", .{ cache, &key });
+    defer allocator.free(img);
+    const ok = try fmtOwned(allocator, "{s}.ok", .{img});
+    defer allocator.free(ok);
+    const img_sub_path = try fmtOwned(allocator, "cache/{s}.sqfs", .{&key});
+    defer allocator.free(img_sub_path);
+    const ok_sub_path = try fmtOwned(allocator, "cache/{s}.sqfs.ok", .{&key});
+    defer allocator.free(ok_sub_path);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = img_sub_path, .data = "cached" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = ok_sub_path, .data = "" });
+
+    const result = try ensureLower(allocator, std.testing.io, .{
+        .host = host,
+        .cache_dir = cache,
+    });
+    defer allocator.free(result.lower_path);
+    try std.testing.expect(result.cache_hit);
+    try std.testing.expectEqualStrings(img, result.lower_path);
+    try std.testing.expect(!fileExists(std.testing.io, ok));
+}

--- a/packages/runtime/native/src/root.zig
+++ b/packages/runtime/native/src/root.zig
@@ -1,2 +1,3 @@
 pub const manifest = @import("manifest.zig");
 pub const mkinitramfs = @import("mkinitramfs.zig");
+pub const mountdisk = @import("mountdisk.zig");

--- a/packages/runtime/src/__tests__/mountdisk-img.test.ts
+++ b/packages/runtime/src/__tests__/mountdisk-img.test.ts
@@ -326,6 +326,25 @@ describe("ensureMountDiskImage", () => {
     }
   });
 
+  it("treats an empty MACHINEN_MKSQUASHFS override as unset", () => {
+    const prev = process.env.MACHINEN_MKSQUASHFS;
+    process.env.MACHINEN_MKSQUASHFS = "";
+    try {
+      const call = () => ensureMountDiskImage(host, { cacheDir });
+      if (resolveMksquashfs()) {
+        expect(call).not.toThrow();
+      } else {
+        expect(call).toThrow(/no mksquashfs binary found|mksquashfs/);
+      }
+    } finally {
+      if (prev === undefined) {
+        delete process.env.MACHINEN_MKSQUASHFS;
+      } else {
+        process.env.MACHINEN_MKSQUASHFS = prev;
+      }
+    }
+  });
+
   it("throws BOOT_MOUNT_HOST_NOT_FOUND when the host dir is missing", () => {
     expect(() => ensureMountDiskImage(join(tmp, "missing"), { cacheDir })).toThrow(
       /host directory not found/,

--- a/packages/runtime/src/mountdisk-img.ts
+++ b/packages/runtime/src/mountdisk-img.ts
@@ -45,26 +45,22 @@
 // overlay path. The runtime expects a working bundled package, the
 // caller's PATH, or the env override.
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
   fsyncSync,
   mkdirSync,
-  mkdtempSync,
   openSync,
   renameSync,
-  rmSync,
-  statSync,
-  truncateSync,
   unlinkSync,
-  writeSync,
 } from "node:fs";
 import { createRequire } from "node:module";
 import { arch, homedir, platform, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import debugLib from "debug";
-import { BootError, ProvisionError } from "./errors.ts";
+import { BootError } from "./errors.ts";
+import { ensureMountDiskImageNative, ensureMountDiskUpperNative } from "./native/mountdisk.ts";
 import { treeManifestHashNative } from "./native/tree-manifest-hash.ts";
 import { resolveMke2fs } from "./rootfs-img.ts";
 
@@ -163,109 +159,32 @@ export function ensureMountDiskImage(
   opts: EnsureMountDiskImageOptions = {},
 ): EnsureMountDiskImageResult {
   const hostResolved = resolve(hostAbs);
-  if (!existsSync(hostResolved)) {
-    throw new BootError(
-      "BOOT_MOUNT_HOST_NOT_FOUND",
-      `ensureMountDiskImage: host directory not found at ${hostResolved}`,
-    );
-  }
-  if (!statSync(hostResolved).isDirectory()) {
-    throw new BootError(
-      "BOOT_MOUNT_INVALID",
-      `ensureMountDiskImage: host path must be a directory: ${hostResolved}`,
-    );
-  }
-
   const cacheDir = opts.cacheDir ?? mountdiskImgCacheDir();
   mkdirSync(cacheDir, { recursive: true });
 
-  const hashT0 = Date.now();
-  const key = treeManifestHash(hostResolved);
-  opts.onPhase?.("manifest-hash", Date.now() - hashT0);
-  const imgPath = join(cacheDir, `${key}.sqfs`);
-  const okPath = okMarkerPath(imgPath);
+  const result = ensureMountDiskImageNative({
+    host: hostResolved,
+    cacheDir,
+    force: opts.force ?? false,
+    mksquashfsEnvOverride: process.env.MACHINEN_MKSQUASHFS || undefined,
+    mksquashfsCandidates: mksquashfsCandidates(),
+  });
 
-  if (!opts.force && existsSync(imgPath)) {
-    debug("cache hit key=%s img=%s", key.slice(0, 12), imgPath);
-    if (!existsSync(okPath)) {
-      // No clean-shutdown marker → the previous owner died mid-build
-      // (or the file was hand-placed). Treat as poisoned and rebuild.
-      debug("cache hit but no clean marker — rematerialising img=%s", imgPath);
-    } else {
-      try {
-        unlinkSync(okPath);
-      } catch {}
-      return { lowerPath: imgPath, key };
-    }
+  opts.onPhase?.("manifest-hash", result.phases.manifestHash);
+  if (result.phases.mksquashfs > 0) {
+    opts.onPhase?.("mksquashfs", result.phases.mksquashfs);
+  }
+  if (result.phases.stagingRename > 0) {
+    opts.onPhase?.("staging-rename", result.phases.stagingRename);
   }
 
-  // Resolve mksquashfs. Same precedence as `resolveMksquashfs()` below.
-  const mksquashfs = resolveMksquashfs();
-  if (!mksquashfs) {
-    throw new BootError(
-      "BOOT_MOUNTDISK_TOOL_MISSING",
-      "ensureMountDiskImage: no mksquashfs binary found (no bundled " +
-        "package for this platform; looked for mksquashfs on PATH and " +
-        "in Homebrew's prefix). Install it:\n" +
-        "  • macOS:  brew install squashfs\n" +
-        "  • Linux:  apt-get install -y squashfs-tools (or your distro's package)\n" +
-        "  • or set MACHINEN_MKSQUASHFS=/abs/path/to/mksquashfs to point at a vendored copy.",
-    );
-  }
-
-  // Materialize into a staging file so a host crash mid-write doesn't
-  // leave a torn `.sqfs` in the cache.
-  const stagingDir = mkdtempSync(join(cacheDir, `${key.slice(0, 12)}-staging-`));
-  const stagingImg = join(stagingDir, "lower.sqfs");
-  try {
-    debug("materialize key=%s host=%s", key.slice(0, 12), hostResolved);
-    const mkT0 = Date.now();
-    const args = [
-      hostResolved,
-      stagingImg,
-      // Determinism: zero out the filesystem-level timestamp and the
-      // per-file timestamps so the same input produces the same bytes.
-      "-mkfs-time",
-      "0",
-      "-all-time",
-      "0",
-      // Quiet output and disable on-write recovery file (we own the
-      // staging dir; if it dies we delete it).
-      "-no-progress",
-      "-no-recovery",
-      // Compression: zstd matches the kernel's CONFIG_SQUASHFS_ZSTD.
-      "-comp",
-      "zstd",
-      // Don't capture xattrs — we don't need them for the per-mount
-      // payload, and skipping makes the manifest hash and the
-      // mksquashfs output align (no xattr bytes vary across host fs).
-      "-no-xattrs",
-    ];
-    const mk = spawnSync(mksquashfs, args, {
-      stdio: ["ignore", "ignore", "pipe"],
-    });
-    opts.onPhase?.("mksquashfs", Date.now() - mkT0);
-    if (mk.status !== 0) {
-      throw new ProvisionError(
-        "PROVISION_INSTALL_HOOK_FAILED",
-        `ensureMountDiskImage: ${mksquashfs} failed (code ${mk.status}): ${mk.stderr?.toString() ?? ""}`,
-      );
-    }
-
-    // squashfs-tools writes a length that's a multiple of 4 KiB but
-    // not always of 512. Round up to the next 512-byte sector if
-    // needed — the VMM's blk.Backend asserts on the alignment.
-    const renameT0 = Date.now();
-    padTo512Boundary(stagingImg);
-    renameSync(stagingImg, imgPath);
-    opts.onPhase?.("staging-rename", Date.now() - renameT0);
-    debug("materialize done key=%s img=%s", key.slice(0, 12), imgPath);
-    return { lowerPath: imgPath, key };
-  } finally {
-    try {
-      rmSync(stagingDir, { recursive: true, force: true });
-    } catch {}
-  }
+  debug(
+    "%s key=%s img=%s",
+    result.cacheHit ? "cache hit" : "materialize done",
+    result.key.slice(0, 12),
+    result.lowerPath,
+  );
+  return { lowerPath: result.lowerPath, key: result.key };
 }
 
 export interface EnsureMountDiskUpperOptions {
@@ -311,7 +230,6 @@ export function ensureMountDiskUpper(
       `mountDiskUpperSizeBytes must be a positive multiple of 4096 (got ${sizeBytes})`,
     );
   }
-  // mke2fs lookup is shared with rootfs-img.ts.
   const mke2fs = resolveMke2fs();
   if (!mke2fs) {
     throw new BootError(
@@ -324,22 +242,11 @@ export function ensureMountDiskUpper(
     );
   }
 
-  const upperPath = join(tmpdir(), `machinen-mountdisk-upper-${process.pid}-${randomSuffix()}.img`);
-  allocateSparseFile(upperPath, sizeBytes);
-  const blocks = Math.floor(sizeBytes / 4096);
-  const r = spawnSync(mke2fs, ["-t", "ext4", "-F", "-q", "-b", "4096", upperPath, String(blocks)], {
-    stdio: ["ignore", "ignore", "pipe"],
+  return ensureMountDiskUpperNative({
+    tmpDir: tmpdir(),
+    sizeBytes,
+    mke2fs,
   });
-  if (r.status !== 0) {
-    try {
-      unlinkSync(upperPath);
-    } catch {}
-    throw new ProvisionError(
-      "PROVISION_INSTALL_HOOK_FAILED",
-      `ensureMountDiskUpper: ${mke2fs} failed (code ${r.status}): ${r.stderr?.toString() ?? ""}`,
-    );
-  }
-  return { upperPath, sizeBytes };
 }
 
 /**
@@ -354,6 +261,12 @@ export function resolveMksquashfs(): string | undefined {
     findBundledMksquashfs() ??
     whichFirst(["mksquashfs"]) ??
     findKegOnlyMksquashfs()
+  );
+}
+
+function mksquashfsCandidates(): string[] {
+  return [findBundledMksquashfs(), whichFirst(["mksquashfs"]), findKegOnlyMksquashfs()].filter(
+    (candidate): candidate is string => Boolean(candidate),
   );
 }
 
@@ -435,38 +348,6 @@ export function treeManifestHash(root: string): string {
   return treeManifestHashNative(root);
 }
 
-function allocateSparseFile(path: string, sizeBytes: number): void {
-  const fd = openSync(path, "w");
-  try {
-    const buf = Buffer.alloc(1);
-    writeSync(fd, buf, 0, 1, sizeBytes - 1);
-  } finally {
-    closeSync(fd);
-  }
-}
-
-/**
- * Pad a file's length up to the next multiple of 512 bytes. Squashfs
- * writes 4-KiB-aligned images, but mksquashfs sometimes emits a tail
- * that's not 512-aligned (xattr table, padding) — and the VMM's
- * blk.Backend.initFromFd asserts on `size % 512 == 0`. We grow with
- * truncate-up (sparse, free) rather than rewriting the file.
- */
-function padTo512Boundary(path: string): void {
-  const sz = statSync(path).size;
-  const remainder = sz % 512;
-  if (remainder === 0) {
-    return;
-  }
-  const padded = sz + (512 - remainder);
-  truncateSync(path, padded);
-}
-
-function randomSuffix(): string {
-  // 12 hex chars is overkill for collision avoidance inside one process.
-  return Math.random().toString(36).slice(2, 8) + Date.now().toString(36).slice(-6);
-}
-
 /**
  * Visible to tests that want to assert without invoking the real
  * materializer.
@@ -477,5 +358,4 @@ export const _mountdiskImgInternal = {
   findBundledMksquashfs,
   findKegOnlyMksquashfs,
   treeManifestHash,
-  padTo512Boundary,
 };

--- a/packages/runtime/src/native/mountdisk.ts
+++ b/packages/runtime/src/native/mountdisk.ts
@@ -1,0 +1,103 @@
+import { BootError, ProvisionError, type ErrorCode, type MachinenErrorOptions } from "../errors.ts";
+import { callRuntimeHelper } from "../native-helper.ts";
+
+interface EnsureMountDiskImageNativeRequest {
+  host: string;
+  cacheDir: string;
+  force?: boolean;
+  mksquashfsCandidates?: string[];
+  mksquashfsEnvOverride?: string;
+}
+
+interface EnsureMountDiskImageNativeData {
+  lowerPath: string;
+  key: string;
+  cacheHit: boolean;
+  phases: {
+    manifestHash: number;
+    mksquashfs: number;
+    stagingRename: number;
+  };
+}
+
+interface EnsureMountDiskUpperNativeRequest {
+  tmpDir: string;
+  sizeBytes: number;
+  mke2fs: string;
+}
+
+interface EnsureMountDiskUpperNativeData {
+  upperPath: string;
+  sizeBytes: number;
+}
+
+export function ensureMountDiskImageNative(
+  request: EnsureMountDiskImageNativeRequest,
+): EnsureMountDiskImageNativeData {
+  return callRuntimeHelper({
+    command: "mountdisk-image",
+    data: request,
+    errorCode: "BOOT_MOUNTDISK_TOOL_MISSING",
+    makeError: mountdiskError,
+    isData: isEnsureMountDiskImageNativeData,
+  });
+}
+
+export function ensureMountDiskUpperNative(
+  request: EnsureMountDiskUpperNativeRequest,
+): EnsureMountDiskUpperNativeData {
+  return callRuntimeHelper({
+    command: "mountdisk-upper",
+    data: request,
+    errorCode: "BOOT_MOUNTDISK_TOOL_MISSING",
+    makeError: mountdiskError,
+    isData: isEnsureMountDiskUpperNativeData,
+  });
+}
+
+function mountdiskError(code: ErrorCode, message: string, opts?: MachinenErrorOptions): Error {
+  if (code === "PROVISION_INSTALL_HOOK_FAILED") {
+    return new ProvisionError(code, message, opts);
+  }
+  return new BootError(code, message, opts);
+}
+
+function isEnsureMountDiskImageNativeData(value: unknown): value is EnsureMountDiskImageNativeData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<EnsureMountDiskImageNativeData>;
+  return (
+    typeof data.lowerPath === "string" &&
+    /^[0-9a-f]{64}$/.test(data.key ?? "") &&
+    typeof data.cacheHit === "boolean" &&
+    isPhases(data.phases)
+  );
+}
+
+function isPhases(value: unknown): value is EnsureMountDiskImageNativeData["phases"] {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const phases = value as Partial<EnsureMountDiskImageNativeData["phases"]>;
+  return (
+    typeof phases.manifestHash === "number" &&
+    Number.isFinite(phases.manifestHash) &&
+    typeof phases.mksquashfs === "number" &&
+    Number.isFinite(phases.mksquashfs) &&
+    typeof phases.stagingRename === "number" &&
+    Number.isFinite(phases.stagingRename)
+  );
+}
+
+function isEnsureMountDiskUpperNativeData(value: unknown): value is EnsureMountDiskUpperNativeData {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const data = value as Partial<EnsureMountDiskUpperNativeData>;
+  return (
+    typeof data.upperPath === "string" &&
+    typeof data.sizeBytes === "number" &&
+    Number.isFinite(data.sizeBytes)
+  );
+}


### PR DESCRIPTION
## Problem

Mountdisk assembly still had deterministic image-building logic in TypeScript. That kept low-level filesystem image behavior outside the native helper core.

## Solution

Move mountdisk assembly into a Zig helper command. TypeScript keeps the public wrapper and the surrounding host orchestration.

## Technical Summary

- Keeps mountdisk assembly separate from initramfs and rootfs work for smaller review.
- Preserves sparse image behavior through the native helper path.
- Continues to avoid daemon, socket, or FFI plumbing.
