### PR TITLE
Reintroduce experimental move command

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,31 +1,32 @@
-# Goal: Product-focused snapshot and restore
+# Goal: Product-focused snapshot, restore, and move
 
 ## North star
 
 Keep Machinen centered on supported product surfaces: boot a Linux VM, snapshot
-it, restore it, and fork it without overstating unsupported portability.
+it, restore it, fork it, and move only explicitly modeled process state without
+overstating unsupported portability.
 
 ## Current product map
 
-| Area                            | Product support                             | Notes                                                                                         |
-| ------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Whole-VM vmstate snapshots      | Supported                                   | Same guest architecture only. Bundles include CPU, RAM, device state, and rootdisk state.     |
-| Cross-HVF/KVM arm64 restore     | Supported when restore invariants match     | PAuth, topology, guest memory layout, and rootdisk identity must be safe.                     |
-| amd64 Linux/KVM vmstate         | Supported path                              | Same guest architecture only.                                                                 |
-| Cross-ISA whole-VM restore      | Unsupported                                 | A vmstate bundle contains ISA-specific machine state and must not be replayed as another ISA. |
-| Cross-ISA process movement      | Not exposed as a public command             | Future work must reconstruct target-native state and refuse unsupported state before start.   |
-| Nested virtualization snapshots | Unsupported for provider-level L1 snapshots | Nested-enabled outer VMs refuse snapshot/fork until EL2 state capture is audited.             |
+| Area                            | Product support                             | Notes                                                                                                      |
+| ------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Whole-VM vmstate snapshots      | Supported                                   | Same guest architecture only. Bundles include CPU, RAM, device state, and rootdisk state.                  |
+| Cross-HVF/KVM arm64 restore     | Supported when restore invariants match     | PAuth, topology, guest memory layout, and rootdisk identity must be safe.                                  |
+| amd64 Linux/KVM vmstate         | Supported path                              | Same guest architecture only.                                                                              |
+| Cross-ISA whole-VM restore      | Unsupported                                 | A vmstate bundle contains ISA-specific machine state and must not be replayed as another ISA.              |
+| `machinen move` descriptors     | Experimental narrow subsets                 | Each accepted route must reconstruct target-native state and refuse unsupported state before target start. |
+| Nested virtualization snapshots | Unsupported for provider-level L1 snapshots | Nested-enabled outer VMs refuse snapshot/fork until EL2 state capture is audited.                          |
 
 ## Product rules
 
 1. Document only product-supported behavior in `docs/`.
 2. Refuse unsupported state explicitly instead of presenting partial migration as success.
-3. Keep same-ISA vmstate restore separate from any future cross-ISA target-native movement.
+3. Keep same-ISA vmstate restore separate from cross-ISA target-native movement.
 4. Do not claim cross-ISA VM restore, source-ISA emulation, sidecar replay, or metadata-only success as product support.
 5. Keep examples runnable through the public CLI/runtime APIs.
 
 ## Next work
 
-- Keep the quickstart, handoff, networking, mounts, and snapshot docs aligned with the current CLI.
+- Keep the quickstart, handoff, networking, mounts, move, and snapshot docs aligned with the current CLI.
 - Keep support boundaries concise and user-facing.
-- Expose cross-ISA process movement only after a public command has clear target-native reconstruction and refusal behavior.
+- Expand move subsets only when they use public product commands and clear refusal behavior.

--- a/docs/snapshot/README.md
+++ b/docs/snapshot/README.md
@@ -1,4 +1,4 @@
-# Snapshot and restore
+# Snapshot, restore, and move
 
 This page describes the current product surfaces only.
 
@@ -17,14 +17,26 @@ Use these commands to save and restore a Machinen VM snapshot. See:
 Whole-VM vmstate restore is same-guest-ISA only. A vmstate bundle contains CPU,
 RAM, device, and rootdisk state for one guest architecture.
 
-## Cross-ISA boundary
+## Cross-ISA movement
 
-Machinen does not expose a public cross-ISA process-move command. Raw vmstate
-bundles replay source kernel, vCPU, device, and rootdisk state, so they are not a
-cross-ISA bridge. A cross-ISA restore attempt fails closed instead of replaying
-state on an incompatible guest architecture.
+`machinen move` is the experimental cross-ISA process descriptor entrypoint. It
+is not a general live workload migration command. Give it a running VM name or
+VMM pid, then a guest PID when saving a descriptor.
+
+```sh
+machinen move scan <vm>
+machinen move save <vm> <guest-pid> <bundle-dir>
+machinen move save <vm> <guest-pid> <bundle-dir> --issue [--issue-repo <owner/repo>]
+machinen move load <vm> <bundle-dir>
+```
+
+`move save` writes a bundle directory containing `move.json`. `move load` accepts
+that same bundle directory shape and refuses file paths or partial descriptors.
+Unsupported files, sockets, threads, or process contexts stay fail-closed with
+typed evidence before target execution.
 
 ## Product boundary
 
-Snapshot and restore are whole-VM operations. Runtime-specific and experimental
-descriptor routes are not part of the public snapshot/restore workflow.
+Snapshot and restore are whole-VM operations. `move` is separate from vmstate: it
+must reconstruct explicitly modeled process/resource state on the target instead
+of replaying source kernel, vCPU, or device state.

--- a/docs/snapshot/vmstate-portability.md
+++ b/docs/snapshot/vmstate-portability.md
@@ -31,10 +31,10 @@ Current policy:
   state.
 - Raw `.vmstate` restore is same-guest-ISA only. A cross-ISA attempt is refused
   as `BOOT_VMSTATE_CROSS_ISA_UNSUPPORTED` with code
-  `cross-isa-vmstate-restore-unsupported`; Machinen does not currently expose a
-  public cross-ISA process-move command. Cross-ISA process movement would need
+  `cross-isa-vmstate-restore-unsupported`; cross-ISA process movement must use
   target-native reconstruction of modeled process/resource state instead of
-  replaying source kernel/vCPU/device state.
+  replaying source kernel/vCPU/device state. The public `machinen move` surface
+  is experimental and refuses anything outside its explicitly modeled subsets.
 
 CRIU remains a Linux process-tree restore mechanism. It does not solve
 HVF↔KVM CPU feature mismatches and is not a replacement for the vmstate

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -9,6 +9,7 @@ recipes, see the [guides](../../docs/).
 ```
 machinen boot     [<image>] [opts] -- <cmd>     Boot a microVM
 machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bundle
+machinen move     <scan|save|load> [opts]       Experimental, fail-closed process move descriptors
 machinen list     (alias: ls, ps)               List running VMs
 machinen exec     [<target>] [--tty] -- <cmd>   Run a command in a running VM
 machinen snapshot [<target>] <out-dir> [--keep-alive] [--dry-run]
@@ -38,7 +39,7 @@ Machinen uses the default VM name: `default`.
 
 Every data-returning command supports `--json` for machine-readable
 output to stdout: `list`, `gc`, `install`, `snapshot`, `stop`,
-`feedback`, `agent-context`, plus `boot --detach` and `fork --detach`
+`move`, `feedback`, `agent-context`, plus `boot --detach` and `fork --detach`
 (where the CLI returns identity instead of taking over stdio).
 Mutating commands (`gc`, `stop`, `snapshot`, `session-kill`) accept
 `--dry-run` to preview without side effects.
@@ -87,6 +88,19 @@ Restores a VM from a snapshot bundle. Vmstate bundles hold `state.vmstate`,
 `rootdisk.img`, and `meta.json`; legacy CRIU bundles hold `img/` plus
 `meta.json`. Anonymous restores auto-name as `<source-name>/<pid>` so lineage
 shows up in `machinen ls`. Resolves base assets the same way `boot` does.
+
+## `machinen move`
+
+```
+machinen move scan <vm> [--json]
+machinen move save <vm> <guest-pid> <bundle-dir> [--issue] [--issue-repo <owner/repo>] [--json]
+machinen move load <vm> <bundle-dir> [--json]
+```
+
+`move` is experimental and narrow. It does not move arbitrary live workloads.
+`move save` writes a bundle directory containing `move.json`; `move load` only
+accepts that bundle directory shape. Unsupported files, sockets, threads, or
+process contexts are refused before target execution.
 
 ## `machinen ls` / `ps`
 

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -13,6 +13,7 @@ import { COMMANDS, EXIT_CODES, SCHEMA_VERSION, buildAgentContext } from "../agen
 
 const SRC_DIR = dirname(fileURLToPath(import.meta.url));
 const CLI_SRC = readFileSync(join(SRC_DIR, "..", "cli.ts"), "utf8");
+const MOVE_COMMAND_SRC = readFileSync(join(SRC_DIR, "..", "commands", "move.ts"), "utf8");
 const RESTORE_COMMAND_SRC = readFileSync(join(SRC_DIR, "..", "commands", "restore.ts"), "utf8");
 const SNAPSHOT_COMMAND_SRC = readFileSync(join(SRC_DIR, "..", "commands", "snapshot.ts"), "utf8");
 const PORTABLE_RESTORE_ADAPTER_SRC = readFileSync(
@@ -37,6 +38,7 @@ const ALLOWED_VERBS = new Set([
   // domain
   "boot",
   "restore",
+  "move",
   "exec",
   "snapshot",
   "fork",
@@ -159,7 +161,7 @@ describe("flag conventions", () => {
     // `fork` is a multi-step submit-and-attach where dry-run would
     //   need to short-circuit before the snapshot, which is the same
     //   thing as not running the command. Skipped intentionally.
-    const exceptions = new Set(["feedback", "fork"]);
+    const exceptions = new Set(["feedback", "fork", "move"]);
     for (const cmd of COMMANDS) {
       if (!cmd.mutating) {
         continue;
@@ -206,12 +208,19 @@ describe("flag conventions", () => {
   });
 });
 
-describe("cross-ISA proof routing stays off the public CLI surface", () => {
-  it("removes legacy portable restore adapter dispatch and does not expose move", () => {
+describe("move-only cross-ISA product route convention", () => {
+  it("keeps legacy portable restore adapter dispatch removed and exposes move as experimental", () => {
     expect(CLI_SRC).not.toContain("const pingPortableRestoreAdapter");
     expect(CLI_SRC).not.toContain("detectPortableRestoreAdapter(snapDir)");
-    expect(CLI_SRC).not.toContain('["move",');
-    expect(COMMANDS.some((cmd) => cmd.name === "move")).toBe(false);
+    expect(MOVE_COMMAND_SRC).toContain("function cmdMove(");
+    expect(MOVE_COMMAND_SRC).toContain("createMoveDescriptorInVm");
+    expect(MOVE_COMMAND_SRC).toContain("loadMoveDescriptor");
+    expect(MOVE_COMMAND_SRC).toContain("runMoveTargetDirectLoaderInVm");
+    expect(MOVE_COMMAND_SRC).toContain(
+      "move load input must be a bundle directory containing move.json",
+    );
+    expect(CLI_SRC).toContain('["move", cmdMove]');
+    expect(COMMANDS.find((cmd) => cmd.name === "move")?.summary).toMatch(/Experimental/);
     expect(PORTABLE_RESTORE_ADAPTER_SRC).toContain("PortableRestoreAdapter");
   });
 });

--- a/packages/cli/src/__tests__/move-executable-identity.test.ts
+++ b/packages/cli/src/__tests__/move-executable-identity.test.ts
@@ -1,0 +1,98 @@
+import type { MoveDescriptor, VmHandle } from "@machinen/runtime";
+import { describe, expect, it } from "vitest";
+
+import { validateMoveLoadTargetInVm } from "../move-executable-identity.ts";
+
+const descriptor: MoveDescriptor = {
+  formatVersion: 1,
+  kind: "machinen.move.descriptor",
+  rootPid: 71,
+  scannedAt: "2026-06-08T00:00:00.000Z",
+  nodes: [],
+  edges: [],
+  translatedStateClasses: ["process-identity", "argv-env-cwd"],
+  refusedStateClasses: [],
+  target: "cross-isa-target-native-pid-translation",
+  productSurface: "machinen move",
+  resourcePlan: {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    resources: [],
+    fdTableEntries: [],
+    targetGuestResources: [],
+    refusals: [],
+    acceptedSubsets: [],
+    capture: {
+      sourceVm: { pid: 100, name: "source" },
+      executablePackage: {
+        path: "/usr/bin/ping",
+        realPath: "/usr/bin/ping",
+        packageName: "iputils-ping",
+        version: "3:20221126-1+deb12u1",
+        architecture: "arm64",
+      },
+    },
+  },
+};
+
+describe("move executable identity validation", () => {
+  it("accepts path/package/version parity on a distinct target VM", async () => {
+    const vm = mockVm(
+      200,
+      "PKG\tiputils-ping\t3:20221126-1+deb12u1\tamd64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation).toMatchObject({ state: "ready", refusals: [] });
+  });
+
+  it("refuses loading back into the same local VM", async () => {
+    const vm = mockVm(
+      100,
+      "PKG\tiputils-ping\t3:20221126-1+deb12u1\tarm64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation.refusals).toContainEqual(
+      expect.objectContaining({ code: "target-process-context-unsupported" }),
+    );
+  });
+
+  it("refuses target package version mismatch before native resume", async () => {
+    const vm = mockVm(
+      200,
+      "PKG\tiputils-ping\t3:older\tamd64\nEXE\t/usr/bin/ping\t/usr/bin/ping\n",
+    );
+
+    const validation = await validateMoveLoadTargetInVm(vm, descriptor, "/usr/bin/ping");
+
+    expect(validation.refusals).toContainEqual(
+      expect.objectContaining({
+        code: "target-build-mismatch",
+        detail: expect.objectContaining({ failure: "version" }),
+      }),
+    );
+  });
+});
+
+function mockVm(pid: number, stdout: string): VmHandle {
+  return {
+    pid,
+    stdin: undefined,
+    stdout: undefined,
+    stderr: undefined,
+    wait: undefined,
+    kill: undefined,
+    detach: undefined,
+    output: undefined,
+    errorOutput: undefined,
+    exec: undefined,
+    execRaw: async () => ({ exitCode: 0, stdout, stderr: "" }),
+    execPty: undefined,
+    writeFile: undefined,
+    snapshot: undefined,
+    memory: undefined,
+  } as unknown as VmHandle;
+}

--- a/packages/cli/src/__tests__/move-rendezvous.test.ts
+++ b/packages/cli/src/__tests__/move-rendezvous.test.ts
@@ -1,0 +1,98 @@
+import type { MoveDescriptor, VmHandle } from "@machinen/runtime";
+import { describe, expect, it } from "vitest";
+
+import { runMoveTargetDirectLoaderInVm } from "../move-rendezvous.ts";
+
+const descriptor: MoveDescriptor = {
+  formatVersion: 1,
+  kind: "machinen.move.descriptor",
+  rootPid: 71,
+  scannedAt: "2026-06-08T00:00:00.000Z",
+  nodes: [
+    {
+      pid: 71,
+      ppid: 1,
+      command: "ping",
+      argv: ["ping", "google.com"],
+      cwd: "/",
+      exe: "/usr/bin/ping",
+    },
+  ],
+  edges: [],
+  translatedStateClasses: ["process-identity", "argv-env-cwd"],
+  refusedStateClasses: [],
+  target: "cross-isa-target-native-pid-translation",
+  productSurface: "machinen move",
+  resourcePlan: {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    resources: [],
+    fdTableEntries: [],
+    targetGuestResources: [],
+    refusals: [],
+    acceptedSubsets: [],
+    capture: { pingState: { ntransmitted: 4, nreceived: 4, nerrors: 0, lastSequence: 4 } },
+  },
+};
+
+describe("move target direct loader", () => {
+  it("launches original target ping and accepts a frozen pre-send capture", async () => {
+    const commands: string[] = [];
+    const vm = mockVm(
+      commands,
+      [
+        "LOAD_PID\t321",
+        "LOAD_LOG\t/tmp/machinen-move-loader.log",
+        "UNAME\tx86_64",
+        "SAFE_BOUNDARY\tpre-send-icmp\tsendto",
+        "FREEZE\tptrace-attached\tstatus:4991",
+        "REG_AMD64\t0x1\t0x2\t0x3\t0x4\t0x5\t0x6\t0x7\t0x8\t0x9\t0xa\t0xb\t0xc\t0xd\t0xe\t0xf\t0x10\t0x11\t0x12\t0x13\t0x14",
+        "PATCH\tping-rts\t0x1000\t4\t4\t0",
+        "PATCH\tping-send-buffer\tready\t0x2000\t64\t5",
+      ].join("\n"),
+    );
+
+    const loader = await runMoveTargetDirectLoaderInVm(vm, descriptor);
+
+    expect(commands[0]).toContain("--load-ping-state 4 4 0");
+    expect(commands[0]).toContain("/usr/bin/ping");
+    expect(commands[0]).toContain("google.com");
+    expect(loader).toMatchObject({
+      state: "ready",
+      strategy: "target-original-ping-direct-loader",
+      targetPid: 321,
+      refusals: [],
+    });
+  });
+
+  it("refuses when target ping does not reach the direct-loader boundary", async () => {
+    const vm = mockVm([], "LOAD_PID\t321\nSAFE_BOUNDARY\trefused\ttimeout\n");
+
+    const loader = await runMoveTargetDirectLoaderInVm(vm, descriptor);
+
+    expect(loader.refusals).toContainEqual(expect.objectContaining({ code: "active-syscall" }));
+  });
+});
+
+function mockVm(commands: string[], stdout: string): VmHandle {
+  return {
+    pid: 200,
+    stdin: undefined,
+    stdout: undefined,
+    stderr: undefined,
+    wait: undefined,
+    kill: undefined,
+    detach: undefined,
+    output: undefined,
+    errorOutput: undefined,
+    exec: undefined,
+    execRaw: async (cmd: string) => {
+      commands.push(cmd);
+      return { exitCode: 0, stdout, stderr: "" };
+    },
+    execPty: undefined,
+    writeFile: undefined,
+    snapshot: undefined,
+    memory: undefined,
+  } as unknown as VmHandle;
+}

--- a/packages/cli/src/__tests__/move-resource-plan.test.ts
+++ b/packages/cli/src/__tests__/move-resource-plan.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMoveResourcePlan, parseGuestMoveResourceScan } from "../move-resource-plan.ts";
+
+const pingNode = {
+  pid: 71,
+  ppid: 70,
+  command: "ping",
+  argv: ["ping", "127.0.0.1"],
+  cwd: "/root",
+};
+
+describe("move resource plan", () => {
+  it("captures ping socket procfs evidence before refusing missing sequence state", () => {
+    const scan = parseGuestMoveResourceScan(
+      [
+        "AGENT\tmachinen-move-capture-v1",
+        "STATUS\t1000\t1000",
+        "PING_RANGE\t0\t2147483647",
+        "FD\t59\tsocket:[12345]",
+        "FDINFO\t59\tflags:\t02",
+        "NET_ICMP\t0: 0100007F:4D50 0100007F:0000 07 00000000:00000000 00:00000000 00000000 1000 0 12345",
+      ].join("\n"),
+    );
+
+    const plan = buildMoveResourcePlan(pingNode, scan);
+
+    expect(plan.resources).toContainEqual(
+      expect.objectContaining({
+        kind: "socket",
+        recipe: expect.objectContaining({
+          pingSocketModel: "loopback-echo-v1",
+          destination: "127.0.0.1",
+          identifier: 0x4d50,
+          uid: 1000,
+          gid: 1000,
+        }),
+      }),
+    );
+    expect(plan.refusals).toContainEqual(
+      expect.objectContaining({ code: "target-socket-syscall-state-unsupported" }),
+    );
+    expect(plan.acceptedSubsets).toEqual([]);
+  });
+
+  it("captures external ping sockets but refuses until sequence state is translated", () => {
+    const scan = parseGuestMoveResourceScan(
+      [
+        "STATUS\t0\t0",
+        "PING_RANGE\t0\t2147483647",
+        "FD\t3\tsocket:[99]",
+        "FDINFO\t3\tflags:\t02",
+        "NET_ICMP\t0: 0A00020F:4D50 08080808:0000 07 00000000:00000000 00:00000000 00000000 0 0 99",
+      ].join("\n"),
+    );
+
+    const plan = buildMoveResourcePlan({ ...pingNode, argv: ["ping", "google.com"] }, scan);
+
+    expect(plan.resources).toContainEqual(
+      expect.objectContaining({
+        kind: "socket",
+        recipe: expect.objectContaining({
+          pingSocketModel: "external-target-egress-v1",
+          destination: "8.8.8.8",
+          networkNamespace: "target-network",
+          route: "target-egress",
+        }),
+      }),
+    );
+    expect(plan.refusals).toContainEqual(
+      expect.objectContaining({
+        code: "non-stdio-kernel-state-unsupported",
+        detail: expect.objectContaining({ kind: "socket", fd: 3 }),
+      }),
+    );
+  });
+});

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -122,6 +122,41 @@ export const COMMANDS: CommandSpec[] = [
     jsonEnvelope: '{"schema_version": 1, "pid": <int>, "name": <string|null>, "detached": <bool>}',
   },
   {
+    name: "move",
+    summary: "Experimental cross-ISA descriptor path for narrow, fail-closed process subsets.",
+    jsonOutput: true,
+    mutating: true,
+    positionals: [
+      { name: "subcommand", description: "scan, save, or load." },
+      {
+        name: "target",
+        required: false,
+        description: "The source or target VM name/pid for the move subcommand.",
+      },
+      { name: "pid", required: false, description: "Guest PID for move save." },
+      {
+        name: "bundle-dir",
+        required: false,
+        description: "Output bundle directory for save or input bundle directory for load.",
+      },
+    ],
+    flags: [
+      {
+        name: "--issue",
+        type: "boolean",
+        description: "Include a redacted issue report for refusals.",
+      },
+      {
+        name: "--issue-repo",
+        type: "string",
+        description: "GitHub repository for the issue report.",
+      },
+      { name: "--json", type: "boolean", description: "Emit move graph/descriptors as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "accepted": <bool>, "bundlePath": <string>, "descriptorPath": <string>, "descriptor": {...}}',
+  },
+  {
     name: "restore",
     summary: "Restore a VM from a snapshot bundle.",
     jsonOutput: false,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { cmdExec } from "./commands/exec.ts";
 import { cmdFork } from "./commands/fork.ts";
 import { cmdInstall } from "./commands/install.ts";
 import { cmdAgentContext, cmdCompletion, cmdFeedback } from "./commands/misc.ts";
+import { cmdMove } from "./commands/move.ts";
 import { cmdGc, cmdLs } from "./commands/registry.ts";
 import { cmdRestore } from "./commands/restore.ts";
 import { cmdSnapshot } from "./commands/snapshot.ts";
@@ -41,6 +42,7 @@ type CommandHandler = (args: string[]) => number | Promise<number>;
 
 const COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ["boot", cmdBoot],
+  ["move", cmdMove],
   ["restore", cmdRestore],
   ["install", cmdInstall],
   ["list", cmdLs],

--- a/packages/cli/src/commands/misc.ts
+++ b/packages/cli/src/commands/misc.ts
@@ -158,7 +158,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion --version --help -h -v"
+  local cmds="boot move restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -186,7 +186,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion)
+  cmds=(boot move restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -212,7 +212,7 @@ compdef _machinen machinen mn
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion
+set -l cmds boot move restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion
 for bin in machinen mn
   complete -c $bin -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
   for sub in exec snapshot fork attach sessions session-kill repl stop

--- a/packages/cli/src/commands/move.ts
+++ b/packages/cli/src/commands/move.ts
@@ -1,0 +1,756 @@
+import {
+  attach,
+  loadMoveDescriptor,
+  MOVE_DESCRIPTOR_FORMAT_VERSION,
+  MOVE_REFUSAL_CODE,
+  type MoveDescriptor,
+  type MovePidGraph,
+  type MovePidGraphNode,
+  type MoveRefusalEvidence,
+  type VmHandle,
+} from "@machinen/runtime";
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+import { consumeJsonFlag } from "../args.ts";
+import {
+  readMoveExecutableIdentityInVm,
+  validateMoveLoadTargetInVm,
+  type MoveLoadTargetValidation,
+} from "../move-executable-identity.ts";
+import { buildMoveResourcePlan, parseGuestMoveResourceScan } from "../move-resource-plan.ts";
+import { runMoveTargetDirectLoaderInVm, type MoveLoadDirectLoader } from "../move-rendezvous.ts";
+import { die, handleError } from "../errors.ts";
+import type { Target } from "../parse-target.ts";
+import { parseTargetFlags, resolveTarget } from "./target.ts";
+
+type MoveHandler = (args: string[], json: boolean) => Promise<number> | number;
+type MoveResourcePlan = NonNullable<MoveDescriptor["resourcePlan"]>;
+type MoveResourceRefusal = MoveResourcePlan["refusals"][number];
+
+const MOVE_HANDLERS = new Map<string, MoveHandler>([
+  ["scan", cmdMoveScan],
+  ["save", cmdMoveSave],
+  ["load", cmdMoveLoad],
+]);
+
+export function cmdMove(args: string[]): Promise<number> | number {
+  const { json, rest } = consumeJsonFlag(args);
+  const handler = MOVE_HANDLERS.get(rest[0] ?? "");
+  if (!handler) {
+    die(moveUsage());
+  }
+  return handler(rest.slice(1), json);
+}
+
+async function cmdMoveScan(args: string[], json: boolean): Promise<number> {
+  const target = parseTargetFlags(args, "move scan");
+  return withMoveVm(target, async (vm) => {
+    const graph = await scanMovePidGraphInVm(vm);
+    if (json) {
+      emitJson({ schema_version: 1, ...graph });
+    } else {
+      process.stdout.write(
+        `move scan: ${graph.nodes.length} in-VM processes; refused=${graph.refusedStateClasses.length}\n`,
+      );
+    }
+    return graph.refusedStateClasses.length === 0 ? 0 : 1;
+  });
+}
+
+async function cmdMoveSave(args: string[], json: boolean): Promise<number> {
+  const options = parseMoveSaveArgs(args);
+  return withMoveVm(options.target, async (vm) => {
+    const descriptor = await createMoveDescriptorInVm(vm, options.pid);
+    const result = writeMoveDescriptorResult(descriptor, options);
+    reportMoveSaveResult(result, json);
+    return moveAcceptedExitCode(result.accepted);
+  });
+}
+
+type MoveSaveOptions = {
+  target: Target;
+  pid: number;
+  outPath: string;
+  issue: boolean;
+  issueRepo?: string;
+};
+
+type MoveSaveResult = {
+  accepted: boolean;
+  bundlePath: string;
+  descriptorPath: string;
+  descriptor: MoveDescriptor;
+  refusalCode?: typeof MOVE_REFUSAL_CODE;
+  issueReport?: MoveIssueReport;
+};
+
+type MoveIssueReport = {
+  title: string;
+  body: string;
+  repository: string;
+};
+
+function parseMoveSaveArgs(args: string[]): MoveSaveOptions {
+  const { target, rest } = resolveTarget(args, "move save");
+  if (rest.length < 2) {
+    die(moveUsage());
+  }
+  const { issue, issueRepo } = parseMoveSaveFlags(rest.slice(2));
+  return {
+    target,
+    pid: parsePositiveInteger(rest[0]!, "pid"),
+    outPath: rest[1]!,
+    issue,
+    issueRepo,
+  };
+}
+
+function parseMoveSaveFlags(args: string[]): { issue: boolean; issueRepo?: string } {
+  let flags = newMoveSaveFlags();
+  for (let index = 0; index < args.length; index += 1) {
+    const parsed = parseMoveSaveFlag(args, index, flags);
+    flags = parsed.flags;
+    index = parsed.index;
+  }
+  return flags;
+}
+
+function newMoveSaveFlags(): { issue: boolean; issueRepo?: string } {
+  return { issue: false };
+}
+
+function parseMoveSaveFlag(
+  args: string[],
+  index: number,
+  flags: { issue: boolean; issueRepo?: string },
+): { index: number; flags: { issue: boolean; issueRepo?: string } } {
+  const arg = args[index]!;
+  if (arg === "--issue") {
+    return { index, flags: { ...flags, issue: true } };
+  }
+  if (arg !== "--issue-repo") {
+    die(`unknown argument: ${arg}`);
+  }
+  return parseMoveSaveIssueRepoFlag(args, index, flags);
+}
+
+function parseMoveSaveIssueRepoFlag(
+  args: string[],
+  index: number,
+  flags: { issue: boolean; issueRepo?: string },
+): { index: number; flags: { issue: boolean; issueRepo?: string } } {
+  const issueRepo = args[index + 1];
+  if (!issueRepo) {
+    die("move save --issue-repo requires <owner/repo>");
+  }
+  return { index: index + 1, flags: { ...flags, issueRepo } };
+}
+
+function writeMoveDescriptorResult(
+  descriptor: MoveDescriptor,
+  options: MoveSaveOptions,
+): MoveSaveResult {
+  const bundlePath = prepareMoveBundleDir(options.outPath);
+  const descriptorPath = join(bundlePath, "move.json");
+  writeFileSync(descriptorPath, `${JSON.stringify(descriptor, null, 2)}\n`);
+  const accepted = descriptor.refusedStateClasses.length === 0;
+  return {
+    accepted,
+    bundlePath,
+    descriptorPath,
+    descriptor,
+    refusalCode: moveRefusalCode(accepted),
+    issueReport: moveIssueReport(descriptor, options),
+  };
+}
+
+function prepareMoveBundleDir(outPath: string): string {
+  const bundlePath = resolve(outPath);
+  if (existsSync(bundlePath) && !statSync(bundlePath).isDirectory()) {
+    die("move save output must be a directory");
+  }
+  mkdirSync(bundlePath, { recursive: true });
+  return bundlePath;
+}
+
+function moveRefusalCode(accepted: boolean): typeof MOVE_REFUSAL_CODE | undefined {
+  return accepted ? undefined : MOVE_REFUSAL_CODE;
+}
+
+function moveIssueReport(
+  descriptor: MoveDescriptor,
+  options: MoveSaveOptions,
+): MoveIssueReport | undefined {
+  if (!options.issue) {
+    return undefined;
+  }
+  return buildMoveIssueReport(descriptor, options.issueRepo ?? "redwoodjs/machinen");
+}
+
+function moveAcceptedExitCode(accepted: boolean): 0 | 1 {
+  return accepted ? 0 : 1;
+}
+
+function reportMoveSaveResult(result: MoveSaveResult, json: boolean): void {
+  if (json) {
+    emitJson({ schema_version: 1, ...result });
+    return;
+  }
+  process.stdout.write(
+    `${result.accepted ? "saved" : "refused"} move descriptor: ${result.descriptorPath}\n`,
+  );
+  printIssueReport(result);
+}
+
+function printIssueReport(result: MoveSaveResult): void {
+  if (!result.issueReport) {
+    return;
+  }
+  process.stdout.write(
+    `issue report: ${result.issueReport.repository}\n${result.issueReport.body}\n`,
+  );
+}
+
+async function cmdMoveLoad(args: string[], json: boolean): Promise<number> {
+  const { target, rest } = resolveTarget(args, "move load");
+  if (rest.length !== 1) {
+    die(moveUsage());
+  }
+  const bundlePath = resolve(rest[0]!);
+  if (!moveBundleValid(bundlePath)) {
+    die("move load input must be a bundle directory containing move.json");
+  }
+  return withMoveVm(target, async (vm) => {
+    const descriptor = loadMoveDescriptor(join(bundlePath, "move.json"));
+    const targetValidation = await validateMoveLoadTargetInVm(
+      vm,
+      descriptor,
+      moveLoadExecutablePath(descriptor),
+    );
+    const loader =
+      targetValidation.state === "ready"
+        ? await runMoveTargetDirectLoaderInVm(vm, descriptor)
+        : undefined;
+    const accepted = moveLoadAccepted(descriptor, bundlePath, targetValidation, loader);
+    reportMoveLoadResult(descriptor, accepted, json, targetValidation, loader);
+    return accepted ? 0 : 1;
+  });
+}
+
+function moveLoadAccepted(
+  descriptor: MoveDescriptor,
+  bundlePath: string,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): boolean {
+  return moveLoadGates(descriptor, bundlePath, targetValidation, loader).every(Boolean);
+}
+
+function moveLoadGates(
+  descriptor: MoveDescriptor,
+  bundlePath: string,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): boolean[] {
+  return [
+    moveBundleValid(bundlePath),
+    moveDescriptorContinuationPlanned(descriptor),
+    targetValidation.state === "ready",
+    loader?.state === "ready" || false,
+  ];
+}
+
+function moveLoadExecutablePath(descriptor: MoveDescriptor): string {
+  return savedExecutablePath(descriptor) ?? descriptorExecutablePath(descriptor) ?? "/usr/bin/ping";
+}
+
+function savedExecutablePath(descriptor: MoveDescriptor): string | undefined {
+  return descriptor.resourcePlan?.capture?.executablePackage?.path;
+}
+
+function descriptorExecutablePath(descriptor: MoveDescriptor): string | undefined {
+  return descriptor.nodes[0]?.exe;
+}
+
+function moveBundleValid(bundlePath: string): boolean {
+  if (!existsSync(bundlePath)) {
+    return false;
+  }
+  if (!statSync(bundlePath).isDirectory()) {
+    return false;
+  }
+  return existsSync(join(bundlePath, "move.json"));
+}
+
+function moveDescriptorContinuationPlanned(descriptor: MoveDescriptor): boolean {
+  return descriptor.refusedStateClasses.length === 0;
+}
+
+function reportMoveLoadResult(
+  descriptor: MoveDescriptor,
+  accepted: boolean,
+  json: boolean,
+  targetValidation: MoveLoadTargetValidation,
+  loader: MoveLoadDirectLoader | undefined,
+): void {
+  if (json) {
+    emitJson({
+      schema_version: 1,
+      accepted,
+      descriptor,
+      targetValidation,
+      loader,
+      rendezvous: loader,
+    });
+    return;
+  }
+  if (accepted) {
+    process.stdout.write(`move load accepted descriptor for in-VM PID ${descriptor.rootPid}\n`);
+    return;
+  }
+  process.stderr.write(
+    `move load refused descriptor for in-VM PID ${descriptor.rootPid}: ${refusedStateClasses(descriptor)}\n`,
+  );
+}
+
+function refusedStateClasses(descriptor: MoveDescriptor): string {
+  return descriptor.refusedStateClasses.map((item) => item.stateClass).join(", ");
+}
+
+async function withMoveVm<T>(target: Target, run: (vm: VmHandle) => Promise<T> | T): Promise<T> {
+  const vm = await attach(target).catch(handleError);
+  try {
+    return await run(vm);
+  } finally {
+    await vm.detach();
+  }
+}
+
+async function createMoveDescriptorInVm(vm: VmHandle, pid: number): Promise<MoveDescriptor> {
+  const nodes = await readMoveProcNodesInVm(vm, pid);
+  const resourcePlan = await scanMoveResourcePlanInVm(vm, nodes[0]!);
+  await attachMoveSourceIdentity(vm, nodes[0]!, resourcePlan);
+  const graph = buildMovePidGraph(pid, nodes, resourcePlan);
+  return {
+    ...graph,
+    kind: "machinen.move.descriptor",
+    target: "cross-isa-target-native-pid-translation",
+    productSurface: "machinen move",
+    resourcePlan,
+  };
+}
+
+async function attachMoveSourceIdentity(
+  vm: VmHandle,
+  node: MovePidGraphNode,
+  resourcePlan: MoveResourcePlan,
+): Promise<void> {
+  resourcePlan.capture = {
+    ...resourcePlan.capture,
+    sourceVm: { pid: vm.pid, name: vm.name },
+    executablePackage: await readMoveExecutableIdentityInVm(vm, node.exe ?? moveProcessPath(node)),
+    pingState: await readMovePingStateInVm(vm, resourcePlan),
+  };
+}
+
+async function readMovePingStateInVm(
+  vm: VmHandle,
+  resourcePlan: MoveResourcePlan,
+): Promise<NonNullable<MoveResourcePlan["capture"]>["pingState"]> {
+  const path = moveStdoutFilePath(resourcePlan);
+  if (!path) {
+    return undefined;
+  }
+  const result = await vm.execRaw(`tail -n 500 ${shellQuote(path)} 2>/dev/null || true`, {
+    execTimeoutMs: 10_000,
+  });
+  return parsePingStateFromOutput(result.stdout);
+}
+
+function moveStdoutFilePath(resourcePlan: MoveResourcePlan): string | undefined {
+  const stdout = resourcePlan.resources.find((resource) => resource.fd === 1);
+  return stdout?.kind === "file" && typeof stdout.path === "string" ? stdout.path : undefined;
+}
+
+function parsePingStateFromOutput(
+  stdout: string,
+): NonNullable<MoveResourcePlan["capture"]>["pingState"] {
+  const sequences = Array.from(stdout.matchAll(/icmp_seq=(\d+)/g), (match) => Number(match[1]));
+  const replies = stdout.split("\n").filter((line) => /bytes from .*icmp_seq=\d+/.test(line));
+  const errors = stdout.split("\n").filter((line) => /^From .*icmp_seq=\d+/.test(line));
+  const lastSequence = sequences.at(-1);
+  if (!lastSequence) {
+    return undefined;
+  }
+  return {
+    ntransmitted: lastSequence,
+    nreceived: replies.length,
+    nerrors: errors.length,
+    lastSequence,
+  };
+}
+
+function moveProcessPath(node: MovePidGraphNode): string {
+  return node.argv[0]?.startsWith("/") ? node.argv[0]! : `/usr/bin/${node.command}`;
+}
+
+async function scanMovePidGraphInVm(vm: VmHandle, rootPid?: number): Promise<MovePidGraph> {
+  const nodes = await readMoveProcNodesInVm(vm, rootPid);
+  return buildMovePidGraph(rootPid, nodes);
+}
+
+function buildMovePidGraph(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+  resourcePlan?: MoveResourcePlan,
+): MovePidGraph {
+  return {
+    formatVersion: MOVE_DESCRIPTOR_FORMAT_VERSION,
+    kind: "machinen.move.pid-graph",
+    rootPid,
+    scannedAt: new Date().toISOString(),
+    nodes,
+    edges: movePidGraphEdges(nodes),
+    translatedStateClasses: translatedStateClasses(resourcePlan),
+    refusedStateClasses: buildRefusals(rootPid, nodes, resourcePlan),
+  };
+}
+
+function movePidGraphEdges(nodes: MovePidGraphNode[]): MovePidGraph["edges"] {
+  const pidSet = new Set(nodes.map((node) => node.pid));
+  return nodes
+    .filter((node) => node.ppid !== undefined && pidSet.has(node.ppid))
+    .map((node) => ({ fromPid: node.ppid!, toPid: node.pid, kind: "parent-child" as const }));
+}
+
+async function readMoveProcNodesInVm(vm: VmHandle, rootPid?: number): Promise<MovePidGraphNode[]> {
+  const result = await vm.execRaw(guestProcScanCommand(rootPid), { execTimeoutMs: 30_000 });
+  if (result.exitCode !== 0) {
+    die(`move proc scan failed inside VM: ${moveProcScanError(result)}`);
+  }
+  return parseGuestProcRows(result.stdout, rootPid);
+}
+
+function moveProcScanError(result: { stderr: string; stdout: string; exitCode: number }): string {
+  return result.stderr || result.stdout || String(result.exitCode);
+}
+
+async function scanMoveResourcePlanInVm(
+  vm: VmHandle,
+  node: MovePidGraphNode,
+): Promise<MoveResourcePlan> {
+  const result = await vm.execRaw(guestMoveResourceScanCommand(node.pid), {
+    execTimeoutMs: 30_000,
+  });
+  if (result.exitCode !== 0) {
+    die(`move resource scan failed inside VM: ${moveProcScanError(result)}`);
+  }
+  return buildMoveResourcePlan(node, parseGuestMoveResourceScan(result.stdout));
+}
+
+function guestMoveResourceScanCommand(pid: number): string {
+  return `pid=${pid}
+if [ -x /sbin/machinen-move-capture ]; then
+  exec /sbin/machinen-move-capture "$pid" --timeout-ms 10000
+fi
+printf 'UNAME\t%s\n' "$(uname -m 2>/dev/null || true)"
+status="/proc/$pid/status"
+uid=""
+gid=""
+if [ -r "$status" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      Uid:*) set -- $line; uid="$2" ;;
+      Gid:*) set -- $line; gid="$2" ;;
+    esac
+  done < "$status"
+fi
+printf 'STATUS\t%s\t%s\n' "$uid" "$gid"
+if [ -r /proc/sys/net/ipv4/ping_group_range ]; then
+  set -- $(cat /proc/sys/net/ipv4/ping_group_range 2>/dev/null || true)
+  printf 'PING_RANGE\t%s\t%s\n' "$1" "$2"
+fi
+for f in /proc/$pid/fd/*; do
+  [ -e "$f" ] || continue
+  fd="\${f##*/}"
+  target=$(readlink "$f" 2>/dev/null || true)
+  printf 'FD\t%s\t%s\n' "$fd" "$target"
+  if [ -r "/proc/$pid/fdinfo/$fd" ]; then
+    while IFS= read -r line; do
+      case "$line" in
+        pos:*|flags:*) printf 'FDINFO\t%s\t%s\n' "$fd" "$line" ;;
+      esac
+    done < "/proc/$pid/fdinfo/$fd"
+  fi
+done
+if [ -r /proc/net/icmp ]; then
+  while IFS= read -r line; do printf 'NET_ICMP\t%s\n' "$line"; done < /proc/net/icmp
+fi
+if [ -r /proc/net/raw ]; then
+  while IFS= read -r line; do printf 'NET_RAW\t%s\n' "$line"; done < /proc/net/raw
+fi`;
+}
+
+function guestProcScanCommand(rootPid?: number): string {
+  const pidSelector =
+    rootPid === undefined
+      ? 'for d in /proc/[0-9]*; do scan_pid "${d##*/}"; done'
+      : `scan_pid ${rootPid}`;
+  return `scan_pid() {
+  pid="$1"
+  d="/proc/$pid"
+  [ -d "$d" ] || return 0
+  stat=$(cat "$d/stat" 2>/dev/null || true)
+  cmd=$(tr '\\000' '\\037' <"$d/cmdline" 2>/dev/null || true)
+  cwd=$(readlink "$d/cwd" 2>/dev/null || true)
+  exe=$(readlink "$d/exe" 2>/dev/null || true)
+  printf '%s	%s	%s	%s	%s\n' "$pid" "$stat" "$cmd" "$cwd" "$exe"
+}
+${pidSelector}`;
+}
+
+function parseGuestProcRows(stdout: string, rootPid?: number): MovePidGraphNode[] {
+  const nodes = stdout
+    .split("\n")
+    .filter(Boolean)
+    .slice(0, rootPid === undefined ? 250 : 1)
+    .map(parseGuestProcRow)
+    .filter((node): node is MovePidGraphNode => node !== undefined)
+    .sort((left, right) => left.pid - right.pid);
+  if (rootPid !== undefined && nodes.length === 0) {
+    die(`in-VM pid ${rootPid} was not found`);
+  }
+  return nodes;
+}
+
+function parseGuestProcRow(row: string): MovePidGraphNode | undefined {
+  const [pidText, stat = "", cmdline = "", cwd = "", exe = ""] = row.split("\t");
+  const pid = parseOptionalPositiveInteger(pidText ?? "");
+  if (pid === undefined) {
+    return undefined;
+  }
+  const argv = cmdline.split("\x1f").filter(Boolean);
+  const command = moveProcCommand(argv, stat, pid);
+  return {
+    pid,
+    ppid: parsePpid(stat),
+    command,
+    argv,
+    cwd: emptyToUndefined(cwd),
+    exe: emptyToUndefined(exe),
+  };
+}
+
+function moveProcCommand(argv: string[], stat: string, pid: number): string {
+  if (argv[0]) {
+    return basename(argv[0]);
+  }
+  return parseStatCommand(stat) ?? `pid-${pid}`;
+}
+
+function emptyToUndefined(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}
+
+function translatedStateClasses(
+  resourcePlan?: MoveResourcePlan,
+): MovePidGraph["translatedStateClasses"] {
+  const base: MovePidGraph["translatedStateClasses"] = ["process-identity", "argv-env-cwd"];
+  if (resourcePlan && resourcePlan.refusals.length === 0) {
+    return [...base, "open-files", "sockets"];
+  }
+  return base;
+}
+
+function buildRefusals(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+  resourcePlan?: MoveResourcePlan,
+): MoveRefusalEvidence[] {
+  if (rootPid === undefined || !resourcePlan) {
+    return genericMoveRefusals(rootPid, nodes);
+  }
+  return resourcePlanRefusals(rootPid, resourcePlan);
+}
+
+function genericMoveRefusals(
+  rootPid: number | undefined,
+  nodes: MovePidGraphNode[],
+): MoveRefusalEvidence[] {
+  return [
+    {
+      stateClass: "open-files",
+      reason: "open file descriptor identity is not translated by this descriptor yet",
+      evidence:
+        rootPid === undefined ? "scan-only-no-root-pid" : `pid:${rootPid}:fd-audit-required`,
+      nextAction:
+        "add a move-owned fd detector and target-native file/socket reconstruction implementation",
+    },
+    {
+      stateClass: "sockets",
+      reason:
+        "kernel socket identity is not preserved across ISA and must be reconstructed or refused",
+      evidence: `nodes:${nodes.length}:socket-audit-required`,
+      nextAction: "attach socket-family evidence and a target-native reconstruction verifier",
+    },
+  ];
+}
+
+function resourcePlanRefusals(
+  rootPid: number,
+  resourcePlan: MoveResourcePlan,
+): MoveRefusalEvidence[] {
+  const refusals = [
+    openFileResourceRefusal(resourcePlan),
+    socketResourceRefusal(resourcePlan),
+    threadResourceRefusal(resourcePlan),
+  ].filter((refusal): refusal is MoveRefusalEvidence => refusal !== undefined);
+  if (resourcePlan.refusals.length > 0 && refusals.length === 0) {
+    return genericMoveRefusals(rootPid, []);
+  }
+  return refusals;
+}
+
+function openFileResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isOpenFileMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "open-files",
+    reason: "one or more open file descriptors still lack a target-native recipe",
+    evidence: JSON.stringify(moveRefusalEvidenceSummary(resourcePlan, "open-files")),
+    nextAction:
+      "model or broker every inherited fd, including stdin/PTY state, before target execution",
+  };
+}
+
+function socketResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isSocketMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "sockets",
+    reason: "one or more socket descriptors still lack proven target-native reconstruction",
+    evidence: JSON.stringify(moveRefusalEvidenceSummary(resourcePlan, "sockets")),
+    nextAction:
+      "graduate the captured socket into a supported ping/raw-ICMP loopback descriptor or keep it refused",
+  };
+}
+
+function threadResourceRefusal(resourcePlan: MoveResourcePlan): MoveRefusalEvidence | undefined {
+  if (!resourcePlan.refusals.some(isThreadMoveRefusal)) {
+    return undefined;
+  }
+  return {
+    stateClass: "threads",
+    reason: "the process was not captured at the supported single-thread sleep/timer boundary",
+    evidence: JSON.stringify({ capture: resourcePlan.capture }),
+    nextAction:
+      "wait for the ping sleep/timer boundary and freeze the single thread before translation",
+  };
+}
+
+function isOpenFileMoveRefusal(refusal: MoveResourceRefusal): boolean {
+  return !isSocketMoveRefusal(refusal) && !isThreadMoveRefusal(refusal);
+}
+
+function isSocketMoveRefusal(refusal: MoveResourceRefusal): boolean {
+  const kind = refusal.detail?.kind;
+  return kind === "socket" || kind === "raw-socket";
+}
+
+function isThreadMoveRefusal(refusal: MoveResourceRefusal): boolean {
+  return refusal.detail?.kind === "thread";
+}
+
+function moveRefusalEvidenceSummary(
+  resourcePlan: MoveResourcePlan,
+  stateClass: "open-files" | "sockets",
+): Record<string, unknown> {
+  const predicate = stateClass === "sockets" ? isSocketMoveRefusal : isOpenFileMoveRefusal;
+  const refusals = resourcePlan.refusals.filter(predicate);
+  return {
+    resourceRefusals: refusals.map((refusal) => ({
+      code: refusal.code,
+      fd: refusal.detail?.fd,
+      kind: refusal.detail?.kind,
+      requiredModel: refusal.detail?.requiredModel,
+    })),
+    acceptedSubsets: resourcePlan.acceptedSubsets,
+  };
+}
+
+function buildMoveIssueReport(
+  descriptor: MoveDescriptor,
+  repository = "redwoodjs/machinen",
+): MoveIssueReport {
+  const stateClasses = descriptor.refusedStateClasses.map((item) => item.stateClass).join(", ");
+  const rootPid = moveDescriptorRootPidLabel(descriptor);
+  return {
+    repository,
+    title: `move refused in-VM PID ${rootPid}: ${moveStateClassLabel(stateClasses, "no refusals")}`,
+    body: [
+      "## Problem",
+      "`machinen move` refused this in-VM PID graph because some state classes are not proven yet.",
+      "",
+      "## Redacted evidence",
+      `- root pid: ${rootPid}`,
+      `- process count: ${descriptor.nodes.length}`,
+      `- refused classes: ${moveStateClassLabel(stateClasses, "none")}`,
+      "",
+      "## Next action",
+      ...descriptor.refusedStateClasses.map((item) => `- ${item.stateClass}: ${item.nextAction}`),
+    ].join("\n"),
+  };
+}
+
+function moveDescriptorRootPidLabel(descriptor: MoveDescriptor): string {
+  return descriptor.rootPid === undefined ? "unknown" : String(descriptor.rootPid);
+}
+
+function moveStateClassLabel(value: string, fallback: string): string {
+  return value === "" ? fallback : value;
+}
+
+function parseStatCommand(stat: string): string | undefined {
+  const match = stat.match(/^\d+\s+\((.*)\)\s+\S+/);
+  return match?.[1];
+}
+
+function parsePpid(stat: string): number | undefined {
+  const match = stat.match(/^\d+\s+\(.*\)\s+\S+\s+(\d+)/);
+  if (!match) {
+    return undefined;
+  }
+  const parsed = Number(match[1]);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function moveUsage(): string {
+  return "usage: machinen move scan <vm> [--json] | machinen move save <vm> <pid> <bundle-dir> [--issue] [--issue-repo <owner/repo>] [--json] | machinen move load <vm> <bundle-dir> [--json]";
+}
+
+function parseOptionalPositiveInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    die(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function emitJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -26,6 +26,12 @@ export function printHelp(): void {
       `                                                 when the host supports it.\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +
+      `  machinen move scan <vm> [--json]             Experimental: scan in-VM process state classes.\n` +
+      `  machinen move save <vm> <pid> <bundle-dir> [--issue]\n` +
+      `                                                 Write a fail-closed move descriptor bundle.\n` +
+      `  machinen move load <vm> <bundle-dir> [--json]\n` +
+      `                                                 Validate/load only explicitly supported subsets.\n` +
+      `\n` +
       `  machinen restore <snap-dir> [--image <tar.gz>] [--name <name>] [-p ...]\n` +
       `                              [--mount-live <host>:<guest>[:<mode>]]\n` +
       `                                                 Restore a VM from a snapshot bundle.\n` +
@@ -119,7 +125,7 @@ export function printHelp(): void {
       `  --json                                         Emit machine-readable JSON to stdout.\n` +
       `                                                 Supported on: list, gc, install,\n` +
       `                                                 snapshot, stop, fork --detach,\n` +
-      `                                                 boot --detach, feedback,\n` +
+      `                                                 boot --detach, move, feedback,\n` +
       `                                                 agent-context.\n` +
       `  --dry-run                                      Preview a mutating command without\n` +
       `                                                 side effects. Supported on: gc, stop,\n` +
@@ -138,6 +144,9 @@ export function printHelp(): void {
       `  machinen exec worker --tty -- vim /etc/passwd        # full-screen TUI in a PTY\n` +
       `  machinen snapshot worker ./warm                      # CRIU snapshot bundle\n` +
       `  machinen restore ./warm\n` +
+      `  machinen move scan worker --json\n` +
+      `  machinen move save worker 1234 ./worker-move --issue\n` +
+      `  machinen move load worker-target ./worker-move --json\n` +
       `\n` +
       `Environment:\n` +
       `  MACHINEN_VMM                             Override the VMM binary path (dev)\n` +

--- a/packages/cli/src/move-executable-identity.ts
+++ b/packages/cli/src/move-executable-identity.ts
@@ -1,0 +1,132 @@
+import type { MoveDescriptor, MoveProcessRefusal, VmHandle } from "@machinen/runtime";
+
+type MoveExecutablePackageIdentity = NonNullable<
+  NonNullable<MoveDescriptor["resourcePlan"]>["capture"]
+>["executablePackage"] extends infer Identity
+  ? NonNullable<Identity>
+  : never;
+
+export interface MoveLoadTargetValidation {
+  state: "ready" | "refused";
+  source?: MoveExecutablePackageIdentity;
+  target?: MoveExecutablePackageIdentity;
+  refusals: MoveProcessRefusal[];
+}
+
+export async function readMoveExecutableIdentityInVm(
+  vm: VmHandle,
+  path: string,
+): Promise<MoveExecutablePackageIdentity> {
+  const result = await vm.execRaw(moveExecutableIdentityCommand(path), { execTimeoutMs: 10_000 });
+  if (result.exitCode !== 0) {
+    return { path };
+  }
+  return parseMoveExecutableIdentity(result.stdout, path);
+}
+
+export async function validateMoveLoadTargetInVm(
+  vm: VmHandle,
+  descriptor: MoveDescriptor,
+  exePath: string,
+): Promise<MoveLoadTargetValidation> {
+  const source = descriptor.resourcePlan?.capture?.executablePackage;
+  const target = await readMoveExecutableIdentityInVm(vm, exePath);
+  const refusals = [
+    sameVmRefusal(vm, descriptor),
+    ...moveExecutableIdentityRefusals(source, target),
+  ].filter((refusal): refusal is MoveProcessRefusal => refusal !== undefined);
+  return { state: refusals.length === 0 ? "ready" : "refused", source, target, refusals };
+}
+
+function moveExecutableIdentityCommand(path: string): string {
+  const quoted = shellQuote(path);
+  return `set -eu
+path=${quoted}
+real=$(readlink -f "$path" 2>/dev/null || printf %s "$path")
+pkg=""
+for candidate in "$path" "$real" "/bin/\${path##*/}" "/usr/bin/\${path##*/}"; do
+  [ -n "$pkg" ] && break
+  pkg=$(dpkg-query -S "$candidate" 2>/dev/null | head -n1 | cut -d: -f1 || true)
+done
+if [ -n "$pkg" ]; then
+  dpkg-query -W -f 'PKG\t\${Package}\t\${Version}\t\${Architecture}\n' "$pkg" 2>/dev/null || true
+fi
+printf 'EXE\t%s\t%s\n' "$path" "$real"`;
+}
+
+function parseMoveExecutableIdentity(
+  stdout: string,
+  fallbackPath: string,
+): MoveExecutablePackageIdentity {
+  const identity: MoveExecutablePackageIdentity = { path: fallbackPath };
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    const parts = row.split("\t");
+    if (parts[0] === "PKG") {
+      identity.packageName = emptyToUndefined(parts[1] ?? "");
+      identity.version = emptyToUndefined(parts[2] ?? "");
+      identity.architecture = emptyToUndefined(parts[3] ?? "");
+    }
+    if (parts[0] === "EXE") {
+      identity.path = parts[1] || fallbackPath;
+      identity.realPath = emptyToUndefined(parts[2] ?? "");
+    }
+  }
+  return identity;
+}
+
+function sameVmRefusal(vm: VmHandle, descriptor: MoveDescriptor): MoveProcessRefusal | undefined {
+  if (descriptor.resourcePlan?.capture?.sourceVm?.pid !== vm.pid) {
+    return undefined;
+  }
+  return {
+    code: "target-process-context-unsupported",
+    message: "move load target is the same local VM that produced the save bundle",
+    detail: { sourceVmPid: vm.pid, boundary: "same-local-vm-load" },
+  };
+}
+
+function moveExecutableIdentityRefusals(
+  source: MoveExecutablePackageIdentity | undefined,
+  target: MoveExecutablePackageIdentity,
+): MoveProcessRefusal[] {
+  if (!source?.packageName || !source.version) {
+    return [
+      {
+        code: "target-build-mismatch",
+        message: "source executable package identity was not captured",
+        detail: { source, target, boundary: "executable-package-identity" },
+      },
+    ];
+  }
+  const failures = executableIdentityFailures(source, target);
+  return failures.map((failure) => ({
+    code: "target-build-mismatch",
+    message: `target executable ${failure} does not match source`,
+    detail: { source, target, boundary: "executable-package-identity", failure },
+  }));
+}
+
+function executableIdentityFailures(
+  source: MoveExecutablePackageIdentity,
+  target: MoveExecutablePackageIdentity,
+): string[] {
+  const failures: string[] = [];
+  if (target.path !== source.path) {
+    failures.push("path");
+  }
+  if (target.packageName !== source.packageName) {
+    failures.push("package");
+  }
+  if (target.version !== source.version) {
+    failures.push("version");
+  }
+  return failures;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function emptyToUndefined(value: string): string | undefined {
+  return value === "" ? undefined : value;
+}

--- a/packages/cli/src/move-rendezvous.ts
+++ b/packages/cli/src/move-rendezvous.ts
@@ -1,0 +1,231 @@
+import type { MoveDescriptor, MoveProcessRefusal, VmHandle } from "@machinen/runtime";
+
+import { parseGuestMoveResourceScan } from "./move-resource-plan.ts";
+
+export interface MoveLoadDirectLoader {
+  state: "ready" | "refused";
+  strategy: "target-original-ping-direct-loader";
+  executable: string;
+  argv: string[];
+  targetPid?: number;
+  logPath?: string;
+  capture?: unknown;
+  patch?: { state: "ready" | "refused"; stdout: string; stderr: string; exitCode: number };
+  refusals: MoveProcessRefusal[];
+}
+
+export async function runMoveTargetDirectLoaderInVm(
+  vm: VmHandle,
+  descriptor: MoveDescriptor,
+): Promise<MoveLoadDirectLoader> {
+  const executable = moveRendezvousExecutable(descriptor);
+  const argv = moveRendezvousArgv(descriptor, executable);
+  const command = moveRendezvousCommand(executable, argv.slice(1), descriptor);
+  const result = await vm.execRaw(command, { execTimeoutMs: 30_000 });
+  const parsed = parseRendezvousOutput(result.stdout);
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    return loaderRefused(executable, argv, parsed, {
+      code: "target-process-context-unsupported",
+      message: "target ping direct loader failed before a capture was produced",
+      detail: { exitCode: result.exitCode, stderr: result.stderr, stdout: result.stdout },
+    });
+  }
+  const capture = parseGuestMoveResourceScan(parsed.captureRows.join("\n"));
+  const patch = moveRendezvousPatchFromOutput(result);
+  const refusals = [...moveRendezvousRefusals(capture), ...movePatchRefusals(patch)];
+  if (refusals.length > 0 && parsed.pid) {
+    await vm.execRaw(`kill -TERM ${parsed.pid} 2>/dev/null || true`, { execTimeoutMs: 5_000 });
+  }
+  return {
+    state: refusals.length === 0 ? "ready" : "refused",
+    strategy: "target-original-ping-direct-loader",
+    executable,
+    argv,
+    targetPid: parsed.pid,
+    logPath: parsed.logPath,
+    capture,
+    patch,
+    refusals,
+  };
+}
+
+function moveRendezvousExecutable(descriptor: MoveDescriptor): string {
+  return (
+    descriptor.resourcePlan?.capture?.executablePackage?.path ??
+    descriptor.nodes[0]?.exe ??
+    "/usr/bin/ping"
+  );
+}
+
+function moveRendezvousArgv(descriptor: MoveDescriptor, executable: string): string[] {
+  const argv = descriptor.nodes[0]?.argv ?? [];
+  if (argv.length === 0) {
+    return [executable];
+  }
+  return [executable, ...argv.slice(1)];
+}
+
+function moveRendezvousCommand(
+  executable: string,
+  args: string[],
+  descriptor: MoveDescriptor,
+): string {
+  const pingState = descriptor.resourcePlan?.capture?.pingState;
+  if (!pingState) {
+    return "printf 'SAFE_BOUNDARY\\trefused\\tsource-ping-state-missing\\n'; exit 2";
+  }
+  const quotedExecutable = shellQuote(executable);
+  const quotedArgs = args.map(shellQuote).join(" ");
+  return `set -eu
+log="/tmp/machinen-move-loader-$$.log"
+if [ -x /sbin/machinen-move-capture ]; then
+  /sbin/machinen-move-capture --load-ping-state ${pingState.ntransmitted} ${pingState.nreceived} ${pingState.nerrors} --log "$log" -- ${quotedExecutable}${quotedArgs ? ` ${quotedArgs}` : ""}
+else
+  printf 'SAFE_BOUNDARY\trefused\tmissing-move-capture-agent\n'
+fi`;
+}
+
+function parseRendezvousOutput(stdout: string): {
+  pid?: number;
+  logPath?: string;
+  captureRows: string[];
+} {
+  const captureRows: string[] = [];
+  let pid: number | undefined;
+  let logPath: string | undefined;
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    const parts = row.split("\t");
+    if (parts[0] === "RENDEZVOUS_PID" || parts[0] === "LOAD_PID") {
+      pid = parsePositiveInteger(parts[1] ?? "");
+    } else if (parts[0] === "RENDEZVOUS_LOG" || parts[0] === "LOAD_LOG") {
+      logPath = parts[1];
+    } else {
+      captureRows.push(row);
+    }
+  }
+  return { pid, logPath, captureRows };
+}
+
+function moveRendezvousPatchFromOutput(result: {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}): MoveLoadDirectLoader["patch"] {
+  const state =
+    result.exitCode === 0 &&
+    result.stdout.includes("PATCH\tping-rts") &&
+    result.stdout.includes("PATCH\tping-send-buffer\tready")
+      ? "ready"
+      : "refused";
+  return {
+    state,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+  };
+}
+
+function movePatchRefusals(patch: MoveLoadDirectLoader["patch"] | undefined): MoveProcessRefusal[] {
+  if (patch?.state === "ready") {
+    return [];
+  }
+  return [
+    loaderRefusal("target-frame-register-value-unavailable", "target ping state patch failed", {
+      patch,
+    }),
+  ];
+}
+
+function moveRendezvousRefusals(capture: {
+  safeBoundary?: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string };
+  freeze?: { state: "ptrace-attached" | "refused"; detail: string };
+  registers?: Record<string, unknown>;
+}): MoveProcessRefusal[] {
+  const refusals: MoveProcessRefusal[] = [];
+  pushBoundaryRefusal(refusals, capture.safeBoundary);
+  pushFreezeRefusal(refusals, capture.freeze);
+  pushRegisterRefusal(refusals, capture.registers);
+  return refusals;
+}
+
+function pushBoundaryRefusal(
+  refusals: MoveProcessRefusal[],
+  safeBoundary: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string } | undefined,
+): void {
+  if (safeBoundary?.state === "sleep-timer" || safeBoundary?.state === "pre-send-icmp") {
+    return;
+  }
+  refusals.push(
+    loaderRefusal(
+      "active-syscall",
+      "target ping direct loader did not reach the pre-send boundary",
+      {
+        boundary: safeBoundary?.detail ?? "missing",
+      },
+    ),
+  );
+}
+
+function pushFreezeRefusal(
+  refusals: MoveProcessRefusal[],
+  freeze: { state: "ptrace-attached" | "refused"; detail: string } | undefined,
+): void {
+  if (freeze?.state === "ptrace-attached") {
+    return;
+  }
+  refusals.push(
+    loaderRefusal("thread-state-unsupported", "target ping was not frozen by direct loader", {
+      freeze: freeze?.detail ?? "missing",
+    }),
+  );
+}
+
+function pushRegisterRefusal(
+  refusals: MoveProcessRefusal[],
+  registers: Record<string, unknown> | undefined,
+): void {
+  if (registers) {
+    return;
+  }
+  refusals.push(
+    loaderRefusal(
+      "target-frame-register-value-unavailable",
+      "target register state was not captured by direct loader",
+      {},
+    ),
+  );
+}
+
+function loaderRefused(
+  executable: string,
+  argv: string[],
+  parsed: { pid?: number; logPath?: string; captureRows: string[] },
+  refusal: MoveProcessRefusal,
+): MoveLoadDirectLoader {
+  return {
+    state: "refused",
+    strategy: "target-original-ping-direct-loader",
+    executable,
+    argv,
+    targetPid: parsed.pid,
+    logPath: parsed.logPath,
+    refusals: [refusal],
+  };
+}
+
+function loaderRefusal(
+  code: MoveProcessRefusal["code"],
+  message: string,
+  detail: Record<string, unknown>,
+): MoveProcessRefusal {
+  return { code, message, detail: { ...detail, boundary: "target-original-ping-direct-loader" } };
+}
+
+function parsePositiveInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/packages/cli/src/move-resource-plan.ts
+++ b/packages/cli/src/move-resource-plan.ts
@@ -1,0 +1,567 @@
+import { basename } from "node:path";
+import type {
+  MoveDescriptor,
+  MovePidGraphNode,
+  MoveProcessArchitecture,
+  MoveProcessRefusal,
+  MoveProcessResource,
+  MoveTargetFdTableEntry,
+  MoveTargetGuestResourceRecipe,
+} from "@machinen/runtime";
+
+function planMoveTargetFdTable(input: {
+  resources: MoveProcessResource[];
+  expectedFds: number[];
+  inheritedStdio: { mode: string };
+}): {
+  resources: MoveProcessResource[];
+  entries: MoveTargetFdTableEntry[];
+  targetGuestResources: MoveTargetGuestResourceRecipe[];
+  refusals: MoveProcessRefusal[];
+} {
+  void input.inheritedStdio;
+  const entries: MoveTargetFdTableEntry[] = input.resources
+    .filter(
+      (resource) => typeof resource.fd === "number" && input.expectedFds.includes(resource.fd),
+    )
+    .map((resource) => ({ fd: resource.fd!, kind: resource.kind, recipe: resource.recipe }));
+  const refusals = input.resources.flatMap((resource) => moveFdResourceRefusals(resource));
+  return { resources: input.resources, entries, targetGuestResources: [], refusals };
+}
+
+function moveFdResourceRefusals(resource: MoveProcessResource): MoveProcessRefusal[] {
+  if (resource.kind !== "socket" && resource.kind !== "raw-socket") {
+    return [];
+  }
+  const model = resource.recipe?.pingSocketModel ?? resource.recipe?.rawIcmpModel;
+  return [
+    {
+      code:
+        model === "loopback-echo-v1" || model === "loopback-raw-icmp-v1"
+          ? "target-socket-syscall-state-unsupported"
+          : "non-stdio-kernel-state-unsupported",
+      message: "move socket state remains refused until target-native sequence state is translated",
+      detail: { kind: resource.kind, fd: resource.fd, requiredModel: model ?? "socket-model" },
+    },
+  ];
+}
+
+type MoveResourcePlan = NonNullable<MoveDescriptor["resourcePlan"]>;
+
+type GuestMoveFd = {
+  fd: number;
+  target: string;
+  flags?: string[];
+  offset?: number;
+};
+
+type GuestMoveNetSocket = {
+  inode: string;
+  localAddress?: string;
+  remoteAddress?: string;
+  txQueue?: number;
+  rxQueue?: number;
+};
+
+type GuestMoveResourceScan = {
+  uid?: number;
+  gid?: number;
+  sourceArch?: MoveProcessArchitecture;
+  pingGroupRangeStart?: number;
+  pingGroupRangeEnd?: number;
+  safeBoundary?: { state: "sleep-timer" | "pre-send-icmp" | "refused"; detail: string };
+  freeze?: { state: "ptrace-attached" | "refused"; detail: string };
+  tasks?: number;
+  wchan?: string;
+  syscall?: string;
+  maps: string[];
+  registers?: Record<string, unknown>;
+  fds: GuestMoveFd[];
+  icmpSockets: GuestMoveNetSocket[];
+  rawSockets: GuestMoveNetSocket[];
+};
+
+export function parseGuestMoveResourceScan(stdout: string): GuestMoveResourceScan {
+  const scan: GuestMoveResourceScan = { maps: [], fds: [], icmpSockets: [], rawSockets: [] };
+  const fdMap = new Map<number, GuestMoveFd>();
+  for (const row of stdout.split("\n").filter(Boolean)) {
+    parseGuestMoveResourceRow(row, scan, fdMap);
+  }
+  scan.fds = Array.from(fdMap.values()).sort((left, right) => left.fd - right.fd);
+  return scan;
+}
+
+type GuestMoveResourceRowParser = (
+  parts: string[],
+  scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+) => void;
+
+const GUEST_MOVE_RESOURCE_ROW_PARSERS: Record<string, GuestMoveResourceRowParser> = {
+  STATUS: parseGuestStatusRow,
+  UNAME: parseGuestUnameRow,
+  PING_RANGE: parseGuestPingRangeRow,
+  FD: parseGuestFdRow,
+  FDINFO: parseGuestFdInfoRow,
+  MAP: parseGuestMapRow,
+  TASKS: parseGuestTasksRow,
+  WCHAN: parseGuestWchanRow,
+  SYSCALL: parseGuestSyscallRow,
+  SAFE_BOUNDARY: parseGuestSafeBoundaryRow,
+  FREEZE: parseGuestFreezeRow,
+  REG_ARM64: parseGuestArm64RegistersRow,
+  REG_AMD64: parseGuestAmd64RegistersRow,
+  NET_ICMP: parseGuestIcmpSocketRow,
+  NET_RAW: parseGuestRawSocketRow,
+};
+
+function parseGuestMoveResourceRow(
+  row: string,
+  scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  const parts = row.split("\t");
+  GUEST_MOVE_RESOURCE_ROW_PARSERS[parts[0] ?? ""]?.(parts, scan, fdMap);
+}
+
+function parseGuestStatusRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.uid = parseOptionalNonNegativeInteger(parts[1] ?? "");
+  scan.gid = parseOptionalNonNegativeInteger(parts[2] ?? "");
+}
+
+function parseGuestUnameRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.sourceArch = nativeArchFromUname(parts[1] ?? "");
+}
+
+function parseGuestPingRangeRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.pingGroupRangeStart = parseOptionalNonNegativeInteger(parts[1] ?? "");
+  scan.pingGroupRangeEnd = parseOptionalNonNegativeInteger(parts[2] ?? "");
+}
+
+function parseGuestFdRow(
+  parts: string[],
+  _scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  upsertGuestFd(fdMap, parts[1] ?? "", parts[2] ?? "");
+}
+
+function parseGuestFdInfoRow(
+  parts: string[],
+  _scan: GuestMoveResourceScan,
+  fdMap: Map<number, GuestMoveFd>,
+): void {
+  updateGuestFdInfo(fdMap, parts[1] ?? "", parts.slice(2).join("\t"));
+}
+
+function parseGuestMapRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.maps.push(parts.slice(1).join("\t"));
+}
+
+function parseGuestTasksRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.tasks = parseOptionalNonNegativeInteger(parts[1] ?? "");
+}
+
+function parseGuestWchanRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.wchan = parts.slice(1).join("\t");
+}
+
+function parseGuestSyscallRow(parts: string[], scan: GuestMoveResourceScan): void {
+  scan.syscall = parts.slice(1).join("\t");
+}
+
+function parseGuestSafeBoundaryRow(parts: string[], scan: GuestMoveResourceScan): void {
+  const state = parts[1] === "sleep-timer" || parts[1] === "pre-send-icmp" ? parts[1] : "refused";
+  scan.safeBoundary = { state, detail: parts.slice(2).join("\t") };
+}
+
+function parseGuestFreezeRow(parts: string[], scan: GuestMoveResourceScan): void {
+  const state = parts[1] === "ptrace-attached" ? "ptrace-attached" : "refused";
+  scan.freeze = { state, detail: parts.slice(2).join("\t") };
+}
+
+function parseGuestArm64RegistersRow(parts: string[], scan: GuestMoveResourceScan): void {
+  if (parts[1] === "refused") {
+    return;
+  }
+  scan.registers = {
+    arch: "arm64",
+    pc: parts[1] ?? "0x0",
+    sp: parts[2] ?? "0x0",
+    pstate: parts[3] ?? "0x0",
+    x: parts.slice(4, 35),
+  };
+}
+
+function parseGuestAmd64RegistersRow(parts: string[], scan: GuestMoveResourceScan): void {
+  if (parts[1] === "refused") {
+    return;
+  }
+  const names = [
+    "rip",
+    "rsp",
+    "rflags",
+    "rax",
+    "rbx",
+    "rcx",
+    "rdx",
+    "rsi",
+    "rdi",
+    "rbp",
+    "r8",
+    "r9",
+    "r10",
+    "r11",
+    "r12",
+    "r13",
+    "r14",
+    "r15",
+    "fsBase",
+    "gsBase",
+  ];
+  scan.registers = { arch: "amd64" };
+  for (const [index, name] of names.entries()) {
+    scan.registers[name] = parts[index + 1] ?? "0x0";
+  }
+}
+
+function parseGuestIcmpSocketRow(parts: string[], scan: GuestMoveResourceScan): void {
+  pushGuestNetSocket(scan.icmpSockets, parts[1] ?? "");
+}
+
+function parseGuestRawSocketRow(parts: string[], scan: GuestMoveResourceScan): void {
+  pushGuestNetSocket(scan.rawSockets, parts[1] ?? "");
+}
+
+function pushGuestNetSocket(sockets: GuestMoveNetSocket[], line: string): void {
+  const socket = parseGuestNetSocket(line);
+  if (socket) {
+    sockets.push(socket);
+  }
+}
+
+function upsertGuestFd(fdMap: Map<number, GuestMoveFd>, fdText: string, target: string): void {
+  const fd = parseOptionalNonNegativeInteger(fdText);
+  if (fd === undefined) {
+    return;
+  }
+  fdMap.set(fd, { ...fdMap.get(fd), fd, target });
+}
+
+function updateGuestFdInfo(fdMap: Map<number, GuestMoveFd>, fdText: string, line: string): void {
+  const fd = parseOptionalNonNegativeInteger(fdText);
+  if (fd === undefined) {
+    return;
+  }
+  const current = fdMap.get(fd) ?? { fd, target: "" };
+  const [, key = "", value = ""] = line.match(/^(pos|flags):\s*(\S+)/) ?? [];
+  if (key === "pos") {
+    fdMap.set(fd, { ...current, offset: parseOptionalNonNegativeInteger(value) });
+  }
+  if (key === "flags") {
+    fdMap.set(fd, { ...current, flags: [`octal:${value}`] });
+  }
+}
+
+function parseGuestNetSocket(line: string): GuestMoveNetSocket | undefined {
+  const fields = line.trim().split(/\s+/);
+  if (fields[0] === "sl" || fields.length < 10) {
+    return undefined;
+  }
+  const [txQueue, rxQueue] = parseQueuePair(fields[4]);
+  return {
+    inode: fields[9]!,
+    localAddress: fields[1],
+    remoteAddress: fields[2],
+    txQueue,
+    rxQueue,
+  };
+}
+
+function parseQueuePair(value: string | undefined): [number | undefined, number | undefined] {
+  const [tx, rx] = (value ?? "").split(":");
+  return [parseOptionalHexInteger(tx ?? ""), parseOptionalHexInteger(rx ?? "")];
+}
+
+export function buildMoveResourcePlan(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+): MoveResourcePlan {
+  const resources = buildMoveResources(node, scan);
+  const plan = planMoveTargetFdTable({
+    resources,
+    expectedFds: scan.fds.map((fd) => fd.fd),
+    inheritedStdio: { mode: "inherit-output" },
+  });
+  return {
+    kind: "machinen.move.resource-plan",
+    source: "guest-procfs",
+    sourceArch: scan.sourceArch,
+    resources: plan.resources,
+    fdTableEntries: plan.entries,
+    targetGuestResources: plan.targetGuestResources,
+    refusals: [...plan.refusals, ...nativeCaptureRefusals(scan)],
+    acceptedSubsets: acceptedMoveResourceSubsets(plan.entries),
+    capture: moveNativeCapture(scan),
+  };
+}
+
+function nativeCaptureRefusals(scan: GuestMoveResourceScan): MoveProcessRefusal[] {
+  const refusals: MoveProcessRefusal[] = [];
+  if (scan.safeBoundary?.state !== "sleep-timer") {
+    refusals.push({
+      code: "active-syscall",
+      message: "move capture did not reach the ping sleep/timer safe boundary",
+      detail: { kind: "thread", boundary: scan.safeBoundary?.detail ?? "missing" },
+    });
+  }
+  if (scan.freeze?.state !== "ptrace-attached") {
+    refusals.push({
+      code: "thread-state-unsupported",
+      message: "move capture did not freeze the process with ptrace",
+      detail: { kind: "thread", freeze: scan.freeze?.detail ?? "missing" },
+    });
+  }
+  return refusals;
+}
+
+function moveNativeCapture(scan: GuestMoveResourceScan): MoveResourcePlan["capture"] {
+  return {
+    safeBoundary: scan.safeBoundary,
+    freeze: scan.freeze,
+    tasks: scan.tasks,
+    wchan: scan.wchan,
+    syscall: scan.syscall,
+    maps: scan.maps,
+    registers: scan.registers,
+  };
+}
+
+function buildMoveResources(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+): MoveProcessResource[] {
+  return [
+    { id: `pid:${node.pid}:argv`, kind: "argv", state: "captured", recipe: { argv: node.argv } },
+    ...(node.cwd
+      ? [
+          {
+            id: `pid:${node.pid}:cwd`,
+            kind: "cwd" as const,
+            state: "captured" as const,
+            path: node.cwd,
+            recipe: { cwd: node.cwd },
+          },
+        ]
+      : []),
+    ...scan.fds.map((fd) => moveResourceFromGuestFd(node, scan, fd)),
+  ];
+}
+
+function moveResourceFromGuestFd(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  fd: GuestMoveFd,
+): MoveProcessResource {
+  const socketInode = socketInodeFromFdTarget(fd.target);
+  if (socketInode) {
+    return socketMoveResource(node, scan, fd, socketInode);
+  }
+  return nonSocketMoveResource(node.pid, fd);
+}
+
+function nonSocketMoveResource(pid: number, fd: GuestMoveFd): MoveProcessResource {
+  const base = nativeResourceBase(pid, fd);
+  if (fd.target.startsWith("pipe:[")) {
+    return { ...base, kind: "pipe", path: fd.target };
+  }
+  if (/^\/dev\/(pts|tty)/.test(fd.target)) {
+    return { ...base, kind: "pty", path: fd.target };
+  }
+  if (fd.target.startsWith("/")) {
+    return { ...base, kind: "file", path: fd.target, offset: fd.offset };
+  }
+  return { ...base, kind: "unknown", path: fd.target };
+}
+
+function socketMoveResource(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  fd: GuestMoveFd,
+  inode: string,
+): MoveProcessResource {
+  const icmpSocket = scan.icmpSockets.find((socket) => socket.inode === inode);
+  if (icmpSocket) {
+    return {
+      ...nativeResourceBase(node.pid, fd, `socket:${inode}:icmp`),
+      kind: "socket",
+      path: fd.target,
+      recipe: pingSocketRecipe(node, scan, icmpSocket),
+    };
+  }
+  const rawSocket = scan.rawSockets.find((socket) => socket.inode === inode);
+  if (rawSocket) {
+    return {
+      ...nativeResourceBase(node.pid, fd, `socket:${inode}:raw-icmp`),
+      kind: "raw-socket",
+      path: fd.target,
+      recipe: rawIcmpRecipe(node, rawSocket),
+    };
+  }
+  return {
+    ...nativeResourceBase(node.pid, fd, `socket:${inode}`),
+    kind: "socket",
+    path: fd.target,
+  };
+}
+
+function nativeResourceBase(
+  pid: number,
+  fd: GuestMoveFd,
+  idSuffix = `fd:${fd.fd}`,
+): Pick<MoveProcessResource, "id" | "state" | "fd" | "flags"> {
+  return { id: `pid:${pid}:${idSuffix}`, state: "captured", fd: fd.fd, flags: fd.flags };
+}
+
+function pingSocketRecipe(
+  node: MovePidGraphNode,
+  scan: GuestMoveResourceScan,
+  socket: GuestMoveNetSocket,
+): Record<string, unknown> | undefined {
+  const base = icmpSocketRecipeBase(node, socket);
+  if (!base) {
+    return undefined;
+  }
+  return {
+    pingSocketModel:
+      base.destination === "127.0.0.1" ? "loopback-echo-v1" : "external-target-egress-v1",
+    ...base,
+    socketType: "dgram",
+    credentialPolicy: "target-ping-group-range",
+    uid: scan.uid,
+    gid: scan.gid,
+    pingGroupRangeStart: scan.pingGroupRangeStart,
+    pingGroupRangeEnd: scan.pingGroupRangeEnd,
+  };
+}
+
+function rawIcmpRecipe(
+  node: MovePidGraphNode,
+  socket: GuestMoveNetSocket,
+): Record<string, unknown> | undefined {
+  const base = icmpSocketRecipeBase(node, socket);
+  if (!base) {
+    return undefined;
+  }
+  return {
+    rawIcmpModel:
+      base.destination === "127.0.0.1" ? "loopback-echo-v1" : "external-target-egress-v1",
+    ...base,
+    socketType: "raw",
+    capability: "cap-net-raw",
+  };
+}
+
+function icmpSocketRecipeBase(
+  node: MovePidGraphNode,
+  socket: GuestMoveNetSocket,
+): Record<string, unknown> | undefined {
+  const identifier = parseProcNetPort(socket.localAddress);
+  const destination = moveIcmpDestination(node, socket);
+  if (!destination || !socketQueuesEmpty(socket) || identifier === undefined) {
+    return undefined;
+  }
+  return {
+    family: "inet4",
+    protocol: "icmp",
+    destination,
+    networkNamespace: destination === "127.0.0.1" ? "target-loopback" : "target-network",
+    route: destination === "127.0.0.1" ? "loopback" : "target-egress",
+    identifier,
+    inFlightPackets: "none",
+    receiveQueue: "empty",
+  };
+}
+
+function moveIcmpDestination(
+  node: MovePidGraphNode,
+  socket: GuestMoveNetSocket,
+): string | undefined {
+  const remote = procNetAddressHost(socket.remoteAddress);
+  const argvDestination = movePingDestination(node.argv);
+  if (remote === "127.0.0.1") {
+    return argvDestination === "127.0.0.1" ? remote : undefined;
+  }
+  return remote;
+}
+
+function movePingDestination(argv: string[]): string | undefined {
+  let destination: string | undefined;
+  for (const arg of argv) {
+    if (!arg.startsWith("-") && basename(arg) !== "ping") {
+      destination = arg;
+    }
+  }
+  return destination === "localhost" ? "127.0.0.1" : destination;
+}
+
+function socketQueuesEmpty(socket: GuestMoveNetSocket): boolean {
+  return socket.txQueue === 0 && socket.rxQueue === 0;
+}
+
+function socketInodeFromFdTarget(target: string): string | undefined {
+  return target.match(/^socket:\[(\d+)\]$/)?.[1];
+}
+
+function parseProcNetPort(value: string | undefined): number | undefined {
+  const port = value?.split(":")[1];
+  return port ? parseOptionalHexInteger(port) : undefined;
+}
+
+function procNetAddressHost(value: string | undefined): string | undefined {
+  const address = value?.split(":")[0];
+  if (!address || address.length !== 8) {
+    return undefined;
+  }
+  const bytes = address
+    .match(/../g)
+    ?.reverse()
+    .map((byte) => Number.parseInt(byte, 16));
+  return bytes?.every((byte) => Number.isInteger(byte)) ? bytes.join(".") : undefined;
+}
+
+function acceptedMoveResourceSubsets(
+  entries: ReturnType<typeof planMoveTargetFdTable>["entries"],
+): string[] {
+  void entries;
+  // Socket resources are modeled as evidence today, but still refused until
+  // target-native sequence state translation is proven. Do not publish accepted
+  // subsets for unreachable synthetic resource kinds.
+  return [];
+}
+
+function nativeArchFromUname(value: string): MoveProcessArchitecture | undefined {
+  if (value === "aarch64" || value === "arm64") {
+    return "arm64";
+  }
+  if (value === "x86_64" || value === "amd64") {
+    return "amd64";
+  }
+  return undefined;
+}
+
+function parseOptionalNonNegativeInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function parseOptionalHexInteger(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 16);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}

--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -180,7 +180,7 @@ describe("vmstate portability metadata", () => {
       });
       expect(error).toMatchObject({
         message: expect.stringMatching(
-          /snapshot guest: arm64[\s\S]*restore guest:\s+amd64[\s\S]*not exposed as a public command/,
+          /snapshot guest: arm64[\s\S]*restore guest:\s+amd64[\s\S]*explicitly supported target-native process subsets/,
         ),
       });
     } finally {

--- a/packages/runtime/src/vm/restore.ts
+++ b/packages/runtime/src/vm/restore.ts
@@ -606,7 +606,7 @@ function validateVmstateGuestArch(vmstate: VmstateSnapshotMeta, facts: VmstateFa
         `  restore guest:  ${target}\n` +
         `  refusal: ${refusal.code}\n` +
         "  Whole-VM .vmstate replays source kernel/vCPU/device state and is same-architecture only.\n" +
-        "  Cross-ISA VM/process movement is not exposed as a public command.",
+        "  Use machinen move only for explicitly supported target-native process subsets.",
     );
   }
 }

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -195,7 +195,7 @@ function performSnapshotPortable(
 ): Promise<SnapshotResult> {
   throw new SnapshotError(
     "SNAPSHOT_PORTABLE_REFUSED",
-    "vm.snapshot: legacy portable Level 0-4 snapshot routes were removed; use vmstate snapshot/restore for same-ISA VM snapshots. Cross-ISA VM/process movement is not exposed as a public command.",
+    "vm.snapshot: legacy portable Level 0-4 snapshot routes were removed; use vmstate snapshot/restore for same-ISA VM snapshots. For cross-ISA process movement, use machinen move only for explicitly supported target-native subsets.",
   );
 }
 


### PR DESCRIPTION
## Problem

Removing `machinen move` keeps the current product honest, but it also leaves no place to review the next version of that idea. The old command mixed real fail-closed checks with wording that sounded too broad.

## Solution

This draft adds `machinen move` back as an experimental command. It documents the narrow scope, keeps unsupported state refused, and makes save/load use one clear bundle directory shape.

## Technical Summary

- Stack this on the removal PR so reviewers can compare the clean removal against the add-back separately.
- Treat `move save` output as a bundle directory and report both `bundlePath` and the real `descriptorPath`.
- Treat `move load` input as a bundle directory containing `move.json`; descriptor file paths are refused instead of half-supported.
- Keep vmstate restore same-ISA only. Cross-ISA process movement stays separate and target-native.
- Remove unreachable accepted-subset reporting for synthetic socket resource kinds so the command does not claim support it cannot prove.
