### PR TITLE
Add agent VM bake recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,79 +62,58 @@ The right native package is pulled automatically via optional dependencies:
 First run fetches the matching kernel + rootfs from a GitHub release on the
 companion repo over plain HTTPS — no auth required.
 
-## Quickstart: a tiny service you own
+## Quickstart: an agent VM on your own machine
 
-Bake an image, boot it as a named VM, and let it accumulate state on your
-machine.
+Bake a Claude Code or Pi agent image, boot it on your current project, and
+reattach whenever you want.
 
 ### 1. Bake
 
-A tiny HTTP server that counts hits in memory:
-
-```js
-// counter.mjs
-import { createServer } from "node:http";
-let count = 0;
-createServer((_, res) => {
-  res.end(JSON.stringify({ count: ++count }) + "\n");
-}).listen(3000);
-```
-
-Bake it into a rootfs tarball with `provision()`:
-
-```ts
-// bake.ts
-import { readFileSync } from "node:fs";
-import { provision } from "@machinen/runtime";
-
-await provision({
-  install: async (vm) => {
-    await vm.exec("apt-get update && apt-get install -y nodejs");
-    await vm.writeFile("/opt/counter.mjs", readFileSync("./counter.mjs"));
-  },
-  cmd: ["/usr/bin/node", "/opt/counter.mjs"],
-  out: "./counter.tar.gz",
-});
-```
-
 ```bash
-node bake.ts
+npx machinen bake claude
+# or:
+npx machinen bake pi
 ```
+
+This writes `~/.machinen/recipes/claude.tar.gz` or
+`~/.machinen/recipes/pi.tar.gz`: a small Debian image with Node 22, common
+developer tools, and the agent CLI installed.
 
 ### 2. Boot
 
 ```bash
-npx machinen boot --name counter -p 3000:3000 --detach ./counter.tar.gz
-curl localhost:3000                        # { count: 1 }
-curl localhost:3000                        # { count: 2 }
+npx machinen boot \
+  --name agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
 ```
 
-The service is now running in a named VM on your machine. The boot command
-has returned, but the VM, the TCP forward, and the guest exec agent are
-still alive in the background.
+The VM is now running in the background on your machine. Your project is live
+mounted at `/mnt/workspace`, so edits made by the agent are edits to your host
+checkout.
 
-Reach into it whenever you want:
+### 3. Attach
 
 ```bash
-npx machinen exec counter -- ps aux         # one-off command
-npx machinen attach counter                 # reconnectable shell/TUI
+npx machinen attach agent
+claude
 ```
 
-### 3. Hand it off when you want
-
-Freeze the VM, copy the bundle to host B, and thaw it there:
+For Pi, use the Pi recipe and run `pi` inside the VM:
 
 ```bash
-npx machinen snapshot counter ./counter.snap
-scp -r ./counter.snap host-b:
-ssh host-b npx machinen restore ./counter.snap -p 3000:3000 &
-curl host-b:3000                           # { count: 3 }  ← same process
+npx machinen boot --name agent --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/pi.tar.gz
+npx machinen attach agent
+pi -p "inspect this repository and suggest a first task"
 ```
 
-Same guest architecture only (arm64 ↔ arm64, amd64 ↔ amd64). Cross-ISA
-restore is not supported. The default vmstate snapshot bundle includes CPU
-state, memory, device state, and the root block image needed to restore the
-VM.
+If your terminal or SSH connection drops, the VM and persistent PTY session keep
+running. Reconnect with the same `npx machinen attach agent` command. Log in to
+the agent inside the VM, then snapshot it if you want that warm auth state to
+survive stopping the VM.
 
 ## Fork
 
@@ -142,31 +121,33 @@ VM.
 running; you get a sibling VM with the same heap, same open files, and a
 copy-on-write disk. Both processes diverge from the same instant.
 
-Pick up from Step 2 above — `counter` is running with `count = 2`:
+For example, branch the agent VM from the quickstart:
 
 ```bash
-npx machinen fork counter --new-name counter-b --detach
+npx machinen fork agent --new-name agent-b --detach \
+  --mount-live "$PWD:/mnt/workspace:rw"
 
-npx machinen exec counter   -- curl -s localhost:3000   # { count: 3 }
-npx machinen exec counter-b -- curl -s localhost:3000   # { count: 3 }
-npx machinen exec counter-b -- curl -s localhost:3000   # { count: 4 }
-npx machinen exec counter   -- curl -s localhost:3000   # { count: 4 }
+npx machinen attach agent
+npx machinen attach agent-b
 ```
 
-Both VMs branched from the same `count = 2` heap and now count
-independently. Use it to clone a warmed-up process: a database with caches
-loaded, a test fixture in exactly the right state, a long-running compute
-job branched into N parallel explorations.
+Both VMs branched from the same warm state and now run independently. Use it to
+clone an agent with caches loaded, a test fixture in exactly the right state, a
+service that has warmed up, or a long-running compute job branched into N
+parallel explorations.
 
 The fork doesn't inherit the source's `-p` host forwards — host ports are
-global, only one process can bind each one. Two ways to reach a fork:
+global, only one process can bind each one. You can always reach a fork over
+vsock:
 
 ```bash
-# A) exec over vsock — works for any guest port, no host forward needed.
-npx machinen exec counter-b -- curl -s localhost:3000
+npx machinen exec agent-b -- ps aux
+```
 
-# B) -p with non-conflicting host ports — forwards on the host.
-npx machinen fork counter --new-name counter-b -p 3001:3000 --detach
+For services, pass non-conflicting host forwards to the fork:
+
+```bash
+npx machinen fork worker --new-name worker-b -p 3001:3000 --detach
 curl localhost:3001                                            # the fork
 curl localhost:3000                                            # still the source
 ```
@@ -178,7 +159,7 @@ and names the VM that's holding it.
 From Node, same shape:
 
 ```ts
-const fork = await vm.fork({ name: "counter-b" });
+const fork = await vm.fork({ name: "sibling" });
 ```
 
 ## From Node
@@ -209,13 +190,12 @@ const restored = await restore({ snapDir: "./counter.snap" });
 
 ## Documentation
 
-- [Quickstart](./docs/quickstart.md) — a longer bake → boot → handoff
-  walkthrough
+- [Quickstart](./docs/quickstart.md) — bake an agent VM and reconnect to it later
 - [Create a VM](./docs/guides/create-a-vm.md) — boot, detach, attach,
   and manage named VMs
 - [Hand off a running VM](./docs/guides/handoff.md) — snapshot → transfer → restore
-- [Guides](./docs/) — recipes for creating VMs, snapshots and forks,
-  mounts, and networking
+- [Guides](./docs/) — recipes for agent VMs, snapshots and forks, mounts,
+  and networking
 - [`@machinen/cli` reference](./packages/cli/API.md) — command and flag reference
 - [`@machinen/runtime` reference](./packages/runtime/API.md) — every
   exported function, type, and error class (typedoc-generated)

--- a/apps/machinen.dev/public/index.md
+++ b/apps/machinen.dev/public/index.md
@@ -9,20 +9,23 @@ No tiny rented slice. No hyperscaler-shaped workflow. Just cloud-shaped computer
 ## The loop
 
 ```bash
-npx machinen boot --name work --detach -- sleep infinity
-npx machinen attach work
+npx machinen bake claude
+npx machinen boot --name agent --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
+npx machinen attach agent
 
 # from another terminal, another SSH session, or after your client drops:
-npx machinen attach work
+npx machinen attach agent
 ```
 
 `attach` opens a real PTY with job control, tab completion, full-screen TUIs, and Ctrl-C going to the guest. By default it creates or reconnects a persistent session named `default`; if your host terminal or SSH connection disappears, the shell keeps running inside the VM.
 
 ```bash
-npx machinen attach --session editor work
-npx machinen sessions work
-npx machinen session-kill work editor
-npx machinen stop work
+npx machinen attach --session editor agent
+npx machinen sessions agent
+npx machinen session-kill agent editor
+npx machinen stop agent
 ```
 
 ## Install
@@ -35,7 +38,7 @@ Then run `npx machinen ...` or `npx mn ...`.
 
 ## What it is
 
-Machinen is a native microVM runtime: arm64 on Apple Silicon/Linux and amd64 on Linux/KVM. Node.js is the first-class target; Python, bash, and anything else that boots in a Linux VM works too.
+Machinen is a native microVM runtime: arm64 on Apple Silicon/Linux and amd64 on Linux/KVM. Node.js is the first-class target; Python, bash, agent CLIs, and anything else that boots in a Linux VM works too.
 
 When you need the power tools, you can snapshot, fork, and hand off a running VM between hosts.
 

--- a/apps/machinen.dev/public/llms.txt
+++ b/apps/machinen.dev/public/llms.txt
@@ -7,14 +7,17 @@ Machinen gives developers small, named Linux VMs on hardware they control: a lap
 Core loop:
 
 ```bash
-npx machinen boot --name work --detach -- sleep infinity
-npx machinen attach work
-npx machinen attach work
+npx machinen bake claude
+npx machinen boot --name agent --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
+npx machinen attach agent
+npx machinen attach agent
 ```
 
 `machinen attach` creates or reconnects a persistent PTY session named `default` by default. The session survives host terminal or SSH disconnects while the VM host keeps running. Use `machinen attach --session <name> <vm>` for additional named sessions, `machinen sessions <vm>` to list them, and `machinen session-kill <vm> [session]` to reset one.
 
-Machinen is a native microVM runtime for arm64 on Apple Silicon/Linux and amd64 on Linux/KVM. It can run Node.js, Python, bash, and other Linux workloads. It supports one-off `exec`, persistent `attach`, port forwards, live mounts, snapshot/restore, fork, and handoff between same-architecture hosts.
+Machinen is a native microVM runtime for arm64 on Apple Silicon/Linux and amd64 on Linux/KVM. It can run Node.js, Python, bash, agent CLIs, and other Linux workloads. It supports `machinen bake claude`, `machinen bake pi`, one-off `exec`, persistent `attach`, port forwards, live mounts, snapshot/restore, fork, and handoff between same-architecture hosts.
 
 Install:
 
@@ -25,12 +28,14 @@ npm i @machinen/cli @machinen/runtime
 Useful commands:
 
 ```bash
-npx machinen boot --name counter -p 3000:3000 --detach ./counter.tar.gz
-npx machinen exec counter -- ps aux
-npx machinen attach counter
-npx machinen snapshot counter ./counter.snap
-npx machinen fork counter --new-name counter-b --detach
-npx machinen stop counter
+npx machinen bake claude
+npx machinen bake pi
+npx machinen boot --name agent --detach --mount-live "$PWD:/mnt/workspace:rw" ~/.machinen/recipes/claude.tar.gz
+npx machinen exec agent -- ps aux
+npx machinen attach agent
+npx machinen snapshot agent ./agent.snap
+npx machinen fork agent --new-name agent-b --detach --mount-live "$PWD:/mnt/workspace:rw"
+npx machinen stop agent
 ```
 
 References:

--- a/apps/machinen.dev/src/app/pages/landing.tsx
+++ b/apps/machinen.dev/src/app/pages/landing.tsx
@@ -2,29 +2,34 @@ import type { ReactNode } from "react";
 
 import { CopyPromptButton } from "./CopyPromptButton";
 
-const LOOP_CLI = `npx machinen boot --name work --detach -- sleep infinity
-npx machinen attach work
+const LOOP_CLI = `npx machinen bake claude
+npx machinen boot --name agent --detach \\
+  --mount-live "$PWD:/mnt/workspace:rw" \\
+  ~/.machinen/recipes/claude.tar.gz
+npx machinen attach agent
 
 # from another terminal, another SSH session, or after your client drops:
-npx machinen attach work`;
+npx machinen attach agent`;
 
-const SESSION_CLI = `npx machinen attach --session editor work   # another persistent terminal
-npx machinen sessions work                  # list live sessions
-npx machinen session-kill work editor       # reset one session
-npx machinen stop work                      # shut down the VM`;
+const SESSION_CLI = `npx machinen attach --session editor agent   # another persistent terminal
+npx machinen sessions agent                  # list live sessions
+npx machinen session-kill agent editor       # reset one session
+npx machinen stop agent                      # shut down the VM`;
 
-const SERVICE_CLI = `npx machinen boot --name counter -p 3000:3000 --detach ./counter.tar.gz
-curl localhost:3000                        # { count: 1 }
-curl localhost:3000                        # { count: 2 }
+const AGENT_CLI = `npx machinen bake pi
+npx machinen boot --name pi-agent --detach \\
+  --mount-live "$PWD:/mnt/workspace:rw" \\
+  ~/.machinen/recipes/pi.tar.gz
 
-npx machinen exec counter -- ps aux         # one-off command
-npx machinen attach counter                 # reconnectable shell/TUI`;
+npx machinen attach pi-agent
+pi -p "inspect this repository"`;
 
-const POWER_CLI = `npx machinen snapshot counter ./counter.snap
-scp -r ./counter.snap host-b:
-ssh host-b npx machinen restore ./counter.snap -p 3000:3000 &
+const POWER_CLI = `npx machinen snapshot agent ./agent.snap
+npx machinen restore ./agent.snap --name agent-restored \\
+  --mount-live "$PWD:/mnt/workspace:rw"
 
-npx machinen fork counter --new-name counter-b --detach`;
+npx machinen fork agent --new-name agent-b --detach \\
+  --mount-live "$PWD:/mnt/workspace:rw"`;
 
 const INSTALL_CLI = `npm i @machinen/cli @machinen/runtime
 npx machinen --help`;
@@ -158,12 +163,13 @@ export const Landing = () => (
         </section>
 
         <section className="mb-16">
-          <SectionTitle>A TINY SERVICE YOU OWN</SectionTitle>
+          <SectionTitle>AN AGENT VM YOU OWN</SectionTitle>
           <p className="mb-6 max-w-[72ch] text-[#aaa]">
-            Boot a service as a named VM, forward a port, and reach into it whenever you want. The
-            VM, port forward, and guest exec agent stay alive after the boot command returns.
+            Bake a Claude or Pi image, mount the current project at <code>/mnt/workspace</code>, and
+            run the agent in a reconnectable terminal. The VM and guest exec agent stay alive after
+            the boot command returns.
           </p>
-          <CodeBlock title="counter.sh" code={SERVICE_CLI} />
+          <CodeBlock title="agent.sh" code={AGENT_CLI} />
         </section>
 
         <section className="mb-16">
@@ -187,6 +193,7 @@ export const Landing = () => (
           <div className="mb-8 space-y-2 text-[#888] select-none">
             <Capability>Small, named Linux VMs on hardware you control</Capability>
             <Capability>Persistent terminal sessions, no tmux required</Capability>
+            <Capability>Baked Claude/Pi agent VM recipes</Capability>
             <Capability>One-off exec for scripts and agent tools</Capability>
             <Capability>Port forwards and live host-directory mounts</Capability>
             <Capability>Snapshot, restore, fork, and handoff</Capability>
@@ -194,8 +201,12 @@ export const Landing = () => (
           </div>
           <div className="border border-[#333] bg-[#0a0a0a] p-4 text-[#888]">
             <PromptLine>npm i @machinen/cli @machinen/runtime</PromptLine>
-            <PromptLine>npx machinen boot --name work --detach -- sleep infinity</PromptLine>
-            <PromptLine>npx machinen attach work</PromptLine>
+            <PromptLine>npx machinen bake claude</PromptLine>
+            <PromptLine>
+              npx machinen boot --name agent --detach --mount-live "$PWD:/mnt/workspace:rw"
+              ~/.machinen/recipes/claude.tar.gz
+            </PromptLine>
+            <PromptLine>npx machinen attach agent</PromptLine>
           </div>
         </section>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,11 @@
 
 Start here:
 
-- [Quickstart](./quickstart.md) — bake → boot → handoff in three steps
+- [Quickstart](./quickstart.md) — bake an agent VM and reconnect to it later
 
 Then dive deeper:
 
+- [Agent VM recipes](./guides/agent-vms.md) — Claude/Pi images and custom agent recipes
 - [Create a VM](./guides/create-a-vm.md) — the three ways to get a workload running
 - [Hand off a running VM](./guides/handoff.md) — snapshot → transfer → restore
 - [Snapshot, restore, and fork](./guides/snapshot-restore-fork.md) — clone a running process, including vmstate timer, entropy, and socket contracts

--- a/docs/guides/agent-vms.md
+++ b/docs/guides/agent-vms.md
@@ -1,0 +1,164 @@
+# Agent VM recipes
+
+An agent VM is a small Linux machine you own: boot it on your laptop or
+workstation, mount a project at `/mnt/workspace`, run an agent inside it, and
+reattach later. The terminal session lives in the VM, not in your host shell.
+
+Machinen ships two starter recipes:
+
+```bash
+npx machinen bake claude   # Claude Code image
+npx machinen bake pi       # Pi coding agent image
+```
+
+Both recipes install:
+
+- Debian base userland
+- Node.js 22 via `fnm`
+- common shell/dev tools (`git`, `curl`, `jq`, `ripgrep`, `vim-tiny`, etc.)
+- the selected agent CLI
+- a default command of `sleep infinity`, so the VM stays alive until stopped
+
+The default output is `~/.machinen/recipes/<recipe>.tar.gz`.
+
+## Claude Code VM
+
+```bash
+npx machinen bake claude
+
+npx machinen boot \
+  --name claude-agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
+
+npx machinen attach claude-agent
+claude
+```
+
+Log in to Claude Code inside the VM on first run. Auth and shell state live in
+the running VM; snapshot it if you want that warm state to survive stopping the
+VM. The image also includes a convenience function named `claude-yolo` that
+expands to:
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+Use that only when you trust the VM and the mounted workspace. The default
+`claude` command keeps Claude Code's normal permission behavior.
+
+## Pi VM
+
+```bash
+npx machinen bake pi
+
+npx machinen boot \
+  --name pi-agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/pi.tar.gz
+
+npx machinen attach pi-agent
+pi -p "summarize this repository"
+```
+
+To reuse an existing host Pi login, mount the host auth directory at
+`/mnt/pi-agent`:
+
+```bash
+npx machinen boot \
+  --name pi-agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  --mount-live "$HOME/.pi/agent:/mnt/pi-agent:rw" \
+  ~/.machinen/recipes/pi.tar.gz
+```
+
+The Pi recipe links `/mnt/pi-agent` to `/root/.pi/agent` when present.
+Machinen mount guest paths intentionally live under `/mnt/...`, so the recipe
+performs the `/root/.pi/agent` link inside the VM. If you log in inside the VM
+instead, snapshot the VM to keep that warm auth state after stop.
+
+## Long-lived sessions
+
+Attach creates a persistent PTY session by default:
+
+```bash
+npx machinen attach claude-agent
+```
+
+If the client connection drops, the session stays in the VM and a later attach
+reconnects to it. Use named sessions for separate terminals:
+
+```bash
+npx machinen attach --session agent claude-agent
+npx machinen attach --session shell claude-agent
+npx machinen sessions claude-agent
+npx machinen session-kill claude-agent agent
+```
+
+## Custom recipe with `provision()`
+
+`machinen bake` is just a packaged recipe. For your own agent image, use the
+runtime API directly:
+
+```ts
+// bake-custom-agent.ts
+import { provision } from "@machinen/runtime";
+
+await provision({
+  install: async (vm) => {
+    await vm.exec("export DEBIAN_FRONTEND=noninteractive; apt-get update");
+    await vm.exec(
+      "export DEBIAN_FRONTEND=noninteractive; " +
+        "apt-get install -y --no-install-recommends ca-certificates curl git jq ripgrep",
+    );
+
+    await vm.exec(
+      "curl -fsSL https://fnm.vercel.app/install | " +
+        "bash -s -- --install-dir /opt/fnm --skip-shell",
+    );
+    await vm.exec("FNM_DIR=/opt/fnm /opt/fnm/fnm install 22");
+    await vm.exec("FNM_DIR=/opt/fnm /opt/fnm/fnm default 22");
+    await vm.exec("ln -sf /opt/fnm/aliases/default/bin/* /usr/local/bin/");
+
+    await vm.exec("npm install -g @anthropic-ai/claude-code");
+    await vm.writeFile(
+      "/etc/profile.d/workspace.sh",
+      "[ -d /mnt/workspace ] && cd /mnt/workspace\n",
+      { mode: 0o644 },
+    );
+    await vm.exec(
+      "touch /root/.bashrc && " +
+        "printf '\n[ -f /etc/profile.d/workspace.sh ] && . /etc/profile.d/workspace.sh\n' >> /root/.bashrc",
+    );
+  },
+  cmd: ["/bin/sleep", "infinity"],
+  out: "./custom-agent.tar.gz",
+});
+```
+
+Boot it the same way:
+
+```bash
+node bake-custom-agent.ts
+npx machinen boot --name custom-agent --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ./custom-agent.tar.gz
+npx machinen attach custom-agent
+```
+
+## Snapshot a warm agent VM
+
+A baked image is a clean starting point. A snapshot is a warm running machine:
+logged in, caches hot, terminals still alive.
+
+```bash
+npx machinen snapshot claude-agent ./claude-agent.snap
+npx machinen restore ./claude-agent.snap --name claude-agent-restored \
+  --mount-live "$PWD:/mnt/workspace:rw"
+```
+
+Use snapshots when you want to preserve VM state. Use `machinen bake --force`
+when you want a fresh image with updated packages.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,103 +1,161 @@
 # Quickstart
 
-You're going to build a tiny HTTP server, boot it inside a VM, hit it a few
-times so it accumulates state in memory, then move that running process to
-another machine and watch it pick up exactly where it left off.
+Your computer is already a cloud. In this quickstart, you will turn the
+current project directory into a long-lived Linux VM that can run an agent
+terminal in the background, keep its session alive, and let you reconnect
+later.
 
-This is the trick machinen exists for: the program's entire state — what
-it's holding in memory, the connections it has open, the files it's
-reading — travels with it. Three steps.
+Pick an agent recipe:
 
-## 1. Bake an image
+- `claude` — installs Claude Code.
+- `pi` — installs the Pi coding agent.
 
-Start with a Node.js server that counts requests in memory — nothing
-persistent, no database. The whole point is that "in memory" survives the
-move.
+## 1. Bake an agent image
 
-```js
-// counter.mjs
-import { createServer } from "node:http";
-let count = 0;
-createServer((_, res) => {
-  res.end(JSON.stringify({ count: ++count }) + "\n");
-}).listen(3000);
-```
-
-To run it inside a VM you need a rootfs tarball: a Linux filesystem with
-Node installed, your script copied in, and a default command that launches
-it. `provision()` builds that for you. Under the hood it boots a Debian
-base, runs the install steps you give it, then archives the result.
-
-```ts
-// bake.ts
-import { readFileSync } from "node:fs";
-import { provision } from "@machinen/runtime";
-
-await provision({
-  install: async (vm) => {
-    await vm.exec("apt-get update && apt-get install -y nodejs");
-    await vm.writeFile("/opt/counter.mjs", readFileSync("./counter.mjs"));
-  },
-  cmd: ["/usr/bin/node", "/opt/counter.mjs"],
-  out: "./counter.tar.gz",
-});
-```
+Bake a reusable rootfs image. This boots a Debian base VM, installs Node 22,
+common developer tools, and the selected agent CLI, then writes a tarball to
+`~/.machinen/recipes/`.
 
 ```bash
-node bake.ts
+npx machinen bake claude
+# or:
+npx machinen bake pi
 ```
 
-You now have `counter.tar.gz` — a self-contained image you can boot
-anywhere machinen runs.
-
-## 2. Boot it and give it some state
+Want a different location?
 
 ```bash
-npx machinen boot --name counter -p 3000:3000 --detach ./counter.tar.gz
-curl localhost:3000                        # { count: 1 }
-curl localhost:3000                        # { count: 2 }
+npx machinen bake claude --out ./claude-agent.tar.gz
 ```
 
-A few things are happening here. `--name counter` registers the VM under
-a name so you can reach it from another shell. `-p 3000:3000` forwards the
-host port to the guest. `--detach` lets the boot command return as soon
-as the guest is ready, instead of holding your terminal.
+If the output image already exists, `bake` reuses it. Pass `--force` to rebuild.
 
-After the two `curl`s, the Node process inside the VM has `count = 2` in
-its heap. That's the state we're about to move.
+## 2. Boot it on your project
 
-## 3. Hand it off to another machine
-
-`machinen snapshot` freezes the running VM into a directory on disk. With the
-default vmstate engine, the directory is the whole snapshot: `state.vmstate`
-holds CPU, RAM, and device state; `rootdisk.img` holds the exact root block
-image bytes; `meta.json` is a small manifest.
+From the project you want the agent to work on:
 
 ```bash
-npx machinen snapshot counter ./counter.snap
-scp -r ./counter.snap host-b:
-ssh host-b npx machinen restore ./counter.snap -p 3000:3000 &
-curl host-b:3000                           # { count: 3 }
+npx machinen boot \
+  --name agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
 ```
 
-The third `curl` returns `{ count: 3 }` because it's the same process —
-it just resumed on a different host. Same heap, same TCP listener, same
-counter. The Node runtime never noticed the move.
+For Pi, swap the image path:
 
-A constraint to know about: the default vmstate engine needs matching guest
-architectures. arm64 to arm64 works, and amd64 to amd64 works on amd64
-Linux/KVM. General arm64 to amd64 vmstate restore is not supported because
-vmstate restores actual machine-code register state, and that doesn't
-translate.
+```bash
+npx machinen boot \
+  --name agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/pi.tar.gz
+```
+
+What those flags mean:
+
+- `--name agent` registers the VM so you can reach it later.
+- `--detach` lets the boot command return while the VM keeps running.
+- `--mount-live "$PWD:/mnt/workspace:rw"` gives the VM live read/write access
+  to your current project at `/mnt/workspace`.
+
+The baked image defaults to `sleep infinity`, so the VM stays up until you stop
+it.
+
+## 3. Attach, log in, and work
+
+Open a reconnectable terminal in the VM:
+
+```bash
+npx machinen attach agent
+```
+
+The shell starts in `/mnt/workspace` when that mount exists.
+
+For Claude Code:
+
+```bash
+claude
+```
+
+For Pi:
+
+```bash
+pi -p "inspect this repository and suggest a first task"
+```
+
+The first run may ask you to log in inside the VM. That is intentional: the VM
+is the owned machine that runs the agent. Auth and shell state live in the
+running VM; snapshot it if you want that warm state to survive stopping the VM.
+
+If you already have Pi auth on the host and want to reuse it, mount it through a
+valid `/mnt/...` guest path:
+
+```bash
+npx machinen boot \
+  --name pi-agent \
+  --detach \
+  --mount-live "$PWD:/mnt/workspace:rw" \
+  --mount-live "$HOME/.pi/agent:/mnt/pi-agent:rw" \
+  ~/.machinen/recipes/pi.tar.gz
+```
+
+The Pi recipe links `/mnt/pi-agent` to `/root/.pi/agent` when that mount is
+present.
+
+## Reconnect later
+
+If your host terminal, SSH connection, or editor pane goes away, the VM and the
+agent session keep running. Reconnect with the same command:
+
+```bash
+npx machinen attach agent
+```
+
+Use named sessions when you want more than one persistent terminal inside the
+same VM:
+
+```bash
+npx machinen attach --session claude agent
+npx machinen attach --session shell agent
+npx machinen sessions agent
+```
+
+To stop the VM:
+
+```bash
+npx machinen stop agent
+```
+
+## Save or branch it
+
+Once the VM is warm — tools installed, auth complete, caches loaded — you can
+snapshot or fork it.
+
+```bash
+npx machinen snapshot agent ./agent.snap
+npx machinen restore ./agent.snap --name agent-restored \
+  --mount-live "$PWD:/mnt/workspace:rw"
+```
+
+Or branch a second copy locally:
+
+```bash
+npx machinen fork agent --new-name agent-b --detach \
+  --mount-live "$PWD:/mnt/workspace:rw"
+```
+
+Snapshot/restore is whole-VM state. It works between matching guest
+architectures, for example arm64 to arm64 or amd64 to amd64. Cross-ISA vmstate
+restore is not supported.
 
 ## Where to go next
 
-- [Create a VM](./guides/create-a-vm.md) once you want more control over
-  what's inside.
-- [Hand off a running VM](./guides/handoff.md) for snapshot → transfer → restore.
-- [Snapshot, restore, and fork](./guides/snapshot-restore-fork.md) covers
-  the cloning trick — running two copies of the same process at once.
-- [Mount files into a VM](./guides/mount-files.md) for sharing data
-  between the host and guest.
-- [Networking](./guides/networking.md) for how the guest reaches the
-  internet and how to expose more ports.
+- [Agent VM recipes](./guides/agent-vms.md) shows how to customize the baked
+  image.
+- [Create a VM](./guides/create-a-vm.md) covers the lower-level boot patterns.
+- [Snapshot, restore, and fork](./guides/snapshot-restore-fork.md) covers the
+  cloning and handoff primitives.
+- [Mount files into a VM](./guides/mount-files.md) explains `--mount-live` and
+  read-only mounts.
+- [Networking](./guides/networking.md) covers port forwards and outbound access.

--- a/examples/fork-pi/README.md
+++ b/examples/fork-pi/README.md
@@ -14,8 +14,9 @@ pi
 /login
 ```
 
-`bake.ts` mounts `~/.pi/agent/` into the source VM at boot, so each
-fork inherits the same session.
+`run.ts` mounts `~/.pi/agent/` into the source VM at `/mnt/pi-agent`; the
+baked image links that to `/root/.pi/agent`, so each fork inherits the same
+session.
 
 ## Run
 

--- a/examples/fork-pi/bake.ts
+++ b/examples/fork-pi/bake.ts
@@ -13,6 +13,7 @@ await provision({
     await vm.exec("ln -sf /opt/fnm/aliases/default/bin/* /usr/local/bin/");
     await vm.exec("npm install -g @earendil-works/pi-coding-agent");
     await vm.exec("ln -sf /opt/fnm/aliases/default/bin/* /usr/local/bin/");
+    await vm.exec("mkdir -p /root/.pi && ln -sfn /mnt/pi-agent /root/.pi/agent");
   },
   cmd: ["/bin/sleep", "infinity"],
   out: "./artifacts/rootfs.tar.gz",

--- a/examples/fork-pi/run.ts
+++ b/examples/fork-pi/run.ts
@@ -15,7 +15,7 @@ rmSync("./artifacts/snapshot", { recursive: true, force: true });
 
 const source = await boot({
   image: "./artifacts/rootfs.tar.gz",
-  mount: { host: piAgentHost, guest: "/root/.pi/agent" },
+  mount: { host: piAgentHost, guest: "/mnt/pi-agent" },
 });
 
 await source.snapshot({ outDir: "./artifacts/snapshot" });

--- a/packages/cli/API.md
+++ b/packages/cli/API.md
@@ -8,6 +8,7 @@ recipes, see the [guides](../../docs/).
 
 ```
 machinen boot     [<image>] [opts] -- <cmd>     Boot a microVM
+machinen bake     <pi|claude> [opts]            Bake an agent VM image recipe
 machinen restore  <snap-dir> [--name <name>]    Restore a VM from a snapshot bundle
 machinen list     (alias: ls, ps)               List running VMs
 machinen exec     [<target>] [--tty] -- <cmd>   Run a command in a running VM
@@ -38,9 +39,9 @@ Machinen uses the default VM name: `default`.
 
 Every data-returning command supports `--json` for machine-readable
 output to stdout: `list`, `gc`, `install`, `snapshot`, `stop`,
-`feedback`, `agent-context`, plus `boot --detach` and `fork --detach`
+`bake`, `feedback`, `agent-context`, plus `boot --detach` and `fork --detach`
 (where the CLI returns identity instead of taking over stdio).
-Mutating commands (`gc`, `stop`, `snapshot`, `session-kill`) accept
+Mutating commands (`gc`, `stop`, `snapshot`, `session-kill`, `bake`) accept
 `--dry-run` to preview without side effects.
 
 `machinen agent-context` emits a versioned JSON description of every
@@ -76,6 +77,36 @@ cache (populated by `machinen install`, or auto-fetched on first use).
 | `--detach`                                      | Detach the VMM from the CLI on first-guest-byte readiness; reattach with `attach`. Composes with `--mount`, `--mount-live`, and `-p`; gvproxy is kept alive with the VM, and live mounts are served inside the VMM. |
 | `--memory <mib>`                                | Guest RAM ceiling, decimal MiB. Debug knob — defaults to `min(host_ram_mib/2, 4096)`, floor 512. See #263                                                                                                           |
 | `--snapshot <path>`                             | Attach `<path>` as `/dev/vda` — scratch disk for a future `vm.snapshot()`                                                                                                                                           |
+
+## `machinen bake`
+
+```
+machinen bake <pi|claude> [--out <tar.gz>] [--force] [--timeout-ms <ms>] [--dry-run] [--json]
+```
+
+Bakes an agent VM image: a Debian rootfs with Node 22, common developer
+shell tools, and either the Pi or Claude Code CLI installed globally. The
+image's default command is `sleep infinity`, so it is meant to run as a
+named, detached VM and be reached with `machinen attach`.
+
+By default the output lands at `~/.machinen/recipes/<recipe>.tar.gz`. If
+that file already exists, `bake` reuses it and exits successfully; pass
+`--force` to rebuild.
+
+```bash
+machinen bake claude
+machinen boot --name agent --detach --mount-live "$PWD:/mnt/workspace:rw" \
+  ~/.machinen/recipes/claude.tar.gz
+machinen attach agent
+```
+
+| Flag                | What it does                                                        |
+| ------------------- | ------------------------------------------------------------------- |
+| `--out <tar.gz>`    | Output image path                                                   |
+| `--force`           | Rebuild even if the image already exists                            |
+| `--timeout-ms <ms>` | Provisioning timeout in milliseconds (default: 20 minutes)          |
+| `--dry-run`         | Print the bake plan without provisioning                            |
+| `--json`            | Emit `{ schema_version, recipe, image, dry_run, reused, ... }` JSON |
 
 ## `machinen restore`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,6 +6,8 @@ or a script — without writing any TypeScript.
 
 ## What you can do with it
 
+- **Bake an agent VM image.** `bake pi` and `bake claude` produce a
+  small Linux image with the agent CLI and common developer tools installed.
 - **Boot a Linux workload in a microVM.** Run a one-shot command, or
   start a long-running service and detach so your shell can exit.
 - **Hand a running process off to another machine.** Snapshot it on
@@ -24,7 +26,7 @@ or a script — without writing any TypeScript.
   running, `stop` to shut one down cleanly, `gc` to clean up after
   detached boots that crashed.
 - **Drive it from an agent.** `--json` on every data-returning
-  command (`list`, `gc`, `install`, `snapshot`, `stop`,
+  command (`list`, `gc`, `install`, `snapshot`, `stop`, `bake`,
   `boot --detach`, `fork --detach`, `feedback`). `mn agent-context`
   emits a versioned JSON description of the whole CLI surface for
   introspection. `mn feedback "<text>"` records friction notes
@@ -55,6 +57,7 @@ companion GitHub release over HTTPS; no GitHub authentication is needed.
 ## At a glance
 
 ```bash
+npx machinen bake claude                         # ~/.machinen/recipes/claude.tar.gz
 npx machinen boot ./image.tar.gz                 # boot a provisioned image
 npx machinen boot --name worker --detach ./image.tar.gz
                                                   # ... and reach it from another shell:

--- a/packages/cli/src/__tests__/bake.test.ts
+++ b/packages/cli/src/__tests__/bake.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBakeArgs, resolveBakePlan } from "../commands/bake.ts";
+
+describe("parseBakeArgs", () => {
+  it("parses a recipe with defaults", () => {
+    const opts = parseBakeArgs(["pi"]);
+
+    expect(opts).toMatchObject({
+      recipe: "pi",
+      force: false,
+      dryRun: false,
+      json: false,
+    });
+  });
+
+  it("parses claude bake flags", () => {
+    const opts = parseBakeArgs([
+      "claude",
+      "--out",
+      "./agent.tar.gz",
+      "--force",
+      "--dry-run",
+      "--json",
+      "--timeout-ms=12345",
+    ]);
+
+    expect(opts).toEqual({
+      recipe: "claude",
+      out: "./agent.tar.gz",
+      force: true,
+      dryRun: true,
+      json: true,
+      timeoutMs: 12345,
+    });
+  });
+});
+
+describe("resolveBakePlan", () => {
+  it("uses ~/.machinen/recipes/<recipe>.tar.gz by default", () => {
+    const plan = resolveBakePlan(parseBakeArgs(["claude", "--dry-run"]));
+
+    expect(plan.recipe.name).toBe("claude");
+    expect(plan.out).toMatch(/\.machinen\/recipes\/claude\.tar\.gz$/);
+    expect(plan.dryRun).toBe(true);
+  });
+});

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -36,6 +36,7 @@ const ALLOWED_VERBS = new Set([
   "completion",
   // domain
   "boot",
+  "bake",
   "restore",
   "exec",
   "snapshot",

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -122,6 +122,43 @@ export const COMMANDS: CommandSpec[] = [
     jsonEnvelope: '{"schema_version": 1, "pid": <int>, "name": <string|null>, "detached": <bool>}',
   },
   {
+    name: "bake",
+    summary: "Bake an agent VM image recipe.",
+    jsonOutput: true,
+    mutating: true,
+    positionals: [
+      {
+        name: "recipe",
+        description: "Agent image recipe to bake: pi or claude.",
+      },
+    ],
+    flags: [
+      {
+        name: "--out",
+        type: "string",
+        description: "Output image path (default: ~/.machinen/recipes/<recipe>.tar.gz).",
+      },
+      {
+        name: "--force",
+        type: "boolean",
+        description: "Rebuild even when the output image already exists.",
+      },
+      {
+        name: "--timeout-ms",
+        type: "integer",
+        description: "Wall-clock provisioning timeout in milliseconds.",
+      },
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description: "Print the bake plan without provisioning.",
+      },
+      { name: "--json", type: "boolean", description: "Emit the bake result as JSON." },
+    ],
+    jsonEnvelope:
+      '{"schema_version": 1, "recipe": "pi"|"claude", "image": <abs-path>, "dry_run": <bool>, "reused": <bool>, "exists": <bool>, "size_bytes": <int|null>, "elapsed_ms": <int|null>}',
+  },
+  {
     name: "restore",
     summary: "Restore a VM from a snapshot bundle.",
     jsonOutput: false,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@
 //
 // Surface:
 //   machinen boot [opts] -- <cmd>
+//   machinen bake <pi|claude> [--out <tar.gz>]
 //   machinen restore <snap-dir> [--name <name>] [-p <hostPort>:<guestPort>]
 //   machinen ls (alias: ps)
 //   machinen exec <name|pid> -- <cmd>
@@ -21,6 +22,7 @@ import { VERSION } from "./base-assets.ts";
 import { printHelp } from "./help.ts";
 import { die } from "./errors.ts";
 import { cmdAttach, cmdRepl, cmdSessionKill, cmdSessions } from "./commands/attach.ts";
+import { cmdBake } from "./commands/bake.ts";
 import { cmdBoot } from "./commands/boot.ts";
 import { cmdExec } from "./commands/exec.ts";
 import { cmdFork } from "./commands/fork.ts";
@@ -41,6 +43,7 @@ type CommandHandler = (args: string[]) => number | Promise<number>;
 
 const COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ["boot", cmdBoot],
+  ["bake", cmdBake],
   ["restore", cmdRestore],
   ["install", cmdInstall],
   ["list", cmdLs],

--- a/packages/cli/src/commands/bake.ts
+++ b/packages/cli/src/commands/bake.ts
@@ -1,0 +1,380 @@
+import { provision, type LogEvent } from "@machinen/runtime";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+import { die, handleError } from "../errors.ts";
+
+export type AgentRecipeName = "pi" | "claude";
+
+interface AgentRecipe {
+  name: AgentRecipeName;
+  displayName: string;
+  npmPackage: string;
+  binary: string;
+  aliases: string;
+  bootstrap: string;
+}
+
+const RECIPES: Record<AgentRecipeName, AgentRecipe> = {
+  pi: {
+    name: "pi",
+    displayName: "Pi",
+    npmPackage: "@earendil-works/pi-coding-agent",
+    binary: "pi",
+    aliases: "",
+    bootstrap:
+      "\n# Optional: mount host Pi auth at /mnt/pi-agent to reuse it in this VM.\n" +
+      "if [ -d /mnt/pi-agent ]; then\n" +
+      "  mkdir -p /root/.pi\n" +
+      "  ln -sfn /mnt/pi-agent /root/.pi/agent\n" +
+      "fi\n",
+  },
+  claude: {
+    name: "claude",
+    displayName: "Claude Code",
+    npmPackage: "@anthropic-ai/claude-code",
+    binary: "claude",
+    aliases:
+      "\n# Optional shortcut for fully-autonomous VM-contained runs.\n" +
+      "claude-yolo() {\n" +
+      '  command claude --dangerously-skip-permissions "$@"\n' +
+      "}\n",
+    bootstrap: "",
+  },
+};
+
+export interface BakeOptions {
+  recipe?: AgentRecipeName;
+  out?: string;
+  force: boolean;
+  dryRun: boolean;
+  json: boolean;
+  timeoutMs?: number;
+}
+
+interface BakePlan {
+  recipe: AgentRecipe;
+  out: string;
+  exists: boolean;
+  force: boolean;
+  dryRun: boolean;
+  json: boolean;
+  timeoutMs?: number;
+}
+
+export async function cmdBake(args: string[]): Promise<number> {
+  const opts = parseBakeArgs(args);
+  const plan = resolveBakePlan(opts);
+  if (plan.dryRun) {
+    reportBakeDryRun(plan);
+    return 0;
+  }
+  if (plan.exists && !plan.force) {
+    reportBakeReuse(plan);
+    return 0;
+  }
+  await runBake(plan).catch(handleError);
+  return 0;
+}
+
+type BakeFlagConsumer = (args: string[], index: number, arg: string, opts: BakeOptions) => number;
+
+const BAKE_FLAG_CONSUMERS: Array<[(arg: string) => boolean, BakeFlagConsumer]> = [
+  [isFlag("--force"), consumeBooleanFlag("force")],
+  [isFlag("--dry-run"), consumeBooleanFlag("dryRun")],
+  [isFlag("--json"), consumeBooleanFlag("json")],
+  [isStringFlag("--out"), consumeOutFlag],
+  [isStringFlag("--timeout-ms"), consumeTimeoutFlag],
+];
+
+export function parseBakeArgs(args: string[]): BakeOptions {
+  const opts: BakeOptions = { force: false, dryRun: false, json: false };
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    const nextIndex = tryConsumeBakeFlag(args, i, arg, opts);
+    if (nextIndex !== undefined) {
+      i = nextIndex;
+    } else {
+      addBakePositional(positional, arg);
+    }
+  }
+  opts.recipe = parseSingleRecipePositional(positional);
+  return opts;
+}
+
+function tryConsumeBakeFlag(
+  args: string[],
+  index: number,
+  arg: string,
+  opts: BakeOptions,
+): number | undefined {
+  const entry = BAKE_FLAG_CONSUMERS.find(([matches]) => matches(arg));
+  return entry?.[1](args, index, arg, opts);
+}
+
+function addBakePositional(positional: string[], arg: string): void {
+  if (arg.startsWith("--")) {
+    die(`unknown bake flag: ${arg}`);
+  }
+  positional.push(arg);
+}
+
+function parseSingleRecipePositional(positional: string[]): AgentRecipeName {
+  if (positional.length !== 1) {
+    die(bakeUsage());
+  }
+  return parseRecipeName(positional[0]!);
+}
+
+function isFlag(name: string): (arg: string) => boolean {
+  return (arg) => arg === name;
+}
+
+function isStringFlag(name: string): (arg: string) => boolean {
+  return (arg) => arg === name || arg.startsWith(`${name}=`);
+}
+
+function consumeBooleanFlag(key: "force" | "dryRun" | "json"): BakeFlagConsumer {
+  return (_args, index, _arg, opts) => {
+    opts[key] = true;
+    return index;
+  };
+}
+
+function consumeOutFlag(args: string[], index: number, arg: string, opts: BakeOptions): number {
+  const { value, nextIndex } = stringFlagValue(args, index, arg, "--out");
+  opts.out = value;
+  return nextIndex;
+}
+
+function consumeTimeoutFlag(args: string[], index: number, arg: string, opts: BakeOptions): number {
+  const { value, nextIndex } = stringFlagValue(args, index, arg, "--timeout-ms");
+  opts.timeoutMs = parsePositiveInteger(value, "--timeout-ms");
+  return nextIndex;
+}
+
+function stringFlagValue(
+  args: string[],
+  index: number,
+  arg: string,
+  name: string,
+): { value: string; nextIndex: number } {
+  const value = arg === name ? args[index + 1] : arg.slice(`${name}=`.length);
+  if (!value) {
+    die(`${name} requires a value`);
+  }
+  return { value, nextIndex: arg === name ? index + 1 : index };
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    die(`${flag}: expected a positive integer, got '${value}'`);
+  }
+  return n;
+}
+
+function parseRecipeName(value: string): AgentRecipeName {
+  if (value === "pi" || value === "claude") {
+    return value;
+  }
+  die(`unknown bake recipe: ${value}\n${bakeUsage()}`);
+}
+
+export function resolveBakePlan(opts: BakeOptions): BakePlan {
+  const recipe = RECIPES[opts.recipe ?? "pi"];
+  const out = resolve(opts.out ?? defaultBakeOut(recipe.name));
+  return {
+    recipe,
+    out,
+    exists: existsSync(out),
+    force: opts.force,
+    dryRun: opts.dryRun,
+    json: opts.json,
+    timeoutMs: opts.timeoutMs,
+  };
+}
+
+function defaultBakeOut(recipe: AgentRecipeName): string {
+  return resolve(homedir(), ".machinen", "recipes", `${recipe}.tar.gz`);
+}
+
+function bakeUsage(): string {
+  return (
+    "usage: machinen bake <pi|claude> [--out <tar.gz>] [--force] " +
+    "[--timeout-ms <ms>] [--dry-run] [--json]"
+  );
+}
+
+function reportBakeDryRun(plan: BakePlan): void {
+  if (plan.json) {
+    emitJson(bakeEnvelope(plan, { dryRun: true, reused: false }));
+    return;
+  }
+  process.stdout.write(
+    `would bake ${plan.recipe.displayName} agent VM image to ${plan.out}` +
+      (plan.exists && !plan.force ? " (already exists; pass --force to rebuild)" : "") +
+      "\n",
+  );
+}
+
+function reportBakeReuse(plan: BakePlan): void {
+  if (plan.json) {
+    emitJson(
+      bakeEnvelope(plan, { dryRun: false, reused: true, sizeBytes: statSync(plan.out).size }),
+    );
+    return;
+  }
+  process.stdout.write(
+    `${plan.recipe.displayName} agent VM image already exists: ${plan.out}\n` +
+      "pass --force to rebuild it\n",
+  );
+}
+
+async function runBake(plan: BakePlan): Promise<void> {
+  mkdirSync(dirname(plan.out), { recursive: true });
+  process.stderr.write(`machinen bake: baking ${plan.recipe.displayName} agent VM image\n`);
+  process.stderr.write(`machinen bake: output ${plan.out}\n`);
+  const started = Date.now();
+  const result = await provision({
+    install: async (vm) => installAgentRecipe(vm, plan.recipe),
+    cmd: ["/bin/sleep", "infinity"],
+    out: plan.out,
+    timeoutMs: plan.timeoutMs ?? 20 * 60_000,
+    onLog: bakeLogPrinter,
+  });
+  if (plan.json) {
+    emitJson(
+      bakeEnvelope(plan, {
+        dryRun: false,
+        reused: false,
+        sizeBytes: result.sizeBytes,
+        elapsedMs: result.elapsedMs,
+      }),
+    );
+    return;
+  }
+  process.stdout.write(
+    `baked ${plan.recipe.displayName} agent VM image: ${result.imagePath}\n` +
+      `size: ${formatBytes(result.sizeBytes)}  elapsed: ${formatMs(Date.now() - started)}\n`,
+  );
+}
+
+async function installAgentRecipe(
+  vm: {
+    exec(cmd: string): Promise<unknown>;
+    writeFile(path: string, contents: string, opts?: { mode?: number }): Promise<void>;
+  },
+  recipe: AgentRecipe,
+): Promise<void> {
+  await vm.exec("export DEBIAN_FRONTEND=noninteractive; apt-get update");
+  await vm.exec(
+    "export DEBIAN_FRONTEND=noninteractive; " +
+      "apt-get install -y --no-install-recommends " +
+      [
+        "bash",
+        "ca-certificates",
+        "curl",
+        "git",
+        "jq",
+        "less",
+        "openssh-client",
+        "ripgrep",
+        "unzip",
+        "vim-tiny",
+        "xz-utils",
+      ].join(" "),
+  );
+  await installNode22(vm);
+  await vm.exec(`npm install -g ${recipe.npmPackage}`);
+  await vm.exec(
+    `ln -sf /opt/fnm/aliases/default/bin/${recipe.binary} /usr/local/bin/${recipe.binary}`,
+  );
+  await vm.exec(`command -v ${recipe.binary}`);
+  await vm.writeFile("/etc/profile.d/machinen-agent-vm.sh", profileScript(recipe), {
+    mode: 0o644,
+  });
+  await vm.exec(
+    "touch /root/.bashrc && " +
+      "printf '\n[ -f /etc/profile.d/machinen-agent-vm.sh ] && . /etc/profile.d/machinen-agent-vm.sh\n' >> /root/.bashrc",
+  );
+  await vm.writeFile("/etc/motd", motd(recipe), { mode: 0o644 });
+}
+
+async function installNode22(vm: { exec(cmd: string): Promise<unknown> }): Promise<void> {
+  await vm.exec(
+    "curl -fsSL https://fnm.vercel.app/install | " +
+      "bash -s -- --install-dir /opt/fnm --skip-shell",
+  );
+  await vm.exec("FNM_DIR=/opt/fnm /opt/fnm/fnm install 22");
+  await vm.exec("FNM_DIR=/opt/fnm /opt/fnm/fnm default 22");
+  await vm.exec("ln -sf /opt/fnm/aliases/default/bin/* /usr/local/bin/");
+  await vm.exec("node --version && npm --version");
+}
+
+function profileScript(recipe: AgentRecipe): string {
+  return `# Installed by machinen bake ${recipe.name}.
+export PATH="/usr/local/bin:$PATH"
+export EDITOR="${"${EDITOR:-vim}"}"
+
+if [ -d /mnt/workspace ] && [ "$PWD" = "$HOME" ]; then
+  cd /mnt/workspace
+fi
+${recipe.bootstrap}${recipe.aliases}`;
+}
+
+function motd(recipe: AgentRecipe): string {
+  return `Machinen ${recipe.displayName} agent VM
+
+This VM is meant to run in the background and be reattached:
+
+  machinen attach <name>
+
+Mount your project at /mnt/workspace when you boot:
+
+  machinen boot --name agent --detach --mount-live "$PWD:/mnt/workspace:rw" <image>
+
+Then reconnect any time with the same attach command.
+`;
+}
+
+function bakeLogPrinter(evt: LogEvent): void {
+  if (evt.source === "phase") {
+    process.stderr.write(`machinen bake: ${evt.kind} completed in ${formatMs(evt.totalMs)}\n`);
+    return;
+  }
+  if (evt.source === "exec-stdout" || evt.source === "exec-stderr") {
+    process.stderr.write(evt.chunk);
+  }
+}
+
+function bakeEnvelope(
+  plan: BakePlan,
+  result: { dryRun: boolean; reused: boolean; sizeBytes?: number; elapsedMs?: number },
+): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    recipe: plan.recipe.name,
+    image: plan.out,
+    dry_run: result.dryRun,
+    reused: result.reused,
+    exists: plan.exists,
+    size_bytes: result.sizeBytes ?? null,
+    elapsed_ms: result.elapsedMs ?? null,
+  };
+}
+
+function emitJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function formatBytes(bytes: number): string {
+  const mib = bytes / 1024 / 1024;
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MiB`;
+}
+
+function formatMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(0)}ms`;
+}

--- a/packages/cli/src/commands/misc.ts
+++ b/packages/cli/src/commands/misc.ts
@@ -158,7 +158,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion --version --help -h -v"
+  local cmds="boot bake restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -186,7 +186,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion)
+  cmds=(boot bake restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -212,7 +212,7 @@ compdef _machinen machinen mn
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion
+set -l cmds boot bake restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion
 for bin in machinen mn
   complete -c $bin -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
   for sub in exec snapshot fork attach sessions session-kill repl stop

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -26,6 +26,14 @@ export function printHelp(): void {
       `                                                 when the host supports it.\n` +
       `    -p <hostPort>:<guestPort>                    Forward host:hostPort → guest:guestPort.\n` +
       `\n` +
+      `  machinen bake <pi|claude> [--out <tar.gz>]    Bake an agent VM image recipe\n` +
+      `    --out <tar.gz>                              Output image path (default:\n` +
+      `                                                 ~/.machinen/recipes/<recipe>.tar.gz)\n` +
+      `    --force                                     Rebuild if the output already exists\n` +
+      `    --timeout-ms <ms>                           Override the provisioning timeout\n` +
+      `    --dry-run                                   Print the plan without provisioning\n` +
+      `    --json                                      Emit a structured result\n` +
+      `\n` +
       `  machinen restore <snap-dir> [--image <tar.gz>] [--name <name>] [-p ...]\n` +
       `                              [--mount-live <host>:<guest>[:<mode>]]\n` +
       `                                                 Restore a VM from a snapshot bundle.\n` +
@@ -126,6 +134,9 @@ export function printHelp(): void {
       `                                                 snapshot.\n` +
       `\n` +
       `Examples:\n` +
+      `  machinen bake claude\n` +
+      `  machinen boot --name agent --detach --mount-live "$PWD:/mnt/workspace:rw" ~/.machinen/recipes/claude.tar.gz\n` +
+      `  machinen attach agent\n` +
       `  machinen boot --name worker -- node server.js\n` +
       `  machinen ls\n` +
       `  machinen exec worker -- ps aux                       # one-off command\n` +


### PR DESCRIPTION
## Problem

Machinen says your computer can act like a cloud, but the quickstart still led with a tiny web server. That did not show the agent VM story clearly. There also was no simple command for trying a Pi or Claude Code VM recipe without writing a provisioning script first.

## Solution

This draft adds a `machinen bake <pi|claude>` command and rewrites the quickstart around a long-lived agent VM. The docs show how to mount a project, attach to the VM, reconnect later, and snapshot a warm agent. This is a draft so we can discuss whether this is the right product shape before merging.

## Technical Summary

- Add `machinen bake` as a small CLI wrapper around `provision()`, not a new runtime primitive.
- Bake recipes install Node 22, common shell tools, and either the Pi or Claude Code CLI, then default the VM command to `sleep infinity`.
- Keep host/project sharing explicit with `--mount-live "$PWD:/mnt/workspace:rw"`.
- Keep Pi host auth under a valid `/mnt/...` guest path and link it inside the VM, instead of mounting directly into `/root`.
- Update README, docs, CLI reference, and website copy to make agent VMs the first example.
- Open question for review: should these recipes live as CLI commands, docs-only examples, or a smaller helper surface?
