### PR TITLE
Make fnm usable in base shell sessions

### DIFF
--- a/.changeset/fuzzy-fnm-shells.md
+++ b/.changeset/fuzzy-fnm-shells.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Make `fnm` available by default in base guest shells, exec calls, PTY sessions, and foreground workloads so Node-based VM recipes can install and run Node without PATH/FNM boilerplate.

--- a/packages/cli/src/__tests__/release-assets.test.ts
+++ b/packages/cli/src/__tests__/release-assets.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
 const SCRIPT = join(ROOT, "scripts/release-base-assets.mjs");
+const BUILD_BASE_ASSETS = join(ROOT, "scripts/build-base-assets.sh");
 const ROOTFS = "rootfs-debian-arm64.tar.gz";
 
 const tmpDirs: string[] = [];
@@ -51,6 +52,19 @@ function runVerify(remoteDir: string, assets = [ROOTFS], env: Record<string, str
     },
   );
 }
+
+describe("scripts/build-base-assets.sh", () => {
+  it("makes fnm default Node installs available to login and attach shells", () => {
+    const script = readFileSync(BUILD_BASE_ASSETS, "utf8");
+
+    expect(script).toContain("install -m 0755 -d /work/rootfs/opt/fnm /work/rootfs/etc/profile.d");
+    expect(script).toContain('export FNM_DIR="${FNM_DIR:-/opt/fnm}"');
+    expect(script).toContain('export PATH="$FNM_DIR/aliases/default/bin:$PATH"');
+    expect(script).toContain("/work/rootfs/etc/profile.d/machinen-fnm.sh");
+    expect(script).toContain("/work/rootfs/etc/bash.bashrc");
+    expect(script).toContain(". /etc/profile.d/machinen-fnm.sh");
+  });
+});
 
 describe("scripts/release-base-assets.mjs verify", () => {
   it("passes when a published asset matches its sidecar", () => {

--- a/packages/microvm/assets/exec-agent.zig
+++ b/packages/microvm/assets/exec-agent.zig
@@ -229,6 +229,11 @@ const SessionEntry = struct {
 
 var sessions: [MAX_SESSIONS]SessionEntry = [_]SessionEntry{.{}} ** MAX_SESSIONS;
 
+const DEFAULT_PATH_ENV = "PATH=/opt/fnm/aliases/default/bin:/usr/local/bin:/usr/bin:/bin:/sbin";
+const DEFAULT_FNM_DIR_ENV = "FNM_DIR=/opt/fnm";
+const DEFAULT_HOME_ENV = "HOME=/root";
+const DEFAULT_TERM_ENV = "TERM=xterm-256color";
+
 fn run_vmstate_reseed(client_fd: c_int, seed_hex: []const u8) void {
     std.debug.assert(client_fd >= 0);
     if (seed_hex.len == 0 or seed_hex.len > MAX_RESEED_HEX) {
@@ -247,7 +252,8 @@ fn run_vmstate_reseed(client_fd: c_int, seed_hex: []const u8) void {
             null,
         };
         const envp = &[_:null]?[*:0]const u8{
-            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            DEFAULT_PATH_ENV,
+            DEFAULT_FNM_DIR_ENV,
             null,
         };
         _ = execve(VMSTATE_RESEED_HELPER, argv, envp);
@@ -286,10 +292,11 @@ fn run_command(client_fd: c_int, cmd: []const u8, alloc: std.mem.Allocator) !voi
         // expand `~` against it. Default to /root since the agent
         // runs as PID 1's child and there's no real login session
         // here. Callers who want a different home can override via
-        // the cmd itself (`HOME=/foo bash -c ...`).
+        // the cmd itself (`HOME=/foo sh -c ...`).
         const envp = &[_:null]?[*:0]const u8{
-            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
-            "HOME=/root",
+            DEFAULT_PATH_ENV,
+            DEFAULT_FNM_DIR_ENV,
+            DEFAULT_HOME_ENV,
             null,
         };
         ignore_int(execve("/bin/sh", argv, envp));
@@ -359,14 +366,15 @@ fn run_pty_command(
         // exec — no signals to clear, no fds to close.
         const argv = &[_:null]?[*:0]const u8{ "sh", "-c", cmd_z.ptr, null };
         const envp = &[_:null]?[*:0]const u8{
-            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
+            DEFAULT_PATH_ENV,
+            DEFAULT_FNM_DIR_ENV,
             // See the matching comment in runCommand — same rationale
             // for HOME (git/npm/ssh-keygen/shells need it).
-            "HOME=/root",
+            DEFAULT_HOME_ENV,
             // Default to a sane TERM so curses-based TUIs work
             // out of the box. The host can override via env in cmd
-            // (e.g. `TERM=xterm-kitty bash -i`) if it knows better.
-            "TERM=xterm-256color",
+            // (e.g. `TERM=xterm-kitty sh -c ...`) if it knows better.
+            DEFAULT_TERM_ENV,
             null,
         };
         ignore_int(execve("/bin/sh", argv, envp));
@@ -726,9 +734,10 @@ fn spawn_session_child(cmd: []const u8, cols: u16, rows: u16, master_fd: *c_int)
     if (child_pid == 0) {
         const argv = &[_:null]?[*:0]const u8{ "sh", "-c", cmd_z, null };
         const envp = &[_:null]?[*:0]const u8{
-            "PATH=/usr/local/bin:/usr/bin:/bin:/sbin",
-            "HOME=/root",
-            "TERM=xterm-256color",
+            DEFAULT_PATH_ENV,
+            DEFAULT_FNM_DIR_ENV,
+            DEFAULT_HOME_ENV,
+            DEFAULT_TERM_ENV,
             null,
         };
         ignore_int(execve("/bin/sh", argv, envp));

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -100,6 +100,10 @@ const EXT4_IOC_RESIZE_FS: c_ulong = 0x40086610;
 
 const CONFIG_PATH = "/machinen-config.json";
 const BATCH_SYNC_SCRIPT = "/run/machinen-batch-sync.sh";
+const DEFAULT_PATH_ENV = "PATH=/opt/fnm/aliases/default/bin:/usr/local/bin:/usr/bin:/bin:/sbin";
+const DEFAULT_FNM_DIR_ENV = "FNM_DIR=/opt/fnm";
+const DEFAULT_HOME_ENV = "HOME=/root";
+const DEFAULT_TERM_ENV = "TERM=linux";
 
 // Where the rootdisk gets mounted before the chroot. Anything not
 // already in use under / works; we pick a name unlikely to collide with
@@ -390,13 +394,16 @@ fn load_config(arena: std.mem.Allocator) !Config {
 
     // env — optional object of string→string.
     var env_count: usize = 0;
+    var saw_path = false;
+    var saw_fnm_dir = false;
+    var saw_home = false;
     var saw_term = false;
     if (obj.get("env")) |env_val| {
         if (env_val != .object) return error.EnvNotObject;
         env_count = env_val.object.count();
     }
 
-    const envp_buf = try arena.alloc(?[*:0]const u8, env_count + 2); // +TERM +null sentinel slack
+    const envp_buf = try arena.alloc(?[*:0]const u8, env_count + 5); // +PATH/FNM_DIR/HOME/TERM +null
     var env_idx: usize = 0;
     if (obj.get("env")) |env_val| {
         var it = env_val.object.iterator();
@@ -405,11 +412,26 @@ fn load_config(arena: std.mem.Allocator) !Config {
             const kv = try std.fmt.allocPrint(arena, "{s}={s}", .{ e.key_ptr.*, e.value_ptr.string });
             envp_buf[env_idx] = try dup_z(arena, kv);
             env_idx += 1;
+            if (std.mem.eql(u8, e.key_ptr.*, "PATH")) saw_path = true;
+            if (std.mem.eql(u8, e.key_ptr.*, "FNM_DIR")) saw_fnm_dir = true;
+            if (std.mem.eql(u8, e.key_ptr.*, "HOME")) saw_home = true;
             if (std.mem.eql(u8, e.key_ptr.*, "TERM")) saw_term = true;
         }
     }
+    if (!saw_path) {
+        envp_buf[env_idx] = try dup_z(arena, DEFAULT_PATH_ENV);
+        env_idx += 1;
+    }
+    if (!saw_fnm_dir) {
+        envp_buf[env_idx] = try dup_z(arena, DEFAULT_FNM_DIR_ENV);
+        env_idx += 1;
+    }
+    if (!saw_home) {
+        envp_buf[env_idx] = try dup_z(arena, DEFAULT_HOME_ENV);
+        env_idx += 1;
+    }
     if (!saw_term) {
-        envp_buf[env_idx] = try dup_z(arena, "TERM=linux");
+        envp_buf[env_idx] = try dup_z(arena, DEFAULT_TERM_ENV);
         env_idx += 1;
     }
     envp_buf[env_idx] = null;

--- a/scripts/build-base-assets.sh
+++ b/scripts/build-base-assets.sh
@@ -39,7 +39,9 @@
 #   fnm @ /usr/local/bin/fnm  ← Node version manager. Hits the public
 #                                node-dist mirror by default; callers
 #                                can redirect via FNM_NODE_DIST_MIRROR
-#                                in `boot({ env })`.
+#                                in `boot({ env })`. The base rootfs
+#                                also sets FNM_DIR=/opt/fnm and puts the
+#                                default Node alias on shell PATH.
 #
 # Requirements:
 #   - docker (with arm64 emulation; GH runners have this by default via
@@ -577,6 +579,27 @@ install -m 0755 -D /stage/net-bench-probe   /work/rootfs/sbin/machinen-net-bench
 install -m 0755 -D /stage/memdirty          /work/rootfs/sbin/machinen-memdirty
 install -m 0755 -D /stage/winsize-agent     /work/rootfs/sbin/machinen-winsize-agent
 install -m 0755 -D /stage/fnm               /work/rootfs/usr/local/bin/fnm
+
+# fnm is baked into the base rootfs so Node-based recipes can install
+# a target Node version without downloading a version manager first.
+# Keep the install root outside /root so baked images can share the same
+# convention across provisioning hooks, login shells, and attach shells.
+install -m 0755 -d /work/rootfs/opt/fnm /work/rootfs/etc/profile.d
+cat > /work/rootfs/etc/profile.d/machinen-fnm.sh <<'EOF'
+export FNM_DIR="${FNM_DIR:-/opt/fnm}"
+case ":$PATH:" in
+  *":$FNM_DIR/aliases/default/bin:"*) ;;
+  *) export PATH="$FNM_DIR/aliases/default/bin:$PATH" ;;
+esac
+EOF
+chmod 0644 /work/rootfs/etc/profile.d/machinen-fnm.sh
+cat >> /work/rootfs/etc/bash.bashrc <<'EOF'
+
+# Machinen: make fnm's default Node install usable in interactive attach shells.
+if [ -r /etc/profile.d/machinen-fnm.sh ]; then
+  . /etc/profile.d/machinen-fnm.sh
+fi
+EOF
 # Shell-script helpers that drive the snapshot/restore contract. Staged
 # in by the host-side build step alongside the zig binaries.
 install -m 0755 -D /stage/machinen-supervisor.sh     /work/rootfs/sbin/machinen-supervisor


### PR DESCRIPTION
## Problem

Node-based VM recipes should be able to use `fnm`, Node, npm, and globally installed npm bins without repeating shell bootstrap code in every recipe.

## Solution

This PR makes the base rootfs and guest runtime defaults point at a shared fnm install root. Shells, `vm.exec()` calls, PTY sessions, and foreground VM workloads all see fnm's default Node bin path by default.

## Technical Summary

- Install `fnm` into the base rootfs.
- Create `/opt/fnm` as the shared fnm install root.
- Add `/etc/profile.d/machinen-fnm.sh` with `FNM_DIR=/opt/fnm` and the default alias bin path on PATH.
- Source that profile from `/etc/bash.bashrc` for interactive attach/login shells.
- Set exec-agent defaults for `PATH`, `FNM_DIR`, `HOME`, and PTY `TERM` so `vm.exec()` and PTY sessions do not need `bash -lc` just to see Node tools.
- Set `/init` workload defaults for `PATH`, `FNM_DIR`, `HOME`, and `TERM`, preserving caller-provided env overrides.
- Add a static release-asset guard test for the fnm profile/bootstrap files.

Fixes #1010.
