### PR TITLE
Allow safe absolute guest mount paths

### DIFF
--- a/.changeset/safe-guest-mount-paths.md
+++ b/.changeset/safe-guest-mount-paths.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Allow safe absolute guest mount paths for mounts and live mounts, with reserved-path protection and an explicit `unsafeGuestPath` escape hatch for advanced use.

--- a/docs/guides/mount-files.md
+++ b/docs/guides/mount-files.md
@@ -130,10 +130,22 @@ await boot({
 });
 ```
 
-A naming rule for both `--mount` and `--mount-live`: the guest path
-must be under `/mnt/`. This is a deliberate constraint — keeping all
-host-shared paths in one place makes it obvious to anyone reading code
-in the guest where data is coming from.
+Guest paths for both `--mount` and `--mount-live` must be safe absolute
+paths. Paths such as `/root/.config/tool`, `/workspace`, `/var/cache/tool`,
+and `/mnt/workspace` are allowed. Machinen rejects paths that hide runtime or
+kernel-managed locations such as `/`, `/dev`, `/proc`, `/sys`, `/run`, `/init`,
+`/exec-agent`, and Machinen's own `/sbin/machinen-*` helpers.
+
+From the Node API, you can bypass that guard for a mount only when you really
+mean it:
+
+```ts
+await boot({
+  image,
+  cmd,
+  mount: { host: "./state", guest: "/run/my-tool", unsafeGuestPath: true },
+});
+```
 
 ## A single file — `vm.writeFile()`
 

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -12,7 +12,7 @@ export function printHelp(): void {
       `    --snapshot <path>                            Attach <path> as /dev/vda — scratch\n` +
       `                                                 disk for a future vm.snapshot().\n` +
       `    --mount <host-dir>:<guest-path>              Expose one host dir inside the guest\n` +
-      `                                                 (path under /mnt/; copy-once).\n` +
+      `                                                 (safe absolute path; copy-once).\n` +
       `    --mount-live <host-dir>:<guest-path>[:<mode>]\n` +
       `                                                 Live-share a host dir over FUSE.\n` +
       `                                                 Guest reads stream in on demand; no\n` +

--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -1768,7 +1768,7 @@ Optional arch-specific base rootfs tarball
 A single host directory copied into the guest between the base
 tarball and the bundle's rootfs. Bundle files win on path
 collisions. The caller is responsible for validating host exists
-and is a directory, and that guest lives under `/mnt/`. See #64.
+and is a directory, and that guest is a safe absolute path. See #64.
 
 ###### host
 
@@ -1839,7 +1839,7 @@ Guest mountpoint for the `--mount` overlay (#272). When set, the
 cpio carries `/etc/machinen-mountdisk-guest` with this path so
 /init knows where to layer the squashfs+ext4 overlay after the
 rootdisk pivot. The actual payload rides on virtio-blk slots 5+6,
-not in the cpio. Must be an absolute path under `/mnt/`.
+not in the cpio. Must be a safe absolute path.
 
 ##### initPath?
 
@@ -4349,30 +4349,10 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-A single host directory exposed to the guest as a writable
-filesystem rooted under `/mnt/<guest>/`. Guest writes survive
-snapshot/restore but never leak to the host source dir.
-
-Implementation (#272): the runtime builds a content-addressed
-read-only squashfs lower from `host` (cached in
-`~/.cache/machinen/mountdisk/`) and a per-VM ext4 sparse upper
-(4 GiB by default; bump via `mountDiskUpperSizeBytes`). Both
-files are fd-passed to the VMM, surfacing inside the guest as
-`/dev/vdc` (RO) and `/dev/vdd` (RW); /init layers them as a
-single overlayfs at `<guest>/`. The squashfs lower stays
-sealed for the VM's lifetime; writes go to the upper, which
-is reflinked into snapshot bundles so forks see prior writes
-without touching the source dir.
-
-Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
-runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is an in-VMM
-virtio-fs pass-through (writes land on the host and restore/fork
-re-establish the same guest mount topology). Pick `mount` for inputs the
-guest may modify but the host shouldn't see; `liveMount` for shared scratch.
-
-See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
-relocation; same shape), #272 (this overlay relocation).
+Copy one host directory into a writable guest overlay at a safe absolute
+path. Guest writes survive snapshot/restore but do not touch the host.
+Use `liveMounts` when writes should sync back. Pass `unsafeGuestPath: true`
+only when intentionally mounting over a reserved runtime path.
 
 ###### host
 
@@ -4381,6 +4361,10 @@ relocation; same shape), #272 (this overlay relocation).
 ###### guest
 
 > **guest**: `string`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ###### Inherited from
 
@@ -4406,25 +4390,10 @@ Must be a positive multiple of 4096. Default 4 GiB.
 
 > `optional` **liveMounts?**: `object`[]
 
-Host directories exposed to the guest as live-share mounts (#78,
-#332). Unlike `mount` (copy-once), these stay connected to the
-host: guest reads stream on demand and `"rw"` writes sync back to
-the host. Set `"ro"` for a one-way share.
-
-Each guest path must live under `/mnt/`. Up to 5 entries are served
-by in-VMM virtio-fs devices; no guest agent or vsock transport is
-involved. Metadata uses the fast policy. `ro` mounts are read-only;
-`rw` mounts sync writes back to the host in batches after guest
-workload exit and host lifecycle calls.
-
-Snapshot / restore / fork record host path, guest path, and mode,
-but not bytes. Restoring on another host fails if the recorded host
-path is missing; pass `restore({ liveMounts })` with matching
-`guest` paths to remap host/mode.
-
-Security note: a live-share mount is a persistent guest-to-host
-filesystem channel bounded to the configured host root. Prefer
-`mount` for untrusted inputs that do not need write-through.
+Host directories exposed as live virtio-fs shares. `ro` is read-only;
+`rw` writes sync back to the host in batches. Guest paths must be safe
+absolute paths unless `unsafeGuestPath: true` is set intentionally.
+Snapshot / restore / fork record path topology, not file bytes.
 
 ###### host
 
@@ -4437,6 +4406,10 @@ filesystem channel bounded to the configured host root. Prefer
 ###### mode?
 
 > `optional` **mode?**: `"ro"` \| `"rw"`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ###### Inherited from
 
@@ -4770,30 +4743,10 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-A single host directory exposed to the guest as a writable
-filesystem rooted under `/mnt/<guest>/`. Guest writes survive
-snapshot/restore but never leak to the host source dir.
-
-Implementation (#272): the runtime builds a content-addressed
-read-only squashfs lower from `host` (cached in
-`~/.cache/machinen/mountdisk/`) and a per-VM ext4 sparse upper
-(4 GiB by default; bump via `mountDiskUpperSizeBytes`). Both
-files are fd-passed to the VMM, surfacing inside the guest as
-`/dev/vdc` (RO) and `/dev/vdd` (RW); /init layers them as a
-single overlayfs at `<guest>/`. The squashfs lower stays
-sealed for the VM's lifetime; writes go to the upper, which
-is reflinked into snapshot bundles so forks see prior writes
-without touching the source dir.
-
-Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
-runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is an in-VMM
-virtio-fs pass-through (writes land on the host and restore/fork
-re-establish the same guest mount topology). Pick `mount` for inputs the
-guest may modify but the host shouldn't see; `liveMount` for shared scratch.
-
-See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
-relocation; same shape), #272 (this overlay relocation).
+Copy one host directory into a writable guest overlay at a safe absolute
+path. Guest writes survive snapshot/restore but do not touch the host.
+Use `liveMounts` when writes should sync back. Pass `unsafeGuestPath: true`
+only when intentionally mounting over a reserved runtime path.
 
 ###### host
 
@@ -4802,6 +4755,10 @@ relocation; same shape), #272 (this overlay relocation).
 ###### guest
 
 > **guest**: `string`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ##### mountDiskUpperSizeBytes?
 
@@ -4819,25 +4776,10 @@ Must be a positive multiple of 4096. Default 4 GiB.
 
 > `optional` **liveMounts?**: `object`[]
 
-Host directories exposed to the guest as live-share mounts (#78,
-#332). Unlike `mount` (copy-once), these stay connected to the
-host: guest reads stream on demand and `"rw"` writes sync back to
-the host. Set `"ro"` for a one-way share.
-
-Each guest path must live under `/mnt/`. Up to 5 entries are served
-by in-VMM virtio-fs devices; no guest agent or vsock transport is
-involved. Metadata uses the fast policy. `ro` mounts are read-only;
-`rw` mounts sync writes back to the host in batches after guest
-workload exit and host lifecycle calls.
-
-Snapshot / restore / fork record host path, guest path, and mode,
-but not bytes. Restoring on another host fails if the recorded host
-path is missing; pass `restore({ liveMounts })` with matching
-`guest` paths to remap host/mode.
-
-Security note: a live-share mount is a persistent guest-to-host
-filesystem channel bounded to the configured host root. Prefer
-`mount` for untrusted inputs that do not need write-through.
+Host directories exposed as live virtio-fs shares. `ro` is read-only;
+`rw` writes sync back to the host in batches. Guest paths must be safe
+absolute paths unless `unsafeGuestPath: true` is set intentionally.
+Snapshot / restore / fork record path topology, not file bytes.
 
 ###### host
 
@@ -4850,6 +4792,10 @@ filesystem channel bounded to the configured host root. Prefer
 ###### mode?
 
 > `optional` **mode?**: `"ro"` \| `"rw"`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ##### portForward?
 
@@ -5183,30 +5129,10 @@ forked from. Set by `restore({ snapDir })`; visible in
 
 > `optional` **mount?**: `object`
 
-A single host directory exposed to the guest as a writable
-filesystem rooted under `/mnt/<guest>/`. Guest writes survive
-snapshot/restore but never leak to the host source dir.
-
-Implementation (#272): the runtime builds a content-addressed
-read-only squashfs lower from `host` (cached in
-`~/.cache/machinen/mountdisk/`) and a per-VM ext4 sparse upper
-(4 GiB by default; bump via `mountDiskUpperSizeBytes`). Both
-files are fd-passed to the VMM, surfacing inside the guest as
-`/dev/vdc` (RO) and `/dev/vdd` (RW); /init layers them as a
-single overlayfs at `<guest>/`. The squashfs lower stays
-sealed for the VM's lifetime; writes go to the upper, which
-is reflinked into snapshot bundles so forks see prior writes
-without touching the source dir.
-
-Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
-runtime channel back to the host source dir, snapshots cleanly,
-but writes don't propagate to the host); `liveMount` is an in-VMM
-virtio-fs pass-through (writes land on the host and restore/fork
-re-establish the same guest mount topology). Pick `mount` for inputs the
-guest may modify but the host shouldn't see; `liveMount` for shared scratch.
-
-See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
-relocation; same shape), #272 (this overlay relocation).
+Copy one host directory into a writable guest overlay at a safe absolute
+path. Guest writes survive snapshot/restore but do not touch the host.
+Use `liveMounts` when writes should sync back. Pass `unsafeGuestPath: true`
+only when intentionally mounting over a reserved runtime path.
 
 ###### host
 
@@ -5215,6 +5141,10 @@ relocation; same shape), #272 (this overlay relocation).
 ###### guest
 
 > **guest**: `string`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ###### Inherited from
 
@@ -5240,25 +5170,10 @@ Must be a positive multiple of 4096. Default 4 GiB.
 
 > `optional` **liveMounts?**: `object`[]
 
-Host directories exposed to the guest as live-share mounts (#78,
-#332). Unlike `mount` (copy-once), these stay connected to the
-host: guest reads stream on demand and `"rw"` writes sync back to
-the host. Set `"ro"` for a one-way share.
-
-Each guest path must live under `/mnt/`. Up to 5 entries are served
-by in-VMM virtio-fs devices; no guest agent or vsock transport is
-involved. Metadata uses the fast policy. `ro` mounts are read-only;
-`rw` mounts sync writes back to the host in batches after guest
-workload exit and host lifecycle calls.
-
-Snapshot / restore / fork record host path, guest path, and mode,
-but not bytes. Restoring on another host fails if the recorded host
-path is missing; pass `restore({ liveMounts })` with matching
-`guest` paths to remap host/mode.
-
-Security note: a live-share mount is a persistent guest-to-host
-filesystem channel bounded to the configured host root. Prefer
-`mount` for untrusted inputs that do not need write-through.
+Host directories exposed as live virtio-fs shares. `ro` is read-only;
+`rw` writes sync back to the host in batches. Guest paths must be safe
+absolute paths unless `unsafeGuestPath: true` is set intentionally.
+Snapshot / restore / fork record path topology, not file bytes.
 
 ###### host
 
@@ -5271,6 +5186,10 @@ filesystem channel bounded to the configured host root. Prefer
 ###### mode?
 
 > `optional` **mode?**: `"ro"` \| `"rw"`
+
+###### unsafeGuestPath?
+
+> `optional` **unsafeGuestPath?**: `boolean`
 
 ###### Inherited from
 

--- a/packages/runtime/native/src/boot_plan.zig
+++ b/packages/runtime/native/src/boot_plan.zig
@@ -421,6 +421,7 @@ pub const LiveMountInput = struct {
     host: []const u8,
     guest: []const u8,
     mode: ?[]const u8 = null,
+    unsafe_guest_path: bool = false,
 };
 
 pub const LiveMountRemovedOptionsInput = struct {
@@ -865,6 +866,7 @@ pub const Input = struct {
     root_disk: RootDiskMode = .unset,
     guest_cwd: ?[]const u8 = null,
     mount_guest: ?[]const u8 = null,
+    mount_unsafe_guest_path: bool = false,
 };
 
 pub const Plan = struct {
@@ -893,7 +895,8 @@ pub const PlanError = error{
     InvalidGuestCwdAbsolute,
     InvalidGuestCwdNul,
     InvalidMountGuestAbsolute,
-    InvalidMountGuestRoot,
+    InvalidMountGuestNul,
+    InvalidMountGuestReserved,
     TooManyLiveMounts,
     InvalidLiveMountMode,
     MissingBundleCommand,
@@ -1181,7 +1184,7 @@ pub fn planLiveMounts(allocator: std.mem.Allocator, mounts: []const LiveMountInp
         if (!std.mem.eql(u8, mode, "ro") and !std.mem.eql(u8, mode, "rw")) {
             return error.InvalidLiveMountMode;
         }
-        const guest = try normalizeMountGuest(mount.guest);
+        const guest = try normalizeMountGuest(mount.guest, mount.unsafe_guest_path);
         var tag_buf: [64]u8 = undefined;
         const tag_text = try std.fmt.bufPrint(&tag_buf, "machinen-lm{d}", .{i});
         const tag = try std.mem.concat(allocator, u8, &.{tag_text});
@@ -2381,7 +2384,7 @@ pub fn planCore(input: Input) PlanError!Plan {
     }
     if (input.guest_cwd) |cwd| try validateGuestCwd(cwd);
     const normalized_mount_guest = if (input.mount_guest) |guest|
-        try normalizeMountGuest(guest)
+        try normalizeMountGuest(guest, input.mount_unsafe_guest_path)
     else
         null;
 
@@ -2422,17 +2425,43 @@ pub fn validateGuestCwd(cwd: []const u8) PlanError!void {
     if (std.mem.indexOfScalar(u8, cwd, 0) != null) return error.InvalidGuestCwdNul;
 }
 
-pub fn normalizeMountGuest(guest: []const u8) PlanError![]const u8 {
+pub fn normalizeMountGuest(guest: []const u8, unsafe_guest_path: bool) PlanError![]const u8 {
     assert(@sizeOf([]const u8) > 0);
 
     if (guest.len == 0 or guest[0] != '/') return error.InvalidMountGuestAbsolute;
+    if (std.mem.indexOfScalar(u8, guest, 0) != null) return error.InvalidMountGuestNul;
     var end = guest.len;
-    while (end > 0 and guest[end - 1] == '/') : (end -= 1) {}
+    while (end > 1 and guest[end - 1] == '/') : (end -= 1) {}
     const trimmed = guest[0..end];
-    if (!std.mem.startsWith(u8, trimmed, "/mnt/") or std.mem.eql(u8, trimmed, "/mnt")) {
-        return error.InvalidMountGuestRoot;
+    if (!unsafe_guest_path and isReservedMountGuest(trimmed)) {
+        return error.InvalidMountGuestReserved;
     }
     return trimmed;
+}
+
+fn isReservedMountGuest(guest: []const u8) bool {
+    assert(guest.len > 0);
+
+    if (std.mem.eql(u8, guest, "/")) return true;
+    if (std.mem.eql(u8, guest, "/mnt")) return true;
+    if (hasPathPrefix(guest, "/dev")) return true;
+    if (hasPathPrefix(guest, "/proc")) return true;
+    if (hasPathPrefix(guest, "/sys")) return true;
+    if (hasPathPrefix(guest, "/run")) return true;
+    if (std.mem.eql(u8, guest, "/init")) return true;
+    if (std.mem.eql(u8, guest, "/exec-agent")) return true;
+    if (std.mem.eql(u8, guest, "/sbin/machinen") or
+        std.mem.startsWith(u8, guest, "/sbin/machinen-")) return true;
+    return false;
+}
+
+fn hasPathPrefix(path: []const u8, prefix: []const u8) bool {
+    assert(prefix.len > 0);
+
+    return std.mem.eql(u8, path, prefix) or
+        (path.len > prefix.len and
+            path[prefix.len] == '/' and
+            std.mem.startsWith(u8, path, prefix));
 }
 
 fn isDecimal(text: []const u8) bool {
@@ -2677,15 +2706,39 @@ test "planCore validates guest cwd and normalizes mount guest paths" {
         .mount_guest = "mnt/app",
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
-    try std.testing.expectError(error.InvalidMountGuestRoot, planCore(.{
-        .mount_guest = "/srv/app",
+    try std.testing.expectError(error.InvalidMountGuestNul, planCore(.{
+        .mount_guest = "/mnt/app\x00bad",
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     }));
+    const reserved_guests = [_][]const u8{
+        "/",
+        "/mnt",
+        "/dev",
+        "/dev/null",
+        "/proc",
+        "/sys/fs",
+        "/run/machinen",
+        "/init",
+        "/exec-agent",
+        "/sbin/machinen-poweroff",
+    };
+    for (reserved_guests) |guest| {
+        try std.testing.expectError(error.InvalidMountGuestReserved, planCore(.{
+            .mount_guest = guest,
+            .host_total_bytes = 8 * 1024 * 1024 * 1024,
+        }));
+    }
     const plan = try planCore(.{
-        .mount_guest = "/mnt/app///",
+        .mount_guest = "/root/.commandcode///",
         .host_total_bytes = 8 * 1024 * 1024 * 1024,
     });
-    try std.testing.expectEqualStrings("/mnt/app", plan.normalized_mount_guest.?);
+    try std.testing.expectEqualStrings("/root/.commandcode", plan.normalized_mount_guest.?);
+    const unsafe = try planCore(.{
+        .mount_guest = "/run/tool-state",
+        .mount_unsafe_guest_path = true,
+        .host_total_bytes = 8 * 1024 * 1024 * 1024,
+    });
+    try std.testing.expectEqualStrings("/run/tool-state", unsafe.normalized_mount_guest.?);
 }
 
 test "planRegistryProcessIdentityReads plans darwin process identity reads" {
@@ -3618,6 +3671,31 @@ test "planLiveMounts validates count guest paths modes and tags" {
     try std.testing.expectEqualStrings("/mnt/b", planned[1].guest);
     try std.testing.expectEqualStrings("ro", planned[1].mode);
     try std.testing.expectEqualStrings("machinen-lm1", planned[1].tag);
+
+    const root_state = [_]LiveMountInput{.{ .host = "./state", .guest = "/root/.commandcode" }};
+    const root_state_planned = try planLiveMounts(std.testing.allocator, &root_state);
+    defer {
+        for (root_state_planned) |mount| std.testing.allocator.free(mount.tag);
+        std.testing.allocator.free(root_state_planned);
+    }
+    try std.testing.expectEqualStrings("/root/.commandcode", root_state_planned[0].guest);
+
+    const reserved = [_]LiveMountInput{.{ .host = "./run", .guest = "/run/tool" }};
+    try std.testing.expectError(
+        error.InvalidMountGuestReserved,
+        planLiveMounts(std.testing.allocator, &reserved),
+    );
+    const unsafe = [_]LiveMountInput{.{
+        .host = "./run",
+        .guest = "/run/tool",
+        .unsafe_guest_path = true,
+    }};
+    const unsafe_planned = try planLiveMounts(std.testing.allocator, &unsafe);
+    defer {
+        for (unsafe_planned) |mount| std.testing.allocator.free(mount.tag);
+        std.testing.allocator.free(unsafe_planned);
+    }
+    try std.testing.expectEqualStrings("/run/tool", unsafe_planned[0].guest);
 
     const bad_mode = [_]LiveMountInput{.{
         .host = "./a",

--- a/packages/runtime/native/src/commands/boot_plan.zig
+++ b/packages/runtime/native/src/commands/boot_plan.zig
@@ -24,6 +24,7 @@ const ParsedRequest = struct {
     root_disk_restore_path: ?[]const u8 = null,
     guest_cwd: ?[]const u8 = null,
     mount_guest: ?[]const u8 = null,
+    mount_unsafe_guest_path: bool = false,
     guest_env: std.json.ObjectMap = .{},
     vmm_env_base: std.json.ObjectMap = .{},
     vmm_env_overrides: std.json.ObjectMap = .{},
@@ -245,6 +246,7 @@ const boot_plan_fields = [_][]const u8{
     "rootDiskRestorePath",
     "guestCwd",
     "mountGuest",
+    "mountUnsafeGuestPath",
     "guestEnv",
     "vmmEnvBase",
     "vmmEnvOverrides",
@@ -3149,6 +3151,7 @@ fn makePlanInput(
         .root_disk = parsed.root_disk,
         .guest_cwd = parsed.guest_cwd,
         .mount_guest = parsed.mount_guest,
+        .mount_unsafe_guest_path = parsed.mount_unsafe_guest_path,
     };
 }
 
@@ -3299,6 +3302,15 @@ fn parseBootShapeFields(
         .restore_path = request.root_disk_restore_path,
     });
     request.root_disk = if (option_root_disk != .unset) option_root_disk else legacy_root_disk;
+    try parseGuestPathEnvFields(object, request);
+}
+
+fn parseGuestPathEnvFields(
+    object: std.json.ObjectMap,
+    request: *ParsedRequest,
+) RequestError!void {
+    assert(@sizeOf(ParsedRequest) > 0);
+
     request.guest_cwd = try optionalStringDefaultNull(
         object,
         "guestCwd",
@@ -3307,6 +3319,11 @@ fn parseBootShapeFields(
     request.mount_guest = try optionalStringDefaultNull(
         object,
         "mountGuest",
+        error.InvalidMountGuest,
+    );
+    request.mount_unsafe_guest_path = try optionalBoolDefaultFalse(
+        object,
+        "mountUnsafeGuestPath",
         error.InvalidMountGuest,
     );
     request.guest_env = try optionalObjectDefaultEmpty(object, "guestEnv", error.InvalidGuestEnv);
@@ -4595,17 +4612,23 @@ fn optionalLiveMounts(
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidLiveMounts;
-        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        try protocol.rejectUnknownFields(
+            item.object,
+            &.{ "host", "guest", "mode", "unsafeGuestPath" },
+        );
         const host = item.object.get("host") orelse return error.InvalidLiveMountHost;
         const guest = item.object.get("guest") orelse return error.InvalidLiveMountGuest;
         const mode = item.object.get("mode") orelse .null;
+        const unsafe = item.object.get("unsafeGuestPath") orelse .null;
         if (host != .string) return error.InvalidLiveMountHost;
         if (guest != .string) return error.InvalidLiveMountGuest;
         if (mode != .null and mode != .string) return error.InvalidLiveMountMode;
+        if (unsafe != .null and unsafe != .bool) return error.InvalidLiveMountGuest;
         try mounts.append(allocator, .{
             .host = host.string,
             .guest = guest.string,
             .mode = if (mode == .string) mode.string else null,
+            .unsafe_guest_path = if (unsafe == .bool) unsafe.bool else false,
         });
     }
     return mounts.toOwnedSlice(allocator);
@@ -4696,7 +4719,10 @@ fn optionalRestoreLiveMountsOverrides(
     errdefer mounts.deinit(allocator);
     for (value.array.items) |item| {
         if (item != .object) return error.InvalidRestoreLiveMountsOverrides;
-        try protocol.rejectUnknownFields(item.object, &.{ "host", "guest", "mode" });
+        try protocol.rejectUnknownFields(
+            item.object,
+            &.{ "host", "guest", "mode", "unsafeGuestPath" },
+        );
         const host = item.object.get("host") orelse return error.InvalidRestoreLiveMountsOverrides;
         const guest = item.object.get("guest") orelse {
             return error.InvalidRestoreLiveMountsOverrides;
@@ -5116,10 +5142,16 @@ fn writePathPlanError(io: std.Io, err: anyerror) !bool {
             "BOOT_MOUNT_INVALID",
             "mount guest path must be absolute",
         ),
-        error.InvalidMountGuestRoot => try writeBootError(
+        error.InvalidMountGuestNul => try writeBootError(
             io,
             "BOOT_MOUNT_INVALID",
-            "mount guest path must live under /mnt/",
+            "mount guest path must not contain NUL bytes",
+        ),
+        error.InvalidMountGuestReserved => try writeBootError(
+            io,
+            "BOOT_MOUNT_INVALID",
+            "mount guest path is reserved; pass unsafeGuestPath: true " ++
+                "if you really intend to mount there",
         ),
         else => return false,
     }

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -668,10 +668,10 @@ describe("mount option", () => {
     }
   });
 
-  it("rejects a mount whose guest path is not under /mnt/", async () => {
+  it("rejects a mount whose guest path is reserved", async () => {
     writeFileSync(fakeImage, "");
     try {
-      for (const guest of ["/srv/app", "/etc/config", "/proc", "/init", "/mntfoo"]) {
+      for (const guest of ["/", "/mnt", "/mnt/", "/proc", "/proc/self", "/run/tool", "/init"]) {
         await expect(
           boot({
             binary: "/bin/sh",
@@ -679,27 +679,7 @@ describe("mount option", () => {
             cmd: mountCmd,
             mount: { host: "/tmp", guest },
           }),
-        ).rejects.toThrow(/must live under \/mnt\//);
-      }
-    } finally {
-      try {
-        unlinkSync(fakeImage);
-      } catch {}
-    }
-  });
-
-  it("rejects a mount whose guest path is the mount root itself", async () => {
-    writeFileSync(fakeImage, "");
-    try {
-      for (const guest of ["/mnt", "/mnt/"]) {
-        await expect(
-          boot({
-            binary: "/bin/sh",
-            image: fakeImage,
-            cmd: mountCmd,
-            mount: { host: "/tmp", guest },
-          }),
-        ).rejects.toThrow(/must live under \/mnt\//);
+        ).rejects.toThrow(/unsafeGuestPath: true/);
       }
     } finally {
       try {
@@ -890,7 +870,7 @@ describe("liveMounts option", () => {
     }
   });
 
-  it("rejects a live mount with a host path outside /mnt/", async () => {
+  it("rejects a live mount with a reserved guest path", async () => {
     writeFileSync(fakeImage, "");
     try {
       await expect(
@@ -898,9 +878,9 @@ describe("liveMounts option", () => {
           binary: "/bin/sh",
           image: fakeImage,
           cmd: mountCmd,
-          liveMounts: [{ host: "/tmp", guest: "/srv/app" }],
+          liveMounts: [{ host: "/tmp", guest: "/run/tool" }],
         }),
-      ).rejects.toThrow(/must live under \/mnt\//);
+      ).rejects.toThrow(/unsafeGuestPath: true/);
     } finally {
       try {
         unlinkSync(fakeImage);

--- a/packages/runtime/src/__tests__/live-mount-cache.test.ts
+++ b/packages/runtime/src/__tests__/live-mount-cache.test.ts
@@ -52,6 +52,29 @@ describe("resolveLiveMounts live-mount options", () => {
     ]);
   });
 
+  it("allows safe absolute guest paths outside /mnt", () => {
+    expect(resolveLiveMounts([{ host: hostDir, guest: "/root/.commandcode" }], undefined)).toEqual([
+      {
+        host: hostDir,
+        guest: "/root/.commandcode",
+        mode: "rw",
+        tag: "machinen-lm0",
+      },
+    ]);
+  });
+
+  it("allows reserved guest paths only with unsafeGuestPath", () => {
+    expect(() => resolveLiveMounts([{ host: hostDir, guest: "/run/tool" }], undefined)).toThrow(
+      /unsafeGuestPath: true/,
+    );
+    expect(
+      resolveLiveMounts(
+        [{ host: hostDir, guest: "/run/tool", unsafeGuestPath: true }],
+        undefined,
+      ).map(({ guest, mode, tag }) => ({ guest, mode, tag })),
+    ).toEqual([{ guest: "/run/tool", mode: "rw", tag: "machinen-lm0" }]);
+  });
+
   it("preserves ro mode", () => {
     expect(
       resolveLiveMounts([{ host: hostDir, guest: "/mnt/fixtures", mode: "ro" }], undefined).map(

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -75,7 +75,7 @@ export interface PackBundleOptions {
    * A single host directory copied into the guest between the base
    * tarball and the bundle's rootfs. Bundle files win on path
    * collisions. The caller is responsible for validating host exists
-   * and is a directory, and that guest lives under `/mnt/`. See #64.
+   * and is a directory, and that guest is a safe absolute path. See #64.
    */
   mount?: { host: string; guest: string };
   /**
@@ -271,7 +271,7 @@ export interface PackTinyBundleOptions {
    * cpio carries `/etc/machinen-mountdisk-guest` with this path so
    * /init knows where to layer the squashfs+ext4 overlay after the
    * rootdisk pivot. The actual payload rides on virtio-blk slots 5+6,
-   * not in the cpio. Must be an absolute path under `/mnt/`.
+   * not in the cpio. Must be a safe absolute path.
    */
   mountGuest?: string;
   /** Optional override for the compiled /init. Default: ../microvm/test-fixtures/init relative to this file. */

--- a/packages/runtime/src/native/boot-plan.ts
+++ b/packages/runtime/src/native/boot-plan.ts
@@ -37,7 +37,12 @@ type RequiredBundleConfigPathsPlan = {
 };
 
 type PortForwardPlanMapping = { hostPort: number; guestPort: number; hostAddr?: string };
-type LiveMountPlanInput = { host: string; guest: string; mode?: string };
+type LiveMountPlanInput = {
+  host: string;
+  guest: string;
+  mode?: string;
+  unsafeGuestPath?: boolean;
+};
 
 interface NativeBootPlanInput {
   memoryMib?: number;
@@ -52,6 +57,7 @@ interface NativeBootPlanInput {
   rootDisk: RootDiskPlanMode;
   guestCwd?: string;
   mountGuest?: string;
+  mountUnsafeGuestPath?: boolean;
   guestEnv?: Record<string, string>;
   name?: string;
   vsockUdsPath?: string;
@@ -187,6 +193,7 @@ function buildBootPlanRequestData(input: NativeBootPlanInput): Record<string, un
     rootDisk: input.rootDisk,
     guestCwd: nullDefault(input.guestCwd),
     mountGuest: nullDefault(input.mountGuest),
+    mountUnsafeGuestPath: input.mountUnsafeGuestPath === true,
     guestEnv: input.guestEnv ?? {},
     name: nullDefault(input.name),
     vsockUdsPath: nullDefault(input.vsockUdsPath),
@@ -372,6 +379,7 @@ function liveMountsData(liveMounts: LiveMountPlanInput[] | undefined): unknown[]
     host: mount.host,
     guest: mount.guest,
     mode: mount.mode ?? null,
+    unsafeGuestPath: mount.unsafeGuestPath === true,
   }));
 }
 

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -218,32 +218,12 @@ export interface BootOptions {
    */
   forkedFrom?: string;
   /**
-   * A single host directory exposed to the guest as a writable
-   * filesystem rooted under `/mnt/<guest>/`. Guest writes survive
-   * snapshot/restore but never leak to the host source dir.
-   *
-   * Implementation (#272): the runtime builds a content-addressed
-   * read-only squashfs lower from `host` (cached in
-   * `~/.cache/machinen/mountdisk/`) and a per-VM ext4 sparse upper
-   * (4 GiB by default; bump via `mountDiskUpperSizeBytes`). Both
-   * files are fd-passed to the VMM, surfacing inside the guest as
-   * `/dev/vdc` (RO) and `/dev/vdd` (RW); /init layers them as a
-   * single overlayfs at `<guest>/`. The squashfs lower stays
-   * sealed for the VM's lifetime; writes go to the upper, which
-   * is reflinked into snapshot bundles so forks see prior writes
-   * without touching the source dir.
-   *
-   * Trade-off vs. `liveMount`: `mount` is copy-into-disk-image (no
-   * runtime channel back to the host source dir, snapshots cleanly,
-   * but writes don't propagate to the host); `liveMount` is an in-VMM
-   * virtio-fs pass-through (writes land on the host and restore/fork
-   * re-establish the same guest mount topology). Pick `mount` for inputs the
-   * guest may modify but the host shouldn't see; `liveMount` for shared scratch.
-   *
-   * See #64 (original `mount`), #78 (`liveMount`), #114 (rootdisk
-   * relocation; same shape), #272 (this overlay relocation).
+   * Copy one host directory into a writable guest overlay at a safe absolute
+   * path. Guest writes survive snapshot/restore but do not touch the host.
+   * Use `liveMounts` when writes should sync back. Pass `unsafeGuestPath: true`
+   * only when intentionally mounting over a reserved runtime path.
    */
-  mount?: { host: string; guest: string };
+  mount?: { host: string; guest: string; unsafeGuestPath?: boolean };
   /**
    * Absolute target size (bytes) for the per-VM ext4 RW upper of
    * the `--mount` overlay (#272). Sparse, so unused capacity costs
@@ -290,30 +270,16 @@ export interface BootOptions {
    */
   _rootDiskRestorePath?: string;
   /**
-   * Host directories exposed to the guest as live-share mounts (#78,
-   * #332). Unlike `mount` (copy-once), these stay connected to the
-   * host: guest reads stream on demand and `"rw"` writes sync back to
-   * the host. Set `"ro"` for a one-way share.
-   *
-   * Each guest path must live under `/mnt/`. Up to 5 entries are served
-   * by in-VMM virtio-fs devices; no guest agent or vsock transport is
-   * involved. Metadata uses the fast policy. `ro` mounts are read-only;
-   * `rw` mounts sync writes back to the host in batches after guest
-   * workload exit and host lifecycle calls.
-   *
-   * Snapshot / restore / fork record host path, guest path, and mode,
-   * but not bytes. Restoring on another host fails if the recorded host
-   * path is missing; pass `restore({ liveMounts })` with matching
-   * `guest` paths to remap host/mode.
-   *
-   * Security note: a live-share mount is a persistent guest-to-host
-   * filesystem channel bounded to the configured host root. Prefer
-   * `mount` for untrusted inputs that do not need write-through.
+   * Host directories exposed as live virtio-fs shares. `ro` is read-only;
+   * `rw` writes sync back to the host in batches. Guest paths must be safe
+   * absolute paths unless `unsafeGuestPath: true` is set intentionally.
+   * Snapshot / restore / fork record path topology, not file bytes.
    */
   liveMounts?: Array<{
     host: string;
     guest: string;
     mode?: "ro" | "rw";
+    unsafeGuestPath?: boolean;
   }>;
   /**
    * Host -> guest TCP port forwards installed via gvproxy's control

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -62,6 +62,7 @@ export function resolveLiveMounts(
     host: string;
     guest: string;
     mode?: "ro" | "rw";
+    unsafeGuestPath?: boolean;
   }>,
   cwd: string | undefined,
 ): ResolvedLiveMount[] {
@@ -291,7 +292,7 @@ function resolveBundleMount(opts: BootOptions): ResolvedMountInput | undefined {
   if (!opts.mount) {
     return undefined;
   }
-  validateMountGuest(opts.mount.guest);
+  validateMountGuest(opts.mount.guest, opts.mount.unsafeGuestPath === true);
   const hostAbs = resolve(opts.cwd ?? process.cwd(), opts.mount.host);
   if (!existsSync(hostAbs)) {
     throw new BootError(
@@ -305,7 +306,10 @@ function resolveBundleMount(opts: BootOptions): ResolvedMountInput | undefined {
       `mount host path must be a directory (got a file): ${opts.mount.host}`,
     );
   }
-  return { host: hostAbs, guest: normalizeMountGuest(opts.mount.guest) };
+  return {
+    host: hostAbs,
+    guest: normalizeMountGuest(opts.mount.guest, opts.mount.unsafeGuestPath === true),
+  };
 }
 
 function packSynthesizedInitramfs(

--- a/packages/runtime/src/vm/helpers.ts
+++ b/packages/runtime/src/vm/helpers.ts
@@ -128,9 +128,10 @@ export function resolveVmmBinary(): string {
 
 // Guest path validation lives in the native boot planner so mount
 // planning rules stay aligned across boot, restore, and live mounts.
-export function normalizeMountGuest(guest: string): string {
+export function normalizeMountGuest(guest: string, unsafeGuestPath: boolean = false): string {
   const plan = planBootCoreNative({
     mountGuest: guest,
+    mountUnsafeGuestPath: unsafeGuestPath,
     vmmMemoryPreset: true,
     hasImage: false,
     hasCmd: false,
@@ -152,8 +153,8 @@ export function validateGuestCwd(cwd: string): void {
   });
 }
 
-export function validateMountGuest(guest: string): void {
-  normalizeMountGuest(guest);
+export function validateMountGuest(guest: string, unsafeGuestPath: boolean = false): void {
+  normalizeMountGuest(guest, unsafeGuestPath);
 }
 
 /**

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -293,9 +293,9 @@ expect_cli_error \
   boot --mount "$HOST_FILE:/mnt/f" -- true
 
 expect_cli_error \
-  "V3: --mount with guest path outside /mnt/" \
-  "must live under /mnt/" \
-  boot --mount "$EMPTY_DIR:/etc/passwd" -- true
+  "V3: --mount with reserved guest path" \
+  "unsafeGuestPath: true" \
+  boot --mount "$EMPTY_DIR:/proc/machinen-test" -- true
 
 expect_cli_error \
   "V4: second --mount rejected" \
@@ -315,9 +315,9 @@ expect_cli_error \
   boot --mount-live "$HOST_FILE:/mnt/f" -- true
 
 expect_cli_error \
-  "V7: --mount-live with guest path outside /mnt/" \
-  "must live under /mnt/" \
-  boot --mount-live "$EMPTY_DIR:/etc/passwd" -- true
+  "V7: --mount-live with reserved guest path" \
+  "unsafeGuestPath: true" \
+  boot --mount-live "$EMPTY_DIR:/run/machinen-test" -- true
 
 expect_cli_error \
   "V8: --mount-live rejects an unknown trailing modifier" \


### PR DESCRIPTION
## Problem

Machinen forced every mounted guest path to live under `/mnt`. That made simple tool state mounts awkward. For example, a tool that expects state at `/root/.commandcode` needed extra symlink setup.

## Solution

Mount paths can now be any safe absolute guest path. Machinen still blocks paths that would hide core runtime or kernel-managed locations, and the error explains how to opt into the unsafe path on purpose.

## Technical Summary

- Change the native mount planner from a `/mnt/...` rule to a safe absolute path rule.
- Deny reserved paths such as `/`, `/dev`, `/proc`, `/sys`, `/run`, `/init`, `/exec-agent`, and `/sbin/machinen-*` by default.
- Add per-mount `unsafeGuestPath: true` for callers that intentionally mount a reserved path.
- Apply the policy to both copy-once `mount` and live `liveMounts`.
- Keep existing host path validation and live-mount mode validation unchanged.
- Update docs, CLI help, unit tests, and smoke validation to match the new policy.
