### PR TITLE
Fix attach-owned vmstate boot asset metadata

### DIFF
--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -14,7 +14,10 @@ import {
   rememberTrustedFileIdentity,
   trustedFileIdentity,
 } from "../vm/vmstate-metadata.ts";
-import { vmstateBootAssetsId } from "../vm/vmstate-boot-assets.ts";
+import {
+  snapshotVmstateBootAssetsIdentity,
+  vmstateBootAssetsId,
+} from "../vm/vmstate-boot-assets.ts";
 import type { SnapshotFileIdentity, VmstateSnapshotMeta } from "../vm-handle.ts";
 
 const MAGIC = Buffer.from("VMSTATE\0");
@@ -461,6 +464,17 @@ describe("vmstate portability metadata", () => {
     await expect(restore({ snapDir: dir, image, binary: "/bin/sh" })).rejects.toThrow(
       /rootdisk identity mismatch/,
     );
+  });
+
+  it("resolves base boot assets when an attach-owned vmstate snapshot lacks recorded paths", () => {
+    const image = join(TMP, "attach-owned-rootfs.tar.gz");
+    writeFileSync(image, "attach rootfs");
+
+    expect(snapshotVmstateBootAssetsIdentity({ sourceImage: image })).toMatchObject({
+      rootfs: fileIdentity(image),
+      kernel: fileIdentity(join(ASSETS, "Image-arm64")),
+      dtb: fileIdentity(join(ASSETS, "virt-arm64.dtb")),
+    });
   });
 
   it("refuses a vmstate bundle that lacks boot asset metadata", async () => {

--- a/packages/runtime/src/vm/vmstate-boot-assets.ts
+++ b/packages/runtime/src/vm/vmstate-boot-assets.ts
@@ -70,18 +70,39 @@ export function snapshotVmstateBootAssetsIdentity(
         "  Reboot with a current runtime/CLI so the registry records the rootfs tarball.",
     );
   }
-  if (!ctx.kernelPath) {
+  const kernelPath = ctx.kernelPath ?? resolveSnapshotBaseKernel();
+  const dtbPath = ctx.dtbPath ?? resolveSnapshotBaseDtb();
+  return buildVmstateBootAssetsIdentity({
+    rootfsPath: ctx.sourceImage,
+    kernelPath,
+    dtbPath,
+  });
+}
+
+function resolveSnapshotBaseKernel(): string {
+  try {
+    return resolveBaseKernel();
+  } catch (err) {
     throw new SnapshotError(
       "SNAPSHOT_DUMP_FAILED",
       "vm.snapshot: cannot record vmstate boot asset identity because the source kernel image is unknown.\n" +
-        "  Boot with an explicit kernel path or through the CLI base-asset resolver.",
+        "  Boot with an explicit kernel path or make the matching Machinen base assets available.",
+      { cause: err },
     );
   }
-  return buildVmstateBootAssetsIdentity({
-    rootfsPath: ctx.sourceImage,
-    kernelPath: ctx.kernelPath,
-    dtbPath: ctx.dtbPath,
-  });
+}
+
+function resolveSnapshotBaseDtb(): string | undefined {
+  try {
+    return resolveBaseDtb();
+  } catch (err) {
+    throw new SnapshotError(
+      "SNAPSHOT_DUMP_FAILED",
+      "vm.snapshot: cannot record vmstate boot asset identity because the source DTB is unknown.\n" +
+        "  Boot with an explicit DTB path or make the matching Machinen base assets available.",
+      { cause: err },
+    );
+  }
 }
 
 export function validateVmstateBootAssets(args: {


### PR DESCRIPTION
## Problem\n\nThe vmstate boot asset check added in #1008 worked for boot-owned snapshots, but CLI snapshots use an attached handle. Attached handles do not carry the original kernel/DTB paths, so vmstate snapshots failed before restore smoke tests could finish.\n\n## Solution\n\nWhen snapshot metadata lacks recorded kernel/DTB paths, resolve the matching Machinen base assets before recording vmstate boot asset identity. This keeps CLI snapshot working while still recording exact rootfs/kernel/DTB bytes.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.58s\n- `pnpm run lint` passed in 0.43s\n- `pnpm run typecheck` passed in 4.88s\n- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/vmstate-portability.test.ts` passed in 3.88s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.33s\n- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` passed in 139.06s