### PR TITLE
Carry vmstate boot asset paths through registry

### DIFF
--- a/packages/runtime/API.md
+++ b/packages/runtime/API.md
@@ -2951,6 +2951,18 @@ Host-side vsock UDS the exec-agent is reachable on.
 
 Path to the image the VM was booted from (diagnostic only).
 
+##### kernelPath?
+
+> `optional` **kernelPath?**: `string`
+
+Guest kernel image the VM was booted with, when known.
+
+##### dtbPath?
+
+> `optional` **dtbPath?**: `string`
+
+Guest DTB the VM was booted with, when applicable and known.
+
 ##### rootDiskPath?
 
 > `optional` **rootDiskPath?**: `string`

--- a/packages/runtime/src/__tests__/registry.test.ts
+++ b/packages/runtime/src/__tests__/registry.test.ts
@@ -314,11 +314,17 @@ describe("boot + attach end-to-end", () => {
 
   it("boot() writes a registry entry that list() + attach() can find", async () => {
     const udsPath = join(tmpdir(), `machinen-attach-${process.pid}.sock`);
+    const kernelPath = join(scratchDir, "Image");
+    const dtbPath = join(scratchDir, "virt.dtb");
+    writeFileSync(kernelPath, "kernel");
+    writeFileSync(dtbPath, "dtb");
     const agent = startFakeAgent({ socketPath: udsPath, stdout: "from-attach\n", exitCode: 0 });
     try {
       const vm = await boot({
         binary: "/usr/bin/yes",
         vmmEnv: { MACHINEN_VSOCK: `in:1978:${udsPath}` },
+        kernel: kernelPath,
+        dtb: dtbPath,
         name: "my-worker",
         timeoutMs: 5_000,
       });
@@ -326,9 +332,10 @@ describe("boot + attach end-to-end", () => {
         expect(vm.pid).toBeGreaterThan(0);
         expect(vm.name).toBe("my-worker");
 
-        // list() should include it, pid alive.
+        // list() should include it, pid alive, with boot asset paths for attached snapshots.
         const entries = list();
         expect(entries.some((e) => e.pid === vm.pid && e.name === "my-worker")).toBe(true);
+        expect(entries.find((e) => e.pid === vm.pid)).toMatchObject({ kernelPath, dtbPath });
 
         // attach({ name }) should connect and exec through the same UDS.
         const attached = await attach({ name: "my-worker" });

--- a/packages/runtime/src/__tests__/vmstate-portability.test.ts
+++ b/packages/runtime/src/__tests__/vmstate-portability.test.ts
@@ -466,15 +466,34 @@ describe("vmstate portability metadata", () => {
     );
   });
 
-  it("resolves base boot assets when an attach-owned vmstate snapshot lacks recorded paths", () => {
+  it("records boot assets from the paths carried by boot and attach handles", () => {
     const image = join(TMP, "attach-owned-rootfs.tar.gz");
+    const kernelPath = join(ASSETS, "Image-arm64");
+    const dtbPath = join(ASSETS, "virt-arm64.dtb");
     writeFileSync(image, "attach rootfs");
 
-    expect(snapshotVmstateBootAssetsIdentity({ sourceImage: image })).toMatchObject({
+    expect(
+      snapshotVmstateBootAssetsIdentity(
+        { sourceImage: image, kernelPath, dtbPath },
+        { guestArch: "arm64" },
+      ),
+    ).toMatchObject({
       rootfs: fileIdentity(image),
-      kernel: fileIdentity(join(ASSETS, "Image-arm64")),
-      dtb: fileIdentity(join(ASSETS, "virt-arm64.dtb")),
+      kernel: fileIdentity(kernelPath),
+      dtb: fileIdentity(dtbPath),
     });
+  });
+
+  it("refuses an arm64 vmstate snapshot when the boot DTB path was not recorded", () => {
+    const image = join(TMP, "missing-dtb-rootfs.tar.gz");
+    writeFileSync(image, "attach rootfs");
+
+    expect(() =>
+      snapshotVmstateBootAssetsIdentity(
+        { sourceImage: image, kernelPath: join(ASSETS, "Image-arm64") },
+        { guestArch: "arm64" },
+      ),
+    ).toThrow(/source DTB is unknown/);
   });
 
   it("refuses a vmstate bundle that lacks boot asset metadata", async () => {

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -48,6 +48,10 @@ export interface RegistryEntry {
   socketPath: string;
   /** Path to the image the VM was booted from (diagnostic only). */
   imagePath?: string;
+  /** Guest kernel image the VM was booted with, when known. */
+  kernelPath?: string;
+  /** Guest DTB the VM was booted with, when applicable and known. */
+  dtbPath?: string;
   /**
    * Host-side path of the root block device currently attached as
    * `/dev/vda`. Vmstate snapshots need the exact bytes because the

--- a/packages/runtime/src/vm/attach.ts
+++ b/packages/runtime/src/vm/attach.ts
@@ -203,6 +203,8 @@ export async function attach(opts: AttachOptions = {}): Promise<VmHandle> {
       pid: entry.pid,
       sourceName: entry.name,
       sourceImage: entry.imagePath,
+      kernelPath: entry.kernelPath,
+      dtbPath: entry.dtbPath,
       rootDiskPath: entry.rootDiskPath,
       rootDiskMode: entry.rootDiskMode,
       memoryCeilingMib: entry.memoryCeilingMib,

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -899,6 +899,8 @@ function buildRegisterArgs(
     vmName: state.vmName,
     vsockUdsPath: args.plan.vsockUdsPath!,
     sourceImageAbs: state.sourceImageAbs,
+    kernelPath: args.plan.env.MACHINEN_KERNEL,
+    dtbPath: args.plan.env.MACHINEN_DTB,
     rootDiskPath: state.rootDiskPath,
     rootDiskMode: state.rootDiskMode,
     diskPath: args.plan.diskAbs,
@@ -1516,13 +1518,8 @@ function closeFds(...fds: number[]): void {
   }
 }
 
-// Backstop for the recycled-pid case: `claimName` already drops pins
-// whose holder fails the recycling/orphan check, but a pre-#268 entry
-// without `vmmExe`/`startedAt` falls back to `kill(pid,0)` and can
-// stay pinned by an unrelated process now sitting on the recycled
-// pid. `runGc` walks the whole registry (also cleaning cleanupPaths)
-// and we retry the claim once. If a still-live VMM genuinely holds
-// the name, the retry fails and we throw.
+// Backstop for stale/recycled-pid name pins: run GC, retry once,
+// then fail if a live VMM still owns the name.
 function claimNameOrThrow(
   vmName: string,
   childPid: number,
@@ -1550,6 +1547,8 @@ interface RegisterArgs {
   vmName: string | undefined;
   vsockUdsPath: string;
   sourceImageAbs: string | undefined;
+  kernelPath: string | undefined;
+  dtbPath: string | undefined;
   rootDiskPath: string | undefined;
   rootDiskMode: "block" | "none";
   diskPath: string | undefined;
@@ -1574,9 +1573,6 @@ interface RegisterArgs {
   nested: boolean | undefined;
 }
 
-// Write the registry entry. Returns true on success; registry-write
-// failures are best-effort (attach won't find this VM but local
-// boot-and-use still works fine).
 function registerInRegistry(args: RegisterArgs): boolean {
   try {
     writeEntry(buildRegistryEntry(args));
@@ -1613,6 +1609,8 @@ function buildRegistryEntry(args: RegisterArgs) {
     name: args.vmName,
     socketPath: args.vsockUdsPath,
     imagePath: args.sourceImageAbs,
+    kernelPath: args.kernelPath,
+    dtbPath: args.dtbPath,
     rootDiskPath: args.rootDiskPath,
     rootDiskMode: args.rootDiskMode,
     diskPath: scalars.diskPath ?? undefined,

--- a/packages/runtime/src/vm/snapshot.ts
+++ b/packages/runtime/src/vm/snapshot.ts
@@ -915,14 +915,15 @@ function buildVmstateMeta(
   rootDisk: VmstateSnapshotMeta["rootDisk"],
 ): VmstateSnapshotMeta {
   const facts = readVmstateFacts(statePath);
+  const guestArch = vmstateGuestArch(facts);
   return {
     sourceBackend: currentVmstateBackend(),
-    guestArch: vmstateGuestArch(facts),
+    guestArch,
     topologyHash: facts.topologyHash,
     memoryCeilingMib: ctx.memoryCeilingMib,
     guestPauth: vmstateGuestPauth(facts),
     rootDisk,
-    bootAssets: snapshotVmstateBootAssetsIdentity(ctx),
+    bootAssets: snapshotVmstateBootAssetsIdentity(ctx, { guestArch }),
     kernel: optionalFileIdentity(ctx.kernelPath),
     dtb: optionalFileIdentity(ctx.dtbPath),
     checkpoint: buildVmstateCheckpoint(ctx, snapDir, parentDir, sequence, flags),

--- a/packages/runtime/src/vm/vmstate-boot-assets.ts
+++ b/packages/runtime/src/vm/vmstate-boot-assets.ts
@@ -62,6 +62,7 @@ function updateBootAssetsIdentityPart(
 
 export function snapshotVmstateBootAssetsIdentity(
   ctx: BootAssetsSnapshotSource,
+  opts: { guestArch?: VmstateSnapshotMeta["guestArch"] } = {},
 ): VmstateSnapshotMeta["bootAssets"] {
   if (!ctx.sourceImage) {
     throw new SnapshotError(
@@ -70,39 +71,25 @@ export function snapshotVmstateBootAssetsIdentity(
         "  Reboot with a current runtime/CLI so the registry records the rootfs tarball.",
     );
   }
-  const kernelPath = ctx.kernelPath ?? resolveSnapshotBaseKernel();
-  const dtbPath = ctx.dtbPath ?? resolveSnapshotBaseDtb();
-  return buildVmstateBootAssetsIdentity({
-    rootfsPath: ctx.sourceImage,
-    kernelPath,
-    dtbPath,
-  });
-}
-
-function resolveSnapshotBaseKernel(): string {
-  try {
-    return resolveBaseKernel();
-  } catch (err) {
+  if (!ctx.kernelPath) {
     throw new SnapshotError(
       "SNAPSHOT_DUMP_FAILED",
       "vm.snapshot: cannot record vmstate boot asset identity because the source kernel image is unknown.\n" +
-        "  Boot with an explicit kernel path or make the matching Machinen base assets available.",
-      { cause: err },
+        "  Reboot with a current runtime/CLI so the registry records the kernel path.",
     );
   }
-}
-
-function resolveSnapshotBaseDtb(): string | undefined {
-  try {
-    return resolveBaseDtb();
-  } catch (err) {
+  if (opts.guestArch === "arm64" && !ctx.dtbPath) {
     throw new SnapshotError(
       "SNAPSHOT_DUMP_FAILED",
       "vm.snapshot: cannot record vmstate boot asset identity because the source DTB is unknown.\n" +
-        "  Boot with an explicit DTB path or make the matching Machinen base assets available.",
-      { cause: err },
+        "  Reboot with a current runtime/CLI so the registry records the DTB path.",
     );
   }
+  return buildVmstateBootAssetsIdentity({
+    rootfsPath: ctx.sourceImage,
+    kernelPath: ctx.kernelPath,
+    dtbPath: ctx.dtbPath,
+  });
 }
 
 export function validateVmstateBootAssets(args: {


### PR DESCRIPTION
## Problem\n\nThe vmstate boot asset metadata should describe the files a VM actually booted with. The previous attach-owned snapshot fallback resolved kernel/DTB assets again at snapshot time, which worked but duplicated the boot asset lookup and could drift if the local asset resolver changed.\n\n## Solution\n\nPersist the resolved kernel and DTB paths in the VM registry at boot time. Attached snapshot handles now read those paths from the registry and pass them into vmstate metadata, so snapshot hashing uses the same boot asset paths the VMM was launched with. The snapshot helper now fails closed if required boot asset paths were not recorded instead of guessing later.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.70s\n- `pnpm run lint` passed in 0.43s\n- `pnpm run build:docs` passed in 1.22s\n- `pnpm run typecheck` passed in 4.55s\n- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/vmstate-portability.test.ts packages/runtime/src/__tests__/registry.test.ts` passed in 3.90s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.34s\n- `MACHINEN_REMOTE_BUILDER=friend@100.126.46.90 pnpm smoke-tests` passed in 139.48s