### PR TITLE
Fix release runtime host tool staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
             packages/microvm/zig-out/bin/machinen-vm
           key: vmm-darwin-arm64-${{ hashFiles('packages/microvm/src/**', 'packages/microvm/assets/**/*.zig', 'packages/microvm/build.zig', 'packages/microvm/build.zig.zon', 'packages/microvm/entitlements.plist') }}
       - name: Setup Zig
-        if: steps.cache.outputs.cache-hit != 'true'
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
@@ -106,6 +105,19 @@ jobs:
           name: vmm-arm64-darwin
           path: |
             packages/microvm/zig-out/bin/machinen-vm
+          if-no-files-found: error
+          retention-days: 7
+      - name: Build runtime helper host tools
+        working-directory: packages/runtime/native
+        run: zig build -Doptimize=ReleaseSafe
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runtime-helper-arm64-darwin
+          path: |
+            packages/runtime/native/zig-out/bin/machinen-runtime-helper
+            packages/runtime/native/zig-out/bin/machinen-pdeathsig
+            packages/runtime/native/zig-out/bin/machinen-pty
+            packages/runtime/native/zig-out/bin/machinen-winsize
           if-no-files-found: error
           retention-days: 7
 
@@ -216,31 +228,36 @@ jobs:
         with:
           name: vmm-x64-linux
           path: packages/native-x64-linux/vmm/bin/
-      - name: Build and stage machinen-runtime-helper
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: runtime-helper-arm64-darwin
+          path: packages/native-arm64-darwin/vmm/bin/
+      - name: Build and stage Linux runtime helper host tools
         run: |
           set -euo pipefail
-          rm -rf "${RUNNER_TEMP}/machinen-runtime-helper"
-          mkdir -p "${RUNNER_TEMP}/machinen-runtime-helper"
+          rm -rf "${RUNNER_TEMP}/runtime-helper-host-tools"
+          mkdir -p "${RUNNER_TEMP}/runtime-helper-host-tools"
           cd packages/runtime/native
-          zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-macos --prefix "${RUNNER_TEMP}/machinen-runtime-helper/arm64-darwin"
-          zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux --prefix "${RUNNER_TEMP}/machinen-runtime-helper/arm64-linux"
-          zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux --prefix "${RUNNER_TEMP}/machinen-runtime-helper/x64-linux"
+          zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux --prefix "${RUNNER_TEMP}/runtime-helper-host-tools/arm64-linux"
+          zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux --prefix "${RUNNER_TEMP}/runtime-helper-host-tools/x64-linux"
           cd ../../..
-          cp "${RUNNER_TEMP}/machinen-runtime-helper/arm64-darwin/bin/machinen-runtime-helper" packages/native-arm64-darwin/vmm/bin/machinen-runtime-helper
-          cp "${RUNNER_TEMP}/machinen-runtime-helper/arm64-linux/bin/machinen-runtime-helper" packages/native-arm64-linux/vmm/bin/machinen-runtime-helper
-          cp "${RUNNER_TEMP}/machinen-runtime-helper/x64-linux/bin/machinen-runtime-helper" packages/native-x64-linux/vmm/bin/machinen-runtime-helper
+          for tool in machinen-runtime-helper machinen-pdeathsig machinen-pty machinen-winsize; do
+            cp "${RUNNER_TEMP}/runtime-helper-host-tools/arm64-linux/bin/${tool}" "packages/native-arm64-linux/vmm/bin/${tool}"
+            cp "${RUNNER_TEMP}/runtime-helper-host-tools/x64-linux/bin/${tool}" "packages/native-x64-linux/vmm/bin/${tool}"
+          done
 
       # chmod host tools so the working copy stays usable locally; the
       # `bin` field in each package's package.json is what makes pnpm
       # pack preserve the +x bit in the published tarball (issue #309).
       - run: |
-          chmod +x \
-            packages/native-arm64-darwin/vmm/bin/machinen-vm \
-            packages/native-arm64-darwin/vmm/bin/machinen-runtime-helper \
-            packages/native-arm64-linux/vmm/bin/machinen-vm \
-            packages/native-arm64-linux/vmm/bin/machinen-runtime-helper \
-            packages/native-x64-linux/vmm/bin/machinen-vm \
-            packages/native-x64-linux/vmm/bin/machinen-runtime-helper
+          for pkg in packages/native-arm64-darwin packages/native-arm64-linux packages/native-x64-linux; do
+            chmod +x \
+              "$pkg/vmm/bin/machinen-vm" \
+              "$pkg/vmm/bin/machinen-runtime-helper" \
+              "$pkg/vmm/bin/machinen-pdeathsig" \
+              "$pkg/vmm/bin/machinen-pty" \
+              "$pkg/vmm/bin/machinen-winsize"
+          done
 
       # gvproxy (containers/gvisor-tap-vsock) — bundled next to the VMM
       # so `@machinen/runtime` can auto-spawn it for virtio-net without

--- a/packages/native-arm64-darwin/.gitignore
+++ b/packages/native-arm64-darwin/.gitignore
@@ -1,8 +1,13 @@
-# VMM + gvproxy + guest ELFs: CI stages these during publish; locally
-# `scripts/build-vmm.sh` + `scripts/install-gvproxy.sh` + the base-asset
-# build produce them. Absent in the repo so `git status` stays clean.
+# VMM + runtime host tools + gvproxy + guest ELFs: CI stages these during
+# publish; locally `scripts/build-vmm.sh`, `scripts/build-runtime-helper.sh`,
+# `scripts/install-gvproxy.sh`, and the base-asset build produce them. Absent
+# in the repo so `git status` stays clean.
 vmm/bin/machinen-vm
 vmm/bin/machinen-vm.inputs-sha256
+vmm/bin/machinen-runtime-helper
+vmm/bin/machinen-pdeathsig
+vmm/bin/machinen-pty
+vmm/bin/machinen-winsize
 vmm/bin/gvproxy
 vmm/guest/init
 vmm/guest/fuse-agent

--- a/packages/native-arm64-linux/.gitignore
+++ b/packages/native-arm64-linux/.gitignore
@@ -1,8 +1,13 @@
-# VMM + gvproxy + guest ELFs: CI stages these during publish; locally
-# `scripts/build-vmm.sh` + `scripts/install-gvproxy.sh` + the base-asset
-# build produce them. Absent in the repo so `git status` stays clean.
+# VMM + runtime host tools + gvproxy + guest ELFs: CI stages these during
+# publish; locally `scripts/build-vmm.sh`, `scripts/build-runtime-helper.sh`,
+# `scripts/install-gvproxy.sh`, and the base-asset build produce them. Absent
+# in the repo so `git status` stays clean.
 vmm/bin/machinen-vm
 vmm/bin/machinen-vm.inputs-sha256
+vmm/bin/machinen-runtime-helper
+vmm/bin/machinen-pdeathsig
+vmm/bin/machinen-pty
+vmm/bin/machinen-winsize
 vmm/bin/gvproxy
 vmm/guest/init
 vmm/guest/fuse-agent

--- a/packages/native-x64-linux/.gitignore
+++ b/packages/native-x64-linux/.gitignore
@@ -1,8 +1,13 @@
-# VMM + gvproxy + guest ELFs: CI stages these during publish; locally
-# `scripts/build-vmm.sh` + `scripts/install-gvproxy.sh` + the base-asset
-# build produce them. Absent in the repo so `git status` stays clean.
+# VMM + runtime host tools + gvproxy + guest ELFs: CI stages these during
+# publish; locally `scripts/build-vmm.sh`, `scripts/build-runtime-helper.sh`,
+# `scripts/install-gvproxy.sh`, and the base-asset build produce them. Absent
+# in the repo so `git status` stays clean.
 vmm/bin/machinen-vm
 vmm/bin/machinen-vm.inputs-sha256
+vmm/bin/machinen-runtime-helper
+vmm/bin/machinen-pdeathsig
+vmm/bin/machinen-pty
+vmm/bin/machinen-winsize
 vmm/bin/gvproxy
 vmm/guest/init
 vmm/guest/fuse-agent


### PR DESCRIPTION
## Problem\n\nThe release build is trying to build the macOS runtime host tools on an Ubuntu runner. The PTY helper uses macOS headers like `util.h`, so that cross-build fails before the release can continue.\n\nThe release step also only staged `machinen-runtime-helper`, while the native packages now expect the related host tools too: `machinen-pdeathsig`, `machinen-pty`, and `machinen-winsize`.\n\n## Solution\n\nBuild the Darwin runtime host tools natively in the existing macOS release job and upload them as an artifact. The Ubuntu release job now downloads those Darwin tools and only cross-builds the Linux host tools. It stages all four runtime host tools for each native package and marks them executable.\n\nI also added those generated tools to the native package `.gitignore` files so local smoke/build runs do not leave them as untracked files.\n\n## Validation\n\n- `zig build -Doptimize=ReleaseSafe --prefix /tmp/machinen-runtime-tools-test/arm64-darwin` passed in 0.26s\n- `zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux --prefix /tmp/machinen-runtime-tools-test/arm64-linux` passed in 10.93s\n- `zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux --prefix /tmp/machinen-runtime-tools-test/x64-linux` passed in 10.65s\n- `pnpm run format:check` passed in 0.56s\n- `pnpm run lint` passed in 0.41s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.30s