### PR TITLE
Relax Vitest hook timeout for release runners

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     include: ["packages/*/src/__tests__/**/*.test.ts"],
     setupFiles: ["./vitest.setup.ts"],
+    // Several runtime suites build the Zig helper in beforeAll(). GitHub
+    // release runners can spend >10s there when tests start in parallel.
+    hookTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Problem\n\nThe release workflow now gets past runtime host tool staging, but the Ubuntu release job can time out in Vitest `beforeAll` hooks. Several runtime test files build the Zig helper in setup, and those builds can take more than Vitest's default 10 second hook timeout when release tests start in parallel.\n\n## Solution\n\nSet Vitest's global `hookTimeout` to 60 seconds. This keeps the normal test timeout unchanged, but gives helper-build setup hooks enough time on release runners.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.57s\n- `pnpm run lint` passed in 0.37s\n- `pnpm run typecheck` passed in 4.21s\n- `MACHINEN_REQUIRE_FIXTURES=0 NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/rootfs-img.test.ts packages/runtime/src/__tests__/memory.test.ts packages/runtime/src/__tests__/boot.test.ts` passed in 19.51s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.28s