### PR TITLE
Allow slow snapshot failure test on CI

### DIFF
--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -1023,7 +1023,7 @@ describe("vm.snapshot", () => {
         rmSync(outDir, { recursive: true, force: true });
       } catch {}
     }
-  });
+  }, 15_000);
 });
 
 // Fake exec-agent — accepts a UDS connection, reads one EXEC line,


### PR DESCRIPTION
## Problem\n\nThe release workflow now passes the host-tool staging and Vitest setup hooks, but the release runner still timed out one snapshot error-path test at Vitest's default 5 second test timeout. That test boots a VM, waits for it to exit, then asks snapshot to fail with a short timeout, so it can legitimately take longer on hosted runners.\n\n## Solution\n\nGive that specific test a 15 second timeout. This does not change the global test timeout.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.65s\n- `pnpm run lint` passed in 1.16s\n- `pnpm run typecheck` passed in 4.50s\n- `MACHINEN_REQUIRE_FIXTURES=0 NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/boot.test.ts` passed in 19.30s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.28s