### PR TITLE
Add missing 0.7 release notes

### DIFF
--- a/.changeset/default-boot-assets.md
+++ b/.changeset/default-boot-assets.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": minor
+---
+
+`boot()` now resolves the release kernel and DTB for normal boots, so callers using the standard Machinen image no longer have to pass those paths by hand. Explicit `kernel` and `dtb` options still win, and test/custom VMM boots that pass `binary` keep their previous behavior.

--- a/.changeset/live-mount-vmstate-native-planning.md
+++ b/.changeset/live-mount-vmstate-native-planning.md
@@ -1,0 +1,8 @@
+---
+"@machinen/runtime": patch
+"@machinen/cli": patch
+"@machinen/microvm": patch
+"@machinen/mount-server": patch
+---
+
+Move more boot, provision, restore, live-mount, and vmstate planning into the Zig runtime helper/VMM boundary. This keeps TypeScript focused on orchestration, improves live-mount batching and metadata handling, and fixes the first KVM vmstate checkpoint dirty-bitmap path.

--- a/.changeset/native-runtime-host-tools.md
+++ b/.changeset/native-runtime-host-tools.md
@@ -1,0 +1,7 @@
+---
+"@machinen/native-arm64-darwin": patch
+"@machinen/native-arm64-linux": patch
+"@machinen/native-x64-linux": patch
+---
+
+Ship the runtime's native host tools with the platform packages: `machinen-runtime-helper`, `machinen-pdeathsig`, `machinen-pty`, and `machinen-winsize`. The release build now stages Darwin tools from macOS and Linux tools from Linux so published packages contain the right binaries for each host.

--- a/.changeset/remove-experimental-move-command.md
+++ b/.changeset/remove-experimental-move-command.md
@@ -1,0 +1,5 @@
+---
+"@machinen/cli": patch
+---
+
+Remove the experimental public `move` command and its proof-only harnesses from the shipped CLI/runtime surface while keeping the snapshot/restore product path focused on vmstate.


### PR DESCRIPTION
## Problem\n\nThe Version Packages PR only had a real changelog entry for the vmstate bootAssets changes. Several packages were bumped because they are in the fixed release group, but their changelog sections were empty even though this release also includes default boot asset resolution, native host-tool packaging, live-mount/vmstate native-planning work, and removal of the experimental move command.\n\n## Solution\n\nAdd changesets for the missing 0.7 release notes so the version PR can regenerate with meaningful entries instead of empty package sections.\n\n## Audit\n\n- Runtime: vmstate bootAssets, default kernel/DTB resolution, native planning/helper migration.\n- CLI: experimental move command removed, runtime dependency update.\n- Native packages: runtime helper, pdeathsig, pty, and winsize host tools are now staged into published packages.\n- MicroVM/mount-server: live-mount batching/metadata and KVM vmstate dirty-bitmap work.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.71s\n- `pnpm run lint` passed in 1.22s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.29s\n- `pnpm changeset status --since runtime-v0.6.1` shows the expected fixed-group 0.7 bump