### PR TITLE
Fix mountdisk helper invalid JSON test

### DIFF
--- a/packages/runtime/src/__tests__/mountdisk-img.test.ts
+++ b/packages/runtime/src/__tests__/mountdisk-img.test.ts
@@ -171,7 +171,7 @@ describe("treeManifestHash", () => {
     const dir = join(tmp, "d");
     mkdirSync(dir, { recursive: true });
     const fake = join(tmp, "fake-machinen-runtime-helper");
-    writeFileSync(fake, "#!/bin/sh\nprintf 'not-json'\n");
+    writeFileSync(fake, "#!/bin/sh\ncat >/dev/null\nprintf 'not-json'\n");
     chmodSync(fake, 0o755);
     const realHelper = process.env.MACHINEN_RUNTIME_HELPER;
     process.env.MACHINEN_RUNTIME_HELPER = fake;


### PR DESCRIPTION
## Problem\n\nAfter merging the version packages PR, the release workflow failed in the mountdisk helper invalid JSON test. The fake helper printed output and exited before reading stdin, so CI could hit EPIPE instead of the intended invalid JSON path.\n\n## Solution\n\nMake the fake helper drain stdin before printing invalid JSON. That keeps the test focused on response parsing instead of process pipe timing.\n\n## Validation\n\n- `pnpm run format:check` passed in 0.61s\n- `pnpm run lint` passed in 1.17s\n- `NPM_CONFIG_USERCONFIG=/dev/null npx vitest run packages/runtime/src/__tests__/mountdisk-img.test.ts` passed in 2.22s\n- `pnpm exec fallow audit --changed-since origin/main` passed in 0.27s