### PR TITLE
Stop VMM sampler threads before teardown

### DIFF
--- a/.changeset/stats-sampler-shutdown.md
+++ b/.changeset/stats-sampler-shutdown.md
@@ -1,0 +1,7 @@
+---
+"@machinen/runtime": patch
+"@machinen/microvm": patch
+"@machinen/native-arm64-darwin": patch
+---
+
+Stop the Darwin VMM stats sampler before teardown so VM shutdown no longer crashes after image commands or Ctrl-C.

--- a/packages/microvm/src/boot_hvf.zig
+++ b/packages/microvm/src/boot_hvf.zig
@@ -367,7 +367,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // `vm.memoryStats().hostRssBytes` reflects balloon reclaim
     // (`MADV_FREE_REUSABLE` doesn't drop `task_basic_info.resident_size`).
     // No-op on Linux. See `stats.zig` for details.
-    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var stats_sampler = stats_mod.PhysFootprintSampler.init(stats_inst.counters);
+    stats_sampler.start();
+    defer stats_sampler.deinit();
     var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
     var balloon_dev = make_balloon_device(ram, &cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;
@@ -489,7 +491,7 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     );
     defer {
         stdin_ctx.stop.store(true, .release);
-        stdin_thread.detach();
+        stdin_thread.join();
     }
 
     var nested_poweroff_detector: nested_poweroff.Detector = .{};
@@ -2239,6 +2241,12 @@ fn stdin_thread_main(ctx: *StdinThread) void {
     assert(ctx.irq >= 32);
     var buf: [256]u8 = undefined;
     while (!ctx.stop.load(.acquire)) {
+        var fds = [_]PollFd{.{ .fd = 0, .events = POLLIN, .revents = 0 }};
+        const ready = poll(&fds, 1, 50);
+        if (ready < 0) return;
+        if (ready == 0) continue;
+        if ((fds[0].revents & POLLIN) == 0) return;
+
         const n = read(0, &buf, buf.len);
         if (n <= 0) {
             // EOF or error — stop polling. The guest can keep running;
@@ -2252,6 +2260,14 @@ fn stdin_thread_main(ctx: *StdinThread) void {
     }
 }
 
+const PollFd = extern struct {
+    fd: c_int,
+    events: c_short,
+    revents: c_short,
+};
+
+const POLLIN: c_short = 0x0001;
+
 // libc bindings — std.posix is heavily reshaped in Zig 0.16 and most
 // file-I/O surface moved behind an Io context. Going straight to libc
 // keeps this file independent of that churn.
@@ -2263,6 +2279,7 @@ extern "c" fn open(path: [*:0]const u8, flags: c_int, ...) c_int;
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn read(fd: c_int, buf: [*]u8, count: usize) isize;
 extern "c" fn write(fd: c_int, buf: [*]const u8, count: usize) isize;
+extern "c" fn poll(fds: [*]PollFd, nfds: c_ulong, timeout_ms: c_int) c_int;
 extern "c" fn lseek(fd: c_int, offset: i64, whence: c_int) i64;
 extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
 extern "c" fn usleep(useconds: c_uint) c_int;

--- a/packages/microvm/src/boot_kvm.zig
+++ b/packages/microvm/src/boot_kvm.zig
@@ -364,7 +364,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
     // No-op on Linux — runtime reads `/proc/<pid>/status:VmRSS`,
     // which is exact and reflects `MADV_DONTNEED` reclaim. See
     // `stats.zig` for the Darwin rationale.
-    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var stats_sampler = stats_mod.PhysFootprintSampler.init(stats_inst.counters);
+    stats_sampler.start();
+    defer stats_sampler.deinit();
     var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
     var balloon_dev = make_balloon_device(ram, &cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;

--- a/packages/microvm/src/boot_kvm_x86_64.zig
+++ b/packages/microvm/src/boot_kvm_x86_64.zig
@@ -229,7 +229,9 @@ pub fn boot(gpa: std.mem.Allocator, cfg: Config) !Result {
 
     var stats_inst = stats_mod.Stats.open_or_stub();
     defer stats_inst.deinit();
-    stats_mod.start_phys_footprint_sampler(stats_inst.counters);
+    var stats_sampler = stats_mod.PhysFootprintSampler.init(stats_inst.counters);
+    stats_sampler.start();
+    defer stats_sampler.deinit();
     var balloon_backend = balloon_mod.Backend.init_with_counters(stats_inst.counters);
     var balloon_dev = make_balloon_device(ram, &cfg, &balloon_backend);
     const balloon_dev_ptr: ?*virtio.Device = &balloon_dev;

--- a/packages/microvm/src/stats.zig
+++ b/packages/microvm/src/stats.zig
@@ -233,6 +233,7 @@ pub const PhysFootprintSampler = struct {
     }
 
     pub fn start(self: *PhysFootprintSampler) void {
+        assert(self.thread == null);
         if (builtin.os.tag != .macos) return;
         self.thread = std.Thread.spawn(
             .{},
@@ -252,6 +253,7 @@ pub const PhysFootprintSampler = struct {
             t.join();
             self.thread = null;
         }
+        assert(self.thread == null);
     }
 };
 
@@ -265,7 +267,7 @@ fn sampler_loop(sampler: *PhysFootprintSampler) void {
         // while still letting shutdown join the thread promptly.
         var slept_slices: u8 = 0;
         while (slept_slices < 10 and !sampler.stop.load(.acquire)) : (slept_slices += 1) {
-            _ = libc.nanosleep(&sleep_slice, null);
+            if (libc.nanosleep(&sleep_slice, null) != 0) continue;
         }
     }
 }
@@ -321,8 +323,6 @@ test "physFootprintSampler stops before counters teardown" {
     sampler.start();
     defer sampler.deinit();
 
-    const sleep_slice = libc.timespec{ .tv_sec = 0, .tv_nsec = 100 * 1_000_000 };
-    _ = libc.nanosleep(&sleep_slice, null);
     sampler.deinit();
     try std.testing.expect(sampler.thread == null);
 }

--- a/packages/microvm/src/stats.zig
+++ b/packages/microvm/src/stats.zig
@@ -206,11 +206,9 @@ const RUSAGE_INFO_V4: c_int = 4;
 const RUSAGE_INFO_V4_SIZE: usize = 296;
 const RUSAGE_PHYS_FOOTPRINT_OFFSET: usize = 72;
 
-/// Spawn a detached background thread that polls this process's
-/// `phys_footprint` every ~500 ms and atomically stores it into
-/// `counters.host_phys_footprint`. macOS-only — Linux callers read
-/// `/proc/<pid>/status:VmRSS`, which is exact, cheap, and reflects
-/// `MADV_DONTNEED` reclaim immediately.
+/// Joinable background sampler for this process's `phys_footprint`.
+/// macOS-only — Linux callers read `/proc/<pid>/status:VmRSS`, which
+/// is exact, cheap, and reflects `MADV_DONTNEED` reclaim immediately.
 ///
 /// Why this exists: after the balloon's `MADV_FREE_REUSABLE` reclaim
 /// on Darwin, `task_basic_info.resident_size` (what `ps -o rss=`
@@ -221,38 +219,54 @@ const RUSAGE_PHYS_FOOTPRINT_OFFSET: usize = 72;
 /// phys_footprint lets the host runtime show a number that tracks
 /// reclaim regardless of host memory pressure.
 ///
-/// Thread runs for the process's lifetime and is intentionally not
-/// joinable — the VMM exits via `std.process.exit` once boot
-/// returns, so there's no cleanup window where the sampler could
-/// race with `Stats.deinit()`.
-pub fn start_phys_footprint_sampler(counters: *Counters) void {
-    if (builtin.os.tag != .macos) return;
-    const handle = std.Thread.spawn(
-        .{},
-        sampler_loop,
-        .{counters},
-    ) catch |err| {
-        if (debug_enabled()) {
-            std.debug.print("stats: sampler spawn failed: {s}\n", .{@errorName(err)});
-        }
-        return;
-    };
-    handle.detach();
-}
+/// The sampler must stop before `Stats.deinit()` unmaps the counters
+/// file. Ctrl-C can make the VMM return through normal defers instead
+/// of exiting immediately; a detached sampler would then keep writing
+/// to unmapped memory and crash during shutdown.
+pub const PhysFootprintSampler = struct {
+    counters: *Counters,
+    stop: std.atomic.Value(bool) = .init(false),
+    thread: ?std.Thread = null,
 
-fn sampler_loop(counters: *Counters) void {
-    const half_second = libc.timespec{ .tv_sec = 0, .tv_nsec = 500 * 1_000_000 };
-    // Intentional daemon loop for the VMM lifetime. Each iteration is
-    // bounded by one synchronous sample plus the sleep below.
-    while (true) {
-        if (sample_phys_footprint()) |bytes| {
-            @atomicStore(u64, &counters.host_phys_footprint, bytes, .monotonic);
+    pub fn init(counters: *Counters) PhysFootprintSampler {
+        return .{ .counters = counters };
+    }
+
+    pub fn start(self: *PhysFootprintSampler) void {
+        if (builtin.os.tag != .macos) return;
+        self.thread = std.Thread.spawn(
+            .{},
+            sampler_loop,
+            .{self},
+        ) catch |err| {
+            if (debug_enabled()) {
+                std.debug.print("stats: sampler spawn failed: {s}\n", .{@errorName(err)});
+            }
+            return;
+        };
+    }
+
+    pub fn deinit(self: *PhysFootprintSampler) void {
+        self.stop.store(true, .release);
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
         }
-        // libc nanosleep — std.Thread.sleep was removed in Zig 0.16
-        // and the new std.Io.sleep needs an Io capability we don't
-        // wire through here. Plain nanosleep is fine: signals don't
-        // interrupt the loop in any way we'd need to react to.
-        _ = libc.nanosleep(&half_second, null);
+    }
+};
+
+fn sampler_loop(sampler: *PhysFootprintSampler) void {
+    const sleep_slice = libc.timespec{ .tv_sec = 0, .tv_nsec = 50 * 1_000_000 };
+    while (!sampler.stop.load(.acquire)) {
+        if (sample_phys_footprint()) |bytes| {
+            @atomicStore(u64, &sampler.counters.host_phys_footprint, bytes, .monotonic);
+        }
+        // Sleep in 50 ms slices for an aggregate ~500 ms poll interval
+        // while still letting shutdown join the thread promptly.
+        var slept_slices: u8 = 0;
+        while (slept_slices < 10 and !sampler.stop.load(.acquire)) : (slept_slices += 1) {
+            _ = libc.nanosleep(&sleep_slice, null);
+        }
     }
 }
 
@@ -298,6 +312,19 @@ test "samplePhysFootprint returns a positive value on Darwin" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
     const v = sample_phys_footprint() orelse return error.UnexpectedNull;
     try std.testing.expect(v > 0);
+}
+
+test "physFootprintSampler stops before counters teardown" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    var local: Counters = .{};
+    var sampler = PhysFootprintSampler.init(&local);
+    sampler.start();
+    defer sampler.deinit();
+
+    const sleep_slice = libc.timespec{ .tv_sec = 0, .tv_nsec = 100 * 1_000_000 };
+    _ = libc.nanosleep(&sleep_slice, null);
+    sampler.deinit();
+    try std.testing.expect(sampler.thread == null);
 }
 
 test "stubCounters returns the same address every call" {

--- a/packages/runtime/src/__tests__/boot.test.ts
+++ b/packages/runtime/src/__tests__/boot.test.ts
@@ -724,6 +724,41 @@ describe("image + cmd", () => {
     expect(stderr).toContain("Linux version");
     expect(stderr).toContain("BUNDLE_MARKER=spawned-via-ts");
   }, 40_000);
+
+  it("powers off after an image cmd without a VMM teardown crash", async () => {
+    if (process.platform !== "darwin" || process.arch !== "arm64") {
+      return;
+    }
+    const binary = resolve(microvmRoot, "../native-arm64-darwin/vmm/bin/machinen-vm");
+    const kernel = resolve(microvmRoot, "../../release-assets/Image-arm64");
+    const dtb = resolve(microvmRoot, "../../release-assets/virt-arm64.dtb");
+    const debianRootfs = resolve(microvmRoot, "../../release-assets/rootfs-debian-arm64.tar.gz");
+    const missing = [binary, kernel, dtb, debianRootfs].filter((p) => !existsSync(p));
+    if (missing.length > 0) {
+      if (process.env.MACHINEN_REQUIRE_FIXTURES === "0") {
+        return;
+      }
+      throw new Error(
+        `test requires arm64 HVF assets (missing: ${missing.join(", ")}); ` +
+          `run scripts/build-vmm.sh + scripts/build-base-assets.sh`,
+      );
+    }
+
+    const vm = await boot({
+      binary,
+      kernel,
+      dtb,
+      image: debianRootfs,
+      cmd: ["/bin/sh", "-lc", "echo TEARDOWN_MARKER; sleep 1"],
+      timeoutMs: 30_000,
+    });
+    const result = await vm.wait();
+    const stderr = await vm.errorOutput();
+
+    expect(result).toEqual({ code: 0, signal: null });
+    expect(stderr).toContain("TEARDOWN_MARKER");
+    expect(stderr).not.toMatch(/Segmentation fault|sampler_loop/);
+  }, 40_000);
 });
 
 describe("mount option", () => {


### PR DESCRIPTION
## Problem

Pressing Ctrl-C while a VM was shutting down could crash the VMM with a segmentation fault. The crash came from a background stats thread writing to memory after that memory had already been unmapped.

There was also a similar shutdown risk in the HVF stdin reader thread. It could keep running after the stack data it used had gone away.

## Solution

Stop those background threads before their memory goes away. The stats sampler is now an owned object with a stop flag and a joined thread. The HVF stdin reader now polls stdin in short intervals, sees the stop flag, and is joined during teardown.

## Technical Summary

- Replace the detached Darwin `phys_footprint` sampler with `PhysFootprintSampler`, which owns the thread and joins before `Stats.deinit()` unmaps the counters file.
- Wire the sampler through HVF and both KVM boot paths so all platforms share the same lifetime shape. On Linux it remains a no-op.
- Change the HVF stdin reader from a detached blocking `read(0)` thread to a poll loop with a 50 ms shutdown check, then join it during boot teardown.
- Add a Zig regression test that starts and stops the sampler before counter storage teardown.
- Add an HVF runtime regression test that boots a real image command to guest poweroff and asserts the VMM exits cleanly without a teardown segfault.
