### PR TITLE
Fix Darwin HVF boot regressions

### DIFF
--- a/.changeset/darwin-hvf-boot-regression.md
+++ b/.changeset/darwin-hvf-boot-regression.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Restore fast Darwin/HVF boots by preferring cached or tar + `mke2fs` rootfs materialization, packing tiny initramfs bundles in process, and keeping common boot planning on the TypeScript fast path.

--- a/packages/runtime/src/mkinitramfs.ts
+++ b/packages/runtime/src/mkinitramfs.ts
@@ -48,6 +48,85 @@ const DEFAULT_WORKSPACE_EXCLUDES = new Set<string>([
   ".pnpm-store",
 ]);
 
+interface NewcOptions {
+  uid?: number;
+  gid?: number;
+  nlink?: number;
+  mtime?: number;
+  rmajor?: number;
+  rminor?: number;
+  data?: Buffer;
+}
+
+interface NormalizedNewcOptions {
+  uid: number;
+  gid: number;
+  nlink: number;
+  mtime: number;
+  rmajor: number;
+  rminor: number;
+  data: Buffer;
+}
+
+/** Emit one newc cpio entry as a Buffer. Kept in-process for the hot tiny initramfs path. */
+function newc(name: string, mode: number, opts: NewcOptions = {}): Buffer {
+  const normalized = normalizeNewcOptions(opts);
+  const nameBytes = Buffer.concat([Buffer.from(name, "utf8"), Buffer.from([0])]);
+  const header = Buffer.from(newcHeader(mode, normalized, nameBytes.length), "ascii");
+  return Buffer.concat([
+    padNewcPart(Buffer.concat([header, nameBytes])),
+    normalized.data,
+    newcPadding(normalized.data.length),
+  ]);
+}
+
+function normalizeNewcOptions(opts: NewcOptions): NormalizedNewcOptions {
+  return {
+    uid: opts.uid ?? 0,
+    gid: opts.gid ?? 0,
+    nlink: opts.nlink ?? 1,
+    mtime: opts.mtime ?? 0,
+    rmajor: opts.rmajor ?? 0,
+    rminor: opts.rminor ?? 0,
+    data: opts.data ?? Buffer.alloc(0),
+  };
+}
+
+function newcHeader(mode: number, opts: NormalizedNewcOptions, nameSize: number): string {
+  return "070701" + newcFields(mode, opts, nameSize).map(newcHexField).join("");
+}
+
+function newcFields(mode: number, opts: NormalizedNewcOptions, nameSize: number): number[] {
+  return [
+    0,
+    mode,
+    opts.uid,
+    opts.gid,
+    opts.nlink,
+    opts.mtime,
+    opts.data.length,
+    0,
+    0,
+    opts.rmajor,
+    opts.rminor,
+    nameSize,
+    0,
+  ];
+}
+
+function newcHexField(value: number): string {
+  return value.toString(16).padStart(8, "0");
+}
+
+function padNewcPart(buf: Buffer): Buffer {
+  const padding = newcPadding(buf.length);
+  return padding.length === 0 ? buf : Buffer.concat([buf, padding]);
+}
+
+function newcPadding(length: number): Buffer {
+  return Buffer.alloc((4 - (length % 4)) % 4);
+}
+
 /** Parse an excludes file (one fnmatch-style pattern per line, `#` comments). */
 function loadExcludes(path: string): string[] {
   const raw = readFileSync(path, "utf8");
@@ -306,20 +385,64 @@ export function packTinyBundle(opts: PackTinyBundleOptions): void {
   }
   const config = prepareConfigPath(cfgPath, opts.env);
   try {
-    const initPath = opts.initPath ?? defaultInitPath();
-    validateInitReadable(initPath);
-    packMkinitramfsNative({
-      mode: "tiny",
-      out: opts.out,
-      initPath,
-      configPath: config.path,
-      injectInit: true,
-      allowMissingInit: allowMissingInitFixture(),
+    const parts = tinyBundleEntries({
+      initPath: opts.initPath ?? defaultInitPath(),
+      config: readFileSync(config.path),
       mountGuest: opts.mountGuest,
     });
+    writeFileSync(opts.out, Buffer.concat(parts));
     debug("packTinyBundle done elapsed=%dms", Date.now() - t0);
   } finally {
     cleanupConfigPath(config);
+  }
+}
+
+function tinyBundleEntries(opts: {
+  initPath: string;
+  config: Buffer;
+  mountGuest?: string;
+}): Buffer[] {
+  const parts: Buffer[] = [newc(".", 0o40755)];
+  const initBytes = readInitBytes(opts.initPath);
+  if (initBytes) {
+    parts.push(newc("init", 0o100755, { data: initBytes }));
+  }
+  parts.push(newc("machinen-config.json", 0o100644, { data: opts.config }));
+  parts.push(newc("etc", 0o40755));
+  parts.push(
+    newc("etc/machinen-boot-epoch", 0o100644, {
+      data: Buffer.from(String(Math.floor(Date.now() / 1000)), "ascii"),
+    }),
+  );
+  if (opts.mountGuest) {
+    parts.push(
+      newc("etc/machinen-mountdisk-guest", 0o100644, {
+        data: Buffer.from(`${opts.mountGuest}\n`, "ascii"),
+      }),
+    );
+  }
+  parts.push(newc("dev", 0o40755));
+  parts.push(newc("dev/console", 0o20600, { rmajor: 5, rminor: 1 }));
+  parts.push(newc("tmp", 0o41777));
+  parts.push(newc("TRAILER!!!", 0));
+  return parts;
+}
+
+const initBytesCache = new Map<string, Buffer | undefined>();
+
+function readInitBytes(initPath: string): Buffer | undefined {
+  if (initBytesCache.has(initPath)) {
+    return initBytesCache.get(initPath);
+  }
+  try {
+    const bytes = readFileSync(initPath);
+    initBytesCache.set(initPath, bytes);
+    return bytes;
+  } catch (err) {
+    if (allowMissingInitFixture()) {
+      return undefined;
+    }
+    throw missingInitError(initPath, err);
   }
 }
 

--- a/packages/runtime/src/rootfs-img.ts
+++ b/packages/runtime/src/rootfs-img.ts
@@ -220,10 +220,18 @@ interface RootfsCachePaths {
  */
 export function ensureRootfsImage(tarPath: string, opts: EnsureRootfsImageOptions = {}): string {
   const paths = resolveRootfsCachePaths(tarPath, opts);
+  const cached = tryReusableCachedRootfs(paths, opts);
+  if (cached) {
+    return cached;
+  }
+
+  const preferredMke2fs = preferMaterializeOverPrebake(opts) ? resolveMke2fs() : undefined;
+  if (preferredMke2fs) {
+    return materializeRootfsFromTar(paths, opts, preferredMke2fs);
+  }
+
   return (
-    tryReusableCachedRootfs(paths, opts) ??
-    tryPrebakedRootfs(paths, opts) ??
-    materializeRootfsFromTar(paths, opts, resolveMke2fsOrThrow())
+    tryPrebakedRootfs(paths, opts) ?? materializeRootfsFromTar(paths, opts, resolveMke2fsOrThrow())
   );
 }
 
@@ -260,6 +268,26 @@ function resolveTarballSha(tarAbs: string, opts: EnsureRootfsImageOptions): stri
   const result = rootfsCacheKeyNative(tarAbs);
   opts.onPhase?.(result.source === "sidecar" ? "sha256.sidecar" : "sha256", Date.now() - keyT0);
   return result.sha;
+}
+
+function preferMaterializeOverPrebake(opts: EnsureRootfsImageOptions): boolean {
+  if (opts.force) {
+    return true;
+  }
+  if (platform() !== "darwin") {
+    return false;
+  }
+  if (process.env.MACHINEN_ROOTFS_PREBAKE === "1") {
+    return false;
+  }
+  const envOverride = process.env.MACHINEN_MKE2FS;
+  if (envOverride && !existsSync(envOverride)) {
+    // Preserve the prebake fast path for callers that deliberately run
+    // without a usable mke2fs. If prebake also fails, the normal
+    // materialize fallback will surface the invalid override.
+    return false;
+  }
+  return true;
 }
 
 function tryReusableCachedRootfs(

--- a/packages/runtime/src/vm/boot-core-plan.ts
+++ b/packages/runtime/src/vm/boot-core-plan.ts
@@ -1,0 +1,192 @@
+import { totalmem } from "node:os";
+
+import { BootError } from "../errors.ts";
+import type { BootOptions } from "./boot.ts";
+import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
+import type { BootResourcesOptions } from "./memory-resources.ts";
+
+export interface BootCorePlan {
+  vmmMemory: string | null;
+  memoryCeilingMib: number | null;
+  cpuPolicy: ResolvedCpuResourcePolicy | undefined;
+  timeoutMs: number | null;
+  detachedReadinessTimeoutMs: number;
+  wantsRootDisk: boolean;
+  needsInitramfs: boolean;
+  usePdeathsig: boolean;
+}
+
+type RootDiskPlanMode = "unset" | "false" | "path" | "true";
+
+export function planBootCore(opts: BootOptions, env: Record<string, string>): BootCorePlan {
+  validateCommandImagePair(opts);
+  const rootDisk = planRootDiskMode(opts);
+  const wantsRootDisk = resolveWantsRootDisk(opts, rootDisk);
+  const timeoutMs = resolveBootTimeout(opts.timeoutMs);
+  const memoryCeilingMib = resolveBootMemoryForEnv(opts, env);
+  return {
+    vmmMemory: memoryCeilingMib === null ? null : String(memoryCeilingMib),
+    memoryCeilingMib,
+    cpuPolicy: resolveBootCpuPolicy(opts.resources?.cpu),
+    timeoutMs,
+    detachedReadinessTimeoutMs: timeoutMs ?? 60_000,
+    wantsRootDisk,
+    needsInitramfs: needsInitramfs(opts),
+    usePdeathsig: opts.detached ? false : (opts.pdeathsig ?? true),
+  };
+}
+
+function validateCommandImagePair(opts: BootOptions): void {
+  if (opts.cmd !== undefined && opts.image === undefined) {
+    throw new BootError("BOOT_CMD_WITHOUT_IMAGE", "boot: `image` is required when `cmd` is set.");
+  }
+}
+
+function planRootDiskMode(opts: BootOptions): RootDiskPlanMode {
+  if (opts.rootDisk === false) {
+    return "false";
+  }
+  if (opts._rootDiskRestorePath !== undefined || typeof opts.rootDisk === "string") {
+    return "path";
+  }
+  return opts.rootDisk === true ? "true" : "unset";
+}
+
+function resolveWantsRootDisk(opts: BootOptions, rootDisk: RootDiskPlanMode): boolean {
+  const wantsRootDisk = rootDisk !== "false" && wantsRootDiskForMode(rootDisk, opts.image);
+  if (wantsRootDisk && rootDisk !== "path" && opts.image === undefined) {
+    throw new BootError(
+      "BOOT_CMD_WITHOUT_IMAGE",
+      "boot: rootDisk: true requires an `image` (the .tar.gz to materialize).",
+    );
+  }
+  return wantsRootDisk;
+}
+
+function wantsRootDiskForMode(rootDisk: RootDiskPlanMode, image: string | undefined): boolean {
+  return rootDisk === "path" || rootDisk === "true" || image !== undefined;
+}
+
+function resolveBootTimeout(timeoutMs: BootOptions["timeoutMs"]): number | null {
+  return timeoutMs === null ? null : (timeoutMs ?? 60_000);
+}
+
+function resolveBootMemoryForEnv(opts: BootOptions, env: Record<string, string>): number | null {
+  return env.MACHINEN_MEMORY === undefined ? resolveBootMemoryCeiling(opts) : null;
+}
+
+function resolveBootMemoryCeiling(opts: BootOptions): number {
+  const resourceMemory = opts.resources?.memory;
+  validateMemoryReclaim(resourceMemory?.reclaim);
+  const aliasCeiling = validateOptionalMemory(
+    opts.memory,
+    "boot: memory must be a positive integer at least 512 MiB",
+  );
+  const resourceCeiling = validateOptionalMemory(
+    resourceMemory?.maxMib,
+    "boot: memory must be a positive integer at least 512 MiB",
+  );
+  validateMemoryConflict(aliasCeiling, resourceCeiling);
+  return resourceCeiling ?? aliasCeiling ?? autoSizeMemoryMibFast(totalmem());
+}
+
+function validateMemoryReclaim(reclaim: BootResourcesOptions["memory"]["reclaim"]): void {
+  if (reclaim !== undefined && reclaim !== "auto") {
+    throw new BootError(
+      "BOOT_MEMORY_INVALID",
+      'boot: resources.memory.reclaim must be "auto" when set.',
+    );
+  }
+}
+
+function validateMemoryConflict(
+  aliasCeiling: number | undefined,
+  resourceCeiling: number | undefined,
+): void {
+  if (aliasCeiling === undefined || resourceCeiling === undefined) {
+    return;
+  }
+  if (aliasCeiling !== resourceCeiling) {
+    throw new BootError(
+      "BOOT_MEMORY_INVALID",
+      "boot: memory conflicts with resources.memory.maxMib. Use one value.",
+    );
+  }
+}
+
+function validateOptionalMemory(value: number | undefined, message: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value < 512) {
+    throw new BootError("BOOT_MEMORY_INVALID", message);
+  }
+  return value;
+}
+
+function autoSizeMemoryMibFast(hostBytes: number): number {
+  const hostMib = Math.floor(hostBytes / (1024 * 1024));
+  return Math.max(512, Math.min(Math.floor(hostMib / 2), 4096));
+}
+
+function resolveBootCpuPolicy(
+  cpu: BootResourcesOptions["cpu"],
+): ResolvedCpuResourcePolicy | undefined {
+  if (!cpu) {
+    return undefined;
+  }
+  const maxVcpus = resolveMaxVcpus(cpu.maxVcpus);
+  return {
+    maxVcpus,
+    quotaCpus: resolveQuotaCpus(cpu.quotaCpus, maxVcpus),
+    weight: resolveCpuWeight(cpu.weight),
+  };
+}
+
+function resolveMaxVcpus(value: number | undefined): number {
+  const maxVcpus = value ?? 1;
+  if (!Number.isInteger(maxVcpus) || maxVcpus < 1) {
+    throw new BootError(
+      "BOOT_CPU_INVALID",
+      "boot: resources.cpu.maxVcpus must be a positive integer",
+    );
+  }
+  if (maxVcpus !== 1) {
+    throw new BootError(
+      "BOOT_CPU_INVALID",
+      "boot: resources.cpu.maxVcpus greater than 1 is not supported yet. CPU quota is scheduling budget, not extra guest-visible CPUs.",
+    );
+  }
+  return maxVcpus;
+}
+
+function resolveQuotaCpus(value: number | undefined, maxVcpus: number): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new BootError("BOOT_CPU_INVALID", "boot: resources.cpu.quotaCpus must be > 0 when set");
+  }
+  if (value > maxVcpus) {
+    throw new BootError(
+      "BOOT_CPU_INVALID",
+      "boot: resources.cpu.quotaCpus cannot exceed resources.cpu.maxVcpus",
+    );
+  }
+  return value;
+}
+
+function resolveCpuWeight(value: number | undefined): number {
+  const weight = value ?? 100;
+  if (!Number.isInteger(weight) || weight < 1 || weight > 10_000) {
+    throw new BootError(
+      "BOOT_CPU_INVALID",
+      "boot: resources.cpu.weight must be an integer in 1..10000",
+    );
+  }
+  return weight;
+}
+
+function needsInitramfs(opts: BootOptions): boolean {
+  return opts.image !== undefined || opts.cmd !== undefined || Boolean(opts.snapshot);
+}

--- a/packages/runtime/src/vm/boot-diagnostics.ts
+++ b/packages/runtime/src/vm/boot-diagnostics.ts
@@ -13,6 +13,7 @@ type DetachedReadinessOutcome =
 export async function runVsockWithBootDiagnostics<T>(
   child: ChildProcessWithoutNullStreams,
   errorCollector: Promise<string>,
+  liveStderrTail: () => string,
   run: () => Promise<T>,
 ): Promise<T> {
   try {
@@ -20,14 +21,12 @@ export async function runVsockWithBootDiagnostics<T>(
   } catch (err) {
     if (err instanceof ExecError) {
       await waitBrieflyForExit(child);
-      if (child.exitCode !== null || child.signalCode !== null) {
-        const stderrTail = (await errorCollector).slice(-CONSOLE_TAIL_BYTES);
-        if (stderrTail) {
-          throw new ExecError(err.code, `${err.message}\n${bootStderrDiagnostic(stderrTail)}`, {
-            cause: err,
-            retryable: err.retryable,
-          });
-        }
+      const stderrTail = await diagnosticStderrTail(child, errorCollector, liveStderrTail);
+      if (stderrTail) {
+        throw new ExecError(err.code, `${err.message}\n${bootStderrDiagnostic(stderrTail)}`, {
+          cause: err,
+          retryable: err.retryable,
+        });
       }
     }
     throw err;
@@ -39,6 +38,22 @@ async function waitBrieflyForExit(child: ChildProcessWithoutNullStreams): Promis
     return;
   }
   await Promise.race([once(child, "exit"), delay(25)]);
+}
+
+async function diagnosticStderrTail(
+  child: ChildProcessWithoutNullStreams,
+  errorCollector: Promise<string>,
+  liveStderrTail: () => string,
+): Promise<string> {
+  const liveTail = liveStderrTail().slice(-CONSOLE_TAIL_BYTES);
+  if (liveTail) {
+    return liveTail;
+  }
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return (await errorCollector).slice(-CONSOLE_TAIL_BYTES);
+  }
+  const collected = await Promise.race([errorCollector, delay(0).then(() => "")]);
+  return collected.slice(-CONSOLE_TAIL_BYTES);
 }
 
 export async function waitForDetachedExecAgent(

--- a/packages/runtime/src/vm/boot-guest-env.ts
+++ b/packages/runtime/src/vm/boot-guest-env.ts
@@ -1,0 +1,30 @@
+import { planBootVirtiofsEnvNative } from "../native/boot-plan.ts";
+import type { BootOptions } from "./boot.ts";
+import { resolveLiveMounts, type ResolvedLiveMount } from "./bundle.ts";
+
+export function setupLiveMountEnv(
+  opts: BootOptions,
+  env: Record<string, string>,
+): ResolvedLiveMount[] {
+  const liveMounts = opts.liveMounts ?? [];
+  if (liveMounts.length === 0) {
+    return [];
+  }
+  const resolved = resolveLiveMounts(liveMounts, opts.cwd);
+  Object.assign(env, planBootVirtiofsEnvNative(resolved));
+  return resolved;
+}
+
+export function buildMergedGuestEnv(
+  opts: BootOptions,
+  vsockUdsPath: string | undefined,
+): Record<string, string> {
+  const env = { ...opts.env };
+  if (opts.name && env.MACHINEN_VM_NAME === undefined) {
+    env.MACHINEN_VM_NAME = opts.name;
+  }
+  if (vsockUdsPath !== undefined && env.MACHINEN_VM_HOSTNAME_WAIT === undefined) {
+    env.MACHINEN_VM_HOSTNAME_WAIT = "1";
+  }
+  return env;
+}

--- a/packages/runtime/src/vm/boot-port-forward.ts
+++ b/packages/runtime/src/vm/boot-port-forward.ts
@@ -1,0 +1,98 @@
+import { BootError } from "../errors.ts";
+import { describePortHolder, probeHostPortFree } from "../gvproxy.ts";
+import {
+  planPortForwardProbeNative,
+  validatePortForwardNetSocketNative,
+} from "../native/port-forward.ts";
+import type { BootOptions } from "./boot.ts";
+
+// Validate portForward up front — before resolving the binary or
+// touching the filesystem — so caller-input errors surface with a
+// clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
+// check happens alongside since it only reads env.
+export async function planPortForwardOpts(
+  opts: BootOptions,
+): Promise<NonNullable<BootOptions["portForward"]>> {
+  const portForward = opts.portForward ?? [];
+  if (portForward.length === 0) {
+    return [];
+  }
+  validatePortForwardMappings(portForward);
+  validatePresetNetSocket(opts, portForward);
+  await validatePortForwardAvailability(portForward);
+  return portForward;
+}
+
+function validatePresetNetSocket(
+  opts: BootOptions,
+  portForward: NonNullable<BootOptions["portForward"]>,
+): void {
+  validatePortForwardNetSocketNative(
+    portForward,
+    (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET,
+  );
+}
+
+async function validatePortForwardAvailability(
+  portForward: NonNullable<BootOptions["portForward"]>,
+): Promise<void> {
+  for (const probe of planPortForwardProbeNative(portForward)) {
+    await validateHostPortFree(probe);
+  }
+}
+
+async function validateHostPortFree(probe: { hostPort: number; probeHost: string }): Promise<void> {
+  const errno = await probeHostPortFree(probe.probeHost, probe.hostPort);
+  if (!errno) {
+    return;
+  }
+  throw new BootError(
+    "BOOT_PORT_FORWARD_IN_USE",
+    `portForward: host port ${probe.probeHost}:${probe.hostPort} is already in use (${errno}). ${await portHolderDetail(probe.hostPort)}`,
+  );
+}
+
+async function portHolderDetail(hostPort: number): Promise<string> {
+  const holder = await describePortHolder(hostPort).catch(() => null);
+  return holder
+    ? `${holder}.`
+    : "Common cause: an orphaned gvproxy from a prior `kill -9` of the VMM. " +
+        "Try `pkill -f gvproxy` to clear it, or pick a different host port.";
+}
+
+function validatePortForwardMappings(portForward: NonNullable<BootOptions["portForward"]>): void {
+  const seen = new Set<number>();
+  for (const mapping of portForward) {
+    validatePortMapping(mapping);
+    validateUniqueHostPort(seen, mapping.hostPort);
+  }
+}
+
+function validatePortMapping(mapping: { hostPort: number; guestPort: number }): void {
+  validateTcpPort(mapping.hostPort, "hostPort");
+  validateTcpPort(mapping.guestPort, "guestPort");
+}
+
+function validateTcpPort(port: number, label: "hostPort" | "guestPort"): void {
+  if (validTcpPort(port)) {
+    return;
+  }
+  throw new BootError(
+    "BOOT_PORT_FORWARD_INVALID",
+    `portForward: ${label} must be an integer in 1..65535 (got ${port})`,
+  );
+}
+
+function validateUniqueHostPort(seen: Set<number>, hostPort: number): void {
+  if (seen.has(hostPort)) {
+    throw new BootError(
+      "BOOT_PORT_FORWARD_CONFLICT",
+      `portForward: duplicate hostPort ${hostPort}`,
+    );
+  }
+  seen.add(hostPort);
+}
+
+function validTcpPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65_535;
+}

--- a/packages/runtime/src/vm/boot-scratch.ts
+++ b/packages/runtime/src/vm/boot-scratch.ts
@@ -1,0 +1,170 @@
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import debugLib from "debug";
+
+import { BootError } from "../errors.ts";
+import { reflinkCopy } from "../reflink.ts";
+import type { BootOptions } from "./boot.ts";
+import { allocateSparseFile, SNAP_SCRATCH_BYTES } from "./helpers.ts";
+
+const debug = debugLib("machinen:boot");
+
+type ScratchMode = "false" | "path" | "auto";
+
+interface ScratchDiskPlan {
+  action: "none" | "existing" | "clone" | "allocate";
+  diskPath: string | null;
+  perBootSnapDisk: string | null;
+  vmmDisk: string | null;
+}
+
+// The scratch virtio-blk device serves two unrelated workloads:
+//   - caller-supplied path (string): a CRIU snapshot bundle to
+//     restore from at boot — the runtime synthesizes
+//     /sbin/machinen-restore when no cmd is given. The bundle is
+//     reflink-cloned into a per-boot path so a future `vm.snapshot()`
+//     against the restored VM doesn't corrupt the source bundle
+//     when machinen-dump.sh re-formats the disk (#207).
+//   - default (undefined): per-boot sparse scratch so any VM is
+//     CRIU-dumpable later via vm.snapshot(). 8 GiB sparse means zero
+//     real disk until the guest writes; cleaned up alongside the
+//     rootdisk reflink on VM exit. Don't synthesize restore for this
+//     case (the file is empty).
+//   - `false`: opt out, no /dev/vdb. Test-fast paths use this.
+export function prepareScratchDisk(
+  opts: BootOptions,
+  env: Record<string, string>,
+): { diskAbs: string | undefined; perBootSnapDisk: string | undefined } {
+  const snapshotPath = resolveSnapshotDiskPath(opts);
+  const scratchPlan = planScratchDisk({
+    mode: planScratchMode(opts.snapshot),
+    hasCmd: opts.cmd !== undefined,
+    hasImage: opts.image !== undefined,
+    snapshotPath,
+    restoreClonePath: snapshotPath ? scratchRestoreClonePath() : undefined,
+    autoPath: opts.snapshot === undefined ? autoScratchPath() : undefined,
+  });
+  applyScratchDiskPlan(scratchPlan, snapshotPath, env);
+  return {
+    diskAbs: scratchPlan.diskPath ?? undefined,
+    perBootSnapDisk: scratchPlan.perBootSnapDisk ?? undefined,
+  };
+}
+
+function planScratchMode(snapshot: BootOptions["snapshot"]): ScratchMode {
+  if (snapshot === false) {
+    return "false";
+  }
+  return typeof snapshot === "string" ? "path" : "auto";
+}
+
+function planScratchDisk(input: {
+  mode: ScratchMode;
+  hasCmd: boolean;
+  hasImage: boolean;
+  snapshotPath?: string;
+  restoreClonePath?: string;
+  autoPath?: string;
+}): ScratchDiskPlan {
+  if (input.mode === "false") {
+    return noScratchDiskPlan();
+  }
+  return input.mode === "path" ? planPathScratchDisk(input) : planAutoScratchDisk(input);
+}
+
+function noScratchDiskPlan(): ScratchDiskPlan {
+  return { action: "none", diskPath: null, perBootSnapDisk: null, vmmDisk: null };
+}
+
+function planPathScratchDisk(input: {
+  hasCmd: boolean;
+  snapshotPath?: string;
+  restoreClonePath?: string;
+}): ScratchDiskPlan {
+  const snapshotPath = requireScratchPath(input.snapshotPath);
+  if (input.hasCmd) {
+    return {
+      action: "existing",
+      diskPath: snapshotPath,
+      perBootSnapDisk: null,
+      vmmDisk: snapshotPath,
+    };
+  }
+  const restoreClonePath = requireScratchPath(input.restoreClonePath);
+  return {
+    action: "clone",
+    diskPath: restoreClonePath,
+    perBootSnapDisk: restoreClonePath,
+    vmmDisk: restoreClonePath,
+  };
+}
+
+function planAutoScratchDisk(input: { hasImage: boolean; autoPath?: string }): ScratchDiskPlan {
+  if (!input.hasImage) {
+    return noScratchDiskPlan();
+  }
+  const autoPath = requireScratchPath(input.autoPath);
+  return {
+    action: "allocate",
+    diskPath: autoPath,
+    perBootSnapDisk: autoPath,
+    vmmDisk: autoPath,
+  };
+}
+
+function requireScratchPath(path: string | undefined): string {
+  if (!path) {
+    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", "boot-plan scratch disk path missing");
+  }
+  return path;
+}
+
+function resolveSnapshotDiskPath(opts: BootOptions): string | undefined {
+  if (typeof opts.snapshot !== "string") {
+    return undefined;
+  }
+  const bundleDisk = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
+  if (!existsSync(bundleDisk)) {
+    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${bundleDisk}`);
+  }
+  return bundleDisk;
+}
+
+function scratchRestoreClonePath(): string {
+  return scratchTempPath("restore");
+}
+
+function autoScratchPath(): string {
+  return scratchTempPath("auto");
+}
+
+function scratchTempPath(kind: "restore" | "auto"): string {
+  const nonce = randomBytes(6).toString("hex");
+  const prefix = kind === "restore" ? "machinen-snap-restore" : "machinen-snap";
+  return join(tmpdir(), `${prefix}-${process.pid}-${nonce}.img`);
+}
+
+function applyScratchDiskPlan(
+  plan: ScratchDiskPlan,
+  snapshotPath: string | undefined,
+  env: Record<string, string>,
+): void {
+  if (plan.vmmDisk) {
+    env.MACHINEN_DISK = plan.vmmDisk;
+  }
+  if (plan.action === "existing") {
+    debug("snap-restore in-place (explicit cmd) path=%s", plan.diskPath);
+    return;
+  }
+  if (plan.action === "clone") {
+    reflinkCopy(snapshotPath!, plan.diskPath!);
+    debug("snap-restore reflink-clone src=%s dst=%s", snapshotPath, plan.diskPath);
+    return;
+  }
+  if (plan.action === "allocate") {
+    allocateSparseFile(plan.diskPath!, SNAP_SCRATCH_BYTES);
+    debug("snap-scratch auto path=%s sizeBytes=%d", plan.diskPath, SNAP_SCRATCH_BYTES);
+  }
+}

--- a/packages/runtime/src/vm/boot-vmstate.ts
+++ b/packages/runtime/src/vm/boot-vmstate.ts
@@ -1,0 +1,95 @@
+import { randomBytes } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import debugLib from "debug";
+
+import type { BootOptions } from "./boot.ts";
+import { resolveSnapshotEngine } from "./snapshot-engine.ts";
+
+const vmstateDebug = debugLib("machinen:vmstate");
+const restoreDebug = debugLib("machinen:restore");
+
+export interface BootVmstateRuntime {
+  statePath: string | undefined;
+  chainId: string;
+  checkpointParent: string | undefined;
+  checkpointSequence: number;
+}
+
+export function setupVmstateBoot(
+  opts: BootOptions,
+  env: Record<string, string>,
+  inputVsockTempDir: string | undefined,
+): { vmstate: BootVmstateRuntime; vsockTempDir: string | undefined } {
+  const temp = setupVmstateTemp(opts, inputVsockTempDir);
+  const vmstate: BootVmstateRuntime = {
+    statePath: temp.stateTempDir ? join(temp.stateTempDir, "state.vmstate") : undefined,
+    chainId: randomBytes(16).toString("hex"),
+    checkpointParent: opts._vmstateRestorePath !== undefined ? opts.forkedFrom : undefined,
+    checkpointSequence: 0,
+  };
+  applyVmstateEnvPlan(opts, env, vmstate.statePath);
+  return { vmstate, vsockTempDir: temp.vsockTempDir };
+}
+
+function setupVmstateTemp(
+  opts: BootOptions,
+  inputVsockTempDir: string | undefined,
+): { stateTempDir: string | undefined; vsockTempDir: string | undefined } {
+  const tempMode = planVmstateTempMode(
+    resolveSnapshotEngine(),
+    opts.snapshot === false,
+    inputVsockTempDir,
+  );
+  return resolveVmstateTempMode(tempMode, inputVsockTempDir);
+}
+
+function resolveVmstateTempMode(
+  mode: { action: "skip" | "reuse" | "allocate"; tempDir?: string },
+  inputVsockTempDir: string | undefined,
+): { stateTempDir: string | undefined; vsockTempDir: string | undefined } {
+  if (mode.action === "skip") {
+    return { stateTempDir: undefined, vsockTempDir: inputVsockTempDir };
+  }
+  if (mode.action === "reuse") {
+    return { stateTempDir: mode.tempDir, vsockTempDir: mode.tempDir };
+  }
+  const tempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
+  return { stateTempDir: tempDir, vsockTempDir: tempDir };
+}
+
+function applyVmstateEnvPlan(
+  opts: BootOptions,
+  env: Record<string, string>,
+  vmstatePath: string | undefined,
+): void {
+  if (vmstatePath) {
+    env.MACHINEN_SNAPSHOT_PATH = vmstatePath;
+  }
+  if (opts._vmstateRestorePath) {
+    env.MACHINEN_RESTORE_PATH = opts._vmstateRestorePath;
+  }
+  if (shouldEnableVmstateTiming(opts, env)) {
+    env.MACHINEN_VMSTATE_TIMING = "1";
+  }
+}
+
+function shouldEnableVmstateTiming(opts: BootOptions, env: Record<string, string>): boolean {
+  return (
+    opts._vmstateRestorePath !== undefined &&
+    (vmstateDebug.enabled || restoreDebug.enabled) &&
+    !env.MACHINEN_VMSTATE_TIMING
+  );
+}
+
+function planVmstateTempMode(
+  engine: string,
+  snapshotDisabled: boolean,
+  existingTempDir: string | undefined,
+): { action: "skip" | "reuse" | "allocate"; tempDir?: string } {
+  if (engine !== "vmstate" || snapshotDisabled) {
+    return { action: "skip" };
+  }
+  return existingTempDir ? { action: "reuse", tempDir: existingTempDir } : { action: "allocate" };
+}

--- a/packages/runtime/src/vm/boot-vsock.ts
+++ b/packages/runtime/src/vm/boot-vsock.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import debugLib from "debug";
+
+const debug = debugLib("machinen:boot");
+
+// #94: always wire up a vsock UDS bridge so `vm.exec()` works out of
+// the box. Callers who set their own `MACHINEN_VSOCK` (e.g. the build
+// flow) win — we parse their spec to extract the UDS path for exec.
+export function setupVsockBridge(env: Record<string, string>): {
+  vsockUdsPath: string | undefined;
+  vsockTempDir: string | undefined;
+} {
+  const existingSpec = env.MACHINEN_VSOCK;
+  if (existingSpec !== undefined) {
+    return callerVsockBridge(existingSpec);
+  }
+  return autoVsockBridge(env);
+}
+
+function callerVsockBridge(existingSpec: string): {
+  vsockUdsPath: string | undefined;
+  vsockTempDir: undefined;
+} {
+  const vsockUdsPath = parseVsockUdsPath(existingSpec);
+  debug("vsock spec from caller env: %s (uds=%s)", existingSpec, vsockUdsPath ?? "<unparsed>");
+  return { vsockUdsPath, vsockTempDir: undefined };
+}
+
+function autoVsockBridge(env: Record<string, string>): {
+  vsockUdsPath: string;
+  vsockTempDir: string;
+} {
+  const vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
+  const vsockUdsPath = join(vsockTempDir, "exec.sock");
+  env.MACHINEN_VSOCK = `in:1978:${vsockUdsPath}`;
+  debug("vsock auto spec=%s uds=%s", env.MACHINEN_VSOCK, vsockUdsPath);
+  return { vsockUdsPath, vsockTempDir };
+}
+
+function parseVsockUdsPath(spec: string): string | undefined {
+  for (const entry of spec.split(",")) {
+    const parsed = parseVsockEntry(entry);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function parseVsockEntry(entry: string): string | undefined {
+  const firstColon = entry.indexOf(":");
+  if (firstColon < 0) {
+    return undefined;
+  }
+  const rest = entry.slice(firstColon + 1);
+  const secondColon = rest.indexOf(":");
+  if (secondColon < 0) {
+    return undefined;
+  }
+  return parseVsockPortAndPath(rest.slice(0, secondColon), rest.slice(secondColon + 1));
+}
+
+function parseVsockPortAndPath(port: string, path: string): string | undefined {
+  if (/^\d+$/.test(port) && path.length > 0) {
+    return path;
+  }
+  return undefined;
+}

--- a/packages/runtime/src/vm/boot.ts
+++ b/packages/runtime/src/vm/boot.ts
@@ -5,9 +5,7 @@
 // `--detached` readiness gate.
 
 import { type ChildProcessWithoutNullStreams, spawn as nodeSpawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import { closeSync, existsSync, mkdtempSync, openSync, rmSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { closeSync, existsSync, openSync, rmSync, unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import debugLib from "debug";
 
@@ -23,14 +21,7 @@ import { detachedLogRoot, writeBootSnapshot } from "../detached-log.ts";
 import { BootError, ExecError, RegistryError, SnapshotError } from "../errors.ts";
 import { VsockExec } from "../exec.ts";
 import { runGc } from "../gc.ts";
-import {
-  describePortHolder,
-  ensureGvproxy,
-  exposePort,
-  probeHostPortFree,
-  spawnGvproxy,
-  warnGvproxyMissing,
-} from "../gvproxy.ts";
+import { ensureGvproxy, exposePort, spawnGvproxy, warnGvproxyMissing } from "../gvproxy.ts";
 import type { OnLog } from "../log.ts";
 import {
   applyNestedVirtualizationEnv,
@@ -39,50 +30,23 @@ import {
 } from "../nested-virt.ts";
 import { ensurePdeathsig } from "../pdeathsig.ts";
 import { PhaseTimer } from "../phase-timer.ts";
-import { readProcessIdentity } from "../pid-validate.ts";
 import { applyCpuControls, type CpuControlResult } from "../cpu-cgroup.ts";
 import { readHostRssBytes } from "../proc-rss.ts";
-import {
-  planBootCoreNative,
-  planBootInitrdEnvNative,
-  planBootMountDiskFdEnvNative,
-  planBootPortForwardNative,
-  planBootRegistryNestedNative,
-  planBootRegistryPortForwardNative,
-  planBootRegistryScalarsNative,
-  planBootRegistryShapeNative,
-  planBootRegistryVmstateNative,
-  planBootScratchDiskNative,
-  planBootVirtiofsEnvNative,
-  planBootVmstateEnvNative,
-  planBootVmstateRuntimeNative,
-  planBootVmmArgvNative,
-} from "../native/boot-plan.ts";
-import { reflinkCopy } from "../reflink.ts";
-import { planGvproxyNative } from "../native/gvproxy-plan.ts";
-import {
-  planPortForwardProbeNative,
-  validatePortForwardNetSocketNative,
-} from "../native/port-forward.ts";
+import { planBootMountDiskFdEnvNative } from "../native/boot-plan.ts";
 import { planGuestHostnameSetNative } from "../native/guest-hostname.ts";
-import { planBootRegistryLifecycleNative } from "../native/registry-lifecycle.ts";
-import {
-  planBootRegistryProcessIdentityNative,
-  planBootRegistryProcessNative,
-} from "../native/registry-process.ts";
-import { planBootRootDiskModeNative } from "../native/root-disk-mode.ts";
-import { planBootScratchModeNative } from "../native/scratch-mode.ts";
-import { planBootScratchTempPathNative } from "../native/scratch-temp-path.ts";
 import { planBootSnapshotBackingNative as planSnapshotBacking } from "../native/snapshot-backing.ts";
 import { planBootSnapshotContextNative } from "../native/snapshot-context.ts";
-import { planBootVmmEnvNative } from "../native/vmm-env.ts";
-import { planBootVsockModeNative } from "../native/vsock-mode.ts";
-import { planBootVmstateTempModeNative as planVmstateTempMode } from "../native/vmstate-temp-mode.ts";
 import { claimName, findEntry, writeEntry } from "../registry.ts";
 import { setupKernelDtbEnv } from "./boot-assets.ts";
+import { planBootCore } from "./boot-core-plan.ts";
+import { buildMergedGuestEnv, setupLiveMountEnv } from "./boot-guest-env.ts";
+import { planPortForwardOpts } from "./boot-port-forward.ts";
 import { materializeRootdisk } from "./boot-rootdisk.ts";
+import { prepareScratchDisk } from "./boot-scratch.ts";
+import { setupVmstateBoot, type BootVmstateRuntime } from "./boot-vmstate.ts";
+import { setupVsockBridge } from "./boot-vsock.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
-import { resolveLiveMounts, synthesizeAndPackBundle, type ResolvedLiveMount } from "./bundle.ts";
+import { synthesizeAndPackBundle, type ResolvedLiveMount } from "./bundle.ts";
 import { installVmExitCleanup } from "./exit-cleanup.ts";
 import { performForkWithRestore } from "./fork-core.ts";
 import { validateBatchLiveMounts, withBatchLiveMountSync } from "./live-mount-batch.ts";
@@ -90,13 +54,11 @@ import type { BootResourcesOptions } from "./memory-resources.ts";
 import { registryCpu } from "./registry-cpu.ts";
 import type { VmHandle } from "../vm-handle.ts";
 import {
-  allocateSparseFile,
   buildWriteFileCmds,
   collect,
   CONSOLE_TAIL_BYTES,
   resolveVmmBinary,
   setGuestHostname,
-  SNAP_SCRATCH_BYTES,
   teeOnLog,
 } from "./helpers.ts";
 import { performSnapshot, type SnapshotContext } from "./snapshot.ts";
@@ -467,6 +429,14 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
 
   const timeoutMs = plan.timeoutMs;
 
+  // In-flight ring buffer of stderr for early boot diagnostics. Attach
+  // before the generic collector so very fast VMM exits do not lose their
+  // panic line to the first `data` listener. Detached boots dump this to
+  // `bootLogPath`; attached boots use it when exec-agent calls fail before
+  // the stderr stream has closed.
+  const bootDiagnosticChunks: Buffer[] = [];
+  installBootStderrCapture(child, bootDiagnosticChunks);
+
   // Start collecting stdout/stderr eagerly. Doing it lazily on the
   // first call to `.output()` / `.errorOutput()` loses data: the
   // streams can flush + close before the listener attaches, and more
@@ -496,17 +466,6 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
   installVmstateTimingRelay(child);
   installFlushPhases(child, phases, onLog);
 
-  // #150 phase 2: in-flight ring buffer of stderr captured *only* for
-  // detached boots, dumped to `bootLogPath` once readiness fires. The
-  // existing `errorCollector` resolves on stream close — too late for
-  // the detach handoff. Capped at the same `CONSOLE_TAIL_BYTES` Phase 1
-  // uses, so a slow boot can't balloon the supervisor heap before
-  // detach completes.
-  const detachedBootChunks: Buffer[] = [];
-  if (opts.detached) {
-    installDetachedBootCapture(child, detachedBootChunks);
-  }
-
   let handle = createBootVmHandle({
     child,
     childPid,
@@ -514,6 +473,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
     timeoutMs,
     outputCollector,
     errorCollector,
+    stderrTail: () => bootStderrTail(bootDiagnosticChunks),
     vsockUdsPath,
     onLog,
     statsFilePath,
@@ -559,7 +519,7 @@ export async function boot(opts: BootOptions = {}): Promise<VmHandle> {
       child,
       timeoutMs: plan.detachedReadinessTimeoutMs,
       bootLogPath,
-      detachedBootChunks,
+      detachedBootChunks: bootDiagnosticChunks,
       handle,
     });
   }
@@ -674,7 +634,7 @@ function packBootInitramfsIfNeeded(
     mountDiskUpperSizeBytes: opts.mountDiskUpperSizeBytes,
     onPhase: (name, ms) => phases.mark(`initramfs-pack.${name}`, ms),
   });
-  plan.env.MACHINEN_INITRD = planBootInitrdEnvNative(packed.cpioPath);
+  plan.env.MACHINEN_INITRD = packed.cpioPath;
   const packMs = phases.end("initramfs-pack");
   debug("initramfs packed cpio=%s elapsed=%dms", packed.cpioPath, packMs ?? -1);
   return { bundleTempDir: packed.tempDir, mountDiskPaths: packed.mountDisk };
@@ -711,11 +671,7 @@ interface SpawnedBootVmm {
 async function spawnBootVmm(args: SpawnBootArgs): Promise<SpawnedBootVmm> {
   args.phases.start("vmm-spawn");
   const vmmPdeathsig = await resolveVmmPdeathsig(args.plan.usePdeathsig);
-  const vmmArgv = planBootVmmArgvNative({
-    binary: args.plan.binary,
-    args: args.opts.args ?? [],
-    pdeathsigPath: vmmPdeathsig,
-  });
+  const vmmArgv = planBootVmmArgv(args.plan.binary, args.opts.args ?? [], vmmPdeathsig);
   const stdio: Array<"pipe" | number> = ["pipe", "pipe", "pipe"];
   const mountDiskFds = maybeOpenMountDiskFds(args.resources.mountDiskPaths, args.plan.env, stdio);
   const child = nodeSpawn(vmmArgv.command, vmmArgv.args, {
@@ -752,6 +708,16 @@ function applySpawnedCpuControls(
 
 async function resolveVmmPdeathsig(usePdeathsig: boolean): Promise<string | null> {
   return usePdeathsig ? ensurePdeathsig() : null;
+}
+
+function planBootVmmArgv(
+  binary: string,
+  args: string[],
+  pdeathsigPath: string | null,
+): { command: string; args: string[] } {
+  return pdeathsigPath
+    ? { command: pdeathsigPath, args: [binary, ...args] }
+    : { command: binary, args };
 }
 
 function maybeOpenMountDiskFds(
@@ -792,7 +758,10 @@ interface BootRegistryState {
   bootLogPath: string | undefined;
 }
 
-type BootRegistryLifecyclePlan = ReturnType<typeof planBootRegistryLifecycleNative>;
+interface BootRegistryLifecyclePlan {
+  claimName: string | null;
+  shouldWrite: boolean;
+}
 
 function registerSpawnedBoot(args: {
   opts: BootOptions;
@@ -802,7 +771,7 @@ function registerSpawnedBoot(args: {
   bootT0: number;
 }): BootRegistryState {
   const state = buildBootRegistryState(args.opts, args.resources, args.spawned);
-  const lifecycle = planBootRegistryLifecycleNative({
+  const lifecycle = planBootRegistryLifecycle({
     name: state.vmName,
     childPid: state.childPid,
     vsockUdsPath: args.plan.vsockUdsPath,
@@ -819,19 +788,13 @@ function buildBootRegistryState(
   spawned: SpawnedBootVmm,
 ): BootRegistryState {
   const childPid = spawned.child.pid ?? -1;
-  const registryShape = planBootRegistryShapeNative({
-    sourceImagePath: registrySourceImage(opts),
-    rootDisk: {
-      perBootRootDisk: resources.perBootRootDisk,
-      callerRootDiskPath: registryCallerRootDiskPath(opts),
-    },
-  });
+  const rootDiskPath = resources.perBootRootDisk ?? registryCallerRootDiskPath(opts);
   return {
     childPid,
     vmName: opts.name,
-    sourceImageAbs: registryShape.sourceImagePath ?? undefined,
-    rootDiskPath: registryShape.rootDiskPath ?? undefined,
-    rootDiskMode: registryShape.rootDiskMode,
+    sourceImageAbs: registrySourceImage(opts),
+    rootDiskPath,
+    rootDiskMode: rootDiskPath ? "block" : "none",
     bootLogPath: registryBootLogPath(opts, childPid),
   };
 }
@@ -847,11 +810,22 @@ function registryCallerRootDiskPath(opts: BootOptions): string | undefined {
 }
 
 function registryBootLogPath(opts: BootOptions, childPid: number): string | undefined {
-  return (
-    planBootRegistryShapeNative({
-      bootLog: { root: detachedLogRoot(), childPid, detached: opts.detached },
-    }).bootLogPath ?? undefined
-  );
+  if (!opts.detached || childPid <= 0) {
+    return undefined;
+  }
+  return join(detachedLogRoot(), `${childPid}.boot.log`);
+}
+
+function planBootRegistryLifecycle(input: {
+  name?: string;
+  childPid: number;
+  vsockUdsPath?: string;
+}): BootRegistryLifecyclePlan {
+  const hasLivePid = input.childPid > 0;
+  return {
+    claimName: hasLivePid ? (input.name ?? null) : null,
+    shouldWrite: hasLivePid && input.vsockUdsPath !== undefined,
+  };
 }
 
 function claimBootNameIfNeeded(
@@ -918,17 +892,25 @@ function buildRegisterArgs(
     vmstateChainId: vmstate.chainId ?? undefined,
     vmstateCheckpointParent: vmstate.checkpointParent ?? undefined,
     vmstateCheckpointSequence: vmstate.checkpointSequence ?? undefined,
-    nested: planBootRegistryNestedNative(args.opts.nested),
+    nested: args.opts.nested || undefined,
   };
 }
 
-function registryVmstate(vmstate: BootVmstateRuntime) {
-  return planBootRegistryVmstateNative({
+function registryVmstate(vmstate: BootVmstateRuntime): {
+  statePath?: string;
+  chainId?: string;
+  checkpointParent?: string;
+  checkpointSequence?: number;
+} {
+  if (!vmstate.statePath) {
+    return {};
+  }
+  return {
     statePath: vmstate.statePath,
     chainId: vmstate.chainId,
     checkpointParent: vmstate.checkpointParent,
     checkpointSequence: vmstate.checkpointSequence,
-  });
+  };
 }
 
 function cleanupPathsForBoot(
@@ -936,18 +918,16 @@ function cleanupPathsForBoot(
   resources: BootResources,
   spawned: SpawnedBootVmm,
 ): string[] {
-  return planBootRegistryShapeNative({
-    cleanup: {
-      perBootRootDisk: resources.perBootRootDisk,
-      perBootSnapDisk: plan.perBootSnapDisk,
-      perBootMountUpper: spawned.perBootMountUpper,
-      bundleTempDir: resources.bundleTempDir,
-      vsockTempDir: plan.vsockTempDir,
-      statsTempDir: plan.statsTempDir,
-      gvSocketDir: resources.gvSocketDir,
-      cpuCgroupPath: spawned.cpuControl.cgroupPath,
-    },
-  }).cleanupPaths;
+  return [
+    resources.perBootRootDisk,
+    plan.perBootSnapDisk,
+    spawned.perBootMountUpper,
+    resources.bundleTempDir,
+    plan.vsockTempDir,
+    plan.statsTempDir,
+    resources.gvSocketDir,
+    spawned.cpuControl.cgroupPath,
+  ].filter((path): path is string => path !== undefined);
 }
 
 function installBootExitCleanup(
@@ -980,27 +960,7 @@ async function prepareBootPlan(opts: BootOptions, phases: PhaseTimer): Promise<B
   const assets = await resolveBootAssets(opts, phases);
   const env = buildVmmEnv(opts);
   configureNestedVirtualization(opts, assets.binary, env);
-  const corePlan = planBootCoreNative({
-    memoryMib: opts.memory,
-    resourcesMemory: opts.resources?.memory,
-    resourcesCpu: opts.resources?.cpu,
-    vmmMemoryPreset: env.MACHINEN_MEMORY !== undefined,
-    hasImage: opts.image !== undefined,
-    hasCmd: opts.cmd !== undefined,
-    hasSnapshot: Boolean(opts.snapshot),
-    detached: opts.detached,
-    pdeathsig: opts.pdeathsig,
-    bootTimeoutMs: opts.timeoutMs,
-    rootDisk:
-      opts.rootDisk === false
-        ? "false"
-        : opts._rootDiskRestorePath !== undefined
-          ? "path"
-          : planBootRootDiskModeNative({
-              rootDisk: opts.rootDisk,
-              restorePath: opts._rootDiskRestorePath,
-            }),
-  });
+  const corePlan = planBootCore(opts, env);
   if (corePlan.vmmMemory !== null) {
     env.MACHINEN_MEMORY = corePlan.vmmMemory;
   }
@@ -1055,10 +1015,13 @@ function resolveBootBinary(opts: BootOptions): string {
 }
 
 function buildVmmEnv(opts: BootOptions): Record<string, string> {
-  return planBootVmmEnvNative({
-    hostEnv: process.env,
-    overrides: opts.vmmEnv,
-  });
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return { ...env, ...opts.vmmEnv };
 }
 
 function prepareBootScratchDisk(
@@ -1070,139 +1033,6 @@ function prepareBootScratchDisk(
   const scratch = prepareScratchDisk(opts, env);
   phases.end("disk-prep");
   return scratch;
-}
-
-function setupVmstateBoot(
-  opts: BootOptions,
-  env: Record<string, string>,
-  inputVsockTempDir: string | undefined,
-): { vmstate: BootVmstateRuntime; vsockTempDir: string | undefined } {
-  let vsockTempDir = inputVsockTempDir;
-  let stateTempDir: string | undefined;
-  const chainId = randomBytes(16).toString("hex");
-  const tempMode = planVmstateTempMode(
-    resolveSnapshotEngine(),
-    opts.snapshot === false,
-    vsockTempDir,
-  );
-  if (tempMode.action === "allocate") {
-    stateTempDir = vsockTempDir = mkdtempSync(join(tmpdir(), "machinen-vsock-"));
-  } else if (tempMode.tempDir) {
-    stateTempDir = vsockTempDir = tempMode.tempDir;
-  }
-  const runtime = planBootVmstateRuntimeNative({
-    stateTempDir,
-    chainId,
-    restorePath: opts._vmstateRestorePath,
-    forkedFrom: opts.forkedFrom,
-  });
-  const vmstate: BootVmstateRuntime = {
-    statePath: runtime.statePath ?? undefined,
-    chainId: runtime.chainId ?? chainId,
-    checkpointParent: runtime.checkpointParent ?? undefined,
-    checkpointSequence: runtime.checkpointSequence ?? 0,
-  };
-  applyVmstateEnvPlan(opts, env, vmstate.statePath);
-  return { vmstate, vsockTempDir };
-}
-function applyVmstateEnvPlan(
-  opts: BootOptions,
-  env: Record<string, string>,
-  vmstatePath: string | undefined,
-): void {
-  const plan = planBootVmstateEnvNative({
-    vmstatePath,
-    restorePath: opts._vmstateRestorePath,
-    enableTiming: vmstateDebug.enabled || restoreDebug.enabled,
-    existingTiming: env.MACHINEN_VMSTATE_TIMING,
-  });
-  if (plan.snapshotPath) {
-    env.MACHINEN_SNAPSHOT_PATH = plan.snapshotPath;
-  }
-  if (plan.restorePath) {
-    env.MACHINEN_RESTORE_PATH = plan.restorePath;
-  }
-  if (plan.vmstateTiming) {
-    env.MACHINEN_VMSTATE_TIMING = plan.vmstateTiming;
-  }
-}
-
-function setupLiveMountEnv(opts: BootOptions, env: Record<string, string>): ResolvedLiveMount[] {
-  const liveMounts = opts.liveMounts ?? [];
-  if (liveMounts.length === 0) {
-    return [];
-  }
-  const resolved = resolveLiveMounts(liveMounts, opts.cwd);
-  Object.assign(env, planBootVirtiofsEnvNative(resolved));
-  return resolved;
-}
-
-function buildMergedGuestEnv(
-  opts: BootOptions,
-  vsockUdsPath: string | undefined,
-): Record<string, string> {
-  return planBootCoreNative({
-    guestEnv: opts.env,
-    name: opts.name,
-    vsockUdsPath,
-    vmmMemoryPreset: true,
-    hasImage: false,
-    hasCmd: false,
-    rootDisk: "false",
-  }).mergedGuestEnv;
-}
-
-// Validate portForward up front — before resolving the binary or
-// touching the filesystem — so caller-input errors surface with a
-// clear message. The env-dependent "pre-set MACHINEN_NET_SOCKET"
-// check happens alongside since it only reads env.
-async function planPortForwardOpts(
-  opts: BootOptions,
-): Promise<NonNullable<BootOptions["portForward"]>> {
-  if ((opts.portForward ?? []).length === 0) {
-    return planBootPortForwardNative(opts.portForward);
-  }
-  const portForward = planBootPortForwardNative(opts.portForward);
-  validatePresetNetSocket(opts, portForward);
-  await validatePortForwardAvailability(portForward);
-  return portForward;
-}
-
-function validatePresetNetSocket(
-  opts: BootOptions,
-  portForward: NonNullable<BootOptions["portForward"]>,
-): void {
-  validatePortForwardNetSocketNative(
-    portForward,
-    (opts.vmmEnv && opts.vmmEnv.MACHINEN_NET_SOCKET) || process.env.MACHINEN_NET_SOCKET,
-  );
-}
-
-async function validatePortForwardAvailability(
-  portForward: NonNullable<BootOptions["portForward"]>,
-): Promise<void> {
-  for (const probe of planPortForwardProbeNative(portForward)) {
-    await validateHostPortFree(probe);
-  }
-}
-
-async function validateHostPortFree(probe: { hostPort: number; probeHost: string }): Promise<void> {
-  const errno = await probeHostPortFree(probe.probeHost, probe.hostPort);
-  if (!errno) {
-    return;
-  }
-  throw new BootError(
-    "BOOT_PORT_FORWARD_IN_USE",
-    `portForward: host port ${probe.probeHost}:${probe.hostPort} is already in use (${errno}). ${await portHolderDetail(probe.hostPort)}`,
-  );
-}
-
-async function portHolderDetail(hostPort: number): Promise<string> {
-  const holder = await describePortHolder(hostPort).catch(() => null);
-  return holder
-    ? `${holder}.`
-    : "Common cause: an orphaned gvproxy from a prior `kill -9` of the VMM. " +
-        "Try `pkill -f gvproxy` to clear it, or pick a different host port.";
 }
 
 // #263 phase A: forward the guest RAM ceiling so the VMM doesn't
@@ -1238,120 +1068,6 @@ function runtimeEntryImportPath(): string {
   return "./index.js";
 }
 
-// The scratch virtio-blk device serves two unrelated workloads:
-//   - caller-supplied path (string): a CRIU snapshot bundle to
-//     restore from at boot — the runtime synthesizes
-//     /sbin/machinen-restore when no cmd is given. The bundle is
-//     reflink-cloned into a per-boot path so a future `vm.snapshot()`
-//     against the restored VM doesn't corrupt the source bundle
-//     when machinen-dump.sh re-formats the disk (#207).
-//   - default (undefined): per-boot sparse scratch so any VM is
-//     CRIU-dumpable later via vm.snapshot(). 8 GiB sparse means zero
-//     real disk until the guest writes; cleaned up alongside the
-//     rootdisk reflink on VM exit. Don't synthesize restore for this
-//     case (the file is empty).
-//   - `false`: opt out, no /dev/vdb. Test-fast paths use this.
-function prepareScratchDisk(
-  opts: BootOptions,
-  env: Record<string, string>,
-): { diskAbs: string | undefined; perBootSnapDisk: string | undefined } {
-  const snapshotPath = resolveSnapshotDiskPath(opts);
-  const scratchPlan = planBootScratchDiskNative({
-    mode: planBootScratchModeNative(opts.snapshot),
-    hasCmd: opts.cmd !== undefined,
-    hasImage: opts.image !== undefined,
-    snapshotPath,
-    restoreClonePath: snapshotPath ? scratchRestoreClonePath() : undefined,
-    autoPath: opts.snapshot === undefined ? autoScratchPath() : undefined,
-  });
-  applyScratchDiskPlan(scratchPlan, snapshotPath, env);
-  return {
-    diskAbs: scratchPlan.diskPath ?? undefined,
-    perBootSnapDisk: scratchPlan.perBootSnapDisk ?? undefined,
-  };
-}
-
-function resolveSnapshotDiskPath(opts: BootOptions): string | undefined {
-  if (typeof opts.snapshot !== "string") {
-    return undefined;
-  }
-  const bundleDisk = resolve(opts.cwd ?? process.cwd(), opts.snapshot);
-  if (!existsSync(bundleDisk)) {
-    throw new BootError("BOOT_SNAPSHOT_NOT_FOUND", `snapshot image not found: ${bundleDisk}`);
-  }
-  return bundleDisk;
-}
-
-function scratchRestoreClonePath(): string {
-  return planBootScratchTempPathNative({
-    kind: "restore",
-    tmpDir: tmpdir(),
-    pid: process.pid,
-    nonce: randomBytes(6).toString("hex"),
-  });
-}
-
-function autoScratchPath(): string {
-  return planBootScratchTempPathNative({
-    kind: "auto",
-    tmpDir: tmpdir(),
-    pid: process.pid,
-    nonce: randomBytes(6).toString("hex"),
-  });
-}
-
-function applyScratchDiskPlan(
-  plan: ReturnType<typeof planBootScratchDiskNative>,
-  snapshotPath: string | undefined,
-  env: Record<string, string>,
-): void {
-  if (plan.vmmDisk) {
-    env.MACHINEN_DISK = plan.vmmDisk;
-  }
-  if (plan.action === "existing") {
-    debug("snap-restore in-place (explicit cmd) path=%s", plan.diskPath);
-    return;
-  }
-  if (plan.action === "clone") {
-    reflinkCopy(snapshotPath!, plan.diskPath!);
-    debug("snap-restore reflink-clone src=%s dst=%s", snapshotPath, plan.diskPath);
-    return;
-  }
-  if (plan.action === "allocate") {
-    allocateSparseFile(plan.diskPath!, SNAP_SCRATCH_BYTES);
-    debug("snap-scratch auto path=%s sizeBytes=%d", plan.diskPath, SNAP_SCRATCH_BYTES);
-  }
-}
-
-// #94: always wire up a vsock UDS bridge so `vm.exec()` works out of
-// the box. Callers who set their own `MACHINEN_VSOCK` (e.g. the build
-// flow) win — we parse their spec to extract the UDS path for exec.
-function setupVsockBridge(env: Record<string, string>): {
-  vsockUdsPath: string | undefined;
-  vsockTempDir: string | undefined;
-} {
-  const mode = planBootVsockModeNative(env.MACHINEN_VSOCK);
-  const existingSpec = mode.existingSpec ?? undefined;
-  const vsockTempDir =
-    mode.action === "existing" ? undefined : mkdtempSync(join(tmpdir(), "machinen-vsock-"));
-  const plan = planBootCoreNative({
-    existingVsockSpec: existingSpec,
-    autoVsockTempDir: vsockTempDir,
-    vmmMemoryPreset: true,
-    hasImage: false,
-    hasCmd: false,
-    rootDisk: "false",
-  });
-  if (plan.vmmVsock !== null) {
-    env.MACHINEN_VSOCK = plan.vmmVsock;
-  }
-  debug(
-    existingSpec ? "vsock spec from caller env: %s (uds=%s)" : "vsock auto spec=%s uds=%s",
-    existingSpec ?? plan.vmmVsock ?? "<unset>",
-    plan.vsockUdsPath ?? "<unparsed>",
-  );
-  return { vsockUdsPath: plan.vsockUdsPath ?? undefined, vsockTempDir };
-}
 interface GvproxyResult {
   gvStop: (() => void) | undefined;
   gvPid: number | undefined;
@@ -1365,11 +1081,7 @@ async function bringUpGvproxy(
   env: Record<string, string>,
   portForward: NonNullable<BootOptions["portForward"]>,
 ): Promise<GvproxyResult> {
-  const existingPlan = planGvproxyNative({
-    portForward,
-    existingNetSocket: env.MACHINEN_NET_SOCKET,
-  });
-  if (existingPlan.action === "skip-existing") {
+  if (env.MACHINEN_NET_SOCKET !== undefined) {
     debug("MACHINEN_NET_SOCKET already set — skipping gvproxy spawn");
     return { gvStop: undefined, gvPid: undefined, gvExe: undefined, gvSocketDir: undefined };
   }
@@ -1377,17 +1089,18 @@ async function bringUpGvproxy(
   // visible stderr line; cached under ~/.machinen so subsequent
   // boots are silent. See #83 follow-up.
   const gvBin = await ensureGvproxy(binary);
-  const gvproxyPlan = planGvproxyNative({
-    portForward,
-    gvproxyPath: gvBin ?? undefined,
-    planningRequired: true,
-  });
-  if (gvproxyPlan.action === "missing-ok") {
+  if (!gvBin) {
+    if (portForward.length > 0) {
+      throw new BootError(
+        "BOOT_PORT_FORWARD_NO_GVPROXY",
+        "portForward requires gvproxy, but no gvproxy binary was found.",
+      );
+    }
     debug("gvproxy not found — booting without networking");
     warnGvproxyMissing();
     return { gvStop: undefined, gvPid: undefined, gvExe: undefined, gvSocketDir: undefined };
   }
-  const gvproxyPath = gvproxyPlan.gvproxyPath!;
+  const gvproxyPath = gvBin;
   debug("starting gvproxy bin=%s", gvproxyPath);
   // Detach gvproxy alongside the VMM so the parent can exit
   // without stranding the guest's networking (#150 phase 2 PR3).
@@ -1551,22 +1264,7 @@ function registerInRegistry(args: RegisterArgs): boolean {
 }
 
 function buildRegistryEntry(args: RegisterArgs) {
-  const scalars = planBootRegistryScalarsNative(args);
-  const identityReads = planBootRegistryProcessIdentityNative({
-    hostPlatform: process.platform,
-    childPid: args.childPid,
-    vmmPdeathsig: args.vmmPdeathsig !== null,
-    gvPid: args.gvPid,
-  });
-  const processPlan = planBootRegistryProcessNative({
-    hostPlatform: process.platform,
-    vmmBinary: args.binary,
-    vmmPdeathsig: args.vmmPdeathsig !== null,
-    vmmObservedExeBase: observedProcessExeBase(identityReads.vmmPid),
-    gvPid: args.gvPid,
-    gvExe: args.gvExe,
-    gvObservedExeBase: observedProcessExeBase(identityReads.gvPid),
-  });
+  const processPlan = registryProcessPlan(args);
   return {
     pid: args.childPid,
     name: args.vmName,
@@ -1576,17 +1274,17 @@ function buildRegistryEntry(args: RegisterArgs) {
     dtbPath: args.dtbPath,
     rootDiskPath: args.rootDiskPath,
     rootDiskMode: args.rootDiskMode,
-    diskPath: scalars.diskPath ?? undefined,
-    forkedFrom: scalars.forkedFrom ?? undefined,
+    diskPath: args.diskPath,
+    forkedFrom: args.forkedFrom,
     bootLogPath: args.bootLogPath,
     cleanupPaths: nonEmptyList(args.cleanupPaths),
     vmmExe: processPlan.vmmExe,
     gvproxyPid: args.gvPid,
     gvproxyExe: processPlan.gvproxyExe,
     portForward: registryPortForward(args.portForward),
-    memoryCeilingMib: scalars.memoryCeilingMib ?? undefined,
+    memoryCeilingMib: args.memoryCeilingMib,
     cpu: registryCpu(args.cpuPolicy, args.cpuControl),
-    statsPath: scalars.statsPath ?? undefined,
+    statsPath: args.statsPath,
     vmstatePath: args.vmstateStatePath,
     vmstateChainId: args.vmstateChainId,
     vmstateCheckpointParent: args.vmstateCheckpointParent,
@@ -1602,31 +1300,30 @@ function nonEmptyList<T>(items: T[]): T[] | undefined {
   return items.length > 0 ? items : undefined;
 }
 
-function observedProcessExeBase(pid: number | undefined): string | undefined {
-  return pid === undefined ? undefined : readProcessIdentity(pid)?.exeBase;
+function registryProcessPlan(args: RegisterArgs): { vmmExe: string; gvproxyExe?: string } {
+  return {
+    vmmExe: process.platform === "darwin" && args.vmmPdeathsig ? args.vmmPdeathsig : args.binary,
+    gvproxyExe: args.gvExe,
+  };
 }
 
 function registryMountDisk(mountDiskPaths: MountDiskPaths | undefined) {
   if (!mountDiskPaths) {
     return undefined;
   }
-  return (
-    planBootRegistryShapeNative({
-      mountDisk: {
-        guest: mountDiskPaths.guest,
-        lowerPath: mountDiskPaths.lowerPath,
-        upperPath: mountDiskPaths.upperPath,
-      },
-    }).mountDisk ?? undefined
-  );
+  return {
+    guest: mountDiskPaths.guest,
+    lowerPath: mountDiskPaths.lowerPath,
+    upperPath: mountDiskPaths.upperPath,
+  };
 }
 
 function registryLiveMounts(liveMountsResolved: ResolvedLiveMount[]) {
-  return nonEmptyList(planBootRegistryShapeNative({ liveMounts: liveMountsResolved }).liveMounts);
+  return nonEmptyList(liveMountsResolved.map(({ guest, host, mode }) => ({ guest, host, mode })));
 }
 
 function registryPortForward(portForward: NonNullable<BootOptions["portForward"]>) {
-  return planBootRegistryPortForwardNative(portForward);
+  return nonEmptyList(portForward);
 }
 
 // #221/#233: stamp first-guest-byte and emit the boot timeline. Either
@@ -1680,7 +1377,7 @@ function installFlushPhases(
   child.once("exit", flush);
 }
 
-function installDetachedBootCapture(child: ChildProcessWithoutNullStreams, sink: Buffer[]): void {
+function installBootStderrCapture(child: ChildProcessWithoutNullStreams, sink: Buffer[]): void {
   let bytes = 0;
   child.stderr.on("data", (chunk: Buffer) => {
     sink.push(chunk);
@@ -1698,6 +1395,7 @@ interface BootHandleArgs {
   timeoutMs: number | null;
   outputCollector: Promise<string>;
   errorCollector: Promise<string>;
+  stderrTail: () => string;
   vsockUdsPath: string | undefined;
   onLog: OnLog | undefined;
   statsFilePath: string | undefined;
@@ -1723,13 +1421,6 @@ interface BootSnapshotContextArgs {
   vmstate: BootVmstateRuntime;
 }
 
-interface BootVmstateRuntime {
-  statePath: string | undefined;
-  chainId: string;
-  checkpointParent: string | undefined;
-  checkpointSequence: number;
-}
-
 function createBootVmHandle(args: BootHandleArgs): VmHandle {
   let handle: VmHandle;
   handle = {
@@ -1743,17 +1434,25 @@ function createBootVmHandle(args: BootHandleArgs): VmHandle {
     detach: makeDetach(args.child),
     output: () => args.outputCollector,
     errorOutput: () => args.errorCollector,
-    exec: makeExec(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
-    execRaw: makeExecRaw(args.vsockUdsPath, args.onLog, args.child, args.errorCollector),
+    exec: makeExec(args.vsockUdsPath, args.onLog, args.child, args.errorCollector, args.stderrTail),
+    execRaw: makeExecRaw(
+      args.vsockUdsPath,
+      args.onLog,
+      args.child,
+      args.errorCollector,
+      args.stderrTail,
+    ),
     reseedVmstateEntropy: makeReseedVmstateEntropy(
       args.vsockUdsPath,
       args.child,
       args.errorCollector,
+      args.stderrTail,
     ),
     syncVmstateSnapshot: makeSyncVmstateSnapshot(
       args.vsockUdsPath,
       args.child,
       args.errorCollector,
+      args.stderrTail,
     ),
     execPty: makeExecPty(args.vsockUdsPath),
     writeFile: makeWriteFile(() => handle),
@@ -1776,10 +1475,11 @@ function makeExec(
   onLog: OnLog | undefined,
   child: ChildProcessWithoutNullStreams,
   errorCollector: Promise<string>,
+  stderrTail: () => string,
 ): VmHandle["exec"] {
   return async (cmd, execOpts) => {
     const udsPath = requireVsockPath(vsockUdsPath, "exec");
-    const res = await runVsockWithBootDiagnostics(child, errorCollector, () =>
+    const res = await runVsockWithBootDiagnostics(child, errorCollector, stderrTail, () =>
       VsockExec.run(udsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
     );
     if (res.exitCode !== 0) {
@@ -1797,12 +1497,13 @@ function makeExecRaw(
   onLog: OnLog | undefined,
   child: ChildProcessWithoutNullStreams,
   errorCollector: Promise<string>,
+  stderrTail: () => string,
 ): VmHandle["execRaw"] {
   return (cmd, execOpts) => {
     if (!vsockUdsPath) {
       return Promise.reject(missingVsockError("execRaw"));
     }
-    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+    return runVsockWithBootDiagnostics(child, errorCollector, stderrTail, () =>
       VsockExec.run(vsockUdsPath, cmd, teeOnLog(cmd, execOpts, onLog)),
     );
   };

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -22,17 +22,8 @@ import {
   markMountDiskImageClean,
 } from "../mountdisk-img.ts";
 import { reflinkCopy } from "../reflink.ts";
-import {
-  planBootBundleCommandNative,
-  planBootBundleConfigPathsNative,
-  planBootBundleEnvNative,
-  planBootBundleWorkspaceNative,
-  planBootLiveMountsNative,
-  planBootMountDiskRuntimeNative,
-  planBootMachinenConfigNative,
-} from "../native/boot-plan.ts";
+import { planBootLiveMountsNative, planBootMountDiskRuntimeNative } from "../native/boot-plan.ts";
 import { planBootBundleMountDiskModeNative } from "../native/bundle-mount-disk-mode.ts";
-import { planBootBundlePackNative } from "../native/bundle-pack.ts";
 import { planBootMountDiskTempPathNative } from "../native/mount-disk-temp-path.ts";
 import { validateLiveMountRemovedOptionsNative } from "../native/live-mount-options.ts";
 import type { BundlePackPlan } from "../native/boot-plan-schema.ts";
@@ -108,7 +99,16 @@ export function buildMachinenConfig(input: {
   imageCwd?: string;
   liveMounts: ResolvedLiveMount[];
 }): Record<string, unknown> {
-  return planBootMachinenConfigNative(input);
+  const config: Record<string, unknown> = {
+    cmd: input.cmd,
+    env: input.env,
+  };
+  const cwd = input.guestCwd ?? input.imageCwd;
+  if (cwd !== undefined) {
+    config.cwd = cwd;
+  }
+  config.liveMounts = input.liveMounts.map(({ guest, tag, mode }) => ({ guest, tag, mode }));
+  return config;
 }
 
 /**
@@ -194,10 +194,7 @@ export function synthesizeAndPackBundle(
     validateOptionalGuestCwd(opts);
     const image = resolveBundleImage(opts, packerOpts);
     const cmd = planBundleCommand(opts, image.imageConfig, liveMounts);
-    const effectiveEnv = planBootBundleEnvNative({
-      imageEnv: image.imageConfig?.env,
-      guestEnv: mergedGuestEnv,
-    });
+    const effectiveEnv = mergeBundleEnv(image.imageConfig?.env, mergedGuestEnv);
     writeBundleConfig(workspace, {
       cmd,
       env: effectiveEnv,
@@ -206,12 +203,12 @@ export function synthesizeAndPackBundle(
       liveMounts,
     });
     const mount = resolveBundleMount(opts);
-    const packPlan = planBootBundlePackNative({
+    const packPlan = planBundlePack({
       useTiny: packerOpts.useTiny,
       mountGuest: mount?.guest,
       restoreMountGuest: opts._restoreMountDisk?.guest,
     });
-    packSynthesizedInitramfs(workspace, image.baseAbs, mount, packPlan, effectiveEnv, packerOpts);
+    packSynthesizedInitramfs(workspace, image.baseAbs, mount, packPlan, packerOpts);
     return {
       tempDir: workspace.tempDir,
       cpioPath: workspace.cpioPath,
@@ -225,11 +222,10 @@ export function synthesizeAndPackBundle(
 
 function createBundleWorkspace(): BundleWorkspace {
   const tempDir = mkdtempSync(join(tmpdir(), "machinen-bundle-"));
-  const plan = planBootBundleWorkspaceNative(tempDir);
   return {
     tempDir,
-    cpioPath: plan.cpioPath,
-    synthBundleDir: plan.synthBundleDir,
+    cpioPath: join(tempDir, "initramfs.cpio"),
+    synthBundleDir: join(tempDir, "bundle"),
     cleanup: () => {
       try {
         rmSync(tempDir, { recursive: true, force: true });
@@ -263,13 +259,76 @@ function planBundleCommand(
   imageConfig: BundleImageConfig | undefined,
   liveMounts: ResolvedLiveMount[],
 ): string[] {
-  return planBootBundleCommandNative({
-    explicitCmd: opts.cmd,
-    imageCmd: imageConfig?.cmd,
-    snapshotRestore: typeof opts.snapshot === "string",
-    vmstateRestore: opts._vmstateRestorePath !== undefined,
-    liveMounts,
-  });
+  const cmd = opts.cmd ?? fallbackBundleCommand(opts, imageConfig);
+  if (!cmd) {
+    throw new BootError(
+      "BOOT_CMD_MISSING",
+      "boot: no cmd to run — pass `cmd` on boot() or bake one into the image via `provision({ cmd })`.",
+    );
+  }
+  if (isSupervisorCommand(cmd)) {
+    return cmd;
+  }
+  const workload = hasWritableLiveMount(liveMounts) ? wrapBatchWorkloadCommand(cmd) : cmd;
+  return [
+    "/sbin/machinen-supervisor",
+    ...(typeof opts.snapshot === "string" ? ["--session"] : []),
+    ...workload,
+  ];
+}
+
+function fallbackBundleCommand(
+  opts: BootOptions,
+  imageConfig: BundleImageConfig | undefined,
+): string[] | undefined {
+  if (typeof opts.snapshot === "string") {
+    return ["/sbin/machinen-restore"];
+  }
+  if (opts._vmstateRestorePath !== undefined) {
+    return ["/sbin/machinen-poweroff"];
+  }
+  return imageConfig?.cmd;
+}
+
+function isSupervisorCommand(cmd: string[]): boolean {
+  return cmd[0] === "/exec-agent" || cmd[0] === "/sbin/machinen-restore";
+}
+
+function hasWritableLiveMount(liveMounts: ResolvedLiveMount[]): boolean {
+  return liveMounts.some((mount) => mount.mode === "rw");
+}
+
+function wrapBatchWorkloadCommand(cmd: string[]): string[] {
+  const batchScript =
+    "batch_sync() { " +
+    "if [ -s /run/machinen-batch-sync.sh ]; then " +
+    "sh /run/machinen-batch-sync.sh; fi; }; " +
+    '"$@" & child=$!; ' +
+    "trap 'kill -TERM \"$child\" 2>/dev/null' TERM; " +
+    "trap 'kill -INT \"$child\" 2>/dev/null' INT; " +
+    'wait "$child"; status=$?; ' +
+    "batch_sync || { sync_status=$?; " +
+    'if [ "$status" -eq 0 ]; then status=$sync_status; fi; }; ' +
+    'exit "$status"';
+  return ["/bin/sh", "-c", batchScript, "machinen-batch-wrapper", ...cmd];
+}
+
+function mergeBundleEnv(
+  imageEnv: Record<string, string> | undefined,
+  guestEnv: Record<string, string>,
+): Record<string, string> {
+  return { ...imageEnv, ...guestEnv };
+}
+
+function planBundlePack(input: {
+  useTiny: boolean;
+  mountGuest?: string;
+  restoreMountGuest?: string;
+}): BundlePackPlan {
+  if (!input.useTiny) {
+    return { kind: "fat", tinyMountGuest: null };
+  }
+  return { kind: "tiny", tinyMountGuest: input.mountGuest ?? input.restoreMountGuest ?? null };
 }
 
 function writeBundleConfig(
@@ -282,10 +341,10 @@ function writeBundleConfig(
     liveMounts: ResolvedLiveMount[];
   },
 ): void {
-  const paths = planBootBundleConfigPathsNative(workspace.synthBundleDir);
-  mkdirSync(paths.rootfsDir, { recursive: true });
+  const rootfsDir = join(workspace.synthBundleDir, "rootfs");
+  mkdirSync(rootfsDir, { recursive: true });
   const configJson = buildMachinenConfig(input);
-  writeFileSync(paths.configPath, JSON.stringify(configJson));
+  writeFileSync(join(workspace.synthBundleDir, "machinen-config.json"), JSON.stringify(configJson));
 }
 
 function resolveBundleMount(opts: BootOptions): ResolvedMountInput | undefined {
@@ -317,15 +376,14 @@ function packSynthesizedInitramfs(
   baseAbs: string | undefined,
   mount: ResolvedMountInput | undefined,
   packPlan: BundlePackPlan,
-  effectiveEnv: Record<string, string>,
   packerOpts: BundlePackerOptions,
 ): void {
   const packT0 = Date.now();
   try {
     if (packPlan.kind === "tiny") {
-      packTinyInitramfs(workspace, packPlan.tinyMountGuest, effectiveEnv);
+      packTinyInitramfs(workspace, packPlan.tinyMountGuest);
     } else {
-      packFatInitramfs(workspace, baseAbs, mount, effectiveEnv);
+      packFatInitramfs(workspace, baseAbs, mount);
     }
     packerOpts.onPhase?.("cpio-write", Date.now() - packT0);
   } catch (err) {
@@ -334,18 +392,13 @@ function packSynthesizedInitramfs(
   }
 }
 
-function packTinyInitramfs(
-  workspace: BundleWorkspace,
-  mountGuest: string | null,
-  effectiveEnv: Record<string, string>,
-): void {
+function packTinyInitramfs(workspace: BundleWorkspace, mountGuest: string | null): void {
   mkinitramfsPackTinyBundle({
     bundle: workspace.synthBundleDir,
     out: workspace.cpioPath,
     // The cpio just carries the guest mountpoint string for /init to
     // read. The actual payload rides on virtio-blk slots 5+6.
     mountGuest: mountGuest ?? undefined,
-    env: effectiveEnv,
   });
 }
 
@@ -353,14 +406,12 @@ function packFatInitramfs(
   workspace: BundleWorkspace,
   baseAbs: string | undefined,
   mount: ResolvedMountInput | undefined,
-  effectiveEnv: Record<string, string>,
 ): void {
   mkinitramfsPackBundle({
     bundle: workspace.synthBundleDir,
     out: workspace.cpioPath,
     base: baseAbs,
     mount,
-    env: effectiveEnv,
   });
 }
 

--- a/packages/runtime/src/vm/live-mount-batch.ts
+++ b/packages/runtime/src/vm/live-mount-batch.ts
@@ -18,7 +18,9 @@ export function validateBatchLiveMounts(
   liveMounts: ReadonlyArray<BatchLiveMount & { tag: string; mode: "ro" | "rw" }>,
   vsockUdsPath: string | undefined,
 ): void {
-  validateBatchLiveMountsNative(liveMounts, vsockUdsPath);
+  if (liveMounts.length > 0) {
+    validateBatchLiveMountsNative(liveMounts, vsockUdsPath);
+  }
 }
 
 export function withBatchLiveMountSync(

--- a/packages/runtime/src/vm/registry-cpu.ts
+++ b/packages/runtime/src/vm/registry-cpu.ts
@@ -1,5 +1,4 @@
 import type { CpuControlResult } from "../cpu-cgroup.ts";
-import { planBootRegistryCpuNative } from "../native/boot-plan.ts";
 import type { RegistryEntry } from "../registry.ts";
 import type { ResolvedCpuResourcePolicy } from "./cpu-resources.ts";
 
@@ -9,5 +8,16 @@ export function registryCpu(
   policy: ResolvedCpuResourcePolicy | undefined,
   control: CpuControlResult,
 ): CpuRegistryEntry | undefined {
-  return planBootRegistryCpuNative({ policy, control });
+  if (!policy) {
+    return undefined;
+  }
+  return {
+    maxVcpus: policy.maxVcpus,
+    quotaCpus: policy.quotaCpus,
+    weight: policy.weight,
+    enforcement: {
+      status: control.status,
+      reason: control.reason,
+    },
+  };
 }

--- a/packages/runtime/src/vm/stats-file.ts
+++ b/packages/runtime/src/vm/stats-file.ts
@@ -3,8 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { STATS_FILE_SIZE } from "../balloon-stats.ts";
-import { planBootStatsFileNative } from "../native/boot-plan.ts";
-import { planBootStatsFileTempModeNative } from "../native/stats-file-mode.ts";
 
 // #274: shared stats file the balloon backend writes counters to.
 // Pre-allocated zero-filled here so the VMM's mmap'd writer and our
@@ -13,28 +11,19 @@ export function setupStatsFile(
   env: Record<string, string>,
   vsockTempDir: string | undefined,
 ): { statsFilePath: string | undefined; statsTempDir: string | undefined } {
-  const mode = planBootStatsFileTempModeNative({
-    existingPath: env.MACHINEN_STATS_FILE,
-    vsockTempDir,
-  });
-  if (mode.action === "existing") {
-    return { statsFilePath: mode.existingPath ?? undefined, statsTempDir: undefined };
+  if (env.MACHINEN_STATS_FILE !== undefined) {
+    return { statsFilePath: env.MACHINEN_STATS_FILE, statsTempDir: undefined };
   }
   let statsTempDir: string | undefined;
   const statsFileTempDir =
-    mode.tempDir ?? (statsTempDir = mkdtempSync(join(tmpdir(), "machinen-stats-")));
-  const plan = planBootStatsFileNative({ tempDir: statsFileTempDir });
-  if (!plan.statsFilePath) {
-    return { statsFilePath: undefined, statsTempDir };
-  }
-  const fd = openSync(plan.statsFilePath, "w");
+    vsockTempDir ?? (statsTempDir = mkdtempSync(join(tmpdir(), "machinen-stats-")));
+  const statsFilePath = join(statsFileTempDir, "stats.bin");
+  const fd = openSync(statsFilePath, "w");
   try {
     writeSync(fd, Buffer.alloc(STATS_FILE_SIZE), 0, STATS_FILE_SIZE, 0);
   } finally {
     closeSync(fd);
   }
-  if (plan.vmmStatsFile) {
-    env.MACHINEN_STATS_FILE = plan.vmmStatsFile;
-  }
-  return { statsFilePath: plan.statsFilePath, statsTempDir };
+  env.MACHINEN_STATS_FILE = statsFilePath;
+  return { statsFilePath, statsTempDir };
 }

--- a/packages/runtime/src/vm/vsock-handle-ops.ts
+++ b/packages/runtime/src/vm/vsock-handle-ops.ts
@@ -9,12 +9,13 @@ export function makeReseedVmstateEntropy(
   vsockUdsPath: string | undefined,
   child: ChildProcessWithoutNullStreams,
   errorCollector: Promise<string>,
+  stderrTail: () => string,
 ): NonNullable<VmHandle["reseedVmstateEntropy"]> {
   return (seedHex, execOpts) => {
     if (!vsockUdsPath) {
       return Promise.reject(missingVsockError("reseedVmstateEntropy"));
     }
-    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+    return runVsockWithBootDiagnostics(child, errorCollector, stderrTail, () =>
       VsockExec.reseedVmstate(vsockUdsPath, seedHex, execOpts),
     );
   };
@@ -24,12 +25,13 @@ export function makeSyncVmstateSnapshot(
   vsockUdsPath: string | undefined,
   child: ChildProcessWithoutNullStreams,
   errorCollector: Promise<string>,
+  stderrTail: () => string,
 ): NonNullable<VmHandle["syncVmstateSnapshot"]> {
   return (execOpts) => {
     if (!vsockUdsPath) {
       return Promise.reject(missingVsockError("syncVmstateSnapshot"));
     }
-    return runVsockWithBootDiagnostics(child, errorCollector, () =>
+    return runVsockWithBootDiagnostics(child, errorCollector, stderrTail, () =>
       VsockExec.syncVmstate(vsockUdsPath, execOpts),
     );
   };


### PR DESCRIPTION
## Problem

Darwin/HVF boots got much slower in v0.7.1. Cold boots spent too much time unpacking compressed prebaked root disks. Warm boots also paid extra host-side work before the guest printed its first byte.

Closes #1032.

## Solution

This PR keeps the fast path on the host side. On macOS, rootfs materialization now prefers the tar + `mke2fs` path when the bundled tool is available. Tiny initramfs packing and simple boot planning now happen in-process instead of spawning the native helper many times.

## Technical Summary

- Prefer reusable cached rootfs images first, then tar + `mke2fs` on Darwin, and only fall back to compressed prebakes when needed or explicitly requested.
- Restore an in-process `newc` cpio writer for tiny initramfs bundles so warm boots avoid the native helper pack path.
- Move simple boot planning, registry shaping, stats/vsock/scratch setup, and gvproxy decisions onto local TypeScript paths for the common boot case.
- Keep the native helper for the heavier paths that still need it, like live-mount validation and mount disk planning.
- Preserve early boot diagnostics for fast-failing VMMs by capturing stderr before the generic collector can drain it.
