### PR TITLE
Add run targets for agent CLIs

### DIFF
--- a/.changeset/run-known-clis.md
+++ b/.changeset/run-known-clis.md
@@ -1,0 +1,5 @@
+---
+"@machinen/cli": minor
+---
+
+Add `machinen run` targets for pi, Command Code, Claude Code, and Codex, with optional persistent PTY sessions.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ const restored = await restore({ snapDir: "./counter.snap" });
 ## Other ways to boot
 
 ```bash
+npx machinen run pi                             # run a known CLI in a VM
+npx machinen run command-code                   # same, for Command Code
+npx machinen run claude --session work          # reconnectable agent session
+npx machinen run codex --session work           # reconnectable agent session
 npx machinen boot -- /bin/sh                    # ad-hoc: boot base + run a cmd
 npx machinen boot ./my-image.tar.gz             # boot a provisioned rootfs tarball
 npx machinen install                            # pre-fetch base assets (CI / airgap)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,11 @@ or a script — without writing any TypeScript.
 - **Manage VM lifecycles.** `list` (alias `ls`) to see what's
   running, `stop` to shut one down cleanly, `gc` to clean up after
   detached boots that crashed.
+- **Run known CLIs in a VM.** `mn run pi`, `mn run command-code`,
+  `mn run claude`, and `mn run codex` bake a cached image on first
+  use, mount the current directory as `/mnt/workspace`, mount the
+  tool's host state, and run the CLI in the foreground. Add
+  `--session <name>` to reconnect later.
 - **Drive it from an agent.** `--json` on every data-returning
   command (`list`, `gc`, `install`, `snapshot`, `stop`,
   `boot --detach`, `fork --detach`, `feedback`). `mn agent-context`
@@ -67,6 +72,10 @@ npx machinen snapshot worker ./warm
 npx machinen restore ./warm
 npx machinen fork worker --new-name worker-b --detach
 npx machinen stop worker
+npx machinen run pi
+npx machinen run command-code
+npx machinen run claude --session work
+npx machinen run codex --session work
 ```
 
 After the subcommand, the first positional is the target VM. Pass a

--- a/packages/cli/src/__tests__/conventions.test.ts
+++ b/packages/cli/src/__tests__/conventions.test.ts
@@ -44,6 +44,7 @@ const ALLOWED_VERBS = new Set([
   "sessions",
   "session-kill",
   "repl",
+  "run",
   "gc",
   // agent-facing meta
   "agent-context",

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -370,6 +370,35 @@ export const COMMANDS: CommandSpec[] = [
       '{"schema_version": 1, "dry_run": <bool>, "results": [{"pid": <int>, "name": <string|null>, "status": <string>, "removed_paths": [...], "failed_paths": [...]}]}',
   },
   {
+    name: "run",
+    summary: "Run a known CLI tool inside a VM.",
+    jsonOutput: false,
+    positionals: [
+      {
+        name: "target",
+        description:
+          "Run target. Built-ins: pi, command-code, claude, codex. Use 'list' to print them.",
+      },
+    ],
+    flags: [
+      {
+        name: "--rebuild",
+        type: "boolean",
+        description: "Delete the cached image for this target and bake it again before running.",
+      },
+      {
+        name: "--session",
+        type: "string",
+        description: "Run or reconnect the tool in a persistent PTY session.",
+      },
+      {
+        name: "--name",
+        type: "string",
+        description: "VM name for --session mode (default: run/<target>/<workspace-hash>).",
+      },
+    ],
+  },
+  {
     name: "install",
     summary: "Pre-fetch the kernel + base rootfs for a release tag.",
     jsonOutput: true,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@
 //   machinen attach <name|pid> [--shell <cmd>]   # PTY shell
 //   machinen attach [--session <session>] [name|pid] # persistent PTY shell
 //   machinen repl   <name|pid>                   # per-line exec
+//   machinen run <target>                        # run a known CLI in a VM
 //   machinen completion <bash|zsh|fish>
 //   machinen --version | -h | --help
 
@@ -28,6 +29,7 @@ import { cmdInstall } from "./commands/install.ts";
 import { cmdAgentContext, cmdCompletion, cmdFeedback } from "./commands/misc.ts";
 import { cmdGc, cmdLs } from "./commands/registry.ts";
 import { cmdRestore } from "./commands/restore.ts";
+import { cmdRun } from "./commands/run.ts";
 import { cmdSnapshot } from "./commands/snapshot.ts";
 import { cmdStop } from "./commands/stop.ts";
 
@@ -53,6 +55,7 @@ const COMMAND_HANDLERS = new Map<string, CommandHandler>([
   ["sessions", cmdSessions],
   ["session-kill", cmdSessionKill],
   ["repl", cmdRepl],
+  ["run", cmdRun],
   ["completion", cmdCompletion],
   ["gc", cmdGc],
   ["stop", cmdStop],

--- a/packages/cli/src/commands/misc.ts
+++ b/packages/cli/src/commands/misc.ts
@@ -158,7 +158,7 @@ const BASH_COMPLETION = `# machinen bash completion — source this from ~/.bash
 _machinen_completion() {
   local cur prev words cword
   _init_completion || return
-  local cmds="boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion --version --help -h -v"
+  local cmds="boot restore install list ls ps exec snapshot fork attach sessions session-kill repl run gc stop feedback agent-context completion --version --help -h -v"
   if [[ \${cword} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "\${cmds}" -- "\${cur}") )
     return
@@ -173,6 +173,10 @@ _machinen_completion() {
         return
       fi
       ;;
+    run)
+      COMPREPLY=( $(compgen -W "pi command-code claude codex list --rebuild --session --name" -- "\${cur}") )
+      return
+      ;;
     gc)
       COMPREPLY=( $(compgen -W "--dry-run" -- "\${cur}") )
       return
@@ -186,7 +190,7 @@ const ZSH_COMPLETION = `# machinen zsh completion — source this from ~/.zshrc,
 #   eval "$(machinen completion zsh)"
 _machinen() {
   local -a cmds
-  cmds=(boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion)
+  cmds=(boot restore install list ls ps exec snapshot fork attach sessions session-kill repl run gc stop feedback agent-context completion)
   if (( CURRENT == 2 )); then
     _describe 'command' cmds
     return
@@ -201,6 +205,10 @@ _machinen() {
         return
       fi
       ;;
+    run)
+      _describe 'target' '(pi command-code claude codex list --rebuild --session --name)'
+      return
+      ;;
     gc)
       _describe 'flag' '(--dry-run)'
       return
@@ -212,7 +220,7 @@ compdef _machinen machinen mn
 
 const FISH_COMPLETION = `# machinen fish completion — source this from your config.fish, or:
 #   machinen completion fish | source
-set -l cmds boot restore install list ls ps exec snapshot fork attach sessions session-kill repl gc stop feedback agent-context completion
+set -l cmds boot restore install list ls ps exec snapshot fork attach sessions session-kill repl run gc stop feedback agent-context completion
 for bin in machinen mn
   complete -c $bin -f -n 'not __fish_seen_subcommand_from $cmds' -a "$cmds"
   for sub in exec snapshot fork attach sessions session-kill repl stop
@@ -220,6 +228,7 @@ for bin in machinen mn
     complete -c $bin -f -n "__fish_seen_subcommand_from $sub" \\
       -a '(machinen ls 2>/dev/null | awk 'NR>1{print $1; if ($2!="-") print $2}')'
   end
+  complete -c $bin -f -n "__fish_seen_subcommand_from run" -a "pi command-code claude codex list --rebuild --session --name"
   complete -c $bin -f -n "__fish_seen_subcommand_from gc" -l dry-run
 end
 `;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,0 +1,317 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { attach, boot, list, provision, type LogEvent, type VmHandle } from "@machinen/runtime";
+
+import { DEFAULT_PTY_SESSION_NAME } from "../defaults.ts";
+import { die } from "../errors.ts";
+import { runPtyExec } from "./pty.ts";
+
+interface RunRecipe {
+  name: string;
+  summary: string;
+  imagePath: string;
+  stateDirs: Array<{ host: string; guest: string }>;
+  install: string;
+  command: string;
+  env?: Record<string, string>;
+}
+
+interface RunOptions {
+  recipe: RunRecipe;
+  rebuild: boolean;
+  sessionName?: string;
+  vmName: string;
+  toolArgs: string[];
+}
+
+const RECIPES: RunRecipe[] = [
+  {
+    name: "pi",
+    summary: "Run the pi coding agent inside a VM.",
+    imagePath: join(homedir(), ".machinen", "run", "pi", "rootfs.tar.gz"),
+    stateDirs: [{ host: join(homedir(), ".pi", "agent"), guest: "/root/.pi/agent" }],
+    install: `
+      fnm install 24
+      fnm default 24
+      npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+      pi --version
+    `,
+    command: "pi",
+  },
+  {
+    name: "command-code",
+    summary: "Run Command Code inside a VM.",
+    imagePath: join(homedir(), ".machinen", "run", "command-code", "rootfs.tar.gz"),
+    stateDirs: [{ host: join(homedir(), ".commandcode"), guest: "/root/.commandcode" }],
+    install: `
+      fnm install 24
+      fnm default 24
+      npm install -g command-code@latest
+      cmd --version
+    `,
+    command: "cmd",
+  },
+  {
+    name: "claude",
+    summary: "Run Claude Code inside a VM.",
+    imagePath: join(homedir(), ".machinen", "run", "claude", "rootfs.tar.gz"),
+    stateDirs: [{ host: join(homedir(), ".claude"), guest: "/root/.claude" }],
+    install: `
+      fnm install 24
+      fnm default 24
+      npm install -g @anthropic-ai/claude-code
+      claude --version
+    `,
+    command: "claude",
+    env: { CLAUDE_CONFIG_DIR: "/root/.claude" },
+  },
+  {
+    name: "codex",
+    summary: "Run Codex inside a VM.",
+    imagePath: join(homedir(), ".machinen", "run", "codex", "rootfs.tar.gz"),
+    stateDirs: [{ host: join(homedir(), ".codex"), guest: "/root/.codex" }],
+    install: `
+      fnm install 24
+      fnm default 24
+      npm install -g @openai/codex
+      codex --version
+    `,
+    command: "codex",
+    env: { CODEX_HOME: "/root/.codex" },
+  },
+];
+
+// fallow-ignore-next-line complexity
+export async function cmdRun(args: string[]): Promise<number> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printRunHelp();
+    return 0;
+  }
+  if (args[0] === "list") {
+    printRunList();
+    return 0;
+  }
+
+  const opts = parseRunCommandArgs(args);
+  await ensureRecipeImage(opts);
+  return await runRecipe(opts);
+}
+
+// fallow-ignore-next-line complexity
+function parseRunCommandArgs(args: string[]): RunOptions {
+  const recipeName = args[0]!;
+  const recipe = RECIPES.find((candidate) => candidate.name === recipeName);
+  if (!recipe) {
+    die(`unknown run target: ${recipeName}\nRun 'machinen run list' to see available targets.`);
+  }
+
+  let rebuild = false;
+  let sessionName: string | undefined;
+  let vmName = defaultSessionVmName(recipe);
+  const toolArgs: string[] = [];
+  let passthrough = false;
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i]!;
+    if (passthrough) {
+      toolArgs.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      passthrough = true;
+      continue;
+    }
+    if (arg === "--rebuild") {
+      rebuild = true;
+      continue;
+    }
+    if (arg === "--session" || arg.startsWith("--session=")) {
+      const parsed = readFlagValue(args, i, arg, "--session");
+      sessionName = parsed.value || DEFAULT_PTY_SESSION_NAME;
+      i = parsed.index;
+      validateSessionName(sessionName);
+      continue;
+    }
+    if (arg === "--name" || arg.startsWith("--name=")) {
+      const parsed = readFlagValue(args, i, arg, "--name");
+      vmName = parsed.value;
+      i = parsed.index;
+      continue;
+    }
+    toolArgs.push(arg);
+  }
+  return { recipe, rebuild, sessionName, vmName, toolArgs };
+}
+
+function defaultSessionVmName(recipe: RunRecipe): string {
+  const cwd = resolve(process.cwd());
+  const label = basename(cwd) || "workspace";
+  const hash = createHash("sha256").update(cwd).digest("hex").slice(0, 10);
+  return `run/${recipe.name}/${label}-${hash}`;
+}
+
+// fallow-ignore-next-line complexity
+function readFlagValue(
+  args: string[],
+  index: number,
+  arg: string,
+  flag: "--name" | "--session",
+): { value: string; index: number } {
+  if (arg.startsWith(`${flag}=`)) {
+    const value = arg.slice(flag.length + 1);
+    if (!value) {
+      die(`${flag} requires a value`);
+    }
+    return { value, index };
+  }
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    die(`${flag} requires a value`);
+  }
+  return { value, index: index + 1 };
+}
+
+function validateSessionName(value: string): void {
+  if (!/^[A-Za-z0-9_.-]{1,64}$/.test(value)) {
+    die("--session must be 1-64 characters using only letters, digits, dot, underscore, or dash");
+  }
+}
+
+async function ensureRecipeImage(opts: RunOptions): Promise<void> {
+  if (opts.rebuild) {
+    rmSync(opts.recipe.imagePath, { force: true });
+  }
+  if (existsSync(opts.recipe.imagePath)) {
+    return;
+  }
+
+  mkdirSync(dirname(opts.recipe.imagePath), { recursive: true });
+  process.stderr.write(`machinen: baking ${opts.recipe.name} image...\n`);
+  await provision({
+    install: async (vm) => {
+      await vm.exec(opts.recipe.install);
+    },
+    out: opts.recipe.imagePath,
+    onLog: writeProvisionLog,
+  });
+  process.stderr.write(`machinen: baked ${opts.recipe.name} image at ${opts.recipe.imagePath}\n`);
+}
+
+function writeProvisionLog(evt: LogEvent): void {
+  if (evt.source === "phase") {
+    return;
+  }
+  if (evt.source === "exec-stdout" || evt.source === "exec-stderr") {
+    process.stderr.write(evt.chunk);
+  }
+}
+
+async function runRecipe(opts: RunOptions): Promise<number> {
+  return opts.sessionName ? runRecipeSession(opts) : runRecipeForeground(opts);
+}
+
+async function runRecipeForeground(opts: RunOptions): Promise<number> {
+  ensureStateDirs(opts.recipe);
+  const vm = await boot({
+    image: opts.recipe.imagePath,
+    liveMounts: liveMountsForRecipe(opts.recipe),
+    guestCwd: "/mnt/workspace",
+    cmd: [
+      "/bin/bash",
+      "-lc",
+      `exec ${opts.recipe.command} "$@"`,
+      opts.recipe.command,
+      ...opts.toolArgs,
+    ],
+    env: envForRecipe(opts.recipe),
+    stdio: "inherit",
+    timeoutMs: null,
+  });
+  const { code } = await vm.wait();
+  return code ?? 0;
+}
+
+async function runRecipeSession(opts: RunOptions): Promise<number> {
+  if (!process.stdin.isTTY) {
+    die("machinen run --session: stdin is not a TTY");
+  }
+  ensureStateDirs(opts.recipe);
+  const vm = await attachOrBootSessionVm(opts);
+  const cmd = recipeShellCommand(opts);
+  process.stderr.write(
+    `attached to ${opts.vmName} session ${opts.sessionName} — reattach with machinen run ${opts.recipe.name} --session ${opts.sessionName}.\n`,
+  );
+  try {
+    return await runPtyExec(vm, cmd, opts.sessionName);
+  } finally {
+    await vm.detach();
+  }
+}
+
+async function attachOrBootSessionVm(opts: RunOptions): Promise<VmHandle> {
+  const existing = list().find((entry) => entry.name === opts.vmName);
+  if (existing) {
+    return await attach({ name: opts.vmName });
+  }
+  await boot({
+    name: opts.vmName,
+    image: opts.recipe.imagePath,
+    liveMounts: liveMountsForRecipe(opts.recipe),
+    guestCwd: "/mnt/workspace",
+    cmd: ["/bin/bash", "-lc", "sleep infinity"],
+    env: envForRecipe(opts.recipe),
+    detached: true,
+    timeoutMs: null,
+  });
+  return await attach({ name: opts.vmName });
+}
+
+function envForRecipe(recipe: RunRecipe): Record<string, string> {
+  return { HOME: "/root", ...recipe.env };
+}
+
+function liveMountsForRecipe(recipe: RunRecipe) {
+  return [
+    { host: resolve(process.cwd()), guest: "/mnt/workspace", mode: "rw" as const },
+    ...recipe.stateDirs.map((dir) => ({ host: dir.host, guest: dir.guest, mode: "rw" as const })),
+  ];
+}
+
+function recipeShellCommand(opts: RunOptions): string {
+  const args = opts.toolArgs.map(shellQuote).join(" ");
+  return args.length === 0 ? opts.recipe.command : `${opts.recipe.command} ${args}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function ensureStateDirs(recipe: RunRecipe): void {
+  for (const dir of recipe.stateDirs) {
+    mkdirSync(dir.host, { recursive: true });
+  }
+}
+
+function printRunList(): void {
+  for (const recipe of RECIPES) {
+    process.stdout.write(`${recipe.name}\t${recipe.summary}\n`);
+  }
+}
+
+function printRunHelp(): void {
+  process.stdout.write(
+    `Usage:\n` +
+      `  machinen run <target> [--rebuild] [--session <name>] [-- <args...>]\n` +
+      `  machinen run list\n` +
+      `\n` +
+      `Targets:\n` +
+      RECIPES.map((recipe) => `  ${recipe.name.padEnd(14)} ${recipe.summary}\n`).join("") +
+      `\n` +
+      `Examples:\n` +
+      `  machinen run pi\n` +
+      `  machinen run command-code -- --help\n` +
+      `  machinen run claude --session work\n` +
+      `  machinen run codex --session work\n`,
+  );
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -102,6 +102,12 @@ export function printHelp(): void {
       `                                                 one-liners; for an interactive shell\n` +
       `                                                 use \`machinen attach\` instead.\n` +
       `\n` +
+      `  machinen run <target> [--rebuild] [-- <args>] Run a known CLI tool in a VM.\n` +
+      `    --session <name>                            Run/reconnect in a persistent PTY session.\n` +
+      `    --name <vm-name>                            VM name for --session (default: per workspace).\n` +
+      `                                                 Targets: pi, command-code, claude, codex.\n` +
+      `  machinen run list                              List run targets.\n` +
+      `\n` +
       `  machinen install                               Pre-fetch the current-tag base assets\n` +
       `    --version <tag>                              Pin to a specific release tag\n` +
       `  machinen agent-context                         Versioned JSON describing every command,\n` +
@@ -138,6 +144,10 @@ export function printHelp(): void {
       `  machinen exec worker --tty -- vim /etc/passwd        # full-screen TUI in a PTY\n` +
       `  machinen snapshot worker ./warm                      # CRIU snapshot bundle\n` +
       `  machinen restore ./warm\n` +
+      `  machinen run pi\n` +
+      `  machinen run command-code -- --help\n` +
+      `  machinen run claude --session work\n` +
+      `  machinen run codex --session work\n` +
       `\n` +
       `Environment:\n` +
       `  MACHINEN_VMM                             Override the VMM binary path (dev)\n` +


### PR DESCRIPTION
## Problem

Running agent CLIs inside Machinen still took custom example scripts. That made tools like pi, Command Code, Claude Code, and Codex feel like demos instead of normal commands. It was also awkward to leave an agent running and reconnect to it later.

## Solution

Add `machinen run` as a small built-in launcher for known CLI tools. It can bake a cached VM image, mount the current folder and the tool's host state, and start the tool inside the VM. It also supports `--session <name>` so an agent can keep running in a persistent PTY and be reattached later.

## Technical Summary

- Keep the first version intentionally small: built-in run targets live in `packages/cli/src/commands/run.ts` instead of a plugin or marketplace system.
- Cache one image per tool under `~/.machinen/run/<target>/rootfs.tar.gz`, with `--rebuild` as the manual escape hatch.
- In normal mode, the tool runs as the VM foreground command and exits with the VM.
- In `--session` mode, Machinen boots or reuses a detached per-workspace VM, then attaches the requested persistent PTY session.
- The command is listed in help, completions, agent-context, docs, and a changeset.
