### PR TITLE
Fetch base assets before running recipes

### DIFF
--- a/.changeset/fetch-run-base-assets.md
+++ b/.changeset/fetch-run-base-assets.md
@@ -1,0 +1,5 @@
+---
+"@machinen/cli": patch
+---
+
+Download missing base assets automatically before baking or starting signed run recipes.

--- a/packages/cli/src/__tests__/run.test.ts
+++ b/packages/cli/src/__tests__/run.test.ts
@@ -1,0 +1,135 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  home: "",
+  attach: vi.fn(),
+  boot: vi.fn(),
+  list: vi.fn(),
+  provision: vi.fn(),
+  resolveCliBaseAssets: vi.fn(),
+  approveRunRecipe: vi.fn(),
+  hasRunRecipeApproval: vi.fn(),
+  loadRunRecipe: vi.fn(),
+  loadRunRegistry: vi.fn(),
+}));
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  homedir: () => mocks.home,
+}));
+
+vi.mock("@machinen/runtime", () => ({
+  attach: mocks.attach,
+  boot: mocks.boot,
+  list: mocks.list,
+  provision: mocks.provision,
+}));
+
+vi.mock("../base-assets.ts", () => ({
+  resolveCliBaseAssets: mocks.resolveCliBaseAssets,
+}));
+
+vi.mock("../run-approval.ts", () => ({
+  approveRunRecipe: mocks.approveRunRecipe,
+  hasRunRecipeApproval: mocks.hasRunRecipeApproval,
+}));
+
+vi.mock("../run-registry.ts", () => ({
+  loadRunRecipe: mocks.loadRunRecipe,
+  loadRunRegistry: mocks.loadRunRegistry,
+}));
+
+import { cmdRun } from "../commands/run.ts";
+
+const baseAssets = {
+  baseDir: "/cache/runtime-v0.8.0/bases/debian-arm64",
+  defaultImagePath: "/cache/runtime-v0.8.0/bases/debian-arm64/rootfs.tar.gz",
+  kernelPath: "/cache/runtime-v0.8.0/bases/debian-arm64/Image",
+  dtbPath: "/cache/runtime-v0.8.0/bases/debian-arm64/virt.dtb",
+};
+
+const verifiedRecipe = {
+  recipe: {
+    schemaVersion: 1,
+    publisher: "machinen.dev",
+    name: "pi",
+    summary: "Run pi.",
+    install: ["npm install -g @mariozechner/pi-coding-agent"],
+    command: ["pi"],
+    permissions: {
+      network: true,
+      workspace: "rw",
+      state: [],
+    },
+  },
+  source: "https://machinen.dev/run/pi",
+  digest: "a".repeat(64),
+  keyId: "machinen.dev-2026-01",
+};
+
+describe("machinen run recipe images", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.home = mkdtempSync(join(tmpdir(), "machinen-run-test-"));
+    mocks.hasRunRecipeApproval.mockReturnValue(true);
+    mocks.loadRunRecipe.mockResolvedValue(verifiedRecipe);
+    mocks.resolveCliBaseAssets.mockResolvedValue(baseAssets);
+    mocks.provision.mockResolvedValue({ imagePath: "unused", sizeBytes: 1, elapsedMs: 1 });
+    mocks.boot.mockResolvedValue({ wait: async () => ({ code: 0 }) });
+    mocks.list.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    rmSync(mocks.home, { recursive: true, force: true });
+  });
+
+  it("automatically fetches and supplies base assets before baking", async () => {
+    await expect(cmdRun([verifiedRecipe.source])).resolves.toBe(0);
+
+    expect(mocks.resolveCliBaseAssets).toHaveBeenCalledOnce();
+    expect(mocks.resolveCliBaseAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.provision.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.provision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base: baseAssets.defaultImagePath,
+        kernel: baseAssets.kernelPath,
+        dtb: baseAssets.dtbPath,
+      }),
+    );
+    expect(mocks.boot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kernel: baseAssets.kernelPath,
+        dtb: baseAssets.dtbPath,
+      }),
+    );
+  });
+
+  it("resolves base assets before booting a cached recipe image", async () => {
+    const imageDir = join(
+      mocks.home,
+      ".machinen",
+      "run",
+      "images",
+      verifiedRecipe.recipe.name,
+      verifiedRecipe.digest,
+    );
+    mkdirSync(imageDir, { recursive: true });
+    writeFileSync(join(imageDir, "rootfs.tar.gz"), "cached image");
+
+    await expect(cmdRun([verifiedRecipe.source])).resolves.toBe(0);
+
+    expect(mocks.resolveCliBaseAssets).toHaveBeenCalledOnce();
+    expect(mocks.provision).not.toHaveBeenCalled();
+    expect(mocks.boot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kernel: baseAssets.kernelPath,
+        dtb: baseAssets.dtbPath,
+      }),
+    );
+  });
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { attach, boot, list, provision, type LogEvent, type VmHandle } from "@machinen/runtime";
 
+import { resolveCliBaseAssets, type CliBaseAssetPaths } from "../base-assets.ts";
 import { DEFAULT_PTY_SESSION_NAME } from "../defaults.ts";
 import { die } from "../errors.ts";
 import { approveRunRecipe, hasRunRecipeApproval } from "../run-approval.ts";
@@ -31,6 +32,7 @@ interface RunOptions extends ParsedRunArgs {
   verified: VerifiedRunRecipe;
   imagePath: string;
   vmName: string;
+  baseAssets: CliBaseAssetPaths;
 }
 
 // fallow-ignore-next-line complexity
@@ -52,7 +54,8 @@ export async function cmdRun(args: string[]): Promise<number> {
     return 0;
   }
   await ensureRecipeApproved(verified, parsed.trust);
-  const opts = buildRunOptions(parsed, verified);
+  const baseAssets = await resolveCliBaseAssets();
+  const opts = buildRunOptions(parsed, verified, baseAssets);
   await ensureRecipeImage(opts);
   return await runRecipe(opts);
 }
@@ -123,12 +126,17 @@ function parseRunCommandArgs(args: string[]): ParsedRunArgs {
   };
 }
 
-function buildRunOptions(parsed: ParsedRunArgs, verified: VerifiedRunRecipe): RunOptions {
+function buildRunOptions(
+  parsed: ParsedRunArgs,
+  verified: VerifiedRunRecipe,
+  baseAssets: CliBaseAssetPaths,
+): RunOptions {
   return {
     ...parsed,
     verified,
     imagePath: recipeImagePath(verified),
     vmName: parsed.vmName ?? defaultSessionVmName(verified),
+    baseAssets,
   };
 }
 
@@ -327,6 +335,9 @@ async function ensureRecipeImage(opts: RunOptions): Promise<void> {
   mkdirSync(dirname(opts.imagePath), { recursive: true });
   process.stderr.write(`machinen: baking ${opts.verified.recipe.name} image...\n`);
   await provision({
+    base: opts.baseAssets.defaultImagePath,
+    kernel: opts.baseAssets.kernelPath,
+    dtb: opts.baseAssets.dtbPath,
     install: async (vm) => {
       await vm.exec(opts.verified.recipe.install.join("\n"));
     },
@@ -353,6 +364,8 @@ async function runRecipeForeground(opts: RunOptions): Promise<number> {
   ensureStateDirs(opts.verified.recipe);
   const vm = await boot({
     image: opts.imagePath,
+    kernel: opts.baseAssets.kernelPath,
+    dtb: opts.baseAssets.dtbPath,
     liveMounts: liveMountsForRecipe(opts.verified.recipe),
     guestCwd: guestCwdForRecipe(opts.verified.recipe),
     cmd: recipeCommand(opts),
@@ -390,6 +403,8 @@ async function attachOrBootSessionVm(opts: RunOptions): Promise<VmHandle> {
   await boot({
     name: opts.vmName,
     image: opts.imagePath,
+    kernel: opts.baseAssets.kernelPath,
+    dtb: opts.baseAssets.dtbPath,
     liveMounts: liveMountsForRecipe(opts.verified.recipe),
     guestCwd: guestCwdForRecipe(opts.verified.recipe),
     cmd: ["/bin/bash", "-lc", "sleep infinity"],


### PR DESCRIPTION
## Problem

Running a signed recipe on a fresh Machinen install could fail while baking its image. The CLI knew how to download the missing base assets, but `machinen run` skipped that setup and showed `PROVISION_BASE_NOT_FOUND` instead.

## Solution

`machinen run` now resolves the standard base assets before it builds or starts a recipe image. If they are missing, the existing CLI asset flow downloads them automatically and continues without another prompt.

## Technical Summary

- Keep downloads at the CLI boundary so the lower-level runtime stays free of automatic network access.
- Resolve assets only after recipe inspection and trust checks have finished.
- Pass the resolved root filesystem, kernel, and device tree into provisioning and both recipe boot paths.
- Resolve assets even when the baked recipe image is cached, since starting that image still needs the kernel and device tree.
