### PR TITLE
Fix writable live-mount shutdown sync

### DIFF
--- a/.changeset/recreate-live-mount-inodes.md
+++ b/.changeset/recreate-live-mount-inodes.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Fix writable live mounts dropping nested files during shutdown sync by assigning recreated paths fresh FUSE node IDs and avoiding a duplicate flush through stale overlay dentries.

--- a/packages/mount-server/src/fuse.zig
+++ b/packages/mount-server/src/fuse.zig
@@ -765,8 +765,12 @@ fn decref_inode(state: *State, ino: u64, n: u64) void {
     if (e.nlookup == NLOOKUP_PINNED) return; // root pinned
     if (n >= e.nlookup) {
         // Drop the entry; free its owned path before remove() invalidates the value pointer.
+        // An unlinked path may already have been recreated under a newer nodeid. FORGET for
+        // the old nodeid must not remove that replacement from the path index.
         const path_to_free = e.rel_path;
-        _ = state.path_index.remove(path_to_free);
+        if (state.path_index.get(path_to_free)) |indexed_ino| {
+            if (indexed_ino == ino) _ = state.path_index.remove(path_to_free);
+        }
         _ = state.inodes.remove(ino);
         state.gpa.free(path_to_free);
     } else {
@@ -1312,6 +1316,10 @@ fn unlink_or_rmdir(
     if (rc != 0) {
         return try build_error_reply(state, hdr.unique, map_fs_error(errno_to_zig_error(errno())));
     }
+    // A FUSE nodeid cannot identify a different inode until the kernel sends FORGET. Stop
+    // reusing the deleted path's nodeid now so an immediate recreate gets a fresh identity.
+    // Keep the old inode entry alive for any outstanding kernel references and open handles.
+    _ = state.path_index.remove(child_rel);
     return try build_error_reply(state, hdr.unique, 0);
 }
 
@@ -2419,6 +2427,42 @@ fn test_lookup(state: *State, name: []const u8) !u64 {
     return std.mem.readInt(u64, r[FUSE_OUT_HEADER_SIZE..][0..8], .little);
 }
 
+fn test_mkdir(state: *State, name: []const u8) !u64 {
+    assert(name.len > 0);
+    var body: [8 + 128]u8 = @splat(0);
+    std.mem.writeInt(u32, body[0..4], 0o755, .little);
+    @memcpy(body[8..][0..name.len], name);
+    const frame = try test_build_frame(
+        state.gpa,
+        @intFromEnum(Op.MKDIR),
+        1,
+        1,
+        body[0 .. 8 + name.len + 1],
+    );
+    defer state.gpa.free(frame);
+    const r = (try dispatch(state, frame)) orelse return error.ExpectedReply;
+    defer state.gpa.free(r);
+    if (std.mem.readInt(i32, r[4..8], .little) != 0) return error.MkdirFailed;
+    return std.mem.readInt(u64, r[FUSE_OUT_HEADER_SIZE..][0..8], .little);
+}
+
+fn test_rmdir(state: *State, name: []const u8) !void {
+    assert(name.len > 0);
+    var body: [128]u8 = @splat(0);
+    @memcpy(body[0..name.len], name);
+    const frame = try test_build_frame(
+        state.gpa,
+        @intFromEnum(Op.RMDIR),
+        1,
+        1,
+        body[0 .. name.len + 1],
+    );
+    defer state.gpa.free(frame);
+    const r = (try dispatch(state, frame)) orelse return error.ExpectedReply;
+    defer state.gpa.free(r);
+    if (std.mem.readInt(i32, r[4..8], .little) != 0) return error.RmdirFailed;
+}
+
 fn test_open(state: *State, nodeid: u64, flags: u32) !u64 {
     var body: [8]u8 = @splat(0);
     std.mem.writeInt(u32, body[0..4], flags, .little);
@@ -2428,6 +2472,34 @@ fn test_open(state: *State, nodeid: u64, flags: u32) !u64 {
     defer state.gpa.free(r);
     if (std.mem.readInt(i32, r[4..8], .little) != 0) return error.OpenFailed;
     return std.mem.readInt(u64, r[FUSE_OUT_HEADER_SIZE..][0..8], .little);
+}
+
+test "dispatch: recreated directory receives a fresh nodeid until the old one is forgotten" {
+    const gpa = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var state = try State.init(gpa, try test_tmp_root_abs(gpa, &tmp), true);
+    defer state.deinit();
+
+    const old_nodeid = try test_mkdir(&state, "recreated");
+    try test_rmdir(&state, "recreated");
+    const new_nodeid = try test_mkdir(&state, "recreated");
+    try testing.expect(old_nodeid != new_nodeid);
+    try testing.expectEqual(new_nodeid, state.path_index.get("recreated").?);
+
+    var forget_body: [8]u8 = undefined;
+    std.mem.writeInt(u64, &forget_body, 1, .little);
+    const forget = try test_build_frame(
+        gpa,
+        @intFromEnum(Op.FORGET),
+        1,
+        old_nodeid,
+        &forget_body,
+    );
+    defer gpa.free(forget);
+    try testing.expect((try dispatch(&state, forget)) == null);
+    try testing.expectEqual(new_nodeid, state.path_index.get("recreated").?);
 }
 
 test "dispatch: OPEN O_WRONLY handles writeback-cache read fill then WRITE existing file" {

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -299,10 +299,13 @@ function hasWritableLiveMount(liveMounts: ResolvedLiveMount[]): boolean {
 }
 
 function wrapBatchWorkloadCommand(cmd: string[]): string[] {
+  // Remove the sync script only after a successful flush. The supervisor treats its presence
+  // as a fallback signal; leaving it behind would mirror the just-replaced lower a second time
+  // through an overlay whose cached lower dentries are now stale.
   const batchScript =
     "batch_sync() { " +
     "if [ -s /run/machinen-batch-sync.sh ]; then " +
-    "sh /run/machinen-batch-sync.sh; fi; }; " +
+    "sh /run/machinen-batch-sync.sh && rm -f /run/machinen-batch-sync.sh; fi; }; " +
     '"$@" & child=$!; ' +
     "trap 'kill -TERM \"$child\" 2>/dev/null' TERM; " +
     "trap 'kill -INT \"$child\" 2>/dev/null' INT; " +

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -428,14 +428,18 @@ echo "T5b: machinen boot --mount-live :rw — guest writes flush at workload exi
 T5B_MARKER="virtiofs-batch-marker-$$"
 T5B_SRC="$FIXTURE/virtiofs-batch-src"
 T5B_LOG="$FIXTURE/t5b.log"
-mkdir -p "$T5B_SRC"
+mkdir -p "$T5B_SRC/preserved/nested"
 echo "delete-me" >"$T5B_SRC/delete-me.txt"
+echo "keep-me" >"$T5B_SRC/preserved/nested/keep.txt"
 run_timeout 60 node "$CLI" boot \
   --mount-live "$T5B_SRC:/mnt/live:rw" \
   -- /bin/sh -c "echo $T5B_MARKER >/mnt/live/from-guest.txt && rm /mnt/live/delete-me.txt" \
   >"$T5B_LOG" 2>&1 || true
-if [[ -f "$T5B_SRC/from-guest.txt" ]] && grep -q "$T5B_MARKER" "$T5B_SRC/from-guest.txt" && [[ ! -e "$T5B_SRC/delete-me.txt" ]]; then
-  pass "guest write/delete through :rw live-mount flushed on workload exit"
+if [[ -f "$T5B_SRC/from-guest.txt" ]] && grep -q "$T5B_MARKER" "$T5B_SRC/from-guest.txt" &&
+  [[ ! -e "$T5B_SRC/delete-me.txt" ]] &&
+  [[ "$(cat "$T5B_SRC/preserved/nested/keep.txt" 2>/dev/null)" == "keep-me" ]] &&
+  ! grep -q "Stale file handle" "$T5B_LOG"; then
+  pass "guest write/delete through :rw live-mount flushed without dropping nested host files"
 else
   tail -80 "$T5B_LOG" >&2
   echo "  host file: $(ls -la "$T5B_SRC" 2>&1)" >&2


### PR DESCRIPTION
## Problem

Writable live mounts copy their final tree back to the host when a VM exits. The sync deleted the host tree, then reused old FUSE node IDs while rebuilding nested directories. The kernel rejected those recreated paths, so users saw many `tar` errors and could lose files. A second shutdown flush could also read through stale directory entries.

## Solution

Deleted paths now receive fresh FUSE node IDs when they are recreated. Forgetting an old node can no longer remove the new path from the index. After a successful flush, Machinen removes the pending sync script so the supervisor does not copy the same tree a second time.

## Technical Summary

- Keep old inode records alive for outstanding kernel references, but detach deleted names from the path index immediately. This preserves FUSE identity rules without breaking open handles.
- Remove a path during `FORGET` only when it still points to that exact node ID. A late `FORGET` cannot erase a newer replacement.
- Keep the supervisor fallback after a failed flush, but clear it after success to avoid reading through a stale overlay.
- Cover both layers of the failure: the FUSE delete/recreate lifecycle and an end-to-end writable live-mount shutdown with preserved nested files.
