### PR TITLE
Preserve live-mount paths during shutdown sync

### DIFF
--- a/.changeset/preserve-live-mount-identities.md
+++ b/.changeset/preserve-live-mount-identities.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Preserve existing writable live-mount paths during shutdown sync and initialize the sync helper in provisioned images so metadata updates do not fail and host files are not dropped.

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -574,12 +574,44 @@ fn mount_live_batch(lm: LiveMount) void {
 fn init_batch_sync_script(mounts: []LiveMount) void {
     std.debug.assert(mounts.len > 0);
     if (!needs_batch_sync_script(mounts)) return;
+    // Provisioned images exclude /run. Create it before writing the shared header;
+    // mount_live_batch() creates it later, but by then only per-mount entries remain.
+    mkdir_parents("/run");
     const fd = open(BATCH_SYNC_SCRIPT, O_WRONLY | O_CREAT | O_TRUNC, @as(c_uint, 0o755));
     if (fd < 0) return;
     defer _ = close(fd);
     write_str(fd,
         \\#!/bin/sh
         \\set -u
+        \\prune_batch_lower() {
+        \\  guest="$1"
+        \\  lower="$2"
+        \\  keep="$3"
+        \\  find "$lower" -depth -mindepth 1 -exec sh -c '
+        \\    guest="$1"
+        \\    lower="$2"
+        \\    keep="$3"
+        \\    shift 3
+        \\    for p do
+        \\      [ "$p" = "$keep" ] && continue
+        \\      rel=${p#"$lower"/}
+        \\      g="$guest/$rel"
+        \\      if [ ! -e "$g" ] && [ ! -L "$g" ]; then
+        \\        rm -rf -- "$p"
+        \\        continue
+        \\      fi
+        \\      remove=0
+        \\      if [ -L "$p" ]; then
+        \\        [ -L "$g" ] || remove=1
+        \\      elif [ -d "$p" ]; then
+        \\        { [ -d "$g" ] && [ ! -L "$g" ]; } || remove=1
+        \\      elif [ -f "$p" ]; then
+        \\        { [ -f "$g" ] && [ ! -L "$g" ]; } || remove=1
+        \\      fi
+        \\      [ "$remove" -eq 0 ] || rm -rf -- "$p"
+        \\    done
+        \\  ' sh "$guest" "$lower" {} +
+        \\}
         \\
     );
 }
@@ -606,13 +638,12 @@ fn append_batch_sync_entry(guest: []const u8, lower: []const u8) void {
     write_str(fd, "\n");
     write_str(fd,
         \\if [ -d "$guest" ] && [ -d "$lower" ]; then
-        \\  tmp="/run/machinen-batch-sync-$$.tar"
-        \\  rm -f "$tmp"
-        \\  (cd "$guest" && tar -cf "$tmp" .) || { rm -f "$tmp"; exit 1; }
-        \\  for p in "$lower"/..?* "$lower"/.[!.]* "$lower"/*; do
-        \\    [ -e "$p" ] || [ -L "$p" ] || continue
-        \\    rm -rf "$p"
-        \\  done
+        \\  # Store the snapshot on the host-backed lower; /run may be smaller than the share.
+        \\  tmp=$(mktemp "$lower/.machinen-batch-sync-XXXXXX") || exit 1
+        \\  tmp_name=${tmp##*/}
+        \\  (cd "$guest" && tar --exclude="./$tmp_name" -cf "$tmp" .) || { rm -f "$tmp"; exit 1; }
+        \\  # Preserve matching paths and their FUSE identities; prune only deletions/type changes.
+        \\  prune_batch_lower "$guest" "$lower" "$tmp" || { rm -f "$tmp"; exit 1; }
         \\  (cd "$lower" && tar -xf "$tmp")
         \\  status=$?
         \\  rm -f "$tmp"

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -428,16 +428,27 @@ echo "T5b: machinen boot --mount-live :rw — guest writes flush at workload exi
 T5B_MARKER="virtiofs-batch-marker-$$"
 T5B_SRC="$FIXTURE/virtiofs-batch-src"
 T5B_LOG="$FIXTURE/t5b.log"
+T5B_IMG="$FIXTURE/t5b-no-run.tar.gz"
+T5B_STAGE="$FIXTURE/t5b-no-run-stage"
+# provision() excludes /run from its output image. Reproduce that shape so init must
+# create /run before writing the shared batch-sync helper, not just the mount entries.
+mkdir -p "$T5B_STAGE"
+tar -xzf "$ROOTFS_TAR" -C "$T5B_STAGE"
+rm -rf "$T5B_STAGE/run"
+tar -C "$T5B_STAGE" -czf "$T5B_IMG" .
+rm -rf "$T5B_STAGE"
 mkdir -p "$T5B_SRC/preserved/nested"
 echo "delete-me" >"$T5B_SRC/delete-me.txt"
-echo "keep-me" >"$T5B_SRC/preserved/nested/keep.txt"
+echo "keep-root" >"$T5B_SRC/keep-root.txt"
+echo "keep-nested" >"$T5B_SRC/preserved/nested/keep.txt"
 run_timeout 60 node "$CLI" boot \
-  --mount-live "$T5B_SRC:/mnt/live:rw" \
+  --mount-live "$T5B_SRC:/mnt/live:rw" "$T5B_IMG" \
   -- /bin/sh -c "echo $T5B_MARKER >/mnt/live/from-guest.txt && rm /mnt/live/delete-me.txt" \
   >"$T5B_LOG" 2>&1 || true
 if [[ -f "$T5B_SRC/from-guest.txt" ]] && grep -q "$T5B_MARKER" "$T5B_SRC/from-guest.txt" &&
   [[ ! -e "$T5B_SRC/delete-me.txt" ]] &&
-  [[ "$(cat "$T5B_SRC/preserved/nested/keep.txt" 2>/dev/null)" == "keep-me" ]] &&
+  [[ "$(cat "$T5B_SRC/keep-root.txt" 2>/dev/null)" == "keep-root" ]] &&
+  [[ "$(cat "$T5B_SRC/preserved/nested/keep.txt" 2>/dev/null)" == "keep-nested" ]] &&
   ! grep -q "Stale file handle" "$T5B_LOG"; then
   pass "guest write/delete through :rw live-mount flushed without dropping nested host files"
 else


### PR DESCRIPTION
## Problem

When an ephemeral VM shut down, Machinen 0.8.2 still replaced every host path while synchronizing writable live mounts back to the host. Even unchanged files were deleted and recreated, which could fail with `Input/output error` and drop nested files. Large workspaces also tried to store a full tar archive inside the 2 GiB guest root disk, where it could run out of space.

## Solution

During VM shutdown, writable-mount sync now keeps host paths that already match the guest tree. It removes only deleted paths and paths whose type changed. The complete sync archive is stored temporarily on the host-backed mount instead of the guest root disk, then removed after extraction.

## Technical Summary

- Preserve matching lower-layer paths so their FUSE identities remain valid throughout sync.
- Walk the lower tree from children to parents and prune only guest deletions or file-type changes before extraction.
- Create `/run` before writing the shared sync helper because provisioned images intentionally omit that directory.
- Keep the tar snapshot on the host-backed lower and exclude its temporary name from the snapshot itself. This avoids the guest root-disk size limit without recursive archiving.
- Extend the smoke test with unchanged root and nested files, plus a provisioned-image shape with no `/run` directory.
