### PR TITLE
Preserve stdin for writable live-mount workloads

### DIFF
--- a/.changeset/preserve-interactive-live-mount-stdin.md
+++ b/.changeset/preserve-interactive-live-mount-stdin.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Preserve stdin for foreground workloads when writable live mounts enable the shutdown sync wrapper, so interactive tools remain attached to the VM terminal instead of exiting on EOF.

--- a/packages/runtime/src/__tests__/bundle-workload.test.ts
+++ b/packages/runtime/src/__tests__/bundle-workload.test.ts
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { wrapBatchWorkloadCommand } from "../vm/bundle.ts";
+
+describe("writable live-mount workload wrapper", () => {
+  it("preserves stdin for the asynchronous workload", () => {
+    const wrapped = wrapBatchWorkloadCommand([
+      "/bin/sh",
+      "-c",
+      'IFS= read -r line && printf "got:%s\\n" "$line"',
+    ]);
+    const result = spawnSync(wrapped[0]!, wrapped.slice(1), {
+      input: "hello\n",
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("got:hello\n");
+  });
+});

--- a/packages/runtime/src/vm/bundle.ts
+++ b/packages/runtime/src/vm/bundle.ts
@@ -298,15 +298,20 @@ function hasWritableLiveMount(liveMounts: ResolvedLiveMount[]): boolean {
   return liveMounts.some((mount) => mount.mode === "rw");
 }
 
-function wrapBatchWorkloadCommand(cmd: string[]): string[] {
+export function wrapBatchWorkloadCommand(cmd: string[]): string[] {
   // Remove the sync script only after a successful flush. The supervisor treats its presence
   // as a fallback signal; leaving it behind would mirror the just-replaced lower a second time
   // through an overlay whose cached lower dentries are now stale.
+  //
+  // Preserve stdin on another descriptor before starting the asynchronous command. POSIX shells
+  // connect an async command's fd 0 to /dev/null before applying its redirections, so `<&0` alone
+  // would still copy /dev/null. Restore the saved descriptor in the child, then close both copies
+  // that are no longer needed. Without this, interactive workloads see immediate EOF and exit.
   const batchScript =
     "batch_sync() { " +
     "if [ -s /run/machinen-batch-sync.sh ]; then " +
     "sh /run/machinen-batch-sync.sh && rm -f /run/machinen-batch-sync.sh; fi; }; " +
-    '"$@" & child=$!; ' +
+    'exec 3<&0; "$@" <&3 3<&- & child=$!; exec 3<&-; ' +
     "trap 'kill -TERM \"$child\" 2>/dev/null' TERM; " +
     "trap 'kill -INT \"$child\" 2>/dev/null' INT; " +
     'wait "$child"; status=$?; ' +

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -21,6 +21,7 @@
 #   T3v    --mount-live :ro streams host data and rejects guest writes — #332.
 #   T5v    --mount-live :rw guest writes flush to the host — #332.
 #   T5b    --mount-live :rw stages writes and flushes on workload exit.
+#   T5i    --mount-live :rw keeps interactive workload stdin attached.
 #   T9v    filesystem-op battery over a virtio-fs live mount — #332.
 #   T4     --env propagates into the guest process env — #89.
 #   P1-P4  Base-rootfs asset contract (criu availability, mounted
@@ -455,6 +456,23 @@ else
   tail -80 "$T5B_LOG" >&2
   echo "  host file: $(ls -la "$T5B_SRC" 2>&1)" >&2
   fail "T5b batch flush did not publish expected host tree"
+fi
+
+# ---- T5i: writable live-mount wrapper preserves interactive stdin ----
+echo "T5i: machinen boot --mount-live :rw — workload stdin remains attached"
+T5I_MARKER="virtiofs-stdin-marker-$$"
+T5I_SRC="$FIXTURE/virtiofs-stdin-src"
+T5I_LOG="$FIXTURE/t5i.log"
+mkdir -p "$T5I_SRC"
+(sleep 3; printf '%s\n' "$T5I_MARKER") | node "$CLI" boot \
+  --mount-live "$T5I_SRC:/mnt/live:rw" \
+  -- /bin/sh -c 'tty; IFS= read -r line && printf "stdin-marker:%s\n" "$line"' \
+  >"$T5I_LOG" 2>&1 || true
+if grep -q '/dev/tty' "$T5I_LOG" && grep -q "stdin-marker:$T5I_MARKER" "$T5I_LOG"; then
+  pass "writable live-mount wrapper preserved the workload terminal and stdin"
+else
+  tail -80 "$T5I_LOG" >&2
+  fail "T5i workload stdin was detached from the guest terminal"
 fi
 
 # ---- T9v: filesystem-operations coverage over a virtio-fs live mount ----


### PR DESCRIPTION
## Problem

Foreground tools lost their input when they ran with writable live mounts. Interactive tools such as Pi saw an immediate end-of-input and exited as soon as the VM started.

## Solution

The writable-mount shutdown wrapper now keeps the VM terminal connected to the foreground tool. Interactive tools stay open and keep receiving keyboard input. Regression coverage checks both the shell wrapper and a real VM boot.

## Technical Summary

- Keep the workload in the background so the wrapper can still forward signals and flush writable mounts after it exits.
- Save standard input before starting the background process. A POSIX shell otherwise replaces a background process's input with `/dev/null` before normal command redirections run.
- Restore the saved input in the child and close the temporary descriptor in both processes.
- Cover the low-level wrapper behavior and the full writable-live-mount terminal path.
