### PR TITLE
Publish only changed live-mount paths

### DIFF
--- a/.changeset/sync-live-mount-changes-only.md
+++ b/.changeset/sync-live-mount-changes-only.md
@@ -1,0 +1,5 @@
+---
+"@machinen/runtime": patch
+---
+
+Publish only changed and deleted writable live-mount paths at sync points. Untouched mounts now skip file copying, so exiting an interactive VM no longer archives and rewrites the full workspace.

--- a/docs/guides/mount-files.md
+++ b/docs/guides/mount-files.md
@@ -36,21 +36,23 @@ are published back to the host at sync points by default. If the guest
 builds a binary into `./workspace/dist/`, you'll see it after the
 workload exits or the next host API sync point.
 
-Default mode is read-write. If you want to share something the guest
-mustn't be able to modify — a directory of test fixtures, say, or a
-read-only data dump — pass `:ro`:
+Default mode is read-write. Guest writes are staged in a VM-local overlay;
+at sync points Machinen publishes only the paths created, changed, or deleted
+in that overlay. Untouched files are not read or rewritten. If you want to
+share something the guest mustn't be able to modify — a directory of test
+fixtures, say, or a read-only data dump — pass `:ro`:
 
 ```bash
 npx machinen boot --mount-live ./fixtures:/mnt/fixtures:ro -- ./run-tests.sh
 ```
 
 Read-only mounts have nothing to write back. For read-write mounts,
-guest writes land in a VM-local overlay, then Machinen publishes the
-final tree in bulk when the workload exits, and after host API calls
-such as `vm.exec()`, `vm.snapshot()`, `vm.fork()`, `vm.kill()`, or
-`machinen stop`. A writable live-mount sync mirrors the guest-visible
-tree over the host directory, so concurrent host edits under that share
-can be overwritten.
+Machinen publishes staged changes when the workload exits, and after host API
+calls such as `vm.exec()`, `vm.snapshot()`, `vm.fork()`, `vm.kill()`, or
+`machinen stop`. A writable live-mount sync applies changed paths and overlay
+deletion markers to the host directory. Concurrent host edits to a path also
+changed by the guest can therefore be overwritten; unrelated host paths are
+left untouched.
 
 You can pass `--mount-live` multiple times for separate shares; each
 one gets its own virtio-fs device slot:

--- a/packages/microvm/assets/init.zig
+++ b/packages/microvm/assets/init.zig
@@ -572,7 +572,104 @@ fn mount_live_batch(lm: LiveMount) void {
         log_line("init: batch overlay mount failed");
         return;
     }
-    append_batch_sync_entry(lm.guest, lower);
+    append_batch_sync_entry(lm.guest, lower, upper);
+}
+
+fn write_batch_sync_collect_helpers(fd: c_int) void {
+    std.debug.assert(fd >= 0);
+    write_str(fd,
+        \\#!/bin/sh
+        \\set -u
+        \\directory_has_entries() {
+        \\  dir="$1"
+        \\  for entry in "$dir"/.[!.]* "$dir"/..?* "$dir"/*; do
+        \\    if [ -e "$entry" ] || [ -L "$entry" ]; then
+        \\      return 0
+        \\    fi
+        \\  done
+        \\  return 1
+        \\}
+        \\collect_changed_paths() {
+        \\  guest="$1"
+        \\  lower="$2"
+        \\  upper="$3"
+        \\  list="$4"
+        \\  shift 4
+        \\  for upper_path do
+        \\    rel=${upper_path#"$upper"/}
+        \\    guest_path="$guest/$rel"
+        \\    lower_path="$lower/$rel"
+        \\    if [ ! -e "$guest_path" ] && [ ! -L "$guest_path" ]; then
+        \\      rm -rf -- "$lower_path"
+        \\      continue
+        \\    fi
+        \\    remove=0
+        \\    if [ -L "$guest_path" ]; then
+        \\      [ -L "$lower_path" ] || remove=1
+        \\    elif [ -d "$guest_path" ]; then
+        \\      { [ -d "$lower_path" ] && [ ! -L "$lower_path" ]; } || remove=1
+        \\    elif [ -f "$guest_path" ]; then
+        \\      { [ -f "$lower_path" ] && [ ! -L "$lower_path" ]; } || remove=1
+        \\    else
+        \\      remove=1
+        \\    fi
+        \\    [ "$remove" -eq 0 ] || rm -rf -- "$lower_path"
+        \\    printf '%s\000' "./$rel" >>"$list"
+        \\  done
+        \\}
+        \\
+    );
+}
+
+fn write_batch_sync_prune_helpers(fd: c_int) void {
+    std.debug.assert(fd >= 0);
+    write_str(fd,
+        \\prune_changed_directories() {
+        \\  guest="$1"
+        \\  lower="$2"
+        \\  upper="$3"
+        \\  keep_list="$4"
+        \\  keep_archive="$5"
+        \\  shift 5
+        \\  for upper_dir do
+        \\    if [ "$upper_dir" = "$upper" ]; then
+        \\      guest_dir="$guest"
+        \\      lower_dir="$lower"
+        \\    else
+        \\      rel=${upper_dir#"$upper"/}
+        \\      guest_dir="$guest/$rel"
+        \\      lower_dir="$lower/$rel"
+        \\    fi
+        \\    if [ ! -d "$guest_dir" ] || [ -L "$guest_dir" ] ||
+        \\       [ ! -d "$lower_dir" ] || [ -L "$lower_dir" ]; then
+        \\      continue
+        \\    fi
+        \\    for lower_path in "$lower_dir"/.[!.]* "$lower_dir"/..?* "$lower_dir"/*; do
+        \\      { [ -e "$lower_path" ] || [ -L "$lower_path" ]; } || continue
+        \\      [ "$lower_path" = "$keep_list" ] && continue
+        \\      [ "$lower_path" = "$keep_archive" ] && continue
+        \\      name=${lower_path##*/}
+        \\      guest_path="$guest_dir/$name"
+        \\      if [ ! -e "$guest_path" ] && [ ! -L "$guest_path" ]; then
+        \\        rm -rf -- "$lower_path"
+        \\      fi
+        \\    done
+        \\  done
+        \\}
+        \\case "${1-}" in
+        \\  --collect-changed-paths)
+        \\    shift
+        \\    collect_changed_paths "$@"
+        \\    exit $?
+        \\    ;;
+        \\  --prune-changed-directories)
+        \\    shift
+        \\    prune_changed_directories "$@"
+        \\    exit $?
+        \\    ;;
+        \\esac
+        \\
+    );
 }
 
 fn init_batch_sync_script(mounts: []LiveMount) void {
@@ -584,40 +681,8 @@ fn init_batch_sync_script(mounts: []LiveMount) void {
     const fd = open(BATCH_SYNC_SCRIPT, O_WRONLY | O_CREAT | O_TRUNC, @as(c_uint, 0o755));
     if (fd < 0) return;
     defer _ = close(fd);
-    write_str(fd,
-        \\#!/bin/sh
-        \\set -u
-        \\prune_batch_lower() {
-        \\  guest="$1"
-        \\  lower="$2"
-        \\  keep="$3"
-        \\  find "$lower" -depth -mindepth 1 -exec sh -c '
-        \\    guest="$1"
-        \\    lower="$2"
-        \\    keep="$3"
-        \\    shift 3
-        \\    for p do
-        \\      [ "$p" = "$keep" ] && continue
-        \\      rel=${p#"$lower"/}
-        \\      g="$guest/$rel"
-        \\      if [ ! -e "$g" ] && [ ! -L "$g" ]; then
-        \\        rm -rf -- "$p"
-        \\        continue
-        \\      fi
-        \\      remove=0
-        \\      if [ -L "$p" ]; then
-        \\        [ -L "$g" ] || remove=1
-        \\      elif [ -d "$p" ]; then
-        \\        { [ -d "$g" ] && [ ! -L "$g" ]; } || remove=1
-        \\      elif [ -f "$p" ]; then
-        \\        { [ -f "$g" ] && [ ! -L "$g" ]; } || remove=1
-        \\      fi
-        \\      [ "$remove" -eq 0 ] || rm -rf -- "$p"
-        \\    done
-        \\  ' sh "$guest" "$lower" {} +
-        \\}
-        \\
-    );
+    write_batch_sync_collect_helpers(fd);
+    write_batch_sync_prune_helpers(fd);
 }
 
 fn needs_batch_sync_script(mounts: []LiveMount) bool {
@@ -628,9 +693,10 @@ fn needs_batch_sync_script(mounts: []LiveMount) bool {
     return false;
 }
 
-fn append_batch_sync_entry(guest: []const u8, lower: []const u8) void {
+fn append_batch_sync_entry(guest: []const u8, lower: []const u8, upper: []const u8) void {
     std.debug.assert(guest.len > 0);
     std.debug.assert(lower.len > 0);
+    std.debug.assert(upper.len > 0);
     const fd = open(BATCH_SYNC_SCRIPT, O_WRONLY | O_CREAT | O_APPEND, @as(c_uint, 0o755));
     if (fd < 0) return;
     defer _ = close(fd);
@@ -640,18 +706,35 @@ fn append_batch_sync_entry(guest: []const u8, lower: []const u8) void {
     write_str(fd, "lower=");
     write_shell_single_quoted(fd, lower);
     write_str(fd, "\n");
+    write_str(fd, "upper=");
+    write_shell_single_quoted(fd, upper);
+    write_str(fd, "\n");
     write_str(fd,
-        \\if [ -d "$guest" ] && [ -d "$lower" ]; then
-        \\  # Store the snapshot on the host-backed lower; /run may be smaller than the share.
-        \\  tmp=$(mktemp "$lower/.machinen-batch-sync-XXXXXX") || exit 1
-        \\  tmp_name=${tmp##*/}
-        \\  (cd "$guest" && tar --exclude="./$tmp_name" -cf "$tmp" .) || { rm -f "$tmp"; exit 1; }
-        \\  # Preserve matching paths and their FUSE identities; prune only deletions/type changes.
-        \\  prune_batch_lower "$guest" "$lower" "$tmp" || { rm -f "$tmp"; exit 1; }
-        \\  (cd "$lower" && tar -xf "$tmp")
-        \\  status=$?
-        \\  rm -f "$tmp"
-        \\  [ "$status" -eq 0 ] || exit "$status"
+        \\if [ -d "$guest" ] && [ -d "$lower" ] && [ -d "$upper" ] &&
+        \\   directory_has_entries "$upper"; then
+        \\  # The overlay upper contains only guest changes. Keep temporary data on the
+        \\  # host-backed lower because /run can be smaller than a large changed file.
+        \\  list=$(mktemp "$lower/.machinen-batch-list-XXXXXX") || exit 1
+        \\  archive=$(mktemp "$lower/.machinen-batch-sync-XXXXXX") || { rm -f "$list"; exit 1; }
+        \\  find "$upper" -depth -mindepth 1 -exec "$0" --collect-changed-paths \
+        \\    "$guest" "$lower" "$upper" "$list" {} + || { rm -f "$list" "$archive"; exit 1; }
+        \\  "$0" --prune-changed-directories \
+        \\    "$guest" "$lower" "$upper" "$list" "$archive" "$upper" || {
+        \\      rm -f "$list" "$archive"; exit 1;
+        \\    }
+        \\  find "$upper" -mindepth 1 -type d -exec "$0" --prune-changed-directories \
+        \\    "$guest" "$lower" "$upper" "$list" "$archive" {} + || {
+        \\      rm -f "$list" "$archive"; exit 1;
+        \\    }
+        \\  if [ -s "$list" ]; then
+        \\    (cd "$guest" && tar --no-recursion --null -T "$list" -cf "$archive") || {
+        \\      rm -f "$list" "$archive"; exit 1;
+        \\    }
+        \\    (cd "$lower" && tar -xf "$archive") || {
+        \\      rm -f "$list" "$archive"; exit 1;
+        \\    }
+        \\  fi
+        \\  rm -f "$list" "$archive"
         \\fi
         \\
     );

--- a/packages/microvm/docs/rootfs.md
+++ b/packages/microvm/docs/rootfs.md
@@ -40,7 +40,9 @@ The compiled `/sbin/machinen-supervisor` is PID 1 for both fresh and
 restored workloads. `/sbin/machinen-restore` is only a supervised CRIU worker.
 The supervisor forwards signals, reaps children, retains workload status,
 flushes writable live mounts once, stops sidecars, and invokes
-`/sbin/machinen-poweroff`. Final sync runs only after the workload has exited.
+`/sbin/machinen-poweroff`. Final sync walks each overlay upper and publishes
+only changed paths and deletions; an untouched mount performs no file copy.
+Final sync runs only after the workload has exited.
 If it ignores shutdown, the host force-stops the VMM without a racy sync. The
 supervisor removes `/run/machinen-batch-sync.sh` only after successful sync,
 leaving failures available for another attempt and logging cleanup failures

--- a/packages/runtime/src/__tests__/guest-shutdown.test.ts
+++ b/packages/runtime/src/__tests__/guest-shutdown.test.ts
@@ -40,6 +40,21 @@ describe("guest-requested shutdown", () => {
     expect(forceKill).toHaveBeenCalledOnce();
   });
 
+  it("runs the guest incremental sync script after host API operations", async () => {
+    const exec = vi.fn(async () => ({ exitCode: 0, stdout: "ok", stderr: "" }));
+    const execRaw = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const base = { ...fakeHandle({}), exec, execRaw } as VmHandle;
+    const handle = withBatchLiveMountSync(base, [{ host: "/host", guest: "/guest", mode: "rw" }]);
+
+    await handle.exec("true");
+
+    expect(exec).toHaveBeenCalledWith("true", undefined);
+    expect(execRaw).toHaveBeenCalledWith(
+      "/bin/sh /run/machinen-batch-sync.sh",
+      expect.objectContaining({ execTimeoutMs: 300_000 }),
+    );
+  });
+
   it("does not publish a racy sync before the force-kill fallback", async () => {
     const forceKill = vi.fn(async () => {});
     const execRaw = vi.fn(async () => ({ exitCode: 127, stdout: "", stderr: "" }));

--- a/packages/runtime/src/vm/live-mount-batch.ts
+++ b/packages/runtime/src/vm/live-mount-batch.ts
@@ -1,13 +1,10 @@
-import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import { ExecError } from "../errors.ts";
 import { validateBatchLiveMountsNative } from "../native/live-mount-batch.ts";
 import type { VmHandle } from "../vm-handle.ts";
 import type { BootOptions } from "./boot.ts";
 import { withGuestShutdown } from "./guest-shutdown.ts";
+const BATCH_SYNC_SCRIPT = "/run/machinen-batch-sync.sh";
+
 interface BatchLiveMount {
   host: string;
   guest: string;
@@ -33,7 +30,7 @@ export function withBatchLiveMountSync(
   if (batchMounts.length === 0) {
     return withGuestShutdown(handle, baseExecRaw);
   }
-  const sync = () => syncBatchLiveMounts(baseExecRaw, batchMounts);
+  const sync = () => syncBatchLiveMounts(baseExecRaw);
   const batchHandle: VmHandle = {
     ...handle,
     execRaw: (cmd, opts) => syncAfterBatchOperation(() => baseExecRaw(cmd, opts), sync),
@@ -78,69 +75,16 @@ async function syncAfterBatchOperation<T>(
   return result as T;
 }
 
-async function syncBatchLiveMounts(
-  execRaw: VmHandle["execRaw"],
-  mounts: ReadonlyArray<Required<BatchLiveMount>>,
-): Promise<void> {
-  for (const mount of mounts) {
-    await syncOneBatchLiveMount(execRaw, mount);
-  }
-}
-
-async function syncOneBatchLiveMount(
-  execRaw: VmHandle["execRaw"],
-  mount: Required<BatchLiveMount>,
-): Promise<void> {
-  const chunks: Buffer[] = [];
+async function syncBatchLiveMounts(execRaw: VmHandle["execRaw"]): Promise<void> {
   const stderr: Buffer[] = [];
-  const result = await execRaw(`cd ${shellQuote(mount.guest)} && tar -cf - .`, {
+  const result = await execRaw(`/bin/sh ${BATCH_SYNC_SCRIPT}`, {
     execTimeoutMs: 300_000,
-    onStdout: (chunk) => chunks.push(Buffer.from(chunk)),
     onStderr: (chunk) => stderr.push(Buffer.from(chunk)),
   });
   if (result.exitCode !== 0) {
     throw new ExecError(
       "EXEC_NONZERO_EXIT",
-      `batch live mount sync failed for ${mount.guest}: ${Buffer.concat(stderr).toString("utf8")}`,
+      `batch live mount sync failed: ${Buffer.concat(stderr).toString("utf8")}`,
     );
   }
-  applyBatchTarToHost(mount.host, Buffer.concat(chunks));
-}
-
-function applyBatchTarToHost(hostDir: string, tarBytes: Buffer): void {
-  const tempDir = mkdtempSync(join(tmpdir(), "machinen-batch-sync-"));
-  try {
-    const extract = spawnSync("tar", ["-xf", "-", "-C", tempDir], {
-      input: tarBytes,
-      encoding: "buffer",
-      stdio: ["pipe", "ignore", "pipe"],
-    });
-    if (extract.error) {
-      throw extract.error;
-    }
-    if (extract.status !== 0) {
-      throw new Error(`host batch tar exited ${extract.status}: ${extract.stderr}`);
-    }
-    mirrorDirectory(tempDir, hostDir);
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function mirrorDirectory(from: string, to: string): void {
-  mkdirSync(to, { recursive: true });
-  for (const entry of readdirSync(to)) {
-    rmSync(join(to, entry), { recursive: true, force: true });
-  }
-  const copy = spawnSync("cp", ["-a", `${from}/.`, to], { stdio: ["ignore", "ignore", "pipe"] });
-  if (copy.error) {
-    throw copy.error;
-  }
-  if (copy.status !== 0) {
-    throw new Error(`host batch copy exited ${copy.status}: ${copy.stderr}`);
-  }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
 }

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -449,6 +449,10 @@ mkdir -p "$T5B_SRC/preserved/nested"
 echo "delete-me" >"$T5B_SRC/delete-me.txt"
 echo "keep-root" >"$T5B_SRC/keep-root.txt"
 echo "keep-nested" >"$T5B_SRC/preserved/nested/keep.txt"
+# An unchanged unreadable file proves final sync does not archive the whole mount.
+# The host user cannot read it, but an incremental publish never needs to.
+echo "do-not-read" >"$T5B_SRC/unchanged-unreadable.txt"
+chmod 000 "$T5B_SRC/unchanged-unreadable.txt"
 run_timeout 60 node "$CLI" boot \
   --mount-live "$T5B_SRC:/mnt/live:rw" "$T5B_IMG" \
   -- /bin/sh -c "echo $T5B_MARKER >/mnt/live/from-guest.txt && rm /mnt/live/delete-me.txt" \
@@ -457,8 +461,9 @@ if [[ -f "$T5B_SRC/from-guest.txt" ]] && grep -q "$T5B_MARKER" "$T5B_SRC/from-gu
   [[ ! -e "$T5B_SRC/delete-me.txt" ]] &&
   [[ "$(cat "$T5B_SRC/keep-root.txt" 2>/dev/null)" == "keep-root" ]] &&
   [[ "$(cat "$T5B_SRC/preserved/nested/keep.txt" 2>/dev/null)" == "keep-nested" ]] &&
+  [[ -f "$T5B_SRC/unchanged-unreadable.txt" ]] &&
   ! grep -q "Stale file handle" "$T5B_LOG"; then
-  pass "guest write/delete through :rw live-mount flushed without dropping nested host files"
+  pass "guest write/delete flushed without reading or rewriting unchanged host files"
 else
   tail -80 "$T5B_LOG" >&2
   echo "  host file: $(ls -la "$T5B_SRC" 2>&1)" >&2
@@ -1620,6 +1625,7 @@ N2L_LOG="$FIXTURE/n2l.log"
 N2L_LOG_DIR="$FIXTURE/n2l-logs"
 N2L_SRC="$FIXTURE/n2l-live"
 N2L_MARKER="n2l-marker-$$"
+N2L_EXEC_MARKER="n2l-exec-marker-$$"
 N2L_STOP_MARKER="n2l-stop-marker-$$"
 mkdir -p "$N2L_SRC" "$N2L_LOG_DIR"
 # Seed the marker BEFORE boot so the post-detach exec can read it.
@@ -1661,6 +1667,17 @@ if cli exec "$N2L_NAME" -- cat /mnt/live/hello.txt >"$N2L_EXEC_LOG" 2>&1; then
 else
   cat "$N2L_EXEC_LOG" >&2
   fail "N2L — post-detach 'machinen exec ... cat' exited non-zero"
+fi
+
+# Host API operations run the same incremental guest sync before returning.
+if cli exec "$N2L_NAME" -- /bin/sh -c "'echo $N2L_EXEC_MARKER >/mnt/live/exec-sync.txt'" \
+    >>"$N2L_EXEC_LOG" 2>&1 &&
+  [[ "$(cat "$N2L_SRC/exec-sync.txt" 2>/dev/null)" == "$N2L_EXEC_MARKER" ]]; then
+  pass "machinen exec published its changed live-mount path before returning"
+else
+  cat "$N2L_EXEC_LOG" >&2
+  ls -la "$N2L_SRC" >&2
+  fail "N2L — host API sync did not publish the exec write"
 fi
 
 # `machinen stop` should signal guest PID 1, which forwards SIGTERM to


### PR DESCRIPTION
## Problem

A writable live mount copied its entire guest-visible directory back to the host at every sync point. Closing a VM with a large workspace could take tens of seconds even when the guest changed nothing. It also read and rewrote files that the guest never touched.

## Solution

Writable live mounts now publish only paths that the guest created, changed, or deleted. An untouched mount skips file copying completely. Workload exit and host API operations use the same incremental guest sync.

## Technical Summary

- Treat the overlay upper directory as the change journal instead of archiving the merged mount tree.
- Apply whiteouts, directory deletions, and file type changes before extracting changed merged-view paths with a NUL-delimited, non-recursive tar list.
- Reconcile children only inside changed directories so opaque directory changes still remove hidden lower entries.
- Run the guest-owned sync script after host API operations instead of streaming a full tar to Node and replacing the host directory.
- Keep existing failure behavior: failed final sync remains available for diagnosis and retry.
